### PR TITLE
improve(go.d/zfspool): add Ubuntu zpool binary path to config

### DIFF
--- a/src/go/plugin/go.d/config/go.d/zfspool.conf
+++ b/src/go/plugin/go.d/config/go.d/zfspool.conf
@@ -6,4 +6,7 @@ jobs:
     binary_path: /usr/bin/zpool
 
   - name: zfspool
+    binary_path: /usr/sbin/zpool # Ubuntu
+
+  - name: zfspool
     binary_path: /sbin/zpool # FreeBSD


### PR DESCRIPTION


##### Summary

Adds the Ubuntu-specific zpool binary path (`/usr/sbin/zpool`) to the zfspool collector configuration. This ensures the collector can properly locate the zpool binary on Ubuntu systems.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
