### PR TITLE
fix(integrations): show functions section even with empty list

### DIFF
--- a/integrations/templates/functions.md
+++ b/integrations/templates/functions.md
@@ -1,4 +1,4 @@
-[% if entry.functions and entry.functions.list %]
+[% if entry.functions %]
 ## Functions
 
 [[ entry.functions.description ]]


### PR DESCRIPTION
The template condition required functions.list to be non-empty, which skipped the entire Functions section (including description) for collectors with user-defined functions like SQL.

Now the section is shown if functions exists, allowing the description to be displayed even when no predefined functions are listed.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the Functions section when entry.functions exists, even if functions.list is empty. This ensures the section description is visible for collectors with user-defined functions (e.g., SQL).

<sup>Written for commit 5abfafd108a1b4f326a29c8b4130e67572ad994b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

