### PR TITLE
trim-all

### DIFF
--- a/src/collectors/windows-events.plugin/windows-events-sources.c
+++ b/src/collectors/windows-events.plugin/windows-events-sources.c
@@ -580,8 +580,9 @@ void wevt_sources_scan(void) {
                 char buf[sizeof(WEVT_SOURCE_ALL_OF_PROVIDER_PREFIX) + strlen(provider)]; // sizeof() includes terminator
                 snprintf(buf, sizeof(buf), WEVT_SOURCE_ALL_OF_PROVIDER_PREFIX "%s", provider);
 
-                if(trim_all(buf) != NULL) {
-                    for (size_t i = 0; i < sizeof(buf) - 1; i++) {
+                trim_all(buf);
+                if(buf[0]) {
+                    for (size_t i = 0; i < sizeof(buf) - 1 && buf[i]; i++) {
                         // remove character that may interfere with our parsing
                         if (isspace((uint8_t) buf[i]) || buf[i] == '%' || buf[i] == '+' || buf[i] == '|' || buf[i] == ':')
                             buf[i] = '_';

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -127,11 +127,7 @@ static void dmi_info(const char *file, const char *alt, char *dst, size_t dst_si
         return;
     }
 
-    char *s = trim_all(dst);
-    if(!s || !*s)
-        dst[0] = '\0';
-    else if(s != dst)
-        memmove(dst, s, strlen(s) + 1);
+    trim_all(dst);
 
     struct {
         const char *found;
@@ -145,10 +141,12 @@ static void dmi_info(const char *file, const char *alt, char *dst, size_t dst_si
         {"System UUID", ""},
     };
 
-    for(size_t i = 0; i < _countof(replacements) ;i++) {
-        if(strcasecmp(dst, replacements[i].found) == 0) {
-            strncpyz(dst, replacements[i].replace, dst_size - 1);
-            break;
+    if(dst[0]) {
+        for (size_t i = 0; i < _countof(replacements); i++) {
+            if (strcasecmp(dst, replacements[i].found) == 0) {
+                strncpyz(dst, replacements[i].replace, dst_size - 1);
+                break;
+            }
         }
     }
 }

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -128,7 +128,7 @@ static void dmi_info(const char *file, const char *alt, char *dst, size_t dst_si
     }
 
     char *s = trim_all(dst);
-    if(!s)
+    if(!s || !*s)
         dst[0] = '\0';
     else if(s != dst)
         memmove(dst, s, strlen(s) + 1);

--- a/src/health/health_config.c
+++ b/src/health/health_config.c
@@ -622,7 +622,7 @@ int health_readfile(const char *filename, void *data __maybe_unused, bool stock_
         key = trim_all(key);
         value = trim_all(value);
 
-        if(!key) {
+        if(!key || !*key) {
             netdata_log_error(
                 "Health configuration has invalid line %zu of file '%s'. Keyword is empty. Ignoring it.",
                 line, filename);
@@ -630,7 +630,7 @@ int health_readfile(const char *filename, void *data __maybe_unused, bool stock_
             continue;
         }
 
-        if(!value) {
+        if(!value || !*value) {
             netdata_log_error(
                 "Health configuration has invalid line %zu of file '%s'. value is empty. Ignoring it.",
                 line, filename);

--- a/src/libnetdata/inlined.h
+++ b/src/libnetdata/inlined.h
@@ -687,16 +687,18 @@ static inline char *trim(char *s) {
     return s;
 }
 
-// like trim(), but also remove duplicate spaces inside the string; may return NULL
+// like trim(), but also remove duplicate spaces inside the string
 static inline char *trim_all(char *buffer) {
     char *d = buffer, *s = buffer;
 
     // skip spaces
-    while(isspace((uint8_t)*s)) s++;
+    while(isspace((uint8_t)*s))
+        s++;
 
     while(*s) {
         // copy the non-space part
-        while(*s && !isspace((uint8_t)*s)) *d++ = *s++;
+        while(*s && !isspace((uint8_t)*s))
+            *d++ = *s++;
 
         // add a space if we have to
         if(*s && isspace((uint8_t)*s)) {
@@ -715,7 +717,6 @@ static inline char *trim_all(char *buffer) {
         if(isspace((uint8_t)*d)) *d = '\0';
     }
 
-    if(!buffer[0]) return NULL;
     return buffer;
 }
 

--- a/src/libnetdata/parsers/timeframe.c
+++ b/src/libnetdata/parsers/timeframe.c
@@ -12,7 +12,7 @@ TIMEFRAME timeframe_parse(const char *txt) {
 char buf[strlen(txt) + 1];
 memcpy(buf, txt, strlen(txt) + 1);
 char *s = trim_all(buf);
-if(!s)
+if(!s || !*s)
     return TIMEFRAME_INVALID;
 
 while(isspace(*s)) s++;


### PR DESCRIPTION
`trim_all()` should never return NULL, as this is error prone.