### PR TITLE
MSSQL collection (windows.plugin)

### DIFF
--- a/src/collectors/windows.plugin/README.md
+++ b/src/collectors/windows.plugin/README.md
@@ -122,6 +122,7 @@ Add the SQL Server connection details to your `netdata.conf` file:
 ```
 [plugin:windows:PerflibMSSQL]
         driver = SQL Server
+        instance = Dev
         server = 127.0.0.1\\Dev, 1433
         #address = [protocol:]Address[,port |\pipe\pipename]
         uid = netdata_user
@@ -135,12 +136,15 @@ Configuration options:
 | Option                   | Description                                                                  |
 |--------------------------|------------------------------------------------------------------------------|
 | `driver`                 | ODBC driver used to connect to the SQL Server                                |
+| `instance`               | Instance name                                                                |
 | `server`                 | Server address or instance name                                              |
 | `address`                | Alternative to `server`; supports named pipes if the server supports them    |
 | `uid`                    | SQL Server user identifier                                                   |
 | `pwd`                    | Password for the specified user                                              |
 | `additional instances`   | Number of additional SQL Server instances to monitor                         |
 | `windows authentication` | Set to `yes` to use Windows credentials instead of SQL Server authentication |
+
+The `instance` option is required when Netdata pulls data from outside an MSSQL server.
 
 For more information on connection parameters, see the [Microsoft Official Documentation](https://learn.microsoft.com/en-us/sql/relational-databases/native-client/applications/using-connection-string-keywords-with-sql-server-native-client?view=sql-server-ver15&viewFallbackFrom=sql-server-ver16).
 
@@ -157,6 +161,7 @@ SQL Server can host multiple instances on the same machine. To monitor additiona
    ```text
    [plugin:windows:PerflibMSSQL1]
         driver = SQL Server
+        instance = Production
         server = 127.0.0.1\\Production, 1434
         uid = netdata_user
         pwd = AnotherReallyStrongPasswordShouldBeInsertedHere2$

--- a/src/collectors/windows.plugin/README.md
+++ b/src/collectors/windows.plugin/README.md
@@ -144,8 +144,6 @@ Configuration options:
 | `additional instances`   | Number of additional SQL Server instances to monitor                         |
 | `windows authentication` | Set to `yes` to use Windows credentials instead of SQL Server authentication |
 
