### PR TITLE
Remove static build timeouts from regular builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,20 +307,10 @@ jobs:
           sudo apt-get upgrade -y
           sudo apt-get install -y qemu-user-static
       - name: Build
-        if: github.event_name != 'workflow_dispatch' && needs.file-check.outputs.run == 'true' # Don’t use retries on PRs.
+        if: needs.file-check.outputs.run == 'true'
         run: |
           [ "${{ matrix.qemu }}" == "true" ] || export SKIP_EMULATION=1
           .github/scripts/build-static.sh ${{ matrix.arch }}
-      - name: Build
-        if: github.event_name == 'workflow_dispatch' && needs.file-check.outputs.run == 'true'
-        id: build
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 150
-          max_attempts: 2
-          command: |
-            [ "${{ matrix.qemu }}" == "true" ] || export SKIP_EMULATION=1
-            .github/scripts/build-static.sh ${{ matrix.arch }}
       - name: Store
         id: store
         if: needs.file-check.outputs.run == 'true'


### PR DESCRIPTION
##### Summary

The builds take in excess of 2.5 hours now, and trying to use a longer timeout runs the risk of the whole job being cancelled due to the hard limit from GHA itself, so we can’t realistically do automatic retries anymore.

##### Test Plan

n/a