### PR TITLE
Prevent race condition during thread exit cleanup

### DIFF
--- a/src/libnetdata/threads/threads.c
+++ b/src/libnetdata/threads/threads.c
@@ -267,10 +267,17 @@ void nd_thread_join_threads()
     do {
         spinlock_lock(&threads_globals.exited.spinlock);
         nti = threads_globals.exited.list;
+        if(nti) {
+            // Remove from exited list while holding the lock to prevent race condition
+            // where another thread with a direct pointer calls nd_thread_join() and frees
+            // the nti before we get a chance to use it
+            DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(threads_globals.exited.list, nti, prev, next);
+            nti->list = ND_THREAD_LIST_NONE;
+        }
         spinlock_unlock(&threads_globals.exited.spinlock);
 
-        // nd_thread_join() handles NULL and will remove from list and free atomically
-        // to avoid race with other callers joining the same thread
+        // nd_thread_join() handles NULL and will skip list removal since we already did it
+        // The atomic CAS in nd_thread_join() still protects against direct callers racing with us
         nd_thread_join(nti);
 
     } while (nti);


### PR DESCRIPTION
##### Summary
- Remove entry from the exited list (under lock) before the join 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent race in nd_thread_join_threads by removing the thread from the exited list under the lock before calling nd_thread_join. This avoids use-after-free when another caller joins the same thread and stabilizes thread cleanup.

<sup>Written for commit b2b6335284a890e3da9bb0208f2a46edf88fbbba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

