### PR TITLE
Add publish latency to the aclk-state command

### DIFF
--- a/src/daemon/pulse/pulse-network.c
+++ b/src/daemon/pulse/pulse-network.c
@@ -92,12 +92,12 @@ static inline size_t aclk_time_histogram_slot(struct aclk_time_histogram *h, use
     return low - 1;
 }
 
-void pulse_aclk_sent_message_acked(usec_t sent_ut, size_t len __maybe_unused) {
-    if(!sent_ut) return;
+void pulse_aclk_sent_message_acked(usec_t publish_latency, size_t len __maybe_unused) {
+    if(!publish_latency) return;
 
-    usec_t usec = now_monotonic_usec() - sent_ut;
+//    usec_t usec = now_monotonic_usec() - publish_latency;
 
-    size_t slot = aclk_time_histogram_slot(&aclk_time_heatmap, usec);
+    size_t slot = aclk_time_histogram_slot(&aclk_time_heatmap, publish_latency);
     internal_fatal(slot >= _countof(aclk_time_heatmap.array), "hey!");
 
     __atomic_add_fetch(&aclk_time_heatmap.array[slot].count, 1, __ATOMIC_RELAXED);

--- a/src/daemon/pulse/pulse-network.h
+++ b/src/daemon/pulse/pulse-network.h
@@ -16,7 +16,7 @@ void pulse_statsd_sent_bytes(size_t bytes);
 void pulse_stream_received_bytes(size_t bytes);
 void pulse_stream_sent_bytes(size_t bytes);
 
-void pulse_aclk_sent_message_acked(usec_t usec, size_t len);
+void pulse_aclk_sent_message_acked(usec_t publish_latency, size_t len);
 
 #ifdef PULSE_INTERNALS
 void aclk_time_histogram_init(void);


### PR DESCRIPTION
##### Summary
- Add publish latency to the `aclk-state cli` command (and api/v1/aclk) end point. 
  This shows latest message publish latency in (usec) based on the publish acknowledgement packet received

Of course more detailed information (histogram chart) is available by enabling extended statistics in the `[pulse]` section of netdata.conf

Example: 
```
ACLK Available: Yes
ACLK Version: 2
Protocols Supported: Protobuf
Protocol Used: Protobuf
MQTT Version: 5
Claimed: Yes
Claimed Id: xxxxxxxxxxxxx
Cloud URL: https://app.netdata.cloud
ACLK Proxy: none
Publish Latency: 121ms 159us
Online: Yes
Reconnect count: 0
```