### PR TITLE
Drop POWER8+ builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -9,7 +9,6 @@ platform_map:  # map packaging architectures to docker platforms
   armv6l: linux/arm/v6
   armv7l: linux/arm/v7
   i386: linux/386
-  ppc64le: linux/ppc64le
   x86_64: linux/amd64
 arch_order:  # sort order for per-architecture jobs in CI
   - amd64
@@ -21,7 +20,6 @@ arch_order:  # sort order for per-architecture jobs in CI
   - armv7l
   - arm64
   - aarch64
-  - ppc64le
 arch_data:  # Mapping of per-architecture matrix behavior.
   amd64: &amd64
     qemu: false
@@ -38,21 +36,16 @@ arch_data:  # Mapping of per-architecture matrix behavior.
     qemu: false
     runner: *arm-runner
   aarch64: *arm64
-  ppc64le:
-    qemu: true
-    runner: *x86-runner
 static_arches:  # Static build architectures
   - x86_64
   - armv6l
   - armv7l
   - aarch64
-  - ppc64le
 docker_arches:  # Docker build archtiectures
   - amd64
   - i386
   - armv7l
   - arm64
-  - ppc64le
 default_sentry: &default_sentry # Default configuration for Sentry usage
   amd64: false
   x86_64: false
@@ -413,7 +406,6 @@ no_include: # Info for platforms not covered in CI
         - linux/amd64
         - linux/arm/v7
         - linux/arm64
-        - linux/ppc64le
 
   - distro: clearlinux
     version: latest

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -53,7 +53,7 @@ to work on these platforms with minimal user effort.
 | Amazon Linux             | 2023           | x86\_64, AArch64                       |                                                                                                                |
 | Amazon Linux             | 2              | x86\_64, AArch64                       |                                                                                                                |
 | CentOS                   | 7.x            | x86\_64                                |                                                                                                                |
-| Docker                   | 19.03 or newer | x86\_64, i386, ARMv7, AArch64, POWER8+ | See our [Docker documentation](/packaging/docker/README.md) for more info on using Netdata on Docker           |
+| Docker                   | 19.03 or newer | x86\_64, i386, ARMv7, AArch64          | See our [Docker documentation](/packaging/docker/README.md) for more info on using Netdata on Docker           |
 | Debian                   | 12.x           | x86\_64, i386, ARMv7, AArch64          |                                                                                                                |
 | Debian                   | 11.x           | x86\_64, i386, ARMv7, AArch64          |                                                                                                                |
 | Fedora                   | 40             | x86\_64, AArch64                       |                                                                                                                |
@@ -166,14 +166,8 @@ We currently provide static builds for the following CPU architectures:
 - ARMv7
 - ARMv6
 - AArch64
-- POWER8+
 
 ## Platform-specific support considerations
-
-### IPMI
-
-Our IPMI collector is based on FreeIPMI. Due to upstream limitations in FreeIPMI, we are unable to support our
-IPMI collector on POWER-based hardware.
 
 ### Systemd
 

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -7,8 +7,6 @@ import TabItem from '@theme/TabItem';
 
 We don’t officially support using Docker’s `--user` option or Docker Compose’s `user:` parameter with our images. While they may work, some features could be unavailable. The Agent drops privileges at startup, so most processes don’t run as UID 0 even without these options.  
 
-Additionally, our **POWER8+ Docker images** don’t support the **FreeIPMI collector** due to a technical limitation in FreeIPMI itself, which we can’t work around.
-
 ## Create a new Netdata Agent container
 
 You can create a new Agent container with `docker run` or `docker-compose`, then access the dashboard at `http://NODE:19999`.  

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -23,7 +23,7 @@ DEFAULT_PLUGIN_PACKAGES=""
 REPOCONFIG_DEB_VERSION="5-1"
 REPOCONFIG_RPM_VERSION="5-1"
 START_TIME="$(date +%s)"
-STATIC_INSTALL_ARCHES="x86_64 armv7l armv6l aarch64 ppc64le"
+STATIC_INSTALL_ARCHES="x86_64 armv7l armv6l aarch64"
 
 # ======================================================================
 # Properly sort out inconsistencies in `$PATH` across distros

