### PR TITLE
docs: Rename 'Top Monitoring' to 'Top Consumers' in Functions documentation

### DIFF
--- a/docs/top-monitoring-netdata-functions.md
+++ b/docs/top-monitoring-netdata-functions.md
@@ -1,4 +1,4 @@
-# Top Monitoring (Netdata Functions)
+# Top Consumers (Functions)
 
 Netdata Agent collectors provide on-demand, runtime executable functions on the host where they are deployed. Available since v1.37.1.
 


### PR DESCRIPTION
## Summary
- Rename the Functions documentation title from 'Top Monitoring (Functions)' to 'Top Consumers (Functions)'
- Ensures consistency with the ToC structure defined in map.csv

## Changes
- Updated title in 
- No changes needed to map.csv as it already uses 'Top Consumers (Functions)'
- The Processes function page is correctly nested under this parent in the ToC

## Test Plan
- [x] Document title matches the sidebar label in map.csv
- [x] Processes function correctly nested under Top Consumers (Functions) in ToC
- [x] No broken links or references

🤖 Generated with [Claude Code](https://claude.ai/code)