### PR TITLE
Update MCP Registry publishing workflow and migrate server.json to latest schema

### DIFF
--- a/.github/workflows/update-mcp-registry.yml
+++ b/.github/workflows/update-mcp-registry.yml
@@ -1,11 +1,16 @@
----
 name: Update MCP Registry
 on:
   release:
     types: [released]
+
 concurrency:
   group: update-mcp-registry-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish-mcp-registry:
     name: Publish to MCP Registry
@@ -14,39 +19,41 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v5
+
       - name: Update server.json version
-        id: update-version
+        id: update_version
         run: |
           VERSION="$(cat packaging/version)"
-          # Remove 'v' prefix if present
           VERSION="${VERSION#v}"
-          # Update version in server.json
-          sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" server.json
+          sed -i 's/"version": ".*"/"version": "'"$VERSION"'"/' server.json
           echo "Updated server.json to version: $VERSION"
-      - name: Install mcp-publisher
-        id: install
+
+      - name: Install mcp-publisher (latest release)
+        id: install_publisher
         run: |
-          # Clone and build mcp-publisher
-          git clone https://github.com/modelcontextprotocol/registry.git /tmp/registry
-          cd /tmp/registry
-          make publisher
-          sudo cp bin/mcp-publisher /usr/local/bin/
+          set -euo pipefail
+          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          URL="https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${OS}_${ARCH}.tar.gz"
+          curl -fsSL "$URL" | tar xz
+          sudo mv mcp-publisher /usr/local/bin/
           mcp-publisher --version
-      - name: Authenticate with GitHub
-        id: auth
-        run: |
-          # GitHub Actions automatically provides GITHUB_TOKEN with OIDC
-          # mcp-publisher will use this for authentication
-          echo "Using GitHub OIDC authentication"
+
+      - name: Validate server.json (dry run)
+        id: validate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mcp-publisher publish server.json --dry-run
+
       - name: Publish to registry
         id: publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cd ${{ github.workspace }}
-          mcp-publisher publish server.json
+        run: mcp-publisher publish server.json
+
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
+        if: failure()
         env:
           SLACK_COLOR: 'danger'
           SLACK_FOOTER: ''
@@ -54,11 +61,10 @@ jobs:
           SLACK_TITLE: 'Failed to publish to MCP Registry:'
           SLACK_USERNAME: 'GitHub Actions'
           SLACK_MESSAGE: |-
-              ${{ github.repository }}: Failed to publish new agent version to MCP Registry.
-              Checkout: ${{ steps.checkout.outcome }}
-              Update version: ${{ steps.update-version.outcome }}
-              Install mcp-publisher: ${{ steps.install.outcome }}
-              Authenticate: ${{ steps.auth.outcome }}
-              Publish: ${{ steps.publish.outcome }}
+            ${{ github.repository }}: Failed to publish new agent version to MCP Registry.
+            Checkout: ${{ steps.checkout.outcome }}
+            Update version: ${{ steps.update_version.outcome }}
+            Install mcp-publisher: ${{ steps.install_publisher.outcome }}
+            Validate: ${{ steps.validate.outcome }}
+            Publish: ${{ steps.publish.outcome }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: failure()

--- a/server.json
+++ b/server.json
@@ -1,16 +1,53 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.netdata/mcp-server",
-  "description": "AI-powered infrastructure monitoring with real-time metrics, logs, alerts, and ML anomaly detection.",
+  "title": "Netdata MCP Server",
+  "description": "Real-time infrastructure monitoring with metrics, logs, alerts, and ML-based anomaly detection.",
   "version": "2.7.1-1",
-  "homepage": "https://www.netdata.cloud",
-  "documentation": "https://learn.netdata.cloud/docs/netdata-ai/mcp",
-  "license": "GPL-3.0",
+  "websiteUrl": "https://www.netdata.cloud",
   "repository": {
     "url": "https://github.com/netdata/netdata",
     "source": "github",
     "subfolder": "docs/netdata-ai/mcp"
   },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "http://localhost:19999/mcp",
+      "headers": [
+        {
+          "type": "named",
+          "name": "Authorization",
+          "value": "Bearer {NETDATA_MCP_API_KEY}",
+          "isSecret": true,
+          "variables": {
+            "NETDATA_MCP_API_KEY": {
+              "description": "Netdata MCP API key",
+              "isSecret": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "sse",
+      "url": "http://localhost:19999/mcp?transport=sse",
+      "headers": [
+        {
+          "type": "named",
+          "name": "Authorization",
+          "value": "Bearer {NETDATA_MCP_API_KEY}",
+          "isSecret": true,
+          "variables": {
+            "NETDATA_MCP_API_KEY": {
+              "description": "Netdata MCP API key",
+              "isSecret": true
+            }
+          }
+        }
+      ]
+    }
+  ],
   "capabilities": {
     "features": [
       "Real-time infrastructure observability",
@@ -194,12 +231,18 @@
   },
   "version_compatibility": {
     "v2.6.0-v2.7.1": {
-      "transports": ["WebSocket"],
+      "transports": [
+        "WebSocket"
+      ],
       "required_bridge": "nd-mcp",
       "direct_connection": false
     },
     "v2.7.2+": {
-      "transports": ["WebSocket", "HTTP Streamable", "SSE"],
+      "transports": [
+        "WebSocket",
+        "HTTP Streamable",
+        "SSE"
+      ],
       "required_bridge": "nd-mcp or mcp-remote (optional for stdio clients)",
       "direct_connection": true,
       "notes": "Currently available in nightly builds"


### PR DESCRIPTION


##### Summary

This PR updates our MCP registry integration to comply with the latest Model Context Protocol (MCP) publishing requirements and improves the GitHub Actions workflow for registry publishing.

- Migrated server.json to the new schema version.
- Improved workflow (.github/workflows/update-mcp-registry.yml)
    - Install mcp-publisher from the latest release instead of building from main
    - Added schema validation step using --dry-run before actual publish


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
