### PR TITLE
Use one spinlock to access v2 and mmap related data

### DIFF
--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -198,7 +198,7 @@ static void njfv2idx_remove(struct rrdengine_datafile *datafile) {
 static struct journal_v2_header *journalfile_v2_mounted_data_get(struct rrdengine_journalfile *journalfile, size_t *data_size) {
     struct journal_v2_header *j2_header = NULL;
 
-    spinlock_lock(&journalfile->mmap.spinlock);
+    spinlock_lock(&journalfile->data_spinlock);
 
     if(!journalfile->mmap.data) {
         journalfile->mmap.data = nd_mmap(NULL, journalfile->mmap.size, PROT_READ, MAP_SHARED, journalfile->mmap.fd, 0);
@@ -209,9 +209,7 @@ static struct journal_v2_header *journalfile_v2_mounted_data_get(struct rrdengin
             journalfile->mmap.data = NULL;
             journalfile->mmap.size = 0;
 
-            spinlock_lock(&journalfile->v2.spinlock);
             journalfile->v2.flags &= ~(JOURNALFILE_FLAG_IS_AVAILABLE | JOURNALFILE_FLAG_IS_MOUNTED);
-            spinlock_unlock(&journalfile->v2.spinlock);
 
             ctx_fs_error(datafile_ctx(journalfile->datafile));
         }
@@ -223,10 +221,8 @@ static struct journal_v2_header *journalfile_v2_mounted_data_get(struct rrdengin
             // madvise_dontneed(journalfile->mmap.data, journalfile->mmap.size);
             madvise_random(journalfile->mmap.data, journalfile->mmap.size);
 
-            spinlock_lock(&journalfile->v2.spinlock);
             journalfile->v2.flags |= JOURNALFILE_FLAG_IS_AVAILABLE | JOURNALFILE_FLAG_IS_MOUNTED;
             JOURNALFILE_FLAGS flags = journalfile->v2.flags;
-            spinlock_unlock(&journalfile->v2.spinlock);
 
             if(flags & JOURNALFILE_FLAG_MOUNTED_FOR_RETENTION) {
                 // we need the entire metrics directory into memory to process it
@@ -242,7 +238,7 @@ static struct journal_v2_header *journalfile_v2_mounted_data_get(struct rrdengin
             *data_size = journalfile->mmap.size;
     }
 
-    spinlock_unlock(&journalfile->mmap.spinlock);
+    spinlock_unlock(&journalfile->data_spinlock);
 
     return j2_header;
 }
@@ -252,20 +248,11 @@ static bool journalfile_v2_mounted_data_unmount(struct rrdengine_journalfile *jo
 
     if(!have_locks) {
         if(!wait) {
-            if (!spinlock_trylock(&journalfile->mmap.spinlock))
+            if (!spinlock_trylock(&journalfile->data_spinlock))
                 return false;
         }
         else
-            spinlock_lock(&journalfile->mmap.spinlock);
-
-        if(!wait) {
-            if(!spinlock_trylock(&journalfile->v2.spinlock)) {
-                spinlock_unlock(&journalfile->mmap.spinlock);
-                return false;
-            }
-        }
-        else
-            spinlock_lock(&journalfile->v2.spinlock);
+            spinlock_lock(&journalfile->data_spinlock);
     }
 
     if(!journalfile->v2.refcount) {
@@ -288,8 +275,7 @@ static bool journalfile_v2_mounted_data_unmount(struct rrdengine_journalfile *jo
     }
 
     if(!have_locks) {
-        spinlock_unlock(&journalfile->v2.spinlock);
-        spinlock_unlock(&journalfile->mmap.spinlock);
+        spinlock_unlock(&journalfile->data_spinlock);
     }
 
     return unmounted;
@@ -309,7 +295,7 @@ void journalfile_v2_data_unmount_cleanup(time_t now_s) {
         for (datafile = ctx->datafiles.first; datafile; datafile = datafile->next) {
             struct rrdengine_journalfile *journalfile = datafile->journalfile;
 
-            if(!spinlock_trylock(&journalfile->v2.spinlock))
+            if(!spinlock_trylock(&journalfile->data_spinlock))
                 continue;
 
             bool unmount = false;
@@ -324,7 +310,7 @@ void journalfile_v2_data_unmount_cleanup(time_t now_s) {
                     // enough time has passed since we last needed this journal
                     unmount = true;
             }
-            spinlock_unlock(&journalfile->v2.spinlock);
+            spinlock_unlock(&journalfile->data_spinlock);
 
             if (unmount)
                 journalfile_v2_mounted_data_unmount(journalfile, false, false);
@@ -334,7 +320,7 @@ void journalfile_v2_data_unmount_cleanup(time_t now_s) {
 }
 
 ALWAYS_INLINE struct journal_v2_header *journalfile_v2_data_acquire(struct rrdengine_journalfile *journalfile, size_t *data_size, time_t wanted_first_time_s, time_t wanted_last_time_s) {
-    spinlock_lock(&journalfile->v2.spinlock);
+    spinlock_lock(&journalfile->data_spinlock);
 
     bool has_data = (journalfile->v2.flags & JOURNALFILE_FLAG_IS_AVAILABLE);
     bool is_mounted = (journalfile->v2.flags & JOURNALFILE_FLAG_IS_MOUNTED);
@@ -356,7 +342,7 @@ ALWAYS_INLINE struct journal_v2_header *journalfile_v2_data_acquire(struct rrden
 
         }
     }
-    spinlock_unlock(&journalfile->v2.spinlock);
+    spinlock_unlock(&journalfile->data_spinlock);
 
     if(do_we_need_it)
         return journalfile_v2_mounted_data_get(journalfile, data_size);
@@ -365,7 +351,7 @@ ALWAYS_INLINE struct journal_v2_header *journalfile_v2_data_acquire(struct rrden
 }
 
 ALWAYS_INLINE void journalfile_v2_data_release(struct rrdengine_journalfile *journalfile) {
-    spinlock_lock(&journalfile->v2.spinlock);
+    spinlock_lock(&journalfile->data_spinlock);
 
     internal_fatal(!journalfile->mmap.data, "trying to release a journalfile without data");
     internal_fatal(journalfile->v2.refcount < 1, "trying to release a non-acquired journalfile");
@@ -380,7 +366,7 @@ ALWAYS_INLINE void journalfile_v2_data_release(struct rrdengine_journalfile *jou
         if(journalfile->v2.flags & JOURNALFILE_FLAG_MOUNTED_FOR_RETENTION)
             unmount = true;
     }
-    spinlock_unlock(&journalfile->v2.spinlock);
+    spinlock_unlock(&journalfile->data_spinlock);
 
     if(unmount)
         journalfile_v2_mounted_data_unmount(journalfile, false, true);
@@ -388,18 +374,18 @@ ALWAYS_INLINE void journalfile_v2_data_release(struct rrdengine_journalfile *jou
 
 bool journalfile_v2_data_available(struct rrdengine_journalfile *journalfile) {
 
-    spinlock_lock(&journalfile->v2.spinlock);
+    spinlock_lock(&journalfile->data_spinlock);
     bool has_data = (journalfile->v2.flags & JOURNALFILE_FLAG_IS_AVAILABLE);
-    spinlock_unlock(&journalfile->v2.spinlock);
+    spinlock_unlock(&journalfile->data_spinlock);
 
     return has_data;
 }
 
 size_t journalfile_v2_data_size_get(struct rrdengine_journalfile *journalfile) {
 
-    spinlock_lock(&journalfile->mmap.spinlock);
+    spinlock_lock(&journalfile->data_spinlock);
     size_t data_size = journalfile->mmap.size;
-    spinlock_unlock(&journalfile->mmap.spinlock);
+    spinlock_unlock(&journalfile->data_spinlock);
 
     return data_size;
 }
@@ -411,8 +397,7 @@ void journalfile_v2_data_set(struct rrdengine_journalfile *journalfile, int fd, 
     if(unlikely(!journalfile->datafile))
         fatal("DBENGINE: JOURNALFILE: trying to set journal data without a datafile");
 
-    spinlock_lock(&journalfile->mmap.spinlock);
-    spinlock_lock(&journalfile->v2.spinlock);
+    spinlock_lock(&journalfile->data_spinlock);
 
     internal_fatal(journalfile->mmap.fd != -1, "DBENGINE JOURNALFILE: trying to re-set journal fd");
     internal_fatal(journalfile->mmap.data, "DBENGINE JOURNALFILE: trying to re-set journal_data");
@@ -431,8 +416,7 @@ void journalfile_v2_data_set(struct rrdengine_journalfile *journalfile, int fd, 
 
     journalfile_v2_mounted_data_unmount(journalfile, true, true);
 
-    spinlock_unlock(&journalfile->v2.spinlock);
-    spinlock_unlock(&journalfile->mmap.spinlock);
+    spinlock_unlock(&journalfile->data_spinlock);
 
     njfv2idx_add(journalfile->datafile);
 }
@@ -446,8 +430,7 @@ static void journalfile_v2_data_unmap_permanently(struct rrdengine_journalfile *
         if (has_references)
             sleep_usec(10 * USEC_PER_MS);
 
-        spinlock_lock(&journalfile->mmap.spinlock);
-        spinlock_lock(&journalfile->v2.spinlock);
+        spinlock_lock(&journalfile->data_spinlock);
 
         if(journalfile_v2_mounted_data_unmount(journalfile, true, true)) {
             if(journalfile->mmap.fd != -1)
@@ -465,8 +448,7 @@ static void journalfile_v2_data_unmap_permanently(struct rrdengine_journalfile *
             internal_error(true, "DBENGINE JOURNALFILE: waiting for journalfile to be available to unmap...");
         }
 
-        spinlock_unlock(&journalfile->v2.spinlock);
-        spinlock_unlock(&journalfile->mmap.spinlock);
+        spinlock_unlock(&journalfile->data_spinlock);
 
     } while(has_references);
 }
@@ -475,8 +457,7 @@ struct rrdengine_journalfile *journalfile_alloc_and_init(struct rrdengine_datafi
 {
     struct rrdengine_journalfile *journalfile = callocz(1, sizeof(struct rrdengine_journalfile));
     journalfile->datafile = datafile;
-    spinlock_init(&journalfile->mmap.spinlock);
-    spinlock_init(&journalfile->v2.spinlock);
+    spinlock_init(&journalfile->data_spinlock);
     spinlock_init(&journalfile->unsafe.spinlock);
     journalfile->mmap.fd = -1;
     datafile->journalfile = journalfile;

--- a/src/database/engine/journalfile.h
+++ b/src/database/engine/journalfile.h
@@ -23,17 +23,15 @@ typedef enum __attribute__ ((__packed__)) {
     JOURNALFILE_FLAG_METRIC_CRC_CHECK      = (1 << 3),
 } JOURNALFILE_FLAGS;
 
-/* only one event loop is supported for now */
 struct rrdengine_journalfile {
+    SPINLOCK data_spinlock;
     struct {
-        SPINLOCK spinlock;
         void *data;                    // MMAPed file of journal v2
         uint32_t size;                 // Total file size mapped
         int fd;
     } mmap;
 
     struct {
-        SPINLOCK spinlock;
         JOURNALFILE_FLAGS flags;
         int32_t refcount;
         time_t first_time_s;


### PR DESCRIPTION
##### Summary
- Use one spinlock to access the mmap and v2 data (instead of two -- in most cases they were acquired in pairs) 

