### PR TITLE
chore(go.d): skip HOST for vnodes during Cleanup with stale label

### DIFF
--- a/src/go/plugin/go.d/agent/module/job.go
+++ b/src/go/plugin/go.d/agent/module/job.go
@@ -312,9 +312,26 @@ func (j *Job) Cleanup() {
 		return
 	}
 
-	if !j.vnodeCreated && j.vnode.GUID != "" {
-		j.sendVnodeHostInfo()
-		j.vnodeCreated = true
+	// Netdata automatically obsoletes vnode charts when no updates are sent.
+	// For virtual nodes with a stale label, we must not send anything:
+	//   - Sending a HOST line would incorrectly mark the vnode as active.
+	isVnodeWithStaleConfig := j.vnode.Labels["_node_stale_after_seconds"] != ""
+
+	if !isVnodeWithStaleConfig {
+		if !j.vnodeCreated && j.vnode.GUID != "" {
+			j.sendVnodeHostInfo()
+			j.vnodeCreated = true
+		}
+		j.api.HOST(j.vnode.GUID)
+
+		if j.charts != nil {
+			for _, chart := range *j.charts {
+				if chart.created {
+					chart.MarkRemove()
+					j.createChart(chart)
+				}
+			}
+		}
 	}
 
 	j.api.HOST("")
@@ -326,17 +343,6 @@ func (j *Job) Cleanup() {
 	if j.collectDurationChart.created {
 		j.collectDurationChart.MarkRemove()
 		j.createChart(j.collectDurationChart)
-	}
-
-	j.api.HOST(j.vnode.GUID)
-
-	if j.charts != nil {
-		for _, chart := range *j.charts {
-			if chart.created {
-				chart.MarkRemove()
-				j.createChart(chart)
-			}
-		}
 	}
 
 	if j.buf.Len() > 0 {


### PR DESCRIPTION
##### Summary

This change updates Job.Cleanup() to avoid sending a HOST line for virtual nodes that have a stale configuration label (_node_stale_after_seconds). Previously, cleanup always emitted HOST <guid>, which incorrectly kept vnodes marked as "active".

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
