### PR TITLE
Handle transient systemd state flag changes.

### DIFF
--- a/src/crates/journal-index/src/file_indexer.rs
+++ b/src/crates/journal-index/src/file_indexer.rs
@@ -98,8 +98,25 @@ impl FileIndexer {
         // Capture indexing timestamp
         let indexed_at = Seconds::now();
 
-        // Capture whether the file was online when indexed
-        let was_online = journal_file.journal_header_ref().state == 1;
+        // Capture whether the file was online when indexed.
+        //
+        // A file is considered online if:
+        // 1. The journal header state is 1 (STATE_ONLINE), OR
+        // 2. The file is an "Active" file by filename (e.g., system.journal
+        //    without the @seqnum_id-head_seqnum-head_realtime suffix)
+        //
+        // We check both conditions because systemd-journal may temporarily set
+        // `state != 1` on active journal files (e.g., during flush operations).
+        // If we only checked the header state, we might incorrectly mark an
+        // active file as offline/archived, causing its cache entry to be
+        // considered "always fresh" and never re-indexed. This would result
+        // in the file being excluded from queries for current time ranges
+        // because its bounded time range (from when it was indexed) doesn't
+        // overlap with the query range.
+        //
+        // The otel-plugin does not suffer from this issue because it always
+        // uses "archived", instead of "active", filenames.
+        let was_online = journal_file.journal_header_ref().state == 1 || file.is_active();
 
         let field_map = journal_file.load_fields()?;
 


### PR DESCRIPTION
When systemd-journal temporarily sets a journal file's header state to something other than STATE_ONLINE (e.g., during flush/sync operations), the file indexer would incorrectly mark the file as offline/archived. This caused the cache entry to be considered "always fresh" and never re-indexed, resulting in the file being excluded from queries when its bounded time range didn't overlap with the current query time.

The fix checks both the journal header state AND the file's status from its filename. If the filename indicates an active file (no @ suffix), it's treated as online regardless of the transient header state.

The otel-plugin implementation always uses "archived" filenames and does not suffer from this issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents active systemd journal files from being misclassified as archived during transient header state changes, so they continue to be re-indexed and included in queries.

- **Bug Fixes**
  - A file is online if the header state is STATE_ONLINE or its filename is active (no @ suffix).
  - Avoids "always fresh" cache entries that skipped re-indexing and led to missing results.

<sup>Written for commit 537cda68ac58a2b5db69b689d3d54f41e87bd2fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

