### PR TITLE
fix cgroup netdev renames

### DIFF
--- a/src/collectors/proc.plugin/proc_net_dev_renames.h
+++ b/src/collectors/proc.plugin/proc_net_dev_renames.h
@@ -13,6 +13,7 @@
 extern DICTIONARY *netdev_renames;
 
 struct rename_task {
+    SPINLOCK spinlock;
     const char *container_device;
     const char *container_name;
     const char *ctx_prefix;
@@ -20,6 +21,11 @@ struct rename_task {
     const DICTIONARY_ITEM *cgroup_netdev_link;
     XXH64_hash_t checksum;
 };
+
+#define freez_and_set_to_null(p) do { \
+    freez((void *)p); \
+    p = NULL; \
+} while(0)
 
 void netdev_renames_init(void);
 

--- a/src/collectors/proc.plugin/proc_net_dev_renames.h
+++ b/src/collectors/proc.plugin/proc_net_dev_renames.h
@@ -19,7 +19,6 @@ struct rename_task {
     const char *ctx_prefix;
     RRDLABELS *chart_labels;
     const DICTIONARY_ITEM *cgroup_netdev_link;
-    XXH64_hash_t checksum;
 };
 
 #define freez_and_set_to_null(p) do { \
@@ -28,8 +27,6 @@ struct rename_task {
 } while(0)
 
 void netdev_renames_init(void);
-
-void rename_task_verify_checksum(struct rename_task *r);
 
 void cgroup_netdev_reset_all(void);
 void cgroup_netdev_release(const DICTIONARY_ITEM *link);


### PR DESCRIPTION
SIGSEGV:

```
  #0 <unknown> [0x7F642DF1562F]
  #1 <unknown> [0x7F642B8BE079]
  #2 <unknown> [0x7F642B8E9178]
  #3 vsnprintfz [0xADA803] (/src/libnetdata/libnetdata.c:68)
  #4 snprintfz [0xADA803] (/src/libnetdata/libnetdata.c:81)
  #5 netdev_rename [0xA3C249] (/src/collectors/proc.plugin/proc_net_dev.c:407)
  #6 netdev_rename_this_device [0xA470B3] (/src/collectors/proc.plugin/proc_net_dev.c:470)
  #7 do_proc_net_dev [0xA470B3] (/src/collectors/proc.plugin/proc_net_dev.c:1058)
  #8 netdev_main [0xA493A2] (/src/collectors/proc.plugin/proc_net_dev.c:1722)
  #9 nd_thread_starting_point [0xAFB6F9] (/src/libnetdata/threads/threads.c:362)
  #10 <unknown> [0x7F642DF0DEA4]
  #11 <unknown> [0x7F642B96FB2C]
  #12 <unknown> [0xFFFFFFFFFFFFFFFF]
```

This is use-after-free.

The problem appears when multiple netdev renames exist for the same device and the device is being processed while cgroups replaces the rename request.
