### PR TITLE
docs: add note about using ``--init` when not running with `pid: host`

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -50,6 +50,12 @@ Both methods create a [volume](https://docs.docker.com/storage/volumes/) for Net
 _within the container_ at `/etc/netdata`.
 See the [configure section](#configure-agent-containers) for details. If you want to access the configuration files from your _host_ machine, see [host-editable configuration](#with-host-editable-configuration).
 
+:::info If you remove `pid: host`
+If you choose **not** to use `pid: host`, you **must** add [`--init`](https://docs.docker.com/reference/cli/docker/container/run/#init) (or [`init: true`](https://docs.docker.com/reference/compose-file/services/#init) in Compose).
+
+`--init` installs a minimal init system that reaps processes and ensures stable container operation.
+:::
+
 <Tabs>
 <TabItem value="docker_run" label="docker run">
 


### PR DESCRIPTION
##### Summary

This PR updates the Install with Docker documentation to clarify the requirement of using `--init` (or `init: true` in Compose) when `pid: host` is removed from the recommended configuration.

Related #20565

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
