### PR TITLE
Remove Fedora 40 from CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -223,13 +223,6 @@ include:
       repo_distro: fedora/41
     test:
       ebpf-core: true
-  - <<: *fedora
-    version: "40"
-    packages:
-      <<: *fedora_packages
-      repo_distro: fedora/40
-    test:
-      ebpf-core: true
 
   - &opensuse
     distro: opensuse
@@ -378,6 +371,13 @@ legacy: # Info for platforms we used to support and still need to handle package
     packages:
       <<: *fedora_packages
       repo_distro: fedora/39
+    test:
+      ebpf-core: true
+  - <<: *fedora
+    version: "40"
+    packages:
+      <<: *fedora_packages
+      repo_distro: fedora/40
     test:
       ebpf-core: true
   - <<: *opensuse


### PR DESCRIPTION
##### Summary

It went EOL upstream on 2025-05-13.

##### Test Plan

n/a

##### Additional Information

Closes: #20193 