### PR TITLE
improve(health/dyncfg): Add source unit field to alert value

### DIFF
--- a/src/health/schema.d/health%3Aalert%3Aprototype.json
+++ b/src/health/schema.d/health%3Aalert%3Aprototype.json
@@ -817,7 +817,7 @@
             },
             "update_every": {
               "ui:help": "The frequency this alarm is to be evaluated, in seconds.",
-              "ui:classNames": "dyncfg-grid-col-span-1-4"
+              "ui:classNames": "dyncfg-grid-col-span-1-2"
             },
             "units_placeholder": {
               "ui:widget": "unitsPlaceholder",


### PR DESCRIPTION
##### Summary

Adds "Source unit" field

<img width="1160" height="229" alt="Screenshot 2025-11-20 at 15 12 28" src="https://github.com/user-attachments/assets/7fb17dd2-c2d1-49a3-a258-4e7fb8b13e30" />

Plus formatting


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Source unit” field to alert values so authors can specify the metric’s original unit used in expressions, avoiding confusion with UI-scaled units.

- **New Features**
  - Added value.units_placeholder to the schema (default “-”), shown as “Source unit” and used before UI scaling.
  - Integrated unitsPlaceholder UI widget with help text.
  - Updated field order in the Value section to include Source unit alongside calculation, units, and update_every.
  - Minor UI layout tweaks (e.g., update_every column span).

<sup>Written for commit d2e28c0b53a93071c1d57cd2a880cfbc54308feb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