--- a/packaging/makeself/README.md
+++ b/packaging/makeself/README.md
@@ -12,9 +12,9 @@ Netdata provides pre-built static binaries for Linux systems where native packag
 | Architecture | Identifier | Notes                            |
 |--------------|------------|----------------------------------|
 | x86_64       | `x86_64`   | 64-bit Intel/AMD processors      |
+| ARMv6        | `armv6l`   | Raspberry Pi 1, some older SBCs  |
 | ARMv7        | `armv7l`   | Raspberry Pi 2/3, many SBCs      |
 | AArch64      | `aarch64`  | ARM 64-bit (Pi 4, newer devices) |
-| POWER8+      | `ppc64le`  | IBM POWER architecture           |
 
 ---
 
@@ -44,11 +44,11 @@ Run the build script with your target [architecture identifier](#supported-archi
 # For ARM 64-bit (AArch64)
 ./packaging/makeself/build-static.sh aarch64
 
+# For ARMv6
+./packaging/makeself/build-static.sh armv6l
+
 # For ARMv7
 ./packaging/makeself/build-static.sh armv7l
-
-# For POWER8+
-./packaging/makeself/build-static.sh ppc64le
 ```
 
 The script will automatically:

--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -53,13 +53,6 @@ case "${BUILDARCH}" in
         GOARM64="v8.0"
         GOARCH="arm64"
         ;;
-    ppc64le) # Baseline POWER8+ CPU
-        QEMU_ARCH="ppc64le"
-        QEMU_CPU="power8nvl"
-        TUNING_FLAGS="-mcpu=power8 -mtune=power9"
-        GOPPC64="power8"
-        GOARCH="ppc64le"
-        ;;
 esac
 
 [ -f "/proc/sys/fs/binfmt_misc/qemu-${QEMU_ARCH}" ] && SKIP_EMULATION=1

--- a/packaging/makeself/jobs/10-libucontext.install.sh
+++ b/packaging/makeself/jobs/10-libucontext.install.sh
@@ -26,7 +26,6 @@ fetch_git "${build_dir}" "${LIBUCONTEXT_SOURCE}" "${LIBUCONTEXT_VERSION}" "${cac
 
 case "${BUILDARCH}" in
     armv6l|armv7l) arch=arm ;;
-    ppc64le) arch=ppc64 ;;
     *) arch="${BUILDARCH}" ;;
 esac
 

--- a/packaging/makeself/jobs/82-cpu-arch-check.sh
+++ b/packaging/makeself/jobs/82-cpu-arch-check.sh
@@ -18,10 +18,6 @@ case "${BUILDARCH}" in
     ELF_MACHINE="ARM"
     ELF_CLASS="ELF32"
     ;;
-  ppc64le)
-    ELF_MACHINE="PowerPC64"
-    ELF_CLASS="ELF64"
-    ;;
   x86_64)
     ELF_MACHINE="X86-64"
     ELF_CLASS="ELF64"

--- a/packaging/makeself/uname2platform.sh
+++ b/packaging/makeself/uname2platform.sh
@@ -11,7 +11,6 @@ case "${BUILDARCH}" in
   armv6l) echo "linux/arm/v6" ;;
   armv7l) echo "linux/arm/v7" ;;
   aarch64) echo "linux/arm64/v8" ;;
-  ppc64le) echo "linux/ppc64le" ;;
   *)
     echo "Unknown target architecture '${BUILDARCH}'." >&2
     exit 1


### PR DESCRIPTION
##### Summary

A few years back we started providing static builds and Docker images for 64-bit little-endian POWER8+ hardware under the assumption that they would be of interest for corporate users. Interested corporate users have completely failed to materialize, and these builds (especially the static builds) have persistently been a significantly greater maintenance burden than most other platforms we build for. Additionally, even on the Community plan, we have so few users using these that they look more like a rounding error than actual interest.

Given this, continuing to provide these builds is not worth the time or effort for us at the moment.

If there is significant demand in the future this decision may be revisited.

##### Test Plan

n/a