### PR TITLE
fix(cgroups.plugin): correct is_cgroup_duplicate check

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/src/collectors/cgroups.plugin/cgroup-discovery.c
@@ -1026,7 +1026,7 @@ static int discovery_is_cgroup_duplicate(struct cgroup *cg) {
     // https://github.com/netdata/netdata/issues/797#issuecomment-241248884
     struct cgroup *c;
     for (c = discovered_cgroup_root; c; c = c->discovered_next) {
-        if (c != cg && c->enabled && (is_cgroup_systemd_service(c) == is_cgroup_systemd_service(cg)) &&
+        if (c != cg && c->enabled && c->available && (is_cgroup_systemd_service(c) == is_cgroup_systemd_service(cg)) &&
             c->hash_chart_id == cg->hash_chart_id && !strcmp(c->chart_id, cg->chart_id)) {
             collector_error(
                     "CGROUP: chart id '%s' already exists with id '%s' and is enabled and available. Disabling cgroup with id '%s'.",


### PR DESCRIPTION
##### Summary

Fixes: #21556

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cgroup duplicate detection in cgroups.plugin to only treat a match as a duplicate when the existing cgroup is both enabled and available. Prevents valid cgroups from being disabled due to false positives (Fixes #21556).

<sup>Written for commit 1595f4029d9c6185fbe34aad7c472813cb63706c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

