### PR TITLE
Enable Rust-based systemd journal handling code in Docker builds.

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -27,8 +27,14 @@ WORKDIR /opt/netdata.git
 RUN chmod +x netdata-installer.sh && \
    cp -rp /deps/* /usr/local/ && \
    /bin/echo -e "INSTALL_TYPE='oci'\nPREBUILT_ARCH='$(uname -m)'" > ./system/.install-type && \
-   CFLAGS="$(packaging/docker/gen-cflags.sh)" LDFLAGS="-Wl,--gc-sections" ./netdata-installer.sh --dont-wait --dont-start-it --use-system-protobuf \
-   ${EXTRA_INSTALL_OPTS} --disable-ebpf --enable-plugin-otel --install-no-prefix / "$([ "$RELEASE_CHANNEL" = stable ] && echo --stable-channel)"
+   CFLAGS="$(packaging/docker/gen-cflags.sh)" LDFLAGS="-Wl,--gc-sections" ./netdata-installer.sh --dont-wait --dont-start-it \
+   --use-system-protobuf \
+   --disable-ebpf \
+   --enable-plugin-otel \
+   --internal-systemd-journal \
+   ${EXTRA_INSTALL_OPTS} \
+   --install-no-prefix / \
+   "$([ "$RELEASE_CHANNEL" = stable ] && echo --stable-channel)"
 
 # files to one directory
 RUN mkdir -p /app/usr/sbin/ \


### PR DESCRIPTION
##### Summary

SSIA

##### Test Plan

Requires manual confirmation that the feature is enabled in the build.