### PR TITLE
Fix MSSQL Charts

### DIFF
--- a/src/collectors/windows.plugin/perflib-mssql-queries.h
+++ b/src/collectors/windows.plugin/perflib-mssql-queries.h
@@ -18,6 +18,9 @@
 #define NETDATA_QUERY_TRANSACTIONS_MASK                                                                                \
     "SELECT counter_name, cntr_value FROM %s.sys.dm_os_performance_counters WHERE instance_name = '%s' AND counter_name IN ('Active Transactions', 'Transactions/sec', 'Write Transactions/sec', 'Backup/Restore Throughput/sec', 'Log Bytes Flushed/sec', 'Log Flushes/sec', 'Number of Deadlocks/sec', 'Lock Waits/sec', 'Lock Timeouts/sec', 'Lock Requests/sec');"
 
+#define NETDATA_QUERY_TRANSACTIONS_PER_INSTANCE_MASK                                                                                \
+    "SELECT counter_name, cntr_value FROM sys.dm_os_performance_counters WHERE (object_name like '%%Buffer Manager%%' or object_name like '%%SQL Statistics%%') AND counter_name IN ('Page reads/sec', 'Page writes/sec', 'SQL Compilations/sec', 'SQL Re-Compilations/sec');"
+
 #define NETDATA_QUERY_CHECK_PERM                                                                                       \
     "SELECT CASE WHEN IS_SRVROLEMEMBER('sysadmin') = 1 OR HAS_PERMS_BY_NAME(null, null, 'VIEW SERVER STATE') = 1 THEN 1 ELSE 0 END AS has_permission;"
 

--- a/src/collectors/windows.plugin/perflib-mssql-queries.h
+++ b/src/collectors/windows.plugin/perflib-mssql-queries.h
@@ -19,7 +19,7 @@
     "SELECT counter_name, cntr_value FROM %s.sys.dm_os_performance_counters WHERE instance_name = '%s' AND counter_name IN ('Active Transactions', 'Transactions/sec', 'Write Transactions/sec', 'Backup/Restore Throughput/sec', 'Log Bytes Flushed/sec', 'Log Flushes/sec', 'Number of Deadlocks/sec', 'Lock Waits/sec', 'Lock Timeouts/sec', 'Lock Requests/sec');"
 
 #define NETDATA_QUERY_TRANSACTIONS_PER_INSTANCE_MASK                                                                                \
-    "SELECT counter_name, cntr_value FROM sys.dm_os_performance_counters WHERE (object_name like '%%Buffer Manager%%' or object_name like '%%SQL Statistics%%') AND counter_name IN ('Page reads/sec', 'Page writes/sec', 'Buffer cache hit ratio', 'Checkpoint pages/sec', 'SQL Compilations/sec', 'SQL Re-Compilations/sec');"
+    "SELECT counter_name, cntr_value FROM sys.dm_os_performance_counters WHERE (object_name like '%%Buffer Manager%%' or object_name like '%%SQL Statistics%%') AND counter_name IN ('Page reads/sec', 'Page writes/sec', 'Buffer cache hit ratio', 'Checkpoint pages/sec', 'Page life expectancy', 'SQL Compilations/sec', 'SQL Re-Compilations/sec');"
 
 #define NETDATA_QUERY_CHECK_PERM                                                                                       \
     "SELECT CASE WHEN IS_SRVROLEMEMBER('sysadmin') = 1 OR HAS_PERMS_BY_NAME(null, null, 'VIEW SERVER STATE') = 1 THEN 1 ELSE 0 END AS has_permission;"

--- a/src/collectors/windows.plugin/perflib-mssql-queries.h
+++ b/src/collectors/windows.plugin/perflib-mssql-queries.h
@@ -19,7 +19,7 @@
     "SELECT counter_name, cntr_value FROM %s.sys.dm_os_performance_counters WHERE instance_name = '%s' AND counter_name IN ('Active Transactions', 'Transactions/sec', 'Write Transactions/sec', 'Backup/Restore Throughput/sec', 'Log Bytes Flushed/sec', 'Log Flushes/sec', 'Number of Deadlocks/sec', 'Lock Waits/sec', 'Lock Timeouts/sec', 'Lock Requests/sec');"
 
 #define NETDATA_QUERY_TRANSACTIONS_PER_INSTANCE_MASK                                                                                \
