### PR TITLE
daemon status 27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1288,6 +1288,8 @@ set(DAEMON_FILES
         src/daemon/status-file-io.h
         src/daemon/status-file-dmi.c
         src/daemon/status-file-dmi.h
+        src/daemon/status-file-product.c
+        src/daemon/status-file-product.h
 )
 
 set(DAEMON_SYSTEMD_WATCHER_FILES

--- a/packaging/tools/agent-events/server.go
+++ b/packaging/tools/agent-events/server.go
@@ -170,7 +170,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if shouldProcess {
-		var fullData interface{}
+		// Always create a fresh map to prevent field reuse between requests
+		fullData := make(map[string]interface{})
+		
 		if err := json.Unmarshal(body, &fullData); err != nil {
 			http.Error(w, "Invalid JSON for full parsing", http.StatusBadRequest)
 			bodyDetail := ""
@@ -178,12 +180,15 @@ func handler(w http.ResponseWriter, r *http.Request) {
 			log.Printf("Discarded: Failed to fully parse JSON (post-dedup): %v%s", err, bodyDetail)
 			return
 		}
+		
+		// Marshal the map back to JSON
 		outputBytes, err := json.Marshal(fullData)
 		if err != nil {
 			http.Error(w, "Internal Server Error during output marshal", http.StatusInternalServerError)
 			log.Printf("Discarded: Failed to marshal JSON for output: %v", err)
 			return
 		}
+		
 		fmt.Println(string(outputBytes))
 		if _, err := w.Write([]byte("OK")); err != nil { log.Printf("Error writing OK response: %v", err) }
 	}

--- a/src/daemon/sentry-native/sentry-native.c
+++ b/src/daemon/sentry-native/sentry-native.c
@@ -161,6 +161,10 @@ void nd_sentry_init(void) {
     nd_sentry_set_tag("cloud_type", daemon_status_file_get_cloud_instance_type());
     nd_sentry_set_tag("cloud_region", daemon_status_file_get_cloud_instance_region());
     nd_sentry_set_tag("timezone", daemon_status_file_get_timezone());
+    
+    nd_sentry_set_tag("hw_sys_vendor", daemon_status_file_get_sys_vendor());
+    nd_sentry_set_tag("hw_product_name", daemon_status_file_get_product_name());
+    nd_sentry_set_tag("hw_product_type", daemon_status_file_get_product_type());
 
     // profile
     CLEAN_BUFFER *profile = buffer_create(0, NULL);

--- a/src/daemon/status-file-dedup.c
+++ b/src/daemon/status-file-dedup.c
@@ -2,6 +2,7 @@
 
 #include "status-file-dedup.h"
 #include "status-file-io.h"
+#include "status-file-dmi.h"
 
 #define DEDUP_FILENAME "dedup-netdata.dat"
 #define DEDUP_VERSION 1
@@ -67,31 +68,31 @@ uint64_t daemon_status_file_hash(DAEMON_STATUS_FILE *ds, const char *msg, const 
 
     dsf_acquire(*ds);
 
-    to_hash.v = ds->v,
-    to_hash.status = ds->status,
-    to_hash.signal_code = ds->fatal.signal_code,
-    to_hash.profile = ds->profile,
-    to_hash.exit_reason = ds->exit_reason,
-    to_hash.db_mode = ds->db_mode,
-    to_hash.db_tiers = ds->db_tiers,
-    to_hash.kubernetes = ds->kubernetes,
-    to_hash.sentry_available = ds->sentry_available,
-    to_hash.sentry_fatal = ds->fatal.sentry,
-    to_hash.host_id = ds->host_id,
-    to_hash.machine_id = ds->machine_id,
-    to_hash.worker_job_id = ds->fatal.worker_job_id,
+    to_hash.v = ds->v;
+    to_hash.status = ds->status;
+    to_hash.signal_code = ds->fatal.signal_code;
+    to_hash.profile = ds->profile;
+    to_hash.exit_reason = ds->exit_reason;
+    to_hash.db_mode = ds->db_mode;
+    to_hash.db_tiers = ds->db_tiers;
+    to_hash.kubernetes = ds->kubernetes;
+    to_hash.sentry_available = ds->sentry_available;
+    to_hash.sentry_fatal = ds->fatal.sentry;
+    to_hash.host_id = ds->host_id;
+    to_hash.machine_id = ds->machine_id;
+    to_hash.worker_job_id = ds->fatal.worker_job_id;
 
-    strncpyz(to_hash.version, ds->version, sizeof(to_hash.version) - 1);
-    strncpyz(to_hash.filename, ds->fatal.filename, sizeof(to_hash.filename) - 1);
-    strncpyz(to_hash.filename, ds->fatal.function, sizeof(to_hash.function) - 1);
-    strncpyz(to_hash.stack_trace, ds->fatal.stack_trace, sizeof(to_hash.stack_trace) - 1);
-    strncpyz(to_hash.thread, ds->fatal.thread, sizeof(to_hash.thread) - 1);
+    safecpy(to_hash.version, ds->version);
+    safecpy(to_hash.filename, ds->fatal.filename);
+    safecpy(to_hash.filename, ds->fatal.function);
+    safecpy(to_hash.stack_trace, ds->fatal.stack_trace);
+    safecpy(to_hash.thread, ds->fatal.thread);
 
     if(msg)
-        strncpyz(to_hash.msg, msg, sizeof(to_hash.msg) - 1);
+        safecpy(to_hash.msg, msg);
 
     if(cause)
-        strncpyz(to_hash.cause, cause, sizeof(to_hash.cause) - 1);
+        safecpy(to_hash.cause, cause);
 
     stack_trace_anonymize(to_hash.stack_trace);
 

--- a/src/daemon/status-file-dmi.c
+++ b/src/daemon/status-file-dmi.c
@@ -57,202 +57,6 @@ static void dmi_clean_field_placeholder(char *buf, size_t buf_size) {
     }
 }
 
-void dmi_normalize_vendor_field(char *buf, size_t buf_size) {
-    if(!buf || !buf_size) return;
-
-    struct {
-        const char *found;
-        const char *replace;
-    } vendors[] = {
-        {"QEMU", "KVM"},
-
-        // Major vendors with multiple variations
-        {"AMD Corporation", "AMD"},
-        {"Advanced Micro Devices, Inc.", "AMD"},
-
-        {"AMI Corp.", "AMI"},
-        {"AMI Corporation", "AMI"},
-        {"American Megatrends", "AMI"},
-        {"American Megatrends Inc.", "AMI"},
-        {"American Megatrends International", "AMI"},
-        {"American Megatrends International, LLC.", "AMI"},
-
-        {"AOPEN", "AOpen"},
-        {"AOPEN Inc.", "AOpen"},
-
-        {"Apache Software Foundation", "Apache"},
-
-        {"Apple Inc.", "Apple"},
-
-        {"ASRock Industrial", "ASRock"},
-        {"ASRockRack", "ASRock"},
-        {"AsrockRack", "ASRock"},
-
-        {"ASUS", "ASUSTeK"},
-        {"ASUSTeK COMPUTER INC.", "ASUSTeK"},
-        {"ASUSTeK COMPUTER INC. (Licensed from AMI)", "ASUSTeK"},
-        {"ASUSTeK Computer INC.", "ASUSTeK"},
-        {"ASUSTeK Computer Inc.", "ASUSTeK"},
-        {"ASUSTek Computer INC.", "ASUSTeK"},
-
-        {"Apache Software Foundation", "Apache"},
-
-        {"BESSTAR (HK) LIMITED", "Besstar"},
-        {"BESSTAR TECH", "Besstar"},
-        {"BESSTAR TECH LIMITED", "Besstar"},
-        {"BESSTAR Tech", "Besstar"},
-
-        {"CHUWI", "Chuwi"},
-        {"CHUWI Innovation And Technology(ShenZhen)co.,Ltd", "Chuwi"},
-
-        {"Cisco Systems Inc", "Cisco"},
-        {"Cisco Systems, Inc.", "Cisco"},
-
-        {"DELL", "Dell"},
-        {"Dell Computer Corporation", "Dell"},
-        {"Dell Inc.", "Dell"},
-
-        {"FUJITSU", "Fujitsu"},
-        {"FUJITSU CLIENT COMPUTING LIMITED", "Fujitsu"},
-        {"FUJITSU SIEMENS", "Fujitsu"},
-        {"FUJITSU SIEMENS // Phoenix Technologies Ltd.", "Fujitsu"},
-        {"FUJITSU // American Megatrends Inc.", "Fujitsu"},
-        {"FUJITSU // American Megatrends International, LLC.", "Fujitsu"},
-        {"FUJITSU // Insyde Software Corp.", "Fujitsu"},
-        {"FUJITSU // Phoenix Technologies Ltd.", "Fujitsu"},
-
-        {"GIGABYTE", "Gigabyte"},
-        {"Giga Computing", "Gigabyte"},
-        {"Gigabyte Technology Co., Ltd.", "Gigabyte"},
-        {"Gigabyte Tecohnology Co., Ltd.", "Gigabyte"},
-
-        {"GOOGLE", "Google"},
-        {"Google Inc", "Google"},
-
-        {"HC Technology.,Ltd.", "HC Tech"},
-
-        {"HP-Pavilion", "HP"},
-        {"HPE", "HP"},
-        {"Hewlett Packard Enterprise", "HP"},
-        {"Hewlett-Packard", "HP"},
-
-        {"HUAWEI", "Huawei"},
-        {"Huawei Technologies Co., Ltd.", "Huawei"},
-
-        {"IBM Corp.", "IBM"},
-
-        {"INSYDE", "Insyde"},
-        {"INSYDE Corp.", "Insyde"},
-        {"Insyde Corp.", "Insyde"},
-
-        {"INTEL", "Intel"},
-        {"INTEL Corporation", "Intel"},
-        {"Intel Corp.", "Intel"},
-        {"Intel Corporation", "Intel"},
-        {"Intel corporation", "Intel"},
-        {"Intel(R) Client Systems", "Intel"},
-        {"Intel(R) Corporation", "Intel"},
-
-        {"LENOVO", "Lenovo"},
-        {"LNVO", "Lenovo"},
-
-        {"Shenzhen Meigao Electronic Equipment Co.,Ltd", "Meigao"},
-        {"Micro Computer (HK) Tech Limited", "Micro Computer"},
-        {"Micro Computer(HK) Tech Limited", "Micro Computer"},
-
-        {"MICRO-STAR INTERNATIONAL CO., LTD", "MSI"},
-        {"MICRO-STAR INTERNATIONAL CO.,LTD", "MSI"},
-        {"MSI", "MSI"},
-        {"Micro-Star International Co., Ltd", "MSI"},
-        {"Micro-Star International Co., Ltd.", "MSI"},
-
-        {"MICROSOFT", "Microsoft"},
-        {"Microsoft Corporation", "Microsoft"},
-
-        {"nVIDIA", "NVIDIA"},
-
-        {"OPENSTACK", "OpenStack"},
-        {"OpenStack Foundation", "OpenStack"},
-
-        {"ORACLE CORPORATI", "Oracle"},
-        {"Oracle Corporation", "Oracle"},
-        {"innotek GmbH", "Oracle"},
-
-        {"Phoenix Technologies LTD", "Phoenix"},
-        {"Phoenix Technologies Ltd", "Phoenix"},
-        {"Phoenix Technologies Ltd.", "Phoenix"},
-        {"Phoenix Technologies, LTD", "Phoenix"},
-
-        {"QNAP Systems, Inc.", "QNAP"},
-
-        {"QUANTA", "Quanta"},
-        {"Quanta Cloud Technology Inc.", "Quanta"},
-        {"Quanta Computer Inc", "Quanta"},
-        {"Quanta Computer Inc.", "Quanta"},
-
-        {"RED HAT", "Red Hat"},
-
-        {"SAMSUNG ELECTRONICS CO., LTD.", "Samsung"},
-
-        {"SUN MICROSYSTEMS", "Sun"},
-
-        {"SuperMicro", "Supermicro"},
-        {"Supermicro Corporation", "Supermicro"},
-
-        {"SYNOLOGY", "Synology"},
-        {"Synology Inc.", "Synology"},
-
-        {"TYAN", "Tyan"},
-        {"TYAN Computer Corporation", "Tyan"},
-        {"Tyan Computer Corporation", "Tyan"},
-        {"$(TYAN_SYSTEM_MANUFACTURER)", "Tyan"},
-
-        {"VMware", "VMware"},
-        {"VMware, Inc.", "VMware"},
-
-        {"XIAOMI", "Xiaomi"},
-
-        {"ZOTAC", "Zotac"},
-        {"Motherboard by ZOTAC", "Zotac"}
-    };
-
-    for (size_t i = 0; i < _countof(vendors); i++) {
-        if (strcasecmp(buf, vendors[i].found) == 0) {
-            strcatz(buf, 0, vendors[i].replace, buf_size);
-            break;
-        }
-    }
-}
-
-bool dmi_is_virtual_machine(const DMI_INFO *dmi) {
-    if(!dmi) return false;
-
-    const char *vm_indicators[] = {
-        "Virt", "KVM", "vServer", "Cloud", "Hyper", "Droplet", "Compute",
-        "HVM domU", "Parallels", "(i440FX", "(q35", "OpenStack", "QEMU",
-        "VMWare", "DigitalOcean", "Oracle", "Linode", "Amazon EC2"
-    };
-
-    const char *strs_to_check[] = {
-        dmi->product.name,
-        dmi->product.family,
-        dmi->sys.vendor,
-        dmi->board.name,
-    };
-
-    for (size_t i = 0; i < _countof(strs_to_check); i++) {
-        if (!strs_to_check[i] || !strs_to_check[i][0])
-            continue;
-
-        for (size_t j = 0; j < _countof(vm_indicators); j++) {
-            if (strcasestr(strs_to_check[i], vm_indicators[j]) != NULL)
-                return true;
-        }
-    }
-
-    return false;
-}
-
 static void dmi_clean_field(char *buf, size_t buf_size) {
     if(!buf || !buf_size) return;
 
@@ -336,27 +140,29 @@ static void linux_get_dmi_field(const char *field, const char *alt, char *dst, s
     strcatz(dst, 0, buf, dst_size);
 }
 
-void os_dmi_info(DAEMON_STATUS_FILE *ds) {
-    linux_get_dmi_field("sys_vendor", NULL, ds->hw.sys.vendor, sizeof(ds->hw.sys.vendor));
+void os_dmi_info_get(DMI_INFO *dmi) {
+    if (!dmi) return;
+    
+    linux_get_dmi_field("sys_vendor", NULL, dmi->sys.vendor, sizeof(dmi->sys.vendor));
 
-    linux_get_dmi_field("product_name", "/proc/device-tree/model", ds->hw.product.name, sizeof(ds->hw.product.name));
-    linux_get_dmi_field("product_version", NULL, ds->hw.product.version, sizeof(ds->hw.product.version));
-    linux_get_dmi_field("product_sku", NULL, ds->hw.product.sku, sizeof(ds->hw.product.sku));
-    linux_get_dmi_field("product_family", NULL, ds->hw.product.family, sizeof(ds->hw.product.family));
+    linux_get_dmi_field("product_name", "/proc/device-tree/model", dmi->product.name, sizeof(dmi->product.name));
+    linux_get_dmi_field("product_version", NULL, dmi->product.version, sizeof(dmi->product.version));
+    linux_get_dmi_field("product_sku", NULL, dmi->product.sku, sizeof(dmi->product.sku));
+    linux_get_dmi_field("product_family", NULL, dmi->product.family, sizeof(dmi->product.family));
 
-    linux_get_dmi_field("chassis_vendor", NULL, ds->hw.chassis.vendor, sizeof(ds->hw.chassis.vendor));
-    linux_get_dmi_field("chassis_version", NULL, ds->hw.chassis.version, sizeof(ds->hw.chassis.version));
+    linux_get_dmi_field("chassis_vendor", NULL, dmi->chassis.vendor, sizeof(dmi->chassis.vendor));
+    linux_get_dmi_field("chassis_version", NULL, dmi->chassis.version, sizeof(dmi->chassis.version));
 
-    linux_get_dmi_field("board_vendor", NULL, ds->hw.board.vendor, sizeof(ds->hw.board.vendor));
-    linux_get_dmi_field("board_name", NULL, ds->hw.board.name, sizeof(ds->hw.board.name));
-    linux_get_dmi_field("board_version", NULL, ds->hw.board.version, sizeof(ds->hw.board.version));
+    linux_get_dmi_field("board_vendor", NULL, dmi->board.vendor, sizeof(dmi->board.vendor));
+    linux_get_dmi_field("board_name", NULL, dmi->board.name, sizeof(dmi->board.name));
+    linux_get_dmi_field("board_version", NULL, dmi->board.version, sizeof(dmi->board.version));
 
-    linux_get_dmi_field("bios_vendor", NULL, ds->hw.bios.vendor, sizeof(ds->hw.bios.vendor));
-    linux_get_dmi_field("bios_version", NULL, ds->hw.bios.version, sizeof(ds->hw.bios.version));
-    linux_get_dmi_field("bios_date", NULL, ds->hw.bios.date, sizeof(ds->hw.bios.date));
-    linux_get_dmi_field("bios_release", NULL, ds->hw.bios.release, sizeof(ds->hw.bios.release));
+    linux_get_dmi_field("bios_vendor", NULL, dmi->bios.vendor, sizeof(dmi->bios.vendor));
+    linux_get_dmi_field("bios_version", NULL, dmi->bios.version, sizeof(dmi->bios.version));
+    linux_get_dmi_field("bios_date", NULL, dmi->bios.date, sizeof(dmi->bios.date));
+    linux_get_dmi_field("bios_release", NULL, dmi->bios.release, sizeof(dmi->bios.release));
 
-    linux_get_dmi_field("chassis_type", NULL, ds->hw.chassis.type, sizeof(ds->hw.chassis.type));
+    linux_get_dmi_field("chassis_type", NULL, dmi->chassis.type, sizeof(dmi->chassis.type));
 }
 #elif defined(OS_MACOS)
 
@@ -442,15 +248,15 @@ static void get_parent_iokit_string_property(io_registry_entry_t entry, CFString
 }
 
 // Get hardware info from IODeviceTree
-static void get_devicetree_info(DAEMON_STATUS_FILE *ds) {
+static void get_devicetree_info(DMI_INFO *dmi) {
     // Initialize all relevant fields to empty
-    if (!ds)
+    if (!dmi)
         return;
 
-    ds->hw.product.name[0] = '\0';
-    ds->hw.board.name[0] = '\0';
-    ds->hw.sys.vendor[0] = '\0';
-    ds->hw.product.family[0] = '\0';
+    dmi->product.name[0] = '\0';
+    dmi->board.name[0] = '\0';
+    dmi->sys.vendor[0] = '\0';
+    dmi->product.family[0] = '\0';
 
     // Get the device tree
     io_registry_entry_t device_tree = IORegistryEntryFromPath(kIOMasterPortDefault, "IODeviceTree:/");
@@ -458,16 +264,16 @@ static void get_devicetree_info(DAEMON_STATUS_FILE *ds) {
         return;
 
     // Get model information - only operate if device_tree is valid
-    get_iokit_string_property(device_tree, CFSTR("model"), ds->hw.product.name, sizeof(ds->hw.product.name));
+    get_iokit_string_property(device_tree, CFSTR("model"), dmi->product.name, sizeof(dmi->product.name));
 
     // Get board ID if available
-    get_iokit_string_property(device_tree, CFSTR("board-id"), ds->hw.board.name, sizeof(ds->hw.board.name));
+    get_iokit_string_property(device_tree, CFSTR("board-id"), dmi->board.name, sizeof(dmi->board.name));
 
     // Look for platform information
     io_registry_entry_t platform = IORegistryEntryFromPath(kIOMasterPortDefault, "IODeviceTree:/platform");
     if (platform) {
         // Platform information can sometimes have manufacturer info
-        get_iokit_string_property(platform, CFSTR("manufacturer"), ds->hw.sys.vendor, sizeof(ds->hw.sys.vendor));
+        get_iokit_string_property(platform, CFSTR("manufacturer"), dmi->sys.vendor, sizeof(dmi->sys.vendor));
 
         // Check compatible property for additional info
         char compatible[256] = {0};
@@ -478,8 +284,8 @@ static void get_devicetree_info(DAEMON_STATUS_FILE *ds) {
             char *family = strstr(compatible, ",");
             if (family && family < compatible + sizeof(compatible) - 1) {
                 family++; // Skip the comma
-                safecpy(ds->hw.product.family, family);
-                dmi_clean_field(ds->hw.product.family, sizeof(ds->hw.product.family));
+                safecpy(dmi->product.family, family);
+                dmi_clean_field(dmi->product.family, sizeof(dmi->product.family));
             }
         }
 
@@ -490,8 +296,8 @@ static void get_devicetree_info(DAEMON_STATUS_FILE *ds) {
 }
 
 // Get hardware info from IOPlatformExpertDevice
-static void get_platform_expert_info(DAEMON_STATUS_FILE *ds) {
-    if (!ds)
+static void get_platform_expert_info(DMI_INFO *dmi) {
+    if (!dmi)
         return;
 
     io_registry_entry_t platform_expert = IORegistryEntryFromPath(
@@ -502,19 +308,19 @@ static void get_platform_expert_info(DAEMON_STATUS_FILE *ds) {
 
     // System vendor - almost always "Apple Inc." for Macs
     get_iokit_string_property(platform_expert, CFSTR("manufacturer"),
-                              ds->hw.sys.vendor, sizeof(ds->hw.sys.vendor));
+                              dmi->sys.vendor, sizeof(dmi->sys.vendor));
 
     // Product name
     get_iokit_string_property(platform_expert, CFSTR("model"),
-                              ds->hw.product.name, sizeof(ds->hw.product.name));
+                              dmi->product.name, sizeof(dmi->product.name));
 
     // Model number - can be used as product version
     get_iokit_string_property(platform_expert, CFSTR("model-number"),
-                              ds->hw.product.version, sizeof(ds->hw.product.version));
+                              dmi->product.version, sizeof(dmi->product.version));
 
     // Board name sometimes available
     get_iokit_string_property(platform_expert, CFSTR("board-id"),
-                              ds->hw.board.name, sizeof(ds->hw.board.name));
+                              dmi->board.name, sizeof(dmi->board.name));
 
     // Hardware UUID can be useful to include
     char uuid_str[64] = {0};
@@ -527,33 +333,33 @@ static void get_platform_expert_info(DAEMON_STATUS_FILE *ds) {
     // Set chassis type based on device_type safely
     if (device_type[0]) {
         if (strcasestr(device_type, "laptop") || strcasestr(device_type, "book"))
-            safecpy(ds->hw.chassis.type, "9");
+            safecpy(dmi->chassis.type, "9");
         else if (strcasestr(device_type, "server"))
-            safecpy(ds->hw.chassis.type, "17");
+            safecpy(dmi->chassis.type, "17");
         else if (strcasestr(device_type, "imac"))
-            safecpy(ds->hw.chassis.type, "13");
+            safecpy(dmi->chassis.type, "13");
         else if (strcasestr(device_type, "mac"))
-            safecpy(ds->hw.chassis.type, "3");
+            safecpy(dmi->chassis.type, "3");
     }
 
     // If chassis type not set, guess based on product name
-    if (!ds->hw.chassis.type[0] && ds->hw.product.name[0]) {
-        if (strcasestr(ds->hw.product.name, "book"))
-            safecpy(ds->hw.chassis.type, "9");
-        else if (strcasestr(ds->hw.product.name, "imac"))
-            safecpy(ds->hw.chassis.type, "13");
-        else if (strcasestr(ds->hw.product.name, "mac") && strcasestr(ds->hw.product.name, "pro"))
-            safecpy(ds->hw.chassis.type, "3");
-        else if (strcasestr(ds->hw.product.name, "mac") && strcasestr(ds->hw.product.name, "mini"))
-            safecpy(ds->hw.chassis.type, "35");
+    if (!dmi->chassis.type[0] && dmi->product.name[0]) {
+        if (strcasestr(dmi->product.name, "book"))
+            safecpy(dmi->chassis.type, "9");
+        else if (strcasestr(dmi->product.name, "imac"))
+            safecpy(dmi->chassis.type, "13");
+        else if (strcasestr(dmi->product.name, "mac") && strcasestr(dmi->product.name, "pro"))
+            safecpy(dmi->chassis.type, "3");
+        else if (strcasestr(dmi->product.name, "mac") && strcasestr(dmi->product.name, "mini"))
+            safecpy(dmi->chassis.type, "35");
     }
 
     IOObjectRelease(platform_expert);
 }
 
 // Get SMC revision and system firmware info
-static void get_firmware_info(DAEMON_STATUS_FILE *ds) {
-    if (!ds)
+static void get_firmware_info(DMI_INFO *dmi) {
+    if (!dmi)
         return;
 
     io_registry_entry_t smc = IOServiceGetMatchingService(
@@ -565,8 +371,8 @@ static void get_firmware_info(DAEMON_STATUS_FILE *ds) {
         get_iokit_string_property(smc, CFSTR("smc-version"), smc_version, sizeof(smc_version));
 
         if (smc_version[0]) {
-            safecpy(ds->hw.bios.version, smc_version);
-            dmi_clean_field(ds->hw.bios.version, sizeof(ds->hw.bios.version));
+            safecpy(dmi->bios.version, smc_version);
+            dmi_clean_field(dmi->bios.version, sizeof(dmi->bios.version));
         }
 
         IOObjectRelease(smc);
@@ -576,19 +382,19 @@ static void get_firmware_info(DAEMON_STATUS_FILE *ds) {
     io_registry_entry_t rom = IORegistryEntryFromPath(kIOMasterPortDefault, "IODeviceTree:/rom");
     if (rom) {
         // "version" contains firmware version
-        get_iokit_string_property(rom, CFSTR("version"), ds->hw.bios.version, sizeof(ds->hw.bios.version));
+        get_iokit_string_property(rom, CFSTR("version"), dmi->bios.version, sizeof(dmi->bios.version));
 
         // Apple is the vendor for all Mac firmware
-        safecpy(ds->hw.bios.vendor, "Apple");
+        safecpy(dmi->bios.vendor, "Apple");
 
         // "release-date" can sometimes be found
-        get_iokit_string_property(rom, CFSTR("release-date"), ds->hw.bios.date, sizeof(ds->hw.bios.date));
+        get_iokit_string_property(rom, CFSTR("release-date"), dmi->bios.date, sizeof(dmi->bios.date));
 
         IOObjectRelease(rom);
     }
 
     // If we still don't have BIOS version, check system version from sysctl
-    if (!ds->hw.bios.version[0]) {
+    if (!dmi->bios.version[0]) {
         char firmware_version[256] = {0};
         size_t len = sizeof(firmware_version) - 1;
 
@@ -598,96 +404,96 @@ static void get_firmware_info(DAEMON_STATUS_FILE *ds) {
             // Extract firmware info if present
             char *firmware_info = strstr(firmware_version, "SMC:");
             if (firmware_info && firmware_info < firmware_version + sizeof(firmware_version) - 1) {
-                safecpy(ds->hw.bios.version, firmware_info);
-                dmi_clean_field(ds->hw.bios.version, sizeof(ds->hw.bios.version));
+                safecpy(dmi->bios.version, firmware_info);
+                dmi_clean_field(dmi->bios.version, sizeof(dmi->bios.version));
             }
         }
     }
 }
 
 // Get system hardware information using sysctl
-static void get_sysctl_info(DAEMON_STATUS_FILE *ds) {
-    if (!ds)
+static void get_sysctl_info(DMI_INFO *dmi) {
+    if (!dmi)
         return;
 
     // Get model identifier using sysctl if not already set
-    if (!ds->hw.product.name[0]) {
+    if (!dmi->product.name[0]) {
         char model[256] = { 0 };
         size_t len = sizeof(model) - 1;
 
         if (sysctlbyname("hw.model", model, &len, NULL, 0) == 0) {
             model[len] = '\0';
-            safecpy(ds->hw.product.name, model);
-            dmi_clean_field(ds->hw.product.name, sizeof(ds->hw.product.name));
+            safecpy(dmi->product.name, model);
+            dmi_clean_field(dmi->product.name, sizeof(dmi->product.name));
 
             // If chassis type is still not set, guess from model
-            if (!ds->hw.chassis.type[0]) {
+            if (!dmi->chassis.type[0]) {
                 if (strncasecmp(model, "MacBook", 7) == 0)
-                    safecpy(ds->hw.chassis.type, "9");
+                    safecpy(dmi->chassis.type, "9");
                 else if (strncasecmp(model, "iMac", 4) == 0)
-                    safecpy(ds->hw.chassis.type, "13");
+                    safecpy(dmi->chassis.type, "13");
                 else if (strncasecmp(model, "Mac", 3) == 0 && strcasestr(model, "Pro") != NULL)
-                    safecpy(ds->hw.chassis.type, "3");
+                    safecpy(dmi->chassis.type, "3");
                 else if (strncasecmp(model, "Mac", 3) == 0 && strcasestr(model, "mini") != NULL)
-                    safecpy(ds->hw.chassis.type, "35");
+                    safecpy(dmi->chassis.type, "35");
                 else
-                    safecpy(ds->hw.chassis.type, "3"); // Default to desktop
+                    safecpy(dmi->chassis.type, "3"); // Default to desktop
             }
         }
     }
 
     // Get CPU information if board name not set
-    if (!ds->hw.board.name[0]) {
+    if (!dmi->board.name[0]) {
         char cpu_brand[256] = {0};
         size_t len = sizeof(cpu_brand) - 1;
 
         if (sysctlbyname("machdep.cpu.brand_string", cpu_brand, &len, NULL, 0) == 0) {
             cpu_brand[len] = '\0'; // Ensure null termination
             // Use CPU information as part of board info if not available
-            safecpy(ds->hw.board.name, cpu_brand);
-            dmi_clean_field(ds->hw.board.name, sizeof(ds->hw.board.name));
+            safecpy(dmi->board.name, cpu_brand);
+            dmi_clean_field(dmi->board.name, sizeof(dmi->board.name));
         }
     }
 }
 
 // Main function to get hardware info
-void os_dmi_info(DAEMON_STATUS_FILE *ds) {
-    if (!ds) return;
+void os_dmi_info_get(DMI_INFO *dmi) {
+    if (!dmi) return;
 
     // Always set Apple as default vendor
-    safecpy(ds->hw.sys.vendor, "Apple");
+    safecpy(dmi->sys.vendor, "Apple");
 
     // Get info from IOPlatformExpertDevice
-    get_platform_expert_info(ds);
+    get_platform_expert_info(dmi);
 
     // Get info from IODeviceTree
-    get_devicetree_info(ds);
+    get_devicetree_info(dmi);
 
     // Get firmware information
-    get_firmware_info(ds);
+    get_firmware_info(dmi);
 
     // Get additional info from sysctl
-    get_sysctl_info(ds);
+    get_sysctl_info(dmi);
 
     // Set board vendor to match system vendor if not set
-    if (!ds->hw.board.vendor[0] && ds->hw.sys.vendor[0])
-        safecpy(ds->hw.board.vendor, ds->hw.sys.vendor);
+    if (!dmi->board.vendor[0] && dmi->sys.vendor[0])
+        safecpy(dmi->board.vendor, dmi->sys.vendor);
 
     // Set chassis vendor to match system vendor if not set
-    if (!ds->hw.chassis.vendor[0] && ds->hw.sys.vendor[0])
-        safecpy(ds->hw.chassis.vendor, ds->hw.sys.vendor);
+    if (!dmi->chassis.vendor[0] && dmi->sys.vendor[0])
+        safecpy(dmi->chassis.vendor, dmi->sys.vendor);
 
     // Set bios vendor to match system vendor if not set
-    if (!ds->hw.bios.vendor[0] && ds->hw.sys.vendor[0])
-        safecpy(ds->hw.bios.vendor, ds->hw.sys.vendor);
+    if (!dmi->bios.vendor[0] && dmi->sys.vendor[0])
+        safecpy(dmi->bios.vendor, dmi->sys.vendor);
 
     // Default product name if all methods failed
-    if (!ds->hw.product.name[0])
-        safecpy(ds->hw.product.name, "Mac");
+    if (!dmi->product.name[0])
+        safecpy(dmi->product.name, "Mac");
 
     // Default chassis type if we couldn't determine it
-    if (!ds->hw.chassis.type[0])
-        safecpy(ds->hw.chassis.type, "3"); // Desktop
+    if (!dmi->chassis.type[0])
+        safecpy(dmi->chassis.type, "3"); // Desktop
 }
 
 #elif defined(OS_FREEBSD)
@@ -716,40 +522,42 @@ static void freebsd_get_kenv_str(const char *name, char *dst, size_t dst_size) {
     }
 }
 
-void os_dmi_info(DAEMON_STATUS_FILE *ds) {
+void os_dmi_info_get(DMI_INFO *dmi) {
+    if (!dmi) return;
+    
     // System information from SMBIOS
-    freebsd_get_sysctl_str("hw.vendor", ds->hw.sys.vendor, sizeof(ds->hw.sys.vendor));
-    freebsd_get_sysctl_str("hw.product", ds->hw.product.name, sizeof(ds->hw.product.name));
-    freebsd_get_sysctl_str("hw.version", ds->hw.product.version, sizeof(ds->hw.product.version));
+    freebsd_get_sysctl_str("hw.vendor", dmi->sys.vendor, sizeof(dmi->sys.vendor));
+    freebsd_get_sysctl_str("hw.product", dmi->product.name, sizeof(dmi->product.name));
+    freebsd_get_sysctl_str("hw.version", dmi->product.version, sizeof(dmi->product.version));
 
     // Try using kenv for additional information
-    freebsd_get_kenv_str("smbios.system.maker", ds->hw.sys.vendor, sizeof(ds->hw.sys.vendor));
-    freebsd_get_kenv_str("smbios.system.product", ds->hw.product.name, sizeof(ds->hw.product.name));
-    freebsd_get_kenv_str("smbios.system.version", ds->hw.product.version, sizeof(ds->hw.product.version));
-    freebsd_get_kenv_str("smbios.system.sku", ds->hw.product.sku, sizeof(ds->hw.product.sku));
-    freebsd_get_kenv_str("smbios.system.family", ds->hw.product.family, sizeof(ds->hw.product.family));
+    freebsd_get_kenv_str("smbios.system.maker", dmi->sys.vendor, sizeof(dmi->sys.vendor));
+    freebsd_get_kenv_str("smbios.system.product", dmi->product.name, sizeof(dmi->product.name));
+    freebsd_get_kenv_str("smbios.system.version", dmi->product.version, sizeof(dmi->product.version));
+    freebsd_get_kenv_str("smbios.system.sku", dmi->product.sku, sizeof(dmi->product.sku));
+    freebsd_get_kenv_str("smbios.system.family", dmi->product.family, sizeof(dmi->product.family));
 
     // Board information
-    freebsd_get_kenv_str("smbios.planar.maker", ds->hw.board.vendor, sizeof(ds->hw.board.vendor));
-    freebsd_get_kenv_str("smbios.planar.product", ds->hw.board.name, sizeof(ds->hw.board.name));
-    freebsd_get_kenv_str("smbios.planar.version", ds->hw.board.version, sizeof(ds->hw.board.version));
+    freebsd_get_kenv_str("smbios.planar.maker", dmi->board.vendor, sizeof(dmi->board.vendor));
+    freebsd_get_kenv_str("smbios.planar.product", dmi->board.name, sizeof(dmi->board.name));
+    freebsd_get_kenv_str("smbios.planar.version", dmi->board.version, sizeof(dmi->board.version));
 
     // BIOS information
-    freebsd_get_kenv_str("smbios.bios.vendor", ds->hw.bios.vendor, sizeof(ds->hw.bios.vendor));
-    freebsd_get_kenv_str("smbios.bios.version", ds->hw.bios.version, sizeof(ds->hw.bios.version));
-    freebsd_get_kenv_str("smbios.bios.reldate", ds->hw.bios.date, sizeof(ds->hw.bios.date));
-    freebsd_get_kenv_str("smbios.bios.release", ds->hw.bios.release, sizeof(ds->hw.bios.release));
+    freebsd_get_kenv_str("smbios.bios.vendor", dmi->bios.vendor, sizeof(dmi->bios.vendor));
+    freebsd_get_kenv_str("smbios.bios.version", dmi->bios.version, sizeof(dmi->bios.version));
+    freebsd_get_kenv_str("smbios.bios.reldate", dmi->bios.date, sizeof(dmi->bios.date));
+    freebsd_get_kenv_str("smbios.bios.release", dmi->bios.release, sizeof(dmi->bios.release));
 
     // Chassis information
-    freebsd_get_kenv_str("smbios.chassis.maker", ds->hw.chassis.vendor, sizeof(ds->hw.chassis.vendor));
-    freebsd_get_kenv_str("smbios.chassis.version", ds->hw.chassis.version, sizeof(ds->hw.chassis.version));
+    freebsd_get_kenv_str("smbios.chassis.maker", dmi->chassis.vendor, sizeof(dmi->chassis.vendor));
+    freebsd_get_kenv_str("smbios.chassis.version", dmi->chassis.version, sizeof(dmi->chassis.version));
 
     // Chassis type
-    freebsd_get_kenv_str("smbios.chassis.type", ds->hw.chassis.type, sizeof(ds->hw.chassis.type));
+    freebsd_get_kenv_str("smbios.chassis.type", dmi->chassis.type, sizeof(dmi->chassis.type));
 
     // If we couldn't get system information from SMBIOS, try to use model
-    if (!ds->hw.product.name[0])
-        freebsd_get_sysctl_str("hw.model", ds->hw.product.name, sizeof(ds->hw.product.name));
+    if (!dmi->product.name[0])
+        freebsd_get_sysctl_str("hw.model", dmi->product.name, sizeof(dmi->product.name));
 }
 
 #elif defined(OS_WINDOWS)
@@ -892,11 +700,11 @@ static smbios_data_t get_smbios_data(void) {
 
 // Process BIOS Information (Type 0)
 static void process_smbios_bios_info(const smbios_header_t *header,
-                                  DAEMON_STATUS_FILE *ds,
+                                  DMI_INFO *dmi,
                                   const char *string_table,
                                   const BYTE *smbios_data,
                                   DWORD smbios_size) {
-    if (header->length < 18) // Minimum size for BIOS info
+    if (header->length < 18 || !dmi) // Minimum size for BIOS info
         return;
         
     const BYTE *data = (const BYTE *)header;
@@ -905,29 +713,29 @@ static void process_smbios_bios_info(const smbios_header_t *header,
     // BIOS Vendor (string index at offset 4)
     if (data[4] > 0 && get_smbios_string(smbios_data, smbios_size, string_table, 
                                      data[4], temp_str, sizeof(temp_str))) {
-        safecpy(ds->hw.bios.vendor, temp_str);
+        safecpy(dmi->bios.vendor, temp_str);
     }
     
     // BIOS Version (string index at offset 5)
     if (data[5] > 0 && get_smbios_string(smbios_data, smbios_size, string_table,
                                      data[5], temp_str, sizeof(temp_str))) {
-        safecpy(ds->hw.bios.version, temp_str);
+        safecpy(dmi->bios.version, temp_str);
     }
     
     // BIOS Release Date (string index at offset 8)
     if (data[8] > 0 && get_smbios_string(smbios_data, smbios_size, string_table,
                                      data[8], temp_str, sizeof(temp_str))) {
-        safecpy(ds->hw.bios.date, temp_str);
+        safecpy(dmi->bios.date, temp_str);
     }
 }
 
 // Process System Information (Type 1)
 static void process_smbios_system_info(const smbios_header_t *header,
-                                    DAEMON_STATUS_FILE *ds,
+                                    DMI_INFO *dmi,
                                     const char *string_table,
                                     const BYTE *smbios_data,
                                     DWORD smbios_size) {
-    if (header->length < 8) // Minimum size for System info
+    if (header->length < 8 || !dmi) // Minimum size for System info
         return;
         
     const BYTE *data = (const BYTE *)header;
@@ -936,36 +744,36 @@ static void process_smbios_system_info(const smbios_header_t *header,
     // Manufacturer (string index at offset 4)
     if (data[4] > 0 && get_smbios_string(smbios_data, smbios_size, string_table,
                                      data[4], temp_str, sizeof(temp_str))) {
-        safecpy(ds->hw.sys.vendor, temp_str);
+        safecpy(dmi->sys.vendor, temp_str);
     }
     
     // Product Name (string index at offset 5)
     if (data[5] > 0 && get_smbios_string(smbios_data, smbios_size, string_table,
                                      data[5], temp_str, sizeof(temp_str))) {
-        safecpy(ds->hw.product.name, temp_str);
+        safecpy(dmi->product.name, temp_str);
     }
     
     // Version (string index at offset 6)
     if (data[6] > 0 && get_smbios_string(smbios_data, smbios_size, string_table,
                                      data[6], temp_str, sizeof(temp_str))) {
-        safecpy(ds->hw.product.version, temp_str);
+        safecpy(dmi->product.version, temp_str);
     }
     
     // If structure is long enough for family (SMBIOS 2.1+)
     if (header->length >= 25 && data[21] > 0 && 
         get_smbios_string(smbios_data, smbios_size, string_table,
                        data[21], temp_str, sizeof(temp_str))) {
-        safecpy(ds->hw.product.family, temp_str);
+        safecpy(dmi->product.family, temp_str);
     }
 }
 
 // Process Baseboard Information (Type 2)
 static void process_smbios_baseboard_info(const smbios_header_t *header,
-                                       DAEMON_STATUS_FILE *ds,
+                                       DMI_INFO *dmi,
                                        const char *string_table,
                                        const BYTE *smbios_data,
                                        DWORD smbios_size) {
-    if (header->length < 8) // Minimum size for Baseboard info
+    if (header->length < 8 || !dmi) // Minimum size for Baseboard info
         return;
         
     const BYTE *data = (const BYTE *)header;
@@ -974,29 +782,29 @@ static void process_smbios_baseboard_info(const smbios_header_t *header,
     // Manufacturer (string index at offset 4)
     if (data[4] > 0 && get_smbios_string(smbios_data, smbios_size, string_table,
                                      data[4], temp_str, sizeof(temp_str))) {
-        safecpy(ds->hw.board.vendor, temp_str);
+        safecpy(dmi->board.vendor, temp_str);
     }
     
     // Product (string index at offset 5)
     if (data[5] > 0 && get_smbios_string(smbios_data, smbios_size, string_table,
                                      data[5], temp_str, sizeof(temp_str))) {
-        safecpy(ds->hw.board.name, temp_str);
+        safecpy(dmi->board.name, temp_str);
     }
     
     // Version (string index at offset 6)
     if (data[6] > 0 && get_smbios_string(smbios_data, smbios_size, string_table,
                                      data[6], temp_str, sizeof(temp_str))) {
-        safecpy(ds->hw.board.version, temp_str);
+        safecpy(dmi->board.version, temp_str);
     }
 }
 
 // Process Chassis Information (Type 3)
 static void process_smbios_chassis_info(const smbios_header_t *header,
-                                     DAEMON_STATUS_FILE *ds,
+                                     DMI_INFO *dmi,
                                      const char *string_table,
                                      const BYTE *smbios_data,
                                      DWORD smbios_size) {
-    if (header->length < 9) // Minimum size for Chassis info
+    if (header->length < 9 || !dmi) // Minimum size for Chassis info
         return;
         
     const BYTE *data = (const BYTE *)header;
@@ -1005,48 +813,50 @@ static void process_smbios_chassis_info(const smbios_header_t *header,
     // Manufacturer (string index at offset 4)
     if (data[4] > 0 && get_smbios_string(smbios_data, smbios_size, string_table,
                                      data[4], temp_str, sizeof(temp_str))) {
-        safecpy(ds->hw.chassis.vendor, temp_str);
+        safecpy(dmi->chassis.vendor, temp_str);
     }
     
     // Type (numerical value at offset 5)
     BYTE chassis_type = data[5] & 0x7F; // Mask out MSB
-    snprintf(ds->hw.chassis.type, sizeof(ds->hw.chassis.type), "%d", chassis_type);
+    snprintf(dmi->chassis.type, sizeof(dmi->chassis.type), "%d", chassis_type);
     
     // Version (string index at offset 6)
     if (data[6] > 0 && get_smbios_string(smbios_data, smbios_size, string_table,
                                      data[6], temp_str, sizeof(temp_str))) {
-        safecpy(ds->hw.chassis.version, temp_str);
+        safecpy(dmi->chassis.version, temp_str);
     }
 }
 
 // Process a complete SMBIOS structure
 static void process_smbios_structure(const smbios_header_t *header, 
-                                  DAEMON_STATUS_FILE *ds,
+                                  DMI_INFO *dmi,
                                   const char *string_table,
                                   const BYTE *smbios_data,
                                   DWORD smbios_size) {
+    if (!dmi) return;
+    
     switch (header->type) {
         case 0: // BIOS Information
-            process_smbios_bios_info(header, ds, string_table, smbios_data, smbios_size);
+            process_smbios_bios_info(header, dmi, string_table, smbios_data, smbios_size);
             break;
             
         case 1: // System Information
-            process_smbios_system_info(header, ds, string_table, smbios_data, smbios_size);
+            process_smbios_system_info(header, dmi, string_table, smbios_data, smbios_size);
             break;
             
         case 2: // Baseboard Information
-            process_smbios_baseboard_info(header, ds, string_table, smbios_data, smbios_size);
+            process_smbios_baseboard_info(header, dmi, string_table, smbios_data, smbios_size);
             break;
             
         case 3: // Chassis Information
-            process_smbios_chassis_info(header, ds, string_table, smbios_data, smbios_size);
+            process_smbios_chassis_info(header, dmi, string_table, smbios_data, smbios_size);
             break;
     }
 }
 
 // Parse all SMBIOS structures with robust error handling
-static void parse_smbios_structures(const smbios_data_t smbios, DAEMON_STATUS_FILE *ds) {
-    if (!smbios.valid || !smbios.data || smbios.size < 8)
+static void parse_smbios_structures(const smbios_data_t smbios, DMI_INFO *dmi) {
+    if (!smbios.valid || !smbios.data || smbios.size < 8 || !dmi)
         return;
         
     // The SMBIOS header is at offset 8
@@ -1105,7 +915,7 @@ static void parse_smbios_structures(const smbios_data_t smbios, DAEMON_STATUS_FI
         // Process the structure based on type
         const char *string_table = (const char *)(current + header->length);
         if (string_table < (const char *)end) {
-            process_smbios_structure(header, ds, string_table, smbios.data, smbios.size);
+            process_smbios_structure(header, dmi, string_table, smbios.data, smbios.size);
         }
         
         // Find string table end (double null terminator)
@@ -1139,36 +949,40 @@ static void parse_smbios_structures(const smbios_data_t smbios, DAEMON_STATUS_FI
             break;
     }
 }
-static void windows_get_smbios_info(DAEMON_STATUS_FILE *ds) {
+static void windows_get_smbios_info(DMI_INFO *dmi) {
+    if (!dmi) return;
+    
     // Get SMBIOS data using our improved container structure
     smbios_data_t smbios = get_smbios_data();
     if (!smbios.valid)
         return;
         
     // Process the SMBIOS data with our improved parser
-    parse_smbios_structures(smbios, ds);
+    parse_smbios_structures(smbios, dmi);
     
     // Clean up
     freez(smbios.data);
 }
 
 // Fallback method using registry
-static void windows_get_registry_info(DAEMON_STATUS_FILE *ds) {
+static void windows_get_registry_info(DMI_INFO *dmi) {
+    if (!dmi) return;
+    
     // System manufacturer and model from registry
     windows_read_registry_string(
         HKEY_LOCAL_MACHINE,
         "HARDWARE\\DESCRIPTION\\System\\BIOS",
         "SystemManufacturer",
-        ds->hw.sys.vendor,
-        sizeof(ds->hw.sys.vendor)
+        dmi->sys.vendor,
+        sizeof(dmi->sys.vendor)
     );
 
     windows_read_registry_string(
         HKEY_LOCAL_MACHINE,
         "HARDWARE\\DESCRIPTION\\System\\BIOS",
         "SystemProductName",
-        ds->hw.product.name,
-        sizeof(ds->hw.product.name)
+        dmi->product.name,
+        sizeof(dmi->product.name)
     );
 
     // BIOS information
@@ -1176,24 +990,24 @@ static void windows_get_registry_info(DAEMON_STATUS_FILE *ds) {
         HKEY_LOCAL_MACHINE,
         "HARDWARE\\DESCRIPTION\\System\\BIOS",
         "BIOSVendor",
-        ds->hw.bios.vendor,
-        sizeof(ds->hw.bios.vendor)
+        dmi->bios.vendor,
+        sizeof(dmi->bios.vendor)
     );
 
     windows_read_registry_string(
         HKEY_LOCAL_MACHINE,
         "HARDWARE\\DESCRIPTION\\System\\BIOS",
         "BIOSVersion",
-        ds->hw.bios.version,
-        sizeof(ds->hw.bios.version)
+        dmi->bios.version,
+        sizeof(dmi->bios.version)
     );
 
     windows_read_registry_string(
         HKEY_LOCAL_MACHINE,
         "HARDWARE\\DESCRIPTION\\System\\BIOS",
         "BIOSReleaseDate",
-        ds->hw.bios.date,
-        sizeof(ds->hw.bios.date)
+        dmi->bios.date,
+        sizeof(dmi->bios.date)
     );
 
     // Board information
@@ -1201,81 +1015,81 @@ static void windows_get_registry_info(DAEMON_STATUS_FILE *ds) {
         HKEY_LOCAL_MACHINE,
         "HARDWARE\\DESCRIPTION\\System\\BIOS",
         "BaseBoardManufacturer",
-        ds->hw.board.vendor,
-        sizeof(ds->hw.board.vendor)
+        dmi->board.vendor,
+        sizeof(dmi->board.vendor)
     );
 
     windows_read_registry_string(
         HKEY_LOCAL_MACHINE,
         "HARDWARE\\DESCRIPTION\\System\\BIOS",
         "BaseBoardProduct",
-        ds->hw.board.name,
-        sizeof(ds->hw.board.name)
+        dmi->board.name,
+        sizeof(dmi->board.name)
     );
 
     windows_read_registry_string(
         HKEY_LOCAL_MACHINE,
         "HARDWARE\\DESCRIPTION\\System\\BIOS",
         "BaseBoardVersion",
-        ds->hw.board.version,
-        sizeof(ds->hw.board.version)
+        dmi->board.version,
+        sizeof(dmi->board.version)
     );
 }
 
 // Main function to get hardware information
-void os_dmi_info(DAEMON_STATUS_FILE *ds) {
+void os_dmi_info_get(DMI_INFO *dmi) {
+    if (!dmi) return;
+    
     // First try SMBIOS data through firmware table API
-    windows_get_smbios_info(ds);
+    windows_get_smbios_info(dmi);
 
     // Try registry as a fallback or to fill missing values
-    windows_get_registry_info(ds);
+    windows_get_registry_info(dmi);
 
     // If chassis type is not set or not a valid number, set a default
-    if (!ds->hw.chassis.type[0] || atoi(ds->hw.chassis.type) <= 0) {
+    if (!dmi->chassis.type[0] || atoi(dmi->chassis.type) <= 0) {
         // Check common system names for laptops
-        if (strcasestr(ds->hw.product.name, "notebook") != NULL ||
-            strcasestr(ds->hw.product.name, "laptop") != NULL ||
-            strcasestr(ds->hw.product.name, "book") != NULL) {
-            safecpy(ds->hw.chassis.type, "9");  // Laptop
+        if (strcasestr(dmi->product.name, "notebook") != NULL ||
+            strcasestr(dmi->product.name, "laptop") != NULL ||
+            strcasestr(dmi->product.name, "book") != NULL) {
+            safecpy(dmi->chassis.type, "9");  // Laptop
         }
         // Check for servers
-        else if (strcasestr(ds->hw.product.name, "server") != NULL) {
-            safecpy(ds->hw.chassis.type, "17");  // Server
+        else if (strcasestr(dmi->product.name, "server") != NULL) {
+            safecpy(dmi->chassis.type, "17");  // Server
         }
         // Default to desktop
         else {
-            safecpy(ds->hw.chassis.type, "3");  // Desktop
+            safecpy(dmi->chassis.type, "3");  // Desktop
         }
     }
 }
 
 #else
-void os_dmi_info(DAEMON_STATUS_FILE *ds) {
-    ;
+void os_dmi_info_get(DMI_INFO *dmi) {
+    // No implementation for this platform
 }
 #endif
 
 // --------------------------------------------------------------------------------------------------------------------
 // public API
 
-void fill_dmi_info(DAEMON_STATUS_FILE *ds) {
-    ds->hw.sys.vendor[0] = '\0';
-    ds->hw.product.name[0] = '\0';
-    ds->hw.product.version[0] = '\0';
-    ds->hw.product.sku[0] = '\0';
-    ds->hw.product.family[0] = '\0';
-    ds->hw.board.vendor[0] = '\0';
-    ds->hw.board.name[0] = '\0';
-    ds->hw.board.version[0] = '\0';
-    ds->hw.bios.vendor[0] = '\0';
-    ds->hw.bios.version[0] = '\0';
-    ds->hw.bios.date[0] = '\0';
-    ds->hw.bios.release[0] = '\0';
-    ds->hw.chassis.vendor[0] = '\0';
-    ds->hw.chassis.version[0] = '\0';
-    ds->hw.chassis.type[0] = '\0';
-
-    os_dmi_info(ds);
-
-    product_name_vendor_type(ds);
+void dmi_info_init(DMI_INFO *dmi) {
+    if (!dmi) return;
+    
+    dmi->sys.vendor[0] = '\0';
+    dmi->product.name[0] = '\0';
+    dmi->product.version[0] = '\0';
+    dmi->product.sku[0] = '\0';
+    dmi->product.family[0] = '\0';
+    dmi->board.vendor[0] = '\0';
+    dmi->board.name[0] = '\0';
+    dmi->board.version[0] = '\0';
+    dmi->bios.vendor[0] = '\0';
+    dmi->bios.version[0] = '\0';
+    dmi->bios.date[0] = '\0';
+    dmi->bios.release[0] = '\0';
+    dmi->chassis.vendor[0] = '\0';
+    dmi->chassis.version[0] = '\0';
+    dmi->chassis.type[0] = '\0';
 }

--- a/src/daemon/status-file-dmi.c
+++ b/src/daemon/status-file-dmi.c
@@ -2,12 +2,6 @@
 
 #include "status-file-dmi.h"
 
-#define safecpy(dst, src) do {                                                                  \
-    _Static_assert(sizeof(dst) != sizeof(char *),                                               \
-                   "safecpy: dst must not be a pointer, but a buffer (e.g., char dst[SIZE])");  \
-    strcatz(dst, 0, src, sizeof(dst));                                                          \
-} while (0)
-
 static void dmi_clean_field_placeholder(char *buf, size_t buf_size) {
     if(!buf || !buf_size) return;
 

--- a/src/daemon/status-file-dmi.c
+++ b/src/daemon/status-file-dmi.c
@@ -57,7 +57,7 @@ static void dmi_clean_field_placeholder(char *buf, size_t buf_size) {
     }
 }
 
-static void dmi_normalize_vendor_field(char *buf, size_t buf_size) {
+void dmi_normalize_vendor_field(char *buf, size_t buf_size) {
     if(!buf || !buf_size) return;
 
     struct {
@@ -224,8 +224,8 @@ static void dmi_normalize_vendor_field(char *buf, size_t buf_size) {
     }
 }
 
-static bool dmi_is_virtual_machine(const DAEMON_STATUS_FILE *ds) {
-    if(!ds) return false;
+bool dmi_is_virtual_machine(const DMI_INFO *dmi) {
+    if(!dmi) return false;
 
     const char *vm_indicators[] = {
         "Virt", "KVM", "vServer", "Cloud", "Hyper", "Droplet", "Compute",
@@ -234,10 +234,10 @@ static bool dmi_is_virtual_machine(const DAEMON_STATUS_FILE *ds) {
     };
 
     const char *strs_to_check[] = {
-        ds->hw.product.name,
-        ds->hw.product.family,
-        ds->hw.sys.vendor,
-        ds->hw.board.name,
+        dmi->product.name,
+        dmi->product.family,
+        dmi->sys.vendor,
+        dmi->board.name,
     };
 
     for (size_t i = 0; i < _countof(strs_to_check); i++) {
@@ -251,69 +251,6 @@ static bool dmi_is_virtual_machine(const DAEMON_STATUS_FILE *ds) {
     }
 
     return false;
-}
-
-static const char *dmi_chassis_type_to_string(int chassis_type) {
-    // Original info from SMBIOS
-    // https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.2.0.pdf
-    // see also inxi: https://github.com/smxi/inxi/blob/master/inxi
-
-    // we categorize chassis types as:
-    //   1. desktop
-    //   2. laptop
-    //   3. server
-    //   4. mini-pc
-    //   5. unknown
-    // elsewhere we mark them also as "vm" (which is preferred over this)
-
-    switch(chassis_type) {
-        case 3: /* "desktop" */
-        case 4: /* "low-profile-desktop" */
-        case 6: /* "mini-tower-desktop" */
-        case 7: /* "tower-desktop" */
-        case 13: /* "all-in-one" */
-        case 15: /* "space-saving-desktop" */
-        case 24: /* "sealed-desktop" */
-        case 26: /* "compact-pci" */
-            return "desktop";
-
-        case 5: /* "pizza-box" - was 1U desktops and some laptops */
-        case 8: /* "portable" */
-        case 9: /* "laptop" */
-        case 10: /* "notebook" */
-        case 11: /* "hand-held" */
-        case 12: /* "docking-station" */
-        case 14: /* "sub-notebook" */
-        case 16: /* "lunch-box" */
-        case 30: /* "tablet" */
-        case 31: /* "convertible" */
-        case 32: /* "detachable" */
-            return "laptop";
-
-        case 17: /* "main-server-chassis" */
-        case 23: /* "rack-mount-server" */
-        case 25: /* "multimount-chassis" */
-        case 27: /* "advanced-tca" */
-        case 28: /* "blade" */
-        case 29: /* "blade-enclosure" */
-            return "server";
-
-        case 33: /* "iot-gateway" */
-        case 34: /* "embedded-pc" */
-        case 35: /* "mini-pc" */
-        case 36: /* "stick-pc" */
-            return "mini-pc";
-
-        case 1: /* "other" */
-        case 2: /* "unknown" */
-        case 18: /* "expansion-chassis" */
-        case 19: /* "sub-chassis" */
-        case 20: /* "bus-expansion" */
-        case 21: /* "peripheral" */
-        case 22: /* "raid" */
-        default:
-            return "unknown";
-    }
 }
 
 static void dmi_clean_field(char *buf, size_t buf_size) {
@@ -1341,86 +1278,4 @@ void fill_dmi_info(DAEMON_STATUS_FILE *ds) {
     os_dmi_info(ds);
 
     product_name_vendor_type(ds);
-}
-
-void product_name_vendor_type(DAEMON_STATUS_FILE *ds) {
-    char *force_type = NULL;
-
-    if(ds->cloud_provider_type[0] && strcasecmp(ds->cloud_provider_type, "unknown") != 0)
-        safecpy(ds->product.vendor, ds->cloud_provider_type);
-    else {
-        // copy one of the names found in DMI
-        if(ds->hw.sys.vendor[0])
-            safecpy(ds->product.vendor, ds->hw.sys.vendor);
-        else if(ds->hw.board.vendor[0])
-            safecpy(ds->product.vendor, ds->hw.board.vendor);
-        else if(ds->hw.chassis.vendor[0])
-            safecpy(ds->product.vendor, ds->hw.chassis.vendor);
-        else if(ds->hw.bios.vendor[0])
-            safecpy(ds->product.vendor, ds->hw.bios.vendor);
-
-        // derive the vendor from other DMI fields
-        if(!ds->product.vendor[0]) {
-            if(strcasestr(ds->hw.product.name, "VirtualMac") != NULL ||
-                (strcasestr(ds->hw.board.name, "Apple") != NULL &&
-                 strcasestr(ds->hw.board.name, "Virtual") != NULL)) {
-                safecpy(ds->product.vendor, "Apple");
-                force_type = "vm";
-            }
-            else if(strcasestr(ds->hw.product.name, "NVIDIA") != NULL &&
-                     strcasestr(ds->hw.product.name, "Kit") != NULL) {
-                safecpy(ds->product.vendor, "NVIDIA");
-                force_type = "vm";
-            }
-            else if(strcasestr(ds->hw.product.name, "Raspberry") != NULL) {
-                safecpy(ds->product.vendor, "Raspberry");
-                force_type = "mini-pc";
-            }
-            else if(strcasestr(ds->hw.product.name, "ODROID") != NULL) {
-                safecpy(ds->product.vendor, "Odroid");
-                force_type = "mini-pc";
-            }
-            else if(strcasestr(ds->hw.product.name, "BananaPi") != NULL ||
-                     strcasestr(ds->hw.product.name, "Banana Pi") != NULL) {
-                safecpy(ds->product.vendor, "BananaPi");
-                force_type = "mini-pc";
-            }
-            else if(strcasestr(ds->hw.product.name, "OrangePi") != NULL ||
-                     strcasestr(ds->hw.product.name, "Orange Pi") != NULL) {
-                safecpy(ds->product.vendor, "OrangePi");
-                force_type = "mini-pc";
-            }
-        }
-
-        if(!ds->product.vendor[0])
-            safecpy(ds->product.vendor, "unknown");
-        else
-            dmi_normalize_vendor_field(ds->product.vendor, sizeof(ds->product.vendor));
-    }
-
-    if(ds->cloud_instance_type[0] && strcasecmp(ds->cloud_instance_type, "unknown") != 0)
-        safecpy(ds->product.name, ds->cloud_instance_type);
-    else {
-        if(ds->hw.product.name[0])
-            safecpy(ds->product.name, ds->hw.product.name);
-        else if(ds->hw.board.name[0])
-            safecpy(ds->product.name, ds->hw.board.name);
-        else
-            safecpy(ds->product.name, "unknown");
-    }
-
-    if(ds->virtualization[0] && strcasecmp(ds->virtualization, "none") != 0 && strcasecmp(ds->virtualization, "unknown") != 0)
-        safecpy(ds->product.type, "vm");
-    else if(force_type)
-        safecpy(ds->product.type, force_type);
-    else if(dmi_is_virtual_machine(ds))
-        safecpy(ds->product.type, "vm");
-    else {
-        char *end = NULL;
-        int type = (int)strtol(ds->hw.chassis.type, &end, 10);
-        if(type && (!end || !*end))
-            safecpy(ds->product.type, dmi_chassis_type_to_string(type));
-        else
-            safecpy(ds->product.type, "unknown");
-    }
 }

--- a/src/daemon/status-file-dmi.h
+++ b/src/daemon/status-file-dmi.h
@@ -3,7 +3,7 @@
 #ifndef NETDATA_STATUS_FILE_DMI_H
 #define NETDATA_STATUS_FILE_DMI_H
 
-#include "status-file.h"
+#include "libnetdata/libnetdata.h"
 
 #define safecpy(dst, src) do {                                                                  \
     _Static_assert(sizeof(dst) != sizeof(char *),                                               \
@@ -12,7 +12,43 @@
     strcatz(dst, 0, src, sizeof(dst));                                                          \
 } while (0)
 
-void product_name_vendor_type(DAEMON_STATUS_FILE *ds);
+typedef struct dmi_info {
+    struct {
+        char vendor[64];
+    } sys;
+
+    struct {
+        char name[64];
+        char version[64];
+        char sku[64];
+        char family[64];
+    } product;
+
+    struct {
+        char name[64];
+        char version[64];
+        char vendor[64];
+    } board;
+
+    struct {
+        char type[16];
+        char vendor[64];
+        char version[64];
+    } chassis;
+
+    struct {
+        char date[16];
+        char release[64];
+        char version[64];
+        char vendor[64];
+    } bios;
+} DMI_INFO;
+
+#include "status-file.h"
+
+bool dmi_is_virtual_machine(const DMI_INFO *dmi);
+void dmi_normalize_vendor_field(char *buf, size_t buf_size);
+
 void fill_dmi_info(DAEMON_STATUS_FILE *ds);
 
 #endif //NETDATA_STATUS_FILE_DMI_H

--- a/src/daemon/status-file-dmi.h
+++ b/src/daemon/status-file-dmi.h
@@ -12,7 +12,7 @@
     strcatz(dst, 0, src, sizeof(dst));                                                          \
 } while (0)
 
-void finalize_vendor_product_vm(DAEMON_STATUS_FILE *ds);
+void product_name_vendor_type(DAEMON_STATUS_FILE *ds);
 void fill_dmi_info(DAEMON_STATUS_FILE *ds);
 
 #endif //NETDATA_STATUS_FILE_DMI_H

--- a/src/daemon/status-file-dmi.h
+++ b/src/daemon/status-file-dmi.h
@@ -5,6 +5,13 @@
 
 #include "status-file.h"
 
+#define safecpy(dst, src) do {                                                                  \
+    _Static_assert(sizeof(dst) != sizeof(char *),                                               \
+                   "safecpy: dst must not be a pointer, but a buffer (e.g., char dst[SIZE])");  \
+                                                                                                \
+    strcatz(dst, 0, src, sizeof(dst));                                                          \
+} while (0)
+
 void finalize_vendor_product_vm(DAEMON_STATUS_FILE *ds);
 void fill_dmi_info(DAEMON_STATUS_FILE *ds);
 

--- a/src/daemon/status-file-dmi.h
+++ b/src/daemon/status-file-dmi.h
@@ -46,9 +46,10 @@ typedef struct dmi_info {
 
 #include "status-file.h"
 
-bool dmi_is_virtual_machine(const DMI_INFO *dmi);
-void dmi_normalize_vendor_field(char *buf, size_t buf_size);
+// Initialize DMI_INFO structure
+void dmi_info_init(DMI_INFO *dmi);
 
-void fill_dmi_info(DAEMON_STATUS_FILE *ds);
+// Platform-specific function to get DMI info 
+void os_dmi_info_get(DMI_INFO *dmi);
 
 #endif //NETDATA_STATUS_FILE_DMI_H

--- a/src/daemon/status-file-dmi.h
+++ b/src/daemon/status-file-dmi.h
@@ -15,6 +15,9 @@
 typedef struct dmi_info {
     struct {
         char vendor[64];
+        char serial[64];  // System serial number
+        char uuid[64];    // System UUID (hardware identifier)
+        char asset_tag[64]; // System asset tag
     } sys;
 
     struct {
@@ -28,12 +31,16 @@ typedef struct dmi_info {
         char name[64];
         char version[64];
         char vendor[64];
+        char serial[64];  // Board serial number
+        char asset_tag[64]; // Board asset tag
     } board;
 
     struct {
         char type[16];
         char vendor[64];
         char version[64];
+        char serial[64];  // Chassis serial number
+        char asset_tag[64]; // Chassis asset tag
     } chassis;
 
     struct {
@@ -41,6 +48,8 @@ typedef struct dmi_info {
         char release[64];
         char version[64];
         char vendor[64];
+        char mode[16];    // Boot mode (UEFI/Legacy)
+        bool secure_boot; // Secure boot status (true/false)
     } bios;
 } DMI_INFO;
 

--- a/src/daemon/status-file-product.c
+++ b/src/daemon/status-file-product.c
@@ -320,7 +320,9 @@ void product_name_vendor_type(DAEMON_STATUS_FILE *ds) {
     if(ds->cloud_instance_type[0] && strcasecmp(ds->cloud_instance_type, "unknown") != 0)
         safecpy(ds->product.name, ds->cloud_instance_type);
     else {
-        if(ds->hw.product.name[0])
+        if(ds->hw.product.family[0])
+            safecpy(ds->product.name, ds->hw.product.family);
+        else if(ds->hw.product.name[0])
             safecpy(ds->product.name, ds->hw.product.name);
         else if(ds->hw.board.name[0])
             safecpy(ds->product.name, ds->hw.board.name);

--- a/src/daemon/status-file-product.c
+++ b/src/daemon/status-file-product.c
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "status-file-dmi.h"
+#include "status-file-product.h"
+
+static const char *dmi_chassis_type_to_string(int chassis_type) {
+    // Original info from SMBIOS
+    // https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.2.0.pdf
+    // see also inxi: https://github.com/smxi/inxi/blob/master/inxi
+
+    // we categorize chassis types as:
+    //   1. desktop
+    //   2. laptop
+    //   3. server
+    //   4. mini-pc
+    //   5. unknown
+    // elsewhere we mark them also as "vm" (which is preferred over this)
+
+    switch(chassis_type) {
+        case 3: /* "desktop" */
+        case 4: /* "low-profile-desktop" */
+        case 6: /* "mini-tower-desktop" */
+        case 7: /* "tower-desktop" */
+        case 13: /* "all-in-one" */
+        case 15: /* "space-saving-desktop" */
+        case 24: /* "sealed-desktop" */
+        case 26: /* "compact-pci" */
+            return "desktop";
+
+        case 5: /* "pizza-box" - was 1U desktops and some laptops */
+        case 8: /* "portable" */
+        case 9: /* "laptop" */
+        case 10: /* "notebook" */
+        case 11: /* "hand-held" */
+        case 12: /* "docking-station" */
+        case 14: /* "sub-notebook" */
+        case 16: /* "lunch-box" */
+        case 30: /* "tablet" */
+        case 31: /* "convertible" */
+        case 32: /* "detachable" */
+            return "laptop";
+
+        case 17: /* "main-server-chassis" */
+        case 23: /* "rack-mount-server" */
+        case 25: /* "multimount-chassis" */
+        case 27: /* "advanced-tca" */
+        case 28: /* "blade" */
+        case 29: /* "blade-enclosure" */
+            return "server";
+
+        case 33: /* "iot-gateway" */
+        case 34: /* "embedded-pc" */
+        case 35: /* "mini-pc" */
+        case 36: /* "stick-pc" */
+            return "mini-pc";
+
+        case 1: /* "other" */
+        case 2: /* "unknown" */
+        case 18: /* "expansion-chassis" */
+        case 19: /* "sub-chassis" */
+        case 20: /* "bus-expansion" */
+        case 21: /* "peripheral" */
+        case 22: /* "raid" */
+        default:
+            return "unknown";
+    }
+}
+
+void product_name_vendor_type(DAEMON_STATUS_FILE *ds) {
+    char *force_type = NULL;
+
+    if(ds->cloud_provider_type[0] && strcasecmp(ds->cloud_provider_type, "unknown") != 0)
+        safecpy(ds->product.vendor, ds->cloud_provider_type);
+    else {
+        // copy one of the names found in DMI
+        if(ds->hw.sys.vendor[0])
+            safecpy(ds->product.vendor, ds->hw.sys.vendor);
+        else if(ds->hw.board.vendor[0])
+            safecpy(ds->product.vendor, ds->hw.board.vendor);
+        else if(ds->hw.chassis.vendor[0])
+            safecpy(ds->product.vendor, ds->hw.chassis.vendor);
+        else if(ds->hw.bios.vendor[0])
+            safecpy(ds->product.vendor, ds->hw.bios.vendor);
+
+        // derive the vendor from other DMI fields
+        if(!ds->product.vendor[0]) {
+            if(strcasestr(ds->hw.product.name, "VirtualMac") != NULL ||
+                (strcasestr(ds->hw.board.name, "Apple") != NULL &&
+                 strcasestr(ds->hw.board.name, "Virtual") != NULL)) {
+                safecpy(ds->product.vendor, "Apple");
+                force_type = "vm";
+            }
+            else if(strcasestr(ds->hw.product.name, "NVIDIA") != NULL &&
+                     strcasestr(ds->hw.product.name, "Kit") != NULL) {
+                safecpy(ds->product.vendor, "NVIDIA");
+                force_type = "vm";
+            }
+            else if(strcasestr(ds->hw.product.name, "Raspberry") != NULL) {
+                safecpy(ds->product.vendor, "Raspberry");
+                force_type = "mini-pc";
+            }
+            else if(strcasestr(ds->hw.product.name, "ODROID") != NULL) {
+                safecpy(ds->product.vendor, "Odroid");
+                force_type = "mini-pc";
+            }
+            else if(strcasestr(ds->hw.product.name, "BananaPi") != NULL ||
+                     strcasestr(ds->hw.product.name, "Banana Pi") != NULL) {
+                safecpy(ds->product.vendor, "BananaPi");
+                force_type = "mini-pc";
+            }
+            else if(strcasestr(ds->hw.product.name, "OrangePi") != NULL ||
+                     strcasestr(ds->hw.product.name, "Orange Pi") != NULL) {
+                safecpy(ds->product.vendor, "OrangePi");
+                force_type = "mini-pc";
+            }
+        }
+
+        if(!ds->product.vendor[0])
+            safecpy(ds->product.vendor, "unknown");
+        else
+            dmi_normalize_vendor_field(ds->product.vendor, sizeof(ds->product.vendor));
+    }
+
+    if(ds->cloud_instance_type[0] && strcasecmp(ds->cloud_instance_type, "unknown") != 0)
+        safecpy(ds->product.name, ds->cloud_instance_type);
+    else {
+        if(ds->hw.product.name[0])
+            safecpy(ds->product.name, ds->hw.product.name);
+        else if(ds->hw.board.name[0])
+            safecpy(ds->product.name, ds->hw.board.name);
+        else
+            safecpy(ds->product.name, "unknown");
+    }
+
+    if(ds->virtualization[0] && strcasecmp(ds->virtualization, "none") != 0 && strcasecmp(ds->virtualization, "unknown") != 0)
+        safecpy(ds->product.type, "vm");
+    else if(force_type)
+        safecpy(ds->product.type, force_type);
+    else if(dmi_is_virtual_machine(&ds->hw))
+        safecpy(ds->product.type, "vm");
+    else {
+        char *end = NULL;
+        int type = (int)strtol(ds->hw.chassis.type, &end, 10);
+        if(type && (!end || !*end))
+            safecpy(ds->product.type, dmi_chassis_type_to_string(type));
+        else
+            safecpy(ds->product.type, "unknown");
+    }
+}

--- a/src/daemon/status-file-product.h
+++ b/src/daemon/status-file-product.h
@@ -1,0 +1,12 @@
+//
+// Created by costa on 4/4/25.
+//
+
+#ifndef NETDATA_STATUS_FILE_PRODUCT_H
+#define NETDATA_STATUS_FILE_PRODUCT_H
+
+#include "status-file.h"
+
+void product_name_vendor_type(DAEMON_STATUS_FILE *ds);
+
+#endif //NETDATA_STATUS_FILE_PRODUCT_H

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -86,6 +86,14 @@ static void set_stack_trace_message_if_empty(DAEMON_STATUS_FILE *ds, const char 
         safecpy(ds->fatal.stack_trace, msg);
 }
 
+static void fill_dmi_info(DAEMON_STATUS_FILE *ds) {
+    if(!ds) return;
+
+    dmi_info_init(&ds->hw);
+    os_dmi_info_get(&ds->hw);
+    product_name_vendor_type(ds);
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 // json generation
 

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -9,6 +9,7 @@
 #include <openssl/pem.h>
 #include <openssl/err.h>
 #include "status-file-dmi.h"
+#include "status-file-product.h"
 
 #ifdef ENABLE_SENTRY
 #include "sentry-native/sentry-native.h"

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -228,9 +228,9 @@ static void daemon_status_file_to_json(BUFFER *wb, DAEMON_STATUS_FILE *ds) {
         buffer_json_member_add_object(wb, "sys");
         {
             buffer_json_member_add_string(wb, "vendor", ds->hw.sys.vendor);
-            buffer_json_member_add_string(wb, "serial", ds->hw.sys.serial);
             buffer_json_member_add_string(wb, "uuid", ds->hw.sys.uuid);
-            buffer_json_member_add_string(wb, "asset_tag", ds->hw.sys.asset_tag);
+            // buffer_json_member_add_string(wb, "serial", ds->hw.sys.serial);
+            // buffer_json_member_add_string(wb, "asset_tag", ds->hw.sys.asset_tag);
         }
         buffer_json_object_close(wb);
 
@@ -248,8 +248,8 @@ static void daemon_status_file_to_json(BUFFER *wb, DAEMON_STATUS_FILE *ds) {
             buffer_json_member_add_string(wb, "name", ds->hw.board.name);
             buffer_json_member_add_string(wb, "version", ds->hw.board.version);
             buffer_json_member_add_string(wb, "vendor", ds->hw.board.vendor);
-            buffer_json_member_add_string(wb, "serial", ds->hw.board.serial);
-            buffer_json_member_add_string(wb, "asset_tag", ds->hw.board.asset_tag);
+            // buffer_json_member_add_string(wb, "serial", ds->hw.board.serial);
+            // buffer_json_member_add_string(wb, "asset_tag", ds->hw.board.asset_tag);
         }
         buffer_json_object_close(wb);
 
@@ -258,8 +258,8 @@ static void daemon_status_file_to_json(BUFFER *wb, DAEMON_STATUS_FILE *ds) {
             buffer_json_member_add_string(wb, "type", ds->hw.chassis.type);
             buffer_json_member_add_string(wb, "vendor", ds->hw.chassis.vendor);
             buffer_json_member_add_string(wb, "version", ds->hw.chassis.version);
-            buffer_json_member_add_string(wb, "serial", ds->hw.chassis.serial);
-            buffer_json_member_add_string(wb, "asset_tag", ds->hw.chassis.asset_tag);
+            // buffer_json_member_add_string(wb, "serial", ds->hw.chassis.serial);
+            // buffer_json_member_add_string(wb, "asset_tag", ds->hw.chassis.asset_tag);
         }
         buffer_json_object_close(wb);
 
@@ -488,9 +488,9 @@ static bool daemon_status_file_from_json(json_object *jobj, void *data, BUFFER *
     JSONC_PARSE_SUBOBJECT(jobj, path, "hw", error, required_v25, {
         JSONC_PARSE_SUBOBJECT(jobj, path, "sys", error, required_v25, {
             JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "vendor", ds->hw.sys.vendor, error, required_v25);
-            JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "serial", ds->hw.sys.serial, error, required_v26);
             JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "uuid", ds->hw.sys.uuid, error, required_v27);
-            JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "asset_tag", ds->hw.sys.asset_tag, error, required_v27);
+            // JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "serial", ds->hw.sys.serial, error, required_v26);
+            // JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "asset_tag", ds->hw.sys.asset_tag, error, required_v27);
         });
 
         JSONC_PARSE_SUBOBJECT(jobj, path, "product", error, required_v25, {
@@ -504,16 +504,16 @@ static bool daemon_status_file_from_json(json_object *jobj, void *data, BUFFER *
             JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "name", ds->hw.board.name, error, required_v25);
             JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "version", ds->hw.board.version, error, required_v25);
             JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "vendor", ds->hw.board.vendor, error, required_v25);
-            JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "serial", ds->hw.board.serial, error, required_v26);
-            JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "asset_tag", ds->hw.board.asset_tag, error, required_v27);
+            // JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "serial", ds->hw.board.serial, error, required_v26);
+            // JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "asset_tag", ds->hw.board.asset_tag, error, required_v27);
         });
 
         JSONC_PARSE_SUBOBJECT(jobj, path, "chassis", error, required_v25, {
             JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "type", ds->hw.chassis.type, error, required_v25);
             JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "vendor", ds->hw.chassis.vendor, error, required_v25);
             JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "version", ds->hw.chassis.version, error, required_v25);
-            JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "serial", ds->hw.chassis.serial, error, required_v26);
-            JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "asset_tag", ds->hw.chassis.asset_tag, error, required_v27);
+            // JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "serial", ds->hw.chassis.serial, error, required_v26);
+            // JSONC_PARSE_TXT2CHAR_OR_ERROR_AND_RETURN(jobj, path, "asset_tag", ds->hw.chassis.asset_tag, error, required_v27);
         });
 
         JSONC_PARSE_SUBOBJECT(jobj, path, "bios", error, required_v25, {
@@ -811,6 +811,7 @@ static void post_status_file(struct post_status_file_thread_data *d) {
     buffer_json_member_add_uint64(wb, "priority", d->priority);
     buffer_json_member_add_uint64(wb, "version_saved", d->status->v);
     buffer_json_member_add_string(wb, "agent_version_now", NETDATA_VERSION);
+    buffer_json_member_add_uint64(wb, "agent_pid_now", getpid());
     buffer_json_member_add_boolean(wb, "host_memory_critical",
                                    OS_SYSTEM_MEMORY_OK(d->status->memory) && d->status->memory.ram_available_bytes <= d->status->oom_protection);
     buffer_json_member_add_uint64(wb, "host_memory_free_percent", (uint64_t)round(os_system_memory_available_percent(d->status->memory)));
@@ -1557,8 +1558,4 @@ ND_MACHINE_GUID daemon_status_file_get_host_id(void) {
 
 size_t daemon_status_file_get_fatal_worker_job_id(void) {
     return session_status.fatal.worker_job_id;
-}
-
-pid_t daemon_status_file_get_pid(void) {
-    return session_status.pid;
 }

--- a/src/daemon/status-file.h
+++ b/src/daemon/status-file.h
@@ -171,6 +171,5 @@ size_t daemon_status_file_get_restarts(void);
 ssize_t daemon_status_file_get_reliability(void);
 ND_MACHINE_GUID daemon_status_file_get_host_id(void);
 size_t daemon_status_file_get_fatal_worker_job_id(void);
-pid_t daemon_status_file_get_pid(void);
 
 #endif //NETDATA_STATUS_FILE_H

--- a/src/daemon/status-file.h
+++ b/src/daemon/status-file.h
@@ -106,7 +106,7 @@ typedef struct daemon_status_file {
         } board;
 
         struct {
-            char type[64];
+            char type[16];
             char vendor[64];
             char version[64];
         } chassis;
@@ -118,6 +118,13 @@ typedef struct daemon_status_file {
             char vendor[64];
         } bios;
     } hw;
+
+    struct {
+        // normalized information from cloud provider and h/w information
+        char vendor[64];
+        char name[64];
+        char type[16];
+    } product;
 
     char stack_traces[63];   // the backend for capturing stack traces
 
@@ -181,9 +188,9 @@ const char *daemon_status_file_get_fatal_errno(void);
 const char *daemon_status_file_get_fatal_stack_trace(void);
 const char *daemon_status_file_get_fatal_thread(void);
 const char *daemon_status_file_get_stack_trace_backend(void);
-const char *daemon_status_file_get_hw_sys_vendor(void);
-const char *daemon_status_file_get_hw_product_name(void);
-const char *daemon_status_file_get_hw_chassis_type(void);
+const char *daemon_status_file_get_sys_vendor(void);
+const char *daemon_status_file_get_product_name(void);
+const char *daemon_status_file_get_product_type(void);
 
 pid_t daemon_status_file_get_fatal_thread_id(void);
 long daemon_status_file_get_fatal_line(void);

--- a/src/daemon/status-file.h
+++ b/src/daemon/status-file.h
@@ -10,7 +10,7 @@
 #include "machine-guid.h"
 #include "status-file-dmi.h"
 
-#define STATUS_FILE_VERSION 26
+#define STATUS_FILE_VERSION 27
 
 typedef enum {
     DAEMON_STATUS_NONE,
@@ -52,6 +52,7 @@ typedef struct daemon_status_file {
     size_t crashes;             // the number of times this agent has crashed (ever)
     size_t posts;               // the number of posts to the backend
     ssize_t reliability;        // consecutive restarts: > 0 reliable, < 0 crashing
+    pid_t pid;                  // the process id of the netdata agent
 
     ND_MACHINE_GUID host_id;    // the machine guid of the system
 
@@ -170,5 +171,6 @@ size_t daemon_status_file_get_restarts(void);
 ssize_t daemon_status_file_get_reliability(void);
 ND_MACHINE_GUID daemon_status_file_get_host_id(void);
 size_t daemon_status_file_get_fatal_worker_job_id(void);
+pid_t daemon_status_file_get_pid(void);
 
 #endif //NETDATA_STATUS_FILE_H

--- a/src/daemon/status-file.h
+++ b/src/daemon/status-file.h
@@ -93,8 +93,8 @@ typedef struct daemon_status_file {
 
     struct {
         // normalized information from cloud provider and h/w information
-        char vendor[64];
-        char name[64];
+        char vendor[32];
+        char name[96];
         char type[16];
     } product;
 

--- a/src/daemon/status-file.h
+++ b/src/daemon/status-file.h
@@ -8,6 +8,7 @@
 #include "database/rrd-database-mode.h"
 #include "claim/cloud-status.h"
 #include "machine-guid.h"
+#include "status-file-dmi.h"
 
 #define STATUS_FILE_VERSION 26
 
@@ -87,37 +88,7 @@ typedef struct daemon_status_file {
     char cloud_instance_region[32];
     bool read_system_info;
 
-    struct {
-        struct {
-            char vendor[64];
-        } sys;
-
-        struct {
-            char name[64];
-            char version[64];
-            char sku[64];
-            char family[64];
-        } product;
-
-        struct {
-            char name[64];
-            char version[64];
-            char vendor[64];
-        } board;
-
-        struct {
-            char type[16];
-            char vendor[64];
-            char version[64];
-        } chassis;
-
-        struct {
-            char date[16];
-            char release[64];
-            char version[64];
-            char vendor[64];
-        } bios;
-    } hw;
+    DMI_INFO hw;
 
     struct {
         // normalized information from cloud provider and h/w information

--- a/src/database/rrdhost-system-info.c
+++ b/src/database/rrdhost-system-info.c
@@ -241,9 +241,9 @@ void rrdhost_system_info_to_rrdlabels(struct rrdhost_system_info *system_info, R
     if (system_info->prebuilt_dist)
         rrdlabels_add(labels, "_prebuilt_dist", system_info->prebuilt_dist, RRDLABEL_SRC_AUTO);
 
-    rrdlabels_add(labels, "_hw_sys_vendor", daemon_status_file_get_hw_sys_vendor(), RRDLABEL_SRC_AUTO);
-    rrdlabels_add(labels, "_hw_product_name", daemon_status_file_get_hw_product_name(), RRDLABEL_SRC_AUTO);
-    rrdlabels_add(labels, "_hw_product_type", daemon_status_file_get_hw_chassis_type(), RRDLABEL_SRC_AUTO);
+    rrdlabels_add(labels, "_hw_sys_vendor", daemon_status_file_get_sys_vendor(), RRDLABEL_SRC_AUTO);
+    rrdlabels_add(labels, "_hw_product_name", daemon_status_file_get_product_name(), RRDLABEL_SRC_AUTO);
+    rrdlabels_add(labels, "_hw_product_type", daemon_status_file_get_product_type(), RRDLABEL_SRC_AUTO);
 }
 
 int rrdhost_system_info_detect(struct rrdhost_system_info *system_info) {
@@ -664,13 +664,13 @@ bool get_daemon_status_fields_from_system_info(DAEMON_STATUS_FILE *ds) {
             ds->kubernetes = false;
     }
 
-    if(ri->cloud_provider_type && strcmp(ri->cloud_provider_type, "unknown") != 0)
+    if(ri->cloud_provider_type && strcasecmp(ri->cloud_provider_type, "unknown") != 0)
         strncpyz(ds->cloud_provider_type, ri->cloud_provider_type, sizeof(ds->cloud_provider_type) - 1);
 
-    if(ri->cloud_instance_type && strcmp(ri->cloud_instance_type, "unknown") != 0)
+    if(ri->cloud_instance_type && strcasecmp(ri->cloud_instance_type, "unknown") != 0)
         strncpyz(ds->cloud_instance_type, ri->cloud_instance_type, sizeof(ds->cloud_instance_type) - 1);
 
-    if(ri->cloud_instance_region && strcmp(ri->cloud_instance_region, "unknown") != 0)
+    if(ri->cloud_instance_region && strcasecmp(ri->cloud_instance_region, "unknown") != 0)
         strncpyz(ds->cloud_instance_region, ri->cloud_instance_region, sizeof(ds->cloud_instance_region) - 1);
 
     ds->read_system_info = true;

--- a/src/libnetdata/inlined.h
+++ b/src/libnetdata/inlined.h
@@ -424,8 +424,16 @@ static inline char *strncpyz(char *dst, const char *src, size_t dst_size_minus_1
 // dst is always null terminated
 static inline size_t strcatz(char *dst, size_t len, const char *src, size_t size) {
     // If starting offset is out of bounds, do nothing.
-    if (len >= size) {
-        dst[size - 1] = '\0';
+    if (unlikely(len >= size)) {
+        if(size > 0)
+            dst[size - 1] = '\0';
+
+        return len;
+    }
+
+    // If the source is not valid or empty, do nothing.
+    if(unlikely(!src || !*src)) {
+        dst[len] = '\0';
         return len;
     }
 


### PR DESCRIPTION
- [x] dmi decoding is now a standalone module that can be enhanced independently of the status file.
- [x] original dmi values are kept intact in the status file and a new `product` section now gets the ones used for host labels, allowing us to review the transformations and rules over time.
- [x] prefer `product family` over `product name` for the host labels. The `product family` is usually some product name that is advertised, while the `product name` is usually a numeric id of the model.
- [x] added mode mode `UEFI` or `Legacy` to status file
- [x] added secure boot boolean to status file
- [x] added netdata pid to status file
- [x] asset tags and serial numbers are now collected but are not saved to status file and are not posted to agent-events
- [x] added system unique `uuid` to status file
- [x] proper mapping for Virtual Macs, NVIDIA VMs, different kinds of Pis
- [x] product type is now limited to `vm`, `desktop`, `laptop`, `server`, `mini-pc`, `unknown`
- [x] code cleanup related to status file and dmi decoding