### PR TITLE
improve(go.d/snmp): dd support for non-identifying tags in table metrics

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/charts.go
+++ b/src/go/plugin/go.d/collector/snmp/charts.go
@@ -395,7 +395,9 @@ func (c *Collector) addProfileTableMetricChart(m ddsnmp.Metric) {
 		"sysName": c.sysInfo.Name,
 	}
 	maps.Copy(tags, m.Profile.Tags)
-	maps.Copy(tags, m.Tags)
+	for k, v := range m.Tags {
+		tags[k] = strings.TrimPrefix(v, "_")
+	}
 
 	for k, v := range tags {
 		chart.Labels = append(chart.Labels, module.Label{Key: k, Value: v})

--- a/src/go/plugin/go.d/collector/snmp/charts.go
+++ b/src/go/plugin/go.d/collector/snmp/charts.go
@@ -396,7 +396,8 @@ func (c *Collector) addProfileTableMetricChart(m ddsnmp.Metric) {
 	}
 	maps.Copy(tags, m.Profile.Tags)
 	for k, v := range m.Tags {
-		tags[k] = strings.TrimPrefix(v, "_")
+		newKey := strings.TrimPrefix(k, "_")
+		tags[newKey] = strings.TrimPrefix(v, "_")
 	}
 
 	for k, v := range tags {

--- a/src/go/plugin/go.d/collector/snmp/charts.go
+++ b/src/go/plugin/go.d/collector/snmp/charts.go
@@ -397,7 +397,7 @@ func (c *Collector) addProfileTableMetricChart(m ddsnmp.Metric) {
 	maps.Copy(tags, m.Profile.Tags)
 	for k, v := range m.Tags {
 		newKey := strings.TrimPrefix(k, "_")
-		tags[newKey] = strings.TrimPrefix(v, "_")
+		tags[newKey] = v
 	}
 
 	for k, v := range tags {

--- a/src/go/plugin/go.d/collector/snmp/collect_profiles.go
+++ b/src/go/plugin/go.d/collector/snmp/collect_profiles.go
@@ -106,9 +106,9 @@ func tableMetricKey(m ddsnmp.Metric) string {
 	sb.WriteString(m.Name)
 
 	for _, k := range keys {
-		if v := m.Tags[k]; v != "" && !strings.HasPrefix(v, "_") {
+		if v := m.Tags[k]; v != "" && !strings.HasPrefix(k, "_") {
 			sb.WriteString("_")
-			sb.WriteString(m.Tags[k])
+			sb.WriteString(v)
 		}
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/collect_profiles.go
+++ b/src/go/plugin/go.d/collector/snmp/collect_profiles.go
@@ -67,6 +67,7 @@ func (c *Collector) collectProfileTableMetrics(mx map[string]int64, pms []*ddsnm
 			}
 
 			key := tableMetricKey(m)
+
 			seen[key] = true
 
 			if !c.seenTableMetrics[key] {
@@ -103,8 +104,9 @@ func tableMetricKey(m ddsnmp.Metric) string {
 	var sb strings.Builder
 
 	sb.WriteString(m.Name)
+
 	for _, k := range keys {
-		if v := m.Tags[k]; v != "" {
+		if v := m.Tags[k]; v != "" && !strings.HasPrefix(v, "_") {
 			sb.WriteString("_")
 			sb.WriteString(m.Tags[k])
 		}

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_generic-if.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_generic-if.yaml
@@ -66,7 +66,7 @@ metrics:
         symbol:
           OID: 1.3.6.1.2.1.2.2.1.2
           name: ifDescr
-      - tag: if_type
+      - tag: _if_type
         symbol:
           OID: 1.3.6.1.2.1.2.2.1.3
           name: ifType
@@ -134,7 +134,7 @@ metrics:
         symbol:
           OID: 1.3.6.1.2.1.2.2.1.2
           name: ifDescr
-      - tag: if_type
+      - tag: _if_type
         table: ifTable
         symbol:
           OID: 1.3.6.1.2.1.2.2.1.3

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/mikrotik-router.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/mikrotik-router.yaml
@@ -199,7 +199,7 @@ metrics:
 
           {{- if $config -}}
             {{- setName .Metric (printf "%s_%s" .Metric.Name (get $config "name")) -}}
-            {{- setFamily .Metric (printf "Health/Sensors/%s" (get $config "family")) -}}
+            {{- setFamily .Metric (printf "Sensors/%s" (get $config "family")) -}}
             {{- with get $config "desc" -}}{{- setDesc $.Metric . -}}{{- end -}}
             {{- with get $config "unit" -}}{{- setUnit $.Metric . -}}{{- end -}}
             {{- with get $config "divisor" -}}{{- setValue $.Metric (int64 (div (float64 $.Value) .)) -}}{{- end -}}

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/mikrotik-router.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/mikrotik-router.yaml
@@ -158,7 +158,7 @@ metrics:
         scale_factor: 1024
         unit: "By"
     metric_tags:
-      - tag: mem_index
+      - tag: _mem_index
         index: 1
       - tag: mem
         symbol:


### PR DESCRIPTION
This PR introduces support for non-identifying tags in SNMP table metrics by using an underscore (`_`) prefix convention. Tags prefixed with `_` are excluded from metric ID generation but are still included in the metric data (with the prefix removed).

When collecting SNMP table metrics, we generate unique IDs by combining the metric name with all tag values. However, not all tags contribute to the uniqueness of a metric - some are purely descriptive. Including these non-identifying tags in the ID makes it unnecessarily long without adding value.

For example, in interface metrics:

- `interface` tag (e.g., "eth0") - identifying: different interfaces have different metrics.
- `if_type` tag (e.g., "ethernetCsmacd") - descriptive: provides context but doesn't identify unique metrics.