### PR TITLE
ci: fix MCP Registry publishing workflow

### DIFF
--- a/.github/workflows/update-mcp-registry.yml
+++ b/.github/workflows/update-mcp-registry.yml
@@ -79,7 +79,7 @@ jobs:
             Checkout: ${{ steps.checkout.outcome }}
             Update version: ${{ steps.update_version.outcome }}
             Install mcp-publisher: ${{ steps.install_publisher.outcome }}
-            MCP Auth: ${{ steps.mcp_auth.outcome }
+            MCP Auth: ${{ steps.mcp_auth.outcome }}
             Validate: ${{ steps.validate.outcome }}
             Publish: ${{ steps.publish.outcome }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
##### Summary

#### Fix MCP publisher login


The workflow previously failed during the validation step because mcp-publisher requires explicit authentication.

Added:

```
mcp-publisher login github-oidc
```

This allows both dry-run and publish steps to authenticate using GitHub OIDC.

#### Allow manual execution

Added workflow_dispatch so the workflow can be triggered manually from the GitHub UI.

#### Prevent accidental manual runs on non-tag refs

Added a guard step that aborts workflow_dispatch runs unless the workflow is triggered on a tag starting with v.

This ensures manual executions behave consistently with release-triggered runs.



##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authenticate mcp-publisher via GitHub OIDC in the Update MCP Registry workflow to fix the failing Validate server.json step and unblock dry-run/publish. Also allow manual runs, limited to v* tags.

- **Bug Fixes**
  - Add mcp-publisher login github-oidc before validation.
  - Replace GITHUB_TOKEN reliance with registry-supported auth to prevent CI failures.

- **New Features**
  - Enable manual execution (workflow_dispatch) with a guard to abort if not run on a v* tag.

<sup>Written for commit 63e2521cda07422a1c9fc77e5df1bd6db1576ea1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







