### PR TITLE
fix(docker): fix bugs and refactor Docker entrypoint script

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -17,7 +17,7 @@ fi
 is_user_in_group() {
   local gid="$1"
   local user="$2"
-  getent group "${gid}" | awk -F: '{print $4}' | tr ',' '\n' | grep -qx "${user}"
+  getent group "${gid}" 2>/dev/null | awk -F: '{print $4}' | tr ',' '\n' | grep -qx "${user}"
 }
 
 # Add user to a group by GID, creating the group if necessary


### PR DESCRIPTION
##### Summary

This PR fixes several bugs in the Docker entrypoint script and refactors group management logic for better maintainability.


- Fixes

| Bug | Description |
|-----|-------------|
| `--apend` typo | `usermod --apend` silently failed, preventing users from being added to the Proxmox config files group |
| Group membership check | `grep -q "${DOCKER_USR}"` matched substrings, causing false positives (e.g., user `net` incorrectly detected as member when `netdata` was in the group) |
| Telemetry disable logic | Setting `DISABLE_TELEMETRY=0` incorrectly disabled telemetry because `-n "$VAR"` is true for any non-empty string including `"0"` |
| Unconditional export | `PGID` and `DOCKER_HOST` were exported even when empty |
| Missing default | `NETDATA_LISTENER_PORT` had no fallback value (now defaults to `19999`) |

- Refactoring

| Change | Description |
|--------|-------------|
| `is_user_in_group()` | New helper function for proper group membership checking |
| `add_user_to_gid()` | New helper function to eliminate duplicate group creation/assignment logic |
| Variable naming | Consistent `group_gid` instead of mixed `group_guid`/`group_gid` |

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multiple issues in the Docker entrypoint to make group assignment and telemetry control reliable, and sets a default Netdata listener port. Refactors group management into small helpers to reduce duplication and improve maintainability.

- **Bug Fixes**
  - Corrected usermod --append and added precise GID-based group membership check (no substring matches).
  - Fixed telemetry opt-out to treat "0" as enabled; export PGID/DOCKER_HOST only when set.
  - Defaulted NETDATA_LISTENER_PORT to 19999; minor robustness tweaks (error redirection, container hostname write).

- **Refactors**
  - Added is_user_in_group and add_user_to_gid helpers and reused them for Docker, Proxmox, and NVIDIA group setup.
  - Standardized variable names (group_gid) and simplified early returns for root/no-GID cases.

<sup>Written for commit 77344f9c2af5d793706f38e583c8f227d49bb37a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



