### PR TITLE
Fix timeout cleanup race for long-running first web requests

### DIFF
--- a/src/libnetdata/socket/poll-events.c
+++ b/src/libnetdata/socket/poll-events.c
@@ -546,9 +546,14 @@ void poll_events(LISTEN_SOCKETS *sockets
                 next = pi->next;
 
                 if(likely(pi->flags & POLLINFO_FLAG_CLIENT_SOCKET)) {
-                    if (unlikely(pi->send_count == 0 && p.complete_request_timeout > 0 && (now - pi->connected_t) >= p.complete_request_timeout)) {
+                    if (unlikely(
+                        !(pi->flags & POLLINFO_FLAG_FIRST_REQUEST_RECEIVED) &&
+                        pi->send_count == 0 &&
+                        p.complete_request_timeout > 0 &&
+                        (now - pi->connected_t) >= p.complete_request_timeout
+                    )) {
                         nd_log(NDLS_DAEMON, NDLP_DEBUG,
-                               "POLLFD: LISTENER: client slot %zu (fd %d) from %s port %s has not sent a complete request in %zu seconds - closing it. "
+                               "POLLFD: LISTENER: client slot %zu (fd %d) from %s port %s has not completed its first request in %zu seconds - closing it. "
                                , i
                                , pi->fd
                                , pi->client_ip ? pi->client_ip : "<undefined-ip>"

--- a/src/libnetdata/socket/poll-events.h
+++ b/src/libnetdata/socket/poll-events.h
@@ -9,6 +9,7 @@
 #define POLLINFO_FLAG_CLIENT_SOCKET     (1U << 1)
 #define POLLINFO_FLAG_DONT_CLOSE        (1U << 2)
 #define POLLINFO_FLAG_REMOVED_FROM_POLL (1U << 3)
+#define POLLINFO_FLAG_FIRST_REQUEST_RECEIVED (1U << 4)
 
 typedef struct poll POLLJOB;
 typedef struct pollinfo POLLINFO;


### PR DESCRIPTION
## Summary
This patch fixes premature web client disconnects when request processing blocks for longer than timeout thresholds.

### What changed
- Added explicit first-request lifecycle state:
  - `POLLINFO_FLAG_FIRST_REQUEST_RECEIVED` in `src/libnetdata/socket/poll-events.h`.
- Updated first-request timeout cleanup condition in `src/libnetdata/socket/poll-events.c`:
  - First-request timeout now applies only before the first request is fully received.
- Updated web receive callback in `src/web/server/static/static-threaded.c`:
  - Refresh `pi->last_received_t` after request processing returns.
  - Mark first-request completion when request ingress is complete (`!web_client_has_wait_receive(w)`).

## Why
Long-running function requests could be closed by cleanup before response write due to stale receive timestamp and first-request timeout interaction.

This patch prevents those premature closes while keeping first-request ingress protection in place.

## Validation
- `cmake -S . -B build -G Ninja -DENABLE_PLUGIN_XENSTAT=OFF`
- `cmake --build build --target netdata -j 8`

Build completed successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a timeout race that closed long-running first web requests before responses were sent. Tracks first-request completion and refreshes the receive timestamp to prevent premature cleanup during processing.

- **Bug Fixes**
  - Added POLLINFO_FLAG_FIRST_REQUEST_RECEIVED to mark when the first request is complete.
  - Applied the first-request timeout only before the first request is fully received; updated the log message.
  - After request processing returns, refresh last_received_t and set the flag when no longer waiting to receive.

<sup>Written for commit 2cbd427c810b69d179ca7be0f217b3656fbea673. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

