### PR TITLE
docs: add rendering of keywords in integration templates

### DIFF
--- a/integrations/templates/overview/collector.md
+++ b/integrations/templates/overview/collector.md
@@ -3,9 +3,9 @@
 Plugin: [[ entry.meta.plugin_name ]]
 Module: [[ entry.meta.module_name ]]
 
-{% if entry.meta.keywords %}
+[% if entry.meta.keywords %]
 Keywords: [[ entry.meta.keywords | join(',  ') ]]
-{% endif %}
+[% endif %]
 
 ## Overview
 

--- a/integrations/templates/overview/exporter.md
+++ b/integrations/templates/overview/exporter.md
@@ -1,8 +1,8 @@
 # [[ entry.meta.name ]]
 
-{% if entry.keywords %}
+[% if entry.keywords %]
 Keywords: [[ entry.keywords | join(',  ') ]]
-{% endif %}
+[% endif %]
 
 [[ entry.overview.exporter_description ]]
 [% if entry.overview.exporter_limitations %]

--- a/integrations/templates/overview/notification.md
+++ b/integrations/templates/overview/notification.md
@@ -1,8 +1,8 @@
 # [[ entry.meta.name ]]
 
-{% if entry.keywords %}
+[% if entry.keywords %]
 Keywords: [[ entry.keywords | join(',  ') ]]
-{% endif %}
+[% endif %]
 
 [[ entry.overview.notification_description ]]
 [% if entry.overview.notification_limitations %]


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render keywords in integration overview templates (collector, exporter, notification) to help users quickly see relevant tags. Each template conditionally adds a "Keywords:" line when keywords are present.

<sup>Written for commit 37b256c5701d77ab672aa01d68f1fea56fc241aa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

