### PR TITLE
docs: fix conf file links in integrations/setup

### DIFF
--- a/integrations/templates/setup.md
+++ b/integrations/templates/setup.md
@@ -131,8 +131,8 @@ Configuration for this specific integration is located in the `[[ entry.setup.co
 [% include 'setup/sample-netdata-config.md' %]
 [% endif %]
 
-You can edit the configuration file using the [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) script from the
-Netdata [config directory](/docs/netdata-agent/configuration/README.md#the-netdata-config-directory).
+You can edit the configuration file using the [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-configuration-files) script from the
+Netdata [config directory](/docs/netdata-agent/configuration/README.md#locate-your-config-directory).
 
 ```bash
 cd /etc/netdata 2>/dev/null || cd /opt/netdata/etc/netdata


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken links in the integrations setup doc so users land on the right configuration guides. Updated the "edit-config" link to #edit-configuration-files and the "config directory" link to #locate-your-config-directory.

<sup>Written for commit 646c06e757407dd10ddfc9ab586109cdcb9a6c86. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

