### PR TITLE
Fix cgroups.plugin supported_platforms to Linux only

### DIFF
--- a/src/collectors/cgroups.plugin/metadata.yaml
+++ b/src/collectors/cgroups.plugin/metadata.yaml
@@ -36,7 +36,8 @@ modules:
         metrics_description: "Monitor containers and virtual machines resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
         method_description: ""
       supported_platforms:
-        include: []
+        include:
+          - Linux
         exclude: []
       multi_instance: true
       additional_permissions:


### PR DESCRIPTION
## Summary

- Set `supported_platforms.include` to `['Linux']` in the cgroups.plugin `metadata.yaml` overview anchor
- This was a pre-existing issue: empty `include: []` / `exclude: []` was interpreted by the generator as "all platforms", producing "This collector is supported on all platforms" on every cgroups integration page
- Since cgroups are a Linux kernel feature, this plugin only runs on Linux

## Test plan

- [ ] Generated integration pages should show "This collector is supported on Linux" instead of "all platforms"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark the cgroups plugin as Linux-only so integration pages show "supported on Linux" instead of "all platforms". Sets supported_platforms.include to ['Linux'] in metadata.yaml.

<sup>Written for commit d5a8aeaaa3e052be89b39e11d5591e2cbb75699d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

