### PR TITLE
Deployment Guides

### DIFF
--- a/docs/deployment-guides/README.md
+++ b/docs/deployment-guides/README.md
@@ -58,7 +58,6 @@ Run Netdata in containers for quick testing. Note: Some features are limited com
 | **Kubernetes**          | [Helm Chart](https://github.com/netdata/helmchart#netdata-helm-chart-for-kubernetes-deployments)                                                                   | Required for K8s API access and pod metadata collection             |
 | **Testing/Development** | [Standalone](/docs/deployment-guides/standalone-deployment.md) or [Docker](/packaging/docker/README.md)                                                            | Quick setup, easy to remove                                         |
 | **Single server**       | [Standalone](/docs/deployment-guides/standalone-deployment.md) (upgrade to [Parent-Child](/docs/deployment-guides/deployment-with-centralization-points.md) later) | Start simple, upgrade when ready for production                     |
-| **Enterprise scale (1000+ nodes)** | [Parent-Child with clustering](/docs/deployment-guides/enterprise-deployment.md) | Multi-tier architecture, high availability, resource optimization |
 
 :::warning Important Notes
 


### PR DESCRIPTION
Production deployment explained, people ask that a lot in askdocs, perhaps we should rename the doc in the sidebar deployment guide instead of quickstart deployment? @ilyam8






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the deployment guide with production-ready guidance, including a new enterprise-scale section for 1000+ nodes. Clarifies Kubernetes Helm usage, Docker limits, and parent-child architecture, and adds tuning, HA, and verification steps.

- **New Features**
  - Architecture patterns for scale: multi-tier parents, active-active clustering, and multi-parent failover.
  - Tuned configs for children, parents, and DB retention, with streaming/replication settings and minimal child mode.
  - Resource sizing for CPU, memory, and disk, with formulas and example calculations.
  - HA options using native failover and HAProxy, plus key metrics to watch and common bottlenecks.
  - Verification commands and guidance on common mistakes; updated method matrix with an enterprise option and clearer notes on Kubernetes (Helm only) and Docker limitations.

<sup>Written for commit 5e2d37e04cc921cfe5f32c31926895543fa87331. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





