### PR TITLE
improve(go.d/ddsnmp): add composite virtual metrics

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/virtual_metrics.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/virtual_metrics.go
@@ -21,4 +21,5 @@ func (vm VirtualMetricConfig) Clone() VirtualMetricConfig {
 type VirtualMetricSourceConfig struct {
 	Metric string `yaml:"metric"`
 	Table  string `yaml:"table"` // Required for now
+	As     string `yaml:"as"`    // dimension name for composite charts
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics.go
@@ -3,6 +3,8 @@
 package ddsnmpcollector
 
 import (
+	"slices"
+
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
@@ -18,20 +20,27 @@ func newVirtualMetricsCollector(log *logger.Logger) *vmetricsCollector {
 	}
 }
 
-// vmetricsSourceKey identifies a metric source
-type vmetricsSourceKey struct {
-	metricName string
-	tableName  string
-}
-
-// vmetricsAggregator holds accumulation state for a virtual metric
-type vmetricsAggregator struct {
-	config      ddprofiledefinition.VirtualMetricConfig
-	sum         int64
-	multiSum    map[string]int64 // For aggregating MultiValue metrics
-	sourceCount int
-	metricType  ddprofiledefinition.ProfileMetricType
-}
+type (
+	// vmetricsSourceKey identifies a metric source
+	vmetricsSourceKey struct {
+		metricName string
+		tableName  string
+	}
+	// which aggregator to feed and under which dimension name
+	vmetricsSink struct {
+		agg *vmetricsAggregator
+		dim string // empty == non-composite (single-source behavior)
+	}
+	// vmetricsAggregator holds accumulation state for a virtual metric
+	vmetricsAggregator struct {
+		config      ddprofiledefinition.VirtualMetricConfig
+		sum         int64
+		multiSum    map[string]int64 // for aggregating MultiValue metrics
+		perDim      map[string]int64 // per-source accumulation when composite
+		sourceCount int
+		metricType  ddprofiledefinition.ProfileMetricType
+	}
+)
 
 func (p *vmetricsCollector) Collect(profDef *ddprofiledefinition.ProfileDefinition, collectedMetrics []ddsnmp.Metric) []ddsnmp.Metric {
 	if len(profDef.VirtualMetrics) == 0 {
@@ -41,18 +50,42 @@ func (p *vmetricsCollector) Collect(profDef *ddprofiledefinition.ProfileDefiniti
 	sourceToAggregators, aggregators := p.buildAggregators(profDef)
 
 	for _, metric := range collectedMetrics {
-		if !metric.IsTable || metric.Table == "" {
-			continue
-		}
-
 		key := vmetricsSourceKey{
 			metricName: metric.Name,
 			tableName:  metric.Table,
 		}
 
-		// Find all aggregators that need this metric
-		if aggrs, found := sourceToAggregators[key]; found {
-			for _, agg := range aggrs {
+		sinks, found := sourceToAggregators[key]
+		if !found {
+			continue
+		}
+
+		for _, sink := range sinks {
+			if sink.agg == nil {
+				continue
+			}
+
+			agg := sink.agg
+
+			// If sink.dim != "" => composite path (this VM has multiple sources)
+			if sink.dim != "" {
+				// We need a single number per source (dimension).
+				// If the incoming base metric is MultiValue, collapse it to a total; else use Value.
+				var v int64
+				if len(metric.MultiValue) > 0 {
+					for _, mv := range metric.MultiValue {
+						v += mv
+					}
+				} else {
+					v = metric.Value
+				}
+
+				if agg.perDim == nil {
+					agg.perDim = make(map[string]int64)
+				}
+				agg.perDim[sink.dim] += v
+			} else {
+				// Non-composite (single-source) => keep existing behavior:
 				if len(metric.MultiValue) > 0 {
 					if agg.multiSum == nil {
 						agg.multiSum = make(map[string]int64)
@@ -63,10 +96,14 @@ func (p *vmetricsCollector) Collect(profDef *ddprofiledefinition.ProfileDefiniti
 				} else {
 					agg.sum += metric.Value
 				}
-				agg.sourceCount++
-				if agg.metricType == "" {
-					agg.metricType = metric.MetricType
-				}
+			}
+
+			agg.sourceCount++
+			if agg.metricType == "" {
+				agg.metricType = metric.MetricType
+			} else if agg.metricType != metric.MetricType {
+				p.log.Debugf("virtual metric %q mixes MetricType (%s vs %s); using %s",
+					agg.config.Name, agg.metricType, metric.MetricType, agg.metricType)
 			}
 		}
 	}
@@ -79,22 +116,33 @@ func (p *vmetricsCollector) Collect(profDef *ddprofiledefinition.ProfileDefiniti
 			continue
 		}
 
-		virtualMetrics = append(virtualMetrics, ddsnmp.Metric{
+		vm := ddsnmp.Metric{
 			Name:        agg.config.Name,
-			Value:       agg.sum,
-			MultiValue:  agg.multiSum,
 			Description: agg.config.ChartMeta.Description,
 			Family:      agg.config.ChartMeta.Family,
 			Unit:        agg.config.ChartMeta.Unit,
 			MetricType:  agg.metricType,
-		})
+		}
+
+		switch {
+		case len(agg.perDim) > 0:
+			// Composite output: one metric with MultiValue where keys are dimension names (sources)
+			vm.MultiValue = agg.perDim
+		case len(agg.multiSum) > 0:
+			// Single-source whose base metric was MultiValue
+			vm.MultiValue = agg.multiSum
+		default:
+			// Single-source
+			vm.Value = agg.sum
+		}
+		virtualMetrics = append(virtualMetrics, vm)
 	}
 
 	return virtualMetrics
 }
 
-func (p *vmetricsCollector) buildAggregators(profDef *ddprofiledefinition.ProfileDefinition) (map[vmetricsSourceKey][]*vmetricsAggregator, []*vmetricsAggregator) {
-	sourceToAggregators := make(map[vmetricsSourceKey][]*vmetricsAggregator)
+func (p *vmetricsCollector) buildAggregators(profDef *ddprofiledefinition.ProfileDefinition) (map[vmetricsSourceKey][]vmetricsSink, []*vmetricsAggregator) {
+	sourceToAggregators := make(map[vmetricsSourceKey][]vmetricsSink)
 	aggregators := make([]*vmetricsAggregator, 0, len(profDef.VirtualMetrics))
 
 	existingNames := p.getDefinedMetricNames(profDef.Metrics)
@@ -105,24 +153,30 @@ func (p *vmetricsCollector) buildAggregators(profDef *ddprofiledefinition.Profil
 			continue
 		}
 
-		agg := &vmetricsAggregator{
-			config: config,
-		}
+		agg := &vmetricsAggregator{config: config}
 		aggregators = append(aggregators, agg)
+
+		isComposite := len(config.Sources) > 1 &&
+			slices.ContainsFunc(config.Sources, func(s ddprofiledefinition.VirtualMetricSourceConfig) bool {
+				return s.As != ""
+			})
 
 		// Register this aggregator for each source it needs
 		for _, source := range config.Sources {
-			if source.Table == "" {
-				p.log.Warningf("virtual metric '%s' source '%s' missing table, skipping source", config.Name, source.Metric)
-				continue
-			}
-
 			key := vmetricsSourceKey{
 				metricName: source.Metric,
 				tableName:  source.Table,
 			}
 
-			sourceToAggregators[key] = append(sourceToAggregators[key], agg)
+			var dim string
+			if isComposite {
+				dim = ternary(source.As != "", source.As, source.Metric)
+			}
+
+			sourceToAggregators[key] = append(sourceToAggregators[key], vmetricsSink{
+				agg: agg,
+				dim: dim,
+			})
 		}
 	}
 


### PR DESCRIPTION
##### Summary

Adds support for composite virtual metrics: when a virtual metric has multiple sources and at least one source declares `as`, the collector emits a single metric with MultiValue where each key is the source’s dimension name. Single-source virtuals and multi-source virtuals without `as` keep the existing "sum into a single value" behavior.

Some metrics (e.g., UCD CPU breakdown) are most useful when shown on a single chart with multiple dimensions rather than separate charts or a single summed value. This change enables this without affecting existing profiles.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
