### PR TITLE
Use static buffer for saving daemon status

### DIFF
--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -1562,8 +1562,8 @@ void daemon_status_file_shutdown_timeout(BUFFER *trace) {
 
     safecpy(session_status.fatal.function, "shutdown_timeout");
 
-    CLEAN_BUFFER *wb = buffer_create(0, NULL);
-    daemon_status_file_save(wb, &session_status, false);
+    static_save_buffer_init();
+    daemon_status_file_save(static_save_buffer, &session_status, false);
 
     // keep the spinlock locked, to prevent further steps updating the status
 }


### PR DESCRIPTION
##### Summary
- Use a previously allocated buffer to prevent allocating memory when saving file which may be unsafe



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the preallocated static save buffer when writing daemon status during shutdown_timeout, instead of creating a new buffer. This avoids heap allocation in a fatal, spinlock-held path, reducing risk of failures and making the save safer.

<sup>Written for commit ce40f3859f572f3b1b49532b0d4097b06a2c5cd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

