### PR TITLE
Switch to a Debian 13 base for our Docker images.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -43,7 +43,6 @@ static_arches:  # Static build architectures
   - aarch64
 docker_arches:  # Docker build archtiectures
   - amd64
-  - i386
   - armv7l
   - arm64
 default_sentry: &default_sentry # Default configuration for Sentry usage

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -2,7 +2,7 @@
 
 # This image contains preinstalled dependencies
 # hadolint ignore=DL3007
-FROM netdata/builder:v2 AS builder
+FROM netdata/builder:v3 AS builder
 
 # One of 'nightly' or 'stable'
 ARG RELEASE_CHANNEL=nightly
@@ -58,7 +58,7 @@ RUN mkdir -p /app/usr/sbin/ \
 #####################################################################
 # This image contains preinstalled dependencies
 # hadolint ignore=DL3007
-FROM netdata/base:v2 AS base
+FROM netdata/base:v3 AS base
 
 ARG BUILD_DATE
 ARG BUILD_VERSION


### PR DESCRIPTION
##### Summary

This also drops 32-bit x86 support in our Docker images. Essentially nobody is actually using this, and Debian is also working on transitioning away from support for this platform as well.

##### Test Plan

CI passes on this PR.

Some additional testing may be warranted for the 32-bit ARM Docker images, as there were backwards incompatible API changes there.