### PR TITLE
feat(iac): Add Ansible role for Netdata deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # Secrets
 gcs-credentials.json
+src/IaC/.netdata-iac-claim.env
+
+# IaC e2e artifacts
+src/IaC/ansible/e2e/work/
+src/IaC/ansible/inventories/e2e/
 
 .deps
 .libs
@@ -209,3 +214,8 @@ compile.sh
 run-ibm.sh
 
 tmp/
+
+integrations/integrations.js
+integrations/integrations.json
+
+.claude/

--- a/src/IaC/AGENTS.md
+++ b/src/IaC/AGENTS.md
@@ -1,0 +1,130 @@
+# IaC Provisioning - Agent Guidelines
+
+This document defines the rules and principles that **all** Netdata provisioning systems (Ansible, Terraform, Puppet, Chef, Salt) must follow.
+
+## Core Principles
+
+### 1. Installation Method
+- All systems use `kickstart.sh` as the installation baseline
+- The kickstart script auto-selects native packages when available
+- Support both `stable` and `nightly` release channels
+- Installation should be idempotent (re-running produces same result)
+
+### 2. Cloud Claiming
+- Claiming to Netdata Cloud is enabled by default
+- Claiming is done by writing `claim.conf` directly and running `netdatacli reload-claiming-state`
+- Do NOT use `netdata-claim.sh` script
+- Support proxy configuration (`env`, `none`, or explicit URL)
+- Support `insecure` option for environments with TLS inspection
+- Disabling claim removes only `claim.conf`, preserves `/var/lib/netdata/cloud.d`
+
+### 3. Profile System (File-Level Isolation)
+- Profiles are **file-level bundles** of configuration
+- Each profile defines a list of managed files
+- A host can use multiple profiles **only if they touch different files**
+- File collisions (same destination from multiple profiles) must be rejected
+- Profiles do NOT merge configuration - they provide complete files
+
+Standard profile types:
+- `standalone` - Single agent, no streaming
+- `child` - Streams to parent, may have local storage
+- `child_minimal` - Streams to parent, minimal local resources
+- `parent` - Receives streams from children
+
+### 4. Managed Files
+- Managed files have `src` (source path) and `dest` (destination relative to config dir)
+- Files can be static or templates
+- File types: `netdata_conf`, `stream_conf`, `health`, `plugin_conf`, `generic`
+- Changes to managed files trigger Netdata restart
+- No change = no restart (idempotent)
+- Do NOT delete unmanaged files - only manage explicit files
+
+### 5. Configuration Approach
+- Full config file ownership (not partial patching)
+- Users provide complete `netdata.conf`, `stream.conf`, etc.
+- Optional ini-style tweaks can be applied after full files
+- If providing full config files, leave per-setting variables empty
+
+### 6. Standard Variables (Cross-Tool Consistency)
+
+All provisioning tools must support these variable names:
+
+**Installation:**
+- `netdata_release_channel` - `stable` or `nightly`
+- `netdata_install_only_if_missing` - Skip if already installed
+
+**Claiming:**
+- `netdata_claim_enabled` - Enable/disable claiming
+- `netdata_claim_token` - Cloud claim token
+- `netdata_claim_rooms` - Cloud room IDs
+- `netdata_claim_url` - Cloud API URL
+- `netdata_claim_proxy` - Proxy setting
+- `netdata_claim_insecure` - Allow insecure TLS
+- `netdata_reclaim` - Force reclaim if already claimed
+
+**Database:**
+- `netdata_db_mode` - `dbengine`, `ram`, or `none`
+- `netdata_db_retention` - Retention in seconds
+- `netdata_dbengine_multihost_disk_space` - Disk space in MB
+
+**Streaming:**
+- `netdata_stream_enabled` - Enable streaming
+- `netdata_stream_destinations` - List of parent addresses
+- `netdata_stream_api_key` - API key for streaming
+- `netdata_stream_parent_keys` - Parent key definitions (for parents)
+
+**Other:**
+- `netdata_web_mode` - Web server mode
+- `netdata_ml_enabled` - Machine learning on/off
+- `netdata_health_enabled` - Alerts on/off
+- `netdata_hostname` - Override hostname
+
+### 7. Directory Structure
+
+Each provisioning system follows this layout:
+```
+src/IaC/<system>/
+  README.md              # End-user documentation
+  AGENTS.md              # Technical details for AI agents
+  roles/ or modules/     # Reusable components
+  playbooks/ or manifests/
+  inventories/example/   # Example configuration
+    inventory.*          # Host definitions
+    group_vars/          # Variable files
+    files/               # Configuration files
+      global/            # Files for all hosts
+      profiles/          # Per-profile file bundles
+  e2e/                   # End-to-end tests
+    README.md
+    run.sh
+```
+
+### 8. Testing Requirements
+
+Each system must have E2E tests covering:
+- Minimum OS matrix: Ubuntu + Debian + RHEL family
+- Service starts and runs
+- Claiming works (when enabled)
+- Streaming connects (parent/child scenarios)
+- Profile application works correctly
+
+E2E environment: libvirt VMs + Docker containers
+
+### 9. Documentation Requirements
+
+Each system must document:
+- Prerequisites (what users need installed)
+- Quickstart (copy, configure, run)
+- Variable reference (all supported variables)
+- Profile system (how to define and use)
+- Enterprise integration (AWX, Terraform Cloud, etc.)
+- Validation steps (how to verify success)
+
+## Implementation Order
+
+Systems are implemented one at a time in this order:
+1. Ansible (DONE)
+2. Terraform
+3. Puppet
+4. Chef
+5. Salt

--- a/src/IaC/README.md
+++ b/src/IaC/README.md
@@ -1,0 +1,99 @@
+# Netdata Infrastructure as Code (IaC)
+
+Deploy and configure Netdata agents at scale using your preferred configuration management tool.
+
+## Supported Tools
+
+| Tool | Status | Directory |
+|------|--------|-----------|
+| Ansible | Ready | [ansible/](ansible/) |
+| Terraform | Planned | - |
+| Puppet | Planned | - |
+| Chef | Planned | - |
+| Salt | Planned | - |
+
+## Key Concepts
+
+### Profiles
+
+Profiles let you define different Netdata configurations for different roles in your infrastructure.
+
+**Common profiles:**
+- **standalone** - Single agent, full local storage, no streaming
+- **parent** - Receives metrics from children, larger retention
+- **child** - Streams metrics to parent, moderate local storage
+- **child_minimal** - Streams metrics to parent, minimal local resources
+
+Each profile is a bundle of configuration files. You assign profiles to hosts, and the provisioning tool deploys the right files.
+
+```
+Host: web-server-01 -> Profile: child
+Host: web-server-02 -> Profile: child
+Host: metrics-parent -> Profile: parent
+```
+
+### File-Based Configuration
+
+Configuration is managed at the **file level**, not by patching individual settings:
+- You provide complete configuration files (`netdata.conf`, `stream.conf`, etc.)
+- The tool deploys your files to the right locations
+- Changes trigger a Netdata restart automatically
+
+This approach is simpler and more predictable than merging partial configurations.
+
+### Cloud Claiming
+
+Netdata Cloud claiming is supported and enabled by default:
+- Provide your claim token and room ID
+- The tool writes `claim.conf` and reloads the claiming state
+- Proxy support included for restricted networks
+
+To disable claiming, set `netdata_claim_enabled: false`.
+
+## Quick Start
+
+1. **Choose your tool** - Pick the provisioning system you already use
+2. **Copy the example** - Each tool has an example inventory/configuration
+3. **Set your values** - Claim token, profiles, hosts
+4. **Run** - Apply the configuration to your infrastructure
+
+See the README in each tool's directory for specific instructions.
+
+## Directory Structure
+
+```
+src/IaC/
+  README.md           # This file
+  AGENTS.md           # Internal guidelines for AI agents
+  ansible/            # Ansible role and playbooks
+  terraform/          # (planned)
+  puppet/             # (planned)
+  chef/               # (planned)
+  salt/               # (planned)
+```
+
+## What Gets Configured
+
+The IaC tools can manage:
+- Netdata installation (via kickstart.sh)
+- Cloud claiming
+- Streaming (parent/child relationships)
+- Database retention settings
+- Web server mode
+- Machine learning on/off
+- Health alerts on/off
+- Custom configuration files
+- Plugin configurations
+
+## Requirements
+
+- Target nodes accessible via SSH (or equivalent for your tool)
+- Sudo/root access on target nodes
+- Internet access to download Netdata (or local mirror)
+- Claim token from Netdata Cloud (if claiming)
+
+## Security Notes
+
+- Store claim tokens securely (Ansible Vault, Terraform secrets, etc.)
+- The tools do not delete unmanaged files
+- Configuration files may contain sensitive data - set appropriate permissions

