### PR TITLE
chore(go.d/snmp): remove hrStorageTable from mikrotik-router.yaml

### DIFF
--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/mikrotik-router.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/mikrotik-router.yaml
@@ -220,40 +220,6 @@ metrics:
       - tag: cpu_index
         index: 1
 
-  # Storage hrStorageTable (https://www.net-snmp.org/docs/mibs/host.html#hrStorageTable)
-  - MIB: HOST-RESOURCES-MIB
-    table:
-      OID: 1.3.6.1.2.1.25.2.3
-      name: hrStorageTable
-    symbols:
-      - OID: 1.3.6.1.2.1.25.2.3.1.5
-        name: memory.total
-        chart_meta:
-          unit: "By"
-        transform: |
-          {{- transformHrStorage .Metric -}}
-      - OID: 1.3.6.1.2.1.25.2.3.1.6
-        name: memory.used
-        chart_meta:
-          unit: "By"
-        transform: |
-          {{- transformHrStorage .Metric -}}
-    metric_tags:
-      - tag: mem_index
-        index: 1
-      - tag: _mem_desc
-        symbol:
-          OID: 1.3.6.1.2.1.25.2.3.1.3
-          name: hrStorageDescr
-      - tag: rm:storage_type # Needed for transformation
-        symbol:
-          OID: 1.3.6.1.2.1.25.2.3.1.2
-          name: hrStorageType
-      - tag: rm:storage_alloc_unit # Needed for transformation
-        symbol:
-          OID: 1.3.6.1.2.1.25.2.3.1.4
-          name: hrStorageAllocationUnits
-
   # Table metrics - Extended health monitoring (multi-sensor support)
   - MIB: MIKROTIK-MIB
     table:


### PR DESCRIPTION
##### Summary

`generic-device.yaml` extends `_std-host-resources-mib.yaml` which has hrStorageTable.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
