### PR TITLE
Improve log message when deferred response is too big.

### DIFF
--- a/src/plugins.d/pluginsd_parser.h
+++ b/src/plugins.d/pluginsd_parser.h
@@ -203,7 +203,7 @@ static inline int parser_action(PARSER *parser, char *input) {
                            (size_t)PLUGINSD_MAX_DEFERRED_SIZE,
                            parser->defer.end_keyword ? parser->defer.end_keyword : "unknown",
                            parser->user.cd ? string2str(parser->user.cd->filename) : "unknown",
-                           parser->defer.action_data ? (const char *)parser->defer.action_data : "none");
+                           parser->defer.action_data ? string2str((STRING *)parser->defer.action_data) : "none");
                     return 1;
                 }
             }


### PR DESCRIPTION
Makes debugging a little bit easier by mentioning the enforced limit, the payload size, the plugin that will be stopped, and the specific transaction id.

Found this by selecting all available facets over a big time range in the logs tab from the UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the “deferred response too big” log to include the payload size, enforced limit, expected end keyword, plugin filename, and transaction id. This makes it easier to identify the offending plugin and understand why it was stopped.

<sup>Written for commit 9bb42b59995ec51568cad2b989794e787fc671a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

