### PR TITLE
bring back systemd-journal.plugin setcap (from source install)

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -817,6 +817,23 @@ if [ "$(id -u)" -eq 0 ]; then
     fi
   fi
 
+  # The Rust-based 'journal-viewer' plugin was added in 2.8-nightly to replace 'systemd-journal'.
+  # TODO: After 2.9 release and proper deprecation announcement, remove this.
+  if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/systemd-journal.plugin" ]; then
+    run chown "root:${NETDATA_GROUP}" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/systemd-journal.plugin"
+    capabilities=0
+    if ! iscontainer && command -v setcap 1> /dev/null 2>&1; then
+      run chmod 0750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/systemd-journal.plugin"
+      if run setcap cap_dac_read_search+ep "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/systemd-journal.plugin"; then
+        capabilities=1
+      fi
+    fi
+
+    if [ $capabilities -eq 0 ]; then
+      run chmod 4750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/systemd-journal.plugin"
+    fi
+  fi
+
   if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/journal-viewer-plugin" ]; then
     run chown "root:${NETDATA_GROUP}" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/journal-viewer-plugin"
     capabilities=0


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore correct permissions and capabilities for the legacy systemd-journal.plugin during source installs to prevent journal read errors. Applies only when the plugin exists, keeping the Rust journal-viewer as default going forward.

- **Bug Fixes**
  - Set owner to root:${NETDATA_GROUP} and try setcap cap_dac_read_search+ep; use 0750 on success.
  - Fallback to setuid root (4750) if setcap is unavailable or fails.
  - Skip capability changes in containers.

<sup>Written for commit 1fe52f141425b8af65a1b487d35b28f37136478d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

