### PR TITLE
improvement(macos.plugin): add options to filter net ifaces and mountpoints

### DIFF
--- a/src/collectors/macos.plugin/macos_fw.c
+++ b/src/collectors/macos.plugin/macos_fw.c
@@ -38,7 +38,7 @@ int do_macos_iokit(int update_every, usec_t dt) {
         excluded_mountpoints = simple_pattern_create(
             inicfg_get(
                 &netdata_config,
-                "plugin:macos:sysctl",
+                "plugin:macos:iokit",
                 "exclude mountpoints by path",
                 "/System/Volumes/* /private/var/folders/* /Volumes/Recovery"),
             NULL,
@@ -47,7 +47,7 @@ int do_macos_iokit(int update_every, usec_t dt) {
         disabled_net_interfaces = simple_pattern_create(
             inicfg_get(
                 &netdata_config,
-                "plugin:macos:sysctl",
+                "plugin:macos:iokit",
                 "disable by default network interfaces matching",
                 "lo* awdl* llw* anpi* gif* bridge* ap*"),
             NULL,


### PR DESCRIPTION
##### Summary

Fixes #19842


```
[plugin:macos:iokit]
	# disk i/o = yes
	# exclude mountpoints by path = /System/Volumes/* /private/var/folders/* /Volumes/Recovery
	# disable by default network interfaces matching = lo* awdl* llw* anpi* gif* bridge* ap*
```

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
