### PR TITLE
Fix heap-use-after-free in query progress updates

### DIFF
--- a/src/daemon/dyncfg/dyncfg-intercept.c
+++ b/src/daemon/dyncfg/dyncfg-intercept.c
@@ -239,7 +239,7 @@ static void dyncfg_apply_action_on_all_template_jobs(struct rrd_function_execute
     dfe_done(df);
 
     if(rfe->progress.cb)
-        rfe->progress.cb(rfe->progress.data, done, all);
+        rfe->progress.cb(rfe->transaction, rfe->progress.data, done, all);
 
     dfe_start_reentrant(dyncfg_globals.nodes, df) {
         if(df->template == template && df->type == DYNCFG_TYPE_JOB) {
@@ -253,7 +253,7 @@ static void dyncfg_apply_action_on_all_template_jobs(struct rrd_function_execute
             dyncfg_echo(df_dfe.item, df, df_dfe.name, cmd_to_send_to_plugin);
 
             if(rfe->progress.cb)
-                rfe->progress.cb(rfe->progress.data, ++done, all);
+                rfe->progress.cb(rfe->transaction, rfe->progress.data, ++done, all);
         }
     }
     dfe_done(df);

--- a/src/database/rrdfunctions.h
+++ b/src/database/rrdfunctions.h
@@ -16,7 +16,7 @@ typedef void (*rrd_function_result_callback_t)(BUFFER *wb, int code, void *resul
 typedef bool (*rrd_function_is_cancelled_cb_t)(void *is_cancelled_cb_data);
 typedef void (*rrd_function_cancel_cb_t)(void *data);
 typedef void (*rrd_function_register_canceller_cb_t)(void *register_cancel_cb_data, rrd_function_cancel_cb_t cancel_cb, void *cancel_cb_data);
-typedef void (*rrd_function_progress_cb_t)(void *data, size_t done, size_t all);
+typedef void (*rrd_function_progress_cb_t)(nd_uuid_t *transaction, void *data, size_t done, size_t all);
 typedef void (*rrd_function_progresser_cb_t)(const char *transaction, void *data);
 typedef void (*rrd_function_register_progresser_cb_t)(void *register_progresser_cb_data, rrd_function_progresser_cb_t progresser_cb, void *progresser_cb_data);
 

--- a/src/plugins.d/pluginsd_functions.c
+++ b/src/plugins.d/pluginsd_functions.c
@@ -437,7 +437,7 @@ PARSER_RC pluginsd_function_progress(char **words, size_t num_words, PARSER *par
         size_t all = all_str && *all_str ? str2u(all_str) : 0;
 
         if(pf->progress.cb)
-            pf->progress.cb(pf->progress.data, done, all);
+            pf->progress.cb(&pf->transaction, pf->progress.data, done, all);
     }
 
     return PARSER_RC_OK;

--- a/src/streaming/stream-sender-execute.c
+++ b/src/streaming/stream-sender-execute.c
@@ -39,15 +39,18 @@ static void stream_execute_function_callback(BUFFER *func_wb, int code, void *da
     freez(tmp);
 }
 
-static void stream_execute_function_progress_callback(void *data, size_t done, size_t all) {
+static void stream_execute_function_progress_callback(nd_uuid_t *transaction, void *data, size_t done, size_t all) {
     struct inflight_stream_function *tmp = data;
     struct sender_state *s = tmp->sender;
 
     if(rrdhost_can_stream_metadata_to_parent(s->host)) {
         CLEAN_BUFFER *wb = buffer_create(0, NULL);
 
+        char transaction_str[UUID_COMPACT_STR_LEN];
+        uuid_unparse_lower_compact(*transaction, transaction_str);
+
         buffer_sprintf(wb, PLUGINSD_KEYWORD_FUNCTION_PROGRESS " '%s' %zu %zu\n",
-                       string2str(tmp->transaction), done, all);
+                       transaction_str, done, all);
 
         sender_commit_clean_buffer(s, wb, STREAM_TRAFFIC_TYPE_FUNCTIONS);
     }

--- a/src/web/api/v1/api_v1_config.c
+++ b/src/web/api/v1/api_v1_config.c
@@ -84,7 +84,7 @@ int api_v1_config(RRDHOST *host, struct web_client *w, char *url __maybe_unused)
     int code = rrd_function_run(host, w->response.data, timeout, w->user_auth.access, cmd,
                                 true, transaction,
                                 NULL, NULL,
-                                web_client_progress_functions_update, w,
+                                web_client_progress_functions_update, NULL,
                                 web_client_interrupt_callback, w,
                                 w->payload, buffer_tostring(source), false);
 

--- a/src/web/api/v1/api_v1_function.c
+++ b/src/web/api/v1/api_v1_function.c
@@ -38,7 +38,7 @@ int api_v1_function(RRDHOST *host, struct web_client *w, char *url) {
 
     return rrd_function_run(host, wb, timeout, w->user_auth.access, function, true, transaction,
                             NULL, NULL,
-                            web_client_progress_functions_update, w,
+                            web_client_progress_functions_update, NULL,
                             web_client_interrupt_callback, w, w->payload,
                             buffer_tostring(source), false);
 }

--- a/src/web/api/web_api.c
+++ b/src/web/api/web_api.c
@@ -144,9 +144,10 @@ void nd_web_api_init(void) {
     time_grouping_init();
 }
 
-void web_client_progress_functions_update(void *data, size_t done, size_t all) {
+void web_client_progress_functions_update(nd_uuid_t *transaction, void *data, size_t done, size_t all) {
     // handle progress updates from the plugin
-    struct web_client *w = data;
-    query_progress_functions_update(&w->transaction, done, all);
+    // data parameter is no longer used - transaction is provided directly
+    (void)data;
+    query_progress_functions_update(transaction, done, all);
 }
 

--- a/src/web/api/web_api.h
+++ b/src/web/api/web_api.h
@@ -20,7 +20,7 @@ struct web_client;
 
 void nd_web_api_init(void);
 
-void web_client_progress_functions_update(void *data, size_t done, size_t all);
+void web_client_progress_functions_update(nd_uuid_t *transaction, void *data, size_t done, size_t all);
 
 void host_labels2json(RRDHOST *host, BUFFER *wb, const char *key);
 


### PR DESCRIPTION
The issue occurred when web_client was freed while plugin threads were still trying to access it through progress callbacks. The progress callback stored a pointer to web_client, which became invalid after the connection was closed.

Solution: Modified the progress callback signature to include the transaction UUID as a parameter, eliminating the need to store web_client pointers.

Changes:
- Updated rrd_function_progress_cb_t typedef to include nd_uuid_t *transaction
- Modified all progress callback implementations to use the transaction parameter
- Updated all callback invocations to pass the transaction from inflight structures
- Removed web_client pointer dependencies by passing NULL as callback data

This ensures that progress updates only use data that remains valid for the lifetime of the function execution.
