### PR TITLE
Adjust lock to prevent crash during ML calculations 

### DIFF
--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -747,9 +747,14 @@ ml_dimension_predict(ml_dimension_t *dim, calculated_number_t value, bool exists
     if (dim->mls != MACHINE_LEARNING_STATUS_ENABLED)
         return false;
 
+    // Acquire lock to protect dim->cns from concurrent access by ml_host_stop()
+    if (spinlock_trylock(&dim->slock) == 0)
+        return false;
+
     // Don't treat values that don't exist as anomalous
     if (!exists) {
         dim->cns.clear();
+        spinlock_unlock(&dim->slock);
         return false;
     }
 
@@ -757,6 +762,7 @@ ml_dimension_predict(ml_dimension_t *dim, calculated_number_t value, bool exists
     unsigned n = Cfg.diff_n + Cfg.max_samples_to_smooth + Cfg.lag_n;
     if (dim->cns.size() < n) {
         dim->cns.push_back(value);
+        spinlock_unlock(&dim->slock);
         return false;
     }
 
@@ -784,12 +790,6 @@ ml_dimension_predict(ml_dimension_t *dim, calculated_number_t value, bool exists
         dim->feature
     };
     ml_features_preprocess(&features, 1.0);
-
-    /*
-     * Lock to predict
-    */
-    if (spinlock_trylock(&dim->slock) == 0)
-        return false;
 
     // Mark the metric time as variable if we received different values
     if (!same_value)


### PR DESCRIPTION
##### Summary
- Acquire lock before attempting to access dimension data in case a ml_host_stop runs in parallel


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a crash during ML predictions by locking the dimension state before accessing cns when ml_host_stop may run concurrently. Moves locking to the start of ml_dimension_predict and unlocks on all early exits.

- **Bug Fixes**
  - Acquire dim->slock before any cns access; return if trylock fails.
  - Unlock on no-value and insufficient-sample early returns.
  - Remove redundant lock later in the function.

<sup>Written for commit da4e511e57e9b65b2a6ea2282d07d6b8598e2a45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

