### PR TITLE
Don't build libunwind in static builds when it's not needed.

### DIFF
--- a/packaging/makeself/jobs/15-libucontext.install.sh
+++ b/packaging/makeself/jobs/15-libucontext.install.sh
@@ -5,6 +5,13 @@
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 # Source of truth for all the packages we bundle in static builds
 . "$(dirname "${0}")/../bundled-packages.version"
+
+
+case "${BUILDARCH}" in
+    armv6l|armv7l) ;;
+    *) exit 0 ;;
+esac
+
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building libucontext" || true
 
@@ -15,11 +22,6 @@ export LDFLAGS=""
 if [ -d "${NETDATA_MAKESELF_PATH}/tmp/libucontext" ]; then
   rm -rf "${NETDATA_MAKESELF_PATH}/tmp/libucontext"
 fi
-
-case "${BUILDARCH}" in
-    armv6l|armv7l) ;;
-    *) return 0 ;;
-esac
 
 cache="${NETDATA_SOURCE_PATH}/artifacts/cache/${BUILDARCH}/libucontext"
 

--- a/packaging/makeself/jobs/15-libucontext.install.sh
+++ b/packaging/makeself/jobs/15-libucontext.install.sh
@@ -16,6 +16,11 @@ if [ -d "${NETDATA_MAKESELF_PATH}/tmp/libucontext" ]; then
   rm -rf "${NETDATA_MAKESELF_PATH}/tmp/libucontext"
 fi
 
+case "${BUILDARCH}" in
+    armv6l|armv7l) ;;
+    *) return 0 ;;
+esac
+
 cache="${NETDATA_SOURCE_PATH}/artifacts/cache/${BUILDARCH}/libucontext"
 
 if [ -d "${cache}" ]; then

--- a/packaging/makeself/jobs/20-libunwind.install.sh
+++ b/packaging/makeself/jobs/20-libunwind.install.sh
@@ -5,6 +5,12 @@
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 # Source of truth for all the packages we bundle in static builds
 . "$(dirname "${0}")/../bundled-packages.version"
+
+case "${BUILDARCH}" in
+    armv6l|armv7l) ;;
+    *) exit 0 ;;
+esac
+
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building libunwind" || true
 
@@ -16,11 +22,6 @@ export PKG_CONFIG="pkg-config --static"
 if [ -d "${NETDATA_MAKESELF_PATH}/tmp/libunwind" ]; then
   rm -rf "${NETDATA_MAKESELF_PATH}/tmp/libunwind"
 fi
-
-case "${BUILDARCH}" in
-    armv6l|armv7l) ;;
-    *) return 0 ;;
-esac
 
 cache="${NETDATA_SOURCE_PATH}/artifacts/cache/${BUILDARCH}/libunwind"
 

--- a/packaging/makeself/jobs/20-libunwind.install.sh
+++ b/packaging/makeself/jobs/20-libunwind.install.sh
@@ -17,6 +17,11 @@ if [ -d "${NETDATA_MAKESELF_PATH}/tmp/libunwind" ]; then
   rm -rf "${NETDATA_MAKESELF_PATH}/tmp/libunwind"
 fi
 
+case "${BUILDARCH}" in
+    armv6l|armv7l) ;;
+    *) return 0 ;;
+esac
+
 cache="${NETDATA_SOURCE_PATH}/artifacts/cache/${BUILDARCH}/libunwind"
 
 if [ -d "${cache}" ]; then


### PR DESCRIPTION
##### Summary

We preferentially use libbacktrace on most platforms, so don’t waste time or resources building libunwind on them.

##### Test Plan

CI passes on this PR.