### PR TITLE
Draft: Sidebar restructure docs

### DIFF
--- a/docs/sidebar-restructure.md
+++ b/docs/sidebar-restructure.md
@@ -5,7 +5,9 @@
   - Deployment Guides
   - Top Monitoring
   - Live Demo
-    **ARCHITECTURE**
+
+    - **ARCHITECTURE**
+    
 - **OBSERVABILITY**
   - Observability Centralization Points
 


### PR DESCRIPTION
I'm proposing a new high-level structure for the documentation menu that organizes existing categories into clearer, thematic groups like “Netdata Project,” “Observability,” “Metrics & Logs,” and “Secure by Design.” 

The goal is to give users a more intuitive path from the start, create a sense that Netdata is easy to understand and use, and reflect the product’s strengths and identity in how the docs look and feel. 

This approach also aligns with our straightforward, no-bullshit marketing by reducing noise and helping people get where they need to go faster. It's a first step toward broader improvements.

Please check commit 48f0f76fb685b6f6ab05fad667f484f5cacaa693 and excuse my git skills. @ilyam8 @Ancairon 