### PR TITLE
docs: Add unclaim/reclaim node guide

### DIFF
--- a/docs/.map/map.csv
+++ b/docs/.map/map.csv
@@ -96,6 +96,7 @@ https://github.com/netdata/netdata/edit/master/docs/netdata-cloud/authentication
 https://github.com/netdata/netdata/edit/master/docs/netdata-cloud/view-plan-and-billing.md,Netdata Plans & Billing,Published,Netdata Cloud,,
 https://github.com/netdata/netdata/edit/master/src/aclk/README.md,Agent-Cloud Link (ACLK),Published,Netdata Cloud,,The Agent-Cloud link (ACLK) is the mechanism responsible for connecting a Netdata agent to Netdata Cloud.
 https://github.com/netdata/netdata/edit/master/docs/learn/remove-node.md,Remove Agent,Published,Netdata Cloud,,
+https://github.com/netdata/netdata/edit/master/docs/learn/unclaim-reclaim-node.md,Unclaim and Reclaim a Node,Published,Netdata Cloud,,
 https://github.com/netdata/netdata/edit/master/docs/delete/netdata/account.md,Account Deletion,Published,Netdata Cloud,,
 ,,,,,
 https://github.com/netdata/netdata-cloud-onprem/edit/master/docs/learn.netdata.cloud/README.md,Netdata Cloud On-Prem,Published,Netdata Cloud On-Prem,,

--- a/docs/learn/unclaim-reclaim-node.md
+++ b/docs/learn/unclaim-reclaim-node.md
@@ -4,10 +4,10 @@
 
 **What's the difference between unclaiming/reclaiming and removing a node?**
 
-| Action | What it does | Agent status |
-|--------|--------------|--------------|
-| **Unclaim & Reclaim** | Disconnect from current Space, connect to a new Space | Agent keeps running |
-| **Remove** | Permanently delete node from Netdata Cloud | Agent may keep running but disconnected |
+| Action                | What it does                                          | Agent status                            |
+|-----------------------|-------------------------------------------------------|-----------------------------------------|
+| **Unclaim & Reclaim** | Disconnect from current Space, connect to a new Space | Agent keeps running                     |
+| **Remove**            | Permanently delete node from Netdata Cloud            | Agent may keep running but disconnected |
 
 If you want to **move a node to a different Space**, use the **unclaim and reclaim** process on this page.
 
@@ -20,6 +20,7 @@ This guide covers how to move a node from one Space to another without removing 
 ## Why Move a Node Between Spaces?
 
 You might need to move a node to a different Space when:
+
 - Reorganizing your infrastructure monitoring structure
 - Transferring node ownership between teams or departments
 - Consolidating multiple Spaces into one
@@ -38,7 +39,8 @@ You might need to move a node to a different Space when:
 
 ## Step 1: Unclaim from Current Space
 
-See our **[Reconnect Agent](/docs/netdata-cloud/connect-agent.md#reconnect-agent)** guide for the exact commands to:
+See our **[Reconnect Agent](/src/claim/README.md#reconnect-agent)** guide for the exact commands to:
+
 - Remove the Cloud connection directory (Linux)
 - Remove connection files and recreate container (Docker)
 
@@ -103,14 +105,16 @@ After reclaiming, verify the node appears in:
 ## Troubleshooting
 
 **Node doesn't appear in new Space:**
+
 - Verify the claim token is correct for the new Space
 - Check `/var/lib/netdata/cloud.d/` was removed before reclaiming
 - Review agent logs using:
-   - `journalctl --namespace netdata -b 0 | grep -i CLAIM`
-   - or:
-   - `grep -i CLAIM /var/log/netdata/daemon.log`
+    - `journalctl --namespace netdata -b 0 | grep -i CLAIM`
+    - or:
+    - `grep -i CLAIM /var/log/netdata/daemon.log`
 
 **Reconnection fails:**
+
 - Check connection status: `curl http://localhost:19999/api/v1/aclk`
 - Ensure the agent has internet access to `app.netdata.cloud`
 - Check for firewall blocking port 443
@@ -118,5 +122,5 @@ After reclaiming, verify the node appears in:
 ## Related Documentation
 
 - [Remove a node from Netdata Cloud entirely](/docs/learn/remove-node.md) - For permanent node removal
-- [Connect Agent to Cloud](/src/claim/README.md) - Initial connection setup
-- [Reconnect Agent](/docs/netdata-cloud/connect-agent#reconnect-agent) - Linux/Docker based installations
+- [Connect Agent to Cloud](/src/claim/README.md#connect-agent-to-cloud) - Initial connection setup
+- [Reconnect Agent](/src/claim/README.md#reconnect-agent) - Linux/ Docker-based installations


### PR DESCRIPTION
Create new documentation for moving nodes between Spaces without complete removal.

Files changed:
- docs/learn/unclaim-reclaim-node.md (new)
- docs/.map/map.csv (map entry added)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a guide for unclaiming and reclaiming nodes to move agents between Spaces without removing them. Updated the docs map to publish it under Netdata Cloud.

- **New Features**
  - Step-by-step unclaim for Linux and Docker, with restart note.
  - Reclaim options: kickstart, config file, env vars.
  - Verification and troubleshooting tips (corrected log path and connection check).
  - Links to removal guide, reconnect agent, and token generation.

<sup>Written for commit 67c7efa71ea59c691b9b9595e8788952bc6a890d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

