### PR TITLE
Use debug level for logging of requests.

### DIFF
--- a/src/crates/Cargo.lock
+++ b/src/crates/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "bridge"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "console-subscriber",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "flatten_otel"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "flatten-serde-json",
  "opentelemetry-proto",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "foundation"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "tokio",
 ]
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "journal-common"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "allocative",
  "nix",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "journal-core"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "allocative",
  "anyhow",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "journal-engine"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "allocative",
  "async-stream",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "journal-function"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "allocative",
  "async-stream",
@@ -1674,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "journal-index"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "allocative",
  "journal-common",
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "journal-log-writer"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "flatten-serde-json",
  "journal-common",
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "journal-registry"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "allocative",
  "journal-common",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "journal-viewer-plugin"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "netdata-plugin-charts-derive"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2042,14 +2042,14 @@ dependencies = [
 
 [[package]]
 name = "netdata-plugin-error"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "netdata-plugin-protocol"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "atoi",
  "bytes",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "netdata-plugin-schema"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "netdata-plugin-error",
  "netdata-plugin-types",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "netdata-plugin-types"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "bitflags 2.10.0",
  "netdata-plugin-error",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "otel-plugin"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "atty",
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "rdp"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "md5",
 ]
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "rt"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "bytes",

--- a/src/crates/Cargo.toml
+++ b/src/crates/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.85"
 

--- a/src/crates/netdata-log-viewer/journal-viewer-plugin/src/catalog.rs
+++ b/src/crates/netdata-log-viewer/journal-viewer-plugin/src/catalog.rs
@@ -501,7 +501,7 @@ impl FunctionHandler for CatalogFunction {
                 message: format!("[{}] transaction already exists", transaction),
             });
         };
-        info!("[{}] started transaction", txn.id());
+        debug!("[{}] started transaction", txn.id());
 
         // Create query time range with automatic alignment
         let time_range = journal_function::QueryTimeRange::new(request.after, request.before)
@@ -510,7 +510,7 @@ impl FunctionHandler for CatalogFunction {
                 netdata_plugin_error::NetdataPluginError::Other { message: msg }
             })?;
 
-        info!(
+        debug!(
             "[{}] time range: [{}, {}), aligned: [{}, {}), bucket duration: {} seconds",
             txn.id(),
             time_range.requested_start(),
@@ -531,7 +531,7 @@ impl FunctionHandler for CatalogFunction {
                 netdata_plugin_error::NetdataPluginError::Other { message: msg }
             })?;
         let find_files_duration = op_start.elapsed();
-        info!("[{}] found {} files in time range", txn.id(), files.len(),);
+        debug!("[{}] found {} files in time range", txn.id(), files.len(),);
         if tracing::enabled!(tracing::Level::DEBUG) {
             for (idx, file_info) in files.iter().enumerate() {
                 debug!(
@@ -546,11 +546,11 @@ impl FunctionHandler for CatalogFunction {
 
         // Build filter expression
         let filter_expr = build_filter_from_selections(&request.selections);
-        info!("[{}] filter expression: {}", txn.id(), filter_expr);
+        debug!("[{}] filter expression: {}", txn.id(), filter_expr);
 
         // Build facets for file indexes
         let facets = Facets::new(&request.facets);
-        info!(
+        debug!(
             "[{}] using {} facets with precomputed hash {}",
             txn.id(),
             facets.len(),
@@ -591,7 +591,7 @@ impl FunctionHandler for CatalogFunction {
         })?;
         let indexing_duration = op_start.elapsed();
 
-        info!(
+        debug!(
             "[{}] retrieved {}/{} file indexes for histogram buckets and log entries",
             txn.id(),
             indexed_files.len(),
@@ -638,7 +638,7 @@ impl FunctionHandler for CatalogFunction {
             request.direction,
         );
         let query_logs_duration = op_start.elapsed();
-        info!(
+        debug!(
             "[{}] retrieved {} log entries (has before: {}, has after: {})",
             txn.id(),
             log_entries.len(),
@@ -699,7 +699,7 @@ impl FunctionHandler for CatalogFunction {
                 message: format!("[{}] transaction does not exist", transaction),
             });
         };
-        info!(
+        debug!(
             "[{}] completed transaction (find_files: {:?}, indexing: {:?}, histogram: {:?}, query_logs: {:?}, total: {:?})",
             txn.id(),
             find_files_duration,


### PR DESCRIPTION
SSIA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch request logging in the journal viewer plugin from info to debug to reduce noise in production while keeping detailed traces available in debug builds. Bumps workspace and internal crates to 0.1.3.

- **Refactors**
  - Use debug! instead of info! for transaction lifecycle, time range, file discovery, filters, facets, indexing, and log retrieval in CatalogFunction.

- **Dependencies**
  - Update workspace and related crates to version 0.1.3 (Cargo.toml/Cargo.lock).

<sup>Written for commit f92524449a9e115e4439bec00b66ef3abf66ab42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

