### PR TITLE
Fix ACLK Backoff Timeout Logic

### DIFF
--- a/src/aclk/aclk_util.c
+++ b/src/aclk/aclk_util.c
@@ -332,7 +332,7 @@ const char *aclk_topic_cache_iterate(size_t *iter)
  *
  */
 
-unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int min, unsigned long int max) {
+unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int min_s, unsigned long int max_s) {
     static int attempt = -1;
 
     if (reset) {
@@ -350,11 +350,11 @@ unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int min, un
 
     delay += (os_random32() % (MAX(1000, delay/2)));
 
-    if (delay <= min * MSEC_PER_SEC)
-        return min;
+    if (delay <= min_s * MSEC_PER_SEC)
+        return min_s * MSEC_PER_SEC;
 
-    if (delay >= max * MSEC_PER_SEC)
-        return max;
+    if (delay >= max_s * MSEC_PER_SEC)
+        return max_s * MSEC_PER_SEC;
 
     return delay;
 }

--- a/src/aclk/aclk_util.c
+++ b/src/aclk/aclk_util.c
@@ -332,7 +332,7 @@ const char *aclk_topic_cache_iterate(size_t *iter)
  *
  */
 
-unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int min_s, unsigned long int max_s) {
+unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int mins_ms, unsigned long int min_ms) {
     static int attempt = -1;
 
     if (reset) {
@@ -350,11 +350,14 @@ unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int min_s, 
 
     delay += (os_random32() % (MAX(1000, delay/2)));
 
-    if (delay <= min_s * MSEC_PER_SEC)
-        return min_s * MSEC_PER_SEC;
+    // Note: this is a bug, the value expected from the env backoff payload should be in seconds
+    // but the code here is in milliseconds. To avoid confusion the cloud will be sending the value
+    // in milliseconds so that the code will work as expected.
+    if (delay <= mins_ms * MSEC_PER_SEC)
+        return mins_ms;
 
-    if (delay >= max_s * MSEC_PER_SEC)
-        return max_s * MSEC_PER_SEC;
+    if (delay >= min_ms * MSEC_PER_SEC)
+        return min_ms;
 
     return delay;
 }

--- a/src/aclk/aclk_util.h
+++ b/src/aclk/aclk_util.h
@@ -103,7 +103,7 @@ extern volatile int aclk_conversation_log_counter;
 #define ACLK_GET_CONV_LOG_NEXT() __atomic_fetch_add(&aclk_conversation_log_counter, 1, __ATOMIC_SEQ_CST)
 #endif
 
-unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int min, unsigned long int max);
+unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int min_s, unsigned long int max_s);
 #define aclk_tbeb_reset(x) aclk_tbeb_delay(1, 0, 0, 0)
 
 void aclk_set_proxy(char **ohost, int *port, char **uname, char **pwd, enum mqtt_wss_proxy_type *type);

--- a/src/aclk/aclk_util.h
+++ b/src/aclk/aclk_util.h
@@ -103,7 +103,7 @@ extern volatile int aclk_conversation_log_counter;
 #define ACLK_GET_CONV_LOG_NEXT() __atomic_fetch_add(&aclk_conversation_log_counter, 1, __ATOMIC_SEQ_CST)
 #endif
 
-unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int min_s, unsigned long int max_s);
+unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int mins_ms, unsigned long int min_ms);
 #define aclk_tbeb_reset(x) aclk_tbeb_delay(1, 0, 0, 0)
 
 void aclk_set_proxy(char **ohost, int *port, char **uname, char **pwd, enum mqtt_wss_proxy_type *type);


### PR DESCRIPTION
##### Summary
- Fix ACLK reconnect delay calculation to return values in milliseconds if a min and max seconds has been returned by the environment call.


