### PR TITLE
NUMA Windows 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2064,6 +2064,7 @@ set(WINDOWS_PLUGIN_FILES
         src/collectors/windows.plugin/perflib-services.c
         src/collectors/windows.plugin/perflib-hyperv.c
         src/collectors/windows.plugin/perflib-exchange.c
+        src/collectors/windows.plugin/perflib-numa.c
 )
 
 set(PROC_PLUGIN_FILES

--- a/src/collectors/windows.plugin/metadata.yaml
+++ b/src/collectors/windows.plugin/metadata.yaml
@@ -3452,3 +3452,90 @@ modules:
               chart_type: line
               dimensions:
                 - name: serviced
+  - meta:
+      plugin_name: windows.plugin
+      module_name: PerflibNUMA
+      monitored_instance:
+        name: NUMA Architecture
+        link: "https://learn.microsoft.com/en-us/windows/win32/procthread/numa-support"
+        categories:
+          - data-collection.windows-systems
+        icon_filename: "windows.svg"
+      related_resources:
+        integrations:
+          list: []
+      info_provided_to_referring_integrations:
+        description: ""
+      keywords:
+        - windows
+        - NUMA
+        - processor
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: |
+          This collector monitors NUMA Architecture on Windows.
+        method_description: |
+          It queries NUMA Node Memory from Perflib in order to gather the metrics.
+      supported_platforms:
+        include: ["windows"]
+        exclude: []
+      multi_instance: false
+      additional_permissions:
+        description: ""
+      default_behavior:
+        auto_detection:
+          description: |
+            The collector automatically detects all of the metrics, no further configuration is required.
+        limits:
+          description: ""
+        performance_impact:
+          description: ""
+    setup:
+      prerequisites:
+        list: []
+      configuration:
+        file:
+          name: "netdata.conf"
+          section_name: "[plugin:windows]"
+          description: "The Netdata main configuration file"
+        options:
+          description: ""
+          folding:
+            title: "Config option"
+            enabled: false
+          list:
+            - name: PerflibNUMA
+              description: An option to enable or disable the data collection.
+              default_value: yes
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ""
+          list: []
+    troubleshooting:
+      problems:
+        list: []
+    alerts: []
+    metrics:
+      folding:
+        title: Metrics
+        enabled: false
+      description: ""
+      availability: []
+      scopes:
+        - name: NUMA
+          description: "These metrics refer to memory utilization on NUMA systems."
+          labels:
+            - name: node
+              description: The identifier of the CPU node.
+          metrics:
+            - name: mem.numa_node_mem_usage
+              description: NUMA Node Memory Usage
+              unit: bytes
+              chart_type: line
+              dimensions:
+                - name: free
+                - name: standby
+                - name: available

--- a/src/collectors/windows.plugin/perflib-numa.c
+++ b/src/collectors/windows.plugin/perflib-numa.c
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "windows_plugin.h"
+#include "windows-internals.h"
+
+struct netdata_numa {
+    RRDSET *st_standby;
+    RRDDIM *rd_standby;
+
+    RRDSET *st_available;
+    RRDDIM *rd_available;
+
+    RRDSET *st_free_zero;
+    RRDDIM *rd_free_zero;
+
+    COUNTER_DATA standby;
+    COUNTER_DATA available;
+    COUNTER_DATA free_zero;
+};
+
+static DICTIONARY *numa_dict = NULL;
+
+static void
+numa_insert_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused)
+{
+    struct netdata_numa *d = value;
+
+    d->standby.key = "";
+    d->available.key = "";
+    d->free_zero.key = "";
+}
+
+static void initialize(void)
+{
+    numa_dict = dictionary_create_advanced(
+        DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE, NULL, sizeof(struct netdata_numa));
+
+    dictionary_register_insert_callback(numa_dict, numa_insert_cb, NULL);
+}
+
+static bool do_numa(PERF_DATA_BLOCK *pDataBlock, int update_every)
+{
+    PERF_OBJECT_TYPE *pObjectType = perflibFindObjectTypeByName(pDataBlock, "NUMA Node Memory");
+    if (!pObjectType)
+        return false;
+
+    PERF_INSTANCE_DEFINITION *pi = NULL;
+    for (LONG i = 0; i < pObjectType->NumInstances; i++) {
+        pi = perflibForEachInstance(pDataBlock, pObjectType, pi);
+        if (!pi)
+            break;
+
+        if (!getInstanceName(pDataBlock, pObjectType, pi, windows_shared_buffer, sizeof(windows_shared_buffer)))
+            strncpyz(windows_shared_buffer, "[unknown]", sizeof(windows_shared_buffer) - 1);
+
+        if (strcasecmp(windows_shared_buffer, "_Total") == 0)
+            continue;
+
+        struct netdata_numa *nn = dictionary_set(dict, windows_shared_buffer, NULL, sizeof(*d));
+        if (!nn)
+            continue;
+    }
+
+    return true;
+}
+
+int do_PerflibNUMA(int update_every, usec_t dt __maybe_unused)
+{
+    static bool initialized = false;
+
+    if (unlikely(!initialized)) {
+        initialize();
+        initialized = true;
+    }
+
+    DWORD id = RegistryFindIDByName("NUMA Node Memory");
+    if (id == PERFLIB_REGISTRY_NAME_NOT_FOUND)
+        return -1;
+
+    PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
+    if (!pDataBlock)
+        return -1;
+
+    do_numa(pDataBlock, update_every);
+
+    return 0;
+}

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -113,10 +113,17 @@ static struct proc_module {
      .func = do_PerflibServices},
 
     {.name = "PerflibExchange",
-        .dim = "PerflibADFS",
-        .enabled = CONFIG_BOOLEAN_YES,
-        .update_every = UPDATE_EVERY_MIN,
-        .func = do_PerflibExchange},
+     .dim = "PerflibADFS",
+     .enabled = CONFIG_BOOLEAN_YES,
+     .update_every = UPDATE_EVERY_MIN,
+     .func = do_PerflibExchange},
+
+    {.name = "PerflibNUMA",
+     .dim = "PerflibNUMA",
+     .enabled = CONFIG_BOOLEAN_YES,
+     .update_every = UPDATE_EVERY_MIN,
+     .func = do_PerflibNUMA},
+
     // the terminator of this array
     {.name = NULL, .dim = NULL, .func = NULL}};
 

