### PR TITLE
chore(go.d/snmp): add ifTypeGroup mapping for interface type categorization

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
@@ -310,8 +310,11 @@ func enrichProfiles(profiles []*Profile) {
 					continue
 				}
 
-				if tagCfg.MappingRef == "ifType" {
+				switch tagCfg.MappingRef {
+				case "ifType":
 					tagCfg.Mapping = sharedMappings.ifType
+				case "ifTypeGroup":
+					tagCfg.Mapping = sharedMappings.ifTypeGroup
 				}
 			}
 		}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/shared.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/shared.go
@@ -3,7 +3,8 @@
 package ddsnmp
 
 var sharedMappings = struct {
-	ifType map[string]string
+	ifType      map[string]string
+	ifTypeGroup map[string]string
 }{
 	ifType: map[string]string{
 		"1":   "other",
@@ -305,5 +306,343 @@ var sharedMappings = struct {
 		"301": "omni",
 		"302": "roe",
 		"303": "p2pOverLan",
+	},
+	ifTypeGroup: map[string]string{
+		// Virtual / logical (includes tunnels, VLANs, bridges)
+		"24":  "virtual", // softwareLoopback
+		"25":  "virtual", // eon
+		"31":  "virtual", // sip (SMDS Interface Protocol)
+		"53":  "virtual", // propVirtual
+		"78":  "virtual", // ipSwitch
+		"109": "virtual", // ipOverCdlc
+		"110": "virtual", // ipOverClaw
+		"112": "virtual", // virtualIpAddress
+		"126": "virtual", // ip
+		"131": "virtual", // tunnel
+		"135": "virtual", // l2vlan
+		"136": "virtual", // l3ipvlan
+		"137": "virtual", // l3ipxvlan
+		"142": "virtual", // ipForward
+		"150": "virtual", // mplsTunnel
+		"202": "virtual", // virtualTg
+		"209": "virtual", // bridge
+		"215": "virtual", // sixToFour
+		"222": "virtual", // ciscoISLvlan
+		"246": "virtual", // ifPwType
+		"258": "virtual", // vmwareVirtualNic
+		"262": "virtual", // ifVfiType
+		"272": "virtual", // vmwareNicTeam
+
+		// Aggregation / bonding
+		"82":  "aggregation", // ds0Bundle
+		"108": "aggregation", // pppMultilinkBundle
+		"155": "aggregation", // compositeLink
+		"161": "aggregation", // ieee8023adLag
+		"163": "aggregation", // frf16MfrBundle
+		"210": "aggregation", // linegroup
+		"297": "aggregation", // ieee8021axDrni
+
+		// Ethernet
+		"6":   "ethernet", // ethernetCsmacd
+		"7":   "ethernet", // iso88023Csmacd
+		"55":  "ethernet", // ieee80212
+		"62":  "ethernet", // fastEther
+		"69":  "ethernet", // fastEtherFX
+		"117": "ethernet", // gigabitEthernet
+		"233": "ethernet", // aviciOpticalEther
+		"303": "ethernet", // p2pOverLan
+
+		// Wireless (WiFi, WiMAX, cellular, point-to-point, microwave)
+		"71":  "wireless", // ieee80211
+		"157": "wireless", // propWirelessP2P
+		"183": "wireless", // hiperlan2
+		"188": "wireless", // radioMAC
+		"216": "wireless", // gtp (GPRS Tunneling Protocol - mobile/cellular)
+		"237": "wireless", // ieee80216WMAN
+		"243": "wireless", // wwanPP
+		"244": "wireless", // wwanPP2
+		"252": "wireless", // capwapDot11Profile
+		"253": "wireless", // capwapDot11Bss
+		"254": "wireless", // capwapWtpVirtualRadio
+		"281": "wireless", // xboxWireless
+		"295": "wireless", // microwaveCarrierTermination
+		"296": "wireless", // microwaveRadioLinkTerminal
+		"299": "wireless", // ieee19061nanocom
+		"300": "wireless", // cpri (Common Public Radio Interface - mobile fronthaul)
+
+		// Optical transport (SONET, DWDM, OTN, metro rings)
+		"39":  "optical", // sonet
+		"50":  "optical", // sonetPath
+		"51":  "optical", // sonetVT
+		"151": "optical", // srp (Spatial Reuse Protocol - SONET rings)
+		"171": "optical", // pos
+		"185": "optical", // sonetOverheadChannel
+		"186": "optical", // digitalWrapperOverheadChannel
+		"195": "optical", // opticalChannel
+		"196": "optical", // opticalTransport
+		"219": "optical", // opticalChannelGroup
+		"221": "optical", // gfp
+		"225": "optical", // rpr (Resilient Packet Ring)
+		"260": "optical", // otnOdu
+		"261": "optical", // otnOtu
+		"291": "optical", // otnOtsi
+		"292": "optical", // otnOtuc
+		"293": "optical", // otnOduc
+		"294": "optical", // otnOtsig
+
+		// DSL
+		"94":  "dsl", // adsl
+		"95":  "dsl", // radsl
+		"96":  "dsl", // sdsl
+		"97":  "dsl", // vdsl
+		"143": "dsl", // msdsl
+		"154": "dsl", // idsl
+		"168": "dsl", // hdsl2
+		"169": "dsl", // shdsl
+		"192": "dsl", // reachDSL
+		"230": "dsl", // adsl2
+		"238": "dsl", // adsl2plus
+		"251": "dsl", // vdsl2
+		"263": "dsl", // g9981
+		"264": "dsl", // g9982
+		"265": "dsl", // g9983
+		"279": "dsl", // gfast
+		"282": "dsl", // fastdsl
+
+		// Cable / DOCSIS / MoCA
+		"127": "cable", // docsCableMaclayer
+		"128": "cable", // docsCableDownstream
+		"129": "cable", // docsCableUpstream
+		"180": "cable", // propDocsWirelessMaclayer
+		"181": "cable", // propDocsWirelessDownstream
+		"182": "cable", // propDocsWirelessUpstream
+		"205": "cable", // docsCableUpstreamChannel
+		"228": "cable", // cblVectaStar
+		"229": "cable", // docsCableMCmtsDownstream
+		"236": "cable", // mocaVersion1
+		"256": "cable", // docsCableUpstreamRfPort
+		"257": "cable", // cableDownstreamRfPort
+		"277": "cable", // docsOfdmDownstream
+		"278": "cable", // docsOfdmaUpstream
+		"283": "cable", // docsCableScte55d1FwdOob
+		"284": "cable", // docsCableScte55d1RetOob
+		"285": "cable", // docsCableScte55d2DsOob
+		"286": "cable", // docsCableScte55d2UsOob
+		"287": "cable", // docsCableNdf
+		"288": "cable", // docsCableNdr
+
+		// PON / fiber access
+		"207": "pon", // pon155
+		"208": "pon", // pon622
+		"250": "pon", // gpon
+		"266": "pon", // aluEpon
+		"267": "pon", // aluEponOnu
+		"268": "pon", // aluEponPhysicalUni
+		"269": "pon", // aluEponLogicalLink
+		"270": "pon", // aluGponOnu
+		"271": "pon", // aluGponPhysicalUni
+
+		// MPLS (label switching, traffic engineering)
+		"166": "mpls", // mpls
+		"200": "mpls", // teLink (Traffic Engineering)
+		"227": "mpls", // lmp (Link Management Protocol - GMPLS)
+
+		// Datacenter fabrics (Fibre Channel, InfiniBand)
+		"56":  "datacenter", // fibreChannel
+		"199": "datacenter", // infiniband
+		"224": "datacenter", // fcipLink
+
+		// Serial / PPP / HDLC / modem
+		"16":  "serial", // lapb
+		"17":  "serial", // sdlc
+		"22":  "serial", // propPointToPointSerial
+		"23":  "serial", // ppp
+		"28":  "serial", // slip
+		"33":  "serial", // rs232
+		"45":  "serial", // v35
+		"46":  "serial", // hssi
+		"48":  "serial", // modem
+		"64":  "serial", // v11
+		"65":  "serial", // v36
+		"77":  "serial", // lapd
+		"84":  "serial", // async
+		"88":  "serial", // arap
+		"118": "serial", // hdlc
+		"119": "serial", // lapf
+		"120": "serial", // v37
+		"123": "serial", // transpHdlc
+		"125": "serial", // fast
+		"298": "serial", // ax25
+
+		// TDM / voice / telephony
+		"18":  "tdm_voice", // ds1
+		"19":  "tdm_voice", // e1
+		"20":  "tdm_voice", // basicISDN
+		"21":  "tdm_voice", // primaryISDN
+		"30":  "tdm_voice", // ds3
+		"63":  "tdm_voice", // isdn
+		"66":  "tdm_voice", // g703at64k
+		"67":  "tdm_voice", // g703at2mb
+		"75":  "tdm_voice", // isdns
+		"76":  "tdm_voice", // isdnu
+		"81":  "tdm_voice", // ds0
+		"100": "tdm_voice", // voiceEM
+		"101": "tdm_voice", // voiceFXO
+		"102": "tdm_voice", // voiceFXS
+		"103": "tdm_voice", // voiceEncap
+		"104": "tdm_voice", // voiceOverIp
+		"133": "tdm_voice", // ces
+		"156": "tdm_voice", // ss7SigLink
+		"164": "tdm_voice", // h323Gatekeeper
+		"165": "tdm_voice", // h323Proxy
+		"167": "tdm_voice", // mfSigLink
+		"170": "tdm_voice", // ds1FDL
+		"175": "tdm_voice", // nfas
+		"176": "tdm_voice", // tr008
+		"177": "tdm_voice", // gr303RDT
+		"178": "tdm_voice", // gr303IDT
+		"179": "tdm_voice", // isup
+		"198": "tdm_voice", // voiceOverCable
+		"201": "tdm_voice", // q2931
+		"203": "tdm_voice", // sipTg
+		"204": "tdm_voice", // sipSig
+		"211": "tdm_voice", // voiceEMFGD
+		"212": "tdm_voice", // voiceFGDEANA
+		"213": "tdm_voice", // voiceDID
+		"235": "tdm_voice", // voiceFGDOS
+		"245": "tdm_voice", // voiceEBS
+
+		// ATM
+		"37":  "atm", // atm
+		"49":  "atm", // aal5
+		"80":  "atm", // atmLogical
+		"105": "atm", // atmDxi
+		"106": "atm", // atmFuni
+		"107": "atm", // atmIma
+		"114": "atm", // ipOverAtm
+		"134": "atm", // atmSubInterface
+		"149": "atm", // atmVirtual
+		"152": "atm", // voiceOverAtm
+		"159": "atm", // rfc1483
+		"187": "atm", // aal2
+		"189": "atm", // atmRadio
+		"194": "atm", // atmVciEndPt
+		"197": "atm", // propAtm
+		"234": "atm", // atmbond
+
+		// Frame Relay
+		"32":  "frame_relay", // frameRelay
+		"44":  "frame_relay", // frameRelayService
+		"58":  "frame_relay", // frameRelayInterconnect
+		"92":  "frame_relay", // frameRelayMPI
+		"153": "frame_relay", // voiceOverFrameRelay
+		"158": "frame_relay", // frForward
+		"193": "frame_relay", // frDlciEndPt
+
+		// WAN (legacy X.25, etc.)
+		"4":   "wan", // ddnX25
+		"5":   "wan", // rfc877x25
+		"27":  "wan", // nsip
+		"38":  "wan", // miox25
+		"40":  "wan", // x25ple
+		"68":  "wan", // qllc
+		"121": "wan", // x25mlp
+		"122": "wan", // x25huntGroup
+
+		// Legacy/obsolete (includes mainframe, protocol translation)
+		"2":   "legacy", // regular1822
+		"3":   "legacy", // hdh1822
+		"8":   "legacy", // iso88024TokenBus
+		"9":   "legacy", // iso88025TokenRing
+		"10":  "legacy", // iso88026Man
+		"11":  "legacy", // starLan
+		"12":  "legacy", // proteon10Mbit
+		"13":  "legacy", // proteon80Mbit
+		"14":  "legacy", // hyperchannel
+		"15":  "legacy", // fddi
+		"26":  "legacy", // ethernet3Mbit
+		"29":  "legacy", // ultra
+		"35":  "legacy", // arcnet
+		"36":  "legacy", // arcnetPlus
+		"41":  "legacy", // iso88022llc
+		"42":  "legacy", // localTalk
+		"43":  "legacy", // smdsDxi
+		"52":  "legacy", // smdsIcip
+		"70":  "legacy", // channel (mainframe)
+		"72":  "legacy", // ibm370parChan (mainframe)
+		"73":  "legacy", // escon (mainframe)
+		"74":  "legacy", // dlsw (protocol translation)
+		"79":  "legacy", // rsrb (protocol translation)
+		"98":  "legacy", // iso88025CRFPInt
+		"99":  "legacy", // myrinet
+		"111": "legacy", // stackToStack (protocol translation)
+		"141": "legacy", // dcn (protocol translation)
+		"206": "legacy", // econet
+		"249": "legacy", // aluELP
+
+		// Broadcast / media (satellite, DVB, MPEG)
+		"139": "broadcast_media", // mediaMailOverIp
+		"140": "broadcast_media", // dtm
+		"146": "broadcast_media", // dvbRccMacLayer
+		"147": "broadcast_media", // dvbRccDownstream
+		"148": "broadcast_media", // dvbRccUpstream
+		"172": "broadcast_media", // dvbAsiIn
+		"173": "broadcast_media", // dvbAsiOut
+		"214": "broadcast_media", // mpegTransport
+		"239": "broadcast_media", // dvbRcsMacLayer
+		"240": "broadcast_media", // dvbTdm
+		"241": "broadcast_media", // dvbRcsTdma
+
+		// Home networking (powerline, G.hn, ZigBee)
+		"138": "home_network", // digitalPowerline
+		"174": "home_network", // plc
+		"220": "home_network", // homepna
+		"259": "home_network", // ieee802154
+		"290": "home_network", // ghn
+
+		// Other/miscellaneous
+		"1":   "other", // other
+		"34":  "other", // para
+		"47":  "other", // hippi
+		"54":  "other", // propMultiplexor
+		"57":  "other", // hippiInterface
+		"59":  "other", // aflane8023
+		"60":  "other", // aflane8025
+		"61":  "other", // cctEmul
+		"83":  "other", // bsc
+		"85":  "other", // cnr
+		"86":  "other", // iso88025Dtr
+		"87":  "other", // eplrs
+		"89":  "other", // propCnls
+		"90":  "other", // hostPad
+		"91":  "other", // termPad
+		"93":  "other", // x213
+		"113": "other", // mpc
+		"115": "other", // iso88025Fiber
+		"116": "other", // tdlc
+		"124": "other", // interleave
+		"130": "other", // a12MppSwitch
+		"132": "other", // coffee
+		"144": "other", // ieee1394
+		"145": "other", // if-gsn
+		"160": "other", // usb
+		"162": "other", // bgppolicyaccounting
+		"184": "other", // propBWAp2Mp
+		"190": "other", // imt
+		"191": "other", // mvl
+		"217": "other", // pdnEtherLoop1
+		"218": "other", // pdnEtherLoop2
+		"223": "other", // actelisMetaLOOP
+		"226": "other", // qam
+		"231": "other", // macSecControlledIF
+		"232": "other", // macSecUncontrolledIF
+		"242": "other", // x86Laps
+		"247": "other", // ilan
+		"248": "other", // pip
+		"255": "other", // bits
+		"280": "other", // sdci
+		"289": "other", // ptm
+		"301": "other", // omni
+		"302": "other", // roe
 	},
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/shared_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/shared_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmp
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSharedMappingsCompleteness(t *testing.T) {
+	// Verify all ifType entries have a corresponding group
+	missingGroups := []string{}
+
+	for ifTypeID := range sharedMappings.ifType {
+		if _, exists := sharedMappings.ifTypeGroup[ifTypeID]; !exists {
+			missingGroups = append(missingGroups, fmt.Sprintf("%s (%s)", ifTypeID, sharedMappings.ifType[ifTypeID]))
+		}
+	}
+
+	assert.Empty(t, missingGroups, "All interface types should have groups")
+	if len(missingGroups) == 0 {
+		t.Logf("✓ All %d interface types have groups", len(sharedMappings.ifType))
+	}
+}
+
+func TestSharedMappingsCount(t *testing.T) {
+	t.Logf("ifType entries: %d", len(sharedMappings.ifType))
+	t.Logf("ifTypeGroup entries: %d", len(sharedMappings.ifTypeGroup))
+
+	// Count items per group
+	groups := make(map[string]int)
+	for _, group := range sharedMappings.ifTypeGroup {
+		groups[group]++
+	}
+
+	// Sort by count descending
+	type groupCount struct {
+		name  string
+		count int
+	}
+	var sorted []groupCount
+	for name, count := range groups {
+		sorted = append(sorted, groupCount{name, count})
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].count > sorted[j].count
+	})
+
+	t.Logf("\nGroup distribution (%d groups):", len(groups))
+	for _, gc := range sorted {
+		t.Logf("  %3d  %s", gc.count, gc.name)
+	}
+
+	// Verify group count doesn't exceed ifType count
+	assert.LessOrEqual(t, len(sharedMappings.ifTypeGroup), len(sharedMappings.ifType),
+		"ifTypeGroup should not have more entries than ifType")
+}

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-if-mib.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-if-mib.yaml
@@ -70,6 +70,11 @@ metrics:
           OID: 1.3.6.1.2.1.2.2.1.3
           name: ifType
         mapping_ref: ifType
