### PR TITLE
Remove retention check during datafile initialization

### DIFF
--- a/src/database/engine/datafile.c
+++ b/src/database/engine/datafile.c
@@ -604,15 +604,6 @@ int init_data_files(struct rrdengine_instance *ctx)
     else {
         if (ctx->loading.create_new_datafile_pair)
             create_new_datafile_pair(ctx);
-
-        while(rrdeng_ctx_tier_cap_exceeded(ctx)) {
-            Word_t Index = 0;
-            Pvoid_t *PValue = JudyLFirst(ctx->datafiles.JudyL, &Index, PJE0);
-            if (PValue && *PValue) {
-                struct rrdengine_datafile *datafile = *PValue;
-                datafile_delete(ctx, datafile, false, true, false);
-            }
-        }
     }
 
     pgc_reset_hot_max(open_cache);


### PR DESCRIPTION
##### Summary
- Skip retention check during agent startup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip retention enforcement during datafile initialization to avoid deleting datafiles on startup and speed up startup. Removed the tier-cap check and delete loop from init_data_files; retention is handled after startup.

<sup>Written for commit bb3757c20086f865833ff3bd09080dddbd29c891. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

