### PR TITLE
Docs: clarify that netdata/netdata defaults to latest and how to use :stable

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -336,7 +336,7 @@ volumes:
 
 #### Restrict access with basic auth
 
-You can restrict access by following the [official caddy guide](https://caddyserver.com/docs/caddyfile/directives/basicauth#basicauth) and adding lines  to Caddyfile.
+You can restrict access by following the [official caddy guide](https://caddyserver.com/docs/caddyfile/directives/basicauth#basicauth) and adding lines to Caddyfile.
 
 ### With Docker socket proxy
 


### PR DESCRIPTION


##### Summary

Closes netdata/learn#2587

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified Docker image tags: using netdata/netdata without a tag pulls latest; use netdata/netdata:stable for the stable release. Added quick tips in install/run/proxy sections and tightened the Caddy basic auth wording to address netdata/learn#2587.

<sup>Written for commit ae4a46a8509e87821640f095f603b2bd28b6b318. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







