### PR TITLE
Add helm repo when adding kuberentes to the nodes

### DIFF
--- a/integrations/deploy.yaml
+++ b/integrations/deploy.yaml
@@ -485,6 +485,7 @@
       commands:
         - channel: nightly
           command: |
+            helm repo add netdata https://netdata.github.io/helmchart/ && helm repo update
             helm install netdata netdata/netdata \
             --set image.tag=edge{% if $showClaimingOptions %} \
             --set parent.claiming.enabled="true" \
@@ -495,6 +496,7 @@
             --set child.claiming.rooms={% $claim_rooms %}{% /if %}
         - channel: stable
           command: |
+            helm repo add netdata https://netdata.github.io/helmchart/ && helm repo update
             helm install netdata netdata/netdata \
             --set image.tag=stable{% if $showClaimingOptions %} \
             --set parent.claiming.enabled="true" \


### PR DESCRIPTION
I missed this one, original problem was discussed here: https://netdata-cloud.slack.com/archives/CS3PB0VJ7/p1753954035377529 . I missed the last msg from Johnny, so I'm doing it now as we have a ticket from user with this exact problem.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
There is no longer a need to explicitly look for adding netdata repo to helm. Doing this command more than once will result in helm saying that such repo already exists but due to `helm repo update` it will also ensure that the customer is installing the newest version of the chart
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the Netdata Helm repo is added and updated before installing the chart when deploying to Kubernetes. This prevents install failures if the repo isn’t configured and ensures the latest chart is used for both nightly and stable channels.

<sup>Written for commit 75998ca043d521a87f3a1ff0bc0591d2e2fbde42. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

