### PR TITLE
Minor fixes

### DIFF
--- a/src/daemon/daemon-shutdown-watcher.c
+++ b/src/daemon/daemon-shutdown-watcher.c
@@ -120,7 +120,7 @@ void *watcher_main(void *arg)
 
     // wait until the agent starts the shutdown process
     completion_wait_for(&shutdown_begin_completion);
-    netdata_log_error("Shutdown process started");
+    netdata_log_info("Shutdown process started");
 
     usec_t shutdown_start_time = now_monotonic_usec();
 
@@ -150,8 +150,10 @@ void *watcher_main(void *arg)
     usec_t shutdown_end_time = now_monotonic_usec();
 
     usec_t shutdown_duration = shutdown_end_time - shutdown_start_time;
-    netdata_log_error("Shutdown process ended in %llu milliseconds",
-                      shutdown_duration / USEC_PER_MS);
+
+    char shutdown_timing[64];
+    duration_snprintf(shutdown_timing, sizeof(shutdown_timing), (int64_t)shutdown_duration, "us", 1);
+    netdata_log_info("Shutdown process ended in %s", shutdown_timing);
 
     daemon_status_file_shutdown_step(NULL, buffer_tostring(steps_timings));
     daemon_status_file_update_status(DAEMON_STATUS_EXITED);

--- a/src/database/rrdset-collection.c
+++ b/src/database/rrdset-collection.c
@@ -682,7 +682,7 @@ void rrdset_timed_done(RRDSET *st, struct timeval now, bool pending_rrdset_next)
             collected_total += rd->collector.collected_value;
 
             if(unlikely(rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE))) {
-                netdata_log_error("Dimension %s in chart '%s' has the OBSOLETE or ARCHIVED flag set, but it is collected.", rrddim_name(rd), rrdset_id(st));
+                netdata_log_error("Dimension %s in chart '%s' has the OBSOLETE flag set, but it is collected.", rrddim_name(rd), rrdset_id(st));
                 if(!spinlock_trylock(&rd->destroy_lock))
                     fatal("RRDSET: dimension '%s' of chart '%s' of host '%s' is being collected while is being destroyed.", rrddim_id(rd), rrdset_id(st), rrdhost_hostname(st->rrdhost));
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2405,6 +2405,8 @@ static void store_hosts_metadata(BUFFER *work_buffer, bool is_worker)
             host_count++;
         }
         dfe_done(host);
+        if (!host_count)
+            host_count = 1; // avoid division by zero
     }
 
     size_t count = 0;


### PR DESCRIPTION
##### Summary
- Switch to info mesage for shutdown messages, reformat the shutdown_timing
- Avoid division by zero (silence coverity)
- Fix message (dimensions cannot be ARCHIVED anymore)
