### PR TITLE
Revert "chore(docs): rename REST API sidebar to Netdata APIs"

### DIFF
--- a/docs/.map/map.csv
+++ b/docs/.map/map.csv
@@ -219,7 +219,7 @@ https://github.com/netdata/netdata/edit/master/docs/security-and-privacy-design/
 ,,,,
 https://github.com/netdata/netdata/edit/master/docs/developer-and-contributor-corner/README.md,Developer and Contributor Corner,Published,Developer and Contributor Corner,
 https://github.com/netdata/netdata/edit/master/docs/category-overview-pages/netdata-apis.md,REST API,Unpublished,Developer and Contributor Corner/REST API,
-https://github.com/netdata/netdata/edit/master/src/web/api/README.md,Netdata API's,Published,Developer and Contributor Corner/REST API,
+https://github.com/netdata/netdata/edit/master/src/web/api/README.md,REST API,Published,Developer and Contributor Corner/REST API,
 https://github.com/netdata/netdata/edit/master/src/web/api/queries/README.md,Queries,Published,Developer and Contributor Corner/REST API/Queries,
 https://github.com/netdata/netdata/edit/master/src/web/api/queries/average/README.md,Average or Mean,Published,Developer and Contributor Corner/REST API/Queries,
 https://github.com/netdata/netdata/edit/master/src/web/api/queries/countif/README.md,CountIf,Published,Developer and Contributor Corner/REST API/Queries,


### PR DESCRIPTION
Reverts netdata/netdata#21029

I am reverting the change @kanelatechnical.

- **Before**

<img width="364" height="161" alt="Screenshot 2025-09-22 at 14 44 20" src="https://github.com/user-attachments/assets/5fd6e4f3-48df-409d-a011-669afe2c65ab" />

---

- **After**

<img width="327" height="168" alt="Screenshot 2025-09-22 at 14 44 43" src="https://github.com/user-attachments/assets/b004abc1-31e8-4636-b9a6-fc4fc147f27d" />