### PR TITLE
(learn): Use new OneLineInstall component implementation

### DIFF
--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -39,16 +39,16 @@ To install and connect to Netdata Cloud in a single step from your terminal:
   <TabItem value="wget" label="wget">
     <OneLineInstall
       method="wget"
-      privacyLink="[privacy](/docs/netdata-agent/configuration/anonymous-telemetry-events.md)"
-      connectLink="[connect](/src/claim/README.md)"
+      privacyMd="[anonymous statistics?](/docs/netdata-agent/configuration/anonymous-telemetry-events.md)"
+      connectMd="[connect](/src/claim/README.md)"
     />
   </TabItem>
 
   <TabItem value="curl" label="curl">
     <OneLineInstall
       method="curl"
-      privacyLink="[privacy](/docs/netdata-agent/configuration/anonymous-telemetry-events.md)"
-      connectLink="[connect](/src/claim/README.md)"
+      privacyMd="[anonymous statistics?](/docs/netdata-agent/configuration/anonymous-telemetry-events.md)"
+      connectMd="[connect](/src/claim/README.md)"
     />
   </TabItem>
 </Tabs>


### PR DESCRIPTION
##### Summary

implementation at https://github.com/netdata/learn/pull/2691

We pass the label and link directly, so we can edit it (cc @kanelatechnical) and the ingest can catch the link and properly route it to a Learn one.

This has been tested and works.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch kickstart docs to the new OneLineInstall component, replacing the wget/curl-specific versions. We now pass the install method and docs links directly, so Learn ingest routes them correctly and labels/links are easy to edit.

- **Refactors**
  - Import OneLineInstall from @site/src/components/OneLineInstall/.
  - Use method="wget" and method="curl" in tabs.
  - Add privacyMd and connectMd linking to anonymous telemetry and claim docs.

<sup>Written for commit 7d73bfa8dfada96600422e8f6845225aff4a013c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

