### PR TITLE
Properly clean up install paths after runtime checks in static builds.

### DIFF
--- a/packaging/makeself/jobs/81-netdata-runtime-check.sh
+++ b/packaging/makeself/jobs/81-netdata-runtime-check.sh
@@ -26,5 +26,7 @@ fi
 
 trap - EXIT
 
+run rm -rv "${NETDATA_INSTALL_PATH}/var/lib/netdata" "${NETDATA_INSTALL_PATH}/var/cache/netdata"
+
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::endgroup::" || true


### PR DESCRIPTION
##### Summary

Prevent the contents of `/var/lib/netdata` and `/var/cache/netdata` from leaking from the CI environment to the install image.

##### Test Plan

Requires manual testing to confirm 