### PR TITLE
improvement(cgroups): improve systemd-nspawn filter for default

### DIFF
--- a/src/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/src/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -338,8 +338,9 @@ void read_cgroup_plugin_configuration() {
 
                        // ----------------------------------------------------------------
 
-                       "!/machine.slice/*/payload*"
-                       "!/machine.slice/*/supervisor*"
+                       " !/machine.slice/*/.control "
+                       " !/machine.slice/*/payload* "
+                       " !/machine.slice/*/supervisor "
                        " /machine.slice/*.service "           // #3367 systemd-nspawn
 
                        // ----------------------------------------------------------------


### PR DESCRIPTION
##### Summary

Follow-up to #20155

##### Test Plan

Ran a single systemd-nspawn container. Modified the filters till there was a single entry.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
