### PR TITLE
SNMP: _generic-ups.yaml

### DIFF
--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_generic-ups.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_generic-ups.yaml
@@ -15,49 +15,49 @@ metrics:
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.2.0
       name: upsSecondsOnBattery
-      description: If the unit is on battery power, the elapsed time since the UPS last switched to battery power, or the time since the network management subsystem was last restarted, whichever is less. Zero shall be returned if the unit is not on battery power.
+      description: If the unit is on battery power, the elapsed time since the UPS last switched to battery power, or the time since the network management subsystem was last restarted, whichever is less. Zero shall be returned if the unit is not on battery power
       family: UPS/Battery
       unit: "s"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.3.0
       name: upsEstimatedMinutesRemaining
-      description: An estimate of the time to battery charge depletion under the present load conditions if the utility power is off and remains off, or if it were to be lost and remain off.
+      description: An estimate of the time to battery charge depletion under the present load conditions if the utility power is off and remains off, or if it were to be lost and remain off
       family: UPS/Battery
       unit: "min"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.4.0
       name: upsEstimatedChargeRemaining
-      description: An estimate of the battery charge remaining expressed as a percent of full charge.
+      description: An estimate of the battery charge remaining expressed as a percent of full charge
       family: UPS/Battery
       unit: "%"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.5.0
       name: upsBatteryVoltage
-      description: The magnitude of the present battery voltage.
+      description: The magnitude of the present battery voltage
       family: UPS/Battery
       unit: "V"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.6.0
       name: upsBatteryCurrent
-      description: The present battery current.
+      description: The present battery current
       family: UPS/Battery
       unit: "A"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.7.0
       name: upsBatteryTemperature
-      description: The ambient temperature at or near the UPS Battery casing.
+      description: The ambient temperature at or near the UPS Battery casing
       family: UPS/Battery
       unit: "Cel"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.3.1.0
       name: upsInputLineBads
-      description: A count of the number of times the input entered an out-of-tolerance condition as defined by the manufacturer. This count is incremented by one each time the input transitions from zero out-of-tolerance lines to one or more input lines out-of-tolerance.
+      description: A count of the number of times the input entered an out-of-tolerance condition as defined by the manufacturer. This count is incremented by one each time the input transitions from zero out-of-tolerance lines to one or more input lines out-of-tolerance
       family: UPS/Input
       unit: "{bad}"
     metric_type: monotonic_count
@@ -65,7 +65,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.2.1.33.1.3.2.0
       name: upsInputNumLines
-      description: The number of input lines utilized in this device. This variable indicates the number of rows in the input table.
+      description: The number of input lines utilized in this device. This variable indicates the number of rows in the input table
       family: UPS/Input
       unit: "{line}"
   - MIB: UPS-MIB
@@ -87,35 +87,35 @@ metrics:
     symbol:
       OID: 1.3.6.1.2.1.33.1.4.2.0
       name: upsOutputFrequency
-      description: The present output frequency.
+      description: The present output frequency
       family: UPS/Output
       unit: "Hz"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.4.3.0
       name: upsOutputNumLines
-      description: The number of output lines utilized in this device. This variable indicates the number of rows in the output table.
+      description: The number of output lines utilized in this device. This variable indicates the number of rows in the output table
       family: UPS/Output
       unit: "{line}"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.5.1.0
       name: upsBypassFrequency
-      description: The present bypass frequency.
+      description: The present bypass frequency
       family: UPS/Bypass
       unit: "Hz"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.5.2.0
       name: upsBypassNumLines
-      description: The number of bypass lines utilized in this device. This entry indicates the number of rows in the bypass table.
+      description: The number of bypass lines utilized in this device. This entry indicates the number of rows in the bypass table
       family: UPS/Bypass
       unit: "{line}"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.6.1.0
       name: upsAlarmsPresent
-      description: The present number of active alarm conditions.
+      description: The present number of active alarm conditions
       family: UPS/Alarms
       unit: "{alarm}"
   - MIB: UPS-MIB
@@ -136,7 +136,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.2.1.33.1.7.5.0
       name: upsTestStartTime
-      description: The value of sysUpTime at the time the test in progress was initiated, or, if no test is in progress, the time the previous test was initiated.
+      description: The value of sysUpTime at the time the test in progress was initiated, or, if no test is in progress, the time the previous test was initiated
       family: UPS/Test Results
       unit: "s"
   - MIB: UPS-MIB
