### PR TITLE
Improve EBPF cleanup

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/src/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -310,8 +310,6 @@ void ebpf_parse_cgroup_shm_data()
         previous,
         shm_ebpf_cgroup.header->cgroup_root_count);
 #endif
-
-    sem_post(shm_sem_ebpf_cgroup);
 }
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
- Remove duplicate sem_post
- Improve cleanup during shutdown (and startup)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve eBPF cgroup startup and shutdown by cleaning up shared memory and semaphores, and removing a redundant semaphore post. Prevents stale IPC objects and unintended signaling.

- **Bug Fixes**
  - Unlink shared memory and named semaphore on startup and shutdown.
  - Close, then unlink the semaphore to avoid leaks.
  - Remove duplicate sem_post in ebpf_cgroup to prevent double signaling.

<sup>Written for commit fa204e484b55f52644c5b3e68f60b816b0fdebec. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

