### PR TITLE
Reset backfill requests on child reconnect

### DIFF
--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -1073,6 +1073,7 @@ static void stream_receiver_replication_reset(RRDHOST *host) {
 
     __atomic_store_n(&host->stream.rcv.status.replication.counter_in, 0, __ATOMIC_RELAXED);
     __atomic_store_n(&host->stream.rcv.status.replication.counter_out, 0, __ATOMIC_RELAXED);
+    __atomic_store_n(&host->stream.rcv.status.replication.backfill_pending, 0, __ATOMIC_RELAXED);
 }
 
 bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {


### PR DESCRIPTION
##### Summary
- Reset backfill request count on child reconnect. When there are pending backfill requests, a new stream connection may cause a host to end up with  invalid backfill request count 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset the backfill_pending counter when the stream receiver reconnects. This prevents stale backfill counts after child reconnects and avoids unnecessary backfill requests.

<sup>Written for commit 83d1da9d3ee8b9aa1c3249c97ce8cd5640777982. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

