### PR TITLE
Fix typo in .github/scripts/gen-docker-tags.py

### DIFF
--- a/.github/scripts/gen-docker-tags.py
+++ b/.github/scripts/gen-docker-tags.py
@@ -55,7 +55,7 @@ all_tags = [x for y in tags.values() for x in y]
 
 def write_output(name: str, value: str) -> None:
     with open(os.getenv('GITHUB_OUTPUT'), 'a') as f:
-        f.write(f'{name}={value}')
+        f.write(f'{name}={value}\n')
 
 
 write_output('tags', ','.join(all_tags))


### PR DESCRIPTION
##### Summary

It’s currently breaking publishing of Docker images.

##### Test Plan

n/a