### PR TITLE
chore(go.d): include Go version in build info

### DIFF
--- a/src/go/pkg/buildinfo/buildinfo.go
+++ b/src/go/pkg/buildinfo/buildinfo.go
@@ -31,8 +31,9 @@ var NetdataBinDir = "/usr/sbin"
 // Info returns all build information as a single line with snake_case keys.
 func Info() string {
 	return fmt.Sprintf(
-		"version=%s user_config_dir=%s stock_config_dir=%s plugins_dir=%s netdata_bin_dir=%s",
+		"version=%s go_version=%s user_config_dir=%s stock_config_dir=%s plugins_dir=%s netdata_bin_dir=%s",
 		Version,
+		runtime.Version(),
 		UserConfigDir,
 		StockConfigDir,
 		PluginsDir,


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the Go runtime version in go.d build info to improve diagnostics and environment visibility. The Info() string now includes a go_version key alongside version and existing paths.

<sup>Written for commit 40d9f79b7669b03b33a234b15a7a41c5ee3bdfd6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

