### PR TITLE
Cancel health initialization if shutdown has been requested

### DIFF
--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -133,11 +133,17 @@ static void health_execute_delayed_initializations(RRDHOST *host) {
     rrdhost_flag_clear(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
 
     rrdset_foreach_reentrant(st, host) {
-        if(!rrdset_flag_check(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION)) continue;
+        if (!rrdset_flag_check(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION))
+            continue;
+
         rrdset_flag_clear(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
 
         worker_is_busy(WORKER_HEALTH_JOB_DELAYED_INIT_RRDSET);
+
         health_prototype_alerts_for_rrdset_incrementally(st);
+
+        if (!service_running(SERVICE_HEALTH))
+            break;
     }
     rrdset_foreach_done(st);
 }
@@ -162,6 +168,10 @@ static void health_initialize_rrdhost(RRDHOST *host) {
     sql_health_alarm_log_load(host);
     rw_spinlock_init(&host->health_log.spinlock);
     rrdhost_flag_set(host, RRDHOST_FLAG_INITIALIZED_HEALTH);
+
+
+    if (!service_running(SERVICE_HEALTH))
+        return;
 
     health_apply_prototypes_to_host(host);
 }
@@ -247,6 +257,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
 
     if (unlikely(!rrdhost_flag_check(host, RRDHOST_FLAG_INITIALIZED_HEALTH)))
         health_initialize_rrdhost(host);
+
 
     health_execute_delayed_initializations(host);
 

--- a/src/health/health_prototypes.c
+++ b/src/health/health_prototypes.c
@@ -617,9 +617,13 @@ static void health_prototype_apply_to_rrdset(RRDSET *st, RRD_ALERT_PROTOTYPE *ap
     rw_spinlock_read_unlock(&ap->_internal.rw_spinlock);
 }
 
+extern __thread bool is_health_thread;
+
 void health_prototype_alerts_for_rrdset_incrementally(RRDSET *st) {
     RRD_ALERT_PROTOTYPE *ap;
     dfe_start_read(health_globals.prototypes.dict, ap) {
+        if (is_health_thread && !service_running(SERVICE_HEALTH))
+            break;
         health_prototype_apply_to_rrdset(st, ap);
     }
     dfe_done(ap);
@@ -689,6 +693,8 @@ void health_apply_prototypes_to_host(RRDHOST *host) {
     // apply all the prototypes for the charts of the host
     RRDSET *st;
     rrdset_foreach_reentrant(st, host) {
+        if (!service_running(SERVICE_HEALTH))
+            break;
         health_prototype_reset_alerts_for_rrdset(st);
     }
     rrdset_foreach_done(st);


### PR DESCRIPTION
##### Summary
- Check service status during health initialization to determine if shutdown has been requested
