### PR TITLE
added checksum to detect corruption in netdev rename tasks

### DIFF
--- a/src/collectors/proc.plugin/proc_net_dev.c
+++ b/src/collectors/proc.plugin/proc_net_dev.c
@@ -317,60 +317,65 @@ static void netdev_charts_release(struct netdev *d) {
 }
 
 static void netdev_free_chart_strings(struct netdev *d) {
-    freez((void *)d->chart_type_net_bytes);
-    freez((void *)d->chart_type_net_compressed);
-    freez((void *)d->chart_type_net_drops);
-    freez((void *)d->chart_type_net_errors);
-    freez((void *)d->chart_type_net_events);
-    freez((void *)d->chart_type_net_fifo);
-    freez((void *)d->chart_type_net_packets);
-    freez((void *)d->chart_type_net_speed);
-    freez((void *)d->chart_type_net_duplex);
-    freez((void *)d->chart_type_net_operstate);
-    freez((void *)d->chart_type_net_carrier);
-    freez((void *)d->chart_type_net_mtu);
+    freez_and_set_to_null(d->chart_type_net_bytes);
+    freez_and_set_to_null(d->chart_type_net_compressed);
+    freez_and_set_to_null(d->chart_type_net_drops);
+    freez_and_set_to_null(d->chart_type_net_errors);
+    freez_and_set_to_null(d->chart_type_net_events);
+    freez_and_set_to_null(d->chart_type_net_fifo);
+    freez_and_set_to_null(d->chart_type_net_packets);
+    freez_and_set_to_null(d->chart_type_net_speed);
+    freez_and_set_to_null(d->chart_type_net_duplex);
+    freez_and_set_to_null(d->chart_type_net_operstate);
+    freez_and_set_to_null(d->chart_type_net_carrier);
+    freez_and_set_to_null(d->chart_type_net_mtu);
 
-    freez((void *)d->chart_id_net_bytes);
-    freez((void *)d->chart_id_net_compressed);
-    freez((void *)d->chart_id_net_drops);
-    freez((void *)d->chart_id_net_errors);
-    freez((void *)d->chart_id_net_events);
-    freez((void *)d->chart_id_net_fifo);
-    freez((void *)d->chart_id_net_packets);
-    freez((void *)d->chart_id_net_speed);
-    freez((void *)d->chart_id_net_duplex);
-    freez((void *)d->chart_id_net_operstate);
-    freez((void *)d->chart_id_net_carrier);
-    freez((void *)d->chart_id_net_mtu);
+    freez_and_set_to_null(d->chart_id_net_bytes);
+    freez_and_set_to_null(d->chart_id_net_compressed);
+    freez_and_set_to_null(d->chart_id_net_drops);
+    freez_and_set_to_null(d->chart_id_net_errors);
+    freez_and_set_to_null(d->chart_id_net_events);
+    freez_and_set_to_null(d->chart_id_net_fifo);
+    freez_and_set_to_null(d->chart_id_net_packets);
+    freez_and_set_to_null(d->chart_id_net_speed);
+    freez_and_set_to_null(d->chart_id_net_duplex);
+    freez_and_set_to_null(d->chart_id_net_operstate);
+    freez_and_set_to_null(d->chart_id_net_carrier);
+    freez_and_set_to_null(d->chart_id_net_mtu);
 
-    freez((void *)d->chart_ctx_net_bytes);
-    freez((void *)d->chart_ctx_net_compressed);
-    freez((void *)d->chart_ctx_net_drops);
-    freez((void *)d->chart_ctx_net_errors);
-    freez((void *)d->chart_ctx_net_events);
-    freez((void *)d->chart_ctx_net_fifo);
-    freez((void *)d->chart_ctx_net_packets);
-    freez((void *)d->chart_ctx_net_speed);
-    freez((void *)d->chart_ctx_net_duplex);
-    freez((void *)d->chart_ctx_net_operstate);
-    freez((void *)d->chart_ctx_net_carrier);
-    freez((void *)d->chart_ctx_net_mtu);
+    freez_and_set_to_null(d->chart_ctx_net_bytes);
+    freez_and_set_to_null(d->chart_ctx_net_compressed);
+    freez_and_set_to_null(d->chart_ctx_net_drops);
+    freez_and_set_to_null(d->chart_ctx_net_errors);
+    freez_and_set_to_null(d->chart_ctx_net_events);
+    freez_and_set_to_null(d->chart_ctx_net_fifo);
+    freez_and_set_to_null(d->chart_ctx_net_packets);
+    freez_and_set_to_null(d->chart_ctx_net_speed);
+    freez_and_set_to_null(d->chart_ctx_net_duplex);
+    freez_and_set_to_null(d->chart_ctx_net_operstate);
+    freez_and_set_to_null(d->chart_ctx_net_carrier);
+    freez_and_set_to_null(d->chart_ctx_net_mtu);
 
-    freez((void *)d->chart_family);
+    freez_and_set_to_null(d->chart_family);
 }
 
 static void netdev_free(struct netdev *d) {
     netdev_charts_release(d);
     netdev_free_chart_strings(d);
-    rrdlabels_destroy(d->chart_labels);
-    cgroup_netdev_release(d->cgroup_netdev_link);
 
-    freez((void *)d->name);
-    freez((void *)d->filename_speed);
-    freez((void *)d->filename_duplex);
-    freez((void *)d->filename_operstate);
-    freez((void *)d->filename_carrier);
-    freez((void *)d->filename_mtu);
+    rrdlabels_destroy(d->chart_labels);
+    d->chart_labels = NULL;
+
+    cgroup_netdev_release(d->cgroup_netdev_link);
+    d->cgroup_netdev_link = NULL;
+
+    freez_and_set_to_null(d->name);
+    freez_and_set_to_null(d->filename_speed);
+    freez_and_set_to_null(d->filename_duplex);
+    freez_and_set_to_null(d->filename_operstate);
+    freez_and_set_to_null(d->filename_carrier);
+    freez_and_set_to_null(d->filename_mtu);
+
     freez((void *)d);
 }
 
