### PR TITLE
Additional check when executing a CLI command

### DIFF
--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -602,7 +602,8 @@ cmd_status_t execute_command(cmd_t idx, char *args, char **message)
     if (command_server_initialized >= command_info_array[idx].init_status)
         status = command_info_array[idx].func(args, message);
     else {
-        *message = strdupz("Agent is initializing");
+        if (message)
+            *message = strdupz("Agent is initializing");
         status = CMD_STATUS_SUCCESS;
     }
     cmd_unlock_by_type[type](idx);


### PR DESCRIPTION
##### Summary
- Prevent crash when executing a command (eg. logs reopen or health reload) via a signal while the agent is initializing


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a NULL check before setting the response message in execute_command to prevent a crash when commands (e.g., logs reopen, health reload) are triggered while the agent is initializing.

<sup>Written for commit 53295a5f11fec2aaae5ed9c19be540a6056ea6b9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

