### PR TITLE
improve(go.d/ddsnmp): add alternatives support for virtual metrics

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/virtual_metrics.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/virtual_metrics.go
@@ -5,25 +5,39 @@ import (
 )
 
 type VirtualMetricConfig struct {
-	Name      string                      `yaml:"name"`
-	PerRow    bool                        `yaml:"per_row"`
-	GroupBy   []string                    `yaml:"group_by"`
-	Sources   []VirtualMetricSourceConfig `yaml:"sources"`
-	ChartMeta ChartMeta                   `yaml:"chart_meta"`
+	Name         string                                  `yaml:"name"`
+	PerRow       bool                                    `yaml:"per_row"`
+	GroupBy      []string                                `yaml:"group_by"`
+	Sources      []VirtualMetricSourceConfig             `yaml:"sources"`
+	Alternatives []VirtualMetricAlternativeSourcesConfig `yaml:"alternatives"`
+	ChartMeta    ChartMeta                               `yaml:"chart_meta"`
 }
 
 func (vm VirtualMetricConfig) Clone() VirtualMetricConfig {
+	alts := make([]VirtualMetricAlternativeSourcesConfig, len(vm.Alternatives))
+	for i, alt := range vm.Alternatives {
+		alts[i] = VirtualMetricAlternativeSourcesConfig{
+			Sources: slices.Clone(alt.Sources),
+		}
+	}
+
 	return VirtualMetricConfig{
-		Name:      vm.Name,
-		PerRow:    vm.PerRow,
-		GroupBy:   slices.Clone(vm.GroupBy),
-		Sources:   slices.Clone(vm.Sources),
-		ChartMeta: vm.ChartMeta,
+		Name:         vm.Name,
+		PerRow:       vm.PerRow,
+		GroupBy:      slices.Clone(vm.GroupBy),
+		Sources:      slices.Clone(vm.Sources),
+		Alternatives: alts,
+		ChartMeta:    vm.ChartMeta,
 	}
 }
 
-type VirtualMetricSourceConfig struct {
-	Metric string `yaml:"metric"`
-	Table  string `yaml:"table"` // Required for now
-	As     string `yaml:"as"`    // dimension name for composite charts
-}
+type (
+	VirtualMetricSourceConfig struct {
+		Metric string `yaml:"metric"`
+		Table  string `yaml:"table"` // Required for now
+		As     string `yaml:"as"`    // dimension name for composite charts
+	}
+	VirtualMetricAlternativeSourcesConfig struct {
+		Sources []VirtualMetricSourceConfig `yaml:"sources"`
+	}
+)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics.go
@@ -231,14 +231,6 @@ func (agg *vmetricsAggregator) emitInto(out *[]ddsnmp.Metric) {
 	agg.emitIntoAs(out, agg.config.Name, agg.config.ChartMeta)
 }
 
