### PR TITLE
rrdhost name fix heap-use-after-free

### DIFF
--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -55,7 +55,7 @@ DICTIONARY *rrdhost_root_index = NULL;
 void rrdhost_init() {
     if(unlikely(!rrdhost_root_index)) {
         rrdhost_root_index = dictionary_create_advanced(
-            DICT_OPTION_NAME_LINK_DONT_CLONE | DICT_OPTION_VALUE_LINK_DONT_CLONE | DICT_OPTION_DONT_OVERWRITE_VALUE,
+            DICT_OPTION_VALUE_LINK_DONT_CLONE | DICT_OPTION_DONT_OVERWRITE_VALUE,
             &dictionary_stats_category_rrdhost, 0);
     }
 }


### PR DESCRIPTION
rrdhost machine guid should not be linked, but copied to the dictionary, so that delayed destruction of the dictionary will not introduce heap-use-after-free
