### PR TITLE
agent-events: add deduplicating web server

### DIFF
--- a/packaging/tools/agent-events/.gitignore
+++ b/packaging/tools/agent-events/.gitignore
@@ -1,1 +1,3 @@
 server
+go.mod
+go.sum

--- a/packaging/tools/agent-events/build.sh
+++ b/packaging/tools/agent-events/build.sh
@@ -1,3 +1,26 @@
 #!/bin/sh
 
-go build server.go
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Optional: Clean slate - remove existing module files
+test -f "go.mod" && rm -f go.mod
+test -f "go.sum" && rm -f go.sum
+
+# 1. Initialize the Go module
+echo "Initializing Go module..."
+go mod init server
+
+# 2. Tidy dependencies
+echo "Tidying dependencies..."
+go mod tidy
+
+# 3. Build the main server executable using '.' for current package
+echo "Building server executable..."
+go build -o ./server .
+
+# 4. Run the unit tests
+echo "Running unit tests..."
+go test -v
+
+echo "Build and test script finished."

--- a/packaging/tools/agent-events/run.sh
+++ b/packaging/tools/agent-events/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-stdbuf -oL /opt/agent-events/server --port=30001 2>/dev/null \
+stdbuf -oL /opt/agent-events/server --port=30001 --dedup-key agent.ephemeral_id --dedup-window 1800 2>/dev/null \
 	| stdbuf -oL log2journal json \
 		--prefix 'AE_' \
 		--inject 'SYSLOG_IDENTIFIER=agent-events' \

--- a/packaging/tools/agent-events/server.go
+++ b/packaging/tools/agent-events/server.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -8,50 +11,237 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
+	"time"
+
+	"github.com/tidwall/gjson"
 )
 
-func handler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
-		log.Printf("Method not allowed: %s\n", r.Method)
-		return
+// --- Constants ---
+const (
+	maxRequestBodySize = 20 * 1024 // 20 KiB
+)
+
+// --- Custom Flag Type for Multi-use --dedup-key ---
+type dedupPaths []string
+
+func (d *dedupPaths) String() string { return fmt.Sprintf("%v", *d) }
+func (d *dedupPaths) Set(value string) error {
+	if value == "" {
+		return fmt.Errorf("dedup-key path cannot be empty")
+	}
+	*d = append(*d, value)
+	return nil
+}
+
+// --- Global variables ---
+var (
+	seenIDs        map[[32]byte]seenEntry
+	mapMutex       = &sync.Mutex{}
+	dedupWindow    time.Duration
+	debugMode      bool
+	keyPaths       dedupPaths
+	dedupSeparator string
+)
+
+// --- Data Structures ---
+type seenEntry struct {
+	timestamp time.Time
+}
+
+// --- Core Logic Functions ---
+
+// checkAndRecordHash accepts the SHA256 hash ([32]byte) for checking.
+// It now REFRESHES the timestamp whenever a hash is found,
+// effectively creating a sliding deduplication window.
+func checkAndRecordHash(hash [32]byte) bool {
+	now := time.Now()
+	mapMutex.Lock()
+	defer mapMutex.Unlock()
+
+	var zeroHash [32]byte
+	if hash == zeroHash {
+		log.Println("Warning: checkAndRecordHash received potentially zero hash.")
+		// Decide if zero hash should always be discarded, e.g. return false
 	}
 
-	// Read the entire request body.
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, "Error reading request", http.StatusInternalServerError)
-		log.Printf("Error reading request: %v\n", err)
-		return
-	}
-	defer r.Body.Close()
+	// Check if the hash exists in the map
+	entry, found := seenIDs[hash]
 
-	// Remove all newline characters.
-	cleaned := strings.ReplaceAll(string(body), "\n", "")
-	cleaned = strings.ReplaceAll(cleaned, "\r", "")
+	if found {
+		// --- Hash Found ---
+		// Check if it was a duplicate based on the *previous* timestamp
+		isRecentDuplicate := now.Sub(entry.timestamp) < dedupWindow
 
-	// Write to stdout with a single newline at the end.
-	fmt.Println(cleaned)
+		// *** Always update the timestamp to 'now' to refresh the window ***
+		seenIDs[hash] = seenEntry{timestamp: now}
 
-	// Respond with OK.
-	if _, err := w.Write([]byte("OK")); err != nil {
-		log.Printf("Error writing response: %v\n", err)
-		return
+		// Return 'false' if it was a recent duplicate (suppress processing),
+		// return 'true' if it was found but expired (allow processing).
+		return !isRecentDuplicate
+
+	} else {
+		// --- Hash Not Found ---
+		// Record the new hash with the current timestamp
+		seenIDs[hash] = seenEntry{timestamp: now}
+		// Return 'true' as this is the first time (or first time after expiry)
+		return true
 	}
 }
 
