### PR TITLE
Enable interface to release sqlite memory

### DIFF
--- a/src/database/sqlite/sqlite_functions.c
+++ b/src/database/sqlite/sqlite_functions.c
@@ -410,8 +410,20 @@ int sqlite_library_init(void)
 
 SPINLOCK sqlite_spinlock = SPINLOCK_INITIALIZER;
 
+int sqlite_release_memory(int bytes)
+{
+    return sqlite3_release_memory(bytes);
+}
+
 void sqlite_library_shutdown(void)
 {
+#ifdef NETDATA_INTERNAL_CHECKS
+    int bytes;
+    do {
+        bytes = sqlite_release_memory(1024 * 1024);
+        netdata_log_info("SQLITE: Released %d bytes of memory", bytes);
+    } while (bytes);
+#endif
     spinlock_lock(&sqlite_spinlock);
     (void) sqlite3_shutdown();
     spinlock_unlock(&sqlite_spinlock);

--- a/src/database/sqlite/sqlite_functions.h
+++ b/src/database/sqlite/sqlite_functions.h
@@ -118,4 +118,5 @@ void sqlite_library_shutdown(void);
 void sql_close_database(sqlite3 *database, const char *database_name);
 void sqlite_close_databases(void);
 uint64_t get_total_database_space(void);
+int sqlite_release_memory(int bytes);
 #endif //NETDATA_SQLITE_FUNCTIONS_H


### PR DESCRIPTION
##### Summary
- When under memory pressure the sqlite library will be able to release non-essential memory allocations (eg. caches)
  - `int freed_bytes = sqlite_release_memory(bytes)` can be used to attempt to free `bytes` 
  According to the sqlite docs, bytes actually freed, may be more or less than the amount requested.
  
##### Test Plan
- If compiled with NETDATA_INTERNAL_CHECKS, agent with release memory during shutdown in 1MB chunks
