### PR TITLE
docs: remove prereq install smartmontools in Docker

### DIFF
--- a/src/go/plugin/go.d/collector/smartctl/metadata.yaml
+++ b/src/go/plugin/go.d/collector/smartctl/metadata.yaml
@@ -54,36 +54,32 @@ modules:
               Install `smartmontools` version 7.0 or later using your distribution's package manager. Version 7.0 introduced the `--json` output mode, which is required for this collector to function properly.
           - title: For Netdata running in a Docker container
             description: |
-              1. **Install smartmontools**.
+              **Provide access to storage devices**.
 
-                  Ensure `smartctl` is available in the container by setting the environment variable `NETDATA_EXTRA_DEB_PACKAGES=smartmontools` when starting the container.
+              Netdata requires the `SYS_RAWIO` capability and access to the storage devices to run the `smartctl` collector inside a Docker container. Here's how you can achieve this:
 
-              2. **Provide access to storage devices**.
+              - `docker run`
 
-                  Netdata requires the `SYS_RAWIO` capability and access to the storage devices to run the `smartctl` collector inside a Docker container. Here's how you can achieve this:
+                ```bash
+                docker run --cap-add SYS_RAWIO --device /dev/sda:/dev/sda ...
+                ```
 
-                  - `docker run`
+              - `docker-compose.yml`
 
-                    ```bash
-                    docker run --cap-add SYS_RAWIO --device /dev/sda:/dev/sda ...
-                    ```
+                ```yaml
+                services:
+                  netdata:
+                    cap_add:
+                      - SYS_PTRACE
+                      - SYS_ADMIN
+                      - SYS_RAWIO # smartctl
+                    devices:
+                      - "/dev/sda:/dev/sda"
+                ```
 
-                  - `docker-compose.yml`
+              > **Multiple Devices**: These examples only show mapping of one device (/dev/sda). You'll need to add additional `--device` options (in docker run) or entries in the `devices` list (in docker-compose.yml) for each storage device you want Netdata's smartctl collector to monitor.
 
-                    ```yaml
-                    services:
-                      netdata:
-                        cap_add:
-                          - SYS_PTRACE
-                          - SYS_ADMIN
-                          - SYS_RAWIO # smartctl
-                        devices:
-                          - "/dev/sda:/dev/sda"
-                    ```
-
-                  > **Multiple Devices**: These examples only show mapping of one device (/dev/sda). You'll need to add additional `--device` options (in docker run) or entries in the `devices` list (in docker-compose.yml) for each storage device you want Netdata's smartctl collector to monitor.
-
-                  > **NVMe Devices**: Do not map NVMe devices using this method. Netdata uses a [dedicated collector](https://github.com/netdata/netdata/tree/master/src/go/plugin/go.d/collector/nvme#readme) to monitor NVMe devices.
+              > **NVMe Devices**: Do not map NVMe devices using this method. Netdata uses a [dedicated collector](https://github.com/netdata/netdata/tree/master/src/go/plugin/go.d/collector/nvme#readme) to monitor NVMe devices.
       configuration:
         file:
           name: go.d/smartctl.conf


### PR DESCRIPTION
##### Summary

Not needed after netdata/helper-images#338.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Docker prerequisite to install smartmontools in the smartctl collector docs, as helper-images already provide smartctl. The instructions now focus on SYS_RAWIO and device access, with notes for multiple devices and NVMe.

<sup>Written for commit 5ee886e354df7848c399cceb235fa0ef67bc1dad. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



