### PR TITLE
add SOC2 badge to security and privacy doc

### DIFF
--- a/docs/security-and-privacy-design/README.md
+++ b/docs/security-and-privacy-design/README.md
@@ -222,6 +222,8 @@ Request a BAA through Netdata Support if required.
 
 ### SOC 2 Compliance
 
+<img src="https://netdata.cloud/img/SOC2 T2 - green - h.png" width="150" alt="SOC2 Badge"/>
+
 Netdata achieved SOC2 Type 2 compliance for these Service Criteria:
 
 | **Principle**        | **Practices**                            |


### PR DESCRIPTION
##### Summary

I have added the png to the [website img folder](https://github.com/netdata/website/tree/master/themes/tailwind/static/img) and access it via our website.

This was a request from @constantinenikitiadis 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a SOC 2 Type 2 badge to the Security and Privacy doc to clearly show our compliance. The badge is rendered under the SOC 2 section and is loaded from the website’s static img folder.

<sup>Written for commit 624c858e711c885f4597b4f0f1fbc5c1bc2a145d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

