### PR TITLE
Improve metadata storage stability

### DIFF
--- a/src/database/sqlite/sqlite_metadata.h
+++ b/src/database/sqlite/sqlite_metadata.h
@@ -33,7 +33,7 @@ void metaqueue_ml_load_models(RRDDIM *rd);
 void detect_machine_guid_change(nd_uuid_t *host_uuid);
 bool metadata_queue_load_host_context();
 void reset_host_context_load_flag();
-void vacuum_database(sqlite3 *database, const char *db_alias, int threshold, int vacuum_pc);
+void vacuum_database(sqlite3 *database, const char *db_alias, int threshold, int vacuum_pc, time_t *next_run);
 
 int sql_metadata_cache_stats(int op);
 

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1042,6 +1042,7 @@ void ml_detect_main(void *arg)
 }
 
 static void ml_flush_pending_models(ml_worker_t *worker) {
+    static time_t next_vacuum_run = 0;
     int op_no = 1;
 
     // begin transaction
@@ -1089,7 +1090,7 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
         worker->num_models_to_prune += worker->pending_model_info.size();
     }
 
-    vacuum_database(ml_db, "ML", 0, 0);
+    vacuum_database(ml_db, "ML", 0, 0, &next_vacuum_run);
 
     worker->pending_model_info.clear();
 }


### PR DESCRIPTION
##### Summary
- Enhance JudyL error handling, refactor database vacuum logic, and fix metadata memory management issues.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens metadata storage stability by hardening JudyL error handling and throttling SQLite vacuum scheduling. Also fixes host lookup and memory management to prevent leaks and crashes under load.

- **Bug Fixes**
  - Use rrdhost_find_and_acquire() in sql_update_node_id with proper release to avoid use-after-free.
  - Check PJERR on all JudyLIns calls; avoid corrupted inserts, clean up on failure, and set values correctly.
  - Return false on prepare failure in sql_set_host_label to prevent silent errors.

- **Refactors**
  - vacuum_database now takes a next_run pointer to throttle vacuums; applied in metadata cleanup and ML model flush.
  - Use UUID_STR_LEN for host GUID handling and improve error logging for alert deletions.

<sup>Written for commit 8708f390622ee83b0102510356dc403a5e85ef07. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

