### PR TITLE
docs: improve config options table with grouped section headers

### DIFF
--- a/integrations/schemas/shared.json
+++ b/integrations/schemas/shared.json
@@ -168,7 +168,7 @@
                       },
                       "detailed_description": {
                         "type": "string",
-                        "description": "Option detailed description. Use it to describe in detail complex options."
+                        "description": "Option detailed description. Use it to describe complex options in detail."
                       },
                       "default_value": {
                         "type": [

--- a/integrations/schemas/shared.json
+++ b/integrations/schemas/shared.json
@@ -158,13 +158,17 @@
                         "type": "string",
                         "description": "Option name."
                       },
+                      "group": {
+                        "type": "string",
+                        "description": "Optional group name. Used to organize related options together in documentation tables."
+                      },
                       "description": {
                         "type": "string",
                         "description": "Option description. Must be short. Use 'detailed_description' for a long description."
                       },
                       "detailed_description": {
                         "type": "string",
-                        "description": "Option detailed description. Use it to describe in details complex options."
+                        "description": "Option detailed description. Use it to describe in detail complex options."
                       },
                       "default_value": {
                         "type": [

--- a/integrations/templates/setup.md
+++ b/integrations/templates/setup.md
@@ -21,7 +21,7 @@ You can configure the **[[ entry.meta.module_name ]]** collector in two ways:
 
 :::important
 
-UI configuration requires paid Netdata Cloud plan. File-based configuration uses the same options and is useful if you prefer configuring via file or need to automate deployments.
+UI configuration requires paid Netdata Cloud plan.
 
 :::
 

--- a/integrations/templates/setup.md
+++ b/integrations/templates/setup.md
@@ -55,11 +55,24 @@ No action required.
 [% if entry.setup.configuration.options.folding.enabled and not clean %]
 {% details open=true summary="[[ entry.setup.configuration.options.folding.title ]]" %}
 [% endif %]
-| Name | Description | Default | Required |
-|:----|:-----------|:-------|:--------:|
+
+[% set has_groups = entry.setup.configuration.options.list | selectattr("group","defined") | list | length > 0 %]
+
+[% if has_groups %]
+| Group | Option | Description | Default | Required |
+|:------|:-----|:------------|:--------|:---------:|
+[% set ns = namespace(last_group=None) %]
+[% for item in entry.setup.configuration.options.list %]
+| [[ ("**" ~ item.group ~ "**") if (item.group is defined and item.group != ns.last_group) else "" ]] | [[ strfy(item.name) ]] | [[ strfy(item.description) ]] | [[ strfy(item.default_value) ]] | [[ strfy(item.required) ]] |
+[% set ns.last_group = item.group if item.group is defined else ns.last_group %]
+[% endfor %]
+[% else %]
+| Option | Description | Default | Required |
+|:-----|:------------|:--------|:---------:|
 [% for item in entry.setup.configuration.options.list %]
 | [[ strfy(item.name) ]] | [[ strfy(item.description) ]] | [[ strfy(item.default_value) ]] | [[ strfy(item.required) ]] |
 [% endfor %]
+[% endif %]
 
 [% for item in entry.setup.configuration.options.list %]
 [% if 'detailed_description' in item %]
@@ -69,6 +82,7 @@ No action required.
 
 [% endif %]
 [% endfor %]
+
 [% if entry.setup.configuration.options.folding.enabled and not clean %]
 {% /details %}
 [% endif %]

--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -83,90 +83,34 @@ modules:
             enabled: true
           list:
             - name: update_every
+              group: Base
               description: Data collection frequency.
               default_value: 10
               required: false
             - name: autodetection_retry
+              group: Base
               description: Recheck interval in seconds. Zero means no recheck will be scheduled.
               default_value: 0
               required: false
             - name: hostname
+              group: Base
               description: Target host (IP or DNS name, IPv4/IPv6).
               default_value: ""
               required: true
-            - name: enable_profiles
-              description: Enable collection of metrics using SNMP profiles.
-              default_value: "true"
-              required: false
-            - name: enable_profiles_table_metrics
-              description: Enable collection of SNMP table metrics from profiles. Enabling this may **increase collection time and memory usage** for devices with many network interfaces.
-              default_value: "true"
-              required: false
-            - name: disable_legacy_collection
-              description: Disable the legacy SNMP collection method, forcing the collector to use only SNMP profiles (YAML-based configuration). When enabled, the collector will ignore any non-profile based collection logic.
-              default_value: "false"
-              required: false
-            - name: create_vnode
-              description: If set, the collector will create a Netdata Virtual Node for this SNMP device, which will appear as a separate Node in Netdata.
-              default_value: "true"
-              required: false
-            - name: vnode_device_down_threshold
-              description: Number of consecutive failed data collections before marking the device as down.
-              default_value: 3
-              required: false
-            - name: vnode.guid
-              description: A unique identifier for the Virtual Node. If not set, a GUID will be automatically generated from the device's IP address.
-              default_value: ""
-              required: false
-            - name: vnode.hostname
-              description: The hostname that will be used for the Virtual Node. If not set, the device's hostname will be used.
-              default_value: ""
-              required: false
-            - name: vnode.labels
-              description: Additional key-value pairs to associate with the Virtual Node.
-              default_value: ""
-              required: false
+
             - name: community
+              group: SNMPv1/2
               description: SNMPv1/2 community string.
               default_value: public
               required: false
-            - name: options.version
-              description: "SNMP version. Available versions: 1, 2, 3."
-              default_value: 2
-              required: false
-            - name: options.port
-              description: Target port.
-              default_value: 161
-              required: false
-            - name: options.retries
-              description: Retries to attempt.
-              default_value: 1
-              required: false
-            - name: options.timeout
-              description: SNMP request/response timeout.
-              default_value: 5
-              required: false
-            - name: options.max_repetitions
-              description: Controls how many SNMP variables to retrieve in a single GETBULK request.
-              default_value: 25
-              required: false
-            - name: options.max_request_size
-              description: Maximum number of OIDs allowed in a single GET request.
-              default_value: 60
-              required: false
-            - name: network_interface_filter.by_name
-              description: "Filter interfaces by their names using [simple patterns](/src/libnetdata/simple_pattern/README.md#simple-patterns)."
-              default_value: ""
-              required: false
-            - name: network_interface_filter.by_type
-              description: "Filter interfaces by their types using [simple patterns](/src/libnetdata/simple_pattern/README.md#simple-patterns)."
-              default_value: ""
-              required: false
+
             - name: user.name
+              group: SNMPv3
               description: SNMPv3 user name.
               default_value: ""
               required: false
             - name: user.level
+              group: SNMPv3
               description: Security level of SNMPv3 messages.
               default_value: ""
               required: false
@@ -179,6 +123,7 @@ modules:
                 |  authNoPriv  |     2     | message authentication and no encryption |
                 |   authPriv   |     3     | message authentication and encryption    |
             - name: user.auth_proto
+              group: SNMPv3
               description: Authentication protocol for SNMPv3 messages.
               default_value: ""
               required: false
@@ -195,10 +140,12 @@ modules:
                 |    sha384    |     6     | SHA message authentication (HMAC-SHA-384) |
                 |    sha512    |     7     | SHA message authentication (HMAC-SHA-512) |
             - name: user.auth_key
+              group: SNMPv3
               description: Authentication protocol pass phrase for SNMPv3 messages.
               default_value: ""
               required: false
             - name: user.priv_proto
+              group: SNMPv3
               description: Privacy protocol for SNMPv3 messages.
               default_value: ""
               required: false
@@ -215,7 +162,92 @@ modules:
                 |   aes192c    |     6     | 192-bit AES encryption (CFB-AES-192) with "Reeder" key localization     |
                 |   aes256c    |     7     | 256-bit AES encryption (CFB-AES-256) with "Reeder" key localization     |
             - name: user.priv_key
+              group: SNMPv3
               description: Privacy protocol pass phrase for SNMPv3 messages.
+              default_value: ""
+              required: false
+
+            - name: options.version
+              group: SNMP transport
+              description: "SNMP version. Available versions: 1, 2, 3."
+              default_value: 2
+              required: false
+            - name: options.port
+              group: SNMP transport
+              description: Target port.
+              default_value: 161
+              required: false
+            - name: options.retries
+              group: SNMP transport
+              description: Retries to attempt.
+              default_value: 1
+              required: false
+            - name: options.timeout
+              group: SNMP transport
+              description: SNMP request/response timeout.
+              default_value: 5
+              required: false
+            - name: options.max_repetitions
+              group: SNMP transport
+              description: Controls how many SNMP variables to retrieve in a single GETBULK request.
+              default_value: 25
+              required: false
+            - name: options.max_request_size
+              group: SNMP transport
+              description: Maximum number of OIDs allowed in a single GET request.
+              default_value: 60
+              required: false
+
+            - name: enable_profiles
+              group: Profiles
+              description: Enable collection of metrics using SNMP profiles.
+              default_value: "true"
+              required: false
+            - name: enable_profiles_table_metrics
+              group: Profiles
+              description: Enable collection of SNMP table metrics from profiles. Enabling this may **increase collection time and memory usage** for devices with many network interfaces.
+              default_value: "true"
+              required: false
+            - name: disable_legacy_collection
+              group: Profiles
+              description: Disable the legacy SNMP collection method, forcing the collector to use only SNMP profiles (YAML-based configuration). When enabled, the collector will ignore any non-profile based collection logic.
+              default_value: "false"
+              required: false
+
+            - name: create_vnode
+              group: Virtual node
+              description: If set, the collector will create a Netdata Virtual Node for this SNMP device, which will appear as a separate Node in Netdata.
+              default_value: "true"
+              required: false
+            - name: vnode_device_down_threshold
+              group: Virtual node
+              description: Number of consecutive failed data collections before marking the device as down.
+              default_value: 3
+              required: false
+            - name: vnode.guid
+              group: Virtual node
+              description: A unique identifier for the Virtual Node. If not set, a GUID will be automatically generated from the device's IP address.
+              default_value: ""
+              required: false
+            - name: vnode.hostname
+              group: Virtual node
+              description: The hostname that will be used for the Virtual Node. If not set, the device's hostname will be used.
+              default_value: ""
+              required: false
+            - name: vnode.labels
+              group: Virtual node
+              description: Additional key-value pairs to associate with the Virtual Node.
+              default_value: ""
+              required: false
+
+            - name: network_interface_filter.by_name
+              group: Filters
+              description: "Filter interfaces by their names using [simple patterns](/src/libnetdata/simple_pattern/README.md#simple-patterns)."
+              default_value: ""
+              required: false
+            - name: network_interface_filter.by_type
+              group: Filters
+              description: "Filter interfaces by their types using [simple patterns](/src/libnetdata/simple_pattern/README.md#simple-patterns)."
               default_value: ""
               required: false
         examples:


### PR DESCRIPTION
##### Summary

This PR improves the presentation of configuration options in collector documentation by introducing grouping:

- Adds a new `group` field for options in `metadata.yaml`.
- Updates the Jinja template to render a single table with a "Group" column when at least one option has a group.
   - If no options define a group, the table remains unchanged (no extra column).
   - The **first option in each group shows the group name in bold**.
   - Subsequent options in the same group leave the group column blank.
- **Ordering of groups is defined by the order of options in** `metadata.yaml`, giving full control to the integration author.
- Ensures tables remain compact and consistent in width while making groups visually distinct.

As a proof of concept, the SNMP collector options have been updated with groups (`Base`, `SNMPv1/2`, `SNMPv3`, `SNMP transport`, `Profiles`, etc.).

This improves clarity for users navigating complex integrations with many related options.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
