### PR TITLE
Record proxy information when establishing ACLK

### DIFF
--- a/src/aclk/aclk_otp.c
+++ b/src/aclk/aclk_otp.c
@@ -8,14 +8,21 @@ static https_client_resp_t aclk_https_request(https_req_t *request, https_req_re
     https_client_resp_t rc;
     // wrapper for ACLK only which loads ACLK specific proxy settings
     // then only calls https_request
-    struct mqtt_wss_proxy proxy_conf = { .host = NULL, .port = 0, .username = NULL, .password = NULL, .type = MQTT_WSS_DIRECT };
-    aclk_set_proxy((char**)&proxy_conf.host, &proxy_conf.port, (char**)&proxy_conf.username, (char**)&proxy_conf.password, &proxy_conf.type);
+    struct mqtt_wss_proxy proxy_conf = { .host = NULL, .port = 0, .username = NULL, .password = NULL, .proxy_destination = NULL, .type = MQTT_WSS_DIRECT };
+    aclk_set_proxy(
+        (char **)&proxy_conf.host,
+        &proxy_conf.port,
+        (char **)&proxy_conf.username,
+        (char **)&proxy_conf.password,
+        (char **)&proxy_conf.proxy_destination,
+        &proxy_conf.type);
 
     if (proxy_conf.type == MQTT_WSS_PROXY_HTTP) {
-        request->proxy_host = (char*)proxy_conf.host; // TODO make it const as well
+        request->proxy_host = (char *)proxy_conf.host;
         request->proxy_port = proxy_conf.port;
         request->proxy_username = proxy_conf.username;
         request->proxy_password = proxy_conf.password;
+        request->proxy = proxy_conf.proxy_destination;
     }
 
     rc = https_request(request, response, fallback_ipv4);
@@ -33,7 +40,7 @@ struct auth_data {
 
 #define PARSE_ENV_JSON_CHK_TYPE(it, type, name)                                                                        \
     if (json_object_get_type(json_object_iter_peek_value(it)) != type) {                                               \
-        netdata_log_error("ACLK: value of key \"%s\" should be %s", name, #type);                                            \
+        netdata_log_error("ACLK: value of key \"%s\" should be %s", name, #type);                                      \
         goto exit;                                                                                                     \
     }
 

--- a/src/aclk/aclk_proxy.c
+++ b/src/aclk/aclk_proxy.c
@@ -76,25 +76,6 @@ static inline void safe_log_proxy_error(char *str, const char *proxy)
     freez(log);
 }
 
-static inline int check_socks_enviroment(const char **proxy)
-{
-    return 1;
-//    char *tmp = getenv("socks_proxy");
-//
-//    if (!tmp || !*tmp)
-//        return 1;
-//
-//    if (aclk_verify_proxy(tmp) == PROXY_TYPE_SOCKS5) {
-//        *proxy = tmp;
-//        return 0;
-//    }
-//
-//    safe_log_proxy_error(
-//        "Environment var \"socks_proxy\" defined but of unknown format. Supported syntax: \"socks5[h]://[user:pass@]host:port\".",
-//        tmp);
-//    return 1;
-}
-
 static inline int check_http_environment(const char **proxy)
 {
     const char *var = "http_proxy";
@@ -132,13 +113,10 @@ const char *aclk_lws_wss_get_proxy_setting(ACLK_PROXY_TYPE *type)
         return proxy;
 
     if (strcmp(proxy, ACLK_PROXY_ENV) == 0) {
-        if (check_socks_enviroment(&proxy) == 0)
-            *type = PROXY_TYPE_SOCKS5;
+        if (check_http_environment(&proxy) == 0)
+            *type = PROXY_TYPE_HTTP;
         else
-            if (check_http_environment(&proxy) == 0)
-                *type = PROXY_TYPE_HTTP;
-            else
-                proxy = NULL;
+            proxy = NULL;
         return proxy;
     }
 

--- a/src/aclk/aclk_proxy.c
+++ b/src/aclk/aclk_proxy.c
@@ -1,7 +1,5 @@
 #include "aclk_proxy.h"
 
-#include "database/rrd.h"
-
 #define ACLK_PROXY_ENV "env"
 #define ACLK_PROXY_CONFIG_VAR "proxy"
 

--- a/src/aclk/aclk_proxy.c
+++ b/src/aclk/aclk_proxy.c
@@ -44,6 +44,9 @@ ACLK_PROXY_TYPE aclk_verify_proxy(const char *string)
 // for logging purposes
 void safe_log_proxy_censor(char *proxy)
 {
+    if (!proxy)
+        return;
+
     size_t length = strlen(proxy);
     char *auth = proxy + length - 1;
     char *cur;
@@ -130,31 +133,18 @@ const char *aclk_lws_wss_get_proxy_setting(ACLK_PROXY_TYPE *type)
         return proxy;
 
     if (strcmp(proxy, ACLK_PROXY_ENV) == 0) {
-        if (check_socks_enviroment(&proxy) == 0) {
-#ifdef LWS_WITH_SOCKS5
+        if (check_socks_enviroment(&proxy) == 0)
             *type = PROXY_TYPE_SOCKS5;
-            return proxy;
-#else
-            safe_log_proxy_error("socks_proxy environment variable set to use SOCKS5 proxy "
-                "but Libwebsockets used doesn't have SOCKS5 support built in. "
-                "Ignoring and checking for other options.",
-                proxy);
-#endif
-        }
-        if (check_http_environment(&proxy) == 0)
-            *type = PROXY_TYPE_HTTP;
+        else
+            if (check_http_environment(&proxy) == 0)
+                *type = PROXY_TYPE_HTTP;
+            else
+                proxy = NULL;
         return proxy;
     }
 
     *type = aclk_verify_proxy(proxy);
-#ifndef LWS_WITH_SOCKS5
-    if (*type == PROXY_TYPE_SOCKS5) {
-        safe_log_proxy_error(
-            "Config var \"" ACLK_PROXY_CONFIG_VAR
-            "\" set to use SOCKS5 proxy but Libwebsockets used is built without support for SOCKS proxy. ACLK will be disabled.",
-            proxy);
-    }
-#endif
+
     if (*type == PROXY_TYPE_UNKNOWN) {
         *type = PROXY_DISABLED;
         safe_log_proxy_error(
@@ -169,14 +159,23 @@ const char *aclk_lws_wss_get_proxy_setting(ACLK_PROXY_TYPE *type)
 // helper function to read settings only once (static)
 // as claiming, challenge/response and ACLK
 // read the same thing, no need to parse again
-const char *aclk_get_proxy(ACLK_PROXY_TYPE *type)
+const char *aclk_get_proxy(ACLK_PROXY_TYPE *return_type, bool for_logging)
 {
     static const char *proxy = NULL;
+    static const char *safe_proxy = NULL;
     static ACLK_PROXY_TYPE proxy_type = PROXY_NOT_SET;
 
-    if (proxy_type == PROXY_NOT_SET)
+    if (proxy_type == PROXY_NOT_SET) {
         proxy = aclk_lws_wss_get_proxy_setting(&proxy_type);
+        char *log = NULL;
+        if (proxy) {
+            log = strdupz(proxy);
+            safe_log_proxy_censor(log);
+        }
+        safe_proxy = log;
+    }
 
-    *type = proxy_type;
-    return proxy;
+    if (return_type)
+        *return_type = proxy_type;
+    return for_logging ? safe_proxy : proxy;
 }

--- a/src/aclk/aclk_proxy.c
+++ b/src/aclk/aclk_proxy.c
@@ -78,20 +78,21 @@ static inline void safe_log_proxy_error(char *str, const char *proxy)
 
 static inline int check_socks_enviroment(const char **proxy)
 {
-    char *tmp = getenv("socks_proxy");
-
-    if (!tmp || !*tmp)
-        return 1;
-
-    if (aclk_verify_proxy(tmp) == PROXY_TYPE_SOCKS5) {
-        *proxy = tmp;
-        return 0;
-    }
-
-    safe_log_proxy_error(
-        "Environment var \"socks_proxy\" defined but of unknown format. Supported syntax: \"socks5[h]://[user:pass@]host:port\".",
-        tmp);
     return 1;
+//    char *tmp = getenv("socks_proxy");
+//
+//    if (!tmp || !*tmp)
+//        return 1;
+//
+//    if (aclk_verify_proxy(tmp) == PROXY_TYPE_SOCKS5) {
+//        *proxy = tmp;
+//        return 0;
+//    }
+//
+//    safe_log_proxy_error(
+//        "Environment var \"socks_proxy\" defined but of unknown format. Supported syntax: \"socks5[h]://[user:pass@]host:port\".",
+//        tmp);
+//    return 1;
 }
 
 static inline int check_http_environment(const char **proxy)

--- a/src/aclk/aclk_proxy.h
+++ b/src/aclk/aclk_proxy.h
@@ -2,6 +2,7 @@
 #define ACLK_PROXY_H
 
 #include <config.h>
+#include <stdbool.h>
 
 #define ACLK_PROXY_PROTO_ADDR_SEPARATOR "://"
 
@@ -16,6 +17,6 @@ typedef enum aclk_proxy_type {
 ACLK_PROXY_TYPE aclk_verify_proxy(const char *string);
 const char *aclk_lws_wss_get_proxy_setting(ACLK_PROXY_TYPE *type);
 void safe_log_proxy_censor(char *proxy);
-const char *aclk_get_proxy(ACLK_PROXY_TYPE *type);
+const char *aclk_get_proxy(ACLK_PROXY_TYPE *type, bool for_logging);
 
 #endif /* ACLK_PROXY_H */

--- a/src/aclk/aclk_proxy.h
+++ b/src/aclk/aclk_proxy.h
@@ -1,8 +1,7 @@
 #ifndef ACLK_PROXY_H
 #define ACLK_PROXY_H
 
-#include <config.h>
-#include <stdbool.h>
+#include "aclk.h"
 
 #define ACLK_PROXY_PROTO_ADDR_SEPARATOR "://"
 

--- a/src/aclk/aclk_util.c
+++ b/src/aclk/aclk_util.c
@@ -386,10 +386,12 @@ static inline int aclk_parse_userpass_pair(const char *src, const char c, char *
 }
 
 #define HTTP_PROXY_PREFIX "http://"
-void aclk_set_proxy(char **ohost, int *port, char **uname, char **pwd, enum mqtt_wss_proxy_type *type)
+void aclk_set_proxy(char **ohost, int *port, char **uname, char **pwd,
+    char **log_proxy, enum mqtt_wss_proxy_type *type)
 {
     ACLK_PROXY_TYPE pt;
-    const char *ptr = aclk_get_proxy(&pt);
+    const char *ptr = aclk_get_proxy(&pt, false);
+    *log_proxy = (char *) aclk_get_proxy(&pt, true);
     char *tmp;
 
     if (pt != PROXY_TYPE_HTTP)

--- a/src/aclk/aclk_util.h
+++ b/src/aclk/aclk_util.h
@@ -106,6 +106,7 @@ extern volatile int aclk_conversation_log_counter;
 unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int mins_ms, unsigned long int min_ms);
 #define aclk_tbeb_reset(x) aclk_tbeb_delay(1, 0, 0, 0)
 
-void aclk_set_proxy(char **ohost, int *port, char **uname, char **pwd, enum mqtt_wss_proxy_type *type);
+void aclk_set_proxy(char **ohost, int *port, char **uname, char **pwd,
+    char **log_proxy, enum mqtt_wss_proxy_type *type);
 
 #endif /* ACLK_UTIL_H */

--- a/src/aclk/https_client.h
+++ b/src/aclk/https_client.h
@@ -64,10 +64,11 @@ typedef struct {
     void *payload;
     size_t payload_size;
 
-    char *proxy_host;
+    const char *proxy_host;
     int proxy_port;
     const char *proxy_username;
     const char *proxy_password;
+    const char *proxy;
 } https_req_t;
 
 typedef struct {

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -2080,7 +2080,8 @@ int handle_incoming_traffic(struct mqtt_ng_client *client)
                 client->client_state = MQTT_STATE_CONNECTED;
                 break;
             }
-            client->client_state = MQTT_STATE_ERROR;            return MQTT_NG_CLIENT_SERVER_RETURNED_ERROR;
+            client->client_state = MQTT_STATE_ERROR;
+            return MQTT_NG_CLIENT_SERVER_RETURNED_ERROR;
 
         case MQTT_CPT_PUBACK:
             worker_is_busy(WORKER_ACLK_CPT_PUBACK);

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -2063,20 +2063,20 @@ int handle_incoming_traffic(struct mqtt_ng_client *client)
             client->connect_msg = NULL;
 
             if (client->client_state != MQTT_STATE_CONNECTING) {
-                nd_log(NDLS_DAEMON, NDLP_ERR, "Received unexpected CONNACK");
+                nd_log(NDLS_DAEMON, NDLP_ERR, "ACLK: Received unexpected CONNACK");
                 client->client_state = MQTT_STATE_ERROR;
                 return MQTT_NG_CLIENT_PROTOCOL_ERROR;
             }
 
             if ((prop = get_property_by_id(client->parser.properties_parser.head, MQTT_PROP_MAX_PKT_SIZE)) != NULL) {
-                nd_log(NDLS_DAEMON, NDLP_INFO, "MQTT server limits message size to %" PRIu32, prop->data.uint32);
+                nd_log(NDLS_DAEMON, NDLP_INFO, "ACLK: MQTT server limits message size to %" PRIu32, prop->data.uint32);
                 client->max_msg_size = prop->data.uint32;
             }
 
             if (client->connack_callback)
                 client->connack_callback(client->user_ctx, client->parser.mqtt_packet.connack.reason_code);
             if (!client->parser.mqtt_packet.connack.reason_code) {
-                nd_log(NDLS_DAEMON, NDLP_INFO, "MQTT Connection Accepted By Server");
+                nd_log(NDLS_DAEMON, NDLP_INFO, "ACLK: MQTT Connection Accepted By Server");
                 client->client_state = MQTT_STATE_CONNECTED;
                 break;
             }

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -488,6 +488,12 @@ int mqtt_wss_connect(
     char port_str[16];
     snprintf(port_str, sizeof(port_str) -1, "%d", client->port);
 
+    bool proxy_used = (proxy && proxy->proxy_destination != NULL);
+
+    nd_log_daemon(NDLP_INFO, "ACLK: Connecting to %s:%d%s%s",
+                  client->target_host, client->target_port,
+                  proxy_used ? " via proxy " : " (no proxy)", proxy_used ? proxy->proxy_destination : "");
+
     struct timeval timeout = { .tv_sec = 10, .tv_usec = 0 };
     int fd = connect_to_this_ip46(IPPROTO_TCP, SOCK_STREAM, client->host, 0, port_str, &timeout, fallback_ipv4);
     if (fd < 0) {
@@ -582,7 +588,6 @@ int mqtt_wss_connect(
 
     client->mqtt_keepalive = (mqtt_params->keep_alive ? mqtt_params->keep_alive : 400);
 
-    nd_log(NDLS_DAEMON, NDLP_INFO, "Going to connect using internal MQTT 5 implementation");
     struct mqtt_auth_properties auth;
     auth.client_id = (char*)mqtt_params->clientid;
     auth.client_id_free = NULL;

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.h
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.h
@@ -95,6 +95,7 @@ struct mqtt_wss_proxy {
     int port;
     const char *username;
     const char *password;
+    const char *proxy_destination;
 };
 
 /* TODO!!! update the description

--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -672,7 +672,6 @@ static void pipe_read_cb(uv_stream_t *client, ssize_t nread, const uv_buf_t *buf
     if (0 == nread) {
         netdata_log_info("%s: Zero bytes read by command pipe.", __func__);
     } else if (UV_EOF == nread) {
-        netdata_log_info("EOF found in command pipe.");
         parse_commands(cmd_ctx);
     } else if (nread < 0) {
         netdata_log_error("%s: %s", __func__, uv_strerror(nread));


### PR DESCRIPTION
##### Summary
- Log if a proxy is specified and used in establishing ACLK connection (via proxy ....) or (no proxy)
- Add `ACLK Proxy:` in `netdatacli aclk-state` output (and /api/v1/aclk)
