### PR TITLE
Update PLATFORM_SUPPORT.md

### DIFF
--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -27,7 +27,7 @@ The following table shows a general outline of the various support tiers and cat
 | Third-party Supported | Users directed to platform maintainers | None                           | None                                                                                              | No                                       | Best Effort          |
 | Previously Supported  | Users asked to upgrade                 | None                           | None                                                                                              | Yes, but only already published versions | Best Effort          |
 
-- 'Bug Support': How we handle of platform-specific bugs.
+- 'Bug Support': How we handle platform-specific bugs.
 - 'Guaranteed Configurations': Which runtime configurations for the Agent we try to guarantee will work with minimal effort from users.
 - 'CI Coverage': What level of coverage we provide for the platform in CI.
 - 'Native Packages': Whether we provide native packages for the system package manager for the platform.


### PR DESCRIPTION
updated platform_support md
 @Ferroin 














<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes PLATFORM_SUPPORT.md with current distro versions and EOL statuses, and adds clear details on the static build process and supported architectures. This keeps the support matrix accurate and improves guidance for static builds.

- **Refactors**
  - Updated Core tier to latest releases: Alpine 3.23/3.22, Debian 13, Fedora 41–43, openSUSE Tumbleweed/Leap 16.0/15.6, Oracle Linux 10, Rocky Linux 10, Ubuntu 25.10/25.04.
  - Removed Docker i386 from Core; now x86_64, ARMv7, AArch64 only.
  - Moved openSUSE Tumbleweed to Core; cleaned up Intermediate (removed Alpine 3.17) and Community notes.
  - Expanded “Previously Supported” with recent EOLs (e.g., Alpine 3.17/3.18, Fedora 39/40, openSUSE Leap 15.5, Ubuntu 24.10).
  - Clarified third-party support (NixOS, Rockstor).
  - Documented static build entrypoint and tooling (build-static.sh, Docker/Podman, QEMU) and standardized arch names (x86_64, armv7l, armv6l, arm64).
  - Copy and formatting cleanup; consistent quotes and a note block for the EOL policy.

<sup>Written for commit b257db28a0cbd4fb99b4c87dc0e11dc5426fb4a9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













