### PR TITLE
fix(kickstart): install epel before repo config pkg

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1789,11 +1789,6 @@ try_package_install() {
 
   if ! check_special_native_deps; then
     warning "Could not find secondary dependencies for ${DISTRO} on ${SYSARCH}."
-    if [ -z "${NO_CLEANUP}" ]; then
-      progress "Attempting to uninstall repository configuration package."
-      # shellcheck disable=SC2086
-      run_as_root env ${env} ${pm_cmd} ${uninstall_subcmd} ${pkg_install_opts} "${repoconfig_name}"
-    fi
     return 2
   fi
 


### PR DESCRIPTION
##### Summary

Fixes #21408

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install EPEL and verify secondary native dependencies before installing the repository configuration package in kickstart.sh. This prevents failed installs on EL systems and avoids unnecessary install/uninstall cycles.

- **Bug Fixes**
  - Run check_special_native_deps before installing the repo config package.
  - Early exit if dependencies are missing.

<sup>Written for commit 9f88502f2d7053a09c9d4c8ab84a1332cc1bf800. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



