### PR TITLE
Improve datafile rotation and indexing

### DIFF
--- a/src/database/engine/datafile.c
+++ b/src/database/engine/datafile.c
@@ -549,7 +549,7 @@ int init_data_files(struct rrdengine_instance *ctx)
             create_new_datafile_pair(ctx, false);
 
         while(rrdeng_ctx_tier_cap_exceeded(ctx))
-            datafile_delete(ctx, ctx->datafiles.first, false, false);
+            datafile_delete(ctx, ctx->datafiles.first, false, true, false);
     }
 
     pgc_reset_hot_max(open_cache);

--- a/src/database/engine/datafile.h
+++ b/src/database/engine/datafile.h
@@ -33,6 +33,7 @@ typedef enum __attribute__ ((__packed__)) {
     DATAFILE_ACQUIRE_OPEN_CACHE = 0,
     DATAFILE_ACQUIRE_PAGE_DETAILS,
     DATAFILE_ACQUIRE_RETENTION,
+    DATAFILE_ACQUIRE_INDEXING,
 
     // terminator
     DATAFILE_ACQUIRE_MAX,

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1266,18 +1266,18 @@ void datafile_delete(
         }
     }
 
-    netdata_log_info("DBENGINE: acquired data file '%s/"
+    netdata_log_info("DBENGINE: acquired data file \"%s/"
                      DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL DATAFILE_EXTENSION
-                     "' for deletion.",
+                     "\" for deletion.",
                      ctx->config.dbfiles_path, ctx->datafiles.first->tier, ctx->datafiles.first->fileno);
 
     if (update_retention)
         update_metrics_first_time_s(ctx, datafile, datafile->next, worker);
 
     __atomic_add_fetch(&rrdeng_cache_efficiency_stats.datafile_deletion_started, 1, __ATOMIC_RELAXED);
-    netdata_log_info("DBENGINE: deleting data file '%s/"
+    netdata_log_info("DBENGINE: deleting data file \"%s/"
          DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL DATAFILE_EXTENSION
-         "'.",
+         "\".",
          ctx->config.dbfiles_path, ctx->datafiles.first->tier, ctx->datafiles.first->fileno);
 
     if(worker)

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1746,11 +1746,13 @@ static void *journal_v2_indexing_tp_worker(struct rrdengine_instance *ctx, void 
         bool available = (datafile->writers.running || datafile->writers.flushed_to_open_running) ? false : true;
         spinlock_unlock(&datafile->writers.spinlock);
 
+        journalfile_v1_generate_path(datafile, path, sizeof(path));
+
         if(!available) {
             nd_log_daemon(NDLP_NOTICE,
-                   "DBENGINE: journal file %u needs to be indexed, but it has writers working on it - "
+                   "DBENGINE: journal file \"%s\" needs to be indexed, but it has writers working on it - "
                    "skipping it for now",
-                   datafile->fileno);
+                   path);
             continue;
         }
 
@@ -1761,8 +1763,7 @@ static void *journal_v2_indexing_tp_worker(struct rrdengine_instance *ctx, void 
             datafile_release(datafile, DATAFILE_ACQUIRE_INDEXING);
             break;
         }
-        journalfile_v1_generate_path(datafile, path, sizeof(path));
-        nd_log_daemon(NDLP_INFO, "DBENGINE: journal file '%s' is ready to be indexed", path);
+        nd_log_daemon(NDLP_INFO, "DBENGINE: journal file \"%s\" is ready to be indexed", path);
 
         pgc_open_cache_to_journal_v2(open_cache, (Word_t) ctx, (int) datafile->fileno, ctx->config.page_type,
                                      journalfile_migrate_to_v2_callback, (void *) datafile->journalfile);

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1731,12 +1731,12 @@ static void *journal_v2_indexing_tp_worker(struct rrdengine_instance *ctx __mayb
 
         if (unlikely(rrdeng_ctx_tier_cap_exceeded(ctx))) {
             nd_log_daemon(
-                NDLP_WARNING, "DBENGINE: tier %d reached quota limit, stopping journal indexing", ctx->config.tier);
+                NDLP_INFO, "DBENGINE: tier %d reached quota limit, stopping journal indexing", ctx->config.tier);
             __atomic_store_n(&ctx->atomic.needs_indexing, true, __ATOMIC_RELAXED);
             break;
         }
 
-        nd_log(NDLS_DAEMON, NDLP_DEBUG, "DBENGINE: journal file %u is ready to be indexed", datafile->fileno);
+        nd_log_daemon(NDLP_INFO, "DBENGINE: journal file %u is ready to be indexed", datafile->fileno);
 
         pgc_open_cache_to_journal_v2(open_cache, (Word_t) ctx, (int) datafile->fileno, ctx->config.page_type,
                                      journalfile_migrate_to_v2_callback, (void *) datafile->journalfile);

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1272,6 +1272,11 @@ void datafile_delete(
         }
     }
 
+    netdata_log_info("DBENGINE: acquired data file '%s/"
+                     DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL DATAFILE_EXTENSION
+                     "' for deletion.",
+                     ctx->config.dbfiles_path, ctx->datafiles.first->tier, ctx->datafiles.first->fileno);
+
     if (update_retention)
         update_metrics_first_time_s(ctx, datafile, datafile->next, worker);
 

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -375,6 +375,9 @@ struct rrdengine_instance {
 
     struct {
         uv_rwlock_t rwlock;                         // the linked list of datafiles is protected by this lock
+        bool disk_time;                             // true: delete for disk quota, false: delete for retention
+        bool pending_rotate;
+        bool pending_index;
         struct rrdengine_datafile *first;           // oldest - the newest with ->first->prev
     } datafiles;
 
@@ -535,7 +538,12 @@ static inline time_t max_acceptable_collected_time(void) {
     return now_realtime_sec() + 1;
 }
 
-void datafile_delete(struct rrdengine_instance *ctx, struct rrdengine_datafile *datafile, bool update_retention, bool worker);
+void datafile_delete(
+    struct rrdengine_instance *ctx,
+    struct rrdengine_datafile *datafile,
+    bool update_retention,
+    bool disk_time,
+    bool worker);
 
 // --------------------------------------------------------------------------------------------------------------------
 // the following functions are used to sort UUIDs in the journal files

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -24,6 +24,17 @@
 
 extern unsigned rrdeng_pages_per_extent;
 
+#define UNLINK_FILE(ctx, path, ret_var)                                                                                \
+    do {                                                                                                               \
+        uv_fs_t _req;                                                                                                  \
+        (ret_var) = uv_fs_unlink(NULL, &(_req), (path), NULL);                                                         \
+        if ((ret_var) < 0) {                                                                                           \
+            netdata_log_error("DBENGINE: uv_fs_unlink(\"%s\"): %s", (path), uv_strerror(ret_var));                     \
+            ctx_fs_error(ctx);                                                                                         \
+        }                                                                                                              \
+        uv_fs_req_cleanup(&(_req));                                                                                   \
+    } while (0)
+
 /* Forward declarations */
 struct rrdengine_instance;
 struct rrdeng_cmd;


### PR DESCRIPTION
##### Summary
- Reduce number of scheduled jobs, check if opcodes already pending
- Pause indexing if quota is exceeded and allow db rotation to run
  - Allow indexing to process at least one file
- Add datafile locking and allow indexing to run alongside with datafile rotation again
