### PR TITLE
Fix duplicate ToC entries for Top Consumers

### DIFF
--- a/docs/.map/map.csv
+++ b/docs/.map/map.csv
@@ -146,7 +146,7 @@ https://github.com/netdata/netdata/edit/master/docs/observability-centralization
 https://github.com/netdata/netdata/edit/master/src/collectors/systemd-journal.plugin/active_journal_centralization_guide_no_encryption.md,Active journal source without encryption,Published,Logs/Logs Centralization Points with systemd-journald,
 ,,,,
 ,,,,
-https://github.com/netdata/netdata/edit/master/docs/top-monitoring-netdata-functions.md,Top Consumers,Published,root,Present the Netdata Functions what these are and why they should be used.
+https://github.com/netdata/netdata/edit/master/docs/top-monitoring-netdata-functions.md,Top Consumers,Published,Top Consumers,Present the Netdata Functions what these are and why they should be used.
 https://github.com/netdata/netdata/edit/master/docs/functions/processes.md,Processes,Published,Top Consumers,
 ,,,,
 https://github.com/netdata/netdata/edit/master/src/health/README.md,Alerts & Notifications,Published,Alerts & Notifications,


### PR DESCRIPTION
## Summary
- Fix duplicate 'Top Consumers' and 'top-consumers' entries in the documentation ToC
- Change learn_rel_path from 'root' to 'Top Consumers' (self-referential) following the same pattern as 'AI & ML' category

## Problem
The documentation was showing two entries:
- 'Top Consumers' at the root level
- 'top-consumers' auto-generated from the folder structure

## Solution
Updated map.csv to use the self-referential pattern where a category has its learn_rel_path set to itself, preventing Docusaurus from creating duplicate entries.

This follows the established pattern used by other categories like 'AI & ML'.