-The `instance` option is required when Netdata pulls data from outside an MSSQL server.
-
 For more information on connection parameters, see the [Microsoft Official Documentation](https://learn.microsoft.com/en-us/sql/relational-databases/native-client/applications/using-connection-string-keywords-with-sql-server-native-client?view=sql-server-ver15&viewFallbackFrom=sql-server-ver16).
 
 ## Monitoring Multiple SQL Server Instances

--- a/src/collectors/windows.plugin/README.md
+++ b/src/collectors/windows.plugin/README.md
@@ -143,6 +143,7 @@ Configuration options:
 | `pwd`                    | Password for the specified user                                              |
 | `additional instances`   | Number of additional SQL Server instances to monitor                         |
 | `windows authentication` | Set to `yes` to use Windows credentials instead of SQL Server authentication |
+| `express`                | Set to `yes` when running SQL Express version                                |
 
 For more information on connection parameters, see the [Microsoft Official Documentation](https://learn.microsoft.com/en-us/sql/relational-databases/native-client/applications/using-connection-string-keywords-with-sql-server-native-client?view=sql-server-ver15&viewFallbackFrom=sql-server-ver16).
 

--- a/src/collectors/windows.plugin/metadata.yaml
+++ b/src/collectors/windows.plugin/metadata.yaml
@@ -1915,7 +1915,7 @@ modules:
               description: Set to yes to use Windows credentials instead of SQL Server authentication.
               default_value: no
               required: false
-            - name: windows authentication
+            - name: express
               description: Set to yes when running SQL Express version.
               default_value: no
               required: false

--- a/src/collectors/windows.plugin/metadata.yaml
+++ b/src/collectors/windows.plugin/metadata.yaml
@@ -1915,6 +1915,10 @@ modules:
               description: Set to yes to use Windows credentials instead of SQL Server authentication.
               default_value: no
               required: false
+            - name: windows authentication
+              description: Set to yes when running SQL Express version.
+              default_value: no
+              required: false
         examples:
           folding:
             enabled: true
@@ -1931,6 +1935,7 @@ modules:
                    server = 127.0.0.1\\Dev, 1433
                    uid = netdata_user
                    pwd = 1ReallyStrongPasswordShouldBeInsertedHere
+                   express = no
             - name: Multiple Instances
               description: An example configuration with two instances.
               folding:
@@ -1942,6 +1947,7 @@ modules:
                   server = 127.0.0.1\\Dev, 1433
                   uid = netdata_user
                   pwd = 1ReallyStrongPasswordShouldBeInsertedHere
+                  express = no
                   additional instances = 1
                 [plugin:windows:PerflibMSSQL1]
                   driver = SQL Server
@@ -1949,6 +1955,7 @@ modules:
                   server = 127.0.0.1\\Production, 1434
                   uid = netdata_user
                   pwd = AnotherReallyStrongPasswordShouldBeInsertedHere2
+                  express = no
     troubleshooting:
       problems:
         list: []

--- a/src/collectors/windows.plugin/metadata.yaml
+++ b/src/collectors/windows.plugin/metadata.yaml
@@ -1887,6 +1887,10 @@ modules:
               description: ODBC driver used to connect to the SQL Server.
               default_value: SQL Server
               required: false
+            - name: instance
+              description: Instance name
+              default_value: empty
+              required: true
             - name: server
               description: Server address or instance name.
               default_value: empty
@@ -1923,6 +1927,7 @@ modules:
               config: |
                 [plugin:windows:PerflibMSSQL]
                    driver = SQL Server
+                   instance = Dev
                    server = 127.0.0.1\\Dev, 1433
                    uid = netdata_user
                    pwd = 1ReallyStrongPasswordShouldBeInsertedHere
@@ -1933,12 +1938,14 @@ modules:
               config: |
                 [plugin:windows:PerflibMSSQL]
                   driver = SQL Server
+                  instance = Dev
                   server = 127.0.0.1\\Dev, 1433
                   uid = netdata_user
                   pwd = 1ReallyStrongPasswordShouldBeInsertedHere
                   additional instances = 1
                 [plugin:windows:PerflibMSSQL1]
                   driver = SQL Server
+                  instance = Production
                   server = 127.0.0.1\\Production, 1434
                   uid = netdata_user
                   pwd = AnotherReallyStrongPasswordShouldBeInsertedHere2

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -528,58 +528,58 @@ int dict_mssql_fill_waits(struct mssql_instance *mi)
     SQLLEN col_wait_type_len = 0, col_total_wait_len = 0, col_resource_wait_len = 0, col_signal_wait_len = 0,
            col_max_wait_len = 0, col_waiting_tasks_len = 0, col_wait_category_len = 0;
 
-    SQLRETURN ret = SQLExecDirect(mi->conn.dbWaitsSTMT, (SQLCHAR *)NETDATA_QUERY_CHECK_WAITS, SQL_NTS);
+    SQLRETURN ret = SQLExecDirect(mi->conn->dbWaitsSTMT, (SQLCHAR *)NETDATA_QUERY_CHECK_WAITS, SQL_NTS);
     if (ret != SQL_SUCCESS) {
-        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn.dbWaitsSTMT, NETDATA_MSSQL_ODBC_QUERY, mi->instanceID);
+        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_QUERY, mi->instanceID);
         goto endwait;
     }
 
-    ret = SQLBindCol(mi->conn.dbWaitsSTMT, 1, SQL_C_CHAR, wait_type, sizeof(wait_type), &col_wait_type_len);
+    ret = SQLBindCol(mi->conn->dbWaitsSTMT, 1, SQL_C_CHAR, wait_type, sizeof(wait_type), &col_wait_type_len);
     if (ret != SQL_SUCCESS) {
-        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn.dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
+        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
         goto endwait;
     }
 
-    ret = SQLBindCol(mi->conn.dbWaitsSTMT, 2, SQL_C_LONG, &total_wait, sizeof(total_wait), &col_total_wait_len);
+    ret = SQLBindCol(mi->conn->dbWaitsSTMT, 2, SQL_C_LONG, &total_wait, sizeof(total_wait), &col_total_wait_len);
     if (ret != SQL_SUCCESS) {
-        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn.dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
-        goto endwait;
-    }
-
-    ret =
-        SQLBindCol(mi->conn.dbWaitsSTMT, 3, SQL_C_LONG, &resource_wait, sizeof(resource_wait), &col_resource_wait_len);
-    if (ret != SQL_SUCCESS) {
-        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn.dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
-        goto endwait;
-    }
-
-    ret = SQLBindCol(mi->conn.dbWaitsSTMT, 4, SQL_C_LONG, &signal_wait, sizeof(signal_wait), &col_signal_wait_len);
-    if (ret != SQL_SUCCESS) {
-        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn.dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
-        goto endwait;
-    }
-
-    ret = SQLBindCol(mi->conn.dbWaitsSTMT, 5, SQL_C_LONG, &max_wait, sizeof(max_wait), &col_max_wait_len);
-    if (ret != SQL_SUCCESS) {
-        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn.dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
+        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
         goto endwait;
     }
 
     ret =
