### PR TITLE
Improve storage collector by using dictionary delete callbacks

### DIFF
--- a/src/collectors/windows.plugin/perflib-storage.c
+++ b/src/collectors/windows.plugin/perflib-storage.c
@@ -103,6 +103,7 @@ static void logical_disk_cleanup(struct logical_disk *d)
     d->collected_metadata = false;
 
     rrdset_is_obsolete___safe_from_collector_thread(d->st_disk_space);
+    d->st_disk_space = NULL;
 }
 
 static void physical_disk_initialize(struct physical_disk *d)


### PR DESCRIPTION
##### Summary
- Ensure proper deallocation of disk-related strings and reset pointers to NULL. 
- Add metadata reset (`collected_metadata = false`) during cleanup to prevent stale data usage.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Windows storage collector to dictionary delete callbacks for logical and physical disks. This centralizes cleanup, fixes memory leaks, and prevents stale metadata.

- **Bug Fixes**
  - Register delete callbacks for logicalDisks and physicalDisks and rely on them for cleanup.
  - Free disk-related strings and set pointers to NULL during cleanup to prevent leaks.
  - Reset collected_metadata to false to avoid stale metadata after deletions.

<sup>Written for commit 456f627613bebc32804d76948a6ce91b808f7815. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

