### PR TITLE
chore(go.d/snmp): refactor static_tags to structured key/value format

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metrics.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metrics.go
@@ -56,8 +56,8 @@ type MetricsConfig struct {
 	Symbols []SymbolConfig `yaml:"symbols,omitempty" json:"symbols,omitempty"`
 
 	// `static_tags` is not exposed as json at the moment since we need to evaluate if we want to expose it via UI
-	StaticTags []string            `yaml:"static_tags,omitempty" json:"-"`
-	MetricTags MetricTagConfigList `yaml:"metric_tags,omitempty" json:"metric_tags,omitempty"`
+	StaticTags []StaticMetricTagConfig `yaml:"static_tags,omitempty" json:"-"`
+	MetricTags MetricTagConfigList     `yaml:"metric_tags,omitempty" json:"metric_tags,omitempty"`
 
 	Options MetricsConfigOption `yaml:"options,omitempty" json:"options,omitempty"`
 
@@ -200,6 +200,18 @@ func (m MetricTagConfig) Clone() MetricTagConfig {
 	m2.Mapping = maps.Clone(m.Mapping)
 	m2.Tags = maps.Clone(m.Tags)
 	return m2
+}
+
+type StaticMetricTagConfig struct {
+	Tag   string `yaml:"tag" json:"tag"`
+	Value string `yaml:"value" json:"value"`
+}
+
+func (s StaticMetricTagConfig) Clone() StaticMetricTagConfig {
+	return StaticMetricTagConfig{
+		Tag:   s.Tag,
+		Value: s.Value,
+	}
 }
 
 // MetricTagConfigList holds configs for a list of metric tags

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metrics_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metrics_test.go
@@ -140,9 +140,8 @@ func TestCloneMetricsConfig(t *testing.T) {
 					ExtractValueCompiled: regexp.MustCompile(".*"),
 				},
 			},
