### PR TITLE
Disable MongoDB exporter for Ubuntu 20.04, 22.04, and 24.04 packages.

### DIFF
--- a/packaging/build-package.sh
+++ b/packaging/build-package.sh
@@ -18,6 +18,8 @@ SCRIPT_SOURCE="$(
 )"
 SOURCE_DIR="$(dirname "$(dirname "${SCRIPT_SOURCE}")")"
 
+. /etc/os-release
+
 CMAKE_ARGS="-S ${SOURCE_DIR} -B ${BUILD_DIR}"
 
 add_cmake_option() {
@@ -46,7 +48,6 @@ add_cmake_option ENABLE_PLUGIN_SYSTEMD_JOURNAL On
 add_cmake_option ENABLE_PLUGIN_SYSTEMD_UNITS On
 
 add_cmake_option ENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE On
-add_cmake_option ENABLE_EXPORTER_MONGODB On
 
 add_cmake_option ENABLE_BUNDLED_PROTOBUF Off
 add_cmake_option ENABLE_BUNDLED_JSONC Off
@@ -80,6 +81,15 @@ case "${PKG_TYPE}" in
                 add_cmake_option ENABLE_PLUGIN_IBM Off
                 ;;
         esac
+
+        if [ "${ID}" = "ubuntu" ]; then
+            case "${VERSION_ID}" in
+                20.04|22.04|24.04) add_cmake_option ENABLE_EXPORTER_MONGODB Off ;;
+                *) add_cmake_option ENABLE_EXPORTER_MONGODB On ;;
+            esac
+        else
+            add_cmake_option ENABLE_EXPORTER_MONGODB On
+        fi
         ;;
     RPM) ;;
     *) echo "Unrecognized package type ${PKG_TYPE}." ; exit 1 ;;


### PR DESCRIPTION
##### Summary

The version of libbson that is available without Ubuntu Pro in these versions of Ubuntu has multiple known security issues (CVE-2024-6381, CVE-2024-6383, CVE-2025-0755). libbson is a mandatory dependency for our MongoDB exporter, and thus Netdata’s native packages being installed on a system running one of these versions of Ubuntu without Ubuntu Pro will cause the system to fail certain types of security audits.

As our MongoDB exporter appears to not be widely used, we’re simply disabling it for native package builds for affected platforms. Users on these platforms who need the MongoDB exporter are encouraged to use our static builds instead, which do not suffer from these security issues.

##### Test Plan

CI passes on this PR.

