### PR TITLE
dont init dyncfg for vnode

### DIFF
--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -226,7 +226,6 @@ static inline PARSER_RC pluginsd_host_define_end(char **words __maybe_unused, si
     rrdhost_flag_set(host, RRDHOST_FLAG_COLLECTOR_ONLINE);
     object_state_activate_if_not_activated(&host->state_id);
     ml_host_start(host);
-    dyncfg_host_init(host);
     pulse_host_status(host, 0, 0); // this will detect the receiver status
 
     if(host->rrdlabels) {


### PR DESCRIPTION
##### Summary

Vnodes don't have dyncfg.

This should fix

```c
#0 <unknown> [0x7F6C1A5C772F]
#1 dictionary_set_and_acquire_item_advanced [0x555B7852B1EF] (/src/libnetdata/dictionary/dictionary.c:690)
#2 rrd_function_add [0x555B781C2F73] (/src/database/rrdfunctions.c:246)
#3 dyncfg_host_init [0x555B78619778] (/src/daemon/dyncfg/dyncfg-tree.c:287)
#4 pluginsd_host_define_end.constprop.0 [0x555B78619778] (/src/plugins.d/pluginsd_parser.c:229)
#5 parser_execute [0x555B7814E8DB] (/src/plugins.d/pluginsd_parser.c:1314)
#6 parser_action [0x555B7814E8DB] (/src/plugins.d/pluginsd_parser.h:229)
#7 pluginsd_process [0x555B7816403D] (/src/plugins.d/pluginsd_parser.c:1216)
#8 pluginsd_worker_thread [0x555B7814044B] (/src/plugins.d/plugins_d.c:162)
#9 nd_thread_starting_point [0x555B7854EE77] (/src/libnetdata/threads/threads.c:367)
#10 <unknown> [0x7F6C1A612809]
#11
```

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
