### PR TITLE
use the same type for all time_group_value values

### DIFF
--- a/src/health/schema.d/health%3Aalert%3Aprototype.json
+++ b/src/health/schema.d/health%3Aalert%3Aprototype.json
@@ -281,7 +281,7 @@
                 "then": {
                   "properties": {
                     "time_group_value": {
-                      "type": "integer",
+                      "type": "number",
                       "default": 1,
                       "title": "Trim %",
                       "description": ""
@@ -305,7 +305,7 @@
                 "then": {
                   "properties": {
                     "time_group_value": {
-                      "type": "integer",
+                      "type": "number",
                       "default": 1,
                       "title": "Trim %",
                       "description": ""
@@ -329,7 +329,7 @@
                 "then": {
                   "properties": {
                     "time_group_value": {
-                      "type": "integer",
+                      "type": "number",
                       "default": 95,
                       "title": "Percentage",
                       "description": ""


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the health alert schema to use the 'number' type for time_group_value in all cases. This fixes validation mismatches and allows decimal values for trim and percentage groups.

<sup>Written for commit 158877b73f294ea2631bd8f5d281416f79d815e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

