### PR TITLE
Patch release 2.5.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,20 +306,10 @@ jobs:
           sudo apt-get upgrade -y
           sudo apt-get install -y qemu-user-static
       - name: Build
-        if: github.event_name != 'workflow_dispatch' && needs.file-check.outputs.run == 'true' # Don’t use retries on PRs.
+        if: needs.file-check.outputs.run == 'true'
         run: |
           [ "${{ matrix.qemu }}" == "true" ] || export SKIP_EMULATION=1
           .github/scripts/build-static.sh ${{ matrix.arch }}
-      - name: Build
-        if: github.event_name == 'workflow_dispatch' && needs.file-check.outputs.run == 'true'
-        id: build
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 150
-          max_attempts: 2
-          command: |
-            [ "${{ matrix.qemu }}" == "true" ] || export SKIP_EMULATION=1
-            .github/scripts/build-static.sh ${{ matrix.arch }}
       - name: Store
         id: store
         if: needs.file-check.outputs.run == 'true'

--- a/packaging/cmake/Modules/NetdataProtobuf.cmake
+++ b/packaging/cmake/Modules/NetdataProtobuf.cmake
@@ -27,22 +27,32 @@ function(netdata_bundle_protobuf)
                 set(ABSL_PROPAGATE_CXX_STD On)
                 set(ABSL_ENABLE_INSTALL Off)
                 set(BUILD_SHARED_LIBS Off)
-                set(absl_repo https://github.com/abseil/abseil-cpp)
+                set(ABSL_BUILD_TESTING Off)
+                set(absl_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/absl-src")
 
                 message(STATUS "Preparing bundled Abseil (required by bundled Protobuf)")
+                find_program(PATCH patch REQUIRED)
                 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
-                        FetchContent_Declare(absl
-                                GIT_REPOSITORY ${absl_repo}
-                                GIT_TAG ${ABSL_TAG}
-                                CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
-                                EXCLUDE_FROM_ALL
-                        )
+                    FetchContent_Declare(absl
+                            GIT_REPOSITORY https://github.com/abseil/abseil-cpp
+                            GIT_TAG ${ABSL_TAG}
+                            SOURCE_DIR ${absl_SOURCE_DIR}
+                            PATCH_COMMAND ${CMAKE_SOURCE_DIR}/packaging/cmake/patches/apply-patches.sh
+                                        ${absl_SOURCE_DIR}
+                                        ${CMAKE_SOURCE_DIR}/packaging/cmake/patches/abseil
+                            CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
+                            EXCLUDE_FROM_ALL
+                    )
                 else()
-                        FetchContent_Declare(absl
-                                GIT_REPOSITORY ${absl_repo}
-                                GIT_TAG ${ABSL_TAG}
-                                CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
-                        )
+                    FetchContent_Declare(absl
+                            GIT_REPOSITORY https://github.com/abseil/abseil-cpp
+                            GIT_TAG ${ABSL_TAG}
+                            SOURCE_DIR ${absl_SOURCE_DIR}
+                            PATCH_COMMAND ${CMAKE_SOURCE_DIR}/packaging/cmake/patches/apply-patches.sh
+                                        ${absl_SOURCE_DIR}
+                                        ${CMAKE_SOURCE_DIR}/packaging/cmake/patches/abseil
+                            CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
+                    )
                 endif()
                 FetchContent_MakeAvailable_NoInstall(absl)
                 message(STATUS "Finished preparing bundled Abseil")

--- a/packaging/cmake/patches/abseil/abseil-musl.patch
+++ b/packaging/cmake/patches/abseil/abseil-musl.patch
@@ -1,0 +1,58 @@
+Patch-Source: https://github.com/void-linux/void-packages/blob/master/srcpkgs/mozc/patches/abseil.patch
+
+Ported from grpc's patches
+
+An all-in-one patch that fixes several issues:
+
+1) UnscaledCycleClock not fully implemented for ppc*-musl (disabled on musl)
+2) powerpc stacktrace implementation only works on glibc (disabled on musl)
+4) examine_stack.cpp makes glibc assumptions on powerpc (fixed)
+
+--- a/absl/debugging/internal/examine_stack.cc
++++ b/absl/debugging/internal/examine_stack.cc
+@@ -33,6 +33,10 @@
+ #include <csignal>
+ #include <cstdio>
+ 
++#if defined(__powerpc__)
++#include <asm/ptrace.h>
++#endif
++
+ #include "absl/base/attributes.h"
+ #include "absl/base/internal/raw_logging.h"
+ #include "absl/base/macros.h"
+@@ -174,8 +178,10 @@
+     return reinterpret_cast<void*>(context->uc_mcontext.pc);
+ #elif defined(__powerpc64__)
+     return reinterpret_cast<void*>(context->uc_mcontext.gp_regs[32]);
++#elif defined(__powerpc__) && defined(__GLIBC__)
++    return reinterpret_cast<void*>(context->uc_mcontext.regs->nip);
+ #elif defined(__powerpc__)
+-    return reinterpret_cast<void*>(context->uc_mcontext.uc_regs->gregs[32]);
++    return reinterpret_cast<void*>(((struct pt_regs *)context->uc_regs)->nip);
+ #elif defined(__riscv)
+     return reinterpret_cast<void*>(context->uc_mcontext.__gregs[REG_PC]);
+ #elif defined(__s390__) && !defined(__s390x__)
+--- a/absl/debugging/internal/stacktrace_config.h
++++ b/absl/debugging/internal/stacktrace_config.h
+@@ -60,7 +60,7 @@
+ #elif defined(__i386__) || defined(__x86_64__)
+ #define ABSL_STACKTRACE_INL_HEADER \
+   "absl/debugging/internal/stacktrace_x86-inl.inc"
+-#elif defined(__ppc__) || defined(__PPC__)
++#elif (defined(__ppc__) || defined(__PPC__)) && defined(__GLIBC__)
+ #define ABSL_STACKTRACE_INL_HEADER \
+   "absl/debugging/internal/stacktrace_powerpc-inl.inc"
+ #elif defined(__aarch64__)
+--- a/absl/base/internal/unscaledcycleclock_config.h
++++ b/absl/base/internal/unscaledcycleclock_config.h
+@@ -21,7 +21,8 @@
+ 
+ // The following platforms have an implementation of a hardware counter.
+ #if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__) || \
+-    defined(__powerpc__) || defined(__ppc__) || defined(__riscv) ||     \
++    defined(__riscv) ||     \
++    ((defined(__powerpc__) || defined(__ppc__)) && defined(__GLIBC__)) || \
+     defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))
+ #define ABSL_HAVE_UNSCALED_CYCLECLOCK_IMPLEMENTATION 1
+ #else

