### PR TITLE
Switch to using a hard-coded release version for RHEL repo configs.

### DIFF
--- a/packaging/repoconfig/CMakeLists.txt
+++ b/packaging/repoconfig/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.16.0...3.30)
 
-list(APPEND RHEL_DISTROS centos centos-stream rocky almalinux cloudlinux)
+list(APPEND RHEL_DISTROS centos centos-stream rhel rocky almalinux cloudlinux)
 list(APPEND SUSE_DISTROS opensuse-leap opensuse-tumbleweed)
 list(APPEND RPM_DISTROS rhel opensuse ol amzn fedora)
 list(APPEND DEB_DISTROS debian ubuntu)
@@ -10,7 +10,7 @@ list(APPEND DEB_DISTROS debian ubuntu)
 set(DEB_GPG_KEY_SOURCE "https://repo.netdata.cloud/netdatabot.gpg.key")
 
 set(PACKAGE_VERSION 5)
-set(PACKAGE_RELEASE 4)
+set(PACKAGE_RELEASE 5)
 
 set(CPACK_THREADS 0)
 set(CPACK_STRIP_FILES NO)
@@ -96,6 +96,10 @@ endif()
 
 if(${DISTRO} IN_LIST RHEL_DISTROS)
   set(DISTRO "rhel")
+  string(FIND "${DISTRO_VERSION}" "." DECIMAL_INDEX)
+  if("${DECIMAL_INDEX}" GREATER 0)
+    string(SUBSTRING "${DISTRO_VERSION}" 0 "${DECIMAL_INDEX}" DISTRO_VERSION)
+  endif()
 elseif(${DISTRO} STREQUAL "opensuse-leap")
   set(DISTRO "opensuse")
 elseif(${DISTRO} STREQUAL "opensuse-tumbleweed")
@@ -219,12 +223,11 @@ elseif(${DISTRO} IN_LIST RPM_DISTROS)
     endif()
   elseif(${DISTRO} STREQUAL "rhel")
     set(DIST_NAME "el")
+    set(DIST_VERSION "${DISTRO_VERSION}")
     set(CPACK_RPM_PACKAGE_REQUIRES "epel-release")
 
     if(${DISTRO_VERSION} VERSION_LESS 8)
       set(CPACK_RPM_PACKAGE_REQUIRES "yum-plugin-priorities, epel-release")
-    elseif(${DISTRO_VERSION} VERSION_GREATER_EQUAL 9)
-      set(DIST_VERSION "$releasever_major")
     endif()
   endif()
 

--- a/packaging/repoconfig/deb.changelog
+++ b/packaging/repoconfig/deb.changelog
@@ -1,3 +1,9 @@
+@PKG_NAME@ (5-5) unstable; urgency=medium
+
+  * Version bump to keep in sync with RPM repo packages
+
+ -- Austin Hemmelgarn <austin@netdata.cloud>  Tue, 27 Jan 2026 11:39:00 -0500
+
 @PKG_NAME@ (5-4) unstable; urgency=medium
 
   * Version bump to keep in sync with RPM repo packages

--- a/packaging/repoconfig/rpm.changelog
+++ b/packaging/repoconfig/rpm.changelog
@@ -1,5 +1,7 @@
+* Tue Jan 27 2026 Austin Hemmelgarn <austin@netdata.cloud> 5-5
+- Use hardcoded release version for RHEL systems
 * Thu Jan 22 2026 Austin Hemmelgarn <austin@netdata.cloud> 5-4
-- Fix logic for usage of $releasever_major.
+- Fix logic for usage of $releasever_major
 * Tue Jan 20 2026 Austin Hemmelgarn <austin@netdata.cloud> 5-3
 - Use $releasever_major instead of $releasever in repo URLs when supported.
 * Thu Nov 13 2025 Austin Hemmelgarn <austin@netdata.cloud> 5-2


### PR DESCRIPTION
##### Summary

'$releasever_major' is a newer thing than we initially realized, and thus broke compatibility with RHEL 9.0 through 9.6 (and equivalent platforms).

We had only ever been using the `$releasever` variable to support clean handling of in-place distribution release upgrades (for example, upgrading from RHEL 9 to RHEL 10 without a clean reinstall of the whole system), but in reality that’s a relatively rare use-case on RHEL systems, so there’s not much advantage to continuing to support it there as doing so would make it significantly more complicated to make the repository configuration work with both older and newer versions of RHEL.

Instead, just use the hardcoded major version of the release in the repository config for these platforms. Fedora, openSUSE, and Oracle Linux will continue to use `$releasever` as they had been, as it continues to work correctly there.

##### Test Plan

n/a

##### Additional Information

This should finally properly fix #21609 

Note that users on RHEL 9 systems prior to version 9.7 will need to manually update the repository configuration package as outlined in that issue to get things working again (I’ll post a comment with updated URLs there once the packages are published).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch RHEL repo configs to a hardcoded major version to restore compatibility on RHEL 9.0–9.6. Fedora, openSUSE, and Oracle Linux continue using $releasever.

- **Bug Fixes**
  - Normalize RHEL DISTRO_VERSION to the major number and set DIST_VERSION accordingly.
  - Stop using $releasever_major on RHEL.
  - Add rhel to RHEL_DISTROS, bump package release to 5, and sync deb/rpm changelogs.

- **Migration**
  - On RHEL 9.0–9.6, update the repo config package to 5-5 to restore repository access.

<sup>Written for commit e58b4b5f7ffc7d53d5261f56f0dd9d032a22930c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

