### PR TITLE
fix(rabbitmq): remove "rabbitmq_version" check

### DIFF
--- a/src/go/plugin/go.d/collector/rabbitmq/collect.go
+++ b/src/go/plugin/go.d/collector/rabbitmq/collect.go
@@ -83,10 +83,6 @@ func (c *Collector) getClusterMeta() (id string, name string, err error) {
 		return "", "", err
 	}
 
-	if resp.RabbitmqVersion == "" {
-		return "", "", fmt.Errorf("unexpected response: rabbitmq version is empty")
-	}
-
 	id = "unknown"
 	name = "unset"
 

--- a/src/go/plugin/go.d/collector/rabbitmq/restapi.go
+++ b/src/go/plugin/go.d/collector/rabbitmq/restapi.go
@@ -40,8 +40,7 @@ func (a *apiWhoamiTags) UnmarshalJSON(data []byte) error {
 }
 
 type apiDefinitionsResp struct {
-	RabbitmqVersion string `json:"rabbitmq_version"`
-	GlobalParams    []struct {
+	GlobalParams []struct {
 		Name  string `json:"name"`
 		Value any    `json:"value"`
 	} `json:"global_parameters"`


### PR DESCRIPTION
##### Summary

Older versions have only `rabbit_version`, current versions have `rabbitmq_version` and `rabbit_version`. We don't really need this check.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the rabbitmq_version check in the RabbitMQ collector to avoid errors with older brokers that only provide rabbit_version. This improves compatibility across versions without changing metrics collection.

<sup>Written for commit 34f54a4d324a7983cd9a82778b17226492ecb8d8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