--- a/packaging/cmake/patches/apply-patches.sh
+++ b/packaging/cmake/patches/apply-patches.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+SRC_DIR="${1}"
+PATCH_DIR="${2}"
+
+set -e
+
+cd "${SRC_DIR}"
+
+for patch_file in "${PATCH_DIR}"/*; do
+    patch -p1 -i "${patch_file}"
+done

--- a/packaging/cmake/patches/apply-patches.sh
+++ b/packaging/cmake/patches/apply-patches.sh
@@ -3,10 +3,16 @@
 SRC_DIR="${1}"
 PATCH_DIR="${2}"
 
-set -e
-
-cd "${SRC_DIR}"
+cd "${SRC_DIR}" || exit 1
 
 for patch_file in "${PATCH_DIR}"/*; do
-    patch -p1 -i "${patch_file}"
+    patch -p1 --forward -i "${patch_file}"
+    ret="${?}"
+
+    # We want to ignore patches that are already applied instead of
+    # failing the patching process, and patch returns 1 for a patch that
+    # is already applied, and higher numbers for other errors.
+    if [ "${ret}" -gt 1 ] ; then
+        exit 1
+    fi
 done

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -661,6 +661,12 @@ declare -A pkg_cmake=(
   ['default']="cmake"
 )
 
+# patch is required for vendoring Abseil
+declare -A pkg_patch=(
+  ['default']="patch"
+  ['gentoo']="dev-util/patch"
+)
+
 declare -A pkg_json_c_dev=(
   ['alpine']="json-c-dev"
   ['arch']="json-c"
@@ -1259,6 +1265,7 @@ packages() {
     require_cmd tar || suitable_package tar
     require_cmd curl || suitable_package curl
     require_cmd gzip || suitable_package gzip
+    require_cmd patch || suitable_package patch
   fi
 
   # -------------------------------------------------------------------------

--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -30,24 +30,28 @@ case "${BUILDARCH}" in
         QEMU_CPU="Nehalem-v2"
         TUNING_FLAGS="-march=x86-64"
         GOAMD64="v1"
+        GOARCH="amd64"
         ;;
     armv6l) # Raspberry Pi 1 equivalent
         QEMU_ARCH="arm"
         QEMU_CPU="arm1176"
         TUNING_FLAGS="-march=armv6zk -mtune=arm1176jzf-s"
         GOARM="6"
+        GOARCH="arm"
         ;;
     armv7l) # Baseline ARMv7 CPU
         QEMU_ARCH="arm"
         QEMU_CPU="cortex-a7"
         TUNING_FLAGS="-march=armv7-a"
         GOARM="7"
+        GOARCH="arm"
         ;;
     aarch64) # Baseline ARMv8 CPU
         QEMU_ARCH="aarch64"
         QEMU_CPU="cortex-a53"
         TUNING_FLAGS="-march=armv8-a"
         GOARM64="v8.0"
+        GOARCH="arm64"
         ;;
 esac
 
@@ -81,7 +85,7 @@ if [ -t 1 ]; then
     --platform "${platform}" ${EXTRA_INSTALL_FLAGS:+-e EXTRA_INSTALL_FLAGS="${EXTRA_INSTALL_FLAGS}"} \
     ${DEBUG_BUILD_INFRA:+-e DEBUG_BUILD_INFRA=1} \
     ${QEMU_CPU:+-e QEMU_CPU="${QEMU_CPU}"} \
-    -e TUNING_FLAGS="${TUNING_FLAGS}" \
+    -e TUNING_FLAGS="${TUNING_FLAGS}" ${GOARCH:+-e GOARCH="${GOARCH}"} \
     ${GOAMD64:+-e GOAMD64="${GOAMD64}"} ${GOARM:+-e GOARM="${GOARM}"} \
     ${GOARM64:+-e GOARM64="${GOARM64}"} ${GOPPC64:+-e GOPPC64="${GOPPC64}"} \
     "${DOCKER_IMAGE_NAME}" /bin/sh /netdata/packaging/makeself/build.sh "${@}"
@@ -90,7 +94,7 @@ else
     -e GITHUB_ACTIONS="${GITHUB_ACTIONS}" --platform "${platform}" \
     ${EXTRA_INSTALL_FLAGS:+-e EXTRA_INSTALL_FLAGS="${EXTRA_INSTALL_FLAGS}"} \
     ${QEMU_CPU:+-e QEMU_CPU="${QEMU_CPU}"} \
-    -e TUNING_FLAGS="${TUNING_FLAGS}" \
+    -e TUNING_FLAGS="${TUNING_FLAGS}" ${GOARCH:+-e GOARCH="${GOARCH}"} \
     ${GOAMD64:+-e GOAMD64="${GOAMD64}"} ${GOARM:+-e GOARM="${GOARM}"} \
     ${GOARM64:+-e GOARM64="${GOARM64}"} ${GOPPC64:+-e GOPPC64="${GOPPC64}"} \
     "${DOCKER_IMAGE_NAME}" /bin/sh /netdata/packaging/makeself/build.sh "${@}"

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -35,7 +35,6 @@ run ./netdata-installer.sh \
   --dont-wait \
   --dont-start-it \
   --disable-exporting-mongodb \
-  --use-system-protobuf \
   --dont-scrub-cflags-even-though-it-may-break-things \
   --one-time-build \
   --enable-lto \

--- a/packaging/makeself/jobs/82-cpu-arch-check.sh
+++ b/packaging/makeself/jobs/82-cpu-arch-check.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# shellcheck source=./packaging/makeself/functions.sh
+. "${NETDATA_MAKESELF_PATH}"/functions.sh "${@}" || exit 1
+
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Checking Go plugin CPU architecture" || true
+
+check_files="${NETDATA_INSTALL_PATH}/bin/netdata ${NETDATA_INSTALL_PATH}/usr/libexec/netdata/plugins.d/go.d.plugin"
+
+case "${BUILDARCH}" in
+  aarch64)
+    ELF_MACHINE="AArch64"
+    ELF_CLASS="ELF64"
+    ;;
+  armv6l | armv7l)
+    ELF_MACHINE="ARM"
+    ELF_CLASS="ELF32"
+    ;;
+  ppc64le)
+    ELF_MACHINE="PowerPC64"
+    ELF_CLASS="ELF64"
+    ;;
+  x86_64)
+    ELF_MACHINE="X86-64"
+    ELF_CLASS="ELF64"
+    ;;
+  *)
+    echo "Buildarch is not recognized for architecture check."
+    exit 1
+    ;;
+esac
+
+for f in ${check_files}; do
+  if [ ! -f "${f}" ]; then
+    echo "File ${f} not found, skipping check"
+    continue
+  fi
+
+  # Get both the machine type and the class (32-bit vs 64-bit)
+  elf_info=$(readelf -h "${f}")
+  file_machine=$(echo "${elf_info}" | grep 'Machine:' | awk -F: '{print $2}' | xargs)
+  file_class=$(echo "${elf_info}" | grep 'Class:' | awk -F: '{print $2}' | xargs)
+
+  echo "Checking ${f}:"
+  echo "  Expected: Class=${ELF_CLASS}, Machine contains '${ELF_MACHINE}'"
+  echo "  Found:    Class=${file_class}, Machine='${file_machine}'"
+
+  if [ "${file_class}" != "${ELF_CLASS}" ]; then
+    echo "ERROR: ${f} has wrong ELF class (${file_class} instead of ${ELF_CLASS})"
+    echo "This indicates a 32-bit/64-bit mismatch!"
+    exit 1
+  fi
+
+  if ! echo "${file_machine}" | grep -q "${ELF_MACHINE}"; then
+    echo "ERROR: ${f} was built for the wrong architecture (${file_machine} does not contain ${ELF_MACHINE})"
+    exit 1
+  fi
+done
+
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::endgroup::" || true

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -166,7 +166,7 @@
             </InstallExecuteSequence>
 
             <!-- Add new files (stream.conf and netdata.conf) -->
-            <CustomAction Id="NDCreateNewFiles" Directory="USRLIBEXECNETDATADIR" ExeCommand='powershell.exe -ExecutionPolicy Bypass -NonInteractive -File &quot;[USRLIBEXECNETDATADIR]\copy_files.ps1&quot;' Execute="deferred" Return="ignore" Impersonate="no"/>
+            <CustomAction Id="NDCreateNewFiles" Directory="USRLIBEXECNETDATADIR" ExeCommand='powershell.exe -NoProfile -ExecutionPolicy Bypass -NonInteractive -File &quot;[USRLIBEXECNETDATADIR]\copy_files.ps1&quot;' Execute="deferred" Return="ignore" Impersonate="no"/>
             <InstallExecuteSequence>
                 <Custom Action="NDCreateNewFiles" Before="InstallFinalize" />
             </InstallExecuteSequence>

--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -405,6 +405,7 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
         fprintf(stderr, "WARNING: STRING has %zu strings still allocated.\n",
                 strings_referenced);
 
+    rrdlabels_aral_destroy(true);
     fprintf(stderr, "All done, exiting...\n");
 #endif
 

--- a/src/daemon/dyncfg/dyncfg-intercept.c
+++ b/src/daemon/dyncfg/dyncfg-intercept.c
@@ -239,7 +239,7 @@ static void dyncfg_apply_action_on_all_template_jobs(struct rrd_function_execute
     dfe_done(df);
 
     if(rfe->progress.cb)
-        rfe->progress.cb(rfe->progress.data, done, all);
+        rfe->progress.cb(rfe->transaction, rfe->progress.data, done, all);
 
     dfe_start_reentrant(dyncfg_globals.nodes, df) {
         if(df->template == template && df->type == DYNCFG_TYPE_JOB) {
@@ -253,7 +253,7 @@ static void dyncfg_apply_action_on_all_template_jobs(struct rrd_function_execute
             dyncfg_echo(df_dfe.item, df, df_dfe.name, cmd_to_send_to_plugin);
 
             if(rfe->progress.cb)
-                rfe->progress.cb(rfe->progress.data, ++done, all);
+                rfe->progress.cb(rfe->transaction, rfe->progress.data, ++done, all);
         }
     }
     dfe_done(df);

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -380,6 +380,7 @@ int netdata_main(int argc, char **argv) {
 
                             if (sqlite_library_init())
                                 return 1;
+                            rrdlabels_aral_init(false);
 
                             if (pluginsd_parser_unittest()) return 1;
                             if (unit_test_static_threads()) return 1;
@@ -410,6 +411,7 @@ int netdata_main(int argc, char **argv) {
                             if (perflibnamestest_main()) return 1;
 #endif
                             sqlite_library_shutdown();
+                            rrdlabels_aral_destroy(false);
                             fprintf(stderr, "\n\nALL TESTS PASSED\n\n");
                             return 0;
                         }
@@ -446,7 +448,10 @@ int netdata_main(int argc, char **argv) {
                         }
                         else if(strcmp(optarg, "rrdlabelstest") == 0) {
                             unittest_running = true;
-                            return rrdlabels_unittest();
+                            rrdlabels_aral_init(true);
+                            int rc = rrdlabels_unittest();
+                            rrdlabels_aral_destroy(true);
+                            return rc;
                         }
                         else if(strcmp(optarg, "buffertest") == 0) {
                             unittest_running = true;
@@ -864,6 +869,7 @@ int netdata_main(int argc, char **argv) {
 
     analytics_reset();
     get_system_timezone();
+    rrdlabels_aral_init(true);
 
     // ----------------------------------------------------------------------------------------------------------------
     delta_startup_time("pulse");

--- a/src/database/rrdfunctions.h
+++ b/src/database/rrdfunctions.h
@@ -16,7 +16,7 @@ typedef void (*rrd_function_result_callback_t)(BUFFER *wb, int code, void *resul
 typedef bool (*rrd_function_is_cancelled_cb_t)(void *is_cancelled_cb_data);
 typedef void (*rrd_function_cancel_cb_t)(void *data);
 typedef void (*rrd_function_register_canceller_cb_t)(void *register_cancel_cb_data, rrd_function_cancel_cb_t cancel_cb, void *cancel_cb_data);
-typedef void (*rrd_function_progress_cb_t)(void *data, size_t done, size_t all);
+typedef void (*rrd_function_progress_cb_t)(nd_uuid_t *transaction, void *data, size_t done, size_t all);
 typedef void (*rrd_function_progresser_cb_t)(const char *transaction, void *data);
 typedef void (*rrd_function_register_progresser_cb_t)(void *register_progresser_cb_data, rrd_function_progresser_cb_t progresser_cb, void *progresser_cb_data);
 

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -28,7 +28,7 @@ typedef struct labels_registry_idx_entry {
 
 typedef struct rrdlabels {
     SPINLOCK spinlock;
-    size_t version;
+    uint32_t version;
     Pvoid_t JudyL;
 } RRDLABELS;
 
@@ -75,14 +75,37 @@ __attribute__((constructor)) void initialize_label_stats(void) {
     dictionary_stats_category_rrdlabels.memory.values = 0;
 }
 
+
+static ARAL *labels_aral;
+
+static struct aral_statistics label_aral_statistics = { 0 };
+
+void rrdlabels_aral_init(bool with_stats)
+{
+    labels_aral =
+        aral_create("label_stat", sizeof(RRDLABELS), 1, 0, &label_aral_statistics, NULL, NULL, false, false, false);
+
+    if (with_stats)
+        pulse_aral_register_statistics(&label_aral_statistics, "labels");
+}
+
+void rrdlabels_aral_destroy(bool with_stats)
+{
+    aral_destroy(labels_aral);
+    if (with_stats)
+        pulse_aral_unregister_statistics(&label_aral_statistics);
+}
+
+
 // ----------------------------------------------------------------------------
 // rrdlabels_create()
 
 RRDLABELS *rrdlabels_create(void)
 {
-    RRDLABELS *labels = callocz(1, sizeof(*labels));
+    RRDLABELS *labels = aral_mallocz(labels_aral);
     spinlock_init(&labels->spinlock);
-    RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, 0, sizeof(RRDLABELS));
+    labels->version = 0;
+    labels->JudyL = NULL;
     return labels;
 }
 
@@ -189,7 +212,7 @@ void rrdlabels_destroy(RRDLABELS *labels)
         return;
 
     rrdlabels_flush(labels);
-    freez(labels);
+    aral_freez(labels_aral, labels);
 }
 
 //
@@ -901,12 +924,12 @@ size_t rrdlabels_entries(RRDLABELS *labels __maybe_unused)
     return count;
 }
 
-size_t rrdlabels_version(RRDLABELS *labels __maybe_unused)
+uint32_t rrdlabels_version(RRDLABELS *labels __maybe_unused)
 {
     if (unlikely(!labels))
         return 0;
 
-    return (size_t) labels->version;
+    return labels->version;
 }
 
 void rrdset_update_rrdlabels(RRDSET *st, RRDLABELS *new_rrdlabels) {

--- a/src/database/rrdlabels.h
+++ b/src/database/rrdlabels.h
@@ -26,6 +26,8 @@ typedef enum __attribute__ ((__packed__)) rrdlabel_source {
 struct rrdlabels;
 typedef struct rrdlabels RRDLABELS;
 
+void rrdlabels_aral_init(bool with_stats);
+void rrdlabels_aral_destroy(bool with_stats);
 RRDLABELS *rrdlabels_create(void);
 void rrdlabels_destroy(RRDLABELS *labels_dict);
 void rrdlabels_flush(RRDLABELS *labels);
@@ -37,7 +39,7 @@ void rrdlabels_get_value_strdup_or_null(RRDLABELS *labels, char **value, const c
 void rrdlabels_get_value_to_buffer_or_unset(RRDLABELS *labels, BUFFER *wb, const char *key, const char *unset);
 bool rrdlabels_exist(RRDLABELS *labels, const char *key);
 size_t rrdlabels_entries(RRDLABELS *labels __maybe_unused);
-size_t rrdlabels_version(RRDLABELS *labels __maybe_unused);
+uint32_t rrdlabels_version(RRDLABELS *labels __maybe_unused);
 void rrdlabels_get_value_strcpyz(RRDLABELS *labels, char *dst, size_t dst_len, const char *key);
 
 void rrdlabels_unmark_all(RRDLABELS *labels);

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -840,8 +840,8 @@ static int chart_label_store_to_sql_callback(const char *name, const char *value
 
 static int check_and_update_chart_labels(RRDSET *st, BUFFER *work_buffer)
 {
-    size_t old_version = st->rrdlabels_last_saved_version;
-    size_t new_version = rrdlabels_version(st->rrdlabels);
+    uint32_t old_version = st->rrdlabels_last_saved_version;
+    uint32_t new_version = rrdlabels_version(st->rrdlabels);
 
     if (new_version == old_version)
         return 0;

--- a/src/go/plugin/go.d/agent/discovery/sd/discoverer/snmpsd/sysinfo.go
+++ b/src/go/plugin/go.d/agent/discovery/sd/discoverer/snmpsd/sysinfo.go
@@ -38,7 +38,7 @@ func GetSysInfo(client gosnmp.Handler) (*SysInfo, error) {
 		Organization: "Unknown",
 	}
 
-	r := strings.NewReplacer("\n", " ", "\r", " ")
+	r := strings.NewReplacer("'", "", "\n", " ", "\r", " ", "\x00", "")
 
 	for _, pdu := range pdus {
 		oid := strings.TrimPrefix(pdu.Name, ".")

--- a/src/go/plugin/go.d/agent/module/job.go
+++ b/src/go/plugin/go.d/agent/module/job.go
@@ -498,7 +498,7 @@ func (j *Job) sendVnodeHostInfo() {
 		j.vnode.Labels["_hostname"] = j.vnode.Hostname
 	}
 	for k, v := range j.vnode.Labels {
-		j.vnode.Labels[k] = lblReplacer.Replace(v)
+		j.vnode.Labels[k] = lblValueReplacer.Replace(v)
 	}
 
 	j.api.HOSTINFO(netdataapi.HostInfo{
@@ -549,15 +549,15 @@ func (j *Job) createChart(chart *Chart) {
 			if ls == 0 {
 				ls = LabelSourceAuto
 			}
-			j.api.CLABEL(l.Key, lblReplacer.Replace(l.Value), ls)
+			j.api.CLABEL(l.Key, lblValueReplacer.Replace(l.Value), ls)
 		}
 	}
 	for k, v := range j.labels {
 		if !seen[k] {
-			j.api.CLABEL(k, lblReplacer.Replace(v), LabelSourceConf)
+			j.api.CLABEL(k, lblValueReplacer.Replace(v), LabelSourceConf)
 		}
 	}
-	j.api.CLABEL("_collect_job", lblReplacer.Replace(j.Name()), LabelSourceAuto)
+	j.api.CLABEL("_collect_job", lblValueReplacer.Replace(j.Name()), LabelSourceAuto)
 	j.api.CLABELCOMMIT()
 
 	for _, dim := range chart.Dims {
@@ -706,4 +706,9 @@ func cleanPluginName(name string) string {
 	return r.Replace(name)
 }
 
-var lblReplacer = strings.NewReplacer("'", "")
+var lblValueReplacer = strings.NewReplacer(
+	"'", "",
+	"\n", " ",
+	"\r", " ",
+	"\x00", "",
+)

--- a/src/go/plugin/go.d/collector/redis/init.go
+++ b/src/go/plugin/go.d/collector/redis/init.go
@@ -41,7 +41,9 @@ func (c *Collector) initRedisClient() (*redis.Client, error) {
 	}
 
 	opts.PoolSize = 1
-	opts.TLSConfig = tlsConfig
+	if tlsConfig != nil {
+		opts.TLSConfig = tlsConfig
+	}
 	opts.DialTimeout = c.Timeout.Duration()
 	opts.ReadTimeout = c.Timeout.Duration()
 	opts.WriteTimeout = c.Timeout.Duration()

--- a/src/go/plugin/go.d/collector/snmp/collect_if_mib.go
+++ b/src/go/plugin/go.d/collector/snmp/collect_if_mib.go
@@ -157,6 +157,8 @@ func (c *Collector) collectNetworkInterfaces(mx map[string]int64) error {
 		iface.updated = true
 	}
 
+	var valReplacer = strings.NewReplacer("'", "", "\n", " ", "\r", " ", "\x00", "")
+
 	for _, iface := range c.netInterfaces {
 		if iface.ifName == "" {
 			iface.ifName = iface.ifDescr
@@ -164,6 +166,10 @@ func (c *Collector) collectNetworkInterfaces(mx map[string]int64) error {
 		if iface.ifName == "" {
 			continue
 		}
+
+		iface.ifName = valReplacer.Replace(iface.ifName)
+		iface.ifDescr = valReplacer.Replace(iface.ifDescr)
+		iface.ifAlias = valReplacer.Replace(iface.ifAlias)
 
 		typeStr := ifTypeMapping[iface.ifType]
 		if c.netIfaceFilterByName.MatchString(iface.ifName) || c.netIfaceFilterByType.MatchString(typeStr) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/load_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/load_test.go
@@ -17,8 +17,10 @@ func Test_loadDDSnmpProfiles(t *testing.T) {
 	require.NoError(t, err)
 	defer f.Close()
 
-	profiles, err := load(dir)
+	profiles, err := loadProfiles(dir)
 	require.NoError(t, err)
+
+	require.NotEmpty(t, profiles)
 
 	names, err := f.Readdirnames(-1)
 	require.NoError(t, err)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
@@ -10,6 +10,8 @@ import (
 )
 
 func Find(sysObjId string) []*Profile {
+	load()
+
 	var profiles []*Profile
 
 	for _, prof := range ddProfiles {

--- a/src/go/plugin/go.d/collector/squidlog/collect.go
+++ b/src/go/plugin/go.d/collector/squidlog/collect.go
@@ -125,7 +125,7 @@ func (c *Collector) collectHTTPCode() {
 
 	code := c.line.httpCode
 	switch {
-	case code >= 100 && code < 300, code == 0, code == 304, code == 401:
+	case code >= 100 && code < 300, code == 0, code == 304, code == 401, code == 429:
 		c.mx.ReqSuccess.Inc()
 	case code >= 300 && code < 400:
 		c.mx.ReqRedirect.Inc()

--- a/src/go/plugin/go.d/collector/weblog/collect.go
+++ b/src/go/plugin/go.d/collector/weblog/collect.go
@@ -196,7 +196,7 @@ func (c *Collector) collectRespCode() {
 
 	code := c.line.respCode
 	switch {
-	case code >= 100 && code < 300, code == 304, code == 401:
+	case code >= 100 && code < 300, code == 304, code == 401, code == 429:
 		c.mx.ReqSuccess.Inc()
 	case code >= 300 && code < 400:
 		c.mx.ReqRedirect.Inc()

--- a/src/health/health.d/web_log.conf
+++ b/src/health/health.d/web_log.conf
@@ -68,7 +68,7 @@ component: Web log
      crit: ($web_log_1m_requests > 120) ? ($this < (($status == $CRITICAL) ? ( 85 ) : ( 75 )) ) : ( 0 )
     delay: up 2m down 15m multiplier 1.5 max 1h
   summary: Web log successful
-     info: Ratio of successful HTTP requests over the last minute (1xx, 2xx, 304, 401)
+     info: Ratio of successful HTTP requests over the last minute (1xx, 2xx, 304, 401, 429)
        to: webmaster
 
  template: web_log_1m_redirects
@@ -98,7 +98,7 @@ component: Web log
      warn: ($web_log_1m_requests > 120) ? ($this > (($status >= $WARNING)  ? ( 10 ) : ( 30 )) ) : ( 0 )
     delay: up 2m down 15m multiplier 1.5 max 1h
   summary: Web log bad requests
-     info: Ratio of client error HTTP requests over the last minute (4xx except 401)
+     info: Ratio of client error HTTP requests over the last minute (4xx except 401 and 429)
        to: webmaster
 
  template: web_log_1m_internal_errors

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -148,7 +148,7 @@ static STRING *rrdcalc_replace_variables_with_rrdset_labels(const char *line, RR
 
 void rrdcalc_update_info_using_rrdset_labels(RRDCALC *rc) {
     if(rc->rrdset && rc->rrdset->rrdlabels) {
-        size_t labels_version = rrdlabels_version(rc->rrdset->rrdlabels);
+        uint32_t labels_version = rrdlabels_version(rc->rrdset->rrdlabels);
         if (rc->labels_version != labels_version) {
             STRING *old;
 

--- a/src/health/rrdcalc.h
+++ b/src/health/rrdcalc.h
@@ -83,7 +83,7 @@ struct rrdcalc {
     // ------------------------------------------------------------------------
     // the chart this alarm it is linked to
 
-    size_t labels_version;
+    uint32_t labels_version;
     struct rrdset *rrdset;
 
     struct rrdcalc *next;

--- a/src/plugins.d/pluginsd_functions.c
+++ b/src/plugins.d/pluginsd_functions.c
@@ -437,7 +437,7 @@ PARSER_RC pluginsd_function_progress(char **words, size_t num_words, PARSER *par
         size_t all = all_str && *all_str ? str2u(all_str) : 0;
 
         if(pf->progress.cb)
-            pf->progress.cb(pf->progress.data, done, all);
+            pf->progress.cb(&pf->transaction, pf->progress.data, done, all);
     }
 
     return PARSER_RC_OK;

--- a/src/registry/registry_internals.h
+++ b/src/registry/registry_internals.h
@@ -49,6 +49,10 @@ struct registry {
     // open files
     FILE *log_fp;
 
+    // save failure tracking
+    time_t last_save_failure;
+    int consecutive_save_failures;
+
     // the database
     DICTIONARY *persons;    // dictionary of REGISTRY_PERSON *,  with key the REGISTRY_PERSON.guid
     DICTIONARY *machines;   // dictionary of REGISTRY_MACHINE *, with key the REGISTRY_MACHINE.guid

--- a/src/streaming/stream-connector.c
+++ b/src/streaming/stream-connector.c
@@ -534,7 +534,7 @@ static void *stream_connector_thread(void *ptr) {
     size_t exiting = 0;
     while(exiting <= 5) {
         worker_is_idle();
-        job_id = completion_wait_for_a_job_with_timeout(&sc->completion, job_id, 1000);
+        job_id = completion_wait_for_a_job_with_timeout(&sc->completion, job_id, exiting ? 250 : 1000);
         size_t nodes = 0, connected_nodes = 0, failed_nodes = 0, cancelled_nodes = 0;
 
         if(!service_running(SERVICE_STREAMING_CONNECTOR))

--- a/src/streaming/stream-sender-execute.c
+++ b/src/streaming/stream-sender-execute.c
@@ -39,15 +39,18 @@ static void stream_execute_function_callback(BUFFER *func_wb, int code, void *da
     freez(tmp);
 }
 
-static void stream_execute_function_progress_callback(void *data, size_t done, size_t all) {
+static void stream_execute_function_progress_callback(nd_uuid_t *transaction, void *data, size_t done, size_t all) {
     struct inflight_stream_function *tmp = data;
     struct sender_state *s = tmp->sender;
 
     if(rrdhost_can_stream_metadata_to_parent(s->host)) {
         CLEAN_BUFFER *wb = buffer_create(0, NULL);
 
+        char transaction_str[UUID_COMPACT_STR_LEN];
+        uuid_unparse_lower_compact(*transaction, transaction_str);
+
         buffer_sprintf(wb, PLUGINSD_KEYWORD_FUNCTION_PROGRESS " '%s' %zu %zu\n",
-                       string2str(tmp->transaction), done, all);
+                       transaction_str, done, all);
 
         sender_commit_clean_buffer(s, wb, STREAM_TRAFFIC_TYPE_FUNCTIONS);
     }

--- a/src/web/api/v1/api_v1_config.c
+++ b/src/web/api/v1/api_v1_config.c
@@ -84,7 +84,7 @@ int api_v1_config(RRDHOST *host, struct web_client *w, char *url __maybe_unused)
     int code = rrd_function_run(host, w->response.data, timeout, w->access, cmd,
                                 true, transaction,
                                 NULL, NULL,
-                                web_client_progress_functions_update, w,
+                                web_client_progress_functions_update, NULL,
                                 web_client_interrupt_callback, w,
                                 w->payload, buffer_tostring(source), false);
 

--- a/src/web/api/v1/api_v1_function.c
+++ b/src/web/api/v1/api_v1_function.c
@@ -38,7 +38,7 @@ int api_v1_function(RRDHOST *host, struct web_client *w, char *url) {
 
     return rrd_function_run(host, wb, timeout, w->access, function, true, transaction,
                             NULL, NULL,
-                            web_client_progress_functions_update, w,
+                            web_client_progress_functions_update, NULL,
                             web_client_interrupt_callback, w, w->payload,
                             buffer_tostring(source), false);
 }

--- a/src/web/api/web_api.c
+++ b/src/web/api/web_api.c
@@ -138,9 +138,10 @@ void nd_web_api_init(void) {
     time_grouping_init();
 }
 
-void web_client_progress_functions_update(void *data, size_t done, size_t all) {
+void web_client_progress_functions_update(nd_uuid_t *transaction, void *data, size_t done, size_t all) {
     // handle progress updates from the plugin
-    struct web_client *w = data;
-    query_progress_functions_update(&w->transaction, done, all);
+    // data parameter is no longer used - transaction is provided directly
+    (void)data;
+    query_progress_functions_update(transaction, done, all);
 }
 

--- a/src/web/api/web_api.h
+++ b/src/web/api/web_api.h
@@ -20,7 +20,7 @@ struct web_client;
 
 void nd_web_api_init(void);
 
-void web_client_progress_functions_update(void *data, size_t done, size_t all);
+void web_client_progress_functions_update(nd_uuid_t *transaction, void *data, size_t done, size_t all);
 
 void host_labels2json(RRDHOST *host, BUFFER *wb, const char *key);
 


### PR DESCRIPTION
##### Summary
1. MSI parameter (#20550)
1. fix(go.d/redis): don't clear tls for rediss (#20478)
1. Weblog collector: Exclude 429 from 4xx (#20443)
1. Enforce correct CPU architecture for Go plugin builds. (#20405)
1. Use ARAL for labels (#20502)
1. 283ab84f2d Vendor protobuf in static builds. (#17774)
   - Correctly ignore patches that are already applied. (#20480)
   - d6ab8ee7d9 Remove static build timeouts from regular builds. (#20470)
1. Fix registry save integer overflow and add failure backoff (#20437)
1. Fix heap-use-after-free in query progress updates (#20431)
1. Adjust stream connector timeout during agent shutdown (#20434)
1. Improve statement finalization and cleanup (#20433)
