### PR TITLE
Fix typo in otel collector build infra.

### DIFF
--- a/src/go/otel-collector/CMakeLists.txt
+++ b/src/go/otel-collector/CMakeLists.txt
@@ -55,4 +55,4 @@ function(_handle_otel)
   )
 endfunction()
 
-handle_otel()
+_handle_otel()


### PR DESCRIPTION
##### Summary

SSIA

##### Test Plan

Requires confirmation that the build now works with the OTel collector enabled.