### PR TITLE
remove info containing broken link

### DIFF
--- a/src/collectors/python.d.plugin/go_expvar/metadata.yaml
+++ b/src/collectors/python.d.plugin/go_expvar/metadata.yaml
@@ -198,10 +198,6 @@ modules:
                 **Note: please do not use dots in the chart or line ID field.
                 See [this issue](https://github.com/netdata/netdata/pull/1902#issuecomment-284494195) for explanation.**
                 
-                Please see these two links to the official Netdata documentation for more information about the values:
-                
-                -   [External plugins - charts](/src/plugins.d/README.md#chart)
-                -   [Chart variables](/src/collectors/python.d.plugin/README.md#global-variables-order-and-chart)
                 
                 **Line definitions**
                 


### PR DESCRIPTION
##### Summary

this snippet has some generic info on link 1 and broken link on link 2.

I removed the snippet altogether.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a docs snippet with a broken link from src/collectors/python.d.plugin/go_expvar/metadata.yaml. This cleans up the metadata and prevents users from following dead or redundant links.

<sup>Written for commit ab3be06f7301a11aadab13dfe2483706f6f241d5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