@@ -231,7 +231,7 @@ metrics:
     symbols:
       - OID: 1.3.6.1.2.1.33.1.6.2.1.3
         name: upsAlarmTime
-        description: The value of sysUpTime when the alarm condition was detected. If the alarm condition was detected at the time of agent startup and presumably existed before agent startup, the value of upsAlarmTime shall equal 0.
+        description: The value of sysUpTime when the alarm condition was detected. If the alarm condition was detected at the time of agent startup and presumably existed before agent startup, the value of upsAlarmTime shall equal 0
         family: UPS/Alarms/Conditions
         unit: "s"
     metric_tags:

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_generic-ups.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_generic-ups.yaml
@@ -4,7 +4,7 @@ metrics:
       OID: 1.3.6.1.2.1.33.1.2.1.0
       name: upsBatteryStatus
       description: The indication of the capacity remaining in the UPS system's batteries
-      family: UPS/Battery
+      family: UPS/Battery/Status
       unit: "{status}"
       mapping:
         1: unknown
@@ -16,64 +16,64 @@ metrics:
       OID: 1.3.6.1.2.1.33.1.2.2.0
       name: upsSecondsOnBattery
       description: If the unit is on battery power, the elapsed time since the UPS last switched to battery power, or the time since the network management subsystem was last restarted, whichever is less. Zero shall be returned if the unit is not on battery power
-      family: UPS/Battery
+      family: UPS/Battery/Charge
       unit: "s"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.3.0
       name: upsEstimatedMinutesRemaining
       description: An estimate of the time to battery charge depletion under the present load conditions if the utility power is off and remains off, or if it were to be lost and remain off
-      family: UPS/Battery
+      family: UPS/Battery/Charge
       unit: "min"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.4.0
       name: upsEstimatedChargeRemaining
       description: An estimate of the battery charge remaining expressed as a percent of full charge
-      family: UPS/Battery
+      family: UPS/Battery/Charge
       unit: "%"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.5.0
       name: upsBatteryVoltage
       description: The magnitude of the present battery voltage
-      family: UPS/Battery
+      family: UPS/Battery/Voltage
       unit: "V"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.6.0
       name: upsBatteryCurrent
       description: The present battery current
-      family: UPS/Battery
+      family: UPS/Battery/Current
       unit: "A"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.7.0
       name: upsBatteryTemperature
       description: The ambient temperature at or near the UPS Battery casing
-      family: UPS/Battery
+      family: UPS/Battery/Temperature
       unit: "Cel"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.3.1.0
       name: upsInputLineBads
       description: A count of the number of times the input entered an out-of-tolerance condition as defined by the manufacturer. This count is incremented by one each time the input transitions from zero out-of-tolerance lines to one or more input lines out-of-tolerance
-      family: UPS/Input
-      unit: "{bad}"
+      family: UPS/Input/Tolerance
+      unit: "{transition}"
     metric_type: monotonic_count
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.3.2.0
       name: upsInputNumLines
       description: The number of input lines utilized in this device. This variable indicates the number of rows in the input table
-      family: UPS/Input
+      family: UPS/Input/Lines
       unit: "{line}"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.4.1.0
       name: upsOutputSource
       description: The present source of output power
-      family: UPS/Output
+      family: UPS/Output/Source
       unit: "{status}"
       mapping:
         1: other
@@ -88,28 +88,28 @@ metrics:
       OID: 1.3.6.1.2.1.33.1.4.2.0
       name: upsOutputFrequency
       description: The present output frequency
-      family: UPS/Output
+      family: UPS/Output/Frequency
       unit: "Hz"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.4.3.0
       name: upsOutputNumLines
       description: The number of output lines utilized in this device. This variable indicates the number of rows in the output table
-      family: UPS/Output
+      family: UPS/Output/Lines
       unit: "{line}"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.5.1.0
       name: upsBypassFrequency
       description: The present bypass frequency
-      family: UPS/Bypass
+      family: UPS/Bypass/Frequency
       unit: "Hz"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.5.2.0
       name: upsBypassNumLines
       description: The number of bypass lines utilized in this device. This entry indicates the number of rows in the bypass table
-      family: UPS/Bypass
+      family: UPS/Bypass/Lines
       unit: "{line}"
   - MIB: UPS-MIB
     symbol:
@@ -123,7 +123,7 @@ metrics:
       OID: 1.3.6.1.2.1.33.1.7.3.0
       name: upsTestResultsSummary
       description: The results of the current or last UPS diagnostics test performed
