### PR TITLE
make function error message key camel case

### DIFF
--- a/src/libnetdata/json/json-c-parser-inline.c
+++ b/src/libnetdata/json/json-c-parser-inline.c
@@ -6,7 +6,7 @@ int rrd_call_function_error(BUFFER *wb, const char *msg, int code) {
     buffer_reset(wb);
     buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_MINIFY);
     buffer_json_member_add_int64(wb, "status", code);
-    buffer_json_member_add_string(wb, "error_message", msg);
+    buffer_json_member_add_string(wb, "errorMessage", msg);
     buffer_json_finalize(wb);
     wb->date = now_realtime_sec();
     wb->expires = wb->date + 1;


### PR DESCRIPTION
##### Summary

UI expects the key to be in camel case.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use camelCase errorMessage key in function error JSON responses to match the UI contract and ensure error text renders correctly.
Replaces "error_message" with "errorMessage" in the response payload.

<sup>Written for commit 4d21a9631ed913f189120f1caaec83ab23596adb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

