### PR TITLE
Detect memory leaks

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -144,6 +144,8 @@ static int become_user(const char *username, int pid_fd) {
         netdata_log_error("Cannot effectively switch to user %s (uid: %u).", username, uid);
         return -1;
     }
+#else
+    fprintf(stderr, "Running with a Sanitizer, skipping setuid/setgid\n");
 #endif
 
     return(0);

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -115,6 +115,7 @@ static int become_user(const char *username, int pid_fd) {
     if(supplementary_groups)
         freez(supplementary_groups);
 
+#if !defined(FSANITIZE_ADDRESS)
     if(os_setresgid(gid, gid, gid) != 0) {
         netdata_log_error("Cannot switch to user's %s group (gid: %u).", username, gid);
         return -1;
@@ -129,10 +130,12 @@ static int become_user(const char *username, int pid_fd) {
         netdata_log_error("Cannot switch to user's %s group (gid: %u).", username, gid);
         return -1;
     }
+
     if(setegid(gid) != 0) {
         netdata_log_error("Cannot effectively switch to user's %s group (gid: %u).", username, gid);
         return -1;
     }
+
     if(setuid(uid) != 0) {
         netdata_log_error("Cannot switch to user %s (uid: %u).", username, uid);
         return -1;
@@ -141,6 +144,7 @@ static int become_user(const char *username, int pid_fd) {
         netdata_log_error("Cannot effectively switch to user %s (uid: %u).", username, uid);
         return -1;
     }
+#endif
 
     return(0);
 }

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -748,6 +748,9 @@ int netdata_main(int argc, char **argv) {
         // the caller may have left open files (lxc-attach has this issue)
         os_close_all_non_std_open_fds_except(NULL, 0, 0);
     }
+#else
+    fprintf(stderr, "Running with a Sanitizer, custom allocators are disabled.\n");
+    fprintf(stderr, "Running with a Sanitizer, not closing open fds.\n");
 #endif
 
     if(!config_loaded) {

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -742,11 +742,13 @@ int netdata_main(int argc, char **argv) {
         }
     }
 
+#if !defined(FSANITIZE_ADDRESS)
     if (close_open_fds == true) {
         // close all open file descriptors, except the standard ones
         // the caller may have left open files (lxc-attach has this issue)
         os_close_all_non_std_open_fds_except(NULL, 0, 0);
     }
+#endif
 
     if(!config_loaded) {
         netdata_conf_load(NULL, 0, &user);
@@ -1140,6 +1142,10 @@ int main(int argc, char *argv[])
     int rc = netdata_main(argc, argv);
     if (rc != 10)
         return rc;
+
+#if defined(FSANITIZE_ADDRESS)
+    fprintf(stderr, "Running with AddressSanitizer - stderr is here...\n");
+#endif
 
     nd_process_signals();
     return 1;

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1144,7 +1144,8 @@ int main(int argc, char *argv[])
         return rc;
 
 #if defined(FSANITIZE_ADDRESS)
-    fprintf(stderr, "Running with AddressSanitizer - stderr is here...\n");
+    fprintf(stdout, "STDOUT: Sanitizers mode enabled...\n");
+    fprintf(stderr, "STDERR: Sanitizers mode enabled...\n");
 #endif
 
     nd_process_signals();

--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -87,9 +87,6 @@ static void posix_unmask_my_signals(void) {
 }
 
 void nd_initialize_signals(void) {
-#if defined(FSANITIZE_ADDRESS)
-    ;
-#else
     signals_block_all_except_deadly();
 
     // Catch signals which we want to use
@@ -112,7 +109,6 @@ void nd_initialize_signals(void) {
         if(sigaction(signals_waiting[i].signo, &sa, NULL) == -1)
             netdata_log_error("SIGNAL: Failed to change signal handler for: %s", signals_waiting[i].name);
     }
-#endif
 }
 
 static void process_triggered_signals(void) {
@@ -165,10 +161,6 @@ static void process_triggered_signals(void) {
 }
 
 void nd_process_signals(void) {
-#if defined(FSANITIZE_ADDRESS)
-    while(true)
-        pause();
-#else
     posix_unmask_my_signals();
     const usec_t save_every_ut = 15 * 60 * USEC_PER_SEC;
     usec_t last_update_mt = now_monotonic_usec();
@@ -183,5 +175,4 @@ void nd_process_signals(void) {
         poll(NULL, 0, 13 * MSEC_PER_SEC + 379);
         process_triggered_signals();
     }
-#endif
 }

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1328,7 +1328,8 @@ void journalfile_migrate_to_v2_callback(Word_t section, unsigned datafile_fileno
 
     int fd_v2;
     uint8_t *data_start = nd_mmap_advanced(path, total_file_size, MAP_SHARED, 0, false, true, &fd_v2);
-    uint8_t *data = data_start;
+    if(!data_start)
+        fatal("DBENGINE: failed to memory map file '%s' of size %zu.", path, total_file_size);
 
     memset(data_start, 0, extent_offset);
 
@@ -1353,7 +1354,7 @@ void journalfile_migrate_to_v2_callback(Word_t section, unsigned datafile_fileno
 
     struct journal_v2_block_trailer *journal_v2_trailer;
 
-    data = journalfile_v2_write_extent_list(JudyL_extents_pos, data_start + extent_offset);
+    uint8_t *data = journalfile_v2_write_extent_list(JudyL_extents_pos, data_start + extent_offset);
     internal_error(true, "DBENGINE: write extent list so far %llu", (now_monotonic_usec() - start_loading) / USEC_PER_MS);
 
     fatal_assert(data == data_start + extent_offset_trailer);

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -525,8 +525,7 @@ static void rrdhost_update(RRDHOST *host
                            , const char *prog_version
                            , int update_every
                            , long history
-                           ,
-    RRD_DB_MODE mode
+                           , RRD_DB_MODE mode
                            , bool health
                            , bool stream
                            , STRING *parents

--- a/src/libnetdata/log/nd_log-internals.c
+++ b/src/libnetdata/log/nd_log-internals.c
@@ -344,7 +344,11 @@ struct nd_log nd_log = {
             .method = NDLM_DEFAULT,
             .format = NDLF_LOGFMT,
             .filename = LOG_DIR "/collector.log",
+#if defined(FSANITIZE_ADDRESS)
+            .fd = -1,
+#else
             .fd = STDERR_FILENO,
+#endif
             .fp = NULL,
             .min_priority = NDLP_INFO,
             .limits = ND_LOG_LIMITS_DEFAULT,
@@ -354,7 +358,11 @@ struct nd_log nd_log = {
             .method = NDLM_DISABLED,
             .format = NDLF_LOGFMT,
             .filename = LOG_DIR "/debug.log",
+#if defined(FSANITIZE_ADDRESS)
+            .fd = -1,
+#else
             .fd = STDOUT_FILENO,
+#endif
             .fp = NULL,
             .min_priority = NDLP_DEBUG,
             .limits = ND_LOG_LIMITS_UNLIMITED,

--- a/src/libnetdata/log/nd_log.h
+++ b/src/libnetdata/log/nd_log.h
@@ -15,7 +15,7 @@ extern "C" {
 #define ND_LOG_DEFAULT_THROTTLE_PERIOD 60
 
 void errno_clear(void);
-int nd_log_systemd_journal_fd(void);
+
 void nd_log_set_user_settings(ND_LOG_SOURCES source, const char *setting);
 void nd_log_set_facility(const char *facility);
 void nd_log_set_priority_level(const char *setting);
@@ -44,8 +44,10 @@ void nd_log_register_fatal_data_cb(log_event_t cb);
 typedef void (*fatal_event_t)(void);
 void nd_log_register_fatal_final_cb(fatal_event_t cb);
 
+int nd_log_systemd_journal_fd(void);
 int nd_log_health_fd(void);
 int nd_log_collectors_fd(void);
+
 typedef bool (*log_formatter_callback_t)(BUFFER *wb, void *data);
 
 struct log_stack_entry {

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -1081,6 +1081,10 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
         os_setproctitle(buf, server->argc, server->argv);
 
         replace_stdio_with_dev_null();
+
+        if(nd_log_collectors_fd() != STDERR_FILENO)
+            dup2(nd_log_collectors_fd(), STDERR_FILENO);
+
         int fds_to_keep[] = {
             server->sock,
             server->pipe[1],

--- a/src/streaming/stream-sender-api.c
+++ b/src/streaming/stream-sender-api.c
@@ -46,12 +46,28 @@ void stream_sender_structures_init(RRDHOST *host, bool stream, STRING *parents, 
     spinlock_init(&host->sender->spinlock);
     replication_sender_init(host->sender);
 
-    host->stream.snd.destination = string_dup(parents);
+    // gracefully swap destination
+    if(host->stream.snd.destination != parents) {
+        STRING *t = string_dup(parents);
+        SWAP(host->stream.snd.destination, t);
+        string_freez(t);
+    }
     rrdhost_stream_parents_update_from_destination(host);
 
-    host->stream.snd.api_key = string_dup(api_key);
-    host->stream.snd.charts_matching = simple_pattern_create(
-        string2str(send_charts_matching), NULL, SIMPLE_PATTERN_EXACT, true);
+    // gracefully swap api_key
+    if(host->stream.snd.api_key != api_key) {
+        STRING *t = string_dup(api_key);
+        SWAP(host->stream.snd.api_key, t);
+        string_freez(t);
+    }
+
+    // gracefully swap send_charts_matching
+    {
+        SIMPLE_PATTERN *t = simple_pattern_create(
+            string2str(send_charts_matching), NULL, SIMPLE_PATTERN_EXACT, true);
+        SWAP(host->stream.snd.charts_matching, t);
+        simple_pattern_free(t);
+    }
 
     rrdhost_option_set(host, RRDHOST_OPTION_SENDER_ENABLED);
 }


### PR DESCRIPTION
- [x] make `stdout` and `stderr` remain intact when compiling with `FSANITIZE_ADDRESS`
- [x] do not switch users when compiling with `FSANITIZE_ADDRESS` as this confuses leak sanitizer believing the program runs under ptrace, gdb, etc.
- [x] make open file descriptor remain open when compiling with `FSANITIZE_ADDRESS`

---

- [x] fix crash when a journal file cannot be memory mapped

---

- [x] fix memory leak in `buildinfo`, which was re-populating data on every json generation
- [x] fix memory leak in streaming, which was re-allocating streaming related data in RRDHOST, via rrdhost_update()
