### PR TITLE
Additional checks in error paths

### DIFF
--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -849,6 +849,12 @@ static void aclk_synchronization_event_loop(void *arg)
                     else {
                         aclk_query_free(query);
                         aclk_query_batch->count--;
+                        
+                        // Clean up the batch structure if this was the first entry that failed
+                        if (aclk_query_batch->count == 0) {
+                            freez(aclk_query_batch);
+                            aclk_query_batch = NULL;
+                        }
                         break;
                     }
 

--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -751,12 +751,18 @@ void aclk_push_alert_config_event(char *node_id __maybe_unused, char *config_has
         return;
     }
 
-    if (!PREPARE_STATEMENT(db_meta, SQL_SELECT_ALERT_CONFIG, &res))
-        return;
-
     nd_uuid_t hash_uuid;
-    if (uuid_parse(config_hash, hash_uuid))
+    if (uuid_parse(config_hash, hash_uuid)) {
+        freez(config_hash);
+        freez(node_id);
         return;
+    }
+
+    if (!PREPARE_STATEMENT(db_meta, SQL_SELECT_ALERT_CONFIG, &res)) {
+        freez(config_hash);
+        freez(node_id);
+        return;
+    }
 
     int param = 0;
     SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &hash_uuid , sizeof(hash_uuid), SQLITE_STATIC));


### PR DESCRIPTION
##### Summary
- Add cleanup for `aclk_query_batch` when the first batch entry fails.
- Ensure proper memory release for `config_hash` and `node_id` in alert configuration error paths.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves error-path cleanup to prevent memory leaks and invalid state in ACLK batch processing and alert configuration handling.

- **Bug Fixes**
  - Free aclk_query_batch when the first batch entry fails in aclk_synchronization_event_loop.
  - Release config_hash and node_id on uuid_parse or statement preparation failures in aclk_push_alert_config_event.

<sup>Written for commit 1324b39ee993a1ccb4301c3dcbbb87fa81f9a396. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

