### PR TITLE
Additional checks during initial context load

### DIFF
--- a/src/database/contexts/rrdcontext-loading.c
+++ b/src/database/contexts/rrdcontext-loading.c
@@ -34,7 +34,7 @@ static void rrdinstance_load_dimension_callback(SQL_DIMENSION_DATA *sd, void *da
     RRDCONTEXT *rc = rrdcontext_acquired_value(rca);
     if(!rc) {
         th_ignored_metrics++;
-        rrdcontext_release(rca);
+        dictionary_acquired_item_release(host->rrdctx.contexts, (DICTIONARY_ITEM *)rca);
         uuidmap_free(id);
         return;
     }


### PR DESCRIPTION
##### Summary
- Add additional checks during initial context load






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds defensive checks and cleanup in RRD context initial load to safely handle null acquisitions. Prevents crashes and memory leaks by skipping invalid instances/metrics and updating ignore counters.

- **Bug Fixes**
  - Guard null returns for rrdcontext/rrdinstance acquisitions.
  - Handle failed dictionary insert/acquire for contexts and instances.
  - Release acquired handles and free strings/UUIDs on early return.
  - Increment th_ignored_instances and th_ignored_metrics when skipping.

<sup>Written for commit d8a01cfc080e82c6c736f7bc405f16dcbbf42c11. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





