### PR TITLE
Fix documentation links to work on both GitHub and learn site

### DIFF
--- a/docs/learn/node-identities.md
+++ b/docs/learn/node-identities.md
@@ -86,7 +86,7 @@ If two Agents have the same Machine GUID:
 - Cloud kicks the older connection offline when the second connects
 - This causes unstable "flapping" connections
 
-See [VM Templates](/docs/netdata-agent/vm-templates) for how to avoid this when cloning VMs.
+See [VM Templates](/docs/learn/vm-templates.md) for how to avoid this when cloning VMs.
 
 :::
 
@@ -124,7 +124,7 @@ When a database contains metadata for multiple nodes (from Children or [Virtual 
 1. **Reports all nodes** - All known nodes are reported to Netdata Cloud
 2. **Retention persistence** - Node entries persist in Cloud until database retention expires (can be years with tiering)
 
-This is normal for Parent nodes receiving data from Children, and for Agents using Virtual Nodes. See [VM Templates](/docs/netdata-agent/vm-templates) for implications when cloning VMs.
+This is normal for Parent nodes receiving data from Children, and for Agents using Virtual Nodes. See [VM Templates](/docs/learn/vm-templates.md) for implications when cloning VMs.
 
 ## Virtual Nodes (vnodes)
 
@@ -232,7 +232,7 @@ Read the file `/var/lib/netdata/registry/netdata.public.unique.id`.
 <details>
 <summary>Can I change my node's Machine GUID?</summary>
 
-Yes, but it will appear as a new node in Netdata Cloud and Netdata Parents. Delete the GUID file and status backups, then restart Netdata. See [VM Templates](/docs/netdata-agent/vm-templates) for the complete procedure.
+Yes, but it will appear as a new node in Netdata Cloud and Netdata Parents. Delete the GUID file and status backups, then restart Netdata. See [VM Templates](/docs/learn/vm-templates.md) for the complete procedure.
 
 </details>
 

--- a/docs/learn/vm-templates.md
+++ b/docs/learn/vm-templates.md
@@ -6,8 +6,8 @@
 
 The commands in this guide **permanently delete**:
 - All historical metrics
-- [Node identity](/docs/netdata-agent/node-identities#agent-self-identity)
-- [Cloud connection](/docs/netdata-agent/node-identities#agent-cloud-link-aclk-identity)
+- [Node identity](/docs/learn/node-identities.md#agent-self-identity)
+- [Cloud connection](/docs/learn/node-identities.md#agent-cloud-link-aclk-identity)
 - Alert history
 
 **This is irreversible. There is no undo.**
@@ -27,7 +27,7 @@ How to prepare a VM template so each clone gets a unique Netdata identity and au
 
 ## Prerequisites
 
-- **Read first**: [Node Identities](/docs/netdata-agent/node-identities) - understand what you're deleting
+- **Read first**: [Node Identities](/docs/learn/node-identities.md) - understand what you're deleting
 - Netdata installed on a VM
 - Hypervisor that supports templates or golden images
 - (Optional) `/etc/netdata/claim.conf` configured for auto-claiming to Cloud
@@ -76,9 +76,9 @@ See [Node Ephemerality](/docs/nodes-ephemerality.md) for full documentation.
 
 | Category | Files | What's Lost |
 |----------|-------|-------------|
-| **[Agent Identity](/docs/netdata-agent/node-identities#agent-self-identity)** | [GUID file](/docs/netdata-agent/node-identities#agent-self-identity), [status backups](/docs/netdata-agent/node-identities#status-file-backups) | Node identity |
-| **[ACLK Auth](/docs/netdata-agent/node-identities#agent-cloud-link-aclk-identity)** | [`cloud.d/`](/docs/netdata-agent/node-identities#agent-cloud-link-aclk-identity) directory | Cloud connection, must re-claim |
-| **[Node Metadata](/docs/netdata-agent/node-identities#parent-children-identities)** | `netdata-meta.db*`, `context-meta.db*` | Node metadata, metric mappings |
+| **[Agent Identity](/docs/learn/node-identities.md#agent-self-identity)** | [GUID file](/docs/learn/node-identities.md#agent-self-identity), [status backups](/docs/learn/node-identities.md#status-file-backups) | Node identity |
+| **[ACLK Auth](/docs/learn/node-identities.md#agent-cloud-link-aclk-identity)** | [`cloud.d/`](/docs/learn/node-identities.md#agent-cloud-link-aclk-identity) directory | Cloud connection, must re-claim |
+| **[Node Metadata](/docs/learn/node-identities.md#parent-children-identities)** | `netdata-meta.db*`, `context-meta.db*` | Node metadata, metric mappings |
 | **Metrics** | `dbengine*` directories (all tiers) | All historical metrics |
 
 **Keep**: `/etc/netdata/claim.conf` - enables auto-claiming on clones
@@ -143,9 +143,9 @@ Should contain:
 
 ## When Clones Boot
 
-1. Netdata starts, no [GUID](/docs/netdata-agent/node-identities#agent-self-identity) found, generates new unique identity
+1. Netdata starts, no [GUID](/docs/learn/node-identities.md#agent-self-identity) found, generates new unique identity
 2. If `claim.conf` exists, auto-claims to Cloud
-3. Cloud assigns [Node ID](/docs/netdata-agent/node-identities#cloud-node-identity), new node appears in your Space
+3. Cloud assigns [Node ID](/docs/learn/node-identities.md#cloud-node-identity), new node appears in your Space
 
 Each clone is a unique, independent node.
 
@@ -202,13 +202,13 @@ Each instance installs fresh with unique identity.
 
 ### Clones share the same identity
 
-Cause: [GUID recovered from status backup](/docs/netdata-agent/node-identities#status-file-backups). Netdata checks multiple backup locations before generating a new GUID.
+Cause: [GUID recovered from status backup](/docs/learn/node-identities.md#status-file-backups). Netdata checks multiple backup locations before generating a new GUID.
 
 Solution: Delete **all** status file locations, not just the primary GUID file. See the cleanup commands in [Step 2](#2-delete-all-identity-and-data-files).
 
 ### Clones don't connect to Parent
 
-Cause: Either clones share the same [Machine GUID](/docs/netdata-agent/node-identities#agent-self-identity) (only one can connect at a time), or `stream.conf` wasn't configured in the template.
+Cause: Either clones share the same [Machine GUID](/docs/learn/node-identities.md#agent-self-identity) (only one can connect at a time), or `stream.conf` wasn't configured in the template.
 
 Solution:
 - Verify each clone has a unique GUID: `cat /var/lib/netdata/registry/netdata.public.unique.id`
@@ -217,7 +217,7 @@ Solution:
 
 ### Stale "template" node appears in Cloud
 
-Cause: [Database files kept](/docs/netdata-agent/node-identities#multiple-node-identities-in-database) from the template. The template's node identity persists in the metadata.
+Cause: [Database files kept](/docs/learn/node-identities.md#multiple-node-identities-in-database) from the template. The template's node identity persists in the metadata.
 
 Solution: Delete databases on all clones. This loses historical metrics but removes the stale node reference.
 
@@ -229,7 +229,7 @@ Solution: Reset `stream.conf` on clones or delete the API key sections that enab
 
 ### Unstable Cloud connections (flapping)
 
-Cause: Two agents have the same [Machine GUID](/docs/netdata-agent/node-identities#agent-self-identity). Cloud kicks the older connection offline when the second connects.
+Cause: Two agents have the same [Machine GUID](/docs/learn/node-identities.md#agent-self-identity). Cloud kicks the older connection offline when the second connects.
 
 Solution: Each agent needs a unique GUID. Run the cleanup procedure on affected clones.
 
@@ -279,14 +279,14 @@ This deletes all historical metrics on the clone. If you skip deleting `cloud.d/
 <details>
 <summary>What if I reboot a clone?</summary>
 
-Identity persists. Netdata only generates a new [GUID](/docs/netdata-agent/node-identities#agent-self-identity) when the file AND all [backups](/docs/netdata-agent/node-identities#status-file-backups) are missing.
+Identity persists. Netdata only generates a new [GUID](/docs/learn/node-identities.md#agent-self-identity) when the file AND all [backups](/docs/learn/node-identities.md#status-file-backups) are missing.
 
 </details>
 
 <details>
 <summary>Can multiple clones use the same claim token?</summary>
 
-Yes. Each clone gets a unique [Machine GUID](/docs/netdata-agent/node-identities#agent-self-identity) and [Claimed ID](/docs/netdata-agent/node-identities#agent-cloud-link-aclk-identity). They authenticate with the same token but appear as separate nodes.
+Yes. Each clone gets a unique [Machine GUID](/docs/learn/node-identities.md#agent-self-identity) and [Claimed ID](/docs/learn/node-identities.md#agent-cloud-link-aclk-identity). They authenticate with the same token but appear as separate nodes.
 
 </details>
 

--- a/src/health/REFERENCE.md
+++ b/src/health/REFERENCE.md
@@ -317,7 +317,7 @@ Complete syntax reference for all alert configuration options. Use this section 
 
 Alarms are processed before templates. If you have `alarm` and `template` entities with the same name that both match the same chart, only the `alarm` will create an active alert for that chart.
 
-For complete details on configuration loading order and precedence rules, see [Alert Configuration Ordering](/docs/alerts-and-notifications/alert-configuration-ordering).
+For complete details on configuration loading order and precedence rules, see [Alert Configuration Ordering](/src/health/alert-configuration-ordering.md).
 
 :::
 

--- a/src/health/alert-configuration-ordering.md
+++ b/src/health/alert-configuration-ordering.md
@@ -184,5 +184,5 @@ This is different from alert-level overriding. With shadowing, you must include 
 
 ## Related Documentation
 
-- [Health Configuration Reference](/docs/alerts-and-notifications/alert-configuration-reference)
-- [Overriding Stock Alerts](/docs/alerts-and-notifications/overriding-stock-alerts)
+- [Health Configuration Reference](/src/health/REFERENCE.md)
+- [Overriding Stock Alerts](/src/health/overriding-stock-alerts.md)

--- a/src/health/overriding-stock-alerts.md
+++ b/src/health/overriding-stock-alerts.md
@@ -17,7 +17,7 @@ Netdata's alerting uses **templates** (match all instances of a context) and **a
 
 To override, create an alert with the **same name**. User definitions are processed before stock definitions, so yours wins.
 
-See [Alert Configuration Ordering](/docs/alerts-and-notifications/alert-configuration-ordering) for the full conceptual explanation.
+See [Alert Configuration Ordering](/src/health/alert-configuration-ordering.md) for the full conceptual explanation.
 
 ## Where to Put Your Overrides
 
@@ -345,5 +345,5 @@ To restore file-based control, remove the dynamic config through the UI (reset t
 
 ## Related Documentation
 
-- [Health Configuration Reference](/docs/alerts-and-notifications/alert-configuration-reference)
-- [Alert Configuration Ordering](/docs/alerts-and-notifications/alert-configuration-ordering)
+- [Health Configuration Reference](/src/health/REFERENCE.md)
+- [Alert Configuration Ordering](/src/health/alert-configuration-ordering.md)

--- a/src/plugins.d/FUNCTION_UI_DEVELOPER_GUIDE.md
+++ b/src/plugins.d/FUNCTION_UI_DEVELOPER_GUIDE.md
@@ -1,6 +1,6 @@
 # Netdata Functions: Developer Guide
 
-> **Note**: This is the practical developer guide. For the complete technical specification, see [Functions v3 Protocol Reference](/docs/developer-and-contributor-corner/external-plugins/functions-v3-protocol-reference).
+> **Note**: This is the practical developer guide. For the complete technical specification, see [Functions v3 Protocol Reference](/src/plugins.d/FUNCTION_UI_REFERENCE.md).
 
 ## Overview
 

--- a/src/plugins.d/FUNCTION_UI_REFERENCE.md
+++ b/src/plugins.d/FUNCTION_UI_REFERENCE.md
@@ -1,6 +1,6 @@
 # Netdata Functions v3 Protocol - Technical Reference
 
-> **Note**: This is the technical specification. For a practical guide to implementing functions, see [Functions Developer Guide](/docs/developer-and-contributor-corner/external-plugins/functions-developer-guide).
+> **Note**: This is the technical specification. For a practical guide to implementing functions, see [Functions Developer Guide](/src/plugins.d/FUNCTION_UI_DEVELOPER_GUIDE.md).
 
 ## Overview
 


### PR DESCRIPTION
## Summary
Convert `/docs/...` URLs (which only work on learn site) to repo-root relative paths (which work on both GitHub and learn site).

## Files fixed
- `docs/learn/node-identities.md`
- `docs/learn/vm-templates.md`
- `src/health/REFERENCE.md`
- `src/health/alert-configuration-ordering.md`
- `src/health/overriding-stock-alerts.md`
- `src/plugins.d/FUNCTION_UI_DEVELOPER_GUIDE.md`
- `src/plugins.d/FUNCTION_UI_REFERENCE.md`

## Context
PR #21688 converted relative `.md` links to `/docs/...` URLs which work on the learn site but break navigation on GitHub. This PR fixes them to use repo-root paths like `/src/health/REFERENCE.md` which work on both platforms.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed documentation links by converting /docs/... URLs to repo-root paths so they work on both GitHub and the learn site. Improves navigation across learn pages, health docs, and functions docs.

- **Bug Fixes**
  - Replaced /docs/... URLs with repo-root paths (e.g., /src/health/REFERENCE.md) across affected markdown files.
  - Corrected cross-links between Node Identities and VM Templates, Health Reference/Alert Ordering/Overriding Stock Alerts, and Functions Developer Guide/Reference.

<sup>Written for commit b4fd9f2f47bf7b36b57126cd956ef3cdc569efd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

