### PR TITLE
fix: mark import groups as not supported SCIM feature

### DIFF
--- a/integrations/cloud-authentication/metadata.yaml
+++ b/integrations/cloud-authentication/metadata.yaml
@@ -132,15 +132,14 @@
       - Update user attributes
       - Deactivate users
       - Create groups
-      - Import groups
-      - Associate users to groups
       - Nested groups supported
       - Patch operations: Supported
-      - Bulk operations: Not supported
       - Filtering: Supported (max results: 200)
+      - Authentication schemes: OAuth Bearer Token
+      - Import groups: Not supported
+      - Bulk operations: Not supported
       - Password synchronization: Not supported, as we rely on SSO/OIDC authentication
       - eTag: Not supported
-      - Authentication schemes: OAuth Bearer Token
 
       ### Netdata Configuration Steps
       1. Click on the Space settings cog (located above your profile icon).


### PR DESCRIPTION
- Mark "import groups" as not supported SCIM feature.
- delete "associate users to groups"