-      family: UPS/Test Results
+      family: UPS/Test
       unit: "{status}"
       mapping:
         1: donePass
@@ -137,7 +137,7 @@ metrics:
       OID: 1.3.6.1.2.1.33.1.7.5.0
       name: upsTestStartTime
       description: The value of sysUpTime at the time the test in progress was initiated, or, if no test is in progress, the time the previous test was initiated
-      family: UPS/Test Results
+      family: UPS/Test
       unit: "s"
   - MIB: UPS-MIB
     table:
@@ -147,22 +147,22 @@ metrics:
       - OID: 1.3.6.1.2.1.33.1.4.4.1.2
         name: upsOutputVoltage
         description: The present output voltage
-        family: UPS/Output/Lines
+        family: UPS/Output/Voltage
         unit: "V"
       - OID: 1.3.6.1.2.1.33.1.4.4.1.3
         name: upsOutputCurrent
         description: The present output current
-        family: UPS/Output/Lines
+        family: UPS/Output/Current
         unit: "A"
       - OID: 1.3.6.1.2.1.33.1.4.4.1.4
         name: upsOutputPower
         description: The present output true power
-        family: UPS/Output/Lines
+        family: UPS/Output/Power
         unit: "W"
       - OID: 1.3.6.1.2.1.33.1.4.4.1.5
         name: upsOutputPercentLoad
         description: The percentage of the UPS power capacity presently being used on this output line
-        family: UPS/Output/Lines
+        family: UPS/Output/Load
         unit: "%"
     metric_tags:
       - symbol:
@@ -177,22 +177,22 @@ metrics:
       - OID: 1.3.6.1.2.1.33.1.3.3.1.2
         name: upsInputFrequency
         description: The present input frequency
-        family: UPS/Input/Lines
+        family: UPS/Input/Frequency
         unit: "Hz"
       - OID: 1.3.6.1.2.1.33.1.3.3.1.3
         name: upsInputVoltage
         description: The magnitude of the present input voltage
-        family: UPS/Input/Lines
+        family: UPS/Input/Voltage
         unit: "V"
       - OID: 1.3.6.1.2.1.33.1.3.3.1.4
         name: upsInputCurrent
         description: The magnitude of the present input current
-        family: UPS/Input/Lines
+        family: UPS/Input/Current
         unit: "A"
       - OID: 1.3.6.1.2.1.33.1.3.3.1.5
         name: upsInputTruePower
         description: The magnitude of the present input true power
-        family: UPS/Input/Lines
+        family: UPS/Input/Power
         unit: "W"
     metric_tags:
       - symbol:
@@ -207,17 +207,17 @@ metrics:
       - OID: 1.3.6.1.2.1.33.1.5.3.1.2
         name: upsBypassVoltage
         description: The present bypass voltage
-        family: UPS/Bypass/Lines
+        family: UPS/Bypass/Voltage
         unit: "V"
       - OID: 1.3.6.1.2.1.33.1.5.3.1.3
         name: upsBypassCurrent
         description: The present bypass current
-        family: UPS/Bypass/Lines
+        family: UPS/Bypass/Current
         unit: "A"
       - OID: 1.3.6.1.2.1.33.1.5.3.1.4
         name: upsBypassPower
         description: The present true power conveyed by the bypass
-        family: UPS/Bypass/Lines
+        family: UPS/Bypass/Power
         unit: "W"
     metric_tags:
       - symbol:
@@ -232,7 +232,7 @@ metrics:
       - OID: 1.3.6.1.2.1.33.1.6.2.1.3
         name: upsAlarmTime
         description: The value of sysUpTime when the alarm condition was detected. If the alarm condition was detected at the time of agent startup and presumably existed before agent startup, the value of upsAlarmTime shall equal 0
-        family: UPS/Alarms/Conditions
+        family: UPS/Alarms
         unit: "s"
     metric_tags:
       - symbol:

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_generic-ups.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_generic-ups.yaml
@@ -1,126 +1,143 @@
 metrics:
