### PR TITLE
improve(go.d/snmp): add `manual_profiles` option

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -168,7 +168,7 @@ func (c *Collector) setupVnode(si *snmputils.SysInfo, deviceMeta map[string]ddsn
 }
 
 func (c *Collector) setupProfiles(sysObjectID string) []*ddsnmp.Profile {
-	snmpProfiles := ddsnmp.FindProfiles(sysObjectID)
+	snmpProfiles := ddsnmp.FindProfiles(sysObjectID, c.ManualProfiles)
 	var profInfo []string
 
 	for _, prof := range snmpProfiles {
@@ -180,7 +180,7 @@ func (c *Collector) setupProfiles(sysObjectID string) []*ddsnmp.Profile {
 		}
 	}
 
-	c.Infof("device matched %d profile(s): %s (sysObjectID: %s)", len(snmpProfiles), strings.Join(profInfo, ", "), sysObjectID)
+	c.Infof("device matched %d profile(s): %s (sysObjectID: '%s')", len(snmpProfiles), strings.Join(profInfo, ", "), sysObjectID)
 
 	return snmpProfiles
 }

--- a/src/go/plugin/go.d/collector/snmp/config.go
+++ b/src/go/plugin/go.d/collector/snmp/config.go
@@ -6,18 +6,20 @@ import "github.com/netdata/netdata/go/plugins/plugin/go.d/agent/vnodes"
 
 type (
 	Config struct {
-		UpdateEvery                int                    `yaml:"update_every,omitempty" json:"update_every"`
-		Hostname                   string                 `yaml:"hostname" json:"hostname"`
-		CreateVnode                bool                   `yaml:"create_vnode,omitempty" json:"create_vnode"`
-		VnodeDeviceDownThreshold   int                    `yaml:"vnode_device_down_threshold,omitempty" json:"vnode_device_down_threshold"`
-		Vnode                      vnodes.VirtualNode     `yaml:"vnode,omitempty" json:"vnode"`
-		Community                  string                 `yaml:"community,omitempty" json:"community"`
-		User                       User                   `yaml:"user,omitempty" json:"user"`
-		Options                    Options                `yaml:"options,omitempty" json:"options"`
+		UpdateEvery              int                `yaml:"update_every,omitempty" json:"update_every"`
+		Hostname                 string             `yaml:"hostname" json:"hostname"`
+		CreateVnode              bool               `yaml:"create_vnode,omitempty" json:"create_vnode"`
+		VnodeDeviceDownThreshold int                `yaml:"vnode_device_down_threshold,omitempty" json:"vnode_device_down_threshold"`
+		Vnode                    vnodes.VirtualNode `yaml:"vnode,omitempty" json:"vnode"`
+		Community                string             `yaml:"community,omitempty" json:"community"`
+		User                     User               `yaml:"user,omitempty" json:"user"`
+		Options                  Options            `yaml:"options,omitempty" json:"options"`
+
 		ChartsInput                []ChartConfig          `yaml:"charts,omitempty" json:"charts"`
 		NetworkInterfaceFilter     NetworkInterfaceFilter `yaml:"network_interface_filter,omitempty" json:"network_interface_filter"`
 		EnableProfiles             bool                   `yaml:"enable_profiles,omitempty" json:"enable_profiles"`
 		EnableProfilesTableMetrics bool                   `yaml:"enable_profiles_table_metrics,omitempty" json:"enable_profiles_table_metrics"`
+		ManualProfiles             []string               `yaml:"manual_profiles,omitempty" json:"manual_profiles"`
 		DisableLegacyCollection    bool                   `yaml:"disable_legacy_collection,omitempty" json:"disable_legacy_collection"`
 	}
 	NetworkInterfaceFilter struct {

--- a/src/go/plugin/go.d/collector/snmp/config.go
+++ b/src/go/plugin/go.d/collector/snmp/config.go
@@ -19,8 +19,8 @@ type (
 		NetworkInterfaceFilter     NetworkInterfaceFilter `yaml:"network_interface_filter,omitempty" json:"network_interface_filter"`
 		EnableProfiles             bool                   `yaml:"enable_profiles,omitempty" json:"enable_profiles"`
 		EnableProfilesTableMetrics bool                   `yaml:"enable_profiles_table_metrics,omitempty" json:"enable_profiles_table_metrics"`
-		ManualProfiles             []string               `yaml:"manual_profiles,omitempty" json:"manual_profiles"`
 		DisableLegacyCollection    bool                   `yaml:"disable_legacy_collection,omitempty" json:"disable_legacy_collection"`
+		ManualProfiles             []string               `yaml:"manual_profiles,omitempty" json:"manual_profiles"`
 	}
 	NetworkInterfaceFilter struct {
 		ByName string `yaml:"by_name,omitempty" json:"by_name"`

--- a/src/go/plugin/go.d/collector/snmp/config_schema.json
+++ b/src/go/plugin/go.d/collector/snmp/config_schema.json
@@ -399,6 +399,7 @@
       "ui:help": "Table metrics include interface statistics, routing tables, and other tabular data."
     },
     "manual_profiles": {
+      "ui:listFlavour": "list",
       "ui:help": "**Profiles are always applied automatically** based on the device sysObjectID. **If no sysObjectID is provided** (rare case, e.g. some printers), the profiles listed here will be applied instead. In most cases, **leave this empty**."
     },
     "network_interface_filter": {

--- a/src/go/plugin/go.d/collector/snmp/config_schema.json
+++ b/src/go/plugin/go.d/collector/snmp/config_schema.json
@@ -362,6 +362,12 @@
         "type": "boolean",
         "default": true
       },
+      "disable_legacy_collection": {
+        "title": "Disable Legacy SNMP Collection",
+        "description": "Disable the legacy SNMP collection method, forcing the collector to use only SNMP profiles (YAML-based configuration). When enabled, the collector will ignore any non-profile based collection logic.",
+        "type": "boolean",
+        "default": false
+      },
       "manual_profiles": {
         "title": "Manual SNMP Profiles",
         "description": "Profiles to apply if automatic detection cannot be used.",
@@ -374,12 +380,6 @@
           "type": "string"
         },
         "uniqueItems": true
-      },
-      "disable_legacy_collection": {
-        "title": "Disable Legacy SNMP Collection",
-        "description": "Disable the legacy SNMP collection method, forcing the collector to use only SNMP profiles (YAML-based configuration). When enabled, the collector will ignore any non-profile based collection logic.",
-        "type": "boolean",
-        "default": false
       }
     },
     "required": [
@@ -515,7 +515,8 @@
           "fields": [
             "enable_profiles",
             "enable_profiles_table_metrics",
-            "disable_legacy_collection"
+            "disable_legacy_collection",
+            "manual_profiles"
           ]
         }
       ]

