### PR TITLE
Enable Rust-based journal file reader in static builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2885,7 +2885,7 @@ if(ENABLE_PLUGIN_SYSTEMD_JOURNAL)
                 FetchContent_MakeAvailable(Corrosion)
 
                 corrosion_import_crate(MANIFEST_PATH src/crates/jf/Cargo.toml)
-                corrosion_add_target_rustflags(journal_reader_ffi -Ctarget-feature=+crt-static)
+                corrosion_add_target_local_rustflags(journal_reader_ffi "-Ctarget-feature=+crt-static")
                 target_compile_definitions(systemd-journal.plugin PRIVATE HAVE_RUST_PROVIDER)
                 target_link_libraries(systemd-journal.plugin journal_reader_ffi)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2885,7 +2885,6 @@ if(ENABLE_PLUGIN_SYSTEMD_JOURNAL)
                 FetchContent_MakeAvailable(Corrosion)
 
                 corrosion_import_crate(MANIFEST_PATH src/crates/jf/Cargo.toml)
-                corrosion_add_target_rustflags(journal_reader_ffi -Ctarget-feature=+crt-static)
                 target_compile_definitions(systemd-journal.plugin PRIVATE HAVE_RUST_PROVIDER)
                 target_link_libraries(systemd-journal.plugin journal_reader_ffi)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2885,7 +2885,7 @@ if(ENABLE_PLUGIN_SYSTEMD_JOURNAL)
                 FetchContent_MakeAvailable(Corrosion)
 
                 corrosion_import_crate(MANIFEST_PATH src/crates/jf/Cargo.toml)
