### PR TITLE
Add health database check before processing alerts and saving logs

### DIFF
--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -625,6 +625,9 @@ done:
 
 bool process_alert_pending_queue(RRDHOST *host)
 {
+    if (!REQUIRE_HEALTH_DB_OPEN())
+        return false;
+
     static __thread sqlite3_stmt *compiled_res = NULL;
     sqlite3_stmt *res = NULL;
 

--- a/src/database/sqlite/sqlite_functions.h
+++ b/src/database/sqlite/sqlite_functions.h
@@ -57,6 +57,10 @@ void analytics_set_data_str(char **name, const char *value);
         (db) != NULL;                                                                                                  \
     })
 
+extern bool sqlite_databases_closed;
+#define REQUIRE_HEALTH_DB_OPEN()                                                                                       \
+    (!__atomic_load_n(&sqlite_databases_closed, __ATOMIC_ACQUIRE))
+
 #define PREPARE_COMPILED_STATEMENT(db, sql, stmt_ptr)                                                                  \
     ({                                                                                                                 \
         bool _ret = true;                                                                                              \

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -337,6 +337,9 @@ done:
 
 void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae)
 {
+    if (!REQUIRE_HEALTH_DB_OPEN())
+        return;
+
     if (ae->flags & HEALTH_ENTRY_FLAG_SAVED)
         sql_health_alarm_log_update(host, ae);
     else
@@ -945,6 +948,9 @@ done:
 
 int sql_health_get_last_executed_event(RRDHOST *host, ALARM_ENTRY *ae, RRDCALC_STATUS *last_executed_status)
 {
+    if (!REQUIRE_HEALTH_DB_OPEN())
+        return -1;
+
     int ret = -1;
     static __thread sqlite3_stmt *compiled_res = NULL;
     sqlite3_stmt *res = NULL;


### PR DESCRIPTION
##### Summary
- Check health database state (ensure that we have not shutdown) before attempting to store 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a guard to skip alert processing and health log operations when the SQLite health database is closed. This prevents writes after shutdown and avoids errors during shutdown.

- **Bug Fixes**
  - Added REQUIRE_HEALTH_DB_OPEN() using an atomic sqlite_databases_closed flag.
  - Early return in process_alert_pending_queue, sql_health_alarm_log_save, and sql_health_get_last_executed_event if the health DB is closed.

<sup>Written for commit 5190a5b2f84995dcea021ecdaaea5746bbe38c7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

