### PR TITLE
docs: Remove parentheses from Top Consumers title to fix URL issues

### DIFF
--- a/docs/.map/map.csv
+++ b/docs/.map/map.csv
@@ -146,8 +146,8 @@ https://github.com/netdata/netdata/edit/master/docs/observability-centralization
 https://github.com/netdata/netdata/edit/master/src/collectors/systemd-journal.plugin/active_journal_centralization_guide_no_encryption.md,Active journal source without encryption,Published,Logs/Logs Centralization Points with systemd-journald,
 ,,,,
 ,,,,
-https://github.com/netdata/netdata/edit/master/docs/top-monitoring-netdata-functions.md,Top Consumers (Functions),Published,root,Present the Netdata Functions what these are and why they should be used.
-https://github.com/netdata/netdata/edit/master/docs/functions/processes.md,Processes,Published,Top Consumers (Functions),
+https://github.com/netdata/netdata/edit/master/docs/top-monitoring-netdata-functions.md,Top Consumers,Published,root,Present the Netdata Functions what these are and why they should be used.
+https://github.com/netdata/netdata/edit/master/docs/functions/processes.md,Processes,Published,Top Consumers,
 ,,,,
 https://github.com/netdata/netdata/edit/master/src/health/README.md,Alerts & Notifications,Published,Alerts & Notifications,
 https://github.com/netdata/netdata/edit/master/docs/alerts-and-notifications/creating-alerts-with-netdata-alerts-configuration-manager.md,Creating Alerts with the Alerts Configuration Manager,Published,Alerts & Notifications,

--- a/docs/top-monitoring-netdata-functions.md
+++ b/docs/top-monitoring-netdata-functions.md
@@ -1,4 +1,4 @@
-# Top Consumers (Functions)
+# Top Consumers
 
 Netdata Agent collectors provide on-demand, runtime executable functions on the host where they are deployed. Available since v1.37.1.
 


### PR DESCRIPTION
## Summary
- Rename 'Top Consumers (Functions)' to 'Top Consumers' in documentation
- Fixes URL generation issues where parentheses were appearing in child page URLs

## Problem
The Docusaurus build system was generating problematic URLs:
- Parent page: `/docs/top-consumers-functions` (correct)
- Child page: `/docs/top-consumers-(functions)/processes` (incorrect, with parentheses)

This caused navigation and routing issues as parentheses in URLs need special handling.

## Solution
Remove parentheses from the title while keeping the meaning clear. The document still clearly describes Netdata Functions functionality.

## Changes
- Updated title in `docs/top-monitoring-netdata-functions.md`
- Updated sidebar labels in `docs/.map/map.csv`

## Test Plan
- [x] Document title updated
- [x] Map.csv entries updated
- [x] Processes function correctly nested under Top Consumers in ToC

🤖 Generated with [Claude Code](https://claude.ai/code)