### PR TITLE
feat(go.d/ddsnmp): sysobjectid-based metadata override support for SNMP profiles

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -34,7 +34,7 @@ func (c *Collector) collect() (map[string]int64, error) {
 		}
 
 		if c.ddSnmpColl == nil {
-			c.ddSnmpColl = ddsnmpcollector.New(c.snmpClient, c.snmpProfiles, c.Logger)
+			c.ddSnmpColl = ddsnmpcollector.New(c.snmpClient, c.snmpProfiles, c.Logger, si.SysObjectID)
 			c.ddSnmpColl.DoTableMetrics = c.EnableProfilesTableMetrics
 		}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metadata.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metadata.go
@@ -73,3 +73,15 @@ func NewMetadataResourceConfig() MetadataResourceConfig {
 func IsMetadataResourceWithScalarOids(resource string) bool {
 	return resource == MetadataDeviceResource
 }
+
+type SysobjectIDMetadataEntryConfig struct {
+	SysobjectID string                 `yaml:"sysobjectid"`
+	Metadata    ListMap[MetadataField] `yaml:"metadata"`
+}
+
+func (e SysobjectIDMetadataEntryConfig) Clone() SysobjectIDMetadataEntryConfig {
+	return SysobjectIDMetadataEntryConfig{
+		SysobjectID: e.SysobjectID,
+		Metadata:    CloneMap(e.Metadata),
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/profile_definition.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/profile_definition.go
@@ -20,14 +20,15 @@ type DeviceMeta struct {
 // 2/ Datadog backend: the profiles are in json format, they are used to store profiles created via UI.
 // The serialisation of json profiles are defined by the json annotation.
 type ProfileDefinition struct {
-	Name         string            `yaml:"name,omitempty" json:"name,omitempty"`
-	Description  string            `yaml:"description,omitempty" json:"description,omitempty"`
-	SysObjectIDs StringArray       `yaml:"sysobjectid,omitempty" json:"sysobjectid,omitempty"`
-	Extends      []string          `yaml:"extends,omitempty" json:"extends,omitempty"`
-	Metadata     MetadataConfig    `yaml:"metadata,omitempty" json:"metadata,omitempty"`
-	MetricTags   []MetricTagConfig `yaml:"metric_tags,omitempty" json:"metric_tags,omitempty"`
-	StaticTags   []string          `yaml:"static_tags,omitempty" json:"static_tags,omitempty"`
-	Metrics      []MetricsConfig   `yaml:"metrics,omitempty" json:"metrics,omitempty"`
+	Name                string                           `yaml:"name,omitempty" json:"name,omitempty"`
+	Description         string                           `yaml:"description,omitempty" json:"description,omitempty"`
+	SysObjectIDs        StringArray                      `yaml:"sysobjectid,omitempty" json:"sysobjectid,omitempty"`
+	Extends             []string                         `yaml:"extends,omitempty" json:"extends,omitempty"`
+	Metadata            MetadataConfig                   `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	SysobjectIDMetadata []SysobjectIDMetadataEntryConfig `yaml:"sysobjectid_metadata,omitempty"`
+	MetricTags          []MetricTagConfig                `yaml:"metric_tags,omitempty" json:"metric_tags,omitempty"`
+	StaticTags          []string                         `yaml:"static_tags,omitempty" json:"static_tags,omitempty"`
+	Metrics             []MetricsConfig                  `yaml:"metrics,omitempty" json:"metrics,omitempty"`
 
 	VirtualMetrics []VirtualMetricConfig `yaml:"virtual_metrics,omitempty" json:"virtual_metrics,omitempty"`
 
@@ -65,15 +66,16 @@ func (p *ProfileDefinition) Clone() *ProfileDefinition {
 		return nil
 	}
 	return &ProfileDefinition{
-		Name:           p.Name,
-		Description:    p.Description,
-		SysObjectIDs:   slices.Clone(p.SysObjectIDs),
-		Extends:        slices.Clone(p.Extends),
-		Metadata:       CloneMap(p.Metadata),
-		MetricTags:     CloneSlice(p.MetricTags),
-		StaticTags:     slices.Clone(p.StaticTags),
-		Metrics:        CloneSlice(p.Metrics),
-		VirtualMetrics: CloneSlice(p.VirtualMetrics),
+		Name:                p.Name,
+		Description:         p.Description,
+		SysObjectIDs:        slices.Clone(p.SysObjectIDs),
+		Extends:             slices.Clone(p.Extends),
+		Metadata:            CloneMap(p.Metadata),
+		SysobjectIDMetadata: CloneSlice(p.SysobjectIDMetadata),
+		MetricTags:          CloneSlice(p.MetricTags),
+		StaticTags:          slices.Clone(p.StaticTags),
+		Metrics:             CloneSlice(p.Metrics),
+		VirtualMetrics:      CloneSlice(p.VirtualMetrics),
 		Device: DeviceMeta{
 			Vendor: p.Device.Vendor,
 		},

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_test.go
@@ -4422,7 +4422,7 @@ func TestCollector_Collect_TableCaching(t *testing.T) {
 			mockHandler := snmpmock.NewMockHandler(ctrl)
 			tc.setupMock(mockHandler)
 
-			collector := New(mockHandler, tc.profiles, logger.New())
+			collector := New(mockHandler, tc.profiles, logger.New(), "")
 			collector.DoTableMetrics = true
 
 			// Configure cache based on test requirements

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
@@ -203,6 +203,9 @@ func (p *Profile) validate() error {
 	for _, err := range ddprofiledefinition.ValidateEnrichMetadata(p.Definition.Metadata) {
 		errs = append(errs, errors.New(err))
 	}
+	for _, err := range ddprofiledefinition.ValidateEnrichSysobjectIDMetadata(p.Definition.SysobjectIDMetadata) {
+		errs = append(errs, errors.New(err))
+	}
 	for _, err := range ddprofiledefinition.ValidateEnrichMetrics(p.Definition.Metrics) {
 		errs = append(errs, errors.New(err))
 	}


### PR DESCRIPTION
##### Summary

Extends SNMP device profile syntax to support sysobjectid-specific metadata overrides, eliminating the need to create separate profiles for each device model.

Previously, to assign model-specific metadata (like model names) for devices sharing the same profile, we had to create individual profiles for each sysobjectid.

Added a new `sysobjectid_metadata` section to the profile syntax that allows metadata assignment based on sysobjectid patterns:

```yaml
sysobjectid_metadata:
  - sysobjectid: 1.3.6.1.4.1.9.1.669
    metadata:
      model:
        value: ASA5510
  - sysobjectid: 1.3.6.1.4.1.9.1.670
    metadata:
      model:
        value: ASA5520
```


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
