### PR TITLE
Update ingest command to use plain HTTPS

### DIFF
--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -57,4 +57,4 @@ jobs:
         run: |
           source ../venv/bin/activate
           echo "Running ingest with local netdata directory"
-          python ingest/ingest.py --local-repo "netdata:${{ github.workspace }}/netdata" --ignore-on-prem-repo --fail-links-netdata
+          python ingest/ingest.py --local-repo "netdata:${{ github.workspace }}/netdata" --ignore-on-prem-repo --fail-links-netdata --use_plain_https


### PR DESCRIPTION
Added --use_plain_https option to ingest command.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the check-markdown workflow to run the ingest command with --use_plain_https. This forces plain HTTPS and makes link checking more reliable in CI environments, especially behind restrictive proxies.

<sup>Written for commit f0beef01c528ec828a0c0364ee54aa582a1dfc9e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

