### PR TITLE
Adding Skills for AI Agents (for users, not devs)

### DIFF
--- a/src/ai-skills/README.md
+++ b/src/ai-skills/README.md
@@ -1,0 +1,105 @@
+# Netdata AI Skills
+
+Dense, AI-consumable instructions for operating and developing Netdata.
+
+## Purpose
+
+These skills are designed to be consumed by AI assistants (Claude, GPT, Gemini, etc.) to help users:
+- Configure Netdata features
+- Troubleshoot issues
+- Perform operational tasks
+- Develop custom plugins
+
+## Directory Structure
+
+```
+src/ai-skills/
+├── skills/                    # AI skill files
+│   ├── netdata-alerts-config.md
+│   ├── netdata-alerts-ops.md
+│   └── ...
+├── tests/                     # Testing framework
+│   ├── framework/             # Test infrastructure
+│   │   ├── models.py          # Model API wrappers
+│   │   ├── normalize.py       # Output normalization
+│   │   └── round_trip.py      # Round-trip test runner
+│   ├── alerts-config/         # Tests for alerts-config skill
+│   │   └── cases/             # Test case files
+│   └── config.yaml            # Model endpoints configuration
+├── results/                   # Test output (gitignored)
+└── README.md
+```
+
+## Skill Naming Convention
+
+Pattern: `netdata-{topic}-{action}.md`
+
+| Action | Meaning | Audience |
+|--------|---------|----------|
+| `-config` | Configure/customize | Users/Admins |
+| `-use` | Use/consume/interact | Users/Admins |
+| `-ops` | Operate/maintain/troubleshoot | Users/Admins |
+| `-dev` | Develop/extend/create | Developers |
+
+## How to Use These Skills
+
+### With Claude Code
+
+Skills can be used as Claude Code slash commands. See `.claude/skills/` for wrappers.
+
+### With Other AI Assistants
+
+Copy the skill content into your prompt or system message:
+
+```
+[Paste content of netdata-alerts-config.md]
+
+User: How do I configure a disk space alert?
+```
+
+### Direct Embedding
+
+Include in your AI application's context:
+
+```python
+with open("skills/netdata-alerts-config.md") as f:
+    skill = f.read()
+
+response = client.chat(
+    messages=[
+        {"role": "system", "content": skill},
+        {"role": "user", "content": user_question}
+    ]
+)
+```
+
+## Testing Framework
+
+Skills are validated using round-trip tests:
+
+1. Give an artifact (e.g., alert config) to the AI
+2. AI describes it in natural language
+3. AI recreates the artifact from the description
+4. Compare: original must equal regenerated
+
+### Test Results
+
+| Large Model | Small Model | Result |
+|-------------|-------------|--------|
+| Pass | Pass | **PASS** - Skill is good |
+| Pass | Fail | **WARNING** - Works but could be clearer |
+| Fail | * | **FAIL** - Skill needs fixing |
+
+### Running Tests
+
+```bash
+cd tests
+python framework/round_trip.py ../skills/netdata-alerts-config.md alerts-config/cases/
+```
+
+## Contributing
+
+1. Create skill file following naming convention
+2. Add test cases
+3. Run tests against both models
+4. Iterate until both models pass

