### PR TITLE
Windows Pluging (Freedom to update every)

### DIFF
--- a/packaging/windows/msys2-dependencies.sh
+++ b/packaging/windows/msys2-dependencies.sh
@@ -41,7 +41,6 @@ pacman -S --noconfirm --needed \
     mingw64/mingw-w64-x86_64-pcre2 \
     mingw64/mingw-w64-x86_64-protobuf \
     mingw64/mingw-w64-x86_64-zlib \
-    mingw64/mingw-w64-x86_64-libxml2 \
     ucrt64/mingw-w64-ucrt-x86_64-brotli \
     ucrt64/mingw-w64-ucrt-x86_64-go \
     ucrt64/mingw-w64-ucrt-x86_64-libuv \
@@ -49,6 +48,5 @@ pacman -S --noconfirm --needed \
     ucrt64/mingw-w64-ucrt-x86_64-openssl \
     ucrt64/mingw-w64-ucrt-x86_64-pcre2 \
     ucrt64/mingw-w64-ucrt-x86_64-protobuf \
-    ucrt64/mingw-w64-ucrt-x86_64-zlib \
-    ucrt64/mingw-w64-ucrt-x86_64-libxml2
+    ucrt64/mingw-w64-ucrt-x86_64-zlib
 ${GITHUB_ACTIONS+echo "::endgroup::"}

--- a/packaging/windows/msys2-dependencies.sh
+++ b/packaging/windows/msys2-dependencies.sh
@@ -41,6 +41,7 @@ pacman -S --noconfirm --needed \
     mingw64/mingw-w64-x86_64-pcre2 \
     mingw64/mingw-w64-x86_64-protobuf \
     mingw64/mingw-w64-x86_64-zlib \
+    mingw64/mingw-w64-x86_64-libxml2 \
     ucrt64/mingw-w64-ucrt-x86_64-brotli \
     ucrt64/mingw-w64-ucrt-x86_64-go \
     ucrt64/mingw-w64-ucrt-x86_64-libuv \
@@ -48,5 +49,6 @@ pacman -S --noconfirm --needed \
     ucrt64/mingw-w64-ucrt-x86_64-openssl \
     ucrt64/mingw-w64-ucrt-x86_64-pcre2 \
     ucrt64/mingw-w64-ucrt-x86_64-protobuf \
-    ucrt64/mingw-w64-ucrt-x86_64-zlib
+    ucrt64/mingw-w64-ucrt-x86_64-zlib \
+    ucrt64/mingw-w64-ucrt-x86_64-libxml2
 ${GITHUB_ACTIONS+echo "::endgroup::"}

--- a/src/collectors/windows.plugin/README.md
+++ b/src/collectors/windows.plugin/README.md
@@ -32,6 +32,7 @@ To change a setting, remove the comment symbol (`#`) from the beginning of the l
         # PerflibADCS = yes
         # PerflibADFS = yes
         # PerflibExchange = yes
+        # PerflibNUMA = yes
 ```
 
 ## Update Every per Thread
@@ -39,11 +40,11 @@ To change a setting, remove the comment symbol (`#`) from the beginning of the l
 When the plugin is running, most threads will collect data using Netdata’s default update `every interval`. However,
 to avoid overloading the host, Netdata uses different `update every` intervals for specific threads, as shown below:
 
-| Period (seconds) | Threads                                       |
-|------------------|-----------------------------------------------|
-| 5                | `HyperV`                                      |
-| 10               | `MSSQL`, `AD`, `ADCS`, `ADFS`, and `Exchange` |
-| 30               | `Services`                                    |
+| Period (seconds) | Threads                                                                          |
+|------------------|----------------------------------------------------------------------------------|
+| 5                | `PerflibHyperV`, `PerflibThermalZone`                                            |
+| 10               | `PerflibMSSQL`, `PerflibAD`, `PerflibADCS`, `PerflibADFS`, and `PerflibExchange` |
+| 30               | `PerflibServices`                                                                |
 
 To customize the update interval for a specific thread, you can set the update every value within the corresponding
 thread configuration in your `netdata.conf` file. For example, to modify the intervals for the `Object`

