### PR TITLE
fix(go.d/pkg/logs):  fix ParserConfig.CSV omitempty behavior

### DIFF
--- a/src/go/plugin/go.d/pkg/logs/csv.go
+++ b/src/go/plugin/go.d/pkg/logs/csv.go
@@ -12,13 +12,17 @@ import (
 	"strings"
 )
 
+type CSVCheckFieldFunc func(string) (string, int, bool)
+
+func (f CSVCheckFieldFunc) IsZero() bool { return true }
+
 type (
 	CSVConfig struct {
-		FieldsPerRecord  int                              `yaml:"fields_per_record,omitempty" json:"fields_per_record"`
-		Delimiter        string                           `yaml:"delimiter,omitempty" json:"delimiter"`
-		TrimLeadingSpace bool                             `yaml:"trim_leading_space,omitempty" json:"trim_leading_space"`
-		Format           string                           `yaml:"format,omitempty" json:"format"`
-		CheckField       func(string) (string, int, bool) `yaml:"-" json:"-"`
+		FieldsPerRecord  int               `yaml:"fields_per_record,omitempty" json:"fields_per_record"`
+		Delimiter        string            `yaml:"delimiter,omitempty" json:"delimiter"`
+		TrimLeadingSpace bool              `yaml:"trim_leading_space,omitempty" json:"trim_leading_space"`
+		Format           string            `yaml:"format,omitempty" json:"format"`
+		CheckField       CSVCheckFieldFunc `yaml:"-" json:"-"`
 	}
 
 	CSVParser struct {


### PR DESCRIPTION
##### Summary

**Problem**:

The `CSVConfig` struct was always being marshaled as `csv_config: {}` in YAML output, even when all configuration fields were empty. This prevented the `omitempty` tag on the parent `ParserConfig.CSV` field from working correctly.

**Solution**:

Created a custom `CSVCheckFieldFunc` type that implements the `IsZeroer` interface from the yaml package. By having `IsZero()` always return `true`, the function field is treated as empty for `omitempty` evaluation purposes.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed CSVConfig YAML omitempty so empty config no longer outputs csv_config: {}. Added CSVCheckFieldFunc with IsZero() to mark CheckField as empty during omitempty evaluation.

<sup>Written for commit 7210c077a27fb15726936404dd53cc4cb5896a0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