--- a/src/go/plugin/go.d/collector/snmp/config_schema.json
+++ b/src/go/plugin/go.d/collector/snmp/config_schema.json
@@ -362,6 +362,19 @@
         "type": "boolean",
         "default": true
       },
+      "manual_profiles": {
+        "title": "Manual SNMP Profiles",
+        "description": "Profiles to apply if automatic detection cannot be used.",
+        "type": [
+          "array",
+          "null"
+        ],
+        "items": {
+          "title": "Profile",
+          "type": "string"
+        },
+        "uniqueItems": true
+      },
       "disable_legacy_collection": {
         "title": "Disable Legacy SNMP Collection",
         "description": "Disable the legacy SNMP collection method, forcing the collector to use only SNMP profiles (YAML-based configuration). When enabled, the collector will ignore any non-profile based collection logic.",
@@ -384,6 +397,9 @@
     },
     "enable_profiles_table_metrics": {
       "ui:help": "Table metrics include interface statistics, routing tables, and other tabular data."
+    },
+    "manual_profiles": {
+      "ui:help": "**Profiles are always applied automatically** based on the device sysObjectID. **If no sysObjectID is provided** (rare case, e.g. some printers), the profiles listed here will be applied instead. In most cases, **leave this empty**."
     },
     "network_interface_filter": {
       "ui:collapsible": true

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
@@ -45,7 +45,7 @@ func FindProfiles(sysObjID string, manualProfiles []string) []*Profile {
 	// Fallback/manual path (no sysObjectID)
 	if sysObjID == "" {
 		if len(manualProfiles) == 0 {
-			log.Warning("empty sysObjectID and no manual profiles specified, cannot select any profile")
+			log.Warning("No sysObjectID found and no manual_profiles configured. Either ensure the device provides sysObjectID or configure manual_profiles option.")
 			return nil
 		}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
@@ -44,8 +44,9 @@ func Test_loadDDSnmpProfiles(t *testing.T) {
 
 func Test_FindProfiles(t *testing.T) {
 	test := map[string]struct {
-		sysObjOId   string
-		wanProfiles int
+		sysObjOId      string
+		manualProfiles []string
+		wanProfiles    int
 	}{
 		"mikrotik": {
 			sysObjOId:   "1.3.6.1.4.1.14988.1",
@@ -63,11 +64,16 @@ func Test_FindProfiles(t *testing.T) {
 			sysObjOId:   "1.3.6.1.4.1.9.1.2170",
 			wanProfiles: 3,
 		},
+		"no sysObjectID, manual profile applied": {
+			sysObjOId:      "",
+			manualProfiles: []string{"generic-device"},
+			wanProfiles:    1,
+		},
 	}
 
 	for name, test := range test {
 		t.Run(name, func(t *testing.T) {
-			profiles := FindProfiles(test.sysObjOId)
+			profiles := FindProfiles(test.sysObjOId, test.manualProfiles)
 
 			require.Len(t, profiles, test.wanProfiles)
 		})
@@ -75,7 +81,7 @@ func Test_FindProfiles(t *testing.T) {
 }
 
 func Test_Profile_merge(t *testing.T) {
-	profiles := FindProfiles("1.3.6.1.4.1.9.1.1216") // cisco-nexus
+	profiles := FindProfiles("1.3.6.1.4.1.9.1.1216", nil) // cisco-nexus
 
 	i := slices.IndexFunc(profiles, func(p *Profile) bool {
 		return strings.HasSuffix(p.SourceFile, "cisco-nexus.yaml")

--- a/src/go/plugin/go.d/collector/snmp/testdata/config.json
+++ b/src/go/plugin/go.d/collector/snmp/testdata/config.json
@@ -56,5 +56,8 @@
   ],
   "enable_profiles": true,
   "enable_profiles_table_metrics": true,
-  "disable_legacy_collection": true
+  "disable_legacy_collection": true,
+  "manual_profiles": [
+    "ok"
+  ]
 }

--- a/src/go/plugin/go.d/collector/snmp/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/snmp/testdata/config.yaml
@@ -5,6 +5,8 @@ vnode_device_down_threshold: 123
 enable_profiles: yes
 enable_profiles_table_metrics: yes
 disable_legacy_collection: yes
+manual_profiles:
+  - "ok"
 vnode:
   name: "ok"
   guid: "ok"


### PR DESCRIPTION
##### Summary

This PR adds a new configuration option, `manual_profiles`, to the SNMP collector.

**Problem**:
- Some rare devices (e.g. certain printers) do not provide a sysObjectID, making it impossible to apply SNMP profiles automatically. Until now, these devices could not benefit from profile-based metric collection.

**Solution**:
- Added `manual_profiles` config option (array of profile names).
- Profile names should be given without file extensions (e.g. `generic-device`, not `generic-device.yaml`).
- When sysObjectID is missing and no automatic match is possible, the collector falls back to applying the profiles specified in `manual_profiles`.
- If both sysObjectID matching and `manual_profiles` are unavailable, no profiles are applied.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
