### PR TITLE
fix(go.d/pkg/ndexec): return the output along with the error

### DIFF
--- a/src/go/plugin/go.d/pkg/ndexec/ndexec.go
+++ b/src/go/plugin/go.d/pkg/ndexec/ndexec.go
@@ -87,7 +87,7 @@ func (r *runner) run(log *logger.Logger, timeout time.Duration, helperPath, labe
 			err = ctx.Err()
 		}
 
-		return nil, cmdStr, fmt.Errorf("%s: %v: %w (stderr: %s)", label, ex, err, strings.TrimSpace(s))
+		return out, cmdStr, fmt.Errorf("%s: %v: %w (stderr: %s)", label, ex, err, strings.TrimSpace(s))
 	}
 
 	return out, cmdStr, nil


### PR DESCRIPTION
##### Summary

Fixes #21404

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update ndexec runner to return captured stdout along with the error when a command fails. This preserves output for debugging and parsing, addressing #21404.

<sup>Written for commit 95d95f490f3475d64ca8715c9b676bc8519971fa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

