### PR TITLE
Improve websocket thread shutdown

### DIFF
--- a/src/web/websocket/websocket-thread.c
+++ b/src/web/websocket/websocket-thread.c
@@ -484,14 +484,65 @@ void websocket_thread(void *ptr) {
 
     // Close all clients in this thread
     WS_CLIENT *wsc = wth->clients;
+
+    // SHUTDOWN MODE: Fast cleanup with timeouts to avoid blocking
+    usec_t cleanup_start = now_monotonic_usec();
+    usec_t max_cleanup_time = 5 * USEC_PER_SEC;
+    size_t clients_closed = 0, clients_skipped = 0;
+
     while(wsc) {
         WS_CLIENT *next = wsc->next;
 
-        websocket_protocol_send_close(wsc, WS_CLOSE_GOING_AWAY, "Server shutting down");
-        websocket_write_data(wsc);
-        websocket_thread_remove_client(wth, wsc, true);
+        // Cache elapsed time to avoid repeated syscalls
+        usec_t elapsed = now_monotonic_usec() - cleanup_start;
 
+        if(elapsed < max_cleanup_time && wsc->sock.fd >= 0) {
+            bool skip_client = false;
+
+            // Ensure socket is non-blocking
+            int flags = fcntl(wsc->sock.fd, F_GETFL, 0);
+            if(flags >= 0 && !(flags & O_NONBLOCK)) {
+                if(fcntl(wsc->sock.fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+                    websocket_debug(wsc, "Failed to set O_NONBLOCK during shutdown: %s", strerror(errno));
+                    skip_client = true;
+                }
+            }
+
+            if(!skip_client) {
+                // Set send timeout: 100ms max per client
+                struct timeval timeout = { .tv_sec = 0, .tv_usec = 100000 };
+                if(setsockopt(wsc->sock.fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) < 0) {
+                    websocket_debug(wsc, "Failed to set SO_SNDTIMEO during shutdown: %s (continuing)", strerror(errno));
+                    // Non-critical, continue anyway
+                }
+
+                // Try to send close frame (won't block due to O_NONBLOCK + SO_SNDTIMEO)
+                websocket_protocol_send_close(wsc, WS_CLOSE_GOING_AWAY, "Server shutting down");
+                ssize_t written = websocket_write_data(wsc);
+                if(written < 0) {
+                    websocket_debug(wsc, "Failed to send close frame during shutdown");
+                }
+                clients_closed++;
+            }
+            else {
+                clients_skipped++;
+            }
+        }
+        else {
+            clients_skipped++;
+        }
+
+        websocket_thread_remove_client(wth, wsc, true);
         wsc = next;
+    }
+
+    netdata_log_info("WEBSOCKET[%zu] shutdown cleanup complete: %zu clients closed gracefully, %zu skipped",
+                     wth->id, clients_closed, clients_skipped);
+
+    if(clients_skipped > 0 && clients_skipped > clients_closed) {
+        nd_log_daemon(NDLP_WARNING, "WEBSOCKET[%zu] skipped more clients (%zu) than closed gracefully (%zu) - "
+                            "possible network issues or timeout reached",
+                            wth->id, clients_skipped, clients_closed);
     }
 
     // Reset thread's client list


### PR DESCRIPTION
##### Summary

  Enhances websocket thread shutdown to prevent indefinite hangs and improve error handling during server shutdown. Adds timeout protection, non-blocking I/O configuration, and comprehensive error handling to ensure graceful and predictable shutdown behavior.

  Problem

  During server shutdown, the websocket thread cleanup could hang indefinitely when attempting to send close frames to unresponsive clients. This was caused by:

  1. No timeout protection - blocked indefinitely on slow/dead connections
  2. Blocking I/O - send() operations could block the shutdown process
  3. No error handling - syscall failures were silently ignored
  4. Poor visibility - no logging of shutdown progress or issues

  This could delay or prevent clean server shutdown, especially under high load or network issues.
