### PR TITLE
MCP test client: fix prompts/resources support and schema validation

### DIFF
--- a/src/web/mcp/mcp-test-client/index.html
+++ b/src/web/mcp/mcp-test-client/index.html
@@ -2078,7 +2078,54 @@
                     });
                 }
             }
-            
+
+            // Add dynamic methods for prompts
+            if (flowName === 'prompts' && Object.keys(availablePrompts).length > 0) {
+                for (const [promptName, prompt] of Object.entries(availablePrompts)) {
+                    allMethods.push({
+                        name: promptName,
+                        title: prompt.title || '',
+                        type: 'request',
+                        description: prompt.description || 'No description available',
+                        dynamic: true,
+                        promptName: promptName,
+                        schema: prompt,
+                        template: {
+                            jsonrpc: "2.0",
+                            id: 1,
+                            method: "prompts/get",
+                            params: {
+                                name: promptName,
+                                arguments: {}
+                            }
+                        }
+                    });
+                }
+            }
+
+            // Add dynamic methods for resources
+            if (flowName === 'resources' && Object.keys(availableResources).length > 0) {
+                for (const [resourceUri, resource] of Object.entries(availableResources)) {
+                    allMethods.push({
+                        name: resource.name || resourceUri,
+                        title: resourceUri,
+                        type: 'request',
+                        description: resource.description || 'No description available',
+                        dynamic: true,
+                        resourceUri: resourceUri,
+                        schema: resource,
+                        template: {
+                            jsonrpc: "2.0",
+                            id: 1,
+                            method: "resources/read",
+                            params: {
+                                uri: resourceUri
+                            }
+                        }
+                    });
+                }
+            }
+
             // Add history for custom flow
             if (flowName === 'custom') {
                 const savedHistory = loadRequestHistory();
@@ -2552,18 +2599,17 @@
                         10000,
                         'Prompts list request timed out'
                     );
+                    if (promptsResponse && promptsResponse.error) {
+                        log('⚠ Prompts list failed: ' + JSON.stringify(promptsResponse.error));
+                    } else {
+                        const promptCount = promptsResponse && promptsResponse.result && promptsResponse.result.prompts
+                            ? promptsResponse.result.prompts.length
+                            : 0;
+                        log('✓ Prompts list received (' + promptCount + ' prompts)');
+                    }
                 } catch (err) {
                     pendingRequests.delete(promptsRequest.id);
-                    throw err;
-                }
-
-                if (promptsResponse && promptsResponse.error) {
-                    log('⚠ Prompts list failed: ' + JSON.stringify(promptsResponse.error));
-                } else {
-                    const promptCount = promptsResponse && promptsResponse.result && promptsResponse.result.prompts
-                        ? promptsResponse.result.prompts.length
-                        : 0;
-                    log('✓ Prompts list received (' + promptCount + ' prompts)');
+                    log('⚠ Prompts list skipped: ' + err.message);
                 }
 
                 // Step 6: Request resources list
@@ -2581,18 +2627,17 @@
                         10000,
                         'Resources list request timed out'
                     );
+                    if (resourcesResponse && resourcesResponse.error) {
+                        log('⚠ Resources list failed: ' + JSON.stringify(resourcesResponse.error));
+                    } else {
+                        const resourceCount = resourcesResponse && resourcesResponse.result && resourcesResponse.result.resources
+                            ? resourcesResponse.result.resources.length
+                            : 0;
+                        log('✓ Resources list received (' + resourceCount + ' resources)');
+                    }
                 } catch (err) {
                     pendingRequests.delete(resourcesRequest.id);
-                    throw err;
-                }
-
-                if (resourcesResponse && resourcesResponse.error) {
-                    log('⚠ Resources list failed: ' + JSON.stringify(resourcesResponse.error));
-                } else {
-                    const resourceCount = resourcesResponse && resourcesResponse.result && resourcesResponse.result.resources
-                        ? resourcesResponse.result.resources.length
-                        : 0;
-                    log('✓ Resources list received (' + resourceCount + ' resources)');
+                    log('⚠ Resources list skipped: ' + err.message);
                 }
 
                 // Step 7: Switch UI to tools flow
@@ -3227,8 +3272,13 @@
                     availablePrompts[prompt.name] = prompt;
                 });
                 log(`Loaded ${Object.keys(availablePrompts).length} prompts`);
+                // Refresh prompts methods if currently viewing
+                const activeFlow = document.querySelector('.flow-item.active');
+                if (activeFlow && activeFlow.dataset.flow === 'prompts') {
+                    displayMethods('prompts');
+                }
             }
-            
+
             // Handle resources/list response
             if (response.result && response.result.resources) {
                 availableResources = {};
@@ -3236,6 +3286,11 @@
                     availableResources[resource.uri] = resource;
                 });
                 log(`Loaded ${Object.keys(availableResources).length} resources`);
+                // Refresh resources methods if currently viewing
+                const activeFlow = document.querySelector('.flow-item.active');
+                if (activeFlow && activeFlow.dataset.flow === 'resources') {
+                    displayMethods('resources');
+                }
             }
         }
         

--- a/src/web/mcp/mcp-test-client/mcp-schema-ui-generator.js
+++ b/src/web/mcp/mcp-test-client/mcp-schema-ui-generator.js
@@ -1631,7 +1631,7 @@ class MCPSchemaUIGenerator {
         }
 
         // Check for allowed root properties
-        const allowedRootProps = ['type', 'properties', 'required', 'title', 'description', 'additionalProperties'];
+        const allowedRootProps = ['type', 'properties', 'required', 'title', 'description', 'additionalProperties', '$schema'];
         for (const prop of Object.keys(schema)) {
             if (!allowedRootProps.includes(prop)) {
                 errors.push(`Unknown root property: "${prop}"`);


### PR DESCRIPTION
## Summary

- Fix JSON schema validation to accept `$schema` property
- Add dynamic method injection for prompts and resources (matching existing tools behavior)
- Refresh prompts/resources UI when data arrives from server
- Make prompts/resources list timeouts non-fatal during handshake

## Changes

**mcp-schema-ui-generator.js:**
- Added `$schema` to allowed root properties in schema validation

**index.html:**
- Added dynamic prompts display in the Prompts flow (creates clickable items for each prompt)
- Added dynamic resources display in the Resources flow
- Added UI refresh when prompts/resources data arrives
- Changed prompts/resources timeout handling from fatal (disconnects client) to non-fatal (logs warning, continues)

## Test plan

- [ ] Connect to an MCP server with prompts support
- [ ] Verify prompts appear in the Prompts flow list
- [ ] Click on a prompt and verify Send button is enabled
- [ ] Connect to an MCP server with resources support
- [ ] Verify resources appear in the Resources flow list
- [ ] Verify that prompts/resources timeout doesn't disconnect the client

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves prompts and resources in the MCP test client with dynamic methods and live UI updates, and fixes JSON schema validation. Handshake now tolerates prompts/resources list timeouts without disconnecting.

- **New Features**
  - Injects dynamic request methods for prompts and resources, matching tools behavior.
  - Displays prompts/resources in their flows with clickable items and auto-refresh when data arrives.

- **Bug Fixes**
  - Accepts $schema in JSON schema root properties.
  - Makes prompts/resources list timeouts non-fatal during handshake (logs and continues).

<sup>Written for commit 77759568733a4c2739ad274f630644c918e2be6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

