### PR TITLE
Improve CI reliability by allowing for better retry behavior.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,8 +284,8 @@ jobs:
         id: build
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 360
-          max_attempts: 3
+          timeout_minutes: 150
+          max_attempts: 2
           command: |
             export EXTRA_INSTALL_FLAGS=${{ needs.file-check.outputs.skip-go }}
             [ "${{ matrix.qemu }}" == "true" ] || export SKIP_EMULATION=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Generate Nightly Changleog
         id: nightly-changelog
         if: steps.target.outputs.run == 'true' && steps.target.outputs.type == 'nightly'
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v3
         with:
           action: heinrichreimer/github-changelog-generator-action@v2.4
           attempt_limit: 3
           attempt_delay: 60
-          with:
+          with: |
             bugLabels: IGNOREBUGS
             excludeLabels: "stale,duplicate,question,invalid,wontfix,discussion,no changelog"
             issues: false
@@ -63,12 +63,12 @@ jobs:
       - name: Generate Release Changelog
         id: release-changelog
         if: steps.target.outputs.run == 'true' && steps.target.outputs.type != 'nightly'
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v3
         with:
           action: heinrichreimer/github-changelog-generator-action@v2.4
           attempt_limit: 3
           attempt_delay: 60
-          with:
+          with: |
             bugLabels: IGNOREBUGS
             excludeLabels: "stale,duplicate,question,invalid,wontfix,discussion,no changelog"
             futureRelease: ${{ github.event.inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,30 +46,38 @@ jobs:
       - name: Generate Nightly Changleog
         id: nightly-changelog
         if: steps.target.outputs.run == 'true' && steps.target.outputs.type == 'nightly'
-        uses: heinrichreimer/github-changelog-generator-action@v2.4
+        uses: Wandalen/wretry.action@master
         with:
-          bugLabels: IGNOREBUGS
-          excludeLabels: "stale,duplicate,question,invalid,wontfix,discussion,no changelog"
-          issues: false
-          sinceTag: v1.10.0
-          token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
-          unreleasedLabel: "**Next release**"
-          verbose: true
-          maxIssues: 500
+          action: heinrichreimer/github-changelog-generator-action@v2.4
+          attempt_limit: 3
+          attempt_delay: 60
+          with:
+            bugLabels: IGNOREBUGS
+            excludeLabels: "stale,duplicate,question,invalid,wontfix,discussion,no changelog"
+            issues: false
+            sinceTag: v1.10.0
+            token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
+            unreleasedLabel: "**Next release**"
+            verbose: true
+            maxIssues: 500
       - name: Generate Release Changelog
         id: release-changelog
         if: steps.target.outputs.run == 'true' && steps.target.outputs.type != 'nightly'
-        uses: heinrichreimer/github-changelog-generator-action@v2.4
+        uses: Wandalen/wretry.action@master
         with:
-          bugLabels: IGNOREBUGS
-          excludeLabels: "stale,duplicate,question,invalid,wontfix,discussion,no changelog"
-          futureRelease: ${{ github.event.inputs.version }}
-          issues: false
-          sinceTag: v1.10.0
-          token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
-          unreleasedLabel: "**Next release**"
-          verbose: true
-          maxIssues: 500
+          action: heinrichreimer/github-changelog-generator-action@v2.4
+          attempt_limit: 3
+          attempt_delay: 60
+          with:
+            bugLabels: IGNOREBUGS
+            excludeLabels: "stale,duplicate,question,invalid,wontfix,discussion,no changelog"
+            futureRelease: ${{ github.event.inputs.version }}
+            issues: false
+            sinceTag: v1.10.0
+            token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
+            unreleasedLabel: "**Next release**"
+            verbose: true
+            maxIssues: 500
       - name: Commit Changes
         id: commit
         if: steps.target.outputs.run == 'true'


### PR DESCRIPTION
##### Summary

- Auto-retry changelog generation during the release process if it fails. This is a known flaky step that almost always works after 1-2 retries, so just automate retrying it.
- Cut the timeout on static builds to 150 minutes. This lets us actually get multiple retries in on them when things are running slow or have hung, and still gives plenty of time for the build to happen (current successful builds take at most 100 minutes).

##### Test Plan

n/a