### PR TITLE
fix(docker): add netdata user to nvidia device group on non-Debian systems

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -12,6 +12,8 @@ fi
 
 # Needed to read Proxmox VMs and (LXC) containers configuration files (name resolution + CPU and memory limits)
 function add_netdata_to_proxmox_conf_files_group() {
+  [ "${DOCKER_USR}" = "root" ] && return
+
   local group_guid
   group_guid="$(stat -c %g /host/etc/pve 2>/dev/null || true)"
   [ -z "${group_guid}" ] && return
@@ -35,6 +37,8 @@ function add_netdata_to_proxmox_conf_files_group() {
 
 # Needed to access NVIDIA GPU monitoring
 function add_netdata_to_nvidia_group() {
+  [ "${DOCKER_USR}" = "root" ] && return
+
   local group_gid
   group_gid="$(stat -c %g /dev/nvidiactl 2>/dev/null || true)"
   [ -z "${group_gid}" ] && return


### PR DESCRIPTION

##### Summary

Fixes #21353

On Debian/Ubuntu, NVIDIA device files are world-readable (crw-rw-rw-), so netdata can access them without special permissions:

```
crw-rw-rw- 1 root root 195, 255 Nov 24 19:22 /dev/nvidiactl
```

However, on some distributions like openSUSE Leap 15.6, these devices are owned by the video group with restricted permissions (crw-rw----):

```
crw-rw---- 1 root video 195, 255 25. Nov 19:53 /dev/nvidiactl
```

This causes GPU monitoring to fail because the netdata user cannot access the device.

This PR adds the `netdata` user to the group that owns `/dev/nvidiactl` (if it's not root), following the same pattern used for Proxmox configuration files access.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Netdata can access NVIDIA device files on non-Debian systems by adding the netdata user to the device’s group at container startup. Fixes broken GPU monitoring on distros where /dev/nvidiactl is group-restricted (e.g., openSUSE).

- **Bug Fixes**
  - Detect /dev/nvidiactl group GID and add netdata to it; skip if root-owned.
  - Create a local group with the device’s GID if it doesn’t exist.
  - Run only when entrypoint is root, the container user is not root, and /dev/nvidiactl is present; applies the same guard to Proxmox group handling.

<sup>Written for commit 7a7d986ccb9469b9ee29da4468d08ba583cfe52c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



