### PR TITLE
Fix compilation on windows

### DIFF
--- a/src/collectors/apps.plugin/apps_os_windows.c
+++ b/src/collectors/apps.plugin/apps_os_windows.c
@@ -449,7 +449,6 @@
 #include <wchar.h>
 #include <psapi.h>
 #include <tchar.h>
-#include <strsafe.h>
 
 WCHAR* GetProcessCommandLine(HANDLE hProcess);
 


### PR DESCRIPTION
##### Summary
- Fix windows build  -- no functions from strsafe are used