### PR TITLE
[action test] Intentional break of a link

### DIFF
--- a/docs/metric-correlations.md
+++ b/docs/metric-correlations.md
@@ -12,7 +12,7 @@ Since it leverages every available metric in your infrastructure with up to 1-se
 
 ## Using Metric Correlations
 
-When viewing the [Metrics tab or a single-node dashboard](/docs/dashboards-and-charts/metrics-tab-and-single-node-tabs.md), you'll find the **Metric Correlations** button in the top-right corner.
+When viewing the [Metrics tab or a single-node dashboard](/WRONGdocs/dashboards-and-charts/metrics-tab-and-single-node-tabs.md), you'll find the **Metric Correlations** button in the top-right corner.
 
 <details>
 <summary><strong>To start:</strong></summary><br/>


### PR DESCRIPTION
##### Summary

this is expected to fail in the checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Intentionally breaks the "Metrics tab or single-node dashboard" link in docs/metric-correlations.md to verify CI link-check behavior. The link now points to /WRONGdocs/... and should fail checks.

<sup>Written for commit f073a7485ed32d07fc97014e91e3ef06738b5e9d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

