### PR TITLE
Code cleanup and improvements

### DIFF
--- a/src/daemon/libuv_workers.c
+++ b/src/daemon/libuv_workers.c
@@ -132,13 +132,16 @@ void init_worker_pool(WorkerPool *pool) {
 // Get a worker from the pool
 // Needs to be called from the uv event loop thread
 worker_data_t *get_worker(WorkerPool *pool) {
+    worker_data_t *worker;
     if (pool->top == 0) {
-        worker_data_t *worker = callocz(1, sizeof(worker_data_t));
+        worker = callocz(1, sizeof(worker_data_t));
         worker->allocated = true;  // Mark as allocated
-        return worker;
+    } else {
+        int index = pool->free_stack[--pool->top]; // Pop from stack
+        worker = &pool->workers[index];
     }
-    int index = pool->free_stack[--pool->top];  // Pop from stack
-    return &pool->workers[index];
+    worker->request.data = worker;
+    return worker;
 }
 
 // Return a worker for reuse

--- a/src/daemon/libuv_workers.c
+++ b/src/daemon/libuv_workers.c
@@ -129,7 +129,8 @@ void init_worker_pool(WorkerPool *pool) {
     pool->top = MAX_ACTIVE_WORKERS;  // All workers are initially free
 }
 
-// Get a worker (reuse if available, NULL if pool exhausted)
+// Get a worker from the pool
+// Needs to be called from the uv event loop thread
 worker_data_t *get_worker(WorkerPool *pool) {
     if (pool->top == 0) {
         worker_data_t *worker = callocz(1, sizeof(worker_data_t));

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -537,7 +537,6 @@ static void start_alert_push(uv_work_t *req __maybe_unused)
 int schedule_query_in_worker(uv_loop_t *loop, struct aclk_sync_config_s *config, aclk_query_t *query) {
 
     worker_data_t *worker = get_worker(&config->worker_pool);
-    worker->request.data = worker;
     worker->payload = query;
     worker->config = config;
 
@@ -574,7 +573,6 @@ static void timer_cb(uv_timer_t *handle)
         worker_data_t *worker;
         if (!config->alert_push_running) {
             worker = get_worker(&config->worker_pool);
-            worker->request.data = worker;
             worker->config = config;
             config->alert_push_running = true;
             if (uv_queue_work(handle->loop, &worker->request, start_alert_push, after_start_alert_push)) {
@@ -763,12 +761,6 @@ static void *aclk_synchronization_event_loop(void *arg)
 
                 case ACLK_DATABASE_NODE_UNREGISTER:
                     worker = get_worker(&config->worker_pool);
-                    if (!worker) {
-                        nd_log_daemon(NDLP_ERR, "Failed to get worker for unregister node");
-                        freez(cmd.param[0]);
-                        break;
-                    }
-                    worker->request.data = worker;
                     worker->config = config;
                     worker->payload = cmd.param[0];
 
@@ -875,11 +867,6 @@ static void *aclk_synchronization_event_loop(void *arg)
                         break;
 
                     worker = get_worker(&config->worker_pool);
-                    if (!worker) {
-                        nd_log_daemon(NDLP_ERR, "Failed to get worker for ACLK batch job");
-                        break;
-                    }
-                    worker->request.data = worker;
                     worker->config = config;
                     worker->payload = aclk_query_batch;
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -1847,8 +1847,8 @@ static void ctx_hosts_load(uv_work_t *req)
 {
     register_libuv_worker_jobs();
 
-    worker_data_t *data = req->data;
-    struct meta_config_s *config = data->config;
+    worker_data_t *worker = req->data;
+    struct meta_config_s *config = worker->config;
 
     worker_is_busy(UV_EVENT_HOST_CONTEXT_LOAD);
     usec_t started_ut = now_monotonic_usec(); (void)started_ut;
@@ -2394,18 +2394,18 @@ static void start_metadata_hosts(uv_work_t *req)
 {
     register_libuv_worker_jobs();
 
-    worker_data_t *data = req->data;
-    struct meta_config_s *config = data->config;
+    worker_data_t *worker = req->data;
+    struct meta_config_s *config = worker->config;
 
-    BUFFER *work_buffer = data->work_buffer;
+    BUFFER *work_buffer = worker->work_buffer;
     usec_t all_started_ut = now_monotonic_usec();
 
-    store_sql_statements((struct judy_list_t *)data->pending_sql_statement, true);
+    store_sql_statements((struct judy_list_t *)worker->pending_sql_statement, true);
 
-    store_alert_transitions((struct judy_list_t *)data->pending_alert_list, true);
+    store_alert_transitions((struct judy_list_t *)worker->pending_alert_list, true);
 
     if (!SHUTDOWN_REQUESTED(config))
-        store_ctx_cleanup_list(config, (struct judy_list_t *)data->pending_ctx_cleanup_list);
+        store_ctx_cleanup_list(config, (struct judy_list_t *)worker->pending_ctx_cleanup_list);
 
     worker_is_busy(UV_EVENT_METADATA_STORE);
 
@@ -2415,7 +2415,7 @@ static void start_metadata_hosts(uv_work_t *req)
     nd_log_daemon(NDLP_DEBUG, "Checking all hosts completed in %s", report_duration);
 
     if (!SHUTDOWN_REQUESTED(config)) {
-        do_pending_uuid_deletion(config, (struct judy_list_t *)data->pending_uuid_deletion);
+        do_pending_uuid_deletion(config, (struct judy_list_t *)worker->pending_uuid_deletion);
         run_metadata_cleanup(config);
     }
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2633,11 +2633,12 @@ static void *metadata_event_loop(void *arg)
     uv_close((uv_handle_t *)&config->async, NULL);
     uv_walk(loop, libuv_close_callback, NULL);
 
-    size_t loop_count = (MAX_SHUTDOWN_TIMEOUT_SECONDS * USEC_PER_MS) / SHUTDOWN_SLEEP_INTERVAL_MS;
-    while ((config->metadata_running || config->ctx_load_running) && --loop_count) {
+    size_t loop_count = (MAX_SHUTDOWN_TIMEOUT_SECONDS * MSEC_PER_SEC) / SHUTDOWN_SLEEP_INTERVAL_MS;
+    while ((config->metadata_running || config->ctx_load_running) && loop_count > 0) {
         if (!uv_run(loop, UV_RUN_NOWAIT))
             break;  // No pending callbacks
         sleep_usec(SHUTDOWN_SLEEP_INTERVAL_MS * USEC_PER_MS);
+        loop_count--;
     }
 
     (void)uv_loop_close(loop);

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2544,7 +2544,6 @@ static void *metadata_event_loop(void *arg)
                         break;
 
                     worker = get_worker(&config->worker_pool);
-                    worker->request.data = worker;
                     worker->config = config;
                     worker->pending_alert_list = pending_alert_list;
                     worker->pending_ctx_cleanup_list = pending_ctx_cleanup_list;
@@ -2572,7 +2571,6 @@ static void *metadata_event_loop(void *arg)
 
                     worker = get_worker(&config->worker_pool);
                     config->ctx_load_running = true;
-                    worker->request.data = worker;
                     worker->config = config;
                     if (uv_queue_work(loop, &worker->request, ctx_hosts_load, after_ctx_hosts_load)) {
                         config->ctx_load_running = false;


### PR DESCRIPTION
##### Summary
- Fix shutdown timeout calculation for metadata thread
- Adjust get_worker function to set the request data before returning worker
- Remove checks for get_worker failure (always returns worker)
- Variable renames for clarity
