### PR TITLE
feat(go.d/ping): add jitter and variance metrics

### DIFF
--- a/src/go/plugin/go.d/collector/ping/charts.go
+++ b/src/go/plugin/go.d/collector/ping/charts.go
@@ -12,16 +12,11 @@ import (
 const (
 	prioHostRTT = module.Priority + iota
 	prioHostStdDevRTT
+	prioHostJitter
+	prioHostVariance
 	prioHostPingPacketLoss
 	prioHostPingPackets
 )
-
-var hostChartsTmpl = module.Charts{
-	hostRTTChartTmpl.Copy(),
-	hostStdDevRTTChartTmpl.Copy(),
-	hostPacketLossChartTmpl.Copy(),
-	hostPacketsChartTmpl.Copy(),
-}
 
 var (
 	hostRTTChartTmpl = module.Chart{
@@ -49,31 +44,62 @@ var (
 			{ID: "host_%s_std_dev_rtt", Name: "std_dev", Div: 1e3},
 		},
 	}
+	hostJitterChartTmpl = module.Chart{
+		ID:       "host_%s_jitter",
+		Title:    "Ping latency jitter",
+		Units:    "milliseconds",
+		Fam:      "latency",
+		Ctx:      "ping.host_jitter",
+		Priority: prioHostJitter,
+		Dims: module.Dims{
+			{ID: "host_%s_mean_jitter", Name: "mean", Div: 1e3},
+			{ID: "host_%s_ewma_jitter", Name: "ewma", Div: 1e3},
+			{ID: "host_%s_sma_jitter", Name: "sma", Div: 1e3},
+		},
+	}
+	hostVarianceChartTmpl = module.Chart{
+		ID:       "host_%s_rtt_variance",
+		Title:    "Ping round-trip time variance",
+		Units:    "ms²",
+		Fam:      "latency",
+		Ctx:      "ping.host_rtt_variance",
+		Priority: prioHostVariance,
+		Dims: module.Dims{
+			{ID: "host_%s_rtt_variance", Name: "variance", Div: 1e6},
+		},
+	}
+	hostPacketLossChartTmpl = module.Chart{
+		ID:       "host_%s_packet_loss",
+		Title:    "Ping packet loss",
+		Units:    "percentage",
+		Fam:      "packet loss",
+		Ctx:      "ping.host_packet_loss",
+		Priority: prioHostPingPacketLoss,
+		Dims: module.Dims{
+			{ID: "host_%s_packet_loss", Name: "loss", Div: 1000},
+		},
+	}
+	hostPacketsChartTmpl = module.Chart{
+		ID:       "host_%s_packets",
+		Title:    "Ping packets transferred",
+		Units:    "packets",
+		Fam:      "packets",
+		Ctx:      "ping.host_packets",
+		Priority: prioHostPingPackets,
+		Dims: module.Dims{
+			{ID: "host_%s_packets_recv", Name: "received"},
+			{ID: "host_%s_packets_sent", Name: "sent"},
+		},
+	}
 )
 
-var hostPacketLossChartTmpl = module.Chart{
-	ID:       "host_%s_packet_loss",
-	Title:    "Ping packet loss",
-	Units:    "percentage",
-	Fam:      "packet loss",
-	Ctx:      "ping.host_packet_loss",
-	Priority: prioHostPingPacketLoss,
-	Dims: module.Dims{
-		{ID: "host_%s_packet_loss", Name: "loss", Div: 1000},
-	},
-}
-
-var hostPacketsChartTmpl = module.Chart{
-	ID:       "host_%s_packets",
-	Title:    "Ping packets transferred",
-	Units:    "packets",
-	Fam:      "packets",
-	Ctx:      "ping.host_packets",
-	Priority: prioHostPingPackets,
-	Dims: module.Dims{
-		{ID: "host_%s_packets_recv", Name: "received"},
-		{ID: "host_%s_packets_sent", Name: "sent"},
-	},
+var hostChartsTmpl = module.Charts{
+	hostRTTChartTmpl.Copy(),
+	hostStdDevRTTChartTmpl.Copy(),
+	hostJitterChartTmpl.Copy(),
+	hostVarianceChartTmpl.Copy(),
+	hostPacketLossChartTmpl.Copy(),
+	hostPacketsChartTmpl.Copy(),
 }
 
 func newHostCharts(host string) *module.Charts {

--- a/src/go/plugin/go.d/collector/ping/collect.go
+++ b/src/go/plugin/go.d/collector/ping/collect.go
@@ -5,6 +5,7 @@ package ping
 import (
 	"fmt"
 	"sync"
+	"time"
 )
 
 func (c *Collector) collect() (map[string]int64, error) {
@@ -42,8 +43,64 @@ func (c *Collector) pingHost(host string, mx map[string]int64, mu *sync.Mutex) {
 		mx[px+"max_rtt"] = stats.MaxRtt.Microseconds()
 		mx[px+"avg_rtt"] = stats.AvgRtt.Microseconds()
 		mx[px+"std_dev_rtt"] = stats.StdDevRtt.Microseconds()
+
+		// variance = stddev² stored as μs² (chart Div: 1e6 converts to ms²)
+		stdDevUs := stats.StdDevRtt.Microseconds()
+		mx[px+"rtt_variance"] = stdDevUs * stdDevUs
 	}
+
+	// jitter requires at least 2 RTT samples
+	if len(stats.Rtts) >= 2 {
+		meanJitter := calcMeanJitter(stats.Rtts)
+		mx[px+"mean_jitter"] = meanJitter.Microseconds()
+		mx[px+"ewma_jitter"] = c.updateEWMAJitter(host, meanJitter).Microseconds()
+		mx[px+"sma_jitter"] = c.updateSMAJitter(host, meanJitter).Microseconds()
+	}
+
 	mx[px+"packets_recv"] = int64(stats.PacketsRecv)
 	mx[px+"packets_sent"] = int64(stats.PacketsSent)
 	mx[px+"packet_loss"] = int64(stats.PacketLoss * 1000)
+}
+
+// calcMeanJitter calculates mean of absolute consecutive RTT differences
+func calcMeanJitter(rtts []time.Duration) time.Duration {
+	if len(rtts) < 2 {
+		return 0
+	}
+	var sum int64
+	for i := 1; i < len(rtts); i++ {
+		diff := rtts[i] - rtts[i-1]
+		if diff < 0 {
+			diff = -diff
+		}
+		sum += int64(diff)
+	}
+	return time.Duration(sum / int64(len(rtts)-1))
+}
+
+// updateEWMAJitter updates exponentially weighted moving average jitter
+// Formula: J(i) = α * current + (1-α) * J(i-1), where α = 1/N
+func (c *Collector) updateEWMAJitter(host string, current time.Duration) time.Duration {
+	prev := c.jitterEWMA[host]
+	curr := float64(current)
+	alpha := 1.0 / float64(c.JitterEWMASamples)
+	ewma := alpha*curr + (1-alpha)*prev
+	c.jitterEWMA[host] = ewma
+	return time.Duration(ewma)
+}
+
+// updateSMAJitter updates simple moving average jitter over a sliding window
+func (c *Collector) updateSMAJitter(host string, current time.Duration) time.Duration {
+	window := c.jitterSMA[host]
+	window = append(window, float64(current))
+	if len(window) > c.JitterSMAWindow {
+		window = window[1:]
+	}
+	c.jitterSMA[host] = window
+
+	var sum float64
+	for _, v := range window {
+		sum += v
+	}
+	return time.Duration(sum / float64(len(window)))
 }

--- a/src/go/plugin/go.d/collector/ping/collector.go
+++ b/src/go/plugin/go.d/collector/ping/collector.go
@@ -37,19 +37,25 @@ func New() *Collector {
 				Packets:    5,
 				Interval:   confopt.Duration(time.Millisecond * 100),
 			},
+			JitterEWMASamples: 16,
+			JitterSMAWindow:   10,
 		},
 
-		charts:    &module.Charts{},
-		hosts:     make(map[string]bool),
-		newProber: NewProber,
+		charts:     &module.Charts{},
+		hosts:      make(map[string]bool),
+		newProber:  NewProber,
+		jitterEWMA: make(map[string]float64),
+		jitterSMA:  make(map[string][]float64),
 	}
 }
 
 type Config struct {
-	Vnode        string   `yaml:"vnode,omitempty" json:"vnode"`
-	UpdateEvery  int      `yaml:"update_every,omitempty" json:"update_every"`
-	Hosts        []string `yaml:"hosts" json:"hosts"`
-	ProberConfig `yaml:",inline" json:",inline"`
+	Vnode             string   `yaml:"vnode,omitempty" json:"vnode"`
+	UpdateEvery       int      `yaml:"update_every,omitempty" json:"update_every"`
+	Hosts             []string `yaml:"hosts" json:"hosts"`
+	JitterEWMASamples int      `yaml:"jitter_ewma_samples,omitempty" json:"jitter_ewma_samples"`
+	JitterSMAWindow   int      `yaml:"jitter_sma_window,omitempty" json:"jitter_sma_window"`
+	ProberConfig      `yaml:",inline" json:",inline"`
 }
 
 type Collector struct {
@@ -61,7 +67,9 @@ type Collector struct {
 	prober    Prober
 	newProber func(ProberConfig, *logger.Logger) Prober
 
-	hosts map[string]bool
+	hosts      map[string]bool
+	jitterEWMA map[string]float64   // EWMA jitter state per host
+	jitterSMA  map[string][]float64 // SMA jitter window per host
 }
 
 func (c *Collector) Configuration() any {

--- a/src/go/plugin/go.d/collector/ping/config_schema.json
+++ b/src/go/plugin/go.d/collector/ping/config_schema.json
@@ -9,7 +9,7 @@
         "description": "Data collection interval, measured in seconds.",
         "type": "integer",
         "minimum": 1,
-        "default": 1
+        "default": 5
       },
       "privileged": {
         "title": "Privileged mode",
@@ -61,6 +61,20 @@
         "description": "The network device name (e.g., `eth0`, `wlan0`) used as the source for ICMP echo requests.",
         "type": "string",
         "default": ""
+      },
+      "jitter_ewma_samples": {
+        "title": "Jitter EWMA samples",
+        "description": "EWMA smoothing factor for jitter calculation. Higher values result in smoother but slower-responding jitter metrics.",
+        "type": "integer",
+        "minimum": 1,
+        "default": 16
+      },
+      "jitter_sma_window": {
+        "title": "Jitter SMA window",
+        "description": "Number of iterations for calculating Simple Moving Average jitter.",
+        "type": "integer",
+        "minimum": 1,
+        "default": 10
       },
       "vnode": {
         "title": "Vnode",

--- a/src/go/plugin/go.d/collector/ping/init.go
+++ b/src/go/plugin/go.d/collector/ping/init.go
@@ -14,6 +14,12 @@ func (c *Collector) validateConfig() error {
 	if c.Packets <= 0 {
 		return errors.New("'send_packets' can't be <= 0")
 	}
+	if c.JitterEWMASamples <= 0 {
+		c.JitterEWMASamples = 16
+	}
+	if c.JitterSMAWindow <= 0 {
+		c.JitterSMAWindow = 10
+	}
 	return nil
 }
 

--- a/src/go/plugin/go.d/collector/ping/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ping/metadata.yaml
@@ -116,6 +116,17 @@ modules:
               required: false
               group: Ping Settings
 
+            - name: jitter_ewma_samples
+              description: EWMA smoothing factor for jitter calculation. Higher values = smoother, slower response.
+              default_value: 16
+              required: false
+              group: Jitter Settings
+            - name: jitter_sma_window
+              description: Number of iterations for SMA jitter calculation.
+              default_value: 10
+              required: false
+              group: Jitter Settings
+
             - name: vnode
               description: Associates this data collection job with a [Virtual Node](https://learn.netdata.cloud/docs/netdata-agent/configuration/organize-systems-metrics-and-alerts#virtual-nodes).
               default_value: ""
@@ -166,7 +177,7 @@ modules:
     alerts:
       - name: ping_host_reachable
         metric: ping.host_packet_loss
-        info: "network host ${lab1el:host} reachability status"
+        info: "network host ${label:host} reachability status"
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ping.conf
       - name: ping_packet_loss
         metric: ping.host_packet_loss
@@ -192,7 +203,7 @@ modules:
             - name: ping.host_rtt
               description: Ping round-trip time
               unit: milliseconds
-              chart_type: line
+              chart_type: area
               dimensions:
                 - name: min
                 - name: max
@@ -203,6 +214,20 @@ modules:
               chart_type: line
               dimensions:
                 - name: std_dev
+            - name: ping.host_jitter
+              description: Ping latency jitter
+              unit: milliseconds
+              chart_type: line
+              dimensions:
+                - name: mean
+                - name: ewma
+                - name: sma
+            - name: ping.host_rtt_variance
+              description: Ping round-trip time variance
+              unit: ms²
+              chart_type: line
+              dimensions:
+                - name: variance
             - name: ping.host_packet_loss
               description: Ping packet loss
               unit: percentage

--- a/src/go/plugin/go.d/collector/ping/prober.go
+++ b/src/go/plugin/go.d/collector/ping/prober.go
@@ -47,7 +47,7 @@ func (p *pingProber) Ping(host string) (*probing.Statistics, error) {
 		return nil, fmt.Errorf("DNS lookup '%s' : %v", host, err)
 	}
 
-	pr.RecordRtts = false
+	pr.RecordRtts = true
 	pr.RecordTTLs = false
 	pr.Interval = p.conf.Interval.Duration()
 	pr.Count = p.conf.Packets

--- a/src/go/plugin/go.d/collector/ping/testdata/config.json
+++ b/src/go/plugin/go.d/collector/ping/testdata/config.json
@@ -8,5 +8,7 @@
   "privileged": true,
   "packets": 123,
   "interval": 123.123,
-  "interface": "ok"
+  "interface": "ok",
+  "jitter_ewma_samples": 123,
+  "jitter_sma_window": 123
 }

--- a/src/go/plugin/go.d/collector/ping/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/ping/testdata/config.yaml
@@ -7,3 +7,5 @@ privileged: yes
 packets: 123
 interval: 123.123
 interface: "ok"
+jitter_ewma_samples: 123
+jitter_sma_window: 123


### PR DESCRIPTION
## Summary

- Add **jitter metrics** (mean, EWMA, SMA) to measure latency consistency
- Add **RTT variance** metric for statistical analysis
- New config options: `jitter_ewma_samples`, `jitter_sma_window`
- Fix pre-existing inconsistencies in metadata/config files

## New Metrics

| Metric | Description |
|--------|-------------|
| `ping.host_jitter` | Mean, EWMA, and SMA jitter (ms) |
| `ping.host_rtt_variance` | RTT variance (ms²) |

## Configuration

```yaml
jobs:
  - name: example
    hosts:
      - 8.8.8.8
    jitter_ewma_samples: 16  # EWMA smoothing factor
    jitter_sma_window: 10    # SMA window size
```

## Bug Fixes

- Fix typo in alert info: `${lab1el:host}` → `${label:host}`
- Fix `update_every` default: `1` → `5` (matches code)
- Fix RTT chart type: `line` → `area` (matches code)

## Test plan

- [x] Unit tests pass
- [x] Code reviewed by multiple AI assistants
- [ ] Manual testing with real hosts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds jitter metrics (mean, EWMA, SMA) and RTT variance to the ping collector to better track latency stability. Also adds config knobs for jitter smoothing and fixes a few metadata inconsistencies.

- **New Features**
  - New charts: ping.host_jitter (mean, EWMA, SMA in ms) and ping.host_rtt_variance (ms²).
  - Config options: jitter_ewma_samples (default 16) and jitter_sma_window (default 10), with validation.
  - Enabled RTT recording to compute jitter.

- **Bug Fixes**
  - Fixed alert info label typo in metadata.yaml.
  - Set update_every default to 5 in config schema.
  - Changed RTT chart type to area in metadata.yaml.

<sup>Written for commit d594064ae7aeb218f2ef24493e8101109e4e6fa7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

