### PR TITLE
Schedule journal file indexing after database file rotation

### DIFF
--- a/src/daemon/libuv_workers.c
+++ b/src/daemon/libuv_workers.c
@@ -26,7 +26,6 @@ static void register_libuv_worker_jobs_internal(void) {
     worker_register_job_name(UV_EVENT_DBENGINE_FLUSHED_TO_OPEN, "flushed to open");
 
     // datafile full
-    worker_register_job_name(UV_EVENT_DBENGINE_JOURNAL_INDEX_WAIT, "jv2 index wait");
     worker_register_job_name(UV_EVENT_DBENGINE_JOURNAL_INDEX, "jv2 indexing");
 
     // db rotation related

--- a/src/daemon/libuv_workers.h
+++ b/src/daemon/libuv_workers.h
@@ -24,7 +24,6 @@ enum event_loop_job {
     UV_EVENT_DBENGINE_FLUSHED_TO_OPEN,
 
     // datafile full
-    UV_EVENT_DBENGINE_JOURNAL_INDEX_WAIT,
     UV_EVENT_DBENGINE_JOURNAL_INDEX,
 
     // db rotation related

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1677,7 +1677,6 @@ NOT_INLINE_HOT void pdc_route_synchronously_first(struct rrdengine_instance *ctx
 
 static void *journal_v2_indexing_tp_worker(struct rrdengine_instance *ctx __maybe_unused, void *data __maybe_unused, struct completion *completion __maybe_unused, uv_work_t *uv_work_req __maybe_unused) {
     unsigned count = 0;
-    worker_is_busy(UV_EVENT_DBENGINE_JOURNAL_INDEX_WAIT);
 
     struct rrdengine_datafile *datafile = ctx->datafiles.first;
     worker_is_busy(UV_EVENT_DBENGINE_JOURNAL_INDEX);

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -396,6 +396,7 @@ struct rrdengine_instance {
 
         PAD64(bool) migration_to_v2_running;
         PAD64(bool) now_deleting_files;
+        PAD64(bool) needs_indexing;
         PAD64(unsigned) extents_currently_being_flushed;   // non-zero until we commit data to disk (both datafile and journal file)
 
         PAD64(time_t) first_time_s;


### PR DESCRIPTION
##### Summary
If a journal indexing job can't be scheduled immediately, set a flag to trigger it after the database rotation job completes.

This ensures more predictable indexing and helps avoid increased memory usage in the database engine due to cache buildup.

