### PR TITLE
change log priorities on agent-events

### DIFF
--- a/src/daemon/daemon-shutdown-watcher.c
+++ b/src/daemon/daemon-shutdown-watcher.c
@@ -9,6 +9,12 @@ static struct completion shutdown_begin_completion;
 static struct completion shutdown_end_completion;
 static ND_THREAD *watcher_thread;
 
+NEVER_INLINE
+static void shutdown_timed_out(void) {
+    // keep this as a separate function, to have it logged like this in sentry
+    abort();
+}
+
 void watcher_shutdown_begin(void) {
     completion_mark_complete(&shutdown_begin_completion);
 }
@@ -87,7 +93,7 @@ static void watcher_wait_for_step(const watcher_step_id_t step_id, usec_t shutdo
 #endif
 
         daemon_status_file_shutdown_step("sentry timeout");
-        abort();
+        shutdown_timed_out();
     }
 }
 

--- a/src/daemon/daemon-status-file.c
+++ b/src/daemon/daemon-status-file.c
@@ -952,10 +952,11 @@ struct log_priority {
     ND_LOG_FIELD_PRIORITY post;
 };
 
-struct log_priority PRI_ALL_NORMAL          = { NDLP_NOTICE, NDLP_DEBUG };
-struct log_priority PRI_USER_SHOULD_FIX     = { NDLP_WARNING, NDLP_INFO };
-struct log_priority PRI_NETDATA_BUG         = { NDLP_CRIT, NDLP_ERR };
-struct log_priority PRI_BAD_BUT_NO_REASON   = { NDLP_ERR, NDLP_WARNING };
+struct log_priority PRI_ALL_NORMAL      = { NDLP_NOTICE, NDLP_DEBUG };
+struct log_priority PRI_USER_SHOULD_FIX = { NDLP_WARNING, NDLP_INFO };
+struct log_priority PRI_FATAL           = { NDLP_ERR, NDLP_ERR };
+struct log_priority PRI_DEADLY_SIGNAL   = { NDLP_CRIT, NDLP_CRIT };
+struct log_priority PRI_KILLED_HARD     = { NDLP_ERR, NDLP_WARNING };
 
 static bool is_ci(void) {
     const char *ci = getenv("CI");
@@ -1021,14 +1022,14 @@ void daemon_status_file_check_crash(void) {
             else if(is_deadly_signal(last_session_status.exit_reason)) {
                 cause = "deadly signal and exit";
                 msg = "Netdata was last stopped gracefully after receiving a deadly signal";
-                pri = PRI_NETDATA_BUG;
+                pri = PRI_DEADLY_SIGNAL;
                 this_is_a_crash = true;
             }
             else if(last_session_status.exit_reason != EXIT_REASON_NONE &&
                      !is_exit_reason_normal(last_session_status.exit_reason)) {
                 cause = "fatal and exit";
                 msg = "Netdata was last stopped gracefully after it encountered a fatal error";
-                pri = PRI_NETDATA_BUG;
+                pri = PRI_FATAL;
                 this_is_a_crash = true;
             }
             else if(last_session_status.exit_reason & EXIT_REASON_SYSTEM_SHUTDOWN) {
@@ -1062,7 +1063,7 @@ void daemon_status_file_check_crash(void) {
             else if(is_deadly_signal(last_session_status.exit_reason)) {
                 cause = "deadly signal on start";
                 msg = "Netdata was last crashed while starting after receiving a deadly signal";
-                pri = PRI_NETDATA_BUG;
+                pri = PRI_DEADLY_SIGNAL;
                 this_is_a_crash = true;
             }
             else if (last_session_status.exit_reason & EXIT_REASON_OUT_OF_MEMORY) {
@@ -1097,12 +1098,12 @@ void daemon_status_file_check_crash(void) {
                      !is_exit_reason_normal(last_session_status.exit_reason)) {
                 cause = "fatal on start";
                 msg = "Netdata was last crashed while starting, because of a fatal error";
-                pri = PRI_NETDATA_BUG;
+                pri = PRI_FATAL;
             }
             else {
                 cause = "killed hard on start";
                 msg = "Netdata was last killed/crashed while starting";
-                pri = PRI_BAD_BUT_NO_REASON;
+                pri = PRI_KILLED_HARD;
             }
             this_is_a_crash = true;
             break;
@@ -1111,27 +1112,29 @@ void daemon_status_file_check_crash(void) {
             if(is_deadly_signal(last_session_status.exit_reason)) {
                 cause = "deadly signal on exit";
                 msg = "Netdata was last crashed while exiting after receiving a deadly signal";
-                pri = PRI_NETDATA_BUG;
-                this_is_a_crash = true;
+                pri = PRI_DEADLY_SIGNAL;
             }
             else if(last_session_status.exit_reason != EXIT_REASON_NONE &&
                 !is_exit_reason_normal(last_session_status.exit_reason)) {
                 cause = "fatal on exit";
                 msg = "Netdata was last killed/crashed while exiting after encountering an error";
+                pri = PRI_FATAL;
             }
             else if(last_session_status.exit_reason & EXIT_REASON_SYSTEM_SHUTDOWN) {
                 cause = "killed hard on shutdown";
                 msg = "Netdata was last killed/crashed while exiting due to system shutdown";
+                pri = PRI_KILLED_HARD;
             }
             else if(new_version || (last_session_status.exit_reason & EXIT_REASON_UPDATE)) {
                 cause = "killed hard on update";
                 msg = "Netdata was last killed/crashed while exiting to update to a new version";
+                pri = PRI_KILLED_HARD;
             }
             else {
                 cause = "killed hard on exit";
                 msg = "Netdata was last killed/crashed while it was instructed to exit";
+                pri = PRI_KILLED_HARD;
             }
-            pri = PRI_NETDATA_BUG;
             this_is_a_crash = true;
             break;
 
@@ -1152,19 +1155,19 @@ void daemon_status_file_check_crash(void) {
             else if(is_deadly_signal(last_session_status.exit_reason)) {
                 cause = "deadly signal";
                 msg = "Netdata was last crashed after receiving a deadly signal";
-                pri = PRI_NETDATA_BUG;
+                pri = PRI_DEADLY_SIGNAL;
                 this_is_a_crash = true;
             }
             else if (last_session_status.exit_reason != EXIT_REASON_NONE &&
                      !is_exit_reason_normal(last_session_status.exit_reason)) {
                 cause = "killed fatal";
                 msg = "Netdata was last crashed due to a fatal error";
-                pri = PRI_NETDATA_BUG;
+                pri = PRI_FATAL;
             }
             else {
                 cause = "killed hard";
                 msg = "Netdata was last killed/crashed while operating normally";
-                pri = PRI_BAD_BUT_NO_REASON;
+                pri = PRI_KILLED_HARD;
                 this_is_a_crash = true;
             }
             break;

--- a/src/daemon/sentry-native/sentry-native.c
+++ b/src/daemon/sentry-native/sentry-native.c
@@ -107,9 +107,9 @@ void nd_sentry_init(void) {
 
     // invocation_id
     ND_UUID invocation_id = nd_log_get_invocation_id();
-    char invocation_str[UUID_STR_LEN];
-    uuid_unparse_lower(invocation_id.uuid, invocation_str);
-    sentry_set_tag("invocation_id", invocation_str);
+    char invocation_str[UUID_COMPACT_STR_LEN];
+    uuid_unparse_lower_compact(invocation_id.uuid, invocation_str);
+    sentry_set_tag("ephemeral_id", invocation_str);
 
     // agent_events_version
     sentry_set_tag("agent_events_version", TOSTRING(STATUS_FILE_VERSION));

--- a/src/libnetdata/common.h
+++ b/src/libnetdata/common.h
@@ -342,6 +342,7 @@ typedef uint32_t uid_t;
 #define ALWAYS_INLINE_HOT inline __attribute__((hot, always_inline))    // Encourages optimization and forces inlining
 #define ALWAYS_INLINE_HOT_FLATTEN inline __attribute__((hot, always_inline, flatten))    // Encourages optimization and forces inlining and flattening
 #define NOT_INLINE_HOT __attribute__((hot))                             // Encourages optimization but doesn’t force inlining.
+#define NEVER_INLINE __attribute__((noinline))
 #else
 #define UNUSED_FUNCTION(x) UNUSED_##x
 #define ALWAYS_INLINE_ONLY
@@ -349,6 +350,7 @@ typedef uint32_t uid_t;
 #define ALWAYS_INLINE_HOT inline
 #define ALWAYS_INLINE_HOT_FLATTEN inline
 #define NOT_INLINE_HOT
+#define NEVER_INLINE
 #endif
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
3 minor changes:

- [x] change the log priorities on agent-events to color deadly signals and killed hard conditions differently.
- [x] call `abort()` from dedicated functions, so that sentry will show the proper conditions under which we called abort.
- [x] `invocation_id` on sentry should be `ephemeral_id` and printed in compact form, to match agent-events and allow us to search by it on either system.

These are not code/functionality changes and are safe to merge before release.