--- a/src/IaC/ansible/AGENTS.md
+++ b/src/IaC/ansible/AGENTS.md
@@ -1,0 +1,213 @@
+# Ansible Implementation - Agent Technical Reference
+
+This document provides technical details for AI agents working on the Ansible provisioning system.
+
+## Architecture
+
+```
+src/IaC/ansible/
+  playbooks/netdata.yml      # Main playbook (imports the role)
+  roles/netdata/             # Reusable role
+    defaults/main.yml        # Default variables
+    handlers/main.yml        # Service handlers
+    tasks/                   # Task files
+    templates/               # Jinja2 templates
+  inventories/example/       # Example inventory
+    inventory.yml            # Host definitions
+    group_vars/              # Variable files per group
+    files/                   # Configuration files
+      global/                # Applied to all hosts
+      profiles/              # Per-profile file bundles
+  e2e/                       # End-to-end tests
+```
+
+## Task Execution Order
+
+The role executes tasks in this order (see `roles/netdata/tasks/main.yml`):
+
+1. **install.yml** - Install Netdata via kickstart.sh
+2. **config-dir.yml** - Detect/set config directory path
+3. **profiles.yml** - Resolve profile definitions to file lists
+4. **managed-files.yml** - Deploy managed configuration files
+5. **configure.yml** - Apply ini-style configuration tweaks
+6. **stream.yml** - Configure streaming (child and parent)
+7. **service.yml** - Ensure service is running
+8. **claim.yml** - Handle Cloud claiming
+
+## Key Variables
+
+### Installation
+```yaml
+netdata_kickstart_url: "https://get.netdata.cloud/kickstart.sh"
+netdata_release_channel: "stable"  # or "nightly"
+netdata_install_only_if_missing: true
+netdata_kickstart_extra_args: []
+```
+
+### Claiming
+```yaml
+netdata_claim_enabled: true
+netdata_claim_token: ""      # Required when enabled
+netdata_claim_rooms: ""      # Required when enabled
+netdata_claim_url: "https://app.netdata.cloud"
+netdata_claim_proxy: ""      # "env", "none", or URL
+netdata_claim_insecure: false
+netdata_reclaim: false
+```
+
+### Paths
+```yaml
+netdata_config_dir: ""       # Auto-detected if empty
+netdata_lib_dir: "/var/lib/netdata"
+netdata_group: "netdata"
+```
+
+### Database
+```yaml
+netdata_db_mode: ""          # "dbengine", "ram", "none"
+netdata_db_retention: ""     # Seconds
+netdata_db_update_every: ""  # Seconds
+netdata_dbengine_multihost_disk_space: ""  # MB
+```
+
+### Streaming (Child)
+```yaml
+netdata_stream_enabled: ""   # true/false
+netdata_stream_destinations: []  # ["parent1:19999", "parent2:19999"]
+netdata_stream_api_key: ""
+netdata_stream_section_options: {}  # Extra [stream] options
+```
+
+### Streaming (Parent)
+```yaml
+netdata_stream_parent_keys: []
+# Each entry:
+#   - key: "API_KEY_STRING"
+#     allow_from: "*"  # Optional
+#     options: {}      # Optional extra settings
+```
+
+### Profiles
+```yaml
+netdata_profiles: []  # Per-host list: [profile1, profile2]
+netdata_profiles_definitions: {}
+# Structure:
+#   profile_name:
+#     managed_files:
+#       - src: files/profiles/X/netdata.conf
+#         dest: netdata.conf
+#         type: netdata_conf
+```
+
+### Managed Files
+```yaml
+netdata_managed_files: []
+# Each entry:
+#   - src: path/to/source
+#     dest: relative/to/config/dir
+#     type: netdata_conf|stream_conf|health|plugin_conf|generic
+#     template: false  # Optional, default false
+#     owner: root      # Optional
+#     group: netdata   # Optional
+#     mode: "0644"     # Optional
+```
+
+## Profile Resolution Logic
+
+File: `roles/netdata/tasks/profiles.yml`
+
+1. Start with empty file list
+2. For each profile in `netdata_profiles`:
+   - Look up definition in `netdata_profiles_definitions`
+   - Add `managed_files` from the profile
+3. Check for destination collisions (same `dest` from multiple sources)
+4. Fail if collision detected
+5. Merge with host-level `netdata_managed_files`
+6. Result stored in `netdata_managed_files_effective`
+
+## Managed Files Deployment
+
+File: `roles/netdata/tasks/managed-files.yml`
+
+1. For each file in `netdata_managed_files_effective`:
+   - If `template: true`: use `template` module
+   - Otherwise: use `copy` module
+2. Source path resolution:
+   - Relative paths resolved from inventory directory
+   - Absolute paths used as-is
+3. Destination path resolution:
+   - Relative paths prefixed with `netdata_config_dir`
+   - Absolute paths used as-is
+4. Register changes for restart decision
+
+## Claiming Implementation
+
+File: `roles/netdata/tasks/claim.yml`
+
+When `netdata_claim_enabled: true`:
+1. Write `claim.conf` from template (`templates/claim.conf.j2`)
+2. Check if already claimed (`/var/lib/netdata/cloud.d/claimed_id`)
+3. If not claimed or `netdata_reclaim: true`:
+   - Run `netdatacli reload-claiming-state`
+
+When `netdata_claim_enabled: false`:
+1. Remove `claim.conf` if it exists
+2. Do NOT remove `/var/lib/netdata/cloud.d/` (preserves claim state)
+
+## Handler Triggers
+
+File: `roles/netdata/handlers/main.yml`
+
+- `Restart Netdata` - Triggered by:
+  - Managed file changes
+  - Configuration changes via `ini_file`
+  - Service state changes
+
+- `Reload Netdata health` - Triggered by:
+  - Health config file changes (type: health)
+
+## Testing
+
+E2E tests use:
+- **libvirt VMs**: Ubuntu 22.04, Rocky 9 (UEFI boot required)
+- **Docker**: Debian 12 systemd container
+
+Test flow:
+1. Provision VMs/containers
+2. Generate test inventory with profiles
+3. Run playbook
+4. Validate: service status, claiming, streaming
+
+Secrets stored in: `src/IaC/.netdata-iac-claim.env` (not committed)
+
+## Common Modifications
+
+### Adding a New Profile
+
+1. Create files in `inventories/example/files/profiles/<profile_name>/`
+2. Add definition to `group_vars/all.yml`:
+   ```yaml
+   netdata_profiles_definitions:
+     new_profile:
+       managed_files:
+         - src: files/profiles/new_profile/netdata.conf
+           dest: netdata.conf
+           type: netdata_conf
+   ```
+3. Assign to hosts in inventory: `netdata_profiles: [new_profile]`
+
+### Adding Global Files
+
+Add to `netdata_managed_files` in `group_vars/all.yml`:
+```yaml
+netdata_managed_files:
+  - src: files/global/health.d/custom.conf
+    dest: health.d/custom.conf
+    type: health
+```
+
+### Supporting New OS
+
+1. Update `install.yml` if package manager handling needed
+2. Add to E2E test matrix in `e2e/run.sh`
+3. Test kickstart.sh compatibility

