### PR TITLE
Report inability to update due to native packages no longer being published.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -1135,7 +1135,6 @@ update_binpkg() {
   esac
 
   initial_version="$(get_current_version)"
-  nd_version="$(netdata -V | cut -f 2 -d ' ')"
 
   if [ -n "${repo_subcmd}" ]; then
     # shellcheck disable=SC2086
@@ -1148,9 +1147,9 @@ update_binpkg() {
   elif ${pkg_installed_check} netdata-repo-edge > /dev/null 2>&1; then
     RELEASE_CHANNEL="nightly"
     repopkg="netdata-repo-edge"
-  elif echo "${nd_version}" | grep -Eq -- 'v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+  elif echo "${initial_version}" | grep -Eq -- '^[0-9]*[1-9][0-9]*0{5}$'; then # All five final digits are zero and at least one preceeding digit is non-zero.
     RELEASE_CHANNEL="stable"
-  elif echo "${nd_version}" | grep -Eq -- '-nightly$'; then
+  elif echo "${initial_version}" | grep -Eq -- '^[0-9]*[1-9][0-9]{0,4}$'; then # At least one of the final five digits is non-zero.
     RELEASE_CHANNEL="nightly"
   else
     RELEASE_CHANNEL="none"


### PR DESCRIPTION
##### Summary

This adds an extra check in the `netdata-updater.sh` script to fail with an error when trying to update a system that uses our native packages if we have stopped publishing our native packages.

The check utilizes a flag file generated by the repository backend code to determine if we are actually publishing packages for the platform or not. If the flag file is not present, then the update process bails very early on with an error message indicating that the user needs to change to a different install type, and a link pointing to our documentation of how to switch install types.

Also, this fixes an issue with the existing version change check that caused it to not function correctly for stable builds (always passing if the new version was a patch release, and always failing if the new version was a major or minor release).

##### Test Plan

Requires manual testing to confirm that regular updates still work.

##### Additional information

Fixes: #21328 