### PR TITLE
Revert "MSSQL Collection (windows.plugin)"

### DIFF
--- a/src/collectors/windows.plugin/MonitorSQL.c
+++ b/src/collectors/windows.plugin/MonitorSQL.c
@@ -7,7 +7,7 @@
 
 DICTIONARY *conn_options;
 
-static inline bool netdata_mssql_check_result(SQLRETURN ret)
+static inline int netdata_mssql_check_result(SQLRETURN ret)
 {
     return (ret != SQL_SUCCESS && ret != SQL_SUCCESS_WITH_INFO);
 }
@@ -63,17 +63,12 @@ static void netdata_MSSQL_error(uint32_t type, SQLHANDLE handle, enum netdata_ms
     }
 }
 
-static inline void netdata_MSSQL_release_results(SQLHSTMT stmt)
+static inline void netdata_MSSQL_release_results(SQLHSTMT *stmt)
 {
-    if (stmt == SQL_NULL_HSTMT)
-        return;
-
     SQLCloseCursor(stmt);
-    SQLFreeStmt(stmt, SQL_UNBIND);
-    SQLFreeStmt(stmt, SQL_RESET_PARAMS);
 }
 
-static ULONGLONG netdata_MSSQL_fill_long_value(SQLHSTMT stmt, const char *mask, const char *dbname, char *instance)
+static ULONGLONG netdata_MSSQL_fill_long_value(SQLHSTMT *stmt, const char *mask, const char *dbname, char *instance)
 {
     long db_size = 0;
     SQLLEN col_data_len = 0;
@@ -86,21 +81,18 @@ static ULONGLONG netdata_MSSQL_fill_long_value(SQLHSTMT stmt, const char *mask, 
     ret = SQLExecDirect(stmt, query, SQL_NTS);
     if (likely(netdata_mssql_check_result(ret))) {
         netdata_MSSQL_error(SQL_HANDLE_STMT, stmt, NETDATA_MSSQL_ODBC_QUERY, instance);
-        netdata_MSSQL_release_results(stmt);
         return (ULONGLONG)ULONG_LONG_MAX;
     }
 
     ret = SQLBindCol(stmt, 1, SQL_C_LONG, &db_size, sizeof(long), &col_data_len);
     if (likely(netdata_mssql_check_result(ret))) {
         netdata_MSSQL_error(SQL_HANDLE_STMT, stmt, NETDATA_MSSQL_ODBC_PREPARE, instance);
-        netdata_MSSQL_release_results(stmt);
         return (ULONGLONG)ULONG_LONG_MAX;
     }
 
     ret = SQLFetch(stmt);
     if (likely(netdata_mssql_check_result(ret))) {
         netdata_MSSQL_error(SQL_HANDLE_STMT, stmt, NETDATA_MSSQL_ODBC_FETCH, instance);
-        netdata_MSSQL_release_results(stmt);
         return (ULONGLONG)ULONG_LONG_MAX;
     }
 
@@ -359,7 +351,7 @@ void dict_mssql_fill_locks(struct mssql_db_instance *mdi, const char *dbname)
     SQLCHAR query[sizeof(NETDATA_QUERY_LOCKS_MASK) + 2 * NETDATA_MAX_INSTANCE_OBJECT + 1];
     snprintfz(
         (char *)query,
-        sizeof(NETDATA_QUERY_LOCKS_MASK) + 2 * NETDATA_MAX_INSTANCE_OBJECT,
+        sizeof(NETDATA_QUERY_TRANSACTIONS_MASK) + 2 * NETDATA_MAX_INSTANCE_OBJECT,
         NETDATA_QUERY_LOCKS_MASK,
         dbname,
         dbname);
@@ -447,33 +439,33 @@ int dict_mssql_fill_waits(struct mssql_instance *mi)
         goto endwait;
     }
 
-    ret = SQLBindCol(mi->conn->dbWaitsSTMT, 2, SQL_C_SBIGINT, &total_wait, sizeof(total_wait), &col_total_wait_len);
+    ret = SQLBindCol(mi->conn->dbWaitsSTMT, 2, SQL_C_LONG, &total_wait, sizeof(total_wait), &col_total_wait_len);
     if (likely(netdata_mssql_check_result(ret))) {
         netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
         goto endwait;
     }
 
     ret =
-        SQLBindCol(mi->conn->dbWaitsSTMT, 3, SQL_C_SBIGINT, &resource_wait, sizeof(resource_wait), &col_resource_wait_len);
+        SQLBindCol(mi->conn->dbWaitsSTMT, 3, SQL_C_LONG, &resource_wait, sizeof(resource_wait), &col_resource_wait_len);
     if (likely(netdata_mssql_check_result(ret))) {
         netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
         goto endwait;
     }
 
-    ret = SQLBindCol(mi->conn->dbWaitsSTMT, 4, SQL_C_SBIGINT, &signal_wait, sizeof(signal_wait), &col_signal_wait_len);
+    ret = SQLBindCol(mi->conn->dbWaitsSTMT, 4, SQL_C_LONG, &signal_wait, sizeof(signal_wait), &col_signal_wait_len);
     if (likely(netdata_mssql_check_result(ret))) {
         netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
         goto endwait;
     }
 
-    ret = SQLBindCol(mi->conn->dbWaitsSTMT, 5, SQL_C_SBIGINT, &max_wait, sizeof(max_wait), &col_max_wait_len);
+    ret = SQLBindCol(mi->conn->dbWaitsSTMT, 5, SQL_C_LONG, &max_wait, sizeof(max_wait), &col_max_wait_len);
     if (likely(netdata_mssql_check_result(ret))) {
         netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
         goto endwait;
     }
 
     ret =
-        SQLBindCol(mi->conn->dbWaitsSTMT, 6, SQL_C_SBIGINT, &waiting_tasks, sizeof(waiting_tasks), &col_waiting_tasks_len);
+        SQLBindCol(mi->conn->dbWaitsSTMT, 6, SQL_C_LONG, &waiting_tasks, sizeof(waiting_tasks), &col_waiting_tasks_len);
     if (likely(netdata_mssql_check_result(ret))) {
         netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
         goto endwait;
@@ -518,9 +510,10 @@ int dict_mssql_fill_waits(struct mssql_instance *mi)
             continue;
 
         mdw->MSSQLDatabaseTotalWait.current.Data = (ULONGLONG)total_wait;
-        if (unlikely(resource_wait < 0))
-            resource_wait = 0;
-        mdw->MSSQLDatabaseResourceWaitMSec.current.Data = (ULONGLONG)resource_wait;
+        // Variable mdw->MSSQLDatabaseResourceWaitMSec.current.Data stores a mathematical operation
+        // that can be negative sometimes. This is the reason we have this if
+        if (likely(resource_wait > mdw->MSSQLDatabaseResourceWaitMSec.current.Data))
+            mdw->MSSQLDatabaseResourceWaitMSec.current.Data = (ULONGLONG)resource_wait;
         mdw->MSSQLDatabaseSignalWaitMSec.current.Data = (ULONGLONG)signal_wait;
         mdw->MSSQLDatabaseMaxWaitTimeMSec.current.Data = (ULONGLONG)max_wait;
         mdw->MSSQLDatabaseWaitingTasks.current.Data = (ULONGLONG)waiting_tasks;
@@ -860,7 +853,8 @@ void netdata_mssql_fill_mssql_status(struct mssql_instance *mi)
     char dbname[SQLSERVER_MAX_NAME_LENGTH + 1];
     int readonly = 0;
     BYTE state = 0;
-    SQLLEN col_data_len = 0, col_state_len = 0, col_readonly_len = 0;
+    SQLLEN col_data_len = 0;
+
     static int next_try = NETDATA_MSSQL_NEXT_TRY - 1;
 
     if (unlikely(++next_try != NETDATA_MSSQL_NEXT_TRY))
@@ -876,13 +870,9 @@ void netdata_mssql_fill_mssql_status(struct mssql_instance *mi)
         goto enddbstate;
     }
 
-    ret = SQLBindCol(mi->conn->dbSQLState, 1, SQL_C_CHAR, dbname, sizeof(dbname), &col_data_len);
-    if (likely(netdata_mssql_check_result(ret))) {
-        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbSQLState, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
-        goto enddbstate;
-    }
+    SQLLEN col_state_len = 0, col_readonly_len = 0;
 
-    ret = SQLBindCol(mi->conn->dbSQLState, 2, SQL_C_TINYINT, &state, sizeof(state), &col_state_len);
+    ret = SQLBindCol(mi->conn->dbSQLState, 1, SQL_C_TINYINT, &state, sizeof(state), &col_state_len);
     if (likely(netdata_mssql_check_result(ret))) {
         netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbSQLState, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
         goto enddbstate;
@@ -890,7 +880,7 @@ void netdata_mssql_fill_mssql_status(struct mssql_instance *mi)
 
     ret = SQLBindCol(mi->conn->dbSQLState, 3, SQL_C_BIT, &readonly, sizeof(readonly), &col_readonly_len);
     if (likely(netdata_mssql_check_result(ret))) {
-        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbSQLState, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
+        netdata_MSSQL_error(SQL_HANDLE_STMT, mi->conn->dbWaitsSTMT, NETDATA_MSSQL_ODBC_PREPARE, mi->instanceID);
         goto enddbstate;
     }
 
@@ -900,8 +890,6 @@ void netdata_mssql_fill_mssql_status(struct mssql_instance *mi)
             goto enddbstate;
         }
 
-        if (col_data_len == SQL_NULL_DATA)
-            continue;
         if (col_state_len == SQL_NULL_DATA)
             state = 0;
         if (col_readonly_len == SQL_NULL_DATA)
@@ -1119,7 +1107,6 @@ void netdata_mssql_fill_dictionary_from_db(struct mssql_instance *mi)
         if (unlikely(!i)) {
             mdi->collect_instance = true;
         }
-        i++;
     } while (true);
 
 enddblist:
