### PR TITLE
Fix ACLK synchronization fatal on shutdown

### DIFF
--- a/src/daemon/libuv_workers.c
+++ b/src/daemon/libuv_workers.c
@@ -128,3 +128,14 @@ int create_uv_thread(uv_thread_t *thread, uv_thread_cb thread_func, void *arg, i
 
     return err;
 }
+
+void libuv_close_callback(uv_handle_t *handle, void *data __maybe_unused)
+{
+    // Only close handles that aren't already closing
+    if (!uv_is_closing(handle)) {
+        if (handle->type == UV_TIMER) {
+            uv_timer_stop((uv_timer_t *)handle);
+        }
+        uv_close(handle, NULL);
+    }
+}

--- a/src/daemon/libuv_workers.h
+++ b/src/daemon/libuv_workers.h
@@ -89,5 +89,6 @@ enum event_loop_job {
 
 void register_libuv_worker_jobs();
 int create_uv_thread(uv_thread_t *thread, uv_thread_cb thread_func, void *arg, int *retries);
+void libuv_close_callback(uv_handle_t *handle, void *data __maybe_unused);
 
 #endif //NETDATA_EVENT_LOOP_H

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -942,8 +942,7 @@ void create_aclk_config(RRDHOST *host __maybe_unused, nd_uuid_t *host_uuid __may
 
 void destroy_aclk_config(RRDHOST *host)
 {
-    struct aclk_sync_cfg_t *ahc;
-    if (!host || !(ahc = host->aclk_config))
+    if (!host || !host->aclk_config)
         return;
 
     freez(host->aclk_config);

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -949,7 +949,6 @@ void destroy_aclk_config(RRDHOST *host)
     if (ahc->timer_initialized) {
         if (uv_is_active((uv_handle_t *)&ahc->timer))
             uv_timer_stop(&ahc->timer);
-        uv_close((uv_handle_t *)&ahc->timer, NULL);
     }
 
     freez(host->aclk_config);

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -946,11 +946,6 @@ void destroy_aclk_config(RRDHOST *host)
     if (!host || !(ahc = host->aclk_config))
         return;
 
-//    if (ahc->timer_initialized) {
-//        if (uv_is_active((uv_handle_t *)&ahc->timer))
-//            uv_timer_stop(&ahc->timer);
-//    }
-
     freez(host->aclk_config);
     host->aclk_config = NULL;
 }

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -946,10 +946,10 @@ void destroy_aclk_config(RRDHOST *host)
     if (!host || !(ahc = host->aclk_config))
         return;
 
-    if (ahc->timer_initialized) {
-        if (uv_is_active((uv_handle_t *)&ahc->timer))
-            uv_timer_stop(&ahc->timer);
-    }
+//    if (ahc->timer_initialized) {
+//        if (uv_is_active((uv_handle_t *)&ahc->timer))
+//            uv_timer_stop(&ahc->timer);
+//    }
 
     freez(host->aclk_config);
     host->aclk_config = NULL;

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -528,15 +528,6 @@ static void node_update_timer_cb(uv_timer_t *handle)
         uv_timer_stop(&ahc->timer);
 }
 
-static void close_callback(uv_handle_t *handle, void *data __maybe_unused)
-{
-    if (handle->type == UV_TIMER) {
-        uv_timer_stop((uv_timer_t *)handle);
-    }
-
-    uv_close(handle, NULL);  // Automatically close and free the handle
-}
-
 static void after_start_alert_push(uv_work_t *req, int status __maybe_unused)
 {
     struct worker_data *data = req->data;
@@ -881,9 +872,7 @@ static void aclk_synchronization_event_loop(void *arg)
         uv_close((uv_handle_t *)&config->timer_req, NULL);
 
     uv_close((uv_handle_t *)&config->async, NULL);
-    uv_run(loop, UV_RUN_NOWAIT);
-
-    uv_walk(loop, (uv_walk_cb) close_callback, NULL);
+    uv_walk(loop, libuv_close_callback, NULL);
     uv_run(loop, UV_RUN_NOWAIT);
 
     (void) uv_loop_close(loop);

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2471,7 +2471,7 @@ static void start_metadata_hosts(uv_work_t *req)
 
 
     COMPUTE_DURATION(report_duration, "us", all_started_ut, now_monotonic_usec());
-    nd_log_daemon(NDLP_DEBUG, "Checking all hosts completed in %s", report_duration);
+    nd_log_daemon(NDLP_DEBUG, "Checking all hots completed in %s", report_duration);
 
     do_pending_uuid_deletion(wc, (struct judy_list_t *)data->pending_uuid_deletion);
 
@@ -2479,15 +2479,6 @@ static void start_metadata_hosts(uv_work_t *req)
 
     wc->metadata_check_after = now_realtime_sec() + METADATA_HOST_CHECK_INTERVAL;
     worker_is_idle();
-}
-
-static void close_callback(uv_handle_t *handle, void *data __maybe_unused)
-{
-    if (handle->type == UV_TIMER) {
-        uv_timer_stop((uv_timer_t *)handle);
-    }
-
-    uv_close(handle, NULL);  // Automatically close and free the handle
 }
 
 #define EVENT_LOOP_NAME "METASYNC"
@@ -2695,7 +2686,7 @@ static void metadata_event_loop(void *arg)
     }
     config->initialized = false;
 
-    uv_walk(loop, (uv_walk_cb) close_callback, NULL);
+    uv_walk(loop, libuv_close_callback, NULL);
     uv_run(loop, UV_RUN_NOWAIT);
 
     int rc;

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2471,7 +2471,7 @@ static void start_metadata_hosts(uv_work_t *req)
 
 
     COMPUTE_DURATION(report_duration, "us", all_started_ut, now_monotonic_usec());
-    nd_log_daemon(NDLP_DEBUG, "Checking all hots completed in %s", report_duration);
+    nd_log_daemon(NDLP_DEBUG, "Checking all hosts completed in %s", report_duration);
 
     do_pending_uuid_deletion(wc, (struct judy_list_t *)data->pending_uuid_deletion);
 


### PR DESCRIPTION
##### Summary
- Add a close callback to improve handle management and replace duplicate code
- Check if the handle is closing before attempting a close otherwise this can lead to a crash
