### PR TITLE
Improve ACLK data transmission

### DIFF
--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -2026,7 +2026,13 @@ static int mqtt_ng_next_to_send(struct mqtt_ng_client *client) {
 
     struct buffer_fragment *frag = BUFFER_FIRST_FRAG(&client->main_buffer.hdr_buffer);
     while (frag) {
-        if ( frag->sent != frag->len )
+        // Skip fragments marked for garbage collection - their data may have
+        // been freed by mark_message_for_gc() after a timeout or ACK
+        if (frag_is_marked_for_gc(frag)) {
+            frag = frag->next;
+            continue;
+        }
+        if (frag->sent != frag->len)
             break;
         frag = frag->next;
     }


### PR DESCRIPTION
##### Summary
- Skip garbage-collected MQTT fragments during send processing


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes and use-after-free in the ACLK MQTT send path by skipping fragments marked for garbage collection. This avoids sending from freed buffers after timeouts or ACKs and improves reliability.

<sup>Written for commit 8a166a3d49e392f962b40ed67adfee9ea136ec50. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

