### PR TITLE
Fix registry save integer overflow and add failure backoff

### DIFF
--- a/src/registry/registry_internals.h
+++ b/src/registry/registry_internals.h
@@ -49,6 +49,10 @@ struct registry {
     // open files
     FILE *log_fp;
 
+    // save failure tracking
+    time_t last_save_failure;
+    int consecutive_save_failures;
+
     // the database
     DICTIONARY *persons;    // dictionary of REGISTRY_PERSON *,  with key the REGISTRY_PERSON.guid
     DICTIONARY *machines;   // dictionary of REGISTRY_MACHINE *, with key the REGISTRY_MACHINE.guid


### PR DESCRIPTION
The registry save functions were accumulating byte counts from fprintf() calls, which could exceed INT_MAX on large registries, causing the dictionary_walkthrough_read() to return negative values and fail.

This fix:
- Changes save functions to return item counts (1 per saved item) instead of accumulated byte counts
- Adds exponential backoff (60s, 120s, 240s... up to 1 hour) to prevent repeated save attempts after failures
- Tracks consecutive failures to implement the backoff mechanism
- Returns 0 on success instead of -1 from registry_db_save()