--- a/src/IaC/ansible/README.md
+++ b/src/IaC/ansible/README.md
@@ -1,0 +1,244 @@
+# Deploy Netdata with Ansible
+
+Install and configure Netdata agents across your infrastructure using Ansible.
+
+## What You Can Do
+
+- Install Netdata on multiple servers in one run
+- Connect agents to Netdata Cloud automatically
+- Set up streaming (parent/child) architectures
+- Deploy different configurations to different server roles
+- Manage custom alert rules and plugin settings
+
+## Prerequisites
+
+- Ansible installed on your control machine
+- SSH access to target servers
+- Sudo privileges on target servers
+- (Optional) Netdata Cloud claim token from https://app.netdata.cloud
+
+## Quick Start
+
+### Step 1: Copy the Example
+
+```bash
+# Copy the example inventory to your own
+cp -r inventories/example inventories/myinfra
+```
+
+### Step 2: Define Your Servers
+
+Edit `inventories/myinfra/inventory.yml`:
+
+```yaml
+all:
+  hosts:
+    web-01:
+      ansible_host: 192.168.1.10
+      netdata_profiles: [standalone]
+    web-02:
+      ansible_host: 192.168.1.11
+      netdata_profiles: [standalone]
+    db-01:
+      ansible_host: 192.168.1.20
+      netdata_profiles: [standalone]
+```
+
+### Step 3: Configure Claiming (Optional)
+
+Edit `inventories/myinfra/group_vars/all.yml`:
+
+```yaml
+# Get these from Netdata Cloud -> Space settings -> Nodes
+netdata_claim_token: "YOUR_TOKEN_HERE"
+netdata_claim_rooms: "YOUR_ROOM_ID"
+
+# To skip Cloud claiming entirely:
+# netdata_claim_enabled: false
+```
+
+### Step 4: Run
+
+```bash
+ansible-playbook -i inventories/myinfra/inventory.yml playbooks/netdata.yml
+```
+
+## Common Scenarios
+
+### Standalone Agents
+
+Every server runs independently with full local storage.
+
+```yaml
+# inventory.yml
+all:
+  hosts:
+    server-01:
+      ansible_host: 10.0.0.1
+      netdata_profiles: [standalone]
+    server-02:
+      ansible_host: 10.0.0.2
+      netdata_profiles: [standalone]
+```
+
+### Parent-Child Streaming
+
+Children stream metrics to a central parent. Useful for:
+- Centralized dashboards
+- Reduced storage on edge nodes
+- Aggregating metrics from many servers
+
+```yaml
+# inventory.yml
+all:
+  hosts:
+    # This server receives metrics from children
+    metrics-parent:
+      ansible_host: 10.0.0.100
+      netdata_profiles: [parent]
+
+    # These servers stream to the parent
+    app-01:
+      ansible_host: 10.0.0.1
+      netdata_profiles: [child]
+    app-02:
+      ansible_host: 10.0.0.2
+      netdata_profiles: [child]
+```
+
+You'll need to configure the streaming keys - see the profile files in `files/profiles/`.
+
+### Minimal Children (Edge/IoT)
+
+For resource-constrained nodes that only stream, with no local storage:
+
+```yaml
+netdata_profiles: [child_minimal]
+```
+
+## Using Profiles
+
+Profiles are bundles of configuration files for different server roles.
+
+**Built-in profiles:**
+| Profile | Use Case |
+|---------|----------|
+| `standalone` | Independent agent, full features |
+| `parent` | Receives streams from children |
+| `child` | Streams to parent, has local storage |
+| `child_minimal` | Streams to parent, minimal resources |
+
+**Assign profiles per host:**
+```yaml
+server-01:
+  netdata_profiles: [child]
+```
+
+**Create your own profiles** by adding files to `files/profiles/yourprofile/` and defining them in `group_vars/all.yml`.
+
+## Adding Custom Configuration Files
+
+Deploy your own Netdata configuration files:
+
+```yaml
+# group_vars/all.yml
+netdata_managed_files:
+  # Custom alert rules for all servers
+  - src: files/global/health.d/my-alerts.conf
+    dest: health.d/my-alerts.conf
+
+  # Custom plugin config
+  - src: files/global/go.d/httpcheck.conf
+    dest: go.d/httpcheck.conf
+```
+
+Place your files in `inventories/myinfra/files/global/`.
+
+## Using with AWX / Automation Controller
+
+The role works standalone - import it into your existing playbooks:
+
+```yaml
+# your-playbook.yml
+- hosts: netdata_servers
+  roles:
+    - netdata
+```
+
+Store secrets (claim tokens) in your controller's credential store or Ansible Vault.
+
+## Verify Installation
+
+After running the playbook:
+
+```bash
+# Check service is running
+ssh server-01 'systemctl status netdata'
+
+# Check claiming (if enabled)
+ssh server-01 'cat /var/lib/netdata/cloud.d/claimed_id'
+
+# View the dashboard
+open http://server-01:19999
+```
+
+If you claimed to Netdata Cloud, your nodes should appear in your Space within a minute.
+
+## Variables Reference
+
+### Claiming
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `netdata_claim_enabled` | `true` | Connect to Netdata Cloud |
+| `netdata_claim_token` | - | Your claim token (required if claiming) |
+| `netdata_claim_rooms` | - | Room ID(s) to join |
+| `netdata_claim_url` | `https://app.netdata.cloud` | Cloud URL |
+| `netdata_claim_proxy` | - | Proxy: `env`, `none`, or URL |
+
+### Installation
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `netdata_release_channel` | `stable` | `stable` or `nightly` |
+| `netdata_install_only_if_missing` | `true` | Skip if already installed |
+
+### Database
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `netdata_db_mode` | - | `dbengine`, `ram`, or `none` |
+| `netdata_db_retention` | - | Retention in seconds |
+| `netdata_dbengine_multihost_disk_space` | - | Disk space in MB |
+
+### Features
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `netdata_ml_enabled` | - | Machine learning on/off |
+| `netdata_health_enabled` | - | Alerts on/off |
+| `netdata_web_mode` | - | Web server mode |
+| `netdata_hostname` | - | Override hostname |
+
+### Streaming (Child)
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `netdata_stream_enabled` | - | Enable streaming |
+| `netdata_stream_destinations` | `[]` | Parent addresses |
+| `netdata_stream_api_key` | - | API key for authentication |
+
+### Streaming (Parent)
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `netdata_stream_parent_keys` | `[]` | Allowed child keys |
+
+## Troubleshooting
+
+**Playbook fails with "claim token required"**
+- Set `netdata_claim_token` and `netdata_claim_rooms`, or
+- Set `netdata_claim_enabled: false` to skip claiming
+
+**Nodes not appearing in Cloud**
+- Check the agent can reach `app.netdata.cloud` (port 443)
+- If behind a proxy, set `netdata_claim_proxy`
+
+**Streaming not working**
+- Ensure parent has `[web].mode = static-threaded` (the parent profile sets this)
+- Verify API keys match between parent and child configs
+- Check firewall allows port 19999 between nodes

--- a/src/IaC/ansible/e2e/README.md
+++ b/src/IaC/ansible/e2e/README.md
@@ -1,0 +1,52 @@
+# Ansible E2E tests (libvirt + Docker)
+
+## Scope
+- Ubuntu 22.04
+- Debian 12
+- Rocky 9
+
+## Prerequisites
+- libvirt + KVM working.
+- Docker working.
+- Ansible installed on the controller.
+- UEFI firmware for Rocky (package `edk2-ovmf` on Arch/Manjaro).
+- Claim token/room for the shared Netdata Cloud Space.
+
+## Tokens
+- Create a local env file (not committed): `src/IaC/.netdata-iac-claim.env`
+- Required variables:
+  - `NETDATA_CLAIM_TOKEN`
+  - `NETDATA_CLAIM_ROOMS`
+  - `NETDATA_CLAIM_URL`
+  - `NETDATA_RELEASE_CHANNEL`
+
+## Test flow (high level)
+1. Provision VMs for the 3 OS targets.
+2. Add them to the Ansible inventory with per-host profile lists and file-based profile definitions.
+3. Run the Ansible playbook with nightly channel.
+4. Verify service status + claiming + streaming connection.
+
+## Run
+- Script: `src/IaC/ansible/e2e/run.sh`
+- It will:
+  - create a libvirt NAT network if missing
+  - download cloud images
+  - create VMs with cloud-init (Ubuntu + Rocky)
+  - use a systemd-based Debian 12 container with SSH on port 2222
+  - generate a local inventory + profile files in `inventories/e2e/`
+  - run the playbook
+  - validate service + claim + streaming
+
+## VM sizing
+- Default disk size is 20G (override with `VM_DISK_SIZE=...` when running the script).
+
+## Validation checks
+- `systemctl status netdata`
+- `/var/lib/netdata/cloud.d/claimed_id`
+- child TCP connection to parent `:19999` (via `ss`/`netstat`)
+- `http://NODE:19999/api/v3/info`
+
+## Notes
+- Docker is used for a fast smoke run; libvirt VMs are the source of truth.
+- The Debian container runs the standalone profile because Docker and libvirt use separate networks by default.
+- E2E automation scripts will live in this folder.

