### PR TITLE
daemon status 26d

### DIFF
--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -47,6 +47,7 @@ static struct {
 static void (*original_handlers[NSIG])(int) = {0};
 static void (*original_sigactions[NSIG])(int, siginfo_t *, void *) = {0};
 
+NEVER_INLINE
 void nd_signal_handler(int signo, siginfo_t *info, void *context __maybe_unused) {
 
     for(size_t i = 0; i < _countof(signals_waiting) ; i++) {
@@ -209,6 +210,7 @@ void nd_initialize_signals(bool chain_existing) {
     }
 }
 
+NEVER_INLINE
 static void process_triggered_signals(void) {
     size_t found;
     do {
@@ -267,6 +269,7 @@ static inline bool threshold_trigger_smaller(bool *last, double threshold, doubl
     return !triggered && *last;
 }
 
+NEVER_INLINE
 void nd_process_signals(void) {
     posix_unmask_my_signals();
     const usec_t save_every_ut = 15 * 60 * USEC_PER_SEC;

--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -168,6 +168,9 @@ void nd_cleanup_deadly_signals(void) {
 
 void nd_initialize_signals(bool chain_existing) {
     signals_block_all_except_deadly();
+    
+    // Set the signal handler name for stack trace filtering
+    capture_stack_trace_set_signal_handler_function("nd_signal_handler");
 
     struct sigaction act;
     memset(&act, 0, sizeof(struct sigaction));

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -1156,6 +1156,7 @@ static void daemon_status_file_save_twice_if_we_can_get_stack_trace(BUFFER *wb, 
         return;
 
     buffer_flush(wb);
+    
     capture_stack_trace(wb);
 
     if(buffer_strlen(wb) > 0) {

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -1140,6 +1140,7 @@ void daemon_status_file_check_crash(void) {
     }
 }
 
+NEVER_INLINE
 static void daemon_status_file_save_twice_if_we_can_get_stack_trace(BUFFER *wb, DAEMON_STATUS_FILE *ds, bool force) {
     // IMPORTANT: NO LOCKS OR ALLOCATIONS HERE, THIS FUNCTION IS CALLED FROM SIGNAL HANDLERS
     // THIS FUNCTION MUST USE ONLY ASYNC-SIGNAL-SAFE OPERATIONS
@@ -1179,6 +1180,7 @@ static void daemon_status_file_save_twice_if_we_can_get_stack_trace(BUFFER *wb, 
 // --------------------------------------------------------------------------------------------------------------------
 // ng_log() hook for receiving fatal message information
 
+NEVER_INLINE
 void daemon_status_file_register_fatal(const char *filename, const char *function, const char *message, const char *errno_str, const char *stack_trace, long line) {
     FUNCTION_RUN_ONCE();
 
@@ -1257,6 +1259,7 @@ static void daemon_status_file_out_of_memory(void) {
     daemon_status_file_save_twice_if_we_can_get_stack_trace(static_save_buffer, &session_status, true);
 }
 
+NEVER_INLINE
 bool daemon_status_file_deadly_signal_received(EXIT_REASON reason, SIGNAL_CODE code, void *fault_address, bool chained_handler) {
     FUNCTION_RUN_ONCE_RET(true);
 
@@ -1322,6 +1325,7 @@ bool daemon_status_file_deadly_signal_received(EXIT_REASON reason, SIGNAL_CODE c
 
 static SPINLOCK shutdown_timeout_spinlock = SPINLOCK_INITIALIZER;
 
+NEVER_INLINE
 void daemon_status_file_shutdown_timeout(BUFFER *trace) {
     FUNCTION_RUN_ONCE();
 

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -1159,6 +1159,11 @@ static void daemon_status_file_save_twice_if_we_can_get_stack_trace(BUFFER *wb, 
     
     capture_stack_trace(wb);
 
+    // Store the first netdata function from the stack trace if available
+    const char *first_nd_fn = capture_stack_trace_root_cause_function();
+    if (first_nd_fn && *first_nd_fn && !ds->fatal.function[0])
+        strncpyz(ds->fatal.function, first_nd_fn, sizeof(ds->fatal.function) - 1);
+
     if(buffer_strlen(wb) > 0) {
         strncpyz(
             ds->fatal.stack_trace,

--- a/src/libnetdata/log/nd_log-stacktrace.c
+++ b/src/libnetdata/log/nd_log-stacktrace.c
@@ -295,6 +295,7 @@ bool capture_stack_trace_available(void) {
     return backtrace_state != NULL && BACKTRACE_SUPPORTED;
 }
 
+NEVER_INLINE
 void capture_stack_trace(BUFFER *wb) {
     if (!backtrace_state) {
         buffer_strcat(wb, NO_STACK_TRACE_PREFIX "libbacktrace not initialized");
@@ -348,6 +349,7 @@ bool capture_stack_trace_available(void) {
     return true;
 }
 
+NEVER_INLINE
 void capture_stack_trace(BUFFER *wb) {
     // this function is async-signal-safe, if the buffer has enough space to hold the stack trace
 
@@ -437,6 +439,7 @@ bool capture_stack_trace_is_async_signal_safe(void) {
     return false;
 }
 
+NEVER_INLINE
 void capture_stack_trace(BUFFER *wb) {
     void *array[50];
     char **messages;
@@ -512,6 +515,7 @@ bool capture_stack_trace_is_async_signal_safe(void) {
     return false;
 }
 
+NEVER_INLINE
 void capture_stack_trace(BUFFER *wb) {
     buffer_strcat(wb, NO_STACK_TRACE_PREFIX "no back-end available");
 
@@ -522,6 +526,7 @@ void capture_stack_trace(BUFFER *wb) {
 
 #endif
 
+NEVER_INLINE
 bool stack_trace_formatter(BUFFER *wb, void *data __maybe_unused) {
     static __thread bool in_stack_trace = false;
 

--- a/src/libnetdata/log/nd_log-stacktrace.c
+++ b/src/libnetdata/log/nd_log-stacktrace.c
@@ -152,7 +152,7 @@ static void add_stack_frame(backtrace_data_t *bt_data, uintptr_t pc, const char 
         bt_data->frame_count = 0;
         bt_data->first_frame = true;
         root_cause_function[0] = '\0';
-        return; // Skip adding the logging function itself
+        // continue to add the function to the stack trace
     }
 
     // Check if this is a netdata source file and store the function name if it is
@@ -394,7 +394,7 @@ void capture_stack_trace(BUFFER *wb) {
             buffer_flush(wb);
             added = 0;
             frames = 0;
-            continue; // Skip adding the logging function itself
+            // continue to add the function to the stack trace
         }
 
         if (frames++)
@@ -473,7 +473,7 @@ void capture_stack_trace(BUFFER *wb) {
                 // Found a logging function, reset the buffer
                 buffer_flush(wb);
                 added = 0;
-                continue; // Skip adding the logging function itself
+                // continue to add the function to the stack trace
             }
 
             if(added)

--- a/src/libnetdata/log/nd_log-stacktrace.c
+++ b/src/libnetdata/log/nd_log-stacktrace.c
@@ -9,9 +9,104 @@ bool nd_log_forked = false;
 // The signal handler function name to filter out in stack traces
 static const char *signal_handler_function = "nd_signal_handler";
 
+// List of auxiliary functions that should not be reported as root cause
+static const char *auxiliary_functions[] = {
+    "nd_uuid_copy",
+    "out_of_memory",
+    "shutdown_timed_out",
+    NULL  // Terminator
+};
+
+// List of logging functions to filter out
+static const char *logging_functions[] = {
+    "netdata_logger",
+    "netdata_logger_with_limit",
+    "netdata_logger_fatal",
+    NULL  // Terminator
+};
+
 // Set the signal handler function name to filter out in stack traces
 void capture_stack_trace_set_signal_handler_function(const char *function_name) {
     signal_handler_function = function_name;
+}
+
+// Exact match check if a function is in the auxiliary list (strcmp)
+static inline bool is_auxiliary_function(const char *function) {
+    if (!function || !*function)
+        return false;
+        
+    for (int i = 0; auxiliary_functions[i]; i++) {
+        if (strcmp(function, auxiliary_functions[i]) == 0)
+            return true;
+    }
+    
+    return false;
+}
+
+// Exact match check if a function is a logging function (strcmp)
+static inline bool is_logging_function(const char *function) {
+    if (!function || !*function)
+        return false;
+        
+    for (int i = 0; logging_functions[i]; i++) {
+        if (strcmp(function, logging_functions[i]) == 0)
+            return true;
+    }
+    
+    return false;
+}
+
+// Substring check if a function contains a logging function name (strstr)
+static inline bool contains_logging_function(const char *text) {
+    if (!text || !*text)
+        return false;
+        
+    for (int i = 0; logging_functions[i]; i++) {
+        if (strstr(text, logging_functions[i]) != NULL)
+            return true;
+    }
+    
+    return false;
+}
+
+static inline bool is_netdata_function(const char *function, const char *filename) {
+    return function && *function && filename && *filename &&
+           strstr(filename, "/src/") &&
+           !strstr(filename, "/vendored/");
+}
+
+// Exact match check if a function is the signal handler (strcmp)
+static inline bool is_signal_handler_function(const char *function) {
+    return function && *function &&
+           signal_handler_function && *signal_handler_function &&
+           strcmp(function, signal_handler_function) == 0;
+}
+
+// Substring check if a function contains the signal handler name (strstr)
+static inline bool contains_signal_handler_function(const char *text) {
+    return text && *text &&
+           signal_handler_function && *signal_handler_function &&
+           strstr(text, signal_handler_function) != NULL;
+}
+
+// Thread-local buffer to store the first netdata function encountered in a stack trace
+static __thread char root_cause_function[48];
+
+// Returns the first netdata function found in the stack trace
+const char *capture_stack_trace_root_cause_function(void) {
+    return root_cause_function[0] ? root_cause_function : NULL;
+}
+
+// Store a function name as the first netdata function found
+static inline void keep_first_root_cause_function(const char *function) {
+    if (!function || !*function || root_cause_function[0])
+        return;  // Already have a function or null input
+    
+    // Skip auxiliary functions and logging functions   
+    if (is_auxiliary_function(function) || is_logging_function(function))
+        return;
+
+    strncpyz(root_cause_function, function, sizeof(root_cause_function) - 1);
 }
 
 #if defined(HAVE_LIBBACKTRACE)
@@ -27,7 +122,6 @@ typedef struct {
     BUFFER *wb;             // Buffer to write to
     size_t frame_count;     // Number of frames processed
     bool first_frame;       // Is this the first frame?
-    bool filter_signal_handler; // Should we filter the signal handler?
     bool found_signal_handler;  // Have we found the signal handler frame?
 } backtrace_data_t;
 
@@ -40,16 +134,31 @@ static void add_stack_frame(backtrace_data_t *bt_data, uintptr_t pc, const char 
         return;
 
     // Check if we found the signal handler frame
-    if (bt_data->filter_signal_handler && !bt_data->found_signal_handler && 
-        function && signal_handler_function && strcmp(function, signal_handler_function) == 0) {
-        
-        // We found the signal handler, reset the buffer
+    if (!bt_data->found_signal_handler && is_signal_handler_function(function)) {
+        // We found the signal handler, reset the buffer and clear function name
         buffer_flush(wb);
         bt_data->frame_count = 0;
         bt_data->first_frame = true;
         bt_data->found_signal_handler = true;
+        root_cause_function[0] = '\0';
         return; // Skip adding the signal handler itself
     }
+    
+    // Check for logging functions, but only if we haven't found a signal handler yet
+    // This prevents double resets when crashing inside logging code
+    if (!bt_data->found_signal_handler && is_logging_function(function)) {
+        // Found a logging function, reset the buffer and clear function name
+        buffer_flush(wb);
+        bt_data->frame_count = 0;
+        bt_data->first_frame = true;
+        root_cause_function[0] = '\0';
+        return; // Skip adding the logging function itself
+    }
+
+    // Check if this is a netdata source file and store the function name if it is
+    // (but only if we haven't already stored one)
+    if (!root_cause_function[0] && is_netdata_function(function, filename))
+        keep_first_root_cause_function(function);
 
     // Add a newline between frames
     if (!bt_data->first_frame)
@@ -196,7 +305,6 @@ void capture_stack_trace(BUFFER *wb) {
         .wb = wb,
         .frame_count = 0,
         .first_frame = true,
-        .filter_signal_handler = (signal_handler_function && *signal_handler_function),
         .found_signal_handler = false
     };
 
@@ -253,7 +361,6 @@ void capture_stack_trace(BUFFER *wb) {
 
     size_t added = 0;
     bool found_signal_handler = false;
-    bool filter = (signal_handler_function && *signal_handler_function);
 
     while (unw_step(&cursor) > 0) {
         unw_word_t offset, pc;
@@ -270,15 +377,22 @@ void capture_stack_trace(BUFFER *wb) {
         }
 
         // Check if we found the signal handler frame
-        if (filter && !found_signal_handler && 
-            strcmp(name, signal_handler_function) == 0) {
-            
+        if (!found_signal_handler && is_signal_handler_function(name)) {
             // We found the signal handler, reset the buffer
             buffer_flush(wb);
             added = 0;
             frames = 0;
             found_signal_handler = true;
             continue; // Skip adding the signal handler itself
+        }
+        
+        // Check for logging functions, but only if we haven't found a signal handler yet
+        if (!found_signal_handler && is_logging_function(name)) {
+            // Found a logging function, reset the buffer
+            buffer_flush(wb);
+            added = 0;
+            frames = 0;
+            continue; // Skip adding the logging function itself
         }
 
         if (frames++)
@@ -338,20 +452,25 @@ void capture_stack_trace(BUFFER *wb) {
 
     size_t added = 0;
     bool found_signal_handler = false;
-    bool filter = (signal_handler_function && *signal_handler_function);
 
     // Format the stack trace (removing the address part)
     for (i = 0; i < size; i++) {
         if(messages[i] && *messages[i]) {
             // Check if we found the signal handler frame
-            if (filter && !found_signal_handler && 
-                strstr(messages[i], signal_handler_function) != NULL) {
-                
+            if (!found_signal_handler && contains_signal_handler_function(messages[i])) {
                 // We found the signal handler, reset the buffer
                 buffer_flush(wb);
                 added = 0;
                 found_signal_handler = true;
                 continue; // Skip adding the signal handler itself
+            }
+            
+            // Check for logging functions, but only if we haven't found a signal handler yet
+            if (!found_signal_handler && contains_logging_function(messages[i])) {
+                // Found a logging function, reset the buffer
+                buffer_flush(wb);
+                added = 0;
+                continue; // Skip adding the logging function itself
             }
 
             if(added)
@@ -420,6 +539,7 @@ bool stack_trace_formatter(BUFFER *wb, void *data __maybe_unused) {
 
     in_stack_trace = true;
 
+    root_cause_function[0] = '\0';
     capture_stack_trace(wb);
 
     in_stack_trace = false; // Ensure the flag is reset

--- a/src/libnetdata/log/nd_log-stacktrace.c
+++ b/src/libnetdata/log/nd_log-stacktrace.c
@@ -310,7 +310,7 @@ void capture_stack_trace(BUFFER *wb) {
     };
 
     // Skip one frame to hide capture_stack_trace() itself
-    backtrace_full(backtrace_state, 1, bt_full_handler,
+    backtrace_full(backtrace_state, 0, bt_full_handler,
                    bt_error_handler, &bt_data);
 
     // If no frames were reported

--- a/src/libnetdata/log/nd_log.c
+++ b/src/libnetdata/log/nd_log.c
@@ -402,6 +402,7 @@ static ND_LOG_SOURCES nd_log_validate_source(ND_LOG_SOURCES source) {
 // --------------------------------------------------------------------------------------------------------------------
 // public API for loggers
 
+NEVER_INLINE
 void netdata_logger(ND_LOG_SOURCES source, ND_LOG_FIELD_PRIORITY priority, const char *file, const char *function, unsigned long line, const char *fmt, ... )
 {
     int saved_errno = errno;
@@ -424,6 +425,7 @@ void netdata_logger(ND_LOG_SOURCES source, ND_LOG_FIELD_PRIORITY priority, const
     va_end(args);
 }
 
+NEVER_INLINE
 void netdata_logger_with_limit(ERROR_LIMIT *erl, ND_LOG_SOURCES source, ND_LOG_FIELD_PRIORITY priority, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... ) {
     int saved_errno = errno;
 
@@ -477,6 +479,7 @@ static void fatal_abort_internal_checks(void) {
     _exit(1);
 }
 
+NEVER_INLINE
 void netdata_logger_fatal(const char *file, const char *function, const unsigned long line, const char *fmt, ... ) {
     static size_t already_in_fatal = 0;
 

--- a/src/libnetdata/log/nd_log.h
+++ b/src/libnetdata/log/nd_log.h
@@ -39,6 +39,7 @@ void capture_stack_trace_flush(void);
 bool capture_stack_trace_available(void);
 bool capture_stack_trace_is_async_signal_safe(void);
 const char *capture_stack_trace_backend(void);
+void capture_stack_trace_set_signal_handler_function(const char *function_name);
 
 typedef void (*log_event_t)(const char *filename, const char *function, const char *message, const char *errno_str, const char *stack_trace, long line);
 void nd_log_register_fatal_hook_cb(log_event_t cb);

--- a/src/libnetdata/log/nd_log.h
+++ b/src/libnetdata/log/nd_log.h
@@ -40,6 +40,7 @@ bool capture_stack_trace_available(void);
 bool capture_stack_trace_is_async_signal_safe(void);
 const char *capture_stack_trace_backend(void);
 void capture_stack_trace_set_signal_handler_function(const char *function_name);
+const char *capture_stack_trace_root_cause_function(void);
 
 typedef void (*log_event_t)(const char *filename, const char *function, const char *message, const char *errno_str, const char *stack_trace, long line);
 void nd_log_register_fatal_hook_cb(log_event_t cb);


### PR DESCRIPTION
- [x] filter signal handler from stack traces
- [x] filter logger functions from stack traces (only when they don't crash - useful for fatal messages)
- [x] detect root cause function from stack traces
- [x] add the root cause function to daemon status file fatal function