### PR TITLE
Fix validation of extent index in journal file

### DIFF
--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -575,7 +575,7 @@ static NOT_INLINE_HOT size_t get_page_list_from_journal_v2(struct rrdengine_inst
                     break;
 
                 // Make sure index is valid for this file
-                if (page_entry_in_journal->extent_index > extent_entries) {
+                if (page_entry_in_journal->extent_index >= extent_entries) {
                     nd_log_limit_static_thread_var(erl, 60, 0);
                     nd_log_limit(&erl, NDLS_DAEMON, NDLP_ERR,
                                  "DBENGINE: Invalid extent index in journalfile %u",


### PR DESCRIPTION
##### Summary
- Adjust extent index validation 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix off‑by‑one validation in journal v2: extent_index equal to extent_entries is now treated as invalid. Prevents out‑of‑bounds page access and ensures correct error logging when parsing the journal.

<sup>Written for commit ac062227b9729ba7c8bcd98a0766df651c2eff4d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

