### PR TITLE
Add default iface info to host labels

### DIFF
--- a/src/database/rrdhost-system-info.c
+++ b/src/database/rrdhost-system-info.c
@@ -135,6 +135,18 @@ int rrdhost_system_info_set_by_name(struct rrdhost_system_info *system_info, cha
         freez(system_info->is_k8s_node);
         system_info->is_k8s_node = strdupz(value);
     }
+    else if(!strcmp(name, "NETDATA_SYSTEM_DEFAULT_INTERFACE_NAME")){
+        freez(system_info->network_default_iface);
+        system_info->network_default_iface = strdupz(value);
+    }
+    else if(!strcmp(name, "NETDATA_SYSTEM_DEFAULT_INTERFACE_IP")){
+        freez(system_info->network_default_iface_ip);
+        system_info->network_default_iface_ip = strdupz(value);
+    }
+    else if(!strcmp(name, "NETDATA_SYSTEM_DEFAULT_INTERFACE_DETECTION")){
+        freez(system_info->network_default_iface_detection);
+        system_info->network_default_iface_detection = strdupz(value);
+    }
     else if (!strcmp(name, "NETDATA_SYSTEM_CPU_VENDOR"))
         return res;
     else if (!strcmp(name, "NETDATA_SYSTEM_CPU_DETECTION"))
@@ -176,7 +188,9 @@ struct rrdhost_system_info *rrdhost_system_info_from_host_labels(RRDLABELS *labe
     rrdlabels_get_value_strdup_or_null(labels, &info->install_type, "_install_type");
     rrdlabels_get_value_strdup_or_null(labels, &info->prebuilt_arch, "_prebuilt_arch");
     rrdlabels_get_value_strdup_or_null(labels, &info->prebuilt_dist, "_prebuilt_dist");
-
+    rrdlabels_get_value_strdup_or_null(labels, &info->network_default_iface, "_net_default_iface");
+    rrdlabels_get_value_strdup_or_null(labels, &info->network_default_iface_ip, "_net_default_iface_ip");
+    rrdlabels_get_value_strdup_or_null(labels, &info->network_default_iface_detection, "_net_default_iface_detection");
     return info;
 }
 
@@ -241,9 +255,14 @@ void rrdhost_system_info_to_rrdlabels(struct rrdhost_system_info *system_info, R
     if (system_info->prebuilt_dist)
         rrdlabels_add(labels, "_prebuilt_dist", system_info->prebuilt_dist, RRDLABEL_SRC_AUTO);
 
-    rrdlabels_add(labels, "_hw_sys_vendor", daemon_status_file_get_sys_vendor(), RRDLABEL_SRC_AUTO);
-    rrdlabels_add(labels, "_hw_product_name", daemon_status_file_get_product_name(), RRDLABEL_SRC_AUTO);
-    rrdlabels_add(labels, "_hw_product_type", daemon_status_file_get_product_type(), RRDLABEL_SRC_AUTO);
+    if (system_info->network_default_iface)
+        rrdlabels_add(labels, "_net_default_iface", system_info->network_default_iface, RRDLABEL_SRC_AUTO);
+
+    if (system_info->network_default_iface_ip)
+        rrdlabels_add(labels, "_net_default_iface_ip", system_info->network_default_iface_ip, RRDLABEL_SRC_AUTO);
+
+    if (system_info->network_default_iface_detection)
+        rrdlabels_add(labels, "_net_default_iface_detection", system_info->network_default_iface_detection, RRDLABEL_SRC_AUTO);
 }
 
 int rrdhost_system_info_detect(struct rrdhost_system_info *system_info) {
@@ -380,6 +399,9 @@ void rrdhost_system_info_free(struct rrdhost_system_info *system_info) {
         freez(system_info->install_type);
         freez(system_info->prebuilt_arch);
         freez(system_info->prebuilt_dist);
+        freez(system_info->network_default_iface);
+        freez(system_info->network_default_iface_ip);
+        freez(system_info->network_default_iface_detection);
         freez(system_info);
     }
 }
@@ -509,7 +531,9 @@ int rrdhost_system_info_foreach(struct rrdhost_system_info *system_info, add_hos
     ret += cb("NETDATA_SYSTEM_CONTAINER", system_info->container, uuid);
     ret += cb("NETDATA_SYSTEM_CONTAINER_DETECTION", system_info->container_detection, uuid);
     ret += cb("NETDATA_HOST_IS_K8S_NODE", system_info->is_k8s_node, uuid);
-
+    ret += cb("NETDATA_SYSTEM_DEFAULT_INTERFACE_NAME", system_info->network_default_iface, uuid);
+    ret += cb("NETDATA_SYSTEM_DEFAULT_INTERFACE_IP", system_info->network_default_iface_ip, uuid);
+    ret += cb("NETDATA_SYSTEM_DEFAULT_INTERFACE_DETECTION", system_info->network_default_iface_detection, uuid);
     return ret;
 }
 

--- a/src/database/rrdhost-system-info.h
+++ b/src/database/rrdhost-system-info.h
@@ -44,6 +44,9 @@ struct rrdhost_system_info {
     char *install_type;
     char *prebuilt_arch;
     char *prebuilt_dist;
+    char *network_default_iface;
+    char *network_default_iface_ip;
+    char *network_default_iface_detection;
     int mc_version;
 };
 #else

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -1018,7 +1018,7 @@ static bool store_host_systeminfo(RRDHOST *host)
     if (unlikely(!system_info))
         return false;
 
-    return (24 != rrdhost_system_info_foreach(system_info, add_host_sysinfo_key_value, &host->host_id.uuid));
+    return (27 != rrdhost_system_info_foreach(system_info, add_host_sysinfo_key_value, &host->host_id.uuid));
 }
 
 


### PR DESCRIPTION
##### Summary
- Add the detected default network interface information to system info and host labels
