### PR TITLE
daemon-status-18

### DIFF
--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -378,11 +378,12 @@ void netdata_cleanup_and_exit(EXIT_REASON reason, const char *action, const char
 #endif
 
 #ifdef ENABLE_SENTRY
-    if (!ret || !shutdown_on_fatal()) {
-        nd_sentry_fini();
-        curl_global_cleanup();
-        exit(ret);
-    }
+    if(ret)
+        shutdown_on_fatal();
+
+    nd_sentry_fini();
+    curl_global_cleanup();
+    exit(ret);
 #else
     if(ret)
         _exit(ret);

--- a/src/daemon/daemon-status-file.c
+++ b/src/daemon/daemon-status-file.c
@@ -161,40 +161,42 @@ static void daemon_status_file_to_json(BUFFER *wb, DAEMON_STATUS_FILE *ds) {
 
     dsf_acquire(*ds);
 
-    buffer_json_member_add_datetime_rfc3339(wb, "@timestamp", ds->timestamp_ut, true); // ECS
-    buffer_json_member_add_uint64(wb, "version", STATUS_FILE_VERSION); // custom
+    buffer_json_member_add_datetime_rfc3339(wb, "@timestamp", ds->timestamp_ut, true);
+    buffer_json_member_add_uint64(wb, "version", STATUS_FILE_VERSION);
 
-    buffer_json_member_add_object(wb, "agent"); // ECS
+    buffer_json_member_add_object(wb, "agent");
     {
-        buffer_json_member_add_uuid(wb, "id", ds->host_id.uuid); // ECS
-        buffer_json_member_add_uuid_compact(wb, "ephemeral_id", ds->invocation.uuid); // ECS
-        buffer_json_member_add_string(wb, "version", ds->version); // ECS
+        buffer_json_member_add_uuid(wb, "id", ds->host_id.uuid);
+        buffer_json_member_add_uuid_compact(wb, "ephemeral_id", ds->invocation.uuid);
+        buffer_json_member_add_string(wb, "version", ds->version);
 
-        buffer_json_member_add_time_t(wb, "uptime", ds->uptime); // custom
+        buffer_json_member_add_time_t(wb, "uptime", ds->uptime);
 
-        buffer_json_member_add_uuid(wb, "ND_node_id", ds->node_id.uuid); // custom
-        buffer_json_member_add_uuid(wb, "ND_claim_id", ds->claim_id.uuid); // custom
-        buffer_json_member_add_uint64(wb, "ND_restarts", ds->restarts); // custom
+        buffer_json_member_add_uuid(wb, "node_id", ds->node_id.uuid);
+        buffer_json_member_add_uuid(wb, "claim_id", ds->claim_id.uuid);
+        buffer_json_member_add_uint64(wb, "restarts", ds->restarts);
 
-        ND_PROFILE_2json(wb, "ND_profile", ds->profile); // custom
-        buffer_json_member_add_string(wb, "ND_status", DAEMON_STATUS_2str(ds->status)); // custom
-        EXIT_REASON_2json(wb, "ND_exit_reason", ds->exit_reason); // custom
+        ND_PROFILE_2json(wb, "profile", ds->profile);
+        buffer_json_member_add_string(wb, "status", DAEMON_STATUS_2str(ds->status));
+        EXIT_REASON_2json(wb, "exit_reason", ds->exit_reason);
 
-        buffer_json_member_add_string_or_empty(wb, "ND_install_type", ds->install_type); // custom
+        buffer_json_member_add_string_or_empty(wb, "install_type", ds->install_type);
 
         if(ds->v >= 14) {
-            buffer_json_member_add_string(wb, "ND_db_mode", rrd_memory_mode_name(ds->db_mode)); // custom
-            buffer_json_member_add_uint64(wb, "ND_db_tiers", ds->db_tiers); // custom
-            buffer_json_member_add_boolean(wb, "ND_kubernetes", ds->kubernetes); // custom
+            buffer_json_member_add_string(wb, "db_mode", rrd_memory_mode_name(ds->db_mode));
+            buffer_json_member_add_uint64(wb, "db_tiers", ds->db_tiers);
+            buffer_json_member_add_boolean(wb, "kubernetes", ds->kubernetes);
         }
 
         if(ds->v >= 16)
-            buffer_json_member_add_boolean(wb, "ND_sentry_available", ds->sentry_available); // custom
+            buffer_json_member_add_boolean(wb, "sentry_available", ds->sentry_available);
 
-        if(ds->v >= 18)
-            buffer_json_member_add_int64(wb, "ND_reliability", ds->reliability); // custom
+        if(ds->v >= 18) {
+            buffer_json_member_add_int64(wb, "reliability", ds->reliability);
+            buffer_json_member_add_string(wb, "stack_traces", ds->stack_traces);
+        }
 
-        buffer_json_member_add_object(wb, "ND_timings"); // custom
+        buffer_json_member_add_object(wb, "timings");
         {
             buffer_json_member_add_time_t(wb, "init", ds->timings.init);
             buffer_json_member_add_time_t(wb, "exit", ds->timings.exit);
@@ -203,28 +205,28 @@ static void daemon_status_file_to_json(BUFFER *wb, DAEMON_STATUS_FILE *ds) {
     }
     buffer_json_object_close(wb);
 
-    buffer_json_member_add_object(wb, "host"); // ECS
+    buffer_json_member_add_object(wb, "host");
     {
         buffer_json_member_add_uuid_compact(wb, "id", ds->machine_id.uuid);
-        buffer_json_member_add_string_or_empty(wb, "architecture", ds->architecture); // ECS
-        buffer_json_member_add_string_or_empty(wb, "virtualization", ds->virtualization); // custom
-        buffer_json_member_add_string_or_empty(wb, "container", ds->container); // custom
-        buffer_json_member_add_time_t(wb, "uptime", ds->boottime); // ECS
+        buffer_json_member_add_string_or_empty(wb, "architecture", ds->architecture);
+        buffer_json_member_add_string_or_empty(wb, "virtualization", ds->virtualization);
+        buffer_json_member_add_string_or_empty(wb, "container", ds->container);
+        buffer_json_member_add_time_t(wb, "uptime", ds->boottime);
 
-        buffer_json_member_add_object(wb, "boot"); // ECS
+        buffer_json_member_add_object(wb, "boot");
         {
-            buffer_json_member_add_uuid_compact(wb, "id", ds->boot_id.uuid); // ECS
+            buffer_json_member_add_uuid_compact(wb, "id", ds->boot_id.uuid);
         }
         buffer_json_object_close(wb);
 
-        buffer_json_member_add_object(wb, "memory"); // custom
+        buffer_json_member_add_object(wb, "memory");
         if(OS_SYSTEM_MEMORY_OK(ds->memory)) {
             buffer_json_member_add_uint64(wb, "total", ds->memory.ram_total_bytes);
             buffer_json_member_add_uint64(wb, "free", ds->memory.ram_available_bytes);
         }
         buffer_json_object_close(wb);
 
-        buffer_json_member_add_object(wb, "disk"); // ECS
+        buffer_json_member_add_object(wb, "disk");
         {
             buffer_json_member_add_object(wb, "db");
             if (OS_SYSTEM_DISK_SPACE_OK(ds->var_cache)) {
@@ -240,18 +242,18 @@ static void daemon_status_file_to_json(BUFFER *wb, DAEMON_STATUS_FILE *ds) {
     }
     buffer_json_object_close(wb);
 
-    buffer_json_member_add_object(wb, "os"); // ECS
+    buffer_json_member_add_object(wb, "os");
     {
-        buffer_json_member_add_string(wb, "type", DAEMON_OS_TYPE_2str(ds->os_type)); // ECS
-        buffer_json_member_add_string_or_empty(wb, "kernel", ds->kernel_version); // ECS
-        buffer_json_member_add_string_or_empty(wb, "name", ds->os_name); // ECS
-        buffer_json_member_add_string_or_empty(wb, "version", ds->os_version); // ECS
-        buffer_json_member_add_string_or_empty(wb, "family", ds->os_id); // ECS
-        buffer_json_member_add_string_or_empty(wb, "platform", ds->os_id_like); // ECS
+        buffer_json_member_add_string(wb, "type", DAEMON_OS_TYPE_2str(ds->os_type));
+        buffer_json_member_add_string_or_empty(wb, "kernel", ds->kernel_version);
+        buffer_json_member_add_string_or_empty(wb, "name", ds->os_name);
+        buffer_json_member_add_string_or_empty(wb, "version", ds->os_version);
+        buffer_json_member_add_string_or_empty(wb, "family", ds->os_id);
+        buffer_json_member_add_string_or_empty(wb, "platform", ds->os_id_like);
     }
     buffer_json_object_close(wb);
 
-    buffer_json_member_add_object(wb, "fatal"); // custom
+    buffer_json_member_add_object(wb, "fatal");
     {
         buffer_json_member_add_uint64(wb, "line", ds->fatal.line);
         buffer_json_member_add_string_or_empty(wb, "filename", ds->fatal.filename);
@@ -273,17 +275,17 @@ static void daemon_status_file_to_json(BUFFER *wb, DAEMON_STATUS_FILE *ds) {
     }
     buffer_json_object_close(wb);
 
-    buffer_json_member_add_array(wb, "dedup"); // custom
+    buffer_json_member_add_array(wb, "dedup");
     {
         for(size_t i = 0; i < _countof(ds->dedup.slot); i++) {
             if (ds->dedup.slot[i].timestamp_ut == 0)
                 continue;
 
-            buffer_json_add_array_item_object(wb); // custom
+            buffer_json_add_array_item_object(wb);
             {
-                buffer_json_member_add_datetime_rfc3339(wb, "@timestamp", ds->dedup.slot[i].timestamp_ut, true); // custom
-                buffer_json_member_add_uint64(wb, "hash", ds->dedup.slot[i].hash); // custom
-                buffer_json_member_add_boolean(wb, "sentry", ds->dedup.slot[i].sentry); // custom
+                buffer_json_member_add_datetime_rfc3339(wb, "@timestamp", ds->dedup.slot[i].timestamp_ut, true);
+                buffer_json_member_add_uint64(wb, "hash", ds->dedup.slot[i].hash);
+                buffer_json_member_add_boolean(wb, "sentry", ds->dedup.slot[i].sentry);
             }
             buffer_json_object_close(wb);
         }
@@ -323,31 +325,45 @@ static bool daemon_status_file_from_json(json_object *jobj, void *data, BUFFER *
     if(datetime[0])
         ds->timestamp_ut = rfc3339_parse_ut(datetime, NULL);
 
+    const char *profile_key = version >= 18 ? "profile" : "ND_profile";
+    const char *status_key = version >= 18 ? "status" : "ND_status";
+    const char *exit_reason_key = version >= 18 ? "exit_reason" : "ND_exit_reason";
+    const char *node_id_key = version >= 18 ? "node_id" : "ND_node_id";
+    const char *claim_id_key = version >= 18 ? "claim_id" : "ND_claim_id";
+    const char *install_type_key = version >= 18 ? "install_type" : "ND_install_type";
+    const char *timings_key = version >= 18 ? "timings" : "ND_timings";
+    const char *restarts_key = version >= 18 ? "restarts" : "ND_restarts";
+    const char *db_mode_key = version >= 18 ? "db_mode" : "ND_db_mode";
+    const char *db_tiers_key = version >= 18 ? "db_tiers" : "ND_db_tiers";
+    const char *kubernetes_key = version >= 18 ? "kubernetes" : "ND_kubernetes";
+    const char *sentry_available_key = version >= 18 ? "sentry_available" : "ND_sentry_available";
+
     // Parse agent object
     JSONC_PARSE_SUBOBJECT(jobj, path, "agent", error, required_v1, {
         JSONC_PARSE_TXT2UUID_OR_ERROR_AND_RETURN(jobj, path, "id", ds->host_id.uuid, error, required_v1);
         JSONC_PARSE_TXT2UUID_OR_ERROR_AND_RETURN(jobj, path, "ephemeral_id", ds->invocation.uuid, error, required_v1);
         JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "version", ds->version, error, required_v1);
         JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, "uptime", ds->uptime, error, required_v1);
-        JSONC_PARSE_ARRAY_OF_TXT2BITMAP_OR_ERROR_AND_RETURN(jobj, path, "ND_profile", ND_PROFILE_2id_one, ds->profile, error, required_v1);
-        JSONC_PARSE_TXT2ENUM_OR_ERROR_AND_RETURN(jobj, path, "ND_status", DAEMON_STATUS_2id, ds->status, error, required_v1);
-        JSONC_PARSE_ARRAY_OF_TXT2BITMAP_OR_ERROR_AND_RETURN(jobj, path, "ND_exit_reason", EXIT_REASON_2id_one, ds->exit_reason, error, required_v1);
-        JSONC_PARSE_TXT2UUID_OR_ERROR_AND_RETURN(jobj, path, "ND_node_id", ds->node_id.uuid, error, required_v1);
-        JSONC_PARSE_TXT2UUID_OR_ERROR_AND_RETURN(jobj, path, "ND_claim_id", ds->claim_id.uuid, error, required_v1);
-        JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "ND_install_type", ds->install_type, error, required_v3);
 
-        JSONC_PARSE_SUBOBJECT(jobj, path, "ND_timings", error, required_v1, {
+        JSONC_PARSE_ARRAY_OF_TXT2BITMAP_OR_ERROR_AND_RETURN(jobj, path, profile_key, ND_PROFILE_2id_one, ds->profile, error, required_v1);
+        JSONC_PARSE_TXT2ENUM_OR_ERROR_AND_RETURN(jobj, path, status_key, DAEMON_STATUS_2id, ds->status, error, required_v1);
+        JSONC_PARSE_ARRAY_OF_TXT2BITMAP_OR_ERROR_AND_RETURN(jobj, path, exit_reason_key, EXIT_REASON_2id_one, ds->exit_reason, error, required_v1);
+        JSONC_PARSE_TXT2UUID_OR_ERROR_AND_RETURN(jobj, path, node_id_key, ds->node_id.uuid, error, required_v1);
+        JSONC_PARSE_TXT2UUID_OR_ERROR_AND_RETURN(jobj, path, claim_id_key, ds->claim_id.uuid, error, required_v1);
+        JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, install_type_key, ds->install_type, error, required_v3);
+
+        JSONC_PARSE_SUBOBJECT(jobj, path, timings_key, error, required_v1, {
             JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, "init", ds->timings.init, error, required_v1);
             JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, "exit", ds->timings.exit, error, required_v1);
         });
 
         if(version >= 4)
-            JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, "ND_restarts", ds->restarts, error, required_v4);
+            JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, restarts_key, ds->restarts, error, required_v4);
 
         if(version >= 14) {
-            JSONC_PARSE_TXT2ENUM_OR_ERROR_AND_RETURN(jobj, path, "ND_db_mode", rrd_memory_mode_id, ds->db_mode, error, required_v14);
-            JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, "ND_db_tiers", ds->db_tiers, error, required_v14);
-            JSONC_PARSE_BOOL_OR_ERROR_AND_RETURN(jobj, path, "ND_kubernetes", ds->kubernetes, error, required_v14);
+            JSONC_PARSE_TXT2ENUM_OR_ERROR_AND_RETURN(jobj, path, db_mode_key, rrd_memory_mode_id, ds->db_mode, error, required_v14);
+            JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, db_tiers_key, ds->db_tiers, error, required_v14);
+            JSONC_PARSE_BOOL_OR_ERROR_AND_RETURN(jobj, path, kubernetes_key, ds->kubernetes, error, required_v14);
         }
         else {
             ds->db_mode = default_rrd_memory_mode;
@@ -356,11 +372,13 @@ static bool daemon_status_file_from_json(json_object *jobj, void *data, BUFFER *
         }
 
         if(version >= 17)
-            JSONC_PARSE_BOOL_OR_ERROR_AND_RETURN(jobj, path, "ND_sentry_available", ds->sentry_available, error, required_v17);
+            JSONC_PARSE_BOOL_OR_ERROR_AND_RETURN(jobj, path, sentry_available_key, ds->sentry_available, error, required_v17);
         else if(version == 16)
             JSONC_PARSE_BOOL_OR_ERROR_AND_RETURN(jobj, path, "ND_sentry", ds->sentry_available, error, required_v16);
-        if(version >= 18)
-            JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "ND_reliability", ds->reliability, error, required_v18);
+        if(version >= 18) {
+            JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "reliability", ds->reliability, error, required_v18);
+            JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "stack_traces", ds->stack_traces, error, required_v18);
+        }
     });
 
     // Parse host object
