### PR TITLE
Account deletion update

### DIFF
--- a/docs/delete/netdata/account.md
+++ b/docs/delete/netdata/account.md
@@ -26,7 +26,7 @@ Once in the Settings page, your profile information will appear in a pop-up wind
 
 Click on **"Delete account"**. A confirmation dialog will appear asking you to verify the account you're about to delete.
 
-![delete dialog](https://raw.githubusercontent.com/kanelatechnical/docs-images/c3aa0d7a4ef13ced5e11baf4a50d0b28e8d1004f/Confirmation%20Dialogue.png)
+![delete dialog](https://raw.githubusercontent.com/netdata/docs-images/master/Confirmation%20Dialogue.png)
 
 :::note
 


### PR DESCRIPTION
(confirmation dialogue now requires email)




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the account deletion guide to include the new confirmation step that requires typing your email, preventing accidental deletion of the wrong account. Replaced the dialog screenshot and added a note explaining the email requirement.

<sup>Written for commit cfb66fcd870ac18b99f8c13bbe340a06cf4fc494. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



