### PR TITLE
fix(go.d/ddsnmp): fix match_pattern regex behavior in metadata and metric collection

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collectors_meta.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collectors_meta.go
@@ -325,12 +325,18 @@ func (dc *deviceMetadataCollector) processSymbolValue(cfg ddprofiledefinition.Sy
 		if sm := cfg.ExtractValueCompiled.FindStringSubmatch(val); len(sm) > 1 {
 			val = sm[1]
 		}
+		// Note: If extract_value doesn't match, we still use the original value
+		// This is intentional as extract_value is for extracting a portion of the value
 	}
 
 	if cfg.MatchPatternCompiled != nil {
-		if sm := cfg.MatchPatternCompiled.FindStringSubmatch(val); len(sm) > 0 {
-			val = replaceSubmatches(cfg.MatchValue, sm)
+		sm := cfg.MatchPatternCompiled.FindStringSubmatch(val)
+		if len(sm) == 0 {
+			// Pattern didn't match - return empty string to indicate no match
+			// When match_pattern is specified, we only use the value if it matches
+			return "", nil
 		}
+		val = replaceSubmatches(cfg.MatchValue, sm)
 	}
 
 	if v, ok := cfg.Mapping[val]; ok {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/value_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/value_processor.go
@@ -102,9 +102,12 @@ func (p *stringValueProcessor) processValue(sym ddprofiledefinition.SymbolConfig
 	}
 
 	if sym.MatchPatternCompiled != nil {
-		if sm := sym.MatchPatternCompiled.FindStringSubmatch(s); len(sm) > 0 {
-			s = replaceSubmatches(sym.MatchValue, sm)
+		sm := sym.MatchPatternCompiled.FindStringSubmatch(s)
+		if len(sm) == 0 {
+			// Pattern didn't match - cannot extract expected value
+			return 0, fmt.Errorf("match_pattern '%s' did not match value '%s'", sym.MatchPattern, s)
 		}
+		s = replaceSubmatches(sym.MatchValue, sm)
 	}
 
 	if v, ok := sym.Mapping[s]; ok && isInt(v) {


### PR DESCRIPTION
##### Summary

This PR fixes a bug in SNMP collector where match_pattern regex configurations were incorrectly returning original values when patterns didn't match, instead of indicating "no match". This particularly affected device metadata collection with multiple fallback patterns (e.g., OS detection).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
