### PR TITLE
store status file in /var/lib/netdata, not in /var/cache/netdata

### DIFF
--- a/src/daemon/daemon-status-file.c
+++ b/src/daemon/daemon-status-file.c
@@ -683,6 +683,8 @@ static void static_save_buffer_init(void) {
 }
 
 static void remove_old_status_files(const char *protected_dir) {
+    FUNCTION_RUN_ONCE();
+    
     char filename[FILENAME_MAX];
 
     set_dynamic_fallbacks();

--- a/src/daemon/daemon-status-file.c
+++ b/src/daemon/daemon-status-file.c
@@ -684,6 +684,8 @@ static void remove_old_status_files(const char *protected_dir) {
         snprintfz(filename, sizeof(filename), "%s/%s", status_file_fallbacks[i], STATUS_FILENAME);
         unlink(filename);
     }
+
+    errno_clear();
 }
 
 static void daemon_status_file_save(BUFFER *wb, DAEMON_STATUS_FILE *ds, bool log) {

--- a/src/daemon/daemon-status-file.h
+++ b/src/daemon/daemon-status-file.h
@@ -33,6 +33,8 @@ typedef struct daemon_status_file {
     EXIT_REASON exit_reason;    // the exit reason (maybe empty)
     ND_PROFILE profile;         // the profile of the agent
     DAEMON_OS_TYPE os_type;
+    RRD_DB_MODE db_mode;
+    uint32_t db_tiers;
 
     time_t boottime;            // system boottime
     time_t uptime;              // netdata uptime

--- a/src/daemon/daemon-status-file.h
+++ b/src/daemon/daemon-status-file.h
@@ -35,7 +35,8 @@ typedef struct daemon_status_file {
     ND_PROFILE profile;         // the profile of the agent
     DAEMON_OS_TYPE os_type;
     RRD_DB_MODE db_mode;
-    uint32_t db_tiers;
+    uint8_t db_tiers;
+    bool kubernetes;
 
     time_t boottime;            // system boottime
     time_t uptime;              // netdata uptime

--- a/src/daemon/daemon-status-file.h
+++ b/src/daemon/daemon-status-file.h
@@ -5,6 +5,7 @@
 
 #include "libnetdata/libnetdata.h"
 #include "daemon/config/netdata-conf-profile.h"
+#include "database/rrd-database-mode.h"
 
 typedef enum {
     DAEMON_STATUS_NONE,

--- a/src/database/rrdhost-system-info.c
+++ b/src/database/rrdhost-system-info.c
@@ -652,5 +652,12 @@ void get_daemon_status_fields_from_system_info(DAEMON_STATUS_FILE *ds) {
     if(ri->host_os_id_like)
         strncpyz(ds->os_id_like, ri->host_os_id_like, sizeof(ds->os_id_like) - 1);
 
+    if(ri->is_k8s_node) {
+        if (strcmp(ri->is_k8s_node, "true") == 0)
+            ds->kubernetes = true;
+        else
+            ds->kubernetes = false;
+    }
+
     ds->read_system_info = true;
 }


### PR DESCRIPTION
- [x] move status file to `/var/lib/netdata`, because `/var/cache/netdata` is ephemeral under k8s
- [x] added db mode
- [x] added db tiers
- [x] added kubernetes flag
- [x] deleted old status files found, after successfully saving the status file