### PR TITLE
Fix ML db model load function

### DIFF
--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -168,7 +168,9 @@ const char *db_models_add_model =
     "    @c10, @c11, @c12, @c13, @c14, @c15);";
 
 const char *db_models_load =
-    "SELECT * FROM models "
+    "SELECT after, before, min_dist, max_dist, "
+    "c00, c01, c02, c03, c04, c05, "
+    "c10, c11, c12, c13, c14, c15 FROM models "
     "WHERE dim_id = @dim_id AND after >= @after ORDER BY before ASC;";
 
 const char *db_models_delete =
@@ -407,29 +409,29 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
     while ((rc = sqlite3_step_monitored(res)) == SQLITE_ROW) {
         ml_kmeans_t km;
 
-        km.after = sqlite3_column_int(res, 2);
-        km.before = sqlite3_column_int(res, 3);
+        km.after = sqlite3_column_int(res, 0);
+        km.before = sqlite3_column_int(res, 1);
 
-        km.min_dist = sqlite3_column_int(res, 4);
-        km.max_dist = sqlite3_column_int(res, 5);
+        km.min_dist = sqlite3_column_double(res, 2);
+        km.max_dist = sqlite3_column_double(res, 3);
 
         km.cluster_centers.resize(2);
 
         km.cluster_centers[0].set_size(Cfg.lag_n + 1);
-        km.cluster_centers[0](0) = sqlite3_column_double(res, 6);
-        km.cluster_centers[0](1) = sqlite3_column_double(res, 7);
-        km.cluster_centers[0](2) = sqlite3_column_double(res, 8);
-        km.cluster_centers[0](3) = sqlite3_column_double(res, 9);
-        km.cluster_centers[0](4) = sqlite3_column_double(res, 10);
-        km.cluster_centers[0](5) = sqlite3_column_double(res, 11);
+        km.cluster_centers[0](0) = sqlite3_column_double(res, 4);
+        km.cluster_centers[0](1) = sqlite3_column_double(res, 5);
+        km.cluster_centers[0](2) = sqlite3_column_double(res, 6);
+        km.cluster_centers[0](3) = sqlite3_column_double(res, 7);
+        km.cluster_centers[0](4) = sqlite3_column_double(res, 8);
+        km.cluster_centers[0](5) = sqlite3_column_double(res, 9);
 
         km.cluster_centers[1].set_size(Cfg.lag_n + 1);
-        km.cluster_centers[1](0) = sqlite3_column_double(res, 12);
-        km.cluster_centers[1](1) = sqlite3_column_double(res, 13);
-        km.cluster_centers[1](2) = sqlite3_column_double(res, 14);
-        km.cluster_centers[1](3) = sqlite3_column_double(res, 15);
-        km.cluster_centers[1](4) = sqlite3_column_double(res, 16);
-        km.cluster_centers[1](5) = sqlite3_column_double(res, 17);
+        km.cluster_centers[1](0) = sqlite3_column_double(res, 10);
+        km.cluster_centers[1](1) = sqlite3_column_double(res, 11);
+        km.cluster_centers[1](2) = sqlite3_column_double(res, 12);
+        km.cluster_centers[1](3) = sqlite3_column_double(res, 13);
+        km.cluster_centers[1](4) = sqlite3_column_double(res, 14);
+        km.cluster_centers[1](5) = sqlite3_column_double(res, 15);
 
         dim->km_contexts.emplace_back(km);
     }


### PR DESCRIPTION
##### Summary
- Adjust query to skip the unused dimension id
- Fix column index and datatypes for min_dist / max_dist


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ML model loading by explicitly selecting needed columns and remapping result indices so distances and cluster centers load correctly. Prevents misread types and offsets that caused incorrect k-means contexts.

- **Bug Fixes**
  - Query selects only used columns (excludes dim_id) and defines a stable column order.
  - Read min_dist/max_dist as doubles; updated indices for all center values to match the new order.

<sup>Written for commit d457128492b6ac827c2ce5703c86daeb66d0f843. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

