### PR TITLE
Update netdata-updater-daily.in

### DIFF
--- a/system/cron/netdata-updater-daily.in
+++ b/system/cron/netdata-updater-daily.in
@@ -1,1 +1,1 @@
-2 57 * * * root @pkglibexecdir_POST@/netdata-updater.sh
+57 2 * * * root @pkglibexecdir_POST@/netdata-updater.sh


### PR DESCRIPTION
bugfix: swap hour and minute in cron job for netdata-updater.sh

##### Summary

The command `sudo install -p -m 0644 -o 0 -g 0 "/opt/netdata/usr/lib/netdata/system/cron/netdata-updater-daily" "/etc/cron.d/netdata-updater"` resulted in a file that had a syntax error due to the incorrect order of hour and minute values (2 57 instead of 57 2). This fix addresses the issue by swapping the values to correct the syntax.

##### Test Plan

1. Run the command `sudo install -p -m 0644 -o 0 -g 0 "/opt/netdata/usr/lib/netdata/system/cron/netdata-updater-daily" "/etc/cron.d/netdata-updater"` to create the cron job file. 
2. Observe the resulting file and verify it has the correct syntax:

- Expected output: `57 2 * * * root /opt/netdata/usr/libexec/netdata/netdata-updater.sh`
- Verify that the hour and minute values are in the correct order (57 2 instead of 2 57)

