### PR TITLE
Skip non-native builds in CI on PRs in most cases.

### DIFF
--- a/.github/scripts/gen-matrix-docker.py
+++ b/.github/scripts/gen-matrix-docker.py
@@ -1,16 +1,21 @@
 #!/usr/bin/env python3
 
 import json
+import sys
 
 from ruamel.yaml import YAML
 
 yaml = YAML(typ='safe')
 entries = list()
+native_only = sys.argv[1]
 
 with open('.github/data/distros.yml') as f:
     data = yaml.load(f)
 
 for arch in data['docker_arches']:
+    if native_only == '1' and data['arch_data'][arch]['qemu']:
+        continue
+
     entries.append({
         'arch': arch,
         'platform': data['platform_map'][arch],

--- a/.github/scripts/gen-matrix-static.py
+++ b/.github/scripts/gen-matrix-static.py
@@ -1,16 +1,21 @@
 #!/usr/bin/env python3
 
 import json
+import sys
 
 from ruamel.yaml import YAML
 
 yaml = YAML(typ='safe')
 entries = list()
+native_only = sys.argv[1]
 
 with open('.github/data/distros.yml') as f:
     data = yaml.load(f)
 
 for arch in data['static_arches']:
+    if native_only == '1' and data['arch_data'][arch]['qemu']:
+        continue
+
     entries.append({
         'arch': arch,
         'runner': data['arch_data'][arch]['runner'],

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       run: ${{ steps.check-run.outputs.run }}
       skip-go: ${{ steps.check-go.outputs.skip-go }}
+      static-native: ${{ steps.check-static.outputs.static-native }}
     steps:
       - name: Checkout
         id: checkout
@@ -80,6 +81,21 @@ jobs:
           files_ignore: |
             **/*.md
             packaging/repoconfig/
+      - name: Check static build files
+        id: check-static-build-files
+        uses: step-security/changed-files@v45
+        with:
+          since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
+          files: |
+            .github/data/distros.yml
+            .github/workflows/build.yml
+            .github/scripts/build-static.sh
+            .github/scripts/get-static-cache-key.sh
+            .github/scripts/gen-matrix-static.py
+            packaging/makeself/
+          files_ignore: |
+            **/*.md
+            packaging/repoconfig/
       - name: List all changed files in pattern
         continue-on-error: true
         if: github.event_name != 'workflow_dispatch'
@@ -109,6 +125,18 @@ jobs:
             fi
           else
             echo 'skip-go=' >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Check Static
+        id: check-static
+        run: |
+          if [ '${{ github.event_name }}' == 'pull_request' ]; then
+            if [ "${{ steps.check-static-build-files.outputs.any_modified }}" == "true" ] || [ "${{ !contains(github.event.pull_request.labels.*.name, 'run-ci/non-native') }}" = "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+              echo 'static-native=0' >> "${GITHUB_OUTPUT}"
+            else
+              echo 'static-native=1' >> "${GITHUB_OUTPUT}"
+            fi
+          else
+            echo 'static-native=0' >> "${GITHUB_OUTPUT}"
           fi
 
   build-dist: # Build the distribution tarball and store it as an artifact.
@@ -187,6 +215,8 @@ jobs:
   static-matrix: # Generate the static build matrix.
     name: Prepare Build Matrix
     runs-on: ubuntu-latest
+    needs:
+      - file-check
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -201,7 +231,7 @@ jobs:
       - name: Read build matrix
         id: set-matrix
         run: |
-          matrix="$(.github/scripts/gen-matrix-static.py)"
+          matrix="$(.github/scripts/gen-matrix-static.py ${{ needs.file-check.outputs.static-native }})"
           echo "Generated matrix: ${matrix}"
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
       - name: Failure Notification

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,7 +231,7 @@ jobs:
       - name: Read build matrix
         id: set-matrix
         run: |
-          matrix="$(.github/scripts/gen-matrix-static.py ${{ needs.file-check.outputs.static-native }})"
+          matrix="$(.github/scripts/gen-matrix-static.py "${{ needs.file-check.outputs.static-native }}")"
           echo "Generated matrix: ${matrix}"
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
       - name: Failure Notification

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,6 +85,25 @@ jobs:
           files_ignore: |
             **/*.md
             packaging/repoconfig/
+      - name: Check Docker files
+        id: check-docker-files
+        if: github.event_name != 'workflow_dispatch'
+        uses: step-security/changed-files@v45
+        with:
+          since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
+          files: |
+            .dockerignore
+            .github/data/distros.yml
+            .github/workflows/docker.yml
+            .github/scripts/docker-test.sh
+            .github/scripts/gen-matrix-docker.py
+            .github/scripts/gen-docker-tags.py
+            .github/scripts/gen-docker-imagetool-args.py
+            packaging/docker/
+            packaging/runtime-check.sh
+          files_ignore: |
+            **/*.md
+            packaging/repoconfig/
       - name: List all changed files in pattern
         continue-on-error: true
         if: github.event_name != 'workflow_dispatch'
@@ -117,10 +136,24 @@ jobs:
           else
             echo 'skip-go=' >> "${GITHUB_OUTPUT}"
           fi
+      - name: Check Native
+        id: check-native
+        run: |
+          if [ '${{ github.event_name }}' == 'pull_request' ]; then
+            if [ "${{ steps.check-docker-files.outputs.any_modified }}" == "true" ] || [ "${{ !contains(github.event.pull_request.labels.*.name, 'run-ci/non-native') }}" = "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+              echo 'docker-native=0' >> "${GITHUB_OUTPUT}"
+            else
+              echo 'docker-native=1' >> "${GITHUB_OUTPUT}"
+            fi
+          else
+            echo 'docker-native=0' >> "${GITHUB_OUTPUT}"
+          fi
 
   matrix:
     name: Generate Docker Build Matrix
     runs-on: ubuntu-latest
+    needs:
+      - file-check
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -135,7 +168,7 @@ jobs:
       - name: Read build matrix
         id: set-matrix
         run: |
-          matrix="$(.github/scripts/gen-matrix-docker.py)"
+          matrix="$(.github/scripts/gen-matrix-docker.py ${{ needs.file-check.outputs.docker-native }})"
           echo "Generated matrix: ${matrix}"
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
       - name: Failure Notification

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       run: ${{ steps.check-run.outputs.run }}
       skip-go: ${{ steps.check-go.outputs.skip-go }}
+      docker-native: ${{ steps.check-native.outputs.docker-native }}
     steps:
       - name: Checkout
         id: checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -140,7 +140,7 @@ jobs:
         id: check-native
         run: |
           if [ '${{ github.event_name }}' == 'pull_request' ]; then
-            if [ "${{ steps.check-docker-files.outputs.any_modified }}" == "true" ] || [ "${{ !contains(github.event.pull_request.labels.*.name, 'run-ci/non-native') }}" = "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            if [ "${{ steps.check-docker-files.outputs.any_modified }}" == "true" ] || [ "${{ !contains(github.event.pull_request.labels.*.name, 'run-ci/non-native') }}" = "true" ]; then
               echo 'docker-native=0' >> "${GITHUB_OUTPUT}"
             else
               echo 'docker-native=1' >> "${GITHUB_OUTPUT}"
@@ -168,7 +168,7 @@ jobs:
       - name: Read build matrix
         id: set-matrix
         run: |
-          matrix="$(.github/scripts/gen-matrix-docker.py ${{ needs.file-check.outputs.docker-native }})"
+          matrix="$(.github/scripts/gen-matrix-docker.py "${{ needs.file-check.outputs.docker-native }}")"
           echo "Generated matrix: ${matrix}"
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
       - name: Failure Notification


### PR DESCRIPTION
##### Summary

They will still be run if changes are made to the infrastructure used for those specific build types.

The detection can be overridden to force running using the `run-ci/non-native` label.

##### Test Plan

n/a