### PR TITLE
Fix LSAN and memory leaks

### DIFF
--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -318,12 +318,12 @@ void netdata_cleanup_and_exit(EXIT_REASON reason, const char *action, const char
 
     watcher_shutdown_end();
     watcher_thread_stop();
-    curl_global_cleanup();
 
     daemon_status_file_shutdown_step(NULL);
     daemon_status_file_update_status(DAEMON_STATUS_EXITED);
 
 #ifdef OS_WINDOWS
+    curl_global_cleanup();
     return;
 #endif
 
@@ -335,12 +335,15 @@ void netdata_cleanup_and_exit(EXIT_REASON reason, const char *action, const char
         abort();
     } else {
         nd_sentry_fini();
+        curl_global_cleanup();
         exit(ret);
     }
 #else
     if(ret)
         _exit(ret);
-    else
+    else {
+        curl_global_cleanup();
         exit(ret);
+    }
 #endif
 }

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1026,20 +1026,19 @@ int netdata_main(int argc, char **argv) {
     struct rrdhost_system_info *system_info = rrdhost_system_info_create();
     rrdhost_system_info_detect(system_info);
 
-    // ----------------------------------------------------------------------------------------------------------------
-    delta_startup_time("install type");
-
     get_install_type(system_info);
+
+    set_late_analytics_variables(system_info);
 
     // ----------------------------------------------------------------------------------------------------------------
     delta_startup_time("RRD structures");
 
     abort_on_fatal_disable();
-    if(rrd_init(netdata_configured_hostname, system_info, false)) {
-        set_late_analytics_variables(system_info);
+    if (rrd_init(netdata_configured_hostname, system_info, false))
         fatal("Cannot initialize localhost instance with name '%s'.", netdata_configured_hostname);
-    }
+
     abort_on_fatal_enable();
+    system_info = NULL; // system_info is now freed by rrd_init
 
     // ----------------------------------------------------------------------------------------------------------------
     delta_startup_time("localhost labels");
@@ -1064,7 +1063,6 @@ int netdata_main(int argc, char **argv) {
 
     netdata_conf_section_web();
 
-    set_late_analytics_variables(system_info);
     for (i = 0; static_threads[i].name != NULL ; i++) {
         struct netdata_static_thread *st = &static_threads[i];
 

--- a/src/database/contexts/api_v2_contexts_alerts.c
+++ b/src/database/contexts/api_v2_contexts_alerts.c
@@ -123,9 +123,10 @@ bool rrdcontext_matches_alert(struct rrdcontext_to_json_v2_data *ctl, RRDCONTEXT
                                         sizeof(struct alert_by_x_entry),
                                         rcl);
 
-                char *module = NULL;
-                rrdlabels_get_value_strdup_or_null(st->rrdlabels, &module, "_collect_module");
-                if(!module || !*module) module = "[unset]";
+                char module[128];
+                rrdlabels_get_value_strcpyz(st->rrdlabels, module, sizeof(module), "_collect_module");
+                if(!*module)
+                    strncpyz(module, "[unset]", sizeof(module) - 1);
 
                 dictionary_set_advanced(ctl->alerts.by_module,
                                         module,

--- a/src/database/rrd.c
+++ b/src/database/rrd.c
@@ -142,6 +142,7 @@ int rrd_init(const char *hostname, struct rrdhost_system_info *system_info, bool
         , 1
         , 0
     );
+    rrdhost_system_info_free(system_info);
 
     if (unlikely(!localhost))
         return 1;

--- a/src/database/rrdhost-system-info.c
+++ b/src/database/rrdhost-system-info.c
@@ -9,7 +9,8 @@
 static inline void coverity_remove_taint(char *s __maybe_unused) { }
 
 void rrdhost_system_info_swap(struct rrdhost_system_info *a, struct rrdhost_system_info *b) {
-    SWAP(*a, *b);
+    if(a && b)
+        SWAP(*a, *b);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/database/rrdhost-system-info.c
+++ b/src/database/rrdhost-system-info.c
@@ -8,6 +8,10 @@
 // coverity[ +tainted_string_sanitize_content : arg-0 ]
 static inline void coverity_remove_taint(char *s __maybe_unused) { }
 
+void rrdhost_system_info_swap(struct rrdhost_system_info *a, struct rrdhost_system_info *b) {
+    SWAP(*a, *b);
+}
+
 // ----------------------------------------------------------------------------
 // RRDHOST - set system info from environment variables
 // system_info fields must be heap allocated or NULL

--- a/src/database/rrdhost-system-info.h
+++ b/src/database/rrdhost-system-info.h
@@ -100,5 +100,6 @@ void rrdhost_system_info_to_node_info(struct rrdhost_system_info *system_info, s
 void rrdhost_system_info_to_streaming_function_array(BUFFER *wb, struct rrdhost_system_info *system_info);
 
 void get_daemon_status_fields_from_system_info(DAEMON_STATUS_FILE *ds);
+void rrdhost_system_info_swap(struct rrdhost_system_info *a, struct rrdhost_system_info *b);
 
 #endif //NETDATA_RRDHOST_SYSTEM_INFO_H

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -174,6 +174,8 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
         system_info,
         1);
 
+    rrdhost_system_info_free(system_info);
+
     if (likely(host)) {
         if (is_ephemeral)
             rrdhost_option_set(host, RRDHOST_OPTION_EPHEMERAL_HOST);

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -194,6 +194,8 @@ static inline PARSER_RC pluginsd_host_define_end(char **words __maybe_unused, si
     if(!parser->user.host_define.parsing_host)
         return PLUGINSD_DISABLE_PLUGIN(parser, PLUGINSD_KEYWORD_HOST_DEFINE_END, "missing initialization, send " PLUGINSD_KEYWORD_HOST_DEFINE " before this");
 
+    struct rrdhost_system_info *system_info = rrdhost_system_info_from_host_labels(parser->user.host_define.rrdlabels);
+
     RRDHOST *host = rrdhost_find_or_create(
         string2str(parser->user.host_define.hostname),
         string2str(parser->user.host_define.hostname),
@@ -215,8 +217,10 @@ static inline PARSER_RC pluginsd_host_define_end(char **words __maybe_unused, si
         stream_receive.replication.enabled,
         stream_receive.replication.period,
         stream_receive.replication.step,
-        rrdhost_system_info_from_host_labels(parser->user.host_define.rrdlabels),
+        system_info,
         false);
+
+    rrdhost_system_info_free(system_info);
 
     rrdhost_option_set(host, RRDHOST_OPTION_VIRTUAL_HOST);
     rrdhost_flag_set(host, RRDHOST_FLAG_COLLECTOR_ONLINE);

--- a/src/streaming/stream-receiver-connection.c
+++ b/src/streaming/stream-receiver-connection.c
@@ -174,6 +174,9 @@ static bool stream_receiver_send_first_response(struct receiver_state *rpt) {
             rpt->system_info,
             0);
 
+        rrdhost_system_info_free(rpt->system_info);
+        rpt->system_info = NULL;
+
         if(!host) {
             stream_receiver_log_status(
                 rpt,

--- a/src/streaming/stream-receiver-connection.c
+++ b/src/streaming/stream-receiver-connection.c
@@ -173,8 +173,6 @@ static bool stream_receiver_send_first_response(struct receiver_state *rpt) {
             rpt->config.replication.step,
             rpt->system_info,
             0);
-        // IMPORTANT: system_info is now consumed!
-        rpt->system_info = NULL;
 
         if(!host) {
             stream_receiver_log_status(


### PR DESCRIPTION
- [x] add SIGUSR1 for exiting immediately, so that LSAN can check for leaks
- [x] fixed memory leak in rrdhost system info
- [x] fixed memory leak in rrdcontexts when matching alerts
- [x] do not free libcurl before sentry sends its report