### PR TITLE
Fix incorrect macro definition for netdata_mutex_destroy

### DIFF
--- a/src/libnetdata/locks/locks.h
+++ b/src/libnetdata/locks/locks.h
@@ -100,7 +100,7 @@ int netdata_rwlock_tryrdlock_debug( const char *file, const char *function, cons
 int netdata_rwlock_trywrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
 
 #define netdata_mutex_init(mutex)    netdata_mutex_init_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
-#define netdata_mutex_destroy(mutex) netdata_mutex_init_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
+#define netdata_mutex_destroy(mutex) netdata_mutex_destroy_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
 #define netdata_mutex_lock(mutex)    netdata_mutex_lock_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
 #define netdata_mutex_trylock(mutex) netdata_mutex_trylock_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
 #define netdata_mutex_unlock(mutex)  netdata_mutex_unlock_debug(__FILE__, __FUNCTION__, __LINE__, mutex)


### PR DESCRIPTION
##### Summary
- This is in dev mode when NETDATA_TRACE_RWLOCKS is used


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the netdata_mutex_destroy macro to call netdata_mutex_destroy_debug (not netdata_mutex_init_debug) when NETDATA_TRACE_RWLOCKS is enabled, ensuring correct mutex cleanup and debug tracing in dev builds.

<sup>Written for commit 0208d0ac79a3d6092bc635ec939b2a88c8617eaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

