### PR TITLE
Escape chars on documentation

### DIFF
--- a/docs/ml-ai/ml-anomaly-detection/ml-accuracy.md
+++ b/docs/ml-ai/ml-anomaly-detection/ml-accuracy.md
@@ -317,7 +317,7 @@ When evaluated against alternative approaches:
 |--------|------------|------------------|---------------|----------------|
 | False Positive Rate | 10^-36 | 0.3% | Variable | Typically 0.1-1% |
 | Configuration Required | None | Minimal | Extensive | Moderate to High |
-| Resource Overhead | 2-5% CPU | <1% CPU | 30-60% CPU | Unknown |
+| Resource Overhead | 2-5% CPU | \<1% CPU | 30-60% CPU | Unknown |
 | Pattern Memory | 57 hours<br/>(configurable) | Unlimited | Model-dependent | Days to Weeks |
 | Adaptation Speed | 3 hours<br/>(configurable) | Immediate | Retraining required | Hours to Days |
 | Metric Coverage | ALL metrics | Selected metrics | Selected metrics | Selected metrics |

--- a/docs/welcome-to-netdata.md
+++ b/docs/welcome-to-netdata.md
@@ -237,7 +237,7 @@ Based on extensive real-world deployments and independent academic validation, N
 |------------------------|:-----------------------:|:-------------------:|:-------------------:|
 | **CPU**                | 5% of a single core     | 3% of a single core | ~10 cores total     |
 | **Memory**             | 200 MB                  | 150 MB              | ~40 GB              |
-| **Network**            | None                    | <1 Mbps to Parent   | ~100 Mbps inbound   |
+| **Network**            | None                    | \<1 Mbps to Parent   | ~100 Mbps inbound   |
 | **Storage Capacity**   | 3 GiB (configurable)    | None                | as needed           |
 | **Storage Throughput** | 5 KiB/s write           | None                | 1 MiB/s write       |
 | **Retention**          | 1 year (configurable)   | None                | as needed           |


### PR DESCRIPTION
##### Summary

@ktsaou when using `<` and `>` make sure to escape them if they are not some html element. It breaks Learn

This has been deployed on local Learn and it works.
