### PR TITLE
Use info-level log for undhandled modification events.

### DIFF
--- a/src/crates/journal-registry/src/registry/mod.rs
+++ b/src/crates/journal-registry/src/registry/mod.rs
@@ -279,7 +279,10 @@ impl Registry {
                 }
             }
             EventKind::Modify(ModifyKind::Name(rename_mode)) => {
-                error!("unhandled rename mode: {:?}", rename_mode);
+                info!(
+                    "unhandled modify event: '{:?}', expecting rename event for newly archived file",
+                    rename_mode
+                );
             }
             event_kind => {
                 // Ignore other events (content modifications, access, etc.)


### PR DESCRIPTION
##### Summary

`inotify` sends two events when systemd archives a file, a modification event followed by a rename event.

While we handle the rename event appropriatly, we still want to log an info-level message for modification events in order to be able to verify that the journal registry properly tracks the files that exist under log directories.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgraded logging for inotify name-modify events to info, noting they precede the expected rename when systemd archives a file. This removes false error noise while keeping visibility to verify the journal registry tracks archived files.

<sup>Written for commit 44a33b23f5fab447f60c3fa36cdc6da86c2b3c5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

