### PR TITLE
Improve exporting documentation clarity and structure

### DIFF
--- a/docs/exporting-metrics/README.md
+++ b/docs/exporting-metrics/README.md
@@ -1,55 +1,61 @@
-# Export metrics to external time-series databases
+# Export Metrics to External Time-Series Databases
 
-Netdata natively supports long term retention of metrics. Its tiered database design typically provides significantly longer retention (months to years) and faster queries (typically 20+ times faster), compared to other common time-series databases.
+Netdata natively provides long-term metrics retention through its tiered database design. This architecture delivers significantly longer retention (months to years) and faster queries (typically 20+ times faster) compared to other common time-series databases.
 
-For integration with other observability tools, Netdata provides a number of exporters allow you to copy metrics to third party time-series databases for additional analysis or integration with other tools.
+For integration with other observability tools, Netdata includes exporters that copy metrics to third-party time-series databases for additional analysis or integration with other tools.
 
-Exporters enable connections to [more than thirty](#supported-databases) supported databases, including InfluxDB, Prometheus, Graphite, ElasticSearch, and much more.
+## Exporting Capabilities
 
-The exporting engine is able to downsample Netdata's per-second metrics at a user-configurable interval (e.g per minute), and can export metrics to multiple time-series databases simultaneously.
+The exporting engine provides these key features:
 
-Based on your needs and resources you allocated to your external time-series database, you can configure the interval
-that metrics are exported or export only certain charts with filtering. You can also choose whether metrics are exported
-as-collected, a normalized average, or the sum/volume of metrics values over the configured interval.
+- **Multi-database support**: Export to [more than thirty](#supported-databases) databases including InfluxDB, Prometheus, Graphite, ElasticSearch, and more
+- **Downsampling**: Configure export intervals from Netdata's per-second metrics (e.g., per minute)
+- **Simultaneous exports**: Send metrics to multiple time-series databases at once
+- **Flexible data processing**: Export metrics as-collected, normalized averages, or sum/volume over configured intervals
+- **Selective exporting**: Filter specific charts based on your needs and allocated resources
 
-## Supported databases
+## Supported Databases
 
-Netdata supports exporting metrics to the following databases through several
-[connectors](/src/exporting/README.md#features). Once you find the connector that works for your database, open its
-documentation and the [enabling a connector](/docs/exporting-metrics/enable-an-exporting-connector.md) doc for details on enabling it.
+Netdata exports metrics to the following databases through various [connectors](/src/exporting/README.md#features). Each connector includes documentation with [enabling instructions](/docs/exporting-metrics/enable-an-exporting-connector.md).
 
-- **AppOptics**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **AWS Kinesis**: [AWS Kinesis Data Streams](/src/exporting/aws_kinesis/README.md).
-- **Azure Data Explorer**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **Azure Event Hubs**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **Blueflood**: [Graphite](/src/exporting/graphite/README.md).
-- **Chronix**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **Cortex**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **CrateDB**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **ElasticSearch**: [Graphite](/src/exporting/graphite/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **Gnocchi**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **Google BigQuery**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **Google Cloud Pub/Sub**: [Google Cloud Pub/Sub Service](/src/exporting/pubsub/README.md).
-- **Graphite**: [Graphite](/src/exporting/graphite/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **InfluxDB**: [Graphite](/src/exporting/graphite/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **IRONdb**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **JSON**: [JSON document databases](/src/exporting/json/README.md).
-- **Kafka**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **KairosDB**: [Graphite](/src/exporting/graphite/README.md), [OpenTSDB](/src/exporting/opentsdb/README.md).
-- **M3DB**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **MetricFire**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **MongoDB**: [MongoDB](/src/exporting/mongodb/README.md).
-- **New Relic**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **OpenTSDB**: [OpenTSDB](/src/exporting/opentsdb/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **PostgreSQL**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) via [PostgreSQL Prometheus Adapter](https://github.com/CrunchyData/postgresql-prometheus-adapter).
-- **Prometheus**: [Prometheus scraper](/src/exporting/prometheus/README.md).
-- **TimescaleDB**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md), [netdata-timescale-relay](/src/exporting/TIMESCALE.md).
-- **QuasarDB**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **SignalFx**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **Splunk**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **TiKV**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **Thanos**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **VictoriaMetrics**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
-- **Wavefront**: [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md).
+| Database | Supported Connectors |
+|:--------:|:-------------------:|
+| **AppOptics** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **AWS Kinesis** | [AWS Kinesis Data Streams](/src/exporting/aws_kinesis/README.md) |
+| **Azure Data Explorer** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **Azure Event Hubs** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **Blueflood** | [Graphite](/src/exporting/graphite/README.md) |
+| **Chronix** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **Cortex** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **CrateDB** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **ElasticSearch** | [Graphite](/src/exporting/graphite/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **Gnocchi** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **Google BigQuery** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **Google Cloud Pub/Sub** | [Google Cloud Pub/Sub Service](/src/exporting/pubsub/README.md) |
+| **Graphite** | [Graphite](/src/exporting/graphite/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **InfluxDB** | [Graphite](/src/exporting/graphite/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **IRONdb** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **JSON** | [JSON document databases](/src/exporting/json/README.md) |
+| **Kafka** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **KairosDB** | [Graphite](/src/exporting/graphite/README.md), [OpenTSDB](/src/exporting/opentsdb/README.md) |
+| **M3DB** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **MetricFire** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **MongoDB** | [MongoDB](/src/exporting/mongodb/README.md) |
+| **New Relic** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **OpenTSDB** | [OpenTSDB](/src/exporting/opentsdb/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **PostgreSQL** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) via [PostgreSQL Prometheus Adapter](https://github.com/CrunchyData/postgresql-prometheus-adapter) |
+| **Prometheus** | [Prometheus scraper](/src/exporting/prometheus/README.md) |
+| **TimescaleDB** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md), [netdata-timescale-relay](/src/exporting/TIMESCALE.md) |
+| **QuasarDB** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **SignalFx** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **Splunk** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **TiKV** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **Thanos** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **VictoriaMetrics** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+| **Wavefront** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
 
-Can't find your preferred external time-series database? Ask our [community](https://community.netdata.cloud/) for solutions, or file an [issue on GitHub](https://github.com/netdata/netdata/issues/new?assignees=&labels=bug%2Cneeds+triage&template=BUG_REPORT.yml).
+:::tip
+
+**Can't find your preferred external time-series database?** Ask our [community](https://community.netdata.cloud/) for solutions, or file an [issue on GitHub](https://github.com/netdata/netdata/issues/new?assignees=&labels=bug%2Cneeds+triage&template=BUG_REPORT.yml).
+
+:::

--- a/docs/exporting-metrics/README.md
+++ b/docs/exporting-metrics/README.md
@@ -16,43 +16,43 @@ The exporting engine provides these key features:
 
 ## Supported Databases
 
-Netdata exports metrics to the following databases through various [connectors](/src/exporting/README.md#features). Each connector includes documentation with [enabling instructions](/docs/exporting-metrics/enable-an-exporting-connector.md).
+Netdata exports metrics to the following databases through various [connectors](/src/exporting/README.md#supported-connectors). Each connector includes documentation with [enabling instructions](/docs/exporting-metrics/enable-an-exporting-connector.md).
 
-| Database | Supported Connectors |
-|:--------:|:-------------------:|
-| **AppOptics** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **AWS Kinesis** | [AWS Kinesis Data Streams](/src/exporting/aws_kinesis/README.md) |
-| **Azure Data Explorer** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **Azure Event Hubs** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **Blueflood** | [Graphite](/src/exporting/graphite/README.md) |
-| **Chronix** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **Cortex** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **CrateDB** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **ElasticSearch** | [Graphite](/src/exporting/graphite/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **Gnocchi** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **Google BigQuery** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **Google Cloud Pub/Sub** | [Google Cloud Pub/Sub Service](/src/exporting/pubsub/README.md) |
-| **Graphite** | [Graphite](/src/exporting/graphite/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **InfluxDB** | [Graphite](/src/exporting/graphite/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **IRONdb** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **JSON** | [JSON document databases](/src/exporting/json/README.md) |
-| **Kafka** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **KairosDB** | [Graphite](/src/exporting/graphite/README.md), [OpenTSDB](/src/exporting/opentsdb/README.md) |
-| **M3DB** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **MetricFire** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **MongoDB** | [MongoDB](/src/exporting/mongodb/README.md) |
-| **New Relic** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **OpenTSDB** | [OpenTSDB](/src/exporting/opentsdb/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **PostgreSQL** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) via [PostgreSQL Prometheus Adapter](https://github.com/CrunchyData/postgresql-prometheus-adapter) |
-| **Prometheus** | [Prometheus scraper](/src/exporting/prometheus/README.md) |
-| **TimescaleDB** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md), [netdata-timescale-relay](/src/exporting/TIMESCALE.md) |
-| **QuasarDB** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **SignalFx** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **Splunk** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **TiKV** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **Thanos** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **VictoriaMetrics** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
-| **Wavefront** | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) |
+|         Database         |                                                                             Supported Connectors                                                                              |
+|:------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+|      **AppOptics**       |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|     **AWS Kinesis**      |                                                       [AWS Kinesis Data Streams](/src/exporting/aws_kinesis/README.md)                                                        |
+| **Azure Data Explorer**  |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|   **Azure Event Hubs**   |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|      **Blueflood**       |                                                                 [Graphite](/src/exporting/graphite/README.md)                                                                 |
+|       **Chronix**        |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|        **Cortex**        |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|       **CrateDB**        |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|    **ElasticSearch**     |                          [Graphite](/src/exporting/graphite/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                           |
+|       **Gnocchi**        |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|   **Google BigQuery**    |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+| **Google Cloud Pub/Sub** |                                                        [Google Cloud Pub/Sub Service](/src/exporting/pubsub/README.md)                                                        |
+|       **Graphite**       |                          [Graphite](/src/exporting/graphite/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                           |
+|       **InfluxDB**       |                          [Graphite](/src/exporting/graphite/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                           |
+|        **IRONdb**        |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|         **JSON**         |                                                           [JSON document databases](/src/exporting/json/README.md)                                                            |
+|        **Kafka**         |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|       **KairosDB**       |                                         [Graphite](/src/exporting/graphite/README.md), [OpenTSDB](/src/exporting/opentsdb/README.md)                                          |
+|         **M3DB**         |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|      **MetricFire**      |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|       **MongoDB**        |                                                                  [MongoDB](/src/exporting/mongodb/README.md)                                                                  |
+|      **New Relic**       |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|       **OpenTSDB**       |                          [OpenTSDB](/src/exporting/opentsdb/README.md), [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                           |
+|      **PostgreSQL**      | [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md) via [PostgreSQL Prometheus Adapter](https://github.com/CrunchyData/postgresql-prometheus-adapter) |
+|      **Prometheus**      |                                                           [Prometheus scraper](/src/exporting/prometheus/README.md)                                                           |
+|     **TimescaleDB**      |                      [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md), [netdata-timescale-relay](/src/exporting/TIMESCALE.md)                      |
+|       **QuasarDB**       |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|       **SignalFx**       |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|        **Splunk**        |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|         **TiKV**         |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|        **Thanos**        |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|   **VictoriaMetrics**    |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
+|      **Wavefront**       |                                                  [Prometheus remote write](/src/exporting/prometheus/remote_write/README.md)                                                  |
 
 :::tip
 

--- a/docs/exporting-metrics/enable-an-exporting-connector.md
+++ b/docs/exporting-metrics/enable-an-exporting-connector.md
@@ -12,7 +12,7 @@ Once you understand how to enable a connector, you can apply that knowledge to a
 
 ## Enable the Exporting Engine
 
-Edit `exporting.conf` using `edit-config` from your [Netdata config directory](/docs/netdata-agent/configuration/README.md#the-netdata-config-directory):
+Edit `exporting.conf` using `edit-config` from your [Netdata config directory](/docs/netdata-agent/configuration/README.md#edit-configuration-files):
 
 ```text
 [exporting:global]
@@ -38,7 +38,7 @@ Replace `my_opentsdb_http_instance` with an instance name of your choice, and ch
 
 [Restart your Agent](/docs/netdata-agent/start-stop-restart.md) to initiate exporting to your OpenTSDB database. The Netdata Agent continuously exports metrics collected from the moment it starts. You can expect to see data appear in your OpenTSDB database within seconds of restarting the Agent.
 
-Any further configuration is optional, based on your needs and the configuration of your OpenTSDB database. See the [OpenTSDB connector doc](/src/exporting/opentsdb/README.md) and [exporting engine reference](/src/exporting/README.md#configuration) for details.
+Any further configuration is optional, based on your needs and the configuration of your OpenTSDB database. See the [OpenTSDB connector doc](/src/exporting/opentsdb/README.md) and [exporting engine reference](/src/exporting/README.md#configuration-structure) for details.
 
 </details>
 
@@ -57,6 +57,6 @@ Replace `netdata` with an instance name of your choice, and change the `destinat
 
 [Restart your Agent](/docs/netdata-agent/start-stop-restart.md) to initiate exporting to your Graphite database. The Netdata Agent continuously exports metrics collected from the moment it starts. You can expect to see data appear in your Graphite database within seconds of restarting the Agent.
 
-Any further configuration is optional, based on your needs and the configuration of your Graphite database. See the [Graphite connector doc](/src/exporting/graphite/README.md) and [exporting engine reference](/src/exporting/README.md#configuration) for details.
+Any further configuration is optional, based on your needs and the configuration of your Graphite database. See the [Graphite connector doc](/src/exporting/graphite/README.md) and [exporting engine reference](/src/exporting/README.md#configuration-structure) for details.
 
 </details>

--- a/docs/exporting-metrics/enable-an-exporting-connector.md
+++ b/docs/exporting-metrics/enable-an-exporting-connector.md
@@ -1,34 +1,32 @@
-# Enable an exporting connector
+# Enable an Exporting Connector
 
-Now that you found the right connector for your [external time-series
-database](/docs/exporting-metrics/README.md#supported-databases), you can now enable the exporting engine and the
-connector itself. We'll walk through the process of enabling the exporting engine itself, followed by two examples using
-the OpenTSDB and Graphite connectors.
+After selecting the right connector for your [external time-series database](/docs/exporting-metrics/README.md#supported-databases), you can enable the exporting engine and configure your connector. This guide walks through enabling the exporting engine itself, followed by two examples using the OpenTSDB and Graphite connectors.
 
-> **Note**
->
-> When you enable the exporting engine and a connector, the Netdata Agent exports metrics _beginning from the time you
-> restart its process_, not the entire
-> [database of long-term metrics](/src/database/README.md).
+:::info
+
+When you enable the exporting engine and a connector, Netdata exports metrics **starting from the Agent restart time**, not the entire [historical database](/src/database/README.md).
+
+:::
 
 Once you understand how to enable a connector, you can apply that knowledge to any other connector.
 
-## Enable the exporting engine
+## Enable the Exporting Engine
 
-Use `edit-config` from your [Netdata config directory](/docs/netdata-agent/configuration/README.md#the-netdata-config-directory) to edit `exporting.conf`.
-
-Enable the exporting engine itself by setting `enabled` to `yes`:
+Edit `exporting.conf` using `edit-config` from your [Netdata config directory](/docs/netdata-agent/configuration/README.md#the-netdata-config-directory):
 
 ```text
 [exporting:global]
     enabled = yes
 ```
 
-Save the file but keep it open, as you will edit it again to enable specific connectors.
+Save the file but keep it open—you will edit it again to enable specific connectors.
 
-## Example: Enable the OpenTSDB connector
+## Examples
 
-Use the following configuration as a starting point. Copy and paste it into `exporting.conf`.
+<details>
+<summary><strong>Enable the OpenTSDB Connector</strong></summary>
+
+Use the following configuration as a starting point. Copy and paste it into `exporting.conf`:
 
 ```text
 [opentsdb:http:my_opentsdb_http_instance]
@@ -41,3 +39,24 @@ Replace `my_opentsdb_http_instance` with an instance name of your choice, and ch
 [Restart your Agent](/docs/netdata-agent/start-stop-restart.md) to initiate exporting to your OpenTSDB database. The Netdata Agent continuously exports metrics collected from the moment it starts. You can expect to see data appear in your OpenTSDB database within seconds of restarting the Agent.
 
 Any further configuration is optional, based on your needs and the configuration of your OpenTSDB database. See the [OpenTSDB connector doc](/src/exporting/opentsdb/README.md) and [exporting engine reference](/src/exporting/README.md#configuration) for details.
+
+</details>
+
+<details>
+<summary><strong>Enable the Graphite Connector</strong></summary>
+
+Use the following configuration as a starting point. Copy and paste it into `exporting.conf`:
+
+```text
+[graphite:netdata]
+    enabled = yes
+    destination = localhost:2003
+```
+
+Replace `netdata` with an instance name of your choice, and change the `destination` setting to the IP address or hostname of your Graphite database.
+
+[Restart your Agent](/docs/netdata-agent/start-stop-restart.md) to initiate exporting to your Graphite database. The Netdata Agent continuously exports metrics collected from the moment it starts. You can expect to see data appear in your Graphite database within seconds of restarting the Agent.
+
+Any further configuration is optional, based on your needs and the configuration of your Graphite database. See the [Graphite connector doc](/src/exporting/graphite/README.md) and [exporting engine reference](/src/exporting/README.md#configuration) for details.
+
+</details>

--- a/src/exporting/README.md
+++ b/src/exporting/README.md
@@ -7,6 +7,7 @@ For a quick introduction, read our [exporting metrics overview](/docs/exporting-
 ## Core Capabilities
 
 The exporting engine features a modular structure that supports:
+
 - Multiple connector instances running simultaneously
 - Different update intervals per connector
 - Custom filters per connector instance
@@ -22,15 +23,16 @@ When you enable the exporting engine, Netdata exports metrics **starting from th
 
 Netdata provides three data export modes:
 
-| Mode | Description | Data Format | Use Case |
-|:----:|:------------|:------------|:---------|
-| **as-collected** | Raw metrics in original units | Counters remain counters, gauges remain gauges | Time-series database experts who need raw data |
-| **average** | Normalized metrics from Netdata database | All metrics sent as gauges in Netdata units | Simplified visualization with Netdata-centric workflows |
-| **sum/volume** | Sum of interpolated values | Aggregated values over the export interval | Long-term trend analysis |
+|       Mode       | Description                              | Data Format                                    | Use Case                                                |
+|:----------------:|:-----------------------------------------|:-----------------------------------------------|:--------------------------------------------------------|
+| **as-collected** | Raw metrics in original units            | Counters remain counters, gauges remain gauges | Time-series database experts who need raw data          |
+|   **average**    | Normalized metrics from Netdata database | All metrics sent as gauges in Netdata units    | Simplified visualization with Netdata-centric workflows |
+|  **sum/volume**  | Sum of interpolated values               | Aggregated values over the export interval     | Long-term trend analysis                                |
 
 :::tip
 
-**Choosing the Right Mode**: 
+**Choosing the Right Mode**:
+
 - Use `as-collected` if you're building monitoring around a time-series database and know how to convert units
 - Use `average` for simpler long-term archiving that matches Netdata's visualization exactly
 
@@ -38,17 +40,17 @@ Netdata provides three data export modes:
 
 ## Supported Connectors
 
-| Connector | Protocol/Format | Metric Format |
-|:----------|:---------------|:--------------|
-| [AWS Kinesis](/src/exporting/aws_kinesis/README.md) | JSON | Stream-based |
-| [Google Pub/Sub](/src/exporting/pubsub/README.md) | JSON | Message-based |
-| [Graphite](/src/exporting/graphite/README.md) | Plaintext | `prefix.hostname.chart.dimension` |
-| [JSON Databases](/src/exporting/json/README.md) | JSON | Document-based |
-| [OpenTSDB](/src/exporting/opentsdb/README.md) | Plaintext/HTTP | `prefix.chart.dimension` with tags |
-| [MongoDB](/src/exporting/mongodb/README.md) | JSON | Document-based |
-| [Prometheus](/src/exporting/prometheus/README.md) | HTTP scraping | Prometheus exposition format |
-| [Prometheus Remote Write](/src/exporting/prometheus/remote_write/README.md) | Snappy-compressed protobuf | Binary over HTTP |
-| [TimescaleDB](/src/exporting/TIMESCALE.md) | JSON streams | Time-series tables |
+| Connector                                                                   | Protocol/Format            | Metric Format                      |
+|:----------------------------------------------------------------------------|:---------------------------|:-----------------------------------|
+| [AWS Kinesis](/src/exporting/aws_kinesis/README.md)                         | JSON                       | Stream-based                       |
+| [Google Pub/Sub](/src/exporting/pubsub/README.md)                           | JSON                       | Message-based                      |
+| [Graphite](/src/exporting/graphite/README.md)                               | Plaintext                  | `prefix.hostname.chart.dimension`  |
+| [JSON Databases](/src/exporting/json/README.md)                             | JSON                       | Document-based                     |
+| [OpenTSDB](/src/exporting/opentsdb/README.md)                               | Plaintext/HTTP             | `prefix.chart.dimension` with tags |
+| [MongoDB](/src/exporting/mongodb/README.md)                                 | JSON                       | Document-based                     |
+| [Prometheus](/src/exporting/prometheus/README.md)                           | HTTP scraping              | Prometheus exposition format       |
+| [Prometheus Remote Write](/src/exporting/prometheus/remote_write/README.md) | Snappy-compressed protobuf | Binary over HTTP                   |
+| [TimescaleDB](/src/exporting/TIMESCALE.md)                                  | JSON streams               | Time-series tables                 |
 
 ## Configuration Structure
 
@@ -130,15 +132,16 @@ Your `exporting.conf` file contains these configuration blocks:
 
 ### Configuration Sections
 
-| Section | Purpose |
-|:--------|:--------|
-| `[exporting:global]` | Default settings for all connectors |
-| `[prometheus:exporter]` | Prometheus API endpoint settings |
-| `[<type>:<name>]` | Individual connector instance configuration |
+| Section                 | Purpose                                     |
+|:------------------------|:--------------------------------------------|
+| `[exporting:global]`    | Default settings for all connectors         |
+| `[prometheus:exporter]` | Prometheus API endpoint settings            |
+| `[<type>:<name>]`       | Individual connector instance configuration |
 
 ### Connector Types
 
 Available connector types with optional modifiers:
+
 - `graphite` | `graphite:http` | `graphite:https`
 - `opentsdb:telnet` | `opentsdb:http` | `opentsdb:https`
 - `prometheus_remote_write` | `prometheus_remote_write:http` | `prometheus_remote_write:https`
@@ -149,45 +152,48 @@ Available connector types with optional modifiers:
 
 ### Basic Settings
 
-| Option | Values | Description |
-|:-------|:-------|:------------|
-| `enabled` | yes/no | Activates the connector instance |
-| `data source` | as-collected/average/sum | Selects data export mode |
-| `hostname` | string | Hostname for external database (default: `[global].hostname`) |
-| `prefix` | string | Prefix added to all metrics |
-| `update every` | seconds | Export interval with automatic randomization |
+| Option         | Values                   | Description                                                   |
+|:---------------|:-------------------------|:--------------------------------------------------------------|
+| `enabled`      | yes/no                   | Activates the connector instance                              |
+| `data source`  | as-collected/average/sum | Selects data export mode                                      |
+| `hostname`     | string                   | Hostname for external database (default: `[global].hostname`) |
+| `prefix`       | string                   | Prefix added to all metrics                                   |
+| `update every` | seconds                  | Export interval with automatic randomization                  |
 
 ### Connection Settings
 
-| Option | Format | Description |
-|:-------|:-------|:------------|
-| `destination` | space-separated list | Target servers in `[PROTOCOL:]IP[:PORT]` format |
-| `buffer on failures` | iterations | Buffer size when database unavailable |
-| `timeout ms` | milliseconds | Processing timeout (default: `2 * update_every * 1000`) |
+| Option               | Format               | Description                                             |
+|:---------------------|:---------------------|:--------------------------------------------------------|
+| `destination`        | space-separated list | Target servers in `[PROTOCOL:]IP[:PORT]` format         |
+| `buffer on failures` | iterations           | Buffer size when database unavailable                   |
+| `timeout ms`         | milliseconds         | Processing timeout (default: `2 * update_every * 1000`) |
 
 #### Destination Examples
 
 IPv4 configuration:
+
 ```text
 destination = 10.11.14.2:4242 10.11.14.3:4242 10.11.14.4:4242
 ```
 
 IPv6 and IPv4 combined:
+
 ```text
 destination = [ffff:...:0001]:2003 10.11.12.1:2003
 ```
 
 Special destinations:
+
 - **Kinesis**: AWS region (e.g., `us-east-1`)
 - **MongoDB**: [MongoDB URI](https://docs.mongodb.com/manual/reference/connection-string/)
 - **Pub/Sub**: Service endpoint
 
 ### Filtering Options
 
-| Option | Pattern Format | Description |
-|:-------|:---------------|:------------|
-| `send hosts matching` | space-separated patterns | Filter hosts using `*` wildcard, `!` for negation |
-| `send charts matching` | space-separated patterns | Filter charts by ID/name, `!` for negation |
+| Option                 | Pattern Format           | Description                                       |
+|:-----------------------|:-------------------------|:--------------------------------------------------|
+| `send hosts matching`  | space-separated patterns | Filter hosts using `*` wildcard, `!` for negation |
+| `send charts matching` | space-separated patterns | Filter charts by ID/name, `!` for negation        |
 
 :::important
 
@@ -199,30 +205,33 @@ Example: `!*child* *db*` matches all `*db*` hosts except those containing `*chil
 
 ### Label Settings
 
-| Option | Values | Description |
-|:-------|:-------|:------------|
-| `send names instead of ids` | yes/no | Use human-friendly names vs system IDs |
-| `send configured labels` | yes/no | Include `[host labels]` from `netdata.conf` |
-| `send automatic labels` | yes/no | Include auto-generated labels (`_os_name`, `_architecture`) |
+| Option                      | Values | Description                                                 |
+|:----------------------------|:-------|:------------------------------------------------------------|
+| `send names instead of ids` | yes/no | Use human-friendly names vs system IDs                      |
+| `send configured labels`    | yes/no | Include `[host labels]` from `netdata.conf`                 |
+| `send automatic labels`     | yes/no | Include auto-generated labels (`_os_name`, `_architecture`) |
 
 ## Chart Filtering
 
 Filter metrics through two methods:
 
 1. **Configuration file**:
-```text
-[prometheus:exporter]
-    send charts matching = system.*
-```
+
+   ```text
+   [prometheus:exporter]
+       send charts matching = system.*
+   ```
 
 2. **URL parameter**:
-```text
-http://localhost:19999/api/v1/allmetrics?format=shell&filter=system.*
-```
+
+   ```text
+   http://localhost:19999/api/v1/allmetrics?format=shell&filter=system.*
+   ```
 
 ## HTTPS Support
 
 For databases without native TLS/SSL support, configure a reverse proxy:
+
 - [Nginx reverse proxy setup](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-nginx.md)
 
 ## Performance Considerations
@@ -239,11 +248,11 @@ Multiple connector instances running batches simultaneously can consume signific
 
 Netdata provides five monitoring charts under **Netdata Monitoring**:
 
-| Chart | Monitors |
-|:------|:---------|
-| **Buffered metrics** | Number of metrics added to dispatch buffer |
-| **Exporting data size** | Data volume (KB) added to buffer |
-| **Exporting operations** | Operation count performed |
+| Chart                          | Monitors                                   |
+|:-------------------------------|:-------------------------------------------|
+| **Buffered metrics**           | Number of metrics added to dispatch buffer |
+| **Exporting data size**        | Data volume (KB) added to buffer           |
+| **Exporting operations**       | Operation count performed                  |
 | **Exporting thread CPU usage** | CPU resources consumed by exporting thread |
 
 ![Exporting engine monitoring](https://cloud.githubusercontent.com/assets/2662304/20463536/eb196084-af3d-11e6-8ee5-ddbd3b4d8449.png)
@@ -252,17 +261,18 @@ Netdata provides five monitoring charts under **Netdata Monitoring**:
 
 The exporting engine includes three automatic alerts:
 
-| Alert | Monitors |
-|:------|:---------|
+| Alert                      | Monitors                                |
+|:---------------------------|:----------------------------------------|
 | `exporting_last_buffering` | Seconds since last successful buffering |
-| `exporting_metrics_sent` | Percentage of successfully sent metrics |
-| `exporting_metrics_lost` | Metrics lost due to repeated failures |
+| `exporting_metrics_sent`   | Percentage of successfully sent metrics |
+| `exporting_metrics_lost`   | Metrics lost due to repeated failures   |
 
 ![Exporting alerts](https://cloud.githubusercontent.com/assets/2662304/20463779/a46ed1c2-af43-11e6-91a5-07ca4533cac3.png)
 
 ## Fallback Script
 
 Netdata includes `nc-exporting.sh` for:
+
 - Saving metrics to disk during database outages
 - Pushing cached metrics when database recovers
 - Monitoring/tracing/debugging metric generation

--- a/src/exporting/prometheus/README.md
+++ b/src/exporting/prometheus/README.md
@@ -15,17 +15,18 @@ Before configuring either method, understand how Netdata structures its exported
 
 Each Netdata chart has several properties common to all its metrics:
 
-| Property | Description |
-|:---------|:------------|
-| `chart_id` | Uniquely identifies a chart |
-| `chart_name` | Human-friendly name for `chart_id`, also unique |
-| `context` | Chart template - all disk I/O charts share the same context, all MySQL request charts share the same context. Used for alert template matching |
-| `family` | Groups charts together as dashboard submenus |
-| `units` | Units for all metrics in the chart |
+| Property     | Description                                                                                                                                    |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `chart_id`   | Uniquely identifies a chart                                                                                                                    |
+| `chart_name` | Human-friendly name for `chart_id`, also unique                                                                                                |
+| `context`    | Chart template - all disk I/O charts share the same context, all MySQL request charts share the same context. Used for alert template matching |
+| `family`     | Groups charts together as dashboard submenus                                                                                                   |
+| `units`      | Units for all metrics in the chart                                                                                                             |
 
 #### Dimensions
 
 Each Netdata chart contains metrics called `dimensions`. All dimensions in a chart:
+
 - Share the same units of measurement
 - Belong to the same contextual category (e.g., disk bandwidth contains `read` and `write` dimensions)
 
@@ -38,6 +39,7 @@ Netdata sends metrics to Prometheus from 3 data sources:
 Sends metrics exactly as collected without conversion. Prometheus prefers this method, but it requires understanding how to extract meaningful values.
 
 **Metric formats:**
+
 - Standard: `CONTEXT{chart="CHART",family="FAMILY",dimension="DIMENSION"}`
 - Counters: `CONTEXT_total{chart="CHART",family="FAMILY",dimension="DIMENSION"}`
 - Heterogeneous dimensions: `CONTEXT_DIMENSION{chart="CHART",family="FAMILY"}`
@@ -50,7 +52,7 @@ Unlike Prometheus, Netdata allows each dimension to have different algorithms an
 
 #### 2. Average
 
-Uses the Netdata database to send metrics as they appear on the dashboard. All metrics become gauges in their dashboard units. This is the easiest to work with.
+Sends metrics as they appear on the dashboard. All metrics become gauges in their dashboard units. This is the easiest to work with.
 
 **Format:** `CONTEXT_UNITS_average{chart="CHART",family="FAMILY",dimension="DIMENSION"}`
 
@@ -63,6 +65,7 @@ Like `average` but sums values instead of averaging them.
 **Format:** `CONTEXT_UNITS_sum{chart="CHART",family="FAMILY",dimension="DIMENSION"}`
 
 To change the data source, add the `source` parameter to the URL:
+
 ```
 http://your.netdata.ip:19999/api/v1/allmetrics?format=prometheus&source=as-collected
 ```
@@ -76,6 +79,7 @@ Early Netdata versions sent metrics as `CHART_DIMENSION{}`.
 ### Querying Metrics
 
 Test the metrics endpoint in your browser:
+
 ```
 http://your.netdata.ip:19999/api/v1/allmetrics?format=prometheus&help=yes
 ```
@@ -153,7 +157,7 @@ The `format=prometheus` parameter only exports the local host's metrics. For par
 ```yaml
 metrics_path: '/api/v1/allmetrics'
 params:
-  format: [ prometheus_all_hosts ]
+  format: [prometheus_all_hosts]
 honor_labels: true
 ```
 
@@ -172,6 +176,7 @@ To expose them, append `variables=yes` to the URL.
 ### TYPE and HELP
 
 `# TYPE` and `# HELP` lines are suppressed by default to save bandwidth (Prometheus doesn't use them). Re-enable with:
+
 ```
 /api/v1/allmetrics?format=prometheus&types=yes&help=yes
 ```
@@ -187,24 +192,28 @@ When enabled, `# TYPE` and `# HELP` lines repeat for every metric occurrence, vi
 Netdata supports both names and IDs for charts and dimensions. IDs are unique system identifiers; names are human-friendly labels (also unique). Most charts have identical ID and name, but some differ (device-mapper disks, interrupts, QoS classes, statsd synthetic charts).
 
 Control the default in `exporting.conf`:
+
 ```text
 [prometheus:exporter]
 	send names instead of ids = yes | no
 ```
 
 Override via URL:
+
 - `&names=no` for IDs (old behavior)
 - `&names=yes` for names
 
 ### Filtering Metrics Sent to Prometheus
 
 Filter metrics with this setting:
+
 ```text
 [prometheus:exporter]
 	send charts matching = *
 ```
 
 This accepts space-separated [simple patterns](/src/libnetdata/simple_pattern/README.md) to match charts. Pattern rules:
+
 - `*` as wildcard (e.g., `*a*b*c*` is valid)
 - `!` prefix for negative match
 - First match (positive or negative) wins
@@ -213,6 +222,7 @@ This accepts space-separated [simple patterns](/src/libnetdata/simple_pattern/RE
 ### Changing the Prefix of Netdata Metrics
 
 Netdata prefixes all metrics with `netdata_`. Change in `netdata.conf`:
+
 ```text
 [prometheus:exporter]
 	prefix = netdata
@@ -222,11 +232,11 @@ Or append `&prefix=netdata` to the URL.
 
 ### Metric Units
 
-| Source | Unit Behavior | Control |
-|:-------|:--------------|:--------|
-| `average` (default) | Adds units to names (e.g., `_KiB_persec`) | `&hideunits=yes` to hide |
-| `as-collected` | No units in names | N/A |
-| All sources | v1.12+ standardized units | `&oldunits=yes` for pre-v1.12 names |
+| Source              | Unit Behavior                             | Control                             |
+|:--------------------|:------------------------------------------|:------------------------------------|
+| `average` (default) | Adds units to names (e.g., `_KiB_persec`) | `&hideunits=yes` to hide            |
+| `as-collected`      | No units in names                         | N/A                                 |
+| All sources         | v1.12+ standardized units                 | `&oldunits=yes` for pre-v1.12 names |
 
 ### Accuracy of Average and Sum Data Sources
 
@@ -270,7 +280,7 @@ scrape_configs:
     # scheme defaults to 'http'.
 
     static_configs:
-      - targets: [ '0.0.0.0:9090' ]
+      - targets: ['0.0.0.0:9090']
 
   - job_name: 'netdata-scrape'
 
@@ -278,7 +288,7 @@ scrape_configs:
     params:
       # format: prometheus | prometheus_all_hosts
       # You can use `prometheus_all_hosts` if you want Prometheus to set the `instance` to your hostname instead of IP 
-      format: [ prometheus ]
+      format: [prometheus]
       #
       # sources: as-collected | raw | average | sum | volume
       # default is: average
@@ -290,7 +300,7 @@ scrape_configs:
     honor_labels: true
 
     static_configs:
-      - targets: [ '{your.netdata.ip}:19999' ]
+      - targets: ['{your.netdata.ip}:19999']
 ```
 
 Replace `{your.netdata.ip}` with your Netdata host's IP or hostname.


### PR DESCRIPTION
designed for optimised human and llm scanning, @Ancairon please place all exporting connectors under enable an exporting connector (makes intuitive sense and will declutter initial clickdown)
