### PR TITLE
fix(notifications): update Matrix sender to comply with Matrix API

### DIFF
--- a/src/health/notifications/alarm-notify.sh.in
+++ b/src/health/notifications/alarm-notify.sh.in
@@ -2196,7 +2196,7 @@ send_matrix() {
 EOF
     )"
 
-    httpcode=$(docurl -X PUT -H "Authorization: Bearer ${accesstoken}" --data "${payload}" "${webhook}")
+    httpcode=$(docurl -X PUT -H "Authorization: Bearer ${accesstoken}" -H "Content-Type: application/json" --data "${payload}" "${webhook}")
     if [ "${httpcode}" == "200" ]; then
       info "sent Matrix notification to '${room}' for ${notification_description}"
       sent=$((sent + 1))


### PR DESCRIPTION
## Summary

- Fix Matrix notifications returning HTTP 404 with `M_UNRECOGNIZED` error
- Update to use PUT method with transaction ID (Matrix API requirement)
- Move access token to Authorization header (security improvement)

## Problem

The Matrix notification sender was using an outdated API format:
- Used `POST` instead of `PUT`
- Missing transaction ID (`txnid`) in URL path
- Access token in query parameter (gets logged in URLs)

This caused modern Matrix homeservers (e.g., Tuwunel 1.4.7) to return:
```json
{"errcode":"M_UNRECOGNIZED","error":"M_UNRECOGNIZED: Not Found"}
```

## Solution

Updated `send_matrix()` function to comply with [Matrix Client-Server API](https://spec.matrix.org/latest/client-server-api/):

| Aspect | Before | After |
|--------|--------|-------|
| HTTP Method | `POST` | `PUT` |
| Transaction ID | None | `nd_{epoch}_{pid}_{random}` |
| Authentication | `?access_token=` in URL | `Authorization: Bearer` header |

## Test plan

- [ ] Configure Matrix notifications in `health_alarm_notify.conf`
- [ ] Run test: `/usr/libexec/netdata/plugins.d/alarm-notify.sh test`
- [ ] Verify successful delivery to Matrix room

Fixes https://github.com/netdata/netdata-cloud/issues/1130

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Matrix notification sender to comply with the Matrix Client-Server API. Fixes 404 M_UNRECOGNIZED responses and avoids exposing access tokens in URLs.

- **Bug Fixes**
  - Use PUT with a transaction ID in the URL path for idempotent sends.
  - Move access token to Authorization: Bearer header to keep tokens out of logs.

<sup>Written for commit 6a15133d01d10e8569a8ed1291dbc36076b705d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

