### PR TITLE
Minor improvements to CMake code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ project(netdata
         HOMEPAGE_URL "https://www.netdata.cloud"
         LANGUAGES C CXX)
 include(CMakeDependentOption)
+include(CMakePushCheckState)
 include(NetdataUtil)
 netdata_fixup_system_processor()
 
@@ -255,6 +256,7 @@ if(ENABLE_JEMALLOC)
     pkg_check_modules(JEMALLOC QUIET jemalloc)
     if(JEMALLOC_FOUND)
         # Check if jemalloc has arena API
+        cmake_push_check_state()
         set(CMAKE_REQUIRED_INCLUDES ${JEMALLOC_INCLUDE_DIRS})
         set(CMAKE_REQUIRED_LIBRARIES ${JEMALLOC_LIBRARIES})
         check_c_source_compiles("
@@ -266,6 +268,7 @@ if(ENABLE_JEMALLOC)
                 return 0;
             }
         " HAVE_JEMALLOC_ARENA_API)
+        cmake_pop_check_state()
 
         if(HAVE_JEMALLOC_ARENA_API)
             set(ENABLE_JEMALLOC ON CACHE BOOL "Enable jemalloc allocator" FORCE)
@@ -503,6 +506,7 @@ int main(void) {
 }
 " HAVE_TM_GMTOFF)
 
+cmake_push_check_state()
 set(CMAKE_REQUIRED_LIBRARIES pthread)
 check_c_source_compiles("
 #define _GNU_SOURCE
@@ -513,6 +517,7 @@ int main() {
         return pthread_getname_np(thread, name, sizeof(name));
 }
 " HAVE_PTHREAD_GETNAME_NP)
+cmake_pop_check_state()
 
 check_c_source_compiles("
 #include <stdio.h>

--- a/packaging/cmake/Modules/NetdataCompilerFlags.cmake
+++ b/packaging/cmake/Modules/NetdataCompilerFlags.cmake
@@ -3,6 +3,7 @@
 
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
+include(CMakePushCheckState)
 
 # Conditionally add an extra compiler flag to C and C++ flags.
 #
@@ -11,6 +12,7 @@ include(CheckCXXCompilerFlag)
 # the compiler flags for the run. Also sets `result` to MATCHED/ADDED/UNSUPPORTED
 # depending on whether the flag was added or not.
 function(add_extra_compiler_flag match flag result)
+  cmake_push_check_state()
   set(CMAKE_REQUIRED_FLAGS "-Werror")
 
   string(MAKE_C_IDENTIFIER "${flag}" flag_name)
@@ -26,6 +28,7 @@ function(add_extra_compiler_flag match flag result)
   else()
     set(matched_cxx TRUE)
   endif()
+  cmake_pop_check_state()
 
   if(HAVE_C_${flag_name} AND HAVE_CXX_${flag_name})
     add_compile_options("${flag}")
@@ -56,12 +59,14 @@ endfunction()
 # Similar logic to add_extra_compiler_flag, but ignores existing
 # instances and throws an error if the flag is not supported.
 function(add_required_compiler_flag flag)
+  cmake_push_check_state()
   set(CMAKE_REQUIRED_FLAGS "-Werror")
 
   string(MAKE_C_IDENTIFIER "${flag}" flag_name)
 
   check_c_compiler_flag("${flag}" HAVE_C_${flag_name})
   check_cxx_compiler_flag("${flag}" HAVE_CXX_${flag_name})
+  cmake_pop_check_state()
 
   if(HAVE_C_${flag_name} AND HAVE_CXX_${flag_name})
     add_compile_options("${flag}")

--- a/packaging/cmake/Modules/NetdataDetectSystemd.cmake
+++ b/packaging/cmake/Modules/NetdataDetectSystemd.cmake
@@ -1,40 +1,41 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # CMake Module to handle all the systemd-related checks for Netdata.
 
+include(CMakePushCheckState)
+
 macro(detect_systemd)
-   find_library(SYSTEMD_LIBRARY NAMES systemd)
+  find_library(SYSTEMD_LIBRARY NAMES systemd)
 
-   set(ENABLE_DSYSTEMD_DBUS NO)
-   pkg_check_modules(SYSTEMD libsystemd)
+  set(ENABLE_DSYSTEMD_DBUS NO)
+  pkg_check_modules(SYSTEMD libsystemd)
 
-   if(SYSTEMD_FOUND)
-       set(CMAKE_REQUIRED_LIBRARIES_BEFORE_SYSTEMD "${CMAKE_REQUIRED_LIBRARIES}")
-       set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES};${SYSTEMD_LIBRARIES}")
+  if(SYSTEMD_FOUND)
+    cmake_push_check_state()
+    set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES};${SYSTEMD_LIBRARIES}")
 
