### PR TITLE
Fix compile without dbengine

### DIFF
--- a/src/daemon/config/netdata-conf-backwards-compatibility.c
+++ b/src/daemon/config/netdata-conf-backwards-compatibility.c
@@ -244,7 +244,9 @@ void netdata_conf_backwards_compatibility(void) {
             found_old_config = true;
     }
 
+#ifdef ENABLE_DBENGINE
     legacy_multihost_db_space = found_old_config;
+#endif
 
     // ----------------------------------------------------------------------------------------------------------------
 

--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -339,6 +339,7 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
         fprintf(stderr, "WARNING: There are %zu dictionaries with references in them, that cannot be destroyed.\n",
                 dictionaries_referenced);
 
+#ifdef ENABLE_DBENGINE
     // destroy the caches in reverse order (extent and open depend on main cache)
     fprintf(stderr, "Destroying extent cache (PGC)...\n");
     pgc_destroy(extent_cache, false);
@@ -352,6 +353,7 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
     if(metrics_referenced)
         fprintf(stderr, "WARNING: MRG had %zu metrics referenced.\n",
             metrics_referenced);
+#endif    
 
     fprintf(stderr, "Destroying UUIDMap...\n");
     size_t uuid_referenced = uuidmap_destroy();

--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -23,6 +23,7 @@ void abort_on_fatal_enable(void) {
     abort_on_fatal = true;
 }
 
+#ifdef ENABLE_SENTRY
 NEVER_INLINE
 static bool shutdown_on_fatal(void) {
     // keep this as a separate function, to have it logged like this in sentry
@@ -31,6 +32,7 @@ static bool shutdown_on_fatal(void) {
     else
         return false;
 }
+#endif
 
 void web_client_cache_destroy(void);
 

--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -102,13 +102,14 @@ void cancel_main_threads(void) {
     static_threads = NULL;
 }
 
+#ifdef ENABLE_DBENGINE
 static void *rrdeng_exit_background(void *ptr) {
     struct rrdengine_instance *ctx = ptr;
     rrdeng_exit(ctx);
     return NULL;
 }
 
-#ifdef ENABLE_DBENGINE
+
 static void rrdeng_flush_everything_and_wait(bool wait_flush, bool wait_collectors, bool dirty_only) {
     static size_t starting_size_to_flush = 0;
 

--- a/src/daemon/pulse/pulse-daemon-memory.c
+++ b/src/daemon/pulse/pulse-daemon-memory.c
@@ -274,6 +274,7 @@ void pulse_daemon_memory_do(bool extended __maybe_unused) {
 
     // ----------------------------------------------------------------------------------------------------------------
 
+#ifdef ENABLE_DBENGINE
     OS_SYSTEM_MEMORY sm = os_system_memory(true);
     if (OS_SYSTEM_MEMORY_OK(sm) && dbengine_out_of_memory_protection) {
         static RRDSET *st_memory_available = NULL;
@@ -304,6 +305,6 @@ void pulse_daemon_memory_do(bool extended __maybe_unused) {
 
         rrdset_done(st_memory_available);
     }
-
+#endif
     // ----------------------------------------------------------------------------------------------------------------
 }

--- a/src/web/api/web_api_v1.c
+++ b/src/web/api/web_api_v1.c
@@ -192,6 +192,7 @@ static struct web_api_command api_commands_v1[] = {
         .callback = api_v1_aclk,
         .allow_subpaths = 0
     },
+#ifdef ENABLE_DBENGINE
     {
         // deprecated - use /api/v2/info
         .api = "dbengine_stats",
@@ -201,6 +202,7 @@ static struct web_api_command api_commands_v1[] = {
         .callback = api_v1_dbengine_stats,
         .allow_subpaths = 0
     },
+#endif
     {
         .api = "ml_info",
         .hash = 0,


### PR DESCRIPTION
##### Summary
- Fix compilation without dbengine support
- Fix compilation when FSANITIZE_ADDRESS and dbengine is off
- Fix warning when sentry is not enabled

##### Test Plan
- Set `ENABLE_DBENGINE=OFF` and compile. The agent should start in ram mode