### PR TITLE
Improve retention calculation after datafile deletion

### DIFF
--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1034,6 +1034,11 @@ time_t find_uuid_first_time(
                 size_t found_index = live_entry - uuid_list;
                 journal_search_start = found_index + 1;  // Next search starts after this match
 
+                if (journal_search_start >= journal_metric_count) {
+                    not_matching_bsearches += (count - index - 1);
+                    break;
+                }
+
                 uuid_original_entry->pages_found += live_entry->entries;
                 uuid_original_entry->df_matched++;
 

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -966,7 +966,7 @@ struct rrdengine_datafile *datafile_release_and_acquire_next_for_retention(struc
     return next_datafile;
 }
 
-time_t find_uuid_first_time(
+static time_t find_uuid_first_time(
     struct rrdengine_instance *ctx,
     struct rrdengine_datafile *datafile,
     struct uuid_first_time_s *uuid_first_entry_list,
@@ -987,6 +987,7 @@ time_t find_uuid_first_time(
     size_t binary_match = 0;
     size_t not_matching_bsearches = 0;
 
+    bool agent_shutdown = false;
     while (datafile) {
         struct journal_v2_header *j2_header = journalfile_v2_data_acquire(datafile->journalfile, NULL, 0, 0);
         if (!j2_header) {
@@ -996,20 +997,21 @@ time_t find_uuid_first_time(
 
         bool any_matching = false;
 
-        time_t journal_start_time_s = (time_t) (j2_header->start_time_ut / USEC_PER_SEC);
+        time_t journal_start_time_s = (time_t)(j2_header->start_time_ut / USEC_PER_SEC);
 
-        if(journal_start_time_s < global_first_time_s)
+        if (journal_start_time_s < global_first_time_s)
             global_first_time_s = journal_start_time_s;
 
-        struct journal_metric_list *uuid_list = (struct journal_metric_list *)((uint8_t *) j2_header + j2_header->metric_offset);
+        struct journal_metric_list *uuid_list =
+            (struct journal_metric_list *)((uint8_t *)j2_header + j2_header->metric_offset);
         struct uuid_first_time_s *uuid_original_entry;
 
         size_t journal_metric_count = j2_header->metric_count;
         char file_path[RRDENG_PATH_MAX];
         journalfile_v2_generate_path(datafile, file_path, sizeof(file_path));
         PROTECTED_ACCESS_SETUP(datafile->journalfile->mmap.data, datafile->journalfile->mmap.size, file_path, "read");
-        if(no_signal_received) {
-            size_t journal_search_start = 0;  // Start of remaining search space
+        if (no_signal_received) {
+            size_t journal_search_start = 0; // Start of remaining search space
             any_matching = false;
             for (size_t index = 0; index < count; ++index) {
                 uuid_original_entry = &uuid_first_entry_list[index];
@@ -1020,7 +1022,7 @@ time_t find_uuid_first_time(
                 any_matching = true;
                 struct journal_metric_list *live_entry = &uuid_list[journal_search_start];
                 // Check if we avoid bsearch
-                 if (journal_metric_uuid_compare(uuid_original_entry->uuid, live_entry->uuid) != 0) {
+                if (journal_metric_uuid_compare(uuid_original_entry->uuid, live_entry->uuid) != 0) {
                     live_entry = bsearch(
                         uuid_original_entry->uuid,
                         uuid_list + journal_search_start,
@@ -1035,7 +1037,7 @@ time_t find_uuid_first_time(
                 }
 
                 size_t found_index = live_entry - uuid_list;
-                journal_search_start = found_index + 1;  // Next search starts after this match
+                journal_search_start = found_index + 1; // Next search starts after this match
 
                 if (journal_search_start >= journal_metric_count) {
                     not_matching_bsearches += (count - index - 1);
@@ -1053,14 +1055,23 @@ time_t find_uuid_first_time(
                     uuid_original_entry->df_index_oldest = uuid_original_entry->df_matched;
 
                 binary_match++;
+
+                if (unlikely(!ctx_is_available_for_queries(ctx))) {
+                    agent_shutdown = true;
+                    break;
+                }
             }
         } else {
-            nd_log_daemon(
-                NDLP_ERR, "DBENGINE: journalfile \"%s\" is corrupted, skipping it", file_path);
+            nd_log_daemon(NDLP_ERR, "DBENGINE: journalfile \"%s\" is corrupted, skipping it", file_path);
+        }
+        journalfile_v2_data_release(datafile->journalfile);
+
+        if (agent_shutdown) {
+            datafile_release(datafile, DATAFILE_ACQUIRE_RETENTION);
+            break;
         }
 
         journalfile_count++;
-        journalfile_v2_data_release(datafile->journalfile);
         datafile = datafile_release_and_acquire_next_for_retention(ctx, datafile);
         if (!any_matching) {
             if (datafile)
@@ -1068,6 +1079,9 @@ time_t find_uuid_first_time(
             break;
         }
     }
+
+    if (agent_shutdown)
+        return global_first_time_s;
 
     // Let's scan the open cache for almost exact match
     size_t open_cache_count = 0;
@@ -1192,15 +1206,28 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
 
     global_first_time_s = find_uuid_first_time(ctx, first_datafile_remaining, uuid_first_entry_list, added);
 
+    if (!ctx_is_available_for_queries(ctx)) {
+        for (size_t index = 0; index < added; ++index) {
+            uuid_first_t_entry = &uuid_first_entry_list[index];
+            mrg_metric_release(main_mrg, uuid_first_t_entry->metric);
+        }
+        goto done;
+    }
+
     if(worker)
         worker_is_busy(UV_EVENT_DBENGINE_POPULATE_MRG);
 
-    netdata_log_info("DBENGINE: updating tier %d metrics registry retention for %zu metrics",
-         ctx->config.tier, added);
+    netdata_log_info("DBENGINE: updating tier %d metrics registry retention for %zu metrics", ctx->config.tier, added);
 
     size_t deleted_metrics = 0, zero_retention_referenced = 0, zero_disk_retention = 0, zero_disk_but_live = 0;
     for (size_t index = 0; index < added; ++index) {
         uuid_first_t_entry = &uuid_first_entry_list[index];
+
+        if (!ctx_is_available_for_queries(ctx)) {
+            mrg_metric_release(main_mrg, uuid_first_t_entry->metric);
+            continue;
+        }
+
         if (likely(uuid_first_t_entry->first_time_s != LONG_MAX)) {
 
             time_t old_first_time_s = mrg_metric_get_first_time_s(main_mrg, uuid_first_t_entry->metric);
@@ -1241,7 +1268,9 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
             }
         }
     }
-    freez(uuid_first_entry_list);
+
+    if (!ctx_is_available_for_queries(ctx))
+        goto done;
 
     internal_error(zero_disk_retention,
                    "DBENGINE: deleted %zu metrics, zero retention but referenced %zu (out of %zu total, of which %zu have main cache retention) zero on-disk retention tier %d metrics from metrics registry",
@@ -1249,6 +1278,9 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
 
     if(global_first_time_s != LONG_MAX)
         __atomic_store_n(&ctx->atomic.first_time_s, global_first_time_s, __ATOMIC_RELAXED);
+
+done:
+    freez(uuid_first_entry_list);
 
     if(worker)
         worker_is_idle();
@@ -1291,6 +1323,13 @@ void datafile_delete(
 
     if (update_retention)
         update_metrics_first_time_s(ctx, datafile, datafile->next, worker);
+
+    if (!ctx_is_available_for_queries(ctx)) {
+        // agent is shutting down, we cannot continue
+        if(worker)
+            worker_is_idle();
+        return;
+    }
 
     __atomic_add_fetch(&rrdeng_cache_efficiency_stats.datafile_deletion_started, 1, __ATOMIC_RELAXED);
     netdata_log_info("DBENGINE: deleting data file \"%s/"
@@ -1752,6 +1791,9 @@ static struct rrdengine_datafile *release_and_aquire_next_datafile_for_indexing(
 
 static void *journal_v2_indexing_tp_worker(struct rrdengine_instance *ctx, void *data, struct completion *completion __maybe_unused, uv_work_t *uv_work_req __maybe_unused) {
     unsigned count = 0;
+
+    if (unlikely(!ctx_is_available_for_queries(ctx)))
+        return data;
 
     worker_is_busy(UV_EVENT_DBENGINE_JOURNAL_INDEX);
     struct rrdengine_datafile *datafile = NULL;

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -994,6 +994,8 @@ time_t find_uuid_first_time(
             continue;
         }
 
+        bool any_matching = false;
+
         time_t journal_start_time_s = (time_t) (j2_header->start_time_ut / USEC_PER_SEC);
 
         if(journal_start_time_s < global_first_time_s)
@@ -1007,32 +1009,35 @@ time_t find_uuid_first_time(
         journalfile_v2_generate_path(datafile, file_path, sizeof(file_path));
         PROTECTED_ACCESS_SETUP(datafile->journalfile->mmap.data, datafile->journalfile->mmap.size, file_path, "read");
         if(no_signal_received) {
+            size_t journal_search_start = 0;  // Start of remaining search space
+            any_matching = false;
             for (size_t index = 0; index < count; ++index) {
                 uuid_original_entry = &uuid_first_entry_list[index];
 
-                // Check here if we should skip this
                 if (uuid_original_entry->df_matched > 3 || uuid_original_entry->pages_found > 5)
                     continue;
 
+                any_matching = true;
+
                 struct journal_metric_list *live_entry = bsearch(
                     uuid_original_entry->uuid,
-                    uuid_list,
-                    journal_metric_count,
+                    uuid_list + journal_search_start,
+                    journal_metric_count - journal_search_start,
                     sizeof(*uuid_list),
                     journal_metric_uuid_compare);
 
                 if (!live_entry) {
-                    // Not found in this journal
                     not_matching_bsearches++;
                     continue;
                 }
+
+                size_t found_index = live_entry - uuid_list;
+                journal_search_start = found_index + 1;  // Next search starts after this match
 
                 uuid_original_entry->pages_found += live_entry->entries;
                 uuid_original_entry->df_matched++;
 
                 time_t old_first_time_s = uuid_original_entry->first_time_s;
-
-                // Calculate first / last for this match
                 time_t first_time_s = live_entry->delta_start_s + journal_start_time_s;
                 uuid_original_entry->first_time_s = MIN(uuid_original_entry->first_time_s, first_time_s);
 
@@ -1049,6 +1054,10 @@ time_t find_uuid_first_time(
         journalfile_count++;
         journalfile_v2_data_release(datafile->journalfile);
         datafile = datafile_release_and_acquire_next_for_retention(ctx, datafile);
+        if (!any_matching) {
+            datafile_release(datafile, DATAFILE_ACQUIRE_RETENTION);
+            break;
+        }
     }
 
     // Let's scan the open cache for almost exact match

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1063,7 +1063,8 @@ time_t find_uuid_first_time(
         journalfile_v2_data_release(datafile->journalfile);
         datafile = datafile_release_and_acquire_next_for_retention(ctx, datafile);
         if (!any_matching) {
-            datafile_release(datafile, DATAFILE_ACQUIRE_RETENTION);
+            if (datafile)
+                datafile_release(datafile, DATAFILE_ACQUIRE_RETENTION);
             break;
         }
     }

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1018,17 +1018,20 @@ time_t find_uuid_first_time(
                     continue;
 
                 any_matching = true;
+                struct journal_metric_list *live_entry = &uuid_list[journal_search_start];
+                // Check if we avoid bsearch
+                 if (journal_metric_uuid_compare(uuid_original_entry->uuid, live_entry->uuid) != 0) {
+                    live_entry = bsearch(
+                        uuid_original_entry->uuid,
+                        uuid_list + journal_search_start,
+                        journal_metric_count - journal_search_start,
+                        sizeof(*uuid_list),
+                        journal_metric_uuid_compare);
 
-                struct journal_metric_list *live_entry = bsearch(
-                    uuid_original_entry->uuid,
-                    uuid_list + journal_search_start,
-                    journal_metric_count - journal_search_start,
-                    sizeof(*uuid_list),
-                    journal_metric_uuid_compare);
-
-                if (!live_entry) {
-                    not_matching_bsearches++;
-                    continue;
+                    if (!live_entry) {
+                        not_matching_bsearches++;
+                        continue;
+                    }
                 }
 
                 size_t found_index = live_entry - uuid_list;


### PR DESCRIPTION
##### Summary
- Reduce bsearch dataset after every match
- Detect when all metrics have been processed to avoid scanning all datafiles
- Detect agent shutdown during retention calculation 
  - Cancel retention calculation to speedup shutdown