--- a/src/ai-skills/TODO-netdata-alerts-config.md
+++ b/src/ai-skills/TODO-netdata-alerts-config.md
@@ -1,0 +1,90 @@
+# TODO - netdata-alerts-config completeness verification
+
+## TL;DR
+- Ensure all Netdata alert documentation is correct and aligned with code.
+- Apply every finding from the completeness review across all relevant docs (not just the AI skill file).
+- Add deterministic alert ordering: load files sorted from disk, build dependency graph, and reorder alert evaluation accordingly.
+
+## Analysis
+- Required lines are misstated: file says `warn/crit` required and `lookup/calc` required, but docs/code allow helper alerts with only `lookup`/`calc` and no `warn/crit` (e.g., `cpu_user_mean`). Evidence: `src/health/REFERENCE.md:333-341`, `src/health/REFERENCE.md:1205-1215`.
+- Status constants conflict between docs and code; file matches code but REFERENCE is outdated (no `$RAISED`, shifted values). Evidence: `src/health/REFERENCE.md:999-1013` vs `src/health/rrdcalc.h:20-27`.
+- `lookup` syntax missing grouping options in parentheses (e.g., `countif(>5)`, `percentile(95)`, `trimmed-mean(5)`), defaults for empty options, and operator set. Evidence: `src/health/health_config.c:190-282`, `src/health/health-config-unittest.c:220-280`.
+- `lookup` grouping methods list is incomplete: missing aliases and extra methods (`avg`, `mean`, `cv`, `rsd`, `coefficient-of-variation`, `ses`, `ema`, `ewma`, `des`, `incremental_sum` plus canonical names). Evidence: `src/web/api/queries/query-group-over-time.c:60-340`.
+- `lookup` options list incomplete/incorrect: parser accepts `abs`/`absolute_sum`, `match_ids`, `match_names`, and treats `sum` as default. Evidence: `src/health/health_config.c:310-364`.
+- Label matching semantics incomplete: parser supports multiple label keys on one line (AND across keys) and multiple values per key (OR), and trims spaces around `=`; commas are not supported. Evidence: `src/health/health_prototypes.c:286-340`, `src/health/health_prototypes.c:347-370`, `src/health/health_prototypes.c:503-522`.
+- Pattern matching evaluation is first-match-wins (including negation): the first matching pattern returns positive/negative and stops evaluation. Evidence: `src/libnetdata/simple_pattern/simple_pattern.c:285-299`.
+- Line continuation with `\` is supported but not documented in the file. Evidence: `src/health/health_config.c:610-626`.
+- Expression evaluation behavior is more specific than the file states: logical operators short-circuit, `nan` is false and `inf` is true in boolean contexts, and final `nan/inf` fails the expression. Evidence: `src/libnetdata/eval/eval-evaluate.c:54-140`, `src/libnetdata/eval/eval-evaluate.c:300-340`.
+- Legacy keys `charts:` and `families:` are accepted but ignored by the parser. Evidence: `src/health/health_config.c:818-826`.
+- Docs list `$collected_total_raw` as a built-in chart variable, but it is not provided by core alert variables; only per-dimension `_raw` values and custom chart vars exist. Evidence: `src/health/rrdvar.c:159-270`.
+- Alert naming rules are incomplete: names are sanitized by `rrdvar_fix_name` and may be auto-renamed; docs also forbid names equal to chart/dimension/family/variable names. Evidence: `src/health/health_config.c:676-684`, `src/libnetdata/sanitizers/chart_id_and_name.c:1-80`, `src/health/REFERENCE.md:368-387`.
+- Defaults missing: `to` defaults to `root`, `exec` defaults to `alarm-notify.sh` from `[health]` in netdata.conf. Evidence: `src/health/health.c:72-92`, `src/health/health_notifications.c:404`.
+- `class`/`type`/`component` are free-form (not validated) and default to `Unknown` when omitted; file presents a partial fixed list. Evidence: `src/health/health_config.c:730-740`, `src/health/health_json.c:85-88`, `src/health/REFERENCE.md:430-510`.
+- Variable resolution is missing key behavior: cross-context references choose the best match by label similarity (highest overlap), and ties depend on iteration order. Evidence: `src/health/health_variable.c:38-111`, `src/health/health_variable.c:340-411`, `src/health/README.md:392-419`.
+- Alert-to-alert references timing is misstated: values for all alerts are computed in a first pass, then warn/crit in a second pass; `calc` may see previous-cycle values depending on evaluation order. Evidence: `src/health/health_event_loop.c:400-446`, `src/health/health_variable.c:340-411`.
+- `options` line accepts `no-clear` alias (not documented). Evidence: `src/health/health_config.c:96-110`.
+- Quoted values are allowed and stripped for several lines; file says “do NOT add quotes”. Evidence: `src/health/health_config.c:730-824`.
+- `foreach` appears in commented stock alert examples but is not parsed as a lookup keyword; this is undocumented/ambiguous. Evidence: `src/health/health.d/ml.conf:24-33`, `src/health/health_config.c:300-380`.
+- Alert file loading order is non-deterministic (uses `readdir()` without sorting). Evidence: `src/libnetdata/paths/paths.c:234-270`, `:276-319`.
+- Alert prototypes are applied per chart first (chart loop, then prototype loop), not by file order. Evidence: `src/health/health_prototypes.c:622-629`, `:693-700`.
+- Alert evaluation iterates the rrdcalc index in insertion order, which follows chart insertion and per-chart prototype application. Evidence: `src/health/health_event_loop.c:293-421`, `src/health/rrdcalc.h:104-114`, `src/libnetdata/dictionary/README.md:194-204`.
+- Cross-alert references resolve the stored value (`rc->value`) with no dependency graph enforcement. Evidence: `src/health/health_variable.c:146-148`.
+- Variable lookup resolves in order: chart dimensions/vars, host vars, then alert names, then cross-context lookups. This makes static “variable name == alert name” dependency detection unreliable. Evidence: `src/health/health_variable.c:60-148`, `:360-379`.
+- Proposed ordering alternative: iterative “weight” pass (count references in calc variables, increase weight per iteration, reorder by weight without explicit graph). This needs clear dependency detection rules and cycle/limit behavior. (Proposal from user)
+
+## Decisions
+1. Source of truth when docs conflict with code (e.g., status constants):
+   - Decision: Option A (align strictly to code behavior).
+   - Implication: This file becomes authoritative, even if REFERENCE.md is outdated.
+2. `class`/`type`/`component` guidance style:
+   - Decision: Option B (full list + free-form/Unknown default).
+3. `lookup` method/option aliases:
+   - Decision: Option B (canonical + aliases).
+4. Alignment rule in the file:
+   - Decision: Option A (keep as MUST).
+5. `foreach` keyword in lookup examples:
+   - Decision: Option C (remove mention entirely).
+6. Fix other docs:
+   - Decision: Option B (update all alert docs: REFERENCE + guides + examples).
+7. Deterministic file loading order:
+   - Decision: pending (sort by filename, full path, or stable directory traversal).
+8. Dependency graph scope:
+   - Decision: pending (per-host only, per-chart only, or global per-host across charts).
+9. Dependency resolution timing:
+   - Decision: pending (build once at load vs recompute on reload vs incremental updates).
+10. Cycle handling:
+   - Decision: pending (detect + warn, break cycles, or allow with stale values).
+11. Evaluation ordering semantics:
+   - Decision: pending (strict topological order for calc/warn/crit, or only for calc).
+12. Ordering algorithm approach:
+   - Decision: pending (explicit dependency graph vs iterative weight pass).
+13. Dependency sources for reordering:
+   - Decision: pending (calc only, calc+warn/crit, or all expressions).
+
+## Plan
+- Summarize all gaps with evidence, aligned to docs and code.
+- Identify all alert-related docs in this repo and audit them for the findings listed above.
+- Update every relevant doc to match code behavior (syntax, methods, options, defaults, behavior notes).
+- Ensure examples reflect actual parser behavior (labels, lookup options, required lines).
+- Define deterministic ordering requirements and dependency semantics.
+- Implement sorted loading (deterministic order) in config loader.
+- Build dependency graph for alert references and apply topological ordering for evaluation.
+- Handle cycles (documented behavior + runtime logging).
+- Update alert ordering docs to reflect new deterministic + dependency behavior.
+
+## Implied Decisions
+- Treat code as authoritative; avoid doc/code mismatch notes.
+
+## Testing Requirements
+- Documentation updates: none.
+- Code changes: add tests for sorted load order and dependency evaluation ordering, plus cycle detection behavior.
+
+## Documentation Updates Required
+- Update all alert-related docs to match code:
+  - `src/ai-skills/skills/netdata-alerts-config.md`
+  - `src/health/REFERENCE.md`
+  - `src/health/README.md`
+  - Any other repo docs that describe alert syntax/behavior (to be located during audit).
+- Update alert ordering docs:
+  - `src/health/alert-configuration-ordering.md`
+  - `src/health/overriding-stock-alerts.md` (ordering caveats)

--- a/src/ai-skills/results/.gitignore
+++ b/src/ai-skills/results/.gitignore
@@ -1,0 +1,3 @@
+# Ignore all test results
+*
+!.gitignore

--- a/src/ai-skills/skills/.gitkeep
+++ b/src/ai-skills/skills/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for skill files

--- a/src/ai-skills/skills/netdata-alerts-config.md
+++ b/src/ai-skills/skills/netdata-alerts-config.md
@@ -1,0 +1,1056 @@
+# Netdata Alert Configuration
+
+## Purpose
+
+Configure Netdata health alert definitions. Output syntactically correct, production-ready `.conf` files.
+
+## Alignment Rules
+
+Alert keys MUST be right-aligned so colons appear in the same column.
+
+**Calculate alignment:**
+1. Find longest key in your alert (e.g., `chart labels` = 12 chars)
+2. For each key: `leading_spaces = longest_key_length - current_key_length`
+3. First line (`template:` or `alarm:`) also needs leading spaces
+
+**Key lengths:**
+| Key | Length |
+|-----|--------|
+| `on` | 2 |
+| `to` | 2 |
+| `os` | 2 |
+| `calc` | 4 |
+| `warn` | 4 |
+| `crit` | 4 |
+| `info` | 4 |
+| `type` | 4 |
+| `units` | 5 |
+| `class` | 5 |
+| `every` | 5 |
+| `delay` | 5 |
+| `exec` | 4 |
+| `alarm` | 5 |
+| `green` | 5 |
+| `red` | 3 |
+| `lookup` | 6 |
+| `repeat` | 6 |
+| `summary` | 7 |
+| `options` | 7 |
+| `hosts` | 6 |
+| `charts` | 6 |
+| `families` | 8 |
+| `plugin` | 6 |
+| `module` | 6 |
+| `template` | 8 |
+| `component` | 9 |
+| `host labels` | 11 |
+| `chart labels` | 12 |
+
+**Example with `chart labels` (12 chars):**
+```
+    template: disk_space_usage
+          on: disk.space
+       class: Utilization
+        type: System
+   component: Disk
+chart labels: mount_point=!/dev !/dev/* *
+        calc: $used * 100 / ($avail + $used)
+       units: %
+       every: 1m
+        warn: $this > 80
+        crit: $this > 90
+       delay: down 15m multiplier 1.5 max 1h
+     summary: Disk ${label:mount_point} space usage
+        info: Total space utilization of disk ${label:mount_point}
+          to: sysadmin
+```
+
+**Example with `component` as longest (9 chars):**
+```
+ template: cpu_usage
+       on: system.cpu
+    class: Utilization
+     type: System
+component: CPU
+   lookup: average -10m unaligned of user,system
+    units: %
+    every: 1m
+     warn: $this > 80
+     crit: $this > 90
+    delay: down 15m multiplier 1.5 max 1h
+  summary: System CPU utilization
+     info: Average CPU utilization over the last 10 minutes
+       to: sysadmin
+```
+
+**Line continuation (backslash):**
+- A line ending with `\` continues on the next line.
+- The backslash is replaced by a single space.
+- Useful for long `info:` or `summary:` lines.
+
+## Entity Types
+
+| Type | Syntax | Use Case |
+|------|--------|----------|
+| `alarm:` | Specific chart ID | Single instance (e.g., `disk_space._mnt_data`) |
+| `template:` | Chart context | All instances (e.g., all disks via `disk.space`) |
+
+**Key difference:**
+- `template on: disk.space` → matches ALL disks (context)
+- `alarm on: disk_space._mnt_data` → matches ONE specific disk (chart ID)
+
+## Naming Rules (code behavior)
+
+- Names are sanitized; spaces and many symbols become `_`.
+- If sanitization changes the name, Netdata logs a rename and uses the sanitized name.
+- Avoid names that collide with chart/dimension/custom variable names (can shadow variables in expressions).
+
+## Configuration Ordering & Precedence
+
+### Precedence Rules (Same Alert Name)
+
+When multiple alerts have the **same name**, only one can exist per instance:
+
+| Priority | Type | Source |
+|----------|------|--------|
+| 1 (highest) | Alarm | User config |
+| 2 | Alarm | Stock config |
+| 3 | Template | User config |
+| 4 (lowest) | Template | Stock config |
+
+**First-match-wins:** The first matching definition creates the alert; later definitions with the same name are skipped.
+
+### File Locations
+
+| Directory | Purpose | Survives Upgrade |
+|-----------|---------|------------------|
+| `/etc/netdata/health.d/` | User config (loaded first) | Yes |
+| `/usr/lib/netdata/conf.d/health.d/` | Stock config (loaded second) | No |
+
+**File shadowing:** If a file with the same filename exists in both directories, only the user file is loaded.
+
+### Overriding Stock Alerts
+
+**Override ALL instances (template):**
+```
+# User file: /etc/netdata/health.d/my-overrides.conf
+# Same name as stock alert
+ template: 10min_cpu_usage
+       on: system.cpu
+    class: Utilization
+     type: System
+component: CPU
+   lookup: average -10m unaligned of user,system,softirq,irq,guest
+    units: %
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (60) : (75))
+     crit: $this > (($status == $CRITICAL) ? (75) : (90))
+    delay: down 15m multiplier 1.5 max 1h
+  summary: System CPU utilization
+     info: Average CPU utilization over the last 10 minutes
+       to: sysadmin
+```
+
+**Override ONE instance (alarm):**
+```
+# Override disk_space_usage only for /mnt/data
+    alarm: disk_space_usage
+       on: disk_space._mnt_data
+    class: Utilization
+     type: System
+component: Disk
+   lookup: max -1m percentage of avail
+    units: %
+    every: 1m
+     warn: $this < 5
+     crit: $this < 2
+    delay: down 15m multiplier 1.5 max 1h
+  summary: Disk /mnt/data space usage
+     info: Space utilization of /mnt/data (custom thresholds)
+       to: sysadmin
+```
+
+**Using chart labels for targeted override:**
+```
+    template: disk_space_usage
+          on: disk.space
+       class: Utilization
+        type: System
+   component: Disk
+chart labels: mount_point=/mnt/data
+        calc: $used * 100 / ($avail + $used)
+       units: %
+       every: 1m
+        warn: $this > 95
+        crit: $this > 99
+       delay: down 15m multiplier 1.5 max 1h
+     summary: Disk /mnt/data space usage
+        info: Space utilization (custom thresholds)
+          to: sysadmin
+```
+
+### Disabling Alerts
+
+**Method 1: Global disable in netdata.conf**
+```ini
+[health]
+    enabled alarms = !20min_steal_cpu !disk_space_usage *
+```
+
+**Method 2: Per-alert disable (match nothing)**
+```
+ template: 20min_steal_cpu
+       on: system.cpu
+host labels: _hostname=!*
+```
+
+The pattern `_hostname=!*` matches no hosts, effectively disabling the alert.
+
+**Method 3: Silence notifications only**
+```
+ template: 20min_steal_cpu
+       on: system.cpu
+   lookup: average -20m unaligned of steal
+    units: %
+    every: 5m
+     warn: $this > (($status >= $WARNING) ? (5) : (10))
+       to: silent
+```
+
+Alert still appears in dashboard but sends no notifications.
+
+### Applying Changes
+
+```bash
+sudo netdatacli reload-health
+```
+
+Or: `sudo killall -USR2 netdata`
+
+## Required Lines
+
+| Line | Required | Notes |
+|------|----------|-------|
+| `alarm:` or `template:` | Yes | First line; name is sanitized (only alphanumerics, `.` and `_` survive) |
+| `on:` | Yes | Chart ID (alarm) or context (template) |
+| `every:` | If no `lookup` | Evaluation frequency |
+
+**Entity rule:** Each alert must include **at least one** of `lookup`, `calc`, `warn`, or `crit`.  
+`warn`/`crit` are **optional** (helper alerts may omit them).
+
+## Configuration Lines
+
+**Quotes:** `class`, `type`, `component`, `units`, `to`, `exec`, `summary`, `info` accept quotes, but Netdata strips them.
+
+### `on:`
+```
+on: system.cpu        # For alarms: chart ID
+on: disk.space        # For templates: context
+```
+
+### `class:`
+Free-form string. Defaults to `Unknown` if missing.
+
+| Value | Use Case |
+|-------|----------|
+| `Errors` | Error counts, failures, drops |
+| `Latency` | Response times, delays |
+| `Utilization` | Resource usage percentages |
+| `Workload` | Rates, throughput, requests |
+
+### `type:`
+Free-form string. Defaults to `Unknown` if missing.
+
+| Type | Description |
+|------|-------------|
+| `Ad Filtering` | Ad filtering services (e.g., Pi-hole) |
+| `Certificates` | Certificate monitoring |
+| `Cgroups` | cgroups CPU/memory |
+| `Computing` | Shared compute apps (e.g., BOINC) |
+| `Containers` | Docker/Kubernetes/container services |
+| `Database` | Databases (MySQL, PostgreSQL, etc.) |
+| `Data Sharing` | Data sharing services |
+| `DHCP` | DHCP services |
+| `DNS` | DNS services |
+| `Kubernetes` | Kubernetes-related |
+| `KV Storage` | Key-value stores (Redis, Memcached) |
+| `Linux` | Linux-specific services (e.g., systemd) |
+| `Messaging` | Messaging systems |
+| `Netdata` | Netdata internal |
+| `Other` | Catch-all |
+| `Power Supply` | Power systems (e.g., apcupsd) |
+| `Search engine` | Search services (e.g., Elasticsearch) |
+| `Storage` | Storage services (not general system disks) |
+| `System` | General system alerts |
+| `Virtual Machine` | VM software |
+| `Web Proxy` | Web proxies (e.g., Squid) |
+| `Web Server` | Web servers (Apache, Nginx) |
+| `Windows` | Windows services |
+
+### `component:`
+Free-form string. Defaults to `Unknown` if missing.  
+Examples: `CPU`, `Memory`, `Disk`, `Network`, `MySQL`, `Redis`, `Docker`, `PostgreSQL`.
+
+### `host labels:`
+```
+host labels: _os=linux                    # Linux only
+host labels: _os=linux freebsd            # Linux OR FreeBSD
+host labels: environment=production       # Custom label
+host labels: _hostname=!*                 # Disable (match nothing)
+```
+
+Special labels: `_os` (linux/windows/freebsd), `_hostname`
+
+### `os:` (legacy)
+
+Legacy syntax for OS-based filtering. Prefer `host labels: _os=linux` instead.
+
+```
+os: linux
+os: linux freebsd
+```
+
+### `hosts:` (legacy)
+
+Legacy syntax for hostname filtering. Prefer `host labels: _hostname=...` instead.
+
+```
+hosts: server1 server2
+```
+
+### `charts:` and `families:` (legacy)
+
+Accepted but **ignored** by the parser (backward compatibility).  
+Use `on:` and `chart labels:` instead.
+
+### `plugin:` and `module:` (chart labels)
+
+These filter charts by their internal collector plugin and module labels.
+
+```
+plugin: python         # Charts from python collector
+module: mysql         # Charts from mysql module
+```
+
+Used with chart labels for combined filtering:
+```
+chart labels: _collect_plugin=python *
+chart labels: _collect_module=mysql *
+```
+
+### `chart labels:` and `host labels:`
+
+These use **Netdata Simple Patterns** - a space-separated list of match expressions.
+
+**Syntax rules:**
+- You must start with `label_key=...` to set the label key.
+- Values without `=` belong to the **current key**.
+- A value without `=` and **no current key** is ignored.
+- Spaces around `=` are trimmed; commas are **not** supported.
+- Multiple values for the same key are evaluated left-to-right; the first match (including `!`) wins.
+
+#### Simple Patterns Syntax
+
+| Pattern | Meaning | Example |
+|---------|---------|---------|
+| `*` | Match everything | `*` matches any value |
+| `pattern` | Exact match | `linux` matches only "linux" |
+| `pattern*` | Starts with | `disk*` matches "disk_space", "disk1" |
+| `*pattern` | Ends with | `*_error` matches "read_error", "write_error" |
+| `*pattern*` | Contains | `*sql*` matches "mysql", "postgresql" |
+| `!pattern` | Exclude exact | `!linux` excludes only "linux" |
+| `!pattern*` | Exclude starts with | `!/dev*` excludes "/dev", "/dev/sda" |
+| `!*pattern` | Exclude ends with | `!*tmp` excludes "/tmp", "/var/tmp" |
+| `!*pattern*` | Exclude contains | `!*test*` excludes "test", "testing", "mytest" |
+
+#### Pattern Matching Rules
+
+1. **Left to right evaluation** - patterns are checked in order
+2. **First match wins** - the first pattern that matches (including `!` negation) decides the result; remaining patterns are ignored
+3. **Implicit deny** - if no pattern matches, the item is excluded
+4. **Trailing `*` catches all** - typically placed last as a default match
+
+#### Examples
+
+**Important:** All patterns after `label_name=` apply to that label **until another `key=` appears**.  
+You can include multiple label keys in the same line; **all keys must match** (AND).
+
+```
+chart labels: mount_point=!/dev !/dev/* !/run !/run/* !HarddiskVolume* *
+```
+This is ONE label filter (`mount_point`) with multiple patterns:
+- `!/dev` - exclude exact "/dev"
+- `!/dev/*` - exclude anything starting with "/dev/"
+- `!/run` - exclude exact "/run"
+- `!/run/*` - exclude anything starting with "/run/"
+- `!HarddiskVolume*` - exclude Windows volumes starting with "HarddiskVolume"
+- `*` - match everything else (default accept)
+
+**Wrong interpretation:** Do NOT split this into `mount_point=...` and `volume=...` - all patterns belong to `mount_point`.
+
+```
+chart labels: device=!wl* !docker* *
+```
+ONE label filter (`device`) with patterns:
+- `!wl*` - exclude wireless interfaces (wlan0, wlp2s0, etc.)
+- `!docker*` - exclude docker interfaces
+- `*` - match everything else
+
+```
+host labels: _os=linux freebsd
+```
+ONE label filter (`_os`) with patterns:
+- `linux` - match "linux"
+- `freebsd` - match "freebsd"
+- (no trailing `*`, so only these two match)
+
+```
+host labels: _hostname=!*
+```
+Special case: `!*` excludes everything - effectively disables the alert
+
+#### Multiple Labels
+
+You can filter multiple label keys in the **same line** or in **separate lines**.  
+Commas are **not** supported.
+Spaces around `=` are trimmed.
+
+```
+chart labels: mount_point=!/dev* * filesystem=ext4 xfs
+```
+
+### Data Flow: `lookup:` → `calc:`
+
+**Important:** The `$this` variable is the central data carrier:
+
+1. If `lookup:` is present, it executes first and stores the result in `$this`
+2. If `calc:` is present, it evaluates using `$this` (from lookup or previous value) and overwrites `$this` with its result
+3. The final `$this` value is used for `warn:` and `crit:` evaluation
+
+This means:
+- `lookup:` alone: `$this` = lookup result
+- `calc:` alone: `$this` = calc result (uses dimension variables)
+- `lookup:` + `calc:`: lookup runs first, calc can transform `$this`
+
+**Evaluation order:**
+- Netdata computes `$this` for all alerts first (lookup/calc pass).
+- Then it evaluates `warn`/`crit` for status changes.
+
+### `lookup:`
+```
+lookup: METHOD[(GROUP-OPTIONS)] AFTER [at BEFORE] [every DURATION] [OPTIONS] [of DIMENSIONS]
+```
+
+**Group options (inside parentheses):**
+- `countif(CONDITION VALUE)` where CONDITION is one of `=`, `==`, `:`, `!=`, `<>`, `>`, `>=`, `<`, `<=`, `!`  
+  - Examples: `countif(>5)`, `countif(<=0)`, `countif(!=0)`, `countif(:0)`  
+  - If no value is provided (e.g., `countif(>)`), it defaults to `0`.
+- `percentile(N)` where N is 0–100 (default `95` if omitted or empty).
+- `trimmed-mean(N)` / `trimmed-median(N)` where N is trim % (default `5` if omitted or empty).
+
+**Methods (time aggregation) + aliases:**
+
+| Method | Aliases / Notes |
+|--------|----------------|
+| `average` | `avg`, `mean` |
+| `min` |  |
+| `max` |  |
+| `sum` |  |
+| `median` |  |
+| `stddev` |  |
+| `cv` | `rsd`, `coefficient-of-variation` |
+| `ses` | `ema`, `ewma` |
+| `des` |  |
+| `incremental_sum` | `incremental-sum` |
+| `trimmed-mean` | `trimmed-mean1/2/3/5/10/15/20/25` |
+| `trimmed-median` | `trimmed-median1/2/3/5/10/15/20/25` |
+| `percentile` | `percentile25/50/75/80/90/95/97/98/99` |
+| `countif` |  |
+| `extremes` |  |
+
+**Time parameters:**
+- `AFTER` - Start of time window (e.g., `-10m` means 10 minutes ago)
+- `at BEFORE` - End of time window for historical queries (e.g., `at -50m` means ending 50 minutes ago)
+
+Example: `lookup: min -10m at -50m` means "get minimum value from the 10-minute window that ended 50 minutes ago" (i.e., from 60 to 50 minutes ago).
+
+**Time window behavior:**
+
+| Parameter | Effect |
+|-----------|----------|
+| `-10m` | Looks at data from 10 minutes ago to now |
+| `-10m at -50m` | Looks at historical data (60-50 minutes ago) |
+| Window slides | As time progresses, the window moves forward |
+
+This creates a **rolling/sliding window** - the query always examines a fixed-duration window relative to the current time.
+
+**Evaluation frequency defaults:**
+- If `every` is not provided, Netdata uses `abs(AFTER)` as the default evaluation interval.
+- You can override it with `every` inside the `lookup:` line, or with a separate `every:` line (last one wins).
+
+**Dimensions:**
+- `of DIMENSIONS` uses simple patterns (space-separated).
+- `of all` (or omitting `of`) includes all dimensions.
+
+**Options:**
+| Option | Effect |
+|--------|--------|
+| `absolute` / `abs` / `absolute_sum` | Use absolute values before aggregating |
+| `percentage` | Percentage of dimensions over total |
+| `unaligned` | Sliding window (don't align to boundaries) |
+| `min` | Aggregate dimensions by minimum |
+| `max` | Aggregate dimensions by maximum |
+| `average` | Aggregate dimensions by average |
+| `min2max` | Aggregate dimensions by (max - min) |
+| `sum` | Aggregate dimensions by sum (default/no-op) |
+| `null2zero` | Convert null values to zero |
+| `match-ids` / `match_ids` | Match dimensions by IDs (default) |
+| `match-names` / `match_names` | Match dimensions by names |
+| `anomaly-bit` | Use anomaly rate as data source |
+
+**Examples:**
+```
+lookup: average -10m unaligned of user,system,softirq,irq,guest
+lookup: max -1h of used
+lookup: sum -5m absolute of errors
+lookup: average -1m percentage of used
+lookup: min -10m at -50m unaligned of avail   # Historical baseline
+```
+
+Result stored in `$this`. Timestamps available as `$after`, `$before`.
+
+### `calc:`
+
+Evaluates an expression and stores result in `$this`.
+
+```
+calc: $used * 100 / ($avail + $used)              # Percentage from dimensions
+calc: ($rate > 0) ? ($remaining / $rate) : (inf)  # Predictive
+calc: ($condition) ? (value_if_true) : (false)    # Conditional
+calc: abs($value)                                  # Absolute value
+calc: 100 - $this                                  # Transform lookup result
+calc: $this / 1024                                 # Unit conversion
+```
+
+When both `lookup:` and `calc:` are present, `calc:` can reference `$this` to transform the lookup result.
+
+### `units:`
+Examples: `%`, `seconds`, `ms`, `MB`, `GB`, `GB/hour`, `requests/s`, `packets`, `errors`, `hours`
+
+### `every:`
+```
+every: 10s    # Critical metrics
+every: 1m     # Standard
+every: 5m     # Trend analysis
+```
+
+### `green:` and `red:`
+
+Set chart visualization thresholds (not alert thresholds). Values available as `$green` and `$red` variables.
+
+```
+green: 50
+red: 90
+```
+
+**Important:**
+- These are for chart display, not alert triggers
+- Values can be referenced in expressions as `$green` and `$red`
+- Only first alert's thresholds per chart are used for visualization
+
+### `warn:` and `crit:`
+
+**Simple:**
+```
+warn: $this > 80
+crit: $this > 90
+```
+
+**With hysteresis (anti-flapping):**
+
+The ternary operator `(condition) ? (value_if_true) : (value_if_false)` enables hysteresis:
+
+```
+warn: $this > (($status >= $WARNING) ? (75) : (85))
+```
+
+Breaking this down:
+- `$status >= $WARNING` - Is the alert ALREADY in warning (or critical) state?
+- If YES (already alarmed): use threshold `75`
+- If NO (currently clear): use threshold `85`
+
+**Result:**
+- To ENTER warning: value must exceed 85%
+- To STAY in warning: value only needs to exceed 75%
+- To CLEAR: value must drop below 75%
+
+This creates a 10% "dead zone" that prevents flapping when values hover near a threshold.
+
+```
+crit: $this > (($status == $CRITICAL) ? (85) : (95))
+```
+
+Same pattern for critical:
+- To ENTER critical: value must exceed 95%
+- To STAY in critical: value only needs to exceed 85%
+
+**Memory aid:** The FIRST value (after `?`) is the LOWER threshold used when ALREADY alarmed. The SECOND value (after `:`) is the HIGHER threshold used to initially TRIGGER the alarm.
+
+**Low-value alerts (inverted):**
+```
+warn: $this < (($status >= $WARNING) ? (15) : (10))
+```
+
+**With conditions:**
+```
+warn: ($requests > 120) ? ($this > 1) : (0)       # Data availability guard
+crit: ($this > 90) && $avail < 5                  # Compound condition
+warn: $this != nan AND $this > 0                   # NaN safety
+```
+
+**Evaluation notes:**
+- Expressions return a number: `0` = false, non-zero = true.
+- In logical checks, `nan` is false and `inf` is true.
+- If the **final** expression result is `nan` or `inf`, evaluation fails and that check becomes **UNDEFINED**.
+- `nan`/`inf` can exist inside comparisons or short-circuited branches without failing the whole expression.
+
+### `delay:`
+```
+delay: [up U] [down D] [multiplier M] [max X]
+```
+
+| Param | Purpose |
+|-------|---------|
+| `up U` | Delay when worsening (CLEAR→WARNING) |
+| `down D` | Delay when improving (WARNING→CLEAR) |
+| `multiplier M` | Multiply delay on repeated changes |
+| `max X` | Maximum delay |
+
+**Common patterns:**
+```
+delay: down 15m multiplier 1.5 max 1h            # Standard
+delay: up 1m down 15m multiplier 1.5 max 1h      # Quick clear, slow trigger
+delay: up 30s down 15m multiplier 1.5 max 1h     # Quick trigger, slow clear
+```
+
+### `repeat:`
+```
+repeat: warning 1h critical 30m
+repeat: off
+```
+
+### `options:`
+```
+options: no-clear-notification
+options: no-clear
+```
+
+Use when clearing conditions are unreliable (baseline comparisons, volatile metrics).
+Aliases: `no-clear-notification` and `no-clear` do the same thing (disable clear notifications).
+
+### `to:`
+```
+to: sysadmin      # System issues
+to: dba           # Database issues
+to: webmaster     # Web server issues
+to: silent        # Monitor only, no notifications
+```
+
+First parameter passed to `exec` script when alert changes status.
+If omitted, the default recipient is `root` (from `[health]` in `netdata.conf`).
+
+### `exec:`
+
+Custom script to execute when alert status changes.
+
+```
+exec: /path/to/script.sh
+```
+
+**Default:** `alarm-notify.sh` (from `[health]` -> `script to execute on alarm` in `netdata.conf`)
+
+**Important:**
+- Script receives alert details as parameters
+- The `to:` value is the first parameter
+- Status changes trigger execution
+
+### `summary:` and `info:`
+
+**Important:** Values are plain strings. Quotes are allowed but stripped, so avoid them.
+
+```
+summary: Disk ${label:mount_point} space usage
+info: Total space utilization of disk ${label:mount_point}
+```
+
+**Variables available:**
+- `${family}` - chart family
+- `${label:LABEL_NAME}` - value of chart label
+
+These variables are expanded at runtime to show context-specific information.
+
+## Variables
+
+### Special
+| Variable | Contains |
+|----------|----------|
+| `$this` | Current calculated value |
+| `$status` | Current alert status (numeric: -2,-1,0,1,3,4) |
+| `$now` | Current Unix timestamp |
+| `$after` | Query start timestamp |
+| `$before` | Query end timestamp |
+| `$update_every` | Chart update frequency |
+| `$green`, `$red` | Threshold values |
+
+### Status Constants
+
+The `$status` variable holds a numeric value that can be compared with these constants:
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `$REMOVED` | -2 | Alert was deleted |
+| `$UNDEFINED` | -1 | Expression evaluation failed |
+| `$UNINITIALIZED` | 0 | Not yet calculated |
+| `$CLEAR` | 1 | Normal state, no issue |
+| `$WARNING` | 3 | Warning threshold exceeded |
+| `$CRITICAL` | 4 | Critical threshold exceeded |
+
+**Understanding status comparisons:**
+- `$status >= $WARNING` is true when `$status >= 3`, i.e., when alert is in WARNING (3) or CRITICAL (4) state
+- `$status == $CRITICAL` is true when `$status == 4`, i.e., only when alert is in CRITICAL state
+
+**Note:** An internal `RAISED = 2` exists, but it is **not** exposed as `$RAISED` in expressions.
+
+This enables hysteresis: check if the alert is ALREADY triggered before deciding which threshold to use.
+
+### Dimension Variables
+- `$dimension_name` - Last calculated value
+- `$dimension_name_raw` - Last raw value
+- `$dimension_name_last_collected_t` - Collection timestamp
+
+### Chart Variables
+- `$last_collected_t` - Unix timestamp of last data collection
+- Custom chart variables may exist (collector-defined). Use the `alarm_variables` API to list them.
+
+**Common dimensions:**
+- CPU: `$user`, `$system`, `$softirq`, `$irq`, `$guest`, `$iowait`, `$nice`, `$steal`
+- Memory: `$used`, `$available`, `$free`, `$cached`, `$buffers`, `$avail`
+- Disk: `$used`, `$avail`, `$free`
+- Network: `$received`, `$sent`, `$inbound`, `$outbound`
+
+### Cross-Chart References
+```
+calc: $this * 100 / ${system.ram.used}
+calc: ($system.ram.used + $system.ram.cached + $system.ram.free)
+```
+
+Format: `${chart.dimension}` or `$chart.dimension`
+
+**Label-aware resolution:**
+- If multiple chart instances match, Netdata picks the one with the **highest label overlap** with the current chart.
+- Ties depend on internal iteration order (not guaranteed stable).
+
+### Other Alert References
+
+Alerts can reference values from other alerts by using the alert name as a variable:
+
+```
+calc: $this * 100 / $baseline_alert
+warn: $this > $other_alert_threshold
+```
+
+**Important:** Variable names must match the exact alert name. If an alert is named `disk_fill_rate`, reference it as `$disk_fill_rate` - not `$fill_rate` or `$diskFillRate`.
+
+**Dependency Resolution:**
+
+Alerts reference the **most recent stored value** of other alerts (`rc->value`).
+
+**Evaluation order:**
+- Netdata does **not** build a dependency graph.
+- Calculations run sequentially; order is not guaranteed.
+- If Alert B references Alert A and A runs **later**, B uses A’s **previous** value.
+- Circular references are **not resolved** and may yield `nan`/`UNDEFINED`.
+
+## Operators
+
+### Operator Precedence (highest to lowest)
+
+| Priority | Operators | Description |
+|----------|-----------|-------------|
+| 1 (highest) | `()` | Parentheses (grouping) |
+| 2 | `!`, `NOT`, unary `+`/`-`, `abs()` | Unary operators |
+| 3 | `*`, `/`, `%` | Multiplication, division, modulo |
+| 4 | `+`, `-` | Addition, subtraction |
+| 5 | `<`, `<=`, `>`, `>=` | Relational comparisons (left-to-right) |
+| 6 | `==`, `!=`, `<>` | Equality comparisons (left-to-right) |
+| 7 | `&&`, `AND`, `\|\|`, `OR` | Logical operators (same precedence, left-to-right) |
+| 8 (lowest) | `? :` | Ternary conditional |
+
+### Operators Reference
+
+| Type | Operators |
+|------|-----------|
+| Arithmetic | `+`, `-`, `*`, `/`, `%` |
+| Comparison | `<`, `>`, `<=`, `>=`, `==`, `!=`, `<>` |
+| Logical | `&&`, `||`, `!`, `AND`, `OR`, `NOT` |
+
+**Important distinctions:**
+- `&&` and `AND` are logical AND (both conditions must be true)
+- `||` and `OR` are logical OR (either condition must be true)
+- **AND and OR have the same precedence** - evaluated left-to-right
+- Equality (`==`, `!=`, `<>`) has lower precedence than relational (`<`, `<=`, `>`, `>=`)
+- **Short-circuiting applies to logical operators** (`&&`, `||`, `AND`, `OR`)
+- Arithmetic operators always evaluate both sides
+- Use parentheses to ensure intended evaluation order when mixing AND/OR
+
+**Functions:** `abs()`
+
+**Conditional (ternary):** `(condition) ? (true_value) : (false_value)`
+
+**Special values:**
+- `nan` - not a number (use `$this != nan` to check)
+- `inf` - infinite (useful inside comparisons or guards)
+
+**Unary signs:** `+value` and `-value` are supported.
+
+## Common Patterns
+
+### Simple Threshold with Hysteresis
+```
+    template: disk_space_usage
+          on: disk.space
+       class: Utilization
+        type: System
+   component: Disk
+chart labels: mount_point=!/dev !/dev/* !/run !/run/* *
+        calc: $used * 100 / ($avail + $used)
+       units: %
+       every: 1m
+        warn: $this > (($status >= $WARNING) ? (80) : (90))
+        crit: ($this > (($status == $CRITICAL) ? (90) : (98))) && $avail < 5
+       delay: up 1m down 15m multiplier 1.5 max 1h
+     summary: Disk ${label:mount_point} space usage
+        info: Total space utilization of disk ${label:mount_point}
+          to: sysadmin
+```
+
+### Rate-Based Alert
+```
+ template: mysql_slow_queries
+       on: mysql.queries
+    class: Latency
+     type: Database
+component: MySQL
+   lookup: sum -10s of slow_queries
+    units: slow queries
+    every: 10s
+     warn: $this > (($status >= $WARNING) ? (5) : (10))
+     crit: $this > (($status == $CRITICAL) ? (10) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL slow queries
+     info: Number of slow queries in the last 10 seconds
+       to: dba
+```
+
+### Predictive (Time to Full)
+```
+   template: disk_fill_rate
+         on: disk.space
+     lookup: min -10m at -50m unaligned of avail
+       calc: ($this - $avail) / (($now - $after) / 3600)
+      every: 1m
+      units: GB/hour
+       info: Average rate the disk fills up over the last hour
+
+   template: out_of_disk_space_time
+         on: disk.space
+       calc: ($disk_fill_rate > 0) ? ($avail / $disk_fill_rate) : (inf)
+      units: hours
+      every: 10s
+       warn: $this > 0 and $this < (($status >= $WARNING) ? (48) : (8))
+       crit: $this > 0 and $this < (($status == $CRITICAL) ? (24) : (2))
+      delay: down 15m multiplier 1.2 max 1h
+    summary: Disk ${label:mount_point} will run out of space
+       info: Estimated time the disk will run out of space
+         to: sysadmin
+```
+
+### Ratio with Data Availability Guard
+```
+ template: web_log_1m_requests
+       on: web_log.type_requests
+    class: Workload
+     type: Web Server
+component: Web log
+   lookup: sum -1m unaligned
+     calc: ($this == 0) ? (1) : ($this)
+    units: requests
+    every: 10s
+     info: Number of HTTP requests in the last minute
+
+ template: web_log_successful_requests
+       on: web_log.type_requests
+    class: Workload
+     type: Web Server
+component: Web log
+   lookup: sum -1m unaligned of success
+     calc: $this * 100 / $web_log_1m_requests
+    units: %
+    every: 10s
+     warn: ($web_log_1m_requests > 120) ? ($this < 95) : (0)
+     crit: ($web_log_1m_requests > 120) ? ($this < 85) : (0)
+    delay: up 2m down 15m multiplier 1.5 max 1h
+  summary: Web log successful requests
+     info: Ratio of successful HTTP requests over the last minute
+       to: webmaster
+```
+
+### Status/Boolean Check
+```
+ template: redis_master_link_down
+       on: redis.master_link_down_since_time
+    class: Errors
+     type: KV Storage
+component: Redis
+    every: 10s
+     calc: $time
+    units: seconds
+     crit: $this != nan && $this > 0
+  summary: Redis master link down
+     info: Time elapsed since the link between master and slave is down
+       to: dba
+```
+
+### Hit Ratio (Inverted)
+```
+ template: postgres_db_cache_io_ratio
+       on: postgres.db_cache_io_ratio
+    class: Workload
+     type: Database
+component: PostgreSQL
+   lookup: average -1m unaligned of miss
+     calc: 100 - $this
+    units: %
+    every: 1m
+     warn: $this < (($status >= $WARNING) ? (70) : (60))
+     crit: $this < (($status == $CRITICAL) ? (60) : (50))
+    delay: down 15m multiplier 1.5 max 1h
+  summary: PostgreSQL DB ${label:database} cache hit ratio
+     info: Average cache hit ratio in db ${label:database} over the last minute
+       to: dba
+```
+
+### Zero-Tolerance Error
+```
+ template: btrfs_device_write_errors
+       on: btrfs.device_errors
+    class: Errors
+     type: System
+component: File system
+    units: errors
+   lookup: max -10m every 1m of write_errs
+     crit: $this > 0
+    delay: up 1m down 15m multiplier 1.5 max 1h
+  summary: BTRFS device write errors
+     info: Number of encountered BTRFS write errors
+       to: sysadmin
+```
+
+### OS-Specific
+```
+   template: 10min_cpu_usage
+         on: system.cpu
+      class: Utilization
+       type: System
+  component: CPU
+host labels: _os=linux
+     lookup: average -10m unaligned of user,system,softirq,irq,guest
+      units: %
+      every: 1m
+       warn: $this > (($status >= $WARNING) ? (75) : (85))
+       crit: $this > (($status == $CRITICAL) ? (85) : (95))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: System CPU utilization
+       info: Average CPU utilization over the last 10 minutes
+         to: sysadmin
+```
+
+### Spike Detection
+```
+   template: 10s_received_packets_storm
+         on: net.packets
+      class: Workload
+       type: System
+  component: Network
+     lookup: average -10s unaligned of received
+       calc: $this * 100 / (($1m_received_packets_rate < 1000) ? (1000) : ($1m_received_packets_rate))
+      every: 10s
+      units: %
+       warn: $this > (($status >= $WARNING) ? (200) : (5000))
+       crit: $this > (($status == $CRITICAL) ? (5000) : (6000))
+    options: no-clear-notification
+    summary: Network interface ${label:device} inbound packet storm
+       info: Ratio of average received packets over last 10 seconds vs last minute
+         to: silent
+```
+
+## Best Practices
+
+### Thresholds
+- Warning: 70-85% capacity
+- Critical: 85-95% capacity
+- Hysteresis gap: 10-20%
+
+### Time Windows
+| Purpose | Window |
+|---------|--------|
+| Real-time | `-10s` to `-1m` |
+| Short-term | `-5m` to `-10m` |
+| Medium-term | `-1h` to `-4h` |
+| Baseline | `-1d`, `-1w` |
+
+### Evaluation Frequency
+| Type | Frequency |
+|------|-----------|
+| Critical metrics | `10s` to `30s` |
+| Resource usage | `1m` to `5m` |
+| Trend analysis | `5m` to `1h` |
+
+### Required Fields
+Strongly recommended:
+- `class`, `type`, `component` - Classification
+- `summary`, `info` - Documentation
+- `units` - Display units
+- `to` - Notification recipient
+- `delay` - Hysteresis control
+
+### Safety Patterns
+```
+calc: ($divisor > 0) ? ($result) : (fallback)   # Division safety
+calc: ($this == 0) ? (1) : ($this)              # Zero protection
+warn: $this != nan AND $this > threshold        # NaN safety
+```
+
+**Expression Error Handling:**
+
+- If the final result is `nan` or `inf`, evaluation fails and that check becomes **UNDEFINED**.
+- Division by zero yields `inf` (so it fails).
+- `1 * nan` yields `nan` (so it fails).
+- Unknown variables yield `nan` **unless** they are short-circuited away by `&&`, `||`, or `?:`.
+
+**Important:**
+- `nan` and `inf` can appear inside expressions (comparisons handle them)
+- `nan == nan` is **true** and `nan != nan` is **false** (Netdata special handling)
+- `inf == inf` is **true** and `inf != inf` is **false**
+- Use `$this != nan` to guard against NaN
+- Division by zero does NOT crash but yields `inf`
+
+## Validation Checklist
+
+1. First line is `alarm:` or `template:`
+2. `on:` line present
+3. At least one of: `lookup`, `calc`, `warn`, `crit`
+4. `every:` present if no `lookup`
+5. All colons aligned in same column
+6. Units match calculated value semantics
+7. Variables exist on target chart

--- a/src/ai-skills/skills/netdata-api-use.md
+++ b/src/ai-skills/skills/netdata-api-use.md
@@ -1,0 +1,294 @@
+# Netdata API Usage
+
+## Purpose
+
+Query Netdata's REST API to retrieve metrics, contexts, alerts, and system information.
+
+## Base URL
+
+```
+http://localhost:19999/api/v3/
+```
+
+For remote nodes or parents, replace `localhost` with the appropriate hostname/IP.
+
+## Contexts API
+
+Get available contexts (metric types) and their instances (charts).
+
+### Endpoints
+
+```bash
+# Contexts only
+curl -s "http://localhost:19999/api/v3/contexts"
+
+# Contexts + instances (chart IDs) + dimensions
+curl -s "http://localhost:19999/api/v3/contexts?options=instances,dimensions"
+
+# With human-readable timestamps
+curl -s "http://localhost:19999/api/v3/contexts?options=instances,retention,rfc3339"
+
+# Filter by node(s)
+curl -s "http://localhost:19999/api/v3/contexts?scope_nodes=hostname1,hostname2&options=instances"
+
+# Filter by context pattern
+curl -s "http://localhost:19999/api/v3/contexts?scope_contexts=disk.*&options=instances"
+
+# Combined filters
+curl -s "http://localhost:19999/api/v3/contexts?scope_nodes=myserver&scope_contexts=disk.space&options=instances,dimensions,labels"
+```
+
+### Options
+
+| Option | Effect |
+|--------|--------|
+| `instances` | Include chart IDs (instances) |
+| `dimensions` | Include dimension names |
+| `labels` | Include chart labels |
+| `retention` | Include first/last entry timestamps |
+| `liveness` | Include live status |
+| `family` | Include family |
+| `units` | Include units |
+| `priorities` | Include priorities |
+| `titles` | Include titles |
+| `rfc3339` | Human-readable timestamps |
+| `long-keys` | Full JSON key names |
+| `minify` | Compact JSON output |
+
+### Filter Parameters
+
+| Parameter | Effect |
+|-----------|--------|
+| `scope_nodes` | Filter by node hostname(s), comma-separated |
+| `scope_contexts` | Filter by context pattern (supports wildcards) |
+| `after` / `before` | Time range (unix timestamp) |
+| `timeout` | Timeout in ms |
+| `cardinality` | Limit number of results |
+
+### Response Structure
+
+```json
+{
+  "api": 2,
+  "nodes": [
+    {
+      "mg": "machine-guid",
+      "nd": "node-id",
+      "nm": "hostname",
+      "ni": 0
+    }
+  ],
+  "contexts": {
+    "disk.space": {
+      "family": "/[x]",
+      "units": "GiB",
+      "priority": 2023,
+      "first_entry": 1766901600,
+      "last_entry": 1769292789,
+      "live": true,
+      "instances": [
+        "disk_space./",
+        "disk_space./tmp",
+        "disk_space./home"
+      ]
+    }
+  }
+}
+```
+
+## Alerts API
+
+Query current alert states and configurations.
+
+### Endpoints
+
+```bash
+# All alerts (nodes list only)
+curl -s "http://localhost:19999/api/v3/alerts"
+
+# All alerts with instances and values
+curl -s "http://localhost:19999/api/v3/alerts?options=instances,values"
+
+# Filter by alert name
+curl -s "http://localhost:19999/api/v3/alerts?alert=disk_space_usage&options=instances,values"
+
+# Filter by status
+curl -s "http://localhost:19999/api/v3/alerts?status=warning&options=instances"
+curl -s "http://localhost:19999/api/v3/alerts?status=critical&options=instances"
+
+# Filter by node
+curl -s "http://localhost:19999/api/v3/alerts?scope_nodes=myserver&options=instances,values"
+
+# Combined filters
+curl -s "http://localhost:19999/api/v3/alerts?scope_nodes=myserver&alert=disk_space_usage&options=instances,values,config"
+```
+
+### Alert-Specific Parameters
+
+| Parameter | Effect |
+|-----------|--------|
+| `alert` | Filter by alert name |
+| `status` | Filter by status: `warning`, `critical`, `clear` |
+| `transition` | Filter by transition ID |
+
+### Alert Options
+
+| Option | Effect |
+|--------|--------|
+| `instances` | Include alert instances in response |
+| `values` | Include current values |
+| `config` | Include configuration source |
+| `summary` | Include summary counts |
+
+### Response Structure
+
+```json
+{
+  "api": 2,
+  "nodes": [...],
+  "alert_instances": [
+    {
+      "ni": 0,
+      "gi": 1768964039135045,
+      "nm": "disk_space_usage",
+      "ctx": "disk.space",
+      "ch": "disk_space./",
+      "ch_n": "disk_space./",
+      "st": "CLEAR",
+      "fami": "/",
+      "info": "Total space utilization of disk ${label:mount_point}",
+      "sum": "Disk / space usage",
+      "units": "%",
+      "src": "line=11,file=/etc/netdata/health.d/disks.conf",
+      "to": "sysadmin",
+      "tp": "System",
+      "cm": "Disk",
+      "cl": "Utilization",
+      "v": 79.56,
+      "t": 1769292816
+    }
+  ]
+}
+```
+
+### Response Fields
+
+| Field | Meaning |
+|-------|---------|
+| `ni` | Node index |
+| `gi` | Global ID |
+| `nm` | Alert name |
+| `ctx` | Context |
+| `ch` | Chart ID |
+| `ch_n` | Chart name |
+| `st` | Status: `CLEAR`, `WARNING`, `CRITICAL` |
+| `fami` | Family |
+| `info` | Alert info text |
+| `sum` | Summary text |
+| `units` | Units |
+| `src` | Source file and line |
+| `to` | Notification recipient |
+| `tp` | Type |
+| `cm` | Component |
+| `cl` | Class |
+| `v` | Current value |
+| `t` | Timestamp |
+
+## Common Use Cases
+
+### Find Chart ID for a Specific Mount Point
+
+```bash
+curl -s "http://localhost:19999/api/v3/contexts?scope_contexts=disk.space&options=instances" | jq '.contexts["disk.space"].instances'
+```
+
+### Check if Alert Override is Active
+
+```bash
+curl -s "http://localhost:19999/api/v3/alerts?alert=disk_space_usage&options=instances,config" | jq '.alert_instances[0].src'
+```
+
+The `src` field shows the config file path. User overrides are in `/etc/netdata/health.d/`, stock configs in `/usr/lib/netdata/conf.d/health.d/`.
+
+### Get All Critical Alerts
+
+```bash
+curl -s "http://localhost:19999/api/v3/alerts?status=critical&options=instances,values" | jq '.alert_instances[] | {name: .nm, chart: .ch, value: .v, info: .sum}'
+```
+
+### Get Dimensions for a Context
+
+```bash
+curl -s "http://localhost:19999/api/v3/contexts?scope_contexts=system.cpu&options=dimensions" | jq '.contexts["system.cpu"]'
+```
+
+### List All Contexts on a Node
+
+```bash
+curl -s "http://localhost:19999/api/v3/contexts?scope_nodes=myserver" | jq '.contexts | keys'
+```
+
+### Get Alert History/Transitions
+
+```bash
+curl -s "http://localhost:19999/api/v3/alert_transitions?alert=disk_space_usage&last=10"
+```
+
+## Data Query API
+
+Query time-series data from charts.
+
+### Endpoints
+
+```bash
+# Query data for a chart
+curl -s "http://localhost:19999/api/v3/data?contexts=system.cpu&after=-300"
+
+# Multiple contexts
+curl -s "http://localhost:19999/api/v3/data?contexts=system.cpu,system.load&after=-300"
+
+# Specific dimensions
+curl -s "http://localhost:19999/api/v3/data?contexts=system.cpu&dimensions=user,system&after=-300"
+
+# With aggregation
+curl -s "http://localhost:19999/api/v3/data?contexts=system.cpu&after=-3600&points=60&group=average"
+```
+
+### Query Parameters
+
+| Parameter | Effect |
+|-----------|--------|
+| `contexts` | Context(s) to query, comma-separated |
+| `scope_nodes` | Filter by node(s) |
+| `dimensions` | Specific dimensions to include |
+| `after` | Start time (negative = seconds ago, or unix timestamp) |
+| `before` | End time (default: now) |
+| `points` | Number of points to return |
+| `group` | Aggregation: `average`, `min`, `max`, `sum` |
+| `format` | Output format: `json`, `csv`, `tsv` |
+
+## Error Handling
+
+### HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 400 | Bad request (invalid parameters) |
+| 404 | Context/chart not found |
+| 503 | Service unavailable |
+
+### Check Node Status
+
+The response includes node status:
+
+```json
+"st": {
+  "ai": 0,
+  "code": 200,
+  "msg": ""
+}
+```
+
+- `code: 200` = OK
+- `code: 503` = Node unavailable

--- a/src/ai-skills/tests/alerts-config/cases/10min_cpu_usage_linux.conf
+++ b/src/ai-skills/tests/alerts-config/cases/10min_cpu_usage_linux.conf
@@ -1,0 +1,15 @@
+   template: 10min_cpu_usage
+         on: system.cpu
+      class: Utilization
+       type: System
+  component: CPU
+host labels: _os=linux
+     lookup: average -10m unaligned of user,system,softirq,irq,guest
+      units: %
+      every: 1m
+       warn: $this > (($status >= $WARNING)  ? (75) : (85))
+       crit: $this > (($status == $CRITICAL) ? (85) : (95))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: System CPU utilization
+       info: Average CPU utilization over the last 10 minutes (excluding iowait, nice and steal)
+         to: sysadmin

--- a/src/ai-skills/tests/alerts-config/cases/disk_fill_rate.conf
+++ b/src/ai-skills/tests/alerts-config/cases/disk_fill_rate.conf
@@ -1,0 +1,7 @@
+   template: disk_fill_rate
+         on: disk.space
+     lookup: min -10m at -50m unaligned of avail
+       calc: ($this - $avail) / (($now - $after) / 3600)
+      every: 1m
+      units: GB/hour
+       info: average rate the disk fills up (positive), or frees up (negative) space, for the last hour

--- a/src/ai-skills/tests/alerts-config/cases/disk_space_usage.conf
+++ b/src/ai-skills/tests/alerts-config/cases/disk_space_usage.conf
@@ -1,0 +1,15 @@
+    template: disk_space_usage
+          on: disk.space
+       class: Utilization
+        type: System
+   component: Disk
+chart labels: mount_point=!/dev !/dev/* !/run !/run/* !HarddiskVolume* *
+        calc: $used * 100 / ($avail + $used)
+       units: %
+       every: 1m
+        warn: $this > (($status >= $WARNING ) ? (80) : (90))
+        crit: ($this > (($status == $CRITICAL) ? (90) : (98))) && $avail < 5
+       delay: up 1m down 15m multiplier 1.5 max 1h
+     summary: Disk ${label:mount_point} space usage
+        info: Total space utilization of disk ${label:mount_point}
+          to: sysadmin

--- a/src/ai-skills/tests/alerts-config/cases/out_of_disk_space_time.conf
+++ b/src/ai-skills/tests/alerts-config/cases/out_of_disk_space_time.conf
@@ -1,0 +1,11 @@
+   template: out_of_disk_space_time
+         on: disk.space
+       calc: ($disk_fill_rate > 0) ? ($avail / $disk_fill_rate) : (inf)
+      units: hours
+      every: 10s
+       warn: $this > 0 and $this < (($status >= $WARNING)  ? (48) : (8))
+       crit: $this > 0 and $this < (($status == $CRITICAL) ? (24) : (2))
+      delay: down 15m multiplier 1.2 max 1h
+    summary: Disk ${label:mount_point} estimation of lack of space
+       info: Estimated time the disk ${label:mount_point} will run out of space, if the system continues to add data with the rate of the last hour
+         to: silent

--- a/src/ai-skills/tests/config.yaml
+++ b/src/ai-skills/tests/config.yaml
@@ -1,0 +1,32 @@
+# AI Skills Test Configuration
+
+models:
+  # Large model - reference for correctness
+  large:
+    name: minimax-m2.1
+    endpoint: http://10.20.4.21:8353/v1
+    model_id: minimax-m2.1
+    max_tokens: 8192
+    is_reasoning: true
+
+  # Small model - tests prompt clarity
+  small:
+    name: gpt-oss-20b
+    endpoint: http://10.20.4.205:8345/v1
+    model_id: gpt-oss-20b
+    max_tokens: 8192
+    is_reasoning: true
+
+# Test result interpretation
+results:
+  # Both pass = PASS (skill is good)
+  # Large pass, small fail = WARNING (skill works but could be clearer)
+  # Large fail = FAIL (skill needs fixing)
+
+test_settings:
+  # Retry failed tests this many times
+  retries: 1
+  # Timeout per API call in seconds
+  timeout: 120
+  # Save reasoning traces for debugging
+  save_reasoning: true

--- a/src/ai-skills/tests/framework/.gitignore
+++ b/src/ai-skills/tests/framework/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/src/ai-skills/tests/framework/__init__.py
+++ b/src/ai-skills/tests/framework/__init__.py
@@ -1,0 +1,4 @@
+# AI Skills Test Framework
+from .models import call_model, get_model_config, load_config, ModelConfig, ModelResponse
+from .normalize import normalize_alert, alerts_equal, parse_alert_config
+from .round_trip import run_test_suite, TestCase, TestResult, TestSuiteResult

--- a/src/ai-skills/tests/framework/models.py
+++ b/src/ai-skills/tests/framework/models.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Model API wrappers for AI Skills testing.
+Supports both standard and reasoning models via OpenAI-compatible endpoints.
+"""
+
+import json
+import requests
+from dataclasses import dataclass
+from typing import Optional
+from pathlib import Path
+import yaml
+
+
+@dataclass
+class ModelResponse:
+    """Response from a model API call."""
+    content: str
+    reasoning: Optional[str] = None
+    model: str = ""
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    finish_reason: str = ""  # "stop", "length", etc.
+    truncated: bool = False  # True if finish_reason == "length"
+    success: bool = True
+    error: Optional[str] = None
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for a model endpoint."""
+    name: str
+    endpoint: str
+    model_id: str
+    max_tokens: int = 4096
+    is_reasoning: bool = False
+    timeout: int = 120
+
+
+def load_config(config_path: Optional[Path] = None) -> dict:
+    """Load configuration from YAML file."""
+    if config_path is None:
+        config_path = Path(__file__).parent.parent / "config.yaml"
+
+    with open(config_path) as f:
+        return yaml.safe_load(f)
+
+
+def get_model_config(model_size: str, config: Optional[dict] = None) -> ModelConfig:
+    """Get model configuration by size (large/small)."""
+    if config is None:
+        config = load_config()
+
+    model_cfg = config["models"][model_size]
+    timeout = config.get("test_settings", {}).get("timeout", 120)
+
+    return ModelConfig(
+        name=model_cfg["name"],
+        endpoint=model_cfg["endpoint"],
+        model_id=model_cfg["model_id"],
+        max_tokens=model_cfg.get("max_tokens", 4096),
+        is_reasoning=model_cfg.get("is_reasoning", False),
+        timeout=timeout,
+    )
+
+
+def call_model(
+    model: ModelConfig,
+    system_prompt: str,
+    user_prompt: str,
+    temperature: float = 0.0,
+) -> ModelResponse:
+    """
+    Call a model with the given prompts.
+
+    Args:
+        model: Model configuration
+        system_prompt: System/instruction prompt
+        user_prompt: User message
+        temperature: Sampling temperature (0.0 for deterministic)
+
+    Returns:
+        ModelResponse with content and optional reasoning
+    """
+    url = f"{model.endpoint}/chat/completions"
+
+    payload = {
+        "model": model.model_id,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "max_tokens": model.max_tokens,
+        "temperature": temperature,
+    }
+
+    try:
+        response = requests.post(
+            url,
+            headers={"Content-Type": "application/json"},
+            json=payload,
+            timeout=model.timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        choice = data["choices"][0]
+        message = choice["message"]
+        usage = data.get("usage", {})
+        finish_reason = choice.get("finish_reason", "")
+
+        # Extract content - handle reasoning models
+        content = message.get("content") or ""
+        reasoning = message.get("reasoning_content") or message.get("reasoning")
+
+        # Check if response was truncated due to max_tokens
+        truncated = finish_reason == "length"
+
+        return ModelResponse(
+            content=content,
+            reasoning=reasoning,
+            model=model.name,
+            prompt_tokens=usage.get("prompt_tokens", 0),
+            completion_tokens=usage.get("completion_tokens", 0),
+            finish_reason=finish_reason,
+            truncated=truncated,
+            success=True,
+        )
+
+    except requests.exceptions.Timeout:
+        return ModelResponse(
+            content="",
+            model=model.name,
+            success=False,
+            error=f"Timeout after {model.timeout}s",
+        )
+    except requests.exceptions.RequestException as e:
+        return ModelResponse(
+            content="",
+            model=model.name,
+            success=False,
+            error=str(e),
+        )
+    except (KeyError, json.JSONDecodeError) as e:
+        return ModelResponse(
+            content="",
+            model=model.name,
+            success=False,
+            error=f"Invalid response: {e}",
+        )
+
+
+def test_model_connection(model: ModelConfig) -> bool:
+    """Test if a model endpoint is reachable and responding."""
+    try:
+        response = requests.get(
+            f"{model.endpoint}/models",
+            timeout=10,
+        )
+        return response.status_code == 200
+    except requests.exceptions.RequestException:
+        return False
+
+
+if __name__ == "__main__":
+    # Quick test of both models
+    config = load_config()
+
+    for size in ["large", "small"]:
+        model = get_model_config(size, config)
+        print(f"\nTesting {model.name} ({size})...")
+
+        if test_model_connection(model):
+            print(f"  Connection: OK")
+            response = call_model(
+                model,
+                system_prompt="You are a helpful assistant.",
+                user_prompt="Say 'test successful' and nothing else.",
+            )
+            if response.success:
+                print(f"  Response: {response.content}")
+                if response.reasoning:
+                    print(f"  Reasoning: {response.reasoning[:100]}...")
+            else:
+                print(f"  Error: {response.error}")
+        else:
+            print(f"  Connection: FAILED")

--- a/src/ai-skills/tests/framework/normalize.py
+++ b/src/ai-skills/tests/framework/normalize.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Normalization utilities for comparing AI-generated outputs with originals.
+Handles alert definitions and other Netdata configuration formats.
+"""
+
+import re
+from typing import Dict, Any, List, Optional
+from dataclasses import dataclass
+
+
+@dataclass
+class NormalizedAlert:
+    """Normalized representation of a Netdata alert."""
+    template: str           # Alert template name
+    on: str                 # Chart/context this applies to
+    class_name: str         # Alert classification
+    type_name: str          # Alert type
+    component: str          # Component name
+    lookup: Optional[str]   # Lookup expression
+    calc: Optional[str]     # Calculation expression
+    every: Optional[str]    # Evaluation frequency
+    units: Optional[str]    # Display units
+    warn: Optional[str]     # Warning condition
+    crit: Optional[str]     # Critical condition
+    delay: Optional[str]    # Delay settings
+    summary: Optional[str]  # Summary template
+    info: Optional[str]     # Info template
+    to: Optional[str]       # Notification target
+    options: List[str]      # Alert options
+    host_labels: Optional[str]
+    chart_labels: Optional[str]
+
+
+def normalize_duration(duration: str) -> str:
+    """
+    Normalize duration strings to canonical form.
+
+    Examples:
+        1m -> 60s
+        1h -> 3600s
+        1d -> 86400s
+        60s -> 60s
+    """
+    if not duration:
+        return ""
+
+    duration = duration.strip().lower()
+
+    # Already in seconds
+    if duration.endswith('s') and duration[:-1].isdigit():
+        return duration
+
+    multipliers = {
+        's': 1,
+        'm': 60,
+        'h': 3600,
+        'd': 86400,
+        'w': 604800,
+    }
+
+    # Handle compound durations like "1h30m"
+    total_seconds = 0
+    current_num = ""
+
+    for char in duration:
+        if char.isdigit() or char == '.':
+            current_num += char
+        elif char in multipliers and current_num:
+            total_seconds += float(current_num) * multipliers[char]
+            current_num = ""
+
+    if total_seconds > 0:
+        return f"{int(total_seconds)}s"
+
+    return duration
+
+
+def normalize_expression(expr: str) -> str:
+    """
+    Normalize mathematical expressions.
+
+    - Remove extra whitespace
+    - Normalize operators
+    - Sort commutative operations where possible
+    """
+    if not expr:
+        return ""
+
+    # Remove extra whitespace
+    expr = " ".join(expr.split())
+
+    # Normalize comparison operators
+    expr = re.sub(r'\s*([<>=!]+)\s*', r' \1 ', expr)
+
+    # Normalize arithmetic operators
+    expr = re.sub(r'\s*([+\-*/])\s*', r' \1 ', expr)
+
+    # Clean up multiple spaces
+    expr = " ".join(expr.split())
+
+    return expr.strip()
+
+
+def normalize_whitespace(text: str) -> str:
+    """Normalize whitespace in text."""
+    if not text:
+        return ""
+    return " ".join(text.split())
+
+
+def parse_alert_config(config_text: str) -> Dict[str, Any]:
+    """
+    Parse a Netdata alert configuration block into a dictionary.
+
+    Args:
+        config_text: Raw alert configuration text
+
+    Returns:
+        Dictionary with normalized alert fields
+    """
+    result = {}
+    current_key = None
+    current_value = []
+
+    for line in config_text.strip().split('\n'):
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith('#'):
+            continue
+
+        # Check if this is a key: value line
+        if ':' in line and not line.startswith(' '):
+            # Save previous key-value if exists
+            if current_key:
+                result[current_key] = normalize_whitespace(' '.join(current_value))
+
+            # Parse new key-value
+            key, _, value = line.partition(':')
+            current_key = key.strip().lower().replace(' ', '_')
+            current_value = [value.strip()] if value.strip() else []
+        else:
+            # Continuation of previous value
+            if current_key:
+                current_value.append(line)
+
+    # Don't forget the last key-value
+    if current_key:
+        result[current_key] = normalize_whitespace(' '.join(current_value))
+
+    return result
+
+
+def normalize_alert(config_text: str) -> Dict[str, str]:
+    """
+    Fully normalize an alert configuration for comparison.
+
+    Args:
+        config_text: Raw alert configuration text
+
+    Returns:
+        Dictionary with normalized, comparable values
+    """
+    parsed = parse_alert_config(config_text)
+    normalized = {}
+
+    # Fields that need duration normalization
+    duration_fields = ['every', 'delay', 'after']
+
+    # Fields that need expression normalization
+    expression_fields = ['lookup', 'calc', 'warn', 'crit']
+
+    for key, value in parsed.items():
+        if key in duration_fields:
+            normalized[key] = normalize_duration(value)
+        elif key in expression_fields:
+            normalized[key] = normalize_expression(value)
+        else:
+            normalized[key] = normalize_whitespace(value)
+
+    return normalized
+
+
+def alerts_equal(alert1: str, alert2: str) -> tuple[bool, List[str]]:
+    """
+    Compare two alert configurations for equality.
+
+    Args:
+        alert1: First alert configuration
+        alert2: Second alert configuration
+
+    Returns:
+        Tuple of (are_equal, list_of_differences)
+    """
+    norm1 = normalize_alert(alert1)
+    norm2 = normalize_alert(alert2)
+
+    differences = []
+
+    # Get all keys from both
+    all_keys = set(norm1.keys()) | set(norm2.keys())
+
+    for key in sorted(all_keys):
+        val1 = norm1.get(key, "<missing>")
+        val2 = norm2.get(key, "<missing>")
+
+        if val1 != val2:
+            differences.append(f"{key}: '{val1}' != '{val2}'")
+
+    return len(differences) == 0, differences
+
+
+if __name__ == "__main__":
+    # Test normalization
+    test_alert = """
+ template: disk_space_usage
+       on: disk.space
+    class: Utilization
+     type: System
+component: Disk
+   lookup: average -1m unaligned of avail
+    units: %
+     calc: $avail * 100 / ($avail + $used)
+    every: 1m
+     warn: $this > 80
+     crit: $this > 90
+    delay: down 15m multiplier 1.5 max 1h
+  summary: Disk space usage on ${label:mount_point}
+     info: Disk space utilization on ${label:mount_point}
+       to: sysadmin
+    """
+
+    print("Parsing alert configuration...")
+    normalized = normalize_alert(test_alert)
+
+    for key, value in sorted(normalized.items()):
+        print(f"  {key}: {value}")

