### PR TITLE
Additional checks for valid db during db_execute

### DIFF
--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -207,7 +207,7 @@ static void sql_delete_aclk_table_list(void)
 
     SQLITE_FINALIZE(res);
 
-    int rc = db_execute(db_meta, buffer_tostring(sql));
+    int rc = db_execute(db_meta, buffer_tostring(sql), NULL);
     if (unlikely(rc))
         netdata_log_error("Failed to drop unused ACLK tables");
 

--- a/src/database/sqlite/sqlite_db_migration.c
+++ b/src/database/sqlite/sqlite_db_migration.c
@@ -402,7 +402,7 @@ static int do_migration_v14_v15(sqlite3 *database)
     SQLITE_FINALIZE(res);
 
     if (count)
-        (void) db_execute(database, buffer_tostring(wb));
+        (void)db_execute(database, buffer_tostring(wb), NULL);
 
     buffer_free(wb);
     return 0;
@@ -431,7 +431,7 @@ static int do_migration_v15_v16(sqlite3 *database)
     SQLITE_FINALIZE(res);
 
     if (count)
-        (void) db_execute(database, buffer_tostring(wb));
+        (void)db_execute(database, buffer_tostring(wb), NULL);
 
     buffer_free(wb);
     return 0;

--- a/src/database/sqlite/sqlite_functions.h
+++ b/src/database/sqlite/sqlite_functions.h
@@ -105,7 +105,7 @@ void finalize_self_prepared_sql_statements();
 void finalize_all_prepared_sql_statements();
 
 int execute_insert(sqlite3_stmt *res);
-int db_execute(sqlite3 *database, const char *cmd);
+int db_execute(sqlite3 *database, const char *cmd, int *sqlite_rc);
 char *get_database_extented_error(sqlite3 *database, int i, const char *description);
 
 void sql_drop_table(const char *table);

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -1412,7 +1412,7 @@ void sql_alert_transitions(
     }
 
     snprintfz(sql, sizeof(sql) - 1, SQL_BUILD_ALERT_TRANSITION, nodes);
-    rc = db_execute(db_meta, sql);
+    rc = db_execute(db_meta, sql, NULL);
     if (rc)
         return;
 
@@ -1519,7 +1519,7 @@ done:
 done_only_drop:
     if (likely(!transition)) {
         (void)snprintfz(sql, sizeof(sql) - 1, "DROP TABLE IF EXISTS v_%p", nodes);
-        (void)db_execute(db_meta, sql);
+        (void)db_execute(db_meta, sql, NULL);
         buffer_free(command);
     }
 }
@@ -1552,7 +1552,7 @@ int sql_get_alert_configuration(
         return added;
 
     snprintfz(sql, sizeof(sql) - 1, SQL_BUILD_CONFIG_TARGET_LIST, configs);
-    rc = db_execute(db_meta, sql);
+    rc = db_execute(db_meta, sql, NULL);
     if (rc)
         return added;
 
@@ -1645,7 +1645,7 @@ int sql_get_alert_configuration(
 
 fail_only_drop:
     (void)snprintfz(sql, sizeof(sql) - 1, "DROP TABLE IF EXISTS c_%p", configs);
-    (void)db_execute(db_meta, sql);
+    (void)db_execute(db_meta, sql, NULL);
     buffer_free(command);
     return added;
 }

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -581,7 +581,7 @@ static void recover_database(const char *sqlite_database, const char *new_sqlite
     netdata_log_info("     to %s", new_sqlite_database);
 
     // This will remove the -shm and -wal files when we close the database
-    (void) db_execute(database, "select count(*) from sqlite_master limit 0");
+    (void)db_execute(database, "select count(*) from sqlite_master limit 0", NULL);
 
     sqlite3_recover *recover = sqlite3_recover_init(database, "main", new_sqlite_database);
     if (recover) {
@@ -736,7 +736,7 @@ int sql_init_meta_database(db_check_action_type_t rebuild, int memory)
             sqlite3_free(err_msg);
         }
         else {
-            (void) db_execute(db_meta, "select count(*) from sqlite_master limit 0");
+            (void)db_execute(db_meta, "select count(*) from sqlite_master limit 0", NULL);
             (void) sqlite3_close(db_meta);
         }
         return 1;
@@ -751,7 +751,7 @@ int sql_init_meta_database(db_check_action_type_t rebuild, int memory)
             sqlite3_free(err_msg);
         }
         else {
-            (void) db_execute(db_meta, "select count(*) from sqlite_master limit 0");
+            (void)db_execute(db_meta, "select count(*) from sqlite_master limit 0", NULL);
             (void) sqlite3_close(db_meta);
         }
         return 1;
@@ -840,7 +840,7 @@ static int check_and_update_chart_labels(RRDSET *st, BUFFER *work_buffer)
     uuid_unparse_lower(st->chart_uuid, tmp.uuid_str);
     rrdlabels_walkthrough_read(st->rrdlabels, chart_label_store_to_sql_callback, &tmp);
     buffer_strcat(work_buffer, " ON CONFLICT (chart_id, label_key) DO UPDATE SET source_type = excluded.source_type, label_value=excluded.label_value, date_created=UNIXEPOCH()");
-    int rc = db_execute(db_meta, buffer_tostring(work_buffer));
+    int rc = db_execute(db_meta, buffer_tostring(work_buffer), NULL);
     if (likely(!rc))
         st->rrdlabels_last_saved_version = new_version;
 
@@ -854,7 +854,7 @@ void detect_machine_guid_change(nd_uuid_t *host_uuid)
 
     rc = exec_statement_with_uuid(CONVERT_EXISTING_LOCALHOST, host_uuid);
     if (!rc) {
-        if (unlikely(db_execute(db_meta, DELETE_MISSING_NODE_INSTANCES)))
+        if (unlikely(db_execute(db_meta, DELETE_MISSING_NODE_INSTANCES, NULL)))
             error_report("Failed to remove deleted hosts from node instances");
     }
 }
