### PR TITLE
Fix max_page_length calculation for GORILLA_32BIT page type

### DIFF
--- a/src/database/engine/pdc.c
+++ b/src/database/engine/pdc.c
@@ -842,7 +842,7 @@ VALIDATED_PAGE_DESCRIPTOR validate_page(
     // If gorilla can not compress the data we might end up needing slightly more
     // than 4KiB. However, gorilla pages extend the page length by increments of
     // 512 bytes.
-    max_page_length += ((page_type == RRDENG_PAGE_TYPE_GORILLA_32BIT) * RRDENG_GORILLA_32BIT_BUFFER_SIZE);
+    max_page_length += ((page_type == RRDENG_PAGE_TYPE_GORILLA_32BIT) * (2 * RRDENG_GORILLA_32BIT_BUFFER_SIZE));
 
     if (!known_page_type                                        ||
         have_read_error                                         ||


### PR DESCRIPTION
##### Summary
Adjust the max page validation to 5120 bytes. This will fix occasional errors like the following

```
DBENGINE: metric '45abdf91-e431-4c56-a6e6-cb3a942db8b8' loaded invalid page of type 2 from 1742197011 to 1742198034 (now 1742296131), update every 1, page length 5120, entries 1024
```
