### PR TITLE
Improve event loop thread creation

### DIFF
--- a/src/daemon/libuv_workers.c
+++ b/src/daemon/libuv_workers.c
@@ -109,3 +109,22 @@ void register_libuv_worker_jobs() {
     registered = true;
     register_libuv_worker_jobs_internal();
 }
+
+// utils
+#define MAX_THREAD_CREATE_RETRIES (10)
+#define MAX_THREAD_CREATE_WAIT_MS (1000)
+
+int create_uv_thread(uv_thread_t *thread, uv_thread_cb thread_func, void *arg, int *retries)
+{
+    int err;
+
+    do {
+        err = uv_thread_create(thread, thread_func, arg);
+        if (err == 0)
+            break;
+
+        uv_sleep(MAX_THREAD_CREATE_WAIT_MS);
+    } while (err == UV_EAGAIN && ++(*retries) < MAX_THREAD_CREATE_RETRIES);
+
+    return err;
+}

--- a/src/daemon/libuv_workers.h
+++ b/src/daemon/libuv_workers.h
@@ -88,5 +88,6 @@ enum event_loop_job {
 };
 
 void register_libuv_worker_jobs();
+int create_uv_thread(uv_thread_t *thread, uv_thread_cb thread_func, void *arg, int *retries);
 
 #endif //NETDATA_EVENT_LOOP_H

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2762,7 +2762,15 @@ void metadata_sync_init(void)
     memset(&metasync_worker, 0, sizeof(metasync_worker));
     completion_init(&metasync_worker.start_stop_complete);
 
-    fatal_assert(0 == uv_thread_create(&metasync_worker.thread, metadata_event_loop, &metasync_worker));
+    int retries = 0;
+    int create_uv_thread_rc = create_uv_thread(&metasync_worker.thread, metadata_event_loop, &metasync_worker, &retries);
+    if (create_uv_thread_rc)
+        nd_log_daemon(NDLP_ERR, "Failed to create SQLite metadata sync thread, error %s, after %d retries", uv_err_name(create_uv_thread_rc), retries);
+
+    fatal_assert(0 == create_uv_thread_rc);
+
+    if (retries)
+        nd_log_daemon(NDLP_WARNING, "SQLite metadata sync thread was created after %d attempts", retries);
 
     completion_wait_for(&metasync_worker.start_stop_complete);
     completion_destroy(&metasync_worker.start_stop_complete);

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -1984,8 +1984,11 @@ static void start_all_host_load_context(uv_work_t *req __maybe_unused)
             hclt[thread_index].host = host;
             rc = uv_thread_create(&hclt[thread_index].thread, restore_host_context, &hclt[thread_index]);
             async_exec += (rc == 0);
+            // if it failed, mark the thread slot as free
+            if (rc)
+                __atomic_store_n(&hclt[thread_index].busy, false, __ATOMIC_RELAXED);
         }
-        // if single thread, thread creation failure or failure to find slot
+        // if single thread, thread creation failure or failure tofind slot
         if (rc || !thread_found) {
             sync_exec++;
             struct host_context_load_thread hclt_sync = {.host = host};


### PR DESCRIPTION
##### Summary
- when setting up event loops for ACLK sync, metadata or DBENGINE, if uv_thread_create fails with EAGAIN, retry 10 times before giving up (resources may become available)
