### PR TITLE
fix(go.d): disable logger color in terminal on Win

### DIFF
--- a/src/go/logger/handler.go
+++ b/src/go/logger/handler.go
@@ -34,6 +34,7 @@ func newTextHandler() slog.Handler {
 
 func newTerminalHandler() slog.Handler {
 	return tint.NewHandler(os.Stderr, &tint.Options{
+		NoColor:   runtime.GOOS == "windows",
 		AddSource: true,
 		Level:     Level.lvl,
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {


### PR DESCRIPTION
##### Summary

It doesn't work.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable terminal color in go.d logger on Windows to prevent unreadable ANSI codes in terminal output. Color remains enabled on Linux and macOS.

<sup>Written for commit 37e7ebb0517d706b0dce813b4a94fa4f055dd205. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

