### PR TITLE
Skip adding Sentry breadcrumb during shutdown timeout

### DIFF
--- a/src/daemon/daemon-shutdown-watcher.c
+++ b/src/daemon/daemon-shutdown-watcher.c
@@ -19,9 +19,12 @@ NEVER_INLINE
 static void shutdown_timed_out(void) {
     // keep this as a separate function, to have it logged like this in sentry
     daemon_status_file_shutdown_timeout(steps_timings);
-#ifdef ENABLE_SENTRY
-    nd_sentry_add_shutdown_timeout_as_breadcrumb();
-#endif
+
+    // NOTE: We intentionally skip adding a Sentry breadcrumb here because:
+    // 1. During shutdown timeout, the status file has already been saved with timeout info
+    // 2. Sentry may crash trying to access potentially freed/corrupted strings from session_status
+    // 3. The abort() below will trigger a signal that Sentry will catch anyway
+
     abort();
 }
 


### PR DESCRIPTION
##### Summary
- Avoid adding breadcrumb during shutdown timeout to prevent crash
  - It can attempt to access information from structures that are not valid:
```
        memcpy (string_fortified.h:29)
        sentry__string_clone_n_unchecked (sentry_string.h:122)
        sentry__slice_to_owned (sentry_slice.c:18)
        sentry_value_set_by_key_n (sentry_value.c:477)
        reserve (sentry_value.c:124)
        sentry_value_append (sentry_value.c:547)
        sentry__value_append_bounded (sentry_value.c:643)
        sentry_add_breadcrumb (sentry_core.c:632)
        shutdown_timed_out (daemon-shutdown-watcher.c:25)
```
