### PR TITLE
Convert go collectors to use ndexec module for external command invocation

### DIFF
--- a/src/go/plugin/go.d/agent/discovery/sd/discoverer/netlistensd/ll.go
+++ b/src/go/plugin/go.d/agent/discovery/sd/discoverer/netlistensd/ll.go
@@ -4,13 +4,12 @@ package netlistensd
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/executable"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type localListeners interface {
@@ -38,12 +37,10 @@ type localListenersExec struct {
 }
 
 func (e *localListenersExec) discover(ctx context.Context) ([]byte, error) {
-	execCtx, cancel := context.WithTimeout(ctx, e.timeout)
-	defer cancel()
-
 	// TCPv4/6 and UPDv4 sockets in LISTEN state
 	// https://github.com/netdata/netdata/blob/master/src/collectors/utils/local_listeners.c
 	args := []string{
+		e.binPath,
 		"no-udp6",
 		"no-local",
 		"no-inbound",
@@ -51,12 +48,5 @@ func (e *localListenersExec) discover(ctx context.Context) ([]byte, error) {
 		"no-namespaces",
 	}
 
-	cmd := exec.CommandContext(execCtx, e.binPath, args...)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on executing '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunUnprivileged(nil, e.timeout, args...)
 }

--- a/src/go/plugin/go.d/collector/adaptecraid/exec.go
+++ b/src/go/plugin/go.d/collector/adaptecraid/exec.go
@@ -5,12 +5,10 @@
 package adaptecraid
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type arcconfCli interface {
@@ -34,24 +32,9 @@ type arcconfCliExec struct {
 }
 
 func (e *arcconfCliExec) logicalDevicesInfo() ([]byte, error) {
-	return e.execute("arcconf-ld-info")
+	return ndexec.RunNDSudo(e.Logger, e.timeout, "arcconf-ld-info")
 }
 
 func (e *arcconfCliExec) physicalDevicesInfo() ([]byte, error) {
-	return e.execute("arcconf-pd-info")
-}
-
-func (e *arcconfCliExec) execute(args ...string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.ndsudoPath, args...)
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunNDSudo(e.Logger, e.timeout, "arcconf-pd-info")
 }

--- a/src/go/plugin/go.d/collector/ap/exec.go
+++ b/src/go/plugin/go.d/collector/ap/exec.go
@@ -5,12 +5,10 @@
 package ap
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type iwBinary interface {
@@ -33,31 +31,9 @@ type iwCliExec struct {
 }
 
 func (e *iwCliExec) devices() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.binPath, "dev")
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunUnprivileged(e.Logger, e.timeout, e.binPath, "dev")
 }
 
 func (e *iwCliExec) stationStatistics(ifaceName string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.binPath, ifaceName, "station", "dump")
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunUnprivileged(e.Logger, e.timeout, e.binPath, ifaceName, "station", "dump")
 }

--- a/src/go/plugin/go.d/collector/chrony/exec.go
+++ b/src/go/plugin/go.d/collector/chrony/exec.go
@@ -3,12 +3,10 @@
 package chrony
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type chronyBinary interface {
@@ -31,16 +29,5 @@ type chronycExec struct {
 }
 
 func (e *chronycExec) serverStats() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.ndsudoPath, "chronyc-serverstats")
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunNDSudo(e.Logger, e.timeout, "chronyc-serverstats")
 }

--- a/src/go/plugin/go.d/collector/dmcache/exec.go
+++ b/src/go/plugin/go.d/collector/dmcache/exec.go
@@ -5,12 +5,10 @@
 package dmcache
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type dmsetupCli interface {
@@ -33,16 +31,5 @@ type dmsetupExec struct {
 }
 
 func (e *dmsetupExec) cacheStatus() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.ndsudoPath, "dmsetup-status-cache")
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunNDSudo(e.Logger, e.timeout, "dmsetup-status-cache")
 }

