### PR TITLE
apps.plugin documentation and grouping matches improvements

### DIFF
--- a/src/collectors/apps.plugin/apps_groups.conf
+++ b/src/collectors/apps.plugin/apps_groups.conf
@@ -40,6 +40,22 @@
 ## Processes of interest
 ## Grouping and/or rename individual processes.
 ## (there is no internal default for this section)
+##
+## Pattern matching rules:
+## - All matches are CASE INSENSITIVE (case sensitive in v2.5.2 and earlier)
+## - Use quotes for process names with spaces: "Process Name"
+## - Patterns work on both Unix-like systems and Windows:
+##   - Exact match: firefox (matches process named firefox)
+##   - Prefix match: firefox* (matches firefox, firefox.exe, firefox-bin, etc.)
+##   - Suffix match: *fox (matches firefox, icefox, etc.)
+##   - Substring match: *firefox* (searches in full command line/path)
+##
+## Windows-specific notes:
+## - Process names work without .exe extension (automatically handled)
+## - Substring patterns (*pattern*) search within the full executable path
+## - No backslash escaping needed for Windows paths
+## - The 'name' field (friendly name) is used for default categories when no pattern matches
+## - v2.5.3+: Patterns also match against the 'name' field (friendly name)
 
 ## NETDATA processes accounting
 netdata: netdata

--- a/src/collectors/apps.plugin/apps_pid_match.c
+++ b/src/collectors/apps.plugin/apps_pid_match.c
@@ -4,46 +4,90 @@
 
 bool pid_match_check(struct pid_stat *p, APPS_MATCH *match) {
     if(!match->starts_with && !match->ends_with) {
+        // Exact match
         if(match->pattern) {
             if(simple_pattern_matches_string(match->pattern, p->comm))
                 return true;
+#if (PROCESSES_HAVE_COMM_AND_NAME == 1)
+            if(p->name && simple_pattern_matches_string(match->pattern, p->name))
+                return true;
+#endif
         }
         else {
-            if(match->compare == p->comm || match->compare == p->comm_orig)
+            if(string_equals_string_nocase(match->compare, p->comm) || 
+               string_equals_string_nocase(match->compare, p->comm_orig))
                 return true;
+#if (PROCESSES_HAVE_COMM_AND_NAME == 1)
+            if(p->name && string_equals_string_nocase(match->compare, p->name))
+                return true;
+#endif
         }
     }
     else if(match->starts_with && !match->ends_with) {
+        // Prefix match
         if(match->pattern) {
             if(simple_pattern_matches_string(match->pattern, p->comm))
                 return true;
+#if (PROCESSES_HAVE_COMM_AND_NAME == 1)
+            if(p->name && simple_pattern_matches_string(match->pattern, p->name))
+                return true;
+#endif
         }
         else {
-            if(string_starts_with_string(p->comm, match->compare) ||
-               (p->comm != p->comm_orig && string_starts_with_string(p->comm, match->compare)))
+            if(string_starts_with_string_nocase(p->comm, match->compare) ||
+               (p->comm != p->comm_orig && string_starts_with_string_nocase(p->comm_orig, match->compare)))
                 return true;
+#if (PROCESSES_HAVE_COMM_AND_NAME == 1)
+            if(p->name && string_starts_with_string_nocase(p->name, match->compare))
+                return true;
+#endif
         }
     }
     else if(!match->starts_with && match->ends_with) {
+        // Suffix match
         if(match->pattern) {
             if(simple_pattern_matches_string(match->pattern, p->comm))
                 return true;
+#if (PROCESSES_HAVE_COMM_AND_NAME == 1)
+            if(p->name && simple_pattern_matches_string(match->pattern, p->name))
+                return true;
+#endif
         }
         else {
-            if(string_ends_with_string(p->comm, match->compare) ||
-               (p->comm != p->comm_orig && string_ends_with_string(p->comm, match->compare)))
+            if(string_ends_with_string_nocase(p->comm, match->compare) ||
+               (p->comm != p->comm_orig && string_ends_with_string_nocase(p->comm_orig, match->compare)))
                 return true;
+#if (PROCESSES_HAVE_COMM_AND_NAME == 1)
+            if(p->name && string_ends_with_string_nocase(p->name, match->compare))
+                return true;
+#endif
         }
     }
-    else if(match->starts_with && match->ends_with && p->cmdline) {
-        if(match->pattern) {
-            if(simple_pattern_matches_string(match->pattern, p->cmdline))
-                return true;
+    else if(match->starts_with && match->ends_with) {
+        // Substring match - search in cmdline and on Windows also in name
+        if(p->cmdline) {
+            if(match->pattern) {
+                if(simple_pattern_matches_string(match->pattern, p->cmdline))
+                    return true;
+            }
+            else {
+                if(strcasestr(string2str(p->cmdline), string2str(match->compare)))
+                    return true;
+            }
         }
-        else {
-            if(strstr(string2str(p->cmdline), string2str(match->compare)))
-                return true;
+#if (PROCESSES_HAVE_COMM_AND_NAME == 1)
+        // On Windows, also search in the name field for substring patterns
+        if(p->name) {
+            if(match->pattern) {
+                if(simple_pattern_matches_string(match->pattern, p->name))
+                    return true;
+            }
+            else {
+                if(strcasestr(string2str(p->name), string2str(match->compare)))
+                    return true;
+            }
         }
+#endif
     }
 
     return false;
@@ -78,7 +122,7 @@ APPS_MATCH pid_match_create(const char *comm) {
     m.compare = string_strdupz(nid);
 
     if(strchr(nid, '*'))
-        m.pattern = simple_pattern_create(comm, SIMPLE_PATTERN_NO_SEPARATORS, SIMPLE_PATTERN_EXACT, true);
+        m.pattern = simple_pattern_create(comm, SIMPLE_PATTERN_NO_SEPARATORS, SIMPLE_PATTERN_EXACT, false);
 
     return m;
 }

--- a/src/libnetdata/string/string.h
+++ b/src/libnetdata/string/string.h
@@ -18,6 +18,9 @@ size_t string_strlen(const STRING *string);
 const char *string2str(const STRING *string) NEVERNULL;
 bool string_ends_with_string(const STRING *whole, const STRING *end);
 bool string_starts_with_string(const STRING *whole, const STRING *end);
+bool string_ends_with_string_nocase(const STRING *whole, const STRING *end);
+bool string_starts_with_string_nocase(const STRING *whole, const STRING *prefix);
+bool string_equals_string_nocase(const STRING *a, const STRING *b);
 size_t string_destroy(void);
 
 // keep common prefix/suffix and replace everything else with [x]


### PR DESCRIPTION
- [x] apps_group matches are now case insensitive. This is required for windows but also a good strategy for linux too.
- [x] windows processes names are now part of the matching, so on windows apps_group matches are now against `comm`, `cmdline` and `name`.
- [x] updated documentation for apps.plugin, especially for Windows and how users can verify their matches using the `processes` function.