-                corrosion_add_target_local_rustflags(journal_reader_ffi "-Ctarget-feature=+crt-static")
+                corrosion_add_target_rustflags(journal_reader_ffi -Ctarget-feature=+crt-static)
                 target_compile_definitions(systemd-journal.plugin PRIVATE HAVE_RUST_PROVIDER)
                 target_link_libraries(systemd-journal.plugin journal_reader_ffi)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1787,6 +1787,7 @@ set(STATSD_PLUGIN_FILES
 
 set(SYSTEMD_JOURNAL_PLUGIN_FILES
         src/collectors/systemd-journal.plugin/systemd-journal.c
+        src/collectors/systemd-journal.plugin/systemd-journal-fstat.c
         src/collectors/systemd-journal.plugin/systemd-internals.h
         src/collectors/systemd-journal.plugin/systemd-main.c
         src/collectors/systemd-journal.plugin/systemd-journal.c
@@ -2868,11 +2869,6 @@ if(ENABLE_PLUGIN_SYSTEMD_JOURNAL AND NOT SYSTEMD_FOUND)
 endif()
 
 if(ENABLE_PLUGIN_SYSTEMD_JOURNAL)
-        if(NOT ENABLE_NETDATA_JOURNAL_FILE_READER)
-                # enable fstat caching only when we do not use our journal file reader implementation
-                list(APPEND SYSTEMD_JOURNAL_PLUGIN_FILES src/collectors/systemd-journal.plugin/systemd-journal-fstat.c)
-        endif()
-
         add_executable(systemd-journal.plugin ${SYSTEMD_JOURNAL_PLUGIN_FILES})
 
         if(ENABLE_NETDATA_JOURNAL_FILE_READER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2885,6 +2885,7 @@ if(ENABLE_PLUGIN_SYSTEMD_JOURNAL)
                 FetchContent_MakeAvailable(Corrosion)
 
                 corrosion_import_crate(MANIFEST_PATH src/crates/jf/Cargo.toml)
+                corrosion_add_target_rustflags(journal_reader_ffi -Ctarget-feature=+crt-static)
                 target_compile_definitions(systemd-journal.plugin PRIVATE HAVE_RUST_PROVIDER)
                 target_link_libraries(systemd-journal.plugin journal_reader_ffi)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1792,7 +1792,6 @@ set(SYSTEMD_JOURNAL_PLUGIN_FILES
         src/collectors/systemd-journal.plugin/systemd-journal.c
         src/collectors/systemd-journal.plugin/systemd-journal-annotations.c
         src/collectors/systemd-journal.plugin/systemd-journal-files.c
-        src/collectors/systemd-journal.plugin/systemd-journal-fstat.c
         src/collectors/systemd-journal.plugin/systemd-journal-watcher.c
         src/collectors/systemd-journal.plugin/systemd-journal-dyncfg.c
         src/collectors/systemd-journal.plugin/provider/netdata_provider.c
@@ -2869,6 +2868,11 @@ if(ENABLE_PLUGIN_SYSTEMD_JOURNAL AND NOT SYSTEMD_FOUND)
 endif()
 
 if(ENABLE_PLUGIN_SYSTEMD_JOURNAL)
+        if(NOT ENABLE_NETDATA_JOURNAL_FILE_READER)
+                # enable fstat caching only when we do not use our journal file reader implementation
+                list(APPEND SYSTEMD_JOURNAL_PLUGIN_FILES src/collectors/systemd-journal.plugin/systemd-journal-fstat.c)
+        endif()
+
         add_executable(systemd-journal.plugin ${SYSTEMD_JOURNAL_PLUGIN_FILES})
 
         if(ENABLE_NETDATA_JOURNAL_FILE_READER)

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -215,6 +215,7 @@ USAGE: ${PROGRAM} [options]
   --disable-plugin-xenstat   Explicitly disable the xenstat plugin.
   --enable-plugin-systemd-journal Enable the systemd journal plugin. Default: enable it when libsystemd is available.
   --disable-plugin-systemd-journal Explicitly disable the systemd journal plugin.
+  --internal-systemd-journal Enable the internal journal file reader instead of using libsystemd
   --enable-exporting-kinesis Enable AWS Kinesis exporting connector. Default: enable it when libaws_cpp_sdk_kinesis
                              and its dependencies are available.
   --disable-exporting-kinesis Explicitly disable AWS Kinesis exporting connector.
@@ -294,6 +295,7 @@ while [ -n "${1}" ]; do
     "--disable-plugin-xenstat") ENABLE_XENSTAT=0 ;;
     "--enable-plugin-systemd-journal") ENABLE_SYSTEMD_JOURNAL=1 ;;
     "--disable-plugin-systemd-journal") ENABLE_SYSTEMD_JOURNAL=0 ;;
+    "--internal-systemd-journal") USE_RUST_JOURNAL_FILE=1 ;;
     "--enable-exporting-kinesis" | "--enable-backend-kinesis")
       # TODO: Needs CMake Support
       ;;

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -330,18 +330,24 @@ prepare_cmake_options() {
   fi
 
   if [ -z "${ENABLE_SYSTEMD_JOURNAL}" ]; then
-      if check_for_module libsystemd; then
-          if check_for_module libelogind; then
-              ENABLE_SYSTEMD_JOURNAL=0
-          else
-              ENABLE_SYSTEMD_JOURNAL=1
-          fi
+    if check_for_module libsystemd; then
+      if check_for_module libelogind; then
+        ENABLE_SYSTEMD_JOURNAL=0
       else
-          ENABLE_SYSTEMD_JOURNAL=0
+        ENABLE_SYSTEMD_JOURNAL=1
       fi
+    else
+      ENABLE_SYSTEMD_JOURNAL=0
+    fi
   fi
 
   enable_feature PLUGIN_SYSTEMD_JOURNAL "${ENABLE_SYSTEMD_JOURNAL}"
+
+  if [ "${ENABLE_SYSTEMD_JOURNAL}" -eq 1 ] && [ -n "${USE_RUST_JOURNAL_FILE}" ]; then
+    enable_feature NETDATA_JOURNAL_FILE_READER 1
+  else
+    enable_feature NETDATA_JOURNAL_FILE_READER 0
+  fi
 
   if check_for_module 'libsystemd >= 221'; then
     enable_feature PLUGIN_SYSTEMD_UNITS 1

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -30,6 +30,8 @@ case "${BUILDARCH}" in
     *) export NETDATA_CMAKE_OPTIONS="-DENABLE_LIBBACKTRACE=On"
 esac
 
+export RUSTFLAGS="-C target-feature=+crt-static"
+
 run ./netdata-installer.sh \
   --install-prefix "${NETDATA_INSTALL_PARENT}" \
   --dont-wait \

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -35,6 +35,7 @@ run ./netdata-installer.sh \
   --dont-wait \
   --dont-start-it \
   --disable-exporting-mongodb \