@@ -1499,9 +1499,13 @@ static void cleanup_health_log(struct meta_config_s *config)
         return;
     }
 
-    (void) db_execute(db_meta,"DELETE FROM health_log WHERE host_id NOT IN (SELECT host_id FROM host)");
-    (void) db_execute(db_meta,"DELETE FROM health_log_detail WHERE health_log_id NOT IN (SELECT health_log_id FROM health_log)");
-    (void) db_execute(db_meta,"DELETE FROM alert_version WHERE health_log_id NOT IN (SELECT health_log_id FROM health_log)");
+    (void)db_execute(db_meta, "DELETE FROM health_log WHERE host_id NOT IN (SELECT host_id FROM host)", NULL);
+    (void)db_execute(
+        db_meta,
+        "DELETE FROM health_log_detail WHERE health_log_id NOT IN (SELECT health_log_id FROM health_log)",
+        NULL);
+    (void)db_execute(
+        db_meta, "DELETE FROM alert_version WHERE health_log_id NOT IN (SELECT health_log_id FROM health_log)", NULL);
     worker_is_idle();
 }
 
@@ -1573,7 +1577,7 @@ void vacuum_database(sqlite3 *database, const char *db_alias, int threshold, int
 
         char sql[128];
         snprintfz(sql, sizeof(sql) - 1, "PRAGMA incremental_vacuum(%d)", do_free_pages);
-        (void)db_execute(database, sql);
+        (void)db_execute(database, sql, NULL);
     }
 }
 
@@ -1972,7 +1976,7 @@ size_t populate_metrics_from_database(void *mrg, void (*populate_cb)(void *mrg, 
     }
 
     if (local_meta_db)
-        (void) db_execute(local_meta_db, "PRAGMA cache_size=10000");
+        (void)db_execute(local_meta_db, "PRAGMA cache_size=10000", NULL);
 
     if (!PREPARE_STATEMENT(local_meta_db ? local_meta_db : db_meta, GET_UUID_LIST, &res)) {
         sqlite3_close(local_meta_db);
@@ -2017,7 +2021,7 @@ static void metadata_scan_host(RRDHOST *host, BUFFER *work_buffer, bool is_worke
     bool load_ml_models = is_worker;
 
     bool host_need_recheck = false;
-    (void)db_execute(db_meta, "BEGIN TRANSACTION");
+    (void)db_execute(db_meta, "BEGIN TRANSACTION", NULL);
 
     rrdset_foreach_reentrant(st, host) {
 
@@ -2095,7 +2099,7 @@ static void metadata_scan_host(RRDHOST *host, BUFFER *work_buffer, bool is_worke
     }
     rrdset_foreach_done(st);
 
-    (void)db_execute(db_meta, "COMMIT TRANSACTION");
+    (void)db_execute(db_meta, "COMMIT TRANSACTION", NULL);
     if (host_need_recheck)
         rrdhost_flag_set(host,RRDHOST_FLAG_METADATA_UPDATE);
 
@@ -2315,7 +2319,7 @@ static void meta_store_host_labels(RRDHOST *host, BUFFER *work_buffer)
     buffer_strcat(
         work_buffer,
         " ON CONFLICT (host_id, label_key) DO UPDATE SET source_type = excluded.source_type, label_value=excluded.label_value, date_created=UNIXEPOCH()");
-    rc = db_execute(db_meta, buffer_tostring(work_buffer));
+    rc = db_execute(db_meta, buffer_tostring(work_buffer), NULL);
 
     if (unlikely(rc)) {
         error_report("METADATA: 'host:%s': failed to update metadata host labels", rrdhost_hostname(host));
@@ -2871,7 +2875,7 @@ done:
 
 void cleanup_agent_event_log(void)
 {
-    (void) db_execute(db_meta, "DELETE FROM agent_event_log WHERE date_created < UNIXEPOCH() - 30 * 86400");
+    (void)db_execute(db_meta, "DELETE FROM agent_event_log WHERE date_created < UNIXEPOCH() - 30 * 86400", NULL);
 }
 
 #define SQL_GET_AGENT_EVENT_TYPE_MEDIAN                                                                                \

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -992,7 +992,7 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
     int op_no = 1;
 
     // begin transaction
-    int rc = db_execute(ml_db, "BEGIN TRANSACTION;");
+    int rc = db_execute(ml_db, "BEGIN TRANSACTION;", NULL);
 
     // add/delete models
     if (!rc) {
@@ -1019,14 +1019,14 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
     // commit transaction
     if (!rc) {
         op_no++;
-        rc = db_execute(ml_db, "COMMIT TRANSACTION;");
+        rc = db_execute(ml_db, "COMMIT TRANSACTION;", NULL);
     }
 
     // rollback transaction on failure
     if (rc) {
         netdata_log_error("Trying to rollback ML transaction because it failed with rc=%d, op_no=%d", rc, op_no);
         op_no++;
-        rc = db_execute(ml_db, "ROLLBACK;");
+        rc = db_execute(ml_db, "ROLLBACK;", NULL);
         if (rc)
             netdata_log_error("ML transaction rollback failed with rc=%d", rc);
     }


### PR DESCRIPTION
##### Summary
- Ensure the database is valid before executing any commands.
- Update db_execute calls to include an sqlite_rc parameter (currently not used). This will return the actual db error and in future improvements, help refine error handling from the caller.
