### PR TITLE
ci: fix docker-test.sh handling to fail on error

### DIFF
--- a/.github/scripts/docker-test.sh
+++ b/.github/scripts/docker-test.sh
@@ -32,4 +32,5 @@ if ! "${SCRIPT_DIR}/../../packaging/runtime-check.sh"; then
   echo "::group::Netdata container logs"
   docker logs netdata 2>&1
   echo "::endgroup::"
+  exit 1
 fi


### PR DESCRIPTION
##### Summary

The CI script did not exit with a non-zero code when `runtime-check.sh` failed.
Although the script was executed, the `if` branch ended with a successful command (`echo`), so the overall job exited with 0 and masked the failure.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
