### PR TITLE
Fix save alert on shutdown

### DIFF
--- a/src/health/health_log.c
+++ b/src/health/health_log.c
@@ -40,15 +40,16 @@ void health_alarm_entry_destroy(ALARM_ENTRY *ae) {
 }
 
 // ----------------------------------------------------------------------------
+extern __thread bool is_health_thread;
 
 inline void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae, bool async)
 {
     bool saved = false;
-    if (async)
+    if (async) {
         saved = metadata_queue_ae_save(host, ae);
-
-    // if not async or async failed to queue, do it now
-    if (false == saved)
+        if (!saved && is_health_thread && service_running(SERVICE_HEALTH))
+            sql_health_alarm_log_save(host, ae);
+    } else
         sql_health_alarm_log_save(host, ae);
 }
 

--- a/src/health/health_log.c
+++ b/src/health/health_log.c
@@ -44,10 +44,9 @@ extern __thread bool is_health_thread;
 
 inline void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae, bool async)
 {
-    bool saved = false;
     if (async) {
-        saved = metadata_queue_ae_save(host, ae);
-        if (!saved && is_health_thread && service_running(SERVICE_HEALTH))
+        bool queued = metadata_queue_ae_save(host, ae);
+        if (!queued && is_health_thread && service_running(SERVICE_HEALTH))
             sql_health_alarm_log_save(host, ae);
     } else
         sql_health_alarm_log_save(host, ae);


### PR DESCRIPTION
##### Summary
- Do not store the alert transition (during host alert configuration) if the agent is shutting down