### PR TITLE
Fix MDX parsing errors in realtime-monitoring.md

### DIFF
--- a/docs/realtime-monitoring.md
+++ b/docs/realtime-monitoring.md
@@ -238,8 +238,8 @@ We believe real-time monitoring is a right, not a premium feature. Our principle
 
 -   **Granularity:** 1-second for all metrics, without exception.
 -   **Volume:** 3,000-20,000+ metrics collected per second per node.
--   **CPU Overhead:** <5% of a single core, typical for 3,000 metrics/s.
--   **RAM Footprint:** <200 MB, typical for 3,000 metrics/s.
+-   **CPU Overhead:** Less than 5% of a single core, typical for 3,000 metrics/s.
+-   **RAM Footprint:** Less than 200 MB, typical for 3,000 metrics/s.
 -   **Fault Tolerance:** Zero data loss during network issues (local buffering + replay).
 -   **Storage Efficiency:** ~0.6 bytes per sample on disk, enabling years of retention for gigabytes, not terabytes.
 


### PR DESCRIPTION
## Summary
- Fixed MDX compilation errors that were preventing the Learn documentation from building
- Replaced '<5%' with 'Less than 5%' and '<200' with 'Less than 200'

## Problem
The MDX parser was interpreting '<5' and '<200' as the start of JSX elements, causing compilation to fail with:
```
Error: MDX compilation failed for file "/docs/welcome-to-netdata/real-time-monitoring.mdx"
Cause: Unexpected character `5` (U+0035) before name, expected a character that can start a name
```

## Solution
Changed the text to use 'Less than' instead of the '<' symbol to avoid MDX parsing issues.

## Test Plan
- [x] Tested locally with `yarn build` in the Learn repository
- [ ] Verify Learn documentation builds successfully in CI