### PR TITLE
Remove Ubuntu 25.04 from CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -383,11 +383,6 @@ include:
       <<: *ubuntu_packages
       repo_distro: ubuntu/questing
   - <<: *ubuntu
-    version: "25.04"
-    packages:
-      <<: *ubuntu_packages
-      repo_distro: ubuntu/plucky
-  - <<: *ubuntu
     version: "22.04"
     packages:
       <<: *ubuntu_packages
@@ -461,6 +456,11 @@ legacy: # Info for platforms we used to support and still need to handle package
     packages:
       <<: *ubuntu_packages
       repo_distro: ubuntu/oracular
+  - <<: *ubuntu
+    version: "25.04"
+    packages:
+      <<: *ubuntu_packages
+      repo_distro: ubuntu/plucky
 no_include: # Info for platforms not covered in CI
   - distro: docker
     version: "19.03 or newer"

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -69,7 +69,6 @@ Our [static builds](#static-builds) are expected to work on these platforms if a
 | Rocky Linux              | 9.x            | x86\_64, AArch64              | Also includes support for Alma Linux and other ABI compatible RHEL derivatives                                 |
 | Rocky Linux              | 8.x            | x86\_64, AArch64              | Also includes support for Alma Linux and other ABI compatible RHEL derivatives                                 |
 | Ubuntu                   | 25.10          | x86\_64, AArch64, ARMv7       |                                                                                                                |
-| Ubuntu                   | 25.04          | x86\_64, AArch64, ARMv7       |                                                                                                                |
 | Ubuntu                   | 24.04          | x86\_64, AArch64, ARMv7       |                                                                                                                |
 | Ubuntu                   | 22.04          | x86\_64, ARMv7, AArch64       |                                                                                                                |
 | Ubuntu                   | 20.04          | x86\_64, ARMv7, AArch64       |                                                                                                                |
@@ -129,9 +128,9 @@ This is a list of platforms that we have supported in the recent past but no lon
 | Fedora       | 39        | EOL as of 2024-05-14 |
 | Fedora       | 38        | EOL as of 2024-05-14 |
 | openSUSE     | Leap 15.5 | EOL as of 2024-12-31 |
+| Ubuntu       | 25.04     | EOL as of 2025-01-17 |
 | Ubuntu       | 24.10     | EOL as of 2024-07-01 |
 | Ubuntu       | 23.10     | EOL as of 2024-07-01 |
-| Ubuntu       | 23.04     | EOL as of 2024-01-20 |
 | Ubuntu       | 18.04     | EOL as of 2023-04-02 |
 
 ## Static builds


### PR DESCRIPTION
##### Summary

It’s EOL upstream as of 2026-01-17.

##### Test Plan

n/a

##### Additional Information

Closes: #21496 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Ubuntu 25.04 from CI and package builds due to upstream EOL on 2026-01-17. CI no longer targets 25.04, packages won’t be produced for it, and docs now list it under legacy/EOL.

<sup>Written for commit 90a586d9929bb2abe421e6da713fe96dabb21c38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