-    "SELECT counter_name, cntr_value FROM sys.dm_os_performance_counters WHERE (object_name like '%%Buffer Manager%%' or object_name like '%%SQL Statistics%%') AND counter_name IN ('Page reads/sec', 'Page writes/sec', 'Buffer cache hit ratio', 'SQL Compilations/sec', 'SQL Re-Compilations/sec');"
+    "SELECT counter_name, cntr_value FROM sys.dm_os_performance_counters WHERE (object_name like '%%Buffer Manager%%' or object_name like '%%SQL Statistics%%') AND counter_name IN ('Page reads/sec', 'Page writes/sec', 'Buffer cache hit ratio', 'Checkpoint pages/sec', 'SQL Compilations/sec', 'SQL Re-Compilations/sec');"
 
 #define NETDATA_QUERY_CHECK_PERM                                                                                       \
     "SELECT CASE WHEN IS_SRVROLEMEMBER('sysadmin') = 1 OR HAS_PERMS_BY_NAME(null, null, 'VIEW SERVER STATE') = 1 THEN 1 ELSE 0 END AS has_permission;"

--- a/src/collectors/windows.plugin/perflib-mssql-queries.h
+++ b/src/collectors/windows.plugin/perflib-mssql-queries.h
@@ -19,7 +19,7 @@
     "SELECT counter_name, cntr_value FROM %s.sys.dm_os_performance_counters WHERE instance_name = '%s' AND counter_name IN ('Active Transactions', 'Transactions/sec', 'Write Transactions/sec', 'Backup/Restore Throughput/sec', 'Log Bytes Flushed/sec', 'Log Flushes/sec', 'Number of Deadlocks/sec', 'Lock Waits/sec', 'Lock Timeouts/sec', 'Lock Requests/sec');"
 
 #define NETDATA_QUERY_TRANSACTIONS_PER_INSTANCE_MASK                                                                                \
