### PR TITLE
add netdata user to video group

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -3249,7 +3249,7 @@ else
 fi
 %endif
 
-for item in docker ceph I2C; do
+for item in docker ceph I2C video; do
   if getent group $item > /dev/null 2>&1; then
     usermod -a -G ${item} %{name}
   fi

--- a/packaging/cmake/pkg-files/deb/user/postinst
+++ b/packaging/cmake/pkg-files/deb/user/postinst
@@ -21,6 +21,9 @@ case "${1}" in
     if [ -d "/etc/pve" ]; then
       groups="${groups} www-data"
     fi
+    if [ -e "/dev/nvidiactl" ]; then
+      groups="${groups} video"
+    fi
 
     for item in ${groups}; do
       if getent group "${item}" > /dev/null 2>&1; then

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -1045,6 +1045,9 @@ create_netdata_accounts() {
   if [ -d "/etc/pve" ]; then
     NETDATA_WANTED_GROUPS="${NETDATA_WANTED_GROUPS} www-data"
   fi
+  if [ -e "/dev/nvidiactl" ]; then
+    NETDATA_WANTED_GROUPS="${NETDATA_WANTED_GROUPS} video"
+  fi
 
   if command -v systemd-sysusers >/dev/null 2>&1; then
     install -m 644 -o root -g root "${NETDATA_PREFIX}/usr/lib/netdata/system/systemd/sysusers/netdata.conf" /usr/lib/sysusers.d/netdata.conf


### PR DESCRIPTION
##### Summary

Related #21353

On Debian/Ubuntu, NVIDIA device files are world-readable (crw-rw-rw-), so netdata can access them without special permissions:

```
crw-rw-rw- 1 root root 195, 255 Nov 24 19:22 /dev/nvidiactl
```

However, on some distributions like openSUSE Leap 15.6, these devices are owned by the video group with restricted permissions (crw-rw----):

```
crw-rw---- 1 root video 195, 255 25. Nov 19:53 /dev/nvidiactl
```

This causes GPU monitoring to fail because the netdata user cannot access the device.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add netdata to the video group during install/update so it can access NVIDIA device files and enable GPU monitoring on distros with restricted permissions.

- **Bug Fixes**
  - RPM spec: include "video" in the default group list.
  - Debian postinst and makeself installer: add "video" only if /dev/nvidiactl exists.
  - Fixes GPU monitoring failures on openSUSE Leap 15.6 and similar systems.

<sup>Written for commit ae53aca39b89043cad5d69096f1a9017947f66b2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





