### PR TITLE
Update libbpf

### DIFF
--- a/packaging/cmake/Modules/NetdataEBPFCORE.cmake
+++ b/packaging/cmake/Modules/NetdataEBPFCORE.cmake
@@ -9,8 +9,8 @@ set(ebpf-co-re_SOURCE_DIR "${CMAKE_BINARY_DIR}/ebpf-co-re")
 function(netdata_fetch_ebpf_co_re)
     ExternalProject_Add(
         ebpf-co-re
-        URL https://github.com/netdata/ebpf-co-re/releases/download/v1.5.0/netdata-ebpf-co-re-glibc-v1.5.0.tar.xz
-        URL_HASH SHA256=9585a5a48853f70efa51c48f57df34b4e47b1af56eaaef731f57525ebd76b90c
+        URL https://github.com/netdata/ebpf-co-re/releases/download/v1.5.1/netdata-ebpf-co-re-glibc-v1.5.1.tar.xz
+        URL_HASH SHA256=a0c64a8d4f61c106c01125b07eeebda92a9ed45af806366c0ebea8197eae83f8
         SOURCE_DIR "${ebpf-co-re_SOURCE_DIR}"
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/packaging/cmake/Modules/NetdataEBPFLegacy.cmake
+++ b/packaging/cmake/Modules/NetdataEBPFLegacy.cmake
@@ -18,19 +18,19 @@ function(netdata_fetch_legacy_ebpf_code)
     endif()
 
     if(need_static)
-        set(_hash ca0c6186b5c9c4640f8ba13ea375b66882203e8ca831a2e6e5e4e039b37f277a)
+        set(_hash 3e258407f758e3d4cd9ccd124ca6ca77307a2f6d9aca30462957b027f475f8a3)
         set(_libc "static")
     elseif(_libc STREQUAL "glibc")
-        set(_hash d3027685e15fdb6406fd36faf45287d79534d40601d388aca5ab87e90959846d)
+        set(_hash 0983c695ee46ba8fe930f2da2c847a7bee96b6cc5e2024464a032103f635ea18)
     elseif(_libc STREQUAL "musl")
-        set(_hash e2268ca1fa012e87d4d3d588e01b3a2389ad8a4b1c878508f6226ce1dad34acf)
+        set(_hash 1e7d7b51d6a7c89d0d77d4f43fe063c8318ff79bce3e02a5e6f33c3b9ce1f7e7)
     else()
         message(FATAL_ERROR "Could not determine libc implementation, unable to install eBPF legacy code.")
     endif()
 
     ExternalProject_Add(
         ebpf-code-legacy
-        URL https://github.com/netdata/kernel-collector/releases/download/v1.5.0/netdata-kernel-collector-${_libc}-v1.5.0.tar.xz
+        URL https://github.com/netdata/kernel-collector/releases/download/v1.5.1/netdata-kernel-collector-${_libc}-v1.5.1.tar.xz
         URL_HASH SHA256=${_hash}
         SOURCE_DIR "${ebpf-legacy_SOURCE_DIR}"
         CONFIGURE_COMMAND ""

--- a/packaging/cmake/Modules/NetdataLibBPF.cmake
+++ b/packaging/cmake/Modules/NetdataLibBPF.cmake
@@ -29,7 +29,7 @@ function(netdata_bundle_libbpf)
     if(USE_LEGACY_LIBBPF)
         set(_libbpf_tag 673424c56127bb556e64095f41fd60c26f9083ec) # v0.0.9_netdata-1
     else()
-        set(_libbpf_tag ad7c3a4266bf5ce301a5691eb7b405dbb27c7f3d) # v1.5.0p_netdata
+        set(_libbpf_tag 3890b7fa29c1670a75195dfc53be61d99a0c99c5) # v1.5.1p_netdata
     endif()
 
     if(DEFINED BUILD_SHARED_LIBS)


### PR DESCRIPTION
##### Summary
This PR brings update for libbpf after official release.

##### Test Plan

1. Check CI.

##### Additional Information
This PR was tested on:

| Linux Dist | Kernel |
|-----------------|-----------|
| Slackware current | 6.12.28|
|Arch Linux | 6.14.-6|
|Debian 12.10 | 6.1.55-1 |

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
