### PR TITLE
Improve Disk Usage Measure (Windows.plugin)

### DIFF
--- a/src/collectors/windows.plugin/perflib-storage.c
+++ b/src/collectors/windows.plugin/perflib-storage.c
@@ -238,6 +238,14 @@ static const char *drive_type_to_str(UINT type)
     }
 }
 
+static inline void netdata_set_hd_usage(PERF_DATA_BLOCK *pDataBlock,
+                                        PERF_OBJECT_TYPE *pObjectType,
+                                        PERF_INSTANCE_DEFINITION *pi,
+                                        struct logical_disk *d)
+{
+    perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentDiskFree);
+}
+
 static bool do_logical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every, usec_t now_ut)
 {
     DICTIONARY *dict = logicalDisks;
@@ -266,7 +274,7 @@ static bool do_logical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every, usec_
             d->collected_metadata = true;
         }
 
-        perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentDiskFree);
+        netdata_set_hd_usage(pDataBlock, pObjectType, pi, d);
         // perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->freeMegabytes);
 
         if (!d->st_disk_space) {


### PR DESCRIPTION
##### Summary

When running current master on different Windows Server it was observer scenarios like this:

<img width="1024" height="791" alt="masterBranch" src="https://github.com/user-attachments/assets/b26455ef-983a-4e71-a413-b59988da51a0" />

In this example, Netdata does not reflect the same data as Windows Exporter. This discrepancy is not directly related to our previous code. Rather, it appears that Microsoft does not expose all files through the API, which can lead to inaccurate results.

This PR improves the situation slightly. However, differences due to temporary files, cache, and rounding can still cause mismatches between the displayed data.
 
<img width="1020" height="797" alt="thisBranch" src="https://github.com/user-attachments/assets/8f2e2728-e459-4416-acd7-1a5cabc8e7dd" />

##### Test Plan

1. Compile this branch
2. Install it on your host.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