-func (agg *vmetricsAggregator) emitGrouped(out *[]ddsnmp.Metric) {
-	agg.emitGroupedAs(out, agg.config.Name, agg.config.ChartMeta)
-}
-
-func (agg *vmetricsAggregator) emitTotal(out *[]ddsnmp.Metric) {
-	agg.emitTotalAs(out, agg.config.Name, agg.config.ChartMeta)
-}
-
 func (agg *vmetricsAggregator) emitIntoAs(out *[]ddsnmp.Metric, name string, meta ddprofiledefinition.ChartMeta) {
 	if agg.grouped {
 		agg.emitGroupedAs(out, name, meta)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics.go
@@ -82,6 +82,20 @@ func (p *vmetricsCollector) emit(aggrs []*vmetricsAggregator) []ddsnmp.Metric {
 	// small pre-alloc: 1 total or ~groups count; start conservative
 	out := make([]ddsnmp.Metric, 0, len(aggrs))
 	for _, agg := range aggrs {
+		// --- Alternatives parent: choose first child with data ---
+		if len(agg.alts) > 0 {
+			i := slices.IndexFunc(agg.alts, func(alt *vmetricsAggregator) bool { return alt.hadData })
+			if i == -1 {
+				p.log.Debugf("no alternative had data for virtual metric '%s'", agg.config.Name)
+				continue
+			}
+			winner := agg.alts[i]
+			// Emit using the parent's name/meta, but the child's accumulated values.
+			winner.emitIntoAs(&out, agg.config.Name, agg.config.ChartMeta)
+			continue
+		}
+
+		// --- Plain VM
 		if !agg.hadData {
 			p.log.Debugf("no source metrics found for virtual metric '%s'", agg.config.Name)
 			continue
@@ -94,26 +108,58 @@ func (p *vmetricsCollector) emit(aggrs []*vmetricsAggregator) []ddsnmp.Metric {
 type (
 	// vmetricsAggregator holds accumulation state for a virtual metric
 	vmetricsAggregator struct {
-		config     ddprofiledefinition.VirtualMetricConfig
+		// alts is non-empty only for an "alternatives parent" aggregator.
+		// Children are plain aggregators (alts == nil) that actually receive samples.
+		// At emit time, the parent picks the first child with hadData and emits that
+		// child's accumulated values under the parent's (name, chart meta).
+		alts []*vmetricsAggregator
+
+		config ddprofiledefinition.VirtualMetricConfig
+		// metricType is inferred from the first seen source sample for this aggregator.
+		// If sources disagree, the first one wins (caller may log/debug mismatches).
 		metricType ddprofiledefinition.ProfileMetricType
 
 		// --- grouping controls ---
-		grouped    bool     // len(GroupBy) > 0
-		perRow     bool     // from cfg.PerRow
-		groupBy    []string // when perRow==true, groupBy are used as row-key hints
-		groupTable string   // sources must share the same table
-		perGroup   map[string]*vmetricsGroupBucket
+		// grouped is true when PerRow is set OR len(GroupBy) > 0.
+		// Grouped aggregators produce table rows keyed by vmBuildGroupKey(...).
+		grouped bool
+		// perRow mirrors cfg.PerRow. When true, each unique tag-set becomes a row key.
+		// groupBy acts as ordered hints for building the key; if any hint is missing,
+		// we fall back to a stable key built from all tags (sorted "k=v").
+		perRow bool
+		// groupBy mirrors cfg.GroupBy. When perRow==false and groupBy!=nil, all listed
+		// labels must be present to form the row key; otherwise the sample is skipped.
+		groupBy []string
+		// groupTable is the SNMP table name all sources must share for grouped VMs.
+		// This constraint is enforced per-aggregator; for alternatives, it is enforced
+		// independently for each child. (No cross-table joins.)
+		groupTable string
+		// perGroup accumulates rows by group key.
+		perGroup map[string]*vmetricsGroupBucket
 
 		// --- dimensions (composite) ---
+		// dimNames defines the stable order of composite dimensions. It is built from
+		// the 'as' names (or metric names when 'as' is empty) in first-seen order.
+		// sink.dimIdx indexes into this slice.
 		dimNames []string
 
-		// --- non-grouped accumulators (existing behavior) ---
-		perDim   map[string]int64 // composite total (dim -> sum)
-		sum      int64            // single-source total
-		multiSum map[string]int64 // merged base MultiValue
+		// --- non-grouped accumulators ---
+		// perDim accumulates totals for composite (multi-source) non-grouped VMs:
+		//   dim name -> sum of values assigned to that dim.
+		perDim map[string]int64
+		// sum accumulates totals for single-source non-grouped VMs (no MultiValue).
+		sum int64
+		// multiSum merges MultiValue maps for single-source non-grouped VMs that
+		// provide MultiValue; keys are preserved and values are summed per key.
+		multiSum map[string]int64
 
+		// hadData is set to true once at least one sample was accumulated into this
+		// aggregator (for grouped or non-grouped). Parents look at children.hadData
+		// to decide which alternative to emit.
 		hadData bool
-		keyBuf  strings.Builder
+
+		// keyBuf is a reusable scratch buffer for building group keys. Not goroutine-safe.
+		keyBuf strings.Builder
 	}
 
 	// vmetricsSourceKey identifies a metric source
@@ -182,24 +228,36 @@ func (agg *vmetricsAggregator) accumulateGroupedWithKey(sink vmetricsSink, gkey 
 }
 
 func (agg *vmetricsAggregator) emitInto(out *[]ddsnmp.Metric) {
-	if agg.grouped {
-		agg.emitGrouped(out)
-	} else {
-		agg.emitTotal(out)
-	}
+	agg.emitIntoAs(out, agg.config.Name, agg.config.ChartMeta)
 }
 
 func (agg *vmetricsAggregator) emitGrouped(out *[]ddsnmp.Metric) {
+	agg.emitGroupedAs(out, agg.config.Name, agg.config.ChartMeta)
+}
+
+func (agg *vmetricsAggregator) emitTotal(out *[]ddsnmp.Metric) {
+	agg.emitTotalAs(out, agg.config.Name, agg.config.ChartMeta)
+}
+
+func (agg *vmetricsAggregator) emitIntoAs(out *[]ddsnmp.Metric, name string, meta ddprofiledefinition.ChartMeta) {
+	if agg.grouped {
+		agg.emitGroupedAs(out, name, meta)
+	} else {
+		agg.emitTotalAs(out, name, meta)
+	}
+}
+
+func (agg *vmetricsAggregator) emitGroupedAs(out *[]ddsnmp.Metric, name string, meta ddprofiledefinition.ChartMeta) {
 	for _, b := range agg.perGroup {
 		vm := ddsnmp.Metric{
-			Name:        agg.config.Name,
-			Description: agg.config.ChartMeta.Description,
-			Family:      agg.config.ChartMeta.Family,
-			Unit:        agg.config.ChartMeta.Unit,
-			ChartType:   agg.config.ChartMeta.Type,
+			Name:        name,
+			Description: meta.Description,
+			Family:      meta.Family,
+			Unit:        meta.Unit,
+			ChartType:   meta.Type,
 			MetricType:  agg.metricType,
 			IsTable:     true,
-			Table:       agg.groupTable,
+			Table:       agg.groupTable, // winner's table (e.g., ifXTable or ifTable)
 			Tags:        b.emitTags,
 		}
 		if len(agg.dimNames) > 0 {
@@ -217,13 +275,13 @@ func (agg *vmetricsAggregator) emitGrouped(out *[]ddsnmp.Metric) {
 	}
 }
 
-func (agg *vmetricsAggregator) emitTotal(out *[]ddsnmp.Metric) {
+func (agg *vmetricsAggregator) emitTotalAs(out *[]ddsnmp.Metric, name string, meta ddprofiledefinition.ChartMeta) {
 	vm := ddsnmp.Metric{
-		Name:        agg.config.Name,
-		Description: agg.config.ChartMeta.Description,
-		Family:      agg.config.ChartMeta.Family,
-		Unit:        agg.config.ChartMeta.Unit,
-		ChartType:   agg.config.ChartMeta.Type,
+		Name:        name,
+		Description: meta.Description,
+		Family:      meta.Family,
+		Unit:        meta.Unit,
+		ChartType:   meta.Type,
 		MetricType:  agg.metricType,
 	}
 	switch {
@@ -238,86 +296,9 @@ func (agg *vmetricsAggregator) emitTotal(out *[]ddsnmp.Metric) {
 }
 
 func (p *vmetricsCollector) buildAggregators(profDef *ddprofiledefinition.ProfileDefinition) (map[vmetricsSourceKey][]vmetricsSink, []*vmetricsAggregator) {
-	sourceToSinks := make(map[vmetricsSourceKey][]vmetricsSink)
-	aggregators := make([]*vmetricsAggregator, 0, len(profDef.VirtualMetrics))
-
 	existingNames := p.getDefinedMetricNames(profDef.Metrics)
-
-	for _, cfg := range profDef.VirtualMetrics {
-		if existingNames[cfg.Name] {
-			p.log.Warningf("virtual metric '%s' conflicts with existing metric, skipping", cfg.Name)
-			continue
-		}
-
-		agg := &vmetricsAggregator{config: cfg}
-
-		agg.grouped = cfg.PerRow || len(cfg.GroupBy) > 0
-
-		if agg.grouped {
-			// require all sources from the same table
-			var table string
-			same := true
-			for i, s := range cfg.Sources {
-				if i == 0 {
-					table = s.Table
-				} else if s.Table != table {
-					same = false
-					break
-				}
-			}
-			if !same || table == "" {
-				p.log.Warningf("virtual metric '%s' uses group_by but sources span tables or have no table; skipping (no joins yet)", cfg.Name)
-				continue
-			}
-
-			agg.perRow = cfg.PerRow
-			agg.groupBy = cfg.GroupBy
-			agg.groupTable = table
-			agg.perGroup = make(map[string]*vmetricsGroupBucket, 64)
-		}
-
-		// --- composite dims? (multiple sources and at least one 'as') ---
-		isComposite := len(cfg.Sources) > 1 &&
-			slices.ContainsFunc(cfg.Sources, func(s ddprofiledefinition.VirtualMetricSourceConfig) bool {
-				return s.As != ""
-			})
-
-		var dimsIdxByName map[string]int
-
-		if isComposite {
-			dimsIdxByName = make(map[string]int, len(cfg.Sources))
-			agg.dimNames = make([]string, 0, len(cfg.Sources))
-			for _, s := range cfg.Sources {
-				name := ternary(s.As != "", s.As, s.Metric)
-				if _, dup := dimsIdxByName[name]; !dup {
-					dimsIdxByName[name] = len(agg.dimNames)
-					agg.dimNames = append(agg.dimNames, name)
-				}
-			}
-		}
-
-		// register sinks
-		for _, src := range cfg.Sources {
-			key := vmetricsSourceKey{metricName: src.Metric, tableName: src.Table}
-
-			dimIdx := int16(-1)
-			if isComposite {
-				name := ternary(src.As != "", src.As, src.Metric)
-				if idx, ok := dimsIdxByName[name]; ok {
-					dimIdx = int16(idx)
-				}
-			}
-
-			sourceToSinks[key] = append(sourceToSinks[key], vmetricsSink{
-				agg:    agg,
-				dimIdx: dimIdx,
-			})
-		}
-
-		aggregators = append(aggregators, agg)
-	}
-
-	return sourceToSinks, aggregators
+	builder := newAggregatorsBuilder(p.log, profDef, existingNames)
+	return builder.build()
 }
 
 func (p *vmetricsCollector) getDefinedMetricNames(profMetrics []ddprofiledefinition.MetricsConfig) map[string]bool {
@@ -434,4 +415,169 @@ func vmCollapseMetricValue(m ddsnmp.Metric) (v int64, mv map[string]int64) {
 		sum += x
 	}
 	return sum, m.MultiValue
+}
+
+type aggregatorsBuilder struct {
+	log           *logger.Logger
+	prof          *ddprofiledefinition.ProfileDefinition
+	existingNames map[string]bool
+
+	sourceToSinks map[vmetricsSourceKey][]vmetricsSink
+	aggregators   []*vmetricsAggregator
+}
+
+func newAggregatorsBuilder(
+	log *logger.Logger, prof *ddprofiledefinition.ProfileDefinition, existingNames map[string]bool) *aggregatorsBuilder {
+	return &aggregatorsBuilder{
+		log:           log,
+		prof:          prof,
+		existingNames: existingNames,
+		sourceToSinks: make(map[vmetricsSourceKey][]vmetricsSink),
+		aggregators:   make([]*vmetricsAggregator, 0, len(prof.VirtualMetrics)),
+	}
+}
+
+func (b *aggregatorsBuilder) build() (map[vmetricsSourceKey][]vmetricsSink, []*vmetricsAggregator) {
+	for _, cfg := range b.prof.VirtualMetrics {
+		b.buildOne(cfg)
+	}
+	return b.sourceToSinks, b.aggregators
+}
+
+func (b *aggregatorsBuilder) buildOne(cfg ddprofiledefinition.VirtualMetricConfig) {
+	if b.existingNames[cfg.Name] {
+		b.log.Warningf("virtual metric '%s' conflicts with existing metric, skipping", cfg.Name)
+		return
+	}
+	if len(cfg.Sources) == 0 && len(cfg.Alternatives) == 0 {
+		b.log.Warningf("virtual metric '%s' has no sources or alternatives; skipping", cfg.Name)
+		return
+	}
+	if len(cfg.Sources) > 0 && len(cfg.Alternatives) > 0 {
+		b.log.Warningf("virtual metric '%s' defines both 'sources' and 'alternatives'; using 'alternatives' only", cfg.Name)
+	}
+	if len(cfg.Alternatives) == 0 {
+		b.buildPlain(cfg)
+	} else {
+		b.buildWithAlternatives(cfg)
+	}
+}
+
+func (b *aggregatorsBuilder) buildPlain(cfg ddprofiledefinition.VirtualMetricConfig) {
+	agg, isComposite, dimIdxByName, ok := b.prepareAggregator(cfg, cfg.Sources)
+	if !ok {
+		return
+	}
+	b.bindSinks(agg, cfg.Sources, dimIdxByName, isComposite)
+	b.aggregators = append(b.aggregators, agg)
+}
+
+func (b *aggregatorsBuilder) buildWithAlternatives(cfg ddprofiledefinition.VirtualMetricConfig) {
+	parent := &vmetricsAggregator{config: cfg}
+
+	for _, alt := range cfg.Alternatives {
+		childCfg := cfg.Clone()
+		childCfg.Sources = slices.Clone(alt.Sources)
+		childCfg.Alternatives = nil
+
+		child, isComposite, dimIdxByName, ok := b.prepareAggregator(childCfg, childCfg.Sources)
+		if !ok {
+			continue
+		}
+		b.bindSinks(child, childCfg.Sources, dimIdxByName, isComposite)
+		parent.alts = append(parent.alts, child)
+	}
+
+	if len(parent.alts) == 0 {
+		b.log.Warningf("virtual metric '%s' has no valid alternatives; skipping", cfg.Name)
+		return
+	}
+	b.aggregators = append(b.aggregators, parent)
+}
+
+func (b *aggregatorsBuilder) sameTableOrEmpty(sources []ddprofiledefinition.VirtualMetricSourceConfig) (table string, ok bool) {
+	for i, s := range sources {
+		if i == 0 {
+			table = s.Table
+			continue
+		}
+		if s.Table != table {
+			return "", false
+		}
+	}
+	return table, table != ""
+}
+
+func (b *aggregatorsBuilder) computeDimIndexMap(sources []ddprofiledefinition.VirtualMetricSourceConfig) (isComposite bool, dimIdxByName map[string]int, dimNames []string) {
+	if len(sources) > 1 {
+		for _, s := range sources {
+			if s.As != "" {
+				isComposite = true
+				break
+			}
+		}
+	}
+	if !isComposite {
+		return
+	}
+	dimIdxByName = make(map[string]int, len(sources))
+	dimNames = make([]string, 0, len(sources))
+	for _, s := range sources {
+		name := s.As
+		if name == "" {
+			name = s.Metric
+		}
+		if _, exists := dimIdxByName[name]; !exists {
+			dimIdxByName[name] = len(dimNames)
+			dimNames = append(dimNames, name)
+		}
+	}
+	return
+}
+
+func (b *aggregatorsBuilder) prepareAggregator(
+	cfg ddprofiledefinition.VirtualMetricConfig,
+	sources []ddprofiledefinition.VirtualMetricSourceConfig,
+) (agg *vmetricsAggregator, isComposite bool, dimIdxByName map[string]int, ok bool) {
+	agg = &vmetricsAggregator{config: cfg}
+
+	agg.grouped = cfg.PerRow || len(cfg.GroupBy) > 0
+	if agg.grouped {
+		table, same := b.sameTableOrEmpty(sources)
+		if !same {
+			b.log.Warningf("virtual metric '%s' uses group_by/per_row but sources span tables or have no table; skipping (no joins yet)", cfg.Name)
+			return nil, false, nil, false
+		}
+		agg.perRow = cfg.PerRow
+		agg.groupBy = cfg.GroupBy
+		agg.groupTable = table
+		agg.perGroup = make(map[string]*vmetricsGroupBucket, 64)
+	}
+
+	isComposite, dimIdxByName, dimNames := b.computeDimIndexMap(sources)
+	if isComposite {
+		agg.dimNames = dimNames
+	}
+	return agg, isComposite, dimIdxByName, true
+}
+
+func (b *aggregatorsBuilder) bindSinks(
+	agg *vmetricsAggregator,
+	sources []ddprofiledefinition.VirtualMetricSourceConfig,
+	dimIdxByName map[string]int, isComposite bool,
+) {
+	for _, src := range sources {
+		key := vmetricsSourceKey{metricName: src.Metric, tableName: src.Table}
+		dimIdx := int16(-1)
+		if isComposite {
+			name := src.As
+			if name == "" {
+				name = src.Metric
+			}
+			if idx, ok := dimIdxByName[name]; ok {
+				dimIdx = int16(idx)
+			}
+		}
+		b.sourceToSinks[key] = append(b.sourceToSinks[key], vmetricsSink{agg: agg, dimIdx: dimIdx})
+	}
 }


### PR DESCRIPTION
##### Summary

This PR extends the virtual metrics system with support for **alternatives**.  
Many SNMP devices expose both 64-bit counters in `ifXTable` and 32-bit counters in `ifTable`.  
Until now, profiles could only declare a single source set, which meant that ifXTable-based virtual metrics would fail on devices that only had ifTable.

- New `alternatives` field in `VirtualMetricConfig`.
  - Each alternative is defined as a list of sources.
  - At runtime, the collector picks the **first alternative whose sources produced data**.
  - All subsequent alternatives are ignored once a winner is found.
- Parent aggregator emits metrics using its configured name and chart meta,
  while sourcing values from the selected child aggregator.
- Grouped/per_row rules (same-table enforcement, group key construction) apply
  independently per alternative.
- If both `sources` and `alternatives` are defined, `alternatives` take precedence.

**Example usage**:

```yaml
virtual_metrics:
  - name: ifTotalTrafficIn
    alternatives:
      - sources:
          - metric: ifHCInOctets
            table: ifXTable   # preferred 64-bit
      - sources:
          - metric: ifInOctets
            table: ifTable    # fallback 32-bit
    chart_meta:
      description: Total inbound traffic across all interfaces
      family: 'Network/Total/Traffic/In'
      unit: "bit/s"
```


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
