### PR TITLE
Fix systemd-cat-native crash on realloc

### DIFF
--- a/src/libnetdata/log/systemd-cat-native.c
+++ b/src/libnetdata/log/systemd-cat-native.c
@@ -110,7 +110,7 @@ static inline void buffer_memcat_replacing_newlines(BUFFER *wb, const char *src,
     buffer_memcat(wb, src, key_len);
     buffer_putc(wb, '\n');
 
-    char *length_ptr = &wb->buffer[wb->len];
+    size_t length_offset = wb->len;
     uint64_t le_size = 0;
     buffer_memcat(wb, &le_size, sizeof(le_size));
 
@@ -122,7 +122,7 @@ static inline void buffer_memcat_replacing_newlines(BUFFER *wb, const char *src,
     buffer_putc(wb, '\n');
 
     le_size = htole64(size);
-    memcpy(length_ptr, &le_size, sizeof(le_size));
+    memcpy(&wb->buffer[length_offset], &le_size, sizeof(le_size));
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
```
Process 3825580 (systemd-cat-nat) of user 995 dumped core.

Module libzstd.so.1 from deb libzstd-1.5.5+dfsg2-2build1.1.amd64
Module libgcc_s.so.1 from deb gcc-14-14.2.0-4ubuntu2~24.04.amd64
Module libsystemd.so.0 from deb systemd-255.4-1ubuntu8.11.amd64
Stack trace of thread 3825580:
#0  0x00005a2fae5a3c49 memcpy (systemd-cat-native + 0x12c49)
#1  0x00005a2fae5fbed3 log_input_to_journal.constprop.0 (systemd-cat-native + 0x6aed3)
#2  0x0000718250c2a1ca n/a (libc.so.6 + 0x2a1ca)
#3  0x0000718250c2a28b __libc_start_main (libc.so.6 + 0x2a28b)
#4  0x00005a2fae5a2ae5 _start (systemd-cat-native + 0x11ae5)
ELF object binary architecture: AMD x86-64
```

## Summary
- store the offset for the journal length placeholder before appending to the buffer
- ensure multi-line entries that trigger realloc no longer segfault in systemd-cat-native

## Testing
- tested it