### PR TITLE
chore(go.d): add build-time configuration directory paths

### DIFF
--- a/src/go/pkg/buildinfo/buildinfo.go
+++ b/src/go/pkg/buildinfo/buildinfo.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package buildinfo
+
+// Version stores the agent's version number. It's set during the build process using build flags.
+var Version = "v0.0.0"
+
+// UserConfigDir stores the path to the user configuration directory.
+// This value is set during the build process using build flags.
+var UserConfigDir = ""
+
+// StockConfigDir stores the path to the stock (default) configuration directory.
+// This value is set during the build process using build flags.
+var StockConfigDir = ""

--- a/src/go/pkg/buildinfo/version.go
+++ b/src/go/pkg/buildinfo/version.go
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-
-package buildinfo
-
-// Version stores the agent's version number. It's set during the build process using build flags.
-var Version = "v0.0.0"

--- a/src/go/plugin/go.d/pkg/pluginconfig/pluginconfig.go
+++ b/src/go/plugin/go.d/pkg/pluginconfig/pluginconfig.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/netdata/netdata/go/plugins/pkg/buildinfo"
 	"github.com/netdata/netdata/go/plugins/pkg/executable"
 	"github.com/netdata/netdata/go/plugins/pkg/multipath"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/cli"
@@ -126,8 +127,10 @@ func (d *directories) initUserRoots(opts *cli.Option, env envData, execDir strin
 	}
 
 	// 2) NETDATA_USER_CONFIG_DIR
-	if env.userDir != "" {
-		roots = append(roots, safePathClean(env.userDir))
+	if buildinfo.UserConfigDir != "" {
+		roots = append(roots, safePathClean(buildinfo.UserConfigDir))
+	} else if dir := safePathClean(env.userDir); dir != "" {
+		roots = append(roots, dir)
 	}
 
 	if len(roots) != 0 {
@@ -157,6 +160,10 @@ func (d *directories) initUserRoots(opts *cli.Option, env envData, execDir strin
 
 // Build step 2: initialize single "stock" root: env, common locations, build-relative fallback.
 func (d *directories) initStockRoot(env envData, execDir string) {
+	if buildinfo.StockConfigDir != "" {
+		d.stockConfigDir = safePathClean(buildinfo.StockConfigDir)
+		return
+	}
 	if stock := safePathClean(env.stockDir); stock != "" {
 		d.stockConfigDir = stock
 		return


### PR DESCRIPTION
##### Summary

Adds build-time configuration for user and stock configuration directory paths that take precedence over environment variables when set.

- Added `UserConfigDir` and `StockConfigDir` variables to the `buildinfo` package
- These variables can be set during the build process using build flags (e.g., `-ldflags`)
- When set at build time, these values will be preferred over runtime environment variables

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
