### PR TITLE
docs: Observability centralization points

### DIFF
--- a/docs/nodes-ephemerality.md
+++ b/docs/nodes-ephemerality.md
@@ -4,20 +4,42 @@
 
 Netdata categorizes nodes into two types:
 
-| Type          | Description                                    | Common Use Cases                                                                                                                                                            |
-|---------------|------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Ephemeral** | Expected to disconnect or reconnect frequently | - Auto-scaling cloud instances<br/>- Dynamic containers and VMs<br/>- IoT devices with intermittent connectivity<br/>- Development/test environments with frequent restarts |
-| **Permanent** | Expected to maintain continuous connectivity   | - Production servers<br/>- Core infrastructure nodes<br/>- Critical monitoring systems<br/>- Stable database servers                                                        |
+| Type | Description | Common Use Cases |
+|------|-------------|------------------|
+| **Ephemeral** | Expected to disconnect or reconnect frequently | • Auto-scaling cloud instances<br>• Dynamic containers and VMs<br>• IoT devices with intermittent connectivity<br>• Development/test environments with frequent restarts |
+| **Permanent** | Expected to maintain continuous connectivity | • Production servers<br>• Core infrastructure nodes<br>• Critical monitoring systems<br>• Stable database servers |
 
-> **Note:** Disconnections in permanent nodes indicate potential system failures and require immediate attention.
+:::note
+
+Disconnections in permanent nodes indicate potential system failures and require immediate attention.
+
+:::
 
 ### Key Benefits
 
-1. **Reduced Alert Noise**: Disconnection alerts now apply only to permanent nodes, helping teams focus on actual issues.
-2. **Improved Dynamic Infrastructure Support**: Auto-scaling cloud instances, containers, and other temporary resources can be designated as ephemeral to prevent unnecessary alerts.
-3. **Automated Node Cleanup**: Ephemeral nodes are removed based on configurable retention periods, keeping dashboards relevant and uncluttered.
+1. **Reduced Alert Noise**: Disconnection alerts now apply only to permanent nodes, helping you focus on actual issues.
+2. **Improved Dynamic Infrastructure Support**: You can designate auto-scaling cloud instances, containers, and other temporary resources as ephemeral to prevent unnecessary alerts.
+3. **Automated Node Cleanup**: You can configure ephemeral nodes to be automatically removed based on your preferred retention periods, keeping your dashboards relevant and uncluttered.
 
 ## Configuring Ephemeral Nodes
+
+```mermaid
+flowchart TD
+    A[Start:<br> Node Permanent by Default] -->|Step 1| B[Open netdata.conf<br> on Target Node]
+    B -->|Step 2| C["Add Configuration"]
+    C -->|Step 3| D[Restart the Node]
+    D --> E[Node Now Marked<br>Ephemeral]
+    E --> F[_is_ephemeral<br>Label Applied]
+    F --> G[Label Propagates to Parents<br>and Cloud]
+    
+    style A fill:#f9f9f9,stroke:#333,stroke-width:1px
+    style B fill:#4caf50,stroke:#333,stroke-width:1px,color:white
+    style C fill:#4caf50,stroke:#333,stroke-width:1px,color:white
+    style D fill:#4caf50,stroke:#333,stroke-width:1px,color:white
+    style E fill:#ffeb3b,stroke:#333,stroke-width:1px,color:black
+    style F fill:#f9f9f9,stroke:#333,stroke-width:1px
+    style G fill:#f9f9f9,stroke:#333,stroke-width:1px
+```
 
 By default, Netdata treats all nodes as permanent. To mark a node as ephemeral:
 
@@ -29,38 +51,42 @@ By default, Netdata treats all nodes as permanent. To mark a node as ephemeral:
    ```
 3. Restart the node.
 
-This setting applies the `_is_ephemeral` host label, which propagates to Netdata Parents and Netdata Cloud.
+This setting applies the `_is_ephemeral` host label, which propagates to your Netdata Parents and Netdata Cloud.
 
 ## Alerts for Parent Nodes
 
 Netdata v2.3.0 introduces two new alerts specifically for permanent nodes:
 
-| Alert                       | Trigger Condition                                         |
-|-----------------------------|-----------------------------------------------------------|
+| Alert | Trigger Condition |
+|-------|-------------------|
 | `streaming_never_connected` | A permanent node has never connected to a Netdata Parent. |
-| `streaming_disconnected`    | A previously connected permanent node has disconnected.   |
+| `streaming_disconnected` | A previously connected permanent node has disconnected. |
 
 ## Monitoring Child Node Status
 
-To investigate an alert:
+```mermaid
+flowchart TD
+    A[Start:<br> Permanently Offline Node] -->|Run CLI Command| B[Use netdatacli Utility]
+    B -->|Specify Target| C[Specify Node<br> to Mark as Ephemeral]
+    C --> D[Node Marked as Ephemeral]
+    D --> E[Metrics Data Remains<br> Available]
+    D --> F[Active Alerts Cleared]
+    D --> G{Node Reconnects?}
+    G -->|Yes, without config| H[Reverts to<br> Permanent Status]
+    G -->|No| I[Remains Ephemeral]
+    
+    style A fill:#f9f9f9,stroke:#333,stroke-width:1px
+    style B fill:#4caf50,stroke:#333,stroke-width:1px,color:white
+    style C fill:#4caf50,stroke:#333,stroke-width:1px,color:white
+    style D fill:#ffeb3b,stroke:#333,stroke-width:1px,color:black
+    style E fill:#f9f9f9,stroke:#333,stroke-width:1px
+    style F fill:#f9f9f9,stroke:#333,stroke-width:1px
+    style G fill:#f9f9f9,stroke:#333,stroke-width:1px,color:black
+    style H fill:#f44336,stroke:#333,stroke-width:1px,color:white
+    style I fill:#ffeb3b,stroke:#333,stroke-width:1px,color:black
+```
 
-1. Open the `Top` tab in your Netdata dashboard.
-2. Select the `Netdata-streaming` function.
-3. Review the node status table:
-    - **Red lines**: Connection issues when nodes attempt to connect to a Parent.
-    - **Yellow lines**: Restreaming issues when a Parent streams data to another Parent.
-    - **Color highlighting applies only to permanent nodes**.
-    - Use the `Ephemerality` filter to view only permanent nodes.
-    - Check `InStatus`, `InReason`, and `InAge` for incoming connection status.
-    - Check `OutStatus`, `OutReason`, and `OutAge` for outgoing streaming status.
-
-## Managing Offline Nodes
-
-The [Netdata CLI](/src/cli/README.md) tool has two commands for working with archived nodes.
-
-### mark-stale-nodes-ephemeral
-
-To mark a permanently offline nodes, including virtual nodes, as ephemeral:
+To mark permanently offline nodes, including virtual nodes, as ephemeral:
 
 ```bash
 netdatacli mark-stale-nodes-ephemeral <node_id | machine_guid | hostname | ALL_NODES>
