### PR TITLE
Improve statement preparation

### DIFF
--- a/src/database/sqlite/sqlite_functions.h
+++ b/src/database/sqlite/sqlite_functions.h
@@ -77,7 +77,7 @@ extern bool sqlite_databases_closed;
 
 #define PREPARE_STATEMENT(db, sql, stmt_ptr)                                                                           \
     ({                                                                                                                 \
-        int _rc = sqlite3_prepare_v2((db), (sql), -1, stmt_ptr, 0);                                                    \
+        int _rc = simple_prepare_statement((db), (sql), stmt_ptr);                                                     \
         if (_rc != SQLITE_OK) {                                                                                        \
             internal_error(true, "Failed to prepare statement \"%s\", rc=%d in %s", (sql), _rc, __FUNCTION__);         \
             nd_log(NDLS_DAEMON, NDLP_ERR, "Failed to prepare statement, rc=%d in %s", _rc, __FUNCTION__);              \
@@ -105,6 +105,7 @@ int configure_sqlite_database(sqlite3 *database, int target_version, const char 
 // Helpers
 int bind_text_null(sqlite3_stmt *res, int position, const char *text, bool can_be_null);
 int prepare_statement(sqlite3 *database, const char *query, sqlite3_stmt **statement);
+int simple_prepare_statement(sqlite3 *database, const char *query, sqlite3_stmt **statement);
 void finalize_self_prepared_sql_statements();
 void finalize_all_prepared_sql_statements();
 


### PR DESCRIPTION
##### Summary
- Wrap statement preparation with spinlock to avoid random crashes during shutdown 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent shutdown-time crashes by making SQLite statement preparation thread-safe. Adds a spinlock-protected helper and updates usage to avoid preparing statements after databases are closed.

- **Bug Fixes**
  - Introduced simple_prepare_statement() that locks sqlite_spinlock and returns SQLITE_MISUSE if sqlite_databases_closed.
  - Updated PREPARE_STATEMENT macro to use the new helper.
  - Wrapped prepare_statement() with the same spinlock and unlocked after pool updates.

<sup>Written for commit 495c019d45a73349cf3b82c99d166cb714080fc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

