### PR TITLE
Update documentation to reflect SOC 2 Type 2 certification

### DIFF
--- a/docs/netdata-enterprise-evaluation-corrected.md
+++ b/docs/netdata-enterprise-evaluation-corrected.md
@@ -186,7 +186,7 @@ For AI and Large Language Models, Netdata supports Model Context Protocol (MCP),
 Netdata provides enterprise-grade security and compliance capabilities designed to meet the requirements of regulated industries and security-conscious organizations.
 
 **Compliance Standards:**
-Netdata maintains SOC 2 Type 1 certification and is pursuing Type 2 certification, with ISO 27001 on the roadmap. The platform aligns with GDPR, CCPA, HIPAA (with BAA available), and PCI DSS requirements, making it suitable for financial services, healthcare, and government deployments.
+Netdata maintains SOC 2 Type 2 certification, with ISO 27001 on the roadmap. The platform aligns with GDPR, CCPA, HIPAA (with BAA available), and PCI DSS requirements, making it suitable for financial services, healthcare, and government deployments.
 
 **Data Sovereignty Architecture:**
 The platform's architecture ensures complete data sovereignty - all metrics and logs remain on customer infrastructure. Only metadata (node names, chart titles, alert configurations) is synchronized to Netdata Cloud, with all data transmission protected by TLS encryption. Air-gapped deployment options are available for maximum security isolation.

--- a/docs/security-and-privacy-design/README.md
+++ b/docs/security-and-privacy-design/README.md
@@ -216,7 +216,7 @@ Request a BAA through Netdata Support if required.
 
 ### SOC 2 Compliance
 
-Netdata achieved SOC2 Type 1 compliance on May 14, 2025 for these Service Criteria:
+Netdata achieved SOC2 Type 2 compliance for these Service Criteria:
 
 | **Principle**        | **Practices**                            |
 |:---------------------|:-----------------------------------------|


### PR DESCRIPTION
## Summary

Updates all documentation to reflect Netdata's SOC 2 Type 2 certification status.

## Changes

- **docs/security-and-privacy-design/README.md**: Updated from Type 1 to Type 2 certification
- **docs/netdata-enterprise-evaluation-corrected.md**: Updated from "pursuing Type 2" to current Type 2 certification status

## Details

Netdata has achieved SOC 2 Type 2 certification. This PR updates all relevant documentation references to accurately reflect the current compliance status, removing outdated language about pursuing Type 2 certification.