### PR TITLE
improve(go.d/snmp): add EATON UPS profile

### DIFF
--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/eaton-ups.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/eaton-ups.yaml
@@ -21,10 +21,6 @@ metadata:
         symbol:
           OID: 1.3.6.1.4.1.534.1.1.6.0
           name: xupsIdentSerialNumber
-      part_number:
-        symbol:
-          OID: 1.3.6.1.4.1.534.1.1.5.0
-          name: xupsIdentPartNumber
 
 # https://mibbrowser.online/mibdb_search.php?mib=XUPS-MIB
 # https://github.com/librenms/librenms/blob/master/mibs/eaton/XUPS-MIB


### PR DESCRIPTION
##### Summary

[Requested on Discord](https://discord.com/channels/847502280503590932/1443257915908821073/1443257915908821073).

Created by claude.ai from: [XUPS-MIB](https://github.com/librenms/librenms/blob/master/mibs/eaton/XUPS-MIB) and [SNMP profile format](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/collector/snmp/profile-format.md).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an SNMP profile for Eaton UPS (XUPS-MIB) to the go.d SNMP collector. Netdata can now auto-discover Eaton units and collect detailed battery, power, and status metrics.

- **New Features**
  - Selector matches sysObjectID 1.3.6.1.4.1.534.1.* and sets device metadata (vendor, type, model, serial).
  - Comprehensive metrics: battery runtime/voltage/current/capacity and ABM status; input/output totals and per‑phase voltage/current/watts/VA/power factor; bypass; environment (temperature, humidity); alarms/event counts; test statuses; configuration (nominal values); receptacles (status, hourly/cumulative energy); topology; control status.
  - Applies scale factors and enum mappings for readable units and states.

<sup>Written for commit a53feee3c15bc422c4e1138526b04d7ed2b5ebaa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



