### PR TITLE
Fix /api/v3 data update_every after filtering

### DIFF
--- a/src/database/contexts/query_target.c
+++ b/src/database/contexts/query_target.c
@@ -792,9 +792,6 @@ static bool query_instance_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_C
     QUERY_TARGET *qt = qtl->qt;
     QUERY_INSTANCE *qi = query_instance_allocate(qt, ria, qn->slot);
 
-    if(qt->db.minimum_latest_update_every_s == 0 || ri->update_every_s < qt->db.minimum_latest_update_every_s)
-        qt->db.minimum_latest_update_every_s = ri->update_every_s;
-
     if(queryable_instance && filter_instances)
         queryable_instance = (SP_MATCHED_POSITIVE == query_instance_matches(
                 qi, ri, qt->instances.pattern, qtl->match_ids, qtl->match_names, qt->request.version, qtl->host_node_id_str));
@@ -836,6 +833,9 @@ static bool query_instance_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_C
     }
     else {
         if(metrics_added) {
+            if(qt->db.minimum_latest_update_every_s == 0 || ri->update_every_s < qt->db.minimum_latest_update_every_s)
+                qt->db.minimum_latest_update_every_s = ri->update_every_s;
+
             qc->instances.selected++;
             qn->instances.selected++;
         }


### PR DESCRIPTION
## Summary
- move the global update_every assignment so only instances with queried metrics update it
- keep metadata for filtered instances untouched so dashboards still expose available filters

## Why
- previously /api/v3/data reported the minimum cadence of every instance in scope, even ones filtered out of the actual query, because metadata collection runs before filters
- this made the top-level db.update_every disagree with tier 0 when dashboards sliced by instance or label

## Testing
- not run
