### PR TITLE
fix(go.d/proxysql): use timeout when pinging proxysql instance

### DIFF
--- a/src/go/plugin/go.d/collector/proxysql/collect.go
+++ b/src/go/plugin/go.d/collector/proxysql/collect.go
@@ -251,7 +251,10 @@ func (c *Collector) openConnection() error {
 
 	db.SetConnMaxLifetime(10 * time.Minute)
 
-	if err := db.Ping(); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout.Duration())
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
 		_ = db.Close()
 		return fmt.Errorf("error on pinging the proxysql instance [%s]: %v", c.DSN, err)
 	}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a context-based timeout when pinging ProxySQL in the go.d collector. This prevents hangs on slow or unreachable instances and respects the configured timeout.

<sup>Written for commit 773bfcfacab56bad425e6e5181b7207a305ae9e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

