### PR TITLE
Update DEB/RPM package signing key info.

### DIFF
--- a/packaging/installer/methods/packages.md
+++ b/packaging/installer/methods/packages.md
@@ -42,7 +42,7 @@ For example, for stable release packages for RHEL 9 on 64-bit x86, the full URL 
 <https://repository.netdata.cloud/repos/stable/el/9/x86_64/>
 
 Our RPM packages and repository metadata are signed using a GPG key with a user name of ‘Netdatabot’. The
-current key fingerprint is `6588FDD7B14721FE7C3115E6F9177B5265F56346`. The associated public key can be fetched from
+current key fingerprint is `6E155DC153906B73765A74A99DD4A74CECFA8F4F`. The associated public key can be fetched from
 `https://repository.netdata.cloud/netdatabot.gpg.key`.
 
 If you are explicitly configuring a system to use our repositories, the recommended setup is to download the
@@ -99,7 +99,7 @@ Enabled: Yes
 Note the `/` at the end of the codename, this is required for the repository to be processed correctly.
 
 Our DEB packages and repository metadata are signed using a GPG key with a user name of ‘Netdatabot’. The
-current key fingerprint is `6588FDD7B14721FE7C3115E6F9177B5265F56346`. The associated public key can be fetched from
+current key fingerprint is `6E155DC153906B73765A74A99DD4A74CECFA8F4F`. The associated public key can be fetched from
 `https://repository.netdata.cloud/netdatabot.gpg.key`.
 
 If you are explicitly configuring a system to use our repositories, the recommended setup is to download the

--- a/packaging/repoconfig/CMakeLists.txt
+++ b/packaging/repoconfig/CMakeLists.txt
@@ -9,8 +9,8 @@ list(APPEND DEB_DISTROS debian ubuntu)
 
 set(DEB_GPG_KEY_SOURCE "https://repo.netdata.cloud/netdatabot.gpg.key")
 
-set(PACKAGE_VERSION 4)
-set(PACKAGE_RELEASE 3)
+set(PACKAGE_VERSION 5)
+set(PACKAGE_RELEASE 1)
 
 set(CPACK_THREADS 0)
 set(CPACK_STRIP_FILES NO)

--- a/packaging/repoconfig/deb.changelog
+++ b/packaging/repoconfig/deb.changelog
@@ -1,3 +1,9 @@
+@PKG_NAME@ (5-1) unstable; urgency=high
+
+  * Deploy new package and metadata signing keys
+
+ -- Austin hemmelgarn <austin@netdata.cloud>  Mon, 17 Mar 2025 10:40:00 -0400
+
 @PKG_NAME@ (4-3) unstable; urgency=medium
 
   * Revert broken priority configuration

--- a/packaging/repoconfig/netdata.repo.dnf
+++ b/packaging/repoconfig/netdata.repo.dnf
@@ -4,6 +4,7 @@ baseurl=https://repository.netdata.cloud/repos/@VARIANT@/@DIST_NAME@/@DIST_VERSI
 repo_gpgcheck=1
 gpgcheck=1
 gpgkey=https://repository.netdata.cloud/netdatabot.gpg.key
+       https://repository.netdata.cloud/netdatabot.old.gpg.key
 enabled=1
 sslverify=1
 priority=50
@@ -14,6 +15,7 @@ baseurl=https://repository.netdata.cloud/repos/repoconfig/@DIST_NAME@/@DIST_VERS
 repo_gpgcheck=1
 gpgcheck=1
 gpgkey=https://repository.netdata.cloud/netdatabot.gpg.key
+       https://repository.netdata.cloud/netdatabot.old.gpg.key
 enabled=1
 sslverify=1
 priority=50

--- a/packaging/repoconfig/rpm.changelog
+++ b/packaging/repoconfig/rpm.changelog
@@ -1,3 +1,5 @@
+* Mon Mar 17 2025 Austin Hemmelgarn <austin@netdata.cloud> 5-1
+- Deploy new package and metadata signing keys
 * Wed Mar 3 2025 Austin Hemmelgarn <austin@netdata.cloud> 4-3
 - Version bump to stay in sync with DEB packages.
 * Mon Feb 24 2025 Austin Hemmelgarn <austin@netdata.cloud> 4-2


### PR DESCRIPTION
##### Summary

- Update key fingerprint in documentation.
- Indirectly re-sync key for APT by rebuilding packages (the package build pulls the key from the public URL, and it’s already deployed there on the server).
- Update the key URLs for the RPM packages so that package signing works until new packages are published with the new signing keys (the change will be reverted with another update once the next stable release has been published).

##### Test Plan

n/a