### PR TITLE
Fix docker plugin trying to connect to `tcp://localhost:2375/var/run/docker.sock`

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -68,11 +68,11 @@ if [ "${EUID}" -eq 0 ]; then
   re='^[0-9]+$'
   if [[ $BALENA_PGID =~ $re ]]; then
     echo "Netdata detected balena-engine.sock"
-    DOCKER_HOST='/var/run/balena-engine.sock'
+    DOCKER_HOST='unix:///var/run/balena-engine.sock'
     PGID="$BALENA_PGID"
   elif [[ $DOCKER_PGID =~ $re ]]; then
     echo "Netdata detected docker.sock"
-    DOCKER_HOST="/var/run/docker.sock"
+    DOCKER_HOST="unix:///var/run/docker.sock"
     PGID="$DOCKER_PGID"
   fi
   export PGID


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

For some reason, when no protocol is specified, the docker plugin appends `tcp://localhost:2375` to `DOCKER_HOST`.

In turn, Netdata is not able to resolve the container names and keeps printing this in the logs:

```
Cannot connect to the Docker daemon at tcp://localhost:2375/var/run/docker.sock. Is the docker daemon running?
```

**I think it should be fixed in the plugin itself**, but I don't know anything about Go, so I'm fixing it in the `run.sh` instead.

This issue was realized in:

- https://github.com/felipecrs/netdata-hass-addon/issues/66

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

I integrated this fix in the Netdata add-on for Home Assistant and it's working as intended.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
If your container names were not being resolved in the Netdata UI:

![image](https://github.com/user-attachments/assets/111d804b-b08c-427e-ad6a-528c7673726f)

Now they will:

![image](https://github.com/user-attachments/assets/87023d24-da24-40d7-a505-eb64ed231f27)

</details>