--- a/src/ai-skills/tests/framework/round_trip.py
+++ b/src/ai-skills/tests/framework/round_trip.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""
+Round-trip test framework for AI Skills.
+
+Tests that an AI model can:
+1. Describe an artifact (alert, config, etc.) in natural language
+2. Recreate the exact artifact from that description
+
+If original == regenerated, the skill contains sufficient information.
+"""
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional, Callable
+
+try:
+    from .models import load_config, get_model_config, call_model, ModelConfig
+    from .normalize import alerts_equal
+except ImportError:
+    from models import load_config, get_model_config, call_model, ModelConfig
+    from normalize import alerts_equal
+
+
+@dataclass
+class TestCase:
+    """A single test case."""
+    name: str
+    original: str
+    skill_path: Path
+
+
+@dataclass
+class TestResult:
+    """Result of a single test."""
+    test_name: str
+    model_name: str
+    model_size: str  # "large" or "small"
+    passed: bool
+    original: str
+    description: str
+    regenerated: str
+    differences: List[str]
+    reasoning_describe: Optional[str] = None
+    reasoning_regenerate: Optional[str] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class TestSuiteResult:
+    """Result of a complete test suite run."""
+    skill_name: str
+    timestamp: str
+    results: List[TestResult]
+    summary: dict
+
+
+def load_skill(skill_path: Path) -> str:
+    """Load a skill file content."""
+    with open(skill_path) as f:
+        return f.read()
+
+
+def run_single_test(
+    test_case: TestCase,
+    model: ModelConfig,
+    model_size: str,
+    skill_content: str,
+    compare_fn: Callable[[str, str], tuple[bool, List[str]]],
+) -> TestResult:
+    """
+    Run a single round-trip test.
+
+    1. Ask model to describe the original artifact
+    2. Ask model to regenerate artifact from description
+    3. Compare original with regenerated
+    """
+    # Step 1: Describe the original
+    describe_prompt = f"""You are given the following Netdata configuration artifact.
+Describe it completely and precisely. Include every detail needed to recreate it exactly.
+
+ARTIFACT:
+```
+{test_case.original}
+```
+
+Provide a complete description that captures all fields, values, and their meanings."""
+
+    describe_response = call_model(
+        model,
+        system_prompt=skill_content,
+        user_prompt=describe_prompt,
+    )
+
+    if not describe_response.success:
+        return TestResult(
+            test_name=test_case.name,
+            model_name=model.name,
+            model_size=model_size,
+            passed=False,
+            original=test_case.original,
+            description="",
+            regenerated="",
+            differences=[],
+            error=f"Describe step failed: {describe_response.error}",
+        )
+
+    description = describe_response.content
+
+    # Step 2: Regenerate from description
+    regenerate_prompt = f"""Based on the following description, recreate the exact Netdata configuration artifact.
+Output ONLY the configuration, no explanations or markdown formatting.
+
+DESCRIPTION:
+{description}
+
+Output the configuration exactly as it should appear in the configuration file."""
+
+    regenerate_response = call_model(
+        model,
+        system_prompt=skill_content,
+        user_prompt=regenerate_prompt,
+    )
+
+    if not regenerate_response.success:
+        return TestResult(
+            test_name=test_case.name,
+            model_name=model.name,
+            model_size=model_size,
+            passed=False,
+            original=test_case.original,
+            description=description,
+            regenerated="",
+            differences=[],
+            reasoning_describe=describe_response.reasoning,
+            error=f"Regenerate step failed: {regenerate_response.error}",
+        )
+
+    regenerated = regenerate_response.content
+
+    # Step 3: Compare
+    passed, differences = compare_fn(test_case.original, regenerated)
+
+    return TestResult(
+        test_name=test_case.name,
+        model_name=model.name,
+        model_size=model_size,
+        passed=passed,
+        original=test_case.original,
+        description=description,
+        regenerated=regenerated,
+        differences=differences,
+        reasoning_describe=describe_response.reasoning,
+        reasoning_regenerate=regenerate_response.reasoning,
+    )
+
+
+def run_test_suite(
+    test_cases: List[TestCase],
+    skill_path: Path,
+    compare_fn: Callable[[str, str], tuple[bool, List[str]]],
+    config: Optional[dict] = None,
+) -> TestSuiteResult:
+    """
+    Run a complete test suite against both models.
+
+    Returns results with summary:
+    - PASS: Both models passed
+    - WARNING: Large passed, small failed
+    - FAIL: Large model failed
+    """
+    if config is None:
+        config = load_config()
+
+    skill_content = load_skill(skill_path)
+    results = []
+
+    large_model = get_model_config("large", config)
+    small_model = get_model_config("small", config)
+
+    for test_case in test_cases:
+        print(f"\n  Testing: {test_case.name}")
+
+        # Test with large model first
+        print(f"    {large_model.name}...", end=" ", flush=True)
+        large_result = run_single_test(
+            test_case, large_model, "large", skill_content, compare_fn
+        )
+        results.append(large_result)
+        print("PASS" if large_result.passed else "FAIL")
+
+        # Test with small model
+        print(f"    {small_model.name}...", end=" ", flush=True)
+        small_result = run_single_test(
+            test_case, small_model, "small", skill_content, compare_fn
+        )
+        results.append(small_result)
+        print("PASS" if small_result.passed else "FAIL")
+
+    # Calculate summary
+    large_results = [r for r in results if r.model_size == "large"]
+    small_results = [r for r in results if r.model_size == "small"]
+
+    large_passed = sum(1 for r in large_results if r.passed)
+    small_passed = sum(1 for r in small_results if r.passed)
+
+    total_tests = len(test_cases)
+
+    # Determine overall status
+    if large_passed == total_tests and small_passed == total_tests:
+        status = "PASS"
+    elif large_passed == total_tests:
+        status = "WARNING"  # Large passed but small failed some
+    else:
+        status = "FAIL"
+
+    summary = {
+        "status": status,
+        "total_tests": total_tests,
+        "large_model": {
+            "name": large_model.name,
+            "passed": large_passed,
+            "failed": total_tests - large_passed,
+        },
+        "small_model": {
+            "name": small_model.name,
+            "passed": small_passed,
+            "failed": total_tests - small_passed,
+        },
+    }
+
+    return TestSuiteResult(
+        skill_name=skill_path.stem,
+        timestamp=datetime.now().isoformat(),
+        results=results,
+        summary=summary,
+    )
+
+
+def save_results(result: TestSuiteResult, output_dir: Path):
+    """Save test results to JSON file."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_file = output_dir / f"{result.skill_name}_{timestamp}.json"
+
+    # Convert to serializable format
+    output = {
+        "skill_name": result.skill_name,
+        "timestamp": result.timestamp,
+        "summary": result.summary,
+        "results": [asdict(r) for r in result.results],
+    }
+
+    with open(output_file, "w") as f:
+        json.dump(output, f, indent=2)
+
+    print(f"\nResults saved to: {output_file}")
+    return output_file
+
+
+def print_summary(result: TestSuiteResult):
+    """Print test summary to console."""
+    s = result.summary
+
+    print("\n" + "=" * 60)
+    print(f"SKILL: {result.skill_name}")
+    print("=" * 60)
+
+    status_colors = {
+        "PASS": "\033[92m",    # Green
+        "WARNING": "\033[93m", # Yellow
+        "FAIL": "\033[91m",    # Red
+    }
+    reset = "\033[0m"
+
+    color = status_colors.get(s["status"], "")
+    print(f"\nStatus: {color}{s['status']}{reset}")
+
+    print(f"\n{s['large_model']['name']} (large):")
+    print(f"  Passed: {s['large_model']['passed']}/{s['total_tests']}")
+
+    print(f"\n{s['small_model']['name']} (small):")
+    print(f"  Passed: {s['small_model']['passed']}/{s['total_tests']}")
+
+    # Show failures
+    failures = [r for r in result.results if not r.passed]
+    if failures:
+        print("\nFailures:")
+        for f in failures:
+            print(f"\n  {f.test_name} ({f.model_name}):")
+            if f.error:
+                print(f"    Error: {f.error}")
+            else:
+                for diff in f.differences[:5]:  # Show first 5 differences
+                    print(f"    - {diff}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run round-trip tests for AI skills"
+    )
+    parser.add_argument(
+        "skill",
+        type=Path,
+        help="Path to skill file",
+    )
+    parser.add_argument(
+        "test_cases",
+        type=Path,
+        help="Path to test cases directory or file",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(__file__).parent.parent.parent / "results",
+        help="Output directory for results",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        help="Path to config file",
+    )
+
+    args = parser.parse_args()
+
+    if not args.skill.exists():
+        print(f"Error: Skill file not found: {args.skill}")
+        sys.exit(1)
+
+    # Load test cases
+    # TODO: Implement test case loading based on format
+    print("Loading test cases...")
+    test_cases = []  # Placeholder
+
+    if not test_cases:
+        print("No test cases found. Please add test cases to run.")
+        sys.exit(0)
+
+    print(f"Running {len(test_cases)} tests...")
+
+    config = None
+    if args.config:
+        import yaml
+        with open(args.config) as f:
+            config = yaml.safe_load(f)
+
+    result = run_test_suite(
+        test_cases,
+        args.skill,
+        alerts_equal,  # Default comparator for alerts
+        config,
+    )
+
+    print_summary(result)
+    save_results(result, args.output)
+
+    # Exit with appropriate code
+    if result.summary["status"] == "FAIL":
+        sys.exit(1)
+    elif result.summary["status"] == "WARNING":
+        sys.exit(2)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ai-skills/tests/framework/skill_tester.py
+++ b/src/ai-skills/tests/framework/skill_tester.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+"""
+Three-call skill testing framework.
+
+Tests that an AI model can:
+1. Describe an artifact in natural language (no config statements)
+2. Recreate the artifact from the description
+3. Self-assess the result and provide skill improvement recommendations
+
+This approach surfaces skill gaps through the model's own reasoning.
+"""
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, asdict, field
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+try:
+    from .models import load_config, get_model_config, call_model, ModelConfig, ModelResponse
+except ImportError:
+    from models import load_config, get_model_config, call_model, ModelConfig, ModelResponse
+
+
+@dataclass
+class Assessment:
+    """LLM self-assessment of the round-trip test."""
+    is_equivalent: bool = False
+    step_1_errors: List[str] = field(default_factory=list)
+    step_2_errors: List[str] = field(default_factory=list)
+    step_1_reasoning_issues: List[str] = field(default_factory=list)
+    step_2_reasoning_issues: List[str] = field(default_factory=list)
+    skill_improvements: List[str] = field(default_factory=list)
+    raw_json: str = ""
+    parse_error: Optional[str] = None
+
+
+@dataclass
+class TestResult:
+    """Complete result of a three-call test."""
+    test_name: str
+    model_name: str
+    model_size: str
+
+    # Step 1: Describe
+    prompt_step1: str = ""
+    description: str = ""
+    reasoning_step1: Optional[str] = None
+
+    # Step 2: Recreate
+    prompt_step2: str = ""
+    recreated: str = ""
+    reasoning_step2: Optional[str] = None
+
+    # Step 3: Assessment
+    prompt_step3: str = ""
+    assessment: Optional[Assessment] = None
+    reasoning_step3: Optional[str] = None
+
+    # Original artifact
+    original: str = ""
+
+    # Status
+    passed: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class TestSuiteResult:
+    """Result of testing a skill with multiple test cases."""
+    skill_name: str
+    timestamp: str
+    model_name: str
+    model_size: str
+    skill_content: str  # The system prompt (skill file contents)
+    results: List[TestResult]
+    all_skill_improvements: List[str]
+    summary: dict
+
+
+def load_skill(skill_path: Path) -> str:
+    """Load skill content from file."""
+    with open(skill_path) as f:
+        return f.read()
+
+
+def load_test_case(case_path: Path) -> str:
+    """Load a single test case (alert definition)."""
+    with open(case_path) as f:
+        return f.read().strip()
+
+
+def extract_json_from_response(text: str) -> Optional[dict]:
+    """Extract JSON object from model response, handling markdown code blocks."""
+    import re
+
+    # Try to find JSON in code block first
+    code_block = re.search(r'```(?:json)?\s*(\{.*?\})\s*```', text, re.DOTALL)
+    if code_block:
+        try:
+            return json.loads(code_block.group(1))
+        except json.JSONDecodeError:
+            pass
+
+    # Try to find raw JSON object
+    json_match = re.search(r'\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}', text, re.DOTALL)
+    if json_match:
+        try:
+            return json.loads(json_match.group())
+        except json.JSONDecodeError:
+            pass
+
+    # Last resort: try the whole text
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def run_step1_describe(
+    model: ModelConfig,
+    skill_content: str,
+    original_alert: str,
+) -> tuple[ModelResponse, str]:
+    """
+    Step 1: Ask model to describe the alert in natural language.
+
+    The description must NOT contain any configuration statements - only
+    natural language that describes what the alert does.
+
+    Returns: (response, user_prompt)
+    """
+    user_prompt = f"""Describe in natural language the following Netdata alert definition.
+
+CRITICAL: Do NOT use any configuration keywords in your description. Describe WHAT the alert does, not HOW it's configured.
+
+RULES:
+1. State the alert name in backticks (e.g., `disk_space_usage`)
+2. Describe the SCOPE: Does it apply to ONE specific instance, or ALL instances of something? (Do NOT say "template" or "alarm" - describe what it monitors)
+3. CRITICAL - Copy the summary and info strings VERBATIM in quotes. Example format:
+   - Summary: "System CPU utilization"
+   - Info: "Average CPU utilization over the last 10 minutes (excluding iowait, nice and steal)"
+   If summary or info is missing from the original, say "No summary provided" or "No info provided"
+4. For label filters, describe in plain English what is included and excluded
+5. Describe the data calculation in ONE sentence: what data is queried, over what time window, and how it's transformed
+6. If the calculation references another alert's value, state the EXACT variable name (e.g., "uses the value from `$disk_fill_rate`")
+7. Explain warning and critical conditions in plain English, including the hysteresis behavior
+8. Include evaluation frequency, delay behavior, and who receives notifications
+9. Mention the units of the result
+10. Mention classification (class, type, component) ONLY if present in the original - if not present, say nothing about classification
+
+FORBIDDEN WORDS: template, alarm, lookup, calc, on:, warn:, crit:, every:, delay:, to:
+
+Write flowing natural language that a user would say when requesting this alert.
+
+ALERT DEFINITION:
+```
+{original_alert}
+```
+
+Write your natural language description:"""
+
+    return call_model(model, system_prompt=skill_content, user_prompt=user_prompt), user_prompt
+
+
+def run_step2_recreate(
+    model: ModelConfig,
+    skill_content: str,
+    description: str,
+) -> tuple[ModelResponse, str]:
+    """
+    Step 2: Ask model to recreate the alert from the description.
+
+    Returns: (response, user_prompt)
+    """
+    user_prompt = f"""Create a Netdata alert configuration based on this description.
+
+RULES:
+1. Include ONLY what is described - do NOT add fields that weren't mentioned
+2. Use EXACT quoted strings for summary and info (they appear in quotes in the description)
+3. If the description doesn't mention classification fields, don't add them
+
+DESCRIPTION:
+{description}
+
+Output ONLY the raw alert configuration. No explanations, no markdown."""
+
+    return call_model(model, system_prompt=skill_content, user_prompt=user_prompt), user_prompt
+
+
+def run_step3_assess(
+    model: ModelConfig,
+    skill_content: str,
+    original_alert: str,
+    step1_reasoning: Optional[str],
+    step1_output: str,
+    step2_reasoning: Optional[str],
+    step2_output: str,
+) -> tuple[ModelResponse, Assessment, str]:
+    """
+    Step 3: Ask model to self-assess and identify skill gaps.
+
+    Returns: (response, assessment, user_prompt)
+    """
+    # Format reasoning sections (handle None)
+    r1 = step1_reasoning if step1_reasoning else "(no reasoning captured)"
+    r2 = step2_reasoning if step2_reasoning else "(no reasoning captured)"
+
+    user_prompt = f"""We need you to identify issues and score your system prompt. To do so, we did the following:
+
+1. We first called you to create a natural language description of this alert:
+
+<original_alert>
+{original_alert}
+</original_alert>
+
+Your reasoning was:
+
+<reasoning_of_step_1>
+{r1}
+</reasoning_of_step_1>
+
+And your output was:
+
+<output_of_step_1>
+{step1_output}
+</output_of_step_1>
+
+2. Then we provided back the `output_of_step_1` and we asked you to recreate the original alert.
+
+Your reasoning was:
+
+<reasoning_of_step_2>
+{r2}
+</reasoning_of_step_2>
+
+And your output was:
+
+<output_of_step_2>
+{step2_output}
+</output_of_step_2>
+
+3. Your system prompt is complete and correct ONLY if `output_of_step_2` is 100% equivalent to the `original_alert`.
+
+You now need to provide your assessment in the following JSON schema (output ONLY valid JSON, no other text):
+
+{{
+  "is_equivalent": true or false,
+  "step_1_errors": ["list of things step 1 description got wrong or missed"],
+  "step_2_errors": ["list of things step 2 recreation got wrong"],
+  "step_1_reasoning_issues": ["stress points or confusions in step 1 reasoning"],
+  "step_2_reasoning_issues": ["stress points or confusions in step 2 reasoning"],
+  "skill_improvements": ["concrete recommendations to improve your system prompt"]
+}}"""
+
+    response = call_model(model, system_prompt=skill_content, user_prompt=user_prompt)
+
+    assessment = Assessment()
+    if response.success:
+        assessment.raw_json = response.content
+        parsed = extract_json_from_response(response.content)
+        if parsed:
+            assessment.is_equivalent = parsed.get("is_equivalent", False)
+            assessment.step_1_errors = parsed.get("step_1_errors", [])
+            assessment.step_2_errors = parsed.get("step_2_errors", [])
+            assessment.step_1_reasoning_issues = parsed.get("step_1_reasoning_issues", [])
+            assessment.step_2_reasoning_issues = parsed.get("step_2_reasoning_issues", [])
+            assessment.skill_improvements = parsed.get("skill_improvements", [])
+        else:
+            assessment.parse_error = "Failed to parse JSON from response"
+
+    return response, assessment, user_prompt
+
+
+def run_single_test(
+    test_name: str,
+    original_alert: str,
+    model: ModelConfig,
+    model_size: str,
+    skill_content: str,
+) -> TestResult:
+    """Run a complete three-call test on a single alert."""
+
+    result = TestResult(
+        test_name=test_name,
+        model_name=model.name,
+        model_size=model_size,
+        original=original_alert,
+    )
+
+    # Step 1: Describe
+    print(f"      Step 1 (describe)...", end=" ", flush=True)
+    resp1, prompt1 = run_step1_describe(model, skill_content, original_alert)
+    result.prompt_step1 = prompt1
+    if not resp1.success:
+        result.error = f"Step 1 failed: {resp1.error}"
+        print("FAILED")
+        return result
+    if resp1.truncated:
+        result.error = f"Step 1 truncated (finish_reason=length, used {resp1.completion_tokens} tokens). Increase max_tokens."
+        print("TRUNCATED")
+        return result
+    result.description = resp1.content
+    result.reasoning_step1 = resp1.reasoning
+    print("OK")
+
+    # Step 2: Recreate
+    print(f"      Step 2 (recreate)...", end=" ", flush=True)
+    resp2, prompt2 = run_step2_recreate(model, skill_content, result.description)
+    result.prompt_step2 = prompt2
+    if not resp2.success:
+        result.error = f"Step 2 failed: {resp2.error}"
+        print("FAILED")
+        return result
+    if resp2.truncated:
+        result.error = f"Step 2 truncated (finish_reason=length, used {resp2.completion_tokens} tokens). Increase max_tokens."
+        print("TRUNCATED")
+        return result
+    result.recreated = resp2.content
+    result.reasoning_step2 = resp2.reasoning
+    print("OK")
+
+    # Step 3: Assess
+    print(f"      Step 3 (assess)...", end=" ", flush=True)
+    resp3, assessment, prompt3 = run_step3_assess(
+        model, skill_content,
+        original_alert,
+        result.reasoning_step1, result.description,
+        result.reasoning_step2, result.recreated,
+    )
+    result.prompt_step3 = prompt3
+    if not resp3.success:
+        result.error = f"Step 3 failed: {resp3.error}"
+        print("FAILED")
+        return result
+    if resp3.truncated:
+        result.error = f"Step 3 truncated (finish_reason=length, used {resp3.completion_tokens} tokens). Increase max_tokens."
+        print("TRUNCATED")
+        return result
+    result.assessment = assessment
+    result.reasoning_step3 = resp3.reasoning
+
+    if assessment.parse_error:
+        print(f"PARSE ERROR")
+        result.error = assessment.parse_error
+    else:
+        result.passed = assessment.is_equivalent
+        print("PASS" if result.passed else "FAIL")
+
+    return result
+
+
+def run_test_suite(
+    test_cases: List[tuple[str, str]],  # List of (name, content)
+    skill_path: Path,
+    model_size: str = "large",
+    config: Optional[dict] = None,
+) -> TestSuiteResult:
+    """
+    Run the full test suite for a skill.
+
+    Args:
+        test_cases: List of (test_name, alert_content) tuples
+        skill_path: Path to the skill file
+        model_size: "large" or "small"
+        config: Optional config dict
+    """
+    if config is None:
+        config = load_config()
+
+    skill_content = load_skill(skill_path)
+    model = get_model_config(model_size, config)
+
+    results = []
+    all_improvements = []
+
+    for test_name, original_alert in test_cases:
+        print(f"\n  Testing: {test_name}")
+        print(f"    Model: {model.name}")
+
+        result = run_single_test(
+            test_name, original_alert, model, model_size, skill_content
+        )
+        results.append(result)
+
+        # Collect improvements
+        if result.assessment and result.assessment.skill_improvements:
+            for imp in result.assessment.skill_improvements:
+                if imp not in all_improvements:
+                    all_improvements.append(imp)
+
+    # Summary
+    passed = sum(1 for r in results if r.passed)
+    failed = len(results) - passed
+
+    summary = {
+        "total": len(results),
+        "passed": passed,
+        "failed": failed,
+        "pass_rate": f"{100 * passed / len(results):.1f}%" if results else "N/A",
+    }
+
+    return TestSuiteResult(
+        skill_name=skill_path.stem,
+        timestamp=datetime.now().isoformat(),
+        model_name=model.name,
+        model_size=model_size,
+        skill_content=skill_content,
+        results=results,
+        all_skill_improvements=all_improvements,
+        summary=summary,
+    )
+
+
+def save_results(result: TestSuiteResult, output_dir: Path) -> Path:
+    """Save test results to JSON file."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"{result.skill_name}_{result.model_size}_{timestamp}.json"
+    output_file = output_dir / filename
+
+    # Convert to serializable dict
+    def serialize_assessment(a: Optional[Assessment]) -> Optional[dict]:
+        if a is None:
+            return None
+        return asdict(a)
+
+    output = {
+        "skill_name": result.skill_name,
+        "timestamp": result.timestamp,
+        "model_name": result.model_name,
+        "model_size": result.model_size,
+        "summary": result.summary,
+        "all_skill_improvements": result.all_skill_improvements,
+        "system_prompt": result.skill_content,
+        "results": [
+            {
+                "test_name": r.test_name,
+                "model_name": r.model_name,
+                "model_size": r.model_size,
+                "passed": r.passed,
+                "error": r.error,
+                "original": r.original,
+                "prompt_step1": r.prompt_step1,
+                "description": r.description,
+                "reasoning_step1": r.reasoning_step1,
+                "prompt_step2": r.prompt_step2,
+                "recreated": r.recreated,
+                "reasoning_step2": r.reasoning_step2,
+                "prompt_step3": r.prompt_step3,
+                "reasoning_step3": r.reasoning_step3,
+                "assessment": serialize_assessment(r.assessment),
+            }
+            for r in result.results
+        ],
+    }
+
+    with open(output_file, "w") as f:
+        json.dump(output, f, indent=2)
+
+    return output_file
+
+
+def print_summary(result: TestSuiteResult):
+    """Print test summary to console."""
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    RED = "\033[91m"
+    CYAN = "\033[96m"
+    RESET = "\033[0m"
+
+    print("\n" + "=" * 70)
+    print(f"SKILL: {result.skill_name}")
+    print(f"MODEL: {result.model_name} ({result.model_size})")
+    print("=" * 70)
+
+    s = result.summary
+    color = GREEN if s["failed"] == 0 else (YELLOW if s["passed"] > 0 else RED)
+    print(f"\n{color}Results: {s['passed']}/{s['total']} passed ({s['pass_rate']}){RESET}")
+
+    # Show failures
+    failures = [r for r in result.results if not r.passed]
+    if failures:
+        print(f"\n{RED}Failures:{RESET}")
+        for r in failures:
+            print(f"\n  {r.test_name}:")
+            if r.error:
+                print(f"    Error: {r.error}")
+            elif r.assessment:
+                if r.assessment.step_1_errors:
+                    print("    Step 1 errors:")
+                    for e in r.assessment.step_1_errors[:3]:
+                        print(f"      - {e}")
+                if r.assessment.step_2_errors:
+                    print("    Step 2 errors:")
+                    for e in r.assessment.step_2_errors[:3]:
+                        print(f"      - {e}")
+
+    # Show skill improvements
+    if result.all_skill_improvements:
+        print(f"\n{CYAN}Skill Improvements Recommended:{RESET}")
+        for i, imp in enumerate(result.all_skill_improvements, 1):
+            print(f"  {i}. {imp}")
+
+    print()
+
+
+def load_test_cases_from_dir(cases_dir: Path) -> List[tuple[str, str]]:
+    """Load all test cases from a directory."""
+    cases = []
+    for case_file in sorted(cases_dir.glob("*.conf")):
+        name = case_file.stem
+        content = load_test_case(case_file)
+        cases.append((name, content))
+    return cases
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run three-call skill tests"
+    )
+    parser.add_argument(
+        "skill",
+        type=Path,
+        help="Path to skill file",
+    )
+    parser.add_argument(
+        "test_cases",
+        type=Path,
+        help="Path to test cases directory",
+    )
+    parser.add_argument(
+        "--model",
+        choices=["large", "small", "both"],
+        default="large",
+        help="Which model to test with (default: large)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(__file__).parent.parent.parent / "results",
+        help="Output directory for results",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        help="Path to config file",
+    )
+
+    args = parser.parse_args()
+
+    if not args.skill.exists():
+        print(f"Error: Skill file not found: {args.skill}")
+        sys.exit(1)
+
+    if not args.test_cases.exists():
+        print(f"Error: Test cases directory not found: {args.test_cases}")
+        sys.exit(1)
+
+    # Load test cases
+    test_cases = load_test_cases_from_dir(args.test_cases)
+    if not test_cases:
+        print(f"No .conf files found in {args.test_cases}")
+        sys.exit(0)
+
+    print(f"Found {len(test_cases)} test cases")
+
+    # Load config
+    config = None
+    if args.config:
+        import yaml
+        with open(args.config) as f:
+            config = yaml.safe_load(f)
+
+    # Run tests
+    models_to_test = ["large", "small"] if args.model == "both" else [args.model]
+
+    all_results = []
+    for model_size in models_to_test:
+        print(f"\n{'='*70}")
+        print(f"Testing with {model_size} model...")
+        print("=" * 70)
+
+        result = run_test_suite(test_cases, args.skill, model_size, config)
+        all_results.append(result)
+
+        print_summary(result)
+
+        output_file = save_results(result, args.output)
+        print(f"Results saved to: {output_file}")
+
+    # Exit code
+    any_failed = any(r.summary["failed"] > 0 for r in all_results)
+    sys.exit(1 if any_failed else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Draft. WIP.

Planned skills:
- [x] alerts configuration (WIP - tests still don't pass
- [ ] notifications configuration
- [ ] API usage with curl
- [ ] MCP usage
- [ ] plugins configuration
- [ ] etc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AI-friendly Netdata skills and a testing framework, enabling assistants to configure alerts and query the API accurately. Aligns health docs with current alert semantics and syntax.

- **New Features**
  - Introduced src/ai-skills with skills for alert configuration (netdata-alerts-config.md) and API usage (netdata-api-use.md).
  - Added round-trip and three-call skill test frameworks (models, normalization, runners) with sample alert .conf cases and model config.
  - Included TODO completeness review for alert config and a results directory for test outputs.

- **Documentation**
  - Updated health README to clarify UNDEFINED state behavior.
  - Updated health REFERENCE to refine simple pattern matching (first match wins, negation) and line-splicing rules, and align alert semantics.

<sup>Written for commit f25fe0253c07d7e8481457eca36e3e5bc84c7870. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

