### PR TITLE
Aclk improvements

### DIFF
--- a/src/aclk/aclk_query_queue.c
+++ b/src/aclk/aclk_query_queue.c
@@ -58,6 +58,7 @@ aclk_query_t *aclk_query_new(aclk_query_type_t type)
 {
     aclk_query_t *query = get_query();
     query->type = type;
+    now_monotonic_high_precision_timeval(&query->created_tv);
     return query;
 }
 

--- a/src/aclk/aclk_rx_msgs.c
+++ b/src/aclk/aclk_rx_msgs.c
@@ -233,12 +233,9 @@ int handle_old_proto_cmd(const char *msg, size_t msg_len)
     char *str = mallocz(msg_len+1);
     memcpy(str, msg, msg_len);
     str[msg_len] = 0;
-    if (aclk_handle_cloud_cmd_message(str)) {
-        freez(str);
-        return 1;
-    }
+    int rc = aclk_handle_cloud_cmd_message(str);
     freez(str);
-    return 0;
+    return rc;
 }
 
 int create_node_instance_result(const char *msg, size_t msg_len)

--- a/src/aclk/mqtt_websockets/common_public.h
+++ b/src/aclk/mqtt_websockets/common_public.h
@@ -25,6 +25,7 @@ struct mqtt_ng_stats {
     int tx_messages_queued;
     int tx_messages_sent;
     int rx_messages_rcvd;
+    int packets_waiting_puback;
     size_t tx_buffer_used;
     size_t tx_buffer_free;
     size_t tx_buffer_size;

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -1255,11 +1255,6 @@ int mqtt_ng_publish(struct mqtt_ng_client *client,
     }
 
     int rc = TRY_GENERATE_MESSAGE(mqtt_ng_generate_publish, topic, topic_free, msg, msg_free, msg_len, publish_flags, packet_id, topic_id);
-    if (rc == MQTT_NG_MSGGEN_BUFFER_OOM) {
-        check_packet_monitor_list_for_timeouts(client);
-        rc = TRY_GENERATE_MESSAGE(mqtt_ng_generate_publish, topic, topic_free, msg, msg_free, msg_len, publish_flags, packet_id, topic_id);
-    }
-
     if (rc == MQTT_NG_MSGGEN_OK)
         add_packet_to_timeout_monitor_list(client, *packet_id);
     return rc;

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -754,17 +754,6 @@ static int t_till_next_keepalive_ms(mqtt_wss_client client)
     return timeout_ms;
 }
 
-#ifdef MQTT_WSS_CPUSTATS
-static uint64_t mqtt_wss_now_usec(void) {
-    struct timespec ts;
-    if(clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
-        nd_log(NDLS_DAEMON, NDLP_ERR, "clock_gettime(CLOCK_MONOTONIC, &timespec) failed.");
-        return 0;
-    }
-    return (uint64_t)ts.tv_sec * USEC_PER_SEC + (ts.tv_nsec % NSEC_PER_SEC) / NSEC_PER_USEC;
-}
-#endif
-
 int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
 {
     char *ptr;
@@ -774,7 +763,7 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
 
 #ifdef MQTT_WSS_CPUSTATS
     uint64_t t2;
-    uint64_t t1 = mqtt_wss_now_usec();
+    uint64_t t1 = now_monotonic_usec();
 #endif
 
     // Check user requested TO doesn't interfere with MQTT keep alives
@@ -787,7 +776,7 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
     }
 
 #ifdef MQTT_WSS_CPUSTATS
-    t2 = mqtt_wss_now_usec();
+    t2 = now_monotonic_usec();
     client->stats.time_keepalive += t2 - t1;
 #endif
 
@@ -805,7 +794,7 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
     worker_is_busy(WORKER_ACLK_POLL_OK);
 
 #ifdef MQTT_WSS_CPUSTATS
-    t1 = mqtt_wss_now_usec();
+    t1 = now_monotonic_usec();
 #endif
 
     if (ret == 0) {
@@ -828,7 +817,7 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
     }
 
 #ifdef MQTT_WSS_CPUSTATS
-    t2 = mqtt_wss_now_usec();
+    t2 = now_monotonic_usec();
     client->stats.time_keepalive += t2 - t1;
 #endif
 
@@ -866,7 +855,7 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
     }
 
 #ifdef MQTT_WSS_CPUSTATS
-    t1 = mqtt_wss_now_usec();
+    t1 = now_monotonic_usec();
     client->stats.time_read_socket += t1 - t2;
 #endif
 
@@ -890,7 +879,7 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
     }
 
 #ifdef MQTT_WSS_CPUSTATS
-    t2 = mqtt_wss_now_usec();
+    t2 = now_monotonic_usec();
     client->stats.time_process_websocket += t2 - t1;
 #endif
 
@@ -907,7 +896,7 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
     }
 
 #ifdef MQTT_WSS_CPUSTATS
-    t1 = mqtt_wss_now_usec();
+    t1 = now_monotonic_usec();
     client->stats.time_process_mqtt += t1 - t2;
 #endif
 
@@ -945,7 +934,7 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
         util_clear_pipe(client->write_notif_pipe[PIPE_READ_END]);
 
 #ifdef MQTT_WSS_CPUSTATS
-    t2 = mqtt_wss_now_usec();
+    t2 = now_monotonic_usec();
     client->stats.time_write_socket += t2 - t1;
 #endif
 

--- a/src/daemon/pulse/pulse-network.c
+++ b/src/daemon/pulse/pulse-network.c
@@ -315,6 +315,7 @@ void pulse_network_do(bool extended __maybe_unused) {
         if(extended) {
             static RRDSET *st_aclk_queue_size = NULL;
             static RRDDIM *rd_messages = NULL;
+            static RRDDIM *rd_puback_wait = NULL;
 
             if (unlikely(!st_aclk_queue_size)) {
                 st_aclk_queue_size = rrdset_create_localhost(
@@ -334,9 +335,11 @@ void pulse_network_do(bool extended __maybe_unused) {
                 rrdlabels_add(st_aclk_queue_size->rrdlabels, "endpoint", "aclk", RRDLABEL_SRC_AUTO);
 
                 rd_messages = rrddim_add(st_aclk_queue_size, "messages", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+                rd_puback_wait = rrddim_add(st_aclk_queue_size, "puback wait", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             }
 
             rrddim_set_by_pointer(st_aclk_queue_size, rd_messages, (collected_number)t.mqtt.tx_messages_queued);
+            rrddim_set_by_pointer(st_aclk_queue_size, rd_puback_wait, (collected_number)t.mqtt.packets_waiting_puback);
             rrdset_done(st_aclk_queue_size);
         }
 


### PR DESCRIPTION
##### Summary
- Add periodic cleanup of pending pubacks instead of waiting for buffer full or ping response
- Fix lock order to prevent deadlocks
- Add additional statistics in aclk-state (pending puback messages)
  ```
  Last Connection Time: 2025-08-07 10:54:38
  Last Connection Time + 3 PUBACKs received: 2025-08-07 10:54:40
  Received Cloud MQTT Messages: 5
  MQTT Messages Confirmed by Remote Broker (PUBACKs): 6
  Pending PUBACKS: 0
  ```
- Graph number of pending puback messages (extended pulse statistics) (`netdata.network_aclk_send_queue`)
  Sample: 
<img width="1196" height="283" alt="image" src="https://github.com/user-attachments/assets/c850dbc3-b6cc-424c-bd1f-5dd5d4607bc5" />
   
