### PR TITLE
Remove Fedora 41 from CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -239,13 +239,6 @@ include:
       repo_distro: fedora/42
     test:
       ebpf-core: true
-  - <<: *fedora
-    version: "41"
-    packages:
-      <<: *fedora_packages
-      repo_distro: fedora/41
-    test:
-      ebpf-core: true
 
   - &opensuse
     distro: opensuse
@@ -432,6 +425,13 @@ legacy: # Info for platforms we used to support and still need to handle package
     packages:
       <<: *fedora_packages
       repo_distro: fedora/40
+    test:
+      ebpf-core: true
+  - <<: *fedora
+    version: "41"
+    packages:
+      <<: *fedora_packages
+      repo_distro: fedora/41
     test:
       ebpf-core: true
   - <<: *opensuse

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -56,7 +56,6 @@ Our [static builds](#static-builds) are expected to work on these platforms if a
 | Debian                   | 11.x           | x86\_64, i386, ARMv7, AArch64 |                                                                                                                |
 | Fedora                   | 43             | x86\_64, AArch64              |                                                                                                                |
 | Fedora                   | 42             | x86\_64, AArch64              |                                                                                                                |
-| Fedora                   | 41             | x86\_64, AArch64              |                                                                                                                |
 | openSUSE                 | Tumbleweed     | x86\_64, AArch64              |                                                                                                                |
 | openSUSE                 | Leap 16.0      | x86\_64, AArch64              |                                                                                                                |
 | openSUSE                 | Leap 15.6      | x86\_64, AArch64              |                                                                                                                |
@@ -124,22 +123,15 @@ This is a list of platforms that we have supported in the recent past but no lon
 | Platform     | Version   | Notes                |
 |--------------|-----------|----------------------|
 | Alpine Linux | 3.18      | EOL as of 2024-05-23 |
-| Alpine Linux | 3.17      | EOL as of 2023-11-01 |
-| Alpine Linux | 3.16      | EOL as of 2024-05-23 |
-| Alpine Linux | 3.15      | EOL as of 2023-11-01 |
-| Alpine Linux | 3.14      | EOL as of 2023-05-01 |
 | Debian       | 10.x      | EOL as of 2024-07-01 |
+| Fedora       | 41        | EOL as of 2025-12-15 |
 | Fedora       | 40        | EOL as of 2024-11-12 |
 | Fedora       | 39        | EOL as of 2024-05-14 |
 | Fedora       | 38        | EOL as of 2024-05-14 |
-| Fedora       | 37        | EOL as of 2023-12-05 |
 | openSUSE     | Leap 15.5 | EOL as of 2024-12-31 |
-| openSUSE     | Leap 15.4 | EOL as of 2023-12-07 |
-| openSUSE     | Leap 15.3 | EOL as of 2022-12-01 |
 | Ubuntu       | 24.10     | EOL as of 2024-07-01 |
 | Ubuntu       | 23.10     | EOL as of 2024-07-01 |
 | Ubuntu       | 23.04     | EOL as of 2024-01-20 |
-| Ubuntu       | 22.10     | EOL as of 2023-07-20 |
 | Ubuntu       | 18.04     | EOL as of 2023-04-02 |
 
 ## Static builds


### PR DESCRIPTION
##### Summary

It went EOL upstream on 2025-12-15.

##### Test Plan

n/a

##### Additional Information

Closes: #21172

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Fedora 41 from CI and package builds after upstream EOL (2025-12-15). Moved Fedora 41 to the legacy distro list and updated platform support docs.

- **Migration**
  - Upgrade to Fedora 42 or 43 for continued CI coverage and package builds.

<sup>Written for commit 00a9ed8483dff9690809ecf9cbfd2a8c0137cb53. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

