### PR TITLE
Remove redundant operations from event loops

### DIFF
--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1827,9 +1827,6 @@ uint64_t last_async_callback;
 
 void async_cb(uv_async_t *handle)
 {
-    uv_stop(handle->loop);
-    uv_update_time(handle->loop);
-
     last_async_callback = uv_hrtime();
 
     netdata_log_debug(D_RRDENGINE, "%s called, active=%d.", __func__, uv_is_active((uv_handle_t *)handle));
@@ -1845,10 +1842,8 @@ static void async_closed_cb(uv_handle_t *handle)
     __atomic_store_n(&main->async_ready, true, __ATOMIC_RELEASE);
 }
 #else
-void async_cb(uv_async_t *handle)
+void async_cb(uv_async_t *handle __maybe_unused)
 {
-    uv_stop(handle->loop);
-    uv_update_time(handle->loop);
     netdata_log_debug(D_RRDENGINE, "%s called, active=%d.", __func__, uv_is_active((uv_handle_t *)handle));
 }
 #endif

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -301,10 +301,9 @@ struct judy_list_t {
     Word_t count;
 };
 
-static void async_cb(uv_async_t *handle)
+static void async_cb(uv_async_t *handle __maybe_unused)
 {
-    uv_stop(handle->loop);
-    uv_update_time(handle->loop);
+    ;
 }
 
 #define TIMER_PERIOD_MS (1000)
@@ -568,8 +567,6 @@ static void free_query_list(Pvoid_t JudyL)
 
 static void timer_cb(uv_timer_t *handle)
 {
-    uv_stop(handle->loop);
-    uv_update_time(handle->loop);
     struct aclk_sync_config_s *config = handle->data;
 
     if (aclk_online_for_alerts()) {

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -1542,10 +1542,9 @@ static cmd_data_t metadata_deq_cmd()
     return ret;
 }
 
-static void async_cb(uv_async_t *handle)
+static void async_cb(uv_async_t *handle __maybe_unused)
 {
-    uv_stop(handle->loop);
-    uv_update_time(handle->loop);
+    ;
 }
 
 #define TIMER_INITIAL_PERIOD_MS (1000)
@@ -1553,9 +1552,6 @@ static void async_cb(uv_async_t *handle)
 
 static void timer_cb(uv_timer_t *handle)
 {
-    uv_stop(handle->loop);
-    uv_update_time(handle->loop);
-
    struct meta_config_s *config = handle->data;
    if (config->metadata_check_after <  now_realtime_sec())
        config->store_metadata = true;


### PR DESCRIPTION
##### Summary
- Remove redundant `uv_stop` and `uv_update_time` calls in async and timer callbacks


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant uv_stop and uv_update_time calls in libuv async and timer callbacks to prevent unnecessary loop interruptions and reduce overhead. Improves loop stability in rrdengine and SQLite (aclk, metadata).

- **Refactors**
  - Removed uv_stop/uv_update_time from async_cb and timer_cb in rrdengine.c, sqlite_aclk.c, and sqlite_metadata.c.
  - Marked callback parameters as __maybe_unused to silence warnings.
  - Callbacks remain lightweight; the event loop runs without forced stops or manual time updates.

<sup>Written for commit ebdcf23553f9b70dbf9e00b378837a75c7a52cf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

