### PR TITLE
feat(go.d/snmp): enable ping by default

### DIFF
--- a/src/go/plugin/go.d/collector/ping/prober.go
+++ b/src/go/plugin/go.d/collector/ping/prober.go
@@ -48,6 +48,7 @@ func (p *pingProber) Ping(host string) (*probing.Statistics, error) {
 	}
 
 	pr.RecordRtts = false
+	pr.RecordTTLs = false
 	pr.Interval = p.conf.Interval.Duration()
 	pr.Count = p.conf.Packets
 	pr.Timeout = p.conf.Timeout

--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -4,6 +4,7 @@ package snmp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -11,6 +12,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/google/uuid"
 	"github.com/gosnmp/gosnmp"
@@ -24,41 +26,19 @@ import (
 )
 
 func (c *Collector) collect() (map[string]int64, error) {
-	if c.snmpClient == nil {
-		snmpClient, err := c.initAndConnectSNMPClient()
-		if err != nil {
-			return nil, err
-		}
-		c.snmpClient = snmpClient
-		if c.ddSnmpColl != nil {
-			c.ddSnmpColl.SetSNMPClient(snmpClient)
-		}
+	if err := c.ensureInitialized(); err != nil {
+		return nil, err
 	}
 
-	if c.sysInfo == nil {
-		si, err := snmputils.GetSysInfo(c.snmpClient)
-		if err != nil {
-			return nil, err
-		}
-
-		if c.enableProfiles {
-			c.snmpProfiles = c.setupProfiles(si)
-		}
-
-		if c.ddSnmpColl == nil {
-			c.ddSnmpColl = ddsnmpcollector.New(c.snmpClient, c.snmpProfiles, c.Logger, si.SysObjectID)
-		}
-
-		if c.CreateVnode {
-			deviceMeta, err := c.ddSnmpColl.CollectDeviceMetadata()
-			if err != nil {
-				return nil, err
-			}
-			c.vnode = c.setupVnode(si, deviceMeta)
-		}
-
-		c.sysInfo = si
+	mx, err := c.collectMetrics()
+	if err != nil {
+		return nil, err
 	}
+
+	return mx, nil
+}
+
+func (c *Collector) collectMetrics() (map[string]int64, error) {
 	var (
 		snmpMx map[string]int64
 		pingMx map[string]int64
@@ -81,7 +61,10 @@ func (c *Collector) collect() (map[string]int64, error) {
 		g.Go(func() error {
 			m := make(map[string]int64)
 			if err := c.collectPing(m); err != nil {
-				c.Debugf("ping: %v", err)
+				c.Errorf("ping: %v", err)
+				if isPingUnrecoverableError(err) {
+					c.prober = nil
+				}
 				return nil
 			}
 			pingMx = m
@@ -93,12 +76,52 @@ func (c *Collector) collect() (map[string]int64, error) {
 		return nil, err
 	}
 
-	mx := make(map[string]int64)
+	mx := make(map[string]int64, len(snmpMx)+len(pingMx))
 
 	maps.Copy(mx, snmpMx)
 	maps.Copy(mx, pingMx)
 
 	return mx, nil
+}
+
+func (c *Collector) ensureInitialized() error {
+	if c.snmpClient == nil {
+		snmpClient, err := c.initAndConnectSNMPClient()
+		if err != nil {
+			return err
+		}
+		c.snmpClient = snmpClient
+		if c.ddSnmpColl != nil {
+			c.ddSnmpColl.SetSNMPClient(snmpClient)
+		}
+	}
+
+	if c.sysInfo == nil {
+		si, err := snmputils.GetSysInfo(c.snmpClient)
+		if err != nil {
+			return err
+		}
+
+		if c.enableProfiles {
+			c.snmpProfiles = c.setupProfiles(si)
+		}
+
+		if c.ddSnmpColl == nil {
+			c.ddSnmpColl = ddsnmpcollector.New(c.snmpClient, c.snmpProfiles, c.Logger, si.SysObjectID)
+		}
+
+		if c.CreateVnode {
+			deviceMeta, err := c.ddSnmpColl.CollectDeviceMetadata()
+			if err != nil {
+				return err
+			}
+			c.vnode = c.setupVnode(si, deviceMeta)
+		}
+
+		c.sysInfo = si
+	}
+
+	return nil
 }
 
 func (c *Collector) setupVnode(si *snmputils.SysInfo, deviceMeta map[string]ddsnmp.MetaTag) *vnodes.VirtualNode {
@@ -203,6 +226,7 @@ func (c *Collector) initAndConnectSNMPClient() (gosnmp.Handler, error) {
 
 	return snmpClient, nil
 }
+
 func (c *Collector) adjustMaxRepetitions(snmpClient gosnmp.Handler) (bool, error) {
 	orig := c.Config.Options.MaxRepetitions
 	maxReps := c.Config.Options.MaxRepetitions
@@ -256,23 +280,7 @@ func walkAll(snmpClient gosnmp.Handler, rootOid string) ([]gosnmp.SnmpPDU, error
 	return snmpClient.BulkWalkAll(rootOid)
 }
 
-func pduToInt(pdu gosnmp.SnmpPDU) (int64, error) {
-	switch pdu.Type {
-	case gosnmp.Counter32, gosnmp.Counter64, gosnmp.Integer, gosnmp.Gauge32, gosnmp.TimeTicks:
-		return gosnmp.ToBigInt(pdu.Value).Int64(), nil
-	default:
-		return 0, fmt.Errorf("unsupported type: '%v'", pdu.Type)
-	}
+func isPingUnrecoverableError(err error) bool {
+	var errno syscall.Errno
+	return errors.As(err, &errno) && (errors.Is(errno, syscall.EPERM) || errors.Is(errno, syscall.EACCES))
 }
-
-//func physAddressToString(pdu gosnmp.SnmpPDU) (string, error) {
-//	address, ok := pdu.Value.([]uint8)
-//	if !ok {
-//		return "", errors.New("physAddress is not a []uint8")
-//	}
-//	parts := make([]string, 0, 6)
-//	for _, v := range address {
-//		parts = append(parts, fmt.Sprintf("%02X", v))
-//	}
-//	return strings.Join(parts, ":"), nil
-//}

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -131,7 +131,6 @@ func (c *Collector) Init(context.Context) error {
 			return fmt.Errorf("failed to initialize ping prober: %v", err)
 		}
 		c.prober = pr
-		c.addPingCharts()
 	}
 
 	c.customOids = c.initCustomOIDs()

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -55,8 +55,8 @@ func New() *Collector {
 				PrivProto:     "aes192c",
 			},
 			Ping: PingConfig{
+				Enabled: true,
 				ProberConfig: ping.ProberConfig{
-					Network:    "ip",
 					Privileged: true,
 					Packets:    3,
 					Interval:   confopt.Duration(time.Millisecond * 100),

--- a/src/go/plugin/go.d/collector/snmp/config_schema.json
+++ b/src/go/plugin/go.d/collector/snmp/config_schema.json
@@ -359,7 +359,7 @@
           "enabled": {
             "title": "Enable ping",
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "Collect ICMP round-trip time using pro-bing alongside SNMP."
           },
           "network": {

--- a/src/go/plugin/go.d/collector/snmp/init.go
+++ b/src/go/plugin/go.d/collector/snmp/init.go
@@ -70,14 +70,13 @@ func (c *Collector) initSNMPClient() (gosnmp.Handler, error) {
 }
 
 func (c *Collector) initProber() (ping.Prober, error) {
-	mul := 0.9
-	if c.UpdateEvery > 1 {
-		mul = 0.8
-	}
-	timeout := time.Millisecond * time.Duration(float64(c.UpdateEvery)*mul*1000)
-	if timeout.Milliseconds() == 0 {
-		return nil, errors.New("zero ping timeout")
-	}
+	// base timeout = update_every seconds
+	timeout := time.Duration(c.UpdateEvery) * time.Second
+
+	// clamp between 1s and 3s
+	const minTimeout = time.Second
+	const maxTimeout = 3 * time.Second
+	timeout = max(min(timeout, maxTimeout), minTimeout)
 
 	conf := c.Ping.ProberConfig
 	conf.Timeout = timeout

--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -202,7 +202,7 @@ modules:
             - name: ping.enabled
               group: Ping
               description: Enable ICMP round-trip measurements (runs alongside SNMP). When disabled, no ping metrics are collected.
-              default_value: false
+              default_value: true
               required: false
             - name: ping.privileged
               group: Ping


### PR DESCRIPTION
##### Summary

This PR enables ping metrics collection by default for the SNMP collector.

- **Feature**: Ping probing is now on by default, improving visibility into device reachability and latency without requiring explicit configuration.
- **Chore**: Internal refactoring and cleanup (method restructuring, error handling improvements) to keep the codebase more maintainable.

No changes are required in existing configs unless ping probing should be explicitly disabled.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
