### PR TITLE
Mark vkalintiris as CODEOWNER for Rust code.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@ src/collectors/freebsd.plugin/ @thiagoftsm
 src/collectors/macos.plugin/ @thiagoftsm
 src/collectors/python.d.plugin/ @ilyam8
 src/collectors/cups.plugin/ @thiagoftsm
+src/crates/ @vkalintiris
 src/exporting/ @thiagoftsm
 src/daemon/ @thiagoftsm @vkalintiris
 src/database/ @thiagoftsm @vkalintiris


### PR DESCRIPTION
##### Summary

This technically should have been done when the directory was first added.

##### Test Plan

n/a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add @vkalintiris as CODEOWNER for Rust code in src/crates/ so PRs automatically request reviews from the right owner. Repo config only; no functional changes.

<sup>Written for commit 51b723bcc10c6516104b40c56c3d8daceb7fbeef. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