@@ -1526,7 +1513,6 @@ void dict_mssql_insert_cb(const DICTIONARY_ITEM *item __maybe_unused, void *valu
         dictionary_register_insert_callback(mi->locks_instances, dict_mssql_insert_locks_cb, NULL);
         mssql_fill_initial_instances(mi);
     }
-
 
     if (unlikely(!mi->databases)) {
         mi->databases = dictionary_create_advanced(
@@ -3016,7 +3002,7 @@ static void mssql_db_state_chart_loop(struct mssql_db_instance *mdi, const char 
     collected_number set_value =
         (mdi->MSSQLDBState.current.Data < 5) ? (collected_number)mdi->MSSQLDBState.current.Data : 5;
     mssql_db_states_chart(mdi, db, update_every);
-    for (collected_number i = 0; i < NETDATA_DB_STATES; i++) {
+    for (collected_number i; i < NETDATA_DB_STATES; i++) {
         rrddim_set_by_pointer(mdi->st_db_state, mdi->rd_db_state[i], i == set_value);
     }
     rrdset_done(mdi->st_db_state);

--- a/src/collectors/windows.plugin/perflib-memory.c
+++ b/src/collectors/windows.plugin/perflib-memory.c
@@ -239,8 +239,7 @@ int do_PerflibMemory(int update_every, usec_t dt __maybe_unused)
     if (!pDataBlock)
         return -1;
 
-    if (!do_memory(pDataBlock, update_every))
-        return -1;
+    do_memory(pDataBlock, update_every);
 
     return 0;
 }

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -422,13 +422,14 @@ void do_mssql_general_stats(PERF_DATA_BLOCK *pDataBlock, struct mssql_instance *
     if (unlikely(!pObjectType))
         return;
 
-    if (unlikely(!mi->conn || !mi->conn->collect_user_connections)) {
-        if (likely(perflibGetObjectCounter(pDataBlock, pObjectType, &mi->MSSQLUserConnections)))
+    if (unlikely(!mi->conn) || unlikely(!mi->conn->collect_user_connections)) {
+        if (likely(perflibGetObjectCounter(pDataBlock, pObjectType, &mi->MSSQLUserConnections))) {
             do_mssql_user_connections(mi, update_every);
+        }
     }
 
-    if (unlikely(!mi->conn || !mi->conn->collect_blocked_processes)) {
-        if (likely(perflibGetObjectCounter(pDataBlock, pObjectType, &mi->MSSQLBlockedProcesses)))
-            netdata_mssql_blocked_processes_chart(mi, update_every);
+    if (unlikely(!mi || !mi->conn || !mi->conn->collect_blocked_processes) &&
+        likely(perflibGetObjectCounter(pDataBlock, pObjectType, &mi->MSSQLBlockedProcesses))) {
+        netdata_mssql_blocked_processes_chart(mi, update_every);
     }
 }


### PR DESCRIPTION
Reverts netdata/netdata#21478

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts recent MSSQL collection changes in the Windows plugin to restore the last stable behavior for MSSQL metrics. This rolls back SQL bindings, error handling, and Perflib paths to prevent regressions.

- **Bug Fixes**
  - Restore column bindings and database state/read-only bindings in MonitorSQL.c.
  - Revert statement cleanup and query formatting to prior logic.
  - Do not treat perflib memory collection (do_memory) as fatal.
  - Collect user connections and blocked processes from Perflib when SQL-based collection is disabled or unavailable.

<sup>Written for commit 2d2b7def60abcd979324ba116be868fcad21032a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

