### PR TITLE
Suppress most known warnings during the build process.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2728,6 +2728,7 @@ if(NEED_NDSUDO)
     install(TARGETS ndsudo
             COMPONENT netdata
             DESTINATION usr/libexec/netdata/plugins.d)
+    set_source_files_properties(${NDSUDO_FILES} PROPERTIES COMPILE_OPTIONS "-Wno-unused-result")
 endif()
 
 if(ENABLE_PLUGIN_CGROUP_NETWORK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1523,6 +1523,7 @@ if(ENABLE_ML)
         if(NOT ENABLE_MIMALLOC)
                 list(APPEND ML_FILES src/ml/ml_memory.cc)
         endif()
+        set_source_files_properties(${ML_FILES} PROPERTIES COMPILE_OPTIONS "-Wno-attributes")
 else()
         set(ML_FILES
                 src/ml/ml_public.h
@@ -2122,7 +2123,7 @@ set(ACLK_FILES
         src/aclk/schema-wrappers/agent_cmds.cc
         src/aclk/schema-wrappers/agent_cmds.h
 )
-
+set_source_files_properties(src/aclk/schema-wrappers/proto_2_json.cc PROPERTIES COMPILE_OPTIONS "-Wno-unused-result")
 
 set(MONGODB_EXPORTING_FILES
         src/exporting/mongodb/mongodb.c
@@ -2204,6 +2205,7 @@ set_source_files_properties(JudyLTables.c PROPERTIES COMPILE_OPTIONS "-I${CMAKE_
 #
 
 add_library(libnetdata STATIC ${LIBNETDATA_FILES})
+set_source_files_properties(src/libnetdata/gorilla/gorilla.cc PROPERTIES COMPILE_OPTIONS "-Wno-attributes")
 
 target_include_directories(libnetdata BEFORE PUBLIC ${CONFIG_H_DIR} ${CMAKE_SOURCE_DIR}/src)
 

--- a/src/collectors/debugfs.plugin/libsensors/CMakeLists.txt
+++ b/src/collectors/debugfs.plugin/libsensors/CMakeLists.txt
@@ -43,7 +43,6 @@ target_include_directories(vendored_libsensors PUBLIC
 # Compile definitions
 target_compile_definitions(vendored_libsensors PRIVATE
         ETCDIR="/etc"       # Define ETCDIR
-        _GNU_SOURCE         # Define GNU extensions
 )
 
 # Suppress warnings for Flex and Bison files


### PR DESCRIPTION
##### Summary

As outlined in the title.

The goal here is to have clean build output so that it is much easier to find actual errors when there is a build error.

##### Test Plan

CI can be easily checked to confirm that the build output is (mostly) clean now.