### PR TITLE
Fix dangling link to sizing documentation

### DIFF
--- a/docs/observability-centralization-points/metrics-centralization-points/faq.md
+++ b/docs/observability-centralization-points/metrics-centralization-points/faq.md
@@ -13,7 +13,7 @@ Answers to common questions about scaling Netdata Parents, clustering, retention
 
 Netdata Parents generally scale well. According [to our tests](https://blog.netdata.cloud/netdata-vs-prometheus-performance-analysis/), Netdata Parents scale better than Prometheus for the same workload: -35% CPU utilization, -49% Memory Consumption, -12% Network Bandwidth, -98% Disk I/O, -75% Disk footprint.
 
-For more information, Check [Sizing Netdata Parents](/docs/observability-centralization-points/metrics-centralization-points/sizing-netdata-parents.md).
+For more information, Check [Sizing Netdata Parents](/docs/netdata-agent/sizing-netdata-agents/README.md).
 
 <br/>
 </details>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated a broken link in the Metrics Centralization FAQ to point to the current Netdata Agent sizing documentation, ensuring readers can access the correct sizing guidance.

<sup>Written for commit 1a30e880b8e7954a75374c16bd216f1db6ca1cf1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