--- a/src/IaC/ansible/e2e/run.sh
+++ b/src/IaC/ansible/e2e/run.sh
@@ -1,0 +1,522 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+GRAY='\033[0;90m'
+NC='\033[0m'
+
+# Execute command with visibility
+run() {
+  printf >&2 "${GRAY}$(pwd) >${NC} ${YELLOW}"
+  printf >&2 "%q " "$@"
+  printf >&2 "${NC}\n"
+  "$@"
+  local exit_code=$?
+  if [[ ${exit_code} -ne 0 ]]; then
+    echo -e >&2 "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e >&2 "${RED}[ERROR]${NC} Command failed with exit code ${exit_code}: ${YELLOW}$1${NC}"
+    echo -e >&2 "${RED}        Full command:${NC} $*"
+    echo -e >&2 "${RED}        Working dir:${NC} $(pwd)"
+    echo -e >&2 "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    return $exit_code
+  fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ANSIBLE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+IAC_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ENV_FILE="${IAC_DIR}/.netdata-iac-claim.env"
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "Missing ${ENV_FILE}. Create it with claim token/rooms/url." >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "${ENV_FILE}"
+set +a
+
+SSH_PUB_KEY="${SSH_PUB_KEY:-$HOME/.ssh/id_rsa.pub}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_rsa}"
+
+if [[ ! -f "${SSH_PUB_KEY}" ]]; then
+  echo "Missing SSH public key: ${SSH_PUB_KEY}" >&2
+  exit 1
+fi
+
+PUB_KEY="$(cat "${SSH_PUB_KEY}")"
+
+WORK_DIR="${SCRIPT_DIR}/work"
+IMAGES_DIR="${WORK_DIR}/images"
+SEEDS_DIR="${WORK_DIR}/seeds"
+DISKS_DIR="${WORK_DIR}/disks"
+VM_DISK_SIZE="${VM_DISK_SIZE:-20G}"
+
+run mkdir -p "${IMAGES_DIR}" "${SEEDS_DIR}" "${DISKS_DIR}"
+
+VIRSH=(sudo virsh)
+VIRT_INSTALL=(sudo virt-install)
+
+# Ensure libvirt default network exists and is active
+if ! "${VIRSH[@]}" net-info default >/dev/null 2>&1; then
+  NET_XML="${WORK_DIR}/default-net.xml"
+  cat > "${NET_XML}" <<'XML'
+<network>
+  <name>default</name>
+  <forward mode='nat'/>
+  <bridge name='virbr0' stp='on' delay='0'/>
+  <ip address='192.168.122.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.122.2' end='192.168.122.254'/>
+    </dhcp>
+  </ip>
+</network>
+XML
+  run "${VIRSH[@]}" net-define "${NET_XML}"
+  run "${VIRSH[@]}" net-start default
+  run "${VIRSH[@]}" net-autostart default
+else
+  if ! "${VIRSH[@]}" net-info default | awk -F': ' '/Active/ {print $2}' | grep -q 'yes'; then
+    run "${VIRSH[@]}" net-start default
+  fi
+fi
+
+VM_OS_LIST=("ubuntu2204" "rocky9")
+ALL_OS_LIST=("ubuntu2204" "debian12" "rocky9")
+PARENT_OS="ubuntu2204"
+CHILD_OS_LIST=("rocky9")
+
+image_url() {
+  case "$1" in
+    ubuntu2204) echo "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img" ;;
+    rocky9) echo "https://download.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2" ;;
+    *) echo "" ;;
+  esac
+}
+
+os_variant() {
+  case "$1" in
+    ubuntu2204) echo "ubuntu22.04" ;;
+    rocky9) echo "rocky9" ;;
+    *) echo "" ;;
+  esac
+}
+
+uefi_code_path() {
+  local candidates=(
+    "/usr/share/OVMF/OVMF_CODE.fd"
+    "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd"
+    "/usr/share/edk2/x64/OVMF_CODE.fd"
+    "/usr/share/edk2/x64/OVMF_CODE.4m.fd"
+  )
+  for p in "${candidates[@]}"; do
+    if [[ -f "${p}" ]]; then
+      echo "${p}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+uefi_vars_path() {
+  local candidates=(
+    "/usr/share/OVMF/OVMF_VARS.fd"
+    "/usr/share/edk2-ovmf/x64/OVMF_VARS.fd"
+    "/usr/share/edk2/x64/OVMF_VARS.fd"
+    "/usr/share/edk2/x64/OVMF_VARS.4m.fd"
+  )
+  for p in "${candidates[@]}"; do
+    if [[ -f "${p}" ]]; then
+      echo "${p}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+vm_name() {
+  echo "nd-e2e-ansible-$1"
+}
+
+make_seed() {
+  local os="$1"
+  local seed_dir="${SEEDS_DIR}/${os}"
+  local user_data="${seed_dir}/user-data"
+  local meta_data="${seed_dir}/meta-data"
+  local net_cfg="${seed_dir}/network-config"
+  local seed_iso="${seed_dir}/seed.iso"
+  run mkdir -p "${seed_dir}"
+
+  cat > "${user_data}" <<'USERDATA'
+#cloud-config
+hostname: __HOSTNAME__
+users:
+  - name: ansible
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - __PUBKEY__
+ssh_pwauth: false
+disable_root: true
+package_update: true
+package_upgrade: false
+packages:
+  - python3
+  - sudo
+USERDATA
+
+  run sed -i "s|__PUBKEY__|${PUB_KEY}|" "${user_data}"
+  run sed -i "s|__HOSTNAME__|nd-${os}|" "${user_data}"
+
+  cat > "${meta_data}" <<METADATA
+instance-id: nd-${os}
+local-hostname: nd-${os}
+METADATA
+
+  if [[ "${os}" != "rocky9" ]]; then
+    cat > "${net_cfg}" <<NETCFG
+version: 2
+ethernets:
+  en:
+    match:
+      name: "en*"
+    dhcp4: true
+  eth:
+    match:
+      name: "eth*"
+    dhcp4: true
+NETCFG
+
+    run genisoimage -output "${seed_iso}" -volid CIDATA -joliet -rock "${user_data}" "${meta_data}" "${net_cfg}"
+  else
+    run genisoimage -output "${seed_iso}" -volid CIDATA -joliet -rock "${user_data}" "${meta_data}"
+  fi
+}
+
+create_vm() {
+  local os="$1"
+  local name
+  name="$(vm_name "${os}")"
+
+  if "${VIRSH[@]}" dominfo "${name}" >/dev/null 2>&1; then
+    echo "VM ${name} already exists. Skipping creation." >&2
+    return 0
+  fi
+
+  local url
+  url="$(image_url "${os}")"
+  local variant
+  variant="$(os_variant "${os}")"
+  local base_img="${IMAGES_DIR}/${os}.qcow2"
+  local overlay_img="${DISKS_DIR}/${os}.qcow2"
+  local seed_iso="${SEEDS_DIR}/${os}/seed.iso"
+  local boot_args=()
+
+  if [[ "${os}" == "rocky9" ]]; then
+    local uefi_code
+    local uefi_vars
+    uefi_code="$(uefi_code_path || true)"
+    uefi_vars="$(uefi_vars_path || true)"
+    if [[ -z "${uefi_code}" || -z "${uefi_vars}" ]]; then
+      echo "Missing OVMF firmware for UEFI boot. Install edk2-ovmf." >&2
+      exit 1
+    fi
+    boot_args+=(--boot "loader=${uefi_code},loader.readonly=yes,loader.type=pflash,nvram.template=${uefi_vars}")
+  fi
+
+  if [[ ! -f "${base_img}" ]]; then
+    run curl -L -o "${base_img}" "${url}"
+  fi
+
+  make_seed "${os}"
+
+  if [[ ! -f "${overlay_img}" ]]; then
+    run qemu-img create -f qcow2 -F qcow2 -b "${base_img}" "${overlay_img}" "${VM_DISK_SIZE}"
+  fi
+
+  run "${VIRT_INSTALL[@]}" \
+    --name "${name}" \
+    --memory 2048 \
+    --vcpus 2 \
+    --cpu host \
+    --disk "path=${overlay_img},format=qcow2" \
+    --disk "path=${seed_iso},device=cdrom" \
+    --os-variant "${variant}" \
+    "${boot_args[@]}" \
+    --network "network=default" \
+    --graphics none \
+    --noautoconsole \
+    --import
+}
+
+get_vm_ip() {
+  local name="$1"
+  local mac
+  mac=$("${VIRSH[@]}" domiflist "${name}" | awk '/network/ {print $5; exit}')
+  if [[ -z "${mac}" ]]; then
+    return 1
+  fi
+  "${VIRSH[@]}" net-dhcp-leases default | awk -v mac="${mac}" '$0 ~ mac {print $5}' | cut -d/ -f1 | head -n1
+}
+
+wait_for_ip() {
+  local name="$1"
+  local ip=""
+  for _ in $(seq 1 60); do
+    ip=$(get_vm_ip "${name}")
+    if [[ -n "${ip}" ]]; then
+      echo "${ip}"
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+wait_for_ssh() {
+  local ip="$1"
+  local port="${2:-22}"
+  for _ in $(seq 1 60); do
+    if ssh -p "${port}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "${SSH_KEY}" ansible@"${ip}" "echo ok" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+gen_uuid() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen
+  else
+    python3 - <<'PY'
+import uuid
+print(uuid.uuid4())
+PY
+  fi
+}
+
+wait_for_stream_connection() {
+  local ip="$1"
+  local port="$2"
+  local parent_ip="$3"
+  for _ in $(seq 1 24); do
+    if ssh -p "${port}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "${SSH_KEY}" ansible@"${ip}" "(command -v ss >/dev/null 2>&1 && sudo ss -tn state established || sudo netstat -tn) | grep -Eq \"(${parent_ip}:19999|::ffff:${parent_ip}:19999)\"" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+setup_debian_container() {
+  local name="nd-e2e-ansible-debian12"
+  local port="2222"
+  if ! docker ps -a --format '{{.Names}}' | grep -q "^${name}$"; then
+    run docker run --privileged --name "${name}" -d --cgroupns=host -p "${port}:22" \
+      -v /sys/fs/cgroup:/sys/fs/cgroup:rw --tmpfs /run --tmpfs /run/lock \
+      jrei/systemd-debian:12
+  else
+    if ! docker ps --format '{{.Names}}' | grep -q "^${name}$"; then
+      run docker rm -f "${name}"
+      run docker run --privileged --name "${name}" -d --cgroupns=host -p "${port}:22" \
+        -v /sys/fs/cgroup:/sys/fs/cgroup:rw --tmpfs /run --tmpfs /run/lock \
+        jrei/systemd-debian:12
+    fi
+  fi
+
+  for _ in $(seq 1 30); do
+    if docker exec "${name}" systemctl is-system-running >/dev/null 2>&1; then
+      break
+    fi
+    sleep 2
+  done
+
+  run docker exec "${name}" bash -c "rm -f /run/nologin"
+
+  run docker exec "${name}" bash -c "DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server sudo python3 iproute2"
+  run docker exec "${name}" bash -c "id -u ansible >/dev/null 2>&1 || useradd -m -s /bin/bash ansible"
+  run docker exec "${name}" bash -c "usermod -aG sudo ansible"
+  run docker exec "${name}" bash -c "passwd -d ansible || true"
+  run docker exec "${name}" bash -c "usermod -U ansible || true"
+  run docker exec "${name}" bash -c "printf 'ansible ALL=(ALL) NOPASSWD:ALL\\n' > /etc/sudoers.d/90-ansible && chmod 440 /etc/sudoers.d/90-ansible"
+  run docker exec "${name}" bash -c "mkdir -p /home/ansible/.ssh && chmod 700 /home/ansible/.ssh"
+  run docker exec "${name}" bash -c "printf '%s\n' \"${PUB_KEY}\" > /home/ansible/.ssh/authorized_keys"
+  run docker exec "${name}" bash -c "chmod 600 /home/ansible/.ssh/authorized_keys && chown -R ansible:ansible /home/ansible/.ssh"
+  run docker exec "${name}" bash -c "systemctl enable --now ssh || systemctl enable --now sshd"
+
+  export IP_debian12="127.0.0.1"
+  export PORT_debian12="${port}"
+}
+
+get_port() {
+  local name="PORT_$1"
+  local port="${!name-}"
+  if [[ -z "${port}" ]]; then
+    port="22"
+  fi
+  echo "${port}"
+}
+
+for os in "${VM_OS_LIST[@]}"; do
+  create_vm "${os}"
+  state=$("${VIRSH[@]}" domstate "$(vm_name "${os}")" 2>/dev/null | tr -d '\r' || true)
+  if [[ "${state}" != "running" ]]; then
+    run "${VIRSH[@]}" start "$(vm_name "${os}")"
+  fi
+  ip=$(wait_for_ip "$(vm_name "${os}")")
+  if [[ -z "${ip}" ]]; then
+    echo "Failed to get IP for $(vm_name "${os}")" >&2
+    exit 1
+  fi
+  echo "${os} IP: ${ip}" >&2
+  if ! wait_for_ssh "${ip}"; then
+    echo "SSH not ready for ${os} (${ip})" >&2
+    exit 1
+  fi
+  export "IP_${os}"="${ip}"
+  run ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "${SSH_KEY}" ansible@"${ip}" "command -v python3 >/dev/null 2>&1 || (command -v dnf >/dev/null 2>&1 && sudo dnf -y install python3) || (sudo apt-get update && sudo apt-get install -y python3)"
+  done
+
+setup_debian_container
+
+if ! wait_for_ssh "${IP_debian12}" "${PORT_debian12}"; then
+  echo "SSH not ready for debian12 (${IP_debian12}:${PORT_debian12})" >&2
+  exit 1
+fi
+
+INV_DIR="${ANSIBLE_DIR}/inventories/e2e"
+
+SEGMENT_A_KEY="$(gen_uuid)"
+run mkdir -p "${INV_DIR}/group_vars"
+run mkdir -p "${INV_DIR}/files/global/health.d"
+run mkdir -p "${INV_DIR}/files/profiles/child_minimal"
+run mkdir -p "${INV_DIR}/files/profiles/parent"
+
+cat > "${INV_DIR}/inventory.yml" <<INV
+all:
+  hosts:
+    ubuntu2204:
+      ansible_host: ${IP_ubuntu2204}
+      ansible_user: ansible
+      ansible_ssh_private_key_file: ${SSH_KEY}
+      netdata_profiles: [parent]
+    debian12:
+      ansible_host: ${IP_debian12}
+      ansible_port: ${PORT_debian12}
+      ansible_user: ansible
+      ansible_ssh_private_key_file: ${SSH_KEY}
+      netdata_profiles: [standalone]
+    rocky9:
+      ansible_host: ${IP_rocky9}
+      ansible_user: ansible
+      ansible_ssh_private_key_file: ${SSH_KEY}
+      netdata_profiles: [child_minimal]
+INV
+
+cat > "${INV_DIR}/files/global/health.d/e2e.conf" <<EOF
+# E2E placeholder alert overrides
+EOF
+
+cat > "${INV_DIR}/files/profiles/child_minimal/netdata.conf" <<EOF
+[db]
+  mode = ram
+  retention = 1200
+  update every = 1
+
+[ml]
+  enabled = no
+
+[health]
+  enabled = no
+
+[web]
+  bind to = localhost
+EOF
+
+cat > "${INV_DIR}/files/profiles/child_minimal/stream.conf" <<EOF
+[stream]
+  enabled = yes
+  destination = ${IP_ubuntu2204}:19999
+  api key = ${SEGMENT_A_KEY}
+EOF
+
+cat > "${INV_DIR}/files/profiles/parent/netdata.conf" <<EOF
+[web]
+  mode = static-threaded
+EOF
+
+cat > "${INV_DIR}/files/profiles/parent/stream.conf" <<EOF
+[stream]
+  enabled = no
+
+[${SEGMENT_A_KEY}]
+  enabled = yes
+EOF
+
+cat > "${INV_DIR}/group_vars/all.yml" <<VARS
+netdata_claim_enabled: true
+netdata_claim_token: "${NETDATA_CLAIM_TOKEN}"
+netdata_claim_rooms: "${NETDATA_CLAIM_ROOMS}"
+netdata_claim_url: "${NETDATA_CLAIM_URL}"
+netdata_release_channel: "${NETDATA_RELEASE_CHANNEL:-nightly}"
+
+netdata_managed_files:
+  - src: files/global/health.d/e2e.conf
+    dest: health.d/e2e.conf
+    type: health
+
+netdata_profiles_definitions:
+  standalone:
+    managed_files: []
+
+  child_minimal:
+    managed_files:
+      - src: files/profiles/child_minimal/netdata.conf
+        dest: netdata.conf
+        type: netdata_conf
+      - src: files/profiles/child_minimal/stream.conf
+        dest: stream.conf
+        type: stream_conf
+
+  parent:
+    managed_files:
+      - src: files/profiles/parent/netdata.conf
+        dest: netdata.conf
+        type: netdata_conf
+      - src: files/profiles/parent/stream.conf
+        dest: stream.conf
+        type: stream_conf
+VARS
+
+export ANSIBLE_HOST_KEY_CHECKING=False
+export ANSIBLE_ROLES_PATH="${ANSIBLE_DIR}/roles"
+run ansible-playbook -i "${INV_DIR}/inventory.yml" "${ANSIBLE_DIR}/playbooks/netdata.yml"
+
+for os in "${ALL_OS_LIST[@]}"; do
+  ip_var="IP_${os}"
+  ip="${!ip_var}"
+  port="$(get_port "${os}")"
+  echo "Validating ${os} (${ip})" >&2
+  run ssh -p "${port}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "${SSH_KEY}" ansible@"${ip}" "systemctl is-active netdata"
+  run ssh -p "${port}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "${SSH_KEY}" ansible@"${ip}" "sudo test -f /var/lib/netdata/cloud.d/claimed_id"
+  done
+
+parent_ip_var="IP_${PARENT_OS}"
+parent_ip="${!parent_ip_var}"
+for os in "${CHILD_OS_LIST[@]}"; do
+  ip_var="IP_${os}"
+  ip="${!ip_var}"
+  port="$(get_port "${os}")"
+  echo "Validating streaming ${os} -> ${parent_ip}" >&2
+  if ! wait_for_stream_connection "${ip}" "${port}" "${parent_ip}"; then
+    echo "Streaming connection not detected from ${os} to ${parent_ip}" >&2
+    exit 1
+  fi
+  done
+
+echo "E2E completed." >&2

--- a/src/IaC/ansible/inventories/example/files/global/health.d/custom.conf
+++ b/src/IaC/ansible/inventories/example/files/global/health.d/custom.conf
@@ -1,0 +1,2 @@
+# Example custom alert override (global)
+# Copy or replace with your own alerts.

--- a/src/IaC/ansible/inventories/example/files/profiles/child/stream.conf
+++ b/src/IaC/ansible/inventories/example/files/profiles/child/stream.conf
@@ -1,0 +1,4 @@
+[stream]
+  enabled = yes
+  destination = PARENT1:19999
+  api key = CHANGE_ME_CHILD_KEY

--- a/src/IaC/ansible/inventories/example/files/profiles/child_minimal/netdata.conf
+++ b/src/IaC/ansible/inventories/example/files/profiles/child_minimal/netdata.conf
@@ -1,0 +1,13 @@
+[db]
+  mode = ram
+  retention = 1200
+  update every = 1
+
+[ml]
+  enabled = no
+
+[health]
+  enabled = no
+
+[web]
+  bind to = localhost

--- a/src/IaC/ansible/inventories/example/files/profiles/child_minimal/stream.conf
+++ b/src/IaC/ansible/inventories/example/files/profiles/child_minimal/stream.conf
@@ -1,0 +1,4 @@
+[stream]
+  enabled = yes
+  destination = PARENT1:19999
+  api key = CHANGE_ME_CHILD_MINIMAL_KEY

--- a/src/IaC/ansible/inventories/example/files/profiles/parent/netdata.conf
+++ b/src/IaC/ansible/inventories/example/files/profiles/parent/netdata.conf
@@ -1,0 +1,2 @@
+[web]
+  mode = static-threaded

--- a/src/IaC/ansible/inventories/example/files/profiles/parent/stream.conf
+++ b/src/IaC/ansible/inventories/example/files/profiles/parent/stream.conf
@@ -1,0 +1,5 @@
+[stream]
+  enabled = no
+
+[CHANGE_ME_PARENT_SEGMENT_KEY]
+  enabled = yes

--- a/src/IaC/ansible/inventories/example/group_vars/all.yml
+++ b/src/IaC/ansible/inventories/example/group_vars/all.yml
@@ -1,0 +1,54 @@
+# Netdata claim (optional)
+netdata_claim_enabled: true
+netdata_claim_token: "CHANGE_ME"
+netdata_claim_rooms: "CHANGE_ME"
+netdata_claim_url: "https://app.netdata.cloud"
+
+# Optional claim proxy settings
+# netdata_claim_proxy: "env"
+# netdata_claim_insecure: false
+
+# Release channel
+netdata_release_channel: "stable"
+
+# Optional overrides
+# netdata_hostname: "my-hostname"
+# netdata_config_dir: "/etc/netdata"
+# netdata_lib_dir: "/var/lib/netdata"
+# netdata_install_only_if_missing: true
+# netdata_kickstart_extra_args: []
+
+# Global managed files (applied to all hosts)
+netdata_managed_files:
+  - src: files/global/health.d/custom.conf
+    dest: health.d/custom.conf
+    type: health
+
+# Profile definitions (file-level isolation)
+netdata_profiles_definitions:
+  standalone:
+    managed_files: []
+
+  child:
+    managed_files:
+      - src: files/profiles/child/stream.conf
+        dest: stream.conf
+        type: stream_conf
+
+  child_minimal:
+    managed_files:
+      - src: files/profiles/child_minimal/netdata.conf
+        dest: netdata.conf
+        type: netdata_conf
+      - src: files/profiles/child_minimal/stream.conf
+        dest: stream.conf
+        type: stream_conf
+
+  parent:
+    managed_files:
+      - src: files/profiles/parent/netdata.conf
+        dest: netdata.conf
+        type: netdata_conf
+      - src: files/profiles/parent/stream.conf
+        dest: stream.conf
+        type: stream_conf

--- a/src/IaC/ansible/inventories/example/group_vars/netdata_child.yml
+++ b/src/IaC/ansible/inventories/example/group_vars/netdata_child.yml
@@ -1,0 +1,1 @@
+# Deprecated: profiles are now defined in group_vars/all.yml via netdata_profiles_definitions.

--- a/src/IaC/ansible/inventories/example/group_vars/netdata_child_minimal.yml
+++ b/src/IaC/ansible/inventories/example/group_vars/netdata_child_minimal.yml
@@ -1,0 +1,1 @@
+# Deprecated: profiles are now defined in group_vars/all.yml via netdata_profiles_definitions.

--- a/src/IaC/ansible/inventories/example/group_vars/netdata_parent.yml
+++ b/src/IaC/ansible/inventories/example/group_vars/netdata_parent.yml
@@ -1,0 +1,1 @@
+# Deprecated: profiles are now defined in group_vars/all.yml via netdata_profiles_definitions.

--- a/src/IaC/ansible/inventories/example/group_vars/netdata_standalone.yml
+++ b/src/IaC/ansible/inventories/example/group_vars/netdata_standalone.yml
@@ -1,0 +1,1 @@
+# Deprecated: profiles are now defined in group_vars/all.yml via netdata_profiles_definitions.

--- a/src/IaC/ansible/inventories/example/inventory.yml
+++ b/src/IaC/ansible/inventories/example/inventory.yml
@@ -1,0 +1,14 @@
+all:
+  hosts:
+    standalone-01:
+      ansible_host: 203.0.113.10
+      netdata_profiles: [standalone]
+    child-01:
+      ansible_host: 203.0.113.11
+      netdata_profiles: [child]
+    child-min-01:
+      ansible_host: 203.0.113.12
+      netdata_profiles: [child_minimal]
+    parent-01:
+      ansible_host: 203.0.113.20
+      netdata_profiles: [parent]

--- a/src/IaC/ansible/playbooks/netdata.yml
+++ b/src/IaC/ansible/playbooks/netdata.yml
@@ -1,0 +1,6 @@
+---
+- name: Install and claim Netdata
+  hosts: all
+  become: true
+  roles:
+    - role: netdata

--- a/src/IaC/ansible/roles/netdata/defaults/main.yml
+++ b/src/IaC/ansible/roles/netdata/defaults/main.yml
@@ -1,0 +1,51 @@
+---
+netdata_kickstart_url: "https://get.netdata.cloud/kickstart.sh"
+netdata_release_channel: "stable"
+
+netdata_claim_enabled: true
+netdata_claim_token: ""
+netdata_claim_rooms: ""
+netdata_claim_url: "https://app.netdata.cloud"
+netdata_claim_proxy: ""
+netdata_claim_insecure: false
+netdata_reclaim: false
+
+netdata_dbengine_multihost_disk_space: ""
+netdata_web_mode: ""
+netdata_hostname: ""
+
+netdata_config_dir: ""
+netdata_lib_dir: "/var/lib/netdata"
+netdata_group: "netdata"
+
+netdata_install_only_if_missing: true
+netdata_kickstart_extra_args: []
+
+netdata_http_client_packages:
+  - curl
+  - wget
+netdata_apt_clean_before_install: true
+
+netdata_db_mode: ""
+netdata_db_retention: ""
+netdata_db_update_every: ""
+netdata_ml_enabled: ""
+netdata_health_enabled: ""
+netdata_web_bind_to: ""
+netdata_stream_enabled: ""
+netdata_stream_destinations: []
+netdata_stream_api_key: ""
+netdata_stream_section_options: {}
+netdata_stream_parent_keys: []
+
+# Profile-based configuration
+netdata_profiles: []
+netdata_profiles_definitions: {}
+
+# Managed files (host-level)
+netdata_managed_files: []
+
+# Optional per-host tweaks for full config files
+netdata_conf_entries: []
+netdata_stream_entries: []
+

--- a/src/IaC/ansible/roles/netdata/handlers/main.yml
+++ b/src/IaC/ansible/roles/netdata/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart Netdata
+  service:
+    name: netdata
+    state: restarted

--- a/src/IaC/ansible/roles/netdata/tasks/claim.yml
+++ b/src/IaC/ansible/roles/netdata/tasks/claim.yml
@@ -1,0 +1,90 @@
+---
+- name: Validate claim settings
+  assert:
+    that:
+      - not netdata_claim_enabled or (netdata_claim_token | length > 0)
+    fail_msg: "netdata_claim_token is required when netdata_claim_enabled=true"
+
+- name: Check claimed marker
+  stat:
+    path: "{{ netdata_lib_dir }}/cloud.d/claimed_id"
+  register: netdata_claimed_id
+
+- name: Find netdatacli in PATH
+  command: command -v netdatacli
+  register: netdata_netdatacli_cmd
+  changed_when: false
+  failed_when: false
+  when: netdata_claim_enabled | bool
+
+- name: Check common netdatacli locations
+  stat:
+    path: "{{ item }}"
+  register: netdata_netdatacli_paths
+  loop:
+    - /usr/sbin/netdatacli
+    - /opt/netdata/bin/netdatacli
+  when: netdata_claim_enabled | bool
+
+- name: Select netdatacli path
+  set_fact:
+    netdatacli_path: >-
+      {{
+        netdata_netdatacli_cmd.stdout if netdata_netdatacli_cmd.stdout | length > 0 else
+        (netdata_netdatacli_paths.results | selectattr('stat.exists') | map(attribute='stat.path') | list | first | default(''))
+      }}
+  when: netdata_claim_enabled | bool
+
+- name: Fail if netdatacli is missing
+  fail:
+    msg: "netdatacli not found on the target host"
+  when:
+    - netdata_claim_enabled | bool
+    - netdatacli_path | length == 0
+
+- name: Remove claimed_id for reclaim
+  file:
+    path: "{{ netdata_lib_dir }}/cloud.d/claimed_id"
+    state: absent
+  when: netdata_reclaim | bool
+
+- name: Ensure claim.conf is absent when claim is disabled
+  file:
+    path: "{{ netdata_config_dir_effective }}/claim.conf"
+    state: absent
+  when: not netdata_claim_enabled | bool
+
+- name: Write claim.conf
+  template:
+    src: claim.conf.j2
+    dest: "{{ netdata_config_dir_effective }}/claim.conf"
+    owner: root
+    group: "{{ netdata_group }}"
+    mode: "0640"
+  register: netdata_claim_conf_write
+  when: netdata_claim_enabled | bool
+
+- name: Wait for netdata control socket
+  wait_for:
+    path: /run/netdata/netdata.pipe
+    timeout: 30
+  when: netdata_claim_enabled | bool
+
+- name: Reload claiming state
+  command:
+    argv:
+      - "{{ netdatacli_path }}"
+      - reload-claiming-state
+  when: netdata_claim_enabled | bool
+  changed_when: >-
+    (netdata_claim_conf_write.changed | default(false))
+    or (netdata_reclaim | bool)
+    or (not netdata_claimed_id.stat.exists)
+
+- name: Wait for claimed_id marker
+  wait_for:
+    path: "{{ netdata_lib_dir }}/cloud.d/claimed_id"
+    timeout: 120
+  when:
+    - netdata_claim_enabled | bool
+    - netdata_reclaim | bool or not netdata_claimed_id.stat.exists

--- a/src/IaC/ansible/roles/netdata/tasks/config-dir.yml
+++ b/src/IaC/ansible/roles/netdata/tasks/config-dir.yml
@@ -1,0 +1,34 @@
+---
+- name: Set config dir from user override
+  set_fact:
+    netdata_config_dir_effective: "{{ netdata_config_dir }}"
+  when: netdata_config_dir | length > 0
+
+- name: Detect config dir (if not set)
+  block:
+    - name: Check /etc/netdata/netdata.conf
+      stat:
+        path: /etc/netdata/netdata.conf
+      register: netdata_etc_conf
+
+    - name: Check /opt/netdata/etc/netdata/netdata.conf
+      stat:
+        path: /opt/netdata/etc/netdata/netdata.conf
+      register: netdata_opt_conf
+
+    - name: Set detected config dir
+      set_fact:
+        netdata_config_dir_effective: >-
+          {{
+            '/etc/netdata' if netdata_etc_conf.stat.exists else
+            ('/opt/netdata/etc/netdata' if netdata_opt_conf.stat.exists else '/etc/netdata')
+          }}
+  when: netdata_config_dir | length == 0
+
+- name: Ensure config dir exists
+  file:
+    path: "{{ netdata_config_dir_effective }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"

--- a/src/IaC/ansible/roles/netdata/tasks/configure.yml
+++ b/src/IaC/ansible/roles/netdata/tasks/configure.yml
@@ -1,0 +1,102 @@
+---
+- name: Set db mode (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/netdata.conf"
+    section: db
+    option: mode
+    value: "{{ netdata_db_mode }}"
+    create: true
+  when: netdata_db_mode | string | length > 0
+  notify: Restart Netdata
+
+- name: Set db retention (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/netdata.conf"
+    section: db
+    option: retention
+    value: "{{ netdata_db_retention }}"
+    create: true
+  when: netdata_db_retention | string | length > 0
+  notify: Restart Netdata
+
+- name: Set db update every (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/netdata.conf"
+    section: db
+    option: update every
+    value: "{{ netdata_db_update_every }}"
+    create: true
+  when: netdata_db_update_every | string | length > 0
+  notify: Restart Netdata
+
+- name: Set dbengine multihost disk space (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/netdata.conf"
+    section: global
+    option: dbengine multihost disk space
+    value: "{{ netdata_dbengine_multihost_disk_space }}"
+    create: true
+  when: netdata_dbengine_multihost_disk_space | string | length > 0
+  notify: Restart Netdata
+
+- name: Set ML enabled (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/netdata.conf"
+    section: ml
+    option: enabled
+    value: "{{ 'yes' if (netdata_ml_enabled | bool) else 'no' }}"
+    create: true
+  when: netdata_ml_enabled | string | length > 0
+  notify: Restart Netdata
+
+- name: Set health enabled (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/netdata.conf"
+    section: health
+    option: enabled
+    value: "{{ 'yes' if (netdata_health_enabled | bool) else 'no' }}"
+    create: true
+  when: netdata_health_enabled | string | length > 0
+  notify: Restart Netdata
+
+- name: Set web mode (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/netdata.conf"
+    section: web
+    option: mode
+    value: "{{ netdata_web_mode }}"
+    create: true
+  when: netdata_web_mode | string | length > 0
+  notify: Restart Netdata
+
+- name: Set web bind to (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/netdata.conf"
+    section: web
+    option: bind to
+    value: "{{ netdata_web_bind_to }}"
+    create: true
+  when: netdata_web_bind_to | string | length > 0
+  notify: Restart Netdata
+
+- name: Set hostname (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/netdata.conf"
+    section: global
+    option: hostname
+    value: "{{ netdata_hostname }}"
+    create: true
+  when: netdata_hostname | length > 0
+  notify: Restart Netdata
+
+- name: Set netdata.conf entries (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/netdata.conf"
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    create: true
+  loop: "{{ netdata_conf_entries }}"
+  when: netdata_conf_entries | length > 0
+  notify: Restart Netdata
+

--- a/src/IaC/ansible/roles/netdata/tasks/install.yml
+++ b/src/IaC/ansible/roles/netdata/tasks/install.yml
@@ -1,0 +1,61 @@
+---
+- name: Gather service facts
+  service_facts:
+
+- name: Check if Netdata service exists
+  set_fact:
+    netdata_installed: "{{ 'netdata.service' in ansible_facts.services }}"
+
+- name: Decide if install is needed
+  set_fact:
+    netdata_install_needed: "{{ (not netdata_installed) or (not netdata_install_only_if_missing | bool) }}"
+
+- name: Ensure HTTP client is installed
+  package:
+    name: "{{ netdata_http_client_packages }}"
+    state: present
+  when: netdata_install_needed
+
+- name: Clean apt cache (optional)
+  command: apt-get clean
+  changed_when: false
+  when:
+    - netdata_install_needed
+    - netdata_apt_clean_before_install | bool
+    - ansible_facts.os_family == "Debian"
+
+- name: Download kickstart script
+  get_url:
+    url: "{{ netdata_kickstart_url }}"
+    dest: /tmp/netdata-kickstart.sh
+    mode: "0755"
+  when: netdata_install_needed
+
+- name: Build kickstart arguments (base)
+  set_fact:
+    netdata_kickstart_argv:
+      - /tmp/netdata-kickstart.sh
+      - --non-interactive
+      - --dont-wait
+      - --release-channel
+      - "{{ netdata_release_channel }}"
+  when: netdata_install_needed
+
+
+- name: Add extra kickstart arguments
+  set_fact:
+    netdata_kickstart_argv: "{{ netdata_kickstart_argv + netdata_kickstart_extra_args }}"
+  when:
+    - netdata_install_needed
+    - netdata_kickstart_extra_args | length > 0
+
+- name: Install Netdata
+  command:
+    argv: "{{ netdata_kickstart_argv }}"
+  when: netdata_install_needed
+  register: netdata_install_result
+  changed_when: netdata_install_needed
+
+- name: Record install run
+  set_fact:
+    netdata_install_ran: "{{ netdata_install_needed }}"

--- a/src/IaC/ansible/roles/netdata/tasks/main.yml
+++ b/src/IaC/ansible/roles/netdata/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Install Netdata
+  import_tasks: install.yml
+
+- name: Set Netdata config directory
+  import_tasks: config-dir.yml
+
+- name: Resolve Netdata profiles
+  import_tasks: profiles.yml
+
+- name: Deploy managed Netdata files
+  import_tasks: managed-files.yml
+  when: netdata_managed_files_effective | length > 0
+
+- name: Configure Netdata
+  import_tasks: configure.yml
+
+- name: Configure Netdata streaming
+  import_tasks: stream.yml
+
+- name: Ensure Netdata service is running
+  import_tasks: service.yml
+
+- name: Claim Netdata
+  import_tasks: claim.yml

--- a/src/IaC/ansible/roles/netdata/tasks/managed-files.yml
+++ b/src/IaC/ansible/roles/netdata/tasks/managed-files.yml
@@ -1,0 +1,83 @@
+---
+- name: Validate managed file entries
+  assert:
+    that:
+      - item.src is defined
+      - item.dest is defined
+    fail_msg: "Each managed file must include 'src' and 'dest'"
+  loop: "{{ netdata_managed_files_effective }}"
+
+- name: Build managed files list with resolved paths
+  set_fact:
+    netdata_managed_files_resolved: "{{ (netdata_managed_files_resolved | default([])) + [ item | combine({'dest_resolved': dest_resolved, 'src_resolved': src_resolved}) ] }}"
+  vars:
+    dest_resolved: >-
+      {{
+        item.dest if (item.dest | regex_search('^/'))
+        else (netdata_config_dir_effective ~ '/' ~ item.dest)
+      }}
+    src_resolved: >-
+      {{
+        item.src if (item.src | regex_search('^/'))
+        else ((inventory_dir | default(playbook_dir)) ~ '/' ~ item.src)
+      }}
+  loop: "{{ netdata_managed_files_effective }}"
+
+- name: Build destination-to-profiles map
+  set_fact:
+    netdata_managed_files_dest_profiles: >-
+      {{
+        netdata_managed_files_dest_profiles | default({})
+        | combine({
+            item.dest_resolved: (netdata_managed_files_dest_profiles[item.dest_resolved] | default([])) + [ item.__profile | default('host') ]
+          }, recursive=True)
+      }}
+  loop: "{{ netdata_managed_files_resolved }}"
+
+- name: Initialize managed file collisions list
+  set_fact:
+    netdata_managed_files_collisions: []
+
+- name: Detect managed file destination collisions
+  set_fact:
+    netdata_managed_files_collisions: "{{ netdata_managed_files_collisions + [item] }}"
+  loop: "{{ netdata_managed_files_dest_profiles | dict2items }}"
+  when: item.value | length > 1
+
+- name: Fail on managed file destination collisions
+  fail:
+    msg: >-
+      Managed file destination collisions detected for {{ item.key }} (profiles: {{ item.value | unique | join(', ') }})
+  loop: "{{ netdata_managed_files_collisions }}"
+  when: netdata_managed_files_collisions | length > 0
+
+- name: Ensure managed file directories exist
+  file:
+    path: "{{ item.dest_resolved | dirname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop: "{{ netdata_managed_files_resolved }}"
+
+- name: Deploy managed files (copy)
+  copy:
+    src: "{{ item.src_resolved }}"
+    dest: "{{ item.dest_resolved }}"
+    owner: "{{ item.owner | default('root') }}"
+    group: "{{ item.group | default('root') }}"
+    mode: "{{ item.mode | default('0644') }}"
+  loop: "{{ netdata_managed_files_resolved }}"
+  when: not (item.template | default(false) | bool)
+  notify: Restart Netdata
+
+- name: Deploy managed files (template)
+  template:
+    src: "{{ item.src_resolved }}"
+    dest: "{{ item.dest_resolved }}"
+    owner: "{{ item.owner | default('root') }}"
+    group: "{{ item.group | default('root') }}"
+    mode: "{{ item.mode | default('0644') }}"
+  loop: "{{ netdata_managed_files_resolved }}"
+  when: item.template | default(false) | bool
+  notify: Restart Netdata

--- a/src/IaC/ansible/roles/netdata/tasks/profile-files.yml
+++ b/src/IaC/ansible/roles/netdata/tasks/profile-files.yml
@@ -1,0 +1,16 @@
+---
+- name: Ensure profile exists
+  assert:
+    that:
+      - netdata_profiles_definitions[profile_name] is defined
+    fail_msg: "Profile '{{ profile_name }}' not found in netdata_profiles_definitions"
+
+- name: Append managed files for profile
+  set_fact:
+    netdata_profile_managed_files: >-
+      {{
+        netdata_profile_managed_files
+        + (netdata_profiles_definitions[profile_name].managed_files | default([])
+          | map('combine', {'__profile': profile_name})
+          | list)
+      }}

--- a/src/IaC/ansible/roles/netdata/tasks/profiles.yml
+++ b/src/IaC/ansible/roles/netdata/tasks/profiles.yml
@@ -1,0 +1,25 @@
+---
+- name: Ensure profile definitions are provided
+  assert:
+    that:
+      - netdata_profiles_definitions is mapping
+    fail_msg: "netdata_profiles_definitions must be a map of profile names to definitions"
+
+- name: Initialize profile managed files list
+  set_fact:
+    netdata_profile_managed_files: []
+
+- name: Collect profile managed files
+  include_tasks: profile-files.yml
+  loop: "{{ netdata_profiles }}"
+  loop_control:
+    loop_var: profile_name
+  when: netdata_profiles | length > 0
+
+- name: Build effective managed files list
+  set_fact:
+    netdata_managed_files_effective: >-
+      {{
+        (netdata_managed_files | default([]) | map('combine', {'__profile': 'host'}) | list)
+        + (netdata_profile_managed_files | default([]))
+      }}

--- a/src/IaC/ansible/roles/netdata/tasks/service.yml
+++ b/src/IaC/ansible/roles/netdata/tasks/service.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure Netdata service is enabled and running
+  service:
+    name: netdata
+    state: started
+    enabled: true

--- a/src/IaC/ansible/roles/netdata/tasks/stream-parent-options.yml
+++ b/src/IaC/ansible/roles/netdata/tasks/stream-parent-options.yml
@@ -1,0 +1,12 @@
+---
+- name: Set parent key option
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/stream.conf"
+    section: "{{ parent_key.key }}"
+    option: "{{ parent_option.key }}"
+    value: "{{ parent_option.value }}"
+    create: true
+  loop: "{{ parent_key.options | dict2items }}"
+  loop_control:
+    loop_var: parent_option
+  notify: Restart Netdata

--- a/src/IaC/ansible/roles/netdata/tasks/stream.yml
+++ b/src/IaC/ansible/roles/netdata/tasks/stream.yml
@@ -1,0 +1,88 @@
+---
+- name: Set stream enabled (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/stream.conf"
+    section: stream
+    option: enabled
+    value: "{{ 'yes' if (netdata_stream_enabled | bool) else 'no' }}"
+    create: true
+  when: netdata_stream_enabled | string | length > 0
+  notify: Restart Netdata
+
+- name: Set stream destinations (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/stream.conf"
+    section: stream
+    option: destination
+    value: "{{ netdata_stream_destinations | join(' ') }}"
+    create: true
+  when: netdata_stream_destinations | length > 0
+  notify: Restart Netdata
+
+- name: Set stream api key (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/stream.conf"
+    section: stream
+    option: api key
+    value: "{{ netdata_stream_api_key }}"
+    create: true
+  when: netdata_stream_api_key | length > 0
+  notify: Restart Netdata
+
+- name: Set stream section options (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/stream.conf"
+    section: stream
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+    create: true
+  loop: "{{ netdata_stream_section_options | dict2items }}"
+  when: netdata_stream_section_options | length > 0
+  notify: Restart Netdata
+
+- name: Enable parent keys
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/stream.conf"
+    section: "{{ item.key }}"
+    option: enabled
+    value: "yes"
+    create: true
+  loop: "{{ netdata_stream_parent_keys }}"
+  when: netdata_stream_parent_keys | length > 0
+  notify: Restart Netdata
+
+- name: Set parent allow from (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/stream.conf"
+    section: "{{ item.key }}"
+    option: allow from
+    value: "{{ item.allow_from }}"
+    create: true
+  loop: "{{ netdata_stream_parent_keys }}"
+  when:
+    - netdata_stream_parent_keys | length > 0
+    - item.allow_from is defined
+    - item.allow_from | length > 0
+  notify: Restart Netdata
+
+- name: Set parent key options (optional)
+  include_tasks: stream-parent-options.yml
+  loop: "{{ netdata_stream_parent_keys }}"
+  loop_control:
+    loop_var: parent_key
+  when:
+    - netdata_stream_parent_keys | length > 0
+    - parent_key.options is defined
+    - parent_key.options | length > 0
+
+- name: Set stream.conf entries (optional)
+  ini_file:
+    path: "{{ netdata_config_dir_effective }}/stream.conf"
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    create: true
+  loop: "{{ netdata_stream_entries }}"
+  when: netdata_stream_entries | length > 0
+  notify: Restart Netdata
+

--- a/src/IaC/ansible/roles/netdata/templates/claim.conf.j2
+++ b/src/IaC/ansible/roles/netdata/templates/claim.conf.j2
@@ -1,0 +1,10 @@
+[global]
+url = {{ netdata_claim_url }}
+token = {{ netdata_claim_token }}
+{% if netdata_claim_rooms | length > 0 %}
+rooms = {{ netdata_claim_rooms }}
+{% endif %}
+{% if netdata_claim_proxy | length > 0 %}
+proxy = {{ netdata_claim_proxy }}
+{% endif %}
+insecure = {{ 'yes' if (netdata_claim_insecure | bool) else 'no' }}


### PR DESCRIPTION
## Summary

- Add Infrastructure as Code (IaC) support for deploying Netdata with Ansible
- Reusable role with profile-based configuration (standalone, parent, child, child_minimal)
- Cloud claiming support via claim.conf
- Streaming configuration for parent/child architectures
- Managed files with automatic restart on changes
- Example inventory and group variables
- E2E testing framework using libvirt VMs and Docker containers

## What's Included

**Role** (`src/IaC/ansible/roles/netdata/`)
- Installation via kickstart.sh
- Config directory auto-detection
- Profile resolution with collision detection
- Managed file deployment (static and templates)
- Streaming setup for both children and parents
- Cloud claiming with proxy support

**Documentation**
- `src/IaC/README.md` - End-user overview of IaC provisioning
- `src/IaC/AGENTS.md` - Internal guidelines for all provisioning systems
- `src/IaC/ansible/README.md` - User guide for Ansible deployment
- `src/IaC/ansible/AGENTS.md` - Technical reference for the implementation

**Example Inventory** (`src/IaC/ansible/inventories/example/`)
- Sample hosts with profile assignments
- Group variables for claiming and profiles
- Configuration files for each profile

**E2E Testing** (`src/IaC/ansible/e2e/`)
- Test script for Ubuntu 22.04, Debian 12, Rocky 9
- libvirt VM provisioning with cloud-init
- Docker container for fast smoke tests

## Test plan

- [x] Run E2E tests on Ubuntu 22.04, Debian 12, Rocky 9
- [x] Verify standalone profile works
- [x] Verify parent/child streaming works
- [ ] Verify Cloud claiming works
- [ ] Test with AWX/Automation Controller

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Ansible role to install and configure Netdata with profiles (standalone, parent, child, child_minimal), Cloud claiming, and streaming. Includes example inventory, documentation, and an E2E test harness for Ubuntu 22.04, Debian 12, and Rocky 9.

- **New Features**
  - Reusable Ansible role using kickstart.sh with config dir auto-detection.
  - Profile-based, file-level configuration with collision detection.
  - Cloud claiming via claim.conf with proxy/insecure options and reclaim support.
  - Streaming for parent/child setups, including parent API key entries.
  - Managed files (static or templates) with automatic service restart.
  - Example inventory/group vars, plus end-user and technical docs; libvirt + Docker E2E tests.

- **Migration**
  - Copy inventories/example, set claim token/rooms, assign profiles per host, then run playbooks/netdata.yml.
  - Store secrets in src/IaC/.netdata-iac-claim.env; .gitignore updated to ignore e2e artifacts.
  - No breaking changes for existing setups.

<sup>Written for commit 1adc8f1c9fbafd54b3282e3083acb8340a4d7a5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

