### PR TITLE
fix(cgroups): improve podman container name resolution

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/src/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -683,7 +683,7 @@ if [ -z "${NAME}" ]; then
     docker_validate_id "${DOCKERID}"
   elif [[ ${CGROUP} =~ ^.*libpod-[a-fA-F0-9]+.*$ ]]; then
     # Podman
-    PODMANID="$(echo "${CGROUP}" | sed "s|^.*libpod-\([a-fA-F0-9]\+\).*$|\1|")"
+    PODMANID="$(echo "${CGROUP}" | sed "s|^.*libpod-\(conmon-\)\?\([a-fA-F0-9]\+\).*$|\2|")"
     podman_validate_id "${PODMANID}"
 
   elif [[ ${CGROUP} =~ machine.slice[_/].*\.service ]]; then


### PR DESCRIPTION
##### Summary

This PR fixes an issue in the Netdata cgroups plugin where Podman container names were not resolved correctly for paths that use the libpod-conmon-<hex> format.

Fixes https://github.com/netdata/netdata/discussions/20926?notification_referrer_id=NT_kwDOAVPhH7QxODY4MTY2MDI4MDoyMjI3NDMzNQ#discussioncomment-14692547

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Podman container name resolution in the cgroups plugin by correctly extracting container IDs when cgroup paths use the libpod-conmon-HEXID format. Containers are now identified even when the conmon prefix is present.

<sup>Written for commit 3db742338586ef36968327d3f272f14b01e0ba85. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