@@ -532,6 +550,8 @@ static void daemon_status_file_migrate_once(void) {
         for (size_t i = 0; i < _countof(session_status.dedup.slot); i++)
             session_status.dedup.slot[i] = last_session_status.dedup.slot[i];
     }
+
+    strncpyz(session_status.stack_traces, capture_stack_trace_backend(), sizeof(session_status.stack_traces) - 1);
 
     dsf_release(last_session_status);
     dsf_release(session_status);
@@ -931,7 +951,6 @@ void post_status_file(struct post_status_file_thread_data *d) {
     buffer_json_member_add_string(wb, "message", d->msg); // ECS
     buffer_json_member_add_uint64(wb, "priority", d->priority); // custom
     buffer_json_member_add_uint64(wb, "version_saved", d->status->v); // custom
-    buffer_json_member_add_string(wb, "stack_traces", capture_stack_trace_backend()); // custom
     daemon_status_file_to_json(wb, d->status);
     buffer_json_finalize(wb);
 
@@ -1486,6 +1505,10 @@ const char *daemon_status_file_get_fatal_errno(void) {
 
 const char *daemon_status_file_get_fatal_stack_trace(void) {
     return session_status.fatal.stack_trace;
+}
+
+const char *daemon_status_file_get_stack_trace_backend(void) {
+    return session_status.stack_traces;
 }
 
 const char *daemon_status_file_get_fatal_thread(void) {

--- a/src/daemon/daemon-status-file.h
+++ b/src/daemon/daemon-status-file.h
@@ -7,7 +7,7 @@
 #include "daemon/config/netdata-conf-profile.h"
 #include "database/rrd-database-mode.h"
 
-#define STATUS_FILE_VERSION 17
+#define STATUS_FILE_VERSION 18
 
 typedef enum {
     DAEMON_STATUS_NONE,
@@ -44,7 +44,8 @@ typedef struct daemon_status_file {
     time_t boottime;            // system boottime
     time_t uptime;              // netdata uptime
     usec_t timestamp_ut;        // the timestamp of the status file
-    size_t restarts;            // the number of times this agent has restarted
+    size_t restarts;            // the number of times this agent has restarted (ever)
+    ssize_t reliability;        // consecutive restarts: > 0 reliable, < 0 crashing
 
     ND_UUID boot_id;            // the boot id of the system
     ND_UUID invocation;         // the netdata invocation id generated the file

--- a/src/daemon/daemon-status-file.h
+++ b/src/daemon/daemon-status-file.h
@@ -84,6 +84,7 @@ typedef struct daemon_status_file {
         char message[512];
         char stack_trace[2048];
         char thread[ND_THREAD_TAG_MAX + 1];
+        pid_t thread_id;
         SIGNAL_CODE signal_code;
         bool sentry;        // true when the error was also reported to sentry
     } fatal;
@@ -130,6 +131,10 @@ const char *daemon_status_file_get_fatal_message(void);
 const char *daemon_status_file_get_fatal_errno(void);
 const char *daemon_status_file_get_fatal_stack_trace(void);
 const char *daemon_status_file_get_fatal_thread(void);
+pid_t daemon_status_file_get_fatal_thread_id(void);
 long daemon_status_file_get_fatal_line(void);
+DAEMON_STATUS daemon_status_file_get_status(void);
+size_t daemon_status_file_get_restarts(void);
+ssize_t daemon_status_file_get_reliability(void);
 
 #endif //NETDATA_DAEMON_STATUS_FILE_H

--- a/src/daemon/daemon-status-file.h
+++ b/src/daemon/daemon-status-file.h
@@ -75,6 +75,8 @@ typedef struct daemon_status_file {
     char os_id_like[64];     // ECS: os.platform
     bool read_system_info;
 
+    char stack_traces[15];   // the backend for capturing stack traces
+
     struct {
         SPINLOCK spinlock;
         long line;
@@ -131,6 +133,7 @@ const char *daemon_status_file_get_fatal_message(void);
 const char *daemon_status_file_get_fatal_errno(void);
 const char *daemon_status_file_get_fatal_stack_trace(void);
 const char *daemon_status_file_get_fatal_thread(void);
+const char *daemon_status_file_get_stack_trace_backend(void);
 pid_t daemon_status_file_get_fatal_thread_id(void);
 long daemon_status_file_get_fatal_line(void);
 DAEMON_STATUS daemon_status_file_get_status(void);

--- a/src/daemon/libuv_workers.c
+++ b/src/daemon/libuv_workers.c
@@ -86,6 +86,9 @@ static void register_libuv_worker_jobs_internal(void) {
     // netdatacli
     worker_register_job_name(UV_EVENT_SCHEDULE_CMD, "schedule command");
 
+    // make sure we have the right thread id
+    gettid_uncached();
+
     static int workers = 0;
     int worker_id = __atomic_add_fetch(&workers, 1, __ATOMIC_RELAXED);
 

--- a/src/daemon/sentry-native/sentry-native.c
+++ b/src/daemon/sentry-native/sentry-native.c
@@ -176,6 +176,7 @@ void nd_sentry_init(void) {
 
     nd_sentry_set_tag_uint64("restarts", daemon_status_file_get_restarts());
     nd_sentry_set_tag_int64("reliability", daemon_status_file_get_reliability());
+    nd_sentry_set_tag("stack_traces", daemon_status_file_get_stack_trace_backend());
 }
 
 void nd_sentry_fini(void) {

--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -138,7 +138,7 @@ static void posix_unmask_my_signals(void) {
         netdata_log_error("SIGNAL: cannot unmask netdata signals");
 }
 
-void nd_cleanup_fatal_signals(void) {
+void nd_cleanup_deadly_signals(void) {
     struct sigaction act;
     memset(&act, 0, sizeof(struct sigaction));
 

--- a/src/daemon/signal-handler.h
+++ b/src/daemon/signal-handler.h
@@ -3,7 +3,7 @@
 #ifndef NETDATA_SIGNAL_HANDLER_H
 #define NETDATA_SIGNAL_HANDLER_H 1
 
-void nd_cleanup_fatal_signals(void);
+void nd_cleanup_deadly_signals(void);
 void nd_initialize_signals(bool chain_existing);
 void nd_process_signals(void) NORETURN;
 

--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -2468,7 +2468,7 @@ void pgc_open_cache_to_journal_v2(PGC *cache, Word_t section, unsigned datafile_
 
         size_t current_extent_index_id;
         Pvoid_t *PValue = JudyLIns(&JudyL_extents_pos, xio->pos, PJE0);
-        if(!PValue || *PValue == PJERR)
+        if(!PValue || PValue == PJERR)
             fatal("Corrupted JudyL extents pos");
 
         struct jv2_extents_info *ei;
@@ -2492,7 +2492,7 @@ void pgc_open_cache_to_journal_v2(PGC *cache, Word_t section, unsigned datafile_
         // update the metrics JudyL
 
         PValue = JudyLIns(&JudyL_metrics, page->metric_id, PJE0);
-        if(!PValue || *PValue == PJERR)
+        if(!PValue || PValue == PJERR)
             fatal("Corrupted JudyL metrics");
 
         struct jv2_metrics_info *mi;
@@ -2518,7 +2518,7 @@ void pgc_open_cache_to_journal_v2(PGC *cache, Word_t section, unsigned datafile_
         }
 
         PValue = JudyLIns(&mi->JudyL_pages_by_start_time, page->start_time_s, PJE0);
-        if(!PValue || *PValue == PJERR)
+        if(!PValue || PValue == PJERR)
             fatal("Corrupted JudyL metric pages");
 
         if(!*PValue) {

--- a/src/libnetdata/log/nd_log-stacktrace.c
+++ b/src/libnetdata/log/nd_log-stacktrace.c
@@ -12,6 +12,10 @@ bool nd_log_forked = false;
 #endif
 #include <libunwind.h>
 
+const char *capture_stack_trace_backend(void) {
+    return "libunwind";
+}
+
 void capture_stack_trace_init(void) {
     unw_set_caching_policy(unw_local_addr_space, UNW_CACHE_NONE);
 }
@@ -79,6 +83,10 @@ void capture_stack_trace(BUFFER *wb) {
 }
 
 #elif defined(HAVE_BACKTRACE)
+
+const char *capture_stack_trace_backend(void) {
+    return "backtrace";
+}
 
 bool capture_stack_trace_available(void) {
     return true;
@@ -150,6 +158,10 @@ void capture_stack_trace(BUFFER *wb) {
 }
 
 #else
+
+const char *capture_stack_trace_backend(void) {
+    return "none";
+}
 
 bool capture_stack_trace_available(void) {
     return false;

--- a/src/libnetdata/log/nd_log.h
+++ b/src/libnetdata/log/nd_log.h
@@ -38,6 +38,7 @@ void capture_stack_trace_init(void);
 void capture_stack_trace_flush(void);
 bool capture_stack_trace_available(void);
 bool capture_stack_trace_is_async_signal_safe(void);
+const char *capture_stack_trace_backend(void);
 
 typedef void (*log_event_t)(const char *filename, const char *function, const char *message, const char *errno_str, const char *stack_trace, long line);
 void nd_log_register_fatal_data_cb(log_event_t cb);

--- a/src/libnetdata/threads/threads.c
+++ b/src/libnetdata/threads/threads.c
@@ -150,9 +150,11 @@ void nd_thread_tag_set(const char *tag) {
 
 // --------------------------------------------------------------------------------------------------------------------
 
-static __thread bool libuv_name_set = false;
-void uv_thread_set_name_np(const char* name) {
-    if(libuv_name_set) return;
+void uv_thread_set_name_np(const char *name) {
+    static __thread bool libuv_name_set = false;
+
+    if(!name || !*name || (libuv_name_set && _nd_thread_os_name[0]))
+        return;
 
     strncpyz(_nd_thread_os_name, name, sizeof(_nd_thread_os_name) - 1);
     os_set_thread_name(_nd_thread_os_name);


### PR DESCRIPTION
## Sentry

- [x] sentry now has uptime tag
- [x] do not send empty tags to sentry
- [x] ephemeral id is now compact, to be compatible with agent-events
- [x] add `thread_id` to fatal breadcrumbs (otherwise, it is impossible to find the stack trace of the thread that called `fatal()`).
- [x] add `restarts` to sentry tags
- [x] add `reliability` to sentry tags
- [x] add `status` to sentry tags
- [x] Find a way for SIGABRT to report the right kind of event/thread/title

## Crash Reports

- [x] added `reliability` value
	- positive = the agent is gracefully restarting without errors
	- negative = the agent is repeatedly crashing
- [x] keep the thread id, in order to add it to sentry
