### PR TITLE
fix(claim): use printf for portable newline handling in claim script

### DIFF
--- a/src/claim/netdata-claim.sh.in
+++ b/src/claim/netdata-claim.sh.in
@@ -52,7 +52,7 @@ write_config() {
     touch "${claim_config}.tmp"
     chmod 0660 "${claim_config}.tmp"
     chown "root:${netdata_group}" "${claim_config}.tmp"
-    echo "${config}" > "${claim_config}.tmp"
+    printf '%b\n' "${config}" > "${claim_config}.tmp"
     chmod 0640 "${claim_config}.tmp"
     mv -f "${claim_config}.tmp" "${claim_config}"
 }


### PR DESCRIPTION
## Summary

- Fix `netdata-claim.sh` failing on Rocky 9 and other systems where `/bin/sh` doesn't interpret `\n` in `echo`
- Replace `echo "${config}"` with `printf '%b\n' "${config}"` for POSIX-portable backslash escape handling
- Ensures `claim.conf` is written with actual newlines instead of literal `\n` characters

## Problem

The claim script builds a config string with `\n` escape sequences:
```sh
config="[global]"
config="${config}\n    url = ${NETDATA_CLAIM_URL}"
```

Then writes it with `echo "${config}"`. POSIX does not guarantee that `echo` interprets `\n`, and on Rocky 9 (and similar systems), the resulting `claim.conf` contains literal `\n` characters instead of newlines, making it invalid INI and causing claiming to fail.

## Fix

Use `printf '%b\n'` which is POSIX-guaranteed to interpret backslash escape sequences.

## Test plan

- [ ] On Rocky 9: run `netdata-claim.sh --claim-token ... --claim-url ...`
- [ ] Verify `cat /etc/netdata/claim.conf` shows proper INI format with real newlines
- [ ] Verify claiming succeeds with valid credentials

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes netdata-claim.sh writing literal \n into claim.conf on systems where /bin/sh doesn’t interpret escapes in echo. Replaces echo with printf '%b\n' to write real newlines, producing valid INI and allowing claiming to succeed (e.g., Rocky 9).

<sup>Written for commit e1dd822695462ada504b5273143e716d9c833e65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

