### PR TITLE
Improve cgroups.plugin discoverability with per-technology modules

### DIFF
--- a/src/collectors/cgroups.plugin/README.md
+++ b/src/collectors/cgroups.plugin/README.md
@@ -12,6 +12,40 @@ To visualize cgroup metrics Netdata provides configuration for cherry-picking th
 Netdata should pick **systemd services**, all kinds of **containers** (lxc, docker, etc.) and **virtual machines** spawn
 by managers that register them with cgroups (qemu, libvirt, etc.).
 
+## Supported Technologies
+
+cgroups.plugin monitors **any process** that creates Linux cgroups. For the following technologies, Netdata also
+resolves friendly names (e.g., showing "my-web-app" instead of a raw cgroup path like
+`/sys/fs/cgroup/system.slice/docker-abc123.scope`).
+
+The **Naming** column below indicates whether Netdata can resolve the cgroup path to a human-readable name
+(e.g., the container name, VM name, or service name):
+
+| Technology | Naming |
+|:---|:---:|
+| Docker | Yes |
+| Podman | Yes |
+| Kubernetes pods/containers | Yes |
+| Nomad (via Docker) | Yes |
+| AWS ECS (via Docker) | Yes |
+| containerd (via Docker) | Yes |
+| Proxmox QEMU/KVM VMs | Yes |
+| Proxmox LXC containers | Yes |
+| libvirt QEMU/KVM VMs | Yes |
+| libvirt LXC containers | Yes |
+| LXC 4.0+ (including Incus) | Yes |
+| systemd-nspawn | Yes |
+| Systemd services | Yes |
+| KubeVirt VMs (in K8s) | Partial |
+
+Technologies that use the above as their underlying infrastructure are also covered. For example:
+- **OpenShift** and other Kubernetes distributions (k3s, RKE, RKE2, MicroK8s, EKS, GKE, AKS) — via Kubernetes cgroup paths
+- **OpenStack Nova** — via libvirt/QEMU cgroup paths
+- **oVirt / RHV** — via libvirt/QEMU cgroup paths
+
+Any other technology creating Linux cgroups is **monitored** (CPU, memory, disk I/O, network), but will show its
+raw cgroup path as the name.
+
 ## Configuring Netdata for cgroups
 
 In general, no additional settings are required. Netdata discovers all available cgroups on the host system and

--- a/src/collectors/cgroups.plugin/metadata.yaml
+++ b/src/collectors/cgroups.plugin/metadata.yaml
@@ -18,10 +18,22 @@ modules:
       keywords:
         - containers
         - docker
+        - podman
+        - containerd
+        - cri-o
+        - lxc
+        - lxd
+        - incus
+        - nomad
+        - ecs
+        - systemd-nspawn
+        - nspawn
+        - cgroups
+        - linux containers
       most_popular: true
     overview: &overview
       data_collection: &data_collection
-        metrics_description: "Monitor Containers for performance, resource usage, and health status."
+        metrics_description: "Monitor containers and virtual machines resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
         method_description: ""
       supported_platforms:
         include: []
@@ -422,12 +434,29 @@ modules:
         - kubernetes
         - pods
         - containers
+        - openshift
+        - rancher
+        - rke
+        - rke2
+        - k3s
+        - microk8s
+        - eks
+        - gke
+        - aks
+        - tanzu
+        - minikube
+        - kind
+        - containerd
+        - cri-o
+        - kubelet
+        - kubepods
+      most_popular: true
     overview:
       <<: *overview
       data-collection:
         <<: *data_collection
-        metrics_description: Monitor Kubernetes Clusters for performance, resource usage, and health status.
-    alerts:
+        metrics_description: Monitor Kubernetes pod and container resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups.
+    alerts: &k8s_alerts
       - name: k8s_cgroup_10min_cpu_usage
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cgroups.conf
         metric: k8s.cgroup.cpu_limit
@@ -446,7 +475,7 @@ modules:
         info:
           ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, compared to the rate over
           the last minute
-    metrics:
+    metrics: &k8s_metrics
       folding:
         title: Metrics
         enabled: false
@@ -814,14 +843,18 @@ modules:
         icon_filename: systemd.svg
         categories:
           - data-collection.systemd
-        keywords:
-          - systemd
-          - services
+      keywords:
+        - systemd
+        - services
+        - units
+        - daemons
+        - systemctl
+        - cgroups
     overview:
       <<: *overview
       data-collection:
         <<: *data_collection
-        metrics_desctiption: "Monitor Systemd Services for performance, resource usage, and health status."
+        metrics_description: "Monitor Systemd service resource utilization — CPU, memory, and disk I/O — via Linux cgroups."
     alerts: []
     metrics:
       folding:
@@ -945,13 +978,23 @@ modules:
           - data-collection.containers-and-vms
       keywords:
         - vms
+        - virtual machines
         - virtualization
