### PR TITLE
Add documentation on using custom CA certificates to Learn

### DIFF
--- a/docs/.map/map.csv
+++ b/docs/.map/map.csv
@@ -58,6 +58,7 @@ https://github.com/netdata/netdata/edit/master/docs/netdata-agent/configuration/
 https://github.com/netdata/netdata/edit/master/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-h2o.md,H2O,Published,Netdata Agent/Configuration/Securing Agents/Running the Agent behind a reverse proxy,
 https://github.com/netdata/netdata/edit/master/docs/netdata-agent/configuration/optimize-the-netdata-agents-performance.md,Performance Optimization,Published,Netdata Agent/Configuration,"While the Netdata Agent is designed to monitor a system with only 1% CPU, you can optimize its performance for low-resource systems."
 https://github.com/netdata/netdata/edit/master/docs/netdata-agent/configuration/organize-systems-metrics-and-alerts.md,"Organize systems, metrics, and alerts",Published,Netdata Agent/Configuration,
+https://github.com/netdata/netdata/edit/master/docs/netdata-agent/configuration/using-custom-ca-certificates-with-netdata.md,"Using custom CA certificates with Netdata",Published,Netdata Agent/Configuration,
 https://github.com/netdata/netdata/edit/master/src/daemon/README.md,Daemon,Published,Netdata Agent,
 https://github.com/netdata/netdata/edit/master/src/database/README.md,Database,Published,Netdata Agent,
 https://github.com/netdata/netdata/edit/master/src/libnetdata/log/README.md,Logging,Published,Netdata Agent,

--- a/docs/netdata-agent/configuration/using-custom-ca-certificates-with-netdata.md
+++ b/docs/netdata-agent/configuration/using-custom-ca-certificates-with-netdata.md
@@ -116,6 +116,6 @@ Windows. Instead, certificates must be installed into the bundled MSYS2 environm
 using the following instructions:
 
 1. Ensure the certificate file to be installed is in PEM or DER format.
-2. Copy the certificate file to `C:\Program FIles\Netdata\etc\pki\ca-trust\source\anchors`. You may need to create
+2. Copy the certificate file to `C:\Program Files\Netdata\etc\pki\ca-trust\source\anchors`. You may need to create
    this directory.
 3. In an administrative command prompt, run `C:\Program Files\Netdata\usr\bin\update-ca-trust.exe`


### PR DESCRIPTION
The [existing documentation on configuring custom CA certificates](https://github.com/netdata/netdata/blob/master/docs/netdata-agent/configuration/using-custom-ca-certificates-with-netdata.md) was missing from Learn. Adding this to the map file so it is included like its sibling documents.
