### PR TITLE
Fix compilation when DBENGINE is disabled

### DIFF
--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -2226,6 +2226,12 @@ static ssize_t weights_do_context_callback(void *data, RRDCONTEXT_ACQUIRED *rca,
 static ssize_t query_scope_foreach_host_parallel(SIMPLE_PATTERN *scope_hosts_sp, SIMPLE_PATTERN *hosts_sp,
                                                   struct query_weights_data *qwd)
 {
+#ifndef ENABLE_DBENGINE
+    return query_scope_foreach_host(scope_hosts_sp, hosts_sp,
+                                    weights_do_node_callback, qwd,
+                                    &qwd->versions, NULL);
+
+#else
     size_t host_count = dictionary_entries(rrdhost_root_index);
     qwd->hosts_array = mallocz(sizeof(RRDHOST *) * host_count);
     qwd->hosts_array_capacity = host_count;
@@ -2305,6 +2311,7 @@ static ssize_t query_scope_foreach_host_parallel(SIMPLE_PATTERN *scope_hosts_sp,
     freez(qwd->hosts_array);
 
     return total_added;
+#endif
 }
 
 static ssize_t weights_do_node_callback(void *data, RRDHOST *host, bool queryable) {


### PR DESCRIPTION
##### Summary
- Fix compilation when DBENGINE is disabled

Fixes #21321

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore compilation when DBENGINE is disabled by gating the parallel host iteration behind ENABLE_DBENGINE. When DBENGINE is off, query_scope_foreach_host is used with weights_do_node_callback, skipping the parallel path.

<sup>Written for commit 97d6b42dcf5afa7e7a81d3214e3cb7ea3c0cb0fa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

