### PR TITLE
Fix SIGSEGV in dbengine extent flush due to unacquired UUID reference

### DIFF
--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -35,7 +35,7 @@ static void main_cache_flush_dirty_page_callback(PGC *cache __maybe_unused, PGC_
         time_t end_time_s = entries_array[Index].end_time_s;
         struct page_descr_with_data *descr = page_descriptor_get();
 
-        descr->id = mrg_metric_uuid(main_mrg, (METRIC *) entries_array[Index].metric_id);
+        descr->uuid_id = mrg_metric_uuidmap_id_dup(main_mrg, (METRIC *) entries_array[Index].metric_id);
         descr->metric_id = entries_array[Index].metric_id;
         descr->start_time_ut = start_time_s * USEC_PER_SEC;
         descr->end_time_ut = end_time_s * USEC_PER_SEC;

--- a/src/database/engine/pagecache.h
+++ b/src/database/engine/pagecache.h
@@ -18,7 +18,7 @@ struct rrdengine_instance;
 extern struct rrdeng_cache_efficiency_stats rrdeng_cache_efficiency_stats;
 
 struct page_descr_with_data {
-    nd_uuid_t *id;
+    UUIDMAP_ID uuid_id;
     Word_t metric_id;
     usec_t start_time_ut;
     usec_t end_time_ut;

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -333,6 +333,7 @@ struct page_descr_with_data *page_descriptor_get(void) {
 }
 
 static inline void page_descriptor_release(struct page_descr_with_data *descr) {
+    uuidmap_free(descr->uuid_id);
     aral_freez(rrdeng_main.descriptors.ar, descr);
 }
 
@@ -950,7 +951,7 @@ datafile_extent_build(struct rrdengine_instance *ctx, struct page_descr_with_dat
     for (i = 0 ; i < count ; ++i) {
         descr = xt_io_descr->descr_array[i];
         header->descr[i].type = descr->type;
-        uuid_copy(*(nd_uuid_t *)header->descr[i].uuid, *descr->id);
+        uuid_copy(*(nd_uuid_t *)header->descr[i].uuid, *uuidmap_uuid_ptr(descr->uuid_id));
         header->descr[i].page_length = descr->page_length;
         header->descr[i].start_time_ut = descr->start_time_ut;
 


### PR DESCRIPTION
##### Summary
- Refactor UUID handling in page descriptor to use UUIDMAP_ID instead of nd_uuid_t (properly acquired and released)




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a segfault during datafile extent flush by switching page descriptor UUID handling to UUIDMAP_ID with proper reference management. UUIDs are now acquired, used, and freed safely across flush.

- **Bug Fixes**
  - Replaced nd_uuid_t* with UUIDMAP_ID in page_descr_with_data; acquire via mrg_metric_uuidmap_id_dup and free via uuidmap_free.
  - Use uuidmap_uuid_ptr when copying UUIDs into extent headers.

<sup>Written for commit bffe93f4cd8ebc94077fa041afc007eedcd33baa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

