### PR TITLE
fix(go.d): fix dyncfg vnodes configs

### DIFF
--- a/src/go/plugin/go.d/agent/jobmgr/dyncfg.go
+++ b/src/go/plugin/go.d/agent/jobmgr/dyncfg.go
@@ -29,10 +29,10 @@ func (m *Manager) dyncfgConfig(fn functions.Function) {
 
 	//m.Infof("QQ FN: '%s'", fn)
 
-	m.dyncfgExec(fn)
+	m.dyncfgQueuedExec(fn)
 }
 
-func (m *Manager) dyncfgExec(fn functions.Function) {
+func (m *Manager) dyncfgQueuedExec(fn functions.Function) {
 	id := fn.Args[0]
 
 	switch {
@@ -40,6 +40,19 @@ func (m *Manager) dyncfgExec(fn functions.Function) {
 		m.dyncfgCollectorExec(fn)
 	case strings.HasPrefix(id, m.dyncfgVnodePrefixValue()):
 		m.dyncfgVnodeExec(fn)
+	default:
+		m.dyncfgApi.SendCodef(fn, 503, "unknown function '%s' (%s).", fn.Name, id)
+	}
+}
+
+func (m *Manager) dyncfgSeqExec(fn functions.Function) {
+	id := fn.Args[0]
+
+	switch {
+	case strings.HasPrefix(id, m.dyncfgCollectorPrefixValue()):
+		m.dyncfgCollectorSeqExec(fn)
+	case strings.HasPrefix(id, m.dyncfgVnodePrefixValue()):
+		m.dyncfgVnodeSeqExec(fn)
 	default:
 		m.dyncfgApi.SendCodef(fn, 503, "unknown function '%s' (%s).", fn.Name, id)
 	}

--- a/src/go/plugin/go.d/agent/jobmgr/manager.go
+++ b/src/go/plugin/go.d/agent/jobmgr/manager.go
@@ -161,7 +161,7 @@ func (m *Manager) run() {
 			case <-m.ctx.Done():
 				return
 			case fn := <-m.dyncfgCh:
-				m.dyncfgExec(fn)
+				m.dyncfgSeqExec(fn)
 			}
 		} else {
 			select {
@@ -172,7 +172,7 @@ func (m *Manager) run() {
 			case cfg := <-m.rmCh:
 				m.removeConfig(cfg)
 			case fn := <-m.dyncfgCh:
-				m.dyncfgExec(fn)
+				m.dyncfgSeqExec(fn)
 			}
 		}
 	}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dynamic config handling for vnode functions in the go.d agent. Vnode configs now execute correctly in both sequential and non-sequential paths.

- **Bug Fixes**
  - Route vnode dynamic configs through the same execution path as collectors in manager.run().
  - Prevents vnode configs from being ignored when sequential execution is enabled.

- **Refactors**
  - Added dyncfgQueuedExec and dyncfgSeqExec to centralize prefix-based routing.
  - Updated dyncfgConfig and manager.run to use these helpers.

<sup>Written for commit 898a82084f35377d3632195a6b8b68c0e214c31f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



