### PR TITLE
Add check for service shutdown while initializing health for a host

### DIFF
--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -555,6 +555,8 @@ void sql_check_removed_alerts_state(RRDHOST *host)
 
            sql_inject_removed_status(host, alarm_id, alarm_event_id, unique_id, ++max_unique_id, &transition_id);
         }
+        if (!service_running(SERVICE_HEALTH))
+            break;
     }
 done:
     REPORT_BIND_FAIL(res, param);


### PR DESCRIPTION
##### Summary
- Cancel host health initialization when a shutdown is requested

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop host health initialization when the health service is shutting down. Breaks out of the alert processing loop in sql_check_removed_alerts_state to avoid extra work and speed up shutdown.

<sup>Written for commit a243e4a37f3e1d3f2193dd556f0a7423bdf61ee9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

