### PR TITLE
add fast path to waitq

### DIFF
--- a/src/libnetdata/locks/waitq.c
+++ b/src/libnetdata/locks/waitq.c
@@ -58,6 +58,14 @@ static ALWAYS_INLINE bool clear_our_priority(WAITQ *waitq, uint64_t our_order) {
 }
 
 ALWAYS_INLINE bool waitq_try_acquire_with_trace(WAITQ *waitq, WAITQ_PRIORITY priority, const char *func __maybe_unused) {
+    // Fast path for no contention - try to get the lock immediately without a sequence number
+    if (__atomic_load_n(&waitq->current_priority, __ATOMIC_RELAXED) == NO_PRIORITY && 
+        spinlock_trylock(&waitq->spinlock)) {
+        waitq->writer = gettid_cached();
+        return true;
+    }
+
+    // Normal path with queuing if contention exists
     uint64_t our_order = get_our_order(waitq, priority);
 
     bool rc = write_our_priority(waitq, our_order) && spinlock_trylock(&waitq->spinlock);
@@ -70,6 +78,14 @@ ALWAYS_INLINE bool waitq_try_acquire_with_trace(WAITQ *waitq, WAITQ_PRIORITY pri
 }
 
 ALWAYS_INLINE void waitq_acquire_with_trace(WAITQ *waitq, WAITQ_PRIORITY priority, const char *func) {
+    // Fast path for no contention - try to get the lock immediately without a sequence number
+    if (__atomic_load_n(&waitq->current_priority, __ATOMIC_RELAXED) == NO_PRIORITY && 
+        spinlock_trylock(&waitq->spinlock)) {
+        waitq->writer = gettid_cached();
+        return;
+    }
+
+    // Normal path with queuing if contention exists
     uint64_t our_order = get_our_order(waitq, priority);
 
     size_t spins = 0;


### PR DESCRIPTION
BEFORE THESE CHANGES ON MY DEV MACHINE:

```
=== Performance Summary (Million locks/sec) ===

Lock Type           1        2        4        8       16       32       64
------------------------------------------------------------------------------
Mutex           86.47    22.15    20.00    13.30    11.62    11.02    11.99
RWLock          54.52    11.23     9.73     7.09     5.73     0.71     0.75
Spinlock       121.25   115.18   110.27   107.83   103.61    98.21    90.24
RW Spinlock     71.67    66.57    63.50    61.32    58.84    55.51    50.87
WaitQ           39.01    38.65    38.76    35.43    32.22    28.25    23.71  <<< THIS

```

WITH THESE CHANGES:

```
=== Performance Summary (Million locks/sec) ===

Lock Type           1        2        4        8       16       32       64
------------------------------------------------------------------------------
Mutex           87.25    21.71    20.07    12.47    10.93    10.50    10.55
RWLock          53.35    12.03    10.31     7.16     6.04     1.06     0.78
Spinlock       119.22   116.81   110.78   107.07   104.98    99.36    91.54
RW Spinlock     72.35    65.27    63.83    60.75    58.84    55.24    50.67
WaitQ          114.06   111.81   109.56    95.48    84.02    69.06    55.65  <<< vs THIS

```

More than double performance on waitq!