### PR TITLE
improve(health/proxysql): add alerts

### DIFF
--- a/src/health/health.d/proxysql.conf
+++ b/src/health/health.d/proxysql.conf
@@ -1,5 +1,18 @@
 # you can disable an alarm notification by setting the 'to' line to: silent
 
+ template: proxysql_hostgroup_no_online_backends
+       on: proxysql.hostgroup_backends_status
+    class: Errors
+     type: Database
+component: ProxySQL
+   lookup: min -1m unaligned of online
+    units: backends
+    every: 10s
+     crit: $this == 0
+  summary: ProxySQL hostgroup ${label:hostgroup} has no ONLINE backends
+     info: ProxySQL hostgroup ${label:hostgroup} currently has zero ONLINE backends. This means no traffic can be served for this hostgroup.
+       to: dba
+
  template: proxysql_backend_shunned
        on: proxysql.backend_status
     class: Errors


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds health alarms for ProxySQL backends entering SHUNNED and OFFLINE_HARD, and when a hostgroup has no ONLINE backends, so DBAs are notified when service is unavailable. Polls proxysql.backend_status and proxysql.hostgroup_backends_status every 10s over the last minute; SHUNNED is crit, OFFLINE_HARD is warn, and messages include host:port and hostgroup.

<sup>Written for commit c106d9ec205bbff2992417ad0edbfd4e062ba1d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

