### PR TITLE
Attempt to fix crashes on 32-bit ARM static builds due to issues with handling of thread-local storage.

### DIFF
--- a/packaging/cmake/Modules/NetdataCompilerFlags.cmake
+++ b/packaging/cmake/Modules/NetdataCompilerFlags.cmake
@@ -144,7 +144,7 @@ endforeach()
 add_simple_extra_compiler_flag("-Wbuiltin-macro-redefined" "-Wno-builtin-macro-redefined")
 add_simple_extra_compiler_flag("-fexceptions" "-fexceptions")
 
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm" AND CMAKE_SIZEOF_VOID_P EQUAL 32)
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm" AND CMAKE_SIZEOF_VOID_P EQUAL 4)
   if(STATIC_BUILD)
     netdata_detect_libc(LIBC_ID)
     if(LIBC_ID STREQUAL "musl")


### PR DESCRIPTION
##### Summary

Updated version of #20807 with the flags handled in CMake and no changes to PIE/PIC handling relative to current master.

##### Test Plan

As we have no reliable reproducer at the moment for the issue this is trying to fix, we will need to merge it and see if the crash numbers in telemetry go down or not.

##### Additional Information

Additional changes may be needed to fully fix the issue, and will be handled in separate PRs if this one does not fix things completely.