### PR TITLE
SOC 2 cloud doc update

### DIFF
--- a/docs/security-and-privacy-design/netdata-cloud-security.md
+++ b/docs/security-and-privacy-design/netdata-cloud-security.md
@@ -12,6 +12,12 @@
 
 :::
 
+:::info
+
+Netdata achieves [SOC 2 Type 1 attestation](https://www.netdata.cloud/blog/soc2-type1/), reinforcing its dedication to robust security practices for user data.
+
+:::
+
 ## Introduction
 
 Netdata Cloud enables secure real-time system insights without storing raw metrics.


### PR DESCRIPTION
Added the SOC 2 Type 1 attestation blog link (https://www.netdata.cloud/blog/soc2-type1/) under :::info at the top of the page.

This placement immediately reassures the reader without cluttering the main text.