### PR TITLE
Patch release 2.5.2

### DIFF
--- a/packaging/cmake/Modules/NetdataEBPFCORE.cmake
+++ b/packaging/cmake/Modules/NetdataEBPFCORE.cmake
@@ -9,8 +9,8 @@ set(ebpf-co-re_SOURCE_DIR "${CMAKE_BINARY_DIR}/ebpf-co-re")
 function(netdata_fetch_ebpf_co_re)
     ExternalProject_Add(
         ebpf-co-re
-        URL https://github.com/netdata/ebpf-co-re/releases/download/v1.5.0/netdata-ebpf-co-re-glibc-v1.5.0.tar.xz
-        URL_HASH SHA256=9585a5a48853f70efa51c48f57df34b4e47b1af56eaaef731f57525ebd76b90c
+        URL https://github.com/netdata/ebpf-co-re/releases/download/v1.5.1/netdata-ebpf-co-re-glibc-v1.5.1.tar.xz
+        URL_HASH SHA256=a0c64a8d4f61c106c01125b07eeebda92a9ed45af806366c0ebea8197eae83f8
         SOURCE_DIR "${ebpf-co-re_SOURCE_DIR}"
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/packaging/cmake/Modules/NetdataEBPFLegacy.cmake
+++ b/packaging/cmake/Modules/NetdataEBPFLegacy.cmake
@@ -18,19 +18,19 @@ function(netdata_fetch_legacy_ebpf_code)
     endif()
 
     if(need_static)
-        set(_hash ca0c6186b5c9c4640f8ba13ea375b66882203e8ca831a2e6e5e4e039b37f277a)
+        set(_hash 3e258407f758e3d4cd9ccd124ca6ca77307a2f6d9aca30462957b027f475f8a3)
         set(_libc "static")
     elseif(_libc STREQUAL "glibc")
-        set(_hash d3027685e15fdb6406fd36faf45287d79534d40601d388aca5ab87e90959846d)
+        set(_hash 0983c695ee46ba8fe930f2da2c847a7bee96b6cc5e2024464a032103f635ea18)
     elseif(_libc STREQUAL "musl")
-        set(_hash e2268ca1fa012e87d4d3d588e01b3a2389ad8a4b1c878508f6226ce1dad34acf)
+        set(_hash 1e7d7b51d6a7c89d0d77d4f43fe063c8318ff79bce3e02a5e6f33c3b9ce1f7e7)
     else()
         message(FATAL_ERROR "Could not determine libc implementation, unable to install eBPF legacy code.")
     endif()
 
     ExternalProject_Add(
         ebpf-code-legacy
-        URL https://github.com/netdata/kernel-collector/releases/download/v1.5.0/netdata-kernel-collector-${_libc}-v1.5.0.tar.xz
+        URL https://github.com/netdata/kernel-collector/releases/download/v1.5.1/netdata-kernel-collector-${_libc}-v1.5.1.tar.xz
         URL_HASH SHA256=${_hash}
         SOURCE_DIR "${ebpf-legacy_SOURCE_DIR}"
         CONFIGURE_COMMAND ""

--- a/packaging/cmake/Modules/NetdataLibBPF.cmake
+++ b/packaging/cmake/Modules/NetdataLibBPF.cmake
@@ -29,7 +29,7 @@ function(netdata_bundle_libbpf)
     if(USE_LEGACY_LIBBPF)
         set(_libbpf_tag 673424c56127bb556e64095f41fd60c26f9083ec) # v0.0.9_netdata-1
     else()
-        set(_libbpf_tag ad7c3a4266bf5ce301a5691eb7b405dbb27c7f3d) # v1.5.0p_netdata
+        set(_libbpf_tag 3890b7fa29c1670a75195dfc53be61d99a0c99c5) # v1.5.1p_netdata
     endif()
 
     if(DEFINED BUILD_SHARED_LIBS)

--- a/src/collectors/windows.plugin/metadata.yaml
+++ b/src/collectors/windows.plugin/metadata.yaml
@@ -1609,34 +1609,117 @@ modules:
       default_behavior:
         auto_detection:
           description: |
-            The collector automatically detects all of the metrics, no further configuration is required.
+            The collector automatically detects some metrics, but transaction metrics require configuration.
         limits:
           description: ""
         performance_impact:
           description: ""
     setup:
       prerequisites:
-        list: []
+        list:
+          - title: Create netdata user
+            description: |
+              Create an SQL Server user with the necessary permissions to collect monitoring data:
+
+              ```tsql
+              USE master;
+              CREATE LOGIN netdata_user WITH PASSWORD = '1ReallyStrongPasswordShouldBeInsertedHere';
+              CREATE USER netdata_user FOR LOGIN netdata_user;
+              GRANT CONNECT SQL TO netdata_user;
+              GRANT VIEW SERVER STATE TO netdata_user;
+              GO
+              ```
+
+              Additionally, enable the [Query Store](https://learn.microsoft.com/en-us/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store?view=sql-server-ver16)
+              on each database you want to monitor:
+
+              ```tsql
+              DECLARE @dbname NVARCHAR(max)
+              DECLARE nd_user_cursor CURSOR FOR SELECT name
+                                  FROM master.dbo.sysdatabases
+                                  WHERE name NOT IN ('master', 'tempdb')
+
+              OPEN nd_user_cursor
+              FETCH NEXT FROM nd_user_cursor INTO @dbname
+              WHILE @@FETCH_STATUS = 0
+              BEGIN
+                EXECUTE ("USE "+ @dbname+"; CREATE USER netdata_user FOR LOGIN netdata_user; ALTER DATABASE "+@dbname+" SET QUERY_STORE = ON ( QUERY_CAPTURE_MODE = ALL, DATA_FLUSH_INTERVAL_SECONDS = 900 )");
+                FETCH next FROM nd_user_cursor INTO @dbname;
+              END
+              CLOSE nd_user_cursor
+              DEALLOCATE nd_user_cursor
+              GO
+              ```
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibMSSQL]"
           description: "The Netdata main configuration file"
         options:
-          description: ""
+          description: "These options allow the collector to connect to your MSSQL instance and collect transaction data from it."
           folding:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibMSSQL
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: driver
+              description: ODBC driver used to connect to the SQL Server.
+              default_value: SQL Server
+              required: false
+            - name: server
+              description: Server address or instance name.
+              default_value: empty
+              required: true
+            - name: address
+              description: Alternative to `server`; supports named pipes if the server supports them.
+              default_value: empty
+              required: true
+            - name: uid
+              description: SQL Server user identifier.
+              default_value: empty
+              required: true
+            - name: pwd
+              description: Password for the specified user.
+              default_value: empty
+              required: true
+            - name: additional instances
+              description: Number of additional SQL Server instances to monitor.
+              default_value: 0
+              required: false
+            - name: windows authentication
+              description: Set to yes to use Windows credentials instead of SQL Server authentication.
+              default_value: no
               required: false
         examples:
           folding:
             enabled: true
             title: ""
-          list: []
+          list:
+            - name: One Instance
+              description: An example configuration.
+              folding:
+                enabled: false
+              config: |
+                [plugin:windows:PerflibMSSQL]
+                   driver = SQL Server
+                   server = 127.0.0.1\\Dev, 1433
+                   uid = netdata_user
+                   pwd = 1ReallyStrongPasswordShouldBeInsertedHere
+            - name: Two Instances
+              description: An example configuration with two instances.
+              folding:
+                enabled: false
+              config: |
+                [plugin:windows:PerflibMSSQL]
+                  driver = SQL Server
+                  server = 127.0.0.1\\Dev, 1433
+                  uid = netdata_user
+                  pwd = 1ReallyStrongPasswordShouldBeInsertedHere
+                  additional instances = 1
+                [plugin:windows:PerflibMSSQL1]
+                  driver = SQL Server
+                  server = 127.0.0.1\\Production, 1434
+                  uid = netdata_user
+                  pwd = AnotherReallyStrongPasswordShouldBeInsertedHere2
     troubleshooting:
       problems:
         list: []

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -16,6 +16,7 @@
 #define NETDATA_MSSQL_NEXT_TRY (60)
 
 BOOL is_sqlexpress = FALSE;
+ND_THREAD *mssql_query_thread = NULL;
 
 struct netdata_mssql_conn {
     const char *driver;
@@ -319,8 +320,8 @@ static ULONGLONG netdata_MSSQL_fill_long_value(SQLHSTMT *stmt, const char *mask,
 
 void dict_mssql_fill_transactions(struct mssql_db_instance *mdi, const char *dbname)
 {
-    char object_name[NETDATA_MAX_INSTANCE_OBJECT + 1];
-    long value;
+    char object_name[NETDATA_MAX_INSTANCE_OBJECT + 1] = {};
+    long value = 0;
     SQLLEN col_object_len = 0, col_value_len = 0;
 
     SQLCHAR query[sizeof(NETDATA_QUERY_TRANSACTIONS_MASK) + 2 * NETDATA_MAX_INSTANCE_OBJECT + 1];
@@ -745,8 +746,6 @@ void dict_mssql_insert_locks_cb(const DICTIONARY_ITEM *item __maybe_unused, void
     // https://learn.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-locks-object
     struct mssql_lock_instance *ptr = value;
     ptr->resourceID = strdupz(resource);
-    ptr->deadLocks.key = "Number of Deadlocks/sec";
-    ptr->lockWait.key = "Lock Waits/sec";
 }
 
 void dict_mssql_insert_databases_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused)
@@ -846,6 +845,7 @@ void dict_mssql_insert_cb(const DICTIONARY_ITEM *item __maybe_unused, void *valu
 {
     struct mssql_instance *mi = value;
     const char *instance = dictionary_acquired_item_name((DICTIONARY_ITEM *)item);
+    bool *create_thread = data;
 
     if (!mi->locks_instances) {
         mi->locks_instances = dictionary_create_advanced(
@@ -863,8 +863,11 @@ void dict_mssql_insert_cb(const DICTIONARY_ITEM *item __maybe_unused, void *valu
     initialize_mssql_keys(mi);
     netdata_read_config_options(&mi->conn);
 
-    if (mi->conn.connectionString)
+    if (mi->conn.connectionString) {
         mi->conn.is_connected = netdata_MSSQL_initialize_conection(&mi->conn);
+        if (mi->conn.is_connected)
+            *create_thread = true;
+    }
 }
 
 static int mssql_fill_dictionary()
@@ -913,16 +916,74 @@ endMSSQLFillDict:
     return (ret == ERROR_SUCCESS) ? 0 : -1;
 }
 
-static int initialize(void)
+int netdata_mssql_reset_value(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused)
 {
+    struct mssql_db_instance *mdi = value;
+
+    mdi->collecting_data = false;
+
+    return 1;
+}
+
+int dict_mssql_query_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused)
+{
+    struct mssql_instance *mi = value;
+    static long have_perm = 1;
+
+    if (mi->conn.is_connected && have_perm) {
+        have_perm = metdata_mssql_check_permission(mi);
+        if (!have_perm) {
+            nd_log(
+                NDLS_COLLECTORS,
+                NDLP_ERR,
+                "User %s does not have permission to run queries on %s",
+                mi->conn.username,
+                mi->instanceID);
+        } else {
+            metdata_mssql_fill_dictionary_from_db(mi);
+            dictionary_sorted_walkthrough_read(mi->databases, dict_mssql_databases_run_queries, NULL);
+        }
+    } else {
+        dictionary_sorted_walkthrough_read(mi->databases, netdata_mssql_reset_value, NULL);
+    }
+
+    return 1;
+}
+
+void *netdata_mssql_queries(void *ptr __maybe_unused)
+{
+    heartbeat_t hb;
+    int update_every = *((int *)ptr);
+    heartbeat_init(&hb, update_every * USEC_PER_SEC);
+
+    while (service_running(SERVICE_COLLECTORS)) {
+        (void)heartbeat_next(&hb);
+
+        if (unlikely(!service_running(SERVICE_COLLECTORS)))
+            break;
+
+        dictionary_sorted_walkthrough_read(mssql_instances, dict_mssql_query_cb, &update_every);
+    }
+
+    return NULL;
+}
+
+static int initialize(int update_every)
+{
+    static bool create_thread = false;
     mssql_instances = dictionary_create_advanced(
         DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE, NULL, sizeof(struct mssql_instance));
 
-    dictionary_register_insert_callback(mssql_instances, dict_mssql_insert_cb, NULL);
+    dictionary_register_insert_callback(mssql_instances, dict_mssql_insert_cb, &create_thread);
 
     if (mssql_fill_dictionary()) {
         return -1;
     }
+
+    if (create_thread)
+        mssql_query_thread = nd_thread_create("mssql_queries",
+                                              NETDATA_THREAD_OPTION_DEFAULT,
+                                              netdata_mssql_queries, &update_every);
 
     return 0;
 }
@@ -1437,17 +1498,17 @@ static void do_mssql_locks(PERF_DATA_BLOCK *pDataBlock, struct mssql_instance *m
         rrdset_done(mi->st_deadLocks);
 }
 
-static void mssql_database_backup_restore_chart(struct mssql_db_instance *mli, const char *db, int update_every)
+static void mssql_database_backup_restore_chart(struct mssql_db_instance *mdi, const char *db, int update_every)
 {
-    if (unlikely(!mli->parent->conn.is_connected))
+    if (unlikely(!mdi->parent->conn.is_connected))
         return;
 
     char id[RRD_ID_LENGTH_MAX + 1];
 
-    if (!mli->st_db_backup_restore_operations) {
-        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_backup_restore_operations", db, mli->parent->instanceID);
+    if (!mdi->st_db_backup_restore_operations) {
+        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_backup_restore_operations", db, mdi->parent->instanceID);
         netdata_fix_chart_name(id);
-        mli->st_db_backup_restore_operations = rrdset_create_localhost(
+        mdi->st_db_backup_restore_operations = rrdset_create_localhost(
             "mssql",
             id,
             NULL,
@@ -1462,37 +1523,35 @@ static void mssql_database_backup_restore_chart(struct mssql_db_instance *mli, c
             RRDSET_TYPE_LINE);
 
         rrdlabels_add(
-            mli->st_db_backup_restore_operations->rrdlabels,
+            mdi->st_db_backup_restore_operations->rrdlabels,
             "mssql_instance",
-            mli->parent->instanceID,
+            mdi->parent->instanceID,
             RRDLABEL_SRC_AUTO);
-        rrdlabels_add(mli->st_db_backup_restore_operations->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
-    }
+        rrdlabels_add(mdi->st_db_backup_restore_operations->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
 
-    if (!mli->rd_db_backup_restore_operations) {
-        mli->rd_db_backup_restore_operations =
-            rrddim_add(mli->st_db_backup_restore_operations, "backup", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        mdi->rd_db_backup_restore_operations =
+            rrddim_add(mdi->st_db_backup_restore_operations, "backup", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
     }
 
     rrddim_set_by_pointer(
-        mli->st_db_backup_restore_operations,
-        mli->rd_db_backup_restore_operations,
-        (collected_number)mli->MSSQLDatabaseBackupRestoreOperations.current.Data);
+        mdi->st_db_backup_restore_operations,
+        mdi->rd_db_backup_restore_operations,
+        (collected_number)mdi->MSSQLDatabaseBackupRestoreOperations.current.Data);
 
-    rrdset_done(mli->st_db_backup_restore_operations);
+    rrdset_done(mdi->st_db_backup_restore_operations);
 }
 
-static void mssql_database_log_flushes_chart(struct mssql_db_instance *mli, const char *db, int update_every)
+static void mssql_database_log_flushes_chart(struct mssql_db_instance *mdi, const char *db, int update_every)
 {
-    if (unlikely(!mli->parent->conn.is_connected))
+    if (unlikely(!mdi->parent->conn.is_connected))
         return;
 
     char id[RRD_ID_LENGTH_MAX + 1];
 
-    if (!mli->st_db_log_flushes) {
-        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_log_flushes", db, mli->parent->instanceID);
+    if (!mdi->st_db_log_flushes) {
+        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_log_flushes", db, mdi->parent->instanceID);
         netdata_fix_chart_name(id);
-        mli->st_db_log_flushes = rrdset_create_localhost(
+        mdi->st_db_log_flushes = rrdset_create_localhost(
             "mssql",
             id,
             NULL,
@@ -1506,31 +1565,31 @@ static void mssql_database_log_flushes_chart(struct mssql_db_instance *mli, cons
             update_every,
             RRDSET_TYPE_LINE);
 
-        rrdlabels_add(mli->st_db_log_flushes->rrdlabels, "mssql_instance", mli->parent->instanceID, RRDLABEL_SRC_AUTO);
-        rrdlabels_add(mli->st_db_log_flushes->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_db_log_flushes->rrdlabels, "mssql_instance", mdi->parent->instanceID, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_db_log_flushes->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
     }
 
-    if (!mli->rd_db_log_flushes) {
-        mli->rd_db_log_flushes = rrddim_add(mli->st_db_log_flushes, "flushes", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+    if (!mdi->rd_db_log_flushes) {
+        mdi->rd_db_log_flushes = rrddim_add(mdi->st_db_log_flushes, "flushes", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
     }
 
     rrddim_set_by_pointer(
-        mli->st_db_log_flushes, mli->rd_db_log_flushes, (collected_number)mli->MSSQLDatabaseLogFlushes.current.Data);
+        mdi->st_db_log_flushes, mdi->rd_db_log_flushes, (collected_number)mdi->MSSQLDatabaseLogFlushes.current.Data);
 
-    rrdset_done(mli->st_db_log_flushes);
+    rrdset_done(mdi->st_db_log_flushes);
 }
 
-static void mssql_database_log_flushed_chart(struct mssql_db_instance *mli, const char *db, int update_every)
+static void mssql_database_log_flushed_chart(struct mssql_db_instance *mdi, const char *db, int update_every)
 {
-    if (unlikely(!mli->parent->conn.is_connected))
+    if (unlikely(!mdi->parent->conn.is_connected))
         return;
 
     char id[RRD_ID_LENGTH_MAX + 1];
 
-    if (!mli->st_db_log_flushed) {
-        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_log_flushed", db, mli->parent->instanceID);
+    if (!mdi->st_db_log_flushed) {
+        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_log_flushed", db, mdi->parent->instanceID);
         netdata_fix_chart_name(id);
-        mli->st_db_log_flushed = rrdset_create_localhost(
+        mdi->st_db_log_flushed = rrdset_create_localhost(
             "mssql",
             id,
             NULL,
@@ -1544,31 +1603,29 @@ static void mssql_database_log_flushed_chart(struct mssql_db_instance *mli, cons
             update_every,
             RRDSET_TYPE_LINE);
 
-        rrdlabels_add(mli->st_db_log_flushed->rrdlabels, "mssql_instance", mli->parent->instanceID, RRDLABEL_SRC_AUTO);
-        rrdlabels_add(mli->st_db_log_flushed->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
-    }
+        rrdlabels_add(mdi->st_db_log_flushed->rrdlabels, "mssql_instance", mdi->parent->instanceID, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_db_log_flushed->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
 
-    if (!mli->rd_db_log_flushed) {
-        mli->rd_db_log_flushed = rrddim_add(mli->st_db_log_flushed, "flushed", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        mdi->rd_db_log_flushed = rrddim_add(mdi->st_db_log_flushed, "flushed", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
     }
 
     rrddim_set_by_pointer(
-        mli->st_db_log_flushed, mli->rd_db_log_flushed, (collected_number)mli->MSSQLDatabaseLogFlushed.current.Data);
+        mdi->st_db_log_flushed, mdi->rd_db_log_flushed, (collected_number)mdi->MSSQLDatabaseLogFlushed.current.Data);
 
-    rrdset_done(mli->st_db_log_flushed);
+    rrdset_done(mdi->st_db_log_flushed);
 }
 
-static void mssql_transactions_chart(struct mssql_db_instance *mli, const char *db, int update_every)
+static void mssql_transactions_chart(struct mssql_db_instance *mdi, const char *db, int update_every)
 {
-    if (unlikely(!mli->parent->conn.is_connected))
+    if (unlikely(!mdi->parent->conn.is_connected))
         return;
 
     char id[RRD_ID_LENGTH_MAX + 1];
 
-    if (!mli->st_db_transactions) {
-        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_transactions", db, mli->parent->instanceID);
+    if (!mdi->st_db_transactions) {
+        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_transactions", db, mdi->parent->instanceID);
         netdata_fix_chart_name(id);
-        mli->st_db_transactions = rrdset_create_localhost(
+        mdi->st_db_transactions = rrdset_create_localhost(
             "mssql",
             id,
             NULL,
@@ -1582,34 +1639,32 @@ static void mssql_transactions_chart(struct mssql_db_instance *mli, const char *
             update_every,
             RRDSET_TYPE_LINE);
 
-        rrdlabels_add(mli->st_db_transactions->rrdlabels, "mssql_instance", mli->parent->instanceID, RRDLABEL_SRC_AUTO);
-        rrdlabels_add(mli->st_db_transactions->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
-    }
+        rrdlabels_add(mdi->st_db_transactions->rrdlabels, "mssql_instance", mdi->parent->instanceID, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_db_transactions->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
 
-    if (!mli->rd_db_transactions) {
-        mli->rd_db_transactions =
-            rrddim_add(mli->st_db_transactions, "transactions", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        mdi->rd_db_transactions =
+            rrddim_add(mdi->st_db_transactions, "transactions", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
     }
 
     rrddim_set_by_pointer(
-        mli->st_db_transactions,
-        mli->rd_db_transactions,
-        (collected_number)mli->MSSQLDatabaseTransactions.current.Data);
+        mdi->st_db_transactions,
+        mdi->rd_db_transactions,
+        (collected_number)mdi->MSSQLDatabaseTransactions.current.Data);
 
-    rrdset_done(mli->st_db_transactions);
+    rrdset_done(mdi->st_db_transactions);
 }
 
-static void mssql_write_transactions_chart(struct mssql_db_instance *mli, const char *db, int update_every)
+static void mssql_write_transactions_chart(struct mssql_db_instance *mdi, const char *db, int update_every)
 {
-    if (unlikely(!mli->parent->conn.is_connected))
+    if (unlikely(!mdi->parent->conn.is_connected))
         return;
 
     char id[RRD_ID_LENGTH_MAX + 1];
 
-    if (!mli->st_db_write_transactions) {
-        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_write_transactions", db, mli->parent->instanceID);
+    if (!mdi->st_db_write_transactions) {
+        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_write_transactions", db, mdi->parent->instanceID);
         netdata_fix_chart_name(id);
-        mli->st_db_write_transactions = rrdset_create_localhost(
+        mdi->st_db_write_transactions = rrdset_create_localhost(
             "mssql",
             id,
             NULL,
@@ -1624,34 +1679,32 @@ static void mssql_write_transactions_chart(struct mssql_db_instance *mli, const 
             RRDSET_TYPE_LINE);
 
         rrdlabels_add(
-            mli->st_db_write_transactions->rrdlabels, "mssql_instance", mli->parent->instanceID, RRDLABEL_SRC_AUTO);
-        rrdlabels_add(mli->st_db_write_transactions->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
-    }
+            mdi->st_db_write_transactions->rrdlabels, "mssql_instance", mdi->parent->instanceID, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_db_write_transactions->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
 
-    if (!mli->rd_db_write_transactions) {
-        mli->rd_db_write_transactions =
-            rrddim_add(mli->st_db_write_transactions, "write", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        mdi->rd_db_write_transactions =
+            rrddim_add(mdi->st_db_write_transactions, "write", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
     }
 
     rrddim_set_by_pointer(
-        mli->st_db_write_transactions,
-        mli->rd_db_write_transactions,
-        (collected_number)mli->MSSQLDatabaseWriteTransactions.current.Data);
+        mdi->st_db_write_transactions,
+        mdi->rd_db_write_transactions,
+        (collected_number)mdi->MSSQLDatabaseWriteTransactions.current.Data);
 
-    rrdset_done(mli->st_db_write_transactions);
+    rrdset_done(mdi->st_db_write_transactions);
 }
 
-static void mssql_lockwait_chart(struct mssql_db_instance *mli, const char *db, int update_every)
+static void mssql_lockwait_chart(struct mssql_db_instance *mdi, const char *db, int update_every)
 {
-    if (unlikely(!mli->parent->conn.is_connected))
+    if (unlikely(!mdi->parent->conn.is_connected))
         return;
 
     char id[RRD_ID_LENGTH_MAX + 1];
 
-    if (!mli->st_db_lockwait) {
-        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_lockwait", db, mli->parent->instanceID);
+    if (!mdi->st_db_lockwait) {
+        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_lockwait", db, mdi->parent->instanceID);
         netdata_fix_chart_name(id);
-        mli->st_db_lockwait = rrdset_create_localhost(
+        mdi->st_db_lockwait = rrdset_create_localhost(
             "mssql",
             id,
             NULL,
@@ -1665,29 +1718,29 @@ static void mssql_lockwait_chart(struct mssql_db_instance *mli, const char *db, 
             update_every,
             RRDSET_TYPE_LINE);
 
-        rrdlabels_add(mli->st_db_lockwait->rrdlabels, "mssql_instance", mli->parent->instanceID, RRDLABEL_SRC_AUTO);
-        rrdlabels_add(mli->st_db_lockwait->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_db_lockwait->rrdlabels, "mssql_instance", mdi->parent->instanceID, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_db_lockwait->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
 
-        mli->rd_db_lockwait = rrddim_add(mli->st_db_lockwait, "lock", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        mdi->rd_db_lockwait = rrddim_add(mdi->st_db_lockwait, "lock", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
     }
 
     rrddim_set_by_pointer(
-        mli->st_db_lockwait, mli->rd_db_lockwait, (collected_number)mli->MSSQLDatabaseLockWaitSec.current.Data);
+        mdi->st_db_lockwait, mdi->rd_db_lockwait, (collected_number)mdi->MSSQLDatabaseLockWaitSec.current.Data);
 
-    rrdset_done(mli->st_db_lockwait);
+    rrdset_done(mdi->st_db_lockwait);
 }
 
-static void mssql_deadlock_chart(struct mssql_db_instance *mli, const char *db, int update_every)
+static void mssql_deadlock_chart(struct mssql_db_instance *mdi, const char *db, int update_every)
 {
-    if (unlikely(!mli->parent->conn.is_connected))
+    if (unlikely(!mdi->parent->conn.is_connected))
         return;
 
     char id[RRD_ID_LENGTH_MAX + 1];
 
-    if (!mli->st_db_deadlock) {
-        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_deadlocks", db, mli->parent->instanceID);
+    if (!mdi->st_db_deadlock) {
+        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_deadlocks", db, mdi->parent->instanceID);
         netdata_fix_chart_name(id);
-        mli->st_db_deadlock = rrdset_create_localhost(
+        mdi->st_db_deadlock = rrdset_create_localhost(
             "mssql",
             id,
             NULL,
@@ -1701,29 +1754,29 @@ static void mssql_deadlock_chart(struct mssql_db_instance *mli, const char *db, 
             update_every,
             RRDSET_TYPE_LINE);
 
-        rrdlabels_add(mli->st_db_deadlock->rrdlabels, "mssql_instance", mli->parent->instanceID, RRDLABEL_SRC_AUTO);
-        rrdlabels_add(mli->st_db_deadlock->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_db_deadlock->rrdlabels, "mssql_instance", mdi->parent->instanceID, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_db_deadlock->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
 
-        mli->rd_db_deadlock = rrddim_add(mli->st_db_deadlock, "deadlocks", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        mdi->rd_db_deadlock = rrddim_add(mdi->st_db_deadlock, "deadlocks", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
     }
 
     rrddim_set_by_pointer(
-        mli->st_db_deadlock, mli->rd_db_deadlock, (collected_number)mli->MSSQLDatabaseDeadLockSec.current.Data);
+        mdi->st_db_deadlock, mdi->rd_db_deadlock, (collected_number)mdi->MSSQLDatabaseDeadLockSec.current.Data);
 
-    rrdset_done(mli->st_db_deadlock);
+    rrdset_done(mdi->st_db_deadlock);
 }
 
-static void mssql_lock_request_chart(struct mssql_db_instance *mli, const char *db, int update_every)
+static void mssql_lock_request_chart(struct mssql_db_instance *mdi, const char *db, int update_every)
 {
-    if (unlikely(!mli->parent->conn.is_connected))
+    if (unlikely(!mdi->parent->conn.is_connected))
         return;
 
     char id[RRD_ID_LENGTH_MAX + 1];
 
-    if (!mli->st_lock_requests) {
-        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_lock_requests", db, mli->parent->instanceID);
+    if (!mdi->st_lock_requests) {
+        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_lock_requests", db, mdi->parent->instanceID);
         netdata_fix_chart_name(id);
-        mli->st_lock_requests = rrdset_create_localhost(
+        mdi->st_lock_requests = rrdset_create_localhost(
             "mssql",
             id,
             NULL,
@@ -1737,29 +1790,29 @@ static void mssql_lock_request_chart(struct mssql_db_instance *mli, const char *
             update_every,
             RRDSET_TYPE_LINE);
 
-        rrdlabels_add(mli->st_lock_requests->rrdlabels, "mssql_instance", mli->parent->instanceID, RRDLABEL_SRC_AUTO);
-        rrdlabels_add(mli->st_lock_requests->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_lock_requests->rrdlabels, "mssql_instance", mdi->parent->instanceID, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_lock_requests->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
 
-        mli->rd_lock_requests = rrddim_add(mli->st_lock_requests, "requests", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        mdi->rd_lock_requests = rrddim_add(mdi->st_lock_requests, "requests", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
     }
 
     rrddim_set_by_pointer(
-        mli->st_lock_requests, mli->rd_lock_requests, (collected_number)mli->MSSQLDatabaseLockRequestsSec.current.Data);
+        mdi->st_lock_requests, mdi->rd_lock_requests, (collected_number)mdi->MSSQLDatabaseLockRequestsSec.current.Data);
 
-    rrdset_done(mli->st_lock_requests);
+    rrdset_done(mdi->st_lock_requests);
 }
 
-static void mssql_lock_timeout_chart(struct mssql_db_instance *mli, const char *db, int update_every)
+static void mssql_lock_timeout_chart(struct mssql_db_instance *mdi, const char *db, int update_every)
 {
-    if (unlikely(!mli->parent->conn.is_connected))
+    if (unlikely(!mdi->parent->conn.is_connected))
         return;
 
     char id[RRD_ID_LENGTH_MAX + 1];
 
-    if (!mli->st_lock_timeouts) {
-        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_lock_timeouts", db, mli->parent->instanceID);
+    if (!mdi->st_lock_timeouts) {
+        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_lock_timeouts", db, mdi->parent->instanceID);
         netdata_fix_chart_name(id);
-        mli->st_lock_timeouts = rrdset_create_localhost(
+        mdi->st_lock_timeouts = rrdset_create_localhost(
             "mssql",
             id,
             NULL,
@@ -1773,29 +1826,29 @@ static void mssql_lock_timeout_chart(struct mssql_db_instance *mli, const char *
             update_every,
             RRDSET_TYPE_LINE);
 
-        rrdlabels_add(mli->st_lock_timeouts->rrdlabels, "mssql_instance", mli->parent->instanceID, RRDLABEL_SRC_AUTO);
-        rrdlabels_add(mli->st_lock_timeouts->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_lock_timeouts->rrdlabels, "mssql_instance", mdi->parent->instanceID, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_lock_timeouts->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
 
-        mli->rd_lock_timeouts = rrddim_add(mli->st_lock_timeouts, "timeouts", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        mdi->rd_lock_timeouts = rrddim_add(mdi->st_lock_timeouts, "timeouts", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
     }
 
     rrddim_set_by_pointer(
-        mli->st_lock_timeouts, mli->rd_lock_timeouts, (collected_number)mli->MSSQLDatabaseLockTimeoutsSec.current.Data);
+        mdi->st_lock_timeouts, mdi->rd_lock_timeouts, (collected_number)mdi->MSSQLDatabaseLockTimeoutsSec.current.Data);
 
-    rrdset_done(mli->st_lock_timeouts);
+    rrdset_done(mdi->st_lock_timeouts);
 }
 
-static void mssql_active_transactions_chart(struct mssql_db_instance *mli, const char *db, int update_every)
+static void mssql_active_transactions_chart(struct mssql_db_instance *mdi, const char *db, int update_every)
 {
-    if (unlikely(!mli->parent->conn.is_connected))
+    if (unlikely(!mdi->parent->conn.is_connected))
         return;
 
     char id[RRD_ID_LENGTH_MAX + 1];
 
-    if (!mli->st_db_active_transactions) {
-        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_active_transactions", db, mli->parent->instanceID);
+    if (!mdi->st_db_active_transactions) {
+        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_active_transactions", db, mdi->parent->instanceID);
         netdata_fix_chart_name(id);
-        mli->st_db_active_transactions = rrdset_create_localhost(
+        mdi->st_db_active_transactions = rrdset_create_localhost(
             "mssql",
             id,
             NULL,
@@ -1810,34 +1863,32 @@ static void mssql_active_transactions_chart(struct mssql_db_instance *mli, const
             RRDSET_TYPE_LINE);
 
         rrdlabels_add(
-            mli->st_db_active_transactions->rrdlabels, "mssql_instance", mli->parent->instanceID, RRDLABEL_SRC_AUTO);
-        rrdlabels_add(mli->st_db_active_transactions->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
-    }
+            mdi->st_db_active_transactions->rrdlabels, "mssql_instance", mdi->parent->instanceID, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_db_active_transactions->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
 
-    if (!mli->rd_db_active_transactions) {
-        mli->rd_db_active_transactions =
-            rrddim_add(mli->st_db_active_transactions, "active", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        mdi->rd_db_active_transactions =
+            rrddim_add(mdi->st_db_active_transactions, "active", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
     }
 
     rrddim_set_by_pointer(
-        mli->st_db_active_transactions,
-        mli->rd_db_active_transactions,
-        (collected_number)mli->MSSQLDatabaseActiveTransactions.current.Data);
+        mdi->st_db_active_transactions,
+        mdi->rd_db_active_transactions,
+        (collected_number)mdi->MSSQLDatabaseActiveTransactions.current.Data);
 
-    rrdset_done(mli->st_db_active_transactions);
+    rrdset_done(mdi->st_db_active_transactions);
 }
 
-static inline void mssql_data_file_size_chart(struct mssql_db_instance *mli, const char *db, int update_every)
+static inline void mssql_data_file_size_chart(struct mssql_db_instance *mdi, const char *db, int update_every)
 {
-    if (unlikely(!mli->parent->conn.is_connected))
+    if (unlikely(!mdi->parent->conn.is_connected))
         return;
 
     char id[RRD_ID_LENGTH_MAX + 1];
 
-    if (unlikely(!mli->st_db_data_file_size)) {
-        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_data_files_size", db, mli->parent->instanceID);
+    if (unlikely(!mdi->st_db_data_file_size)) {
+        snprintfz(id, RRD_ID_LENGTH_MAX, "db_%s_instance_%s_data_files_size", db, mdi->parent->instanceID);
         netdata_fix_chart_name(id);
-        mli->st_db_data_file_size = rrdset_create_localhost(
+        mdi->st_db_data_file_size = rrdset_create_localhost(
             "mssql",
             id,
             NULL,
@@ -1852,26 +1903,24 @@ static inline void mssql_data_file_size_chart(struct mssql_db_instance *mli, con
             RRDSET_TYPE_LINE);
 
         rrdlabels_add(
-            mli->st_db_data_file_size->rrdlabels, "mssql_instance", mli->parent->instanceID, RRDLABEL_SRC_AUTO);
-        rrdlabels_add(mli->st_db_data_file_size->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
+            mdi->st_db_data_file_size->rrdlabels, "mssql_instance", mdi->parent->instanceID, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(mdi->st_db_data_file_size->rrdlabels, "database", db, RRDLABEL_SRC_AUTO);
+
+        mdi->rd_db_data_file_size = rrddim_add(mdi->st_db_data_file_size, "size", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
     }
 
-    if (unlikely(!mli->rd_db_data_file_size)) {
-        mli->rd_db_data_file_size = rrddim_add(mli->st_db_data_file_size, "size", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    }
+    collected_number data = mdi->MSSQLDatabaseDataFileSize.current.Data;
+    rrddim_set_by_pointer(mdi->st_db_data_file_size, mdi->rd_db_data_file_size, data);
 
-    collected_number data = mli->MSSQLDatabaseDataFileSize.current.Data;
-    rrddim_set_by_pointer(mli->st_db_data_file_size, mli->rd_db_data_file_size, data);
-
-    rrdset_done(mli->st_db_data_file_size);
+    rrdset_done(mdi->st_db_data_file_size);
 }
 
 int dict_mssql_databases_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused)
 {
-    struct mssql_db_instance *mli = value;
+    struct mssql_db_instance *mdi = value;
     const char *db = dictionary_acquired_item_name((DICTIONARY_ITEM *)item);
 
-    if (!mli->collecting_data) {
+    if (!mdi->collecting_data) {
         goto endchartcb;
     }
 
@@ -1895,7 +1944,7 @@ int dict_mssql_databases_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, v
 
     int i;
     for (i = 0; transaction_chart[i]; i++) {
-        transaction_chart[i](mli, db, *update_every);
+        transaction_chart[i](mdi, db, *update_every);
     }
 
 endchartcb:
@@ -2064,37 +2113,10 @@ static void do_mssql_memory_mgr(PERF_DATA_BLOCK *pDataBlock, struct mssql_instan
     }
 }
 
-int netdata_mssql_reset_value(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused)
-{
-    struct mssql_db_instance *mdi = value;
-
-    mdi->collecting_data = false;
-
-    return 1;
-}
-
 int dict_mssql_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused)
 {
     struct mssql_instance *mi = value;
-    static long have_perm = 1;
     int *update_every = data;
-
-    if (mi->conn.is_connected && have_perm) {
-        have_perm = metdata_mssql_check_permission(mi);
-        if (!have_perm) {
-            nd_log(
-                NDLS_COLLECTORS,
-                NDLP_ERR,
-                "User %s does not have permission to run queries on %s",
-                mi->conn.username,
-                mi->instanceID);
-        } else {
-            metdata_mssql_fill_dictionary_from_db(mi);
-            dictionary_sorted_walkthrough_read(mi->databases, dict_mssql_databases_run_queries, NULL);
-        }
-    } else {
-        dictionary_sorted_walkthrough_read(mi->databases, netdata_mssql_reset_value, NULL);
-    }
 
     static void (*doMSSQL[])(PERF_DATA_BLOCK *, struct mssql_instance *, int) = {
         do_mssql_general_stats,
@@ -2132,7 +2154,7 @@ int do_PerflibMSSQL(int update_every, usec_t dt __maybe_unused)
     static bool initialized = false;
 
     if (unlikely(!initialized)) {
-        if (initialize())
+        if (initialize(update_every))
             return -1;
 
         initialized = true;

--- a/src/daemon/daemon-shutdown-watcher.c
+++ b/src/daemon/daemon-shutdown-watcher.c
@@ -120,7 +120,7 @@ void *watcher_main(void *arg)
 
     // wait until the agent starts the shutdown process
     completion_wait_for(&shutdown_begin_completion);
-    netdata_log_error("Shutdown process started");
+    netdata_log_info("Shutdown process started");
 
     usec_t shutdown_start_time = now_monotonic_usec();
 
@@ -150,8 +150,10 @@ void *watcher_main(void *arg)
     usec_t shutdown_end_time = now_monotonic_usec();
 
     usec_t shutdown_duration = shutdown_end_time - shutdown_start_time;
-    netdata_log_error("Shutdown process ended in %llu milliseconds",
-                      shutdown_duration / USEC_PER_MS);
+
+    char shutdown_timing[64];
+    duration_snprintf(shutdown_timing, sizeof(shutdown_timing), (int64_t)shutdown_duration, "us", 1);
+    netdata_log_info("Shutdown process ended in %s", shutdown_timing);
 
     daemon_status_file_shutdown_step(NULL, buffer_tostring(steps_timings));
     daemon_status_file_update_status(DAEMON_STATUS_EXITED);

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -488,10 +488,10 @@ int become_daemon(int dont_fork, const char *user) {
     if(user && *user) {
         daemon_status_file_startup_step("startup(become daemon - user)");
         if(become_user(user, pidfd) != 0) {
-            netdata_log_error("Cannot become user '%s'. Continuing as we are.", user);
+            netdata_log_error("Cannot switch to user '%s'. Continuing with current privileges.", user);
         }
         else
-            netdata_log_debug(D_SYSTEM, "Successfully became user '%s'.", user);
+            netdata_log_info("Successfully switched to user '%s'.", user);
     }
     else {
         daemon_status_file_startup_step("startup(become daemon - dirs)");

--- a/src/daemon/dyncfg/dyncfg.c
+++ b/src/daemon/dyncfg/dyncfg.c
@@ -91,11 +91,23 @@ static bool dyncfg_conflict_cb(const DICTIONARY_ITEM *item __maybe_unused, void 
     dyncfg_normalize(nv);
 
     if(!UUIDeq(v->host_uuid, nv->host_uuid)) {
+        char u1[UUID_STR_LEN], u2[UUID_STR_LEN];
+        nd_uuid_unparse_lower(v->host_uuid.uuid, u1);
+        nd_uuid_unparse_lower(nv->host_uuid.uuid, u2);
+
+        nd_log(NDLS_DAEMON, NDLP_NOTICE,
+               "DYNCFG: configuration '%s' changed host id from '%s' to '%s'",
+               dictionary_acquired_item_name(item), u1, u2);
+
         SWAP(v->host_uuid, nv->host_uuid);
         changes++;
     }
 
     if(v->path != nv->path) {
+        nd_log(NDLS_DAEMON, NDLP_NOTICE,
+               "DYNCFG: configuration '%s' changed path from '%s' to '%s'",
+               dictionary_acquired_item_name(item), string2str(v->path), string2str(nv->path));
+
         SWAP(v->path, nv->path);
         changes++;
     }

--- a/src/daemon/libuv_workers.c
+++ b/src/daemon/libuv_workers.c
@@ -26,7 +26,6 @@ static void register_libuv_worker_jobs_internal(void) {
     worker_register_job_name(UV_EVENT_DBENGINE_FLUSHED_TO_OPEN, "flushed to open");
 
     // datafile full
-    worker_register_job_name(UV_EVENT_DBENGINE_JOURNAL_INDEX_WAIT, "jv2 index wait");
     worker_register_job_name(UV_EVENT_DBENGINE_JOURNAL_INDEX, "jv2 indexing");
 
     // db rotation related

--- a/src/daemon/libuv_workers.h
+++ b/src/daemon/libuv_workers.h
@@ -24,7 +24,6 @@ enum event_loop_job {
     UV_EVENT_DBENGINE_FLUSHED_TO_OPEN,
 
     // datafile full
-    UV_EVENT_DBENGINE_JOURNAL_INDEX_WAIT,
     UV_EVENT_DBENGINE_JOURNAL_INDEX,
 
     // db rotation related

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -919,6 +919,8 @@ done:
 
 static void after_database_rotate(struct rrdengine_instance *ctx __maybe_unused, void *data __maybe_unused, struct completion *completion __maybe_unused, uv_work_t* req __maybe_unused, int status __maybe_unused) {
     __atomic_store_n(&ctx->atomic.now_deleting_files, false, __ATOMIC_RELAXED);
+    if (__atomic_load_n(&ctx->atomic.needs_indexing, __ATOMIC_RELAXED))
+        rrdeng_enq_cmd(ctx, RRDENG_OPCODE_JOURNAL_INDEX, NULL, NULL, STORAGE_PRIORITY_INTERNAL_DBENGINE, NULL, NULL);
 }
 
 struct uuid_first_time_s {
@@ -1675,7 +1677,6 @@ NOT_INLINE_HOT void pdc_route_synchronously_first(struct rrdengine_instance *ctx
 
 static void *journal_v2_indexing_tp_worker(struct rrdengine_instance *ctx __maybe_unused, void *data __maybe_unused, struct completion *completion __maybe_unused, uv_work_t *uv_work_req __maybe_unused) {
     unsigned count = 0;
-    worker_is_busy(UV_EVENT_DBENGINE_JOURNAL_INDEX_WAIT);
 
     struct rrdengine_datafile *datafile = ctx->datafiles.first;
     worker_is_busy(UV_EVENT_DBENGINE_JOURNAL_INDEX);
@@ -2180,8 +2181,11 @@ void dbengine_event_loop(void* arg) {
                     struct rrdengine_datafile *datafile = cmd.data;
                     if (NOT_INDEXING_OR_DELETING_FILES(ctx) && ctx_is_available_for_queries(ctx)) {
                         __atomic_store_n(&ctx->atomic.migration_to_v2_running, true, __ATOMIC_RELAXED);
+                        __atomic_store_n(&ctx->atomic.needs_indexing, false, __ATOMIC_RELAXED);
                         work_dispatch(ctx, datafile, NULL, opcode, journal_v2_indexing_tp_worker, after_journal_v2_indexing);
                     }
+                    else
+                        __atomic_store_n(&ctx->atomic.needs_indexing, true, __ATOMIC_RELAXED);
                     break;
                 }
 

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -396,6 +396,7 @@ struct rrdengine_instance {
 
         PAD64(bool) migration_to_v2_running;
         PAD64(bool) now_deleting_files;
+        PAD64(bool) needs_indexing;
         PAD64(unsigned) extents_currently_being_flushed;   // non-zero until we commit data to disk (both datafile and journal file)
 
         PAD64(time_t) first_time_s;

--- a/src/database/rrdfunctions-inflight.c
+++ b/src/database/rrdfunctions-inflight.c
@@ -680,7 +680,7 @@ void rrd_function_progress(const char *transaction) {
     functions_stop_monotonic_update_on_progress(&r->stop_monotonic_ut);
 
     if(r->progresser.cb)
-        r->progresser.cb(r->progresser.data);
+        r->progresser.cb(transaction, r->progresser.data);
 
     rrd_collector_dispatcher_release(r->rdcf->collector);
 
@@ -689,6 +689,9 @@ cleanup:
 }
 
 void rrd_function_call_progresser(nd_uuid_t *transaction) {
+    if(uuid_is_null(*transaction))
+        return;
+
     char str[UUID_COMPACT_STR_LEN];
     uuid_unparse_lower_compact(*transaction, str);
     rrd_function_progress(str);

--- a/src/database/rrdfunctions.h
+++ b/src/database/rrdfunctions.h
@@ -17,7 +17,7 @@ typedef bool (*rrd_function_is_cancelled_cb_t)(void *is_cancelled_cb_data);
 typedef void (*rrd_function_cancel_cb_t)(void *data);
 typedef void (*rrd_function_register_canceller_cb_t)(void *register_cancel_cb_data, rrd_function_cancel_cb_t cancel_cb, void *cancel_cb_data);
 typedef void (*rrd_function_progress_cb_t)(void *data, size_t done, size_t all);
-typedef void (*rrd_function_progresser_cb_t)(void *data);
+typedef void (*rrd_function_progresser_cb_t)(const char *transaction, void *data);
 typedef void (*rrd_function_register_progresser_cb_t)(void *register_progresser_cb_data, rrd_function_progresser_cb_t progresser_cb, void *progresser_cb_data);
 
 struct rrd_function_execute {

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -782,7 +782,6 @@ void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host) {
     __atomic_sub_fetch(&netdata_buffers_statistics.rrdhost_allocations_size, sizeof(RRDHOST), __ATOMIC_RELAXED);
 
     freez(host->cache_dir);
-    rrdhost_stream_parents_free(host, false);
     simple_pattern_free(host->stream.snd.charts_matching);
     rrdhost_system_info_free(host->system_info);
 

--- a/src/database/rrdset-collection.c
+++ b/src/database/rrdset-collection.c
@@ -682,7 +682,7 @@ void rrdset_timed_done(RRDSET *st, struct timeval now, bool pending_rrdset_next)
             collected_total += rd->collector.collected_value;
 
             if(unlikely(rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE))) {
-                netdata_log_error("Dimension %s in chart '%s' has the OBSOLETE or ARCHIVED flag set, but it is collected.", rrddim_name(rd), rrdset_id(st));
+                netdata_log_error("Dimension %s in chart '%s' has the OBSOLETE flag set, but it is collected.", rrddim_name(rd), rrdset_id(st));
                 if(!spinlock_trylock(&rd->destroy_lock))
                     fatal("RRDSET: dimension '%s' of chart '%s' of host '%s' is being collected while is being destroyed.", rrddim_id(rd), rrdset_id(st), rrdhost_hostname(st->rrdhost));
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2405,6 +2405,8 @@ static void store_hosts_metadata(BUFFER *work_buffer, bool is_worker)
             host_count++;
         }
         dfe_done(host);
+        if (!host_count)
+            host_count = 1; // avoid division by zero
     }
 
     size_t count = 0;

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2720,12 +2720,17 @@ void metadata_sync_shutdown(void)
 {
     struct metadata_cmd cmd;
     memset(&cmd, 0, sizeof(cmd));
-    nd_log_daemon(NDLP_DEBUG, "METADATA: Sending a shutdown command");
     cmd.opcode = METADATA_SYNC_SHUTDOWN;
-    metadata_enq_cmd(&cmd);
 
-    /* wait for metadata thread to shut down */
-    nd_log_daemon(NDLP_DEBUG, "METADATA: Waiting for shutdown ACK");
+    // if we can't sent command return
+    // This should not happen but if we wait we may not get a completion
+    // and shutdown will timeout
+    if (!metadata_enq_cmd(&cmd)) {
+        nd_log_daemon(NDLP_WARNING, "METADATA: Failed to send a shutdown command");
+        return;
+    }
+    nd_log_daemon(NDLP_INFO, "METADATA: Submitted shutdown command, waiting for ACK");
+
     completion_wait_for(&meta_config.start_stop_complete);
     completion_destroy(&meta_config.start_stop_complete);
     int rc = uv_thread_join(&meta_config.thread);

--- a/src/go/plugin/go.d/agent/discovery/sd/discoverer/snmpsd/sysinfo.go
+++ b/src/go/plugin/go.d/agent/discovery/sd/discoverer/snmpsd/sysinfo.go
@@ -38,16 +38,15 @@ func GetSysInfo(client gosnmp.Handler) (*SysInfo, error) {
 		Organization: "Unknown",
 	}
 
-	r := strings.NewReplacer("\n", "\\n", "\r", "\\r")
+	r := strings.NewReplacer("\n", " ", "\r", " ")
 
 	for _, pdu := range pdus {
 		oid := strings.TrimPrefix(pdu.Name, ".")
 
 		switch oid {
 		case OidSysDescr:
-			if si.Descr, err = PduToString(pdu); err == nil {
-				si.Descr = r.Replace(si.Descr)
-			}
+			si.Descr, err = PduToString(pdu)
+			si.Descr = r.Replace(si.Descr)
 		case OidSysObject:
 			var sysObj string
 			if sysObj, err = PduToString(pdu); err == nil {
@@ -55,10 +54,13 @@ func GetSysInfo(client gosnmp.Handler) (*SysInfo, error) {
 			}
 		case OidSysContact:
 			si.Contact, err = PduToString(pdu)
+			si.Contact = r.Replace(si.Contact)
 		case OidSysName:
 			si.Name, err = PduToString(pdu)
+			si.Name = r.Replace(si.Name)
 		case OidSysLocation:
 			si.Location, err = PduToString(pdu)
+			si.Location = r.Replace(si.Location)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("OID '%s': %v", pdu.Name, err)

--- a/src/go/plugin/go.d/agent/module/job.go
+++ b/src/go/plugin/go.d/agent/module/job.go
@@ -497,6 +497,9 @@ func (j *Job) sendVnodeHostInfo() {
 	if _, ok := j.vnode.Labels["_hostname"]; !ok {
 		j.vnode.Labels["_hostname"] = j.vnode.Hostname
 	}
+	for k, v := range j.vnode.Labels {
+		j.vnode.Labels[k] = lblReplacer.Replace(v)
+	}
 
 	j.api.HOSTINFO(netdataapi.HostInfo{
 		GUID:     j.vnode.GUID,

--- a/src/plugins.d/pluginsd_dyncfg.c
+++ b/src/plugins.d/pluginsd_dyncfg.c
@@ -6,7 +6,8 @@
 // ----------------------------------------------------------------------------
 
 PARSER_RC pluginsd_config(char **words, size_t num_words, PARSER *parser) {
-    RRDHOST *host = pluginsd_require_scope_host(parser, PLUGINSD_KEYWORD_CONFIG);
+    // config command is only available to localhost
+    RRDHOST *host = localhost; /* pluginsd_require_scope_host(parser, PLUGINSD_KEYWORD_CONFIG);*/
     if(!host) return PARSER_RC_ERROR;
 
     size_t i = 1;

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -226,7 +226,6 @@ static inline PARSER_RC pluginsd_host_define_end(char **words __maybe_unused, si
     rrdhost_flag_set(host, RRDHOST_FLAG_COLLECTOR_ONLINE);
     object_state_activate_if_not_activated(&host->state_id);
     ml_host_start(host);
-    dyncfg_host_init(host);
     pulse_host_status(host, 0, 0); // this will detect the receiver status
 
     if(host->rrdlabels) {

--- a/src/streaming/stream-parents.c
+++ b/src/streaming/stream-parents.c
@@ -959,6 +959,7 @@ void rrdhost_stream_parents_free(RRDHOST *host, bool having_write_lock) {
     }
 
     host->stream.snd.parents.all = NULL;
+    host->stream.snd.parents.current = NULL;
 
     if(!having_write_lock)
         rw_spinlock_write_unlock(&host->stream.snd.parents.spinlock);

--- a/src/streaming/stream-sender-api.c
+++ b/src/streaming/stream-sender-api.c
@@ -92,6 +92,7 @@ void stream_sender_structures_free(struct rrdhost *host) {
     host->sender = NULL;
 
     sender_host_buffer_free(host);
+    rrdhost_stream_parents_free(host, false);
 
     rrdhost_flag_clear(host, RRDHOST_FLAG_STREAM_SENDER_INITIALIZED);
 }


### PR DESCRIPTION
##### Summary
1. dont init dyncfg for vnode (#20324)
1. Update libbpf (#20316)
1. Improve MSSQL (Part III) (#20230)
1. replace newline control chars with spaces in system info (#20301)
1. fix(go.d): sanitize vnode labels before creating vnode (#20293)
1. plugins dyncfg is always on localhost (#20312)
1. Improve metasync shutdown (#20303)
1. Improve user transition log messages (#20308)
1. fix use after free of streaming current parent (#20305)
1. fix heap-use-after-free in plugins.d inflight functions (#20304)
1. Minor fixes (#20263)
1. Schedule journal file indexing after database file rotation (#20264)

