### PR TITLE
Document function naming conventions

### DIFF
--- a/src/plugins.d/README.md
+++ b/src/plugins.d/README.md
@@ -572,7 +572,12 @@ This naming convention:
 - Improves discoverability in the Functions API
 - Follows the same colon-separator pattern used by [Dynamic Configuration (DynCfg)](#config) for consistency
 
-> **Note**: This naming convention is distinct from DynCfg configuration IDs. DynCfg commands are sent through the special `config` function (e.g., `config go.d:mysql:local get`), while module functions use their own unique names directly (e.g., `mysql:top-queries`).
+:::note
+
+This naming convention is distinct from DynCfg configuration IDs. DynCfg commands are sent through the special `config` function (e.g., `config go.d:mysql:local get`), while module functions use their own unique names directly (e.g., 
+`mysql:top-queries`).
+
+:::
 
 ##### Functions cancellation
 


### PR DESCRIPTION
Fills the lack of documentation about this in https://github.com/netdata/netdata/pull/21595.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add function naming conventions to src/plugins.d/README.md, recommending colon-separated module:method names (e.g., mysql:top-queries) for plugin functions. This improves consistency and discoverability in the Functions API and clarifies how this differs from DynCfg config IDs.

<sup>Written for commit b38f88550b471affbccc2112e98936260ec06273. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