+      - tag: _if_type_group
+        symbol:
+          OID: 1.3.6.1.2.1.2.2.1.3
+          name: ifType
+        mapping_ref: ifTypeGroup
 
   # =========================
   # IF-MIB::ifXTable (64-bit + extras)
@@ -111,6 +116,12 @@ metrics:
           OID: 1.3.6.1.2.1.2.2.1.3
           name: ifType
         mapping_ref: ifType
+      - tag: _if_type_group
+        table: ifTable
+        symbol:
+          OID: 1.3.6.1.2.1.2.2.1.3
+          name: ifType
+        mapping_ref: ifTypeGroup
 
 virtual_metrics:
   # ======================

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-ip-mib.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-ip-mib.yaml
@@ -404,3 +404,12 @@ metrics:
         index_transform:
           - start: 1
             end: 1
+      - tag: _if_type_group
+        table: ifTable
+        symbol:
+          OID: 1.3.6.1.2.1.2.2.1.3
+          name: ifType
+        mapping_ref: ifTypeGroup
+        index_transform:
+          - start: 1
+            end: 1


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds interface type categorization to the go.d SNMP collector and exposes a new _if_type_group tag in default profiles. This enables grouping (e.g., ethernet, wireless, optical) for easier filtering and visualization.

- **New Features**
  - Introduced ifTypeGroup mapping with categories for every IF-MIB ifType.
  - Added _if_type_group tag to _std-if-mib.yaml and _std-ip-mib.yaml profiles.
  - Added tests to verify all ifType values have a group and basic count checks.

<sup>Written for commit 35ac9b69c6443124a278dad8b167410b0f371197. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

