### PR TITLE
feat(go.d/snmp profile): add fallback support for duplicate metric tags

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collect_device_meta.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collect_device_meta.go
@@ -67,7 +67,9 @@ func (c *Collector) collectDeviceMetadata(prof *ddsnmp.Profile) (map[string]stri
 					errs = append(errs, fmt.Errorf("failed to process meta device tag value for '%s': %v", name, err))
 					continue
 				}
-				tags[name] = v
+				if existing, ok := tags[name]; !ok || existing == "" {
+					tags[name] = v
+				}
 			case len(field.Symbols) > 0:
 				for _, sym := range field.Symbols {
 					v, err := processSymbolTagValue(sym, pdus)
@@ -75,7 +77,9 @@ func (c *Collector) collectDeviceMetadata(prof *ddsnmp.Profile) (map[string]stri
 						errs = append(errs, fmt.Errorf("failed to process meta device tag value for '%s': %v", name, err))
 						continue
 					}
-					tags[name] = v
+					if existing, ok := tags[name]; !ok || existing == "" {
+						tags[name] = v
+					}
 				}
 			}
 		}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collect_global_tags.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collect_global_tags.go
@@ -5,7 +5,6 @@ package ddsnmpcollector
 import (
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 
@@ -51,12 +50,16 @@ func (c *Collector) collectGlobalTags(prof *ddsnmp.Profile) (map[string]string, 
 	}
 
 	for _, cfg := range prof.Definition.MetricTags {
-		v, err := processMetricTagValue(cfg, pdus)
+		metricTags, err := processMetricTagValue(cfg, pdus)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to process tag value for '%s/%s': %v", cfg.Tag, cfg.Symbol.Name, err))
 			continue
 		}
-		maps.Copy(tags, v)
+		for k, val := range metricTags {
+			if existing, ok := tags[k]; !ok || existing == "" {
+				tags[k] = val
+			}
+		}
 	}
 
 	if len(errs) > 0 && len(tags) == 0 {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collect_table.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collect_table.go
@@ -210,8 +210,10 @@ func (c *Collector) processTableData(cfg ddprofiledefinition.MetricsConfig, pdus
 				}
 
 				for k, v := range tags {
-					rowTags[k] = v
-					tagCache[index][k] = v
+					if existing, ok := rowTags[k]; !ok || existing == "" {
+						rowTags[k] = v
+						tagCache[index][k] = v
+					}
 				}
 			}
 		}
@@ -269,8 +271,10 @@ func (c *Collector) processTableData(cfg ddprofiledefinition.MetricsConfig, pdus
 			}
 
 			for k, v := range tags {
-				rowTags[k] = v
-				tagCache[index][k] = v
+				if existing, ok := rowTags[k]; !ok || existing == "" {
+					rowTags[k] = v
+					tagCache[index][k] = v
+				}
 			}
 		}
 

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_generic-if.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_generic-if.yaml
@@ -64,11 +64,15 @@ metrics:
         family: Interfaces/Speed
         unit: "bit/s"
     metric_tags:
-      - symbol:
+      - tag: interface
+        table: ifXTable
+        symbol:
           OID: 1.3.6.1.2.1.31.1.1.1.1
           name: ifName
-        table: ifXTable
-        tag: interface
+      - tag: interface
+        symbol:
+          OID: 1.3.6.1.2.1.2.2.1.2
+          name: ifDescr
       - tag: if_type
         symbol:
           OID: 1.3.6.1.2.1.2.2.1.3
@@ -131,6 +135,11 @@ metrics:
         symbol:
           OID: 1.3.6.1.2.1.31.1.1.1.1
           name: ifName
+      - tag: interface
+        table: ifTable
+        symbol:
+          OID: 1.3.6.1.2.1.2.2.1.2
+          name: ifDescr
       - tag: if_type
         table: ifTable
         symbol:


### PR DESCRIPTION
##### Summary

Allow metric tags with the same name to use fallback values when the primary value is empty. When multiple `metric_tags` share the same tag name, subsequent tags will now override previous ones only if the previous value is an empty string.

This change is needed for network interface monitoring where interface naming can be inconsistent across devices. Some devices may have empty `ifName` values but populated `ifDescr` values, or vice versa.



##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
