### PR TITLE
skip our signal handler from stack traces

### DIFF
--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -47,6 +47,7 @@ static struct {
 static void (*original_handlers[NSIG])(int) = {0};
 static void (*original_sigactions[NSIG])(int, siginfo_t *, void *) = {0};
 
+NEVER_INLINE
 void nd_signal_handler(int signo, siginfo_t *info, void *context __maybe_unused) {
 
     for(size_t i = 0; i < _countof(signals_waiting) ; i++) {
@@ -71,7 +72,8 @@ void nd_signal_handler(int signo, siginfo_t *info, void *context __maybe_unused)
             if (info && (signo == SIGSEGV || signo == SIGBUS || signo == SIGILL || signo == SIGFPE))
                 fault_address = info->si_addr;
 
-            if(daemon_status_file_deadly_signal_received(signals_waiting[i].reason, sc, fault_address, chained_handler)) {
+            // Tell daemon_status_file_deadly_signal_received to skip the nd_signal_handler frame
+            if(daemon_status_file_deadly_signal_received(signals_waiting[i].reason, sc, fault_address, chained_handler, 1)) {
                 // this is a duplicate event, do not send it to sentry
 #ifdef ENABLE_SENTRY
                 nd_sentry_crash_report(false);

--- a/src/daemon/status-file.h
+++ b/src/daemon/status-file.h
@@ -146,7 +146,8 @@ typedef struct daemon_status_file {
 void daemon_status_file_update_status(DAEMON_STATUS status);
 
 // returns true when the event is duplicate and should not be reported again
-bool daemon_status_file_deadly_signal_received(EXIT_REASON reason, SIGNAL_CODE code, void *fault_address, bool chained_handler);
+NEVER_INLINE
+bool daemon_status_file_deadly_signal_received(EXIT_REASON reason, SIGNAL_CODE code, void *fault_address, bool chained_handler, int skip_frames);
 
 // check for a crash
 void daemon_status_file_check_crash(void);

--- a/src/libnetdata/log/nd_log.h
+++ b/src/libnetdata/log/nd_log.h
@@ -33,7 +33,8 @@ const char *nd_log_id2priority(ND_LOG_FIELD_PRIORITY priority);
 const char *nd_log_method_for_external_plugins(const char *s);
 ND_UUID nd_log_get_invocation_id(void);
 
-void capture_stack_trace(BUFFER *wb);
+NEVER_INLINE
+void capture_stack_trace(BUFFER *wb, int skip_frames);
 void capture_stack_trace_init(void);
 void capture_stack_trace_flush(void);
 bool capture_stack_trace_available(void);


### PR DESCRIPTION
I am still experiments in an alternative way to do this.