### PR TITLE
Rename default port for the OpenTelemetry Collector

### DIFF
--- a/src/go/plugin/go.d/agent/discovery/sd/pipeline/promport.go
+++ b/src/go/plugin/go.d/agent/discovery/sd/pipeline/promport.go
@@ -370,7 +370,7 @@ var prometheusPortAllocations = map[int]string{
 	9461:  "aws_lambda_read_adapter",
 	9462:  "php_opcache_exporter",
 	9463:  "virgin_media_liberty_global_hub3_exporter",
-	9464:  "opencensus-nodejs_prometheus_exporter",
+	9464:  "otelcol",
 	9465:  "hetzner_cloud_k8s_cloud_controller_manager",
 	9466:  "mqtt_push_gateway",
 	9467:  "nginx-prometheus-shiny-exporter",


### PR DESCRIPTION
In 2019, OpenTracing and OpenCensus were anounced to be merging. After
this, the OpenCensus code base was
[sunset](https://opentelemetry.io/blog/2023/sunsetting-opencensus/),
including its Prometheus exporter. Since the default port of the
Prometheus exporter in OpenTelemetry Collector is the same as this, the
latter is used extensively, and the projects are now merged, we can
safely rename this to `otelcol`, which is the lowercased version of the accepted shorthand [OTelCol](https://opentelemetry.io/docs/concepts/glossary/#otelcol).
