### PR TITLE
Add object size and bounds validation when reading journal files.

### DIFF
--- a/src/crates/journal-core/src/error.rs
+++ b/src/crates/journal-core/src/error.rs
@@ -12,6 +12,12 @@ pub enum JournalError {
     #[error("invalid object type")]
     InvalidObjectType,
 
+    #[error("invalid object size: {0}")]
+    InvalidObjectSize(u64),
+
+    #[error("object exceeds file bounds")]
+    ObjectExceedsFileBounds,
+
     #[error("invalid object location")]
     InvalidObjectLocation,
 

--- a/src/crates/journal-core/src/file/file.rs
+++ b/src/crates/journal-core/src/file/file.rs
@@ -420,9 +420,15 @@ impl<M: MemoryMap> JournalFile<M> {
     {
         validate_offset_alignment(offset)?;
 
-        let is_compact = self
-            .journal_header_ref()
-            .has_incompatible_flag(HeaderIncompatibleFlags::Compact);
+        let journal_header = self.journal_header_ref();
+        let is_compact = journal_header.has_incompatible_flag(HeaderIncompatibleFlags::Compact);
+        let header_size = journal_header.header_size;
+        let arena_end = header_size + journal_header.arena_size;
+
+        // Objects cannot be located in the file header
+        if offset.get() < header_size {
+            return Err(JournalError::ObjectExceedsFileBounds);
+        }
 
         self.window_manager.with_guarded(offset, |wm| {
             // Get the object header to determine size
@@ -431,8 +437,17 @@ impl<M: MemoryMap> JournalFile<M> {
                     wm.get_slice(offset.get(), std::mem::size_of::<ObjectHeader>() as u64)?;
                 let header = ObjectHeader::ref_from_bytes(header_slice)
                     .map_err(|_| JournalError::ZerocopyFailure)?;
-                header.size
+                header.validated_size()?
             };
+
+            // Validate that the object doesn't exceed the journal's arena bounds
+            let end_offset = offset
+                .get()
+                .checked_add(size_needed)
+                .ok_or(JournalError::ObjectExceedsFileBounds)?;
+            if end_offset > arena_end {
+                return Err(JournalError::ObjectExceedsFileBounds);
+            }
 
             // Get the full object data
             let data = wm.get_slice(offset.get(), size_needed)?;
@@ -869,15 +884,22 @@ impl<M: MemoryMapMut> JournalFile<M> {
     {
         validate_offset_alignment(offset)?;
 
-        let is_compact = self
-            .journal_header_ref()
-            .has_incompatible_flag(HeaderIncompatibleFlags::Compact);
+        let journal_header = self.journal_header_ref();
+        let is_compact = journal_header.has_incompatible_flag(HeaderIncompatibleFlags::Compact);
+        let header_size = journal_header.header_size;
+        let arena_end = header_size + journal_header.arena_size;
+
+        // Objects cannot be located in the file header
+        if offset.get() < header_size {
+            return Err(JournalError::ObjectExceedsFileBounds);
+        }
 
         self.window_manager.with_guarded(offset, |wm| {
             // Get or set the size
             let size_needed = match size {
                 Some(size) => {
-                    // Setting object header for a new object
+                    // Setting object header for a new object (no bounds check needed,
+                    // the file will be extended as necessary)
                     let header_slice =
                         wm.get_slice_mut(offset.get(), std::mem::size_of::<ObjectHeader>() as u64)?;
                     let header = ObjectHeader::mut_from_bytes(header_slice)
@@ -895,7 +917,18 @@ impl<M: MemoryMapMut> JournalFile<M> {
                     if header.type_ != type_ as u8 {
                         return Err(JournalError::InvalidObjectType);
                     }
-                    header.size
+                    let size = header.validated_size()?;
+
+                    // Validate that the object doesn't exceed the journal's arena bounds
+                    let end_offset = offset
+                        .get()
+                        .checked_add(size)
+                        .ok_or(JournalError::ObjectExceedsFileBounds)?;
+                    if end_offset > arena_end {
+                        return Err(JournalError::ObjectExceedsFileBounds);
+                    }
+
+                    size
                 }
             };
 

--- a/src/crates/journal-core/src/file/object.rs
+++ b/src/crates/journal-core/src/file/object.rs
@@ -419,6 +419,21 @@ impl ObjectHeader {
     pub fn aligned_size(&self) -> u64 {
         (self.size + 7) & !7
     }
+
+    /// Validates that the object size is sane.
+    ///
+    /// Returns the size if valid, or an error if the size is invalid.
+    /// This should be called when reading an ObjectHeader from a journal file
+    /// to protect against corrupted data.
+    pub fn validated_size(&self) -> crate::error::Result<u64> {
+        let min_size = std::mem::size_of::<ObjectHeader>() as u64;
+
+        if self.size < min_size {
+            return Err(crate::error::JournalError::InvalidObjectSize(self.size));
+        }
+
+        Ok(self.size)
+    }
 }
 
 #[derive(Debug, Copy, Clone, FromBytes, IntoBytes, KnownLayout, Immutable)]

--- a/src/crates/journal-core/src/file/writer.rs
+++ b/src/crates/journal-core/src/file/writer.rs
@@ -146,7 +146,7 @@ impl JournalWriter {
 
             entry_guard.header.object_header.aligned_size()
         };
-        self.object_added(entry_offset, entry_size);
+        self.object_added(journal_file, entry_offset, entry_size);
 
         self.append_to_entry_array(journal_file, entry_offset)?;
         for entry_item_index in 0..self.entry_items.len() {
@@ -158,10 +158,20 @@ impl JournalWriter {
         Ok(())
     }
 
-    fn object_added(&mut self, object_offset: NonZeroU64, object_size: u64) {
+    fn object_added(
+        &mut self,
+        journal_file: &mut JournalFile<MmapMut>,
+        object_offset: NonZeroU64,
+        object_size: u64,
+    ) {
         self.tail_object_offset = object_offset;
         self.append_offset = object_offset.saturating_add(object_size);
         self.num_written_objects += 1;
+
+        // Update arena_size immediately after writing, so subsequent reads
+        // within the same write operation can find the newly written object.
+        let header = journal_file.journal_header_mut();
+        header.arena_size = self.append_offset.get() - header.header_size;
     }
 
     fn entry_added(&mut self, header: &mut JournalHeader, realtime: u64, monotonic: u64) {
@@ -211,7 +221,7 @@ impl JournalWriter {
                     data_guard.header.object_header.aligned_size()
                 };
 
-                self.object_added(data_offset, data_size);
+                self.object_added(journal_file, data_offset, data_size);
 
                 // Update hash table
                 journal_file.data_hash_table_set_tail_offset(hash, data_offset)?;
@@ -264,7 +274,7 @@ impl JournalWriter {
                     field_guard.set_payload(payload);
                     field_guard.header.object_header.aligned_size()
                 };
-                self.object_added(field_offset, field_size);
+                self.object_added(journal_file, field_offset, field_size);
 
                 // Update hash table
                 journal_file.field_hash_table_set_tail_offset(hash, field_offset)?;
@@ -277,7 +287,7 @@ impl JournalWriter {
 
     fn allocate_new_array(
         &mut self,
-        journal_file: &JournalFile<MmapMut>,
+        journal_file: &mut JournalFile<MmapMut>,
         capacity: NonZeroU64,
     ) -> Result<NonZeroU64> {
         // let new_capacity = previous_capacity.saturating_mul(NonZeroU64::new(2).unwrap());
@@ -288,7 +298,7 @@ impl JournalWriter {
 
             array_guard.header.object_header.aligned_size()
         };
-        self.object_added(array_offset, array_size);
+        self.object_added(journal_file, array_offset, array_size);
 
         Ok(array_offset)
     }


### PR DESCRIPTION
1. Validate object size is at least sizeof(ObjectHeader)
2. Check that objects are not located in the file header area
3. Verify object offset + size doesn't overflow
4. Check objects don't exceed the journal's arena bounds

On the writer side we update `arena_size` immediately after writing each object (rather than at entry completion, similar to systemd). This ensures subsequent reads within the same write operation can find newly written objects.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add strict validation when reading journal objects to prevent out-of-bounds access and bad reads. The writer now updates arena_size after each object so same-operation reads can see newly written objects.

- **Bug Fixes**
  - Validate object size (>= ObjectHeader) and reject objects in the file header region; ensure offset + size doesn’t overflow and stays within the arena.
  - Update writer to increment arena_size after each object; add errors InvalidObjectSize and ObjectExceedsFileBounds.

<sup>Written for commit 0ad27caeed2f3455ed6f1c3b66f0842fb6769e11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

