### PR TITLE
chore(go.d/pkg/logs): make CSVConfig.CheckField unexported

### DIFF
--- a/src/go/plugin/go.d/collector/squidlog/collector.go
+++ b/src/go/plugin/go.d/collector/squidlog/collector.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 func New() *Collector {
-	return &Collector{
+	clr := &Collector{
 		Config: Config{
 			Path:        "/var/log/squid/access.log",
 			ExcludePath: "*.gz",
@@ -34,11 +34,12 @@ func New() *Collector {
 					Delimiter:        " ",
 					TrimLeadingSpace: true,
 					Format:           "- $resp_time $client_address $result_code $resp_size $req_method - - $hierarchy $mime_type",
-					CheckField:       checkCSVFormatField,
 				},
 			},
 		},
 	}
+	clr.Config.CSV.SetCheckField(checkCSVFormatField)
+	return clr
 }
 
 type Config struct {

--- a/src/go/plugin/go.d/collector/weblog/collector.go
+++ b/src/go/plugin/go.d/collector/weblog/collector.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 func New() *Collector {
-	return &Collector{
+	clr := &Collector{
 		Config: Config{
 			ExcludePath:    "*.gz",
 			GroupRespCodes: true,
@@ -33,7 +33,6 @@ func New() *Collector {
 					FieldsPerRecord:  -1,
 					Delimiter:        " ",
 					TrimLeadingSpace: false,
-					CheckField:       checkCSVFormatField,
 				},
 				LTSV: logs.LTSVConfig{
 					FieldDelimiter: "\t",
@@ -44,6 +43,8 @@ func New() *Collector {
 			},
 		},
 	}
+	clr.Config.CSV.SetCheckField(checkCSVFormatField)
+	return clr
 }
 
 type (

--- a/src/go/plugin/go.d/collector/weblog/collector_test.go
+++ b/src/go/plugin/go.d/collector/weblog/collector_test.go
@@ -1150,7 +1150,6 @@ func prepareWebLogCollectFull(t *testing.T) *Collector {
 				Delimiter:        " ",
 				TrimLeadingSpace: false,
 				Format:           format,
-				CheckField:       checkCSVFormatField,
 			},
 		},
 		Path:        "testdata/full.log",
@@ -1186,6 +1185,7 @@ func prepareWebLogCollectFull(t *testing.T) *Collector {
 		Histogram:      metrix.DefBuckets,
 		GroupRespCodes: true,
 	}
+	cfg.CSV.SetCheckField(checkCSVFormatField)
 	collr := New()
 	collr.Config = cfg
 	require.NoError(t, collr.Init(context.Background()))
@@ -1218,7 +1218,6 @@ func prepareWebLogCollectCommon(t *testing.T) *Collector {
 				Delimiter:        " ",
 				TrimLeadingSpace: false,
 				Format:           format,
-				CheckField:       checkCSVFormatField,
 			},
 		},
 		Path:           "testdata/common.log",
@@ -1228,6 +1227,7 @@ func prepareWebLogCollectCommon(t *testing.T) *Collector {
 		Histogram:      nil,
 		GroupRespCodes: false,
 	}
+	cfg.CSV.SetCheckField(checkCSVFormatField)
 
 	collr := New()
 	collr.Config = cfg
@@ -1256,7 +1256,6 @@ func prepareWebLogCollectCustom(t *testing.T) *Collector {
 				Delimiter:        " ",
 				TrimLeadingSpace: false,
 				Format:           format,
-				CheckField:       checkCSVFormatField,
 			},
 		},
 		CustomFields: []customField{
@@ -1281,6 +1280,7 @@ func prepareWebLogCollectCustom(t *testing.T) *Collector {
 		Histogram:      nil,
 		GroupRespCodes: false,
 	}
+	cfg.CSV.SetCheckField(checkCSVFormatField)
 	collr := New()
 	collr.Config = cfg
 	require.NoError(t, collr.Init(context.Background()))
@@ -1308,7 +1308,6 @@ func prepareWebLogCollectCustomTimeFields(t *testing.T) *Collector {
 				Delimiter:        " ",
 				TrimLeadingSpace: false,
 				Format:           format,
-				CheckField:       checkCSVFormatField,
 			},
 		},
 		CustomTimeFields: []customTimeField{
@@ -1327,6 +1326,7 @@ func prepareWebLogCollectCustomTimeFields(t *testing.T) *Collector {
 		Histogram:      nil,
 		GroupRespCodes: false,
 	}
+	cfg.CSV.SetCheckField(checkCSVFormatField)
 	collr := New()
 	collr.Config = cfg
 	require.NoError(t, collr.Init(context.Background()))
@@ -1354,7 +1354,6 @@ func prepareWebLogCollectCustomNumericFields(t *testing.T) *Collector {
 				Delimiter:        " ",
 				TrimLeadingSpace: false,
 				Format:           format,
-				CheckField:       checkCSVFormatField,
 			},
 		},
 		CustomNumericFields: []customNumericField{
@@ -1373,6 +1372,7 @@ func prepareWebLogCollectCustomNumericFields(t *testing.T) *Collector {
 		Histogram:      nil,
 		GroupRespCodes: false,
 	}
+	cfg.CSV.SetCheckField(checkCSVFormatField)
 	collr := New()
 	collr.Config = cfg
 	require.NoError(t, collr.Init(context.Background()))
@@ -1413,7 +1413,6 @@ func prepareWebLogCollectIISFields(t *testing.T) *Collector {
 				Delimiter:        " ",
 				TrimLeadingSpace: false,
 				Format:           format,
-				CheckField:       checkCSVFormatField,
 			},
 		},
 		Path:           "testdata/u_ex221107.log",
@@ -1423,6 +1422,7 @@ func prepareWebLogCollectIISFields(t *testing.T) *Collector {
 		GroupRespCodes: false,
 	}
 
+	cfg.CSV.SetCheckField(checkCSVFormatField)
 	collr := New()
 	collr.Config = cfg
 	require.NoError(t, collr.Init(context.Background()))

--- a/src/go/plugin/go.d/collector/weblog/parser_test.go
+++ b/src/go/plugin/go.d/collector/weblog/parser_test.go
@@ -206,14 +206,14 @@ func prepareWebLog() *Collector {
 	cfg := logs.ParserConfig{
 		LogType: typeAuto,
 		CSV: logs.CSVConfig{
-			Delimiter:  " ",
-			CheckField: checkCSVFormatField,
+			Delimiter: " ",
 		},
 		LTSV: logs.LTSVConfig{
 			FieldDelimiter: "\t",
 			ValueDelimiter: ":",
 		},
 	}
+	cfg.CSV.SetCheckField(checkCSVFormatField)
 
 	return &Collector{
 		Config: Config{

--- a/src/go/plugin/go.d/pkg/logs/csv.go
+++ b/src/go/plugin/go.d/pkg/logs/csv.go
@@ -14,11 +14,12 @@ import (
 
 type (
 	CSVConfig struct {
-		FieldsPerRecord  int                              `yaml:"fields_per_record,omitempty" json:"fields_per_record"`
-		Delimiter        string                           `yaml:"delimiter,omitempty" json:"delimiter"`
-		TrimLeadingSpace bool                             `yaml:"trim_leading_space,omitempty" json:"trim_leading_space"`
-		Format           string                           `yaml:"format,omitempty" json:"format"`
-		CheckField       func(string) (string, int, bool) `yaml:"-" json:"-"`
+		FieldsPerRecord  int    `yaml:"fields_per_record,omitempty" json:"fields_per_record"`
+		Delimiter        string `yaml:"delimiter,omitempty" json:"delimiter"`
+		TrimLeadingSpace bool   `yaml:"trim_leading_space,omitempty" json:"trim_leading_space"`
+		Format           string `yaml:"format,omitempty" json:"format"`
+
+		checkField func(string) (string, int, bool)
 	}
 
 	CSVParser struct {
@@ -38,6 +39,10 @@ type (
 		idx  int
 	}
 )
+
+func (c *CSVConfig) SetCheckField(f func(string) (string, int, bool)) {
+	c.checkField = f
+}
 
 func NewCSVParser(config CSVConfig, in io.Reader) (*CSVParser, error) {
 	if config.Format == "" {
@@ -118,7 +123,7 @@ func newCSVFormat(config CSVConfig) (*csvFormat, error) {
 		return nil, err
 	}
 
-	fields, err := createCSVFields(record, config.CheckField)
+	fields, err := createCSVFields(record, config.checkField)
 	if err != nil {
 		return nil, err
 	}

--- a/src/go/plugin/go.d/pkg/logs/csv_test.go
+++ b/src/go/plugin/go.d/pkg/logs/csv_test.go
@@ -67,7 +67,7 @@ func TestNewCSVFormat(t *testing.T) {
 		t.Run(tt.format, func(t *testing.T) {
 			c := testCSVConfig
 			c.Format = tt.format
-			c.CheckField = testCheckCSVFormatField
+			c.checkField = testCheckCSVFormatField
 			tt.wantFormat.raw = tt.format
 
 			f, err := newCSVFormat(c)


### PR DESCRIPTION
The `CSVConfig` struct was always being marshaled as `csv_config: {}` in YAML output, even when all configuration fields were empty. This prevented the `omitempty` tag on the parent `ParserConfig.CSV` field from working correctly.

The issue was caused by the exported `CheckField` function field, which cannot be marshaled to YAML but still prevented the struct from being considered "empty" for `omitempty` purposes.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix YAML marshaling of CSVConfig so empty configs are omitted from output. Made the function field internal and added a setter to keep it out of serialization.

- **Bug Fixes**
  - Unexported CheckField and added CSVConfig.SetCheckField to store the runtime-only function without affecting YAML.
  - Updated squidlog and weblog collectors and tests to use the setter. ParserConfig.CSV now respects omitempty and skips csv_config when empty.

<sup>Written for commit e7ed7a2f90fcd677592a877a8feb34f5cf103e69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

