### PR TITLE
refactor(go.d/snmp): recreate client on SNMPv3 "packet is not authentic" errors

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/collect_if_mib.go
+++ b/src/go/plugin/go.d/collector/snmp/collect_if_mib.go
@@ -20,12 +20,12 @@ const (
 )
 
 func (c *Collector) collectNetworkInterfaces(mx map[string]int64) error {
-	ifMibTable, err := c.walkAll(rootOidIfMibIfTable)
+	ifMibTable, err := walkAll(c.snmpClient, rootOidIfMibIfTable)
 	if err != nil {
 		return err
 	}
 
-	ifMibXTable, err := c.walkAll(rootOidIfMibIfXTable)
+	ifMibXTable, err := walkAll(c.snmpClient, rootOidIfMibIfXTable)
 	if err != nil {
 		return err
 	}

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"strings"
 
 	"github.com/gosnmp/gosnmp"
 
@@ -54,18 +55,15 @@ func New() *Collector {
 			},
 		},
 
-		charts: &module.Charts{},
-
-		seenMetrics: make(map[string]bool),
+		charts:            &module.Charts{},
+		seenScalarMetrics: make(map[string]bool),
+		seenTableMetrics:  make(map[string]bool),
 
 		newSnmpClient: gosnmp.NewHandler,
 
 		snmpBulkWalkOk: true,
 		netInterfaces:  make(map[string]*netInterface),
 		collectIfMib:   true,
-
-		seenScalarMetrics: make(map[string]bool),
-		seenTableMetrics:  make(map[string]bool),
 	}
 }
 