@@ -379,6 +384,8 @@ static netdata_mutex_t netdev_mutex = NETDATA_MUTEX_INITIALIZER;
 // ----------------------------------------------------------------------------
 
 static inline void netdev_rename(struct netdev *d, struct rename_task *r) {
+    rename_task_verify_checksum(r);
+
     collector_info("CGROUP: renaming network interface '%s' as '%s' under '%s'", d->name, r->container_device, r->container_name);
 
     netdev_charts_release(d);

--- a/src/collectors/proc.plugin/proc_net_dev_renames.h
+++ b/src/collectors/proc.plugin/proc_net_dev_renames.h
@@ -5,6 +5,11 @@
 
 #include "plugin_proc.h"
 
+#define freez_and_set_to_null(p) do { \
+    freez((void *)p); \
+    p = NULL; \
+} while(0)
+
 extern DICTIONARY *netdev_renames;
 
 struct rename_task {
@@ -13,9 +18,12 @@ struct rename_task {
     const char *ctx_prefix;
     RRDLABELS *chart_labels;
     const DICTIONARY_ITEM *cgroup_netdev_link;
+    XXH64_hash_t checksum;
 };
 
 void netdev_renames_init(void);
+
+void rename_task_verify_checksum(struct rename_task *r);
 
 void cgroup_netdev_reset_all(void);
 void cgroup_netdev_release(const DICTIONARY_ITEM *link);


### PR DESCRIPTION
SIGSEGV:

```
  #0 <unknown> [0x7F642DF1562F]
  #1 <unknown> [0x7F642B8BE079]
  #2 <unknown> [0x7F642B8E9178]
  #3 vsnprintfz [0xADA803] (/src/libnetdata/libnetdata.c:68)
  #4 snprintfz [0xADA803] (/src/libnetdata/libnetdata.c:81)
  #5 netdev_rename [0xA3C249] (/src/collectors/proc.plugin/proc_net_dev.c:407)
  #6 netdev_rename_this_device [0xA470B3] (/src/collectors/proc.plugin/proc_net_dev.c:470)
  #7 do_proc_net_dev [0xA470B3] (/src/collectors/proc.plugin/proc_net_dev.c:1058)
  #8 netdev_main [0xA493A2] (/src/collectors/proc.plugin/proc_net_dev.c:1722)
  #9 nd_thread_starting_point [0xAFB6F9] (/src/libnetdata/threads/threads.c:362)
  #10 <unknown> [0x7F642DF0DEA4]
  #11 <unknown> [0x7F642B96FB2C]
  #12 <unknown> [0xFFFFFFFFFFFFFFFF]
```

Looking at line 407 in proc_net_dev.c, that points to:

```c
  snprintfz(buffer, RRD_ID_LENGTH_MAX, "net_%s", r->container_device);
```

This is crashing with a fault address of 0x30, which indicates it's trying to dereference a pointer that's either NULL or very close to NULL (possibly NULL + an offset).

However the offending member (r->container_device) is not at 0x30 offset. So, the only explanation is corruption.

We have now added a checksum on this structure to detection corruption.