### PR TITLE
perf(go.d/ddsnmp): cache group key per aggregator per metric

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics_test.go
@@ -1273,13 +1273,10 @@ func Benchmark_CollectorAccumulate_PerRowFallback(b *testing.B) {
 				groupBy:    nil,
 				groupTable: tableName,
 				perGroup:   make(map[string]*vmetricsGroupBucket, 64),
-				dims: vmetricsDimSpec{
-					names: make([]string, c.sinks),
-					count: c.sinks,
-				},
+				dimNames:   make([]string, c.sinks),
 			}
 			for i := 0; i < c.sinks; i++ {
-				agg.dims.names[i] = "d" + strconv.Itoa(i)
+				agg.dimNames[i] = "d" + strconv.Itoa(i)
 			}
 
 			// Build lookup with N sinks pointing to the SAME aggregator.


### PR DESCRIPTION
##### Summary

This PR optimizes the grouped accumulation path by computing the group key once per (metric, aggregator) and reusing it across all sinks/dimensions for that aggregator. Functional behavior is unchanged; this is a pure performance refactor.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
