### PR TITLE
Adjust curl options when submitting events

### DIFF
--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -924,6 +924,14 @@ static const char *agent_health(DAEMON_STATUS_FILE *ds) {
         return "healthy-recovered";
 }
 
+// Callback to discard curl response data.
+// Without this, curl writes to stdout which can crash on Windows when running as a service.
+static size_t post_status_file_discard_response(void *ptr, size_t size, size_t nmemb, void *userdata) {
+    (void)ptr;
+    (void)userdata;
+    return size * nmemb;
+}
+
 static void post_status_file(struct post_status_file_thread_data *d) {
     daemon_status_file_startup_step("startup(crash reports json)");
 
@@ -953,6 +961,15 @@ static void post_status_file(struct post_status_file_thread_data *d) {
     curl_easy_setopt(curl, CURLOPT_URL, "https://agent-events.netdata.cloud/agent-events");
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_data);
+
+    // Discard response data - without this curl writes to stdout which can crash
+    // on Windows when running as a service or without a console
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, post_status_file_discard_response);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, NULL);
+
+    // Prevent signal-based timeouts which can cause issues on Windows/MSYS2
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+
     struct curl_slist *headers = NULL;
     headers = curl_slist_append(headers, "Content-Type: application/json");
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);


### PR DESCRIPTION
##### Summary
- Discard curl response / disable signal-based timeouts


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent cURL from writing response bodies to stdout and disable signal-based timeouts when posting agent events. This avoids crashes for Windows services and improves cross-platform stability.

- **Bug Fixes**
  - Discard response data via CURLOPT_WRITEFUNCTION to stop stdout writes.
  - Set CURLOPT_NOSIGNAL=1 to avoid signal-based timeouts on Windows/MSYS2.

<sup>Written for commit fb636f053fdde8c215e3cabf43b3174f51478883. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