-#  - MIB: UPS-MIB
-#    symbol:
-#      OID: 1.3.6.1.2.1.33.1.2.1.0
-#      name: upsBatteryStatus
-#      enum:
-#        unknown: 1
-#        batteryNormal: 2
-#        batteryLow: 3
-#        batteryDepleted: 4
-#      TODO: enum in scalar metric is not supported yet (keep this metric and this
-#        comment in profile until it's fixed)
+  - MIB: UPS-MIB
+    symbol:
+      OID: 1.3.6.1.2.1.33.1.2.1.0
+      name: upsBatteryStatus
+      description: The indication of the capacity remaining in the UPS system's batteries
+      family: UPS/Battery
+      unit: "{status}"
+      mapping:
+        1: unknown
+        2: batteryNormal
+        3: batteryLow
+        4: batteryDepleted
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.2.0
       name: upsSecondsOnBattery
       description: If the unit is on battery power, the elapsed time since the UPS last switched to battery power, or the time since the network management subsystem was last restarted, whichever is less. Zero shall be returned if the unit is not on battery power.
+      family: UPS/Battery
       unit: "s"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.3.0
       name: upsEstimatedMinutesRemaining
       description: An estimate of the time to battery charge depletion under the present load conditions if the utility power is off and remains off, or if it were to be lost and remain off.
+      family: UPS/Battery
       unit: "min"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.4.0
       name: upsEstimatedChargeRemaining
       description: An estimate of the battery charge remaining expressed as a percent of full charge.
+      family: UPS/Battery
       unit: "%"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.5.0
       name: upsBatteryVoltage
       description: The magnitude of the present battery voltage.
+      family: UPS/Battery
       unit: "V"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.6.0
       name: upsBatteryCurrent
       description: The present battery current.
+      family: UPS/Battery
       unit: "A"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.2.7.0
       name: upsBatteryTemperature
       description: The ambient temperature at or near the UPS Battery casing.
+      family: UPS/Battery
       unit: "Cel"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.3.1.0
       name: upsInputLineBads
       description: A count of the number of times the input entered an out-of-tolerance condition as defined by the manufacturer. This count is incremented by one each time the input transitions from zero out-of-tolerance lines to one or more input lines out-of-tolerance.
-      unit: "{event}"
+      family: UPS/Input
+      unit: "{bad}"
     metric_type: monotonic_count
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.3.2.0
       name: upsInputNumLines
       description: The number of input lines utilized in this device. This variable indicates the number of rows in the input table.
-      unit: "{input_line}"
-#  - MIB: UPS-MIB
-#    symbol:
-#      OID: 1.3.6.1.2.1.33.1.4.1.0
-#      name: upsOutputSource
-#      enum:
-#        other: 1
-#        none: 2
-#        normal: 3
-#        bypass: 4
-#        battery: 5
-#        booster: 6
-#        reducer: 7
-#      TODO: enum in scalar metric is not supported yet (keep this metric and this
-#        comment in profile until it's fixed)
+      family: UPS/Input
+      unit: "{line}"
+  - MIB: UPS-MIB
+    symbol:
+      OID: 1.3.6.1.2.1.33.1.4.1.0
+      name: upsOutputSource
+      description: The present source of output power
+      family: UPS/Output
+      unit: "{status}"
+      mapping:
+        1: other
+        2: none
+        3: normal
+        4: bypass
+        5: battery
+        6: booster
+        7: reducer
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.4.2.0
       name: upsOutputFrequency
       description: The present output frequency.
+      family: UPS/Output
       unit: "Hz"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.4.3.0
       name: upsOutputNumLines
       description: The number of output lines utilized in this device. This variable indicates the number of rows in the output table.
-      unit: "{output_line}"
+      family: UPS/Output
+      unit: "{line}"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.5.1.0
       name: upsBypassFrequency
       description: The present bypass frequency.
+      family: UPS/Bypass
       unit: "Hz"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.5.2.0
       name: upsBypassNumLines
       description: The number of bypass lines utilized in this device. This entry indicates the number of rows in the bypass table.
-      unit: "{bypass_line}"
+      family: UPS/Bypass
+      unit: "{line}"
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.6.1.0
       name: upsAlarmsPresent
       description: The present number of active alarm conditions.
+      family: UPS/Alarms
       unit: "{alarm}"
-#  - MIB: UPS-MIB
-#    symbol:
-#      OID: 1.3.6.1.2.1.33.1.7.3.0
-#      name: upsTestResultsSummary
-#      enum:
-#        donePass: 1
-#        doneWarning: 2
-#        doneError: 3
-#        aborted: 4
-#        inProgress: 5
-#        noTestsInitiated: 6
-#      TODO: enum in scalar metric is not supported yet (keep this metric and this
-#        comment in profile until it's fixed)
+  - MIB: UPS-MIB
+    symbol:
+      OID: 1.3.6.1.2.1.33.1.7.3.0
+      name: upsTestResultsSummary
+      description: The results of the current or last UPS diagnostics test performed
+      family: UPS/Test Results
+      unit: "{status}"
+      mapping:
+        1: donePass
+        2: doneWarning
+        3: doneError
+        4: aborted
+        5: inProgress
+        6: noTestsInitiated
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.7.5.0
       name: upsTestStartTime
