### PR TITLE
Check that there is a valid thread when performing ACLK sync shutdown

### DIFF
--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -1022,6 +1022,9 @@ static inline bool queue_aclk_sync_cmd(enum aclk_database_opcode opcode, const v
 
 void aclk_synchronization_shutdown(void)
 {
+    if (!aclk_sync_config.thread)
+        return;
+
     // Send shutdown command, not that the completion is initialized
     // on init and still valid
     aclk_mqtt_client_reset();


### PR DESCRIPTION
##### Summary
- Check that the ACLK sync thread has been properly initialized during shutdown
  - This will ensure that the thread exists and completion structure has been initialized