-        SQLBindCol(mi->conn.dbWaitsSTMT, 6, SQL_C_LONG, &waiting_tasks, sizeof(waiting_tasks), &col_waiting_tasks_len);
+        SQLBindCol(mi->conn->dbWaitsSTMT, 3, SQL_C_LONG, &resource_wait, sizeof(resource_wait), &col_resource_wait_len);
     if (ret != SQL_SUCCESS) {
-        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn.dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
+        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
         goto endwait;
     }
 
-    ret = SQLBindCol(mi->conn.dbWaitsSTMT, 7, SQL_C_CHAR, wait_category, sizeof(wait_category), &col_wait_category_len);
+    ret = SQLBindCol(mi->conn->dbWaitsSTMT, 4, SQL_C_LONG, &signal_wait, sizeof(signal_wait), &col_signal_wait_len);
     if (ret != SQL_SUCCESS) {
-        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn.dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
+        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
+        goto endwait;
+    }
+
+    ret = SQLBindCol(mi->conn->dbWaitsSTMT, 5, SQL_C_LONG, &max_wait, sizeof(max_wait), &col_max_wait_len);
+    if (ret != SQL_SUCCESS) {
+        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
+        goto endwait;
+    }
+
+    ret =
+        SQLBindCol(mi->conn->dbWaitsSTMT, 6, SQL_C_LONG, &waiting_tasks, sizeof(waiting_tasks), &col_waiting_tasks_len);
+    if (ret != SQL_SUCCESS) {
+        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
+        goto endwait;
+    }
+
+    ret = SQLBindCol(mi->conn->dbWaitsSTMT, 7, SQL_C_CHAR, wait_category, sizeof(wait_category), &col_wait_category_len);
+    if (ret != SQL_SUCCESS) {
+        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
         goto endwait;
     }
 
     do {
-        ret = SQLFetch(mi->conn.dbWaitsSTMT);
+        ret = SQLFetch(mi->conn->dbWaitsSTMT);
         switch (ret) {
             case SQL_SUCCESS:
             case SQL_SUCCESS_WITH_INFO:
@@ -608,7 +608,7 @@ int dict_mssql_fill_waits(struct mssql_instance *mi)
     } while (true);
 
 endwait:
-    netdata_MSSQL_release_results(mi->conn.dbWaitsSTMT);
+    netdata_MSSQL_release_results(mi->conn->dbWaitsSTMT);
 
     return success;
 }
@@ -1188,7 +1188,7 @@ int dict_mssql_query_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value,
     struct mssql_instance *mi = value;
     static long collecting = 1;
 
