### PR TITLE
Ensure chat exists before handling message input

### DIFF
--- a/src/web/mcp/mcp-web-client/web/app.js
+++ b/src/web/mcp/mcp-web-client/web/app.js
@@ -7014,6 +7014,9 @@ class NetdataMCPChat {
     
     // Messaging
     async sendMessage(chatId, messageParam = null, isResume = false) {
+        const chat = this.chats.get(chatId);
+        if (!chat) {return;}
+
         // If no message provided, get it from the input
         let message = messageParam;
         if (message === null) {
@@ -7039,10 +7042,7 @@ class NetdataMCPChat {
                 return;
             }
         }
-        
-        const chat = this.chats.get(chatId);
-        if (!chat) {return;}
-        
+
         // Clear error state when sending new message
         chat.hasError = false;
         chat.lastError = null;


### PR DESCRIPTION
##### Summary
This small PR adds an early check to ensure the chat exists before proceeding with message handling. It prevents runtime errors caused by referencing an undefined `chat` object when attempting to send a message (in `if (!chat.isSubChat) {` part).