### PR TITLE
fix cleanup and exit and memory leaks

### DIFF
--- a/src/collectors/proc.plugin/plugin_proc.c
+++ b/src/collectors/proc.plugin/plugin_proc.c
@@ -37,7 +37,7 @@ static struct proc_module {
     {.name = "/sys/kernel/mm/ksm",           .dim = "ksm",          .func = do_sys_kernel_mm_ksm},
     {.name = "/sys/block/zram",              .dim = "zram",         .func = do_sys_block_zram},
     {.name = "/sys/devices/system/edac/mc",  .dim = "edac",         .func = do_proc_sys_devices_system_edac_mc},
-    {.name = "/sys/devices/pci/aer",         .dim = "pci_aer",      .func = do_proc_sys_devices_pci_aer},
+    {.name = "/sys/devices/pci/aer",         .dim = "pci_aer",      .func = do_proc_sys_devices_pci_aer, .cleanup = pci_aer_plugin_cleanup},
     {.name = "/sys/devices/system/node",     .dim = "numa",         .func = do_proc_sys_devices_system_node},
     {.name = "/proc/pagetypeinfo",           .dim = "pagetypeinfo", .func = do_proc_pagetypeinfo},
 

--- a/src/collectors/proc.plugin/plugin_proc.h
+++ b/src/collectors/proc.plugin/plugin_proc.h
@@ -57,6 +57,7 @@ void proc_stat_plugin_cleanup(void);
 void proc_net_sockstat_plugin_cleanup(void);
 void proc_loadavg_plugin_cleanup(void);
 void sys_class_infiniband_plugin_cleanup(void);
+void pci_aer_plugin_cleanup(void);
 
 // metrics that need to be shared among data collectors
 extern unsigned long long zfs_arcstats_shrinkable_cache_size_bytes;

--- a/src/collectors/statsd.plugin/statsd.c
+++ b/src/collectors/statsd.plugin/statsd.c
@@ -2425,6 +2425,16 @@ static void statsd_main_cleanup(void *pptr) {
     dictionary_destroy(statsd.sets.dict);
     dictionary_destroy(statsd.timers.dict);
 
+    // Clean up app dictionaries
+    STATSD_APP *app = statsd.apps;
+    while(app) {
+        if(app->dict) {
+            dictionary_destroy(app->dict);
+            app->dict = NULL;
+        }
+        app = app->next;
+    }
+
     collector_info("STATSD: cleanup completed.");
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 

--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -21,6 +21,7 @@ extern void inicfg_free(struct config *root);
 extern void claim_config_free(void);
 extern void stream_config_free(void);
 extern void exporting_config_free(void);
+extern void rrd_functions_inflight_destroy(void);
 
 static bool abort_on_fatal = true;
 
@@ -219,7 +220,7 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
                         ABILITY_STREAMING_CONNECTIONS | SERVICE_SYSTEMD);
     watcher_step_complete(WATCHER_STEP_ID_DISABLE_MAINTENANCE_NEW_QUERIES_NEW_WEB_REQUESTS_NEW_STREAMING_CONNECTIONS);
 
-    service_wait_exit(SERVICE_MAINTENANCE | SERVICE_SYSTEMD, 3 * USEC_PER_SEC);
+    service_wait_exit(SERVICE_MAINTENANCE | SERVICE_SYSTEMD, 5 * USEC_PER_SEC);
     watcher_step_complete(WATCHER_STEP_ID_STOP_MAINTENANCE_THREAD);
 
     service_wait_exit(SERVICE_EXPORTERS | SERVICE_HEALTH | SERVICE_WEB_SERVER | SERVICE_HTTPD, 3 * USEC_PER_SEC);
@@ -236,14 +237,14 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
         rrdeng_flush_everything_and_wait(false, false, true);
 #endif
 
-    service_wait_exit(SERVICE_REPLICATION, 3 * USEC_PER_SEC);
+    service_wait_exit(SERVICE_REPLICATION, 5 * USEC_PER_SEC);
     watcher_step_complete(WATCHER_STEP_ID_STOP_REPLICATION_THREADS);
 
     ml_stop_threads();
     ml_fini();
     watcher_step_complete(WATCHER_STEP_ID_DISABLE_ML_DETEC_AND_TRAIN_THREADS);
 
-    service_wait_exit(SERVICE_CONTEXT, 3 * USEC_PER_SEC);
+    service_wait_exit(SERVICE_CONTEXT, 5 * USEC_PER_SEC);
     watcher_step_complete(WATCHER_STEP_ID_STOP_CONTEXT_THREAD);
 
     web_client_cache_destroy();
@@ -257,7 +258,7 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
     service_wait_exit(SERVICE_ACLK, 3 * USEC_PER_SEC);
     watcher_step_complete(WATCHER_STEP_ID_STOP_ACLK_MQTT_THREAD);
 
-    service_wait_exit(~0, 10 * USEC_PER_SEC);
+    service_wait_exit(~0, 20 * USEC_PER_SEC);
     watcher_step_complete(WATCHER_STEP_ID_STOP_ALL_REMAINING_WORKER_THREADS);
 
     cancel_main_threads();
@@ -345,6 +346,9 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
 
     fprintf(stderr, "Freeing all RRDHOSTs...\n");
     rrdhost_free_all();
+    dyncfg_shutdown();
+    rrd_functions_inflight_destroy();
+    health_plugin_destroy();
 
     fprintf(stderr, "Cleaning up destroyed dictionaries...\n");
     size_t dictionaries_referenced = cleanup_destroyed_dictionaries();

--- a/src/daemon/dyncfg/dyncfg-inline.c
+++ b/src/daemon/dyncfg/dyncfg-inline.c
@@ -64,3 +64,11 @@ void dyncfg_init(bool load_saved) {
     dyncfg_nodes = dyncfg_nodes_dictionary_create();
     dyncfg_init_low_level(load_saved);
 }
+
+void dyncfg_shutdown(void) {
+    if(dyncfg_nodes) {
+        dictionary_destroy(dyncfg_nodes);
+        dyncfg_nodes = NULL;
+    }
+    dyncfg_shutdown_low_level();
+}

--- a/src/daemon/dyncfg/dyncfg.c
+++ b/src/daemon/dyncfg/dyncfg.c
@@ -182,6 +182,16 @@ void dyncfg_init_low_level(bool load_saved) {
     }
 }
 