-    if (mi->conn.is_connected && collecting) {
+    if (mi->conn->is_connected && collecting) {
         collecting = metdata_mssql_check_permission(mi);
         if (!collecting) {
             nd_log(
@@ -1256,7 +1256,7 @@ static int initialize(int update_every)
     dictionary_register_insert_callback(mssql_instances, dict_mssql_insert_cb, &create_thread);
 
     int total_options = netdata_parse_mssql_options();
-    if (mssql_fill_dictionary() && !total_options) {
+    if (mssql_fill_dictionary(update_every) && !total_options) {
         return -1;
     }
 

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -1115,7 +1115,7 @@ void dict_mssql_insert_cb(const DICTIONARY_ITEM *item __maybe_unused, void *valu
     mi->conn = netdata_attach_connection(instance);
 
     if (mi->conn && mi->conn->connectionString) {
-        mi->conn->is_sqlexpress = (!strcmp(avalue, "SQLEXPRESS")) ? TRUE : FALSE;
+        mi->conn->is_sqlexpress = (!strcmp(instance, "SQLEXPRESS")) ? TRUE : FALSE;
         mi->conn->is_connected = netdata_MSSQL_initialize_conection(mi->conn);
         if (mi->conn->is_connected)
             *create_thread = true;

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -816,7 +816,7 @@ static void initialize_mssql_objects(struct mssql_instance *mi, const char *inst
     } else if (!strcmp(instance, "SQLEXPRESS")) {
         strncpyz(prefix, "MSSQL$SQLEXPRESS:", (size_t)sizeof(prefix) - 1);
     } else {
-        char *express = (!mi->conn || !mi->conn->is_sqlexpress) ? "" : "SQLEXPRESS:";
+        char *express = (mi->conn && mi->conn->is_sqlexpress) ? "SQLEXPRESS:" : "";
         snprintfz(prefix, (size_t)sizeof(prefix) - 1, "MSSQL$%s%s:", express, instance);
     }
 

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -1786,6 +1786,9 @@ int dict_mssql_locks_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void 
 
 static void do_mssql_locks(PERF_DATA_BLOCK *pDataBlock, struct mssql_instance *mi, int update_every __maybe_unused)
 {
+    if (unlikely(!mi->conn) || unlikely(!mi->conn->is_connected))
+        return;
+
     PERF_OBJECT_TYPE *pObjectType = perflibFindObjectTypeByName(pDataBlock, mi->objectName[NETDATA_MSSQL_LOCKS]);
     if (pObjectType) {
         if (pObjectType->NumInstances) {

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -681,9 +681,6 @@ endperm:
 
 static void metdata_mssql_fill_dictionary_from_db(struct mssql_instance *mi)
 {
-    if (!mi->conn)
-        return;
-
     char dbname[SQLSERVER_MAX_NAME_LENGTH + 1];
     SQLLEN col_data_len = 0;
 
@@ -1188,7 +1185,6 @@ int dict_mssql_query_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value,
 
     if(mi->conn && mi->conn->is_connected && collecting) {
         collecting = metdata_mssql_check_permission(mi);
-        /*
         if (!collecting) {
             nd_log(
                 NDLS_COLLECTORS,
@@ -1199,10 +1195,8 @@ int dict_mssql_query_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value,
         } else {
             metdata_mssql_fill_dictionary_from_db(mi);
             dictionary_sorted_walkthrough_read(mi->databases, dict_mssql_databases_run_queries, NULL);
+            // collecting = dict_mssql_fill_waits(mi);
         }
-
-        collecting = dict_mssql_fill_waits(mi);
-         */
     }
 
     return 1;
@@ -1247,10 +1241,6 @@ static int netdata_parse_mssql_options()
         last = curr;
         counter++;
     }
-    nd_log(
-            NDLS_COLLECTORS,
-            NDLP_ERR,
-            "KILLME COUNTER %d", counter);
     return counter;
 }
 
@@ -2623,9 +2613,9 @@ int dict_mssql_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value
         do_mssql_sql_statistics,
         do_mssql_access_methods,
 
+        do_mssql_databases,
         // Data Get with queries
         /*
-        do_mssql_databases,
         do_mssql_locks,
         do_mssql_waits,
          */
@@ -2635,7 +2625,7 @@ int dict_mssql_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value
 
     static bool collect_perflib[NETDATA_MSSQL_METRICS_END] = {true, true, true, true, true, true, true, true};
 
-    for (i = 0; doMSSQL[i]; i++) {
+    for (i = 0; i < NETDATA_MSSQL_DATABASE; i++) {
         if (!collect_perflib[i])
             continue;
 
@@ -2657,11 +2647,9 @@ int dict_mssql_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value
     if (!mi->conn)
         return 1;
 
-    /*
-    for (i = NETDATA_MSSQL_DATABASE; i < NETDATA_MSSQL_METRICS_END; i++) {
+    for (i = NETDATA_MSSQL_DATABASE; doMSSQL[i]; i++) {
         doMSSQL[i](NULL, mi, *update_every);
     }
-     */
 
     return 1;
 }

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -1159,6 +1159,7 @@ static int mssql_fill_dictionary(int update_every)
             continue;
 
         struct mssql_instance *p = dictionary_set(mssql_instances, avalue, NULL, (size_t)sizeof(*p));
+        (void)p;
     }
 
 endMSSQLFillDict:

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -17,7 +17,6 @@
 #define SQLSERVER_MAX_NAME_LENGTH NETDATA_MAX_INSTANCE_OBJECT
 #define NETDATA_MSSQL_NEXT_TRY (60)
 
-BOOL has_mssql_installed = TRUE;
 ND_THREAD *mssql_query_thread = NULL;
 
 struct netdata_mssql_conn {
@@ -1169,7 +1168,6 @@ endMSSQLFillDict:
         RegCloseKey(hKey);
 
     if (ret != ERROR_SUCCESS) {
-        has_mssql_installed = FALSE;
         return -1;
     }
 
@@ -1205,8 +1203,6 @@ int dict_mssql_query_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value,
         }
 
         collecting = dict_mssql_fill_waits(mi);
-    } else {
-        dictionary_sorted_walkthrough_read(mi->databases, netdata_mssql_reset_value, NULL);
     }
 
     return 1;
@@ -1224,7 +1220,7 @@ void *netdata_mssql_queries(void *ptr __maybe_unused)
         if (unlikely(!service_running(SERVICE_COLLECTORS)))
             break;
 
-     //   dictionary_sorted_walkthrough_read(mssql_instances, dict_mssql_query_cb, &update_every);
+        dictionary_sorted_walkthrough_read(mssql_instances, dict_mssql_query_cb, &update_every);
     }
 
     return NULL;


### PR DESCRIPTION
##### Summary
This PR completely separates the PerfLib collection from the database collection, enabling users to monitor remote instances. Additional details will follow after final testing.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
