### PR TITLE
fix(go.d/snmp): handle invalid SFP temperature readings for empty slots

### DIFF
--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/mikrotik-router.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/mikrotik-router.yaml
@@ -89,6 +89,10 @@ metrics:
           description: Temperature at sensor chip
           family: 'Hardware/OpticalModule/Temperature/Value'
           unit: "Cel"
+        transform: | # Set temperature to 0 when no SFP module present (MikroTik returns ~4294967168 for empty slots)
+          {{- if gt .Metric.Value 4294967000 -}}
+            {{- setValue .Metric 0 -}}
+          {{- end -}}
       - OID: 1.3.6.1.4.1.14988.1.1.19.1.1.10
         name: mtxrOpticalRxPower
         chart_meta:
@@ -146,6 +150,7 @@ metrics:
         symbol:
           OID: 1.3.6.1.4.1.14988.1.1.19.1.1.2
           name: mtxrOpticalName
+
   - MIB: MIKROTIK-MIB
     table:
       OID: 1.3.6.1.4.1.14988.1.1.15.1


### PR DESCRIPTION
##### Summary

When querying SFP module temperatures via SNMP (OID: 1.3.6.1.4.1.14988.1.1.19.1.1.6), MikroTik devices return a sentinel value of `4294967168` (near max uint32) for empty SFP slots instead of a valid temperature reading. This causes incorrect temperature data in monitoring.

Added a transform that detects these invalid values (anything > 4294967000) and converts them to 0, indicating no module present.



##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
