### PR TITLE
docs: Add Windows telemetry opt-out instructions

### DIFF
--- a/docs/netdata-agent/configuration/anonymous-telemetry-events.md
+++ b/docs/netdata-agent/configuration/anonymous-telemetry-events.md
@@ -75,6 +75,7 @@ To see exactly what and how is collected, you can review the script template `da
 🖥️  Windows             → Use Method 2 (Windows-specific)
 🐳 Docker              → Use Method 3 (Environment variable)
 📦 Manual/Offline      → Use Method 1 (File-based)
+🔷 FreeBSD             → Use Method 1 (File-based)
 ```
 
 :::note
@@ -91,22 +92,26 @@ When opt-out is enabled, the anonymous statistics script exits immediately witho
 ## Opt-out Methods
 
 <details>
-<summary><strong>Method 1: Create opt-out file (Linux/macOS)</strong></summary><br/>
+<summary><strong>Method 1: Create opt-out file (Linux/macOS/FreeBSD)</strong></summary><br/>
 
-**When to use**: Standard Linux installations, manual installations, macOS, or offline setups.
+**When to use**: Standard Linux installations, FreeBSD, manual installations, macOS, or offline setups.
 
 **Steps**:
 
-1. Navigate to your Netdata configuration directory (usually `/etc/netdata`)
+1. Navigate to your Netdata configuration directory
 2. Create an empty file called `.opt-out-from-anonymous-statistics`
 
 ```bash
+# Linux
 touch /etc/netdata/.opt-out-from-anonymous-statistics
+
+# FreeBSD
+touch /usr/local/etc/netdata/.opt-out-from-anonymous-statistics
 ```
 
 :::tip
 
-This method works for all installation types including manual, offline, and macOS installations. The file simply needs to exist—the content doesn't matter.
+This method works for all installation types including FreeBSD, manual, offline, and macOS installations. The file simply needs to exist—the content doesn't matter.
 
 :::
 
@@ -197,6 +202,7 @@ See the [installation documentation](/packaging/installer/README.md) for availab
 | Docker            | N/A (use environment variable)         |
 | macOS (Homebrew)  | `/usr/local/etc/netdata`               |
 | macOS (other)     | `/etc/netdata`                         |
+| FreeBSD           | `/usr/local/etc/netdata`               |
 
 ## Verification
 


### PR DESCRIPTION
This PR adds documentation for disabling anonymous telemetry on Windows.

## Changes
- Added Windows section to the opt-out documentation
- Documented the Windows configuration directory path (C:\Program Files\Netdata\etc\netdata)
- Added PowerShell command to create .opt-out-from-anonymous-statistics file
- Added PowerShell command to set DISABLE_TELEMETRY environment variable
- Added instructions to restart Netdata service after changes
- Added Quick Decision Guide for different installation types
- Added Installation-specific paths table with macOS variants
- All claims verified against source code

## Source Code Verification
- Opt-out file: analytics.c:940-949, anonymous-statistics.sh.in:21
- DISABLE_TELEMETRY: analytics.c:944, anonymous-statistics.sh.in:22  
- Windows path: packaging/windows/copy_files.ps1:35
- Script location: anonymous-statistics.sh.in reference to plugins dir

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows opt-out instructions for anonymous telemetry, with verified config path, PowerShell file/env methods, and a service restart step. Streamlines the doc with a quick decision guide, install-specific paths (incl. macOS and FreeBSD), a clearer list of data collected, simple verification steps, and wording aligned to source code.

<sup>Written for commit c487b10fc77f48949a47672ad99f988c567aeadc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