@@ -68,9 +94,29 @@ netdatacli mark-stale-nodes-ephemeral <node_id | machine_guid | hostname | ALL_N
 
 This keeps the previously collected metrics data available for querying and clears any active alerts.
 
-> **Note:** Nodes will revert to permanent status if they reconnect unless explicitly configured as ephemeral in `netdata.conf`.
+:::note
+
+Nodes will revert to permanent status if they reconnect unless explicitly configured as ephemeral in `netdata.conf`.
+
+:::
 
 ### remove-stale-node
+
+```mermaid
+flowchart TD
+    A[Start:<br>Offline Node Detected] -->|Use CLI Tool| B[Run Node Removal<br> Command]
+    B -->|Specify Target| C[Select Node to Remove]
+    C --> D[Node Removed from System]
+    D --> E[Node No Longer Queryable]
+    D --> F[Alerts for Node Cleared]
+    
+    style A fill:#4caf50,stroke:#333,stroke-width:1px,color:white
+    style B fill:#4caf50,stroke:#333,stroke-width:1px,color:white
+    style C fill:#4caf50,stroke:#333,stroke-width:1px,color:white
+    style D fill:#f44336,stroke:#333,stroke-width:1px,color:white
+    style E fill:#f9f9f9,stroke:#333,stroke-width:1px
+    style F fill:#f9f9f9,stroke:#333,stroke-width:1px
+```
 
 To fully remove permanently offline nodes:
 
@@ -88,7 +134,29 @@ From v2.3.0 onward, Netdata Cloud sends unreachable-node notifications **only fo
 
 ## Automatically Removing Ephemeral Nodes
 
-By default, Netdata does not automatically remove disconnected ephemeral nodes. To enable automatic cleanup:
+```mermaid
+flowchart TD
+    A[Start:<br> Configure Auto-Removal] -->|Edit Configuration| B[Open netdata.conf<br> on Parent Nodes]
+    B -->|Add Configuration| C["Add: [db]\ncleanup<br> ephemeral hosts after = 1d"]
+    C -->|Restart Node| D[Restart Netdata]
+    D --> E[Ephemeral Node<br> Disconnects]
+    E -->|Wait Period| F{24 Hours Passed?}
+    F -->|Yes| G[Node<br> Automatically Removed]
+    F -->|No| H[Node Remains in System]
+    G -->|If All Parents Remove Node| I[Node Removed from Cloud]
+    
+    style A fill:#4caf50,stroke:#333,stroke-width:1px,color:white
+    style B fill:#f9f9f9,stroke:#333,stroke-width:1px
+    style C fill:#f9f9f9,stroke:#333,stroke-width:1px
+    style D fill:#f9f9f9,stroke:#333,stroke-width:1px
+    style E fill:#ffeb3b,stroke:#333,stroke-width:1px,color:black
+    style F fill:#f9f9f9,stroke:#333,stroke-width:1px,color:black
+    style G fill:#f44336,stroke:#333,stroke-width:1px,color:white
+    style H fill:#f9f9f9,stroke:#333,stroke-width:1px
+    style I fill:#f44336,stroke:#333,stroke-width:1px,color:white
+```
+
+By default, Netdata does not automatically remove disconnected ephemeral nodes. **To enable automatic cleanup**:
 
 1. Open the `netdata.conf` file on Netdata Parent nodes.
 2. Add the following configuration:
@@ -99,3 +167,6 @@ By default, Netdata does not automatically remove disconnected ephemeral nodes. 
 3. Restart the node.
 
 This setting removes ephemeral nodes from queries after 24 hours of disconnection. Once all parent nodes remove a node, Netdata Cloud automatically deletes it as well.
+
+
+

--- a/docs/observability-centralization-points/README.md
+++ b/docs/observability-centralization-points/README.md
@@ -1,26 +1,79 @@
-# **Observability Centralization Points**
+# Observability Centralization Points
 
-Netdata allows you to set up multiple **Observability Centralization Points** to aggregate metrics, logs, and metadata across your infrastructure.
+## What Are Centralization Points?
 
-## **Why Use Centralization Points?**
+Observability Centralization Points are specialized Netdata installations that you can configure to **receive, store, and process** observability data (metrics and logs) from multiple other systems in your infrastructure.
 
-- **Ephemeral Systems**:
-    - Ideal for **Kubernetes nodes or temporary VMs** that frequently go offline.
-    - Ensures metrics and logs remain available for analysis and troubleshooting.
+These centralization points give you several core functions:
+* **Receiving and storing** metrics and logs from multiple systems
+* **Processing and analyzing** your collected data
+* **Running health checks and alerts**
+* Providing **unified dashboards** across all your systems
+* **Replicating data** for your historical analysis
 
-- **Limited Resources**:
-    - Offloads observability tasks from systems with **low disk space, CPU, RAM, or I/O bandwidth**.
-    - Keeps production systems running efficiently without performance trade-offs.
+This **distributed yet centralized** approach gives you the benefits of both decentralized collection and centralized analysis.
 
-- **Multi-Node Dashboards Without Netdata Cloud**:
-    - Aggregates data from multiple nodes for **centralized dashboards**, similar to Netdata Cloud.
+## Why Use Centralization Points?
 
-- **Restricted Netdata Cloud Access**:
-    - Acts as a **bridge** when monitored systems can’t connect to Netdata Cloud due to **firewall restrictions**.
+| Use Case | Description | Benefits |
+|----------|-------------|---------| 
+| **Ephemeral Systems** | Ideal for your Kubernetes nodes or temporary VMs that frequently go offline | You retain metrics and logs for analysis and troubleshooting even after node termination |
+| **Limited Resources** | Offloads observability tasks from your systems with low disk space, CPU, RAM, or I/O bandwidth | Your production systems run efficiently without performance trade-offs |
+| **Multi-Node Dashboards Without Netdata Cloud** | Aggregates data from all your nodes for centralized dashboards | You get Cloud-like functionality in environments that prefer or require on-premises solutions |
+| **Restricted Netdata Cloud Access** | Acts as a bridge when your monitored systems can't connect to Netdata Cloud | You can still use Cloud features despite firewall restrictions or security policies |
 
-## **How Multiple Centralization Points Work**
+## How Multiple Centralization Points Work
 
