### PR TITLE
fix(netdata-updater): fix major version detection for native packages

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -1240,10 +1240,11 @@ update_binpkg() {
     fi
   fi
 
-  current_major="$(netdata -v | cut -f 2 -d ' ' | cut -f 1 -d '.' | tr -d 'v')"
+  current_major="$(get_current_version | head -c 4 | awk '{ print $1 + 0 }')"
   latest_major="$(get_new_binpkg_major)"
 
-  if [ -n "${latest_major}" ] && [ "${latest_major}" -ne "${current_major}" ]; then
+  # current_major == 0 means we could not determine the installed version
+  if [ -n "${latest_major}" ] && [ "${current_major}" -ne 0 ] && [ "${latest_major}" -ne "${current_major}" ]; then
     update_safe=0
 
     for v in ${NETDATA_ACCEPT_MAJOR_VERSIONS}; do


### PR DESCRIPTION
##### Summary

Fixes: #21484

##### Test Plan

```bash
$ echo 000200800000139 | head -c 4 | awk '{ print $1 + 0 }'
2
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect major version detection in netdata-updater for native packages. The updater now uses get_current_version to read the installed major and skips the check when the version is unknown, preventing wrong skip/upgrade decisions.

<sup>Written for commit 4f3e993131f24ccb5d89ae108965601839621a2d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



