### PR TITLE
limit the max number of threads based on memory too

### DIFF
--- a/src/daemon/config/netdata-conf-global.h
+++ b/src/daemon/config/netdata-conf-global.h
@@ -13,6 +13,7 @@ size_t netdata_conf_cpus(void);
 void libuv_initialize(void);
 
 void netdata_conf_glibc_malloc_initialize(size_t wanted_arenas, size_t trim_threshold);
+void netdata_conf_reset_stack_size(void);
 
 #include "netdata-conf.h"
 

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -258,7 +258,6 @@ int netdata_main(int argc, char **argv) {
     int i;
     int config_loaded = 0;
     bool close_open_fds = true; (void)close_open_fds;
-    size_t default_stacksize;
     const char *user = NULL;
 
 #ifdef OS_WINDOWS
@@ -833,18 +832,6 @@ int netdata_main(int argc, char **argv) {
     nd_profile_setup();
 
     // ----------------------------------------------------------------------------------------------------------------
-    delta_startup_time("stack size");
-
-    // initialize thread - this is required before the first nd_thread_create()
-    default_stacksize = netdata_threads_init();
-
-    // musl default thread stack size is 128k, let's set it to a higher value to avoid random crashes
-    if (default_stacksize < 1 * 1024 * 1024)
-        default_stacksize = 1 * 1024 * 1024;
-
-    netdata_threads_set_stack_size(default_stacksize);
-
-    // ----------------------------------------------------------------------------------------------------------------
     delta_startup_time("crash reports");
 
     daemon_status_file_check_crash();
@@ -1021,8 +1008,7 @@ int netdata_main(int argc, char **argv) {
     // ----------------------------------------------------------------------------------------------------------------
     delta_startup_time("threads after fork");
 
-    netdata_threads_set_stack_size(
-        (size_t)inicfg_get_size_bytes(&netdata_config, CONFIG_SECTION_GLOBAL, "pthread stack size", default_stacksize));
+    netdata_conf_reset_stack_size();
 
     // ----------------------------------------------------------------------------------------------------------------
     delta_startup_time("registry");


### PR DESCRIPTION
We see a lot of crashes on `work_dispatch()`, during startup. These crashes happen because the system cannot handle the number of libuv threads we configure (cpus x 6).

In cases the system has a small memory (e.g. 1 - 3 GiB of RAM), but a high number of CPUs (e.g. 23-64), the amount of memory requested just the threads stacks exceeds the total amount of memory. In these cases, glibc calls `abort()` making the program to exit.

The fix in this patch takes into account the total and available system memory when configuring libuv:

1. It starts with cpus x 6
2. But then checks the total and available RAM.
3. It takes MIN(5% of total, 10% of available) and based on this it limits the max number of threads that libuv will use.

The number of libuv threads cannot be less than 16 (as before).