### PR TITLE
Rename SNMP Profile Format to Profile Format

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -1,4 +1,4 @@
-# SNMP Profile Format
+# Profile Format
 
 ## Overview
 


### PR DESCRIPTION
##### Summary

test for search needs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the doc title from “SNMP Profile Format” to “Profile Format” to match the page context and improve search relevance. This removes redundant wording since the page already sits under the SNMP collector docs.

<sup>Written for commit 6a57bedf6cbb9debef7445fc108778cb942dabbb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

