### PR TITLE
SIGABRT and already running are fatal conditions

### DIFF
--- a/src/libnetdata/exit/exit_initiated.h
+++ b/src/libnetdata/exit/exit_initiated.h
@@ -62,7 +62,6 @@ typedef enum {
         | EXIT_REASON_SIGSEGV           \
         | EXIT_REASON_SIGFPE            \
         | EXIT_REASON_SIGILL            \
-        | EXIT_REASON_SIGABRT           \
         | EXIT_REASON_SIGSYS            \
         | EXIT_REASON_SIGXCPU           \
         | EXIT_REASON_SIGXFSZ           \
@@ -71,7 +70,9 @@ typedef enum {
 #define EXIT_REASON_ABNORMAL            \
     (                                   \
           EXIT_REASON_DEADLY_SIGNAL     \
+        | EXIT_REASON_SIGABRT           \
         | EXIT_REASON_FATAL             \
+        | EXIT_REASON_ALREADY_RUNNING   \
         | EXIT_REASON_OUT_OF_MEMORY     \
     )
 


### PR DESCRIPTION
Minor change in the classification of `EXIT_REASON_SIGABRT` and `EXIT_REASON_ALREADY_RUNNING`.

- `EXIT_REASON_SIGABRT` was incorrectly classified as deadly signal, but it is triggered by fatal conditions in the code, so it should be an abnormal condition and not a deadly signal.
- `EXIT_REASON_ALREADY_RUNNING` was missed from all classifications.