### PR TITLE
add stack trace information to the compiler and linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,12 +487,10 @@ check_function_exists(sysinfo HAVE_SYSINFO)
 
 check_function_exists(timegm HAVE_TIMEGM)
 
-# Add -rdynamic when backtrace is available but libunwind is not
-if(HAVE_BACKTRACE AND NOT ENABLE_LIBUNWIND AND NOT STATIC_BUILD)
-    if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
-        add_link_options(-rdynamic)
-        message(STATUS "Adding -rdynamic to link options for better backtrace support")
-    endif()
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(-funwind-tables)
+    add_link_options(-rdynamic)
+    message(STATUS "Adding -rdynamic (link) and -funwind-tables (compile) for better stack trace support")
 endif()
 
 #


### PR DESCRIPTION
@Ferroin we have the issue that many stack traces we get are useless, like this:

```
#0 _ZdaPv+0x375AB5
#1 <unknown>
#2 _ZdaPv+0x39F8D0
#3 _ZdaPv+0x3A191C
#4 _ZdaPv+0x2E6FFA
#5 _ZdaPv+0x174BD4
#6 _ZdaPv+0x1760B6
#7 _ZdaPv+0x17A315
#8 _ZdaPv+0x2F4FE3
#9 pthread_condattr_setpshared+0x513
#10 __xmknodat+0x230
```

The above is from binpkg-deb.

I read that there are a couple of options that significantly affect libunwind's ability to resolve functions names:

`-rdynamic` I had added this for backtrace(), now I am adding it always.

`-funwind-tables` I read this may have the compiler generate unwind tables.

Both of these options should not have any effect on performance. They may affect Netdata binary loading (when it starts) and the size of the binary, but there is no runtime impact.

There is another option that could be helpful: `-fno-omit-frame-pointer`, but this may hurt runtime performance so I am not adding it.
