### PR TITLE
Correctly ignore patches that are already applied.

### DIFF
--- a/packaging/cmake/patches/apply-patches.sh
+++ b/packaging/cmake/patches/apply-patches.sh
@@ -3,10 +3,16 @@
 SRC_DIR="${1}"
 PATCH_DIR="${2}"
 
-set -e
-
-cd "${SRC_DIR}"
+cd "${SRC_DIR}" || exit 1
 
 for patch_file in "${PATCH_DIR}"/*; do
-    patch -p1 -i "${patch_file}"
+    patch -p1 --forward -i "${patch_file}"
+    ret="${?}"
+
+    # We want to ignore patches that are already applied instead of
+    # failing the patching process, and patch returns 1 for a patch that
+    # is already applied, and higher numbers for other errors.
+    if [ "${ret}" -gt 1 ] ; then
+        exit 1
+    fi
 done


### PR DESCRIPTION
##### Summary

When trying to process a patch that has already been applied, `patch` will return a non-zero exit code. Additionally, there is no option to override this behavior and simply ignore patches that are already applied.

Given this, restructure our patching script so that it just ignores patches that have already been applied, since we obviously don’t need to apply them.

##### Test Plan

Requires testing to confirm the change is working.