### PR TITLE
feat(go.d.plugin): add RequireCloud for database functions

### DIFF
--- a/integrations/schemas/collector.json
+++ b/integrations/schemas/collector.json
@@ -581,6 +581,10 @@
                     "availability": {
                       "type": "string",
                       "description": "Availability and enablement notes."
+                    },
+                    "require_cloud": {
+                      "type": "boolean",
+                      "description": "Whether the function requires cloud connection."
                     }
                   },
                   "required": [

--- a/integrations/templates/functions.md
+++ b/integrations/templates/functions.md
@@ -11,6 +11,7 @@
 | Aspect | Description |
 |:-------|:------------|
 | Name | `[[ strfy(entry.meta.module_name)|capitalize ]]:[[ strfy(func.id) ]]` |
+| Require Cloud | [[ 'yes' if func.require_cloud else 'no' ]] |
 | Performance | [[ strfy(func.performance) ]] |
 | Security | [[ strfy(func.security) ]] |
 | Availability | [[ strfy(func.availability) ]] |

--- a/src/go/plugin/go.d/agent/jobmgr/manager.go
+++ b/src/go/plugin/go.d/agent/jobmgr/manager.go
@@ -139,12 +139,19 @@ func (m *Manager) Run(ctx context.Context, in chan []*confgroup.Group) {
 				if help == "" {
 					help = fmt.Sprintf("%s %s data function", name, method.ID)
 				}
+
+				// https://github.com/netdata/netdata/blob/1bc1775a17590b3c0fe3a4fe547dc6146d07be89/src/libnetdata/user-auth/http-access.h#L21
+				const cloudAccess = "0x0013" // SIGNED_ID | SAME_SPACE | SENSITIVE_DATA
+				access := "0x0000"
+				if method.RequireCloud {
+					access = cloudAccess
+				}
 				m.dyncfgApi.FunctionGlobal(netdataapi.FunctionGlobalOpts{
 					Name:     funcName,
 					Timeout:  60,
 					Help:     help,
 					Tags:     "top",
-					Access:   "0x0000",
+					Access:   access,
 					Priority: 100,
 					Version:  3,
 				})

--- a/src/go/plugin/go.d/agent/module/registry.go
+++ b/src/go/plugin/go.d/agent/module/registry.go
@@ -29,6 +29,7 @@ type MethodConfig struct {
 	Name           string                // Display name (e.g., "Top Queries")
 	UpdateEvery    int                   // Default UI refresh interval
 	Help           string                // Description for UI
+	RequireCloud   bool                  // Indicates whether the method requires cloud connection
 	RequiredParams []funcapi.ParamConfig // Required parameters for this method (including __sort if used)
 }
 

--- a/src/go/plugin/go.d/collector/clickhouse/functions.go
+++ b/src/go/plugin/go.d/collector/clickhouse/functions.go
@@ -99,10 +99,11 @@ func clickhouseMethods() []module.MethodConfig {
 	sortOptions := buildClickHouseSortOptions(clickhouseAllColumns)
 	return []module.MethodConfig{
 		{
-			UpdateEvery: 10,
-			ID:          "top-queries",
-			Name:        "Top Queries",
-			Help:        "Top SQL queries from ClickHouse system.query_log",
+			UpdateEvery:  10,
+			ID:           "top-queries",
+			Name:         "Top Queries",
+			Help:         "Top SQL queries from ClickHouse system.query_log",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{{
 				ID:         paramSort,
 				Name:       "Filter By",

--- a/src/go/plugin/go.d/collector/clickhouse/metadata.yaml
+++ b/src/go/plugin/go.d/collector/clickhouse/metadata.yaml
@@ -382,6 +382,7 @@ modules:
                   :::
           availability: |
             Available when:<br/>• The collector has successfully connected to ClickHouse<br/>• `system.query_log` table is accessible<br/>• Returns HTTP 503 if `system.query_log` is not accessible<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
     metrics:
       folding:
         title: Metrics

--- a/src/go/plugin/go.d/collector/cockroachdb/functions.go
+++ b/src/go/plugin/go.d/collector/cockroachdb/functions.go
@@ -118,19 +118,21 @@ var crdbRunningColumns = []crdbColumnMeta{
 func cockroachMethods() []module.MethodConfig {
 	return []module.MethodConfig{
 		{
-			UpdateEvery: 10,
-			ID:          "top-queries",
-			Name:        "Top Queries",
-			Help:        "Top SQL statements from crdb_internal.cluster_statement_statistics. WARNING: Query text may contain unmasked literals (potential PII).",
+			UpdateEvery:  10,
+			ID:           "top-queries",
+			Name:         "Top Queries",
+			Help:         "Top SQL statements from crdb_internal.cluster_statement_statistics. WARNING: Query text may contain unmasked literals (potential PII).",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{
 				buildCrdbSortParam(crdbTopColumns),
 			},
 		},
 		{
-			UpdateEvery: 10,
-			ID:          "running-queries",
-			Name:        "Running Queries",
-			Help:        "Currently running SQL statements from SHOW CLUSTER STATEMENTS. WARNING: Query text may contain unmasked literals (potential PII).",
+			UpdateEvery:  10,
+			ID:           "running-queries",
+			Name:         "Running Queries",
+			Help:         "Currently running SQL statements from SHOW CLUSTER STATEMENTS. WARNING: Query text may contain unmasked literals (potential PII).",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{
 				buildCrdbSortParam(crdbRunningColumns),
 			},

--- a/src/go/plugin/go.d/collector/cockroachdb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/cockroachdb/metadata.yaml
@@ -399,6 +399,7 @@ modules:
                   :::
           availability: |
             Available when:<br/>• The collector has successfully connected to CockroachDB<br/>• The SQL user has `VIEWACTIVITY` or `VIEWACTIVITYREDACTED` privileges<br/>• Returns HTTP 503 if the SQL connection cannot be established<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
         - id: running-queries
           name: Running Queries
           description: |
@@ -500,6 +501,7 @@ modules:
                      :::
           availability: |
             Available when:<br/>• The collector has successfully connected to CockroachDB<br/>• The SQL user has `VIEWACTIVITY` or `VIEWACTIVITYREDACTED` privileges<br/>• Returns HTTP 503 if the SQL connection cannot be established<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
     metrics:
       folding:
         title: Metrics

--- a/src/go/plugin/go.d/collector/couchbase/functions.go
+++ b/src/go/plugin/go.d/collector/couchbase/functions.go
@@ -132,10 +132,11 @@ func couchbaseMethods() []module.MethodConfig {
 	sortOptions := buildCouchbaseSortOptions(couchbaseAllColumns)
 	return []module.MethodConfig{
 		{
-			UpdateEvery: 10,
-			ID:          "top-queries",
-			Name:        "Top Queries",
-			Help:        "Top N1QL requests from system:completed_requests",
+			UpdateEvery:  10,
+			ID:           "top-queries",
+			Name:         "Top Queries",
+			Help:         "Top N1QL requests from system:completed_requests",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{{
 				ID:         paramSort,
 				Name:       "Filter By",

--- a/src/go/plugin/go.d/collector/couchbase/metadata.yaml
+++ b/src/go/plugin/go.d/collector/couchbase/metadata.yaml
@@ -301,6 +301,7 @@ modules:
                      :::
           availability: |
             Available when:<br/>• The collector has successfully connected to Couchbase<br/>• The N1QL (Query) service is running<br/>• Returns HTTP 503 if collector is still initializing<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
     metrics:
       folding:
         title: Metrics

--- a/src/go/plugin/go.d/collector/elasticsearch/functions.go
+++ b/src/go/plugin/go.d/collector/elasticsearch/functions.go
@@ -119,10 +119,11 @@ func elasticsearchMethods() []module.MethodConfig {
 	sortOptions := buildElasticsearchSortOptions(esAllColumns)
 	return []module.MethodConfig{
 		{
-			UpdateEvery: 10,
-			ID:          "top-queries",
-			Name:        "Top Queries",
-			Help:        "Running queries from Elasticsearch Tasks API",
+			UpdateEvery:  10,
+			ID:           "top-queries",
+			Name:         "Top Queries",
+			Help:         "Running queries from Elasticsearch Tasks API",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{
 				{
 					ID:         paramSort,

--- a/src/go/plugin/go.d/collector/elasticsearch/metadata.yaml
+++ b/src/go/plugin/go.d/collector/elasticsearch/metadata.yaml
@@ -379,6 +379,7 @@ modules:
                   :::
           availability: |
             Available when:<br/>• The collector has successfully connected to Elasticsearch/OpenSearch<br/>• The user has `monitor` or `manage` cluster privileges<br/>• Returns HTTP 503 if collector is still initializing<br/>• Returns HTTP 500 if the Tasks API query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
     metrics:
       folding:
         title: Metrics

--- a/src/go/plugin/go.d/collector/mongodb/functions.go
+++ b/src/go/plugin/go.d/collector/mongodb/functions.go
@@ -275,10 +275,11 @@ func mongoMethods() []module.MethodConfig {
 	}
 
 	return []module.MethodConfig{{
-		UpdateEvery: 10,
-		ID:          "top-queries",
-		Name:        "Top Queries",
-		Help:        topQueriesHelpText,
+		UpdateEvery:  10,
+		ID:           "top-queries",
+		Name:         "Top Queries",
+		Help:         topQueriesHelpText,
+		RequireCloud: true,
 		RequiredParams: []funcapi.ParamConfig{
 			{
 				ID:         paramSort,

--- a/src/go/plugin/go.d/collector/mongodb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mongodb/metadata.yaml
@@ -369,6 +369,7 @@ modules:
                   :::
           availability: |
             Available when:<br/>• The collector has successfully connected to MongoDB<br/>• Profiling is enabled on at least one user database<br/>• Returns HTTP 503 if collector is still initializing or profiling is disabled on all databases<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
     metrics:
       folding:
         title: Metrics

--- a/src/go/plugin/go.d/collector/mssql/functions.go
+++ b/src/go/plugin/go.d/collector/mssql/functions.go
@@ -208,10 +208,11 @@ func mssqlMethods() []module.MethodConfig {
 
 	return []module.MethodConfig{
 		{
-			UpdateEvery: 10,
-			ID:          "top-queries",
-			Name:        "Top Queries",
-			Help:        "Top SQL queries from Query Store",
+			UpdateEvery:  10,
+			ID:           "top-queries",
+			Name:         "Top Queries",
+			Help:         "Top SQL queries from Query Store",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{
 				{
 					ID:         paramSort,

--- a/src/go/plugin/go.d/collector/mssql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mssql/metadata.yaml
@@ -581,6 +581,7 @@ modules:
                   :::
           availability: |
             Available when:<br/>• The collector has successfully connected to SQL Server<br/>• Query Store is enabled on at least one user database<br/>• Returns HTTP 503 if collector is still initializing<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
     metrics:
       folding:
         title: Metrics

--- a/src/go/plugin/go.d/collector/mysql/functions.go
+++ b/src/go/plugin/go.d/collector/mysql/functions.go
@@ -187,10 +187,11 @@ func mysqlMethods() []module.MethodConfig {
 
 	return []module.MethodConfig{
 		{
-			UpdateEvery: 10,
-			ID:          "top-queries",
-			Name:        "Top Queries",
-			Help:        "Top SQL queries from performance_schema",
+			UpdateEvery:  10,
+			ID:           "top-queries",
+			Name:         "Top Queries",
+			Help:         "Top SQL queries from performance_schema",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{
 				{
 					ID:         paramSort,

--- a/src/go/plugin/go.d/collector/mysql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mysql/metadata.yaml
@@ -499,6 +499,7 @@ modules:
                      ```
           availability: |
             Available when:<br/>• The collector has successfully connected to MySQL<br/>• Performance Schema is enabled with statement digest collection<br/>• Returns HTTP 503 if collector is still initializing<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
     metrics:
       folding:
         title: Metrics

--- a/src/go/plugin/go.d/collector/oracledb/functions.go
+++ b/src/go/plugin/go.d/collector/oracledb/functions.go
@@ -115,19 +115,21 @@ var oracleRunningColumns = []oracleColumnMeta{
 func oracleMethods() []module.MethodConfig {
 	return []module.MethodConfig{
 		{
-			UpdateEvery: 10,
-			ID:          "top-queries",
-			Name:        "Top Queries",
-			Help:        "Top SQL statements from V$SQLSTATS. WARNING: Query text may contain unmasked literals (potential PII).",
+			UpdateEvery:  10,
+			ID:           "top-queries",
+			Name:         "Top Queries",
+			Help:         "Top SQL statements from V$SQLSTATS. WARNING: Query text may contain unmasked literals (potential PII).",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{
 				buildOracleSortParam(oracleTopColumns),
 			},
 		},
 		{
-			UpdateEvery: 10,
-			ID:          "running-queries",
-			Name:        "Running Queries",
-			Help:        "Currently running SQL statements from V$SESSION. WARNING: Query text may contain unmasked literals (potential PII).",
+			UpdateEvery:  10,
+			ID:           "running-queries",
+			Name:         "Running Queries",
+			Help:         "Currently running SQL statements from V$SESSION. WARNING: Query text may contain unmasked literals (potential PII).",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{
 				buildOracleSortParam(oracleRunningColumns),
 			},

--- a/src/go/plugin/go.d/collector/oracledb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/oracledb/metadata.yaml
@@ -274,6 +274,7 @@ modules:
                   :::
           availability: |
             Available when:<br/>• The collector has successfully connected to Oracle DB<br/>• The user has SELECT privilege on `V$SQLSTATS`<br/>• Returns HTTP 503 if the connection cannot be established<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
         - id: running-queries
           name: Running Queries
           description: |
@@ -389,6 +390,7 @@ modules:
                   :::
           availability: |
             Available when:<br/>• The collector has successfully connected to Oracle DB<br/>• The user has SELECT privilege on `V$SESSION` and `V$SQL`<br/>• Returns HTTP 503 if the connection cannot be established<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
     metrics:
       folding:
         title: Metrics

--- a/src/go/plugin/go.d/collector/postgres/functions.go
+++ b/src/go/plugin/go.d/collector/postgres/functions.go
@@ -214,10 +214,11 @@ func pgMethods() []module.MethodConfig {
 
 	return []module.MethodConfig{
 		{
-			UpdateEvery: 10,
-			ID:          "top-queries",
-			Name:        "Top Queries",
-			Help:        "Top SQL queries from pg_stat_statements",
+			UpdateEvery:  10,
+			ID:           "top-queries",
+			Name:         "Top Queries",
+			Help:         "Top SQL queries from pg_stat_statements",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{
 				{
 					ID:         paramSort,

--- a/src/go/plugin/go.d/collector/postgres/metadata.yaml
+++ b/src/go/plugin/go.d/collector/postgres/metadata.yaml
@@ -485,6 +485,7 @@ modules:
                   :::
           availability: |
             Available when:<br/>• The `pg_stat_statements` extension is installed in the database<br/>• The collector has successfully connected to PostgreSQL<br/>• Returns HTTP 503 if extension is not installed (with instructions to install)<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
     metrics:
       folding:
         title: Metrics

--- a/src/go/plugin/go.d/collector/proxysql/functions.go
+++ b/src/go/plugin/go.d/collector/proxysql/functions.go
@@ -93,10 +93,11 @@ func proxysqlMethods() []module.MethodConfig {
 	sortOptions := buildProxySQLSortOptions(proxysqlAllColumns)
 	return []module.MethodConfig{
 		{
-			UpdateEvery: 10,
-			ID:          "top-queries",
-			Name:        "Top Queries",
-			Help:        "Top SQL queries from ProxySQL query digest stats",
+			UpdateEvery:  10,
+			ID:           "top-queries",
+			Name:         "Top Queries",
+			Help:         "Top SQL queries from ProxySQL query digest stats",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{{
 				ID:         paramSort,
 				Name:       "Filter By",

--- a/src/go/plugin/go.d/collector/proxysql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/proxysql/metadata.yaml
@@ -228,6 +228,7 @@ modules:
             Query text may contain unmasked literal values including potentially sensitive data:<br/>• Personal information in WHERE clauses or INSERT values<br/>• Business data embedded in queries<br/>• Access should be restricted to authorized personnel only
           availability: |
             Available when:<br/>• The collector has successfully connected to ProxySQL admin interface<br/>• Returns HTTP 503 if the connection cannot be established<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
     metrics:
       folding:
         title: Metrics

--- a/src/go/plugin/go.d/collector/redis/functions.go
+++ b/src/go/plugin/go.d/collector/redis/functions.go
@@ -84,10 +84,11 @@ func redisMethods() []module.MethodConfig {
 	sortOptions := buildRedisSortOptions(redisAllColumns)
 	return []module.MethodConfig{
 		{
-			UpdateEvery: 10,
-			ID:          "top-queries",
-			Name:        "Top Queries",
-			Help:        "Slow commands from Redis SLOWLOG. WARNING: Command arguments may contain unmasked literals (potential PII).",
+			UpdateEvery:  10,
+			ID:           "top-queries",
+			Name:         "Top Queries",
+			Help:         "Slow commands from Redis SLOWLOG. WARNING: Command arguments may contain unmasked literals (potential PII).",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{{
 				ID:         paramSort,
 				Name:       "Filter By",

--- a/src/go/plugin/go.d/collector/redis/metadata.yaml
+++ b/src/go/plugin/go.d/collector/redis/metadata.yaml
@@ -249,6 +249,7 @@ modules:
             Command arguments may contain unmasked literal values including potentially sensitive data:<br/>• Redis keys and values in command arguments<br/>• Application-specific identifiers or session tokens<br/>• Access should be restricted to authorized personnel only
           availability: |
             Available when:<br/>• The collector has successfully connected to Redis<br/>• SLOWLOG is enabled (`slowlog-log-slower-than` > 0)<br/>• Returns HTTP 503 if collector is still initializing<br/>• Returns HTTP 500 if the command fails<br/>• Returns HTTP 504 if the command times out
+          require_cloud: true
     metrics:
       folding:
         title: Metrics

--- a/src/go/plugin/go.d/collector/rethinkdb/functions.go
+++ b/src/go/plugin/go.d/collector/rethinkdb/functions.go
@@ -77,10 +77,11 @@ func rethinkdbMethods() []module.MethodConfig {
 	sortOptions := buildRethinkSortOptions(rethinkRunningColumns)
 	return []module.MethodConfig{
 		{
-			UpdateEvery: 10,
-			ID:          "running-queries",
-			Name:        "Running Queries",
-			Help:        "Currently running queries from rethinkdb.jobs. WARNING: Query text may contain unmasked literals (potential PII).",
+			UpdateEvery:  10,
+			ID:           "running-queries",
+			Name:         "Running Queries",
+			Help:         "Currently running queries from rethinkdb.jobs. WARNING: Query text may contain unmasked literals (potential PII).",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{
 				{
 					ID:         paramSort,

--- a/src/go/plugin/go.d/collector/rethinkdb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/rethinkdb/metadata.yaml
@@ -224,6 +224,7 @@ modules:
                   :::
           availability: |
             Available when:<br/>• The collector has successfully connected to RethinkDB<br/>• The user has admin access to `rethinkdb.jobs` table<br/>• Returns HTTP 503 if collector is still initializing<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
     metrics:
       folding:
         title: Metrics

--- a/src/go/plugin/go.d/collector/yugabytedb/functions.go
+++ b/src/go/plugin/go.d/collector/yugabytedb/functions.go
@@ -109,19 +109,21 @@ var ybRunningColumns = []ybColumnMeta{
 func yugabyteMethods() []module.MethodConfig {
 	return []module.MethodConfig{
 		{
-			UpdateEvery: 10,
-			ID:          "top-queries",
-			Name:        "Top Queries",
-			Help:        "Top SQL queries from pg_stat_statements. WARNING: Query text may contain unmasked literals (potential PII).",
+			UpdateEvery:  10,
+			ID:           "top-queries",
+			Name:         "Top Queries",
+			Help:         "Top SQL queries from pg_stat_statements. WARNING: Query text may contain unmasked literals (potential PII).",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{
 				buildYBSortParam(ybTopColumns),
 			},
 		},
 		{
-			UpdateEvery: 10,
-			ID:          "running-queries",
-			Name:        "Running Queries",
-			Help:        "Currently running SQL statements from pg_stat_activity. WARNING: Query text may contain unmasked literals (potential PII).",
+			UpdateEvery:  10,
+			ID:           "running-queries",
+			Name:         "Running Queries",
+			Help:         "Currently running SQL statements from pg_stat_activity. WARNING: Query text may contain unmasked literals (potential PII).",
+			RequireCloud: true,
 			RequiredParams: []funcapi.ParamConfig{
 				buildYBSortParam(ybRunningColumns),
 			},

--- a/src/go/plugin/go.d/collector/yugabytedb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/yugabytedb/metadata.yaml
@@ -348,6 +348,7 @@ modules:
                   :::
           availability: |
             Available when:<br/>• The collector has successfully connected to YSQL<br/>• The `pg_stat_statements` extension is installed<br/>• Returns HTTP 503 if the SQL connection cannot be established or extension is not installed<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
         - id: running-queries
           name: Running Queries
           description: |
@@ -445,6 +446,7 @@ modules:
                   :::
           availability: |
             Available when:<br/>• The collector has successfully connected to YSQL<br/>• Returns HTTP 503 if the SQL connection cannot be established<br/>• Returns HTTP 500 if the query fails<br/>• Returns HTTP 504 if the query times out
+          require_cloud: true
     metrics:
       folding:
         title: Metrics


### PR DESCRIPTION
Add RequireCloud field to MethodConfig and set it for database collector functions that expose potentially sensitive query data.

Changes:
- Add require_cloud property to collector.json schema
- Add "Require Cloud" row to functions.md template
- Set RequireCloud=true for functions in: clickhouse, cockroachdb, couchbase, elasticsearch, mongodb, mssql, mysql, oracledb, postgres, proxysql, redis, rethinkdb, yugabytedb
- Add require_cloud: yes to corresponding metadata.yaml files

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a RequireCloud flag to go.d.plugin database functions and enforces cloud-only access for functions that can expose query text. Improves data security by gating sensitive function outputs behind a cloud connection.

- **New Features**
  - MethodConfig.RequireCloud added and enforced in job manager (sets function access to cloud-only).
  - collector.json: new require_cloud boolean in function schema.
  - functions.md: added “Require Cloud” row in the template.
  - Set RequireCloud=true and require_cloud: true for functions in: clickhouse, cockroachdb, couchbase, elasticsearch, mongodb, mssql, mysql, oracledb, postgres, proxysql, redis, rethinkdb, yugabytedb.

<sup>Written for commit 27c69b15da574bc9975ddfaef2980a71ec03eaff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

