### PR TITLE
ignore maintenance signals on exit

### DIFF
--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -227,17 +227,25 @@ static void process_triggered_signals(void) {
 
             switch (signals_waiting[i].action) {
                 case NETDATA_SIGNAL_RELOAD_HEALTH:
-                    nd_log_limits_unlimited();
-                    netdata_log_info("SIGNAL: Received %s. Reloading HEALTH configuration...", name);
-                    nd_log_limits_reset();
-                    execute_command(CMD_RELOAD_HEALTH, NULL, NULL);
+                    if(exit_initiated_get())
+                        netdata_log_info("SIGNAL: Received %s. Ignoring it, as we are exiting...", name);
+                    else {
+                        nd_log_limits_unlimited();
+                        netdata_log_info("SIGNAL: Received %s. Reloading HEALTH configuration...", name);
+                        nd_log_limits_reset();
+                        execute_command(CMD_RELOAD_HEALTH, NULL, NULL);
+                    }
                     break;
 
                 case NETDATA_SIGNAL_REOPEN_LOGS:
-                    nd_log_limits_unlimited();
-                    netdata_log_info("SIGNAL: Received %s. Reopening all log files...", name);
-                    nd_log_limits_reset();
-                    execute_command(CMD_REOPEN_LOGS, NULL, NULL);
+                    if(exit_initiated_get())
+                        netdata_log_info("SIGNAL: Received %s. Ignoring it, as we are exiting...", name);
+                    else {
+                        nd_log_limits_unlimited();
+                        netdata_log_info("SIGNAL: Received %s. Reopening all log files...", name);
+                        nd_log_limits_reset();
+                        execute_command(CMD_REOPEN_LOGS, NULL, NULL);
+                    }
                     break;
 
                 case NETDATA_SIGNAL_EXIT_CLEANLY:


### PR DESCRIPTION
Fix this:

```
AE_EXIT_CAUSE
fatal on exit

AE_FATAL_FAULT_ADDRESS
0x0

AE_FATAL_FUNCTION
execute_command

AE_FATAL_SIGNAL_CODE
SIGABRT/SI_TKILL

AE_FATAL_STACK_TRACE
#0 <unknown> [0x7FBFFBE5B04F]
#1 <unknown> [0x7FBFFBEA9EEC]
#2 <unknown> [0x7FBFFBE5AFB1]
#3 <unknown> [0x7FBFFBE45471]
#4 <unknown> [0x7FBFFC61A201]
#5 execute_command [0x5589D20CB28B] (/src/daemon/commands.c:586)
#6 process_triggered_signals [0x5589D20CA536] (/src/daemon/signal-handler.c:240)
#7 nd_process_signals [0x5589D20CA78E] (/src/daemon/signal-handler.c:298)
#8 main [0x5589D1F791A4] (/src/daemon/main.c:1174)
#9 <unknown> [0x7FBFFBE46249]
#10 <unknown> [0x7FBFFBE46304]
#11 <unknown> [0x5589D20B83A0]
#12 <unknown> [0xFFFFFFFFFFFFFFFF]
```

Reloading health or exiting are ignored while we are exiting.