-        - container
+        - hypervisor
+        - kvm
+        - qemu
+        - libvirt
+        - proxmox
+        - proxmox ve
+        - ovirt
+        - openstack
+        - openstack nova
+        - cgroups
     overview:
       <<: *overview
       data_collection:
         <<: *data_collection
-        metrics_description: "Monitor Virtual Machines for performance, resource usage, and health status."
+        metrics_description: "Monitor virtual machine resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
   - <<: *module
     meta:
       <<: *meta
@@ -964,60 +1007,255 @@ modules:
       keywords:
         - lxc
         - lxd
+        - incus
+        - linux containers
+        - system containers
         - container
     overview:
       <<: *overview
       data_collection:
         <<: *data_collection
-        metrics_description: "Monitor LXC Containers for performance, resource usage, and health status."
+        metrics_description: "Monitor LXC/LXD/Incus container resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
   - <<: *module
     meta:
       <<: *meta
       monitored_instance:
-        name: Libvirt Containers
+        name: Libvirt VMs and Containers
         link: ""
         icon_filename: libvirt.png
         categories:
           - data-collection.containers-and-vms
       keywords:
         - libvirt
+        - kvm
+        - qemu
+        - virsh
+        - virt-manager
+        - virtual machine
+        - vm
         - container
     overview:
       <<: *overview
       data_collection:
         <<: *data_collection
-        metrics_description: "Monitor Libvirt for performance, resource usage, and health status."
+        metrics_description: "Monitor libvirt-managed VM and container resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
   - <<: *module
     meta:
       <<: *meta
       monitored_instance:
-        name: oVirt Containers
+        name: oVirt VMs
         link: ""
         icon_filename: ovirt.svg
         categories:
           - data-collection.containers-and-vms
       keywords:
         - ovirt
-        - container
+        - rhev
+        - red hat virtualization
+        - red hat enterprise virtualization
+        - kvm
+        - qemu
+        - libvirt
+        - virtual machine
+        - vm
     overview:
       <<: *overview
       data_collection:
         <<: *data_collection
-        metrics_description: "Monitor oVirt for performance, resource usage, and health status."
+        metrics_description: "Monitor oVirt/RHEV virtual machine resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
   - <<: *module
     meta:
       <<: *meta
       monitored_instance:
-        name: Proxmox Containers
+        name: Proxmox VMs and Containers
         link: ""
         icon_filename: proxmox.png
         categories:
           - data-collection.containers-and-vms
       keywords:
         - proxmox
+        - proxmox ve
+        - pve
+        - kvm
+        - qemu
+        - lxc
+        - libvirt
+        - virtual machine
+        - vm
         - container
     overview:
       <<: *overview
       data_collection:
         <<: *data_collection
