### PR TITLE
Properly check for ODBC for IBM plugin at configuration time.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3159,6 +3159,7 @@ endif()
 #
 
 if(ENABLE_PLUGIN_IBM)
+    pkg_check_modules(ODBC REQUIRED odbc)
     include(NetdataIBMPlugin)
     add_ibm_plugin_target()
 


### PR DESCRIPTION
##### Summary

It’s a mandatory dependency for the IBM plugin, so we should be checking it before we get to the build.

##### Test Plan

n/a