### PR TITLE
fix(updater): fix deleting /dev/null when URL check fails

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -574,7 +574,7 @@ _safe_download() {
 
     if "${curl}" -fsSL --connect-timeout 10 --retry 3 "${url}" > "${dest}"; then
       succeeded=1
-    else
+    elif [ "${dest}" != "/dev/null" ]; then
       rm -f "${dest}"
     fi
   fi
@@ -585,7 +585,7 @@ _safe_download() {
 
       if wget -T 15 -O - "${url}" > "${dest}"; then
         succeeded=1
-      else
+      elif [ "${dest}" != "/dev/null" ]; then
         rm -f "${dest}"
       fi
     fi


### PR DESCRIPTION
##### Summary

Fixes #21427

Bug added in #21288

Fix a bug in `_safe_download()` that deletes `/dev/null` when a download fails.

In `update_binpkg()`, the function `_safe_download` is called with `/dev/null` as the
destination to check if native packages are still being published:

```sh
_safe_download "${check_url}" /dev/null
```

When the download fails (either via curl or wget), `_safe_download` attempts to clean up
by running `rm -f "${dest}"`. Since `dest` is `/dev/null`, this deletes the special
device file, which can cause widespread system issues.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents deleting /dev/null when the updater’s URL check fails. _safe_download now skips rm -f if the destination is /dev/null, so update_binpkg checks no longer risk breaking the device file.

<sup>Written for commit a57233b2fea6e68ed908b7d7f730e4a6b1fd617d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

