### PR TITLE
chore(go.d): remove wmi->win collector rename handling

### DIFF
--- a/src/go/plugin/go.d/agent/setup.go
+++ b/src/go/plugin/go.d/agent/setup.go
@@ -105,23 +105,6 @@ func (a *Agent) buildDiscoveryConf(enabled module.Registry) discovery.Config {
 	}
 
 	for name := range enabled {
-		// TODO: properly handle module renaming
-		// We need to announce this change in Netdata v1.39.0 release notes and then remove this workaround.
-		// This is just a quick fix for wmi=>windows. We need to prefer user wmi.conf over windows.conf
-		// 2nd part of this fix is in /agent/job/discovery/file/parse.go parseStaticFormat()
-		if name == "windows" {
-			cfgName := "wmi.conf"
-			a.Debugf("looking for '%s' in %v", cfgName, a.CollectorsConfDir)
-
-			path, err := a.CollectorsConfDir.Find(cfgName)
-
-			if err == nil && strings.Contains(path, "etc/netdata") {
-				a.Infof("found '%s", path)
-				readPaths = append(readPaths, path)
-				continue
-			}
-		}
-
 		cfgName := name + ".conf"
 		a.Debugf("looking for '%s' in %v", cfgName, a.CollectorsConfDir)
 


### PR DESCRIPTION
##### Summary

Not needed anymore. We no longer have go.d/windows.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
