### PR TITLE
Add  check before releasing metric buffer

### DIFF
--- a/src/libnetdata/gorilla/gorilla.cc
+++ b/src/libnetdata/gorilla/gorilla.cc
@@ -436,14 +436,13 @@ void aral_unmark_allocation(struct aral *ar, void *ptr);
 void gorilla_writer_aral_unmark(const gorilla_writer_t *gw, struct aral *ar)
 {
     const gorilla_buffer_t *curr_gbuf = __atomic_load_n(&gw->head_buffer, __ATOMIC_ACQUIRE);
-    do {
+    while (curr_gbuf) {
         const gorilla_buffer_t *next_gbuf = __atomic_load_n(&curr_gbuf->header.next, __ATOMIC_ACQUIRE);
 
-        // Call the C function here
         aral_unmark_allocation(ar, const_cast<void*>(static_cast<const void*>(curr_gbuf)));
 
         curr_gbuf = next_gbuf;
-    } while (curr_gbuf);
+    }
 }
 
 /*


### PR DESCRIPTION
##### Summary
-   Fix potential NULL dereference in gorilla_writer_aral_unmark()                                                                                                                                        


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a potential crash when releasing metric buffers by guarding against a NULL head_buffer in gorilla_writer_aral_unmark. Replaces the do-while with a while loop to only unmark when curr_gbuf is valid.

<sup>Written for commit 752fcdde9bf8c50d5c40b9c26dae6409a5f4af7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