-        metrics_description: "Monitor Proxmox for performance, resource usage, and health status."
+        metrics_description: "Monitor Proxmox VE virtual machine and container resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
+  - <<: *module
+    meta:
+      <<: *meta
+      monitored_instance:
+        name: Docker Containers
+        link: https://www.docker.com/
+        icon_filename: docker.svg
+        categories:
+          - data-collection.containers-and-vms
+      keywords:
+        - docker
+        - containers
+        - docker compose
+        - docker swarm
+        - moby
+        - containerd
+        - runc
+    overview:
+      <<: *overview
+      data_collection:
+        <<: *data_collection
+        metrics_description: "Monitor Docker container resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
+  - <<: *module
+    meta:
+      <<: *meta
+      monitored_instance:
+        name: Podman Containers
+        link: https://podman.io/
+        icon_filename: podman.svg
+        categories:
+          - data-collection.containers-and-vms
+      keywords:
+        - podman
+        - containers
+        - pods
+        - oci
+        - crun
+        - runc
+    overview:
+      <<: *overview
+      data_collection:
+        <<: *data_collection
+        metrics_description: "Monitor Podman container resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
+  - <<: *module
+    meta:
+      <<: *meta
+      monitored_instance:
+        name: AWS ECS Containers
+        link: https://aws.amazon.com/ecs/
+        icon_filename: aws.svg
+        categories:
+          - data-collection.containers-and-vms
+      keywords:
+        - aws
+        - ecs
+        - elastic container service
+        - amazon
+        - containers
+    overview:
+      <<: *overview
+      data_collection:
+        <<: *data_collection
+        metrics_description: "Monitor AWS ECS container resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
+  - <<: *module
+    meta:
+      <<: *meta
+      monitored_instance:
+        name: Nomad Containers
+        link: https://www.nomadproject.io/
+        icon_filename: nomad.svg
+        categories:
+          - data-collection.containers-and-vms
+      keywords:
+        - nomad
+        - hashicorp
+        - containers
+        - orchestrator
+    overview:
+      <<: *overview
+      data_collection:
+        <<: *data_collection
+        metrics_description: "Monitor HashiCorp Nomad container resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
+  - <<: *module
+    meta:
+      <<: *meta
+      monitored_instance:
+        name: containerd Containers
+        link: https://containerd.io/
+        icon_filename: containerd.svg
+        categories:
+          - data-collection.containers-and-vms
+      keywords:
+        - containerd
+        - containers
+        - cri
+        - container runtime
+        - nerdctl
+    overview:
+      <<: *overview
+      data_collection:
+        <<: *data_collection
+        metrics_description: "Monitor containerd container resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
+  - <<: *module
+    meta:
+      <<: *meta
+      monitored_instance:
+        name: systemd-nspawn Containers
+        link: https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html
+        icon_filename: systemd.svg
+        categories:
+          - data-collection.containers-and-vms
+      keywords:
+        - systemd-nspawn
+        - nspawn
+        - machinectl
+        - systemd
+        - containers
+    overview:
+      <<: *overview
+      data_collection:
+        <<: *data_collection
+        metrics_description: "Monitor systemd-nspawn container resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
+  - <<: *module
+    meta:
+      <<: *meta
+      monitored_instance:
+        name: OpenShift Containers
+        link: https://www.redhat.com/en/technologies/cloud-computing/openshift
+        icon_filename: openshift.svg
+        categories:
+          - data-collection.containers-and-vms
+          - data-collection.kubernetes
+      keywords:
+        - openshift
+        - red hat openshift
+        - okd
+        - kubernetes
+        - k8s
+        - containers
+        - pods
+    overview:
+      <<: *overview
+      data_collection:
+        <<: *data_collection
+        metrics_description: "Monitor Red Hat OpenShift container resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
+    alerts: *k8s_alerts
+    metrics: *k8s_metrics
+  - <<: *module
+    meta:
+      <<: *meta
+      monitored_instance:
+        name: OpenStack VMs
+        link: https://www.openstack.org/
+        icon_filename: openstack.svg
+        categories:
+          - data-collection.containers-and-vms
+      keywords:
+        - openstack
+        - openstack nova
+        - openstack compute
+        - kvm
+        - qemu
+        - libvirt
+        - virtual machine
+        - vm
+        - cloud
+    overview:
+      <<: *overview
+      data_collection:
+        <<: *data_collection
+        metrics_description: "Monitor OpenStack Nova virtual machine resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."


### PR DESCRIPTION
## Summary

- Add 8 new module entries in `metadata.yaml` for Docker, Podman, AWS ECS, Nomad, containerd, systemd-nspawn, OpenShift, and OpenStack — each technology gets its own integration page
- Enrich keywords on all 8 existing modules with technology synonyms (e.g., `kvm`, `qemu`, `proxmox ve`, `pve`, `openshift`, `rhev`, `incus`, etc.)
- Rename misleading module names: "Libvirt Containers" → "Libvirt VMs and Containers", "oVirt Containers" → "oVirt VMs", "Proxmox Containers" → "Proxmox VMs and Containers"
- Add "Supported Technologies" section to README.md listing all 14 technologies with cgroup naming support
- Fix Systemd Services keywords indentation bug and metrics_description typo

## Why

Searching for "proxmox", "kvm", "openshift", "podman", etc. in the codebase or docs either missed relevant cgroups.plugin entries or returned misleading results (e.g., "Proxmox Containers" implying only LXC, not VMs). This affected Docusaurus search, AI support agents using `rg`/`grep`, and search engine indexing.

## Test plan

- [x] YAML validates correctly (`python3 -c "import yaml; yaml.safe_load(open('src/collectors/cgroups.plugin/metadata.yaml'))"`)
- [x] `rg "proxmox"` on metadata.yaml finds Proxmox entries with comprehensive keywords
- [x] `rg "openshift"` finds the OpenShift entry
- [x] `rg "kvm"` finds VM-related entries (Virtual Machines, Libvirt, oVirt, Proxmox, OpenStack)
- [ ] CI integration generator creates 16 integration pages (8 existing + 8 new)
- [x] No broken YAML anchors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves cgroups.plugin discoverability with per-technology modules and richer keywords, so searches for Docker, Podman, Proxmox, KVM, OpenShift, etc. route to the right integration pages. Also documents supported technologies and fixes small Systemd issues.

- **New Features**
  - Add 8 modules: Docker, Podman, AWS ECS, Nomad, containerd, systemd-nspawn, OpenShift, OpenStack.
  - Enrich keywords with synonyms (e.g., kvm, qemu, proxmox ve, pve, incus, rhev).
  - Rename modules for clarity: Libvirt VMs and Containers, oVirt VMs, Proxmox VMs and Containers.
  - Add “Supported Technologies” to README with 14 technologies that get friendly naming.

- **Bug Fixes**
  - Fix Systemd Services keywords indentation.
  - Correct metrics_description typo in Systemd Services.

<sup>Written for commit c25e2b0a8f588e8cd61ea4ae17c33b7c25aaac3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

