### PR TITLE
Address Chart name (Windows Hyper V)

### DIFF
--- a/src/collectors/windows.plugin/perflib-hyperv.c
+++ b/src/collectors/windows.plugin/perflib-hyperv.c
@@ -333,10 +333,9 @@ static bool do_hyperv_health_summary(PERF_DATA_BLOCK *pDataBlock, int update_eve
 
     if (!p->charts_created) {
         p->charts_created = true;
-        netdata_fix_chart_name(windows_shared_buffer);
         p->st_health = rrdset_create_localhost(
             "vms_health",
-            windows_shared_buffer,
+            "hyperv_health_status",
             NULL,
             HYPERV,
             HYPERV ".vms_health",

--- a/src/collectors/windows.plugin/perflib-hyperv.c
+++ b/src/collectors/windows.plugin/perflib-hyperv.c
@@ -142,6 +142,8 @@ static bool do_hyperv_memory(PERF_DATA_BLOCK *pDataBlock, int update_every, void
 
         if (!p->charts_created) {
             p->charts_created = true;
+            netdata_fix_chart_name(windows_shared_buffer);
+
             if (!p->st_vm_memory_physical) {
                 p->st_vm_memory_physical = rrdset_create_localhost(
                     "vm_memory_physical",
@@ -246,6 +248,7 @@ static bool do_hyperv_vid_partition(PERF_DATA_BLOCK *pDataBlock, int update_ever
 
         if (!p->charts_created) {
             p->charts_created = true;
+            netdata_fix_chart_name(windows_shared_buffer);
 
             p->st_vm_vid_physical_pages_allocated = rrdset_create_localhost(
                 "vm_vid_physical_pages_allocated",
@@ -330,6 +333,7 @@ static bool do_hyperv_health_summary(PERF_DATA_BLOCK *pDataBlock, int update_eve
 
     if (!p->charts_created) {
         p->charts_created = true;
+        netdata_fix_chart_name(windows_shared_buffer);
         p->st_health = rrdset_create_localhost(
             "vms_health",
             windows_shared_buffer,
@@ -494,6 +498,7 @@ static bool do_hyperv_root_partition(PERF_DATA_BLOCK *pDataBlock, int update_eve
         // Create charts
         if (!p->charts_created) {
             p->charts_created = true;
+            netdata_fix_chart_name(windows_shared_buffer);
             p->st_device_space_pages = rrdset_create_localhost(
                 "root_partition_device_space_pages",
                 windows_shared_buffer,
@@ -819,6 +824,7 @@ static bool do_hyperv_storage_device(PERF_DATA_BLOCK *pDataBlock, int update_eve
 
         if (!p->charts_created) {
             p->charts_created = true;
+            netdata_fix_chart_name(windows_shared_buffer);
             if (!p->st_operations) {
                 p->st_operations = rrdset_create_localhost(
                     "vm_storage_device_operations",
@@ -1054,6 +1060,7 @@ static bool do_hyperv_switch(PERF_DATA_BLOCK *pDataBlock, int update_every, void
 
         if (!p->charts_created) {
             p->charts_created = true;
+            netdata_fix_chart_name(windows_shared_buffer);
 
             p->st_bytes = rrdset_create_localhost(
                 "vswitch_traffic",
@@ -1418,6 +1425,7 @@ static bool do_hyperv_network_adapter(PERF_DATA_BLOCK *pDataBlock, int update_ev
 
         if (!p->charts_created) {
             p->charts_created = true;
+            netdata_fix_chart_name(windows_shared_buffer);
             p->st_dropped_packets = rrdset_create_localhost(
                 "vm_net_interface_packets_dropped",
                 windows_shared_buffer,
@@ -1679,6 +1687,7 @@ static bool do_hyperv_processor(PERF_DATA_BLOCK *pDataBlock, int update_every, v
 
         if (!p->charts_created) {
             p->charts_created = true;
+            netdata_fix_chart_name(windows_shared_buffer);
             p->st_HypervisorProcessorTotal = rrdset_create_localhost(
                 "vm_cpu_usage",
                 windows_shared_buffer,

--- a/src/collectors/windows.plugin/perflib-hyperv.c
+++ b/src/collectors/windows.plugin/perflib-hyperv.c
@@ -142,12 +142,14 @@ static bool do_hyperv_memory(PERF_DATA_BLOCK *pDataBlock, int update_every, void
 
         if (!p->charts_created) {
             p->charts_created = true;
-            netdata_fix_chart_name(windows_shared_buffer);
+            char id[RRD_ID_LENGTH_MAX + 1];
+            snprintfz(id, RRD_ID_LENGTH_MAX, "%s", windows_shared_buffer);
+            netdata_fix_chart_name(id);
 
             if (!p->st_vm_memory_physical) {
                 p->st_vm_memory_physical = rrdset_create_localhost(
                     "vm_memory_physical",
-                    windows_shared_buffer,
+                    id,
                     NULL,
                     HYPERV,
                     HYPERV ".vm_memory_physical",
@@ -248,11 +250,13 @@ static bool do_hyperv_vid_partition(PERF_DATA_BLOCK *pDataBlock, int update_ever
 
         if (!p->charts_created) {
             p->charts_created = true;
-            netdata_fix_chart_name(windows_shared_buffer);
+            char id[RRD_ID_LENGTH_MAX + 1];
+            snprintfz(id, RRD_ID_LENGTH_MAX, "%s", windows_shared_buffer);
+            netdata_fix_chart_name(id);
 
             p->st_vm_vid_physical_pages_allocated = rrdset_create_localhost(
                 "vm_vid_physical_pages_allocated",
-                windows_shared_buffer,
+                id,
                 NULL,
                 HYPERV,
                 HYPERV ".vm_vid_physical_pages_allocated",
@@ -497,10 +501,13 @@ static bool do_hyperv_root_partition(PERF_DATA_BLOCK *pDataBlock, int update_eve
         // Create charts
         if (!p->charts_created) {
             p->charts_created = true;
-            netdata_fix_chart_name(windows_shared_buffer);
+            char id[RRD_ID_LENGTH_MAX + 1];
+            snprintfz(id, RRD_ID_LENGTH_MAX, "%s", windows_shared_buffer);
+            netdata_fix_chart_name(id);
+
             p->st_device_space_pages = rrdset_create_localhost(
                 "root_partition_device_space_pages",
-                windows_shared_buffer,
+                id,
                 NULL,
                 HYPERV,
                 HYPERV ".root_partition_device_space_pages",
@@ -823,11 +830,14 @@ static bool do_hyperv_storage_device(PERF_DATA_BLOCK *pDataBlock, int update_eve
 
         if (!p->charts_created) {
             p->charts_created = true;
-            netdata_fix_chart_name(windows_shared_buffer);
+            char id[RRD_ID_LENGTH_MAX + 1];
+            snprintfz(id, RRD_ID_LENGTH_MAX, "%s", windows_shared_buffer);
+            netdata_fix_chart_name(id);
+
             if (!p->st_operations) {
                 p->st_operations = rrdset_create_localhost(
                     "vm_storage_device_operations",
-                    windows_shared_buffer,
+                    id,
                     NULL,
                     HYPERV,
                     HYPERV ".vm_storage_device_operations",
@@ -1059,11 +1069,13 @@ static bool do_hyperv_switch(PERF_DATA_BLOCK *pDataBlock, int update_every, void
 
         if (!p->charts_created) {
             p->charts_created = true;
-            netdata_fix_chart_name(windows_shared_buffer);
+            char id[RRD_ID_LENGTH_MAX + 1];
+            snprintfz(id, RRD_ID_LENGTH_MAX, "%s", windows_shared_buffer);
+            netdata_fix_chart_name(id);
 
             p->st_bytes = rrdset_create_localhost(
                 "vswitch_traffic",
-                windows_shared_buffer,
+                id,
                 NULL,
                 HYPERV,
                 HYPERV ".vswitch_traffic",
@@ -1424,10 +1436,13 @@ static bool do_hyperv_network_adapter(PERF_DATA_BLOCK *pDataBlock, int update_ev
 
         if (!p->charts_created) {
             p->charts_created = true;
-            netdata_fix_chart_name(windows_shared_buffer);
+            char id[RRD_ID_LENGTH_MAX + 1];
+            snprintfz(id, RRD_ID_LENGTH_MAX, "%s", windows_shared_buffer);
+            netdata_fix_chart_name(id);
+
             p->st_dropped_packets = rrdset_create_localhost(
                 "vm_net_interface_packets_dropped",
-                windows_shared_buffer,
+                id,
                 NULL,
                 HYPERV,
                 HYPERV ".vm_net_interface_packets_dropped",
@@ -1686,10 +1701,13 @@ static bool do_hyperv_processor(PERF_DATA_BLOCK *pDataBlock, int update_every, v
 
         if (!p->charts_created) {
             p->charts_created = true;
-            netdata_fix_chart_name(windows_shared_buffer);
+            char id[RRD_ID_LENGTH_MAX + 1];
+            snprintfz(id, RRD_ID_LENGTH_MAX, "%s", windows_shared_buffer);
+            netdata_fix_chart_name(id);
+
             p->st_HypervisorProcessorTotal = rrdset_create_localhost(
                 "vm_cpu_usage",
-                windows_shared_buffer,
+                id,
                 NULL,
                 HYPERV,
                 HYPERV ".vm_cpu_usage",

--- a/src/collectors/windows.plugin/perflib-hyperv.c
+++ b/src/collectors/windows.plugin/perflib-hyperv.c
@@ -26,7 +26,7 @@ static void get_and_sanitize_instance_value(
 
 #define DICT_PERF_OPTION (DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE)
 
-#define DEFINE_RD(counter_name) RRDDIM *rd_##counter_name
+#define DEFINE_RD(counter_name) RRDDIM(*rd_##counter_name)
 
 #define GET_INSTANCE_COUNTER(counter)                                                                                  \
     do {                                                                                                               \
@@ -369,7 +369,7 @@ struct hypervisor_root_partition {
     RRDSET *st_DeviceDMAErrors;
     RRDSET *st_DeviceInterruptErrors;
     RRDSET *st_DeviceInterruptThrottleEvents;
-    RRDSET *st_IOΤLBFlushesSec;
+    RRDSET *st_IOTLBFlushesSec;
     RRDSET *st_AddressSpaces;
     RRDSET *st_VirtualTLBPages;
     RRDSET *st_VirtualTLBFlushEntiresSec;
@@ -388,7 +388,7 @@ struct hypervisor_root_partition {
     DEFINE_RD(DeviceDMAErrors);
     DEFINE_RD(DeviceInterruptErrors);
     DEFINE_RD(DeviceInterruptThrottleEvents);
-    DEFINE_RD(IOΤLBFlushesSec);
+    DEFINE_RD(IOTLBFlushesSec);
     DEFINE_RD(AddressSpaces);
     DEFINE_RD(VirtualTLBPages);
     DEFINE_RD(VirtualTLBFlushEntiresSec);
@@ -405,7 +405,7 @@ struct hypervisor_root_partition {
     COUNTER_DATA DeviceDMAErrors;
     COUNTER_DATA DeviceInterruptErrors;
     COUNTER_DATA DeviceInterruptThrottleEvents;
-    COUNTER_DATA IOΤLBFlushesSec;
+    COUNTER_DATA IOTLBFlushesSec;
     COUNTER_DATA AddressSpaces;
     COUNTER_DATA VirtualTLBPages;
     COUNTER_DATA VirtualTLBFlushEntiresSec;
@@ -429,7 +429,7 @@ void initialize_hyperv_root_partition_keys(struct hypervisor_root_partition *p)
     p->DeviceDMAErrors.key = "Device DMA Errors";
     p->DeviceInterruptErrors.key = "Device Interrupt Errors";
     p->DeviceInterruptThrottleEvents.key = "Device Interrupt Throttle Events";
-    p->IOΤLBFlushesSec.key = "I/O TLB Flushes/sec";
+    p->IOTLBFlushesSec.key = "I/O TLB Flushes/sec";
     p->AddressSpaces.key = "Address Spaces";
     p->VirtualTLBPages.key = "Virtual TLB Pages";
     p->VirtualTLBFlushEntiresSec.key = "Virtual TLB Flush Entires/sec";
@@ -486,7 +486,7 @@ static bool do_hyperv_root_partition(PERF_DATA_BLOCK *pDataBlock, int update_eve
         GET_INSTANCE_COUNTER(DeviceDMAErrors);
         GET_INSTANCE_COUNTER(DeviceInterruptErrors);
         GET_INSTANCE_COUNTER(DeviceInterruptThrottleEvents);
-        GET_INSTANCE_COUNTER(IOΤLBFlushesSec);
+        GET_INSTANCE_COUNTER(IOTLBFlusesSec);
         GET_INSTANCE_COUNTER(AddressSpaces);
         GET_INSTANCE_COUNTER(VirtualTLBPages);
         GET_INSTANCE_COUNTER(VirtualTLBFlushEntiresSec);
@@ -630,7 +630,7 @@ static bool do_hyperv_root_partition(PERF_DATA_BLOCK *pDataBlock, int update_eve
             p->rd_DeviceInterruptThrottleEvents =
                 rrddim_add(p->st_DeviceInterruptThrottleEvents, "throttling", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
 
-            p->st_IOΤLBFlushesSec = rrdset_create_localhost(
+            p->st_IOTLBFlushesSec = rrdset_create_localhost(
                 "root_partition_io_tlb_flush",
                 windows_shared_buffer,
                 NULL,
@@ -644,7 +644,7 @@ static bool do_hyperv_root_partition(PERF_DATA_BLOCK *pDataBlock, int update_eve
                 update_every,
                 RRDSET_TYPE_LINE);
 
-            p->rd_IOΤLBFlushesSec = rrddim_add(p->st_IOΤLBFlushesSec, "gpa", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+            p->rd_IOTLBFlushesSec = rrddim_add(p->st_IOTLBFlushesSec, "gpa", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             p->st_AddressSpaces = rrdset_create_localhost(
                 "root_partition_address_space",
@@ -714,7 +714,7 @@ static bool do_hyperv_root_partition(PERF_DATA_BLOCK *pDataBlock, int update_eve
         SETP_DIM_VALUE(st_DeviceDMAErrors, DeviceDMAErrors);
         SETP_DIM_VALUE(st_DeviceInterruptErrors, DeviceInterruptErrors);
         SETP_DIM_VALUE(st_DeviceInterruptThrottleEvents, DeviceInterruptThrottleEvents);
-        SETP_DIM_VALUE(st_IOΤLBFlushesSec, IOΤLBFlushesSec);
+        SETP_DIM_VALUE(st_IOTLBFlushesSec, IOTLBFlusesSec);
         SETP_DIM_VALUE(st_AddressSpaces, AddressSpaces);
         SETP_DIM_VALUE(st_VirtualTLBPages, VirtualTLBPages);
         SETP_DIM_VALUE(st_VirtualTLBFlushEntiresSec, VirtualTLBFlushEntiresSec);
@@ -727,7 +727,7 @@ static bool do_hyperv_root_partition(PERF_DATA_BLOCK *pDataBlock, int update_eve
         rrdset_done(p->st_deposited_pages);
         rrdset_done(p->st_DeviceInterruptErrors);
         rrdset_done(p->st_DeviceInterruptThrottleEvents);
-        rrdset_done(p->st_IOΤLBFlushesSec);
+        rrdset_done(p->st_IOTLBFlushesSec);
         rrdset_done(p->st_AddressSpaces);
         rrdset_done(p->st_DeviceDMAErrors);
         rrdset_done(p->st_VirtualTLBPages);

--- a/src/collectors/windows.plugin/perflib-hyperv.c
+++ b/src/collectors/windows.plugin/perflib-hyperv.c
@@ -490,7 +490,7 @@ static bool do_hyperv_root_partition(PERF_DATA_BLOCK *pDataBlock, int update_eve
         GET_INSTANCE_COUNTER(DeviceDMAErrors);
         GET_INSTANCE_COUNTER(DeviceInterruptErrors);
         GET_INSTANCE_COUNTER(DeviceInterruptThrottleEvents);
-        GET_INSTANCE_COUNTER(IOTLBFlusesSec);
+        GET_INSTANCE_COUNTER(IOTLBFlushesSec);
         GET_INSTANCE_COUNTER(AddressSpaces);
         GET_INSTANCE_COUNTER(VirtualTLBPages);
         GET_INSTANCE_COUNTER(VirtualTLBFlushEntiresSec);
@@ -719,7 +719,7 @@ static bool do_hyperv_root_partition(PERF_DATA_BLOCK *pDataBlock, int update_eve
         SETP_DIM_VALUE(st_DeviceDMAErrors, DeviceDMAErrors);
         SETP_DIM_VALUE(st_DeviceInterruptErrors, DeviceInterruptErrors);
         SETP_DIM_VALUE(st_DeviceInterruptThrottleEvents, DeviceInterruptThrottleEvents);
-        SETP_DIM_VALUE(st_IOTLBFlushesSec, IOTLBFlusesSec);
+        SETP_DIM_VALUE(st_IOTLBFlushesSec, IOTLBFlushesSec);
         SETP_DIM_VALUE(st_AddressSpaces, AddressSpaces);
         SETP_DIM_VALUE(st_VirtualTLBPages, VirtualTLBPages);
         SETP_DIM_VALUE(st_VirtualTLBFlushEntiresSec, VirtualTLBFlushEntiresSec);

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -25,7 +25,7 @@ static struct proc_module {
     {.name = "PerflibStorage", .dim = "PerflibStorage", .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibStorage},
     {.name = "PerflibNetwork", .dim = "PerflibNetwork", .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibNetwork},
     {.name = "PerflibObjects", .dim = "PerflibObjects", .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibObjects},
-    {.name = "PerflibHyperV", .dim = "PerflibHyperV", .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibHyperV},
+    {.name = "PerflibHyperV", .dim = "PerflibHyperV", .enabled = CONFIG_BOOLEAN_NO, .func = do_PerflibHyperV},
 
     {.name = "PerflibThermalZone",
      .dim = "PerflibThermalZone",

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -25,7 +25,7 @@ static struct proc_module {
     {.name = "PerflibStorage", .dim = "PerflibStorage", .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibStorage},
     {.name = "PerflibNetwork", .dim = "PerflibNetwork", .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibNetwork},
     {.name = "PerflibObjects", .dim = "PerflibObjects", .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibObjects},
-    {.name = "PerflibHyperV", .dim = "PerflibHyperV", .enabled = CONFIG_BOOLEAN_NO, .func = do_PerflibHyperV},
+    {.name = "PerflibHyperV", .dim = "PerflibHyperV", .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibHyperV},
 
     {.name = "PerflibThermalZone",
      .dim = "PerflibThermalZone",


### PR DESCRIPTION
##### Summary
![hyperv](https://github.com/user-attachments/assets/1968515f-baf8-468c-ad8c-9b76684d9af3)
Figure 1: Chart showing the metric responsible for the issue.

This PR address the issue:

```sh
AE_FATAL_STACK_TRACE
#0 daemon_status_file_save_twice_if_we_can_get_stack_trace [0x1005CFE24] (/src/daemon/status-file.c:1073)
#1 daemon_status_file_register_fatal [0x1005CFBA6] (/src/daemon/status-file.c:1129)
#2 nd_log_fatal_hook [0x10069B0B5] (/src/libnetdata/log/nd_log.c:135)
#3 nd_logger_log_fields [0x10069B0B5] (/src/libnetdata/log/nd_log.c:154)
#4 nd_logger [0x1006982D7] (/src/libnetdata/log/nd_log.c:342)
#5 netdata_logger_fatal [0x1006AD19F] (/src/libnetdata/log/nd_log.c:515)
#6 rrdset_create_custom [0x10076C9F9] (/src/database/rrdset-index-id.c:409)
#7 rrdset_create [0x1005EB93A] (/src/database/rrdset-index-id.h:41)
#8 rrdset_create_localhost [0x1005EB93A] (/src/database/rrdset-index-id.h:59)
#9 do_hyperv_health_summary [0x1005EB93A] (/src/collectors/windows.plugin/perflib-hyperv.c:333)
#10 do_PerflibHyperV [0x1005E7870] (/src/collectors/windows.plugin/perflib-hyperv.c:1829)
#11 win_plugin_main [0x10085B458] (/src/collectors/windows.plugin/windows_plugin.c:128)
#12 nd_thread_starting_point [0x10069F2F0] (/src/libnetdata/threads/threads.c:362)
#13 <unknown> [0x1800A9D96]
#14 <unknown> [0x180044840]
#15 <unknown> [0xFFFFFFFFFFFFFFFF]
```

We overlooked that the windows_shared_buffer values for a specific metric were not populated.

In addition to fixing this issue, this PR introduces a validation check for the metric name to disallow unsupported characters.

##### Test Plan

1. Compile this branch locally
2. Create the installer.
3. Install on a host with Hyper V, and another without it, to be sure everything is working as expected.


##### Additional Information
This PR was tested on 

|Windows Version | Is hyper-V available?| Was it configured?|
|--------------------------|-------------------------------|----------------------------|
|     11 Home           |                  No               |             No                |
|    2019 Server       |                 Yes               |           Yes                |
|    2022 Server        |               Yes                 |         No                  |
<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