-    "SELECT counter_name, cntr_value FROM sys.dm_os_performance_counters WHERE (object_name like '%%Buffer Manager%%' or object_name like '%%SQL Statistics%%') AND counter_name IN ('Page reads/sec', 'Page writes/sec', 'SQL Compilations/sec', 'SQL Re-Compilations/sec');"
+    "SELECT counter_name, cntr_value FROM sys.dm_os_performance_counters WHERE (object_name like '%%Buffer Manager%%' or object_name like '%%SQL Statistics%%') AND counter_name IN ('Page reads/sec', 'Page writes/sec', 'Buffer cache hit ratio', 'SQL Compilations/sec', 'SQL Re-Compilations/sec');"
 
 #define NETDATA_QUERY_CHECK_PERM                                                                                       \
     "SELECT CASE WHEN IS_SRVROLEMEMBER('sysadmin') = 1 OR HAS_PERMS_BY_NAME(null, null, 'VIEW SERVER STATE') = 1 THEN 1 ELSE 0 END AS has_permission;"

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -119,6 +119,7 @@ struct mssql_instance {
     RRDSET *st_buff_checkpoint_pages;
     RRDDIM *rd_buff_checkpoint_pages;
 
+    RRDSET *st_access_method_page_splits;
     RRDDIM *rd_access_method_page_splits;
 
     RRDSET *st_sql_errors;
@@ -1984,6 +1985,7 @@ int dict_mssql_buffman_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, voi
         return 1;
 
     if (!mdi->st_buff_page_iops) {
+        char id[RRD_ID_LENGTH_MAX + 1];
         snprintfz(id, RRD_ID_LENGTH_MAX, "instance_%s_bufman_iops", mi->instanceID);
         netdata_fix_chart_name(id);
         mdi->st_buff_page_iops = rrdset_create_localhost(
@@ -1997,7 +1999,7 @@ int dict_mssql_buffman_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, voi
                 PLUGIN_WINDOWS_NAME,
                 "PerflibMSSQL",
                 PRIO_MSSQL_BUFF_MAN_IOPS,
-                update_every,
+                mi->update_every,
                 RRDSET_TYPE_LINE);
 
         mdi->rd_buff_page_reads = rrddim_add(mdi->st_buff_page_iops, "read", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -1332,7 +1332,7 @@ static void do_mssql_general_stats(PERF_DATA_BLOCK *pDataBlock, struct mssql_ins
     }
 }
 
-static void do_mssql_sql_statistics(PERF_DATA_BLOCK *pDataBlock, struct mssql_instance *mi, int update_every)
+static void do_mssql_statistics_perflib(PERF_DATA_BLOCK *pDataBlock, struct mssql_instance *mi, int update_every)
 {
     char id[RRD_ID_LENGTH_MAX + 1];
 
@@ -1494,7 +1494,7 @@ static void do_mssql_sql_statistics(PERF_DATA_BLOCK *pDataBlock, struct mssql_in
      */
 }
 
-static void do_mssql_buffer_management(PERF_DATA_BLOCK *pDataBlock, struct mssql_instance *mi, int update_every)
+static void do_mssql_bufferman_perflib(PERF_DATA_BLOCK *pDataBlock, struct mssql_instance *mi, int update_every)
 {
     char id[RRD_ID_LENGTH_MAX + 1];
 
@@ -2637,19 +2637,19 @@ int dict_mssql_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value
     int *update_every = data;
 
     static void (*doMSSQL[])(PERF_DATA_BLOCK *, struct mssql_instance *, int) = {
-        do_mssql_general_stats,
-        do_mssql_errors,
-        do_mssql_memory_mgr,
-        do_mssql_buffer_management,
-        do_mssql_sql_statistics,
-        do_mssql_access_methods,
+            do_mssql_general_stats,
+            do_mssql_errors,
+            do_mssql_memory_mgr,
+            do_mssql_bufferman_perflib,
+            do_mssql_statistics_perflib,
+            do_mssql_access_methods,
 
-        do_mssql_databases,
-        do_mssql_locks,
-        do_mssql_waits,
-        do_mssql_bufferman_sql,
+            do_mssql_databases,
+            do_mssql_locks,
+            do_mssql_waits,
+            do_mssql_bufferman_sql,
 
-        NULL};
+            NULL};
 
     DWORD i;
     PERF_DATA_BLOCK *pDataBlock;

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -389,7 +389,6 @@ void dict_mssql_fill_instance_transactions(struct mssql_db_instance *mdi)
             default:
                 goto enditransactions;
         }
-#define NETDATA_MSSQL_BUFFER_PAGE_CACHE_METRIC "Buffer cache hit ratio"
 
         // We cannot use strcmp, because buffer is filled with spaces instead NULL.
         if (!strncmp(

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -50,13 +50,13 @@ enum netdata_mssql_metrics {
     NETDATA_MSSQL_GENERAL_STATS,
     NETDATA_MSSQL_SQL_ERRORS,
     NETDATA_MSSQL_MEMORY,
-    NETDATA_MSSQL_BUFFER_MANAGEMENT,
     NETDATA_MSSQL_SQL_STATS,
     NETDATA_MSSQL_ACCESS_METHODS,
 
     NETDATA_MSSQL_DATABASE,
     NETDATA_MSSQL_LOCKS,
     NETDATA_MSSQL_WAITS,
+    NETDATA_MSSQL_BUFFER_MANAGEMENT,
 
     NETDATA_MSSQL_METRICS_END
 };
@@ -113,9 +113,6 @@ struct mssql_instance {
     RRDSET *st_buff_cache_page_life_expectancy;
     RRDDIM *rd_buff_cache_page_life_expectancy;
 
-    RRDSET *st_buff_checkpoint_pages;
-    RRDDIM *rd_buff_checkpoint_pages;
-
     RRDSET *st_access_method_page_splits;
     RRDDIM *rd_access_method_page_splits;
 
@@ -141,7 +138,6 @@ struct mssql_instance {
     DICTIONARY *waits;
 
     COUNTER_DATA MSSQLAccessMethodPageSplits;
-    COUNTER_DATA MSSQLBufferCheckpointPages;
     COUNTER_DATA MSSQLBufferPageLifeExpectancy;
     COUNTER_DATA MSSQLBlockedProcesses;
     COUNTER_DATA MSSQLUserConnections;
@@ -189,6 +185,7 @@ struct mssql_db_instance {
     RRDSET *st_lock_requests;
     RRDSET *st_buff_page_iops;
     RRDSET *st_buff_cache_hits;
+    RRDSET *st_buff_checkpoint_pages;
 
     RRDSET *st_stats_compilation;
     RRDSET *st_stats_recompiles;
@@ -209,6 +206,7 @@ struct mssql_db_instance {
     RRDDIM *rd_buff_page_reads;
     RRDDIM *rd_buff_page_writes;
     RRDDIM *rd_buff_cache_hits;
+    RRDDIM *rd_buff_checkpoint_pages;
 
     RRDDIM *rd_stats_compilation;
     RRDDIM *rd_stats_recompiles;
@@ -231,6 +229,7 @@ struct mssql_db_instance {
     COUNTER_DATA MSSQLBufferPageReads;
     COUNTER_DATA MSSQLBufferPageWrites;
     COUNTER_DATA MSSQLBufferCacheHits;
+    COUNTER_DATA MSSQLBufferCheckpointPages;
 
     COUNTER_DATA MSSQLCompilations;
     COUNTER_DATA MSSQLRecompilations;
@@ -341,6 +340,7 @@ static ULONGLONG netdata_MSSQL_fill_long_value(SQLHSTMT *stmt, const char *mask,
 #define NETDATA_MSSQL_BUFFER_PAGE_READS_METRIC "Page reads/sec"
 #define NETDATA_MSSQL_BUFFER_PAGE_WRITES_METRIC "Page writes/sec"
 #define NETDATA_MSSQL_BUFFER_PAGE_CACHE_METRIC "Buffer cache hit ratio"
+#define NETDATA_MSSQL_BUFFER_CHECKPOINT_METRIC "Checkpoint pages/sec"
 
 #define NETDATA_MSSQL_STATS_COMPILATIONS_METRIC "SQL Compilations/sec"
 #define NETDATA_MSSQL_STATS_RECOMPILATIONS_METRIC "SQL Re-Compilations/sec"
@@ -403,6 +403,9 @@ void dict_mssql_fill_instance_transactions(struct mssql_db_instance *mdi)
         else if (!strncmp(
                 object_name, NETDATA_MSSQL_BUFFER_PAGE_CACHE_METRIC, sizeof(NETDATA_MSSQL_BUFFER_PAGE_CACHE_METRIC) - 1))
             mdi->MSSQLBufferCacheHits.current.Data = (ULONGLONG)value;
+        else if (!strncmp(
+                object_name, NETDATA_MSSQL_BUFFER_CHECKPOINT_METRIC, sizeof(NETDATA_MSSQL_BUFFER_CHECKPOINT_METRIC) - 1))
+            mdi->MSSQLBufferCheckpointPages.current.Data = (ULONGLONG)value;
         else if (!strncmp(
                 object_name, NETDATA_MSSQL_STATS_COMPILATIONS_METRIC, sizeof(NETDATA_MSSQL_STATS_COMPILATIONS_METRIC) - 1))
             mdi->MSSQLCompilations.current.Data = (ULONGLONG)value;
@@ -943,7 +946,6 @@ static inline void initialize_mssql_keys(struct mssql_instance *mi)
     mi->MSSQLStatSafeAutoParameterization.key = "Safe Auto-Params/sec";
 
     mi->MSSQLBufferPageLifeExpectancy.key = "Page life expectancy";
-    mi->MSSQLBufferCheckpointPages.key = "Checkpoint pages/sec";
 
     // Access Methods (https://learn.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-access-methods-object)
     mi->MSSQLAccessMethodPageSplits.key = "Page Splits/sec";
@@ -1509,37 +1511,6 @@ static void do_mssql_bufferman_perflib(PERF_DATA_BLOCK *pDataBlock, struct mssql
     if (!pObjectType)
         return;
 
-    if (perflibGetObjectCounter(pDataBlock, pObjectType, &mi->MSSQLBufferCheckpointPages)) {
-        if (!mi->st_buff_checkpoint_pages) {
-            snprintfz(id, RRD_ID_LENGTH_MAX, "instance_%s_bufman_checkpoint_pages", mi->instanceID);
-            netdata_fix_chart_name(id);
-            mi->st_buff_checkpoint_pages = rrdset_create_localhost(
-                "mssql",
-                id,
-                NULL,
-                "buffer cache",
-                "mssql.instance_bufman_checkpoint_pages",
-                "Flushed pages",
-                "pages/s",
-                PLUGIN_WINDOWS_NAME,
-                "PerflibMSSQL",
-                PRIO_MSSQL_BUFF_CHECKPOINT_PAGES,
-                update_every,
-                RRDSET_TYPE_LINE);
-
-            mi->rd_buff_checkpoint_pages =
-                rrddim_add(mi->st_buff_checkpoint_pages, "log", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-
-            rrdlabels_add(mi->st_buff_checkpoint_pages->rrdlabels, "mssql_instance", mi->instanceID, RRDLABEL_SRC_AUTO);
-        }
-
-        rrddim_set_by_pointer(
-            mi->st_buff_checkpoint_pages,
-            mi->rd_buff_checkpoint_pages,
-            (collected_number)mi->MSSQLBufferCheckpointPages.current.Data);
-        rrdset_done(mi->st_buff_checkpoint_pages);
-    }
-
     if (perflibGetObjectCounter(pDataBlock, pObjectType, &mi->MSSQLBufferPageLifeExpectancy)) {
         if (!mi->st_buff_cache_page_life_expectancy) {
             snprintfz(id, RRD_ID_LENGTH_MAX, "instance_%s_bufman_page_life_expectancy", mi->instanceID);
@@ -2019,6 +1990,39 @@ void mssql_buffman_cache_hit_ratio_chart(struct mssql_db_instance *mdi, struct m
     rrdset_done(mdi->st_buff_cache_hits);
 }
 
+void mssql_buffman_checkpoints_pages_chart(struct mssql_db_instance *mdi, struct mssql_instance *mi)
+{
+    if (!mdi->st_buff_checkpoint_pages) {
+        char id[RRD_ID_LENGTH_MAX + 1];
+        snprintfz(id, RRD_ID_LENGTH_MAX, "instance_%s_bufman_checkpoint_pages", mi->instanceID);
+        netdata_fix_chart_name(id);
+        mdi->st_buff_checkpoint_pages = rrdset_create_localhost(
+                "mssql",
+                id,
+                NULL,
+                "buffer cache",
+                "mssql.instance_bufman_checkpoint_pages",
+                "Flushed pages",
+                "pages/s",
+                PLUGIN_WINDOWS_NAME,
+                "PerflibMSSQL",
+                PRIO_MSSQL_BUFF_CHECKPOINT_PAGES,
+                mi->update_every,
+                RRDSET_TYPE_LINE);
+
+        mdi->rd_buff_checkpoint_pages =
+                rrddim_add(mdi->st_buff_checkpoint_pages, "log", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+
+        rrdlabels_add(mdi->st_buff_checkpoint_pages->rrdlabels, "mssql_instance", mi->instanceID, RRDLABEL_SRC_AUTO);
+    }
+
+    rrddim_set_by_pointer(
+            mdi->st_buff_checkpoint_pages,
+            mdi->rd_buff_checkpoint_pages,
+            (collected_number)mdi->MSSQLBufferCheckpointPages.current.Data);
+    rrdset_done(mdi->st_buff_checkpoint_pages);
+}
+
 int dict_mssql_buffman_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused)
 {
     struct mssql_db_instance *mdi = value;
@@ -2028,6 +2032,8 @@ int dict_mssql_buffman_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, voi
         return 1;
 
     mssql_buffman_iops_chart(mdi, mi);
+    mssql_buffman_cache_hit_ratio_chart(mdi, mi);
+    mssql_buffman_checkpoints_pages_chart(mdi, mi);
 
     return 1;
 }
@@ -2653,7 +2659,6 @@ int dict_mssql_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value
             do_mssql_general_stats,
             do_mssql_errors,
             do_mssql_memory_mgr,
-            do_mssql_bufferman_perflib,
             do_mssql_statistics_perflib,
             do_mssql_access_methods,
 

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -1976,14 +1976,8 @@ static void do_mssql_waits(PERF_DATA_BLOCK *pDataBlock, struct mssql_instance *m
     dictionary_sorted_walkthrough_read(mi->waits, dict_mssql_waits_charts_cb, mi);
 }
 
-int dict_mssql_buffman_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused)
+void mssql_buffman_iops_chart(struct mssql_db_instance *mdi, struct mssql_instance *mi)
 {
-    struct mssql_db_instance *mdi = value;
-    struct mssql_instance *mi = data;
-
-    if (unlikely(!mdi->collect_instance))
-        return 1;
-
     if (!mdi->st_buff_page_iops) {
         char id[RRD_ID_LENGTH_MAX + 1];
         snprintfz(id, RRD_ID_LENGTH_MAX, "instance_%s_bufman_iops", mi->instanceID);
@@ -2015,6 +2009,17 @@ int dict_mssql_buffman_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, voi
             mdi->st_buff_page_iops, mdi->rd_buff_page_writes, (collected_number)mdi->MSSQLBufferPageWrites.current.Data);
 
     rrdset_done(mdi->st_buff_page_iops);
+}
+
+int dict_mssql_buffman_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused)
+{
+    struct mssql_db_instance *mdi = value;
+    struct mssql_instance *mi = data;
+
+    if (unlikely(!mdi->collect_instance))
+        return 1;
+
+    mssql_buffman_iops_chart(mdi, mi);
 
     return 1;
 }


### PR DESCRIPTION
##### Summary
Some of the MSSQL charts were displaying a value of zero because Perflib was not returning accurate results.

This PR addresses the issue as part of the ongoing effort to fix https://github.com/netdata/netdata/issues/20123.

Master Branch:
<img width="773" height="283" alt="master" src="https://github.com/user-attachments/assets/740906db-5b6d-4afe-8863-dcf11eca2ff8" />

This PR:

<img width="1818" height="915" alt="buffer" src="https://github.com/user-attachments/assets/ab03463d-53bb-471c-8a6a-ff01a7486372" />


##### Test Plan

1. Compile this branch.
2. Install it on a host running Microsoft SQL Server.
3. Verify that the metrics are no longer zero.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
