### PR TITLE
Use improved compression algorithms when building DEB packages.

### DIFF
--- a/packaging/cmake/Modules/Packaging.cmake
+++ b/packaging/cmake/Modules/Packaging.cmake
@@ -17,6 +17,44 @@ set(CPACK_DEBIAN_DEBUGINFO_PACKAGE NO)
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
 set(CPACK_DEBIAN_COMPRESSION_TYPE "xz")
 
+if(OS_LINUX)
+  set(OS_DISTRO_ID "unknown")
+  set(OS_VERSION_ID "unknown")
+
+  find_file(OS_RELEASE_PATH os-release PATHS /etc /usr/lib
+            NO_DEFAULT_PATH
+            NO_PACKAGE_ROOT_PATH
+            NO_CMAKE_PATH
+            NO_CMAKE_ENVIRONMENT_PATH
+            NO_SYSTEM_ENVIRONMENT_PATH
+            NO_CMAKE_SYSTEM_PATH
+            NO_CMAKE_INSTALL_PREFIX)
+
+  if(NOT OS_RELEASE_PATH STREQUAL OS_RELEASE_PATH-NOTFOUND)
+    file(STRINGS "${OS_RELEASE_PATH}" OS_RELEASE_LINES)
+
+    foreach(_line IN LISTS OS_RELEASE_LINES)
+      if(_line MATCHES "^ID=.*$")
+        string(SUBSTRING "${_line}" 3 -1 OS_DISTRO_ID)
+        string(REPLACE "\"" "" OS_DISTRO_ID "${OS_DISTRO_ID}")
+      elseif(_line MATCHES "^VERSION_ID=.*$")
+        string(SUBSTRING "${_line}" 11 -1 OS_VERSION_ID)
+        string(REPLACE "\"" "" OS_VERSION_ID "${OS_VERSION_ID}")
+      endif()
+    endforeach()
+  endif()
+
+  if(OS_DISTRO_ID STREQUAL "debian")
+    if(OS_VERSION_ID VERSION_GREATER_EQUAL 12)
+      set(CPACK_DEBIAN_COMPRESSION_TYPE "zstd")
+    endif()
+  elseif(OS_DISTRO_ID STREQUAL "ubuntu")
+    if(OS_VERSION_ID VERSION_GREATER_EQUAL 21.10)
+      set(CPACK_DEBIAN_COMPRESSION_TYPE "zstd")
+    endif()
+  endif()
+endif()
+
 set(CPACK_PACKAGING_INSTALL_PREFIX "/")
 
 set(CPACK_PACKAGE_VENDOR "Netdata Inc.")


### PR DESCRIPTION
##### Summary

This PR updates our DEB package builds to utilize either XZ or zstd compression instead of the gzip compression we are currently using.

For Debian 12 and newer, and Ubuntu 21.10 and newer, we now use zstd for compression, which is consistent with what those distros use for their repository packages. This provides a roughly 8.6% space savings for a full collection of our packages in comparison to our existing gzip compression (tested using Debian 13 packages), as well as providing a slight reduction in decompression overhead when unpacking the packages.

For older versions of Debian and Ubuntu, we now use XZ for compression, which is also consistent with what those distros use for their repository packages. This provides an absolutely absurd 34.2% space savings for a full collection of our packages in comparison to our existing gzip compression (again, tested using Debian 13 packages), but at the cost of imposing a significantly higher decompression overhead when unpacking the packages.

##### Test Plan

Requires manual cross-checking to confirm that packages are being built with the new compression methods.

Compression of DEB packages can be checked by mounting the package file with `archivemount` (available in almost all distro’s official repositories via a package of the same name) and inspecting the extension of the `data.tar` file.

