### PR TITLE
Adjust page cache locking

### DIFF
--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -715,6 +715,8 @@ static ALWAYS_INLINE void pgc_queue_del(PGC *cache __maybe_unused, struct pgc_qu
 
     page_flag_clear(page, q->flags);
 
+    struct section_pages *sp_to_free = NULL;
+
     if(q->linked_list_in_sections_judy) {
         Pvoid_t *section_pages_pptr = JudyLGet(q->sections_judy, page->section, PJE0);
         if(section_pages_pptr == NULL || section_pages_pptr == PJERR)
@@ -735,8 +737,7 @@ static ALWAYS_INLINE void pgc_queue_del(PGC *cache __maybe_unused, struct pgc_qu
             if(!rc)
                 fatal("DBENGINE CACHE: cannot delete section from Judy LL");
 
-            // freez(sp);
-            aral_freez(pgc_sections_aral, sp);
+            sp_to_free = sp;
 
             mem_delta -= sizeof(struct section_pages);
             mem_delta += JudyAllocThreadPulseGetAndReset();
@@ -751,6 +752,9 @@ static ALWAYS_INLINE void pgc_queue_del(PGC *cache __maybe_unused, struct pgc_qu
 
     if(!having_lock)
         pgc_queue_unlock(cache, q);
+
+    if (sp_to_free)
+        aral_freez(pgc_sections_aral, sp_to_free);
 }
 
 static ALWAYS_INLINE void page_has_been_accessed(PGC *cache, PGC_PAGE *page) {


### PR DESCRIPTION
##### Summary
- Make sure (aral) free always happens after releasing the queue lock
