### PR TITLE
Release memory on shutdown - detect invalid extent in journal files

### DIFF
--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -530,6 +530,7 @@ static ALWAYS_INLINE_HOT size_t get_page_list_from_journal_v2(struct rrdengine_i
         struct journal_page_header *page_list_header = (struct journal_page_header *) ((uint8_t *) j2_header + uuid_entry->page_offset);
         struct journal_page_list *page_list = (struct journal_page_list *)((uint8_t *) page_list_header + sizeof(*page_list_header));
         struct journal_extent_list *extent_list = (void *)((uint8_t *)j2_header + j2_header->extent_offset);
+        uint32_t extent_entries = j2_header->extent_count;
         uint32_t uuid_page_entries = page_list_header->entries;
 
         for (uint32_t index = 0; index < uuid_page_entries; index++) {
@@ -544,6 +545,13 @@ static ALWAYS_INLINE_HOT size_t get_page_list_from_journal_v2(struct rrdengine_i
 
             if(prc == PAGE_IS_IN_THE_FUTURE)
                 break;
+
+            // Make sure index is valid for this file
+            if (page_entry_in_journal->extent_index > extent_entries) {
+                nd_log_daemon(NDLP_ERR, "DBENGINE: Invalid extent index %u in journal file %u (total indexes %u)",
+                              page_entry_in_journal->extent_index, datafile->fileno, extent_entries);
+                break;
+            }
 
             uint32_t page_update_every_s = page_entry_in_journal->update_every_s;
             size_t page_length = page_entry_in_journal->page_length;

--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -548,8 +548,8 @@ static ALWAYS_INLINE_HOT size_t get_page_list_from_journal_v2(struct rrdengine_i
 
             // Make sure index is valid for this file
             if (page_entry_in_journal->extent_index > extent_entries) {
-                nd_log_daemon(NDLP_ERR, "DBENGINE: Invalid extent index %u in journal file %u (total indexes %u)",
-                              page_entry_in_journal->extent_index, datafile->fileno, extent_entries);
+                nd_log_limit_static_thread_var(erl, 60, 0);
+                nd_log_limit(&erl, NDLS_DAEMON, NDLP_ERR, "DBENGINE: Invalid extent index in journalfile %u", datafile->fileno);
                 break;
             }
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2417,6 +2417,15 @@ static void start_metadata_hosts(uv_work_t *req)
     worker_is_idle();
 }
 
+static void close_callback(uv_handle_t *handle, void *data __maybe_unused)
+{
+    if (handle->type == UV_TIMER) {
+        uv_timer_stop((uv_timer_t *)handle);
+    }
+
+    uv_close(handle, NULL);  // Automatically close and free the handle
+}
+
 static void metadata_event_loop(void *arg)
 {
     worker_register("METASYNC");
@@ -2430,7 +2439,6 @@ static void metadata_event_loop(void *arg)
     worker_register_job_name(METADATA_DEL_HOST_AE, "delete host alert entry");
 
     int ret;
-    uv_loop_t *loop;
     unsigned cmd_batch_size;
     struct metadata_wc *wc = arg;
     enum metadata_opcode opcode;
@@ -2438,12 +2446,13 @@ static void metadata_event_loop(void *arg)
     wc->ar = aral_by_size_acquire(sizeof(struct metadata_cmd));
 
     uv_thread_set_name_np("METASYNC");
-    loop = wc->loop = mallocz(sizeof(uv_loop_t));
+    uv_loop_t *loop = wc->loop = mallocz(sizeof(uv_loop_t));
     ret = uv_loop_init(loop);
     if (ret) {
         netdata_log_error("uv_loop_init(): %s", uv_strerror(ret));
         goto error_after_loop_init;
     }
+
     loop->data = wc;
 
     ret = uv_async_init(wc->loop, &wc->async, async_cb);
@@ -2619,17 +2628,21 @@ static void metadata_event_loop(void *arg)
         } while (opcode != METADATA_DATABASE_NOOP);
     }
 
-    if (!uv_timer_stop(&wc->timer_req))
-        uv_close((uv_handle_t *)&wc->timer_req, NULL);
+//    if (!uv_timer_stop(&wc->timer_req))
+//        uv_close((uv_handle_t *)&wc->timer_req, NULL);
+//
+//    uv_close((uv_handle_t *)&wc->async, NULL);
 
-    uv_close((uv_handle_t *)&wc->async, NULL);
+    uv_walk(loop, (uv_walk_cb) close_callback, NULL);
+    uv_run(loop, UV_RUN_NOWAIT);
+
     int rc;
     do {
         rc = uv_loop_close(loop);
     } while (rc != UV_EBUSY);
 
     buffer_free(work_buffer);
-    freez(loop);
+//    freez(loop);
     worker_unregister();
 
     nd_log(NDLS_DAEMON, NDLP_DEBUG, "Shutting down metadata thread");
@@ -2668,8 +2681,8 @@ error_after_timer_init:
     uv_close((uv_handle_t *)&wc->async, NULL);
 error_after_async_init:
     fatal_assert(0 == uv_loop_close(loop));
-error_after_loop_init:
     freez(loop);
+error_after_loop_init:
     aral_by_size_release(wc->ar);
     worker_unregister();
 }

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2628,11 +2628,6 @@ static void metadata_event_loop(void *arg)
         } while (opcode != METADATA_DATABASE_NOOP);
     }
 
-//    if (!uv_timer_stop(&wc->timer_req))
-//        uv_close((uv_handle_t *)&wc->timer_req, NULL);
-//
-//    uv_close((uv_handle_t *)&wc->async, NULL);
-
     uv_walk(loop, (uv_walk_cb) close_callback, NULL);
     uv_run(loop, UV_RUN_NOWAIT);
 
@@ -2642,7 +2637,6 @@ static void metadata_event_loop(void *arg)
     } while (rc != UV_EBUSY);
 
     buffer_free(work_buffer);
-//    freez(loop);
     worker_unregister();
 
     nd_log(NDLS_DAEMON, NDLP_DEBUG, "Shutting down metadata thread");

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2675,8 +2675,8 @@ error_after_timer_init:
     uv_close((uv_handle_t *)&wc->async, NULL);
 error_after_async_init:
     fatal_assert(0 == uv_loop_close(loop));
-    freez(loop);
 error_after_loop_init:
+    freez(loop);
     aral_by_size_release(wc->ar);
     worker_unregister();
 }


### PR DESCRIPTION
##### Summary
- Free all METASYNC thread resources when the agent shuts down
- Add check for invalid extent index when processing metric data pages