### PR TITLE
improvement(go.d/ddsnmp): add table metrics and tags caching optimization

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/charts.go
+++ b/src/go/plugin/go.d/collector/snmp/charts.go
@@ -315,7 +315,7 @@ func newUserInputChart(cfg ChartConfig) (*module.Chart, error) {
 	return chart, nil
 }
 
-func (c *Collector) addProfileScalarMetricChart(m ddsnmpcollector.Metric) {
+func (c *Collector) addProfileScalarMetricChart(pm *ddsnmpcollector.ProfileMetrics, m ddsnmpcollector.Metric) {
 	if m.Name == "" {
 		return
 	}
@@ -343,7 +343,7 @@ func (c *Collector) addProfileScalarMetricChart(m ddsnmpcollector.Metric) {
 		"vendor":  c.sysInfo.Organization,
 		"sysName": c.sysInfo.Name,
 	}
-	maps.Copy(tags, m.Tags)
+	maps.Copy(tags, pm.Tags)
 	for k, v := range tags {
 		chart.Labels = append(chart.Labels, module.Label{Key: k, Value: v})
 	}

--- a/src/go/plugin/go.d/collector/snmp/charts.go
+++ b/src/go/plugin/go.d/collector/snmp/charts.go
@@ -365,15 +365,6 @@ func (c *Collector) addProfileScalarMetricChart(pm *ddsnmpcollector.ProfileMetri
 	}
 }
 
-func (c *Collector) removeProfileScalarMetricChart(metricName string) {
-	r := strings.NewReplacer(".", "_", " ", "_")
-	id := fmt.Sprintf("snmp_device_prof_%s", r.Replace(metricName))
-	if chart := c.Charts().Get(id); chart != nil {
-		chart.MarkRemove()
-		chart.MarkNotCreated()
-	}
-}
-
 func dimAlgoFromDdSnmpType(m ddsnmpcollector.Metric) module.DimAlgo {
 	if m.MetricType == ddprofiledefinition.ProfileMetricTypeGauge {
 		return module.Absolute

--- a/src/go/plugin/go.d/collector/snmp/collect_profiles.go
+++ b/src/go/plugin/go.d/collector/snmp/collect_profiles.go
@@ -22,18 +22,15 @@ func (c *Collector) collectProfiles(mx map[string]int64) error {
 		return err
 	}
 
-	seen := make(map[string]bool)
-
 	for _, pm := range profMetrics {
 		for _, m := range pm.Metrics {
 			if m.IsTable {
 				continue
 			}
 
-			seen[m.Name] = true
 			if !c.seenScalarMetrics[m.Name] {
 				c.seenScalarMetrics[m.Name] = true
-				c.addProfileScalarMetricChart(m)
+				c.addProfileScalarMetricChart(pm, m)
 			}
 
 			if len(m.Mappings) > 0 {
@@ -45,13 +42,6 @@ func (c *Collector) collectProfiles(mx map[string]int64) error {
 				id := fmt.Sprintf("snmp_device_prof_%s", m.Name)
 				mx[id] = m.Value
 			}
-		}
-	}
-
-	for name := range c.seenScalarMetrics {
-		if !seen[name] {
-			delete(c.seenScalarMetrics, name)
-			c.removeProfileScalarMetricChart(name)
 		}
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collect_scalar.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collect_scalar.go
@@ -84,18 +84,18 @@ func (c *Collector) collectScalarMetric(cfg ddprofiledefinition.MetricsConfig, p
 		return nil, fmt.Errorf("error processing value for OID %s (%s): %w", cfg.Symbol.Name, cfg.Symbol.OID, err)
 	}
 
-	tags := make(map[string]string)
+	staticTags := make(map[string]string)
 
 	for _, tag := range cfg.StaticTags {
 		if n, v, _ := strings.Cut(tag, ":"); n != "" && v != "" {
-			tags[n] = v
+			staticTags[n] = v
 		}
 	}
 
 	return &Metric{
 		Name:        cfg.Symbol.Name,
 		Value:       value,
-		Tags:        tags,
+		StaticTags:  ternary(len(staticTags) > 0, staticTags, nil),
 		Unit:        cfg.Symbol.Unit,
 		Description: cfg.Symbol.Description,
 		Family:      cfg.Symbol.Family,

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collect_table.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collect_table.go
@@ -25,6 +25,16 @@ func (c *Collector) collectTableMetrics(prof *ddsnmp.Profile) ([]Metric, error) 
 		if cfg.IsScalar() || cfg.Table.OID == "" || doneOids[cfg.Table.OID] {
 			continue
 		}
+		for _, tagCfg := range cfg.MetricTags {
+			if tagCfg.Table != "" && tagCfg.Table != cfg.Table.Name {
+				c.log.Debugf("Skipping table %s: has cross-table tag from %s", cfg.Table.Name, tagCfg.Table)
+				continue
+			}
+			if len(tagCfg.IndexTransform) > 0 {
+				c.log.Debugf("Skipping table %s: has index transformation", cfg.Table.Name)
+				continue
+			}
+		}
 		if c.missingOIDs[trimOID(cfg.Table.OID)] {
 			missingOIDs = append(missingOIDs, cfg.Table.OID)
 			continue
@@ -51,15 +61,25 @@ func (c *Collector) collectTableMetrics(prof *ddsnmp.Profile) ([]Metric, error) 
 }
 
 func (c *Collector) collectSingleTable(cfg ddprofiledefinition.MetricsConfig) ([]Metric, error) {
+	columnOIDs := make(map[string]ddprofiledefinition.SymbolConfig)
+	for _, sym := range cfg.Symbols {
+		columnOIDs[trimOID(sym.OID)] = sym
+	}
+
+	tagColumnOIDs := make(map[string]ddprofiledefinition.MetricTagConfig)
 	for _, tagCfg := range cfg.MetricTags {
-		if tagCfg.Table != "" && tagCfg.Table != cfg.Table.Name {
-			c.log.Debugf("Skipping table %s: has cross-table tag from %s", cfg.Table.Name, tagCfg.Table)
-			return nil, nil
+		if tagCfg.Table == "" || tagCfg.Table == cfg.Table.Name {
+			tagColumnOIDs[trimOID(tagCfg.Symbol.OID)] = tagCfg
 		}
-		if len(tagCfg.IndexTransform) > 0 {
-			c.log.Debugf("Skipping table %s: has index transformation", cfg.Table.Name)
-			return nil, nil
+	}
+
+	if cachedOIDs, cachedTags, ok := c.tableCache.getCachedData(cfg.Table.OID); ok {
+		metrics, err := c.collectTableWithCache(cfg, cachedOIDs, cachedTags, columnOIDs)
+		if err == nil {
+			c.log.Debugf("Successfully collected table %s using cache", cfg.Table.Name)
+			return metrics, nil
 		}
+		c.log.Debugf("Cached collection failed for table %s, falling back to walk: %v", cfg.Table.Name, err)
 	}
 
 	pdus, err := c.snmpWalk(cfg.Table.OID)
@@ -71,28 +91,18 @@ func (c *Collector) collectSingleTable(cfg ddprofiledefinition.MetricsConfig) ([
 		return nil, nil
 	}
 
-	symColumnOIDs := make(map[string]ddprofiledefinition.SymbolConfig)
-	for _, sym := range cfg.Symbols {
-		symColumnOIDs[trimOID(sym.OID)] = sym
-	}
-
-	tagColumnOIDs := make(map[string]ddprofiledefinition.MetricTagConfig)
-	for _, tagCfg := range cfg.MetricTags {
-		if tagCfg.Table == "" || tagCfg.Table == cfg.Table.Name {
-			tagColumnOIDs[trimOID(tagCfg.Symbol.OID)] = tagCfg
-		}
-	}
-
-	allColumnOIDs := make([]string, 0, len(symColumnOIDs)+len(tagColumnOIDs))
-	for oid := range symColumnOIDs {
+	allColumnOIDs := make([]string, 0, len(columnOIDs)+len(tagColumnOIDs))
+	for oid := range columnOIDs {
 		allColumnOIDs = append(allColumnOIDs, oid)
 	}
 	for oid := range tagColumnOIDs {
 		allColumnOIDs = append(allColumnOIDs, oid)
 	}
 
-	// Group PDUs by row index (index -> column OID -> PDU)
-	rows := make(map[string]map[string]gosnmp.SnmpPDU, len(pdus)/len(allColumnOIDs))
+	// Group PDUs by row index and build cache structure
+	rows := make(map[string]map[string]gosnmp.SnmpPDU)
+	oidCache := make(map[string]map[string]string) // For caching: index -> column OID -> full OID
+	tagCache := make(map[string]map[string]string) // For caching: index -> tag name -> value
 
 	for oid, pdu := range pdus {
 		for _, columnOID := range allColumnOIDs {
@@ -101,87 +111,165 @@ func (c *Collector) collectSingleTable(cfg ddprofiledefinition.MetricsConfig) ([
 
 				if rows[index] == nil {
 					rows[index] = make(map[string]gosnmp.SnmpPDU)
+					oidCache[index] = make(map[string]string)
+					tagCache[index] = make(map[string]string)
 				}
 				rows[index][columnOID] = pdu
+				oidCache[index][columnOID] = oid
 				break
 			}
 		}
 	}
 
-	var metrics []Metric
-	for index, rowPDUs := range rows {
-		rowMetrics, err := c.processTableRow(rowPDUs, symColumnOIDs, tagColumnOIDs, cfg.StaticTags)
-		if err != nil {
-			c.log.Debugf("Error processing row %s: %v", index, err)
-			continue
+	rowStaticTags := make(map[string]string)
+	for _, tag := range cfg.StaticTags {
+		if n, v, _ := strings.Cut(tag, ":"); n != "" && v != "" {
+			rowStaticTags[n] = v
 		}
-		metrics = append(metrics, rowMetrics...)
 	}
+
+	var metrics []Metric
+
+	for index, rowPDUs := range rows {
+		rowTags := make(map[string]string)
+
+		for columnOID, tagCfg := range tagColumnOIDs {
+			pdu, ok := rowPDUs[columnOID]
+			if !ok {
+				continue
+			}
+
+			tags, err := processTableMetricTagValue(tagCfg, pdu)
+			if err != nil {
+				c.log.Debugf("Error processing tag %s: %v", tagCfg.Tag, err)
+				continue
+			}
+
+			for k, v := range tags {
+				rowTags[k] = v
+				tagCache[index][k] = v
+			}
+		}
+
+		for columnOID, sym := range columnOIDs {
+			pdu, ok := rowPDUs[columnOID]
+			if !ok {
+				continue
+			}
+
+			value, err := processSymbolValue(sym, pdu)
+			if err != nil {
+				c.log.Debugf("Error processing value for %s: %v", sym.Name, err)
+				continue
+			}
+
+			metric := Metric{
+				Name:        sym.Name,
+				Value:       value,
+				StaticTags:  ternary(len(rowStaticTags) > 0, rowStaticTags, nil),
+				Tags:        maps.Clone(ternary(len(rowTags) > 0, rowTags, nil)),
+				Unit:        sym.Unit,
+				Description: sym.Description,
+				MetricType:  getMetricType(sym, pdu),
+				Family:      sym.Family,
+				Mappings:    convSymMappingToNumeric(sym),
+				IsTable:     true,
+			}
+
+			metrics = append(metrics, metric)
+		}
+	}
+
+	c.tableCache.cacheData(cfg.Table.OID, oidCache, tagCache)
+	c.log.Debugf("Cached table %s structure with %d rows", cfg.Table.Name, len(oidCache))
 
 	return metrics, nil
 }
 
-func (c *Collector) processTableRow(
-	rowPDUs map[string]gosnmp.SnmpPDU,
+func (c *Collector) collectTableWithCache(
+	cfg ddprofiledefinition.MetricsConfig,
+	cachedOIDs map[string]map[string]string,
+	cachedTags map[string]map[string]string,
 	columnOIDs map[string]ddprofiledefinition.SymbolConfig,
-	tagColumnOIDs map[string]ddprofiledefinition.MetricTagConfig,
-	staticTags []string,
 ) ([]Metric, error) {
+	var oidsToGet []string
+	oidToLocation := make(map[string]struct{ index, column string }) // full OID -> location
+
+	for index, columns := range cachedOIDs {
+		for columnOID, fullOID := range columns {
+			// Only GET metric columns, tags are cached
+			if _, isMetric := columnOIDs[columnOID]; isMetric {
+				oidsToGet = append(oidsToGet, fullOID)
+				oidToLocation[trimOID(fullOID)] = struct{ index, column string }{index, columnOID}
+			}
+		}
+	}
+
+	if len(oidsToGet) == 0 {
+		return nil, nil
+	}
+
+	pdus, err := c.snmpGet(oidsToGet)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cached OIDs: %w", err)
+	}
+
+	if len(pdus) < len(oidsToGet)/2 { // If we got less than half, probably table structure changed
+		return nil, fmt.Errorf("table structure may have changed, got %d/%d PDUs", len(pdus), len(oidsToGet))
+	}
+
+	rowStaticTags := make(map[string]string)
+
+	for _, tag := range cfg.StaticTags {
+		if n, v, _ := strings.Cut(tag, ":"); n != "" && v != "" {
+			rowStaticTags[n] = v
+		}
+	}
+
 	var metrics []Metric
 
-	// Process tags first to ensure all metrics in the row get the same tags
-	rowTags := make(map[string]string)
+	for index, columns := range cachedOIDs {
+		rowTags := make(map[string]string)
 
-	for _, tag := range staticTags {
-		if n, v, _ := strings.Cut(tag, ":"); n != "" && v != "" {
-			rowTags[n] = v
-		}
-	}
-
-	for columnOID, tagCfg := range tagColumnOIDs {
-		pdu, ok := rowPDUs[columnOID]
-		if !ok {
-			continue
+		if tags, ok := cachedTags[index]; ok {
+			for k, v := range tags {
+				rowTags[k] = v
+			}
 		}
 
-		tags, err := processTableMetricTagValue(tagCfg, pdu)
-		if err != nil {
-			c.log.Debugf("Error processing tag %s: %v", tagCfg.Tag, err)
-			continue
+		for columnOID, fullOID := range columns {
+			sym, isMetric := columnOIDs[columnOID]
+			if !isMetric {
+				continue
+			}
+
+			pdu, ok := pdus[trimOID(fullOID)]
+			if !ok {
+				c.log.Debugf("Missing PDU for cached OID %s", fullOID)
+				continue
+			}
+
+			value, err := processSymbolValue(sym, pdu)
+			if err != nil {
+				c.log.Debugf("Error processing value for %s: %v", sym.Name, err)
+				continue
+			}
+
+			metric := Metric{
+				Name:        sym.Name,
+				Value:       value,
+				StaticTags:  ternary(len(rowStaticTags) > 0, rowStaticTags, nil),
+				Tags:        ternary(len(rowTags) > 0, rowTags, nil),
+				Unit:        sym.Unit,
+				Description: sym.Description,
+				MetricType:  getMetricType(sym, pdu),
+				Family:      sym.Family,
+				Mappings:    convSymMappingToNumeric(sym),
+				IsTable:     true,
+			}
+
+			metrics = append(metrics, metric)
 		}
-
-		for k, v := range tags {
-			rowTags[k] = v
-		}
-	}
-
-	for columnOID, sym := range columnOIDs {
-		pdu, ok := rowPDUs[columnOID]
-		if !ok {
-			continue
-		}
-
-		value, err := processSymbolValue(sym, pdu)
-		if err != nil {
-			c.log.Debugf("Error processing value for %s: %v", sym.Name, err)
-			continue
-		}
-
-		metric := Metric{
-			Name:        sym.Name,
-			Value:       value,
-			Tags:        make(map[string]string),
-			Unit:        sym.Unit,
-			Description: sym.Description,
-			MetricType:  getMetricType(sym, pdu),
-			Family:      sym.Family,
-			Mappings:    convSymMappingToNumeric(sym),
-			IsTable:     true,
-		}
-
-		maps.Copy(metric.Tags, rowTags)
-
-		metrics = append(metrics, metric)
 	}
 
 	return metrics, nil

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_test.go
@@ -76,7 +76,6 @@ func TestCollector_Collect(t *testing.T) {
 						{
 							Name:       "sysUpTime",
 							Value:      123456,
-							Tags:       map[string]string{},
 							MetricType: "gauge",
 						},
 						// sysName will be skipped because it can't be converted to int64
@@ -140,11 +139,11 @@ func TestCollector_Collect(t *testing.T) {
 			expectedResult: []*ProfileMetrics{
 				{
 					DeviceMetadata: nil,
+					Tags:           map[string]string{"device_vendor": "Cisco IOS"},
 					Metrics: []Metric{
 						{
 							Name:       "sysUpTime",
 							Value:      123456,
-							Tags:       map[string]string{"device_vendor": "Cisco IOS"},
 							MetricType: "gauge",
 						},
 					},
@@ -220,7 +219,6 @@ func TestCollector_Collect(t *testing.T) {
 						{
 							Name:       "sysUpTime",
 							Value:      123456,
-							Tags:       map[string]string{},
 							MetricType: "gauge",
 						},
 					},
@@ -266,7 +264,6 @@ func TestCollector_Collect(t *testing.T) {
 						{
 							Name:       "memoryKilobytes",
 							Value:      1024000, // 1024 * 1000
-							Tags:       map[string]string{},
 							MetricType: "gauge",
 						},
 					},
@@ -395,7 +392,6 @@ func TestCollector_Collect(t *testing.T) {
 						{
 							Name:       "sysUpTime",
 							Value:      123456,
-							Tags:       map[string]string{},
 							MetricType: "gauge",
 						},
 					},
@@ -441,7 +437,6 @@ func TestCollector_Collect(t *testing.T) {
 						{
 							Name:       "temperature",
 							Value:      25,
-							Tags:       map[string]string{},
 							MetricType: "gauge",
 						},
 					},
@@ -508,11 +503,11 @@ func TestCollector_Collect(t *testing.T) {
 			expectedResult: []*ProfileMetrics{
 				{
 					DeviceMetadata: nil,
+					Tags:           map[string]string{"device_type": "router"},
 					Metrics: []Metric{
 						{
 							Name:       "sysUpTime",
 							Value:      123456,
-							Tags:       map[string]string{"device_type": "router"},
 							MetricType: "gauge",
 						},
 					},
@@ -582,7 +577,6 @@ func TestCollector_Collect(t *testing.T) {
 						{
 							Name:       "clusterHealth",
 							Value:      1,
-							Tags:       map[string]string{},
 							MetricType: "gauge",
 							Mappings: map[int64]string{
 								0: "OK",
@@ -639,7 +633,6 @@ func TestCollector_Collect(t *testing.T) {
 						{
 							Name:       "ifOperStatus",
 							Value:      2,
-							Tags:       map[string]string{},
 							MetricType: "gauge",
 							Mappings: map[int64]string{
 								1: "up",
@@ -697,7 +690,6 @@ func TestCollector_Collect(t *testing.T) {
 						{
 							Name:       "fanStatus",
 							Value:      2,
-							Tags:       map[string]string{},
 							MetricType: "gauge",
 							Mappings: map[int64]string{
 								1: "normal",
@@ -752,7 +744,6 @@ func TestCollector_Collect(t *testing.T) {
 						{
 							Name:       "ifAdminStatus",
 							Value:      0, // mapped from 2 -> 0
-							Tags:       map[string]string{},
 							MetricType: "gauge",
 							Mappings: map[int64]string{
 								1: "1",
@@ -878,7 +869,6 @@ func TestCollector_Collect(t *testing.T) {
 						{
 							Name:       "sysUpTime",
 							Value:      123456,
-							Tags:       map[string]string{},
 							MetricType: "gauge",
 							Mappings:   nil, // No mappings
 						},
@@ -1215,10 +1205,12 @@ func TestCollector_Collect(t *testing.T) {
 						{
 							Name:  "myMetric",
 							Value: 100,
-							Tags: map[string]string{
+							StaticTags: map[string]string{
 								"table_type": "performance",
 								"source":     "snmp",
-								"interface":  "eth0",
+							},
+							Tags: map[string]string{
+								"interface": "eth0",
 							},
 							MetricType: ddprofiledefinition.ProfileMetricTypeGauge,
 							IsTable:    true,
@@ -1299,7 +1291,7 @@ func TestCollector_Collect(t *testing.T) {
 						{
 							Name:       "ifInOctets",
 							Value:      2000,
-							Tags:       map[string]string{}, // No interface tag because it's missing
+							Tags:       nil, // No interface tag because it's missing
 							MetricType: ddprofiledefinition.ProfileMetricTypeRate,
 							IsTable:    true,
 						},
@@ -1320,6 +1312,7 @@ func TestCollector_Collect(t *testing.T) {
 
 			collector := New(mockHandler, tc.profiles, logger.New())
 			collector.doTableMetrics = true
+			collector.tableCache.setTTL(0, 0)
 
 			result, err := collector.Collect()
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_cache.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_cache.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// Table Cache Overview:
+// The table cache converts repeated SNMP walks into efficient GET operations.
+// - First collection: Full walk, cache structure and tags
+// - Subsequent collections: GET metrics only, use cached tags
+// - Per-table TTL with jitter prevents simultaneous refreshes
+
+type tableCache struct {
+	// Table OID -> row index -> column OID -> full OID
+	tables map[string]map[string]map[string]string
+
+	// Table OID -> when cached
+	timestamps map[string]time.Time
+
+	// Table OID -> specific TTL for this table (with jitter applied)
+	tableTTLs map[string]time.Duration
+
+	// Table OID -> tag values (index -> tag name -> value)
+	tagValues map[string]map[string]map[string]string
+
+	baseTTL   time.Duration
+	jitterPct float64
+	mu        sync.RWMutex
+	rng       *rand.Rand
+}
+
+func newTableCache(baseTTL time.Duration, jitterPct float64) *tableCache {
+	return &tableCache{
+		tables:     make(map[string]map[string]map[string]string),
+		timestamps: make(map[string]time.Time),
+		tableTTLs:  make(map[string]time.Duration),
+		tagValues:  make(map[string]map[string]map[string]string),
+		baseTTL:    baseTTL,
+		jitterPct:  jitterPct,
+		rng:        rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+func (tc *tableCache) calculateTableTTL() time.Duration {
+	base := float64(tc.baseTTL)
+	jitter := tc.jitterPct
+
+	// Random jitter between -jitterPct and +jitterPct
+	// Note: This is called from within lock, so don't acquire lock here
+	randFloat := tc.rng.Float64()
+	multiplier := 1.0 + (randFloat*2-1)*jitter
+
+	return time.Duration(base * multiplier)
+}
+
+func (tc *tableCache) getCachedData(tableOID string) (oids map[string]map[string]string, tags map[string]map[string]string, found bool) {
+	tc.mu.RLock()
+	defer tc.mu.RUnlock()
+
+	if tc.baseTTL == 0 {
+		return nil, nil, false
+	}
+
+	timestamp, exists := tc.timestamps[tableOID]
+	if !exists {
+		return nil, nil, false
+	}
+
+	ttl, exists := tc.tableTTLs[tableOID]
+	if !exists || time.Since(timestamp) > ttl {
+		return nil, nil, false
+	}
+
+	oids = tc.tables[tableOID]
+	tags = tc.tagValues[tableOID]
+	return oids, tags, true
+}
+
+func (tc *tableCache) cacheData(tableOID string, oidMap map[string]map[string]string, tagValues map[string]map[string]string) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	if tc.baseTTL == 0 {
+		return
+	}
+
+	// Deep copy the maps to avoid reference issues
+	oidsCopy := make(map[string]map[string]string, len(oidMap))
+	for index, columns := range oidMap {
+		columnsCopy := make(map[string]string, len(columns))
+		for colOID, fullOID := range columns {
+			columnsCopy[colOID] = fullOID
+		}
+		oidsCopy[index] = columnsCopy
+	}
+
+	tagsCopy := make(map[string]map[string]string, len(tagValues))
+	for index, tags := range tagValues {
+		tagCopy := make(map[string]string, len(tags))
+		for name, value := range tags {
+			tagCopy[name] = value
+		}
+		tagsCopy[index] = tagCopy
+	}
+
+	tc.tables[tableOID] = oidsCopy
+	tc.tagValues[tableOID] = tagsCopy
+	tc.timestamps[tableOID] = time.Now()
+	tc.tableTTLs[tableOID] = tc.calculateTableTTL()
+}
+
+func (tc *tableCache) clearExpired() []string {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	var expired []string
+	now := time.Now()
+
+	for tableOID, timestamp := range tc.timestamps {
+		ttl := tc.tableTTLs[tableOID]
+		if now.Sub(timestamp) > ttl {
+			delete(tc.tables, tableOID)
+			delete(tc.timestamps, tableOID)
+			delete(tc.tableTTLs, tableOID)
+			delete(tc.tagValues, tableOID)
+			expired = append(expired, tableOID)
+		}
+	}
+
+	return expired
+}
+
+func (tc *tableCache) setTTL(baseTTL time.Duration, jitterPct float64) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	tc.baseTTL = baseTTL
+	tc.jitterPct = jitterPct
+
+	if baseTTL == 0 {
+		// Clear cache if caching is disabled
+		tc.tables = make(map[string]map[string]map[string]string)
+		tc.timestamps = make(map[string]time.Time)
+		tc.tableTTLs = make(map[string]time.Duration)
+		tc.tagValues = make(map[string]map[string]map[string]string)
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_cache_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_cache_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableCache(t *testing.T) {
+	tests := map[string]struct {
+		name string
+	}{
+		"basic cache operations": {},
+	}
+
+	for name := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Create cache with 100ms TTL and 20% jitter
+			cache := newTableCache(100*time.Millisecond, 0.2)
+
+			// Test data
+			tableOID := "1.3.6.1.2.1.2.2"
+			oidMap := map[string]map[string]string{
+				"1": {
+					"1.3.6.1.2.1.2.2.1.2":  "1.3.6.1.2.1.2.2.1.2.1",
+					"1.3.6.1.2.1.2.2.1.10": "1.3.6.1.2.1.2.2.1.10.1",
+				},
+				"2": {
+					"1.3.6.1.2.1.2.2.1.2":  "1.3.6.1.2.1.2.2.1.2.2",
+					"1.3.6.1.2.1.2.2.1.10": "1.3.6.1.2.1.2.2.1.10.2",
+				},
+			}
+			tagValues := map[string]map[string]string{
+				"1": {"interface": "eth0"},
+				"2": {"interface": "eth1"},
+			}
+
+			// Cache data
+			cache.cacheData(tableOID, oidMap, tagValues)
+
+			// Retrieve cached data - should work
+			cachedOIDs, cachedTags, found := cache.getCachedData(tableOID)
+			assert.True(t, found)
+			assert.Equal(t, oidMap, cachedOIDs)
+			assert.Equal(t, tagValues, cachedTags)
+
+			// Wait for expiration (considering jitter)
+			time.Sleep(150 * time.Millisecond)
+
+			// Should be expired now
+			_, _, found = cache.getCachedData(tableOID)
+			assert.False(t, found)
+
+			// Clean expired entries
+			expired := cache.clearExpired()
+			assert.Contains(t, expired, tableOID)
+
+			// Cache should be empty now
+			assert.Empty(t, cache.tables)
+			assert.Empty(t, cache.timestamps)
+			assert.Empty(t, cache.tableTTLs)
+			assert.Empty(t, cache.tagValues)
+		})
+	}
+}
+
+func TestTableCacheJitter(t *testing.T) {
+	cache := newTableCache(1*time.Second, 0.2) // 1 second with 20% jitter
+
+	// Calculate multiple TTLs to verify jitter
+	ttls := make([]time.Duration, 10)
+	for i := range ttls {
+		ttls[i] = cache.calculateTableTTL()
+		time.Sleep(1 * time.Millisecond) // Ensure different timestamps
+	}
+
+	// All TTLs should be between 800ms and 1200ms (±20%)
+	for _, ttl := range ttls {
+		assert.GreaterOrEqual(t, ttl, 800*time.Millisecond)
+		assert.LessOrEqual(t, ttl, 1200*time.Millisecond)
+	}
+
+	// Verify they're not all the same (jitter is working)
+	uniqueTTLs := make(map[time.Duration]bool)
+	for _, ttl := range ttls {
+		uniqueTTLs[ttl] = true
+	}
+	assert.Greater(t, len(uniqueTTLs), 1, "Expected different TTLs due to jitter")
+}
+
+func TestTableCacheDisabled(t *testing.T) {
+	cache := newTableCache(0, 0) // Disabled cache
+
+	tableOID := "1.3.6.1.2.1.2.2"
+	oidMap := map[string]map[string]string{
+		"1": {"1.3.6.1.2.1.2.2.1.2": "1.3.6.1.2.1.2.2.1.2.1"},
+	}
+	tagValues := map[string]map[string]string{
+		"1": {"interface": "eth0"},
+	}
+
+	// Try to cache data
+	cache.cacheData(tableOID, oidMap, tagValues)
+
+	// Should not find anything
+	_, _, found := cache.getCachedData(tableOID)
+	assert.False(t, found)
+
+	// Cache should remain empty
+	assert.Empty(t, cache.tables)
+}
+
+func TestTableCacheDeepCopy(t *testing.T) {
+	cache := newTableCache(1*time.Hour, 0)
+
+	// Original data
+	oidMap := map[string]map[string]string{
+		"1": {"col1": "1.2.3.4.1"},
+	}
+	tagValues := map[string]map[string]string{
+		"1": {"tag1": "value1"},
+	}
+
+	// Cache the data
+	cache.cacheData("table1", oidMap, tagValues)
+
+	// Modify original maps
+	oidMap["1"]["col2"] = "should not appear"
+	tagValues["1"]["tag2"] = "should not appear"
+
+	// Retrieve cached data
+	cachedOIDs, cachedTags, found := cache.getCachedData("table1")
+	require.True(t, found)
+
+	// Cached data should not have the modifications
+	assert.NotContains(t, cachedOIDs["1"], "col2")
+	assert.NotContains(t, cachedTags["1"], "tag2")
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
@@ -250,3 +250,14 @@ func isMappingKeysNumeric(mapping map[string]string) bool {
 	}
 	return true
 }
+func cleanTags(metrics []*ProfileMetrics) {
+	for _, pm := range metrics {
+		for _, m := range pm.Metrics {
+			for k, v := range m.Tags {
+				m.Tags[k] = tagReplacer.Replace(v)
+			}
+		}
+	}
+}
+
+var tagReplacer = strings.NewReplacer("'", "", "\n", " ", "\r", " ")


### PR DESCRIPTION
##### Summary

The table cache converts repeated SNMP walks into efficient GET operations:

- First collection: Full walk, cache structure and tags
- Subsequent collections: GET metrics only, use cached tags
- Per-table TTL with jitter prevents simultaneous refreshes

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
