### PR TITLE
Dump Netdata buildinfo during CI.

### DIFF
--- a/.github/scripts/docker-test.sh
+++ b/.github/scripts/docker-test.sh
@@ -8,6 +8,10 @@ if [ -z "$(command -v nc 2>/dev/null)" ] && [ -z "$(command -v netcat 2>/dev/nul
     sudo apt-get update && sudo apt-get upgrade -y && sudo apt-get install -y netcat
 fi
 
+echo "::group::Netdata buildinfo"
+docker run -i --rm netdata/netdata:test -W buildinfo
+echo "::endgroup::"
+
 docker run -d --name=netdata \
            -p 19999:19999 \
            -v netdataconfig:/etc/netdata \

--- a/.github/scripts/pkg-test.sh
+++ b/.github/scripts/pkg-test.sh
@@ -128,6 +128,10 @@ case "${DISTRO}" in
     ;;
 esac
 
+echo "::group::Netdata buildinfo"
+/usr/sbin/netdata -W buildinfo
+echo "::endgroup::"
+
 trap dump_log EXIT
 
 export NETDATA_LIBEXEC_PREFIX=/usr/libexec/netdata

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -356,7 +356,12 @@ jobs:
         if: needs.file-check.outputs.run == 'true'
         env:
           BUILD_DIR: ${{ github.workspace }}\build
-        run: ./packaging/windows/build.ps1
+        run: |
+          ./packaging/windows/build.ps1
+          Write-Host "::group::Netdata buildinfo"
+          $netdata = "$env:BUILD_DIR\netdata.exe"
+          & $netdata -W buildinfo
+          Write-Host "::endgroup::"
       - name: Sign Agent Code
         id: sign-agent
         if: needs.file-check.outputs.run == 'true' && github.event_name != 'pull_request'
@@ -1091,6 +1096,9 @@ jobs:
         id: test-agent
         if: needs.file-check.outputs.run == 'true'
         run: |
+          echo "::group::Netdata buildinfo"
+          /usr/local/netdata/usr/sbin/netdata -W buildinfo
+          echo "::endgroup::"
           /usr/local/netdata/usr/sbin/netdata -D > ./netdata.log 2>&1 &
           ./packaging/runtime-check.sh
       - name: Failure Notification

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -356,12 +356,7 @@ jobs:
         if: needs.file-check.outputs.run == 'true'
         env:
           BUILD_DIR: ${{ github.workspace }}\build
-        run: |
-          ./packaging/windows/build.ps1
-          Write-Host "::group::Netdata buildinfo"
-          $netdata = "$env:BUILD_DIR\netdata.exe"
-          & $netdata -W buildinfo
-          Write-Host "::endgroup::"
+        run: ./packaging/windows/build.ps1
       - name: Sign Agent Code
         id: sign-agent
         if: needs.file-check.outputs.run == 'true' && github.event_name != 'pull_request'

--- a/packaging/makeself/jobs/89-buildinfo.install.sh
+++ b/packaging/makeself/jobs/89-buildinfo.install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# shellcheck source=./packaging/makeself/functions.sh
+. "${NETDATA_MAKESELF_PATH}"/functions.sh "${@}" || exit 1
+
+
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Netdata buildinfo" || true
+
+run "${NETDATA_INSTALL_PATH}/bin/netdata" -W buildinfo
+
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::endgroup::" || true

--- a/packaging/windows/compile-on-windows.sh
+++ b/packaging/windows/compile-on-windows.sh
@@ -54,8 +54,7 @@ cmake --build "${build}" -- ${build_args}
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
 ${GITHUB_ACTIONS+echo "::group::Netdata buildinfo"}
-ls -alFhs "${build}"
-"${build}/netdata.exe" -W buildinfo
+"${build}/netdata.exe" -W buildinfo || true
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
 if [ -t 1 ]; then

--- a/packaging/windows/compile-on-windows.sh
+++ b/packaging/windows/compile-on-windows.sh
@@ -53,6 +53,11 @@ ${GITHUB_ACTIONS+echo "::group::Building"}
 cmake --build "${build}" -- ${build_args}
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
+${GITHUB_ACTIONS+echo "::group::Netdata buildinfo"}
+ls -alFhs "${build}"
+"${build}/netdata.exe" -W buildinfo
+${GITHUB_ACTIONS+echo "::endgroup::"}
+
 if [ -t 1 ]; then
     echo
     echo "Compile with:"


### PR DESCRIPTION
##### Summary

This adds logging of the output of `netdata -W buildinfo` for most of our build jobs in CI:

- For static builds this is done during the build step.
- For Windows builds, this is also done during the build step, but it is not working consistently right now (I plan to dig into that in a separate PR).
- For macOS builds, Docker builds, and DEB/RPM builds this is done during the build test step.
- In all cases, the data is in a log group called ‘Netdata buildinfo’ that is collapsed by default.

##### Test Plan

CI jobs pass on this PR and include the information outlined in the summary.