-      description: The value of sysUpTime at the time the test in progress was initiated, or, if no test is in progress, the time the previous test was initiated. If the value of upsTestResultsSummary is noTestsInitiated(6), upsTestStartTime has the value 0.
+      description: The value of sysUpTime at the time the test in progress was initiated, or, if no test is in progress, the time the previous test was initiated.
+      family: UPS/Test Results
       unit: "s"
   - MIB: UPS-MIB
     table:
@@ -129,19 +146,23 @@ metrics:
     symbols:
       - OID: 1.3.6.1.2.1.33.1.4.4.1.2
         name: upsOutputVoltage
-        description: The present output voltage.
+        description: The present output voltage
+        family: UPS/Output/Lines
         unit: "V"
       - OID: 1.3.6.1.2.1.33.1.4.4.1.3
         name: upsOutputCurrent
-        description: The present output current.
+        description: The present output current
+        family: UPS/Output/Lines
         unit: "A"
       - OID: 1.3.6.1.2.1.33.1.4.4.1.4
         name: upsOutputPower
-        description: The present output true power.
+        description: The present output true power
+        family: UPS/Output/Lines
         unit: "W"
       - OID: 1.3.6.1.2.1.33.1.4.4.1.5
         name: upsOutputPercentLoad
-        description: The percentage of the UPS power capacity presently being used on this output line, i.e., the greater of the percent load of true power capacity and the percent load of VA.
+        description: The percentage of the UPS power capacity presently being used on this output line
+        family: UPS/Output/Lines
         unit: "%"
     metric_tags:
       - symbol:
@@ -155,19 +176,23 @@ metrics:
     symbols:
       - OID: 1.3.6.1.2.1.33.1.3.3.1.2
         name: upsInputFrequency
-        description: The present input frequency.
+        description: The present input frequency
+        family: UPS/Input/Lines
         unit: "Hz"
       - OID: 1.3.6.1.2.1.33.1.3.3.1.3
         name: upsInputVoltage
-        description: The magnitude of the present input voltage.
+        description: The magnitude of the present input voltage
+        family: UPS/Input/Lines
         unit: "V"
       - OID: 1.3.6.1.2.1.33.1.3.3.1.4
         name: upsInputCurrent
-        description: The magnitude of the present input current.
+        description: The magnitude of the present input current
+        family: UPS/Input/Lines
         unit: "A"
       - OID: 1.3.6.1.2.1.33.1.3.3.1.5
         name: upsInputTruePower
-        description: The magnitude of the present input true power.
+        description: The magnitude of the present input true power
+        family: UPS/Input/Lines
         unit: "W"
     metric_tags:
       - symbol:
@@ -181,15 +206,18 @@ metrics:
     symbols:
       - OID: 1.3.6.1.2.1.33.1.5.3.1.2
         name: upsBypassVoltage
-        description: The present bypass voltage.
+        description: The present bypass voltage
+        family: UPS/Bypass/Lines
         unit: "V"
       - OID: 1.3.6.1.2.1.33.1.5.3.1.3
         name: upsBypassCurrent
-        description: The present bypass current.
+        description: The present bypass current
+        family: UPS/Bypass/Lines
         unit: "A"
       - OID: 1.3.6.1.2.1.33.1.5.3.1.4
         name: upsBypassPower
-        description: The present true power conveyed by the bypass.
+        description: The present true power conveyed by the bypass
+        family: UPS/Bypass/Lines
         unit: "W"
     metric_tags:
       - symbol:
@@ -204,6 +232,7 @@ metrics:
       - OID: 1.3.6.1.2.1.33.1.6.2.1.3
         name: upsAlarmTime
         description: The value of sysUpTime when the alarm condition was detected. If the alarm condition was detected at the time of agent startup and presumably existed before agent startup, the value of upsAlarmTime shall equal 0.
+        family: UPS/Alarms/Conditions
         unit: "s"
     metric_tags:
       - symbol:


### PR DESCRIPTION
##### Summary

@ilyam8 there could be family `UPS/Input/Lines` or `UPS/Lines/Input`. I went with the first one.
