### PR TITLE
fix(go.d): avoid blocking all jobs when stopping a slow job

### DIFF
--- a/src/go/plugin/go.d/agent/jobmgr/manager.go
+++ b/src/go/plugin/go.d/agent/jobmgr/manager.go
@@ -259,12 +259,10 @@ func (m *Manager) runNotifyRunningJobs() {
 }
 
 func (m *Manager) startRunningJob(job *module.Job) {
+	m.stopRunningJob(job.FullName())
+
 	m.runningJobs.lock()
 	defer m.runningJobs.unlock()
-
-	if job, ok := m.runningJobs.lookup(job.FullName()); ok {
-		job.Stop()
-	}
 
 	go job.Start()
 	m.runningJobs.add(job.FullName(), job)
@@ -272,11 +270,14 @@ func (m *Manager) startRunningJob(job *module.Job) {
 
 func (m *Manager) stopRunningJob(name string) {
 	m.runningJobs.lock()
-	defer m.runningJobs.unlock()
-
-	if job, ok := m.runningJobs.lookup(name); ok {
-		job.Stop()
+	job, ok := m.runningJobs.lookup(name)
+	if ok {
 		m.runningJobs.remove(name)
+	}
+	m.runningJobs.unlock()
+
+	if ok {
+		job.Stop()
 	}
 }
 


### PR DESCRIPTION
The manager previously called `job.Stop()` while holding the `runningJobs` mutex.
Since `Stop()` is a blocking call—it waits until the job’s goroutine exits—this created a scenario where a job stuck in `runOnce()` could hold the mutex for an extended time.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved job Stop() out of the runningJobs mutex to avoid blocking the manager when stopping slow or stuck jobs. This keeps other jobs responsive during stop operations.

- **Bug Fixes**
  - stopRunningJob now removes the job under lock, unlocks, then calls Stop().
  - startRunningJob calls stopRunningJob before locking, then starts and registers the new job.
  - Prevents global stalls caused by a slow Stop() while holding the mutex.

<sup>Written for commit eaf7bd4e89aef15cb936be2b98e43a9a52b6e686. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

