### PR TITLE
Switch to poll from epoll

### DIFF
--- a/src/libnetdata/socket/nd-poll.c
+++ b/src/libnetdata/socket/nd-poll.c
@@ -6,7 +6,7 @@
 #define POLLRDHUP 0
 #endif
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX_DISABLE_EPOLL_DUE_TO_BUG)
 #include <sys/epoll.h>
 
 struct fd_info {


### PR DESCRIPTION
##### Summary
- Disable epoll for now -- (random high cpu usage observed in kernels 6.14.4+) 

https://lists.linaro.org/archives/list/linux-stable-mirror@lists.linaro.org/message/6ADQXH5GBYZKRWOE3RHPFAO7BOOXMYO7/


Fixes #20266.
