### PR TITLE
feat(go.d/snmp): add `ping_only` option

### DIFF
--- a/src/go/plugin/go.d/collector/ping/prober.go
+++ b/src/go/plugin/go.d/collector/ping/prober.go
@@ -47,14 +47,26 @@ func (p *pingProber) Ping(host string) (*probing.Statistics, error) {
 		return nil, fmt.Errorf("DNS lookup '%s' : %v", host, err)
 	}
 
+	pr.SetLogger(nil)
 	pr.RecordRtts = false
 	pr.RecordTTLs = false
-	pr.Interval = p.conf.Interval.Duration()
-	pr.Count = p.conf.Packets
-	pr.Timeout = p.conf.Timeout
+
 	pr.InterfaceName = p.conf.Interface
 	pr.SetPrivileged(p.conf.Privileged)
-	pr.SetLogger(nil)
+
+	pr.Interval = time.Millisecond * 100
+	pr.Count = 3
+	pr.Timeout = time.Second * 5
+
+	if p.conf.Interval.Duration().Milliseconds() > 0 {
+		pr.Interval = p.conf.Interval.Duration()
+	}
+	if p.conf.Packets > 0 {
+		pr.Count = p.conf.Packets
+	}
+	if p.conf.Timeout.Milliseconds() > 0 {
+		pr.Timeout = p.conf.Timeout
+	}
 
 	if err := pr.Run(); err != nil {
 		return nil, fmt.Errorf("pinging host '%s' (ip '%s' iface '%s'): %v",

--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -30,15 +30,23 @@ func (c *Collector) collect() (map[string]int64, error) {
 		return nil, err
 	}
 
-	mx, err := c.collectMetrics()
-	if err != nil {
+	if c.PingOnly {
+		return c.collectPingOnly()
+	}
+	return c.collectDeviceMetrics()
+}
+
+func (c *Collector) collectPingOnly() (map[string]int64, error) {
+	mx := make(map[string]int64)
+
+	if err := c.collectPing(mx); err != nil {
 		return nil, err
 	}
 
 	return mx, nil
 }
 
-func (c *Collector) collectMetrics() (map[string]int64, error) {
+func (c *Collector) collectDeviceMetrics() (map[string]int64, error) {
 	var (
 		snmpMx map[string]int64
 		pingMx map[string]int64
@@ -121,7 +129,7 @@ func (c *Collector) ensureInitialized() error {
 
 	c.sysInfo = si
 
-	if c.Ping.Enabled {
+	if c.PingOnly || c.Ping.Enabled {
 		c.addPingCharts()
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -119,7 +119,7 @@ func (c *Collector) Init(context.Context) error {
 		return fmt.Errorf("failed to initialize SNMP client: %v", err)
 	}
 
-	if c.Ping.Enabled {
+	if c.PingOnly || c.Ping.Enabled {
 		pr, err := c.initProber()
 		if err != nil {
 			return fmt.Errorf("failed to initialize ping prober: %v", err)

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/ping"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
-	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/confopt"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
 
 	"github.com/golang/mock/gomock"
@@ -299,8 +298,6 @@ func TestCollector_Collect(t *testing.T) {
 				collr := New()
 				collr.Config = prepareV2Config()
 				collr.PingOnly = true
-				collr.Ping.Interval = confopt.Duration(100 * time.Millisecond)
-				collr.Ping.Packets = 3
 				collr.CreateVnode = false
 				collr.newSnmpClient = func() gosnmp.Handler { return m }
 				collr.newProber = func(cfg ping.ProberConfig, log *logger.Logger) ping.Prober { return &mockProber{} }

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -8,10 +8,16 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
+	probing "github.com/prometheus-community/pro-bing"
+
+	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/agent/module"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/ping"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/confopt"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
 
 	"github.com/golang/mock/gomock"
@@ -285,6 +291,29 @@ func TestCollector_Collect(t *testing.T) {
 				"snmp_device_prof_if_octets_eth0_out": 2,
 			},
 		},
+		"collects ping only metrics": {
+			prepare: func(m *snmpmock.MockHandler) *Collector {
+				setMockClientInitExpect(m)
+				setMockClientSysInfoExpect(m)
+
+				collr := New()
+				collr.Config = prepareV2Config()
+				collr.PingOnly = true
+				collr.Ping.Interval = confopt.Duration(100 * time.Millisecond)
+				collr.Ping.Packets = 3
+				collr.CreateVnode = false
+				collr.newSnmpClient = func() gosnmp.Handler { return m }
+				collr.newProber = func(cfg ping.ProberConfig, log *logger.Logger) ping.Prober { return &mockProber{} }
+
+				return collr
+			},
+			want: map[string]int64{
+				"ping_rtt_min":    (10 * time.Millisecond).Microseconds(),
+				"ping_rtt_max":    (20 * time.Millisecond).Microseconds(),
+				"ping_rtt_avg":    (15 * time.Millisecond).Microseconds(),
+				"ping_rtt_stddev": (5 * time.Millisecond).Microseconds(),
+			},
+		},
 	}
 
 	for name, tc := range tests {
@@ -303,6 +332,31 @@ func TestCollector_Collect(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+type mockProber struct {
+	errOnPing bool
+}
+
+func (m *mockProber) Ping(host string) (*probing.Statistics, error) {
+	if m.errOnPing {
+		return nil, errors.New("mock.Ping() error")
+	}
+
+	stats := probing.Statistics{
+		PacketsRecv:           5,
+		PacketsSent:           5,
+		PacketsRecvDuplicates: 0,
+		PacketLoss:            0,
+		Addr:                  host,
+		Rtts:                  nil,
+		MinRtt:                time.Millisecond * 10,
+		MaxRtt:                time.Millisecond * 20,
+		AvgRtt:                time.Millisecond * 15,
+		StdDevRtt:             time.Millisecond * 5,
+	}
+
+	return &stats, nil
 }
 
 type mockDdSnmpCollector struct {

--- a/src/go/plugin/go.d/collector/snmp/config.go
+++ b/src/go/plugin/go.d/collector/snmp/config.go
@@ -22,7 +22,8 @@ type (
 
 		ManualProfiles []string `yaml:"manual_profiles,omitempty" json:"manual_profiles"`
 
-		Ping PingConfig `yaml:"ping,omitempty" json:"ping"`
+		PingOnly bool       `yaml:"ping_only,omitempty" json:"ping_only"`
+		Ping     PingConfig `yaml:"ping,omitempty" json:"ping"`
 	}
 
 	PingConfig struct {
@@ -45,25 +46,5 @@ type (
 		Version        string `yaml:"version,omitempty" json:"version"`
 		MaxOIDs        int    `yaml:"max_request_size,omitempty" json:"max_request_size"`
 		MaxRepetitions int    `yaml:"max_repetitions,omitempty" json:"max_repetitions"`
-	}
-)
-
-type (
-	ChartConfig struct {
-		ID         string            `yaml:"id" json:"id"`
-		Title      string            `yaml:"title" json:"title"`
-		Units      string            `yaml:"units" json:"units"`
-		Family     string            `yaml:"family" json:"family"`
-		Type       string            `yaml:"type" json:"type"`
-		Priority   int               `yaml:"priority" json:"priority"`
-		IndexRange []int             `yaml:"multiply_range,omitempty" json:"multiply_range"`
-		Dimensions []DimensionConfig `yaml:"dimensions" json:"dimensions"`
-	}
-	DimensionConfig struct {
-		OID        string `yaml:"oid" json:"oid"`
-		Name       string `yaml:"name" json:"name"`
-		Algorithm  string `yaml:"algorithm" json:"algorithm"`
-		Multiplier int    `yaml:"multiplier" json:"multiplier"`
-		Divisor    int    `yaml:"divisor" json:"divisor"`
 	}
 )

--- a/src/go/plugin/go.d/collector/snmp/config_schema.json
+++ b/src/go/plugin/go.d/collector/snmp/config_schema.json
@@ -201,6 +201,12 @@
         },
         "uniqueItems": true
       },
+      "ping_only": {
+        "title": "Ping only",
+        "description": "Collect only ICMP round-trip time and skip SNMP profile metrics.",
+        "type": "boolean",
+        "default": false
+      },
       "ping": {
         "title": "Ping",
         "type": [
@@ -311,6 +317,9 @@
         "ui:widget": "password"
       }
     },
+    "ping_only": {
+      "ui:help": "A minimal SNMP sysInfo query still runs during vnode setup for identification/metadata."
+    },
     "ping": {
       "interface": {
         "ui:widget": "hidden"
@@ -334,6 +343,7 @@
         {
           "title": "Ping",
           "fields": [
+            "ping_only",
             "ping"
           ]
         },

--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -199,6 +199,11 @@ modules:
               default_value: 60
               required: false
 
+            - name: ping_only
+              group: Ping
+              description: Collect only ICMP round-trip metrics and skip periodic SNMP metrics. A minimal SNMP sysInfo request is still performed when setting up the Virtual Node (for naming/labels and metadata).
+              default_value: false
+              required: false
             - name: ping.enabled
               group: Ping
               description: Enable ICMP round-trip measurements (runs alongside SNMP). When disabled, no ping metrics are collected.

--- a/src/go/plugin/go.d/collector/snmp/testdata/config.json
+++ b/src/go/plugin/go.d/collector/snmp/testdata/config.json
@@ -31,6 +31,7 @@
   "manual_profiles": [
     "ok"
   ],
+  "ping_only": true,
   "ping": {
     "enabled": true,
     "network": "ip",

--- a/src/go/plugin/go.d/collector/snmp/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/snmp/testdata/config.yaml
@@ -30,6 +30,7 @@ options:
   max_request_size: 123
   max_repetitions: 123
 
+ping_only: yes
 ping:
   enabled: yes
   network: ip


### PR DESCRIPTION
##### Summary

This PR introduces a new `ping_only` configuration option for the SNMP collector.

New option:

- `ping_only` (boolean, default: false)
- When enabled, the collector collects only ICMP round-trip time metrics during Collect().
- SNMP is still used during Check() and vnode setup to query sysInfo and profile metadata required for Virtual Node creation and labeling.
- SNMP profile metrics are skipped during the periodic Collect() loop.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
