### PR TITLE
fix(go.d/vnodes): add additionalProperties to config_schema.json

### DIFF
--- a/src/go/plugin/go.d/agent/vnodes/config_schema.json
+++ b/src/go/plugin/go.d/agent/vnodes/config_schema.json
@@ -20,7 +20,10 @@
         "type": [
           "object",
           "null"
-        ]
+        ],
+        "additionalProperties": {
+          "type": "string"
+        }
       }
     },
     "required": [


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the go.d vnodes config schema to allow labels with arbitrary keys and string values, fixing validation failures in dynamic config.

- **Bug Fixes**
  - Added additionalProperties: { type: "string" } to the labels field in config_schema.json to accept any label keys with string values.

<sup>Written for commit 80ad3a78bc5ebeab6a5436d5a6350ec70e3eadd9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