--- a/src/collectors/windows.plugin/windows_plugin.h
+++ b/src/collectors/windows.plugin/windows_plugin.h
@@ -11,6 +11,10 @@
 // 2^24
 #define WINDOWS_MAX_KERNEL_OBJECT 16777216
 
+#ifndef MEGA_FACTOR
+#define MEGA_FACTOR (1048576)
+#endif
+
 void *win_plugin_main(void *ptr);
 
 extern char windows_shared_buffer[8192];

--- a/src/collectors/windows.plugin/windows_plugin.h
+++ b/src/collectors/windows.plugin/windows_plugin.h
@@ -38,6 +38,7 @@ int do_PerflibADFS(int update_every, usec_t dt);
 int do_PerflibHyperV(int update_every, usec_t dt);
 int do_PerflibServices(int update_every, usec_t dt);
 int do_PerflibExchange(int update_every, usec_t dt __maybe_unused);
+int do_PerflibNUMA(int update_every, usec_t dt __maybe_unused);
 
 enum PERFLIB_PRIO {
     PRIO_WEBSITE_IIS_REQUESTS_RATE = 21000, // PRIO selected, because APPS is using 20YYY


### PR DESCRIPTION
##### Summary
This PR adds NUMA monitoring to the ` windows.plugin`.

![VirtualBox_WIN11_24_06_2025_22_15_22](https://github.com/user-attachments/assets/a85d2310-0a8d-455c-9f29-dec9c417b758)

During development, I tested on three different VMs. Certain metrics remained at `zero`. To verify this behavior, I used the RAMMap tool. However, the actual data may not be zero. I also have some dumps generated by Netdata showing non-zero values for these metrics—though only a few bytes.

##### Test Plan

1. Compile this branch.
2. Make installer.
3. Install it and confirm the chart.

##### Additional Information
This PR was tested on Windows 11, Windows 2019 and Windows 2022.

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