+void dyncfg_shutdown_low_level(void) {
+    if(dyncfg_globals.nodes) {
+        dictionary_destroy(dyncfg_globals.nodes);
+        dyncfg_globals.nodes = NULL;
+    }
+    
+    freez((void *)dyncfg_globals.dir);
+    dyncfg_globals.dir = NULL;
+}
+
 // ----------------------------------------------------------------------------
 
 const DICTIONARY_ITEM *dyncfg_add_internal(RRDHOST *host, const char *id, const char *path,

--- a/src/daemon/dyncfg/dyncfg.h
+++ b/src/daemon/dyncfg/dyncfg.h
@@ -22,6 +22,7 @@ bool dyncfg_add_low_level(RRDHOST *host, const char *id, const char *path, DYNCF
 void dyncfg_del_low_level(RRDHOST *host, const char *id);
 void dyncfg_status_low_level(RRDHOST *host, const char *id, DYNCFG_STATUS status);
 void dyncfg_init_low_level(bool load_saved);
+void dyncfg_shutdown_low_level(void);
 
 // high-level API for internal modules
 bool dyncfg_add(RRDHOST *host, const char *id, const char *path, DYNCFG_STATUS status, DYNCFG_TYPE type,
@@ -32,5 +33,6 @@ void dyncfg_del(RRDHOST *host, const char *id);
 void dyncfg_status(RRDHOST *host, const char *id, DYNCFG_STATUS status);
 
 void dyncfg_init(bool load_saved);
+void dyncfg_shutdown(void);
 
 #endif //NETDATA_DYNCFG_H

--- a/src/database/pattern-array.c
+++ b/src/database/pattern-array.c
@@ -8,35 +8,35 @@ struct pattern_array *pattern_array_allocate()
     return pa;
 }
 
-void pattern_array_add_lblkey_with_sp(struct pattern_array *pa, const char *key, SIMPLE_PATTERN *sp)
-{
-    if (!pa || !key || !sp)
+void pattern_array_add_lblkey_with_sp(struct pattern_array *pa, const char *key, SIMPLE_PATTERN *sp) {
+    if (!pa || !key) {
+        simple_pattern_free(sp);
+        return;
+    }
+
+    if(!sp)
         return;
 
     STRING *string_key = string_strdupz(key);
     Pvoid_t *Pvalue = JudyLIns(&pa->JudyL, (Word_t) string_key, PJE0);
-    if (!Pvalue) {
+    if (!Pvalue || Pvalue == PJERR) {
         string_freez(string_key);
         simple_pattern_free(sp);
         return;
     }
 
-    struct pattern_array_item *pai;
-    if (*Pvalue) {
-        pai = *Pvalue;
-    } else {
-        *Pvalue = pai = callocz(1, sizeof(*pai));
-        pa->key_count++;
+    if(*Pvalue) {
+        // the string was already there
+        string_freez(string_key);
     }
 
-    pai->size++;
-    Pvalue = JudyLIns(&pai->JudyL, (Word_t) pai->size, PJE0);
-    if (!Pvalue) {
+    Pvoid_t *Pvalue2 = JudyLIns(Pvalue, (Word_t)sp, PJE0);
+    if (!Pvalue2 || Pvalue2 == PJERR || *Pvalue2 == sp) {
         simple_pattern_free(sp);
         return;
     }
 
-    *Pvalue = sp;
+    *Pvalue2 = sp;
 }
 
 bool pattern_array_label_match(
@@ -52,17 +52,17 @@ bool pattern_array_label_match(
     Word_t Index = 0;
     bool first_then_next = true;
     while ((Pvalue = JudyLFirstThenNext(pa->JudyL, &Index, &first_then_next))) {
-        // for each label key in the patterns array
+        // for each label key in the pattern array
 
-        struct pattern_array_item *pai = *Pvalue;
-        SIMPLE_PATTERN_RESULT match = SP_NOT_MATCHED ;
-        for (Word_t i = 1; i <= pai->size; i++) {
+        SIMPLE_PATTERN_RESULT match = SP_NOT_MATCHED;
+        Pvoid_t *Pvalue2;
+        Word_t Index2 = 0;
+        bool first_then_next2 = true;
+        while((Pvalue2 = JudyLFirstThenNext(*Pvalue, &Index2, &first_then_next2))) {
             // for each pattern in the label key pattern list
 
-            if (!(Pvalue = JudyLGet(pai->JudyL, i, PJE0)) || !*Pvalue)
-                continue;
-
-            match = rrdlabels_match_simple_pattern_parsed(labels, (SIMPLE_PATTERN *)(*Pvalue), eq, searches);
+            SIMPLE_PATTERN *sp = *Pvalue2;
+            match = rrdlabels_match_simple_pattern_parsed(labels, sp, eq, searches);
 
             if(match != SP_NOT_MATCHED)
                 break;
@@ -134,18 +134,17 @@ void pattern_array_free(struct pattern_array *pa)
     Word_t Index = 0;
     bool first = true;
     while ((Pvalue = JudyLFirstThenNext(pa->JudyL, &Index, &first))) {
-        struct pattern_array_item *pai = *Pvalue;
 
         Word_t Index2 = 0;
+        Pvoid_t *Pvalue2;
         bool first2 = true;
-        while ((Pvalue = JudyLFirstThenNext(pai->JudyL, &Index2, &first2))) {
-            SIMPLE_PATTERN *sp = (SIMPLE_PATTERN *)*Pvalue;
+        while ((Pvalue2 = JudyLFirstThenNext(*Pvalue, &Index2, &first2))) {
+            SIMPLE_PATTERN *sp = (SIMPLE_PATTERN *)*Pvalue2;
             simple_pattern_free(sp);
         }
 
-        JudyLFreeArray(&(pai->JudyL), PJE0);
+        JudyLFreeArray(Pvalue, PJE0);
         string_freez((STRING *)Index);
-        freez(pai);
     }
 
     JudyLFreeArray(&(pa->JudyL), PJE0);

--- a/src/database/pattern-array.h
+++ b/src/database/pattern-array.h
@@ -6,13 +6,7 @@
 #include "libnetdata/libnetdata.h"
 #include "rrdlabels.h"
 
-struct pattern_array_item {
-    Word_t size;
-    Pvoid_t JudyL;
-};
-
 struct pattern_array {
-    Word_t key_count;
     Pvoid_t JudyL;
 };
 

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -781,9 +781,6 @@ void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host) {
     pulse_host_status(host, PULSE_HOST_STATUS_DELETED, 0);
     __atomic_sub_fetch(&netdata_buffers_statistics.rrdhost_allocations_size, sizeof(RRDHOST), __ATOMIC_RELAXED);
 
-    if (host == localhost)
-        health_plugin_destroy();
-
     freez(host->cache_dir);
     rrdhost_stream_parents_free(host, false);
     simple_pattern_free(host->stream.snd.charts_matching);

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -310,7 +310,6 @@ static void rrdcalc_rrdhost_insert_callback(const DICTIONARY_ITEM *item __maybe_
     rc->chart = string_dup(st->id);
 
     health_prototype_copy_config(&rc->config, &ap->config);
-    health_prototype_copy_match_without_patterns(&rc->match, &ap->match);
 
     rc->next_event_id = 1;
     rc->value = NAN;
@@ -375,7 +374,6 @@ static void rrdcalc_rrdhost_delete_callback(const DICTIONARY_ITEM *item __maybe_
     // any destruction actions that require other locks
     // have to be placed in rrdcalc_del(), because the object is actually locked for deletion
 
-    rrd_alert_match_cleanup(&rc->match);
     rrd_alert_config_cleanup(&rc->config);
 
     string_freez(rc->key);

--- a/src/health/rrdcalc.h
+++ b/src/health/rrdcalc.h
@@ -49,7 +49,6 @@ struct rrdcalc {
     STRING *key;                    // the unique key in the host's rrdcalc_root_index
     STRING *chart;                  // the chart id this should be linked to
 
-    struct rrd_alert_match match;
     struct rrd_alert_config config;
 
     // ------------------------------------------------------------------------

--- a/src/plugins.d/plugins_d.h
+++ b/src/plugins.d/plugins_d.h
@@ -49,7 +49,6 @@ size_t pluginsd_process(struct rrdhost *host, struct plugind *cd, int fd_input, 
 
 struct parser;
 void pluginsd_process_cleanup(struct parser *parser);
-void pluginsd_process_thread_cleanup(void *pptr);
 
 size_t pluginsd_initialize_plugin_directories();
 


### PR DESCRIPTION
Extracted from: https://github.com/netdata/netdata/pull/20106

- cleanup on exit for many modules
- plugins.d threads are now joinable
- fix memory leaks in diskspace plugin
- fix strings leak in pattern-arrays