### PR TITLE
Libunwind

### DIFF
--- a/src/libnetdata/stacktrace/stacktrace-libunwind.c
+++ b/src/libnetdata/stacktrace/stacktrace-libunwind.c
@@ -9,7 +9,7 @@
 #include <libunwind.h>
 #include <dlfcn.h>
 
-const char *stacktrace_capture_backend(void) {
+const char *stacktrace_backend(void) {
     return "libunwind";
 }
 
@@ -34,7 +34,7 @@ bool stacktrace_available(void) {
 }
 
 NEVER_INLINE
-void stack_trace_capture(BUFFER *wb) {
+void stacktrace_capture(BUFFER *wb) {
     // this function is async-signal-safe, if the buffer has enough space to hold the stack trace
 
     root_cause_function[0] = '\0';


### PR DESCRIPTION
##### Summary
fix build failed if ENABLE_LIBUNWIND

##### Test Plan

N/A

##### Additional Information
1. <dlfcn.h> is missing, error below:
 >  stacktrace-libunwind.c:170:13: error: call to undeclared function 'dladdr'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]

2. typo:
   stacktrace_capture_backend => stacktrace_backend
    stack_trace_capture => stacktrace_capture
