### PR TITLE
improve(go.d/snmp): add Go template-based metric transformations for SNMP profiles

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/charts.go
+++ b/src/go/plugin/go.d/collector/snmp/charts.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/agent/module"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
-	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
 )
 
 const (
@@ -310,7 +310,7 @@ func newUserInputChart(cfg ChartConfig) (*module.Chart, error) {
 	return chart, nil
 }
 
-func (c *Collector) addProfileScalarMetricChart(m ddsnmpcollector.Metric) {
+func (c *Collector) addProfileScalarMetricChart(m ddsnmp.Metric) {
 	if m.Name == "" {
 		return
 	}
@@ -332,6 +332,9 @@ func (c *Collector) addProfileScalarMetricChart(m ddsnmpcollector.Metric) {
 	}
 	if chart.Fam == "" {
 		chart.Fam = m.Name
+	}
+	if chart.Units == "bits/s" {
+		chart.Type = module.Area
 	}
 
 	tags := map[string]string{
@@ -361,7 +364,7 @@ func (c *Collector) addProfileScalarMetricChart(m ddsnmpcollector.Metric) {
 	}
 }
 
-func (c *Collector) addProfileTableMetricChart(m ddsnmpcollector.Metric) {
+func (c *Collector) addProfileTableMetricChart(m ddsnmp.Metric) {
 	if m.Name == "" {
 		return
 	}
@@ -415,7 +418,7 @@ func (c *Collector) addProfileTableMetricChart(m ddsnmpcollector.Metric) {
 	}
 }
 
-func dimAlgoFromDdSnmpType(m ddsnmpcollector.Metric) module.DimAlgo {
+func dimAlgoFromDdSnmpType(m ddsnmp.Metric) module.DimAlgo {
 	if m.MetricType == ddprofiledefinition.ProfileMetricTypeGauge {
 		return module.Absolute
 	}

--- a/src/go/plugin/go.d/collector/snmp/collect_profiles.go
+++ b/src/go/plugin/go.d/collector/snmp/collect_profiles.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/metrix"
 )
@@ -31,7 +32,7 @@ func (c *Collector) collectProfiles(mx map[string]int64) error {
 	return nil
 }
 
-func (c *Collector) collectProfileScalarMetrics(mx map[string]int64, pms []*ddsnmpcollector.ProfileMetrics) {
+func (c *Collector) collectProfileScalarMetrics(mx map[string]int64, pms []*ddsnmp.ProfileMetrics) {
 	for _, pm := range pms {
 		for _, m := range pm.Metrics {
 			if m.IsTable || m.Name == "" {
@@ -56,7 +57,7 @@ func (c *Collector) collectProfileScalarMetrics(mx map[string]int64, pms []*ddsn
 	}
 }
 
-func (c *Collector) collectProfileTableMetrics(mx map[string]int64, pms []*ddsnmpcollector.ProfileMetrics) {
+func (c *Collector) collectProfileTableMetrics(mx map[string]int64, pms []*ddsnmp.ProfileMetrics) {
 	seen := make(map[string]bool)
 
 	for _, pm := range pms {
@@ -92,7 +93,7 @@ func (c *Collector) collectProfileTableMetrics(mx map[string]int64, pms []*ddsnm
 	}
 }
 
-func tableMetricKey(m ddsnmpcollector.Metric) string {
+func tableMetricKey(m ddsnmp.Metric) string {
 	keys := make([]string, 0, len(m.Tags))
 	for k := range m.Tags {
 		keys = append(keys, k)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metrics.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metrics.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"regexp"
 	"slices"
+	"text/template"
 )
 
 // ProfileMetricType metric type used to override default type of the metric
@@ -78,11 +79,15 @@ type SymbolConfig struct {
 	//   When empty, by default, the metric type is derived from SNMP OID value type.
 	//   Valid `metric_type` types: `gauge`, `rate`, `monotonic_count`, `monotonic_count_and_rate`
 	//   Deprecated types: `counter` (use `rate` instead), percent (use `scale_factor` instead)
-	MetricType  ProfileMetricType `yaml:"metric_type,omitempty" json:"metric_type,omitempty"`
-	Unit        string            `yaml:"unit,omitempty" json:"unit,omitempty"`
-	Description string            `yaml:"description,omitempty" json:"description,omitempty"`
-	Family      string            `yaml:"family,omitempty" json:"family,omitempty"`
-	Mapping     map[string]string `yaml:"mapping,omitempty" json:"mapping,omitempty"`
+	MetricType ProfileMetricType `yaml:"metric_type,omitempty" json:"metric_type,omitempty"`
+
+	Unit        string `yaml:"unit,omitempty" json:"unit,omitempty"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+	Family      string `yaml:"family,omitempty" json:"family,omitempty"`
+
+	Mapping           map[string]string  `yaml:"mapping,omitempty" json:"mapping,omitempty"`
+	Transform         string             `yaml:"transform,omitempty" json:"transform,omitempty"`
+	TransformCompiled *template.Template `yaml:"-" json:"-"`
 }
 
 // Clone creates a duplicate of this SymbolConfig

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_test.go
@@ -5,6 +5,7 @@ package ddsnmpcollector
 import (
 	"errors"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,7 +25,7 @@ func TestCollector_Collect_ScalarMetrics(t *testing.T) {
 	tests := map[string]struct {
 		profiles       []*ddsnmp.Profile
 		setupMock      func(m *snmpmock.MockHandler)
-		expectedResult []*ProfileMetrics
+		expectedResult []*ddsnmp.ProfileMetrics
 		expectedError  bool
 		errorContains  string
 		enableCache    bool // Whether to enable cache for this test
@@ -70,11 +71,11 @@ func TestCollector_Collect_ScalarMetrics(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "sysUpTime",
 							Value:      123456,
@@ -138,12 +139,12 @@ func TestCollector_Collect_ScalarMetrics(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
 					Tags:           map[string]string{"device_vendor": "Cisco IOS"},
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "sysUpTime",
 							Value:      123456,
@@ -212,14 +213,14 @@ func TestCollector_Collect_ScalarMetrics(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source: "test-profile.yaml",
 					DeviceMetadata: map[string]string{
 						"vendor":        "dell",
 						"serial_number": "ABC123",
 					},
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "sysUpTime",
 							Value:      123456,
@@ -261,11 +262,11 @@ func TestCollector_Collect_ScalarMetrics(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "memoryKilobytes",
 							Value:      1024000, // 1024 * 1000
@@ -307,11 +308,11 @@ func TestCollector_Collect_ScalarMetrics(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "temperature",
 							Value:      25,
@@ -378,12 +379,12 @@ func TestCollector_Collect_ScalarMetrics(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
 					Tags:           map[string]string{"device_type": "router"},
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "sysUpTime",
 							Value:      123456,
@@ -424,10 +425,10 @@ func TestCollector_Collect_ScalarMetrics(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					DeviceMetadata: nil,
-					Metrics:        []Metric{},
+					Metrics:        []ddsnmp.Metric{},
 				},
 			},
 			expectedError: false,
@@ -471,10 +472,10 @@ func TestCollector_Collect_ScalarMetrics(t *testing.T) {
 			setupMock: func(m *snmpmock.MockHandler) {
 				m.EXPECT().MaxOids().Return(10).AnyTimes()
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					DeviceMetadata: nil,
-					Metrics:        []Metric{},
+					Metrics:        []ddsnmp.Metric{},
 				},
 			},
 			expectedError: false,
@@ -528,11 +529,11 @@ func TestCollector_Collect_ScalarMetrics(t *testing.T) {
 					errors.New("connection refused"),
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "profile1.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "sysUpTime",
 							Value:      123456,
@@ -599,7 +600,7 @@ func TestCollector_Collect_ValueMappings(t *testing.T) {
 	tests := map[string]struct {
 		profiles       []*ddsnmp.Profile
 		setupMock      func(m *snmpmock.MockHandler)
-		expectedResult []*ProfileMetrics
+		expectedResult []*ddsnmp.ProfileMetrics
 		expectedError  bool
 		errorContains  string
 	}{
@@ -638,11 +639,11 @@ func TestCollector_Collect_ValueMappings(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "clusterHealth",
 							Value:      1,
@@ -695,11 +696,11 @@ func TestCollector_Collect_ValueMappings(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifOperStatus",
 							Value:      2,
@@ -753,11 +754,11 @@ func TestCollector_Collect_ValueMappings(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "fanStatus",
 							Value:      2,
@@ -808,11 +809,11 @@ func TestCollector_Collect_ValueMappings(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifAdminStatus",
 							Value:      0, // mapped from 2 -> 0
@@ -936,11 +937,11 @@ func TestCollector_Collect_ValueMappings(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "sysUpTime",
 							Value:      123456,
@@ -987,11 +988,11 @@ func TestCollector_Collect_ValueMappings(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifAdminStatus",
 							Value:      1,
@@ -1043,11 +1044,11 @@ func TestCollector_Collect_ValueMappings(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "upsBasicBatteryStatus",
 							Value:      1,
@@ -1114,7 +1115,7 @@ func TestCollector_Collect_TableMetricsBasic(t *testing.T) {
 	tests := map[string]struct {
 		profiles       []*ddsnmp.Profile
 		setupMock      func(m *snmpmock.MockHandler)
-		expectedResult []*ProfileMetrics
+		expectedResult []*ddsnmp.ProfileMetrics
 		expectedError  bool
 		errorContains  string
 		enableCache    bool
@@ -1178,11 +1179,11 @@ func TestCollector_Collect_TableMetricsBasic(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifInOctets",
 							Value:      1000,
@@ -1291,11 +1292,11 @@ func TestCollector_Collect_TableMetricsBasic(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						// Row 1
 						{
 							Name:       "ifInOctets",
@@ -1426,11 +1427,11 @@ func TestCollector_Collect_TableMetricsBasic(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifInErrors",
 							Value:      10,
@@ -1531,11 +1532,11 @@ func TestCollector_Collect_TableMetricsBasic(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						// Row 1 - complete
 						{
 							Name:       "ifInOctets",
@@ -1632,11 +1633,11 @@ func TestCollector_Collect_TableMetricsBasic(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:  "ifInOctets",
 							Value: 1000,
@@ -1713,11 +1714,11 @@ func TestCollector_Collect_TableMetricsBasic(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifInErrors",
 							Value:      10,
@@ -1815,11 +1816,11 @@ func TestCollector_Collect_TableMetricsBasic(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:  "ifInOctets",
 							Value: 1000,
@@ -1874,11 +1875,11 @@ func TestCollector_Collect_TableMetricsBasic(t *testing.T) {
 					[]gosnmp.SnmpPDU{}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics:        []Metric{},
+					Metrics:        []ddsnmp.Metric{},
 				},
 			},
 			expectedError: false,
@@ -1967,11 +1968,11 @@ func TestCollector_Collect_TableMetricsBasic(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "cpmCPUMemoryUsed",
 							Value:      2097152, // 2048 * 1024
@@ -2033,11 +2034,11 @@ func TestCollector_Collect_TableMetricsBasic(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifInOctets",
 							Value:      1000,
@@ -2106,7 +2107,7 @@ func TestCollector_Collect_CrossTableTags(t *testing.T) {
 	tests := map[string]struct {
 		profiles       []*ddsnmp.Profile
 		setupMock      func(m *snmpmock.MockHandler)
-		expectedResult []*ProfileMetrics
+		expectedResult []*ddsnmp.ProfileMetrics
 		expectedError  bool
 		errorContains  string
 		enableCache    bool
@@ -2190,11 +2191,11 @@ func TestCollector_Collect_CrossTableTags(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifInErrors",
 							Value:      10,
@@ -2298,11 +2299,11 @@ func TestCollector_Collect_CrossTableTags(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifInErrors",
 							Value:      10,
@@ -2427,11 +2428,11 @@ func TestCollector_Collect_CrossTableTags(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:  "ifInErrors",
 							Value: 10,
@@ -2568,11 +2569,11 @@ func TestCollector_Collect_CrossTableTags(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:  "cieIfResetCount",
 							Value: 5,
@@ -2662,11 +2663,11 @@ func TestCollector_Collect_CrossTableTags(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifInErrors",
 							Value:      10,
@@ -2756,11 +2757,11 @@ func TestCollector_Collect_CrossTableTags(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifInOctets",
 							Value:      1000,
@@ -2872,11 +2873,11 @@ func TestCollector_Collect_CrossTableTags(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:  "ifInErrors",
 							Value: 10,
@@ -2962,11 +2963,11 @@ func TestCollector_Collect_CrossTableTags(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifInErrors",
 							Value:      10,
@@ -3036,7 +3037,7 @@ func TestCollector_Collect_IndexBasedAndTransforms(t *testing.T) {
 	tests := map[string]struct {
 		profiles       []*ddsnmp.Profile
 		setupMock      func(m *snmpmock.MockHandler)
-		expectedResult []*ProfileMetrics
+		expectedResult []*ddsnmp.ProfileMetrics
 		expectedError  bool
 		errorContains  string
 		enableCache    bool
@@ -3088,11 +3089,11 @@ func TestCollector_Collect_IndexBasedAndTransforms(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ipSystemStatsHCInReceives",
 							Value:      1000,
@@ -3167,11 +3168,11 @@ func TestCollector_Collect_IndexBasedAndTransforms(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "cfwConnectionStatValue",
 							Value:      100,
@@ -3256,11 +3257,11 @@ func TestCollector_Collect_IndexBasedAndTransforms(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ipSystemStatsHCInReceives",
 							Value:      1000,
@@ -3337,11 +3338,11 @@ func TestCollector_Collect_IndexBasedAndTransforms(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifInOctets",
 							Value:      1000,
@@ -3435,11 +3436,11 @@ func TestCollector_Collect_IndexBasedAndTransforms(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "cpiPduBranchCurrent",
 							Value:      150,
@@ -3525,11 +3526,11 @@ func TestCollector_Collect_IndexBasedAndTransforms(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "customMetric",
 							Value:      500,
@@ -3619,11 +3620,11 @@ func TestCollector_Collect_IndexBasedAndTransforms(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifInOctets",
 							Value:      1000,
@@ -3699,7 +3700,7 @@ func TestCollector_Collect_OpaqueTypes(t *testing.T) {
 	tests := map[string]struct {
 		profiles       []*ddsnmp.Profile
 		setupMock      func(m *snmpmock.MockHandler)
-		expectedResult []*ProfileMetrics
+		expectedResult []*ddsnmp.ProfileMetrics
 		expectedError  bool
 		errorContains  string
 		enableCache    bool
@@ -3760,11 +3761,11 @@ func TestCollector_Collect_OpaqueTypes(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "cpmCPULoadAvg1min",
 							Value:      0, // 0.75 truncated to int64
@@ -3841,11 +3842,11 @@ func TestCollector_Collect_OpaqueTypes(t *testing.T) {
 					}, nil,
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "cpqHeSysBatteryVoltage",
 							Value:      12, // 12.6 truncated to int64
@@ -3922,7 +3923,7 @@ func TestCollector_Collect_TableCaching(t *testing.T) {
 	tests := map[string]struct {
 		profiles       []*ddsnmp.Profile
 		setupMock      func(m *snmpmock.MockHandler)
-		expectedResult []*ProfileMetrics
+		expectedResult []*ddsnmp.ProfileMetrics
 		expectedError  bool
 		errorContains  string
 		enableCache    bool
@@ -4071,11 +4072,11 @@ func TestCollector_Collect_TableCaching(t *testing.T) {
 					}, nil,
 				).Times(1)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifInOctets",
 							Value:      1200, // Latest value
@@ -4205,11 +4206,11 @@ func TestCollector_Collect_TableCaching(t *testing.T) {
 					),
 				)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						{
 							Name:       "ifInOctets",
 							Value:      1200,
@@ -4372,11 +4373,11 @@ func TestCollector_Collect_TableCaching(t *testing.T) {
 					}, nil,
 				).Times(1)
 			},
-			expectedResult: []*ProfileMetrics{
+			expectedResult: []*ddsnmp.ProfileMetrics{
 				{
 					Source:         "test-profile.yaml",
 					DeviceMetadata: nil,
-					Metrics: []Metric{
+					Metrics: []ddsnmp.Metric{
 						// From first config
 						{
 							Name:       "ifInOctets",
@@ -4436,7 +4437,7 @@ func TestCollector_Collect_TableCaching(t *testing.T) {
 				collector.tableCache.setTTL(0, 0) // Disable cache
 			}
 
-			var result []*ProfileMetrics
+			var result []*ddsnmp.ProfileMetrics
 			var err error
 
 			// Perform multiple collections to test caching behavior
@@ -4454,6 +4455,559 @@ func TestCollector_Collect_TableCaching(t *testing.T) {
 			}
 
 			// Clear circular references in final result
+			for _, profile := range result {
+				for i := range profile.Metrics {
+					profile.Metrics[i].Profile = nil
+				}
+			}
+
+			if tc.expectedError {
+				assert.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tc.expectedResult != nil {
+				require.Equal(t, len(tc.expectedResult), len(result))
+				for i := range tc.expectedResult {
+					assert.Equal(t, tc.expectedResult[i].DeviceMetadata, result[i].DeviceMetadata)
+					assert.Equal(t, tc.expectedResult[i].Tags, result[i].Tags)
+					assert.ElementsMatch(t, tc.expectedResult[i].Metrics, result[i].Metrics)
+				}
+			} else {
+				assert.Nil(t, result)
+			}
+		})
+	}
+}
+
+func TestCollector_Collect_MetricTransforms(t *testing.T) {
+	tests := map[string]struct {
+		profiles       []*ddsnmp.Profile
+		setupMock      func(m *snmpmock.MockHandler)
+		expectedResult []*ddsnmp.ProfileMetrics
+		expectedError  bool
+		errorContains  string
+	}{
+		"basic metric name transformation": {
+			profiles: []*ddsnmp.Profile{
+				{
+					SourceFile: "test-profile.yaml",
+					Definition: &ddprofiledefinition.ProfileDefinition{
+						Metrics: []ddprofiledefinition.MetricsConfig{
+							{
+								Symbol: ddprofiledefinition.SymbolConfig{
+									OID:       "1.3.6.1.4.1.12345.1.1",
+									Name:      "sensorValue",
+									Transform: `{{- setName .Metric "customName" -}}`,
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMock: func(m *snmpmock.MockHandler) {
+				m.EXPECT().MaxOids().Return(10).AnyTimes()
+				m.EXPECT().Get([]string{"1.3.6.1.4.1.12345.1.1"}).Return(
+					&gosnmp.SnmpPacket{
+						Variables: []gosnmp.SnmpPDU{
+							{
+								Name:  "1.3.6.1.4.1.12345.1.1",
+								Type:  gosnmp.Gauge32,
+								Value: uint(100),
+							},
+						},
+					}, nil,
+				)
+			},
+			expectedResult: []*ddsnmp.ProfileMetrics{
+				{
+					Source:         "test-profile.yaml",
+					DeviceMetadata: nil,
+					Metrics: []ddsnmp.Metric{
+						{
+							Name:       "customName",
+							Value:      100,
+							MetricType: "gauge",
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		"table metric with sensor type transformation": {
+			profiles: []*ddsnmp.Profile{
+				{
+					SourceFile: "test-profile.yaml",
+					Definition: &ddprofiledefinition.ProfileDefinition{
+						Metrics: []ddprofiledefinition.MetricsConfig{
+							{
+								Table: ddprofiledefinition.SymbolConfig{
+									OID:  "1.3.6.1.4.1.14988.1.1.3.100",
+									Name: "mtxrHlTable",
+								},
+								Symbols: []ddprofiledefinition.SymbolConfig{
+									{
+										OID:  "1.3.6.1.4.1.14988.1.1.3.100.1.3",
+										Name: "mtxrHlSensorValue",
+										Transform: `
+{{- $sensorType := index .Metric.Tags "sensor_type" | default "" -}}
+{{- if eq $sensorType "1" -}}
+  {{- setName .Metric (printf "%s_temperature" .Metric.Name) -}}
+  {{- setUnit .Metric "celsius" -}}
+  {{- setFamily .Metric "Health/Temperature" -}}
+{{- else if eq $sensorType "3" -}}
+  {{- setName .Metric (printf "%s_voltage" .Metric.Name) -}}
+  {{- setUnit .Metric "volts" -}}
+  {{- setValue .Metric (int64 (div (float64 .Metric.Value) 10.0)) -}}
+  {{- setFamily .Metric "Health/Power" -}}
+{{- end -}}
+{{- deleteTag .Metric "sensor_type" -}}`,
+									},
+								},
+								MetricTags: []ddprofiledefinition.MetricTagConfig{
+									{
+										Tag: "sensor_name",
+										Symbol: ddprofiledefinition.SymbolConfigCompat{
+											OID:  "1.3.6.1.4.1.14988.1.1.3.100.1.2",
+											Name: "mtxrHlSensorName",
+										},
+									},
+									{
+										Tag: "sensor_type",
+										Symbol: ddprofiledefinition.SymbolConfigCompat{
+											OID:  "1.3.6.1.4.1.14988.1.1.3.100.1.4",
+											Name: "mtxrHlSensorType",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMock: func(m *snmpmock.MockHandler) {
+				m.EXPECT().MaxOids().Return(10).AnyTimes()
+				m.EXPECT().Version().Return(gosnmp.Version2c)
+				m.EXPECT().BulkWalkAll("1.3.6.1.4.1.14988.1.1.3.100").Return(
+					[]gosnmp.SnmpPDU{
+						// Temperature sensor (type 1)
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.3.1",
+							Type:  gosnmp.Integer,
+							Value: 25,
+						},
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.2.1",
+							Type:  gosnmp.OctetString,
+							Value: []byte("cpu-temperature"),
+						},
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.4.1",
+							Type:  gosnmp.Integer,
+							Value: 1,
+						},
+						// Voltage sensor (type 3)
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.3.2",
+							Type:  gosnmp.Integer,
+							Value: 120, // 12.0V in decivolts
+						},
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.2.2",
+							Type:  gosnmp.OctetString,
+							Value: []byte("input-voltage"),
+						},
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.4.2",
+							Type:  gosnmp.Integer,
+							Value: 3,
+						},
+					}, nil,
+				)
+			},
+			expectedResult: []*ddsnmp.ProfileMetrics{
+				{
+					Source:         "test-profile.yaml",
+					DeviceMetadata: nil,
+					Metrics: []ddsnmp.Metric{
+						{
+							Name:       "mtxrHlSensorValue_temperature",
+							Value:      25,
+							Tags:       map[string]string{"sensor_name": "cpu-temperature"},
+							Unit:       "celsius",
+							Family:     "Health/Temperature",
+							MetricType: "gauge",
+							IsTable:    true,
+						},
+						{
+							Name:       "mtxrHlSensorValue_voltage",
+							Value:      12, // Converted from decivolts
+							Tags:       map[string]string{"sensor_name": "input-voltage"},
+							Unit:       "volts",
+							Family:     "Health/Power",
+							MetricType: "gauge",
+							IsTable:    true,
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		"transformation with value mappings": {
+			profiles: []*ddsnmp.Profile{
+				{
+					SourceFile: "test-profile.yaml",
+					Definition: &ddprofiledefinition.ProfileDefinition{
+						Metrics: []ddprofiledefinition.MetricsConfig{
+							{
+								Symbol: ddprofiledefinition.SymbolConfig{
+									OID:  "1.3.6.1.4.1.12345.1.1",
+									Name: "deviceStatus",
+									Transform: `
+{{- setMappings .Metric (i64map 0 "down" 1 "up" 2 "testing") -}}`,
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMock: func(m *snmpmock.MockHandler) {
+				m.EXPECT().MaxOids().Return(10).AnyTimes()
+				m.EXPECT().Get([]string{"1.3.6.1.4.1.12345.1.1"}).Return(
+					&gosnmp.SnmpPacket{
+						Variables: []gosnmp.SnmpPDU{
+							{
+								Name:  "1.3.6.1.4.1.12345.1.1",
+								Type:  gosnmp.Integer,
+								Value: 1,
+							},
+						},
+					}, nil,
+				)
+			},
+			expectedResult: []*ddsnmp.ProfileMetrics{
+				{
+					Source:         "test-profile.yaml",
+					DeviceMetadata: nil,
+					Metrics: []ddsnmp.Metric{
+						{
+							Name:  "deviceStatus",
+							Value: 1,
+							Mappings: map[int64]string{
+								0: "down",
+								1: "up",
+								2: "testing",
+							},
+							MetricType: "gauge",
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		"complex transformation with sprig functions": {
+			profiles: []*ddsnmp.Profile{
+				{
+					SourceFile: "test-profile.yaml",
+					Definition: &ddprofiledefinition.ProfileDefinition{
+						Metrics: []ddprofiledefinition.MetricsConfig{
+							{
+								Table: ddprofiledefinition.SymbolConfig{
+									OID:  "1.3.6.1.2.1.2.2",
+									Name: "ifTable",
+								},
+								Symbols: []ddprofiledefinition.SymbolConfig{
+									{
+										OID:  "1.3.6.1.2.1.2.2.1.10",
+										Name: "ifInOctets",
+										Transform: `
+{{- $ifName := index .Metric.Tags "interface" | lower -}}
+{{- if contains "eth" $ifName -}}
+  {{- setFamily .Metric "Interfaces/Ethernet" -}}
+{{- else if contains "lo" $ifName -}}
+  {{- setFamily .Metric "Interfaces/Loopback" -}}
+{{- end -}}
+{{- setDesc .Metric (printf "Traffic on %s interface" (index .Metric.Tags "interface")) -}}`,
+									},
+								},
+								MetricTags: []ddprofiledefinition.MetricTagConfig{
+									{
+										Tag: "interface",
+										Symbol: ddprofiledefinition.SymbolConfigCompat{
+											OID:  "1.3.6.1.2.1.2.2.1.2",
+											Name: "ifDescr",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMock: func(m *snmpmock.MockHandler) {
+				m.EXPECT().MaxOids().Return(10).AnyTimes()
+				m.EXPECT().Version().Return(gosnmp.Version2c)
+				m.EXPECT().BulkWalkAll("1.3.6.1.2.1.2.2").Return(
+					[]gosnmp.SnmpPDU{
+						{
+							Name:  "1.3.6.1.2.1.2.2.1.10.1",
+							Type:  gosnmp.Counter32,
+							Value: uint(1000),
+						},
+						{
+							Name:  "1.3.6.1.2.1.2.2.1.2.1",
+							Type:  gosnmp.OctetString,
+							Value: []byte("eth0"),
+						},
+						{
+							Name:  "1.3.6.1.2.1.2.2.1.10.2",
+							Type:  gosnmp.Counter32,
+							Value: uint(2000),
+						},
+						{
+							Name:  "1.3.6.1.2.1.2.2.1.2.2",
+							Type:  gosnmp.OctetString,
+							Value: []byte("lo0"),
+						},
+					}, nil,
+				)
+			},
+			expectedResult: []*ddsnmp.ProfileMetrics{
+				{
+					Source:         "test-profile.yaml",
+					DeviceMetadata: nil,
+					Metrics: []ddsnmp.Metric{
+						{
+							Name:        "ifInOctets",
+							Value:       1000,
+							Tags:        map[string]string{"interface": "eth0"},
+							Family:      "Interfaces/Ethernet",
+							Description: "Traffic on eth0 interface",
+							MetricType:  "rate",
+							IsTable:     true,
+						},
+						{
+							Name:        "ifInOctets",
+							Value:       2000,
+							Tags:        map[string]string{"interface": "lo0"},
+							Family:      "Interfaces/Loopback",
+							Description: "Traffic on lo0 interface",
+							MetricType:  "rate",
+							IsTable:     true,
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		"transformation with invalid template": {
+			profiles: []*ddsnmp.Profile{
+				{
+					SourceFile: "test-profile.yaml",
+					Definition: &ddprofiledefinition.ProfileDefinition{
+						Metrics: []ddprofiledefinition.MetricsConfig{
+							{
+								Symbol: ddprofiledefinition.SymbolConfig{
+									OID:               "1.3.6.1.4.1.12345.1.1",
+									Name:              "testMetric",
+									Transform:         `{{- invalid template syntax {{`,
+									TransformCompiled: nil, // Will fail compilation
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMock: func(m *snmpmock.MockHandler) {
+				// This test should fail during profile validation, not during collection
+			},
+			expectedResult: nil,
+			expectedError:  true,
+			errorContains:  "template",
+		},
+		"mikrotik sensor table real-world example": {
+			profiles: []*ddsnmp.Profile{
+				{
+					SourceFile: "mikrotik-profile.yaml",
+					Definition: &ddprofiledefinition.ProfileDefinition{
+						Metrics: []ddprofiledefinition.MetricsConfig{
+							{
+								Table: ddprofiledefinition.SymbolConfig{
+									OID:  "1.3.6.1.4.1.14988.1.1.3.100",
+									Name: "mtxrHlTable",
+								},
+								Symbols: []ddprofiledefinition.SymbolConfig{
+									{
+										OID:  "1.3.6.1.4.1.14988.1.1.3.100.1.3",
+										Name: "mtxrHlSensorValue",
+										Transform: `
+{{- $config := get (dict 
+    "1" (dict "name" "temperature" "unit" "celsius" "family" "Health/Temperature")
+    "2" (dict "name" "fan_speed" "unit" "rpm" "family" "Health/Cooling")
+    "3" (dict "name" "voltage" "unit" "volts" "family" "Health/Power" "divisor" 10.0)
+    "6" (dict "name" "sensor_status" "family" "Health/Status" 
+         "mapping" (i64map 0 "not_ok" 1 "ok"))
+) (index .Metric.Tags "sensor_type" | default "") -}}
+
+{{- if $config -}}
+  {{- setName .Metric (printf "%s_%s" .Metric.Name (get $config "name")) -}}
+  {{- setFamily .Metric (get $config "family") -}}
+  {{- with get $config "unit" -}}{{- setUnit $.Metric . -}}{{- end -}}
+  {{- with get $config "divisor" -}}{{- setValue $.Metric (int64 (div (float64 $.Metric.Value) .)) -}}{{- end -}}
+  {{- with get $config "mapping" -}}{{- setMappings $.Metric . -}}{{- end -}}
+{{- end -}}
+
+{{- deleteTag .Metric "sensor_type" -}}`,
+									},
+								},
+								MetricTags: []ddprofiledefinition.MetricTagConfig{
+									{
+										Tag: "sensor_name",
+										Symbol: ddprofiledefinition.SymbolConfigCompat{
+											OID:  "1.3.6.1.4.1.14988.1.1.3.100.1.2",
+											Name: "mtxrHlSensorName",
+										},
+									},
+									{
+										Tag: "sensor_type",
+										Symbol: ddprofiledefinition.SymbolConfigCompat{
+											OID:  "1.3.6.1.4.1.14988.1.1.3.100.1.4",
+											Name: "mtxrHlSensorType",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMock: func(m *snmpmock.MockHandler) {
+				m.EXPECT().MaxOids().Return(10).AnyTimes()
+				m.EXPECT().Version().Return(gosnmp.Version2c)
+				m.EXPECT().BulkWalkAll("1.3.6.1.4.1.14988.1.1.3.100").Return(
+					[]gosnmp.SnmpPDU{
+						// Temperature sensor
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.3.1",
+							Type:  gosnmp.Integer,
+							Value: 45,
+						},
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.2.1",
+							Type:  gosnmp.OctetString,
+							Value: []byte("cpu-temperature"),
+						},
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.4.1",
+							Type:  gosnmp.Integer,
+							Value: 1,
+						},
+						// PSU status sensor
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.3.2",
+							Type:  gosnmp.Integer,
+							Value: 1,
+						},
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.2.2",
+							Type:  gosnmp.OctetString,
+							Value: []byte("psu1-state"),
+						},
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.4.2",
+							Type:  gosnmp.Integer,
+							Value: 6,
+						},
+						// Voltage sensor
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.3.3",
+							Type:  gosnmp.Integer,
+							Value: 240, // 24.0V
+						},
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.2.3",
+							Type:  gosnmp.OctetString,
+							Value: []byte("psu-voltage"),
+						},
+						{
+							Name:  "1.3.6.1.4.1.14988.1.1.3.100.1.4.3",
+							Type:  gosnmp.Integer,
+							Value: 3,
+						},
+					}, nil,
+				)
+			},
+			expectedResult: []*ddsnmp.ProfileMetrics{
+				{
+					Source:         "mikrotik-profile.yaml",
+					DeviceMetadata: nil,
+					Metrics: []ddsnmp.Metric{
+						{
+							Name:       "mtxrHlSensorValue_temperature",
+							Value:      45,
+							Tags:       map[string]string{"sensor_name": "cpu-temperature"},
+							Unit:       "celsius",
+							Family:     "Health/Temperature",
+							MetricType: "gauge",
+							IsTable:    true,
+						},
+						{
+							Name:   "mtxrHlSensorValue_sensor_status",
+							Value:  1,
+							Tags:   map[string]string{"sensor_name": "psu1-state"},
+							Family: "Health/Status",
+							Mappings: map[int64]string{
+								0: "not_ok",
+								1: "ok",
+							},
+							MetricType: "gauge",
+							IsTable:    true,
+						},
+						{
+							Name:       "mtxrHlSensorValue_voltage",
+							Value:      24,
+							Tags:       map[string]string{"sensor_name": "psu-voltage"},
+							Unit:       "volts",
+							Family:     "Health/Power",
+							MetricType: "gauge",
+							IsTable:    true,
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockHandler := snmpmock.NewMockHandler(ctrl)
+			tc.setupMock(mockHandler)
+
+			// Compile transforms for profiles
+			for _, profile := range tc.profiles {
+				if err := ddsnmp.CompileTransforms(profile); err != nil {
+					if tc.expectedError && tc.errorContains != "" && strings.Contains(err.Error(), tc.errorContains) {
+						return // Expected error during compilation
+					}
+					t.Fatalf("Failed to compile transforms: %v", err)
+				}
+			}
+
+			collector := New(mockHandler, tc.profiles, logger.New())
+			collector.DoTableMetrics = true
+			collector.tableCache.setTTL(0, 0) // Disable cache
+
+			result, err := collector.Collect()
+
+			// Clear circular references
 			for _, profile := range result {
 				for i := range profile.Metrics {
 					profile.Metrics[i].Profile = nil

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/load.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/load.go
@@ -93,6 +93,10 @@ func loadProfilesFromDir(dirpath string, extendsPaths multipath.MultiPath) ([]*P
 			log.Warningf("invalid profile '%s': %v", path, err)
 			return nil
 		}
+		if err := CompileTransforms(profile); err != nil {
+			log.Warningf("invalid profile '%s': %v", path, err)
+			return nil
+		}
 
 		profile.removeConstantMetrics()
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/metric.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/metric.go
@@ -1,0 +1,26 @@
+package ddsnmp
+
+import (
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+type ProfileMetrics struct {
+	Source         string
+	DeviceMetadata map[string]string
+	Tags           map[string]string
+	Metrics        []Metric
+}
+
+type Metric struct {
+	Profile     *ProfileMetrics
+	Name        string
+	Description string
+	Family      string
+	Unit        string
+	MetricType  ddprofiledefinition.ProfileMetricType
+	StaticTags  map[string]string
+	Tags        map[string]string
+	Mappings    map[int64]string
+	IsTable     bool
+	Value       int64
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmp
+
+import (
+	"errors"
+	"fmt"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+)
+
+// CompileTransforms exported for testing purposes only
+func CompileTransforms(prof *Profile) error {
+	var errs []error
+
+	for i := range prof.Definition.Metrics {
+		metric := &prof.Definition.Metrics[i]
+
+		switch {
+		case metric.IsScalar():
+			if metric.Symbol.Transform == "" {
+				continue
+			}
+			tmpl, err := compileTransform(metric.Symbol.Transform)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("metric_transform parsing failed for scalar metric '%s': %v",
+					metric.Symbol.Name, err))
+				continue
+			}
+			metric.Symbol.TransformCompiled = tmpl
+		case metric.IsColumn():
+			for j := range metric.Symbols {
+				sym := &metric.Symbols[j]
+				if sym.Transform == "" {
+					continue
+				}
+				tmpl, err := compileTransform(sym.Transform)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("metric_transform parsing failed for table '%s' metric '%s': %v",
+						metric.Table.Name, sym.Name, err))
+					continue
+				}
+				sym.TransformCompiled = tmpl
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+
+	}
+
+	return nil
+}
+
+func compileTransform(transform string) (*template.Template, error) {
+	return template.New("metric_transform").
+		Option("missingkey=zero").
+		Funcs(newMetricTransformFuncMap()).
+		Parse(transform)
+}
+
+func newMetricTransformFuncMap() template.FuncMap {
+	fm := sprig.TxtFuncMap()
+
+	extra := map[string]any{
+		"deleteTag": func(m *Metric, key string) interface{} {
+			delete(m.Tags, key)
+			return nil
+		},
+		"setName": func(m *Metric, name string) string {
+			m.Name = name
+			return ""
+		},
+		"setUnit": func(m *Metric, unit string) string {
+			m.Unit = unit
+			return ""
+		},
+		"setFamily": func(m *Metric, family string) string {
+			m.Family = family
+			return ""
+		},
+		"setDesc": func(m *Metric, desc string) string {
+			m.Description = desc
+			return ""
+		},
+		"setValue": func(m *Metric, value int64) string {
+			m.Value = value
+			return ""
+		},
+		"setMappings": func(m *Metric, mappings map[int64]string) string {
+			m.Mappings = mappings
+			return ""
+		},
+		"i64map": func(pairs ...any) map[int64]string {
+			m := make(map[int64]string)
+			for i := 0; i < len(pairs)-1; i += 2 {
+				key := int64(0)
+				switch k := pairs[i].(type) {
+				case int:
+					key = int64(k)
+				case int64:
+					key = k
+				case float64:
+					key = int64(k)
+				}
+
+				if val, ok := pairs[i+1].(string); ok {
+					m[key] = val
+				}
+			}
+			return m
+		},
+	}
+
+	for name, fn := range extra {
+		fm[name] = fn
+	}
+
+	return fm
+}

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/mikrotik-router.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/mikrotik-router.yaml
@@ -174,37 +174,48 @@ metrics:
         name: mtxrHlSensorValue
         description: Sensor value
         family: Health/Sensors
+        transform: |
+          {{- $sensorType := index .Metric.Tags "sensor_type" | default "" -}}
+          {{- $config := get (dict 
+              "1" (dict "name" "temperature" "unit" "celsius" "family" "Temperature" 
+                   "desc" "Temperature reading")
+              "2" (dict "name" "fan_speed" "unit" "rpm" "family" "Fan" 
+                   "desc" "Fan rotation speed")
+              "3" (dict "name" "voltage" "unit" "volts" "family" "Power" "divisor" 10.0 
+                   "desc" "Voltage measurement")
+              "4" (dict "name" "current" "unit" "amperes" "family" "Power" "divisor" 10.0 
+                   "desc" "Current draw")
+              "5" (dict "name" "power" "unit" "watts" "family" "Power" "divisor" 10.0 
+                   "desc" "Power consumption")
+              "6" (dict "name" "sensor_status" "family" "Status" 
+                   "mapping" (i64map 0 "absent_or_faulty" 1 "present_and_ok")
+                   "desc" "Component presence and operational status")
+              "7" (dict "name" "sensor_state" "family" "Status" 
+                   "mapping" (i64map 0 "false" 1 "true")
+                   "desc" "Boolean sensor state")
+              "8" (dict "name" "usage_percentage" "unit" "percentage" "family" "Usage" 
+                   "desc" "Resource utilization percentage")
+          ) $sensorType -}}
+
+          {{- if $config -}}
+            {{- setName .Metric (printf "%s_%s" .Metric.Name (get $config "name")) -}}
+            {{- setFamily .Metric (printf "Health/Sensors/%s" (get $config "family")) -}}
+            {{- with get $config "desc" -}}{{- setDesc $.Metric . -}}{{- end -}}
+            {{- with get $config "unit" -}}{{- setUnit $.Metric . -}}{{- end -}}
+            {{- with get $config "divisor" -}}{{- setValue $.Metric (int64 (div (float64 $.Value) .)) -}}{{- end -}}
+            {{- with get $config "mapping" -}}{{- setMappings $.Metric . -}}{{- end -}}
+          {{- end -}}
+
+          {{- deleteTag .Metric "sensor_type" -}}
     metric_tags:
       - tag: sensor_name
         symbol:
           OID: 1.3.6.1.4.1.14988.1.1.3.100.1.2
           name: mtxrHlSensorName
-      - tag: "_unit"
+      - tag: sensor_type
         symbol:
           OID: 1.3.6.1.4.1.14988.1.1.3.100.1.4
           name: mtxrHlSensorUnit
-        mapping:
-          1: celsius
-          2: rpm
-          3: dV      # decivolts
-          4: dA      # deciamps
-          5: dW      # deciwatts
-          6: status
-          7: boolean
-          8: percentage
-      - tag: "_metric_suffix"
-        symbol:
-          OID: 1.3.6.1.4.1.14988.1.1.3.100.1.4
-          name: mtxrHlSensorType
-        mapping:
-          1: temperature
-          2: fan_speed
-          3: voltage
-          4: current
-          5: power
-          6: state
-          7: boolean
-          8: percentage
 
 metric_tags:
   - OID: 1.3.6.1.4.1.14988.1.1.4.1.0


### PR DESCRIPTION
This PR adds a Go template-based transformation system for SNMP metrics, allowing dynamic metric processing directly within SNMP profile definitions. This feature is particularly useful for handling heterogeneous SNMP tables where different rows represent fundamentally different types of data (e.g., MikroTik sensor tables with temperature, voltage, fan speed, etc. in the same table).

Previously, SNMP profiles had limited ability to handle tables where:
- Different rows require different metric names, units, and families
- Values need different scaling factors based on row type
- Some rows need value mappings (e.g., status indicators)
- Metric names need to be dynamically constructed based on row data

The workaround involved special tags (`_unit`, `_metric_suffix`) that required post-processing, but this approach couldn't handle value mappings or complex transformations.

Added a `transform` field to metric definitions that accepts Go templates with full access to:
- Sprig template functions for string/math/logic operations
- Custom functions for metric field manipulation
- Access to all metric properties and tags