### PR TITLE
Use datafile block pos

### DIFF
--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -2484,15 +2484,15 @@ void pgc_open_cache_to_journal_v2(
         // update the extents JudyL
 
         size_t current_extent_index_id;
-        Pvoid_t *PValue = JudyLIns(&JudyL_extents_pos, xio->pos, PJE0);
+        Pvoid_t *PValue = JudyLIns(&JudyL_extents_pos, xio->block, PJE0);
         if(!PValue || PValue == PJERR)
             fatal("CACHE: JudyLIns(JudyL_extents_pos, %" PRIu64 ") failed, JudyL_extents_pos = %p, result = %p",
-                  xio->pos, JudyL_extents_pos, PValue);
+                  (uint64_t) xio->block << 12, JudyL_extents_pos, PValue);
 
         struct jv2_extents_info *ei;
         if(!*PValue) {
             ei = aral_mallocz(ar_ei); // callocz(1, sizeof(struct jv2_extents_info));
-            ei->pos = xio->pos;
+            ei->block = xio->block;
             ei->bytes = xio->bytes;
             ei->number_of_pages = 1;
             ei->index = master_extent_index_id++;

--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -2487,7 +2487,7 @@ void pgc_open_cache_to_journal_v2(
         Pvoid_t *PValue = JudyLIns(&JudyL_extents_pos, xio->block, PJE0);
         if(!PValue || PValue == PJERR)
             fatal("CACHE: JudyLIns(JudyL_extents_pos, %" PRIu64 ") failed, JudyL_extents_pos = %p, result = %p",
-                  (uint64_t) xio->block << 12, JudyL_extents_pos, PValue);
+                  BLOCK_TO_OFFSET(xio->block), JudyL_extents_pos, PValue);
 
         struct jv2_extents_info *ei;
         if(!*PValue) {

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1184,7 +1184,7 @@ void *journalfile_v2_write_extent_list(Pvoid_t JudyL_extents_pos, void *data)
         ext_info = *PValue;
         size_t index = ext_info->index;
         j2_extent_base[index].file_index = 0;
-        j2_extent_base[index].datafile_offset = ((uint64_t) ext_info->block) << 12;
+        j2_extent_base[index].datafile_offset = BLOCK_TO_OFFSET(ext_info->block);
         j2_extent_base[index].datafile_size = ext_info->bytes;
         j2_extent_base[index].pages = ext_info->number_of_pages;
         count++;

--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -462,9 +462,8 @@ static ALWAYS_INLINE_HOT size_t list_has_time_gaps(
 
                 internal_fatal(pd->status & PDC_PAGE_SKIP, "page is disk pending and skipped");
                 internal_fatal(!pd->datafile.ptr, "datafile is NULL");
-                internal_fatal(!pd->datafile.extent.bytes, "datafile.extent.bytes zero");
-                internal_fatal(!pd->datafile.extent.pos, "datafile.extent.pos is zero");
-                internal_fatal(!pd->datafile.fileno, "datafile.fileno is zero");
+                internal_fatal(!pd->datafile.bytes, "datafile.bytes zero");
+                internal_fatal(!pd->datafile.block, "datafile.block is zero");
             }
         }
         else {

--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -591,7 +591,7 @@ static NOT_INLINE_HOT size_t get_page_list_from_journal_v2(struct rrdengine_inst
                     // add this page to open cache
                     bool added = false;
                     struct extent_io_data ei = {0};
-                    ei.block = (extent_list[page_entry_in_journal->extent_index].datafile_offset) >> 12;
+                    ei.block = OFFSET_TO_BLOCK(extent_list[page_entry_in_journal->extent_index].datafile_offset);
                     ei.bytes = extent_list[page_entry_in_journal->extent_index].datafile_size;
                     ei.fileno = datafile->fileno;
 
@@ -1052,7 +1052,7 @@ void pgc_open_add_hot_page(
 
     struct extent_io_data ext_io_data = {
             .fileno = datafile->fileno,
-            .block = extent_offset >> 12,
+            .block = OFFSET_TO_BLOCK(extent_offset),
             .bytes = extent_size,
     };
 

--- a/src/database/engine/pagecache.h
+++ b/src/database/engine/pagecache.h
@@ -46,6 +46,14 @@ void pg_cache_preload(struct rrdeng_query_handle *handle);
 struct pgc_page *pg_cache_lookup_next(struct rrdengine_instance *ctx, struct page_details_control *pdc, time_t now_s, uint32_t last_update_every_s, size_t *entries);
 void pgc_and_mrg_initialize(void);
 
-void pgc_open_add_hot_page(Word_t section, Word_t metric_id, time_t start_time_s, time_t end_time_s, uint32_t update_every_s, struct rrdengine_datafile *datafile, uint64_t extent_offset, unsigned extent_size, uint32_t page_length);
+void pgc_open_add_hot_page(
+    Word_t section,
+    Word_t metric_id,
+    time_t start_time_s,
+    time_t end_time_s,
+    uint32_t update_every_s,
+    struct rrdengine_datafile *datafile,
+    uint64_t extent_offset,
+    unsigned extent_size);
 
 #endif /* NETDATA_PAGECACHE_H */

--- a/src/database/engine/pdc.c
+++ b/src/database/engine/pdc.c
@@ -1308,9 +1308,8 @@ NOT_INLINE_HOT void epdl_find_extent_and_populate_pages(struct rrdengine_instanc
     bool should_stop = __atomic_load_n(&epdl->pdc->workers_should_stop, __ATOMIC_RELAXED);
     for(EPDL *ep = epdl->query.next; ep ;ep = ep->query.next) {
         internal_fatal(ep->datafile != epdl->datafile, "DBENGINE: datafiles do not match");
-        internal_fatal(ep->extent_offset != epdl->extent_offset, "DBENGINE: extent offsets do not match");
+        internal_fatal(ep->extent_block != epdl->extent_block, "DBENGINE: extent blocks do not match");
         internal_fatal(ep->extent_size != epdl->extent_size, "DBENGINE: extent sizes do not match");
-        internal_fatal(ep->file != epdl->file, "DBENGINE: files do not match");
 
         if(!__atomic_load_n(&ep->pdc->workers_should_stop, __ATOMIC_RELAXED)) {
             should_stop = false;

--- a/src/database/engine/pdc.c
+++ b/src/database/engine/pdc.c
@@ -1020,7 +1020,7 @@ static void epdl_extent_loading_error_log(struct rrdengine_instance *ctx, EPDL *
                 "%s from %ld (%s) to %ld (%s) %s%s: "
                 "%s",
                 epdl->datafile->fileno, ctx->config.tier,
-                (uint64_t) epdl->extent_block << 12, epdl->extent_size,
+                BLOCK_TO_OFFSET(epdl->extent_block), epdl->extent_size,
                 used_epdl ? "to extract page (PD)" : used_descr ? "expected page (DESCR)" : "part of a query (PDC)",
                 start_time_s, start_time_str, end_time_s, end_time_str,
                 used_epdl || used_descr ? " of metric " : "",
@@ -1284,7 +1284,7 @@ static inline void *datafile_extent_read(struct rrdengine_instance *ctx, uv_file
     (void)posix_memalignz(&buffer, RRDFILE_ALIGNMENT, real_io_size);
 
     uv_buf_t iov = uv_buf_init(buffer, real_io_size);
-    int ret = uv_fs_read(NULL, &request, file, &iov, 1, (int64_t)block << 12, NULL);
+    int ret = uv_fs_read(NULL, &request, file, &iov, 1, (int64_t) BLOCK_TO_OFFSET(block), NULL);
     if (unlikely(-1 == ret)) {
         ctx_io_error(ctx);
         posix_memalign_freez(buffer);

--- a/src/database/engine/pdc.c
+++ b/src/database/engine/pdc.c
@@ -610,16 +610,12 @@ ALWAYS_INLINE_HOT void pdc_to_epdl_router(struct rrdengine_instance *ctx, PDC *p
             if (PValue2 && !*PValue2) {
                 *PValue2 = epdl = epdl_get();
                 epdl->page_details_by_metric_id_JudyL = NULL;
-//                epdl->number_of_pages_in_JudyL = 0;
-//                epdl->file = pd->datafile.ptr->file;
                 epdl->extent_block = pd->datafile.block;
                 epdl->extent_size = pd->datafile.bytes;
                 epdl->datafile = pd->datafile.ptr;
             }
             else
                 epdl = *PValue2;
-
-//            epdl->number_of_pages_in_JudyL++;
 
             Pvoid_t *pd_by_first_time_s_judyL = PDCJudyLIns(&epdl->page_details_by_metric_id_JudyL, pd->metric_id, PJE0);
             Pvoid_t *pd_pptr = PDCJudyLIns(pd_by_first_time_s_judyL, pd->first_time_s, PJE0);

--- a/src/database/engine/pdc.c
+++ b/src/database/engine/pdc.c
@@ -4,10 +4,8 @@
 #include "dbengine-compression.h"
 
 struct extent_page_details_list {
-    uv_file file;
-    uint64_t extent_offset;
+    uint32_t extent_block;
     uint32_t extent_size;
-    unsigned number_of_pages_in_JudyL;
     Pvoid_t page_details_by_metric_id_JudyL;
     struct page_details_control *pdc;
     struct rrdengine_datafile *datafile;
@@ -497,7 +495,7 @@ static ALWAYS_INLINE struct rrdeng_cmd *epdl_get_cmd(void *epdl_ptr) {
 static ALWAYS_INLINE EPDL_EXTENT *epdl_find_extent_base(EPDL *epdl) {
     EPDL_EXTENT *e = NULL;
     rw_spinlock_read_lock(&epdl->datafile->extent_epdl.spinlock);
-    Pvoid_t *PValue = JudyLGet(epdl->datafile->extent_epdl.epdl_per_extent, epdl->extent_offset, PJE0);
+    Pvoid_t *PValue = JudyLGet(epdl->datafile->extent_epdl.epdl_per_extent, epdl->extent_block, PJE0);
     internal_fatal(PValue == PJERR, "DBENGINE: corrupted pending extent judy");
     if(PValue)
         e = *PValue;
@@ -508,7 +506,7 @@ static ALWAYS_INLINE EPDL_EXTENT *epdl_find_extent_base(EPDL *epdl) {
         e = epdl_extent_get();
 
         rw_spinlock_write_lock(&epdl->datafile->extent_epdl.spinlock);
-        PValue = JudyLIns(&epdl->datafile->extent_epdl.epdl_per_extent, epdl->extent_offset, PJE0);
+        PValue = JudyLIns(&epdl->datafile->extent_epdl.epdl_per_extent, epdl->extent_block, PJE0);
         internal_fatal(!PValue || PValue == PJERR, "DBENGINE: corrupted pending extent judy");
         if(!*PValue) {
             *PValue = e;
@@ -599,29 +597,29 @@ ALWAYS_INLINE_HOT void pdc_to_epdl_router(struct rrdengine_instance *ctx, PDC *p
             internal_fatal(pd->page,
                            "DBENGINE: page details has a page linked to it, but it is marked for loading");
 
-            PValue1 = PDCJudyLIns(&JudyL_datafile_list, pd->datafile.fileno, PJE0);
+            PValue1 = PDCJudyLIns(&JudyL_datafile_list, pd->datafile.ptr->fileno, PJE0);
             if (PValue1 && !*PValue1) {
                 *PValue1 = deol = deol_get();
                 deol->extent_pd_list_by_extent_offset_JudyL = NULL;
-                deol->fileno = pd->datafile.fileno;
+                deol->fileno = pd->datafile.ptr->fileno;
             }
             else
                 deol = *PValue1;
 
-            PValue2 = PDCJudyLIns(&deol->extent_pd_list_by_extent_offset_JudyL, pd->datafile.extent.pos, PJE0);
+            PValue2 = PDCJudyLIns(&deol->extent_pd_list_by_extent_offset_JudyL, pd->datafile.block, PJE0);
             if (PValue2 && !*PValue2) {
                 *PValue2 = epdl = epdl_get();
                 epdl->page_details_by_metric_id_JudyL = NULL;
-                epdl->number_of_pages_in_JudyL = 0;
-                epdl->file = pd->datafile.file;
-                epdl->extent_offset = pd->datafile.extent.pos;
-                epdl->extent_size = pd->datafile.extent.bytes;
+//                epdl->number_of_pages_in_JudyL = 0;
+//                epdl->file = pd->datafile.ptr->file;
+                epdl->extent_block = pd->datafile.block;
+                epdl->extent_size = pd->datafile.bytes;
                 epdl->datafile = pd->datafile.ptr;
             }
             else
                 epdl = *PValue2;
 
-            epdl->number_of_pages_in_JudyL++;
+//            epdl->number_of_pages_in_JudyL++;
 
             Pvoid_t *pd_by_first_time_s_judyL = PDCJudyLIns(&epdl->page_details_by_metric_id_JudyL, pd->metric_id, PJE0);
             Pvoid_t *pd_pptr = PDCJudyLIns(pd_by_first_time_s_judyL, pd->first_time_s, PJE0);
@@ -1022,7 +1020,7 @@ static void epdl_extent_loading_error_log(struct rrdengine_instance *ctx, EPDL *
                 "%s from %ld (%s) to %ld (%s) %s%s: "
                 "%s",
                 epdl->datafile->fileno, ctx->config.tier,
-                epdl->extent_offset, epdl->extent_size,
+                (uint64_t) epdl->extent_block << 12, epdl->extent_size,
                 used_epdl ? "to extract page (PD)" : used_descr ? "expected page (DESCR)" : "part of a query (PDC)",
                 start_time_s, start_time_str, end_time_s, end_time_str,
                 used_epdl || used_descr ? " of metric " : "",
@@ -1277,7 +1275,7 @@ static bool epdl_populate_pages_from_extent_data(
     return true;
 }
 
-static inline void *datafile_extent_read(struct rrdengine_instance *ctx, uv_file file, uint64_t pos, unsigned size_bytes)
+static inline void *datafile_extent_read(struct rrdengine_instance *ctx, uv_file file, uint32_t block, unsigned size_bytes)
 {
     void *buffer = NULL;
     uv_fs_t request;
@@ -1286,7 +1284,7 @@ static inline void *datafile_extent_read(struct rrdengine_instance *ctx, uv_file
     (void)posix_memalignz(&buffer, RRDFILE_ALIGNMENT, real_io_size);
 
     uv_buf_t iov = uv_buf_init(buffer, real_io_size);
-    int ret = uv_fs_read(NULL, &request, file, &iov, 1, (int64_t)pos, NULL);
+    int ret = uv_fs_read(NULL, &request, file, &iov, 1, (int64_t)block << 12, NULL);
     if (unlikely(-1 == ret)) {
         ctx_io_error(ctx);
         posix_memalign_freez(buffer);
@@ -1335,7 +1333,7 @@ NOT_INLINE_HOT void epdl_find_extent_and_populate_pages(struct rrdengine_instanc
     void *extent_compressed_data = NULL;
     PGC_PAGE *extent_cache_page = pgc_page_get_and_acquire(
             extent_cache, (Word_t)ctx,
-            (Word_t)epdl->datafile->fileno, (time_t)epdl->extent_offset,
+            (Word_t)epdl->datafile->fileno, (time_t)epdl->extent_block,
             PGC_SEARCH_EXACT);
 
     if(extent_cache_page) {
@@ -1351,7 +1349,7 @@ NOT_INLINE_HOT void epdl_find_extent_and_populate_pages(struct rrdengine_instanc
         if(worker)
             worker_is_busy(UV_EVENT_DBENGINE_EXTENT_MMAP);
 
-        void *extent_data = datafile_extent_read(ctx, epdl->file, epdl->extent_offset, epdl->extent_size);
+        void *extent_data = datafile_extent_read(ctx, epdl->datafile->file, epdl->extent_block, epdl->extent_size);
         if(extent_data != NULL) {
 
             void *tmp = dbengine_extent_alloc(epdl->extent_size);
@@ -1367,7 +1365,7 @@ NOT_INLINE_HOT void epdl_find_extent_and_populate_pages(struct rrdengine_instanc
                     .hot = false,
                     .section = (Word_t) ctx,
                     .metric_id = (Word_t) epdl->datafile->fileno,
-                    .start_time_s = (time_t) epdl->extent_offset,
+                    .start_time_s = (time_t) epdl->extent_block,
                     .size = epdl->extent_size,
                     .end_time_s = 0,
                     .update_every_s = 0,

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -697,12 +697,14 @@ extent_flush_to_open(struct rrdengine_instance *ctx, struct extent_io_descriptor
 
         if (likely(still_running && !have_error))
             pgc_open_add_hot_page(
-                    (Word_t)ctx, descr->metric_id,
-                    (time_t) (descr->start_time_ut / USEC_PER_SEC),
-                    (time_t) (descr->end_time_ut / USEC_PER_SEC),
-                    descr->update_every_s,
-                    datafile,
-                    xt_io_descr->pos, xt_io_descr->bytes, descr->page_length);
+                (Word_t)ctx,
+                descr->metric_id,
+                (time_t)(descr->start_time_ut / USEC_PER_SEC),
+                (time_t)(descr->end_time_ut / USEC_PER_SEC),
+                descr->update_every_s,
+                datafile,
+                xt_io_descr->pos,
+                xt_io_descr->bytes);
 
         page_descriptor_release(descr);
     }

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -136,13 +136,8 @@ PDC *pdc_get(void);
 struct page_details {
     struct {
         struct rrdengine_datafile *ptr;
-        uv_file file;
-        unsigned fileno;
-
-        struct {
-            uint64_t pos;
-            uint32_t bytes;
-        } extent;
+        uint32_t block;     // the block in the datafile. Offset in the datafile is block * RRDENG_BLOCK_SIZE
+        uint32_t bytes;
     } datafile;
 
     struct pgc_page *page;
@@ -165,10 +160,10 @@ struct page_details *page_details_get(void);
 #define pdc_page_status_clear(pd, flag) __atomic_and_fetch(&((od)->status), ~(flag), __ATOMIC_RELEASE)
 
 struct jv2_extents_info {
-    size_t index;
-    uint64_t pos;
+    uint32_t index;
+    uint32_t block;
     unsigned bytes;
-    size_t number_of_pages;
+    uint32_t number_of_pages;
 };
 
 struct jv2_metrics_info {
@@ -301,10 +296,8 @@ enum rrdeng_opcode {
 
 struct extent_io_data {
     unsigned fileno;
-    uv_file file;
-    uint64_t pos;
+    uint32_t block;
     unsigned bytes;
-    uint16_t page_length;
 };
 
 struct extent_io_descriptor {

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -24,6 +24,9 @@
 
 extern unsigned rrdeng_pages_per_extent;
 
+#define BLOCK_TO_OFFSET(block) ((uint64_t)(block) << 12)
+#define OFFSET_TO_BLOCK(ofs) ((uint64_t)(ofs) >> 12)
+
 #define UNLINK_FILE(ctx, path, ret_var)                                                                                \
     do {                                                                                                               \
         uv_fs_t _req;                                                                                                  \


### PR DESCRIPTION
##### Summary
-  Use datafile block numbers instead of offsets
   - Reduce internal structure size (improved performance, reduced memory use)

