### PR TITLE
Improve installer (Windows)

### DIFF
--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -190,12 +190,6 @@
                 <Custom Action="InstallManifest" After="InstallFiles" />
             </InstallExecuteSequence>
 
-            <!-- Added StopNetdataService custom action to ensure service is stopped before file operations -->
-            <!-- CustomAction Id="StopNetdataService" Directory="System64Folder" ExeCommand='net stop Netdata' Execute="immediate" Return="ignore" />
-            <InstallExecuteSequence>
-                <Custom Action="StopNetdataService" Before="InstallValidate" Condition="Installed AND NOT REMOVE" />
-            </InstallExecuteSequence -->
-
             <Component Id="NetdataService" Directory="USRBINDIR">
                 <File Id="netdata.exe" Source="C:\msys64\opt\netdata\usr\bin\netdata.exe" KeyPath="yes" />
 
@@ -225,21 +219,6 @@
 
                 <ServiceControl Id="StartService" Name="Netdata" Start="install" Wait="no" />
                 <ServiceControl Id="StopService" Name="Netdata" Remove="uninstall" Stop="both" Wait="yes" />
-
-                <!-- Modified to ensure proper service handling during update -->
-                <!--ServiceControl Id="ControlService"
-                                Name="Netdata"
-                                Stop="both"
-                                Start="install"
-                                Remove="uninstall"
-                                Wait="yes" /-->
-
-
-                 <!-- RegistryValue Root="HKLM"
-                               Key="System\CurrentControlSet\Services\Netdata"
-                               Name="DelayedAutoStart"
-                               Value="1"
-                               Type="integer" / -->
             </Component>
     </Fragment>
 

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -97,6 +97,41 @@
             <WixVariable Id="WixUIDialogBmp" Value="BackGround.bmp" />
             <UIRef Id="WixUI_ErrorProgressText" />
             <ui:WixUI Id="FeatureTree_ViewLicense" />
+
+            <SetProperty
+                Id="NDKillProcess"
+                Value="&quot;[WindowsFolder]System32\taskkill.exe&quot; /T /F /IM netdata.exe"
+                Before="NDKillProcess"
+                Sequence="execute"
+            />
+            <CustomAction
+                Id="NDKillProcess"
+                BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)"
+                DllEntry="WixQuietExec"
+                Execute="deferred"
+                Return="ignore"
+                Impersonate="no"
+            />
+
+            <SetProperty
+                Id="NDConfigureServiceRecovery"
+                Value="&quot;[WindowsFolder]System32\sc.exe&quot; failureflag &quot;netdata&quot; 1"
+                Before="NDConfigureServiceRecovery"
+                Sequence="execute"
+            />
+            <CustomAction
+                Id="NDConfigureServiceRecovery"
+                BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)"
+                DllEntry="WixQuietExec"
+                Execute="deferred"
+                Return="ignore"
+                Impersonate="no"
+            />
+
+            <InstallExecuteSequence>
+                <Custom Action="NDConfigureServiceRecovery" After="InstallServices" Condition="NOT REMOVE" />
+                <Custom Action="NDKillProcess" Before="RemoveFiles" />
+            </InstallExecuteSequence>
     </Package>
 
     <Fragment>

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -191,10 +191,10 @@
             </InstallExecuteSequence>
 
             <!-- Added StopNetdataService custom action to ensure service is stopped before file operations -->
-            <CustomAction Id="StopNetdataService" Directory="System64Folder" ExeCommand='net stop Netdata' Execute="immediate" Return="ignore" />
+            <!-- CustomAction Id="StopNetdataService" Directory="System64Folder" ExeCommand='net stop Netdata' Execute="immediate" Return="ignore" />
             <InstallExecuteSequence>
                 <Custom Action="StopNetdataService" Before="InstallValidate" Condition="Installed AND NOT REMOVE" />
-            </InstallExecuteSequence>
+            </InstallExecuteSequence -->
 
             <Component Id="NetdataService" Directory="USRBINDIR">
                 <File Id="netdata.exe" Source="C:\msys64\opt\netdata\usr\bin\netdata.exe" KeyPath="yes" />
@@ -204,22 +204,42 @@
                                 DisplayName="Netdata Agent"
                                 Description="Distributed, real-time, performance and health monitoring for systems and applications."
                                 Type="ownProcess"
+                                Interactive="no"
                                 Start="auto"
-                                ErrorControl="normal" />
+                                ErrorControl="normal"
+                                Vital="yes">
+
+                    <ServiceConfig
+                        DelayedAutoStart="yes"
+                        OnInstall="yes"
+                        OnReinstall="yes" />
+
+                    <util:ServiceConfig
+                            ResetPeriodInDays="0"
+                            FirstFailureActionType="restart"
+                            SecondFailureActionType="restart"
+                            ThirdFailureActionType="restart"
+                            RestartServiceDelayInSeconds="60"
+                     />
+                </ServiceInstall>
+
+                <ServiceControl Id="StartService" Name="Netdata" Start="install" Wait="no" />
+                <ServiceControl Id="StopService" Name="Netdata" Remove="uninstall" Stop="both" Wait="yes" />
 
                 <!-- Modified to ensure proper service handling during update -->
-                <ServiceControl Id="ControlService"
+                <!--ServiceControl Id="ControlService"
                                 Name="Netdata"
                                 Stop="both"
                                 Start="install"
                                 Remove="uninstall"
-                                Wait="yes" />
+                                Wait="yes" /-->
 
-                 <RegistryValue Root="HKLM"
+
+                 <!-- RegistryValue Root="HKLM"
                                Key="System\CurrentControlSet\Services\Netdata"
                                Name="DelayedAutoStart"
                                Value="1"
-                               Type="integer" />
+                               Type="integer" / -->
             </Component>
     </Fragment>
 


### PR DESCRIPTION
##### Summary
The Netdata installer failed to stop the Netdata service during installation. It also did not raise errors or provide feedback about this failure.

This PR addresses these issues by modifying the service management mechanism.

##### Test Plan

1. Install Netdata version 2.7.1.
2. Compile this branch.
3.  Run the installer. You will receive a warning, which is expected. For the specific features we are working on, `ServiceConfig` functions correctly.
4. Open Task Manager and search for netdata.
5. Install this branch. You will now observe that the installer displays warnings and successfully terminates the Netdata software.
6. Let Netdata run for a short while, and then run the installer again. You will see that it is faster now.


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
