### PR TITLE
Improve forced new datafile on startup

### DIFF
--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1606,7 +1606,7 @@ int journalfile_load(struct rrdengine_instance *ctx, struct rrdengine_journalfil
 
     bool is_last_file = (ctx_last_fileno_get(ctx) == journalfile->datafile->fileno);
     bool has_old_data = false;
-    if (ctx->config.tier == 0)
+    if (ctx->config.tier == 0 && journalfile->v2.last_time_s > 0)
         has_old_data = (now_realtime_sec() - journalfile->v2.last_time_s) > 86400;
 
     if (is_last_file && journalfile->datafile->pos <= rrdeng_target_data_file_size(ctx) / 3 && !has_old_data) {


### PR DESCRIPTION
##### Summary
Currently on agent startup a new datafile is created when the last datafile size is over one third of the optimal calculated size. 

This PR adds a check to force  a new datafile when the last datafile contains data more than a day old (this applies to tier 0 only)
