### PR TITLE
improve(go.d/sql): add per-query execution time charts

### DIFF
--- a/src/go/plugin/go.d/collector/sql/collector.go
+++ b/src/go/plugin/go.d/collector/sql/collector.go
@@ -32,7 +32,6 @@ func New() *Collector {
 		},
 		charts:     &module.Charts{},
 		seenCharts: make(map[string]bool),
-		skipValues: make(map[string]bool),
 	}
 }
 
@@ -45,7 +44,6 @@ type Collector struct {
 	db *sql.DB
 
 	seenCharts map[string]bool
-	skipValues map[string]bool
 }
 
 func (c *Collector) Configuration() any {

--- a/src/go/plugin/go.d/collector/sql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/sql/metadata.yaml
@@ -229,7 +229,7 @@ modules:
             - name: dsn
               description: >
                 Database connection string (DSN). The format depends on the selected driver (
-                ([MySQL](https://github.com/go-sql-driver/mysql#dsn-data-source-name),
+                [MySQL](https://github.com/go-sql-driver/mysql#dsn-data-source-name),
                 [PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS),
                 [MS SQL Server](https://github.com/denisenkom/go-mssqldb#connection-parameters-and-dsn)).
               default_value: ""

--- a/src/go/plugin/go.d/collector/sql/query.go
+++ b/src/go/plugin/go.d/collector/sql/query.go
@@ -9,13 +9,13 @@ import (
 	"time"
 )
 
-// QueryRowsCache maps query_id -> slice of row maps (col -> string value)
-type QueryRowsCache map[string][]map[string]string
+// queryRowsCache maps query_id -> slice of row maps (col -> string value)
+type queryRowsCache map[string][]map[string]string
 
 // execReusableQueries runs all queries declared in Config.Queries (new schema)
 // and returns their full rowsets in memory. It also returns per-query durations (ms).
-func (c *Collector) execReusableQueries(ctx context.Context) (QueryRowsCache, map[string]int64, error) {
-	cache := make(QueryRowsCache, len(c.Queries))
+func (c *Collector) execReusableQueries(ctx context.Context) (queryRowsCache, map[string]int64, error) {
+	cache := make(queryRowsCache, len(c.Queries))
 	durations := make(map[string]int64, len(c.Queries))
 
 	for i, q := range c.Queries {
@@ -40,8 +40,8 @@ func (c *Collector) execReusableQueries(ctx context.Context) (QueryRowsCache, ma
 // execMetricQueries resolves and executes the query for each metric block.
 // If a metric uses query_ref, it reuses rows from qcache (no re-query).
 // If a metric has inline query, it executes it and stores the rows.
-func (c *Collector) execMetricQueries(ctx context.Context, qcache QueryRowsCache) (QueryRowsCache, map[string]int64, error) {
-	cache := make(QueryRowsCache, len(c.Metrics))
+func (c *Collector) execMetricQueries(ctx context.Context, qcache queryRowsCache) (queryRowsCache, map[string]int64, error) {
+	cache := make(queryRowsCache, len(c.Metrics))
 	durations := make(map[string]int64, len(c.Metrics))
 
 	for i, m := range c.Metrics {
@@ -57,7 +57,6 @@ func (c *Collector) execMetricQueries(ctx context.Context, qcache QueryRowsCache
 				return nil, nil, fmt.Errorf("metrics[%d] query_ref %q not found in queries cache", i+1, m.QueryRef)
 			}
 			cache[m.ID] = rows
-			durations[m.ID] = 0
 		case m.Query != "":
 			rows, dur, err := c.runSQL(ctx, m.Query)
 			if err != nil {


### PR DESCRIPTION
##### Summary

This PR adds query execution time charts to the generic SQL collector.


Every SQL query now exposes its own timing metric so users can understand the performance characteristics of their database queries.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-query execution time charts to the SQL collector, exposing a “duration” metric per query to help spot slow statements. Also updates chart metadata and connection handling.

- **New Features**
  - Per-query timing charts (ms) for reusable and inline metric queries.
  - One chart per query_id with driver/query_id labels and a single “duration” dimension.
  - Timing metrics emitted via collectQueryTimingMetrics using buildTimingChartIDFromQueryID.

- **Refactors**
  - Renamed buildChartID to buildMetricChartID; added createMetricBlockChart with updated context and labels.
  - Split chart priorities; chart context now sql.<driver>_<context>.
  - openConnection(ctx) with PingContext respecting Timeout; conn max lifetime set to 10m.
  - Renamed QueryRowsCache to queryRowsCache; removed unused skipValues.
  - Fixed MySQL DSN link in metadata.

<sup>Written for commit 1bc9ca05da14386267de76bf5cc18d633b793c31. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



