### PR TITLE
test(go.d/snmp): fix tests

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/func_interfaces_test.go
+++ b/src/go/plugin/go.d/collector/snmp/func_interfaces_test.go
@@ -114,9 +114,9 @@ func TestFuncIfacesColumns(t *testing.T) {
 					case "Type Group":
 						assert.Equal(t, "ethernet", col.Value(entry))
 					case "Traffic In":
-						assert.Equal(t, rate/1_000_000, col.Value(entry))
+						assert.Equal(t, rate, col.Value(entry))
 					case "Packets In":
-						assert.Equal(t, rate/1_000, col.Value(entry))
+						assert.Equal(t, rate, col.Value(entry))
 					case "Errors In":
 						assert.Equal(t, rate, col.Value(entry))
 					case "Discards In":
@@ -226,10 +226,10 @@ func TestFuncInterfaces_buildRow(t *testing.T) {
 				assert.Equal(t, "eth0", row[nameIdx])
 				assert.Equal(t, "ethernetCsmacd", row[typeIdx])
 				assert.Equal(t, "ethernet", row[typeGroupIdx])
-				assert.Equal(t, rate1/1_000_000, row[trafficInIdx])
-				assert.Equal(t, rate2/1_000_000, row[trafficOutIdx])
-				assert.Equal(t, (rate1*3)/1_000, row[packetsInIdx])
-				assert.Equal(t, (rate2*3)/1_000, row[packetsOutIdx])
+				assert.Equal(t, rate1, row[trafficInIdx])
+				assert.Equal(t, rate2, row[trafficOutIdx])
+				assert.Equal(t, rate1*3, row[packetsInIdx])
+				assert.Equal(t, rate2*3, row[packetsOutIdx])
 				assert.Equal(t, "up", row[adminIdx])
 				assert.Equal(t, "up", row[operIdx])
 				assert.Nil(t, row[rowOptionsIdx])


### PR DESCRIPTION
Remove scaling factors from expected values to match the code change that now uses bit/s and packets/s instead of Mbits and Kpps.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update SNMP interfaces function tests to expect base units (bit/s and packets/s) instead of Mbit/s and Kpps. Removes scaling in expected values to match the code change and fixes failing tests.

<sup>Written for commit 2f150b9cee2d834b2a0c5a323e93f645102eda52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

