### PR TITLE
Fix compilation when using FSANITIZE_ADDRESS

### DIFF
--- a/src/libnetdata/dictionary/dictionary-internals.h
+++ b/src/libnetdata/dictionary/dictionary-internals.h
@@ -78,8 +78,10 @@ struct dictionary_item {
 #ifdef FSANITIZE_ADDRESS
     STACKTRACE_ARRAY stacktraces;   // stack traces from all acquisition points
 #endif
+#if defined(FSANITIZE_ADDRESS) || defined(NETDATA_INTERNAL_CHECKS)
+    DICTIONARY *dict;                     // the dictionary this item belongs to
+#endif
 #ifdef NETDATA_INTERNAL_CHECKS
-    DICTIONARY *dict;
     pid_t creator_pid;
     pid_t deleter_pid;
     pid_t ll_adder_pid;

--- a/src/libnetdata/dictionary/dictionary-item.h
+++ b/src/libnetdata/dictionary/dictionary-item.h
@@ -83,7 +83,7 @@ static inline DICTIONARY_ITEM *dict_item_create(DICTIONARY *dict __maybe_unused,
         *allocated_bytes += size;
     }
 
-#ifdef NETDATA_INTERNAL_CHECKS
+#if defined(FSANITIZE_ADDRESS) || defined(NETDATA_INTERNAL_CHECKS)
     item->dict = dict;
 #endif
     return item;


### PR DESCRIPTION

##### Summary
- Fix compilation when using only FSANITIZE_ADDRESS without NETDATA_INTERNAL_CHECKS
