### PR TITLE
improve(go.d/rabbitmq): add support for old RabbitMQ whoami tags format

### DIFF
--- a/src/go/plugin/go.d/collector/rabbitmq/restapi.go
+++ b/src/go/plugin/go.d/collector/rabbitmq/restapi.go
@@ -2,6 +2,11 @@
 
 package rabbitmq
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 const (
 	urlPathAPIWhoami      = "/api/whoami"
 	urlPathAPIDefinitions = "/api/definitions"
@@ -12,8 +17,31 @@ const (
 )
 
 type apiWhoamiResp struct {
-	Name string   `json:"name"`
-	Tags []string `json:"tags"`
+	Name string        `json:"name"`
+	Tags apiWhoamiTags `json:"tags"`
+}
+
+type apiWhoamiTags []string
+
+func (a *apiWhoamiTags) UnmarshalJSON(data []byte) error {
+	var multi []string
+	if err := json.Unmarshal(data, &multi); err == nil {
+		*a = multi
+		return nil
+	}
+
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*a = []string{single}
+		return nil
+	}
+
+	if string(data) == "null" {
+		*a = nil
+		return nil
+	}
+
+	return fmt.Errorf("unexpected tags format: %s", string(data))
 }
 
 type apiDefinitionsResp struct {


### PR DESCRIPTION
##### Summary

Fixes: #21048

Older RabbitMQ versions return the tags field in the `/whoami` response as a string, while newer versions return it as an array of strings.
This change introduces a custom JSON unmarshaller for apiWhoamiTags, supporting both formats to ensure compatibility with all RabbitMQ versions.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
