### PR TITLE
stacktrace-common: define USE_NOTRACE if no HAVE_BACKTRACE

### DIFF
--- a/src/libnetdata/stacktrace/stacktrace-common.h
+++ b/src/libnetdata/stacktrace/stacktrace-common.h
@@ -24,7 +24,7 @@
 #define USE_BACKTRACE 1
 #endif
 
-#if !defined(USE_LIBBACKTRACE) && !defined(USE_LIBUNWIND) && !defined(USE_BACKTRACE) && defined(HAVE_BACKTRACE)
+#if !defined(USE_LIBBACKTRACE) && !defined(USE_LIBUNWIND) && !defined(USE_BACKTRACE) && !defined(HAVE_BACKTRACE)
 #define USE_NOTRACE 1
 #endif
 


### PR DESCRIPTION
##### Summary
for musl libc,  backtrace() is not available, build is failed with undefined reference to `stacktrace_flush' etc if no ENABLE_LIBUNWIND/ENABLE_LIBBACKTRACE

##### Test Plan

##### Additional Information
for example, musl doesn't have backtrace() available, if no ENABLE_LIBUNWIND/ENABLE_LIBBACKTRACE, then build is failed with message (and many more) like below:

> undefined reference to `stacktrace_flush'

because USE_LIBBACKTRACE/USE_LIBUNWIND/USE_BACKTRACE/USE_NOTRACE are all undefined.