### PR TITLE
feat(aclk): Add detailed pulse metrics for ACLK telemetry

### DIFF
--- a/src/aclk/mqtt_websockets/common_public.h
+++ b/src/aclk/mqtt_websockets/common_public.h
@@ -4,6 +4,7 @@
 #define MQTT_WEBSOCKETS_COMMON_PUBLIC_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 /* free_fnc_t in general (in whatever function or struct it is used)
  * decides how the related data will be handled.
@@ -31,6 +32,13 @@ struct mqtt_ng_stats {
     size_t tx_buffer_size;
     // part of transaction buffer that containes mesages we can free alredy during the garbage colleciton step
     size_t tx_buffer_reclaimable;
+    // maximum time (in microseconds) a QoS1 message is currently waiting for PUBACK
+    uint64_t max_puback_wait_us;
+    // maximum time (in microseconds) a message has been waiting in the send queue without starting transmission
+    uint64_t max_send_queue_wait_us;
+    // split of send-queue wait into unsent and partial (diagnostics)
+    uint64_t max_unsent_wait_us;
+    uint64_t max_partial_wait_us;
 };
 
 #endif /* MQTT_WEBSOCKETS_COMMON_PUBLIC_H */

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -41,6 +41,8 @@ struct buffer_fragment {
     uint16_t packet_id;
     void (*free_fnc)(void *ptr);
     unsigned char *data;
+    // timestamp (monotonic usec) of when this MQTT packet was enqueued into the transaction buffer (set on HEAD)
+    usec_t enqueued_monotonic_ut;
     usec_t sent_monotonic_ut;
     struct buffer_fragment *next;
 };
