### PR TITLE
Small fixes

### DIFF
--- a/src/web/api/http_auth.c
+++ b/src/web/api/http_auth.c
@@ -302,6 +302,10 @@ static void bearer_tokens_load_from_disk(void) {
 bool web_client_bearer_token_auth(struct web_client *w, const char *v) {
     bool rc = false;
 
+    // javascript may send "null" or "undefined"
+    if(!v || !*v || strcmp(v, "null") == 0 || strcmp(v, "undefined") == 0)
+        return rc;
+
     if(!uuid_parse_flexi(v, w->auth.bearer_token)) {
         char uuid_str[UUID_COMPACT_STR_LEN];
         uuid_unparse_lower_compact(w->auth.bearer_token, uuid_str);

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -1298,9 +1298,14 @@ NETDATA_DOUBLE *rrd2rrdr_ks2(
     for(size_t tr = 0; tr < nd_profile.storage_tiers; tr++)
         stats->db_points_per_tier[tr] += r->internal.qt->db.tiers[tr].points;
 
+    if(!r->d || !r->internal.qt->query.used) {
+        // the result is empty - no data to query for this metric
+        goto cleanup;
+    }
+    
     if(r->d != 1 || r->internal.qt->query.used != 1) {
         netdata_log_error("WEIGHTS: on query '%s' expected 1 dimension in RRDR but got %zu r->d and %zu qt->query.used",
-              r->internal.qt->id, r->d, (size_t)r->internal.qt->query.used);
+                          r->internal.qt->id, r->d, (size_t)r->internal.qt->query.used);
         goto cleanup;
     }
 


### PR DESCRIPTION
- [x] do not log `null` bearer tokens
- [x] do not log empty weights responses