### PR TITLE
Make native package dependencies consistent between DEB/RPM packages.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -256,9 +256,9 @@ Suggests: %{name}-plugin-cups = %{version}
 Recommends: %{name}-plugin-systemd-journal = %{version}
 Recommends: %{name}-plugin-systmed-units = %{version}
 Recommends: %{name}-plugin-network-viewer = %{version}
-Recommends: %{name}-plugin-logs-management = %{version}
 %else
 Requires: %{name}-plugin-systemd-journal = %{version}
+Requires: %{name}-plugin-systemd-units = %{version}
 Requires: %{name}-plugin-network-viewer = %{version}
 %endif
 

--- a/packaging/cmake/Modules/Packaging.cmake
+++ b/packaging/cmake/Modules/Packaging.cmake
@@ -56,9 +56,9 @@ set(CPACK_DEBIAN_NETDATA_PACKAGE_NAME "netdata")
 set(CPACK_DEBIAN_NETDATA_PACKAGE_SECTION "net")
 set(CPACK_DEBIAN_NETDATA_PACKAGE_PREDEPENDS "adduser, libcap2-bin")
 set(CPACK_DEBIAN_NETDATA_PACKAGE_SUGGESTS
-		"netdata-plugin-cups, netdata-plugin-freeipmi")
+		"netdata-plugin-cups, netdata-plugin-freeipmi, netdata-plugin-ibm, ")
 set(CPACK_DEBIAN_NETDATA_PACKAGE_RECOMMENDS
-		"netdata-plugin-systemd-journal, \
+		"netdata-plugin-systemd-journal, netdata-plugin-systemd-units, \
 netdata-plugin-network-viewer")
 set(CPACK_DEBIAN_NETDATA_PACKAGE_CONFLICTS
 		"netdata-core, netdata-plugins-bash, netdata-plugins-python, netdata-web")
@@ -81,10 +81,6 @@ endif()
 
 if(ENABLE_PLUGIN_GO)
         list(APPEND _main_deps "netdata-plugin-go")
-endif()
-
-if(ENABLE_PLUGIN_IBM)
-        list(APPEND _main_deps "netdata-plugin-ibm")
 endif()
 
 if(ENABLE_PLUGIN_DEBUGFS)


### PR DESCRIPTION
##### Summary

- Correctly list the IBM plugin as suggested in DEB packages.
- Add missing recommends for systemd-units plugin in DEB packages.
- Drop old logs-management reference in RPM dependencies.
- Correctly depend on systemd-units plugin on ancient RPM systems.

##### Test Plan

n/a
