### PR TITLE
Fix incorrect column index for `old_value` in SQLite health query

### DIFF
--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -1113,7 +1113,7 @@ void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, time_t after, const ch
         if (sqlite3_column_type(stmt_query, 24) == SQLITE_NULL)
             buffer_json_member_add_string(wb, "old_value", NULL);
         else
-            buffer_json_member_add_double(wb, "old_value", sqlite3_column_double(stmt_query, 23));
+            buffer_json_member_add_double(wb, "old_value", sqlite3_column_double(stmt_query, 24));
 
         freez(edit_command);
 


### PR DESCRIPTION
##### Summary
- Fix incorrect column index for `old_value` in SQLite health query


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the column index for old_value in the SQLite health alarm log JSON conversion so the correct value is read. Uses column 24 instead of 23 to prevent wrong numbers in the JSON output.

<sup>Written for commit f54b3bdb2727666985cc089cc6854f7b1da06a58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

