### PR TITLE
Create ingest dry run check

### DIFF
--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           path: netdata
 
       - name: Checkout netdata/learn repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: netdata/learn
           path: learn


### PR DESCRIPTION
##### Summary

I used HTTP clone to test on my fork, thus the on-prem private repo can't be cloned (would be nice to be able to, to not cause side-effects), but the main thing we want to test and fail on, is the PR's repo owner and branch of `X/netdata:Y`

This was requested internally, and it does make sense to quickly see if something breaks ingest.
