### PR TITLE
Add readme for otel-signal-viewer plugin.

### DIFF
--- a/src/crates/netdata-log-viewer/otel-signal-viewer-plugin/README.md
+++ b/src/crates/netdata-log-viewer/otel-signal-viewer-plugin/README.md
@@ -25,7 +25,7 @@ sudo ./edit-config otel-signal-viewer.yaml
 ### Journal
 
 The `journal` section specifies the directories containing journal files to
-watch and index. By default, it points to the the same directory the `otel`
+watch and index. By default, it points to the same directory the `otel`
 plugin uses to store OpenTelemetry logs. At least one path must be specified:
 
 ```yaml


### PR DESCRIPTION
SSIA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a README for the OpenTelemetry Signal Viewer plugin with setup guidance and YAML examples. Covers journal paths (systemd journal files), cache tuning, indexing limits, and removes a duplicate word.

<sup>Written for commit 01f04fe92e3cb58583e9f43782842ca832089729. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

