### PR TITLE
Improve agent shutdown

### DIFF
--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -285,7 +285,7 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
             for (size_t tier = 0; tier < nd_profile.storage_tiers; tier++)
                 nd_thread_join(th[tier]);
 
-            rrdeng_enq_cmd(NULL, RRDENG_OPCODE_SHUTDOWN_EVLOOP, NULL, NULL, STORAGE_PRIORITY_INTERNAL_DBENGINE, NULL, NULL);
+            dbengine_shutdown();
             watcher_step_complete(WATCHER_STEP_ID_STOP_DBENGINE_TIERS);
         }
         else {

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -2097,3 +2097,14 @@ void dbengine_event_loop(void* arg) {
     (void) uv_loop_close(&main->loop);
     worker_unregister();
 }
+
+void dbengine_shutdown()
+{
+    rrdeng_enq_cmd(NULL, RRDENG_OPCODE_SHUTDOWN_EVLOOP, NULL, NULL, STORAGE_PRIORITY_INTERNAL_DBENGINE, NULL, NULL);
+
+    int rc = uv_thread_join(&rrdeng_main.thread);
+    if (rc)
+        nd_log_daemon(NDLP_ERR, "DBENGINE: Failed to join thread, error %s", uv_err_name(rc));
+    else
+        nd_log_daemon(NDLP_INFO, "DBENGINE: thread shutdown completed");
+}

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -549,5 +549,6 @@ static inline int journal_metric_uuid_compare(const void *key, const void *metri
 uint64_t rrdeng_get_used_disk_space(struct rrdengine_instance *ctx);
 void rrdeng_calculate_tier_disk_space_percentage(void);
 uint64_t rrdeng_get_directory_free_bytes_space(struct rrdengine_instance *ctx);
+void dbengine_shutdown();
 
 #endif /* NETDATA_RRDENGINE_H */

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -1020,7 +1020,11 @@ void aclk_synchronization_shutdown(void)
 
     completion_wait_for(&aclk_sync_config.start_stop_complete);
     completion_destroy(&aclk_sync_config.start_stop_complete);
-    nd_log_daemon(NDLP_INFO, "ACLK sync shutdown completed");
+    int rc = uv_thread_join(&aclk_sync_config.thread);
+    if (rc)
+        nd_log_daemon(NDLP_ERR, "ACLK: Failed to join synchronization thread, error %s", uv_err_name(rc));
+    else
+        nd_log_daemon(NDLP_INFO, "ACLK: synchronization thread shutdown completed");
 }
 
 // Public

--- a/src/database/sqlite/sqlite_context.c
+++ b/src/database/sqlite/sqlite_context.c
@@ -155,9 +155,9 @@ done:
 
 void ctx_get_label_list(nd_uuid_t *chart_uuid, void (*dict_cb)(SQL_CLABEL_DATA *, void *), void *data)
 {
-    static __thread sqlite3_stmt *res = NULL;
+    sqlite3_stmt *res = NULL;
 
-    if (!PREPARE_COMPILED_STATEMENT(db_context_meta, CTX_GET_LABEL_LIST, &res))
+    if (!PREPARE_STATEMENT(db_context_meta, CTX_GET_LABEL_LIST, &res))
         return;
 
     int param = 0;
@@ -175,7 +175,7 @@ void ctx_get_label_list(nd_uuid_t *chart_uuid, void (*dict_cb)(SQL_CLABEL_DATA *
 
 done:
     REPORT_BIND_FAIL(res, param);
-    SQLITE_RESET(res);
+    SQLITE_FINALIZE(res);
 }
 
 // CONTEXT LIST

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2709,7 +2709,7 @@ void metadata_sync_shutdown(void)
     if (rc)
         nd_log_daemon(NDLP_ERR, "METADATA: Failed to join synchronization thread, error %s", uv_err_name(rc));
     else
-        nd_log_daemon(NDLP_DEBUG, "METADATA: synchronization thread shutdown completed");
+        nd_log_daemon(NDLP_INFO, "METADATA: synchronization thread shutdown completed");
 }
 
 void metadata_sync_shutdown_prepare(void)

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -968,10 +968,10 @@ done:
 
 static void delete_dimension_uuid(nd_uuid_t *dimension_uuid, sqlite3_stmt **action_res __maybe_unused, bool flag __maybe_unused)
 {
-    static __thread sqlite3_stmt *res = NULL;
+    sqlite3_stmt *res = NULL;
     int rc;
 
-    if (!PREPARE_COMPILED_STATEMENT(db_meta, DELETE_DIMENSION_UUID, &res))
+    if (!PREPARE_STATEMENT(db_meta, DELETE_DIMENSION_UUID, &res))
         return;
 
     int param = 0;
@@ -984,7 +984,7 @@ static void delete_dimension_uuid(nd_uuid_t *dimension_uuid, sqlite3_stmt **acti
 
 done:
     REPORT_BIND_FAIL(res, param);
-    SQLITE_RESET(res);
+    SQLITE_FINALIZE(res);
 }
 
 //


### PR DESCRIPTION
##### Summary
- Properly join ACLK and metadata threads during shutdown
  - This will allow for a proper cleanup (finalize) of pre-compiled statements before closing database connections (otherwise it can lead to crashes)
- Remove some more precompiled statements
