### PR TITLE
Improve systemd-journal logs 

### DIFF
--- a/src/collectors/systemd-journal.plugin/systemd-internals.h
+++ b/src/collectors/systemd-journal.plugin/systemd-internals.h
@@ -88,6 +88,7 @@ struct nd_journal_file {
 
 extern DICTIONARY *nd_journal_files_registry;
 extern DICTIONARY *used_hashes_registry;
+extern DICTIONARY *column_order_registry;
 extern DICTIONARY *boot_ids_to_first_ut;
 
 int nd_journal_file_dict_items_backward_compar(const void *a, const void *b);

--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -9,6 +9,7 @@
 struct journal_directory journal_directories[MAX_JOURNAL_DIRECTORIES] = {0};
 DICTIONARY *nd_journal_files_registry = NULL;
 DICTIONARY *used_hashes_registry = NULL;
+DICTIONARY *column_order_registry = NULL;
 
 static usec_t systemd_journal_session = 0;
 
@@ -855,6 +856,12 @@ void nd_journal_init_files_and_directories(void)
     // initialize the used hashes files registry
 
     used_hashes_registry = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+
+    // ------------------------------------------------------------------------
+    // initialize the column order registry for stable column indices
+
+    column_order_registry = dictionary_create_advanced(
+        DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE, NULL, sizeof(uint32_t));
 
     systemd_journal_session = (now_realtime_usec() / USEC_PER_SEC) * USEC_PER_SEC;
 

--- a/src/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal.c
@@ -981,7 +981,7 @@ static int nd_sd_journal_query(BUFFER *wb, LOGS_QUERY_STATUS *lqs)
     if (!lqs->rq.data_only || lqs->rq.tail)
         buffer_json_member_add_uint64(wb, "last_modified", lqs->last_modified);
 
-    facets_sort_and_reorder_keys(facets);
+    facets_sort_and_reorder_keys(facets, column_order_registry);
     facets_report(facets, wb, used_hashes_registry);
 
     wb->expires = now_realtime_sec() + (lqs->rq.data_only ? 3600 : 0);

--- a/src/collectors/windows-events.plugin/windows-events-sources.c
+++ b/src/collectors/windows-events.plugin/windows-events-sources.c
@@ -161,6 +161,7 @@ BITMAP_STR_DEFINE_FUNCTIONS(WEVT_SOURCE_TYPE, WEVTS_NONE, "");
 
 DICTIONARY *wevt_sources = NULL;
 DICTIONARY *used_hashes_registry = NULL;
+DICTIONARY *column_order_registry = NULL;
 static usec_t wevt_session = 0;
 
 void wevt_sources_del_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused) {
@@ -209,6 +210,9 @@ void wevt_sources_init(void) {
     wevt_session = now_realtime_usec();
 
     used_hashes_registry = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+
+    column_order_registry = dictionary_create_advanced(
+        DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE, NULL, sizeof(uint32_t));
 
     wevt_sources = dictionary_create_advanced(DICT_OPTION_FIXED_SIZE | DICT_OPTION_DONT_OVERWRITE_VALUE,
                                               NULL, sizeof(LOGS_QUERY_SOURCE));

--- a/src/collectors/windows-events.plugin/windows-events-sources.h
+++ b/src/collectors/windows-events.plugin/windows-events-sources.h
@@ -64,6 +64,7 @@ typedef struct {
 
 extern DICTIONARY *wevt_sources;
 extern DICTIONARY *used_hashes_registry;
+extern DICTIONARY *column_order_registry;
 
 void wevt_sources_init(void);
 void wevt_sources_scan(void);

--- a/src/collectors/windows-events.plugin/windows-events.c
+++ b/src/collectors/windows-events.plugin/windows-events.c
@@ -1222,7 +1222,7 @@ static int wevt_master_query(BUFFER *wb __maybe_unused, LOGS_QUERY_STATUS *lqs _
     if(!lqs->rq.data_only || lqs->rq.tail)
         buffer_json_member_add_uint64(wb, "last_modified", lqs->last_modified);
 
-    facets_sort_and_reorder_keys(facets);
+    facets_sort_and_reorder_keys(facets, column_order_registry);
     facets_report(facets, wb, used_hashes_registry);
 
     wb->expires = now_realtime_sec() + (lqs->rq.data_only ? 3600 : 0);

--- a/src/libnetdata/facets/facets.h
+++ b/src/libnetdata/facets/facets.h
@@ -136,7 +136,7 @@ bool facets_key_name_is_facet(FACETS *facets, const char *key);
 bool facets_key_name_value_length_is_selected(FACETS *facets, const char *key, size_t key_length, const char *value, size_t value_length);
 void facets_add_possible_value_name_to_key(FACETS *facets, const char *key, size_t key_length, const char *value, size_t value_length);
 
-void facets_sort_and_reorder_keys(FACETS *facets);
+void facets_sort_and_reorder_keys(FACETS *facets, DICTIONARY *column_order_registry);
 usec_t facets_row_oldest_ut(FACETS *facets);
 usec_t facets_row_newest_ut(FACETS *facets);
 uint32_t facets_rows(FACETS *facets);


### PR DESCRIPTION
##### Summary
- Introduce `column_order_registry` to assign and maintain a stable order for facet keys across sessions. 
- Update - `facets_sort_and_reorder_keys()` to use this registry for consistent key ordering.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep facet column order stable across sessions for systemd-journal and Windows events by introducing a shared column order registry. This prevents columns from shifting between queries and keeps facet indices consistent.

- **New Features**
  - Added a DICTIONARY-backed column order registry that assigns and remembers a numeric order per facet key.
  - Updated facets_sort_and_reorder_keys() to use the registry; falls back to alphabetical when absent.
  - Thread-safe registry access with a spinlock and a _next_order_ counter to allocate new orders.

- **Migration**
  - facets_sort_and_reorder_keys(FACETS *, DICTIONARY *) now requires the column_order_registry parameter.
  - Initialize and pass the registry wherever facets are sorted (updated for systemd-journal and Windows events).

<sup>Written for commit db519866976c639b4fe9f68ca1d9b526b3c5c44e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

