### PR TITLE
Make OpenTelemetry plugin a required dependency for native DEB/RPM packages.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -235,6 +235,9 @@ Requires: %{name}-dashboard
 %if 0%{?_have_ebpf}
 Requires: %{name}-plugin-ebpf = %{version}
 %endif
+%if 0%{?_have_rust}
+Requires: %{name}-plugin-otel = %{version}
+%endif
 Requires: %{name}-plugin-apps = %{version}
 Requires: %{name}-plugin-pythond = %{version}
 Requires: %{name}-plugin-go = %{version}

--- a/packaging/cmake/Modules/Packaging.cmake
+++ b/packaging/cmake/Modules/Packaging.cmake
@@ -67,6 +67,10 @@ if(ENABLE_DASHBOARD)
   list(APPEND _main_deps "netdata-dashboard")
 endif()
 
+if(ENABLE_PLUGIN_OTEL)
+  list(APPEND _main_deps "netdata-plugin-otel")
+endif()
+
 if(ENABLE_PLUGIN_CHARTS)
   list(APPEND _main_deps "netdata-plugin-chartsd")
 endif()


### PR DESCRIPTION
##### Summary

The plugin is extremely lightweight and has essentially zero external dependencies, so there is little downside to making it mandatory.

Additionally, the long-term plan is to have this be a core part of data collection for Netdata, so it’s desirable to have it out there and being used sooner as opposed to later to help catch issues early.

##### Test Plan

n/a