### PR TITLE
Add On-Prem Release Notes to map.csv

### DIFF
--- a/docs/.map/map.csv
+++ b/docs/.map/map.csv
@@ -107,6 +107,7 @@ https://github.com/netdata/netdata-cloud-onprem/edit/master/docs/learn.netdata.c
 https://github.com/netdata/netdata-cloud-onprem/edit/master/docs/learn.netdata.cloud/poc-without-k8s.md,PoC without K8s,Published,Netdata Cloud On-Prem,,
 https://github.com/netdata/netdata-cloud-onprem/edit/master/docs/learn.netdata.cloud/ecr-mirror.md,Mirroring image registry,Published,Netdata Cloud On-Prem,,
 https://github.com/netdata/netdata-cloud-onprem/edit/master/docs/learn.netdata.cloud/troubleshooting.md,Troubleshooting,Published,Netdata Cloud On-Prem,,
+https://github.com/netdata/netdata-cloud-onprem/edit/master/netdata-cloud-onprem/RELEASE-NOTES.md,Release Notes,Published,Netdata Cloud On-Prem,,
 ,,,,,
 ,,,,,
 ,,,,,


### PR DESCRIPTION
##### Summary

Request from @M4itee, add that md to the map and hence to Learn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the On‑Prem Release Notes to the docs map so they show up in Learn under Netdata Cloud On‑Prem. This publishes netdata-cloud-onprem/RELEASE-NOTES.md as “Release Notes”.

<sup>Written for commit c171d09ae17b500fc513d39cfe3d6099c08357d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

