### PR TITLE
fix(edit-config): ignore container variable inherited from /etc/profile

### DIFF
--- a/system/edit-config
+++ b/system/edit-config
@@ -7,7 +7,7 @@ fi
 # shellcheck disable=SC1091
 [ -f /etc/profile ] && . /etc/profile
 
-if [ "${_container_saved+x}" = x ]; then
+if [ "${_container_saved+x}" = "x" ]; then
   container=$_container_saved
 else
   unset container


### PR DESCRIPTION
##### Summary

Fixes: #21504

- **Issue**:
`edit-config` sources `/etc/profile`, which may define a container environment variable (e.g. `container=lxc` in LXC environments).

   If `container` is not explicitly set by the caller, this inherited value is later treated as a command, causing failures.

- **Fix**:
Preserve the container variable only if it was explicitly set by the caller before sourcing `/etc/profile`.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent edit-config from using a container value inherited from /etc/profile unless the caller set it. This avoids failures where inherited values (e.g., container=lxc) are treated as commands.

- **Bug Fixes**
  - Save caller-provided container before sourcing /etc/profile.
  - Restore it after sourcing; otherwise unset container.

<sup>Written for commit bdae96f3eb07284ff22c17a07bf4d7287d97649f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



