### PR TITLE
Add a default busy timeout

### DIFF
--- a/src/database/sqlite/sqlite_functions.c
+++ b/src/database/sqlite/sqlite_functions.c
@@ -272,7 +272,7 @@ int db_execute(sqlite3 *db, const char *cmd)
             break;
 
         ++cnt;
-        error_report("Failed to execute '%s', rc = %d (%s) -- attempt %d", cmd, rc, err_msg ? err_msg : "unknown", cnt);
+        nd_log_daemon(NDLP_WARNING, "Failed to execute '%s', rc = %d (%s) -- attempt %d", cmd, rc, err_msg ? err_msg : "unknown", cnt);
         if (err_msg) {
             sqlite3_free(err_msg);
         }

--- a/src/database/sqlite/sqlite_functions.h
+++ b/src/database/sqlite/sqlite_functions.h
@@ -83,6 +83,7 @@ void analytics_set_data_str(char **name, const char *value);
 
 #define SQL_MAX_RETRY (100)
 #define SQLITE_INSERT_DELAY (10)        // Insert delay in case of lock
+#define SQLITE_BUSY_DELAY_MS (30)          // Busy timeout delay
 
 SQLITE_API int sqlite3_step_monitored(sqlite3_stmt *stmt);
 SQLITE_API int sqlite3_exec_monitored(

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -797,7 +797,8 @@ int sql_init_meta_database(db_check_action_type_t rebuild, int memory)
         goto close_database;
 
     netdata_log_info("SQLite database initialization completed");
-    sqlite3_busy_timeout(db_meta, SQLITE_BUSY_DELAY_MS);
+    if (sqlite3_busy_timeout(db_meta, SQLITE_BUSY_DELAY_MS) != SQLITE_OK)
+        nd_log_daemon(NDLP_WARNING, "SQLITE: Failed to set busy timeout to %d ms", SQLITE_BUSY_DELAY_MS);
 
     return 0;
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -797,6 +797,7 @@ int sql_init_meta_database(db_check_action_type_t rebuild, int memory)
         goto close_database;
 
     netdata_log_info("SQLite database initialization completed");
+    sqlite3_busy_timeout(db_meta, SQLITE_BUSY_DELAY_MS);
 
     return 0;
 


### PR DESCRIPTION
##### Summary
- Switch a message to warning instead of error
- Configure a busy timeout for database operations