@@ -1151,6 +1153,9 @@ int mqtt_ng_generate_publish(struct transaction_buffer *trx_buf,
     if (!qos)
         trx_buf->hdr_buffer.tail_frag->flags |= BUFFER_FRAG_GARBAGE_COLLECT_ON_SEND;
     transaction_buffer_transaction_commit(trx_buf)
+    // mark enqueue time on the HEAD fragment (after commit) so we measure from commit time
+    if (mqtt_msg)
+        mqtt_msg->enqueued_monotonic_ut = now_monotonic_usec();
     return MQTT_NG_MSGGEN_OK;
 fail_rollback:
     transaction_buffer_transaction_rollback(trx_buf, mqtt_msg);
@@ -2261,20 +2266,73 @@ void mqtt_ng_get_stats(struct mqtt_ng_client *client, struct mqtt_ng_stats *stat
 
     stats->tx_bytes_queued = 0;
     stats->tx_buffer_reclaimable = 0;
+    stats->max_puback_wait_us = 0;
+    stats->max_send_queue_wait_us = 0;
+    stats->max_unsent_wait_us = 0;
+    stats->max_partial_wait_us = 0;
 
+    // First pass: compute buffer usage/queued bytes and max send-queue wait time (unsent messages)
     LOCK_HDR_BUFFER(&client->main_buffer);
     stats->tx_buffer_used = BUFFER_BYTES_USED(&client->main_buffer.hdr_buffer);
     stats->tx_buffer_free = BUFFER_BYTES_AVAILABLE(&client->main_buffer.hdr_buffer);
     stats->tx_buffer_size = client->main_buffer.hdr_buffer.size;
     struct buffer_fragment *frag = BUFFER_FIRST_FRAG(&client->main_buffer.hdr_buffer);
+    usec_t now_ut = now_monotonic_usec();
     while (frag) {
         stats->tx_bytes_queued += frag->len - frag->sent;
         if (frag_is_marked_for_gc(frag))
             stats->tx_buffer_reclaimable += FRAG_SIZE_IN_BUFFER(frag);
 
+        // For HEAD fragments that are not fully sent yet (unsent or partially sent),
+        // track max send-queue wait time. Prefer the enqueue timestamp; if missing, fall back to first-send.
+        if ((frag->flags & BUFFER_FRAG_MQTT_PACKET_HEAD) && frag->sent < frag->len) {
+            usec_t base = frag->enqueued_monotonic_ut ? frag->enqueued_monotonic_ut : frag->sent_monotonic_ut;
+            if (base) {
+                usec_t waited = now_ut - base;
+                uint64_t w = (uint64_t)waited;
+                if (frag->sent == 0) {
+                    if (w > stats->max_unsent_wait_us) stats->max_unsent_wait_us = w;
+                } else {
+                    if (w > stats->max_partial_wait_us) stats->max_partial_wait_us = w;
+                }
+                if (w > stats->max_send_queue_wait_us) stats->max_send_queue_wait_us = w;
+            } else {
+                // Throttled debug if enqueue time is missing on an unsent HEAD
+                if (frag->sent == 0) {
+                    static time_t last_warn = 0;
+                    time_t now_s = now_monotonic_sec();
+                    if (now_s - last_warn > 60) {
+                        nd_log(NDLS_DAEMON, NDLP_DEBUG, "ACLK: Missing enqueue timestamp on unsent MQTT packet head");
+                        last_warn = now_s;
+                    }
+                }
+            }
+        }
+
         frag = frag->next;
     }
     UNLOCK_HDR_BUFFER(&client->main_buffer);
+
+    // Second pass: compute max PUBACK wait time by correlating HEAD fragments with pending packet IDs
+    spinlock_lock(&client->pending_packets.spinlock);
+    LOCK_HDR_BUFFER(&client->main_buffer);
+    frag = BUFFER_FIRST_FRAG(&client->main_buffer.hdr_buffer);
+    while (frag) {
+        if ((frag->flags & BUFFER_FRAG_MQTT_PACKET_HEAD) && frag->packet_id) {
+            Pvoid_t *Pvalue = JudyLGet(client->pending_packets.JudyL, (Word_t)frag->packet_id, PJE0);
+            if (Pvalue) {
+                // message is still pending PUBACK
+                if (frag->sent_monotonic_ut) {
+                    usec_t waited = now_ut - frag->sent_monotonic_ut;
+                    if ((uint64_t)waited > stats->max_puback_wait_us)
+                        stats->max_puback_wait_us = (uint64_t)waited;
+                }
+            }
+        }
+        frag = frag->next;
+    }
+    UNLOCK_HDR_BUFFER(&client->main_buffer);
+    spinlock_unlock(&client->pending_packets.spinlock);
 }
 
 int mqtt_ng_set_topic_alias(struct mqtt_ng_client *client, const char *topic)

--- a/src/daemon/pulse/pulse-network.c
+++ b/src/daemon/pulse/pulse-network.c
@@ -93,10 +93,10 @@ static inline size_t aclk_time_histogram_slot(struct aclk_time_histogram *h, use
 }
 
 // Per-iteration PUBACK latency accumulators (microseconds)
-static _Atomic uint64_t aclk_ack_count = 0;
-static _Atomic uint64_t aclk_ack_sum_us = 0;
-static _Atomic uint64_t aclk_ack_min_us = UINT64_MAX;
-static _Atomic uint64_t aclk_ack_max_us = 0;
+static uint64_t aclk_ack_count = 0;
+static uint64_t aclk_ack_sum_us = 0;
+static uint64_t aclk_ack_min_us = UINT64_MAX;
+static uint64_t aclk_ack_max_us = 0;
 
 void pulse_aclk_sent_message_acked(usec_t publish_latency, size_t len __maybe_unused) {
     if(!publish_latency) return;

--- a/src/daemon/pulse/pulse-network.c
+++ b/src/daemon/pulse/pulse-network.c
@@ -92,6 +92,12 @@ static inline size_t aclk_time_histogram_slot(struct aclk_time_histogram *h, use
     return low - 1;
 }
 
+// Per-iteration PUBACK latency accumulators (microseconds)
+static _Atomic uint64_t aclk_ack_count = 0;
+static _Atomic uint64_t aclk_ack_sum_us = 0;
+static _Atomic uint64_t aclk_ack_min_us = UINT64_MAX;
+static _Atomic uint64_t aclk_ack_max_us = 0;
+
 void pulse_aclk_sent_message_acked(usec_t publish_latency, size_t len __maybe_unused) {
     if(!publish_latency) return;
 
@@ -101,6 +107,23 @@ void pulse_aclk_sent_message_acked(usec_t publish_latency, size_t len __maybe_un
     internal_fatal(slot >= _countof(aclk_time_heatmap.array), "hey!");
 
     __atomic_add_fetch(&aclk_time_heatmap.array[slot].count, 1, __ATOMIC_RELAXED);
+
+    // Track per-iteration min/avg/max in microseconds using atomics
+    __atomic_add_fetch(&aclk_ack_count, 1, __ATOMIC_RELAXED);
+    __atomic_add_fetch(&aclk_ack_sum_us, (uint64_t)publish_latency, __ATOMIC_RELAXED);
+
+    // atomic min update
+    uint64_t cur_min = __atomic_load_n(&aclk_ack_min_us, __ATOMIC_RELAXED);
+    while (publish_latency < cur_min &&
+           !__atomic_compare_exchange_n(&aclk_ack_min_us, &cur_min, (uint64_t)publish_latency, true, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+        ;
+    }
+    // atomic max update
+    uint64_t cur_max = __atomic_load_n(&aclk_ack_max_us, __ATOMIC_RELAXED);
+    while (publish_latency > cur_max &&
+           !__atomic_compare_exchange_n(&aclk_ack_max_us, &cur_max, (uint64_t)publish_latency, true, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+        ;
+    }
 }
 
 static void pulse_aclk_time_heatmap(void) {
@@ -372,5 +395,122 @@ void pulse_network_do(bool extended __maybe_unused) {
             rrddim_set_by_pointer(st_aclk_messages, rd_out, (collected_number)t.mqtt.tx_messages_sent);
             rrdset_done(st_aclk_messages);
         }
+
+        if(extended) {
+            // Bytes queued for send
+            static RRDSET *st_aclk_bytes = NULL;
+            static RRDDIM *rd_bytes = NULL;
+            if (unlikely(!st_aclk_bytes)) {
+                st_aclk_bytes = rrdset_create_localhost(
+                    "netdata",
+                    "network_aclk_send_queue_bytes",
+                    NULL,
+                    PULSE_NETWORK_CHART_FAMILY,
+                    "netdata.network_aclk_send_queue_bytes",
+                    "Netdata ACLK Send Queue Bytes",
+                    "bytes",
+                    "netdata",
+                    "pulse",
+                    PULSE_NETWORK_CHART_PRIORITY + 2,
+                    localhost->rrd_update_every,
+                    RRDSET_TYPE_LINE);
+                rrdlabels_add(st_aclk_bytes->rrdlabels, "endpoint", "aclk", RRDLABEL_SRC_AUTO);
+                rd_bytes = rrddim_add(st_aclk_bytes, "bytes", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            }
+            rrddim_set_by_pointer(st_aclk_bytes, rd_bytes, (collected_number)t.mqtt.tx_bytes_queued);
+            rrdset_done(st_aclk_bytes);
+        }
+
+        if(extended) {
+            // Max wait times for PUBACK and send queue (convert us->s via divisor)
+            static RRDSET *st_aclk_puback_wait = NULL;
+            static RRDDIM *rd_puback_max = NULL;
+            if (unlikely(!st_aclk_puback_wait)) {
+                st_aclk_puback_wait = rrdset_create_localhost(
+                    "netdata",
+                    "network_aclk_puback_wait",
+                    NULL,
+                    PULSE_NETWORK_CHART_FAMILY,
+                    "netdata.network_aclk_puback_wait",
+                    "Netdata ACLK PUBACK Max Wait",
+                    "seconds",
+                    "netdata",
+                    "pulse",
+                    PULSE_NETWORK_CHART_PRIORITY + 3,
+                    localhost->rrd_update_every,
+                    RRDSET_TYPE_LINE);
+                rrdlabels_add(st_aclk_puback_wait->rrdlabels, "endpoint", "aclk", RRDLABEL_SRC_AUTO);
+                rd_puback_max = rrddim_add(st_aclk_puback_wait, "max", NULL, 1, USEC_PER_SEC, RRD_ALGORITHM_ABSOLUTE);
+            }
+            rrddim_set_by_pointer(st_aclk_puback_wait, rd_puback_max, (collected_number)t.mqtt.max_puback_wait_us);
+            rrdset_done(st_aclk_puback_wait);
+        }
+
+        if(extended) {
+            static RRDSET *st_aclk_send_wait = NULL;
+            static RRDDIM *rd_overall = NULL, *rd_unsent = NULL, *rd_partial = NULL;
+            if (unlikely(!st_aclk_send_wait)) {
+                st_aclk_send_wait = rrdset_create_localhost(
+                    "netdata",
+                    "network_aclk_send_queue_wait",
+                    NULL,
+                    PULSE_NETWORK_CHART_FAMILY,
+                    "netdata.network_aclk_send_queue_wait",
+                    "Netdata ACLK Send Queue Wait (Overall/Unsent/Partial)",
+                    "seconds",
+                    "netdata",
+                    "pulse",
+                    PULSE_NETWORK_CHART_PRIORITY + 3,
+                    localhost->rrd_update_every,
+                    RRDSET_TYPE_LINE);
+                rrdlabels_add(st_aclk_send_wait->rrdlabels, "endpoint", "aclk", RRDLABEL_SRC_AUTO);
+                rd_overall = rrddim_add(st_aclk_send_wait, "overall", NULL, 1, USEC_PER_SEC, RRD_ALGORITHM_ABSOLUTE);
+                rd_unsent  = rrddim_add(st_aclk_send_wait, "unsent",  NULL, 1, USEC_PER_SEC, RRD_ALGORITHM_ABSOLUTE);
+                rd_partial = rrddim_add(st_aclk_send_wait, "partial", NULL, 1, USEC_PER_SEC, RRD_ALGORITHM_ABSOLUTE);
+            }
+            rrddim_set_by_pointer(st_aclk_send_wait, rd_overall, (collected_number)t.mqtt.max_send_queue_wait_us);
+            rrddim_set_by_pointer(st_aclk_send_wait, rd_unsent,  (collected_number)t.mqtt.max_unsent_wait_us);
+            rrddim_set_by_pointer(st_aclk_send_wait, rd_partial, (collected_number)t.mqtt.max_partial_wait_us);
+            rrdset_done(st_aclk_send_wait);
+        }
+    }
+
+    // Publish PUBACK latency min/avg/max per iteration
+    {
+        static RRDSET *st_stats = NULL;
+        static RRDDIM *rd_min = NULL, *rd_avg = NULL, *rd_max = NULL;
+
+        // pull and reset accumulators
+        uint64_t count = __atomic_exchange_n(&aclk_ack_count, 0, __ATOMIC_RELAXED);
+        uint64_t sum_us = __atomic_exchange_n(&aclk_ack_sum_us, 0, __ATOMIC_RELAXED);
+        uint64_t min_us = __atomic_exchange_n(&aclk_ack_min_us, UINT64_MAX, __ATOMIC_RELAXED);
+        uint64_t max_us = __atomic_exchange_n(&aclk_ack_max_us, 0, __ATOMIC_RELAXED);
+
+        uint64_t avg_us = (count ? (sum_us / count) : 0);
+        if (min_us == UINT64_MAX) min_us = 0;
+
+        if (unlikely(!st_stats)) {
+            st_stats = rrdset_create_localhost(
+                "netdata",
+                "aclk_puback_latency_stats",
+                NULL,
+                PULSE_NETWORK_CHART_FAMILY,
+                "netdata.aclk_puback_latency_stats",
+                "Netdata ACLK PubACK Latency (Min/Avg/Max)",
+                "milliseconds",
+                "netdata",
+                "pulse",
+                PULSE_NETWORK_CHART_PRIORITY + 1,
+                localhost->rrd_update_every,
+                RRDSET_TYPE_LINE);
+            rd_min = rrddim_add(st_stats, "min", NULL, 1, USEC_PER_MS, RRD_ALGORITHM_ABSOLUTE);
+            rd_avg = rrddim_add(st_stats, "avg", NULL, 1, USEC_PER_MS, RRD_ALGORITHM_ABSOLUTE);
+            rd_max = rrddim_add(st_stats, "max", NULL, 1, USEC_PER_MS, RRD_ALGORITHM_ABSOLUTE);
+        }
+
+        rrddim_set_by_pointer(st_stats, rd_min, (collected_number)min_us);
+        rrddim_set_by_pointer(st_stats, rd_avg, (collected_number)avg_us);
+        rrddim_set_by_pointer(st_stats, rd_max, (collected_number)max_us);
+        rrdset_done(st_stats);
     }
 }


### PR DESCRIPTION
This PR introduces several new charts to the internal 'pulse' telemetry system to provide deeper insight into ACLK performance, including detailed latency and queue wait time statistics. All new timing charts are in milliseconds.