### PR TITLE
Properly handle package check URL creation for RHEL derivatives.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -1044,7 +1044,7 @@ update_binpkg() {
   DISTRO="${ID}"
   SYSVERSION="${VERSION_ID}"
 
-  supported_compat_names="debian ubuntu centos fedora opensuse ol amzn"
+  supported_compat_names="debian ubuntu centos centos-stream fedora opensuse ol amzn"
 
   if str_in_list "${DISTRO}" "${supported_compat_names}"; then
     DISTRO_COMPAT_NAME="${DISTRO}"


### PR DESCRIPTION
##### Summary

#21288 incorrectly handled templating of the check URL for RPM based distributions other than openSUSE and Fedora. This PR fixes this issue so that the URLs are generated correctly and the check works properly for these platforms.

##### Test Plan

Requires testing on affected platforms to confirm that things work now.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RPM updater check URL generation for RHEL-family distros so the package check works on Amazon Linux, Oracle Linux, Fedora, CentOS Stream, and EL variants.

- **Bug Fixes**
  - Added distro-specific repo_path mapping: amzn→amazonlinux, centos-stream→el/cXS, fedora→fedora, ol→ol, default→el with major version.
  - Marked centos-stream as supported (not aliased to centos) to use the correct repo path.

<sup>Written for commit a4565661a4c9257bf090607cdab12fcf6bcb561e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