+  --internal-systemd-journal \
   --dont-scrub-cflags-even-though-it-may-break-things \
   --one-time-build \
   --enable-lto \

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -27,7 +27,14 @@ NETDATA_BUILD_DIR="$(build_path netdata)"
 export NETDATA_BUILD_DIR
 
 case "${BUILDARCH}" in
-    *) export NETDATA_CMAKE_OPTIONS="-DENABLE_LIBBACKTRACE=On"
+    armv6l)
+        export NETDATA_CMAKE_OPTIONS="-DENABLE_LIBBACKTRACE=On"
+        export INSTALLER_ARGS="--disable-plugin-systemd-journal"
+        ;;
+    *)
+        export NETDATA_CMAKE_OPTIONS="-DENABLE_LIBBACKTRACE=On"
+        export INSTALLER_ARGS="--enable-plugin-systemd-journal --internal-systemd-journal"
+        ;;
 esac
 
 export RUSTFLAGS="-C target-feature=+crt-static"
@@ -38,8 +45,8 @@ run ./netdata-installer.sh \
   --dont-start-it \
   --disable-exporting-mongodb \
   --enable-plugin-systemd-journal \
-  --internal-systemd-journal \
   --dont-scrub-cflags-even-though-it-may-break-things \
   --one-time-build \
   --enable-lto \
+  ${INSTALLER_ARGS:+${INSTALLER_ARGS}} \
   ${EXTRA_INSTALL_FLAGS:+${EXTRA_INSTALL_FLAGS}} \

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -35,6 +35,7 @@ run ./netdata-installer.sh \
   --dont-wait \
   --dont-start-it \
   --disable-exporting-mongodb \
+  --enable-plugin-systemd-journal \
   --internal-systemd-journal \
   --dont-scrub-cflags-even-though-it-may-break-things \
   --one-time-build \

--- a/src/collectors/systemd-journal.plugin/systemd-journal-fstat.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-fstat.c
@@ -2,6 +2,8 @@
 
 #include "systemd-internals.h"
 
+#if !defined(HAVE_RUST_PROVIDER)
+
 // ----------------------------------------------------------------------------
 // fstat64 overloading to speed up libsystemd
 // https://github.com/systemd/systemd/pull/29261
@@ -76,3 +78,16 @@ int fstat64(int fd, struct stat64 *buf)
 
     return ret;
 }
+
+#else // HAVE_RUST_PROVIDER
+
+// When using Rust provider, disable fstat caching entirely since
+// we will not rely on libsystemd.
+
+__thread size_t fstat_thread_calls = 0;
+__thread size_t fstat_thread_cached_responses = 0;
+
+void fstat_cache_enable_on_thread(void) { }
+void fstat_cache_disable_on_thread(void) { }
+
+#endif

--- a/src/collectors/systemd-journal.plugin/systemd-journal-fstat.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-fstat.c
@@ -1,9 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-
 #include "systemd-internals.h"
 
 // ----------------------------------------------------------------------------

--- a/src/collectors/systemd-journal.plugin/systemd-journal-fstat.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-fstat.c
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include "systemd-internals.h"
 
 // ----------------------------------------------------------------------------

--- a/src/crates/jf/Cargo.toml
+++ b/src/crates/jf/Cargo.toml
@@ -2,13 +2,13 @@
 resolver = "2"
 members = [
     "error",
-    "main",
+    # "main",
     "journal_file",
-    "journal_writer",
+    # "journal_writer",
     "journal_reader",
     "journal_reader_ffi",
-    "journal_logger",
-    "journal_forwarder",
+    # "journal_logger",
+    # "journal_forwarder",
     "window_manager",
     "sigbus",
 ]
@@ -29,7 +29,7 @@ duct = "0.13"
 serde_json = "1.0"
 walkdir = "2"
 ruzstd = "0.8"
-systemd = { path = "/home/vk/repos/crates/rust-systemd"}
+# systemd = { path = "/home/vk/repos/crates/rust-systemd"}
 libc = "0.2"
 
 [profile.release]


### PR DESCRIPTION
##### Summary

This also adds an option to the `netdata-installer.sh` script to enable it when running that script, called `--internal-systemd-journal`.

##### Test Plan

Basic testing requires confirming that CI passes on this PR.

Prior to merging this requires additional testing to confirm that the systemd-journal plugin is built and included in the static builds.