### PR TITLE
Finding leaks No 2

### DIFF
--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -410,7 +410,7 @@ static cmd_status_t cmd_remove_stale_node_internal(char *args, char **message, b
     RRDHOST *host = NULL;
     host = rrdhost_find_by_guid(args);
     if (!host)
-        host = find_host_by_node_id(args);
+        host = rrdhost_find_by_node_id(args);
 
     if (!host) {
         sqlite3_stmt *res = NULL;

--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -119,7 +119,7 @@ static void rrdeng_flush_everything_and_wait(bool wait_flush, bool wait_collecto
 
     if(wait_collectors) {
         size_t running = 1;
-        size_t count = 10;
+        size_t count = 50;
         while (running && count) {
             running = 0;
             for (size_t tier = 0; tier < nd_profile.storage_tiers; tier++)
@@ -272,7 +272,7 @@ void netdata_cleanup_and_exit(EXIT_REASON reason, const char *action, const char
                 th[tier] = nd_thread_create("rrdeng-exit", NETDATA_THREAD_OPTION_JOINABLE, rrdeng_exit_background, multidb_ctx[tier]);
 
             // flush anything remaining again - just in case
-            rrdeng_flush_everything_and_wait(true, false, false);
+            rrdeng_flush_everything_and_wait(true, true, false);
 
             for (size_t tier = 0; tier < nd_profile.storage_tiers; tier++)
                 nd_thread_join(th[tier]);
@@ -334,11 +334,11 @@ void netdata_cleanup_and_exit(EXIT_REASON reason, const char *action, const char
 
     // destroy the caches in reverse order (extent and open depend on main cache)
     fprintf(stderr, "Destroying extent cache (PGC)...\n");
-    pgc_destroy(extent_cache);
+    pgc_destroy(extent_cache, false);
     fprintf(stderr, "Destroying open cache (PGC)...\n");
-    pgc_destroy(open_cache);
+    pgc_destroy(open_cache, false);
     fprintf(stderr, "Destroying main cache (PGC)...\n");
-    pgc_destroy(main_cache);
+    pgc_destroy(main_cache, false);
 
     fprintf(stderr, "Destroying metrics registry (MRG)...\n");
     size_t metrics_referenced = mrg_destroy(main_mrg);

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -214,7 +214,7 @@ void rrdcontext_hub_checkpoint_command(void *ptr) {
         return;
     }
 
-    RRDHOST *host = find_host_by_node_id(cmd->node_id);
+    RRDHOST *host = rrdhost_find_by_node_id(cmd->node_id);
     if(!host) {
         nd_log(NDLS_DAEMON, NDLP_WARNING,
                "RRDCONTEXT: received checkpoint command for claim id '%s', node id '%s', "
@@ -286,7 +286,7 @@ void rrdcontext_hub_stop_streaming_command(void *ptr) {
         return;
     }
 
-    RRDHOST *host = find_host_by_node_id(cmd->node_id);
+    RRDHOST *host = rrdhost_find_by_node_id(cmd->node_id);
     if(!host) {
         nd_log(NDLS_DAEMON, NDLP_WARNING,
                "RRDCONTEXT: received stop streaming command for claim id '%s', node id '%s', "

--- a/src/database/engine/cache.h
+++ b/src/database/engine/cache.h
@@ -175,7 +175,7 @@ PGC *pgc_create(const char *name,
                 PGC_OPTIONS options, size_t partitions, size_t additional_bytes_per_page);
 
 // destroy the cache
-void pgc_destroy(PGC *cache);
+void pgc_destroy(PGC *cache, bool flush);
 
 #define PGC_SECTION_ALL ((Word_t)0)
 void pgc_flush_dirty_pages(PGC *cache, Word_t section);

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -337,8 +337,7 @@ RRDHOST *rrdhost_create(
         host->cache_dir  = strdupz(netdata_configured_cache_dir);
 
     // this is also needed for custom host variables - not only health
-    if(!host->rrdvars)
-        host->rrdvars = rrdvariables_create();
+    host->rrdvars = rrdvariables_create();
 
     if (likely(!uuid_parse(host->machine_guid, host->host_id.uuid)))
         sql_load_node_id(host);
@@ -821,6 +820,14 @@ void rrdhost_free_all(void) {
 
     localhost = NULL;
 
+    RRDHOST *host;
+    dfe_start_write(rrdhost_root_index, host) {
+        fprintf(stderr, "RRDHOST: MACHINE_GUID '%s' is still in the dictionary!\n",
+                host_dfe.name);
+    }
+    dfe_done(host);
+
+    dictionary_garbage_collect(rrdhost_root_index);
     dictionary_destroy(rrdhost_root_index);
     rrdhost_root_index = NULL;
 

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -90,28 +90,22 @@ inline RRDHOST *rrdhost_find_by_guid(const char *guid) {
 }
 
 static inline RRDHOST *rrdhost_index_add_by_guid(RRDHOST *host) {
-    RRDHOST *ret_machine_guid = dictionary_set(rrdhost_root_index, host->machine_guid, host, sizeof(RRDHOST));
-    if(ret_machine_guid == host)
-        rrdhost_option_set(host, RRDHOST_OPTION_INDEXED_MACHINE_GUID);
-    else {
-        rrdhost_option_clear(host, RRDHOST_OPTION_INDEXED_MACHINE_GUID);
-        nd_log(NDLS_DAEMON, NDLP_NOTICE,
-               "RRDHOST: host with machine guid '%s' is already indexed. Not adding it again.",
-               host->machine_guid);
-    }
-
-    return host;
+    return dictionary_set(rrdhost_root_index, host->machine_guid, host, sizeof(RRDHOST));
 }
 
 static void rrdhost_index_del_by_guid(RRDHOST *host) {
-    if(rrdhost_option_check(host, RRDHOST_OPTION_INDEXED_MACHINE_GUID)) {
-        if(!dictionary_del(rrdhost_root_index, host->machine_guid))
-        nd_log(NDLS_DAEMON, NDLP_NOTICE,
-               "RRDHOST: failed to delete machine guid '%s' from index",
-               host->machine_guid);
-
-        rrdhost_option_clear(host, RRDHOST_OPTION_INDEXED_MACHINE_GUID);
+    RRDHOST *t = rrdhost_find_by_guid(host->machine_guid);
+    if(t == host) {
+        if (!dictionary_del(rrdhost_root_index, host->machine_guid))
+            nd_log(
+                NDLS_DAEMON, NDLP_NOTICE,
+                "RRDHOST: failed to delete machine guid '%s' from index",
+                host->machine_guid);
     }
+    else
+        nd_log(NDLS_DAEMON, NDLP_NOTICE,
+               "RRDHOST: failed to delete machine guid '%s' from index, not found",
+               host->machine_guid);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -94,17 +94,13 @@ typedef enum __attribute__ ((__packed__)) rrdhost_flags {
 #define rrdhost_flag_set_and_clear(host, set, clear)   atomic_flags_set_and_clear(&((host)->flags), set, clear)
 
 typedef enum __attribute__ ((__packed__)) {
-    // Indexing
-    RRDHOST_OPTION_INDEXED_MACHINE_GUID     = (1 << 0), // when set, we have indexed its machine guid
-    RRDHOST_OPTION_INDEXED_HOSTNAME         = (1 << 1), // when set, we have indexed its hostname
-
     // Streaming configuration
-    RRDHOST_OPTION_SENDER_ENABLED           = (1 << 2), // set when the host is configured to send metrics to a parent
-    RRDHOST_OPTION_REPLICATION              = (1 << 3), // when set, we support replication for this host
+    RRDHOST_OPTION_SENDER_ENABLED           = (1 << 0), // set when the host is configured to send metrics to a parent
+    RRDHOST_OPTION_REPLICATION              = (1 << 1), // when set, we support replication for this host
 
     // Other options
-    RRDHOST_OPTION_VIRTUAL_HOST             = (1 << 4), // when set, this host is a virtual one
-    RRDHOST_OPTION_EPHEMERAL_HOST           = (1 << 5), // when set, this host is an ephemeral one
+    RRDHOST_OPTION_VIRTUAL_HOST             = (1 << 2), // when set, this host is a virtual one
+    RRDHOST_OPTION_EPHEMERAL_HOST           = (1 << 3), // when set, this host is an ephemeral one
 } RRDHOST_OPTIONS;
 
 #define rrdhost_option_check(host, flag) ((host)->options & (flag))

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -388,7 +388,7 @@ void rrdhost_acquired_release(RRDHOST_ACQUIRED *rha);
 
 RRDHOST *rrdhost_find_by_hostname(const char *hostname);
 RRDHOST *rrdhost_find_by_guid(const char *guid);
-RRDHOST *find_host_by_node_id(char *node_id);
+RRDHOST *rrdhost_find_by_node_id(char *node_id);
 
 #ifdef RRDHOST_INTERNALS
 RRDHOST *rrdhost_create(

--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -742,7 +742,7 @@ void aclk_push_alert_config_event(char *node_id __maybe_unused, char *config_has
     sqlite3_stmt *res = NULL;
     struct aclk_sync_cfg_t *wc;
 
-    RRDHOST *host = find_host_by_node_id(node_id);
+    RRDHOST *host = rrdhost_find_by_node_id(node_id);
 
     if (unlikely(!host || !(wc = host->aclk_config))) {
         freez(config_hash);
@@ -1053,7 +1053,7 @@ void aclk_start_alert_streaming(char *node_id, uint64_t cloud_version)
         return;
 
     struct aclk_sync_cfg_t *wc;
-    RRDHOST *host = find_host_by_node_id(node_id);
+    RRDHOST *host = rrdhost_find_by_node_id(node_id);
 
     if (unlikely(!host || !(wc = host->aclk_config))) {
         nd_log(NDLS_ACCESS, NDLP_NOTICE, "ACLK STA [%s (N/A)]: Ignoring request to stream alert state changes, invalid node.", node_id);
@@ -1087,7 +1087,7 @@ void aclk_alert_version_check(char *node_id, char *claim_id, uint64_t cloud_vers
     }
 
     struct aclk_sync_cfg_t *wc;
-    RRDHOST *host = find_host_by_node_id(node_id);
+    RRDHOST *host = rrdhost_find_by_node_id(node_id);
 
     if ((!host || !(wc = host->aclk_config)))
         nd_log(NDLS_ACCESS, NDLP_NOTICE,

--- a/src/libnetdata/dictionary/dictionary-unittest.c
+++ b/src/libnetdata/dictionary/dictionary-unittest.c
@@ -845,8 +845,10 @@ static void *unittest_dict_view_thread(void *arg) {
     return arg;
 }
 
-static int dictionary_unittest_view_threads() {
+static struct dictionary_stats stats_master = { 0 };
+static struct dictionary_stats stats_view = { 0 };
 
+static int dictionary_unittest_view_threads() {
     struct thread_view_unittest tv = {
         .join = 0,
         .master = NULL,
@@ -856,8 +858,6 @@ static int dictionary_unittest_view_threads() {
     };
 
     // threads testing of dictionary
-    struct dictionary_stats stats_master = {};
-    struct dictionary_stats stats_view = {};
     tv.master = dictionary_create_advanced(DICT_OPTION_NAME_LINK_DONT_CLONE | DICT_OPTION_DONT_OVERWRITE_VALUE, &stats_master, 0);
     tv.view = dictionary_create_view(tv.master);
     tv.view->stats = &stats_view;

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -606,7 +606,6 @@ size_t dictionary_destroy(DICTIONARY *dict) {
 
     ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE);
 
-    dict_flag_set(dict, DICT_FLAG_DESTROYED);
     DICTIONARY_STATS_DICT_DESTRUCTIONS_PLUS1(dict);
 
     size_t referenced_items = dictionary_referenced_items(dict);

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -595,6 +595,8 @@ void dictionary_flush(DICTIONARY *dict) {
     ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
 
     DICTIONARY_STATS_DICT_FLUSHES_PLUS1(dict);
+
+    dictionary_garbage_collect(dict);
 }
 
 size_t dictionary_destroy(DICTIONARY *dict) {

--- a/src/web/server/h2o/http_server.c
+++ b/src/web/server/h2o/http_server.c
@@ -145,7 +145,7 @@ static inline int _netdata_uberhandler(h2o_req_t *req, RRDHOST **host)
         if (!*host)
             *host = rrdhost_find_by_guid(c_host_id);
         if (!*host)
-            *host = find_host_by_node_id(c_host_id);
+            *host = rrdhost_find_by_node_id(c_host_id);
         if (!*host) {
             req->res.status = HTTP_RESP_BAD_REQUEST;
             req->res.reason = "Wrong host id";

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -987,19 +987,19 @@ static inline int web_client_switch_host(RRDHOST *host, struct web_client *w, ch
         netdata_log_debug(D_WEB_CLIENT, "%llu: Searching for host with name '%s'.", w->id, tok);
 
         if(nodeid) {
-            host = find_host_by_node_id(tok);
-            if(!host) {
-                host = rrdhost_find_by_hostname(tok);
-                if (!host)
-                    host = rrdhost_find_by_guid(tok);
-            }
-        }
-        else {
-            host = rrdhost_find_by_hostname(tok);
+            host = rrdhost_find_by_node_id(tok);
             if(!host) {
                 host = rrdhost_find_by_guid(tok);
                 if (!host)
-                    host = find_host_by_node_id(tok);
+                    host = rrdhost_find_by_hostname(tok);
+            }
+        }
+        else {
+            host = rrdhost_find_by_guid(tok);
+            if(!host) {
+                host = rrdhost_find_by_node_id(tok);
+                if (!host)
+                    host = rrdhost_find_by_hostname(tok);
             }
         }
 


### PR DESCRIPTION
- [x] remove the RRDHOST hostname index
- [x] fixed bug in dictionaries, that the garbage collector was missing queued dictionaries
- [x] pgc: do not attempt to flush remaining pages when dbengine has been shutdown