### PR TITLE
fix(go.d): prefer env-provided dirs over build-time defaults

### DIFF
--- a/src/go/pkg/pluginconfig/pluginconfig.go
+++ b/src/go/pkg/pluginconfig/pluginconfig.go
@@ -19,6 +19,8 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/cli"
 	"github.com/netdata/netdata/go/plugins/pkg/executable"
 	"github.com/netdata/netdata/go/plugins/pkg/multipath"
+
+	"github.com/mattn/go-isatty"
 )
 
 var (
@@ -255,19 +257,28 @@ func (d *directories) validate() error {
 	return nil
 }
 
+var isTerm = isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsTerminal(os.Stdout.Fd())
+
 func readEnvFromOS(execDir string) envData {
 	e := envData{
 		cygwinBase: os.Getenv("NETDATA_CYGWIN_BASE_PATH"),
 		userDir:    os.Getenv("NETDATA_USER_CONFIG_DIR"),
 		stockDir:   os.Getenv("NETDATA_STOCK_CONFIG_DIR"),
-		varLibDir:  os.Getenv("NETDATA_LIB_DIR"),
 		watchPath:  os.Getenv("NETDATA_PLUGINS_GOD_WATCH_PATH"),
+		varLibDir:  os.Getenv("NETDATA_LIB_DIR"),
 		logLevel:   os.Getenv("NETDATA_LOG_LEVEL"),
 	}
 	e.userDir = handleDirOnWin(e.cygwinBase, safePathClean(e.userDir), execDir)
 	e.stockDir = handleDirOnWin(e.cygwinBase, safePathClean(e.stockDir), execDir)
 	e.varLibDir = handleDirOnWin(e.cygwinBase, safePathClean(e.varLibDir), execDir)
 	e.watchPath = handleDirOnWin(e.cygwinBase, safePathClean(e.watchPath), execDir)
+
+	if isTerm {
+		e.userDir = ""
+		e.stockDir = ""
+		e.watchPath = ""
+	}
+
 	return e
 }
 


### PR DESCRIPTION
##### Summary

Fixes #21343

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritizes environment-provided config directories in go.d over build-time defaults, so runtime overrides take effect. In terminal runs, ignores env-provided dirs and watch path to prevent accidental overrides.

- **Bug Fixes**
  - User config: initUserRoots now checks NETDATA_USER_CONFIG_DIR (env) before buildinfo.UserConfigDir.
  - Stock config: initStockRoot now uses the env-provided stock config dir first, then buildinfo.StockConfigDir, then the relative fallback.
  - Terminal runs: if stdout/stderr is a TTY, ignore NETDATA_USER_CONFIG_DIR, NETDATA_STOCK_CONFIG_DIR, and NETDATA_PLUGINS_GOD_WATCH_PATH.

<sup>Written for commit 9fb07ce6815d61086c3e771609ca06b67b36653a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



