### PR TITLE
Format workspace with `cargo fmt`

### DIFF
--- a/src/crates/journal-core/src/file/cursor.rs
+++ b/src/crates/journal-core/src/file/cursor.rs
@@ -1,7 +1,7 @@
-use crate::file::{file::JournalFile, filter::FilterExpr, offset_array, offset_array::Direction};
-use crate::error::{JournalError, Result};
-use std::num::NonZeroU64;
 use super::mmap::MemoryMap;
+use crate::error::{JournalError, Result};
+use crate::file::{file::JournalFile, filter::FilterExpr, offset_array, offset_array::Direction};
+use std::num::NonZeroU64;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Location {

--- a/src/crates/journal-core/src/file/filter.rs
+++ b/src/crates/journal-core/src/file/filter.rs
@@ -1,7 +1,7 @@
-use crate::file::{file::JournalFile, offset_array::InlinedCursor};
-use crate::error::{JournalError, Result};
-use std::num::NonZeroU64;
 use super::mmap::MemoryMap;
+use crate::error::{JournalError, Result};
+use crate::file::{file::JournalFile, offset_array::InlinedCursor};
+use std::num::NonZeroU64;
 
 #[derive(Clone, Debug)]
 pub enum FilterExpr {

--- a/src/crates/journal-core/src/file/mod.rs
+++ b/src/crates/journal-core/src/file/mod.rs
@@ -26,7 +26,7 @@ pub use cursor::JournalCursor;
 pub use filter::{FilterExpr, JournalFilter, LogicalOp};
 
 // For FFI compatibility and advanced object manipulation
-pub use object::{EntryItemsType, HashableObject, JournalState, HeaderIncompatibleFlags};
+pub use object::{EntryItemsType, HashableObject, HeaderIncompatibleFlags, JournalState};
 
 // Re-export commonly needed external types
 pub use mmap::{Mmap, MmapMut};

--- a/src/crates/journal-core/src/file/object.rs
+++ b/src/crates/journal-core/src/file/object.rs
@@ -998,8 +998,7 @@ impl<B: ByteSlice> DataObject<B> {
                 return Err(JournalError::DecompressorError);
             }
 
-            let uncompressed_size =
-                u64::from_le_bytes(payload[..8].try_into().unwrap()) as usize;
+            let uncompressed_size = u64::from_le_bytes(payload[..8].try_into().unwrap()) as usize;
             let compressed_data = &payload[8..];
 
             buf.clear();

--- a/src/crates/journal-engine/src/histogram.rs
+++ b/src/crates/journal-engine/src/histogram.rs
@@ -198,7 +198,7 @@ impl HistogramEngine {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             responses: RwLock::new(LruCache::new(
-                NonZeroUsize::new(capacity).expect("capacity must be non-zero")
+                NonZeroUsize::new(capacity).expect("capacity must be non-zero"),
             )),
         }
     }
@@ -288,8 +288,7 @@ impl HistogramEngine {
                     };
 
                     // Count total entries in this file for this bucket's time range
-                    let all_entries =
-                        Bitmap::insert_range(0..file_index.total_entries() as u32);
+                    let all_entries = Bitmap::insert_range(0..file_index.total_entries() as u32);
                     let unfiltered_total = file_index
                         .count_entries_in_time_range(
                             &all_entries,
@@ -358,7 +357,11 @@ impl HistogramEngine {
             // Cache only the responses that are safe to cache (no online file contributions)
             let mut responses_guard = self.responses.write();
             for (bucket_request, response) in &new_responses {
-                if bucket_cacheable.get(bucket_request).copied().unwrap_or(false) {
+                if bucket_cacheable
+                    .get(bucket_request)
+                    .copied()
+                    .unwrap_or(false)
+                {
                     responses_guard.put(bucket_request.clone(), response.clone());
                 }
             }

--- a/src/crates/journal-engine/src/indexing.rs
+++ b/src/crates/journal-engine/src/indexing.rs
@@ -9,11 +9,11 @@ use crate::{
     error::{EngineError, Result},
     query_time_range::QueryTimeRange,
 };
-use tokio_util::sync::CancellationToken;
 use journal_index::{FileIndex, FileIndexer, IndexingLimits};
 use journal_registry::Registry;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, trace};
 
 // ============================================================================

--- a/src/crates/journal-engine/src/query_time_range.rs
+++ b/src/crates/journal-engine/src/query_time_range.rs
@@ -1,7 +1,7 @@
 //! Query time range with automatic alignment for histogram bucketing
 
-use crate::histogram::calculate_bucket_duration;
 use crate::EngineError;
+use crate::histogram::calculate_bucket_duration;
 use journal_index::Seconds;
 
 /// A time range for querying journal entries with automatic alignment.
@@ -55,10 +55,7 @@ impl QueryTimeRange {
     /// ```
     pub fn new(start: u32, end: u32) -> Result<Self, EngineError> {
         if start >= end {
-            return Err(EngineError::InvalidTimeRange {
-                start,
-                end,
-            });
+            return Err(EngineError::InvalidTimeRange { start, end });
         }
 
         let duration = end - start;
@@ -181,7 +178,10 @@ mod tests {
         assert_eq!(range.requested_end(), 500);
         assert_eq!(range.requested_duration(), 400);
         assert!(range.bucket_duration() > 0);
-        assert_eq!(range.aligned_duration(), range.aligned_end() - range.aligned_start());
+        assert_eq!(
+            range.aligned_duration(),
+            range.aligned_end() - range.aligned_start()
+        );
     }
 
     #[test]

--- a/src/crates/journal-index/src/lib.rs
+++ b/src/crates/journal-index/src/lib.rs
@@ -21,7 +21,8 @@ pub use file_index::{
 
 pub mod file_indexer;
 pub use file_indexer::{
-    FileIndexer, IndexingLimits, DEFAULT_MAX_FIELD_PAYLOAD_SIZE, DEFAULT_MAX_UNIQUE_VALUES_PER_FIELD,
+    DEFAULT_MAX_FIELD_PAYLOAD_SIZE, DEFAULT_MAX_UNIQUE_VALUES_PER_FIELD, FileIndexer,
+    IndexingLimits,
 };
 
 pub mod bitmap;

--- a/src/crates/journal-index/tests/pagination.rs
+++ b/src/crates/journal-index/tests/pagination.rs
@@ -130,13 +130,21 @@ fn test_pagination_forward_with_same_timestamps() {
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
     println!("First page: {} entries", results.len());
-    assert_eq!(results.len(), PAGE_SIZE, "First page should return PAGE_SIZE entries");
+    assert_eq!(
+        results.len(),
+        PAGE_SIZE,
+        "First page should return PAGE_SIZE entries"
+    );
 
     // Verify all have the same timestamp
     for entry in &results {
         assert_eq!(entry.timestamp, same_timestamp);
         all_offsets.push(entry.offset);
-        assert!(all_positions.insert(entry.position), "Position {} appeared twice", entry.position);
+        assert!(
+            all_positions.insert(entry.position),
+            "Position {} appeared twice",
+            entry.position
+        );
     }
 
     if let Some(last_entry) = results.last() {
@@ -152,13 +160,21 @@ fn test_pagination_forward_with_same_timestamps() {
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
     println!("Second page: {} entries", results.len());
-    assert_eq!(results.len(), TOTAL_ENTRIES - PAGE_SIZE, "Second page should return remaining entries");
+    assert_eq!(
+        results.len(),
+        TOTAL_ENTRIES - PAGE_SIZE,
+        "Second page should return remaining entries"
+    );
 
     // Verify all have the same timestamp
     for entry in &results {
         assert_eq!(entry.timestamp, same_timestamp);
         all_offsets.push(entry.offset);
-        assert!(all_positions.insert(entry.position), "Position {} appeared twice", entry.position);
+        assert!(
+            all_positions.insert(entry.position),
+            "Position {} appeared twice",
+            entry.position
+        );
     }
 
     if let Some(last_entry) = results.last() {
@@ -177,14 +193,26 @@ fn test_pagination_forward_with_same_timestamps() {
     assert_eq!(results.len(), 0, "Third page should be empty");
 
     // Verify we got all entries
-    assert_eq!(all_offsets.len(), TOTAL_ENTRIES, "Should have retrieved all entries");
+    assert_eq!(
+        all_offsets.len(),
+        TOTAL_ENTRIES,
+        "Should have retrieved all entries"
+    );
 
     // Verify all offsets are unique (no duplicates)
     let unique_offsets: HashSet<_> = all_offsets.iter().collect();
-    assert_eq!(unique_offsets.len(), TOTAL_ENTRIES, "All offsets should be unique");
+    assert_eq!(
+        unique_offsets.len(),
+        TOTAL_ENTRIES,
+        "All offsets should be unique"
+    );
 
     // Verify all positions are unique and contiguous
-    assert_eq!(all_positions.len(), TOTAL_ENTRIES, "Should have unique positions");
+    assert_eq!(
+        all_positions.len(),
+        TOTAL_ENTRIES,
+        "Should have unique positions"
+    );
     for i in 0..TOTAL_ENTRIES {
         assert!(all_positions.contains(&i), "Position {} missing", i);
     }
@@ -231,13 +259,21 @@ fn test_pagination_backward_with_same_timestamps() {
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
     println!("First page: {} entries", results.len());
-    assert_eq!(results.len(), PAGE_SIZE, "First page should return PAGE_SIZE entries");
+    assert_eq!(
+        results.len(),
+        PAGE_SIZE,
+        "First page should return PAGE_SIZE entries"
+    );
 
     // Verify all have the same timestamp
     for entry in &results {
         assert_eq!(entry.timestamp, same_timestamp);
         all_offsets.push(entry.offset);
-        assert!(all_positions.insert(entry.position), "Position {} appeared twice", entry.position);
+        assert!(
+            all_positions.insert(entry.position),
+            "Position {} appeared twice",
+            entry.position
+        );
     }
 
     if let Some(last_entry) = results.last() {
@@ -253,13 +289,21 @@ fn test_pagination_backward_with_same_timestamps() {
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
     println!("Second page: {} entries", results.len());
-    assert_eq!(results.len(), TOTAL_ENTRIES - PAGE_SIZE, "Second page should return remaining entries");
+    assert_eq!(
+        results.len(),
+        TOTAL_ENTRIES - PAGE_SIZE,
+        "Second page should return remaining entries"
+    );
 
     // Verify all have the same timestamp
     for entry in &results {
         assert_eq!(entry.timestamp, same_timestamp);
         all_offsets.push(entry.offset);
-        assert!(all_positions.insert(entry.position), "Position {} appeared twice", entry.position);
+        assert!(
+            all_positions.insert(entry.position),
+            "Position {} appeared twice",
+            entry.position
+        );
     }
 
     if let Some(last_entry) = results.last() {
@@ -278,14 +322,26 @@ fn test_pagination_backward_with_same_timestamps() {
     assert_eq!(results.len(), 0, "Third page should be empty");
 
     // Verify we got all entries
-    assert_eq!(all_offsets.len(), TOTAL_ENTRIES, "Should have retrieved all entries");
+    assert_eq!(
+        all_offsets.len(),
+        TOTAL_ENTRIES,
+        "Should have retrieved all entries"
+    );
 
     // Verify all offsets are unique (no duplicates)
     let unique_offsets: HashSet<_> = all_offsets.iter().collect();
-    assert_eq!(unique_offsets.len(), TOTAL_ENTRIES, "All offsets should be unique");
+    assert_eq!(
+        unique_offsets.len(),
+        TOTAL_ENTRIES,
+        "All offsets should be unique"
+    );
 
     // Verify all positions are unique and contiguous
-    assert_eq!(all_positions.len(), TOTAL_ENTRIES, "Should have unique positions");
+    assert_eq!(
+        all_positions.len(),
+        TOTAL_ENTRIES,
+        "Should have unique positions"
+    );
     for i in 0..TOTAL_ENTRIES {
         assert!(all_positions.contains(&i), "Position {} missing", i);
     }
@@ -305,7 +361,7 @@ fn test_pagination_forward_with_mixed_timestamps() {
         entries.push(
             TestEntry::new(timestamp1)
                 .with_field("MESSAGE", format!("Batch 1 Entry {}", i))
-                .with_field("ENTRY_ID", format!("1-{}", i))
+                .with_field("ENTRY_ID", format!("1-{}", i)),
         );
     }
 
@@ -315,7 +371,7 @@ fn test_pagination_forward_with_mixed_timestamps() {
         entries.push(
             TestEntry::new(timestamp2)
                 .with_field("MESSAGE", format!("Batch 2 Entry {}", i))
-                .with_field("ENTRY_ID", format!("2-{}", i))
+                .with_field("ENTRY_ID", format!("2-{}", i)),
         );
     }
 
@@ -394,16 +450,12 @@ fn test_pagination_empty_journal() {
 #[test]
 fn test_pagination_single_entry() {
     let timestamp = JAN_1_2024_MIDNIGHT;
-    let entries = vec![
-        TestEntry::new(timestamp).with_field("MESSAGE", "Single entry"),
-    ];
+    let entries = vec![TestEntry::new(timestamp).with_field("MESSAGE", "Single entry")];
 
     let (_temp_dir, file) = create_test_journal(entries).unwrap();
 
     let mut indexer = FileIndexer::default();
-    let file_index = indexer
-        .index(&file, None, &[], Seconds(3600))
-        .unwrap();
+    let file_index = indexer.index(&file, None, &[], Seconds(3600)).unwrap();
 
     // Query forward with large limit
     let params = LogQueryParamsBuilder::new(Anchor::Head, Direction::Forward)
@@ -445,7 +497,11 @@ fn test_pagination_single_entry() {
         .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
-    assert_eq!(results.len(), 0, "Backward from position 0 should return empty");
+    assert_eq!(
+        results.len(),
+        0,
+        "Backward from position 0 should return empty"
+    );
 }
 
 #[test]
@@ -459,9 +515,7 @@ fn test_pagination_two_entries() {
     let (_temp_dir, file) = create_test_journal(entries).unwrap();
 
     let mut indexer = FileIndexer::default();
-    let file_index = indexer
-        .index(&file, None, &[], Seconds(3600))
-        .unwrap();
+    let file_index = indexer.index(&file, None, &[], Seconds(3600)).unwrap();
 
     // Forward: Get both entries at once with limit 10
     let params = LogQueryParamsBuilder::new(Anchor::Head, Direction::Forward)
@@ -550,9 +604,7 @@ fn test_pagination_limit_zero() {
     let (_temp_dir, file) = create_test_journal(entries).unwrap();
 
     let mut indexer = FileIndexer::default();
-    let file_index = indexer
-        .index(&file, None, &[], Seconds(3600))
-        .unwrap();
+    let file_index = indexer.index(&file, None, &[], Seconds(3600)).unwrap();
 
     // Query with limit 0 should return empty results
     let params = LogQueryParamsBuilder::new(Anchor::Head, Direction::Forward)
@@ -586,9 +638,7 @@ fn test_pagination_limit_exact_match() {
     let (_temp_dir, file) = create_test_journal(entries).unwrap();
 
     let mut indexer = FileIndexer::default();
-    let file_index = indexer
-        .index(&file, None, &[], Seconds(3600))
-        .unwrap();
+    let file_index = indexer.index(&file, None, &[], Seconds(3600)).unwrap();
 
     // Query with limit exactly equal to total entries
     let params = LogQueryParamsBuilder::new(Anchor::Head, Direction::Forward)
@@ -625,9 +675,7 @@ fn test_pagination_limit_exceeds_total() {
     let (_temp_dir, file) = create_test_journal(entries).unwrap();
 
     let mut indexer = FileIndexer::default();
-    let file_index = indexer
-        .index(&file, None, &[], Seconds(3600))
-        .unwrap();
+    let file_index = indexer.index(&file, None, &[], Seconds(3600)).unwrap();
 
     // Query with limit much larger than total entries
     let params = LogQueryParamsBuilder::new(Anchor::Head, Direction::Forward)
@@ -654,7 +702,11 @@ fn test_pagination_limit_exceeds_total() {
         .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
-    assert_eq!(results.len(), TOTAL_ENTRIES, "Should return all entries backward");
+    assert_eq!(
+        results.len(),
+        TOTAL_ENTRIES,
+        "Should return all entries backward"
+    );
 }
 
 #[test]
@@ -670,9 +722,7 @@ fn test_pagination_resume_out_of_bounds() {
     let (_temp_dir, file) = create_test_journal(entries).unwrap();
 
     let mut indexer = FileIndexer::default();
-    let file_index = indexer
-        .index(&file, None, &[], Seconds(3600))
-        .unwrap();
+    let file_index = indexer.index(&file, None, &[], Seconds(3600)).unwrap();
 
     // Forward: Resume from position equal to total entries (at boundary)
     let params = LogQueryParamsBuilder::new(Anchor::Head, Direction::Forward)
@@ -682,7 +732,11 @@ fn test_pagination_resume_out_of_bounds() {
         .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
-    assert_eq!(results.len(), 0, "Resume from last position should return empty");
+    assert_eq!(
+        results.len(),
+        0,
+        "Resume from last position should return empty"
+    );
 
     // Forward: Resume from position beyond total entries
     let params = LogQueryParamsBuilder::new(Anchor::Head, Direction::Forward)
@@ -720,7 +774,11 @@ fn test_pagination_resume_out_of_bounds() {
         .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
-    assert_eq!(results.len(), 0, "Backward from position 0 should return empty");
+    assert_eq!(
+        results.len(),
+        0,
+        "Backward from position 0 should return empty"
+    );
 
     // Backward: Resume from position equal to total entries
     let params = LogQueryParamsBuilder::new(Anchor::Tail, Direction::Backward)
@@ -781,19 +839,15 @@ fn test_pagination_anchor_before_all_entries() {
     let (_temp_dir, file) = create_test_journal(entries).unwrap();
 
     let mut indexer = FileIndexer::default();
-    let file_index = indexer
-        .index(&file, None, &[], Seconds(3600))
-        .unwrap();
+    let file_index = indexer.index(&file, None, &[], Seconds(3600)).unwrap();
 
     // Anchor at 09:00 (before all entries), going forward
     let anchor_timestamp = Microseconds(base_timestamp.0 + 9 * 3600_000_000);
-    let params = LogQueryParamsBuilder::new(
-        Anchor::Timestamp(anchor_timestamp),
-        Direction::Forward,
-    )
-    .with_limit(10)
-    .build()
-    .unwrap();
+    let params =
+        LogQueryParamsBuilder::new(Anchor::Timestamp(anchor_timestamp), Direction::Forward)
+            .with_limit(10)
+            .build()
+            .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
     assert_eq!(
@@ -803,13 +857,11 @@ fn test_pagination_anchor_before_all_entries() {
     );
 
     // Anchor at 09:00, going backward
-    let params = LogQueryParamsBuilder::new(
-        Anchor::Timestamp(anchor_timestamp),
-        Direction::Backward,
-    )
-    .with_limit(10)
-    .build()
-    .unwrap();
+    let params =
+        LogQueryParamsBuilder::new(Anchor::Timestamp(anchor_timestamp), Direction::Backward)
+            .with_limit(10)
+            .build()
+            .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
     assert_eq!(
@@ -835,19 +887,15 @@ fn test_pagination_anchor_after_all_entries() {
     let (_temp_dir, file) = create_test_journal(entries).unwrap();
 
     let mut indexer = FileIndexer::default();
-    let file_index = indexer
-        .index(&file, None, &[], Seconds(3600))
-        .unwrap();
+    let file_index = indexer.index(&file, None, &[], Seconds(3600)).unwrap();
 
     // Anchor at 13:00 (after all entries), going forward
     let anchor_timestamp = Microseconds(base_timestamp.0 + 13 * 3600_000_000);
-    let params = LogQueryParamsBuilder::new(
-        Anchor::Timestamp(anchor_timestamp),
-        Direction::Forward,
-    )
-    .with_limit(10)
-    .build()
-    .unwrap();
+    let params =
+        LogQueryParamsBuilder::new(Anchor::Timestamp(anchor_timestamp), Direction::Forward)
+            .with_limit(10)
+            .build()
+            .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
     assert_eq!(
@@ -857,13 +905,11 @@ fn test_pagination_anchor_after_all_entries() {
     );
 
     // Anchor at 13:00, going backward
-    let params = LogQueryParamsBuilder::new(
-        Anchor::Timestamp(anchor_timestamp),
-        Direction::Backward,
-    )
-    .with_limit(10)
-    .build()
-    .unwrap();
+    let params =
+        LogQueryParamsBuilder::new(Anchor::Timestamp(anchor_timestamp), Direction::Backward)
+            .with_limit(10)
+            .build()
+            .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
     assert_eq!(
@@ -893,19 +939,15 @@ fn test_pagination_anchor_in_middle_with_pagination() {
     let (_temp_dir, file) = create_test_journal(entries).unwrap();
 
     let mut indexer = FileIndexer::default();
-    let file_index = indexer
-        .index(&file, None, &[], Seconds(3600))
-        .unwrap();
+    let file_index = indexer.index(&file, None, &[], Seconds(3600)).unwrap();
 
     // Anchor at 12:00 (middle), going forward with limit 2
     let anchor_timestamp = Microseconds(base_timestamp.0 + 12 * 3600_000_000);
-    let params = LogQueryParamsBuilder::new(
-        Anchor::Timestamp(anchor_timestamp),
-        Direction::Forward,
-    )
-    .with_limit(2)
-    .build()
-    .unwrap();
+    let params =
+        LogQueryParamsBuilder::new(Anchor::Timestamp(anchor_timestamp), Direction::Forward)
+            .with_limit(2)
+            .build()
+            .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
     assert_eq!(
@@ -918,27 +960,23 @@ fn test_pagination_anchor_in_middle_with_pagination() {
     assert_eq!(results[1].position, 3);
 
     // Paginate forward to get the rest
-    let params = LogQueryParamsBuilder::new(
-        Anchor::Timestamp(anchor_timestamp),
-        Direction::Forward,
-    )
-    .with_limit(2)
-    .with_resume_position(results[1].position)
-    .build()
-    .unwrap();
+    let params =
+        LogQueryParamsBuilder::new(Anchor::Timestamp(anchor_timestamp), Direction::Forward)
+            .with_limit(2)
+            .with_resume_position(results[1].position)
+            .build()
+            .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
     assert_eq!(results.len(), 1, "Should return remaining 1 entry");
     assert_eq!(results[0].position, 4);
 
     // Anchor at 12:00, going backward with limit 2
-    let params = LogQueryParamsBuilder::new(
-        Anchor::Timestamp(anchor_timestamp),
-        Direction::Backward,
-    )
-    .with_limit(2)
-    .build()
-    .unwrap();
+    let params =
+        LogQueryParamsBuilder::new(Anchor::Timestamp(anchor_timestamp), Direction::Backward)
+            .with_limit(2)
+            .build()
+            .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
     assert_eq!(
@@ -951,14 +989,12 @@ fn test_pagination_anchor_in_middle_with_pagination() {
     assert_eq!(results[1].position, 1);
 
     // Paginate backward to get the rest
-    let params = LogQueryParamsBuilder::new(
-        Anchor::Timestamp(anchor_timestamp),
-        Direction::Backward,
-    )
-    .with_limit(2)
-    .with_resume_position(results[1].position)
-    .build()
-    .unwrap();
+    let params =
+        LogQueryParamsBuilder::new(Anchor::Timestamp(anchor_timestamp), Direction::Backward)
+            .with_limit(2)
+            .with_resume_position(results[1].position)
+            .build()
+            .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
     assert_eq!(results.len(), 1, "Should return remaining 1 entry");
@@ -980,9 +1016,7 @@ fn test_pagination_with_time_boundaries() {
     let (_temp_dir, file) = create_test_journal(entries).unwrap();
 
     let mut indexer = FileIndexer::default();
-    let file_index = indexer
-        .index(&file, None, &[], Seconds(3600))
-        .unwrap();
+    let file_index = indexer.index(&file, None, &[], Seconds(3600)).unwrap();
 
     // Query with after and before boundaries: entries from hour 5 to hour 15 (exclusive)
     // That's entries 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 (10 entries total)
@@ -1032,7 +1066,11 @@ fn test_pagination_with_time_boundaries() {
         .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
-    assert_eq!(results.len(), 2, "Third page should return remaining 2 entries");
+    assert_eq!(
+        results.len(),
+        2,
+        "Third page should return remaining 2 entries"
+    );
     // Should get entries 13, 14
     assert_eq!(results[0].position, 13);
     assert_eq!(results[1].position, 14);
@@ -1081,9 +1119,7 @@ fn test_pagination_backward_with_time_boundaries() {
     let (_temp_dir, file) = create_test_journal(entries).unwrap();
 
     let mut indexer = FileIndexer::default();
-    let file_index = indexer
-        .index(&file, None, &[], Seconds(3600))
-        .unwrap();
+    let file_index = indexer.index(&file, None, &[], Seconds(3600)).unwrap();
 
     // Query backward with boundaries: entries from hour 5 to hour 15 (exclusive)
     // That's entries 5-14 (10 entries total), going backward from 14 to 5
@@ -1133,7 +1169,11 @@ fn test_pagination_backward_with_time_boundaries() {
         .unwrap();
 
     let results = file_index.find_log_entries(&file, &params).unwrap();
-    assert_eq!(results.len(), 2, "Third page should return remaining 2 entries");
+    assert_eq!(
+        results.len(),
+        2,
+        "Third page should return remaining 2 entries"
+    );
     // Should get 6, 5
     assert_eq!(results[0].position, 6);
     assert_eq!(results[1].position, 5);

--- a/src/crates/journal-log-writer/tests/log_writer.rs
+++ b/src/crates/journal-log-writer/tests/log_writer.rs
@@ -245,7 +245,11 @@ fn test_boot_id_injection() {
         })
         .collect();
 
-    assert_eq!(journal_files.len(), 1, "Should have created exactly one journal file");
+    assert_eq!(
+        journal_files.len(),
+        1,
+        "Should have created exactly one journal file"
+    );
 
     let journal_path = journal_files[0].path();
     let boot_id = load_boot_id().unwrap();

--- a/src/crates/netdata-log-viewer/journal-function/src/lib.rs
+++ b/src/crates/netdata-log-viewer/journal-function/src/lib.rs
@@ -11,9 +11,9 @@ pub mod netdata;
 // Re-export types from journal-engine for convenience
 pub use journal_engine::{
     BucketRequest, BucketResponse, CellValue, ColumnInfo, Facets, FileIndexCache,
-    FileIndexCacheBuilder, FileIndexKey, Histogram, HistogramEngine, IndexingLimits,
-    LogEntryData, LogQuery, QueryTimeRange, Result, Table, batch_compute_file_indexes,
-    calculate_bucket_duration, entry_data_to_table,
+    FileIndexCacheBuilder, FileIndexKey, Histogram, HistogramEngine, IndexingLimits, LogEntryData,
+    LogQuery, QueryTimeRange, Result, Table, batch_compute_file_indexes, calculate_bucket_duration,
+    entry_data_to_table,
 };
 
 // Re-export Netdata-specific charts/metrics

--- a/src/crates/netdata-log-viewer/journal-function/src/netdata/facets.rs
+++ b/src/crates/netdata-log-viewer/journal-function/src/netdata/facets.rs
@@ -3,11 +3,11 @@
 //! This module converts histogram responses into facet structures for the
 //! Netdata dashboard filtering UI.
 
-use journal_engine::Histogram;
 use super::transformations::TransformationRegistry;
 use super::ui_types::{Facet, FacetOption};
-use journal_index::FieldValuePair;
 use journal_core::collections::HashMap;
+use journal_engine::Histogram;
+use journal_index::FieldValuePair;
 
 /// Creates a list of facets from a Histogram.
 ///

--- a/src/crates/netdata-log-viewer/journal-function/src/netdata/histogram.rs
+++ b/src/crates/netdata-log-viewer/journal-function/src/netdata/histogram.rs
@@ -66,7 +66,8 @@ fn chart_from_histogram(
     field: &FieldName,
     transformations: &TransformationRegistry,
 ) -> Chart {
-    let (raw_values, result) = chart_result_from_histogram(histogram_response, field, transformations);
+    let (raw_values, result) =
+        chart_result_from_histogram(histogram_response, field, transformations);
     let view = chart_view_from_histogram(histogram_response, field, &raw_values, &result.labels);
 
     Chart { view, result }

--- a/src/crates/netdata-log-viewer/journal-function/src/netdata/transformations.rs
+++ b/src/crates/netdata-log-viewer/journal-function/src/netdata/transformations.rs
@@ -625,7 +625,10 @@ pub fn systemd_transformations() -> TransformationRegistry {
     registry.register("MESSAGE_ID", Arc::new(MessageIdTransformation));
 
     // OpenTelemetry log fields
-    registry.register("log.severity_number", Arc::new(OtelSeverityNumberTransformation));
+    registry.register(
+        "log.severity_number",
+        Arc::new(OtelSeverityNumberTransformation),
+    );
 
     // Also register variations that exist in the wild
     registry.register("OBJECT_UID", Arc::new(UidTransformation));

--- a/src/crates/netdata-otel/flatten_otel/src/metrics.rs
+++ b/src/crates/netdata-otel/flatten_otel/src/metrics.rs
@@ -1,10 +1,10 @@
-use serde_json::{json, Map as JsonMap, Value as JsonValue};
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
 
 use opentelemetry_proto::tonic::{
     collector::metrics::v1::ExportMetricsServiceRequest,
     metrics::v1::{
-        metric::Data, AggregationTemporality, Gauge, Histogram, HistogramDataPoint, Metric,
-        NumberDataPoint, ResourceMetrics, ScopeMetrics, Sum,
+        AggregationTemporality, Gauge, Histogram, HistogramDataPoint, Metric, NumberDataPoint,
+        ResourceMetrics, ScopeMetrics, Sum, metric::Data,
     },
 };
 

--- a/src/crates/netdata-otel/otel-plugin/src/flattened_point.rs
+++ b/src/crates/netdata-otel/otel-plugin/src/flattened_point.rs
@@ -101,7 +101,10 @@ impl FlattenedPoint {
                     Some(JsonValue::Number(n)) => n.to_string(),
                     Some(JsonValue::Bool(b)) => b.to_string(),
                     Some(value) => {
-                        eprintln!("Only strings/number/bool values can be used for dimension name >>>{:#?}<<<", value);
+                        eprintln!(
+                            "Only strings/number/bool values can be used for dimension name >>>{:#?}<<<",
+                            value
+                        );
                         return None;
                     }
                     _ => {

--- a/src/crates/netdata-otel/otel-plugin/src/logs_service.rs
+++ b/src/crates/netdata-otel/otel-plugin/src/logs_service.rs
@@ -153,7 +153,12 @@ impl LogsService for NetdataLogsService {
                 }
 
                 let entry_refs: Vec<&[u8]> = entry_data.iter().map(|v| v.as_slice()).collect();
-                if let Err(e) = self.log.lock().unwrap().write_entry(&entry_refs, source_timestamp_usec) {
+                if let Err(e) = self
+                    .log
+                    .lock()
+                    .unwrap()
+                    .write_entry(&entry_refs, source_timestamp_usec)
+                {
                     eprintln!("Failed to write log entry: {}", e);
                     return Err(Status::internal(format!(
                         "Failed to write log entry: {}",

--- a/src/crates/netdata-otel/otel-plugin/src/metrics_service.rs
+++ b/src/crates/netdata-otel/otel-plugin/src/metrics_service.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use flatten_otel::flatten_metrics_request;
 use opentelemetry_proto::tonic::collector::metrics::v1::{
-    metrics_service_server::MetricsService, ExportMetricsServiceRequest,
-    ExportMetricsServiceResponse,
+    ExportMetricsServiceRequest, ExportMetricsServiceResponse,
+    metrics_service_server::MetricsService,
 };
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/crates/netdata-otel/otel-plugin/src/netdata_chart.rs
+++ b/src/crates/netdata-otel/otel-plugin/src/netdata_chart.rs
@@ -282,7 +282,11 @@ impl NetdataChart {
     }
 
     fn emit_set(&self, buffer: &mut ChartOutputBuffer, dimension_name: &str, value: f64) {
-        buffer.push_str(&format!("SET {} {}\n", dimension_name, value * self.divisor as f64));
+        buffer.push_str(&format!(
+            "SET {} {}\n",
+            dimension_name,
+            value * self.divisor as f64
+        ));
     }
 
     fn emit_end(&self, buffer: &mut ChartOutputBuffer) {

--- a/src/crates/netdata-plugin/charts-derive/src/lib.rs
+++ b/src/crates/netdata-plugin/charts-derive/src/lib.rs
@@ -5,7 +5,7 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Data, DeriveInput, Fields};
+use syn::{Data, DeriveInput, Fields, parse_macro_input};
 
 /// Derive macro for NetdataChart trait
 ///

--- a/src/crates/netdata-plugin/error/src/lib.rs
+++ b/src/crates/netdata-plugin/error/src/lib.rs
@@ -9,31 +9,31 @@ pub enum NetdataPluginError {
     /// Transport layer error (I/O, network)
     #[error("transport error: {0}")]
     Transport(#[from] std::io::Error),
-    
+
     /// Protocol parsing or communication error
     #[error("protocol error: {message}")]
     Protocol { message: String },
-    
+
     /// Runtime error during plugin execution
-    #[error("runtime error: {message}")]  
+    #[error("runtime error: {message}")]
     Runtime { message: String },
-    
+
     /// Configuration error
     #[error("configuration error: {message}")]
     Config { message: String },
-    
+
     /// Function handler error
     #[error("function handler error: {message}")]
     FunctionHandler { message: String },
-    
+
     /// Schema validation error
     #[error("schema validation error: {message}")]
     Schema { message: String },
-    
+
     /// Transport is closed
     #[error("transport is closed")]
     Closed,
-    
+
     /// Generic error with custom message
     #[error("{message}")]
     Other { message: String },

--- a/src/crates/netdata-plugin/rt/src/charts/chart_trait.rs
+++ b/src/crates/netdata-plugin/rt/src/charts/chart_trait.rs
@@ -2,7 +2,7 @@
 
 use super::metadata::{ChartMetadata, ChartType, DimensionAlgorithm, DimensionMetadata};
 use super::writer::ChartWriter;
-use schemars::{schema_for, JsonSchema};
+use schemars::{JsonSchema, schema_for};
 use serde_json::Value;
 
 /// Trait for writing chart dimensions efficiently.
@@ -142,7 +142,10 @@ fn extract_chart_metadata<T: serde::Serialize>(schema: &T) -> ChartMetadata {
 }
 
 /// Extract dimension metadata from a field schema
-fn extract_dimension_metadata(field_name: &str, field_obj: &serde_json::Map<String, Value>) -> DimensionMetadata {
+fn extract_dimension_metadata(
+    field_name: &str,
+    field_obj: &serde_json::Map<String, Value>,
+) -> DimensionMetadata {
     let mut dim = DimensionMetadata::new(field_name);
 
     if let Some(name) = extract_string_from_json(field_obj, "x-dimension-name") {
@@ -176,9 +179,7 @@ fn extract_dimension_metadata(field_name: &str, field_obj: &serde_json::Map<Stri
 
 /// Helper to extract string from JSON object
 fn extract_string_from_json(obj: &serde_json::Map<String, Value>, key: &str) -> Option<String> {
-    obj.get(key)
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
+    obj.get(key).and_then(|v| v.as_str()).map(|s| s.to_string())
 }
 
 /// Helper to extract i64 from JSON object

--- a/src/crates/netdata-plugin/rt/src/charts/registry.rs
+++ b/src/crates/netdata-plugin/rt/src/charts/registry.rs
@@ -184,7 +184,11 @@ trait ChartSampler: Send + Sync {
     /// # Parameters
     /// - `buffer`: Buffer to write the chart data to
     /// - `collection_time`: When the data was collected
-    async fn sample_to_buffer(&mut self, buffer: &mut bytes::BytesMut, collection_time: std::time::SystemTime);
+    async fn sample_to_buffer(
+        &mut self,
+        buffer: &mut bytes::BytesMut,
+        collection_time: std::time::SystemTime,
+    );
     fn interval(&self) -> Duration;
 }
 
@@ -200,7 +204,11 @@ impl<T> ChartSampler for SingletonChartSampler<T>
 where
     T: NetdataChart + Default + PartialEq + Clone + Send + Sync,
 {
-    async fn sample_to_buffer(&mut self, buffer: &mut BytesMut, collection_time: std::time::SystemTime) {
+    async fn sample_to_buffer(
+        &mut self,
+        buffer: &mut BytesMut,
+        collection_time: std::time::SystemTime,
+    ) {
         // Sample the current value
         let current = {
             let guard = self.data.read();

--- a/src/crates/netdata-plugin/rt/src/charts/tracker.rs
+++ b/src/crates/netdata-plugin/rt/src/charts/tracker.rs
@@ -22,7 +22,11 @@ impl<T: NetdataChart + Default + PartialEq + Clone> TrackedChart<T> {
     }
 
     /// Create a new tracked chart with explicit metadata (used for instantiated templates)
-    pub(crate) fn new_with_metadata(initial: T, interval: Duration, metadata: ChartMetadata) -> Self {
+    pub(crate) fn new_with_metadata(
+        initial: T,
+        interval: Duration,
+        metadata: ChartMetadata,
+    ) -> Self {
         Self {
             previous: initial.clone(),
             current: initial,
@@ -116,15 +120,24 @@ mod tests {
 
     #[test]
     fn test_change_detection() {
-        let initial = TestMetrics { value1: 10, value2: 20 };
+        let initial = TestMetrics {
+            value1: 10,
+            value2: 20,
+        };
         let mut tracker = TrackedChart::new(initial.clone(), Duration::from_secs(1));
 
         assert!(!tracker.has_changed());
 
-        tracker.update(TestMetrics { value1: 15, value2: 20 });
+        tracker.update(TestMetrics {
+            value1: 15,
+            value2: 20,
+        });
         assert!(tracker.has_changed());
 
-        tracker.update(TestMetrics { value1: 15, value2: 20 });
+        tracker.update(TestMetrics {
+            value1: 15,
+            value2: 20,
+        });
         assert!(!tracker.has_changed());
     }
 

--- a/src/crates/netdata-plugin/rt/src/charts/writer.rs
+++ b/src/crates/netdata-plugin/rt/src/charts/writer.rs
@@ -42,7 +42,8 @@ impl ChartWriter {
         self.buffer.put_slice(b"' '");
         self.buffer.put_slice(metadata.context.as_bytes());
         self.buffer.put_slice(b"' ");
-        self.buffer.put_slice(metadata.chart_type.as_str().as_bytes());
+        self.buffer
+            .put_slice(metadata.chart_type.as_str().as_bytes());
         self.buffer.put_slice(b" ");
         self.write_i64(metadata.priority);
         self.buffer.put_slice(b" ");
@@ -201,7 +202,10 @@ mod tests {
         writer.end_chart(UNIX_EPOCH + Duration::from_secs(1609459200)); // 2021-01-01 00:00:00 UTC
 
         let output = String::from_utf8_lossy(&writer.buffer);
-        assert_eq!(output, "BEGIN test.chart 1000000\nSET value1 = 42\nSET value2 = 13\nEND 1609459200\n");
+        assert_eq!(
+            output,
+            "BEGIN test.chart 1000000\nSET value1 = 42\nSET value2 = 13\nEND 1609459200\n"
+        );
     }
 
     #[test]

--- a/src/crates/netdata-plugin/rt/src/lib.rs
+++ b/src/crates/netdata-plugin/rt/src/lib.rs
@@ -825,8 +825,7 @@ where
             .expect("outbound_rx consumed only once");
 
         let writer_task = tokio::spawn(async move {
-            let mut keepalive =
-                tokio::time::interval(tokio::time::Duration::from_secs(60));
+            let mut keepalive = tokio::time::interval(tokio::time::Duration::from_secs(60));
 
             loop {
                 tokio::select! {

--- a/src/crates/netdata-plugin/types/src/dyncfg_source_type.rs
+++ b/src/crates/netdata-plugin/types/src/dyncfg_source_type.rs
@@ -78,21 +78,51 @@ mod tests {
 
     #[test]
     fn test_from_name() {
-        assert_eq!(DynCfgSourceType::from_name("internal"), Some(DynCfgSourceType::Internal));
-        assert_eq!(DynCfgSourceType::from_name("stock"), Some(DynCfgSourceType::Stock));
-        assert_eq!(DynCfgSourceType::from_name("user"), Some(DynCfgSourceType::User));
-        assert_eq!(DynCfgSourceType::from_name("dyncfg"), Some(DynCfgSourceType::Dyncfg));
-        assert_eq!(DynCfgSourceType::from_name("discovered"), Some(DynCfgSourceType::Discovered));
+        assert_eq!(
+            DynCfgSourceType::from_name("internal"),
+            Some(DynCfgSourceType::Internal)
+        );
+        assert_eq!(
+            DynCfgSourceType::from_name("stock"),
+            Some(DynCfgSourceType::Stock)
+        );
+        assert_eq!(
+            DynCfgSourceType::from_name("user"),
+            Some(DynCfgSourceType::User)
+        );
+        assert_eq!(
+            DynCfgSourceType::from_name("dyncfg"),
+            Some(DynCfgSourceType::Dyncfg)
+        );
+        assert_eq!(
+            DynCfgSourceType::from_name("discovered"),
+            Some(DynCfgSourceType::Discovered)
+        );
         assert_eq!(DynCfgSourceType::from_name("invalid"), None);
     }
 
     #[test]
     fn test_from_slice() {
-        assert_eq!(DynCfgSourceType::from_slice(b"internal"), Some(DynCfgSourceType::Internal));
-        assert_eq!(DynCfgSourceType::from_slice(b"  stock  "), Some(DynCfgSourceType::Stock));
-        assert_eq!(DynCfgSourceType::from_slice(b"user"), Some(DynCfgSourceType::User));
-        assert_eq!(DynCfgSourceType::from_slice(b"dyncfg"), Some(DynCfgSourceType::Dyncfg));
-        assert_eq!(DynCfgSourceType::from_slice(b"discovered"), Some(DynCfgSourceType::Discovered));
+        assert_eq!(
+            DynCfgSourceType::from_slice(b"internal"),
+            Some(DynCfgSourceType::Internal)
+        );
+        assert_eq!(
+            DynCfgSourceType::from_slice(b"  stock  "),
+            Some(DynCfgSourceType::Stock)
+        );
+        assert_eq!(
+            DynCfgSourceType::from_slice(b"user"),
+            Some(DynCfgSourceType::User)
+        );
+        assert_eq!(
+            DynCfgSourceType::from_slice(b"dyncfg"),
+            Some(DynCfgSourceType::Dyncfg)
+        );
+        assert_eq!(
+            DynCfgSourceType::from_slice(b"discovered"),
+            Some(DynCfgSourceType::Discovered)
+        );
         assert_eq!(DynCfgSourceType::from_slice(b"invalid"), None);
         assert_eq!(DynCfgSourceType::from_slice(&[0xFF, 0xFE]), None); // Invalid UTF-8
     }
@@ -108,11 +138,26 @@ mod tests {
 
     #[test]
     fn test_from_str() {
-        assert_eq!("internal".parse::<DynCfgSourceType>(), Ok(DynCfgSourceType::Internal));
-        assert_eq!("stock".parse::<DynCfgSourceType>(), Ok(DynCfgSourceType::Stock));
-        assert_eq!("user".parse::<DynCfgSourceType>(), Ok(DynCfgSourceType::User));
-        assert_eq!("dyncfg".parse::<DynCfgSourceType>(), Ok(DynCfgSourceType::Dyncfg));
-        assert_eq!("discovered".parse::<DynCfgSourceType>(), Ok(DynCfgSourceType::Discovered));
+        assert_eq!(
+            "internal".parse::<DynCfgSourceType>(),
+            Ok(DynCfgSourceType::Internal)
+        );
+        assert_eq!(
+            "stock".parse::<DynCfgSourceType>(),
+            Ok(DynCfgSourceType::Stock)
+        );
+        assert_eq!(
+            "user".parse::<DynCfgSourceType>(),
+            Ok(DynCfgSourceType::User)
+        );
+        assert_eq!(
+            "dyncfg".parse::<DynCfgSourceType>(),
+            Ok(DynCfgSourceType::Dyncfg)
+        );
+        assert_eq!(
+            "discovered".parse::<DynCfgSourceType>(),
+            Ok(DynCfgSourceType::Discovered)
+        );
         assert_eq!("invalid".parse::<DynCfgSourceType>(), Err(()));
     }
 

--- a/src/crates/netdata-plugin/types/src/dyncfg_status.rs
+++ b/src/crates/netdata-plugin/types/src/dyncfg_status.rs
@@ -87,19 +87,43 @@ mod tests {
     #[test]
     fn test_from_name() {
         assert_eq!(DynCfgStatus::from_name("none"), Some(DynCfgStatus::None));
-        assert_eq!(DynCfgStatus::from_name("accepted"), Some(DynCfgStatus::Accepted));
-        assert_eq!(DynCfgStatus::from_name("running"), Some(DynCfgStatus::Running));
-        assert_eq!(DynCfgStatus::from_name("failed"), Some(DynCfgStatus::Failed));
-        assert_eq!(DynCfgStatus::from_name("disabled"), Some(DynCfgStatus::Disabled));
-        assert_eq!(DynCfgStatus::from_name("orphan"), Some(DynCfgStatus::Orphan));
-        assert_eq!(DynCfgStatus::from_name("incomplete"), Some(DynCfgStatus::Incomplete));
+        assert_eq!(
+            DynCfgStatus::from_name("accepted"),
+            Some(DynCfgStatus::Accepted)
+        );
+        assert_eq!(
+            DynCfgStatus::from_name("running"),
+            Some(DynCfgStatus::Running)
+        );
+        assert_eq!(
+            DynCfgStatus::from_name("failed"),
+            Some(DynCfgStatus::Failed)
+        );
+        assert_eq!(
+            DynCfgStatus::from_name("disabled"),
+            Some(DynCfgStatus::Disabled)
+        );
+        assert_eq!(
+            DynCfgStatus::from_name("orphan"),
+            Some(DynCfgStatus::Orphan)
+        );
+        assert_eq!(
+            DynCfgStatus::from_name("incomplete"),
+            Some(DynCfgStatus::Incomplete)
+        );
         assert_eq!(DynCfgStatus::from_name("invalid"), None);
     }
 
     #[test]
     fn test_from_slice() {
-        assert_eq!(DynCfgStatus::from_slice(b"running"), Some(DynCfgStatus::Running));
-        assert_eq!(DynCfgStatus::from_slice(b"  failed  "), Some(DynCfgStatus::Failed));
+        assert_eq!(
+            DynCfgStatus::from_slice(b"running"),
+            Some(DynCfgStatus::Running)
+        );
+        assert_eq!(
+            DynCfgStatus::from_slice(b"  failed  "),
+            Some(DynCfgStatus::Failed)
+        );
         assert_eq!(DynCfgStatus::from_slice(b"invalid"), None);
         assert_eq!(DynCfgStatus::from_slice(&[0xFF, 0xFE]), None); // Invalid UTF-8
     }


### PR DESCRIPTION
SSIA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied cargo fmt across the workspace to standardize Rust formatting and keep code style consistent. No behavior changes; only import reordering, line wrapping, trailing commas, and minor test formatting updates.

<sup>Written for commit 964b7f42b8785e5012c509152795bf9816b75ab1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

