### PR TITLE
remove devType/Vendor/ from ddsnmp metric families

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
@@ -139,35 +139,6 @@ func (c *Collector) collectProfile(ps *profileState) (*ddsnmp.ProfileMetrics, er
 }
 
 func (c *Collector) updateMetrics(pms []*ddsnmp.ProfileMetrics) {
-	// Find device vendor and type from any profile that has them.
-	// Multiple profiles can be loaded for a single device (e.g., base profiles, generic MIB profiles),
-	// but only device-specific profiles contain vendor/type information.
-	// We need to apply vendor/type to ALL metrics across ALL profiles to ensure consistent
-	// metric family naming (e.g., "interface/stats" → "router/cisco/interface/stats").
-	for _, ps := range c.profiles {
-		if !ps.initialized {
-			continue
-		}
-		if ps.profile.Definition == nil {
-			continue
-		}
-		res, ok := ps.profile.Definition.Metadata["device"]
-		if !ok {
-			continue
-		}
-		dt, dv := res.Fields["type"].Value, res.Fields["vendor"].Value
-		if dt == "" || dv == "" {
-			continue
-		}
-		for _, pm := range pms {
-			for i := range pm.Metrics {
-				m := &pm.Metrics[i]
-				m.Family = processMetricFamily(m.Family, dt, dv)
-			}
-		}
-		break
-	}
-
 	for _, pm := range pms {
 		for i := range pm.Metrics {
 			m := &pm.Metrics[i]


### PR DESCRIPTION
##### Summary

Can't have different families for metrics with the same context.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
