### PR TITLE
action test

### DIFF
--- a/integrations/cloud-authentication/metadata.yaml
+++ b/integrations/cloud-authentication/metadata.yaml
@@ -95,7 +95,7 @@
 
       ### SP-initiated SSO
 
-      If you start your authentication flow from Netdata sign-in page please check [these steps](/WRONGdocs/netdata-cloud/authentication-and-authorization/enterprise-sso-authentication.md).
+      If you start your authentication flow from Netdata sign-in page please check [these steps](/WRONGABCdocs/netdata-cloud/authentication-and-authorization/enterprise-sso-authentication.md).
 
 
       ### Reference


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Intentionally changed the SP-initiated SSO docs link in integrations/cloud-authentication/metadata.yaml to a wrong path (/WRONGABCdocs/...) to test CI link-check behavior. No functional impact; only documentation metadata updated.

<sup>Written for commit f7cc036fc8a949fa4cd49be1b1bd7eb6d8ec7250. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





