### PR TITLE
Free all memory on exit

### DIFF
--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -322,6 +322,23 @@ void netdata_cleanup_and_exit(EXIT_REASON reason, const char *action, const char
     daemon_status_file_shutdown_step(NULL);
     daemon_status_file_update_status(DAEMON_STATUS_EXITED);
 
+#if defined(FSANITIZE_ADDRESS)
+    if(cleanup_destroyed_dictionaries())
+        fprintf(stderr, "WARNING: There are still dictionaries with references in them, that cannot be destroyed.\n");
+
+    // destroy the caches in reverse order (extent and open depend on main cache)
+    pgc_destroy(extent_cache);
+    pgc_destroy(open_cache);
+    pgc_destroy(main_cache);
+    mrg_destroy(main_mrg); // this is incomplete
+    // uuidmap_destroy();
+    // strings_destroy();
+    // rrdcontexts_destroy();
+    // web_clients_cache_destroy();
+    // functions_destroy();
+    // dyncfg_destroy();
+#endif
+
 #ifdef OS_WINDOWS
     curl_global_cleanup();
     return;

--- a/src/daemon/pulse/pulse-aral.c
+++ b/src/daemon/pulse/pulse-aral.c
@@ -33,6 +33,17 @@ void pulse_aral_register_statistics(struct aral_statistics *stats, const char *n
     spinlock_unlock(&globals.spinlock);
 }
 
+void pulse_aral_unregister_statistics(struct aral_statistics *stats) {
+    spinlock_lock(&globals.spinlock);
+    struct aral_info *ai = ARAL_STATS_GET(&globals.idx, (Word_t)stats);
+    if(ai) {
+        ARAL_STATS_DEL(&globals.idx, (Word_t)stats);
+        freez((void *)ai->name);
+        freez(ai);
+    }
+    spinlock_unlock(&globals.spinlock);
+}
+
 void pulse_aral_register(ARAL *ar, const char *name) {
     if(!ar) return;
 
@@ -47,15 +58,7 @@ void pulse_aral_register(ARAL *ar, const char *name) {
 void pulse_aral_unregister(ARAL *ar) {
     if(!ar) return;
     struct aral_statistics *stats = aral_get_statistics(ar);
-
-    spinlock_lock(&globals.spinlock);
-    struct aral_info *ai = ARAL_STATS_GET(&globals.idx, (Word_t)stats);
-    if(ai) {
-        ARAL_STATS_DEL(&globals.idx, (Word_t)stats);
-        freez((void *)ai->name);
-        freez(ai);
-    }
-    spinlock_unlock(&globals.spinlock);
+    pulse_aral_unregister_statistics(stats);
 }
 
 void pulse_aral_init(void) {

--- a/src/daemon/pulse/pulse-aral.h
+++ b/src/daemon/pulse/pulse-aral.h
@@ -6,6 +6,8 @@
 #include "daemon/common.h"
 
 void pulse_aral_register_statistics(struct aral_statistics *stats, const char *name);
+void pulse_aral_unregister_statistics(struct aral_statistics *stats);
+
 void pulse_aral_register(ARAL *ar, const char *name);
 void pulse_aral_unregister(ARAL *ar);
 

--- a/src/database/engine/metric.c
+++ b/src/database/engine/metric.c
@@ -357,7 +357,7 @@ struct aral_statistics *mrg_aral_stats(void) {
     return &mrg_aral_statistics;
 }
 
-ALWAYS_INLINE void mrg_destroy(MRG *mrg __maybe_unused) {
+void mrg_destroy(MRG *mrg __maybe_unused) {
     // no destruction possible
     // we can't traverse the metrics list
 

--- a/src/database/engine/metric.h
+++ b/src/database/engine/metric.h
@@ -41,7 +41,9 @@ struct mrg_statistics {
 };
 
 MRG *mrg_create(void);
-void mrg_destroy(MRG *mrg);
+
+// returns the number of metrics that could not be freed because they are referenced
+size_t mrg_destroy(MRG *mrg);
 
 METRIC *mrg_metric_dup(MRG *mrg, METRIC *metric);
 void mrg_metric_release(MRG *mrg, METRIC *metric);

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -863,5 +863,12 @@ void rrdhost_free_all(void) {
     if(localhost)
         rrdhost_free___while_having_rrd_wrlock(localhost);
 
+    localhost = NULL;
+
+    dictionary_destroy(rrdhost_root_index_hostname);
+    dictionary_destroy(rrdhost_root_index);
+    rrdhost_root_index_hostname = NULL;
+    rrdhost_root_index = NULL;
+
     rrd_wrunlock();
 }

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -330,11 +330,11 @@ static void dictionary_queue_for_destruction(DICTIONARY *dict) {
     netdata_mutex_unlock(&dictionaries_waiting_to_be_destroyed_mutex);
 }
 
-void cleanup_destroyed_dictionaries(void) {
+bool cleanup_destroyed_dictionaries(void) {
     netdata_mutex_lock(&dictionaries_waiting_to_be_destroyed_mutex);
     if (!dictionaries_waiting_to_be_destroyed) {
         netdata_mutex_unlock(&dictionaries_waiting_to_be_destroyed_mutex);
-        return;
+        return false;
     }
 
     DICTIONARY *dict, *last = NULL, *next = NULL;
@@ -371,7 +371,10 @@ void cleanup_destroyed_dictionaries(void) {
         }
     }
 
+    bool ret = dictionaries_waiting_to_be_destroyed != NULL;
     netdata_mutex_unlock(&dictionaries_waiting_to_be_destroyed_mutex);
+
+    return ret;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/libnetdata/dictionary/dictionary.h
+++ b/src/libnetdata/dictionary/dictionary.h
@@ -168,7 +168,7 @@ void dictionary_version_increment(DICTIONARY *dict);
 
 void dictionary_garbage_collect(DICTIONARY *dict);
 
-void cleanup_destroyed_dictionaries(void);
+bool cleanup_destroyed_dictionaries(void);
 
 // ----------------------------------------------------------------------------
 // Set an item in the dictionary


### PR DESCRIPTION
- [x] free all hosts (and their rrdcontexts), including `localhost`
- [x] free the dbengine caches (PGC)
- [x] free the dbengine metrics registry (MRG)
- [ ] free UUIDMap
- [ ] free inline functions
- [ ] free ACLK data linked to `localhost`