### PR TITLE
improve(go.d/nvidia_smi): add autodetection_retry option

### DIFF
--- a/src/go/plugin/go.d/collector/nvidia_smi/collector.go
+++ b/src/go/plugin/go.d/collector/nvidia_smi/collector.go
@@ -44,10 +44,11 @@ func New() *Collector {
 }
 
 type Config struct {
-	UpdateEvery int              `yaml:"update_every,omitempty" json:"update_every"`
-	Timeout     confopt.Duration `yaml:"timeout,omitempty" json:"timeout"`
-	BinaryPath  string           `yaml:"binary_path" json:"binary_path"`
-	LoopMode    bool             `yaml:"loop_mode,omitempty" json:"loop_mode"`
+	UpdateEvery        int              `yaml:"update_every,omitempty" json:"update_every"`
+	AutoDetectionRetry int              `yaml:"autodetection_retry,omitempty" json:"autodetection_retry"`
+	Timeout            confopt.Duration `yaml:"timeout,omitempty" json:"timeout"`
+	BinaryPath         string           `yaml:"binary_path" json:"binary_path"`
+	LoopMode           bool             `yaml:"loop_mode,omitempty" json:"loop_mode"`
 }
 
 type Collector struct {

--- a/src/go/plugin/go.d/collector/nvidia_smi/config_schema.json
+++ b/src/go/plugin/go.d/collector/nvidia_smi/config_schema.json
@@ -11,6 +11,13 @@
         "minimum": 1,
         "default": 10
       },
+      "autodetection_retry": {
+        "title": "Detection retry",
+        "description": "Recheck interval in seconds. Zero means no recheck will be scheduled.",
+        "type": "integer",
+        "minimum": 0,
+        "default": 60
+      },
       "binary_path": {
         "title": "Binary path",
         "description": "Path to the `nvidia-smi` binary.",

--- a/src/go/plugin/go.d/collector/nvidia_smi/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nvidia_smi/metadata.yaml
@@ -57,7 +57,7 @@ modules:
               default_value: 10
               required: false
             - name: autodetection_retry
-              description: Recheck interval in seconds. Zero means no recheck will be scheduled.
+              description: Autodetection retry interval (seconds). Set 0 to disable.
               default_value: 0
               required: false
             - name: binary_path

--- a/src/go/plugin/go.d/collector/nvidia_smi/testdata/config.json
+++ b/src/go/plugin/go.d/collector/nvidia_smi/testdata/config.json
@@ -1,5 +1,6 @@
 {
   "update_every": 123,
+  "autodetection_retry": 123,
   "timeout": 123.123,
   "binary_path": "ok",
   "loop_mode": true

--- a/src/go/plugin/go.d/collector/nvidia_smi/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/nvidia_smi/testdata/config.yaml
@@ -1,4 +1,5 @@
 update_every: 123
+autodetection_retry: 123
 timeout: 123.123
 binary_path: "ok"
 loop_mode: true


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added autodetection_retry to the go.d nvidia_smi collector to control how often GPU autodetection rechecks run. Set to 0 to disable rechecks.

- **New Features**
  - New autodetection_retry config field with schema, metadata, and test config updates.

<sup>Written for commit 010c52af9b1b109864434215f9d8369b14b0dfad. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

