### PR TITLE
fix RRDCALC crash due to being linked to RRDSET

### DIFF
--- a/src/health/health_dyncfg.c
+++ b/src/health/health_dyncfg.c
@@ -516,7 +516,7 @@ int dyncfg_health_prototype_to_conf(BUFFER *wb, RRD_ALERT_PROTOTYPE *ap, const c
             buffer_sprintf(wb, "%13s: %s\n", "to", string2str(nap->config.recipient));
     }
 
-    return 200;
+    return HTTP_RESP_OK;
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/src/libnetdata/dictionary/dictionary-callbacks.h
+++ b/src/libnetdata/dictionary/dictionary-callbacks.h
@@ -84,10 +84,17 @@ static inline void dictionary_execute_delete_callback(DICTIONARY *dict, DICTIONA
                    dict->creation_line,
                    dict->creation_file);
 
-    dict->hooks->delete_callback(item, item->shared->value, dict->hooks->delelte_callback_data);
+    dict->hooks->delete_callback(item, item->shared->value, dict->hooks->delete_callback_data);
 
     DICTIONARY_STATS_CALLBACK_DELETES_PLUS1(dict);
 }
 
+static inline void dictionary_execute_on_delete_callback(DICTIONARY *dict, DICTIONARY_ITEM *item) {
+    if(likely(!dict->hooks || !dict->hooks->on_delete_callback) || item_shared_flag_check(item, ITEM_FLAG_ON_DELETE_RUN))
+        return;
+
+    item_shared_flag_set(item, ITEM_FLAG_ON_DELETE_RUN);
+    dict->hooks->on_delete_callback(item, item->shared->value, dict->hooks->on_delete_callback_data);
+}
 
 #endif //NETDATA_DICTIONARY_CALLBACKS_H

--- a/src/libnetdata/dictionary/dictionary-internals.h
+++ b/src/libnetdata/dictionary/dictionary-internals.h
@@ -35,6 +35,7 @@ typedef enum __attribute__ ((__packed__)) item_flags {
     ITEM_FLAG_NONE              = 0,
     ITEM_FLAG_DELETED           = (1 << 0), // this item is marked deleted, so it is not available for traversal (deleted from the index too)
     ITEM_FLAG_BEING_CREATED     = (1 << 1), // this item is currently being created - this flag is removed when construction finishes
+    ITEM_FLAG_ON_DELETE_RUN     = (1 << 2), // the on_delete callback has been run for this item
 
     // IMPORTANT: This is 8-bit
 } ITEM_FLAGS;
@@ -123,7 +124,10 @@ struct dictionary_hooks {
     void *react_callback_data;
 
     dict_cb_delete_t delete_callback;
-    void *delelte_callback_data;
+    void *delete_callback_data;
+
+    dict_cb_delete_t on_delete_callback;
+    void *on_delete_callback_data;
 };
 
 struct dictionary {

--- a/src/libnetdata/dictionary/dictionary-item.h
+++ b/src/libnetdata/dictionary/dictionary-item.h
@@ -210,6 +210,8 @@ static inline void dict_item_reset_value_with_hooks(DICTIONARY *dict, DICTIONARY
 static inline size_t dict_item_free_with_hooks(DICTIONARY *dict, DICTIONARY_ITEM *item) {
     netdata_log_debug(D_DICTIONARY, "Destroying name value entry for name '%s'.", item_get_name(item));
 
+    dictionary_execute_on_delete_callback(dict, item);
+
     if(!item_flag_check(item, ITEM_FLAG_DELETED))
         DICTIONARY_ENTRIES_MINUS1(dict);
 
@@ -326,6 +328,7 @@ static inline void dict_item_free_or_mark_deleted(DICTIONARY *dict, DICTIONARY_I
         case RC_ITEM_IS_REFERENCED:
         case RC_ITEM_IS_CURRENTLY_BEING_CREATED:
             // the item is currently referenced by others
+            dictionary_execute_on_delete_callback(dict, item);
             dict_item_shared_set_deleted(dict, item);
             dict_item_set_deleted(dict, item);
             // after this point do not touch the item

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -106,7 +106,16 @@ void dictionary_register_delete_callback(DICTIONARY *dict, dict_cb_delete_t dele
 
     dictionary_hooks_allocate(dict);
     dict->hooks->delete_callback = delete_callback;
-    dict->hooks->delelte_callback_data = data;
+    dict->hooks->delete_callback_data = data;
+}
+
+void dictionary_register_on_delete_callback(DICTIONARY *dict, dict_cb_delete_t on_delete_callback,  void *data) {
+    if(unlikely(is_view_dictionary(dict)))
+        fatal("DICTIONARY: called %s() on a view.", __FUNCTION__ );
+
+    dictionary_hooks_allocate(dict);
+    dict->hooks->on_delete_callback = on_delete_callback;
+    dict->hooks->on_delete_callback_data = data;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/libnetdata/dictionary/dictionary.h
+++ b/src/libnetdata/dictionary/dictionary.h
@@ -140,6 +140,9 @@ void dictionary_register_insert_callback(DICTIONARY *dict, dict_cb_insert_t inse
 typedef void (*dict_cb_delete_t)(const DICTIONARY_ITEM *item, void *value, void *data);
 void dictionary_register_delete_callback(DICTIONARY *dict, dict_cb_delete_t delete_callback, void *data);
 
+// a on_delete callback to be called when an item is marked for deletion
+void dictionary_register_on_delete_callback(DICTIONARY *dict, dict_cb_delete_t on_delete_callback, void *data);
+
 // a merge callback to be called when DICT_OPTION_DONT_OVERWRITE_VALUE
 // and an item is already found in the dictionary - the dictionary does nothing else in this case
 // the old_value will remain in the dictionary - the new_value is ignored


### PR DESCRIPTION
make sure alerts are unlinked from rrdsets when either rrdset is deleted or rrdcalc is deleted

IT SEEMS IT IS NOT NEEDED ANYMORE.