+
+// cleanupExpiredEntries uses the hash ([32]byte) as the key type.
+func cleanupExpiredEntries(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	cleanedCount := 0
+	lastCleanupLogTime := time.Now()
+	for range ticker.C {
+		mapMutex.Lock()
+		now := time.Now()
+		for h, entry := range seenIDs {
+			if now.Sub(entry.timestamp) >= dedupWindow {
+				delete(seenIDs, h)
+				cleanedCount++
+			}
+		}
+		mapMutex.Unlock()
+		// Simplified periodic logging for cleanup
+		if cleanedCount > 0 && time.Since(lastCleanupLogTime) > time.Hour {
+			if debugMode {
+				log.Printf("Debug: Cleaned up %d expired entries in the past hour.", cleanedCount)
+			}
+			cleanedCount = 0 // Reset count after logging
+			lastCleanupLogTime = time.Now()
+		}
+	}
+}
+
+// --- HTTP Handler ---
+func handler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		log.Printf("Discarded: Method not allowed (%s) from %s", r.Method, r.RemoteAddr)
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			http.Error(w, fmt.Sprintf("Request body exceeds limit (%d bytes)", maxRequestBodySize), http.StatusRequestEntityTooLarge)
+			log.Printf("Discarded: Request body too large (limit %d bytes) from %s", maxRequestBodySize, r.RemoteAddr)
+		} else {
+			http.Error(w, "Error reading request", http.StatusInternalServerError)
+			log.Printf("Discarded: Error reading request body: %v", err)
+		}
+		return
+	}
+
+	shouldProcess := true
+	if len(keyPaths) > 0 {
+		var keyBuilder strings.Builder
+		for i, path := range keyPaths {
+			result := gjson.GetBytes(body, path)
+			var valueStr string
+			if result.Exists() { valueStr = result.String() } else { valueStr = "" }
+			keyBuilder.WriteString(valueStr)
+			if i < len(keyPaths)-1 { keyBuilder.WriteString(dedupSeparator) }
+		}
+		finalKeyString := keyBuilder.String()
+		dedupHash := sha256.Sum256([]byte(finalKeyString))
+		if debugMode {
+			log.Printf("Debug: Generated dedup key string: \"%s\"", finalKeyString)
+			log.Printf("Debug: Generated dedup hash: %x", dedupHash)
+		}
+
+		// Call the updated checkAndRecordHash function
+		if !checkAndRecordHash(dedupHash) {
+			// It was determined to be a duplicate (based on previous timestamp)
+			shouldProcess = false
+			if debugMode { log.Printf("Debug: Discarded duplicate hash: %x (timestamp refreshed)", dedupHash) } // Updated log message
+			// Respond OK for duplicate and stop processing
+			if _, err := w.Write([]byte("OK")); err != nil { log.Printf("Error writing response after duplicate discard: %v", err) }
+			return // Exit handler early for duplicates
+		}
+		// If we reach here, it was not a recent duplicate (new or expired)
+	} else {
+		if debugMode { log.Println("Debug: No --dedup-key flags provided, skipping deduplication.") }
+	}
+
+	if shouldProcess {
+		var fullData interface{}
+		if err := json.Unmarshal(body, &fullData); err != nil {
+			http.Error(w, "Invalid JSON for full parsing", http.StatusBadRequest)
+			bodyDetail := ""
+			if debugMode { bodyDetail = fmt.Sprintf(", Body: %s", string(body)) } else { bodyDetail = fmt.Sprintf(", Body snippet: %s", limitString(string(body), 100)) }
+			log.Printf("Discarded: Failed to fully parse JSON (post-dedup): %v%s", err, bodyDetail)
+			return
+		}
+		outputBytes, err := json.Marshal(fullData)
+		if err != nil {
+			http.Error(w, "Internal Server Error during output marshal", http.StatusInternalServerError)
+			log.Printf("Discarded: Failed to marshal JSON for output: %v", err)
+			return
+		}
+		fmt.Println(string(outputBytes))
+		if _, err := w.Write([]byte("OK")); err != nil { log.Printf("Error writing OK response: %v", err) }
+	}
+}
+
+// --- Main Function ---
 func main() {
-	// Configure logging to write to stderr.
 	log.SetOutput(os.Stderr)
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
-	// Parse the port from the command line.
+	// --- Command Line Flags ---
 	port := flag.Int("port", 8080, "Port to listen on")
+	dedupSeconds := flag.Int("dedup-window", 1800, "Deduplication window in seconds (e.g., 1800 for 30 minutes)")
+	flag.BoolVar(&debugMode, "debug", false, "Enable debug mode for verbose logging")
+	flag.Var(&keyPaths, "dedup-key", "JSON path (dot-notation) for deduplication key (can be used multiple times)")
+	flag.StringVar(&dedupSeparator, "dedup-separator", "-", "Separator used between values from multiple --dedup-key paths")
 	flag.Parse()
 
-	http.HandleFunc("/", handler)
-	log.Printf("Server listening on port %d\n", *port)
-	if err := http.ListenAndServe(fmt.Sprintf(":%d", *port), nil); err != nil {
-		log.Fatalf("Server failed: %v\n", err)
+	seenIDs = make(map[[32]byte]seenEntry)
+	dedupWindow = time.Duration(*dedupSeconds) * time.Second
+
+	if dedupWindow > 0 && len(keyPaths) > 0 {
+		cleanupInterval := dedupWindow / 10
+		if cleanupInterval < 1*time.Minute { cleanupInterval = 1 * time.Minute } else if cleanupInterval > 15*time.Minute { cleanupInterval = 15 * time.Minute }
+		log.Printf("Cleanup goroutine started. Interval: %v", cleanupInterval)
+		go cleanupExpiredEntries(cleanupInterval)
+	} else if dedupWindow <= 0 && len(keyPaths) > 0 {
+        log.Println("Warning: Deduplication keys provided, but window is zero or negative. Deduplication effectively disabled.")
+    }
+
+	// --- Configure HTTP Server ---
+	readTimeout := 10 * time.Second
+	writeTimeout := 10 * time.Second
+	idleTimeout := 60 * time.Second
+	server := &http.Server{
+		Addr:         fmt.Sprintf(":%d", *port),
+		Handler:      http.DefaultServeMux,
+		ReadTimeout:  readTimeout,
+		WriteTimeout: writeTimeout,
+		IdleTimeout:  idleTimeout,
 	}
+	http.HandleFunc("/", handler)
+
+	// --- Start Server ---
+	log.Printf("Server listening on port %d", *port)
+	log.Printf("Maximum request body size: %d bytes", maxRequestBodySize)
+	if len(keyPaths) > 0 {
+		log.Printf("Deduplication enabled: Keys=%v, Separator='%s', Window=%v (Sliding window: timestamp refreshed on duplicate)", keyPaths, dedupSeparator, dedupWindow) // Updated log message
+	} else {
+		log.Println("Deduplication disabled (no --dedup-key specified).")
+	}
+	log.Printf("Debug mode enabled: %t", debugMode)
+	log.Printf("Server timeouts -> Read: %v, Write: %v, Idle: %v", readTimeout, writeTimeout, idleTimeout)
+	log.Fatal(server.ListenAndServe())
+}
+
+// --- Helper Functions ---
+func limitString(s string, maxLen int) string {
+	if len(s) <= maxLen { return s }
+	return s[:maxLen] + "..."
 }

--- a/packaging/tools/agent-events/server_test.go
+++ b/packaging/tools/agent-events/server_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Helper function to capture stdout/stderr during a test run
+func captureOutput(t *testing.T, f func()) (stdout, stderr string) {
+	t.Helper() // Marks this as a helper function for testing framework
+
+	originalStdout := os.Stdout
+	originalStderr := os.Stderr
+	originalLogOutput := log.Writer() // Get current log output writer
+
+	// Create pipes to capture output
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+
+	// Redirect stdout and stderr
+	os.Stdout = wOut
+	os.Stderr = wErr
+	log.SetOutput(wErr) // Redirect default logger to stderr pipe
+
+	// Use t.Cleanup to ensure restoration even if the test panics
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		os.Stderr = originalStderr
+		log.SetOutput(originalLogOutput) // Restore original log output
+	})
+
+	// Channels to signal when reading is done
+	outCh := make(chan string)
+	errCh := make(chan string)
+
+	// Goroutine to read stdout
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, rOut)
+		outCh <- buf.String()
+	}()
+
+	// Goroutine to read stderr
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, rErr)
+		errCh <- buf.String()
+	}()
+
+	// --- Execute the function under test ---
+	f()
+	// ---                                ---
+
+	// Close the writers to signal EOF to the readers
+	_ = wOut.Close()
+	_ = wErr.Close()
+
+	// Read captured output
+	stdout = <-outCh
+	stderr = <-errCh
+
+	// Optional: Print captured output via test logger if needed for debugging
+	// t.Logf("Captured Stdout:\n%s", stdout)
+	// t.Logf("Captured Stderr:\n%s", stderr)
+
+	return stdout, stderr
+}
+
+// --- Test Suite ---
+
+func TestHandler(t *testing.T) {
+	// --- Test Setup ---
+	// Configure global variables for the tests
+	keyPaths = []string{"id"} // Simple dedup key for testing
+	dedupSeparator = "-"
+	dedupWindow = 30 * time.Second // Use a reasonable window for tests
+	debugMode = false              // Start with debug off, can enable per test case
+
+	// Ensure the map is initialized and clean before starting tests
+	mapMutex.Lock()
+	seenIDs = make(map[[32]byte]seenEntry)
+	mapMutex.Unlock()
+
+	// Helper to reset state between sub-tests
+	resetState := func() {
+		mapMutex.Lock()
+		seenIDs = make(map[[32]byte]seenEntry) // Clear the map
+		mapMutex.Unlock()
+		keyPaths = []string{"id"} // Reset paths just in case
+		debugMode = false
+		// Reset other globals if they were modified
+	}
+
+	// --- Test Cases ---
+
+	t.Run("FirstValidRequest", func(t *testing.T) {
+		t.Cleanup(resetState) // Ensure state is reset after this sub-test
+
+		// Prepare request
+		jsonBody := `{"id": "uuid-1", "data": "value1"}`
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(jsonBody))
+		rr := httptest.NewRecorder() // Records the HTTP response
+
+		// Execute handler and capture output
+		stdout, stderr := captureOutput(t, func() {
+			handler(rr, req)
+		})
+
+		// Assertions
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+		}
+		expectedResponse := `OK`
+		if rr.Body.String() != expectedResponse {
+			t.Errorf("handler returned unexpected body: got %v want %v", rr.Body.String(), expectedResponse)
+		}
+		// Check stdout contains the *exact* JSON (json.Marshal might reorder fields)
+		// A simpler check is that it's not empty and maybe contains key parts.
+		// For exact match, we'd need to unmarshal stdout and compare.
+		if !strings.Contains(stdout, `"id":"uuid-1"`) || !strings.Contains(stdout, `"data":"value1"`) {
+			t.Errorf("handler produced unexpected stdout:\ngot: %q\nwant it to contain parts of: %q", stdout, jsonBody)
+		}
+		if stderr != "" {
+			t.Errorf("handler produced unexpected stderr: got %q want empty", stderr)
+		}
+
+		// Check internal state (optional, needs mutex)
+		mapMutex.Lock()
+		if len(seenIDs) != 1 {
+			t.Errorf("expected 1 entry in seenIDs map, got %d", len(seenIDs))
+		}
+		mapMutex.Unlock()
+	})
+
+	t.Run("DuplicateRequestWithinWindow", func(t *testing.T) {
+		t.Cleanup(resetState)
+
+		// --- Setup: Simulate the first request having happened ---
+		firstJsonBody := `{"id": "uuid-2", "data": "value2"}`
+		firstReq := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(firstJsonBody))
+		firstRr := httptest.NewRecorder()
+		// Run handler once, ignore output for this setup run
+		captureOutput(t, func() { handler(firstRr, firstReq) })
+		if firstRr.Code != http.StatusOK {
+			t.Fatalf("Setup failed: first request did not return OK")
+		}
+		// Verify setup placed item in map
+		mapMutex.Lock()
+		if len(seenIDs) != 1 {
+			t.Fatalf("Setup failed: map size not 1 after first request")
+		}
+		mapMutex.Unlock()
+		// --- End Setup ---
+
+
+		// Prepare the duplicate request
+		// Note: Using the *same* body string as the first request
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(firstJsonBody))
+		rr := httptest.NewRecorder()
+
+		// Execute handler and capture output
+		stdout, stderr := captureOutput(t, func() {
+			handler(rr, req)
+		})
+
+		// Assertions
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code for duplicate: got %v want %v", status, http.StatusOK)
+		}
+		expectedResponse := `OK`
+		if rr.Body.String() != expectedResponse {
+			t.Errorf("handler returned unexpected body for duplicate: got %v want %v", rr.Body.String(), expectedResponse)
+		}
+		// Stdout should be empty for a duplicate
+		if stdout != "" {
+			t.Errorf("handler produced unexpected stdout for duplicate: got %q want empty", stdout)
+		}
+		// Stderr should be empty (unless debug mode logs duplicates)
+		if stderr != "" {
+			t.Errorf("handler produced unexpected stderr for duplicate: got %q want empty", stderr)
+		}
+        // Map size should remain 1
+        mapMutex.Lock()
+		if len(seenIDs) != 1 {
+			t.Errorf("expected 1 entry in seenIDs map after duplicate, got %d", len(seenIDs))
+		}
+		mapMutex.Unlock()
+	})
+
+	t.Run("InvalidJSON", func(t *testing.T) {
+		t.Cleanup(resetState)
+
+		// Prepare request
+		jsonBody := `{"id": "uuid-3", "data":` // Invalid JSON
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(jsonBody))
+		rr := httptest.NewRecorder()
+
+		// Execute handler and capture output
+		stdout, stderr := captureOutput(t, func() {
+			handler(rr, req)
+		})
+
+		// Assertions
+		if status := rr.Code; status != http.StatusBadRequest {
+			t.Errorf("handler returned wrong status code for invalid JSON: got %v want %v", status, http.StatusBadRequest)
+		}
+		// Stdout should be empty
+		if stdout != "" {
+			t.Errorf("handler produced unexpected stdout for invalid JSON: got %q want empty", stdout)
+		}
+		// Stderr should contain the parsing error log message
+		if !strings.Contains(stderr, "Failed to fully parse JSON") {
+			t.Errorf("handler did not produce expected stderr log for invalid JSON: got %q", stderr)
+		}
+	})
+
+    t.Run("MissingDedupKey", func(t *testing.T) {
+        t.Cleanup(resetState)
+
+		// Prepare request - JSON is valid but missing the 'id' field used by keyPaths
+		jsonBody := `{"other_id": "uuid-4", "data": "value4"}`
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(jsonBody))
+		rr := httptest.NewRecorder()
+
+		// Execute handler and capture output
+		stdout, stderr := captureOutput(t, func() {
+			handler(rr, req)
+		})
+
+		// Assertions for missing key (results in empty string "" for the key part)
+		// This *should* be processed correctly, as "" is a valid key string before hashing
+        // The hash of "" will be deduplicated like any other hash.
+
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code for missing key: got %v want %v", status, http.StatusOK)
+		}
+        // Stdout should contain the JSON
+        if !strings.Contains(stdout, `"other_id":"uuid-4"`) || !strings.Contains(stdout, `"data":"value4"`) {
+			t.Errorf("handler produced unexpected stdout for missing key:\ngot: %q\nwant it to contain parts of: %q", stdout, jsonBody)
+		}
+		if stderr != "" {
+			t.Errorf("handler produced unexpected stderr for missing key: got %q want empty", stderr)
+		}
+        // Check map (hash of "" should be present)
+        mapMutex.Lock()
+		if len(seenIDs) != 1 {
+			t.Errorf("expected 1 entry in seenIDs map for missing key, got %d", len(seenIDs))
+		}
+		mapMutex.Unlock()
+	})
+
+	// Add more test cases: Wrong method (GET), expired duplicate, multiple dedup keys, etc.
+}


### PR DESCRIPTION
The key problem is duplicate requests received from cloudflare.
Now the web server uses the ephemeral_id of the JSON object to deduplicate requests received. It caches hashes of it for 30min.