### PR TITLE
Metadata event loop code cleanup

### DIFF
--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -459,8 +459,7 @@ RRDHOST *rrdhost_create(
         rrdhost_flag_set(host, RRDHOST_FLAG_METADATA_INFO | RRDHOST_FLAG_METADATA_UPDATE);
         if (is_localhost) {
             BUFFER *buf = buffer_create(0, NULL);
-            size_t query_counter = 0;
-            store_host_info_and_metadata(host, buf, &query_counter);
+            store_host_info_and_metadata(host, buf);
             buffer_free(buf);
         }
         rrdhost_load_rrdcontext_data(host);

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -958,7 +958,7 @@ void sql_aclk_sync_init(void)
 
     netdata_log_info("Created %d archived hosts", number_of_children);
     // Trigger host context load for hosts that have been created
-    metadata_queue_load_host_context(NULL);
+    metadata_queue_load_host_context();
 
     if (!number_of_children)
         aclk_queue_node_info(localhost, true);

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2813,12 +2813,9 @@ void metaqueue_ml_load_models(RRDDIM *rd)
     rrddim_flag_set(rd, RRDDIM_FLAG_ML_MODEL_LOAD);
 }
 
-void metadata_queue_load_host_context(RRDHOST *host)
+void metadata_queue_load_host_context()
 {
-    if (unlikely(!host))
-        return;
-
-    queue_metadata_cmd(METADATA_LOAD_HOST_CONTEXT, host, NULL);
+    queue_metadata_cmd(METADATA_LOAD_HOST_CONTEXT, NULL, NULL);
     nd_log(NDLS_DAEMON, NDLP_DEBUG, "Queued command to load host contexts");
 }
 

--- a/src/database/sqlite/sqlite_metadata.h
+++ b/src/database/sqlite/sqlite_metadata.h
@@ -32,7 +32,7 @@ void metaqueue_delete_dimension_uuid(nd_uuid_t *uuid);
 void metaqueue_store_claim_id(nd_uuid_t *host_uuid, nd_uuid_t *claim_uuid);
 void metaqueue_ml_load_models(RRDDIM *rd);
 void detect_machine_guid_change(nd_uuid_t *host_uuid);
-void metadata_queue_load_host_context(RRDHOST *host);
+void metadata_queue_load_host_context();
 void vacuum_database(sqlite3 *database, const char *db_alias, int threshold, int vacuum_pc);
 
 int sql_metadata_cache_stats(int op);

--- a/src/database/sqlite/sqlite_metadata.h
+++ b/src/database/sqlite/sqlite_metadata.h
@@ -60,7 +60,7 @@ void commit_alert_transitions(RRDHOST *host);
 void metadata_sync_shutdown_background(void);
 void metadata_sync_shutdown_background_wait(void);
 void metadata_queue_ctx_host_cleanup(nd_uuid_t *host_uuid, const char *context);
-void store_host_info_and_metadata(RRDHOST *host, BUFFER *work_buffer, size_t *query_counter);
+void store_host_info_and_metadata(RRDHOST *host, BUFFER *work_buffer);
 void metadata_execute_store_statement(sqlite3_stmt *stmt);
 
 // UNIT TEST


### PR DESCRIPTION
##### Summary
- Add additional checks to prevent crash during shutdown 
  - Allocate event loop in the stack
  - Use explicit initialized variable instead of relying on the allocation of the loop
  - Add check on every command submission
- Remove query counters from logs in debug mode (only timings are reported)

