### PR TITLE
docs: add node-states-and-transitions to learn map

### DIFF
--- a/docs/.map/map.csv
+++ b/docs/.map/map.csv
@@ -96,6 +96,7 @@ https://github.com/netdata/netdata/edit/master/docs/netdata-cloud/authentication
 https://github.com/netdata/netdata/edit/master/docs/netdata-cloud/view-plan-and-billing.md,Netdata Plans & Billing,Published,Netdata Cloud,,
 https://github.com/netdata/netdata/edit/master/src/aclk/README.md,Agent-Cloud Link (ACLK),Published,Netdata Cloud,,The Agent-Cloud link (ACLK) is the mechanism responsible for connecting a Netdata agent to Netdata Cloud.
 https://github.com/netdata/netdata/edit/master/docs/learn/remove-node.md,Remove Agent,Published,Netdata Cloud,,
+https://github.com/netdata/netdata/edit/master/docs/netdata-cloud/node-states-and-transitions.md,Node States and Transitions,Published,Netdata Cloud,"node states,live,stale,offline,unseen,transitions",Understanding node connection states and state transitions in Netdata Cloud
 https://github.com/netdata/netdata/edit/master/docs/learn/unclaim-reclaim-node.md,Unclaim and Reclaim a Node,Published,Netdata Cloud,,
 https://github.com/netdata/netdata/edit/master/docs/delete/netdata/account.md,Account Deletion,Published,Netdata Cloud,,
 ,,,,,


### PR DESCRIPTION
## Summary
- Add the new node states documentation page to the navigation map (`docs/.map/map.csv`)
- Places it under the Netdata Cloud section with appropriate keywords

This is a follow-up to PR #21630 which added the documentation but missed the map.csv entry.

## Test plan
- [ ] Verify the page appears in the learn.netdata.cloud navigation under "Netdata Cloud"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the “Node States and Transitions” docs page to the learn map so it appears under Netdata Cloud in navigation. Includes keywords to improve search and discovery.

<sup>Written for commit b5d699bfce53d383b011a84c9b5b42ea1b511d4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

