### PR TITLE
fix contexts labels to avoid clearing the rrdlabels pointer

### DIFF
--- a/src/database/contexts/api_v1_contexts.c
+++ b/src/database/contexts/api_v1_contexts.c
@@ -131,13 +131,18 @@ static inline int rrdinstance_to_json_callback(const DICTIONARY_ITEM *item, void
     if(before && (!ri->first_time_s || before < ri->first_time_s))
         return 0;
 
-    if(t_parent->chart_label_key && rrdlabels_match_simple_pattern_parsed(ri->rrdlabels, t_parent->chart_label_key,
-                                                                           '\0', NULL) != SP_MATCHED_POSITIVE)
+    RRDLABELS *labels = rrdinstance_labels(ri);
+
+    if(t_parent->chart_label_key && rrdlabels_match_simple_pattern_parsed(
+                                         labels,
+                                         t_parent->chart_label_key,
+                                         '\0', NULL) != SP_MATCHED_POSITIVE)
         return 0;
 
-    if(t_parent->chart_labels_filter && rrdlabels_match_simple_pattern_parsed(ri->rrdlabels,
-                                                                               t_parent->chart_labels_filter, ':',
-                                                                               NULL) != SP_MATCHED_POSITIVE)
+    if(t_parent->chart_labels_filter && rrdlabels_match_simple_pattern_parsed(
+                                             labels,
+                                             t_parent->chart_labels_filter, ':',
+                                             NULL) != SP_MATCHED_POSITIVE)
         return 0;
 
     time_t first_time_s = ri->first_time_s;
@@ -213,9 +218,9 @@ static inline int rrdinstance_to_json_callback(const DICTIONARY_ITEM *item, void
         buffer_json_array_close(wb);
     }
 
-    if(options & RRDCONTEXT_OPTION_SHOW_LABELS && ri->rrdlabels && rrdlabels_entries(ri->rrdlabels)) {
+    if(options & RRDCONTEXT_OPTION_SHOW_LABELS && rrdlabels_entries(labels)) {
         buffer_json_member_add_object(wb, "labels");
-        rrdlabels_to_buffer_json_members(ri->rrdlabels, wb);
+        rrdlabels_to_buffer_json_members(labels, wb);
         buffer_json_object_close(wb);
     }
 

--- a/src/database/contexts/api_v2_contexts.c
+++ b/src/database/contexts/api_v2_contexts.c
@@ -118,8 +118,9 @@ static FTS_MATCH rrdcontext_to_json_v2_full_text_search(struct rrdcontext_to_jso
         dfe_done(rm);
 
         size_t label_searches = 0;
-        if(unlikely(ri->rrdlabels && rrdlabels_entries(ri->rrdlabels) &&
-                    rrdlabels_match_simple_pattern_parsed(ri->rrdlabels, q, ':', &label_searches) == SP_MATCHED_POSITIVE)) {
+        RRDLABELS *labels = rrdinstance_labels(ri);
+        if(unlikely(rrdlabels_entries(labels) &&
+                    rrdlabels_match_simple_pattern_parsed(labels, q, ':', &label_searches) == SP_MATCHED_POSITIVE)) {
             ctl->q.fts.searches += label_searches;
             ctl->q.fts.char_searches += label_searches;
             matched = FTS_MATCHED_LABEL;

--- a/src/database/contexts/internal.h
+++ b/src/database/contexts/internal.h
@@ -481,4 +481,6 @@ void get_metric_retention_by_id(RRDHOST *host, UUIDMAP_ID id, time_t *min_first_
 void rrdcontext_delete_after_loading(RRDHOST *host, RRDCONTEXT *rc);
 void rrdcontext_initial_processing_after_loading(RRDCONTEXT *rc);
 
+RRDLABELS *rrdinstance_labels(RRDINSTANCE *ri);
+
 #endif //NETDATA_RRDCONTEXT_INTERNAL_H

--- a/src/database/contexts/query_target.c
+++ b/src/database/contexts/query_target.c
@@ -732,12 +732,13 @@ static inline bool query_instance_matches_labels(
     SIMPLE_PATTERN *labels_sp)
 {
 
-    if (chart_label_key_sp && rrdlabels_match_simple_pattern_parsed(ri->rrdlabels, chart_label_key_sp, '\0', NULL) != SP_MATCHED_POSITIVE)
+    RRDLABELS *labels = rrdinstance_labels(ri);
+    if (chart_label_key_sp && rrdlabels_match_simple_pattern_parsed(labels, chart_label_key_sp, '\0', NULL) != SP_MATCHED_POSITIVE)
         return false;
 
     if (labels_sp) {
         struct pattern_array *pa = pattern_array_add_simple_pattern(NULL, labels_sp, ':');
-        bool found = pattern_array_label_match(pa, ri->rrdlabels, ':', NULL);
+        bool found = pattern_array_label_match(pa, labels, ':', NULL);
         pattern_array_free(pa);
         return found;
     }

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -183,8 +183,7 @@ static void delete_label(RRDLABEL *label)
 // ----------------------------------------------------------------------------
 // rrdlabels_destroy()
 
-void rrdlabels_destroy(RRDLABELS *labels)
-{
+void rrdlabels_flush(RRDLABELS *labels) {
     if (unlikely(!labels))
         return;
 
@@ -199,6 +198,14 @@ void rrdlabels_destroy(RRDLABELS *labels)
     size_t memory_freed = JudyLFreeArray(&labels->JudyL, PJE0);
     STATS_MINUS_MEMORY(&dictionary_stats_category_rrdlabels, 0, memory_freed + sizeof(RRDLABELS), 0);
     spinlock_unlock(&labels->spinlock);
+}
+
+void rrdlabels_destroy(RRDLABELS *labels)
+{
+    if (unlikely(!labels))
+        return;
+
+    rrdlabels_flush(labels);
     freez(labels);
 }
 

--- a/src/database/rrdlabels.h
+++ b/src/database/rrdlabels.h
@@ -35,6 +35,7 @@ typedef struct rrdlabels RRDLABELS;
 
 RRDLABELS *rrdlabels_create(void);
 void rrdlabels_destroy(RRDLABELS *labels_dict);
+void rrdlabels_flush(RRDLABELS *labels);
 void rrdlabels_add(RRDLABELS *labels, const char *name, const char *value, RRDLABEL_SRC ls);
 void rrdlabels_add_pair(RRDLABELS *labels, const char *string, RRDLABEL_SRC ls);
 void rrdlabels_value_to_buffer_array_item_or_null(RRDLABELS *labels, BUFFER *wb, const char *key);


### PR DESCRIPTION
Fixed the following bug.

The idea is that the rrdlabels pointer given to queries should never be freed while there is retention for the instance, since it may be used in queries.

```
=================================================================
==2291354==ERROR: AddressSanitizer: heap-use-after-free on address 0x6030039480a0 at pc 0x55a47794abdd bp 0x7f28b57ff4d0 sp 0x7f28b57ff4c8
READ of size 1 at 0x6030039480a0 thread T63
    #0 0x55a47794abdc in spinlock_lock_with_trace /usr/src/netdata-ktsaou.git/src/libnetdata/locks/spinlock.c:22
    #1 0x55a476170bd0 in rrdlabels_get_value_to_buffer_or_unset /usr/src/netdata-ktsaou.git/src/database/rrdlabels.c:454
    #2 0x55a4753c5fea in query_group_by_make_dimension_key /usr/src/netdata-ktsaou.git/src/web/api/queries/query.c:2461
    #3 0x55a4753cb131 in rrd2rrdr_group_by_initialize /usr/src/netdata-ktsaou.git/src/web/api/queries/query.c:2739
    #4 0x55a4753d9970 in rrd2rrdr /usr/src/netdata-ktsaou.git/src/web/api/queries/query.c:3389
    #5 0x55a47549eb44 in data_query_execute /usr/src/netdata-ktsaou.git/src/web/api/formatters/rrd2json.c:128
    #6 0x55a4752ffd44 in api_v2_data /usr/src/netdata-ktsaou.git/src/web/api/v2/api_v2_data.c:277
    #7 0x55a47513cbb1 in web_client_api_request_vX /usr/src/netdata-ktsaou.git/src/web/api/web_api.c:75
    #8 0x55a47515aeb4 in web_client_api_request_v3 /usr/src/netdata-ktsaou.git/src/web/api/web_api_v3.c:279
    #9 0x55a476c8f304 in web_client_api_request /usr/src/netdata-ktsaou.git/src/web/server/web_client.c:560
    #10 0x55a476c8d801 in check_host_and_call /usr/src/netdata-ktsaou.git/src/web/server/web_client.c:526
    #11 0x55a476c98262 in web_client_api_request_with_node_selection /usr/src/netdata-ktsaou.git/src/web/server/web_client.c:1079
    #12 0x55a4771fc3ad in http_api_v2 /usr/src/netdata-ktsaou.git/src/aclk/aclk_query.c:149
    #13 0x55a47620cd71 in aclk_run_query /usr/src/netdata-ktsaou.git/src/database/sqlite/sqlite_aclk.c:363
    #14 0x55a47620d5bb in aclk_run_query_job /usr/src/netdata-ktsaou.git/src/database/sqlite/sqlite_aclk.c:442
    #15 0x7f28d8ef8da4  (/lib/x86_64-linux-gnu/libuv.so.1+0xada4)
    #16 0x7f28d7ea8133 in start_thread nptl/pthread_create.c:442
    #17 0x7f28d7f287db in clone3 ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81

0x6030039480a0 is located 0 bytes inside of 24-byte region [0x6030039480a0,0x6030039480b8)
freed by thread T185 here:
    #0 0x7f28d90b76a8 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x55a4779b35ff in freez /usr/src/netdata-ktsaou.git/src/libnetdata/memory/nd-mallocz.c:455
    #2 0x55a47616dbc6 in rrdlabels_destroy /usr/src/netdata-ktsaou.git/src/database/rrdlabels.c:202
    #3 0x55a47609eb41 in rrdinstance_conflict_callback /usr/src/netdata-ktsaou.git/src/database/contexts/instance.c:214
    #4 0x55a4775aba01 in dictionary_execute_conflict_callback /usr/src/netdata-ktsaou.git/src/libnetdata/dictionary/dictionary-callbacks.h:43
    #5 0x55a4775b0cfd in dict_item_add_or_reset_value_and_acquire /usr/src/netdata-ktsaou.git/src/libnetdata/dictionary/dictionary-item.h:495
    #6 0x55a4775b4e24 in dictionary_set_and_acquire_item_advanced /usr/src/netdata-ktsaou.git/src/libnetdata/dictionary/dictionary.c:653
    #7 0x55a4760a1556 in rrdinstance_from_rrdset /usr/src/netdata-ktsaou.git/src/database/contexts/instance.c:327
    #8 0x55a4760f33a8 in rrdcontext_updated_rrdset /usr/src/netdata-ktsaou.git/src/database/contexts/rrdcontext.c:72
    #9 0x55a47619102c in rrdset_metadata_updated /usr/src/netdata-ktsaou.git/src/database/rrdset.c:8
    #10 0x55a4767ff30b in rrdset_react_callback /usr/src/netdata-ktsaou.git/src/database/rrdset-index-id.c:287
    #11 0x55a4775abeac in dictionary_execute_react_callback /usr/src/netdata-ktsaou.git/src/libnetdata/dictionary/dictionary-callbacks.h:66
    #12 0x55a4775b0dc8 in dict_item_add_or_reset_value_and_acquire /usr/src/netdata-ktsaou.git/src/libnetdata/dictionary/dictionary-item.h:516
    #13 0x55a4775b4e24 in dictionary_set_and_acquire_item_advanced /usr/src/netdata-ktsaou.git/src/libnetdata/dictionary/dictionary.c:653
    #14 0x55a4775b4e7e in dictionary_set_advanced /usr/src/netdata-ktsaou.git/src/libnetdata/dictionary/dictionary.c:659
    #15 0x55a4767ff98c in rrdset_index_add /usr/src/netdata-ktsaou.git/src/database/rrdset-index-id.c:315
    #16 0x55a476801173 in rrdset_create_custom /usr/src/netdata-ktsaou.git/src/database/rrdset-index-id.c:447
    #17 0x55a475fbb3ee in rrdset_create /usr/src/netdata-ktsaou.git/src/database/rrdset-index-id.h:41
    #18 0x55a475fc5aad in pluginsd_chart /usr/src/netdata-ktsaou.git/src/plugins.d/pluginsd_parser.c:358
    #19 0x55a475fd115e in parser_execute /usr/src/netdata-ktsaou.git/src/plugins.d/pluginsd_parser.c:1270
    #20 0x55a476aace97 in parser_action /usr/src/netdata-ktsaou.git/src/plugins.d/pluginsd_parser.h:229
    #21 0x55a476ab6272 in stream_receive_and_process /usr/src/netdata-ktsaou.git/src/streaming/stream-receiver.c:644
    #22 0x55a476ab87f8 in stream_receiver_receive_data /usr/src/netdata-ktsaou.git/src/streaming/stream-receiver.c:816
    #23 0x55a476ab9dbd in stream_receive_process_poll_events /usr/src/netdata-ktsaou.git/src/streaming/stream-receiver.c:907
    #24 0x55a476c11a82 in stream_thread_process_poll_slot /usr/src/netdata-ktsaou.git/src/streaming/stream-thread.c:363
    #25 0x55a476c13aa7 in stream_thread /usr/src/netdata-ktsaou.git/src/streaming/stream-thread.c:615
    #26 0x55a4776cb505 in nd_thread_starting_point /usr/src/netdata-ktsaou.git/src/libnetdata/threads/threads.c:358
    #27 0x7f28d7ea8133 in start_thread nptl/pthread_create.c:442

```
