### PR TITLE
Fix feature size calculation and add error handling for KMeans training

### DIFF
--- a/src/ml/ml_features.cc
+++ b/src/ml/ml_features.cc
@@ -53,7 +53,7 @@ static void ml_features_lag(ml_features_t *features, double sampling_ratio)
 
     for (size_t idx = 0; idx != n; idx++) {
         DSample &DS = features->preprocessed_features[sample_idx++];
-        DS.set_size(features->lag_n);
+        DS.set_size(features->lag_n + 1);
 
         if (Cfg.random_nums[idx % Cfg.random_nums.size()] > cutoff) {
             sample_idx--;

--- a/src/ml/ml_kmeans.cc
+++ b/src/ml/ml_kmeans.cc
@@ -32,6 +32,11 @@ ml_kmeans_train(ml_kmeans_t *kmeans, const ml_features_t *features, unsigned max
 
     kmeans->cluster_centers.clear();
 
+    if (features->preprocessed_features.size() < 2) {
+        netdata_log_error("ml_kmeans_train: not enough features to train kmeans (size=%zu)", features->preprocessed_features.size());
+        return;
+    }
+
     dlib::pick_initial_centers(2, kmeans->cluster_centers, features->preprocessed_features);
     dlib::find_clusters_using_kmeans(features->preprocessed_features, kmeans->cluster_centers, max_iters);
 


### PR DESCRIPTION
##### Summary
- Allocate enough elements in the vector to prevent buffer overflow
- Add check to ensure we have at least 2 data points (ml_kmeans_train)
