### PR TITLE
Remove log message

### DIFF
--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -748,7 +748,6 @@ static bool datafile_is_full(struct rrdengine_instance *ctx, struct rrdengine_da
 #ifdef OS_WINDOWS
     time_t now = now_realtime_sec();
     if (now - datafile->writers.last_sync_time > 60) {
-        nd_log_daemon(NDLP_INFO, "DBENGINE: datafile %d, last sync time: %ld, now: %ld", datafile->fileno, datafile->writers.last_sync_time, now);
         sync_uv_file_data(datafile->file);
         sync_uv_file_data(datafile->journalfile->file);
         datafile->writers.last_sync_time = now_realtime_sec();


### PR DESCRIPTION
##### Summary
- Remove log line

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a noisy INFO log from the Windows datafile sync path in rrdengine to reduce log spam during periodic syncs. No functional changes.

<sup>Written for commit 3ddda8b276e5f3d0d4a83f049e8a43cbbbf978bf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

