### PR TITLE
fix(systemd-units.plugin): correct resp content type on info

### DIFF
--- a/src/collectors/systemd-units.plugin/plugin_systemd_units.c
+++ b/src/collectors/systemd-units.plugin/plugin_systemd_units.c
@@ -1186,7 +1186,7 @@ static void netdata_systemd_units_function_info(const char *transaction)
     buffer_json_finalize(wb);
     netdata_mutex_lock(&stdout_mutex);
     wb->response_code = HTTP_RESP_OK;
-    wb->content_type = CT_TEXT_PLAIN;
+    wb->content_type = CT_APPLICATION_JSON;
     wb->expires = now_realtime_sec() + 3600;
     pluginsd_function_result_to_stdout(transaction, wb);
     netdata_mutex_unlock(&stdout_mutex);


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the systemd-units.plugin info response to use application/json instead of text/plain. Aligns the header with the JSON payload to prevent client parsing issues.

<sup>Written for commit 1ff37b2478dc2caa4f4d6ecfea9ed2eda375a81b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

