### PR TITLE
Create Empty Directories

### DIFF
--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -46,6 +46,10 @@
                 <ComponentRef Id="NetdataRoot" />
                 <ComponentRef Id="NetdataVarLib" />
                 <ComponentRef Id="NetdataVarLibNetdata" />
+                <ComponentRef Id="NetdataEtcGo" />
+                <ComponentRef Id="NetdataEtcHealth" />
+                <ComponentRef Id="NetdataEtcPython" />
+                <ComponentRef Id="NetdataEtcStatsd" />
                 <ComponentGroupRef Id="WevtComponents" />
                 <ComponentRef Id="NetdataService" />
             </Feature>
@@ -65,7 +69,12 @@
                         </Directory>
                     </Directory>
                     <Directory Id="ETCDIR" Name="etc">
-                        <Directory Id="ETCDIRNETDATA" Name="netdata" />
+                        <Directory Id="ETCDIRNETDATA" Name="netdata">
+                            <Directory Id="ETCDIRNETDATAGO" Name="go.d" />
+                            <Directory Id="ETCDIRNETDATAHEALTH" Name="health.d" />
+                            <Directory Id="ETCDIRNETDATAPYTHON" Name="python.d" />
+                            <Directory Id="ETCDIRNETDATASTATSD" Name="statsd.d" />
+                        </Directory>
                     </Directory>
                     <Directory Id="DEVDIR" Name="dev">
                         <Directory Id="DEVSHMDIR" Name="shm" />
@@ -128,6 +137,22 @@
             </Component>
 
             <Component Id="NetdataHome" Directory="HOMEDIR" Guid="13056229-7734-45ac-a982-572fa99f8e72">
+                <CreateFolder />
+            </Component>
+
+            <Component Id="NetdataEtcGo" Directory="ETCDIRNETDATAGO" Guid="9d9b7859-75c0-4119-b2fc-a704599a3157">
+                <CreateFolder />
+            </Component>
+
+            <Component Id="NetdataEtcHealth" Directory="ETCDIRNETDATAHEALTH" Guid="177b08a0-7bb6-4878-9bcf-c68642c1aa23">
+                <CreateFolder />
+            </Component>
+
+            <Component Id="NetdataEtcPython" Directory="ETCDIRNETDATAPYTHON" Guid="9f4f1e99-47e1-4d88-8836-c02a98d30056">
+                <CreateFolder />
+            </Component>
+
+            <Component Id="NetdataEtcStatsd" Directory="ETCDIRNETDATASTATSD" Guid="5f53221b-691f-4026-8396-52c6b2ac025f">
                 <CreateFolder />
             </Component>
 


### PR DESCRIPTION
##### Summary

To remove some warnings/errors on some windows systems, we are creating empty directories inside `c:\Program Files\Netdata\etc\netdata`:

![newDirs](https://github.com/user-attachments/assets/0d8a1a94-27de-400d-b1ad-dabec44640d3)

##### Test Plan

1. Check CI.
2. Compile this branch
3. Generate installer.
4. Install Netdata and confirm you have new directories.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