--- a/src/go/plugin/go.d/collector/ethtool/exec.go
+++ b/src/go/plugin/go.d/collector/ethtool/exec.go
@@ -3,12 +3,10 @@
 package ethtool
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type ethtoolCli interface {
@@ -31,21 +29,5 @@ type ethtoolCLIExec struct {
 }
 
 func (e *ethtoolCLIExec) moduleEeprom(iface string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx,
-		e.ndsudoPath,
-		"ethtool-module-info",
-		"--devname",
-		iface,
-	)
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunNDSudo(e.Logger, e.timeout, "ethtool-module-info", "--devname", iface)
 }

--- a/src/go/plugin/go.d/collector/exim/exec.go
+++ b/src/go/plugin/go.d/collector/exim/exec.go
@@ -3,12 +3,10 @@
 package exim
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type eximBinary interface {
@@ -31,17 +29,5 @@ type eximExec struct {
 }
 
 func (e *eximExec) countMessagesInQueue() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.ndsudoPath, "exim-bpc")
-
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunNDSudo(e.Logger, e.timeout, "exim-bpc")
 }

--- a/src/go/plugin/go.d/collector/fail2ban/exec.go
+++ b/src/go/plugin/go.d/collector/fail2ban/exec.go
@@ -5,15 +5,12 @@
 package fail2ban
 
 import (
-	"context"
 	"errors"
-	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 var errJailNotExist = errors.New("jail not exist")
@@ -66,19 +63,5 @@ func (e *fail2banClientCliExec) jailStatus(jail string) ([]byte, error) {
 }
 
 func (e *fail2banClientCliExec) execute(args ...string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.ndsudoPath, args...)
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		if strings.HasPrefix(strings.TrimSpace(string(bs)), "Sorry but the jail") {
-			return nil, errJailNotExist
-		}
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunNDSudo(e.Logger, e.timeout, args...)
 }

--- a/src/go/plugin/go.d/collector/hpssa/exec.go
+++ b/src/go/plugin/go.d/collector/hpssa/exec.go
@@ -3,12 +3,10 @@
 package hpssa
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type ssacliBinary interface {
@@ -31,20 +29,5 @@ type ssacliExec struct {
 }
 
 func (e *ssacliExec) controllersInfo() ([]byte, error) {
-	return e.execute("ssacli-controllers-info")
-}
-
-func (e *ssacliExec) execute(args ...string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.ndsudoPath, args...)
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunNDSudo(e.Logger, e.timeout, "ssacli-controllers-info")
 }

--- a/src/go/plugin/go.d/collector/lvm/exec.go
+++ b/src/go/plugin/go.d/collector/lvm/exec.go
@@ -5,12 +5,10 @@
 package lvm
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type lvmCLI interface {
@@ -33,21 +31,11 @@ type lvmCLIExec struct {
 }
 
 func (e *lvmCLIExec) lvsReportJson() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx,
-		e.ndsudoPath,
+	return ndexec.RunNDSudo(
+		e.Logger,
+		e.timeout,
 		"lvs-report-json",
 		"--options",
 		"vg_name,lv_name,lv_size,data_percent,metadata_percent,lv_attr",
 	)
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
 }

--- a/src/go/plugin/go.d/collector/megacli/exec.go
+++ b/src/go/plugin/go.d/collector/megacli/exec.go
@@ -5,12 +5,10 @@
 package megacli
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type megaCli interface {
@@ -34,24 +32,9 @@ type megaCliExec struct {
 }
 
 func (e *megaCliExec) physDrivesInfo() ([]byte, error) {
-	return e.execute("megacli-disk-info")
+	return ndexec.RunNDSudo(e.Logger, e.timeout, "megacli-disk-info")
 }
 
 func (e *megaCliExec) bbuInfo() ([]byte, error) {
-	return e.execute("megacli-battery-info")
-}
-
-func (e *megaCliExec) execute(args ...string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.ndsudoPath, args...)
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunNDSudo(e.Logger, e.timeout, "megacli-battery-info")
 }