-- **With Netdata Cloud**:
-    - Queries all centralization points in parallel for a unified view of the infrastructure.
-- **Without Netdata Cloud**:
-    - Parent nodes consolidate data from connected systems, providing a local view of metrics and logs.
+| Scenario | Operation | Advantages |
+|----------|-----------|------------|
+| **With Netdata Cloud** | Queries all your centralization points in parallel for a unified view | You get a seamless experience regardless of your underlying architecture |
+| **Without Netdata Cloud** | Your centralization points consolidate data from connected systems | You have a local view of metrics and logs without external dependencies |
+| **High Availability Setup** | Your centralization points share data with each other, forming a cluster | You won't lose data if one centralization point fails |
+
+```mermaid
+graph TD
+    A[Centralization Points<br>Architecture] --> B[Single Centralization Point<br> Setup]
+    A --> C[Multiple Independent<br>Centralization Points]
+    A --> D[High Availability Cluster]
+    
+    B --> B1[All systems stream<br>to one centralization point]
+    C --> C1[Systems divided<br>by region/service/team]
+    D --> D1[Centralization points<br>share data with each other]
+    
+classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
+classDef green fill:#4caf50,stroke:#333,stroke-width:1px,color:black;
+class A default;
+class B,C,D,B1,C1,D1 green;
+```
+
+## Technical Implementation
+
+Observability Centralization Points consist of two major components you can deploy:
+
+1. **Metrics Centralization** - Uses Netdata's streaming and replication features to centralize your metrics data
+2. **Logs Centralization** - Uses systemd-journald methodologies to centralize your log data
+
+You can configure your systems to connect to **multiple centralization points** for redundancy. If a connection fails, they automatically switch to an available alternative.
+
+In a **high-availability setup**, your centralization points can form a cluster by sharing data with each other, ensuring all points have a complete copy of all your metrics and logs.
+
+```mermaid
+graph TD
+    CP1[Centralization Point 1] --- CP2[Centralization Point 2]
+    
+    S1[System 1] --> CP1
+    S2[System 2] --> CP1
+    S3[System 3] --> CP2
+    S4[System 4] --> CP2
+    
+    S1 -.-> CP2
+    S2 -.-> CP2
+    S3 -.-> CP1
+    S4 -.-> CP1
+    
+classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
+classDef green fill:#4caf50,stroke:#333,stroke-width:1px,color:black;
+classDef blue fill:#2196F3,stroke:#333,stroke-width:1px,color:white;
+class CP1,CP2 default;
+class S1,S2,S3,S4 blue;
+```

--- a/docs/observability-centralization-points/best-practices.md
+++ b/docs/observability-centralization-points/best-practices.md
@@ -4,32 +4,91 @@
 
 When setting up Observability Centralization Points, consider the following:
 
-1. **System Volume**: The number of monitored systems impacts scaling. Larger infrastructures may need multiple centralization points to maintain performance.
-2. **Data Transfer Costs**: In multi-cloud or hybrid environments, placing centralization points strategically reduces egress bandwidth costs.
-3. **Usability Without Netdata Cloud**: Using fewer centralization points simplifies access and management when Netdata Cloud is not in use.
-4. **Optimized Deployment with Netdata Cloud**: Netdata Cloud provides a complete infrastructure view, allowing you to optimize based on:
-    - **Security** (internet access controls)
-    - **Cost** (bandwidth and resource allocation)
-    - **Operational needs** (regional, service, or team-based isolation)
+| Factor | Description | Impact |
+|--------|-------------|--------|
+| **System Volume** | The number of monitored systems | Larger infrastructures may need multiple centralization points to maintain performance |
+| **Data Transfer Costs** | Bandwidth usage between environments | Strategic placement reduces egress bandwidth costs in multi-cloud or hybrid environments |
+| **Usability Without Netdata Cloud** | Standalone operation considerations | Fewer centralization points simplifies access and management |
+| **Optimized Deployment with Netdata Cloud** | Cloud integration benefits | Provides complete infrastructure view with optimized security, cost, and operational controls |
+
+```mermaid
+graph TD
+    A[Optimized Deployment<br>with Netdata Cloud] --> B[Security]
+    A --> C[Cost]
+    A --> D[Operational Needs]
+    
+    B --> B1[Internet access controls]
+    C --> C1[Bandwidth and<br>resource allocation]
+    D --> D1[Regional, service, or<br>team-based isolation]
+    
+classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
+classDef green fill:#4caf50,stroke:#333,stroke-width:1px,color:black;
+class A default;
+class B,C,D,B1,C1,D1 green;
+```
 
 ## Cost Optimization Strategies
 
 Netdata is designed to keep observability efficient and cost-effective. To manage costs:
 
-- **Scale Out**: Use multiple smaller centralization points to improve efficiency and performance.
-- **Use Existing Resources**: Leverage spare capacity before dedicating new resources to observability.
-- **Centralized or Separate Logs & Metrics**: Choose whether to store logs and metrics together or separately based on access needs, retention policies, and compliance.
-- **Flexible Configuration Management**: Each centralization point can have unique retention and alert settings, helping to control costs and tailor observability for different teams or services.
+| Strategy | Description | Benefit |
+|----------|-------------|---------|
+| **Scale Out** | Use multiple smaller centralization points | Improves efficiency and performance across distributed systems |
+| **Use Existing Resources** | Leverage spare capacity | Minimize additional hardware costs by using available resources |
+| **Centralized or Separate Logs & Metrics** | Choose storage approach based on needs | Optimize based on access patterns, retention policies, and compliance requirements |
+| **Flexible Configuration Management** | Customize each centralization point | Control costs with unique retention and alert settings tailored for different teams or services |
+
+```mermaid
+graph TD
+    A[Cost Optimization<br>Strategies] --> B[Scale Out]
+    A --> C[Use Existing<br>Resources]
+    A --> D[Centralized or<br>Separate Logs & Metrics]
+    A --> E[Flexible<br>Configuration Management]
+    
+    B --> B1[Multiple smaller<br>centralization points]
+    C --> C1[Leverage spare capacity]
+    D --> D1[Based on access needs,<br>retention policies,<br>and compliance]
+    E --> E1[Unique settings for<br>different teams or services]
+    
+classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
+classDef green fill:#4caf50,stroke:#333,stroke-width:1px,color:black;
+class A default;
+class B,C,D,E,B1,C1,D1,E1 green;
+```
 
 ## Advantages of Netdata's Approach
 
 Netdata provides several benefits over other observability solutions:
 
-- **Scalability & Flexibility**: Multiple independent centralization points allow for customized observability by region, service, or team.
-- **Resilience & Reliability**: Built-in replication ensures that observability continues even if a centralization point fails.
-- **Optimized Cost & Performance**: Distributing workloads prevents bottlenecks and improves resource efficiency.
-- **Ease of Use**: Netdata Agents require minimal setup and maintenance, reducing complexity.
-- **On-Prem Control**: Centralization points remain on-prem even when using Netdata Cloud, keeping data within your infrastructure.
-- **Comprehensive Observability**: Netdata enables deep visibility by segmenting infrastructure into independent observability points with tailored retention, alerts, and machine learning, while Netdata Cloud provides a unified view.
+| Advantage | Description | Value |
+|-----------|-------------|-------|
+| **Scalability & Flexibility** | Multiple independent centralization points | Customized observability by region, service, or team |
+| **Resilience & Reliability** | Built-in replication | Observability continues even if a centralization point fails |
+| **Optimized Cost & Performance** | Distributed workloads | Prevents bottlenecks and improves resource efficiency |
+| **Ease of Use** | Minimal setup and maintenance | Reduces complexity and operational overhead |
+| **On-Prem Control** | Data remains within your infrastructure | Enhanced security and compliance, even when using Netdata Cloud |
+| **Comprehensive Observability** | Segmented infrastructure with unified view | Deep visibility with tailored retention, alerts, and machine learning |
 