@@ -75,29 +73,26 @@ type Collector struct {
 
 	vnode *vnodes.VirtualNode
 
-	charts      *module.Charts
-	seenMetrics map[string]bool
+	charts            *module.Charts
+	seenScalarMetrics map[string]bool
+	seenTableMetrics  map[string]bool
 
 	newSnmpClient func() gosnmp.Handler
 	snmpClient    gosnmp.Handler
 	ddSnmpColl    *ddsnmpcollector.Collector
 
-	netIfaceFilterByName matcher.Matcher
-	netIfaceFilterByType matcher.Matcher
-
-	snmpBulkWalkOk bool
-	collectIfMib   bool // only for tests
-
-	netInterfaces map[string]*netInterface
-
-	sysInfo *snmputils.SysInfo
-
-	customOids []string
-
+	sysInfo      *snmputils.SysInfo
 	snmpProfiles []*ddsnmp.Profile
 
-	seenScalarMetrics map[string]bool
-	seenTableMetrics  map[string]bool
+	adjMaxRepetitions uint32
+	snmpBulkWalkOk    bool
+
+	// legacy data collection parameters
+	netIfaceFilterByName matcher.Matcher
+	netIfaceFilterByType matcher.Matcher
+	collectIfMib         bool // only for tests
+	netInterfaces        map[string]*netInterface
+	customOids           []string
 }
 
 func (c *Collector) Configuration() any {
@@ -105,21 +100,13 @@ func (c *Collector) Configuration() any {
 }
 
 func (c *Collector) Init(context.Context) error {
-	err := c.validateConfig()
-	if err != nil {
+	if err := c.validateConfig(); err != nil {
 		return fmt.Errorf("config validation failed: %v", err)
 	}
 
-	snmpClient, err := c.initSNMPClient()
-	if err != nil {
+	if _, err := c.initSNMPClient(); err != nil {
 		return fmt.Errorf("failed to initialize SNMP client: %v", err)
 	}
-
-	err = snmpClient.Connect()
-	if err != nil {
-		return fmt.Errorf("SNMP client connection failed: %v", err)
-	}
-	c.snmpClient = snmpClient
 
 	byName, byType, err := c.initNetIfaceFilters()
 	if err != nil {
@@ -140,17 +127,17 @@ func (c *Collector) Init(context.Context) error {
 }
 
 func (c *Collector) Check(context.Context) error {
+	if c.snmpClient == nil {
+		snmpClient, err := c.initAndConnectSNMPClient()
+		if err != nil {
+			return fmt.Errorf("failed to init and connect SNMP client: %v", err)
+		}
+		c.snmpClient = snmpClient
+	}
+
 	if _, err := snmputils.GetSysInfo(c.snmpClient); err != nil {
 		return err
 	}
-	ok, err := c.adjustMaxRepetitions()
-	if err != nil {
-		return err
-	}
-	if !ok {
-		c.Warningf("SNMP bulk walk disabled: table metrics collection unavailable (device may not support GETBULK or max-repetitions adjustment failed)")
-	}
-	c.snmpBulkWalkOk = ok
 
 	return nil
 }
@@ -159,10 +146,18 @@ func (c *Collector) Charts() *module.Charts {
 	return c.charts
 }
 
-func (c *Collector) Collect(context.Context) map[string]int64 {
+func (c *Collector) Collect(ctx context.Context) map[string]int64 {
 	mx, err := c.collect()
 	if err != nil {
 		c.Error(err)
+		// Some buggy SNMPv3 devices occasionally get stuck with
+		// "packet is not authentic" errors. Closing and dropping
+		// the client here forces a reconnect on the next scrape,
+		// which usually recovers the session.
+		if strings.Contains(err.Error(), "packet is not authentic") {
+			c.Cleanup(ctx)
+			c.snmpClient = nil
+		}
 	}
 
 	if len(mx) == 0 {

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -102,20 +102,6 @@ func TestCollector_Cleanup(t *testing.T) {
 	tests := map[string]struct {
 		prepareSNMP func(t *testing.T, m *snmpmock.MockHandler) *Collector
 	}{
-		"cleanup call if snmpClient initialized": {
-			prepareSNMP: func(t *testing.T, m *snmpmock.MockHandler) *Collector {
-				collr := New()
-				collr.Config = prepareV2Config()
-				collr.newSnmpClient = func() gosnmp.Handler { return m }
-				setMockClientInitExpect(m)
-
-				require.NoError(t, collr.Init(context.Background()))
-
-				m.EXPECT().Close().Times(1)
-
-				return collr
-			},
-		},
 		"cleanup call does not panic if snmpClient not initialized": {
 			prepareSNMP: func(t *testing.T, m *snmpmock.MockHandler) *Collector {
 				collr := New()
@@ -583,6 +569,7 @@ func setMockClientInitExpect(m *snmpmock.MockHandler) {
 	m.EXPECT().SetMsgFlags(gomock.Any()).AnyTimes()
 	m.EXPECT().SetSecurityParameters(gomock.Any()).AnyTimes()
 	m.EXPECT().Connect().Return(nil).AnyTimes()
+	m.EXPECT().MaxRepetitions().Return(uint32(25)).AnyTimes()
 }
 
 func setMockClientSysObjectidExpect(m *snmpmock.MockHandler) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
@@ -21,7 +21,6 @@ import (
 func New(snmpClient gosnmp.Handler, profiles []*ddsnmp.Profile, log *logger.Logger, sysobjectid string) *Collector {
 	coll := &Collector{
 		log:         log.With(slog.String("ddsnmp", "collector")),
-		snmpClient:  snmpClient,
 		profiles:    make(map[string]*profileState),
 		missingOIDs: make(map[string]bool),
 		tableCache:  newTableCache(30*time.Minute, 1),
@@ -45,7 +44,6 @@ func New(snmpClient gosnmp.Handler, profiles []*ddsnmp.Profile, log *logger.Logg
 type (
 	Collector struct {
 		log         *logger.Logger
-		snmpClient  gosnmp.Handler
 		profiles    map[string]*profileState
 		missingOIDs map[string]bool
 		tableCache  *tableCache
@@ -120,6 +118,21 @@ func (c *Collector) Collect() ([]*ddsnmp.ProfileMetrics, error) {
 	return metrics, nil
 }
 
+func (c *Collector) SetSNMPClient(snmpClient gosnmp.Handler) {
+	if c.globalTagsCollector != nil {
+		c.globalTagsCollector.snmpClient = snmpClient
+	}
+	if c.deviceMetadataCollector != nil {
+		c.deviceMetadataCollector.snmpClient = snmpClient
+	}
+	if c.scalarCollector != nil {
+		c.scalarCollector.snmpClient = snmpClient
+	}
+	if c.tableCollector != nil {
+		c.tableCollector.snmpClient = snmpClient
+	}
+}
+
 func (c *Collector) collectProfile(ps *profileState) (*ddsnmp.ProfileMetrics, error) {
 	if !ps.initialized {
 		globalTag, err := c.globalTagsCollector.Collect(ps.profile)
@@ -182,27 +195,6 @@ func (c *Collector) updateProfileMetrics(pm *ddsnmp.ProfileMetrics) {
 			m.Tags[k] = metricMetaReplacer.Replace(v)
 		}
 	}
-}
-
-func (c *Collector) snmpGet(oids []string) (map[string]gosnmp.SnmpPDU, error) {
-	pdus := make(map[string]gosnmp.SnmpPDU)
-
-	for chunk := range slices.Chunk(oids, c.snmpClient.MaxOids()) {
-		result, err := c.snmpClient.Get(chunk)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, pdu := range result.Variables {
-			if !isPduWithData(pdu) {
-				c.missingOIDs[trimOID(pdu.Name)] = true
-				continue
-			}
-			pdus[trimOID(pdu.Name)] = pdu
-		}
-	}
-
-	return pdus, nil
 }
 
 var metricMetaReplacer = strings.NewReplacer(


### PR DESCRIPTION
##### Summary

This PR improves the SNMP collector’s robustness by resetting the SNMP client when "packet is not authentic" errors are encountered.

We **cannot reproduce** this issue ourselves, but based on user logs we observed that:

- After some time, go.d/snmp begins failing with "packet is not authentic".

- Restarting Netdata clears the problem.

- We suspect this is because restarting forces the SNMP client connection to be recreated.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