--- a/src/go/plugin/go.d/collector/nsd/exec.go
+++ b/src/go/plugin/go.d/collector/nsd/exec.go
@@ -5,12 +5,10 @@
 package nsd
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type nsdControlBinary interface {
@@ -33,17 +31,5 @@ type nsdControlExec struct {
 }
 
 func (e *nsdControlExec) stats() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.ndsudoPath, "nsd-control-stats")
-
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunNDSudo(e.Logger, e.timeout, "nsd-control-stats")
 }

--- a/src/go/plugin/go.d/collector/nvidia_smi/exec.go
+++ b/src/go/plugin/go.d/collector/nvidia_smi/exec.go
@@ -5,15 +5,16 @@ package nvidia_smi
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"errors"
-	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/pkg/buildinfo"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type nvidiaSmiBinary interface {
@@ -52,18 +53,7 @@ type nvidiaSmiExec struct {
 }
 
 func (e *nvidiaSmiExec) queryGPUInfo() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.binPath, "-q", "-x")
-
-	e.Debugf("executing '%s'", cmd)
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunUnprivileged(e.Logger, e.timeout, e.binPath, "-q", "-x")
 }
 
 func (e *nvidiaSmiExec) stop() error { return nil }
@@ -102,7 +92,8 @@ func (e *nvidiaSmiLoopExec) run() error {
 		secs = e.updateEvery
 	}
 
-	cmd := exec.Command(e.binPath, "-q", "-x", "-l", strconv.Itoa(secs))
+	ndrunPath := filepath.Join(buildinfo.NetdataBinDir, "nd-run")
+	cmd := exec.Command(ndrunPath, e.binPath, "-q", "-x", "-l", strconv.Itoa(secs))
 
 	e.Debugf("executing '%s'", cmd)
 

--- a/src/go/plugin/go.d/collector/nvme/exec.go
+++ b/src/go/plugin/go.d/collector/nvme/exec.go
@@ -6,12 +6,12 @@ package nvme
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type nvmeDeviceList struct {
@@ -149,7 +149,7 @@ type nvmeCLIExec struct {
 }
 
 func (n *nvmeCLIExec) list() (*nvmeDeviceList, error) {
-	bs, err := n.execute("nvme-list")
+	bs, err := ndexec.RunNDSudo(nil, n.timeout, "nvme-list")
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (n *nvmeCLIExec) list() (*nvmeDeviceList, error) {
 }
 
 func (n *nvmeCLIExec) smartLog(devicePath string) (*nvmeDeviceSmartLog, error) {
-	bs, err := n.execute("nvme-smart-log", "--device", devicePath)
+	bs, err := ndexec.RunNDSudo(nil, n.timeout, "nvme-smart-log", "--device", devicePath)
 	if err != nil {
 		return nil, err
 	}
@@ -174,11 +174,4 @@ func (n *nvmeCLIExec) smartLog(devicePath string) (*nvmeDeviceSmartLog, error) {
 	}
 
 	return &v, nil
-}
-
-func (n *nvmeCLIExec) execute(arg ...string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), n.timeout)
-	defer cancel()
-
-	return exec.CommandContext(ctx, n.ndsudoPath, arg...).Output()
 }

--- a/src/go/plugin/go.d/collector/postfix/exec.go
+++ b/src/go/plugin/go.d/collector/postfix/exec.go
@@ -3,12 +3,10 @@
 package postfix
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type postqueueBinary interface {
@@ -30,16 +28,5 @@ type postqueueExec struct {
 }
 
 func (p *postqueueExec) list() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, p.binPath, "-p")
-	p.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunUnprivileged(p.Logger, p.timeout, p.binPath, "-p")
 }

