### PR TITLE
fix(go.d/ddsnmp): correct profile matching, metadata precedence, and OID handling

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -104,7 +104,7 @@ func (c *Collector) walkAll(rootOid string) ([]gosnmp.SnmpPDU, error) {
 	return c.snmpClient.BulkWalkAll(rootOid)
 }
 
-func (c *Collector) setupVnode(si *snmpsd.SysInfo, deviceMeta map[string]map[string]string) *vnodes.VirtualNode {
+func (c *Collector) setupVnode(si *snmpsd.SysInfo, deviceMeta map[string]string) *vnodes.VirtualNode {
 	if c.Vnode.GUID == "" {
 		c.Vnode.GUID = uuid.NewSHA1(uuid.NameSpaceDNS, []byte(c.Hostname)).String()
 	}
@@ -130,9 +130,7 @@ func (c *Collector) setupVnode(si *snmpsd.SysInfo, deviceMeta map[string]map[str
 	}
 
 	maps.Copy(labels, c.Vnode.Labels)
-	for _, meta := range deviceMeta {
-		maps.Copy(labels, meta)
-	}
+	maps.Copy(labels, deviceMeta)
 
 	if _, ok := labels["sys_object_id"]; !ok {
 		labels["sys_object_id"] = si.SysObjectID

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -38,6 +38,7 @@ func New() *Collector {
 			EnableProfiles:             true,
 			EnableProfilesTableMetrics: true,
 			VnodeDeviceDownThreshold:   3,
+			Community:                  "public",
 			Options: Options{
 				Port:           161,
 				Retries:        1,

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
@@ -66,15 +66,16 @@ type (
 	}
 )
 
-func (c *Collector) CollectDeviceMetadata() (map[string]map[string]string, error) {
-	meta := make(map[string]map[string]string)
+func (c *Collector) CollectDeviceMetadata() (map[string]string, error) {
+	meta := make(map[string]string)
 
 	for _, prof := range c.profiles {
-		deviceMeta, err := c.deviceMetadataCollector.Collect(prof.profile)
+		profDeviceMeta, err := c.deviceMetadataCollector.Collect(prof.profile)
 		if err != nil {
 			return nil, err
 		}
-		meta[prof.profile.SourceFile] = deviceMeta
+
+		mergeTagsIfAbsent(meta, profDeviceMeta)
 	}
 
 	return meta, nil

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collectors_meta_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collectors_meta_test.go
@@ -947,6 +947,9 @@ func TestDeviceMetadataCollector_Collect(t *testing.T) {
 								"vendor": {
 									Value: "Cisco",
 								},
+								"platform": {
+									Value: "Default Platform", // Will be overridden
+								},
 							},
 						},
 					},
@@ -955,7 +958,7 @@ func TestDeviceMetadataCollector_Collect(t *testing.T) {
 							SysobjectID: "1.3.6.1.4.1.9.*", // All Cisco devices
 							Metadata: ddprofiledefinition.ListMap[ddprofiledefinition.MetadataField]{
 								"platform": {
-									Value: "Enterprise",
+									Value: "Enterprise", // Overrides base metadata
 								},
 								"support": {
 									Value: "Premium",
@@ -971,6 +974,9 @@ func TestDeviceMetadataCollector_Collect(t *testing.T) {
 								"series": {
 									Value: "ASA",
 								},
+								"support": {
+									Value: "Standard", // Won't override "Premium" - first wins
+								},
 							},
 						},
 						{
@@ -980,7 +986,7 @@ func TestDeviceMetadataCollector_Collect(t *testing.T) {
 									Value: "ASA5510",
 								},
 								"series": {
-									Value: "ASA5500", // Override the previous series value
+									Value: "ASA5500", // Won't override "ASA" - first wins
 								},
 							},
 						},
@@ -990,12 +996,12 @@ func TestDeviceMetadataCollector_Collect(t *testing.T) {
 			setupMock:   func(m *snmpmock.MockHandler) {},
 			sysobjectid: "1.3.6.1.4.1.9.1.669",
 			expectedResult: map[string]string{
-				"vendor":   "Cisco",
-				"platform": "Enterprise",
-				"support":  "Premium",
-				"type":     "Firewall",
-				"series":   "ASA5500", // Last match wins
-				"model":    "ASA5510",
+				"vendor":   "Cisco",      // From base metadata (not overridden)
+				"platform": "Enterprise", // From first sysobjectid match (overrides base "Default Platform")
+				"support":  "Premium",    // From first sysobjectid match (second match can't override)
+				"type":     "Firewall",   // From second sysobjectid match
+				"series":   "ASA",        // From second match (third match can't override)
+				"model":    "ASA5510",    // From third sysobjectid match
 			},
 			expectedError: false,
 		},

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
@@ -214,7 +214,7 @@ func isInt(s string) bool {
 	return err == nil
 }
 
-func mergeTagsWithEmptyFallback(dest, src map[string]string) {
+func mergeTagsIfAbsent(dest, src map[string]string) {
 	for k, v := range src {
 		if existing, ok := dest[k]; !ok || existing == "" {
 			dest[k] = v

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
@@ -6,38 +6,82 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
 
-	"github.com/netdata/netdata/go/plugins/pkg/matcher"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
 )
 
+var oidOnly = regexp.MustCompile(`^[0-9]+(\.[0-9]+)*$`)
+
+func OidMatches(sysObjId, id string) bool {
+	if oidOnly.MatchString(id) {
+		return sysObjId == id
+	}
+	re, err := regexp.Compile(id)
+	if err != nil {
+		log.Warningf("invalid regex %q: %v", id, err)
+		return false
+	}
+	return re.MatchString(sysObjId)
+}
+
 // FindProfiles returns profiles matching the given sysObjectID.
-// Profiles are loaded once on the first call and cached globally.
+// Profiles are sorted by match specificity: most specific (longest) first,
+// with exact OIDs preferred over patterns of the same length.
 func FindProfiles(sysObjId string) []*Profile {
 	loadProfiles()
 
-	var profiles []*Profile
+	type match struct {
+		profile *Profile
+		oid     string // matching OID
+	}
+
+	var matches []match
 
 	for _, prof := range ddProfiles {
+		// Use first matching OID (profile author's responsibility to order them)
 		for _, id := range prof.Definition.SysObjectIDs {
-			m, err := matcher.NewRegExpMatcher(id)
-			if err != nil {
-				log.Warningf("failed to compile regular expression from '%s': %v", id, err)
-				continue
-			}
-			if m.MatchString(sysObjId) {
-				profiles = append(profiles, prof.clone())
+			if OidMatches(sysObjId, id) {
+				matches = append(matches, match{
+					profile: prof.clone(),
+					oid:     id,
+				})
 				break
 			}
 		}
 	}
 
+	// Sort by match specificity
+	slices.SortFunc(matches, func(a, b match) int {
+		// 1. Longer OIDs first (more specific)
+		if diff := len(b.oid) - len(a.oid); diff != 0 {
+			return diff
+		}
+
+		// 2. Same length: exact OIDs before patterns
+		aIsExact := oidOnly.MatchString(a.oid)
+		bIsExact := oidOnly.MatchString(b.oid)
+		if aIsExact != bIsExact {
+			if aIsExact {
+				return -1
+			}
+			return 1
+		}
+
+		// 3. Same type: lexicographic order for stability
+		return strings.Compare(a.oid, b.oid)
+	})
+
+	profiles := make([]*Profile, len(matches))
+	for i, m := range matches {
+		profiles[i] = m.profile
+	}
+
 	enrichProfiles(profiles)
 	deduplicateMetricsAcrossProfiles(profiles)
-
 	return profiles
 }
 
@@ -114,11 +158,11 @@ func cloneExtensionHierarchy(extensions []*extensionInfo) []*extensionInfo {
 }
 
 func (p *Profile) merge(base *Profile) {
+	p.mergeMetadata(base)
 	p.mergeMetrics(base)
 	// Append other fields as before (these likely don't need deduplication)
 	p.Definition.MetricTags = append(p.Definition.MetricTags, base.Definition.MetricTags...)
 	p.Definition.StaticTags = append(p.Definition.StaticTags, base.Definition.StaticTags...)
-	p.mergeMetadata(base)
 }
 
 func (p *Profile) mergeMetrics(base *Profile) {
@@ -192,6 +236,19 @@ func (p *Profile) mergeMetadata(base *Profile) {
 		}
 
 		p.Definition.Metadata[resName] = targetRes
+	}
+
+	if len(base.Definition.SysobjectIDMetadata) > 0 {
+		existingOIDs := make(map[string]bool)
+		for _, entry := range p.Definition.SysobjectIDMetadata {
+			existingOIDs[entry.SysobjectID] = true
+		}
+
+		for _, baseEntry := range base.Definition.SysobjectIDMetadata {
+			if !existingOIDs[baseEntry.SysobjectID] {
+				p.Definition.SysobjectIDMetadata = append(p.Definition.SysobjectIDMetadata, baseEntry)
+			}
+		}
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
@@ -59,6 +59,10 @@ func Test_FindProfiles(t *testing.T) {
 			sysObjOId:   "0.1.2.3",
 			wanProfiles: 0,
 		},
+		"Cisco-WLC-5520": {
+			sysObjOId:   "1.3.6.1.4.1.9.1.2170",
+			wanProfiles: 3,
+		},
 	}
 
 	for name, test := range test {

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/aruba-mobility-controller.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/aruba-mobility-controller.yaml
@@ -13,4 +13,4 @@ metadata:
   device:
     fields:
       type:
-        value: "WLC"
+        value: "Wireless LAN Controller"

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/cisco-legacy-wlc.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/cisco-legacy-wlc.yaml
@@ -17,7 +17,7 @@ metadata:
           OID: 1.3.6.1.4.1.14179.1.1.1.4
           name: agentInventorySerialNumber
       type:
-        value: "WLC"
+        value: "Wireless LAN Controller"
       vendor:
         value: "Cisco"
 
@@ -36,6 +36,64 @@ sysobjectid:
   - 1.3.6.1.4.1.9.1.2170 # cisco5520WLC
   - 1.3.6.1.4.1.9.1.2171 # cisco8540Wlc
   - 1.3.6.1.4.1.9.1.2427 # cisco3504WLC
+
+sysobjectid_metadata:
+  - sysobjectid: 1.3.6.1.4.1.9.1.818
+    metadata:
+      model:
+        value: NM-WLC-E
+  - sysobjectid: 1.3.6.1.4.1.9.1.828
+    metadata:
+      model:
+        value: AIR-WLC2106-K9
+  - sysobjectid: 1.3.6.1.4.1.9.1.926
+    metadata:
+      model:
+        value: 520-WLC
+  - sysobjectid: 1.3.6.1.4.1.9.1.1069
+    metadata:
+      model:
+        value: 5500-WLC
+  - sysobjectid: 1.3.6.1.4.1.9.1.1279
+    metadata:
+      model:
+        value: AIR-CT2504-K9
+  - sysobjectid: 1.3.6.1.4.1.9.1.1295
+    metadata:
+      model:
+        value: 7500-WLC
+  - sysobjectid: 1.3.6.1.4.1.9.1.1615
+    metadata:
+      model:
+        value: 8500-WLC
+  - sysobjectid: 1.3.6.1.4.1.9.1.1631
+    metadata:
+      model:
+        value: Virtual-WLC
+  - sysobjectid: 1.3.6.1.4.1.9.1.1645
+    metadata:
+      model:
+        value: 5760-WLC
+  - sysobjectid: 1.3.6.1.4.1.9.1.1926
+    metadata:
+      model:
+        value: WLC-CT5508-K9
+  - sysobjectid: 1.3.6.1.4.1.9.1.1927
+    metadata:
+      model:
+        value: WLC-CT2504-K9
+  - sysobjectid: 1.3.6.1.4.1.9.1.2170
+    metadata:
+      model:
+        value: 5520-WLC
+  - sysobjectid: 1.3.6.1.4.1.9.1.2171
+    metadata:
+      model:
+        value: 8540-WLC
+  - sysobjectid: 1.3.6.1.4.1.9.1.2427
+    metadata:
+      model:
+        value: 3504-WLC
 
 metrics:
   - MIB: AIRESPACE-SWITCHING-MIB

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/ruckus-unleashed.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/ruckus-unleashed.yaml
@@ -13,7 +13,7 @@ metadata:
   device:
     fields:
       type:
-        value: "WLC"
+        value: "Wireless LAN Controller"
 
 metric_tags:
   - tag: ruckus_unleashed_system_model


### PR DESCRIPTION
##### Summary

Fixes critical issues in SNMP profile matching and metadata collection that were causing incorrect device identification and metadata assignment.

#### 1. Sysobjectid-Specific Metadata Not Applied
**Problem**: The SNMP collector wasn't properly handling sysobjectid-specific metadata. When profiles defined both general metadata and sysobjectid-specific metadata, the more specific values weren't being applied correctly. This meant devices couldn't have model-specific metadata without creating separate profiles.

**Solution**: Fixed metadata collection logic to process sysobjectid-specific metadata before base metadata, ensuring specific values take precedence over generic defaults.

**Example**: cisco-asa.yaml supports 80+ ASA models, but couldn't specify individual model names - all devices would report generic metadata instead of their specific model.


#### 2. OID Pattern Matching Too Broad
**Problem**: OIDs were being compiled as regex patterns without escaping dots, causing incorrect matches. For example, OID `1.3.6.1.4.1.9.1.217` would incorrectly match devices with OID `1.3.6.1.4.1.9.1.2170` because dots were interpreted as regex wildcards.

**Solution**: Now properly escapes dots in OID patterns before regex compilation, ensuring exact matching for numeric OIDs while still supporting intentional wildcards (e.g., `1.3.6.1.4.1.9.*`).

#### 3. Profile Matching Order Not Prioritized
**Problem**: When multiple profiles matched a device, there was no consistent prioritization - generic profiles could override specific ones.

**Solution**: Profiles are now sorted by match specificity:
- Longer OIDs (more specific) come first
- Among same length, exact OIDs are preferred over patterns
- Ensures most specific profile takes precedence

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
