### PR TITLE
fix memory leaks

### DIFF
--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -421,8 +421,15 @@ bool claim_agent_from_environment(void) {
     return claim_agent(url, token, rooms, proxy, insecure);
 }
 
+// Static config for claim.conf
+static struct config claim_config = APPCONFIG_INITIALIZER;
+
+// Function to free the static claim_config for shutdown cleanup
+void claim_config_free(void) {
+    inicfg_free(&claim_config);
+}
+
 bool claim_agent_from_claim_conf(void) {
-    static struct config claim_config = APPCONFIG_INITIALIZER;
     static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
     bool ret = false;
 

--- a/src/collectors/cgroups.plugin/cgroup-internals.h
+++ b/src/collectors/cgroups.plugin/cgroup-internals.h
@@ -253,10 +253,6 @@ struct cgroup {
     unsigned long long memory_limit;
     const RRDVAR_ACQUIRED *chart_var_memory_limit;
 
-    char *filename_memoryswap_limit;
-    unsigned long long memoryswap_limit;
-    const RRDVAR_ACQUIRED *chart_var_memoryswap_limit;
-
     const DICTIONARY_ITEM *cgroup_netdev_link;
 
     struct cgroup *next;

--- a/src/collectors/proc.plugin/ipc.c
+++ b/src/collectors/proc.plugin/ipc.c
@@ -277,14 +277,22 @@ static int ipc_shm_get_info(const char *shm_filename, struct shm_stats *shm) {
     return 0;
 }
 
-int do_ipc(int update_every, usec_t dt) {
+static const RRDVAR_ACQUIRED *arrays_max = NULL, *semaphores_max = NULL;
+void proc_ipc_cleanup(void) {
+    if(arrays_max)
+        rrdvar_host_variable_release(localhost, arrays_max);
+
+    if(semaphores_max)
+        rrdvar_host_variable_release(localhost, semaphores_max);
+}
+
+int do_proc_ipc(int update_every, usec_t dt) {
     (void)dt;
 
     static int do_sem = -1, do_msg = -1, do_shm = -1;
     static int read_limits_next = -1;
     static struct ipc_limits limits;
     static struct ipc_status status;
-    static const RRDVAR_ACQUIRED *arrays_max = NULL, *semaphores_max = NULL;
     static RRDSET *st_arrays = NULL;
     static RRDDIM *rd_arrays = NULL;
     static const char *msg_filename = NULL;

--- a/src/collectors/proc.plugin/plugin_proc.h
+++ b/src/collectors/proc.plugin/plugin_proc.h
@@ -41,13 +41,22 @@ int do_sys_fs_btrfs(int update_every, usec_t dt);
 int do_proc_net_sockstat(int update_every, usec_t dt);
 int do_proc_net_sockstat6(int update_every, usec_t dt);
 int do_proc_net_sctp_snmp(int update_every, usec_t dt);
-int do_ipc(int update_every, usec_t dt);
+int do_proc_ipc(int update_every, usec_t dt);
 int do_sys_class_power_supply(int update_every, usec_t dt);
 int do_proc_pagetypeinfo(int update_every, usec_t dt);
 int do_sys_class_infiniband(int update_every, usec_t dt);
 int do_sys_class_drm(int update_every, usec_t dt);
 int get_numa_node_count(void);
 int do_run_reboot_required(int update_every, usec_t dt);
+
+// Plugin cleanup functions
+void proc_ipc_cleanup(void);
+void proc_net_netstat_cleanup(void);
+void proc_net_stat_conntrack_cleanup(void);
+void proc_stat_plugin_cleanup(void);
+void proc_net_sockstat_plugin_cleanup(void);
+void proc_loadavg_plugin_cleanup(void);
+void sys_class_infiniband_plugin_cleanup(void);
 
 // metrics that need to be shared among data collectors
 extern unsigned long long zfs_arcstats_shrinkable_cache_size_bytes;

--- a/src/collectors/proc.plugin/proc_net_dev.c
+++ b/src/collectors/proc.plugin/proc_net_dev.c
@@ -1692,6 +1692,14 @@ static void netdev_main_cleanup(void *pptr) {
     if(CLEANUP_FUNCTION_GET_PTR(pptr) != (void *)0x01)
         return;
 
+    netdata_mutex_lock(&netdev_mutex);
+    while(netdev_root) {
+        struct netdev *d = netdev_root;
+        DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(netdev_root, d, prev, next);
+        netdev_free(d);
+    }
+    netdata_mutex_unlock(&netdev_mutex);
+
     worker_unregister();
 }
 

--- a/src/collectors/proc.plugin/proc_net_netstat.c
+++ b/src/collectors/proc.plugin/proc_net_netstat.c
@@ -1195,6 +1195,13 @@ static void do_proc_net_snmp6(int update_every) {
     }
 }
 
+static const RRDVAR_ACQUIRED *tcp_max_connections_var = NULL;
+
+void proc_net_netstat_cleanup(void) {
+    if(tcp_max_connections_var)
+        rrdvar_host_variable_release(localhost, tcp_max_connections_var);
+}
+
 int do_proc_net_netstat(int update_every, usec_t dt) {
     (void)dt;
 
@@ -1221,8 +1228,6 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
     static ARL_BASE *arl_tcp = NULL;
     static ARL_BASE *arl_udp = NULL;
     static ARL_BASE *arl_udplite = NULL;
-
-    static const RRDVAR_ACQUIRED *tcp_max_connections_var = NULL;
 
     // --------------------------------------------------------------------
     // IP

--- a/src/collectors/proc.plugin/proc_net_sockstat.c
+++ b/src/collectors/proc.plugin/proc_net_sockstat.c
@@ -25,11 +25,34 @@ static struct proc_net_sockstat {
 } sockstat_root = { 0 };
 
 
+static const RRDVAR_ACQUIRED
+    *tcp_mem_low_threshold = NULL,
+    *tcp_mem_pressure_threshold = NULL,
+    *tcp_mem_high_threshold = NULL,
+    *tcp_max_orphans_var = NULL;
+
+void proc_net_sockstat_plugin_cleanup(void) {
+    // Cleanup any acquired RRDVARs
+    if (tcp_mem_low_threshold) {
+        rrdvar_host_variable_release(localhost, tcp_mem_low_threshold);
+        tcp_mem_low_threshold = NULL;
+    }
+    if (tcp_mem_pressure_threshold) {
+        rrdvar_host_variable_release(localhost, tcp_mem_pressure_threshold);
+        tcp_mem_pressure_threshold = NULL;
+    }
+    if (tcp_mem_high_threshold) {
+        rrdvar_host_variable_release(localhost, tcp_mem_high_threshold);
+        tcp_mem_high_threshold = NULL;
+    }
+    if (tcp_max_orphans_var) {
+        rrdvar_host_variable_release(localhost, tcp_max_orphans_var);
+        tcp_max_orphans_var = NULL;
+    }
+}
+
 static int read_tcp_mem(void) {
     static char *filename = NULL;
-    static const RRDVAR_ACQUIRED *tcp_mem_low_threshold = NULL,
-                  *tcp_mem_pressure_threshold = NULL,
-                  *tcp_mem_high_threshold = NULL;
 
     if(unlikely(!tcp_mem_low_threshold)) {
         tcp_mem_low_threshold      = rrdvar_host_variable_add_and_acquire(localhost, "tcp_mem_low");
@@ -69,7 +92,6 @@ static int read_tcp_mem(void) {
 
 static kernel_uint_t read_tcp_max_orphans(void) {
     static char *filename = NULL;
-    static const RRDVAR_ACQUIRED *tcp_max_orphans_var = NULL;
 
     if(unlikely(!filename)) {
         char buffer[FILENAME_MAX + 1];

--- a/src/collectors/proc.plugin/proc_net_stat_conntrack.c
+++ b/src/collectors/proc.plugin/proc_net_stat_conntrack.c
@@ -6,13 +6,19 @@
 #define RRD_TYPE_NET_STAT_CONNTRACK     "conntrack"
 #define PLUGIN_PROC_MODULE_CONNTRACK_NAME "/proc/net/stat/nf_conntrack"
 
+static const RRDVAR_ACQUIRED *rrdvar_max = NULL;
+
+void proc_net_stat_conntrack_cleanup(void) {
+    if(rrdvar_max)
+        rrdvar_host_variable_release(localhost, rrdvar_max);
+}
+
 int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
     static procfile *ff = NULL;
     static int do_sockets = -1, do_new = -1, do_changes = -1, do_expect = -1, do_search = -1, do_errors = -1;
     static usec_t get_max_every = 10 * USEC_PER_SEC, usec_since_last_max = 0;
     static int read_full = 1;
     static const char *nf_conntrack_filename, *nf_conntrack_count_filename, *nf_conntrack_max_filename;
-    static const RRDVAR_ACQUIRED *rrdvar_max = NULL;
 
     unsigned long long aentries = 0, asearched = 0, afound = 0, anew = 0, ainvalid = 0, aignore = 0, adelete = 0, adelete_list = 0,
             ainsert = 0, ainsert_failed = 0, adrop = 0, aearly_drop = 0, aicmp_error = 0, aexpect_new = 0, aexpect_create = 0, aexpect_delete = 0, asearch_restart = 0;

--- a/src/collectors/proc.plugin/proc_stat.c
+++ b/src/collectors/proc.plugin/proc_stat.c
@@ -475,6 +475,16 @@ static int read_cpuidle_states(const char *cpuidle_name_filename, const char *cp
     return 0;
 }
 
+static const RRDVAR_ACQUIRED *cpus_var = NULL;
+
+void proc_stat_plugin_cleanup(void) {
+    // Cleanup any acquired RRDVARs
+    if (cpus_var) {
+        rrdvar_host_variable_release(localhost, cpus_var);
+        cpus_var = NULL;
+    }
+}
+
 int do_proc_stat(int update_every, usec_t dt) {
     (void)dt;
 
@@ -486,7 +496,7 @@ int do_proc_stat(int update_every, usec_t dt) {
     static uint32_t hash_intr, hash_ctxt, hash_processes, hash_procs_running, hash_procs_blocked;
     static const char *core_throttle_count_filename = NULL, *package_throttle_count_filename = NULL, *scaling_cur_freq_filename = NULL,
            *time_in_state_filename = NULL, *schedstat_filename = NULL, *cpuidle_name_filename = NULL, *cpuidle_time_filename = NULL;
-    static const RRDVAR_ACQUIRED *cpus_var = NULL;
+
     static int accurate_freq_avail = 0, accurate_freq_is_used = 0;
     size_t cores_found = (size_t)os_get_system_cpus();
 

--- a/src/collectors/proc.plugin/sys_class_infiniband.c
+++ b/src/collectors/proc.plugin/sys_class_infiniband.c
@@ -186,6 +186,7 @@ static struct ibport {
 
     const RRDVAR_ACQUIRED *stv_speed;
 
+
     usec_t speed_last_collected_usec;
 
     struct ibport *next;
@@ -216,6 +217,17 @@ void infiniband_hwcounters_parse_mlx(struct ibport *port)
     if (port->do_hwpackets != CONFIG_BOOLEAN_NO)
         FOREACH_HWCOUNTER_MLX_PACKETS(GEN_DO_HWCOUNTER_READ, port, port->hwcounters_mlx)
 }
+void sys_class_infiniband_plugin_cleanup(void) {
+    // Cleanup any acquired RRDVARs
+    struct ibport *port;
+    for (port = ibport_root; port; port = port->next) {
+        if (port->stv_speed) {
+            rrdvar_chart_variable_release(port->st_bytes, port->stv_speed);
+            port->stv_speed = NULL;
+        }
+    }
+}
+
 void infiniband_hwcounters_dorrd_mlx(struct ibport *port)
 {
     if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {

--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -13,6 +13,15 @@
 #include "sentry-native/sentry-native.h"
 #endif
 
+// External configuration structures that need cleanup
+extern struct config netdata_config;
+extern struct config cloud_config;
+extern void inicfg_free(struct config *root);
+// Functions to free various configurations
+extern void claim_config_free(void);
+extern void stream_config_free(void);
+extern void exporting_config_free(void);
+
 static bool abort_on_fatal = true;
 
 void abort_on_fatal_disable(void) {
@@ -373,6 +382,16 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
         fprintf(stderr, "WARNING: UUIDMAP had %zu UUIDs referenced.\n",
             uuid_referenced);
 
+    fprintf(stderr, "Freeing configuration resources...\n");
+    claim_config_free();
+    exporting_config_free();
+    stream_config_free();
+    inicfg_free(&cloud_config);
+    inicfg_free(&netdata_config);
+    
+    fprintf(stderr, "Cleaning up worker utilization...\n");
+    worker_utilization_cleanup();
+    
     size_t strings_referenced = string_destroy();
     if(strings_referenced)
         fprintf(stderr, "WARNING: STRING has %zu strings still allocated.\n",

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -256,7 +256,7 @@ int netdata_main(int argc, char **argv) {
 
     int i;
     int config_loaded = 0;
-    bool close_open_fds = true;
+    bool close_open_fds = true; (void)close_open_fds;
     size_t default_stacksize;
     const char *user = NULL;
 

--- a/src/exporting/exporting_engine.h
+++ b/src/exporting/exporting_engine.h
@@ -299,6 +299,14 @@ void send_internal_metrics(struct instance *instance);
 void clean_instance(struct instance *ptr);
 void simple_connector_cleanup(struct instance *instance);
 
+/**
+ * Free exporting configuration
+ * 
+ * Free all memory associated with the exporting configuration.
+ * Called during shutdown to prevent memory leaks.
+ */
+void exporting_config_free(void);
+
 static inline void disable_instance(struct instance *instance)
 {
     instance->disabled = 1;

--- a/src/exporting/read_config.c
+++ b/src/exporting/read_config.c
@@ -7,6 +7,16 @@ const char *global_exporting_prefix = "netdata";
 
 struct config exporting_config = APPCONFIG_INITIALIZER;
 
+/**
+ * Free exporting configuration
+ * 
+ * Free all memory associated with the exporting configuration.
+ * Called during shutdown to prevent memory leaks.
+ */
+void exporting_config_free(void) {
+    inicfg_free(&exporting_config);
+}
+
 struct instance *prometheus_exporter_instance = NULL;
 
 static _CONNECTOR_INSTANCE *find_instance(const char *section)

--- a/src/libnetdata/inicfg/inicfg.h
+++ b/src/libnetdata/inicfg/inicfg.h
@@ -173,6 +173,16 @@ extern struct config netdata_config;
 bool stream_conf_needs_dbengine(struct config *root);
 bool stream_conf_has_api_enabled(struct config *root);
 
+/**
+ * Free all configuration resources
+ * 
+ * This function frees all memory associated with a configuration,
+ * including all sections and options.
+ * 
+ * @param root The config structure to free
+ */
+void inicfg_free(struct config *root);
+
 const char *inicfg_get(struct config *root, const char *section, const char *name, const char *default_value);
 const char *inicfg_set(struct config *root, const char *section, const char *name, const char *value);
 

--- a/src/libnetdata/inicfg/inicfg_cleanup.c
+++ b/src/libnetdata/inicfg/inicfg_cleanup.c
@@ -58,3 +58,57 @@ void inicfg_section_option_destroy_non_loaded(struct config *root, const char *s
     SECTION_UNLOCK(sect);
 }
 
+/**
+ * Free all config memory
+ * 
+ * This function frees all memory associated with a config structure,
+ * including all sections and options.
+ * 
+ * @param root The config structure to free
+ */
+void inicfg_free(struct config *root) {
+    if (!root)
+        return;
+
+    nd_log(NDLS_DAEMON, NDLP_DEBUG, "Freeing config memory");
+    
+    // First let's free the linked list (this will properly free all sections and options)
+    APPCONFIG_LOCK(root);
+    struct config_section *sect = root->sections;
+    
+    while (sect) {
+        struct config_section *next_sect = sect->next;
+        
+        // Remove and free all options in this section
+        SECTION_LOCK(sect);
+        struct config_option *opt = sect->values;
+        while (opt) {
+            struct config_option *next_opt = opt->next;
+            
+            // Remove from index
+            if(inicfg_option_del(sect, opt)) { ; }
+            
+            // Free the option
+            inicfg_option_free(opt);
+            
+            opt = next_opt;
+        }
+        SECTION_UNLOCK(sect);
+        
+        // Remove from index
+        if(inicfg_section_del(root, sect)) { ; }
+        
+        // Free the section
+        inicfg_section_free(sect);
+        
+        sect = next_sect;
+    }
+    
+    // Reset the sections pointer
+    root->sections = NULL;
+    APPCONFIG_UNLOCK(root);
+    
+    // Destroy the tree
+    avl_destroy_lock(&root->index);
+}
+

--- a/src/libnetdata/libjudy/judy-malloc.c
+++ b/src/libnetdata/libjudy/judy-malloc.c
@@ -160,6 +160,9 @@ void libjudy_malloc_init(void) {
     // IMPORTANT: this is not called on external plugins
     // the allocator should run even if this is not called
 
+    (void)jemalloc_initialized;
+    (void)jemalloc_arena_index;
+
 #ifdef HAVE_JEMALLOC_ARENA_API
     jemalloc_init();
     if(!jemalloc_initialized)

--- a/src/libnetdata/worker_utilization/worker_utilization.c
+++ b/src/libnetdata/worker_utilization/worker_utilization.c
@@ -113,6 +113,15 @@ void workers_utilization_enable(void) {
     workers_globals.enabled = true;
 }
 
+void worker_utilization_cleanup(void) {
+    if(!workers_globals.enabled)
+        return;
+
+    spinlock_lock(&workers_globals.spinlock);
+    JudyHSFreeArray(&workers_globals.worknames_JudyHS, PJE0);
+    spinlock_unlock(&workers_globals.spinlock);
+}
+
 size_t workers_allocated_memory(void) {
     if(!workers_globals.enabled)
         return 0;
@@ -213,7 +222,8 @@ void worker_unregister(void) {
     workers_globals.memory -= sizeof(struct worker) + strlen(worker->tag) + 1 + strlen(worker->workname) + 1;
     spinlock_unlock(&workers_globals.spinlock);
 
-    for(int i  = 0; i < WORKER_UTILIZATION_MAX_JOB_TYPES ;i++) {
+    // Free all thread-local resources associated with this worker
+    for(int i = 0; i < WORKER_UTILIZATION_MAX_JOB_TYPES; i++) {
         string_freez(worker->per_job_type[i].name);
         string_freez(worker->per_job_type[i].units);
     }

--- a/src/libnetdata/worker_utilization/worker_utilization.h
+++ b/src/libnetdata/worker_utilization/worker_utilization.h
@@ -42,6 +42,7 @@ void worker_register(const char *name);
 void worker_register_job_name(size_t job_id, const char *name);
 void worker_register_job_custom_metric(size_t job_id, const char *name, const char *units, WORKER_METRIC_TYPE type);
 void worker_unregister(void);
+void worker_utilization_cleanup(void);
 
 size_t workers_get_last_job_id();
 

--- a/src/streaming/stream-conf.c
+++ b/src/streaming/stream-conf.c
@@ -7,6 +7,16 @@
 
 static struct config stream_config = APPCONFIG_INITIALIZER;
 
+/**
+ * Free stream configuration
+ * 
+ * Free all memory associated with the stream configuration.
+ * Called during shutdown to prevent memory leaks.
+ */
+void stream_config_free(void) {
+    inicfg_free(&stream_config);
+}
+
 struct _stream_send stream_send = {
     .enabled = false,
     .api_key = NULL,

--- a/src/streaming/stream-conf.h
+++ b/src/streaming/stream-conf.h
@@ -99,4 +99,12 @@ bool stream_conf_api_key_allows_client(const char *api_key, const char *client_i
 
 void stream_conf_set_sender_compression_levels(ND_COMPRESSION_PROFILE profile);
 
+/**
+ * Free stream configuration
+ * 
+ * Free all memory associated with the stream configuration.
+ * Called during shutdown to prevent memory leaks.
+ */
+void stream_config_free(void);
+
 #endif //NETDATA_STREAM_CONF_H


### PR DESCRIPTION
extracted from: https://github.com/netdata/netdata/pull/20106

## Leaks Found and Fixed

- [x] `cgroups.plugin` was leaking 2 dictionaries and 2 rrdvars (1 rrdvar per dictionary), for all cgroups ever discovered!
- [x] `proc_netdev` module was also leaking 1 dictionary and 1 rrdvar for each network device ever discovered.

So, in total for container systems (since we monitor the network interfaces of containers) there were 3 dictionaries and 3 rrdvars per container ever discovered. This is a big memory leak that affects Netdata in kubernetes and highly volatile container systems.

## Cleanup

- [x] `cgroups.plugin` had some unused structures, which have been removed.


## Shutdown Process

- [x] `cgroups.plugin` frees all cgroups when it exits.
- [x] many `proc.plugin` modules free their resources when they exit.
- [x] `inicfg` frees all configurations when it exits (in sanitization mode).
- [x] `worker_utilization` frees its index when it exits (in sanitization mode).