### PR TITLE
fix(kickstart): fix incorrect find command patterns

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2118,7 +2118,9 @@ try_build_install() {
   fi
 
   if [ "${DRY_RUN}" -ne 1 ]; then
-    cd "$(find "${tmpdir}" -mindepth 1 -maxdepth 1 -type d -name netdata-)" || fatal "Cannot change directory to netdata source tree" F0006
+    netdata_src_dir="$(find "${tmpdir}" -mindepth 1 -maxdepth 1 -type d -name 'netdata-*' | head -n 1)"
+    [ -z "${netdata_src_dir}" ] && fatal "Cannot find netdata source directory in ${tmpdir}" F0006
+    cd "${netdata_src_dir}" || fatal "Cannot change directory to netdata source tree" F0006
   fi
 
   if [ -x netdata-installer.sh ] || [ "${DRY_RUN}" -eq 1 ]; then
@@ -2179,7 +2181,7 @@ prepare_offline_install_source() {
         fi
       fi
 
-      if ! find . -name '*.gz.run'; then
+      if [ -z "$(find . -name '*.gz.run')" ]; then
         fatal "Did not actually download any static installer archives, cannot continue. ${BADNET_MSG}." F0516
       fi
 


### PR DESCRIPTION
##### Summary

Fixes #21397

Fix two bugs in `find` command usage that could cause installation failures.

- **Fix source directory detection in `try_build_install()`**

The find pattern `-name netdata-` was looking for an exact match, but extracted source directories are named like `netdata-v2.8.0` or `netdata-v2.8.0-66-g7c36d8289`. Changed to use wildcard pattern.

- **Fix archive existence check in `prepare_offline_install_source()`**

The command `find . -name '*.gz.run'` always returns exit code 0 even when no files are found, so `if ! find ...` never triggered the fatal error. Changed to check if output is empty.



##### Test Plan

Run `./kickstart.sh --reinstall` on FreeBSD.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix build and offline install failures caused by incorrect `find` patterns in kickstart.sh. This improves reliability when detecting the source directory and verifying downloaded archives.

- **Bug Fixes**
  - Detect source directory with `find ... -name 'netdata-*'` and fail if none found before cd.
  - Validate static installer archives by checking `find . -name '*.gz.run'` output is non-empty.

<sup>Written for commit 56370edac43bc81b5b044358319dc91bad06ebc6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