--- a/src/collectors/windows.plugin/README.md
+++ b/src/collectors/windows.plugin/README.md
@@ -34,6 +34,29 @@ To change a setting, remove the comment symbol (`#`) from the beginning of the l
         # PerflibExchange = yes
 ```
 
+## Update Every per Thread
+
+When the plugin is running, most threads will collect data using Netdata’s default update `every interval`. However,
+to avoid overloading the host, Netdata uses different `update every` intervals for specific threads, as shown below:
+
+| Period (seconds) | Threads                                       |
+|------------------|-----------------------------------------------|
+| 5                | `HyperV`                                      |
+| 10               | `MSSQL`, `AD`, `ADCS`, `ADFS`, and `Exchange` |
+| 30               | `Services`                                    |
+
+To customize the update interval for a specific thread, you can set the update every value within the corresponding
+thread configuration in your `netdata.conf` file. For example, to modify the intervals for the `Object`
+and `HyperV` threads:
+
+```text
+[plugin:windows:PerflibObjects]
+        #update every = 10s
+
+[plugin:windows:PerflibHyperV]
+        #update every = 15s
+```
+
 ## Microsoft SQL Server Integration
 
 To collect metrics from [Microsoft SQL Server](https://www.microsoft.com/en-us/sql-server), Netdata needs access to internal server data. This requires configuration on both the Windows system and Netdata sides.

--- a/src/collectors/windows.plugin/metadata.yaml
+++ b/src/collectors/windows.plugin/metadata.yaml
@@ -46,7 +46,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibProcessor]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -54,9 +54,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibProcessor
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 1
               required: false
         examples:
           folding:
@@ -150,7 +150,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibMemory]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -158,9 +158,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibMemory
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 1
               required: false
         examples:
           folding:
@@ -254,7 +254,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibProcesses]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -262,9 +262,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibProcesses
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 1
               required: false
         examples:
           folding:
@@ -358,7 +358,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibStorage]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -366,9 +366,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibStorage
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 1
               required: false
         examples:
           folding:
@@ -541,7 +541,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibNetwork]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -549,9 +549,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibNetwork
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 1
               required: false
         examples:
           folding:
@@ -865,7 +865,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibObjects]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -873,9 +873,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibObjects
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 1
               required: false
         examples:
           folding:
@@ -946,7 +946,7 @@ modules:
         list: []
       configuration:
         file:
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibThermalZone]"
           name: "netdata.conf"
           description: "The Netdata main configuration file."
         options:
@@ -955,9 +955,9 @@ modules:
             title: "Config Option"
             enabled: false
           list:
-            - name: PerflibThermalZone
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 5
               required: false
         examples:
           folding:
@@ -1027,7 +1027,7 @@ modules:
         list: []
       configuration:
         file:
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:GetPowerSupply]"
           name: "netdata.conf"
           description: "The Netdata main configuration file."
         options:
@@ -1036,9 +1036,9 @@ modules:
             title: "Config Option"
             enabled: false
           list:
-            - name: GetPowerSupply
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 1
               required: false
         examples:
           folding:
@@ -1123,7 +1123,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibWebService]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -1131,9 +1131,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibWebService
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 1
               required: false
         examples:
           folding:
@@ -1442,7 +1442,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibHyperV]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -1450,9 +1450,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibHyperV
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 5
               required: false
         examples:
           folding:
@@ -1883,6 +1883,10 @@ modules:
             title: "Config option"
             enabled: false
           list:
+            - name: update every
+              description: Data collection frequency.
+              default_value: 10
+              required: false
             - name: driver
               description: ODBC driver used to connect to the SQL Server.
               default_value: SQL Server
@@ -2242,7 +2246,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibNetFramework]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -2250,9 +2254,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibNetFramework
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 1
               required: false
         examples:
           folding:
@@ -2508,7 +2512,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibAD]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -2516,9 +2520,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibAD
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 10
               required: false
         examples:
           folding:
@@ -2687,7 +2691,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibADCS]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -2695,9 +2699,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibADCS
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 10
               required: false
         examples:
           folding:
@@ -2864,7 +2868,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibADFS]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -2872,9 +2876,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibADFS
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 10
               required: false
         examples:
           folding:
@@ -3140,7 +3144,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibServices]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -3148,9 +3152,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibServices
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 30
               required: false
         examples:
           folding:
@@ -3233,7 +3237,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibExchange]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -3241,9 +3245,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibExchange
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 10
               required: false
         examples:
           folding:
@@ -3497,7 +3501,7 @@ modules:
       configuration:
         file:
           name: "netdata.conf"
-          section_name: "[plugin:windows]"
+          section_name: "[plugin:windows:PerflibNUMA]"
           description: "The Netdata main configuration file"
         options:
           description: ""
@@ -3505,9 +3509,9 @@ modules:
             title: "Config option"
             enabled: false
           list:
-            - name: PerflibNUMA
-              description: An option to enable or disable the data collection.
-              default_value: yes
+            - name: update every
+              description: Data collection frequency.
+              default_value: 1
               required: false
         examples:
           folding:

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -18,7 +18,6 @@
 #define NETDATA_MSSQL_NEXT_TRY (60)
 
 BOOL is_sqlexpress = FALSE;
-ND_THREAD *mssql_query_thread = NULL;
 
 struct netdata_mssql_conn {
     const char *driver;
@@ -1128,8 +1127,8 @@ int dict_mssql_query_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value,
 void *netdata_mssql_queries(void *ptr __maybe_unused)
 {
     heartbeat_t hb;
-    int update_every = *((int *)ptr);
-    heartbeat_init(&hb, update_every * USEC_PER_SEC);
+    heartbeat_init(&hb, USEC_PER_SEC);
+    int update_every = UPDATE_EVERY_MIN;
 
     while (service_running(SERVICE_COLLECTORS)) {
         (void)heartbeat_next(&hb);
@@ -1156,8 +1155,7 @@ static int initialize(int update_every)
     }
 
     if (create_thread)
-        mssql_query_thread =
-            nd_thread_create("mssql_queries", NETDATA_THREAD_OPTION_DEFAULT, netdata_mssql_queries, &update_every);
+        nd_thread_create("mssql_queries", NETDATA_THREAD_OPTION_DEFAULT, netdata_mssql_queries, &update_every);
 
     return 0;
 }

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -205,7 +205,7 @@ void *win_plugin_main(void *ptr)
         pm->enabled = inicfg_get_boolean(&netdata_config, "plugin:windows", pm->name, pm->enabled);
         pm->rd = NULL;
 
-        pm->update_every = (int)inicfg_get_duration_seconds(&netdata_config, buf, "update every", pm->update_every);
+        pm->update_every = (int)inicfg_get_duration_seconds(&netdata_config, buf, "update every", update_every);
 
         if (pm->enabled && unlikely(update_every != pm->update_every)) {
             char tag_name[ND_THREAD_TAG_MAX];

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -73,7 +73,7 @@ static struct proc_module {
     {.name = "PerflibThermalZone",
      .dim = "PerflibThermalZone",
      .enabled = CONFIG_BOOLEAN_NO,
-     .update_every = UPDATE_EVERY_MIN,
+     .update_every = 5*UPDATE_EVERY_MIN,
      .func = do_PerflibThermalZone},
 
     {.name = "PerflibWebService",

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -173,6 +173,7 @@ void *win_plugin_main(void *ptr)
     // check the enabled status for each module
     int i;
     char buf[CONFIG_MAX_NAME + 1];
+    int update_every = localhost->rrd_update_every;
     for (i = 0; win_modules[i].name; i++) {
         struct proc_module *pm = &win_modules[i];
 
@@ -182,7 +183,7 @@ void *win_plugin_main(void *ptr)
         pm->rd = NULL;
 
         pm->update_every =
-            (int)inicfg_get_duration_seconds(&netdata_config, buf, "update every", localhost->rrd_update_every);
+            (int)inicfg_get_duration_seconds(&netdata_config, buf, "update every", update_every);
 
         worker_register_job_name(i, win_modules[i].dim);
     }
@@ -212,6 +213,9 @@ void *win_plugin_main(void *ptr)
                 break;
 
             struct proc_module *pm = &win_modules[i];
+            if (unlikely(update_every != win_modules[i].update_every))
+                continue;
+
             if (unlikely(!pm->enabled))
                 continue;
 

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -67,7 +67,7 @@ static struct proc_module {
     {.name = "PerflibHyperV",
      .dim = "PerflibHyperV",
      .enabled = CONFIG_BOOLEAN_YES,
-     .update_every = UPDATE_EVERY_MIN,
+     .update_every = 5 * UPDATE_EVERY_MIN,
      .func = do_PerflibHyperV},
 
     {.name = "PerflibThermalZone",
@@ -84,7 +84,7 @@ static struct proc_module {
     {.name = "PerflibMSSQL",
      .dim = "PerflibMSSQL",
      .enabled = CONFIG_BOOLEAN_YES,
-     .update_every = UPDATE_EVERY_MIN,
+     .update_every = 10 * UPDATE_EVERY_MIN,
      .func = do_PerflibMSSQL},
 
     {.name = "PerflibNetFramework",
@@ -95,19 +95,19 @@ static struct proc_module {
     {.name = "PerflibAD",
      .dim = "PerflibAD",
      .enabled = CONFIG_BOOLEAN_YES,
-     .update_every = UPDATE_EVERY_MIN,
+     .update_every = 10 * UPDATE_EVERY_MIN,
      .func = do_PerflibAD},
 
     {.name = "PerflibADCS",
      .dim = "PerflibADCS",
      .enabled = CONFIG_BOOLEAN_YES,
-     .update_every = UPDATE_EVERY_MIN,
+     .update_every = 10 * UPDATE_EVERY_MIN,
      .func = do_PerflibADCS},
 
     {.name = "PerflibADFS",
      .dim = "PerflibADFS",
      .enabled = CONFIG_BOOLEAN_YES,
-     .update_every = UPDATE_EVERY_MIN,
+     .update_every = 10 * UPDATE_EVERY_MIN,
      .func = do_PerflibADFS},
 
     {.name = "PerflibServices",
@@ -119,7 +119,7 @@ static struct proc_module {
     {.name = "PerflibExchange",
      .dim = "PerflibExchange",
      .enabled = CONFIG_BOOLEAN_YES,
-     .update_every = UPDATE_EVERY_MIN,
+     .update_every = 10 * UPDATE_EVERY_MIN,
      .func = do_PerflibExchange},
 
     {.name = "PerflibNUMA",
@@ -205,7 +205,7 @@ void *win_plugin_main(void *ptr)
         pm->enabled = inicfg_get_boolean(&netdata_config, "plugin:windows", pm->name, pm->enabled);
         pm->rd = NULL;
 
-        pm->update_every = (int)inicfg_get_duration_seconds(&netdata_config, buf, "update every", update_every);
+        pm->update_every = (int)inicfg_get_duration_seconds(&netdata_config, buf, "update every", (update_every != pm->update_every)? pm->update_every: update_every);
 
         if (pm->enabled && unlikely(update_every != pm->update_every)) {
             char tag_name[ND_THREAD_TAG_MAX];

--- a/src/daemon/analytics.c
+++ b/src/daemon/analytics.c
@@ -735,11 +735,18 @@ void get_system_timezone(void)
     const char *timezone = NULL;
     const char *tz = NULL;
 #ifdef OS_WINDOWS
-    TIME_ZONE_INFORMATION win_tz;
-    GetTimeZoneInformation(&win_tz);
-    WideCharToMultiByte(CP_UTF8, 0, win_tz.StandardName, -1, buffer, FILENAME_MAX, NULL, NULL);
-
+    _tzset();
+    size_t s;
+    _get_tzname(&s, buffer, sizeof(buffer) -1, 0 );
     timezone = buffer;
+
+    /*
+    TIME_ZONE_INFORMATION win_tz;
+    DWORD tzresult = GetTimeZoneInformation(&win_tz);
+    if (tzresult != TIME_ZONE_ID_INVALID) {
+        WideCharToMultiByte(CP_UTF8, 0, win_tz.DaylightName, -1, buffer, FILENAME_MAX, NULL, NULL);
+    }
+    */
 #else
     // avoid flood calls to stat(/etc/localtime)
     // http://stackoverflow.com/questions/4554271/how-to-avoid-excessive-stat-etc-localtime-calls-in-strftime-on-linux
@@ -836,7 +843,11 @@ void get_system_timezone(void)
         char sign[2], hh[3], mm[3];
 
         t = now_realtime_sec();
+#ifdef OS_WINDOWS
+        tmp = NULL;
+#else
         tmp = localtime_r(&t, &tmbuf);
+#endif
 
         if (tmp != NULL) {
             if (strftime(zone, FILENAME_MAX, "%Z", tmp) == 0) {
@@ -861,6 +872,22 @@ void get_system_timezone(void)
                     sign[0] == '-' ? -netdata_configured_utc_offset : netdata_configured_utc_offset;
             }
         } else {
+#ifdef OS_WINDOWS
+            long offset;
+            if (!_get_timezone(&offset)) {
+                offset /= 3600;
+            } else {
+                offset = 0;
+            }
+
+            DWORD tzresult = GetTimeZoneInformation(&win_tz);
+            if (tzresult != TIME_ZONE_ID_INVALID) {
+                WideCharToMultiByte(CP_UTF8, 0, win_tz.StandardName, -1, buffer, FILENAME_MAX, NULL, NULL);
+                netdata_configured_abbrev_timezone = strdupz(buffer);
+                netdata_configured_utc_offset = offset;
+                return;
+            }
+#endif
             netdata_configured_abbrev_timezone = strdupz("UTC");
             netdata_configured_utc_offset = 0;
         }


### PR DESCRIPTION
##### Summary
This PR allows users to configure custom update intervals for each monitored service:

![update](https://github.com/user-attachments/assets/42e338eb-11f1-4a7b-a4f3-a0f19749c1ec)

Additionally, it fixes timezone detection:

![VirtualBox_WIN11_09_07_2025_22_01_07](https://github.com/user-attachments/assets/4e4614aa-3e2e-4182-a9cf-c14ca3389b45)


Finally, it modifies documentation and metadata.

##### Test Plan

1. Compile this PR
2. Make an installer
3. Change your netdata.conf according to documentation setting different `update every` for some threads.
4. Install it.
5. Access dashboard or API and confirm data are correct.

##### Additional Information
This PR were tested on Windows 11, Windows 2019, and Windows 2022. All threads were tested and they are running as expected.

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
