### PR TITLE
Some fixes for macOS < 11

### DIFF
--- a/src/collectors/apps.plugin/apps_os_macos.c
+++ b/src/collectors/apps.plugin/apps_os_macos.c
@@ -136,6 +136,7 @@ bool apps_os_get_pid_cmdline_macos(struct pid_stat *p, char *cmdline, size_t max
     return true;
 }
 
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
 bool apps_os_read_pid_io_macos(struct pid_stat *p, void *ptr) {
     struct pid_info *pi = ptr;
 
@@ -146,6 +147,11 @@ bool apps_os_read_pid_io_macos(struct pid_stat *p, void *ptr) {
 
     return true;
 }
+#else
+bool apps_os_read_pid_io_macos(struct pid_stat *p __maybe_unused, void *ptr __maybe_unused) {
+    return false;
+}
+#endif
 
 bool apps_os_read_pid_limits_macos(struct pid_stat *p __maybe_unused, void *ptr __maybe_unused) {
     return false;
@@ -319,11 +325,13 @@ bool apps_os_collect_all_pids_macos(void) {
             continue;
         }
 
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
         st = proc_pid_rusage(pid, RUSAGE_INFO_V4, (rusage_info_t *)&pi.rusageinfo);
         if (st < 0) {
             netdata_log_error("Failed to get resource usage info for PID %d", pid);
             continue;
         }
+#endif
 
         incrementally_collect_data_for_pid(pid, &pi);
     }

--- a/src/collectors/apps.plugin/apps_plugin.h
+++ b/src/collectors/apps.plugin/apps_plugin.h
@@ -47,12 +47,15 @@
 #include <sys/proc_info.h>
 #include <sys/sysctl.h>
 #include <mach/mach_time.h> // For mach_timebase_info_data_t and mach_timebase_info
+#include <AvailabilityMacros.h>
 
 struct pid_info {
     struct kinfo_proc proc;
     struct proc_taskinfo taskinfo;
     struct proc_bsdinfo bsdinfo;
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
     struct rusage_info_v4 rusageinfo;
+#endif
 };
 
 #define OS_INIT_PID                          1

--- a/src/collectors/timex.plugin/plugin_timex.c
+++ b/src/collectors/timex.plugin/plugin_timex.c
@@ -2,6 +2,12 @@
 
 #include "database/rrd.h"
 
+#ifdef OS_MACOS
+#include <AvailabilityMacros.h>
+#endif
+
+#if !defined(OS_MACOS) || (MAC_OS_X_VERSION_MIN_REQUIRED >= 101300)
+
 #define PLUGIN_TIMEX_NAME "timex.plugin"
 
 #define CONFIG_SECTION_TIMEX "plugin:timex"
@@ -182,3 +188,5 @@ void *timex_main(void *ptr)
 exit:
     return NULL;
 }
+
+#endif // !defined(OS_MACOS) || (MAC_OS_X_VERSION_MIN_REQUIRED >= 101300)

--- a/src/daemon/static_threads_macos.c
+++ b/src/daemon/static_threads_macos.c
@@ -2,10 +2,16 @@
 
 #include "common.h"
 
+#include <AvailabilityMacros.h>
+
 void *macos_main(void *ptr);
-void *timex_main(void *ptr);
+
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101300
+    void *timex_main(void *ptr);
+#endif
 
 static const struct netdata_static_thread static_threads_macos[] = {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101300
     {
         .name = "P[timex]",
         .config_section = CONFIG_SECTION_PLUGINS,
@@ -15,6 +21,7 @@ static const struct netdata_static_thread static_threads_macos[] = {
         .init_routine = NULL,
         .start_routine = timex_main
     },
+#endif
     {
         .name = "P[macos]",
         .config_section = CONFIG_SECTION_PLUGINS,

--- a/src/database/rrddim.h
+++ b/src/database/rrddim.h
@@ -11,6 +11,13 @@ typedef struct rrddim_acquired RRDDIM_ACQUIRED;
 typedef struct ml_dimension rrd_ml_dimension_t;
 typedef struct rrdmetric_acquired RRDMETRIC_ACQUIRED;
 
+// gcc with libstdc++ may require this,
+// but with libc++ it does not work correctly.
+#if defined(__cplusplus) && !defined(_LIBCPP_VERSION)
+#include <cmath>
+using std::isnan;
+#endif
+
 #include "rrdset.h"
 
 // options are permanent configuration options (no atomics to alter/access them)

--- a/src/libnetdata/buffer/buffer.h
+++ b/src/libnetdata/buffer/buffer.h
@@ -10,6 +10,14 @@
 
 #define BUFFER_JSON_MAX_DEPTH 32 // max is 255
 
+// gcc with libstdc++ may require this,
+// but with libc++ it does not work correctly.
+#if defined(__cplusplus) && !defined(_LIBCPP_VERSION)
+#include <cmath>
+using std::isinf;
+using std::isnan;
+#endif
+
 extern const char hex_digits[16];
 extern const char hex_digits_lower[16];
 extern const char base64_digits[64];

--- a/src/libnetdata/os/adjtimex.c
+++ b/src/libnetdata/os/adjtimex.c
@@ -2,8 +2,13 @@
 
 #include "../libnetdata.h"
 
+#ifdef OS_MACOS
+#include <AvailabilityMacros.h>
+#endif
+
 int os_adjtimex(struct timex *buf __maybe_unused) {
-#if defined(OS_MACOS) || defined(OS_FREEBSD)
+#if (defined(OS_MACOS) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 101300)) || \
+    defined(OS_FREEBSD)
     return ntp_adjtime(buf);
 #endif
 

--- a/src/libnetdata/os/adjtimex.h
+++ b/src/libnetdata/os/adjtimex.h
@@ -3,7 +3,12 @@
 #ifndef NETDATA_ADJTIMEX_H
 #define NETDATA_ADJTIMEX_H
 
-#if defined(OS_LINUX) || defined(OS_FREEBSD) || defined(OS_MACOS)
+#ifdef OS_MACOS
+#include <AvailabilityMacros.h>
+#endif
+
+#if defined(OS_LINUX) || defined(OS_FREEBSD) || \
+    (defined(OS_MACOS) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 101300))
 #include <sys/timex.h>
 #endif
 

--- a/src/libnetdata/os/uuid_generate.c
+++ b/src/libnetdata/os/uuid_generate.c
@@ -24,7 +24,9 @@ void os_uuid_generate_time(void *out) {
 
 #else
 
-#if !defined(OS_MACOS)
+#if defined(OS_MACOS)
+#include <uuid/uuid.h>
+#else
 #include <uuid.h>
 #endif
 

--- a/src/ml/ml_kmeans.cc
+++ b/src/ml/ml_kmeans.cc
@@ -4,6 +4,14 @@
 #include "libnetdata/libnetdata.h"
 #include "dlib/dlib/clustering.h"
 
+// gcc with libstdc++ may require this,
+// but with libc++ it does not work correctly.
+#if !defined(_LIBCPP_VERSION)
+#include <cmath>
+using std::isinf;
+using std::isnan;
+#endif
+
 void
 ml_kmeans_init(ml_kmeans_t *kmeans)
 {


### PR DESCRIPTION
##### Summary

With these fixes `netdata` can be built on macOS 10.6.8.

There should be no effects on other systems. No new functionality is implemented, this only addressed build errors.

P. S. If someone could help improving fallbacks, it will be great.