--- a/src/go/plugin/go.d/collector/samba/exec.go
+++ b/src/go/plugin/go.d/collector/samba/exec.go
@@ -3,12 +3,10 @@
 package samba
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type smbStatusBinary interface {
@@ -31,17 +29,5 @@ type smbStatusExec struct {
 }
 
 func (e *smbStatusExec) profile() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.ndsudoPath, "smbstatus-profile")
-
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunNDSudo(e.Logger, e.timeout, "smbstatus-profile")
 }

--- a/src/go/plugin/go.d/collector/smartctl/init.go
+++ b/src/go/plugin/go.d/collector/smartctl/init.go
@@ -43,10 +43,10 @@ func (c *Collector) initDeviceSelector() (matcher.Matcher, error) {
 }
 
 func (c *Collector) initSmartctlCli() (smartctlCli, error) {
-	if runtime.GOOS == "linux" {
-		return c.initNdsudoSmartctlCli()
+	if runtime.GOOS == "windows" {
+		return c.initDirectSmartctlCli()
 	}
-	return c.initDirectSmartctlCli()
+	return c.initNdsudoSmartctlCli()
 }
 
 func (c *Collector) initNdsudoSmartctlCli() (smartctlCli, error) {

--- a/src/go/plugin/go.d/collector/storcli/exec.go
+++ b/src/go/plugin/go.d/collector/storcli/exec.go
@@ -5,12 +5,10 @@
 package storcli
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type storCli interface {
@@ -34,24 +32,9 @@ type storCliExec struct {
 }
 
 func (e *storCliExec) controllersInfo() ([]byte, error) {
-	return e.execute("storcli-controllers-info")
+	return ndexec.RunNDSudo(e.Logger, e.timeout, "storcli-controllers-info")
 }
 
 func (e *storCliExec) drivesInfo() ([]byte, error) {
-	return e.execute("storcli-drives-info")
-}
-
-func (e *storCliExec) execute(args ...string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.ndsudoPath, args...)
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunNDSudo(e.Logger, e.timeout, "storcli-drives-info")
 }

--- a/src/go/plugin/go.d/collector/varnish/exec.go
+++ b/src/go/plugin/go.d/collector/varnish/exec.go
@@ -4,13 +4,12 @@ package varnish
 
 import (
 	"context"
-	"fmt"
-	"os/exec"
 	"strconv"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/dockerhost"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type varnishstatBinary interface {
@@ -35,18 +34,7 @@ type varnishstatExec struct {
 }
 
 func (e *varnishstatExec) statistics() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.binPath, "varnishstat-stats", "--instanceName", e.instanceName)
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunUnprivileged(e.Logger, e.timeout, "varnishstat-stats", "--instanceName", e.instanceName)
 }
 
 func newVarnishstatDockerExecBinary(cfg Config, log *logger.Logger) varnishstatBinary {

--- a/src/go/plugin/go.d/collector/zfspool/exec.go
+++ b/src/go/plugin/go.d/collector/zfspool/exec.go
@@ -5,12 +5,10 @@
 package zfspool
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 )
 
 type zpoolCli interface {
@@ -33,31 +31,9 @@ type zpoolCLIExec struct {
 }
 
 func (e *zpoolCLIExec) list() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.binPath, "list", "-p")
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunUnprivileged(e.Logger, e.timeout, e.binPath, "list", "-p")
 }
 
 func (e *zpoolCLIExec) listWithVdev(pool string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, e.binPath, "list", "-p", "-v", "-L", pool)
-	e.Debugf("executing '%s'", cmd)
-
-	bs, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("error on '%s': %v", cmd, err)
-	}
-
-	return bs, nil
+	return ndexec.RunUnprivileged(e.Logger, e.timeout, e.binPath, "list", "-p", "-v", "-L", pool)
 }


### PR DESCRIPTION
##### Summary

Also, update the logic for the smartctl collector to use ndsudo on all systems except for Windows.

##### Test Plan

Requires explicit testing of all collectors that are modified by this PR.