### PR TITLE
Detect in kickstart script if we publish native packages for the platform

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2273,7 +2273,7 @@ install_on_linux() {
         case "${NETDATA_REQUESTED_INSTALL_TYPE}" in
           native|auto)
             case "${SELECTED_RELEASE_CHANNEL}" in
-              stable) fatal "A stable build with native packages has not yet been published for this system, but is expected to be published within hte next few weeks. If you need to install now, you should be able to do so either by using a nightly build (add --release-channel=nightly to the options passed to this script) or by using a static build (add --install-type=static to the options passed to this script). Note that if you use a static build, you may have to reinstall once a stable build is published with native packages for this system to get full support." F051D ;;
+              stable) fatal "A stable build with native packages has not yet been published for this system, but is expected to be published within the next few weeks. If you need to install now, you should be able to do so either by using a nightly build (add --release-channel=nightly to the options passed to this script) or by using a static build (add --install-type=static to the options passed to this script). Note that if you use a static build, you may have to reinstall once a stable build is published with native packages for this system to get full support." F051D ;;
               nightly) fatal "A nightly build with native packages has not yet been published for this system, but is expected to be published at 01:00 UTC tomorrow. Please try again tomorrow." F051E ;;
             esac
             ;;
@@ -2316,8 +2316,8 @@ install_on_linux() {
 
 install_on_macos() {
   case "${NETDATA_REQUESTED_INSTALL_TYPE}" in
-    native) fatal "User requested native package, but native packages are not available for macOS. Try installing without \`--only-native\` option." F0305 ;;
-    static) fatal "User requested static build, but static builds are not available for macOS. Try installing without \`--only-static\` option." F0306 ;;
+    native) fatal "User requested native package, but native packages are not available for macOS. Try installing without \`--native-only\` option." F0305 ;;
+    static) fatal "User requested static build, but static builds are not available for macOS. Try installing without \`--static-only\` option." F0306 ;;
     *)
       SELECTED_INSTALL_METHOD="build"
       INSTALL_TYPE="kickstart-build"
@@ -2333,8 +2333,8 @@ install_on_macos() {
 
 install_on_freebsd() {
   case "${NETDATA_REQUESTED_INSTALL_TYPE}" in
-    native) fatal "User requested native package, but native packages are not available for FreeBSD. Try installing without \`--only-native\` option." F0308 ;;
-    static) fatal "User requested static build, but static builds are not available for FreeBSD. Try installing without \`--only-static\` option." F0309 ;;
+    native) fatal "User requested native package, but native packages are not available for FreeBSD. Try installing without \`--native-only\` option." F0308 ;;
+    static) fatal "User requested static build, but static builds are not available for FreeBSD. Try installing without \`--static-only\` option." F0309 ;;
     *)
       SELECTED_INSTALL_METHOD="build"
       INSTALL_TYPE="kickstart-build"


### PR DESCRIPTION
##### Summary

This allows more intelligent fallback behavior, insisting on using native packages if they are being published (and are actually available) and only falling back if they aren’t. It also means that users installing on platforms we still have packages available for but no longer publish packages for will end up with static installs instead of native package installs.

This change includes a new option for the kickstart script called `--install-type`, which can be used to specify the install type to use. It supports five possible values currently, `native`, `static`, `build`, `auto`, and `any`. The first three are equivalent to the existing `--native-only`, `--static-only`, and `--build-only` options. The `any` value indicates to use our existing fallback behavior (try each install type in order until we find one that works). The `auto` value, which is the new default, acts like `native` if the script detects that we publish native packages for the platform, and `any` otherwise.

The actual checking done for `auto` involves confirming that:

1. We have CI configured to publish native packages for the detected platform (confirmed looking for a flag file in the repositories that is generated by the repository backend code from `.github/data/distros.yaml`).
2. A repository configuration package exists for the detected platform.
3. Repository metadata exists for the selected release channel and the requested platform. This is used to confirm that we’ve actually published packages for the platform.

If either of the first two checks fail when in `auto` mode, the install itself will fall back to using static builds like it does currently.

If the third check fails when in `auto` mode, the install will fail with an error message indicating that packages have not yet been published for this platform, but are expected to be published soon. For nightlies it asks the user to try again tomorrow (which will almost always work), while for stable builds it suggests the possibility of using a nightly build or a static build for the install.

If all three checks pass when in `auto` mode but the package install fails, the install will fail with an error message indicating that the package couldn’t be installed despite appearing to be available, and suggests that the user should look into what’s wrong with their system, or try with `any` mode to install regardless.

##### Test Plan

Requires some manual testing to confirm that the changes behave as expected.