### PR TITLE
Update libbpf

### DIFF
--- a/packaging/cmake/Modules/NetdataLibBPF.cmake
+++ b/packaging/cmake/Modules/NetdataLibBPF.cmake
@@ -69,7 +69,7 @@ function(netdata_bundle_libbpf)
         GIT_TAG ${_libbpf_tag}
         SOURCE_DIR "${libbpf_SOURCE_DIR}"
         CONFIGURE_COMMAND ""
-        BUILD_COMMAND ${MAKE_COMMAND} -C src CC=${CMAKE_C_COMPILER} CFLAGS="-Wno-format -Wno-sign-compare -Wno-unused-parameter" BUILD_STATIC_ONLY=1 OBJDIR=build/ DESTDIR=../ LIBSUBDIR=${_libbpf_lib_dir} install
+        BUILD_COMMAND ${MAKE_COMMAND} -C src CC=${CMAKE_C_COMPILER} BUILD_STATIC_ONLY=1 OBJDIR=build/ DESTDIR=../ LIBSUBDIR=${_libbpf_lib_dir} install
         BUILD_IN_SOURCE 1
         BUILD_BYPRODUCTS "${_libbpf_library}"
         INSTALL_COMMAND ""


### PR DESCRIPTION
##### Summary
Update libbpf on netdata/netdata repo.

##### Test Plan

1. Check if CI compiled libbpf library.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update bundled libbpf to v1.6.3.1p_netdata to bring in upstream fixes and improve compatibility.

- **Dependencies**
  - Bumped libbpf from v1.6.2p_netdata to v1.6.3.1p_netdata.

<sup>Written for commit 32ac1ef5e113297be405e47842e634703bf37966. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

