### PR TITLE
Change chart variable (Windows.plugin)

### DIFF
--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -348,7 +348,7 @@ void do_mssql_errors(PERF_DATA_BLOCK *pDataBlock, struct mssql_instance *mi, int
         }
 
         rrddim_set_by_pointer(
-                mi->st_sql_errors, mi->rd_sql_errors, (collected_number)mi->MSSQLAccessMethodPageSplits.current.Data);
+                mi->st_sql_errors, mi->rd_sql_errors, (collected_number)mi->MSSQLSQLErrorsTotal.current.Data);
         rrdset_done(mi->st_sql_errors);
     }
 }


### PR DESCRIPTION
##### Summary
This PR fixes variable assign in "do_mssql_errors"

##### Test Plan

1. Check CI

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the MSSQL errors chart in the Windows plugin to use the correct metric (MSSQLSQLErrorsTotal) in do_mssql_errors. This ensures the chart shows the actual total SQL errors instead of page splits.

<sup>Written for commit fd8e94b18d3cf45454af4fab6f6510babeb6ca32. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