-Following these best practices helps maintain a **cost-effective**, **high-performance** observability setup with Netdata.
+```mermaid
+graph TD
+    A[Advantages of<br>Netdata's Approach] --> B[Scalability & Flexibility]
+    A --> C[Resilience & Reliability]
+    A --> D[Optimized Cost &<br>Performance]
+    A --> E[Ease of Use]
+    A --> F[On-Prem Control]
+    A --> G[Comprehensive<br>Observability]
+    
+    B --> B1[Customized observability<br>by region, service, or team]
+    C --> C1[Observability continues<br> even if a centralization<br> point fails]
+    D --> D1[Prevents bottlenecks<br>and improves<br>resource efficiency]
+    E --> E1[Minimal setup and maintenance]
+    F --> F1[Data remains within<br>your infrastructure]
+    G --> G1[Unified view with<br>tailored segments]
+    
+classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
+classDef green fill:#4caf50,stroke:#333,stroke-width:1px,color:black;
+class A default;
+class B,C,D,E,F,G,B1,C1,D1,E1,F1,G1 green;
+```
+
+Following these best practices helps you maintain a **cost-effective**, **high-performance** observability setup with Netdata.

--- a/src/streaming/README.md
+++ b/src/streaming/README.md
@@ -1,6 +1,67 @@
 # Streaming and Replication Reference
 
