### PR TITLE
ci: handle boolean values in EOL API responses for newly released distros

### DIFF
--- a/.github/scripts/platform-impending-eol.py
+++ b/.github/scripts/platform-impending-eol.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
-'''Check if a given distro is going to be EOL soon.
+"""Check if a given distro is going to be EOL soon.
 
    This queries the public API of https://endoflife.date to fetch EOL dates.
 
-   ‘soon’ is defined by LEAD_DAYS, currently 30 days.'''
+   'soon' is defined by LEAD_DAYS, currently 30 days."""
 
 import datetime
 import json
-import sys
 import urllib.request
+
+import sys
 
 URL_BASE = 'https://endoflife.date/api'
 NOW = datetime.date.today()
@@ -24,30 +25,29 @@ EXIT_NO_DATA = 2
 EXIT_FAILURE = 3
 
 try:
-    with urllib.request.urlopen(f'{ URL_BASE }/{ DISTRO }/{ RELEASE }.json') as response:
+    with urllib.request.urlopen(f'{URL_BASE}/{DISTRO}/{RELEASE}.json') as response:
         match response.status:
             case 200:
                 data = json.load(response)
             case _:
                 print(
-                    f'Failed to retrieve data for { DISTRO } { RELEASE } ' +
-                    f'(status: { response.status }).',
+                    f'Failed to retrieve data for {DISTRO} {RELEASE} ' +
+                    f'(status: {response.status}).',
                     file=sys.stderr
                 )
                 sys.exit(EXIT_FAILURE)
 except urllib.error.HTTPError as e:
     match e.code:
         case 404:
-            print(f'No data available for { DISTRO } { RELEASE }.', file=sys.stderr)
+            print(f'No data available for {DISTRO} {RELEASE}.', file=sys.stderr)
             sys.exit(EXIT_NO_DATA)
         case _:
             print(
-                f'Failed to retrieve data for { DISTRO } { RELEASE } ' +
-                f'(status: { e.code }).',
+                f'Failed to retrieve data for {DISTRO} {RELEASE} ' +
+                f'(status: {e.code}).',
                 file=sys.stderr
             )
             sys.exit(EXIT_FAILURE)
-
 
 if LTS == '1' and 'extendedSupport' in data:
     ref = 'extendedSupport'
@@ -55,7 +55,45 @@ else:
     ref = 'eol'
     LTS = False
 
-eol = datetime.date.fromisoformat(data[ref])
+# Handle boolean values for eol/extendedSupport fields
+eol_value = data[ref]
+
+# Check if the value is a boolean
+if isinstance(eol_value, bool):
+    if ref == 'eol':
+        if not eol_value:
+            # False for eol means no EOL date set (still actively supported)
+            sys.exit(EXIT_NOT_IMPENDING)
+        else:
+            # True for eol would mean EOL has occurred (unusual, but handle it)
+            # Without a date, we can't determine if it's within LEAD_DAYS
+            # Conservative approach: treat as impending
+            print(f'{DISTRO} {RELEASE} has reached EOL (boolean true)', file=sys.stderr)
+            sys.exit(EXIT_IMPENDING)
+    elif ref == 'extendedSupport':
+        if not eol_value:
+            # False for extendedSupport when LTS was requested is unexpected
+            print(
+                f'Unexpected value for {DISTRO} {RELEASE} extendedSupport: false ' +
+                '(LTS was requested but extended support is not available)',
+                file=sys.stderr
+            )
+            sys.exit(EXIT_FAILURE)
+        else:
+            # True for extendedSupport means LTS available but date not determined
+            # Can't calculate if impending without a date
+            sys.exit(EXIT_NOT_IMPENDING)
+
+# If we get here, it should be a date string
+try:
+    eol = datetime.date.fromisoformat(eol_value)
+except (ValueError, TypeError):
+    print(
+        f'Invalid date format for {DISTRO} {RELEASE} {ref}: {eol_value}',
+        file=sys.stderr
+    )
+    sys.exit(EXIT_FAILURE)
+
 offset = abs(eol - NOW)
 
 if offset <= LEAD_DAYS:

--- a/.github/scripts/platform-impending-eol.py
+++ b/.github/scripts/platform-impending-eol.py
@@ -7,9 +7,8 @@
 
 import datetime
 import json
-import urllib.request
-
 import sys
+import urllib.request
 
 URL_BASE = 'https://endoflife.date/api'
 NOW = datetime.date.today()


### PR DESCRIPTION
##### Summary

Fixes #20789
Fixes #20790

Fixes script failure when checking EOL status for newly released distributions (e.g., Debian 13) where the API returns boolean values instead of date strings.

The script was failing with a `ValueError` when calling `datetime.date.fromisoformat()` on boolean values returned by the endoflife.date API. This occurs for:
- Newly released distributions where `eol: false` (no EOL date set yet)
- Distributions with `extendedSupport: true` (LTS available but date not determined)

Added explicit type checking and handling for boolean values in both `eol` and `extendedSupport` fields:

- **`eol: false`** → Not impending (still actively supported)
- **`eol: true`** → Impending (conservative approach for unusual case)
- **`extendedSupport: false`** → Failure (unexpected when LTS requested)
- **`extendedSupport: true`** → Not impending (date not yet determined)

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
