### PR TITLE
Update nodes-ephemerality.md

### DIFF
--- a/docs/nodes-ephemerality.md
+++ b/docs/nodes-ephemerality.md
@@ -62,12 +62,6 @@ If a child node is deleted and later reconnects, it's automatically recreated in
 
 :::
 
-:::warning Data Loss Risk
-
-If **all instances** of a node are deleted from Cloud, the node entry itself is permanently removed. When the node reconnects, it will appear as a new node.
-
-:::
-
 ## Monitoring and Managing Node Status
 
 ### Mark Permanently Offline Nodes as Ephemeral


### PR DESCRIPTION
Added the Automatic Node Instance Cleanup here, seemed appropriate









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated nodes-ephemerality docs to cover automatic cleanup of offline child node instances in Netdata Cloud and clarify retention rules for direct and ephemeral nodes. Also simplified visuals by removing collapsible sections and refining Mermaid diagrams.

- **New Features**
  - Documented automatic cleanup: child nodes (hops > 0) deleted after 48 hours when the child or Parent is offline; directly claimed nodes kept for 60 days; ephemeral nodes configurable.
  - Clarified reconnection: deleted child instances are recreated on reconnect; historical data is available if retained on the Parent.

- **Refactors**
  - Removed collapsible <details> wrappers around flows.
  - Standardized Mermaid diagram styling for clearer, consistent visuals.

<sup>Written for commit 65d11f401f6dbd1750f21eba83f5604ecf65c798. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







