### PR TITLE
Fix deadlock in dictionary cleanup

### DIFF
--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -346,8 +346,11 @@ size_t dictionary_destroy_delayed_count(void) {
     return count;
 }
 
-size_t cleanup_destroyed_dictionaries(bool shutdown __maybe_unused) {
-    netdata_mutex_lock(&dictionaries_waiting_to_be_destroyed_mutex);
+size_t cleanup_destroyed_dictionaries(bool shutdown __maybe_unused)
+{
+    if (netdata_mutex_trylock(&dictionaries_waiting_to_be_destroyed_mutex) != 0)
+        return 0;
+
     if (!dictionaries_waiting_to_be_destroyed) {
         netdata_mutex_unlock(&dictionaries_waiting_to_be_destroyed_mutex);
         return 0;


### PR DESCRIPTION
##### Summary
cleanup_destroyed_dictionaries now returns immediately when lock cannot be acquired. This can prevent a 
deadlock that can be caused with the following sequence

```
cleanup_destroyed_dictionaries
  dictionary_free_all_resources
    dict_item_free_with_hooks
      dictionary_execute_delete_callback
        rrdset_delete_callback
          dictionary_destroy
            cleanup_destroyed_dictionaries (deadlock)
```