### PR TITLE
Fix Locks (Windows Locks)

### DIFF
--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -863,6 +863,9 @@ static void do_mssql_locks(PERF_DATA_BLOCK *pDataBlock, struct mssql_instance *p
     if (!pObjectType)
         return;
 
+    if (!pObjectType->NumInstances)
+        return;
+
     dict_mssql_locks_wait_charts(p, update_every);
     dict_mssql_dead_locks_charts(p, update_every);
     PERF_INSTANCE_DEFINITION *pi = NULL;

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -235,11 +235,11 @@ static inline void initialize_mssql_keys(struct mssql_instance *p)
 
 void dict_mssql_insert_locks_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused)
 {
-    const char *instance = dictionary_acquired_item_name((DICTIONARY_ITEM *)item);
+    const char *resource = dictionary_acquired_item_name((DICTIONARY_ITEM *)item);
 
     // https://learn.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-locks-object
     struct mssql_lock_instance *ptr = value;
-    ptr->instanceID = strdupz(instance);
+    ptr->resourceID = strdupz(resource);
     ptr->deadLocks.key = "Number of Deadlocks/sec";
     ptr->lockWait.key = "Lock Waits/sec";
 }
@@ -840,8 +840,6 @@ void dict_mssql_dead_locks_charts(struct mssql_instance *mi, int update_every)
         rrdlabels_add(
             mi->st_deadLocks->rrdlabels, "mssql_instance", mi->instanceID, RRDLABEL_SRC_AUTO);
     }
-
-    return 1;
 }
 
 void dict_mssql_deadlocks_dimension(struct mssql_instance *mi, struct mssql_lock_instance *mli)
@@ -888,7 +886,7 @@ static void do_mssql_locks(PERF_DATA_BLOCK *pDataBlock, struct mssql_instance *p
             dict_mssql_locks_wait_dimension(p, mli);
 
         if (perflibGetObjectCounter(pDataBlock, pObjectType, &mli->deadLocks))
-            dict_mssql_deadlocks_dimension(p, mli, p->instanceID);
+            dict_mssql_deadlocks_dimension(p, mli);
     }
 
     if (p->st_lockWait)

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -807,7 +807,7 @@ void dict_mssql_locks_wait_dimension(struct mssql_instance *mi, struct mssql_loc
 {
     if (!mli->rd_lockWait) {
         char id[RRD_ID_LENGTH_MAX + 1];
-        snprintfz(id, RRD_ID_LENGTH_MAX, "instance_%s_resource_%s_locks_lock_wait", mi->instanceID, mli->resourceID);
+        snprintfz(id, RRD_ID_LENGTH_MAX, "%s", mli->resourceID);
         netdata_fix_chart_name(id);
 
         mli->rd_lockWait = rrddim_add(mi->st_lockWait, id, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
@@ -846,7 +846,7 @@ void dict_mssql_deadlocks_dimension(struct mssql_instance *mi, struct mssql_lock
 {
     if (!mli->rd_deadLocks) {
         char id[RRD_ID_LENGTH_MAX + 1];
-        snprintfz(id, RRD_ID_LENGTH_MAX, "instance_%s_resource_%s_locks_deadlocks", mi->instanceID, mli->resourceID);
+        snprintfz(id, RRD_ID_LENGTH_MAX, "%s", mli->resourceID);
         netdata_fix_chart_name(id);
 
         mli->rd_deadLocks = rrddim_add(mi->st_deadLocks, id, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);


### PR DESCRIPTION
##### Summary

Fix issue:

```c
# 7 rrdset_done [0x1006CE246] (/src/database/rrdset-collection.c:507)
#8 do_mssql_locks [0x100548CA0] (/src/collectors/windows.plugin/perflib-mssql.c:892)
#9 dict_mssql_charts_cb [0x100534C17] (/src/collectors/windows.plugin/perflib-mssql.c:1422)
#10 dictionary_sorted_walkthrough_rw [0x100537EAA] (/src/libnetdata/dictionary/dictionary-traversal.c:247)
#11 do_PerflibMSSQL [0x10053D71C] (/src/collectors/windows.plugin/perflib-mssql.c:1439)
#12 win_plugin_main [0x1007BB961] (/src/collectors/windows.plugin/windows_plugin.c:196)
#13 nd_thread_starting_point [0x1005F7DD0] (/src/libnetdata/threads/threads.c:362)
``` 

##### Test Plan

1.  Check CI
2. Compile build locally
3. Make an installer.
4. Install on host running MSSQL Server.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
