### PR TITLE
Compute timestamps needed for status file

### DIFF
--- a/src/daemon/machine-guid.c
+++ b/src/daemon/machine-guid.c
@@ -99,6 +99,7 @@ static bool machine_guid_read_from_file(const char *filename, ND_MACHINE_GUID *h
 
     // Update last modified timestamp.
     h.last_modified_ut = STAT_GET_MTIME_SEC(st) * USEC_PER_SEC + STAT_GET_MTIME_NSEC(st) / 1000;
+    rfc3339_datetime_ut(h.last_modified_ut_rfc3339, sizeof(h.last_modified_ut_rfc3339), h.last_modified_ut, 2, true);
     *host_id = h;
 
     nd_log(NDLS_DAEMON, NDLP_INFO, "MACHINE_GUID: GUID read from file '%s'", filename);
@@ -125,6 +126,7 @@ static bool machine_guid_write_to_file(const char *filename, ND_MACHINE_GUID *ho
     if (host_id) {
         h.uuid = host_id->uuid;
         h.last_modified_ut = host_id->last_modified_ut;
+        safecpy(h.last_modified_ut_rfc3339, host_id->last_modified_ut_rfc3339);
     }
 
     // Create the text representation before writing.
@@ -204,6 +206,7 @@ static ND_MACHINE_GUID machine_guid_get_or_create(void) {
         nd_log(NDLS_DAEMON, NDLP_INFO, "MACHINE_GUID: got previous GUID from daemon status file");
 
     h.last_modified_ut = now_realtime_usec();
+    rfc3339_datetime_ut(h.last_modified_ut_rfc3339, sizeof(h.last_modified_ut_rfc3339), h.last_modified_ut, 2, true);
     nd_machine_guid = h;
 
     // Ensure the registry directory exists.

--- a/src/daemon/machine-guid.h
+++ b/src/daemon/machine-guid.h
@@ -9,6 +9,7 @@ typedef struct nd_machine_guid {
     char txt[UUID_STR_LEN];
     ND_UUID uuid;
     usec_t last_modified_ut;
+    char last_modified_ut_rfc3339[RFC3339_MAX_LENGTH]; // pre-calculated RFC3339 for async-signal-safe use
 } ND_MACHINE_GUID;
 
 ND_MACHINE_GUID *machine_guid_get(void);

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -100,7 +100,7 @@ static void daemon_status_file_to_json(BUFFER *wb, DAEMON_STATUS_FILE *ds) {
 
     dsf_acquire(*ds);
 
-    buffer_json_member_add_datetime_rfc3339(wb, "@timestamp", ds->timestamp_ut, true);
+    buffer_json_member_add_string(wb, "@timestamp", ds->timestamp_ut_rfc3339);
     buffer_json_member_add_uint64(wb, "version", STATUS_FILE_VERSION);
 
     buffer_json_member_add_object(wb, "agent");
@@ -108,7 +108,7 @@ static void daemon_status_file_to_json(BUFFER *wb, DAEMON_STATUS_FILE *ds) {
         buffer_json_member_add_uuid(wb, "id", ds->host_id.uuid.uuid);
 
         if(ds->v >= 24 && ds->host_id.last_modified_ut)
-            buffer_json_member_add_datetime_rfc3339(wb, "since", ds->host_id.last_modified_ut, true);
+            buffer_json_member_add_string(wb, "since", ds->host_id.last_modified_ut_rfc3339);
 
         buffer_json_member_add_uuid_compact(wb, "ephemeral_id", ds->invocation.uuid);
         buffer_json_member_add_string(wb, "version", ds->version);
@@ -246,7 +246,7 @@ static void daemon_status_file_to_json(BUFFER *wb, DAEMON_STATUS_FILE *ds) {
             buffer_json_member_add_uint64(wb, "dbengine", ds->disk_footprint.dbengine);
             buffer_json_member_add_uint64(wb, "sqlite", ds->disk_footprint.sqlite);
             buffer_json_member_add_uint64(wb, "other", ds->disk_footprint.other);
-            buffer_json_member_add_datetime_rfc3339(wb, "last_updated", ds->disk_footprint.last_updated_ut, true);
+            buffer_json_member_add_string(wb, "last_updated", ds->disk_footprint.last_updated_ut_rfc3339);
             buffer_json_object_close(wb);
         }
         buffer_json_object_close(wb);
@@ -748,6 +748,8 @@ static void daemon_status_file_refresh(DAEMON_STATUS status) {
     session_status.boottime = now_boottime_sec();
     session_status.uptime = now_realtime_sec() - netdata_start_time;
     session_status.timestamp_ut = now_ut;
+    rfc3339_datetime_ut(session_status.timestamp_ut_rfc3339, sizeof(session_status.timestamp_ut_rfc3339),
+                        session_status.timestamp_ut, 2, true);
     session_status.invocation = nd_log_get_invocation_id();
     session_status.db_mode = default_rrd_memory_mode;
     session_status.db_tiers = nd_profile.storage_tiers;
@@ -829,10 +831,13 @@ static void daemon_status_file_refresh(DAEMON_STATUS status) {
         
         // Calculate other files (total - dbengine - sqlite)
         session_status.disk_footprint.other = total_size.bytes - dbengine_size.bytes - sqlite_size.bytes;
-        
+
         // Update last updated timestamp
         session_status.disk_footprint.last_updated_ut = now_ut;
-        
+        rfc3339_datetime_ut(session_status.disk_footprint.last_updated_ut_rfc3339,
+                            sizeof(session_status.disk_footprint.last_updated_ut_rfc3339),
+                            session_status.disk_footprint.last_updated_ut, 2, true);
+
         // Clean up patterns
         simple_pattern_free(dbengine_pattern);
         simple_pattern_free(sqlite_pattern);
@@ -1062,9 +1067,26 @@ void daemon_status_file_init(void) {
 
     if(last_session_status.v <= 26)
         fill_dmi_info(&last_session_status);
-    
+
     if(last_session_status.v <= 27)
         last_session_status.system_cpus = os_get_system_cpus();
+
+    // Regenerate RFC3339 strings from loaded timestamps for async-signal-safe compatibility
+    // (these fields don't exist in saved JSON, they're runtime-only for signal handlers)
+    if(last_session_status.timestamp_ut)
+        rfc3339_datetime_ut(last_session_status.timestamp_ut_rfc3339,
+                            sizeof(last_session_status.timestamp_ut_rfc3339),
+                            last_session_status.timestamp_ut, 2, true);
+
+    if(last_session_status.host_id.last_modified_ut)
+        rfc3339_datetime_ut(last_session_status.host_id.last_modified_ut_rfc3339,
+                            sizeof(last_session_status.host_id.last_modified_ut_rfc3339),
+                            last_session_status.host_id.last_modified_ut, 2, true);
+
+    if(last_session_status.disk_footprint.last_updated_ut)
+        rfc3339_datetime_ut(last_session_status.disk_footprint.last_updated_ut_rfc3339,
+                            sizeof(last_session_status.disk_footprint.last_updated_ut_rfc3339),
+                            last_session_status.disk_footprint.last_updated_ut, 2, true);
 
     daemon_status_file_migrate_once();
 }

--- a/src/daemon/status-file.h
+++ b/src/daemon/status-file.h
@@ -48,6 +48,7 @@ typedef struct daemon_status_file {
     time_t boottime;            // system boottime
     time_t uptime;              // netdata uptime
     usec_t timestamp_ut;        // the timestamp of the status file
+    char timestamp_ut_rfc3339[RFC3339_MAX_LENGTH]; // pre-calculated RFC3339 for async-signal-safe use
     size_t restarts;            // the number of times this agent has restarted (ever)
     size_t crashes;             // the number of times this agent has crashed (ever)
     size_t posts;               // the number of posts to the backend
@@ -79,6 +80,7 @@ typedef struct daemon_status_file {
         uint64_t sqlite;       // Size of sqlite files
         uint64_t other;        // Size of other files (total - dbengine - sqlite)
         usec_t last_updated_ut; // Last time the footprint was updated (microseconds)
+        char last_updated_ut_rfc3339[RFC3339_MAX_LENGTH]; // pre-calculated RFC3339 for async-signal-safe use
     } disk_footprint;
     
     // Metrics statistics


### PR DESCRIPTION

##### Summary
- Store timestamps needed in structures properly formatted so as to avoid signal async unsafe calls 