-       check_c_source_compiles("
-       #include <systemd/sd-journal.h>
+    check_c_source_compiles("
+    #include <systemd/sd-journal.h>
 
-       int main() {
-           int x = SD_JOURNAL_OS_ROOT;
-           return 0;
-       }" HAVE_SD_JOURNAL_OS_ROOT)
+    int main() {
+      int x = SD_JOURNAL_OS_ROOT;
+      return 0;
+    }" HAVE_SD_JOURNAL_OS_ROOT)
 
-       check_symbol_exists(SD_JOURNAL_OS_ROOT "systemd/sd-journal.h" HAVE_SD_JOURNAL_OS_ROOT)
-       check_symbol_exists(sd_journal_open_files_fd "systemd/sd-journal.h" HAVE_SD_JOURNAL_OPEN_FILES_FD)
-       check_symbol_exists(sd_journal_restart_fields "systemd/sd-journal.h" HAVE_SD_JOURNAL_RESTART_FIELDS)
-       check_symbol_exists(sd_journal_get_seqnum "systemd/sd-journal.h" HAVE_SD_JOURNAL_GET_SEQNUM)
+    check_symbol_exists(SD_JOURNAL_OS_ROOT "systemd/sd-journal.h" HAVE_SD_JOURNAL_OS_ROOT)
+    check_symbol_exists(sd_journal_open_files_fd "systemd/sd-journal.h" HAVE_SD_JOURNAL_OPEN_FILES_FD)
+    check_symbol_exists(sd_journal_restart_fields "systemd/sd-journal.h" HAVE_SD_JOURNAL_RESTART_FIELDS)
+    check_symbol_exists(sd_journal_get_seqnum "systemd/sd-journal.h" HAVE_SD_JOURNAL_GET_SEQNUM)
 
-       check_symbol_exists(sd_bus_default_system "systemd/sd-bus.h" HAVE_SD_BUS_DEFAULT_SYSTEM)
-       check_symbol_exists(sd_bus_call_method "systemd/sd-bus.h" HAVE_SD_BUS_CALL_METHOD)
-       check_symbol_exists(sd_bus_message_enter_container "systemd/sd-bus.h" HAVE_SD_BUS_MESSAGE_ENTER_CONTAINER)
-       check_symbol_exists(sd_bus_message_read "systemd/sd-bus.h" HAVE_SD_BUS_MESSAGE_READ)
-       check_symbol_exists(sd_bus_message_exit_container "systemd/sd-bus.h" HAVE_SD_BUS_MESSAGE_EXIT_CONTAINER)
+    check_symbol_exists(sd_bus_default_system "systemd/sd-bus.h" HAVE_SD_BUS_DEFAULT_SYSTEM)
+    check_symbol_exists(sd_bus_call_method "systemd/sd-bus.h" HAVE_SD_BUS_CALL_METHOD)
+    check_symbol_exists(sd_bus_message_enter_container "systemd/sd-bus.h" HAVE_SD_BUS_MESSAGE_ENTER_CONTAINER)
+    check_symbol_exists(sd_bus_message_read "systemd/sd-bus.h" HAVE_SD_BUS_MESSAGE_READ)
+    check_symbol_exists(sd_bus_message_exit_container "systemd/sd-bus.h" HAVE_SD_BUS_MESSAGE_EXIT_CONTAINER)
 
-       set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES_BEFORE_SYSTEMD}")
-
-       set(HAVE_SYSTEMD True)
-       if(HAVE_SD_BUS_DEFAULT_SYSTEM AND HAVE_SD_BUS_CALL_METHOD AND HAVE_SD_BUS_MESSAGE_ENTER_CONTAINER AND HAVE_SD_BUS_MESSAGE_READ AND HAVE_SD_BUS_MESSAGE_EXIT_CONTAINER)
-           set(ENABLE_SYSTEMD_DBUS YES)
-       endif()
-   endif()
+    cmake_pop_check_state()
+    set(HAVE_SYSTEMD True)
+    if(HAVE_SD_BUS_DEFAULT_SYSTEM AND HAVE_SD_BUS_CALL_METHOD AND HAVE_SD_BUS_MESSAGE_ENTER_CONTAINER AND HAVE_SD_BUS_MESSAGE_READ AND HAVE_SD_BUS_MESSAGE_EXIT_CONTAINER)
+      set(ENABLE_SYSTEMD_DBUS YES)
+    endif()
+  endif()
 endmacro()


### PR DESCRIPTION
##### Summary

- Instead of rolling our own CPP-safe escaping routine, just use CMake’s built-in functionality for this. This makes our code a bit tidier, and the CMake provided implementation covers a number of cases that our in-house implementation did not.
- Use the CMakePushCheckState module to better isolate the state used during individual checks from each other. This should help avoid obscure bugs resulting from state being leaked between checks.

Both of these are bringing things more in-line with best practices for CMake code.

##### Test Plan

CI still passes on this PR without issue.