### PR TITLE
Detect netdata CLI initialization failure

### DIFF
--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -896,6 +896,7 @@ void commands_init(void)
 
 after_error:
     netdata_log_error("Failed to initialize command server. The netdata cli tool will be unable to send commands.");
+    command_server_initialized = CMD_INIT_STATUS_OFF;
 }
 
 void commands_exit(void)


### PR DESCRIPTION
##### Summary
- Prevent crash when attempting to shutdown the CLI thread when in fact it was never initialized

