### PR TITLE
Switch to using a relative RUNPATH for IBM plugin library lookup.

### DIFF
--- a/packaging/cmake/Modules/NetdataIBMPlugin.cmake
+++ b/packaging/cmake/Modules/NetdataIBMPlugin.cmake
@@ -8,8 +8,9 @@ include(FetchContent)
 # This plugin requires CGO and IBM DB2/MQ headers for compilation.
 # The plugin will download IBM libraries on first run.
 macro(add_ibm_plugin_target)
-  set(IBM_MQ_BUILD_DIR "${CMAKE_BINARY_DIR}/ibm-mqclient")
-  set(IBM_MQ_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/usr/lib/netdata/ibm-mqclient")
+  set(IBM_MQ_DIR_NAME "ibm-mqclient")
+  set(IBM_MQ_BUILD_DIR "${CMAKE_BINARY_DIR}/${IBM_MQ_DIR_NAME}")
+  set(IBM_MQ_INSTALL_SUFFIX "lib/netdata/${IBM_MQ_DIR_NAME}")
 
   FetchContent_Declare(
     ibm_mq
@@ -44,7 +45,7 @@ macro(add_ibm_plugin_target)
   if(EXISTS "${IBM_MQ_BUILD_DIR}/inc/cmqc.h")
     set(IBM_CGO_CFLAGS "-I${IBM_MQ_BUILD_DIR}/inc")
     set(IBM_CGO_LDFLAGS "-L${IBM_MQ_BUILD_DIR}/lib64 -lmqic_r")
-    set(IBM_RPATH_FLAGS "-Wl,-rpath,${IBM_MQ_INSTALL_DIR}/lib64")
+    set(IBM_RPATH_FLAGS "-Wl,-rpath,$ORIGIN/../../../${IBM_MQ_INSTALL_SUFFIX}/lib64")
     set(MQ_INSTALLATION_PATH "${IBM_MQ_BUILD_DIR}")
   else()
     message(WARNING "IBM MQ client libraries not found - MQ PCF collector will be disabled")


### PR DESCRIPTION
##### Summary

We can’t realistically hardcode a reliably correct absolute RUNPATH value when building the plugin, because `CMAKE_INSTALL_PREFIX` is not guaranteed to be the same at build time as what gets used at install time. This type of mismatch won’t happen in any of our builds, but it’s entirely possible for anybody who builds locally to run into this, which would completely break the plugin.

Instead of hardcoding an absolute path, use the `$ORIGIN` keyword (which expands at runtime to the directory that the executable is located in) to construct a RUNPATH relative to the executable itself, which completely avoids this potential pitfall.

This also makes our builds more reproducible.

##### Test Plan

Manual testing is required to confirm that the plugin still runs correctly.