### PR TITLE
chore(go.d/ddsnmp): Improve profile sorting by match specificity

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
@@ -259,12 +259,27 @@ func sortProfilesBySpecificity(profiles []*Profile, matchedOIDs map[*Profile]str
 		aOID := matchedOIDs[a]
 		bOID := matchedOIDs[b]
 
-		// 1. Longer OIDs first (more specific)
+		// 0) Profiles with an OID match (non-empty) come before descr-only matches (empty)
+		aHasOID := aOID != ""
+		bHasOID := bOID != ""
+		if aHasOID != bHasOID {
+			if aHasOID {
+				return -1
+			}
+			return 1
+		}
+
+		// If both are descr-only (both empty), keep stable order.
+		if !aHasOID && !bHasOID {
+			return 0
+		}
+
+		// 1) Longer OIDs first (more specific)
 		if diff := len(bOID) - len(aOID); diff != 0 {
 			return diff
 		}
 
-		// 2. Same length: exact OIDs before patterns
+		// 2) Same length: exact OIDs before patterns
 		aIsExact := ddprofiledefinition.IsPlainOid(aOID)
 		bIsExact := ddprofiledefinition.IsPlainOid(bOID)
 		if aIsExact != bIsExact {
@@ -274,7 +289,7 @@ func sortProfilesBySpecificity(profiles []*Profile, matchedOIDs map[*Profile]str
 			return 1
 		}
 
-		// 3. Same type: lexicographic order for stability
+		// 3) Same type: lexicographic order for stability
 		return strings.Compare(aOID, bOID)
 	})
 }


### PR DESCRIPTION
##### Summary

This change refines how profiles are ordered when multiple matches occur:
- Profiles matched by **longer OIDs** still come first (more specific).
- Within the same length, **exact OID** matches are prioritized over regex or pattern matches.
- Profiles matched only via **sysDescr** (no OID) are placed after OID-based matches.
- Lexicographic order is preserved for stability when specificity is equal.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
