### PR TITLE
Fix handling of LZ4 dependency version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2376,12 +2376,14 @@ else()
 endif()
 
 # lz4
-pkg_check_modules(LIBLZ4 liblz4>=1.7.1)
-set(ENABLE_LZ4 On)
+pkg_check_modules(LIBLZ4 REQUIRED liblz4>=1.7.1)
+if(LIBLZ4_FOUND)
+  set(ENABLE_LZ4 On)
 
-target_include_directories(libnetdata BEFORE PUBLIC ${LIBLZ4_INCLUDE_DIRS})
-target_compile_options(libnetdata PUBLIC ${LIBLZ4_CFLAGS_OTHER})
-target_link_libraries(libnetdata PUBLIC ${LIBLZ4_LDFLAGS})
+  target_include_directories(libnetdata BEFORE PUBLIC ${LIBLZ4_INCLUDE_DIRS})
+  target_compile_options(libnetdata PUBLIC ${LIBLZ4_CFLAGS_OTHER})
+  target_link_libraries(libnetdata PUBLIC ${LIBLZ4_LDFLAGS})
+endif()
 
 # zstd
 pkg_check_modules(LIBZSTD libzstd)


### PR DESCRIPTION
##### Summary

The strange split in how we handle our LZ4 dependency in the build system is an artefact of now removed features that depended on version 1.9 or later, combined with a lack of understanding of the evolution of the liblz4 API over the years.

With the current state of things, none of our LZ4 dependent code actually gets built unless we find LZ4 version 1.9 or newer despite our checking for an older version afterwards, and we don’t actually depend on anything in the API that’s newer than version 1.7.1.

Given this, just check for LZ4 version 1.7.1 or newer and don’t try any fallback checks.

The only functional effect of this change aside from declaring our dependencies properly is that LZ4 support will be available on a small handful of systems it was not previously available on.

##### Test Plan

Confirm that CI passes on this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified LZ4 detection by requiring liblz4 >= 1.7.1 and enabling LZ4. This removes the 1.9+ split logic that blocked LZ4 builds on systems with older versions.

- **Dependencies**
  - Use pkg-config check for liblz4>=1.7.1; drop fallback path and always set ENABLE_LZ4.
  - We only use APIs available since 1.7.1, so behavior is unchanged; LZ4 now builds on systems with 1.7.x/1.8.x.

<sup>Written for commit bc8543902f86257b3ffc1317b9b4dda3b300eed2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

