### PR TITLE
Ignore duplicate entries when rebuilding the alert version table

### DIFF
--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -577,7 +577,7 @@ done:
 }
 
 #define SQL_REBUILD_HOST_ALERT_VERSION_TABLE                                                                           \
-    "INSERT INTO alert_version (health_log_id, unique_id, status, version, date_submitted) "                           \
+    "INSERT OR IGNORE INTO alert_version (health_log_id, unique_id, status, version, date_submitted) "                 \
     " SELECT hl.health_log_id, hld.unique_id, hld.new_status, hld.when_key, UNIXEPOCH() "                              \
     " FROM health_log hl, health_log_detail hld WHERE "                                                                \
     "  hl.host_id = @host_id AND hld.health_log_id = hl.health_log_id AND hld.transition_id = hl.last_transition_id"


### PR DESCRIPTION
##### Summary
- Ignore duplicate entries when rebuilding the alert version table.
  If an alert snapshot needs to be created, the alert version entries are first deleted and then recreated.