### PR TITLE
Make `nd-run` silent unless exiting with an error

### DIFF
--- a/src/collectors/utils/nd-run.c
+++ b/src/collectors/utils/nd-run.c
@@ -148,8 +148,6 @@ int main(int argc, char *argv[]) {
 
     struct passwd *pw = getpwnam(NETDATA_USER);
     if (!pw) {
-        fprintf(stderr, "User '%s' not found, falling back to '%s'\n",
-                NETDATA_USER, FALLBACK_USER);
         pw = getpwnam(FALLBACK_USER);
         if (!pw) {
             fprintf(stderr, "Fallback user '%s' not found either\n", FALLBACK_USER);
@@ -158,13 +156,9 @@ int main(int argc, char *argv[]) {
     }
 
     if (euid != pw->pw_uid) {
-        fprintf(stderr, "Attempting to run as user: %s (UID=%d, GID=%d)\n", pw->pw_name, (int)pw->pw_uid, (int)pw->pw_gid);
-
         // Set supplementary groups for this user (must be done before dropping privs)
         if (initgroups(pw->pw_name, pw->pw_gid) != 0) {
             if (euid == 0) {
-                perror("initgroups");
-
                 if (setgroups(0, NULL) != 0) {
                     fatal("setgroups");
                 }


### PR DESCRIPTION
##### Summary

This PR updates `nd-run` to avoid polluting stderr of the invoked command.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
