### PR TITLE
Ignore timestamps recording in gzip metadata (for reproducible builds)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3943,7 +3943,7 @@ endif()
 #
 
 install(CODE "
-        execute_process(COMMAND gzip -c \"${CMAKE_BINARY_DIR}/CMakeCache.txt\"
+        execute_process(COMMAND gzip -nc \"${CMAKE_BINARY_DIR}/CMakeCache.txt\"
                         OUTPUT_FILE \"${BUILD_INFO_CMAKE_CACHE_ARCHIVE_NAME}\"
                         WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}\"
                         RESULT_VARIABLE result)


### PR DESCRIPTION
##### Summary

Use the `-n / --noname` option to ignore non-deterministric information, such as timestamps, in gzip metadata.

##### Test Plan

NA

##### Additional Information

This is required for [reproducible builds](https://reproducible-builds.org/).