### PR TITLE
ci: update azure/trusted-signing-action after rebranding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -380,13 +380,13 @@ jobs:
       - name: Sign Agent Code
         id: sign-agent
         if: needs.file-check.outputs.run == 'true' && github.event_name != 'pull_request'
-        uses: azure/trusted-signing-action@v1.0.0
+        uses: azure/artifact-signing-action@v1.0.0
         with:
           azure-tenant-id: ${{ secrets.CODE_SIGNING_TENNANT_ID }}
           azure-client-id: ${{ secrets.CODE_SIGNING_CLIENT_ID }}
           azure-client-secret: ${{ secrets.CODE_SIGNING_CLIENT_SECRET }}
           endpoint: "https://eus.codesigning.azure.net/"
-          trusted-signing-account-name: Netdata
+          signing-account-name: Netdata
           certificate-profile-name: Netdata
           files-folder: ${{ github.workspace }}\build
           files-folder-filter: exe,dll,sys
@@ -403,13 +403,13 @@ jobs:
       - name: Sign Installer
         id: sign-installer
         if: needs.file-check.outputs.run == 'true' && github.event_name != 'pull_request'
-        uses: azure/trusted-signing-action@v1.0.0
+        uses: azure/artifact-signing-action@v1.0.0
         with:
           azure-tenant-id: ${{ secrets.CODE_SIGNING_TENNANT_ID }}
           azure-client-id: ${{ secrets.CODE_SIGNING_CLIENT_ID }}
           azure-client-secret: ${{ secrets.CODE_SIGNING_CLIENT_SECRET }}
           endpoint: "https://eus.codesigning.azure.net/"
-          trusted-signing-account-name: Netdata
+          signing-account-name: Netdata
           certificate-profile-name: Netdata
           files-folder: ${{ github.workspace }}\packaging\windows
           files-folder-filter: msi


### PR DESCRIPTION
##### Summary

See [azure/artifact-signing-action](https://github.com/Azure/artifact-signing-action#example) example

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI to use azure/artifact-signing-action@v1.0.0 after Azure’s signing service rebrand. Keeps Windows agent binaries and installer signing working with the new input name.

- **Dependencies**
  - Replaced azure/trusted-signing-action with azure/artifact-signing-action in both signing steps.
  - Renamed input trusted-signing-account-name to signing-account-name; secrets and endpoint unchanged.

<sup>Written for commit 47b826af73a84d5170a8e60153b90b728740fea1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

