### PR TITLE
Attempt to fix broken /dev/null resulting from bug in updater script.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -326,10 +326,11 @@ dev_null_fix() {
         #
         # This check doesn’t use /dev/null as trying to access it
         # without the right security context being set may fail.
-        if command -v restorecon >/tmp/nd-null 2>&1; then
+        dummy_null="$(mktemp)"
+        if command -v restorecon >"${dummy_null}" 2>&1; then
             restorecon /dev/null
         fi
-        rm -f /tmp/nd-null # Cleanup from the above check
+        rm -f "${dummy_null}" || true # Cleanup from the above check
         ;;
       *) ;;
     esac


### PR DESCRIPTION
##### Summary

This checks if `/dev/null` either doesn’t exist, or is a regular file, and attempts to recreate it correctly as a device file if either of those situations is the case.

This is intended to automatically repair systems that were affected by the bug fixed by PR #21428.

##### Test Plan

This can be tested locally by preparing an environment with Netdata installed, removing `/dev/null` or replacing it with a regular file and then running the script. After running the script, `/dev/null` should be a proper device node again.









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects and repairs broken /dev/null caused by a past updater bug. Recreates it as a proper character device with correct mode, ownership, and SELinux context on Linux.

- **Bug Fixes**
  - Detects when /dev/null is missing or is a regular file.
  - Linux: creates /dev/.null (c 1,3, mode 666), copies ownership from /dev/full if present, applies SELinux context with restorecon if available, then replaces /dev/null.
  - Runs dev_null_fix after self_update to fix affected systems automatically.

<sup>Written for commit 5efbfbdddee54c7bc9ac7d0a2980c4ab16a93231. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









