### PR TITLE
fix(go.d/ddsnmp): respect metric tag order from profile definition

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
@@ -64,57 +64,69 @@ type tableWalkResult struct {
 	config ddprofiledefinition.MetricsConfig
 }
 
-type tableProcessingContext struct {
-	// === Input data (set when context is created) ===
+type (
+	tableProcessingContext struct {
+		// === Input data (set when context is created) ===
 
-	// config is the metric configuration for this table
-	// Contains table OID, symbols to collect, and tag configurations
-	config ddprofiledefinition.MetricsConfig
+		// config is the metric configuration for this table
+		// Contains table OID, symbols to collect, and tag configurations
+		config ddprofiledefinition.MetricsConfig
 
-	// pdus contains all PDUs from walking this specific table
-	// Key: full OID (e.g., "1.3.6.1.2.1.2.2.1.10.1"), Value: SNMP PDU
-	pdus map[string]gosnmp.SnmpPDU
+		// pdus contains all PDUs from walking this specific table
+		// Key: full OID (e.g., "1.3.6.1.2.1.2.2.1.10.1"), Value: SNMP PDU
+		pdus map[string]gosnmp.SnmpPDU
 
-	// walkedData contains PDUs from ALL walked tables in this collection
-	// Used for cross-table tag resolution
-	// Key: table OID → map[full OID]PDU
-	walkedData map[string]map[string]gosnmp.SnmpPDU
+		// walkedData contains PDUs from ALL walked tables in this collection
+		// Used for cross-table tag resolution
+		// Key: table OID → map[full OID]PDU
+		walkedData map[string]map[string]gosnmp.SnmpPDU
 
-	// tableNameToOID maps table names to their OIDs
-	// Used to resolve cross-table references (e.g., "ifXTable" → "1.3.6.1.2.1.31.1.1")
-	tableNameToOID map[string]string
+		// tableNameToOID maps table names to their OIDs
+		// Used to resolve cross-table references (e.g., "ifXTable" → "1.3.6.1.2.1.31.1.1")
+		tableNameToOID map[string]string
 
-	// === Computed during processing (set by various methods) ===
+		// === Computed during processing (set by various methods) ===
 
-	// columnOIDs maps column OIDs to their symbol configurations
-	// Built from config.Symbols, used to identify which columns contain metrics
-	// Key: column OID (e.g., "1.3.6.1.2.1.2.2.1.10"), Value: symbol config
-	columnOIDs map[string]ddprofiledefinition.SymbolConfig
+		// columnOIDs maps column OIDs to their symbol configurations
+		// Built from config.Symbols, used to identify which columns contain metrics
+		// Key: column OID (e.g., "1.3.6.1.2.1.2.2.1.10"), Value: symbol config
+		columnOIDs map[string]ddprofiledefinition.SymbolConfig
 
-	// sameTableTagOIDs maps column OIDs to tag configurations for same-table tags only
-	// Built from config.MetricTags, excludes cross-table tags
-	// Key: column OID → list of tag configs (multiple tags can use same column)
-	sameTableTagOIDs map[string][]ddprofiledefinition.MetricTagConfig
+		// staticTags contains tags that apply to all metrics from this table
+		// Parsed from config.StaticTags (e.g., "source:network")
+		staticTags map[string]string
 
-	// staticTags contains tags that apply to all metrics from this table
-	// Parsed from config.StaticTags (e.g., "source:network")
-	staticTags map[string]string
+		// rows contains PDUs organized by row index
+		// Created by organizePDUsByRow from flat PDU list
+		// Key: row index (e.g., "1", "2.3") → map[column OID]PDU
+		rows map[string]map[string]gosnmp.SnmpPDU
 
-	// rows contains PDUs organized by row index
-	// Created by organizePDUsByRow from flat PDU list
-	// Key: row index (e.g., "1", "2.3") → map[column OID]PDU
-	rows map[string]map[string]gosnmp.SnmpPDU
+		// oidCache stores the mapping of column OID to full OID for each row
+		// Used for caching table structure
+		// Key: row index → map[column OID]full OID
+		oidCache map[string]map[string]string
 
-	// oidCache stores the mapping of column OID to full OID for each row
-	// Used for caching table structure
-	// Key: row index → map[column OID]full OID
-	oidCache map[string]map[string]string
+		// tagCache stores computed tag values for each row
+		// Populated during row processing, used for caching
+		// Key: row index → map[tag name]tag value
+		tagCache map[string]map[string]string
 
-	// tagCache stores computed tag values for each row
-	// Populated during row processing, used for caching
-	// Key: row index → map[tag name]tag value
-	tagCache map[string]map[string]string
-}
+		// orderedTags contains metric tags in profile-defined order to ensure correct
+		// precedence when multiple tags share the same name (first non-empty wins)
+		orderedTags []orderedTagConfig
+	}
+	orderedTagConfig struct {
+		config  ddprofiledefinition.MetricTagConfig
+		tagType tagType
+	}
+	tagType int
+)
+
+const (
+	tagTypeSameTable tagType = iota
+	tagTypeCrossTable
+	tagTypeIndex
+)
 
 type cacheProcessingContext struct {
 	// config is the metric configuration for this table
@@ -343,7 +355,8 @@ func (tc *tableCollector) tryCollectFromCache(cfg ddprofiledefinition.MetricsCon
 // processTableData processes walked table data
 func (tc *tableCollector) processTableData(ctx *tableProcessingContext) ([]ddsnmp.Metric, error) {
 	ctx.columnOIDs = buildColumnOIDs(ctx.config)
-	ctx.sameTableTagOIDs = buildSameTableTagOIDs(ctx.config)
+
+	ctx.orderedTags = buildOrderedTags(ctx.config)
 
 	ctx.rows, ctx.oidCache, ctx.tagCache = tc.organizePDUsByRow(ctx)
 
@@ -362,12 +375,16 @@ func (tc *tableCollector) processTableData(ctx *tableProcessingContext) ([]ddsnm
 // organizePDUsByRow groups PDUs by their row index
 func (tc *tableCollector) organizePDUsByRow(ctx *tableProcessingContext) (rows map[string]map[string]gosnmp.SnmpPDU, oidCache, tagCache map[string]map[string]string) {
 	// Combine all column OIDs
-	allColumnOIDs := make([]string, 0, len(ctx.columnOIDs)+len(ctx.sameTableTagOIDs))
+	allColumnOIDs := make([]string, 0, len(ctx.columnOIDs)+len(ctx.orderedTags))
+
 	for oid := range ctx.columnOIDs {
 		allColumnOIDs = append(allColumnOIDs, oid)
 	}
-	for oid := range ctx.sameTableTagOIDs {
-		allColumnOIDs = append(allColumnOIDs, oid)
+	for _, orderedTag := range ctx.orderedTags {
+		if orderedTag.tagType == tagTypeSameTable && orderedTag.config.Symbol.OID != "" {
+			oid := trimOID(orderedTag.config.Symbol.OID)
+			allColumnOIDs = append(allColumnOIDs, oid)
+		}
 	}
 
 	rows = make(map[string]map[string]gosnmp.SnmpPDU)
@@ -414,10 +431,10 @@ func (tc *tableCollector) processRows(ctx *tableProcessingContext) ([]ddsnmp.Met
 		crossTableCtx.rowTags = row.tags
 
 		rowCtx := &tableRowProcessingContext{
-			config:           ctx.config,
-			columnOIDs:       ctx.columnOIDs,
-			sameTableTagOIDs: ctx.sameTableTagOIDs,
-			crossTableCtx:    crossTableCtx,
+			config:        ctx.config,
+			columnOIDs:    ctx.columnOIDs,
+			crossTableCtx: crossTableCtx,
+			orderedTags:   ctx.orderedTags,
 		}
 		rowMetrics, err := tc.rowProcessor.processRow(row, rowCtx)
 		if err != nil {
@@ -592,17 +609,6 @@ func buildColumnOIDs(cfg ddprofiledefinition.MetricsConfig) map[string]ddprofile
 	return columnOIDs
 }
 
-func buildSameTableTagOIDs(cfg ddprofiledefinition.MetricsConfig) map[string][]ddprofiledefinition.MetricTagConfig {
-	tagColumnOIDs := make(map[string][]ddprofiledefinition.MetricTagConfig)
-	for _, tagCfg := range cfg.MetricTags {
-		if tagCfg.Table == "" || tagCfg.Table == cfg.Table.Name {
-			oid := trimOID(tagCfg.Symbol.OID)
-			tagColumnOIDs[oid] = append(tagColumnOIDs[oid], tagCfg)
-		}
-	}
-	return tagColumnOIDs
-}
-
 func extractTableDependencies(cfg ddprofiledefinition.MetricsConfig, tableNameToOID map[string]string) []string {
 	deps := make(map[string]bool)
 
@@ -623,4 +629,27 @@ func extractTableDependencies(cfg ddprofiledefinition.MetricsConfig, tableNameTo
 	}
 
 	return result
+}
+
+func buildOrderedTags(cfg ddprofiledefinition.MetricsConfig) []orderedTagConfig {
+	var ordered []orderedTagConfig
+
+	for _, tagCfg := range cfg.MetricTags {
+		var tt tagType
+		switch {
+		case tagCfg.Index != 0:
+			tt = tagTypeIndex
+		case tagCfg.Table != "" && tagCfg.Table != cfg.Table.Name:
+			tt = tagTypeCrossTable
+		default:
+			tt = tagTypeSameTable
+		}
+
+		ordered = append(ordered, orderedTagConfig{
+			config:  tagCfg,
+			tagType: tt,
+		})
+	}
+
+	return ordered
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
@@ -28,10 +28,10 @@ type (
 	}
 	// tableRowProcessingContext contains context needed for processing a row
 	tableRowProcessingContext struct {
-		config           ddprofiledefinition.MetricsConfig
-		columnOIDs       map[string]ddprofiledefinition.SymbolConfig
-		sameTableTagOIDs map[string][]ddprofiledefinition.MetricTagConfig
-		crossTableCtx    *crossTableContext
+		config        ddprofiledefinition.MetricsConfig
+		columnOIDs    map[string]ddprofiledefinition.SymbolConfig
+		crossTableCtx *crossTableContext
+		orderedTags   []orderedTagConfig
 	}
 )
 
@@ -53,62 +53,51 @@ func (p *tableRowProcessor) processRow(row *tableRowData, ctx *tableRowProcessin
 }
 
 func (p *tableRowProcessor) processRowTags(row *tableRowData, ctx *tableRowProcessingContext) error {
-	p.processSameTableTags(row, ctx.sameTableTagOIDs)
-
-	if ctx.crossTableCtx != nil {
-		p.processCrossTableTags(row, ctx)
+	// Process tags in the order they appear in the profile
+	for _, orderedTag := range ctx.orderedTags {
+		switch orderedTag.tagType {
+		case tagTypeSameTable:
+			p.processSingleSameTableTag(row, orderedTag.config)
+		case tagTypeCrossTable:
+			if ctx.crossTableCtx != nil {
+				p.processSingleCrossTableTag(row, orderedTag.config, ctx)
+			}
+		case tagTypeIndex:
+			p.processSingleIndexTag(row, orderedTag.config)
+		}
 	}
-
-	p.processIndexBasedTags(row, ctx.config.MetricTags)
 
 	return nil
 }
 
-func (p *tableRowProcessor) processSameTableTags(row *tableRowData, tagColumnOIDs map[string][]ddprofiledefinition.MetricTagConfig) {
-	for columnOID, tagConfigs := range tagColumnOIDs {
-		pdu, ok := row.pdus[columnOID]
-		if !ok {
-			continue
-		}
+func (p *tableRowProcessor) processSingleSameTableTag(row *tableRowData, tagCfg ddprofiledefinition.MetricTagConfig) {
+	columnOID := trimOID(tagCfg.Symbol.OID)
+	pdu, ok := row.pdus[columnOID]
+	if !ok {
+		return
+	}
 
-		ta := tagAdder{tags: row.tags}
-
-		for _, tagCfg := range tagConfigs {
-			if err := p.tagProc.processTag(tagCfg, pdu, ta); err != nil {
-				p.log.Debugf("Error processing tag %s: %v", tagCfg.Tag, err)
-				continue
-			}
-		}
+	ta := tagAdder{tags: row.tags}
+	if err := p.tagProc.processTag(tagCfg, pdu, ta); err != nil {
+		p.log.Debugf("Error processing tag %s: %v", tagCfg.Tag, err)
 	}
 }
 
-func (p *tableRowProcessor) processCrossTableTags(row *tableRowData, ctx *tableRowProcessingContext) {
-	for _, tagCfg := range ctx.config.MetricTags {
-		if !p.crossTableResolver.isCrossTable(tagCfg, ctx.config.Table.Name) {
-			continue
-		}
-
-		if err := p.crossTableResolver.resolveCrossTableTag(tagCfg, row.index, ctx.crossTableCtx); err != nil {
-			p.log.Debugf("Error resolving cross-table tag %s: %v", tagCfg.Tag, err)
-			continue
-		}
+func (p *tableRowProcessor) processSingleCrossTableTag(row *tableRowData, tagCfg ddprofiledefinition.MetricTagConfig, ctx *tableRowProcessingContext) {
+	if err := p.crossTableResolver.resolveCrossTableTag(tagCfg, row.index, ctx.crossTableCtx); err != nil {
+		p.log.Debugf("Error resolving cross-table tag %s: %v", tagCfg.Tag, err)
 	}
 }
 
-func (p *tableRowProcessor) processIndexBasedTags(row *tableRowData, metricTags []ddprofiledefinition.MetricTagConfig) {
-	for _, tagCfg := range metricTags {
-		if tagCfg.Index == 0 {
-			continue
-		}
-
-		tagName, indexValue, ok := p.processIndexTag(tagCfg, row.index)
-		if !ok {
-			p.log.Debugf("Cannot extract position %d from index %s", tagCfg.Index, row.index)
-			continue
-		}
-
-		row.tags[tagName] = indexValue
+func (p *tableRowProcessor) processSingleIndexTag(row *tableRowData, tagCfg ddprofiledefinition.MetricTagConfig) {
+	tagName, indexValue, ok := p.processIndexTag(tagCfg, row.index)
+	if !ok {
+		p.log.Debugf("Cannot extract position %d from index %s", tagCfg.Index, row.index)
+		return
 	}
+
+	ta := tagAdder{tags: row.tags}
+	ta.addTag(tagName, indexValue)
 }
 
 func (p *tableRowProcessor) processIndexTag(cfg ddprofiledefinition.MetricTagConfig, index string) (string, string, bool) {


### PR DESCRIPTION
##### Summary

Fixes tag resolution order to respect the sequence defined in SNMP profiles. Previously, tags were processed in a hardcoded order (same-table → cross-table → index-based), which could override earlier tag definitions with later ones. This change ensures tags are processed in the exact order they appear in the profile, allowing proper fallback behavior when multiple tags share the same name.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
