### PR TITLE
Update synology.md

### DIFF
--- a/packaging/installer/methods/synology.md
+++ b/packaging/installer/methods/synology.md
@@ -8,22 +8,23 @@
 
 The [one-line installation script](/packaging/installer/methods/kickstart.md) works on Synology NAS devices with amd64 architecture. The script installs Netdata to `/opt/netdata/`.
 
-For current Synology systems (DSM 7.2.2+), the kickstart script automatically handles the complete installation process. Netdata runs as the `netdata` user and can be managed through standard systemd commands.
-
-## Older systems
-
-<details>
-<summary>For DSM versions older than 7.2.2, additional configuration is required.</summary>
+For current Synology systems (DSM 7.2.2+), the kickstart script automatically handles the complete installation process and can be managed through standard systemd commands, except it fails to create the `netdata` users and group.
 
 ### Run as netdata user
 
-By default, Netdata runs as `root` on older systems. To run it as the netdata user instead:
+By default, Netdata runs as `root`. To run it as the `netdata` user instead:
 
 1. Create a `netdata` group through the Synology control panel (no special access needed)
 2. Create a `netdata` user through the Synology control panel:
     - Assign it to the netdata group
     - Set a random password
     - Grant no access permission
+    
+    or alternatively from the CLI.
+    ```sh
+    sudo synouser --add netdata <SomeGoodPassword> "netdata agent" 0 "" 0
+    sudo synogroup --add netdata netdata
+    ```
 3. Set correct ownership permissions:
     ```bash
     chown -R root:netdata /opt/netdata/usr/share/netdata
@@ -34,6 +35,11 @@ By default, Netdata runs as `root` on older systems. To run it as the netdata us
     ```sh
     /etc/rc.netdata restart
     ```
+
+## Older systems
+
+<details>
+<summary>For DSM versions older than 7.2.2, additional configuration is required.</summary>
 
 ### Create a Startup Script
 

--- a/packaging/installer/methods/synology.md
+++ b/packaging/installer/methods/synology.md
@@ -2,13 +2,13 @@
 
 > This community-maintained guide may not reflect the latest changes.
 > Please verify the installation steps before proceeding.
-> 
+>
 > Help improve this guide by submitting a PR with your suggestions.
 > Thank you!
 
 The [one-line installation script](/packaging/installer/methods/kickstart.md) works on Synology NAS devices with amd64 architecture. The script installs Netdata to `/opt/netdata/`.
 
-For current Synology systems (DSM 7.2.2+), the kickstart script automatically handles the complete installation process and can be managed through standard systemd commands, except it fails to create the `netdata` users and group.
+On current Synology systems (DSM 7.2.2+), the kickstart script automates the entire installation process but doesn't create the necessary `netdata` user and group. As a result, Netdata operates with root privileges instead. Once installed, it can be controlled using standard systemd commands.
 
 ### Run as netdata user
 
@@ -19,8 +19,8 @@ By default, Netdata runs as `root`. To run it as the `netdata` user instead:
     - Assign it to the netdata group
     - Set a random password
     - Grant no access permission
-    
-    or alternatively from the CLI.
+
+   or alternatively from the CLI:
     ```sh
     sudo synouser --add netdata <SomeGoodPassword> "netdata agent" 0 "" 0
     sudo synogroup --add netdata netdata


### PR DESCRIPTION
My previous change was not correct.

Actually the kickstart install failed to create the `netdata` user and group, thus it has to be created manually

##### Summary

move the section about creating the `netdata` user/group first section of the page.
also add CLI commands to create user/group


##### Test Plan
##### Additional Information