### PR TITLE
Enable ARM package builds in PR CI runs.

### DIFF
--- a/.github/scripts/gen-matrix-packaging.py
+++ b/.github/scripts/gen-matrix-packaging.py
@@ -5,7 +5,7 @@ import sys
 
 from ruamel.yaml import YAML
 
-ALWAYS_RUN_ARCHES = ["amd64", "x86_64"]
+ALWAYS_RUN_ARCHES = ["amd64", "x86_64", 'i386', 'armhf', 'aarch64', 'arm64']
 SHORT_RUN = sys.argv[1]
 yaml = YAML(typ='safe')
 entries = list()

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -203,7 +203,7 @@ jobs:
       # build failure for one version doesn't prevent us from publishing
       # successfully built and tested packages for another version.
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 16
     steps:
       - name: Skip Check
         id: skip


### PR DESCRIPTION
##### Summary

They obviously are not being properly tested by the developers, so ensure they actually get tested in CI.

This also doubles the max concurrency for the package build jobs, which should mostly offset the impact of having more jobs.

##### Test Plan

All the packaging CI jobs actually run on this PR.

