### PR TITLE
chore(go.d): fix get dim value

### DIFF
--- a/src/go/plugin/go.d/agent/module/job.go
+++ b/src/go/plugin/go.d/agent/module/job.go
@@ -182,20 +182,11 @@ type collectedMetrics struct {
 	floatMetrics map[string]float64
 }
 
-func (cm *collectedMetrics) getDimValue(dim *Dim) (float64, bool) {
-	if dim.Float {
-		v, ok := cm.floatMetrics[dim.ID]
-		return v, ok
+func (cm *collectedMetrics) getValue(id string) (float64, bool) {
+	if v, ok := cm.floatMetrics[id]; ok {
+		return v, true
 	}
-	v, ok := cm.intMetrics[dim.ID]
-	return float64(v), ok
-}
-
-func (cm *collectedMetrics) getVarValue(vr *Var) (float64, bool) {
-	if v, ok := cm.floatMetrics[vr.ID]; ok {
-		return v, ok
-	}
-	v, ok := cm.intMetrics[vr.ID]
+	v, ok := cm.intMetrics[id]
 	return float64(v), ok
 }
 
@@ -683,7 +674,7 @@ func (j *Job) updateChart(chart *Chart, mx collectedMetrics, sinceLastRun int) b
 			if dim.remove {
 				continue
 			}
-			if _, hasData = mx.getDimValue(dim); hasData {
+			if _, hasData = mx.getValue(dim.ID); hasData {
 				break
 			}
 		}
@@ -708,7 +699,7 @@ func (j *Job) updateChart(chart *Chart, mx collectedMetrics, sinceLastRun int) b
 		i++
 
 		name := firstNotEmpty(dim.Name, dim.ID)
-		v, ok := mx.getDimValue(dim)
+		v, ok := mx.getValue(dim.ID)
 		if !ok {
 			j.api.SETEMPTY(name)
 			continue
@@ -724,7 +715,7 @@ func (j *Job) updateChart(chart *Chart, mx collectedMetrics, sinceLastRun int) b
 	chart.Dims = chart.Dims[:i]
 
 	for _, vr := range chart.Vars {
-		if v, ok := mx.getVarValue(vr); ok {
+		if v, ok := mx.getValue(vr.ID); ok {
 			name := firstNotEmpty(vr.Name, vr.ID)
 			j.api.VARIABLE(name, v)
 		}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes value retrieval for chart dims and vars by checking both float and int metric maps, preventing empty values caused by type mismatches. Simplifies metrics access with a single getValue helper.

- **Bug Fixes**
  - Read metric values by ID from floatMetrics first, then intMetrics, so dims/vars no longer miss data.

- **Refactors**
  - Removed getDimValue/getVarValue; added getValue(id string).
  - Updated updateChart to use getValue for dims and vars.

<sup>Written for commit 0f3b770edb34fd3018aaf744a4b7e1f0601349f2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