-This guide covers advanced streaming options and recommended deployment strategies for production environments. If you're new to Netdata streaming, start with the [quick introduction to streaming](/docs/observability-centralization-points/README.md) to set up a basic parent-child configuration.
+## Introduction
+
+This guide covers Netdata's advanced streaming and replication capabilities, which allow you to build centralized observability points across your infrastructure.
+
+**[Streaming and replication](https://learn.netdata.cloud/docs/developer-and-contributor-corner/glossary#r)** work together to send metrics data from one Netdata Agent (child) to another Netdata Agent (parent). Streaming sends metrics in real-time, while replication ensures historical data is copied as well, maintaining complete data integrity even after connection interruptions.
+
+::: tip
+
+If you're new to Netdata streaming or prefer a guided approach, [jump to our step-by-step guide](#step-by-step-setup-guide) at the end of this document. The guide will walk you through setting up a basic streaming configuration and then connecting to the comprehensive reference sections as needed.
+
+For a quick reference on setting up the parent-child relationship, see the [example configurations](#complete-configuration-examples) or refer to our comprehensive [Centralized Deployment Guide](https://learn.netdata.cloud/docs/deployment-guides/centralized) for more details.
+
+:::
+
+## Understanding Streaming Architecture
+
+Before diving into configuration details, it's important to understand the key concepts behind Netdata's streaming architecture:
+
+```mermaid
+graph TD
+    A[Child Node] -->|Streams real-time metrics| B[Parent Node]
+    A -->|Replicates historical data| B
+    C[Child Node] -->|Streams real-time metrics| B
+    C -->|Replicates historical data| B
+    B -->|Presents unified dashboard| D[Monitoring User]
+    
+classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
+classDef green fill:#4caf50,stroke:#333,stroke-width:1px,color:black;
+class A,C green;
+class B,D default;
+```
+
+### Parent-Child Relationship
+
+- **Child nodes** (data sources) collect metrics directly from systems they monitor
+- **Parent nodes** (data centralization points) receive, store, and visualize metrics from multiple child nodes
+- **A single parent can receive data from many children**, creating a centralized monitoring hub
+- **Child nodes maintain independence and continue collecting metrics** even if the connection to a parent is lost
+
+### Data Flow
+
+1. **Collection**: Child nodes collect metrics from their local systems
+2. **Streaming**: Child nodes send real-time metrics to parent nodes
+3. **Replication**: When a connection is established or restored, child nodes replicate historical data to ensure parents have complete history
+4. **Storage**: Parent nodes store metrics based on their configured retention policies
+5. **Visualization**: Users access the parent node's dashboard to view metrics from all connected child nodes
+
+### Benefits of This Architecture
+
+- **Efficiency**: Distribute collection workload across multiple nodes while centralizing visualization
+- **Resilience**: Maintain data collection even during network disruptions or parent node failures
+- **Scalability**: Add more child nodes or additional parent nodes as your infrastructure grows
+- **Flexibility**: Configure retention, alerts, and dashboards according to your specific needs
+
+## Quick Reference
+
+| Task | Configuration | Example |
+|------|--------------|---------|
+| Enable streaming on a child | Set `enabled = yes` in `[stream]` section | `[stream]`<br>`enabled = yes`<br>`destination = 192.168.1.5` |
+| Configure a parent to accept connections | Create an `[API_KEY]` section | `[API_KEY]`<br>`enabled = yes`<br>`allow from = *` |
+| Set up high availability | Configure multiple destinations on child | `[stream]`<br>`destination = parent1:19999 parent2:19999` |
+| Filter which metrics to send | Use `send charts matching` setting | `send charts matching = system.* !system.uptime` |
 
 ## Configuration Overview
 
@@ -12,7 +73,10 @@ Netdata's streaming capabilities are configured through two key files:
 To edit these files, navigate to your Netdata configuration directory (typically `/etc/netdata`) and run:
 
 ```sh
+# Edit streaming configuration
 sudo ./edit-config stream.conf
+
+# Edit global Netdata settings
 sudo ./edit-config netdata.conf
 ```
 
@@ -20,9 +84,9 @@ sudo ./edit-config netdata.conf
 
 The `stream.conf` file has three main sections:
 
-- **`[stream]`** – Configures child nodes.
-- **`[API_KEY]`** – Defines settings for all child nodes using the same API key.
-- **`[MACHINE_GUID]`** – Sets configurations for a specific child node matching the given GUID.
+1. **`[stream]`** – With these settings, you can configure how child nodes send metrics.
+2. **`[API_KEY]`** – Here you can define settings for authentication and access control between parents and children.
+3. **`[MACHINE_GUID]`** – This area lets you customize settings for specific child nodes by their unique ID.
 
 ### Identifying a Node's GUID
 
@@ -38,24 +102,67 @@ This file is generated automatically the first time Netdata starts and remains u
 
 For a production-ready streaming setup, consider the following best practices:
 
-- **Use Multiple Parent Nodes** – Ensures redundancy and improves resilience.
-- **Optimize Data Retention** – Configure retention periods to balance storage costs and data availability.
-- **Secure Communications** – Enable encryption and authentication to protect data streams.
-- **Monitor Performance** – Regularly review logs and metrics to ensure efficient streaming operations.
+```mermaid
+graph TD
+    A[Recommended Strategies] --> B[Multiple Parent Nodes]
+    A --> C[Optimized Data Retention]
+    A --> D[Secure Communications]
+    A --> E[Performance Monitoring]
+    
+    B --> B1[Improved redundancy<br>and resilience]
+    C --> C1[Balance storage costs<br>and data availability]
+    D --> D1[Enable encryption<br>and authentication]
+    E --> E1[Regular log and<br>metric reviews]
+    
+classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
+classDef green fill:#4caf50,stroke:#333,stroke-width:1px,color:black;
+class A default;
+class B,C,D,E,B1,C1,D1,E1 green;
+```
 
-By following these guidelines, you can set up a scalable and reliable Netdata streaming environment.
+:::tip
 
-## `stream.conf`
+### Multiple Parent Nodes
 
-The `stream.conf` file consists of three main sections:
+Setting up multiple parent nodes creates redundancy in your monitoring infrastructure. **If one parent fails, child nodes can automatically switch to another available parent.** This approach:
 
-1. **`[stream]`** – Configures child nodes (data senders).
-2. **`[API_KEY]`** – Defines API keys for parent nodes (data receivers).
-3. **`[MACHINE_GUID]`** – Customizes settings for specific child nodes.
+- **Prevents single points of failure** in your monitoring system
+- **Allows for maintenance** on parent nodes without monitoring interruptions
+- Can be **geographically distributed to reduce latency** for global deployments
+
+### Optimized Data Retention
+
+Configure data retention settings based on your specific monitoring needs:
+
+- **Use longer retention periods** for critical systems and metrics
+- **Implement tiered storage strategies** with different retention policies
+- **Balance storage requirements with data availability** for historical analysis
+
+### Secure Communications
+
+**Protect your metrics data** during transmission:
+
+- **Enable SSL/TLS encryption** for all streaming connections
+- Implement **proper API key management** and rotation
+- Use **IP-based restrictions** to control which nodes can connect
+
+### Performance Monitoring
+
+Regularly evaluate the **health of your** streaming **setup**:
+
+- **Monitor network traffic** between child and parent nodes
+- **Check for buffer overflows** or connection issues
+- **Adjust settings** like buffer size based on actual performance
+
+**By following these guidelines, you can set up a scalable and reliable Netdata streaming environment.**
+
+:::
+
+## `stream.conf` Detailed Reference
 
 ### `[stream]` Section (Child Node Settings)
 
-This section configures a child node to send metrics to a parent.
+With these settings, you can configure how your child nodes send metrics to parent nodes.
 
 | Setting                                         | Default                   | Description                                                         |
 |-------------------------------------------------|---------------------------|---------------------------------------------------------------------|
@@ -75,7 +182,7 @@ This section configures a child node to send metrics to a parent.
 
 ### `[API_KEY]` Section (Parent Node Authentication)
 
-This section allows parent nodes to accept streaming data from child nodes using an API key.
+Here you can define settings for authentication and access control between parents and children.
 
 | Setting                      | Default    | Description                                                 |
 |------------------------------|------------|-------------------------------------------------------------|
@@ -99,11 +206,11 @@ This section allows parent nodes to accept streaming data from child nodes using
 
 ### `[MACHINE_GUID]` Section (Per-Node Customization)
 
-This section customizes settings for specific child nodes using their unique Machine GUID.
+This area lets you customize settings for specific child nodes by their unique ID.
 
 | Setting                      | Default    | Description                                              |
 |------------------------------|------------|----------------------------------------------------------|
-| `enabled`                    | `no`       | Enables or disables this specific node’s configuration.  |
+| `enabled`                    | `no`       | Enables or disables this specific node's configuration.  |
 | `type`                       | `machine`  | Defines the section as a machine-specific configuration. |
 | [`allow from`](#allow-from)  | `*`        | Lists IP addresses allowed to stream metrics.            |
 | `retention`                  | `3600`     | Retention period for child metrics in RAM-based storage. |
@@ -138,6 +245,7 @@ Example (TCP connection with SSL to `203.0.113.0` on port `20000`):
 
 ```ini
 [stream]
+    # Send metrics securely to the parent at 203.0.113.0:20000
     destination = tcp:203.0.113.0:20000:SSL
 ```
 
@@ -150,6 +258,7 @@ Controls which charts are streamed.
 
   ```ini
   [stream]
+      # Only send CPU application charts and all system charts
       send charts matching = apps.cpu system.*
   ```
 
@@ -157,6 +266,7 @@ Controls which charts are streamed.
 
   ```ini
   [stream]
+      # Send all charts except CPU application charts
       send charts matching = !apps.cpu *
   ```
 
@@ -168,6 +278,7 @@ Defines which child nodes (by IP) can connect.
 
   ```ini
   [API_KEY]
+      # Only allow connections from 203.0.113.10
       allow from = 203.0.113.10
   ```
 
@@ -175,6 +286,7 @@ Defines which child nodes (by IP) can connect.
 
   ```ini
   [API_KEY]
+      # Allow all 10.*.*.* addresses except 10.1.2.3
       allow from = !10.1.2.3 10.*
   ```
 
@@ -188,18 +300,15 @@ Defines the database mode:
 
 ```ini
 [API_KEY]
+    # Use disk-based database for all metrics
     db = dbengine
 ```
 
-Here’s an optimized version of the `netdata.conf` structure with clearer, more direct language. I've broken down the key sections for readability and made the content less dense:
+## `netdata.conf` Settings Affecting Streaming
 
-## `netdata.conf`
+The `netdata.conf` file is the primary configuration file for the Netdata agent. The following sections can impact streaming:
 
-The `netdata.conf` file is the primary configuration file for the Netdata agent. It controls the agent’s settings, including networking, data collection, logging, and resource usage.
-
-### Sections
-
-#### [global]
+### [global]
 
 This section defines global settings for the Netdata agent.
 
@@ -207,7 +316,7 @@ This section defines global settings for the Netdata agent.
 - **memory mode**: Choose the memory mode for data collection (e.g., `ram` or `swap`).
 - **error log file**: Path to the file where error logs are saved.
 
-#### [web]
+### [web]
 
 Configure the web interface settings here.
 
@@ -215,14 +324,7 @@ Configure the web interface settings here.
 - **port**: Set the port for the web interface (default: 19999).
 - **disable SSL**: Set to `yes` to disable SSL support.
 
-#### [plugin]
-
-This section configures individual plugins for data collection.
-
-- **enabled**: Enable or disable the plugin.
-- **update every**: Define the update frequency (in seconds).
-
-#### [database]
+### [database]
 
 Manage database settings for data storage and retention.
 
@@ -230,108 +332,518 @@ Manage database settings for data storage and retention.
 - **data retention**: Set how long to keep historical data.
 - **compression**: Enable or disable data compression.
 
-#### [logging]
+## Complete Configuration Examples
 
-Configure logging behavior for Netdata.
+### Basic Parent-Child Setup
 
-- **log file**: Define the log file location.
-- **log level**: Set the verbosity of logs (e.g., `info`, `debug`).
+**Parent node configuration (stream.conf):**
+```ini
+# Generate a random UUID first: uuidgen
+[11111111-2222-3333-4444-555555555555]
+    # Enable this API key
+    enabled = yes
+    # Allow all IPs to connect with this key
+    allow from = *
+    # Store data using dbengine for persistence
+    db = dbengine
+```
 
-## Troubleshooting
+**Child node configuration (stream.conf):**
+```ini
+[stream]
+    # Enable streaming on this node
+    enabled = yes
+    # Connect to parent at 192.168.1.5 port 19999
+    destination = 192.168.1.5
+    # Use the same API key defined on the parent
+    api key = 11111111-2222-3333-4444-555555555555
+```
 
-Both parent and child nodes log information in `/var/log/netdata/error.log`.
+### High Availability Setup with Multiple Parents
 
-If the child successfully connects to the parent, you’ll see logs similar to the following on the parent:
+**Parent nodes configuration (stream.conf on both parents):**
+```ini
+# Configuration for accepting metrics from children
+[11111111-2222-3333-4444-555555555555]
+    enabled = yes
+    allow from = *
+    db = dbengine
+
+# Configuration for accepting metrics from other parents
+[22222222-3333-4444-5555-666666666666]
+    enabled = yes
+    # Only allow the other parent's IP
+    allow from = 192.168.1.6
+    db = dbengine
+```
+
+**First parent node's configuration for streaming to second parent:**
+```ini
+[stream]
+    enabled = yes
+    destination = 192.168.1.6
+    api key = 22222222-3333-4444-5555-666666666666
+```
+
+**Second parent node's configuration for streaming to first parent:**
+```ini
+[stream]
+    enabled = yes
+    destination = 192.168.1.5
+    api key = 22222222-3333-4444-5555-666666666666
+```
+
+**Child node configuration:**
+```ini
+[stream]
+    enabled = yes
+    # List both parents for failover
+    destination = 192.168.1.5 192.168.1.6
+    api key = 11111111-2222-3333-4444-555555555555
+```
+
+## Verifying Successful Connections
+
+If the streaming configuration is working correctly, you'll see logs similar to the following.
+
+On the parent side:
 
 ```
 2017-03-09 09:38:52: netdata: INFO : STREAM [receive from [10.11.12.86]:38564]: new client connection.
 2017-03-09 09:38:52: netdata: INFO : STREAM xxx [10.11.12.86]:38564: receive thread created (task id 27721)
-2017-03-09 09:38:52: netdata: INFO : STREAM xxx [receive from [10.11.12.86]:38564]: client willing to stream metrics for host 'xxx' with machine_guid '1234567-1976-11e6-ae19-7cdd9077342a': update every = 1, history = 3600, memory mode = ram, health auto
-2017-03-09 09:38:52: netdata: INFO : STREAM xxx [receive from [10.11.12.86]:38564]: initializing communication...
-2017-03-09 09:38:52: netdata: INFO : STREAM xxx [receive from [10.11.12.86]:38564]: receiving metrics...
 ```
 
-On the child side, you might see:
+On the child side:
 
 ```
 2017-03-09 09:38:28: netdata: INFO : STREAM xxx [send to box:19999]: connecting...
-2017-03-09 09:38:28: netdata: INFO : STREAM xxx [send to box:19999]: initializing communication...
-2017-03-09 09:38:28: netdata: INFO : STREAM xxx [send to box:19999]: waiting response from remote netdata...
 2017-03-09 09:38:28: netdata: INFO : STREAM xxx [send to box:19999]: established communication - sending metrics...
 ```
 
-The following sections cover common issues when connecting parent and child nodes.
+Both parent and child nodes log information in `/var/log/netdata/error.log`.
 
-### Slow Connections Between Parent and Child
+## Troubleshooting
 
-Slow connections may lead to several errors, mainly logged in the child’s `error.log`:
+<details>
+<summary><strong>Slow Connection Issues</strong></summary>
+<br/>
 
-```bash
+**Symptoms:**
+- Buffer overflow errors
+- Connection resets
+- Partial message errors
+
+**Child logs:**
+```
 netdata ERROR : STREAM_SENDER[CHILD HOSTNAME] : STREAM CHILD HOSTNAME [send to PARENT IP:PARENT PORT]: too many data pending - buffer is X bytes long, Y unsent - we have sent Z bytes in total, W on this connection. Closing connection to flush the data.
 ```
 
-On the parent side, you might see:
-
+**Parent logs:**
 ```
 netdata ERROR : STREAM_PARENT[CHILD HOSTNAME,[CHILD IP]:CHILD PORT] : read failed: end of file
 ```
 
-Another issue in slow connections is the child sending partial messages to the parent. In this case, the parent will log:
+**What's happening:**
+Slow network connections or high-latency links can cause the streaming buffer to fill up faster than it can be transmitted. When the buffer reaches its maximum size, Netdata closes the connection to flush the pending data, then re-establishes the connection. This can lead to data gaps or inconsistencies if it happens frequently.
 
-```
-ERROR : STREAM_RECEIVER[CHILD HOSTNAME,[CHILD IP]:CHILD PORT] : sent command 'B' which is not known by netdata, for host 'HOSTNAME'. Disabling it.
-```
+**Solutions:**
+- Increase buffer size in `stream.conf`: `buffer size bytes = 20971520` (20MB)
+- Check network bandwidth and latency between nodes
+- Consider reducing the collection frequency on high-volume metrics
+- If possible, place parent nodes closer (network-wise) to child nodes
+</details>
 
-Slow connections can also cause the parent to miss a message. For example, if the parent misses a message about the child’s charts and then receives a `SET` command for a chart, the parent might log:
+<details>
+<summary><strong>Connection Issues</strong></summary>
+<br/>
 
-```
-ERROR : STREAM_RECEIVER[CHILD HOSTNAME,[CHILD IP]:CHILD PORT] : requested a SET on chart 'CHART NAME' of host 'HOSTNAME', without a dimension. Disabling it.
-```
+**Symptoms:**
+- Child can't establish connection to parent
+- Repeated reconnection attempts
 
-### Child Can’t Connect to Parent
-
-If the child can't connect to the parent (due to misconfiguration, networking issues, firewalls, or the parent being down), the child will log:
-
+**Child logs:**
 ```
 ERROR : STREAM_SENDER[HOSTNAME] : Failed to connect to 'PARENT IP', port 'PARENT PORT' (errno 113, No route to host)
 ```
 
-### 'Is This a Netdata?'
+**What's happening:**
+This error indicates network connectivity problems between the child and parent nodes. It could be due to firewall rules, incorrect IP addresses, or the parent node not running.
 
-This error typically occurs when the parent is using SSL and the child attempts a plain-text connection, or if the child tries to connect to a non-Netdata server. The error message looks like this:
+**Solutions:**
+- Verify firewalls allow traffic on port 19999 (or your custom port)
+- Check parent node is running and listening on the correct interface
+- Verify IP address/hostname is correct in child's configuration
+- Test basic connectivity with tools like `ping` or `telnet`
+- Check network routing between the nodes
+</details>
 
+<details>
+<summary><strong>Authentication and Permission Issues</strong></summary>
+<br/>
+
+**Symptoms:**
+- Connection established but immediately rejected
+- "Forbidding access" errors
+
+**Parent logs:**
+```
+STREAM [receive from [child HOSTNAME]:child IP]: `API key 'VALUE' is not allowed`. Forbidding access.
+```
+
+**What's happening:**
+The parent node is rejecting the connection because the API key doesn't match or the child's IP address is not allowed by the `allow from` setting.
+
+**Solutions:**
+- Verify API key matches exactly between parent and child
+- Check `allow from` setting permits the child's IP address
+- Ensure GUID formats are valid
+- Check for whitespace or invisible characters in the API key
+- Remember that API keys are case-sensitive
+</details>
+
+<details>
+<summary><strong>'Is This a Netdata?' Error</strong></summary>
+<br/>
+
+**Symptoms:**
+- Child tries to connect but receives an unexpected response
+
+**Child logs:**
 ```
 ERROR : STREAM_SENDER[CHILD HOSTNAME] : STREAM child HOSTNAME [send to PARENT HOSTNAME:PARENT PORT]: server is not replying properly (is it a netdata?).
 ```
 
-### Stream Charts Wrong
+**What's happening:**
+The child node is connecting to the destination, but the server is not responding with the expected Netdata streaming protocol. This commonly occurs when there's a mismatch in SSL/TLS settings or when the destination is not a Netdata server.
 
-If chart data is inconsistent between the parent and child (e.g., gaps in metrics collection), it likely indicates a mismatch in the `[db].db` settings between the parent and child. Refer to our [db documentation](/src/database/README.md) for more information on how Netdata stores metrics to ensure data consistency.
+**Solutions:**
+- Check SSL settings in the destination URL (add or remove `:SSL` as needed)
+- Verify you're connecting to a Netdata server and not another service
+- Ensure both nodes are running compatible Netdata versions
+- Check if a proxy or firewall is altering the connection
+</details>
 
-### Forbidding Access
+<details>
+<summary><strong>Stream Charts Wrong</strong></summary>
+<br/>
 
-Access might be forbidden for several reasons, such as slow connections or other failures. Look for the following errors in the parent’s `error.log`:
+**Symptoms:**
+- Data inconsistencies between parent and child
+- Gaps in metrics collection
 
+**What's happening:**
+When the database settings between parent and child nodes don't match, it can cause inconsistencies in how data is stored and displayed. The most common cause is different memory modes or retention settings.
+
+**Solutions:**
+- Check for mismatch in the `[db].db` settings between the parent and child 
+- Ensure database retention settings are compatible
+- Verify replication is enabled and properly configured
+- Make sure both nodes are using the same (or compatible) database engine
+- Check that clocks are synchronized between nodes
+</details>
+
+## FAQ
+
+<details>
+<summary><strong>Can I stream to multiple parents simultaneously?</strong></summary>
+<br/>
+
+No, you can't stream to multiple parents at the same time. However, you can configure multiple destinations for failover. Your child node will connect to the first available parent in the list.
+</details>
+
+<details>
+<summary><strong>How does replication work with interrupted connections?</strong></summary>
+<br/>
+
+When you re-establish a connection, your child node will replicate historical data based on the `replication period` setting. This ensures your parent has a complete history even after interruptions.
+</details>
+
+<details>
+<summary><strong>How much bandwidth does streaming use?</strong></summary>
+<br/>
+
+Your streaming setup will be very efficient, especially with compression enabled. Typically, it uses about 10-20 KB/s for a moderately active node. The actual bandwidth depends on the number of metrics and collection frequency you've configured.
+</details>
+
+<details>
+<summary><strong>Can I filter which metrics are sent to the parent?</strong></summary>
+<br/>
+
+Yes, you can use the `send charts matching` setting to include or exclude specific metrics from streaming. This works with wildcard patterns, giving you precise control over what metrics are transferred.
+</details>
+
+<details>
+<summary><strong>How do I secure the streaming connection?</strong></summary>
+<br/>
+
+You can enable SSL in the destination setting by adding `:SSL` at the end. Configure proper certificates using the `CAfile` and `CApath` settings for production environments to ensure your metric data is protected in transit.
+</details>
+
+<details>
+<summary><strong>Do I need to configure streaming on every child node?</strong></summary>
+<br/>
+
+Yes, you need to configure each child node with its own streaming configuration. However, you can use configuration management tools to deploy a standard configuration across your infrastructure, making this process more efficient.
+</details>
+
+## Step-by-Step Setup Guide
+
+This guide will walk you through setting up Netdata streaming between nodes. **By following these sequential steps, you'll create a basic streaming configuration** that you can later customize based on your needs.
+
+<details>
+<summary><strong>Step 1: Prepare Your Environment</strong></summary>
+<br/>
+
+Before configuring streaming, ensure you have:
+
+1. At least two Netdata instances installed (one to act as parent, one as child)
+2. Network connectivity between the instances
+3. Administrative access to edit configuration files on both systems
+</details>
+
+<details>
+<summary><strong>Step 2: Generate an API Key</strong></summary>
+<br/>
+
+The API key is used to authenticate the connection between parent and child nodes.
+
+1. On the parent node, generate a UUID to use as your API key:
+
+   ```bash
+   uuidgen
+   ```
+
+2. If the command isn't available, you can use an online UUID generator or create one with:
+
+   ```bash
+   cat /proc/sys/kernel/random/uuid
+   ```
+
+3. Copy the generated UUID (it should look like `11111111-2222-3333-4444-555555555555`)
+</details>
+
+<details>
+<summary><strong>Step 3: Configure the Parent Node</strong></summary>
+<br/>
+
+The parent node receives and stores metrics from child nodes.
+
+1. Open the stream configuration file for editing:
+
+   ```bash
+   cd /etc/netdata
+   sudo ./edit-config stream.conf
+   ```
+
+2. Add a section for your API key (replace with your actual UUID):
+
+   ```ini
+   [11111111-2222-3333-4444-555555555555]
+       enabled = yes
+       allow from = *
+       default memory mode = dbengine
+   ```
+
+3. Save and close the file
+
+4. Restart Netdata to apply changes:
+
+   ```bash
+   sudo systemctl restart netdata
+   ```
+
+:::tip 
+
+**Deployment Strategy**
+For critical environments, consider setting up at least two parent nodes for redundancy. Each parent should have enough disk space for your required retention period.
+
+:::
+
+</details>
+
+<details>
+<summary><strong>Step 4: Configure the Child Node</strong></summary>
+<br/>
+
+The child node streams its metrics to the parent node.
+
+1. Open the stream configuration file on the child node:
+
+   ```bash
+   cd /etc/netdata
+   sudo ./edit-config stream.conf
+   ```
+
+2. Find the `[stream]` section and update it (replace PARENT_IP with your parent's actual IP address):
+
+   ```ini
+   [stream]
+       enabled = yes
+       destination = PARENT_IP:19999
+       api key = 11111111-2222-3333-4444-555555555555
+   ```
+
+3. Save and close the file
+
+4. Restart Netdata on the child node:
+
+   ```bash
+   sudo systemctl restart netdata
+   ```
+
+:::tip 
+
+**Security**
+
+For production environments, enable SSL by adding `:SSL` to your destination. This encrypts the metric data in transit.
+
+:::
+
+</details>
+
+<details>
+<summary><strong>Step 5: Verify the Connection</strong></summary>
+<br/>
+
+Check that streaming is working properly between your nodes.
+
+1. Check the Netdata logs on the parent node:
+
+   ```bash
+   tail -f /var/log/netdata/error.log | grep STREAM
+   ```
+
+2. You should see connection messages similar to:
+
+   ```
+   STREAM [receive from [CHILD_IP]]: new client connection.
+   STREAM xxx [CHILD_IP]: receive thread created (task id xxxxx)
+   ```
+
+3. On the child node, you should see:
+
+   ```
+   STREAM xxx [send to PARENT_IP:19999]: connecting...
+   STREAM xxx [send to PARENT_IP:19999]: established communication - sending metrics...
+   ```
+
+4. Open the Netdata dashboard on the parent node (http://PARENT_IP:19999) and look for the child node's hostname in the menu
+
+:::tip 
+
+**Performance**
+Monitor the connection logs for the first few hours to ensure there are no buffer overflow issues or frequent disconnections.
+
+:::
+
+</details>
+
+<details>
+<summary><strong>Step 6: Customize Your Setup (Optional)</strong></summary>
+<br/>
+
+Now that you have a working basic setup, you can customize it based on your deployment strategy:
+
+### To Filter Which Metrics Are Streamed (Optimize Performance)
+
+Add the following to the child's `[stream]` section:
+
+```ini
+[stream]
+    # Only send system and disk metrics, but not uptime
+    send charts matching = system.* disk.* !system.uptime
 ```
-STREAM [receive from [child HOSTNAME]:child IP]: `MESSAGE`. Forbidding access."
+
+### To Enable SSL Encryption (Security Enhancement)
+
+1. On the child node, update the destination to include SSL:
+
+   ```ini
+   [stream]
+       destination = PARENT_IP:19999:SSL
+   ```
+
+2. If using self-signed certificates, you may need to add:
+
+   ```ini
+   [stream]
+       ssl skip certificate verification = yes
+   ```
+
+### To Set Up Multiple Parents for High Availability (Redundancy Strategy)
+
+1. Configure multiple destinations on the child:
+
+   ```ini
+   [stream]
+       destination = PARENT1_IP:19999 PARENT2_IP:19999
+   ```
+
+2. The child will connect to the first available parent, and automatically switch if that connection fails
+
+### Optimizing Data Retention (Storage Strategy)
+
+On the parent node, you can configure different retention settings for different types of data:
+
+```ini
+[API_KEY]
+    # Use different retention for different types of metrics
+    memory mode = dbengine
+    
+    # In netdata.conf, not stream.conf
+    # [db]
+    # dbengine multihost disk space MB = 1024
+    # dbengine page cache size MB = 128
 ```
 
-Possible causes for this error include:
+:::tip 
 
-- `request without KEY`: Incomplete message, missing API key, hostname, or machine GUID.
-- `API key 'VALUE' is not valid GUID`: Invalid UUID format.
-- `machine GUID 'VALUE' is not GUID.`: Invalid machine GUID.
-- `API key 'VALUE' is not allowed`: Invalid API key.
-- `API key 'VALUE' is not permitted from this IP`: IP not allowed to use STREAM with this parent.
-- `machine GUID 'VALUE' is not allowed.`: GUID not permitted.
-- `Machine GUID 'VALUE' is not permitted from this IP.`: IP not matching the allowed pattern.
+**Advanced**
+For large-scale deployments, consider setting up parent-to-parent streaming to create a hierarchical architecture that balances local responsiveness with centralized monitoring.
 
-### Netdata Could Not Create a Stream
+:::
 
-If the parent can’t convert the initial connection into a stream, it will log the following error:
+</details>
 
-```
-file descriptor given is not a valid stream
-```
+## Quick Troubleshooting Tips
 
-After logging this error, Netdata will close the stream.
+<details>
+<summary><strong>Connection Problems</strong></summary>
+<br/>
+
+Verify that:
+- Firewalls allow traffic on port 19999
+- Both Netdata instances are running
+- The API key matches exactly on both systems
+- The parent IP address is correct
+</details>
+
+<details>
+<summary><strong>Metrics Not Appearing</strong></summary>
+<br/>
+
+Verify that:
+- The connection is established (check logs)
+- The child node hasn't been excluded with `allow from` settings
+- The metrics aren't being filtered out with `send charts matching`
+</details>
+
+<details>
+<summary><strong>SSL/TLS Issues</strong></summary>
+<br/>
+
+If you're using SSL encryption:
+- Make sure both `:SSL` is added to the destination on the child node
+- Set `ssl skip certificate verification = yes` if using self-signed certificates
+- Check that certificate paths are correct if using custom certificates
+</details>
+
+<details>
+<summary><strong>Performance Problems</strong></summary>
+<br/>
+
+If streaming is slow or unstable:
+- Increase the buffer size: `buffer size bytes = 20971520` (20MB)
+- Check network quality between nodes
+- Consider streaming fewer metrics with `send charts matching`
+</details>


### PR DESCRIPTION
Finalized documentation updates on Netdata’s observability centralization:

- Rewrote and expanded the Streaming and Replication Reference
- Added a new Best Practices guide
- Updated the agent-side Streaming README
- Refined the nodes-ephemerality.md doc

Everything’s formatted for Docusaurus, with updated diagrams, configuration examples, and detailed troubleshooting.

I aimed to make streaming accessible both as a reference point for familiar users and as a clear guide for newcomers without sacrificing depth or precision.