### PR TITLE
Fix response when no log entries have been found.

### DIFF
--- a/src/crates/netdata-log-viewer/journal-function/src/netdata/builder.rs
+++ b/src/crates/netdata-log-viewer/journal-function/src/netdata/builder.rs
@@ -81,7 +81,7 @@ pub fn build_ui_response(
     log_entries: &[LogEntryData],
 ) -> (serde_json::Value, serde_json::Value) {
     if log_entries.is_empty() {
-        return (serde_json::json!([]), serde_json::json!([]));
+        return (serde_json::json!({}), serde_json::json!([]));
     }
 
     // Generate column schema from histogram


### PR DESCRIPTION
SSIA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return an empty schema object ({}) and an empty rows array ([]) when no log entries are found, fixing the response shape and preventing client errors.

<sup>Written for commit b3a62ffe3f490047ce8c5c8db3f71cf16e4a7cb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

