### PR TITLE
daemon status 22

### DIFF
--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -30,12 +30,16 @@ mqtt_wss_client mqttwss_client;
 static bool aclk_connected = false;
 static inline void aclk_set_connected(void) {
     __atomic_store_n(&aclk_connected, true, __ATOMIC_RELAXED);
+
+    daemon_status_file_update_status(DAEMON_STATUS_NONE);
 }
 static inline void aclk_set_disconnected(void) {
     __atomic_store_n(&aclk_connected, false, __ATOMIC_RELAXED);
 
     if(mqttwss_client)
         mqtt_wss_reset_stats(mqttwss_client);
+
+    daemon_status_file_update_status(DAEMON_STATUS_NONE);
 }
 
 inline bool aclk_online(void) {

--- a/src/claim/cloud-status.c
+++ b/src/claim/cloud-status.c
@@ -2,28 +2,18 @@
 
 #include "claim.h"
 
-const char *cloud_status_to_string(CLOUD_STATUS status) {
-    switch(status) {
-        default:
-        case CLOUD_STATUS_AVAILABLE:
-            return "available";
+ENUM_STR_MAP_DEFINE(CLOUD_STATUS) = {
+    { CLOUD_STATUS_AVAILABLE, "available"},
+    { CLOUD_STATUS_BANNED, "banned"},
+    { CLOUD_STATUS_OFFLINE, "offline"},
+    { CLOUD_STATUS_ONLINE, "online"},
+    { CLOUD_STATUS_CONNECTING, "connecting"},
+    { CLOUD_STATUS_INDIRECT, "indirect"},
 
-        case CLOUD_STATUS_BANNED:
-            return "banned";
-
-        case CLOUD_STATUS_OFFLINE:
-            return "offline";
-
-        case CLOUD_STATUS_ONLINE:
-            return "online";
-
-        case CLOUD_STATUS_CONNECTING:
-            return "connecting";
-
-        case CLOUD_STATUS_INDIRECT:
-            return "indirect";
-    }
-}
+    // terminator
+    { 0, NULL },
+};
+ENUM_STR_DEFINE_FUNCTIONS(CLOUD_STATUS, CLOUD_STATUS_AVAILABLE, "available");
 
 CLOUD_STATUS cloud_status(void) {
     if(unlikely(aclk_disable_runtime))
@@ -36,7 +26,8 @@ CLOUD_STATUS cloud_status(void) {
             return CLOUD_STATUS_CONNECTING;
     }
 
-    if(localhost->sender &&
+    if(localhost &&
+        localhost->sender &&
         rrdhost_flag_check(localhost, RRDHOST_FLAG_STREAM_SENDER_READY_4_METRICS) &&
         stream_sender_has_capabilities(localhost, STREAM_CAP_NODE_ID) &&
         !UUIDiszero(localhost->node_id) &&
@@ -83,7 +74,7 @@ CLOUD_STATUS buffer_json_cloud_status(BUFFER *wb, time_t now_s) {
         time_t last_change = cloud_last_change();
         time_t next_connect = cloud_next_connection_attempt();
         buffer_json_member_add_uint64(wb, "id", id);
-        buffer_json_member_add_string(wb, "status", cloud_status_to_string(status));
+        buffer_json_member_add_string(wb, "status", CLOUD_STATUS_2str(status));
         buffer_json_member_add_time_t(wb, "since", last_change);
         buffer_json_member_add_time_t(wb, "age", now_s - last_change);
 

--- a/src/claim/cloud-status.c
+++ b/src/claim/cloud-status.c
@@ -3,12 +3,11 @@
 #include "claim.h"
 
 ENUM_STR_MAP_DEFINE(CLOUD_STATUS) = {
+    { CLOUD_STATUS_ONLINE, "online"},
+    { CLOUD_STATUS_INDIRECT, "indirect"},
     { CLOUD_STATUS_AVAILABLE, "available"},
     { CLOUD_STATUS_BANNED, "banned"},
     { CLOUD_STATUS_OFFLINE, "offline"},
-    { CLOUD_STATUS_ONLINE, "online"},
-    { CLOUD_STATUS_CONNECTING, "connecting"},
-    { CLOUD_STATUS_INDIRECT, "indirect"},
 
     // terminator
     { 0, NULL },
@@ -19,12 +18,8 @@ CLOUD_STATUS cloud_status(void) {
     if(unlikely(aclk_disable_runtime))
         return CLOUD_STATUS_BANNED;
 
-    if(likely(aclk_online())) {
-        if (localhost && rrdhost_flag_check(localhost, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS))
-            return CLOUD_STATUS_ONLINE;
-        else
-            return CLOUD_STATUS_CONNECTING;
-    }
+    if(likely(aclk_online()))
+        return CLOUD_STATUS_ONLINE;
 
     if(localhost &&
         localhost->sender &&

--- a/src/claim/cloud-status.c
+++ b/src/claim/cloud-status.c
@@ -20,7 +20,7 @@ CLOUD_STATUS cloud_status(void) {
         return CLOUD_STATUS_BANNED;
 
     if(likely(aclk_online())) {
-        if (rrdhost_flag_check(localhost, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS))
+        if (localhost && rrdhost_flag_check(localhost, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS))
             return CLOUD_STATUS_ONLINE;
         else
             return CLOUD_STATUS_CONNECTING;

--- a/src/claim/cloud-status.h
+++ b/src/claim/cloud-status.h
@@ -3,7 +3,8 @@
 #ifndef NETDATA_CLOUD_STATUS_H
 #define NETDATA_CLOUD_STATUS_H
 
-#include "daemon/common.h"
+#include "libnetdata/libnetdata.h"
+#include "claim/cloud-status.h"
 
 typedef enum __attribute__((packed)) {
     CLOUD_STATUS_AVAILABLE = 1,     // cloud and aclk functionality is available, but the agent is not claimed
@@ -14,7 +15,8 @@ typedef enum __attribute__((packed)) {
     CLOUD_STATUS_ONLINE,            // the agent is connected to cloud
 } CLOUD_STATUS;
 
-const char *cloud_status_to_string(CLOUD_STATUS status);
+ENUM_STR_DEFINE_FUNCTIONS_EXTERN(CLOUD_STATUS);
+
 CLOUD_STATUS cloud_status(void);
 
 time_t cloud_last_change(void);

--- a/src/claim/cloud-status.h
+++ b/src/claim/cloud-status.h
@@ -11,7 +11,6 @@ typedef enum __attribute__((packed)) {
     CLOUD_STATUS_BANNED,            // the agent has been banned from cloud
     CLOUD_STATUS_OFFLINE,           // the agent tries to connect to cloud, but cannot do it
     CLOUD_STATUS_INDIRECT,          // the agent is connected to cloud via a parent
-    CLOUD_STATUS_CONNECTING,        // the agent is connecting
     CLOUD_STATUS_ONLINE,            // the agent is connected to cloud
 } CLOUD_STATUS;
 

--- a/src/daemon/daemon-status-file.c
+++ b/src/daemon/daemon-status-file.c
@@ -1046,10 +1046,13 @@ void post_status_file(struct post_status_file_thread_data *d) {
 
     CURLcode rc = curl_easy_perform(curl);
     if(rc == CURLE_OK) {
+        nd_log(NDLS_DAEMON, NDLP_INFO, "Posted last status to agent-events successfully.");
         uint64_t hash = daemon_status_file_hash(d->status, d->msg, d->cause);
         dedup_keep_hash(&session_status, hash, false);
         daemon_status_file_save(wb, &session_status, true);
     }
+    else
+        nd_log(NDLS_DAEMON, NDLP_INFO, "Failed to post last status to agent-events.");
 
     curl_easy_cleanup(curl);
     curl_slist_free_all(headers);

--- a/src/daemon/daemon-status-file.c
+++ b/src/daemon/daemon-status-file.c
@@ -1028,7 +1028,7 @@ static const char *agent_health(DAEMON_STATUS_FILE *ds) {
         return "healthy-recovered";
 }
 
-void post_status_file(struct post_status_file_thread_data *d) {
+static void post_status_file(struct post_status_file_thread_data *d) {
     daemon_status_file_startup_step("startup(crash reports json)");
 
     CLEAN_BUFFER *wb = buffer_create(0, NULL);
@@ -1367,9 +1367,11 @@ void daemon_status_file_check_crash(void) {
     if( // must be first for netdata.conf option to be used
         (r == DSF_REPORT_ALL || (this_is_a_crash && r == DSF_REPORT_CRASHES)) &&
 
-        // we have a previous status, or
-        // (we managed to save the current one, and (we have more than 2 restarts, or this is not a CI run))
-        (!no_previous_status || (daemon_status_file_saved && (last_session_status.restarts > 2 || !is_ci()))) &&
+        // we have a previous status, or we managed to save the current one
+        (!no_previous_status || daemon_status_file_saved) &&
+
+        // we have more than 2 restarts, or this is not a CI run
+        (last_session_status.restarts > 2 || !is_ci()) &&
 
         // we have not reported this
         !dedup_already_posted(&session_status, daemon_status_file_hash(&last_session_status, msg, cause), false)

--- a/src/daemon/daemon-status-file.h
+++ b/src/daemon/daemon-status-file.h
@@ -6,6 +6,7 @@
 #include "libnetdata/libnetdata.h"
 #include "daemon/config/netdata-conf-profile.h"
 #include "database/rrd-database-mode.h"
+#include "claim/cloud-status.h"
 
 #define STATUS_FILE_VERSION 22
 
@@ -37,6 +38,7 @@ typedef struct daemon_status_file {
     ND_PROFILE profile;         // the profile of the agent
     DAEMON_OS_TYPE os_type;
     RRD_DB_MODE db_mode;
+    CLOUD_STATUS cloud_status;
     uint8_t db_tiers;
     bool kubernetes;
     bool sentry_available;      // true when sentry support is compiled in

--- a/src/daemon/daemon-status-file.h
+++ b/src/daemon/daemon-status-file.h
@@ -7,7 +7,7 @@
 #include "daemon/config/netdata-conf-profile.h"
 #include "database/rrd-database-mode.h"
 
-#define STATUS_FILE_VERSION 21
+#define STATUS_FILE_VERSION 22
 
 typedef enum {
     DAEMON_STATUS_NONE,
@@ -116,7 +116,7 @@ bool daemon_status_file_deadly_signal_received(EXIT_REASON reason, SIGNAL_CODE c
 // check for a crash
 void daemon_status_file_check_crash(void);
 
-bool daemon_status_file_has_last_crashed(void);
+bool daemon_status_file_has_last_crashed(DAEMON_STATUS_FILE *ds);
 bool daemon_status_file_was_incomplete_shutdown(void);
 
 void daemon_status_file_startup_step(const char *step);

--- a/src/daemon/daemon-status-file.h
+++ b/src/daemon/daemon-status-file.h
@@ -45,6 +45,7 @@ typedef struct daemon_status_file {
     time_t uptime;              // netdata uptime
     usec_t timestamp_ut;        // the timestamp of the status file
     size_t restarts;            // the number of times this agent has restarted (ever)
+    size_t posts;               // the number of posts to the backend
     ssize_t reliability;        // consecutive restarts: > 0 reliable, < 0 crashing
 
     ND_UUID boot_id;            // the boot id of the system

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -922,15 +922,8 @@ int netdata_main(int argc, char **argv) {
     web_server_threading_selection();
 
     delta_startup_time("web server sockets");
-    if(web_server_mode != WEB_SERVER_MODE_NONE) {
-        errno_clear();
-        if (!api_listen_sockets_setup()) {
-            exit_initiated_add(EXIT_REASON_ALREADY_RUNNING);
-            daemon_status_file_update_status(DAEMON_STATUS_NONE);
-            fatal("Cannot setup listen port(s). Is Netdata already running?");
-            exit(1);
-        }
-    }
+    if(web_server_mode != WEB_SERVER_MODE_NONE)
+        web_server_listen_sockets_setup();
 
     // ----------------------------------------------------------------------------------------------------------------
     delta_startup_time("sqlite");

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1105,7 +1105,7 @@ int netdata_main(int argc, char **argv) {
 
         analytics_statistic_t start_statistic = {"START", "-", "-"};
         analytics_statistic_send(&start_statistic);
-        if (daemon_status_file_has_last_crashed()) {
+        if (daemon_status_file_has_last_crashed(NULL)) {
             analytics_statistic_t crash_statistic = {"CRASH", "-", "-"};
             analytics_statistic_send(&crash_statistic);
         }

--- a/src/daemon/sentry-native/sentry-native.c
+++ b/src/daemon/sentry-native/sentry-native.c
@@ -46,7 +46,7 @@ static void nd_sentry_set_tag_uint64(const char *key, uint64_t value) {
     nd_sentry_set_tag(key, buf);
 }
 
-static void nd_sentry_set_tag_uuid(const char *key, const ND_UUID uuid) {
+static inline void nd_sentry_set_tag_uuid(const char *key, const ND_UUID uuid) {
     if(UUIDiszero(uuid))
         return;
 

--- a/src/libnetdata/log/nd_log-stacktrace.c
+++ b/src/libnetdata/log/nd_log-stacktrace.c
@@ -97,7 +97,7 @@ static void bt_error_handler(void *data, const char *msg, int errnum) {
 }
 
 // Full callback for libbacktrace
-static int bt_full_handler(void *data, uintptr_t pc,
+static int bt_full_handler(void *data, uintptr_t pc __maybe_unused,
                            const char *filename, int lineno,
                            const char *function) {
     backtrace_data_t *bt_data = (backtrace_data_t *)data;

--- a/src/registry/registry.c
+++ b/src/registry/registry.c
@@ -183,7 +183,7 @@ int registry_request_hello_json(RRDHOST *host, struct web_client *w, bool do_not
     buffer_json_object_close(w->response.data);
 
     CLOUD_STATUS status = cloud_status();
-    buffer_json_member_add_string(w->response.data, "cloud_status", cloud_status_to_string(status));
+    buffer_json_member_add_string(w->response.data, "cloud_status", CLOUD_STATUS_2str(status));
     buffer_json_member_add_string(w->response.data, "cloud_base_url", registry.cloud_base_url);
 
     buffer_json_member_add_string(w->response.data, "registry", registry.registry_to_announce);

--- a/src/web/api/v2/api_v2_claim.c
+++ b/src/web/api/v2/api_v2_claim.c
@@ -90,7 +90,6 @@ static bool agent_can_be_claimed(void) {
 
         case CLOUD_STATUS_BANNED:
         case CLOUD_STATUS_ONLINE:
-        case CLOUD_STATUS_CONNECTING:
             return false;
     }
 

--- a/src/web/server/web_server.c
+++ b/src/web/server/web_server.c
@@ -57,16 +57,18 @@ void debug_sockets() {
 	buffer_free(wb);
 }
 
-bool api_listen_sockets_setup(void) {
-	int socks = listen_sockets_setup(&api_sockets);
+void web_server_listen_sockets_setup(void) {
+    errno_clear();
 
-	if(!socks)
-        return false;
+	int socks = listen_sockets_setup(&api_sockets);
+	if(!socks) {
+        exit_initiated_add(EXIT_REASON_ALREADY_RUNNING);
+        daemon_status_file_update_status(DAEMON_STATUS_NONE);
+        fatal("Cannot setup listen port(s). Is Netdata already running?");
+    }
 
 	if(unlikely(debug_flags & D_WEB_CLIENT))
 		debug_sockets();
-
-	return true;
 }
 
 

--- a/src/web/server/web_server.h
+++ b/src/web/server/web_server.h
@@ -38,7 +38,7 @@ extern WEB_SERVER_MODE web_server_mode;
 WEB_SERVER_MODE web_server_mode_id(const char *mode);
 const char *web_server_mode_name(WEB_SERVER_MODE id);
 
-bool api_listen_sockets_setup(void);
+void web_server_listen_sockets_setup(void);
 
 #define DEFAULT_TIMEOUT_TO_RECEIVE_FIRST_WEB_REQUEST 60
 #define DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS 60


### PR DESCRIPTION
- [x] annotate crash and healthy loops
- [x] log successful and failed posts to agent-events
- [x] move `already running` outside `netdata_main()`
- [x] keep track of the number of posts made to the backend
- [x] added more information to `startup(crash reports)` to find the exact place netdata is `killed hard`.
- [x] added `aclk` status
- [x] do not post CI duplicates