### PR TITLE
docs(go.d): add UI configuration instructions and restructure Configuration section

### DIFF
--- a/integrations/templates/setup.md
+++ b/integrations/templates/setup.md
@@ -66,7 +66,7 @@ There are no configuration options.
 The **[[ entry.meta.module_name ]]** collector can be configured directly through the Netdata web interface:
 
 1. Go to **Nodes**.
-2. Select the node **where you want the [[ entry.meta.module_name ]] data-collection job to run** and click the :gear: (**Configure this node**). This node will be responsible for collecting metrics..
+2. Select the node **where you want the [[ entry.meta.module_name ]] data-collection job to run** and click the :gear: (**Configure this node**). This node will be responsible for collecting metrics.
 3. The **Collectors → Jobs** view opens by default.
 4. In the Search box, type [[ entry.meta.module_name ]] (or scroll the list) to locate the **[[ entry.meta.module_name ]]** collector.
 5. Click the **+** next to the **[[ entry.meta.module_name ]]** collector to add a new job.

--- a/integrations/templates/setup.md
+++ b/integrations/templates/setup.md
@@ -68,7 +68,7 @@ The **[[ entry.meta.module_name ]]** collector can be configured directly throug
 1. Go to **Nodes**.
 2. Select the node **where you want the [[ entry.meta.module_name ]] data-collection job to run** and click the :gear: (**Configure this node**). This node will be responsible for collecting metrics.
 3. The **Collectors → Jobs** view opens by default.
-4. In the Search box, type [[ entry.meta.module_name ]] (or scroll the list) to locate the **[[ entry.meta.module_name ]]** collector.
+4. In the Search box, type _[[ entry.meta.module_name ]]_ (or scroll the list) to locate the **[[ entry.meta.module_name ]]** collector.
 5. Click the **+** next to the **[[ entry.meta.module_name ]]** collector to add a new job.
 6. Fill in the job fields, then **Test** the configuration and **Submit**.
 

--- a/integrations/templates/setup.md
+++ b/integrations/templates/setup.md
@@ -30,7 +30,51 @@ No action required.
 [% endif %]
 ### Configuration
 
-#### File
+#### Options
+
+[[ entry.setup.configuration.options.description ]]
+
+[% if entry.setup.configuration.options.list %]
+[% if entry.setup.configuration.options.folding.enabled and not clean %]
+{% details open=true summary="[[ entry.setup.configuration.options.folding.title ]]" %}
+[% endif %]
+| Name | Description | Default | Required |
+|:----|:-----------|:-------|:--------:|
+[% for item in entry.setup.configuration.options.list %]
+| [[ strfy(item.name) ]] | [[ strfy(item.description) ]] | [[ strfy(item.default_value) ]] | [[ strfy(item.required) ]] |
+[% endfor %]
+
+[% for item in entry.setup.configuration.options.list %]
+[% if 'detailed_description' in item %]
+##### [[ item.name ]]
+
+[[ item.detailed_description ]]
+
+[% endif %]
+[% endfor %]
+[% if entry.setup.configuration.options.folding.enabled and not clean %]
+{% /details %}
+[% endif %]
+[% elif not entry.setup.configuration.options.description %]
+There are no configuration options.
+
+[% endif %]
+
+[% if entry.meta.plugin_name == 'go.d.plugin' %]
+#### via UI
+
+The **[[ entry.meta.module_name ]]** collector can be configured directly through the Netdata web interface:
+
+1. Go to **Nodes**.
+2. Select the node **where you want the [[ entry.meta.module_name ]] data-collection job to run** and click the :gear: (**Configure this node**). This node will be responsible for collecting metrics..
+3. The **Collectors → Jobs** view opens by default.
+4. In the Search box, type [[ entry.meta.module_name ]] (or scroll the list) to locate the **[[ entry.meta.module_name ]]** collector.
+5. Click the **+** next to the **[[ entry.meta.module_name ]]** collector to add a new job.
+6. Fill in the job fields, then **Test** the configuration and **Submit**.
+
+[% endif %]
+
+#### via File
 
 [% if entry.setup.configuration.file.name %]
 The configuration file name for this integration is `[[ entry.setup.configuration.file.name ]]`.
@@ -64,40 +108,12 @@ sudo ./edit-config [[ entry.setup.configuration.file.name ]]
 [% else %]
 There is no configuration file.
 [% endif %]
-#### Options
 
-[[ entry.setup.configuration.options.description ]]
-
-[% if entry.setup.configuration.options.list %]
-[% if entry.setup.configuration.options.folding.enabled and not clean %]
-{% details open=true summary="[[ entry.setup.configuration.options.folding.title ]]" %}
-[% endif %]
-| Name | Description | Default | Required |
-|:----|:-----------|:-------|:--------:|
-[% for item in entry.setup.configuration.options.list %]
-| [[ strfy(item.name) ]] | [[ strfy(item.description) ]] | [[ strfy(item.default_value) ]] | [[ strfy(item.required) ]] |
-[% endfor %]
-
-[% for item in entry.setup.configuration.options.list %]
-[% if 'detailed_description' in item %]
-##### [[ item.name ]]
-
-[[ item.detailed_description ]]
-
-[% endif %]
-[% endfor %]
-[% if entry.setup.configuration.options.folding.enabled and not clean %]
-{% /details %}
-[% endif %]
-[% elif not entry.setup.configuration.options.description %]
-There are no configuration options.
-
-[% endif %]
-#### Examples
+##### Examples
 [% if entry.setup.configuration.examples.list %]
 
 [% for example in entry.setup.configuration.examples.list %]
-##### [[ example.name ]]
+###### [[ example.name ]]
 
 [[ example.description ]]
 


### PR DESCRIPTION


##### Summary

This PR improves the consistency and usability of collector documentation:

1. **Added a new "via UI" subsection** under **Configuration** for go.d collectors. It explains how to create and manage data-collection jobs directly from the Netdata web interface.
2. **Restructured the Configuration** section to follow a clearer sequence:
   - Options
   - via UI
   - via File
      - Examples

This makes the setup flow more logical (options first, then methods of applying them) and helps users quickly choose between UI or file-based configuration.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