-			StaticTags: []string{
-				"foo",
-				"bar",
+			StaticTags: []StaticMetricTagConfig{
+				{Tag: "foo", Value: "bar"},
 			},
 			MetricTags: []MetricTagConfig{
 				{
@@ -161,7 +160,7 @@ func TestCloneMetricsConfig(t *testing.T) {
 
 	conf2 := conf.Clone()
 	assert.Equal(t, conf, conf2)
-	conf2.StaticTags[0] = "baz"
+	conf2.StaticTags[0] = StaticMetricTagConfig{Tag: "bar", Value: "baz"}
 	conf2.MetricTags[0].IndexTransform = []MetricIndexTransform{{5, 7}}
 	conf2.Options.Placement = 2
 	conf2.Options.MetricSuffix = ".bar"

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/profile_definition.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/profile_definition.go
@@ -15,7 +15,7 @@ type ProfileDefinition struct {
 	SysobjectIDMetadata []SysobjectIDMetadataEntryConfig `yaml:"sysobjectid_metadata,omitempty"`
 	Metrics             []MetricsConfig                  `yaml:"metrics,omitempty" json:"metrics,omitempty"`
 	MetricTags          []MetricTagConfig                `yaml:"metric_tags,omitempty" json:"metric_tags,omitempty"`
-	StaticTags          []string                         `yaml:"static_tags,omitempty" json:"static_tags,omitempty"`
+	StaticTags          []StaticMetricTagConfig          `yaml:"static_tags,omitempty" json:"static_tags,omitempty"`
 
 	VirtualMetrics []VirtualMetricConfig `yaml:"virtual_metrics,omitempty" json:"virtual_metrics,omitempty"`
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_global_tags.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_global_tags.go
@@ -48,7 +48,7 @@ func (gc *globalTagsCollector) Collect(prof *ddsnmp.Profile) (map[string]string,
 	return tags, nil
 }
 
-func (gc *globalTagsCollector) processStaticTags(staticTags []string, globalTags map[string]string) {
+func (gc *globalTagsCollector) processStaticTags(staticTags []ddprofiledefinition.StaticMetricTagConfig, globalTags map[string]string) {
 	ta := tagAdder{tags: globalTags}
 	ta.addTags(parseStaticTags(staticTags))
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_global_tags_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_global_tags_test.go
@@ -29,7 +29,7 @@ func TestGlobalTagsCollector_Collect(t *testing.T) {
 			profile: &ddsnmp.Profile{
 				Definition: &ddprofiledefinition.ProfileDefinition{
 					MetricTags: []ddprofiledefinition.MetricTagConfig{},
-					StaticTags: []string{},
+					StaticTags: []ddprofiledefinition.StaticMetricTagConfig{},
 				},
 			},
 			setupMock:      func(m *snmpmock.MockHandler) {},
@@ -39,10 +39,10 @@ func TestGlobalTagsCollector_Collect(t *testing.T) {
 		"static tags only": {
 			profile: &ddsnmp.Profile{
 				Definition: &ddprofiledefinition.ProfileDefinition{
-					StaticTags: []string{
-						"environment:production",
-						"region:us-east-1",
-						"service:network",
+					StaticTags: []ddprofiledefinition.StaticMetricTagConfig{
+						{Tag: "environment", Value: "production"},
+						{Tag: "region", Value: "us-east-1"},
+						{Tag: "service", Value: "network"},
 					},
 				},
 			},
@@ -106,9 +106,9 @@ func TestGlobalTagsCollector_Collect(t *testing.T) {
 		"mixed static and dynamic tags": {
 			profile: &ddsnmp.Profile{
 				Definition: &ddprofiledefinition.ProfileDefinition{
-					StaticTags: []string{
-						"environment:production",
-						"managed:true",
+					StaticTags: []ddprofiledefinition.StaticMetricTagConfig{
+						{Tag: "environment", Value: "production"},
+						{Tag: "managed", Value: "true"},
 					},
 					MetricTags: []ddprofiledefinition.MetricTagConfig{
 						{

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar_test.go
@@ -274,9 +274,9 @@ func TestScalarCollector_Collect(t *testing.T) {
 								OID:  "1.3.6.1.2.1.1.3.0",
 								Name: "sysUpTime",
 							},
-							StaticTags: []string{
-								"source:system",
-								"type:uptime",
+							StaticTags: []ddprofiledefinition.StaticMetricTagConfig{
+								{Tag: "source", Value: "system"},
+								{Tag: "type", Value: "uptime"},
 							},
 						},
 					},

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
@@ -597,11 +597,11 @@ func (tc *tableCollector) snmpGet(oids []string) (map[string]gosnmp.SnmpPDU, err
 	return pdus, nil
 }
 
-func parseStaticTags(staticTags []string) map[string]string {
-	tags := make(map[string]string)
+func parseStaticTags(staticTags []ddprofiledefinition.StaticMetricTagConfig) map[string]string {
+	tags := make(map[string]string, len(staticTags))
 	for _, tag := range staticTags {
-		if n, v, _ := strings.Cut(tag, ":"); n != "" && v != "" {
-			tags[n] = v
+		if tag.Tag != "" && tag.Value != "" {
+			tags[tag.Tag] = tag.Value
 		}
 	}
 	return tags

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_test.go
@@ -780,9 +780,9 @@ func TestTableCollector_Collect(t *testing.T) {
 									Name: "ifInOctets",
 								},
 							},
-							StaticTags: []string{
-								"source:interface",
-								"table:if",
+							StaticTags: []ddprofiledefinition.StaticMetricTagConfig{
+								{Tag: "source", Value: "interface"},
+								{Tag: "table", Value: "if"},
 							},
 							MetricTags: []ddprofiledefinition.MetricTagConfig{
 								{
@@ -1004,8 +1004,8 @@ func TestTableCollector_Collect(t *testing.T) {
 									Name: "ifInOctets",
 								},
 							},
-							StaticTags: []string{
-								"source:network",
+							StaticTags: []ddprofiledefinition.StaticMetricTagConfig{
+								{Tag: "source", Value: "network"},
 							},
 							MetricTags: []ddprofiledefinition.MetricTagConfig{
 								{


### PR DESCRIPTION
##### Summary

This PR changes the static_tags field from a list of raw strings to a list of structured key/value pairs using the new StaticMetricTagConfig type.

Before:

```yaml
static_tags:
  - "environment:production"
  - "region:us-east-1"
  - "service:network"
```

After:

```yaml
static_tags:
  - tag: environment
    value: production
  - tag: region
    value: us-east-1
  - tag: service
    value: network
```

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
