### PR TITLE
Improve shutdown and datafile rotation

### DIFF
--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1249,7 +1249,7 @@ void datafile_delete(struct rrdengine_instance *ctx, struct rrdengine_datafile *
         worker_is_busy(UV_EVENT_DBENGINE_DATAFILE_DELETE);
 
     struct rrdengine_journalfile *journal_file;
-    unsigned deleted_bytes, journal_file_bytes, datafile_bytes;
+    size_t deleted_bytes, journal_file_bytes, datafile_bytes;
     int ret;
     char path[RRDENG_PATH_MAX];
 
@@ -1300,7 +1300,7 @@ void datafile_delete(struct rrdengine_instance *ctx, struct rrdengine_datafile *
     freez(datafile);
 
     ctx_current_disk_space_decrease(ctx, deleted_bytes);
-    netdata_log_info("DBENGINE: reclaimed %u bytes of disk space.", deleted_bytes);
+    netdata_log_info("DBENGINE: reclaimed %zu bytes of disk space.", deleted_bytes);
 }
 
 static void *database_rotate_tp_worker(struct rrdengine_instance *ctx __maybe_unused, void *data __maybe_unused, struct completion *completion __maybe_unused, uv_work_t *uv_work_req __maybe_unused) {

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -2025,8 +2025,8 @@ void dbengine_event_loop(void* arg) {
                 case RRDENG_OPCODE_DATABASE_ROTATE: {
                     struct rrdengine_instance *ctx = cmd.ctx;
                     if (!__atomic_load_n(&ctx->atomic.now_deleting_files, __ATOMIC_RELAXED) &&
-                         ctx->datafiles.first->next != NULL &&
-                         ctx->datafiles.first->next->next != NULL &&
+                        !__atomic_load_n(&ctx->atomic.migration_to_v2_running, __ATOMIC_RELAXED) &&
+                        ctx->datafiles.first->next != NULL && ctx->datafiles.first->next->next != NULL &&
                         rrdeng_ctx_tier_cap_exceeded(ctx)) {
 
                         __atomic_store_n(&ctx->atomic.now_deleting_files, true, __ATOMIC_RELAXED);

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -521,7 +521,7 @@ static void node_update_timer_cb(uv_timer_t *handle)
     struct aclk_sync_cfg_t *ahc = handle->data;
     RRDHOST *host = ahc->host;
 
-    if(aclk_host_state_update_auto(host))
+    if(!host || aclk_host_state_update_auto(host))
         uv_timer_stop(&ahc->timer);
 }
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2076,7 +2076,7 @@ size_t populate_metrics_from_database(void *mrg, void (*populate_cb)(void *mrg, 
     }
 
     if (local_meta_db)
-        db_execute(local_meta_db, "PRAGMA cache_size=10000");
+        (void) db_execute(local_meta_db, "PRAGMA cache_size=10000");
 
     if (!PREPARE_STATEMENT(local_meta_db ? local_meta_db : db_meta, GET_UUID_LIST, &res)) {
         sqlite3_close(local_meta_db);


### PR DESCRIPTION
##### Summary
- Eliminate additional cases in alarm_log and contexts API calls when alerts are included in the payload
  - Remove more precompiled statements
- Add additional checks in ACLK synchronization thread 
- Avoid datafile rotation when journal indexing is in progress
