### PR TITLE
Enable analytics data collection 

### DIFF
--- a/src/daemon/analytics.c
+++ b/src/daemon/analytics.c
@@ -652,12 +652,13 @@ void *analytics_main(void *ptr)
     while (service_running(SERVICE_ANALYTICS) && likely(sec <= ANALYTICS_INIT_SLEEP_SEC)) {
         heartbeat_next(&hb);
         sec++;
+        if (sec == ANALYTICS_INIT_IMMUTABLE_DATA_SEC)
+            analytics_gather_immutable_meta_data();
     }
 
     if (unlikely(!service_running(SERVICE_ANALYTICS)))
         goto cleanup;
 
-    analytics_gather_immutable_meta_data();
     analytics_gather_mutable_meta_data();
 
     analytics_statistic_t statistic = { "META_START", "-", "-"  };

--- a/src/daemon/analytics.h
+++ b/src/daemon/analytics.h
@@ -7,7 +7,7 @@
 #include "database/rrdhost-system-info.h"
 
 /* Max number of seconds before the first META analytics is sent */
-#define ANALYTICS_INIT_SLEEP_SEC 120
+#define ANALYTICS_INIT_SLEEP_SEC (10)
 
 /* Send a META event every X seconds */
 #define ANALYTICS_HEARTBEAT (6 * 3600)

--- a/src/daemon/analytics.h
+++ b/src/daemon/analytics.h
@@ -7,7 +7,9 @@
 #include "database/rrdhost-system-info.h"
 
 /* Max number of seconds before the first META analytics is sent */
-#define ANALYTICS_INIT_SLEEP_SEC (10)
+#define ANALYTICS_INIT_SLEEP_SEC (120)
+#define ANALYTICS_INIT_IMMUTABLE_DATA_SEC (10)
+
 
 /* Send a META event every X seconds */
 #define ANALYTICS_HEARTBEAT (6 * 3600)

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1097,8 +1097,11 @@ int netdata_main(int argc, char **argv) {
 
     // ----------------------------------------------------------------------------------------------------------------
 
-    if(analytics_check_enabled()) {
-        delta_startup_time("anonymous analytics");
+    {
+        if(analytics_check_enabled())
+            delta_startup_time("anonymous analytics");
+        else // collect data but do not send it (needed in /api/v1/info)
+            delta_startup_time("anonymous analytics (disabled)");
 
         analytics_statistic_t start_statistic = {"START", "-", "-"};
         analytics_statistic_send(&start_statistic);


### PR DESCRIPTION
##### Summary
- The analytics thread is now started even when disabled to support data population for the `/api/v1/info` endpoint. Data is collected locally but not sent when analytics is disabled.
