### PR TITLE
Restructure integration categories, fix related_resources, add guides

### DIFF
--- a/integrations/categories.yaml
+++ b/integrations/categories.yaml
@@ -17,7 +17,6 @@
       priority: 2
       children: []
     - id: deploy.provisioning-systems
-      parent: deploy
       name: Provisioning Systems
       description: ""
       most_popular: false
@@ -29,384 +28,66 @@
   most_popular: true
   priority: 2
   children:
-    - id: data-collection.other
-      name: Other
-      description: ""
-      most_popular: false
-      priority: -1
-      collector_default: true
-      children: []
-    - id: data-collection.ebpf
-      name: eBPF
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.freebsd
-      name: FreeBSD
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.containers-and-vms
-      name: Containers and VMs
-      description: ""
-      most_popular: true
-      priority: 6
-      children: []
-    - id: data-collection.database-servers
+    - id: data-collection.databases
       name: Databases
       description: ""
       most_popular: true
       priority: 1
       children: []
-    - id: data-collection.kubernetes
-      name: Kubernetes
-      description: ""
-      most_popular: true
-      priority: 7
-      children: []
-    - id: data-collection.notifications
-      name: Incident Management
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.service-discovery-registry
-      name: Service Discovery / Registry
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.web-servers-and-web-proxies
-      name: Web Servers and Web Proxies
+    - id: data-collection.web-servers-and-proxies
+      name: Web Servers and Proxies
       description: ""
       most_popular: true
       priority: 2
       children: []
-    - id: data-collection.cloud-provider-managed
-      name: Cloud Provider Managed
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.windows-systems
-      name: Windows Systems
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.apm
-      name: APM
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.hardware-devices-and-sensors
-      name: Hardware Devices and Sensors
-      description: ""
-      most_popular: true
-      priority: 4
-      children: []
-    - id: data-collection.macos-systems
-      name: macOS Systems
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.message-brokers
-      name: Message Brokers
+    - id: data-collection.containers-and-orchestration
+      name: Containers and Orchestration
       description: ""
       most_popular: true
       priority: 3
       children: []
-    - id: data-collection.provisioning-systems
-      name: Provisioning Systems
+    - id: data-collection.operating-systems
+      name: Operating Systems
       description: ""
-      most_popular: false
-      priority: -1
+      most_popular: true
+      priority: 4
       children: []
-    - id: data-collection.search-engines
-      name: Search Engines
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.linux-systems
-      name: Linux Systems
+    - id: data-collection.networking
+      name: Networking
       description: ""
       most_popular: true
       priority: 5
-      children:
-        - id: data-collection.linux-systems.system-metrics
-          name: System
-          description: ""
-          most_popular: true
-          priority: 1
-          children: []
-        - id: data-collection.linux-systems.memory-metrics
-          name: Memory
-          description: ""
-          most_popular: true
-          priority: 3
-          children: []
-        - id: data-collection.linux-systems.cpu-metrics
-          name: CPU
-          description: ""
-          most_popular: true
-          priority: 2
-          children: []
-        - id: data-collection.linux-systems.pressure-metrics
-          name: Pressure
-          description: ""
-          most_popular: false
-          priority: -1
-          children: []
-        - id: data-collection.linux-systems.network-metrics
-          name: Network
-          description: ""
-          most_popular: true
-          priority: 5
-          children: []
-        - id: data-collection.linux-systems.ipc-metrics
-          name: IPC
-          description: ""
-          most_popular: false
-          priority: -1
-          children: []
-        - id: data-collection.linux-systems.disk-metrics
-          name: Disk
-          description: ""
-          most_popular: true
-          priority: 4
-          children: []
-        - id: data-collection.linux-systems.firewall-metrics
-          name: Firewall
-          description: ""
-          most_popular: false
-          priority: -1
-          children: []
-        - id: data-collection.linux-systems.power-supply-metrics
-          name: Power Supply
-          description: ""
-          most_popular: false
-          priority: -1
-          children: []
-        - id: data-collection.linux-systems.filesystem-metrics
-          name: Filesystem
-          description: ""
-          most_popular: false
-          priority: -1
-          children:
-            - id: data-collection.linux-systems.filesystem-metrics.zfs
-              name: ZFS
-              description: ""
-              most_popular: false
-              priority: -1
-              children: []
-            - id: data-collection.linux-systems.filesystem-metrics.btrfs
-              name: BTRFS
-              description: ""
-              most_popular: false
-              priority: -1
-              children: []
-            - id: data-collection.linux-systems.filesystem-metrics.nfs
-              name: NFS
-              description: ""
-              most_popular: false
-              priority: -1
-              children: []
-        - id: data-collection.linux-systems.kernel-metrics
-          name: Kernel
-          description: ""
-          most_popular: false
-          priority: -1
-          children: []
-    - id: data-collection.networking-stack-and-network-interfaces
-      name: Networking Stack and Network Interfaces
-      description: ""
-      most_popular: false
-      priority: -1
       children: []
-    - id: data-collection.synthetic-checks
-      name: Synthetic Checks
+    - id: data-collection.cloud-and-devops
+      name: Cloud and DevOps
       description: ""
-      most_popular: false
-      priority: -1
+      most_popular: true
+      priority: 6
       children: []
-    - id: data-collection.ci-cd-systems
-      name: CICD Platforms
+    - id: data-collection.hardware-and-iot
+      name: Hardware and IoT
       description: ""
-      most_popular: false
-      priority: -1
+      most_popular: true
+      priority: 7
       children: []
-    - id: data-collection.ups
-      name: UPS
+    - id: data-collection.applications
+      name: Applications
       description: ""
-      most_popular: false
-      priority: -1
+      most_popular: true
+      priority: 8
+      collector_default: true
       children: []
-    - id: data-collection.freebsd-systems
-      name: FreeBSD Systems
+    - id: data-collection.storage
+      name: Storage
       description: ""
-      most_popular: false
-      priority: -1
+      most_popular: true
+      priority: 9
       children: []
-    - id: data-collection.logs-servers
-      name: Logs Servers
+    - id: data-collection.synthetic-testing
+      name: Synthetic Testing
       description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.security-systems
-      name: Security Systems
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.observability
-      name: Observability
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.gaming
-      name: Gaming
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.iot-devices
-      name: IoT Devices
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.media-streaming-servers
-      name: Media Services
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.authentication-and-authorization
-      name: Authentication and Authorization
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.project-management
-      name: Project Management
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.application-servers
-      name: Application Servers
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.dns-and-dhcp-servers
-      name: DNS and DHCP Servers
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.mail-servers
-      name: Mail Servers
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.processes-and-system-services
-      name: Processes and System Services
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.storage-mount-points-and-filesystems
-      name: Storage, Mount Points and Filesystems
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.systemd
-      name: Systemd
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.telephony-servers
-      name: Telephony Servers
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.vpns
-      name: VPNs
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.blockchain-servers
-      name: Blockchain Servers
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.distributed-computing-systems
-      name: Distributed Computing Systems
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.generic-data-collection
-      name: Generic Data Collection
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.p2p
-      name: P2P
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.snmp-and-networked-devices
-      name: SNMP and Networked Devices
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.system-clock-and-ntp
-      name: System Clock and NTP
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.nas
-      name: NAS
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.api-gateways
-      name: API Gateways
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.task-queues
-      name: Task Queues
-      description: ""
-      most_popular: false
-      priority: -1
-      children: []
-    - id: data-collection.ftp-servers
-      name: FTP Servers
-      description: ""
-      most_popular: false
-      priority: -1
+      most_popular: true
+      priority: 10
       children: []
 - id: logs
   name: Logs

--- a/integrations/gen_integrations.py
+++ b/integrations/gen_integrations.py
@@ -28,6 +28,7 @@ COLLECTOR_SOURCES = [
     (AGENT_REPO, REPO_PATH / 'src' / 'collectors', True),
     (AGENT_REPO, REPO_PATH / 'src' / 'collectors' / 'charts.d.plugin', True),
     (AGENT_REPO, REPO_PATH / 'src' / 'collectors' / 'python.d.plugin', True),
+    (AGENT_REPO, REPO_PATH / 'src' / 'collectors' / 'guides', True),
     (AGENT_REPO, REPO_PATH / 'src' / 'go' / 'plugin' / 'go.d' / 'collector', True),
 ]
 
@@ -623,7 +624,47 @@ def render_collectors(categories, collectors, ids):
     collectors, ids = dedupe_integrations(collectors, ids)
     clean_collectors = []
 
-    idmap = {i['id']: i for i in collectors}
+    # Build hierarchical indexes for cascading related_resources lookup:
+    #   Level 1: plugin_name + module_name + monitored_instance_name (exact)
+    #   Level 2: plugin_name + module_name (all instances of that module)
+    #   Level 3: plugin_name (all modules of that plugin)
+    by_pm_instance = {}  # (plugin, module, instance) -> [items]
+    by_pm = {}           # (plugin, module) -> [items]
+    by_plugin = {}       # plugin -> [items]
+
+    for i in collectors:
+        m = i['meta']
+        pn = m['plugin_name']
+        mn = m['module_name']
+        inst = m['monitored_instance']['name']
+
+        by_pm_instance.setdefault((pn, mn, inst), []).append(i)
+        by_pm.setdefault((pn, mn), []).append(i)
+        by_plugin.setdefault(pn, []).append(i)
+
+    def find_related(res):
+        """Cascading lookup: try most specific first, relax until a match is found."""
+        pn = res['plugin_name']
+        mn = res.get('module_name')
+        inst = res.get('monitored_instance_name')
+
+        # Level 1: all three specified
+        if mn and inst:
+            matches = by_pm_instance.get((pn, mn, inst))
+            if matches:
+                return matches
+            debug(f'No exact related_resources match for plugin={pn!r}, '
+                  f'module={mn!r}, monitored_instance_name={inst!r}; '
+                  f'falling back to all instances of that module.')
+
+        # Level 2: plugin + module
+        if mn:
+            # When module_name is explicitly specified, don't fall back to
+            # plugin-only — that would mask typos in the reference.
+            return by_pm.get((pn, mn), [])
+
+        # Level 3: plugin only (no module specified)
+        return by_plugin.get(pn, [])
 
     for item in collectors:
         debug(f'Processing {item["id"]}.')
@@ -633,21 +674,30 @@ def render_collectors(categories, collectors, ids):
         clean_item = deepcopy(item)
 
         related = []
+        seen_ids = set()
 
         for res in item['meta']['related_resources']['integrations']['list']:
-            res_id = make_id(res)
+            matches = find_related(res)
 
-            if res_id not in idmap.keys():
-                warn(f'Could not find related integration {res_id}, ignoring it.', item['_src_path'])
+            if not matches:
+                warn(f'Could not find related integration for {res}, ignoring it.', item['_src_path'])
                 continue
 
-            related.append({
-                'plugin_name': res['plugin_name'],
-                'module_name': res['module_name'],
-                'id': res_id,
-                'name': idmap[res_id]['meta']['monitored_instance']['name'],
-                'info': idmap[res_id]['meta']['info_provided_to_referring_integrations'],
-            })
+            for match in matches:
+                mid = match['id']
+
+                # skip self-references and duplicates
+                if mid == item['id'] or mid in seen_ids:
+                    continue
+
+                seen_ids.add(mid)
+                related.append({
+                    'plugin_name': match['meta']['plugin_name'],
+                    'module_name': match['meta']['module_name'],
+                    'id': mid,
+                    'name': match['meta']['monitored_instance']['name'],
+                    'info': match['meta']['info_provided_to_referring_integrations'],
+                })
 
         item_cats = set(item['meta']['monitored_instance']['categories'])
         bogus_cats = item_cats - valid_cats

--- a/integrations/schemas/collector.json
+++ b/integrations/schemas/collector.json
@@ -49,12 +49,18 @@
                             "module_name": {
                               "type": "string",
                               "description": "Related integration module name."
+                            },
+                            "monitored_instance_name": {
+                              "type": "string",
+                              "description": "Related integration monitored instance name. Use to reference a specific module when a plugin+module combination has multiple monitored instances (e.g. cgroups.plugin)."
                             }
                           },
                           "required": [
-                            "plugin_name",
-                            "module_name"
-                          ]
+                            "plugin_name"
+                          ],
+                          "dependencies": {
+                            "monitored_instance_name": ["module_name"]
+                          }
                         }
                       }
                     },
@@ -346,7 +352,8 @@
                             "enum": [
                               "line",
                               "area",
-                              "stacked"
+                              "stacked",
+                              "heatmap"
                             ]
                           },
                           "dimensions": {

--- a/src/collectors/apps.plugin/metadata.yaml
+++ b/src/collectors/apps.plugin/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Applications
         link: ""
         categories:
-          - data-collection.processes-and-system-services
+          - data-collection.operating-systems
         icon_filename: "applications.svg"
       related_resources:
         integrations:
@@ -197,7 +197,7 @@ modules:
         name: User Groups
         link: ""
         categories:
-          - data-collection.processes-and-system-services
+          - data-collection.operating-systems
         icon_filename: "user.svg"
       related_resources:
         integrations:
@@ -388,7 +388,7 @@ modules:
         name: Users
         link: ""
         categories:
-          - data-collection.processes-and-system-services
+          - data-collection.operating-systems
         icon_filename: "users.svg"
       related_resources:
         integrations:

--- a/src/collectors/cgroups.plugin/metadata.yaml
+++ b/src/collectors/cgroups.plugin/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Containers
         link: ""
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
         icon_filename: container.svg
       related_resources:
         integrations:
@@ -428,8 +428,8 @@ modules:
         link: https://kubernetes.io/
         icon_filename: kubernetes.svg
         categories:
-          #- data-collection.containers-and-vms
-          - data-collection.kubernetes
+          #- data-collection.containers-and-orchestration
+          - data-collection.containers-and-orchestration
       keywords:
         - k8s
         - kubernetes
@@ -843,7 +843,7 @@ modules:
         link: ""
         icon_filename: systemd.svg
         categories:
-          - data-collection.systemd
+          - data-collection.operating-systems
       keywords:
         - systemd
         - services
@@ -976,7 +976,7 @@ modules:
         link: ""
         icon_filename: container.svg
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - vms
         - virtual machines
@@ -1004,7 +1004,7 @@ modules:
         link: ""
         icon_filename: lxc.png
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - lxc
         - lxd
@@ -1025,7 +1025,7 @@ modules:
         link: ""
         icon_filename: libvirt.png
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - libvirt
         - kvm
@@ -1048,7 +1048,7 @@ modules:
         link: ""
         icon_filename: ovirt.svg
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - ovirt
         - rhev
@@ -1072,7 +1072,7 @@ modules:
         link: ""
         icon_filename: proxmox.png
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - proxmox
         - proxmox ve
@@ -1097,7 +1097,7 @@ modules:
         link: https://www.docker.com/
         icon_filename: docker.svg
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - docker
         - containers
@@ -1119,7 +1119,7 @@ modules:
         link: https://podman.io/
         icon_filename: podman.svg
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - podman
         - containers
@@ -1140,7 +1140,7 @@ modules:
         link: https://aws.amazon.com/ecs/
         icon_filename: aws.svg
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - aws
         - ecs
@@ -1160,7 +1160,7 @@ modules:
         link: https://www.nomadproject.io/
         icon_filename: nomad.svg
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - nomad
         - hashicorp
@@ -1179,7 +1179,7 @@ modules:
         link: https://containerd.io/
         icon_filename: containerd.svg
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - containerd
         - containers
@@ -1199,7 +1199,7 @@ modules:
         link: https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html
         icon_filename: systemd.svg
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - systemd-nspawn
         - nspawn
@@ -1219,8 +1219,7 @@ modules:
         link: https://www.redhat.com/en/technologies/cloud-computing/openshift
         icon_filename: openshift.svg
         categories:
-          - data-collection.containers-and-vms
-          - data-collection.kubernetes
+          - data-collection.containers-and-orchestration
       keywords:
         - openshift
         - red hat openshift
@@ -1244,7 +1243,7 @@ modules:
         link: https://www.openstack.org/
         icon_filename: openstack.svg
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - openstack
         - openstack nova

--- a/src/collectors/charts.d.plugin/libreswan/metadata.yaml
+++ b/src/collectors/charts.d.plugin/libreswan/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Libreswan
         link: "https://libreswan.org/"
         categories:
-          - data-collection.vpns
+          - data-collection.networking
         icon_filename: "libreswan.png"
       related_resources:
         integrations:

--- a/src/collectors/charts.d.plugin/opensips/metadata.yaml
+++ b/src/collectors/charts.d.plugin/opensips/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: OpenSIPS
         link: "https://opensips.org/"
         categories:
-          - data-collection.telephony-servers
+          - data-collection.applications
         icon_filename: "opensips.png"
       related_resources:
         integrations:

--- a/src/collectors/cups.plugin/metadata.yaml
+++ b/src/collectors/cups.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: CUPS
         link: "https://www.cups.org/"
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
         icon_filename: "cups.png"
       related_resources:
         integrations:

--- a/src/collectors/debugfs.plugin/metadata.yaml
+++ b/src/collectors/debugfs.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: System Memory Fragmentation
         link: 'https://www.kernel.org/doc/html/next/admin-guide/sysctl/vm.html'
         categories:
-          - data-collection.linux-systems.memory-metrics
+          - data-collection.operating-systems
         icon_filename: 'microchip.svg'
       related_resources:
         integrations:
@@ -149,7 +149,7 @@ modules:
         name: Linux ZSwap
         link: 'https://www.kernel.org/doc/html/latest/admin-guide/mm/zswap.html'
         categories:
-          - data-collection.linux-systems.memory-metrics
+          - data-collection.operating-systems
         icon_filename: 'microchip.svg'
       related_resources:
         integrations:
@@ -294,7 +294,7 @@ modules:
         name: Power Capping
         link: 'https://www.kernel.org/doc/html/next/power/powercap/powercap.html'
         categories:
-          - data-collection.linux-systems.kernel-metrics
+          - data-collection.operating-systems
         icon_filename: 'powersupply.svg'
       related_resources:
         integrations:

--- a/src/collectors/diskspace.plugin/metadata.yaml
+++ b/src/collectors/diskspace.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Disk space
         link: ""
         categories:
-          - data-collection.linux-systems
+          - data-collection.operating-systems
         icon_filename: "hard-drive.svg"
       related_resources:
         integrations:

--- a/src/collectors/ebpf.plugin/metadata.yaml
+++ b/src/collectors/ebpf.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: eBPF Filedescriptor
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -15,7 +15,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       info_provided_to_referring_integrations:
         description: ""
       keywords:
@@ -231,7 +232,7 @@ modules:
         name: eBPF Processes
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -239,7 +240,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       info_provided_to_referring_integrations:
         description: ""
       keywords:
@@ -486,7 +488,7 @@ modules:
         name: eBPF Disk
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -594,7 +596,7 @@ modules:
         name: eBPF Hardirq
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -700,7 +702,7 @@ modules:
         name: eBPF Cachestat
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -708,7 +710,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       info_provided_to_referring_integrations:
         description: ""
       keywords:
@@ -932,7 +935,7 @@ modules:
         name: eBPF Sync
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -1114,7 +1117,7 @@ modules:
         name: eBPF MDflush
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -1218,7 +1221,7 @@ modules:
         name: eBPF SWAP
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -1226,7 +1229,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       info_provided_to_referring_integrations:
         description: ""
       keywords:
@@ -1398,7 +1402,7 @@ modules:
         name: eBPF OOMkill
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -1406,7 +1410,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       info_provided_to_referring_integrations:
         description: ""
       keywords:
@@ -1526,7 +1531,7 @@ modules:
         name: eBPF Socket
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -1534,7 +1539,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       info_provided_to_referring_integrations:
         description: ""
       keywords:
@@ -1885,7 +1891,7 @@ modules:
         name: eBPF DCstat
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -1893,7 +1899,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       info_provided_to_referring_integrations:
         description: ""
       keywords:
@@ -2107,7 +2114,7 @@ modules:
         name: eBPF Filesystem
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -2269,7 +2276,7 @@ modules:
         name: eBPF SHM
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -2277,7 +2284,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       info_provided_to_referring_integrations:
         description: ""
       keywords:
@@ -2505,7 +2513,7 @@ modules:
         name: eBPF SoftIRQ
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -2611,7 +2619,7 @@ modules:
         name: eBPF Mount
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -2735,7 +2743,7 @@ modules:
         name: eBPF VFS
         link: "https://kernel.org/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:
@@ -2743,7 +2751,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       info_provided_to_referring_integrations:
         description: ""
       keywords:
@@ -3170,7 +3179,7 @@ modules:
         name: eBPF Process
         link: "https://github.com/netdata/netdata/"
         categories:
-          - data-collection.ebpf
+          - data-collection.operating-systems
         icon_filename: "ebpf.jpg"
       related_resources:
         integrations:

--- a/src/collectors/freebsd.plugin/metadata.yaml
+++ b/src/collectors/freebsd.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: vm.loadavg
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "freebsd.svg"
       related_resources:
         integrations:
@@ -106,7 +106,7 @@ modules:
         name: vm.vmtotal
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "memory.svg"
       related_resources:
         integrations:
@@ -208,7 +208,7 @@ modules:
         name: kern.cp_time
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "freebsd.svg"
       related_resources:
         integrations:
@@ -322,7 +322,7 @@ modules:
         name: dev.cpu.temperature
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "freebsd.svg"
       related_resources:
         integrations:
@@ -399,7 +399,7 @@ modules:
         name: dev.cpu.0.freq
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "freebsd.svg"
       related_resources:
         integrations:
@@ -476,7 +476,7 @@ modules:
         name: hw.intrcnt
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "freebsd.svg"
       related_resources:
         integrations:
@@ -559,7 +559,7 @@ modules:
         name: vm.stats.sys.v_intr
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "freebsd.svg"
       related_resources:
         integrations:
@@ -636,7 +636,7 @@ modules:
         name: vm.stats.sys.v_soft
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "freebsd.svg"
       related_resources:
         integrations:
@@ -713,7 +713,7 @@ modules:
         name: vm.stats.sys.v_swtch
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "freebsd.svg"
       related_resources:
         integrations:
@@ -796,7 +796,7 @@ modules:
         name: vm.swap_info
         link: ""
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "freebsd.svg"
       related_resources:
         integrations:
@@ -879,7 +879,7 @@ modules:
         name: system.ram
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "memory.svg"
       related_resources:
         integrations:
@@ -988,7 +988,7 @@ modules:
         name: vm.stats.vm.v_swappgs
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "memory.svg"
       related_resources:
         integrations:
@@ -1071,7 +1071,7 @@ modules:
         name: vm.stats.vm.v_pgfaults
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "memory.svg"
       related_resources:
         integrations:
@@ -1152,7 +1152,7 @@ modules:
         name: kern.ipc.sem
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "freebsd.svg"
       related_resources:
         integrations:
@@ -1245,7 +1245,7 @@ modules:
         name: kern.ipc.shm
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "memory.svg"
       related_resources:
         integrations:
@@ -1328,7 +1328,7 @@ modules:
         name: kern.ipc.msq
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "freebsd.svg"
       related_resources:
         integrations:
@@ -1418,7 +1418,7 @@ modules:
         name: uptime
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "freebsd.svg"
       related_resources:
         integrations:
@@ -1495,7 +1495,7 @@ modules:
         name: net.isr
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "freebsd.svg"
       related_resources:
         integrations:
@@ -1609,7 +1609,7 @@ modules:
         name: devstat
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "hard-drive.svg"
       related_resources:
         integrations:
@@ -1801,7 +1801,7 @@ modules:
         name: net.inet.tcp.states
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "network.svg"
       related_resources:
         integrations:
@@ -1883,7 +1883,7 @@ modules:
         name: net.inet.tcp.stats
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "network.svg"
       related_resources:
         integrations:
@@ -2070,7 +2070,7 @@ modules:
         name: net.inet.udp.stats
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "network.svg"
       related_resources:
         integrations:
@@ -2172,7 +2172,7 @@ modules:
         name: net.inet.icmp.stats
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "network.svg"
       related_resources:
         integrations:
@@ -2275,7 +2275,7 @@ modules:
         name: net.inet.ip.stats
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "network.svg"
       related_resources:
         integrations:
@@ -2394,7 +2394,7 @@ modules:
         name: net.inet6.ip6.stats
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "network.svg"
       related_resources:
         integrations:
@@ -2515,7 +2515,7 @@ modules:
         name: net.inet6.icmp6.stats
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "network.svg"
       related_resources:
         integrations:
@@ -2681,7 +2681,7 @@ modules:
         name: ipfw
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "firewall.svg"
       related_resources:
         integrations:
@@ -2791,7 +2791,7 @@ modules:
         name: getifaddrs
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "network.svg"
       related_resources:
         integrations:
@@ -3011,7 +3011,7 @@ modules:
         name: getmntinfo
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "hard-drive.svg"
       related_resources:
         integrations:
@@ -3124,7 +3124,7 @@ modules:
         name: zfs
         link: "https://www.freebsd.org/"
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
         icon_filename: "filesystem.svg"
       related_resources:
         integrations:

--- a/src/collectors/freeipmi.plugin/metadata.yaml
+++ b/src/collectors/freeipmi.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Intelligent Platform Management Interface (IPMI)
         link: "https://en.wikipedia.org/wiki/Intelligent_Platform_Management_Interface"
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
         icon_filename: "netdata.png"
       related_resources:
         integrations:

--- a/src/collectors/guides/proxmox/metadata.yaml
+++ b/src/collectors/guides/proxmox/metadata.yaml
@@ -1,0 +1,149 @@
+# yamllint disable rule:line-length
+---
+plugin_name: guides
+modules:
+  - meta:
+      plugin_name: guides
+      module_name: proxmox
+      monitored_instance:
+        name: Proxmox VE Monitoring
+        link: https://www.proxmox.com/
+        icon_filename: proxmox.png
+        categories:
+          - data-collection.containers-and-orchestration
+      keywords:
+        - proxmox
+        - proxmox ve
+        - pve
+        - kvm
+        - qemu
+        - lxc
+        - virtualization
+        - hypervisor
+        - virtual machines
+        - containers
+        - ceph
+        - zfs
+        - corosync
+        - cluster
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: cgroups.plugin
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Proxmox VMs and Containers
+            - plugin_name: cgroups.plugin
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Systemd Services
+            - plugin_name: apps.plugin
+              module_name: apps
+              monitored_instance_name: Applications
+            - plugin_name: go.d.plugin
+              module_name: zfspool
+            - plugin_name: go.d.plugin
+              module_name: ceph
+            - plugin_name: go.d.plugin
+              module_name: smartctl
+            - plugin_name: go.d.plugin
+              module_name: sensors
+            - plugin_name: proc.plugin
+              module_name: /proc/net/dev
+            - plugin_name: proc.plugin
+              module_name: /proc/diskstats
+            - plugin_name: proc.plugin
+              module_name: /proc/stat
+            - plugin_name: proc.plugin
+              module_name: /proc/meminfo
+            - plugin_name: proc.plugin
+              module_name: /proc/spl/kstat/zfs/arcstats
+      info_provided_to_referring_integrations:
+        description: ""
+      most_popular: true
+    overview:
+      data_collection:
+        metrics_description: |
+          This guide describes how Netdata monitors Proxmox VE hypervisors. Netdata provides comprehensive, zero-configuration monitoring of Proxmox hosts, including per-VM and per-container resource utilization, host system metrics, storage health, and cluster components.
+
+          When installed on a Proxmox host, Netdata automatically discovers and monitors all KVM/QEMU virtual machines and LXC containers through Linux cgroups, resolving friendly names for each VM and container.
+        method_description: |
+          Netdata uses multiple collectors working together to provide full Proxmox visibility:
+
+          - **cgroups.plugin** monitors per-VM and per-container CPU, memory, disk I/O, and network via Linux cgroups. It automatically resolves VM names from `/etc/pve/qemu-server/<VMID>.conf` and container hostnames from `/etc/pve/lxc/<CTID>.conf`.
+          - **proc.plugin** monitors host-level system metrics (CPU, memory, network interfaces, disk I/O).
+          - **apps.plugin** monitors Proxmox-specific process groups (`proxmox-ve`, `libvirt`, `qemu-guest-agent`).
+          - **go.d/zfspool** monitors ZFS pool health, space utilization, and fragmentation (ZFS is common on Proxmox).
+          - **go.d/ceph** monitors Ceph cluster health and performance (for Proxmox clusters using Ceph storage).
+          - **go.d/smartctl** monitors physical disk SMART health data.
+          - **go.d/sensors** monitors hardware temperature, fan speed, and voltage.
+          - **ebpf.plugin** provides kernel-level visibility into VM/container syscalls, file I/O, and network activity.
+      supported_platforms:
+        include:
+          - Linux
+        exclude: []
+      multi_instance: false
+      additional_permissions:
+        description: ""
+      default_behavior:
+        auto_detection:
+          description: |
+            When Netdata is installed on a Proxmox VE host, it automatically detects and monitors:
+
+            - All running KVM/QEMU virtual machines
+            - All running LXC containers
+            - Host system resources (CPU, memory, network, disks)
+            - Systemd services (pveproxy, pvedaemon, pvestatd, corosync, etc.)
+            - ZFS pools (if ZFS is used)
+        limits:
+          description: ""
+        performance_impact:
+          description: ""
+    setup:
+      prerequisites:
+        list:
+          - title: Install Netdata on the Proxmox host
+            description: |
+              Netdata must be installed directly on the Proxmox VE host (not inside a VM or container) to access cgroups for all VMs and containers.
+
+              ```bash
+              wget -O /tmp/netdata-kickstart.sh https://get.netdata.cloud/kickstart.sh && sh /tmp/netdata-kickstart.sh
+              ```
+      configuration:
+        file:
+          name: ""
+          description: "No configuration is required. All Proxmox monitoring works automatically."
+        options:
+          description: ""
+          folding:
+            title: ""
+            enabled: true
+          list: []
+        examples:
+          folding:
+            enabled: true
+            title: ""
+          list: []
+    troubleshooting:
+      problems:
+        list:
+          - name: VM or container names not resolved
+            description: |
+              If VMs or containers show raw cgroup paths instead of friendly names, verify that:
+
+              1. Netdata is installed on the Proxmox host (not inside a VM)
+              2. The `/etc/pve/` directory is accessible to the netdata user
+              3. The `cgroup-name.sh` script can read VM/container configuration files
+          - name: Missing ZFS metrics
+            description: |
+              If ZFS pool metrics are not showing, ensure the `zfspool` collector is enabled and the `zpool` command is available to the netdata user.
+          - name: Missing Ceph metrics
+            description: |
+              Ceph metrics require the Ceph collector to be configured with the Ceph REST API endpoint. See the Ceph integration page for details.
+    alerts: []
+    metrics:
+      folding:
+        title: ""
+        enabled: false
+      description: |
+        This guide does not collect metrics directly. Metrics are collected by the related integrations listed above. See each integration's page for detailed metric documentation.
+      availability: []
+      scopes: []

--- a/src/collectors/idlejitter.plugin/metadata.yaml
+++ b/src/collectors/idlejitter.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Idle OS Jitter
         link: ''
         categories:
-          - data-collection.synthetic-checks
+          - data-collection.synthetic-testing
         icon_filename: 'syslog.png'
       related_resources:
         integrations:

--- a/src/collectors/ioping.plugin/metadata.yaml
+++ b/src/collectors/ioping.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: IOPing
         link: "https://github.com/koct9i/ioping"
         categories:
-          - data-collection.synthetic-checks
+          - data-collection.synthetic-testing
         icon_filename: "syslog.png"
       related_resources:
         integrations:

--- a/src/collectors/macos.plugin/metadata.yaml
+++ b/src/collectors/macos.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: macOS
         link: "https://www.apple.com/macos"
         categories:
-          - data-collection.macos-systems
+          - data-collection.operating-systems
         icon_filename: "macos.svg"
       related_resources:
         integrations:

--- a/src/collectors/nfacct.plugin/metadata.yaml
+++ b/src/collectors/nfacct.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Netfilter
         link: 'https://www.netfilter.org/'
         categories:
-          - data-collection.linux-systems.firewall-metrics
+          - data-collection.operating-systems
         icon_filename: 'netfilter.png'
       related_resources:
         integrations:

--- a/src/collectors/perf.plugin/metadata.yaml
+++ b/src/collectors/perf.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: CPU performance
         link: "https://kernel.org/"
         categories:
-          - data-collection.linux-systems
+          - data-collection.operating-systems
         icon_filename: "bolt.svg"
       related_resources:
         integrations:

--- a/src/collectors/proc.plugin/metadata.yaml
+++ b/src/collectors/proc.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: System statistics
         link: ""
         categories:
-          - data-collection.linux-systems.system-metrics
+          - data-collection.operating-systems
         icon_filename: "linuxserver.svg"
       related_resources:
         integrations:
@@ -206,7 +206,7 @@ modules:
         name: Entropy
         link: ""
         categories:
-          - data-collection.linux-systems.system-metrics
+          - data-collection.operating-systems
         icon_filename: "syslog.png"
       related_resources:
         integrations:
@@ -314,7 +314,7 @@ modules:
         name: System Uptime
         link: ""
         categories:
-          - data-collection.linux-systems.system-metrics
+          - data-collection.operating-systems
         icon_filename: "linuxserver.svg"
       related_resources:
         integrations:
@@ -398,7 +398,7 @@ modules:
         name: Memory Statistics
         link: ""
         categories:
-          - data-collection.linux-systems.memory-metrics
+          - data-collection.operating-systems
         icon_filename: "linuxserver.svg"
       related_resources:
         integrations:
@@ -617,7 +617,7 @@ modules:
         name: Interrupts
         link: ""
         categories:
-          - data-collection.linux-systems.cpu-metrics
+          - data-collection.operating-systems
         icon_filename: "linuxserver.svg"
       related_resources:
         integrations:
@@ -732,7 +732,7 @@ modules:
         name: System Load Average
         link: ""
         categories:
-          - data-collection.linux-systems.system-metrics
+          - data-collection.operating-systems
         icon_filename: "linuxserver.svg"
       related_resources:
         integrations:
@@ -861,7 +861,7 @@ modules:
         name: Pressure Stall Information
         link: ""
         categories:
-          - data-collection.linux-systems.pressure-metrics
+          - data-collection.operating-systems
         icon_filename: "linuxserver.svg"
       related_resources:
         integrations:
@@ -1035,7 +1035,7 @@ modules:
         name: SoftIRQ statistics
         link: ""
         categories:
-          - data-collection.linux-systems.cpu-metrics
+          - data-collection.operating-systems
         icon_filename: "linuxserver.svg"
       related_resources:
         integrations:
@@ -1143,7 +1143,7 @@ modules:
         name: Softnet Statistics
         link: ""
         categories:
-          - data-collection.linux-systems.network-metrics
+          - data-collection.operating-systems
         icon_filename: "linuxserver.svg"
       related_resources:
         integrations:
@@ -1268,7 +1268,7 @@ modules:
         name: Memory Usage
         link: ""
         categories:
-          - data-collection.linux-systems.memory-metrics
+          - data-collection.operating-systems
         icon_filename: "linuxserver.svg"
       related_resources:
         integrations:
@@ -1510,7 +1510,7 @@ modules:
         name: Page types
         link: ""
         categories:
-          - data-collection.linux-systems.memory-metrics
+          - data-collection.operating-systems
         icon_filename: "microchip.svg"
       related_resources:
         integrations:
@@ -1599,7 +1599,7 @@ modules:
         name: Memory modules (DIMMs)
         link: ""
         categories:
-          - data-collection.linux-systems.memory-metrics
+          - data-collection.operating-systems
         icon_filename: "microchip.svg"
       related_resources:
         integrations:
@@ -1743,7 +1743,7 @@ modules:
         name: Non-Uniform Memory Access
         link: ""
         categories:
-          - data-collection.linux-systems.memory-metrics
+          - data-collection.operating-systems
         icon_filename: "linuxserver.svg"
       related_resources:
         integrations:
@@ -1835,7 +1835,7 @@ modules:
         name: Kernel Same-Page Merging
         link: ""
         categories:
-          - data-collection.linux-systems.memory-metrics
+          - data-collection.operating-systems
         icon_filename: "microchip.svg"
       related_resources:
         integrations:
@@ -1932,7 +1932,7 @@ modules:
         name: ZRAM
         link: ""
         categories:
-          - data-collection.linux-systems.memory-metrics
+          - data-collection.operating-systems
         icon_filename: "microchip.svg"
       related_resources:
         integrations:
@@ -2031,7 +2031,7 @@ modules:
         name: Inter Process Communication
         link: ""
         categories:
-          - data-collection.linux-systems.ipc-metrics
+          - data-collection.operating-systems
         icon_filename: "network-wired.svg"
       related_resources:
         integrations:
@@ -2160,7 +2160,7 @@ modules:
         name: Disk Statistics
         link: ""
         categories:
-          - data-collection.linux-systems.disk-metrics
+          - data-collection.operating-systems
         icon_filename: "hard-drive.svg"
       related_resources:
         integrations:
@@ -2444,7 +2444,7 @@ modules:
         name: MD RAID
         link: ""
         categories:
-          - data-collection.linux-systems.disk-metrics
+          - data-collection.operating-systems
         icon_filename: "hard-drive.svg"
       related_resources:
         integrations:
@@ -2585,7 +2585,7 @@ modules:
         name: Network interfaces
         link: ""
         categories:
-          - data-collection.linux-systems.network-metrics
+          - data-collection.operating-systems
         icon_filename: "network-wired.svg"
       related_resources:
         integrations:
@@ -2807,7 +2807,7 @@ modules:
         name: Wireless network interfaces
         link: ""
         categories:
-          - data-collection.linux-systems.network-metrics
+          - data-collection.operating-systems
         icon_filename: "network-wired.svg"
       related_resources:
         integrations:
@@ -2917,7 +2917,7 @@ modules:
         name: InfiniBand
         link: ""
         categories:
-          - data-collection.linux-systems.network-metrics
+          - data-collection.operating-systems
         icon_filename: "network-wired.svg"
       related_resources:
         integrations:
@@ -3060,7 +3060,7 @@ modules:
         name: Network statistics
         link: ""
         categories:
-          - data-collection.linux-systems.network-metrics
+          - data-collection.operating-systems
         icon_filename: "network-wired.svg"
       related_resources:
         integrations:
@@ -3645,7 +3645,7 @@ modules:
         name: Socket statistics
         link: ""
         categories:
-          - data-collection.linux-systems.network-metrics
+          - data-collection.operating-systems
         icon_filename: "network-wired.svg"
       related_resources:
         integrations:
@@ -3779,7 +3779,7 @@ modules:
         name: IPv6 Socket Statistics
         link: ""
         categories:
-          - data-collection.linux-systems.network-metrics
+          - data-collection.operating-systems
         icon_filename: "network-wired.svg"
       related_resources:
         integrations:
@@ -3876,7 +3876,7 @@ modules:
         name: IP Virtual Server
         link: ""
         categories:
-          - data-collection.linux-systems.network-metrics
+          - data-collection.operating-systems
         icon_filename: "network-wired.svg"
       related_resources:
         integrations:
@@ -3963,7 +3963,7 @@ modules:
         name: NFS Client
         link: ""
         categories:
-          - data-collection.linux-systems.filesystem-metrics.nfs
+          - data-collection.operating-systems
         icon_filename: "nfs.png"
       related_resources:
         integrations:
@@ -4064,7 +4064,7 @@ modules:
         name: NFS Server
         link: ""
         categories:
-          - data-collection.linux-systems.filesystem-metrics.nfs
+          - data-collection.operating-systems
         icon_filename: "nfs.png"
       related_resources:
         integrations:
@@ -4198,7 +4198,7 @@ modules:
         name: SCTP Statistics
         link: ""
         categories:
-          - data-collection.linux-systems.network-metrics
+          - data-collection.operating-systems
         icon_filename: "network-wired.svg"
       related_resources:
         integrations:
@@ -4302,7 +4302,7 @@ modules:
         name: Conntrack
         link: ""
         categories:
-          - data-collection.linux-systems.firewall-metrics
+          - data-collection.operating-systems
         icon_filename: "firewall.svg"
       related_resources:
         integrations:
@@ -4423,7 +4423,7 @@ modules:
         name: Synproxy
         link: ""
         categories:
-          - data-collection.linux-systems.firewall-metrics
+          - data-collection.operating-systems
         icon_filename: "firewall.svg"
       related_resources:
         integrations:
@@ -4510,7 +4510,7 @@ modules:
         name: ZFS Adaptive Replacement Cache
         link: ""
         categories:
-          - data-collection.linux-systems.filesystem-metrics.zfs
+          - data-collection.operating-systems
         icon_filename: "filesystem.svg"
       related_resources:
         integrations:
@@ -4776,7 +4776,7 @@ modules:
         name: BTRFS
         link: ""
         categories:
-          - data-collection.linux-systems.filesystem-metrics.btrfs
+          - data-collection.operating-systems
         icon_filename: "filesystem.svg"
       related_resources:
         integrations:
@@ -4966,7 +4966,7 @@ modules:
         name: Power Supply
         link: ""
         categories:
-          - data-collection.linux-systems.power-supply-metrics
+          - data-collection.operating-systems
         icon_filename: "powersupply.svg"
       related_resources:
         integrations:
@@ -5082,7 +5082,7 @@ modules:
         name: AMD GPU
         link: "https://www.amd.com"
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
         icon_filename: amd.svg
       related_resources:
         integrations:

--- a/src/collectors/python.d.plugin/am2320/metadata.yaml
+++ b/src/collectors/python.d.plugin/am2320/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: AM2320
         link: 'https://learn.adafruit.com/adafruit-am2320-temperature-humidity-i2c-sensor/overview'
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
         icon_filename: 'microchip.svg'
       related_resources:
         integrations:

--- a/src/collectors/python.d.plugin/go_expvar/metadata.yaml
+++ b/src/collectors/python.d.plugin/go_expvar/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Go applications (EXPVAR)
         link: "https://pkg.go.dev/expvar"
         categories:
-          - data-collection.apm
+          - data-collection.applications
         icon_filename: "go.png"
       related_resources:
         integrations:

--- a/src/collectors/python.d.plugin/haproxy/metadata.yaml
+++ b/src/collectors/python.d.plugin/haproxy/metadata.yaml
@@ -9,7 +9,7 @@
 #     name: HAProxy
 #     link: 'https://www.haproxy.org/'
 #     categories:
-#     - data-collection.web-servers-and-web-proxies
+#     - data-collection.web-servers-and-proxies
 #     icon_filename: 'haproxy.png'
 #   related_resources:
 #     integrations:

--- a/src/collectors/python.d.plugin/pandas/metadata.yaml
+++ b/src/collectors/python.d.plugin/pandas/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Pandas
         link: https://pandas.pydata.org/
         categories:
-          - data-collection.generic-data-collection
+          - data-collection.applications
         icon_filename: pandas.png
       related_resources:
         integrations:

--- a/src/collectors/slabinfo.plugin/metadata.yaml
+++ b/src/collectors/slabinfo.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Linux kernel SLAB allocator statistics
         link: "https://kernel.org/"
         categories:
-          - data-collection.linux-systems.kernel-metrics
+          - data-collection.operating-systems
         icon_filename: 'linuxserver.svg'
       related_resources:
         integrations:

--- a/src/collectors/tc.plugin/metadata.yaml
+++ b/src/collectors/tc.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: tc QoS classes
         link: "https://wiki.linuxfoundation.org/networking/iproute2"
         categories:
-          - data-collection.linux-systems.network-metrics
+          - data-collection.operating-systems
         icon_filename: "netdata.png"
       related_resources:
         integrations:

--- a/src/collectors/timex.plugin/metadata.yaml
+++ b/src/collectors/timex.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Timex
         link: ""
         categories:
-          - data-collection.system-clock-and-ntp
+          - data-collection.networking
         icon_filename: "syslog.png"
       related_resources:
         integrations:

--- a/src/collectors/windows.plugin/metadata.yaml
+++ b/src/collectors/windows.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Processor
         link: "https://learn.microsoft.com/en-us/windows-hardware/design/minimum/windows-processor-requirements"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -113,7 +113,7 @@ modules:
         name: Memory statistics
         link: "https://learn.microsoft.com/en-us/windows/win32/Memory/memory-management"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -216,7 +216,7 @@ modules:
         name: System statistics
         link: "https://learn.microsoft.com/en-us/windows/win32/procthread/processes-and-threads"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -317,7 +317,7 @@ modules:
         name: Physical and Logical Disk Performance Metrics
         link: "https://learn.microsoft.com/en-us/windows/win32/fileio/disk-management"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -500,7 +500,7 @@ modules:
         name: Network Subsystem
         link: "https://learn.microsoft.com/en-us/windows/win32/networking"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -824,7 +824,7 @@ modules:
         name: Semaphore statistics
         link: "https://learn.microsoft.com/en-us/windows/win32/sync/semaphore-objects"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -916,7 +916,7 @@ modules:
         name: Hardware information collected from kernel ring.
         link: "https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -998,7 +998,7 @@ modules:
         name: System thermal zone
         link: "https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/design-guide"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -1080,7 +1080,7 @@ modules:
         name: Power supply
         link: "https://learn.microsoft.com/en-us/windows/win32/power/power-management-portal"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "powersupply.svg"
       related_resources:
         integrations:
@@ -1173,7 +1173,7 @@ modules:
         name: Sensors
         link: "https://learn.microsoft.com/en-us/windows/win32/sensorsapi/portal"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -1399,7 +1399,7 @@ modules:
         name: IIS
         link: "https://www.iis.net/"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -1716,7 +1716,7 @@ modules:
         name: Hyper-V
         link: "https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -2084,7 +2084,7 @@ modules:
         name: MS SQL Server
         link: "https://www.microsoft.com/en-us/sql-server/"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -2707,7 +2707,7 @@ modules:
         name: NET Framework
         link: "https://dotnet.microsoft.com/en-us/learn/dotnet/what-is-dotnet-framework"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "dotnet.svg"
       related_resources:
         integrations:
@@ -2973,7 +2973,7 @@ modules:
         name: Active Directory
         link: "https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/get-started/virtual-dc/active-directory-domain-services-overview"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -3139,7 +3139,7 @@ modules:
         name: Active Directory Certificate Service
         link: "https://learn.microsoft.com/en-us/windows-server/identity/ad-cs/"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -3316,7 +3316,7 @@ modules:
         name: Active Directory Federation Service
         link: "https://learn.microsoft.com/en-us/windows-server/identity/ad-fs/ad-fs-overview"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -3594,7 +3594,7 @@ modules:
         name: Windows Services
         link: "https://learn.microsoft.com/en-us/dotnet/framework/windows-services/"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -3686,7 +3686,7 @@ modules:
         name: MS Exchange
         link: "https://www.microsoft.com/en-us/microsoft-365/exchange/email"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "exchange.svg"
       related_resources:
         integrations:
@@ -3951,7 +3951,7 @@ modules:
         name: NUMA Architecture
         link: "https://learn.microsoft.com/en-us/windows/win32/procthread/numa-support"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:
@@ -4037,7 +4037,7 @@ modules:
         name: ASP.NET
         link: "https://dotnet.microsoft.com/en-us/apps/aspnet"
         categories:
-          - data-collection.windows-systems
+          - data-collection.operating-systems
         icon_filename: "windows.svg"
       related_resources:
         integrations:

--- a/src/collectors/xenstat.plugin/metadata.yaml
+++ b/src/collectors/xenstat.plugin/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Xen XCP-ng
         link: "https://xenproject.org/"
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
         icon_filename: "xen.png"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/activemq/metadata.yaml
+++ b/src/go/plugin/go.d/collector/activemq/metadata.yaml
@@ -6,7 +6,7 @@ modules:
       plugin_name: go.d.plugin
       monitored_instance:
         categories:
-          - data-collection.message-brokers
+          - data-collection.databases
         icon_filename: activemq.png
         name: ActiveMQ
         link: https://activemq.apache.org/

--- a/src/go/plugin/go.d/collector/adaptecraid/metadata.yaml
+++ b/src/go/plugin/go.d/collector/adaptecraid/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: "https://www.microchip.com/en-us/products/storage"
         icon_filename: "adaptec.svg"
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords:
         - storage
         - raid-controller

--- a/src/go/plugin/go.d/collector/ap/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ap/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Access Points
         link: ""
         categories:
-          - data-collection.linux-systems.network-metrics
+          - data-collection.operating-systems
         icon_filename: "network-wired.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/apache/metadata.yaml
+++ b/src/go/plugin/go.d/collector/apache/metadata.yaml
@@ -10,14 +10,14 @@ modules:
         link: https://httpd.apache.org/
         icon_filename: apache.svg
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
       keywords:
         - webserver
       related_resources:
         integrations:
           list:
             - plugin_name: go.d.plugin
-              module_name: weblog
+              module_name: web_log
             - plugin_name: go.d.plugin
               module_name: httpcheck
             - plugin_name: apps.plugin
@@ -337,4 +337,4 @@ modules:
         link: https://httpd.apache.org/
         icon_filename: apache.svg
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies

--- a/src/go/plugin/go.d/collector/apcupsd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/apcupsd/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.apc.com
         icon_filename: apc.svg
         categories:
-          - data-collection.ups
+          - data-collection.hardware-and-iot
       keywords:
         - ups
         - apcupsd

--- a/src/go/plugin/go.d/collector/beanstalk/metadata.yaml
+++ b/src/go/plugin/go.d/collector/beanstalk/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Beanstalk
         link: https://beanstalkd.github.io/
         categories:
-          - data-collection.message-brokers
+          - data-collection.databases
         icon_filename: "beanstalk.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/boinc/metadata.yaml
+++ b/src/go/plugin/go.d/collector/boinc/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: BOINC
         link: https://boinc.berkeley.edu/
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
         icon_filename: "bolt.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/cassandra/metadata.yaml
+++ b/src/go/plugin/go.d/collector/cassandra/metadata.yaml
@@ -6,7 +6,7 @@ modules:
       plugin_name: go.d.plugin
       monitored_instance:
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
         icon_filename: cassandra.svg
         name: Cassandra
         link: https://cassandra.apache.org/_/index.html

--- a/src/go/plugin/go.d/collector/ceph/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ceph/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Ceph
         link: "https://ceph.io/"
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
         icon_filename: "ceph.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/chrony/metadata.yaml
+++ b/src/go/plugin/go.d/collector/chrony/metadata.yaml
@@ -6,7 +6,7 @@ modules:
       plugin_name: go.d.plugin
       monitored_instance:
         categories:
-          - data-collection.system-clock-and-ntp
+          - data-collection.networking
         icon_filename: chrony.jpg
         name: Chrony
         link: https://chrony.tuxfamily.org/

--- a/src/go/plugin/go.d/collector/clickhouse/metadata.yaml
+++ b/src/go/plugin/go.d/collector/clickhouse/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://clickhouse.com/
         icon_filename: clickhouse.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords:
         - database
       related_resources:

--- a/src/go/plugin/go.d/collector/cockroachdb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/cockroachdb/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.cockroachlabs.com/
         icon_filename: cockroachdb.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords:
         - cockroachdb
         - databases

--- a/src/go/plugin/go.d/collector/consul/metadata.yaml
+++ b/src/go/plugin/go.d/collector/consul/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Consul
         link: https://www.consul.io/
         categories:
-          - data-collection.service-discovery-registry
+          - data-collection.applications
         icon_filename: consul.svg
       alternative_monitored_instances: []
       related_resources:

--- a/src/go/plugin/go.d/collector/coredns/metadata.yaml
+++ b/src/go/plugin/go.d/collector/coredns/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://coredns.io/
         icon_filename: coredns.svg
         categories:
-          - data-collection.dns-and-dhcp-servers
+          - data-collection.networking
       keywords:
         - coredns
         - dns

--- a/src/go/plugin/go.d/collector/couchbase/metadata.yaml
+++ b/src/go/plugin/go.d/collector/couchbase/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.couchbase.com/
         icon_filename: couchbase.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords:
         - couchbase
         - databases

--- a/src/go/plugin/go.d/collector/couchdb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/couchdb/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://couchdb.apache.org/
         icon_filename: couchdb.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords:
         - couchdb
         - databases

--- a/src/go/plugin/go.d/collector/dmcache/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dmcache/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: ""
         icon_filename: filesystem.svg
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords:
         - dmcache
       related_resources:

--- a/src/go/plugin/go.d/collector/dnsdist/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dnsdist/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://dnsdist.org/
         icon_filename: network-wired.svg
         categories:
-          - data-collection.dns-and-dhcp-servers
+          - data-collection.networking
       keywords:
         - dnsdist
         - dns

--- a/src/go/plugin/go.d/collector/dnsmasq/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dnsmasq/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://thekelleys.org.uk/dnsmasq/doc.html
         icon_filename: dnsmasq.svg
         categories:
-          - data-collection.dns-and-dhcp-servers
+          - data-collection.networking
       keywords:
         - dnsmasq
         - dns

--- a/src/go/plugin/go.d/collector/dnsmasq_dhcp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dnsmasq_dhcp/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.thekelleys.org.uk/dnsmasq/doc.html
         icon_filename: dnsmasq.svg
         categories:
-          - data-collection.dns-and-dhcp-servers
+          - data-collection.networking
       keywords:
         - dnsmasq
         - dhcp

--- a/src/go/plugin/go.d/collector/dnsquery/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dnsquery/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: ""
         icon_filename: network-wired.svg
         categories:
-          - data-collection.dns-and-dhcp-servers
+          - data-collection.networking
       keywords:
         - dns
       related_resources:

--- a/src/go/plugin/go.d/collector/docker/metadata.yaml
+++ b/src/go/plugin/go.d/collector/docker/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         name: Docker
         link: https://www.docker.com/
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
         icon_filename: docker.svg
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/docker_engine/metadata.yaml
+++ b/src/go/plugin/go.d/collector/docker_engine/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         name: Docker Engine
         link: https://docs.docker.com/engine/
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
         icon_filename: docker.svg
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/dockerhub/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dockerhub/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://hub.docker.com/
         icon_filename: docker.svg
         categories:
-          - data-collection.containers-and-vms # FIXME
+          - data-collection.containers-and-orchestration # FIXME
       keywords:
         - dockerhub
       related_resources:

--- a/src/go/plugin/go.d/collector/dovecot/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dovecot/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Dovecot
         link: 'https://www.dovecot.org/'
         categories:
-          - data-collection.mail-servers
+          - data-collection.applications
         icon_filename: "dovecot.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/elasticsearch/metadata.yaml
+++ b/src/go/plugin/go.d/collector/elasticsearch/metadata.yaml
@@ -10,7 +10,7 @@ modules:
         link: https://www.elastic.co/elasticsearch/
         icon_filename: elasticsearch.svg
         categories:
-          - data-collection.search-engines
+          - data-collection.databases
       keywords:
         - elastic
         - elasticsearch
@@ -22,7 +22,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true
@@ -795,4 +796,4 @@ modules:
         link: https://opensearch.org/
         icon_filename: opensearch.svg
         categories:
-          - data-collection.search-engines
+          - data-collection.databases

--- a/src/go/plugin/go.d/collector/envoy/metadata.yaml
+++ b/src/go/plugin/go.d/collector/envoy/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.envoyproxy.io/
         icon_filename: envoy.svg
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
       keywords:
         - envoy
         - proxy

--- a/src/go/plugin/go.d/collector/ethtool/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ethtool/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: ""
         icon_filename: network-wired.svg
         categories:
-          - data-collection.networking-stack-and-network-interfaces
+          - data-collection.networking
       keywords:
         - sfp
         - ddm

--- a/src/go/plugin/go.d/collector/exim/metadata.yaml
+++ b/src/go/plugin/go.d/collector/exim/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: "https://www.exim.org/"
         icon_filename: 'exim.jpg'
         categories:
-          - data-collection.mail-servers
+          - data-collection.applications
       keywords:
         - exim
         - mail

--- a/src/go/plugin/go.d/collector/fail2ban/metadata.yaml
+++ b/src/go/plugin/go.d/collector/fail2ban/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: "https://github.com/fail2ban/fail2ban#readme"
         icon_filename: fail2ban.png
         categories:
-          - data-collection.authentication-and-authorization
+          - data-collection.applications
       keywords:
         - fail2ban
         - security

--- a/src/go/plugin/go.d/collector/filecheck/metadata.yaml
+++ b/src/go/plugin/go.d/collector/filecheck/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: ""
         icon_filename: filesystem.svg
         categories:
-          - data-collection.other
+          - data-collection.applications
       keywords:
         - files
         - directories

--- a/src/go/plugin/go.d/collector/fluentd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/fluentd/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.fluentd.org/
         icon_filename: fluentd.svg
         categories:
-          - data-collection.logs-servers
+          - data-collection.applications
       keywords:
         - fluentd
         - logging

--- a/src/go/plugin/go.d/collector/freeradius/metadata.yaml
+++ b/src/go/plugin/go.d/collector/freeradius/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: FreeRADIUS
         link: https://freeradius.org/
         categories:
-          - data-collection.authentication-and-authorization
+          - data-collection.applications
         icon_filename: freeradius.svg
       keywords:
         - freeradius

--- a/src/go/plugin/go.d/collector/gearman/metadata.yaml
+++ b/src/go/plugin/go.d/collector/gearman/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Gearman
         link: https://gearman.org/
         categories:
-          - data-collection.distributed-computing-systems
+          - data-collection.applications
         icon_filename: "gearman.png"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/geth/metadata.yaml
+++ b/src/go/plugin/go.d/collector/geth/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://github.com/ethereum/go-ethereum
         icon_filename: geth.png
         categories:
-          - data-collection.blockchain-servers
+          - data-collection.applications
       keywords:
         - geth
         - ethereum

--- a/src/go/plugin/go.d/collector/haproxy/metadata.yaml
+++ b/src/go/plugin/go.d/collector/haproxy/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.haproxy.org/
         icon_filename: haproxy.svg
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
       keywords:
         - haproxy
         - web

--- a/src/go/plugin/go.d/collector/hddtemp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/hddtemp/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: HDD temperature
         link: https://linux.die.net/man/8/hddtemp
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
         icon_filename: "hard-drive.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/hdfs/metadata.yaml
+++ b/src/go/plugin/go.d/collector/hdfs/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://hadoop.apache.org/docs/r1.2.1/hdfs_design.html
         icon_filename: hadoop.svg
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords:
         - hdfs
         - hadoop

--- a/src/go/plugin/go.d/collector/hpssa/metadata.yaml
+++ b/src/go/plugin/go.d/collector/hpssa/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: "https://buy.hpe.com/us/en/options/controller-controller-options/smart-array-controllers-smart-host-bus-adapters/c/7109730"
         icon_filename: "hp.svg"
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords:
         - storage
         - raid-controller

--- a/src/go/plugin/go.d/collector/httpcheck/metadata.yaml
+++ b/src/go/plugin/go.d/collector/httpcheck/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: ""
         icon_filename: globe.svg
         categories:
-          - data-collection.synthetic-checks
+          - data-collection.synthetic-testing
       keywords:
         - webserver
       related_resources:

--- a/src/go/plugin/go.d/collector/icecast/metadata.yaml
+++ b/src/go/plugin/go.d/collector/icecast/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Icecast
         link: "https://icecast.org/"
         categories:
-          - data-collection.media-streaming-servers
+          - data-collection.applications
         icon_filename: "icecast.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/intelgpu/metadata.yaml
+++ b/src/go/plugin/go.d/collector/intelgpu/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.intel.com/
         icon_filename: microchip.svg
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
       keywords:
         - intel
         - gpu

--- a/src/go/plugin/go.d/collector/ipfs/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ipfs/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: IPFS
         link: "https://ipfs.tech/"
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
         icon_filename: "ipfs.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/isc_dhcpd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/isc_dhcpd/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: ISC DHCP
         link: https://www.isc.org/dhcp/
         categories:
-          - data-collection.dns-and-dhcp-servers
+          - data-collection.networking
         icon_filename: isc.png
       keywords:
         - dhcpd

--- a/src/go/plugin/go.d/collector/k8s_apiserver/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_apiserver/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://kubernetes.io/docs/concepts/overview/components/#kube-apiserver
         icon_filename: kubernetes.svg
         categories:
-          - data-collection.kubernetes
+          - data-collection.containers-and-orchestration
       keywords:
         - kubernetes
         - k8s

--- a/src/go/plugin/go.d/collector/k8s_kubelet/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_kubelet/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://kubernetes.io/docs/concepts/overview/components/#kubelet
         icon_filename: kubernetes.svg
         categories:
-          - data-collection.kubernetes
+          - data-collection.containers-and-orchestration
       keywords:
         - kubelet
         - kubernetes

--- a/src/go/plugin/go.d/collector/k8s_kubeproxy/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_kubeproxy/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://kubernetes.io/docs/concepts/overview/components/#kube-proxy
         icon_filename: kubernetes.svg
         categories:
-          - data-collection.kubernetes
+          - data-collection.containers-and-orchestration
       keywords:
         - kubeproxy
         - kubernetes

--- a/src/go/plugin/go.d/collector/k8s_state/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_state/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://kubernetes.io/
         icon_filename: kubernetes.svg
         categories:
-          - data-collection.kubernetes
+          - data-collection.containers-and-orchestration
       keywords:
         - kubernetes
         - k8s

--- a/src/go/plugin/go.d/collector/lighttpd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/lighttpd/metadata.yaml
@@ -9,14 +9,14 @@ modules:
         link: https://www.lighttpd.net/
         icon_filename: lighttpd.svg
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
       keywords:
         - webserver
       related_resources:
         integrations:
           list:
             - plugin_name: go.d.plugin
-              module_name: weblog
+              module_name: web_log
             - plugin_name: go.d.plugin
               module_name: httpcheck
             - plugin_name: apps.plugin

--- a/src/go/plugin/go.d/collector/litespeed/metadata.yaml
+++ b/src/go/plugin/go.d/collector/litespeed/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Litespeed
         link: "https://www.litespeedtech.com/products/litespeed-web-server"
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
         icon_filename: "litespeed.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/logind/metadata.yaml
+++ b/src/go/plugin/go.d/collector/logind/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.freedesktop.org/software/systemd/man/systemd-logind.service.html
         icon_filename: users.svg
         categories:
-          - data-collection.systemd
+          - data-collection.operating-systems
       keywords:
         - logind
         - systemd

--- a/src/go/plugin/go.d/collector/logstash/metadata.yaml
+++ b/src/go/plugin/go.d/collector/logstash/metadata.yaml
@@ -9,9 +9,9 @@ modules:
         link: https://www.elastic.co/products/logstash
         icon_filename: elastic-logstash.svg
         categories:
-          - data-collection.logs-servers
+          - data-collection.applications
       keywords:
-        - logstatsh
+        - logstash
       related_resources:
         integrations:
           list: []

--- a/src/go/plugin/go.d/collector/lvm/metadata.yaml
+++ b/src/go/plugin/go.d/collector/lvm/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: ""
         icon_filename: filesystem.svg
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords:
         - lvm
         - lvs

--- a/src/go/plugin/go.d/collector/maxscale/metadata.yaml
+++ b/src/go/plugin/go.d/collector/maxscale/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: MaxScale
         link: https://mariadb.com/kb/en/maxscale/
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
         icon_filename: maxscale.svg
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/megacli/metadata.yaml
+++ b/src/go/plugin/go.d/collector/megacli/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: "https://wikitech.wikimedia.org/wiki/MegaCli"
         icon_filename: "hard-drive.svg"
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords:
         - storage
         - raid-controller

--- a/src/go/plugin/go.d/collector/memcached/metadata.yaml
+++ b/src/go/plugin/go.d/collector/memcached/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Memcached
         link: https://memcached.org/
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
         icon_filename: "memcached.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/mongodb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mongodb/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.mongodb.com/
         icon_filename: mongodb.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords:
         - mongodb
         - databases

--- a/src/go/plugin/go.d/collector/monit/metadata.yaml
+++ b/src/go/plugin/go.d/collector/monit/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Monit
         link: https://mmonit.com/monit/
         categories:
-          - data-collection.synthetic-checks
+          - data-collection.synthetic-testing
         icon_filename: monit.png
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/mssql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mssql/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         name: Microsoft SQL Server
         link: https://www.microsoft.com/en-us/sql-server
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
         icon_filename: mssql.svg
       related_resources:
         integrations:
@@ -17,7 +17,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       info_provided_to_referring_integrations:
         description: ""
       keywords:

--- a/src/go/plugin/go.d/collector/mysql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mysql/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         name: MySQL
         link: https://www.mysql.com/
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
         icon_filename: mysql.svg
       related_resources:
         integrations:
@@ -17,7 +17,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       info_provided_to_referring_integrations:
         description: ""
       keywords:
@@ -1299,7 +1300,7 @@ modules:
         link: https://mariadb.org/
         icon_filename: mariadb.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
   - <<: *module
     meta:
       <<: *meta
@@ -1310,4 +1311,4 @@ modules:
         link: https://www.percona.com/software/mysql-database/percona-server
         icon_filename: percona.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases

--- a/src/go/plugin/go.d/collector/nats/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nats/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: NATS
         link: https://nats.io/
         categories:
-          - data-collection.message-brokers
+          - data-collection.databases
         icon_filename: nats.svg
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/nginx/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nginx/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: NGINX
         link: https://www.nginx.com/
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
         icon_filename: nginx.svg
       related_resources:
         integrations:
@@ -20,7 +20,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       alternative_monitored_instances: []
       info_provided_to_referring_integrations:
         description: ""

--- a/src/go/plugin/go.d/collector/nginxplus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nginxplus/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.nginx.com/products/nginx/
         icon_filename: nginxplus.svg
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
       keywords:
         - nginxplus
         - nginx

--- a/src/go/plugin/go.d/collector/nginxunit/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nginxunit/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: NGINX Unit
         link: https://unit.nginx.org/
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
         icon_filename: nginx.svg
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/nginxvts/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nginxvts/metadata.yaml
@@ -9,14 +9,14 @@ modules:
         link: https://www.nginx.com/
         icon_filename: nginx.svg
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
       keywords:
         - webserver
       related_resources:
         integrations:
           list:
             - plugin_name: go.d.plugin
-              module_name: weblog
+              module_name: web_log
             - plugin_name: go.d.plugin
               module_name: httpcheck
             - plugin_name: apps.plugin

--- a/src/go/plugin/go.d/collector/nsd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nsd/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: "https://nsd.docs.nlnetlabs.nl/en/latest"
         icon_filename: 'nsd.svg'
         categories:
-          - data-collection.dns-and-dhcp-servers
+          - data-collection.networking
       keywords:
         - nsd
         - dns

--- a/src/go/plugin/go.d/collector/ntpd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ntpd/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.ntp.org/documentation/4.2.8-series/ntpd
         icon_filename: ntp.png
         categories:
-          - data-collection.system-clock-and-ntp
+          - data-collection.networking
       keywords:
         - ntpd
         - ntp

--- a/src/go/plugin/go.d/collector/nvidia_smi/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nvidia_smi/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.nvidia.com/en-us/
         icon_filename: nvidia.svg
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
       keywords:
         - nvidia
         - gpu

--- a/src/go/plugin/go.d/collector/nvme/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nvme/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: ""
         icon_filename: nvme.svg
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords:
         - nvme
       related_resources:

--- a/src/go/plugin/go.d/collector/openldap/metadata.yaml
+++ b/src/go/plugin/go.d/collector/openldap/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: OpenLDAP
         link: https://www.openldap.org/
         categories:
-          - data-collection.authentication-and-authorization
+          - data-collection.applications
         icon_filename: openldap.svg
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/openvpn/metadata.yaml
+++ b/src/go/plugin/go.d/collector/openvpn/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://openvpn.net/
         icon_filename: openvpn.svg
         categories:
-          - data-collection.vpns
+          - data-collection.networking
       keywords:
         - openvpn
         - vpn

--- a/src/go/plugin/go.d/collector/openvpn_status_log/metadata.yaml
+++ b/src/go/plugin/go.d/collector/openvpn_status_log/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://openvpn.net/
         icon_filename: openvpn.svg
         categories:
-          - data-collection.vpns
+          - data-collection.networking
       keywords:
         - openvpn
         - vpn

--- a/src/go/plugin/go.d/collector/oracledb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/oracledb/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Oracle DB
         link: https://www.oracle.com/database/
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
         icon_filename: oracle.svg
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/pgbouncer/metadata.yaml
+++ b/src/go/plugin/go.d/collector/pgbouncer/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.pgbouncer.org/
         icon_filename: postgres.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords:
         - pgbouncer
       related_resources:

--- a/src/go/plugin/go.d/collector/phpdaemon/metadata.yaml
+++ b/src/go/plugin/go.d/collector/phpdaemon/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://github.com/kakserpom/phpdaemon
         icon_filename: php.svg
         categories:
-          - data-collection.apm
+          - data-collection.applications
       keywords:
         - phpdaemon
         - php

--- a/src/go/plugin/go.d/collector/phpfpm/metadata.yaml
+++ b/src/go/plugin/go.d/collector/phpfpm/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://php-fpm.org/
         icon_filename: php.svg
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
       keywords:
         - phpfpm
         - php

--- a/src/go/plugin/go.d/collector/pihole/metadata.yaml
+++ b/src/go/plugin/go.d/collector/pihole/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://pi-hole.net
         icon_filename: pihole.png
         categories:
-          - data-collection.dns-and-dhcp-servers
+          - data-collection.networking
       keywords:
         - pihole
       related_resources:

--- a/src/go/plugin/go.d/collector/pika/metadata.yaml
+++ b/src/go/plugin/go.d/collector/pika/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://github.com/OpenAtomFoundation/pika
         icon_filename: pika.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords:
         - pika
         - databases

--- a/src/go/plugin/go.d/collector/ping/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ping/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: ""
         icon_filename: globe.svg
         categories:
-          - data-collection.synthetic-checks
+          - data-collection.synthetic-testing
       keywords:
         - ping
       related_resources:

--- a/src/go/plugin/go.d/collector/portcheck/metadata.yaml
+++ b/src/go/plugin/go.d/collector/portcheck/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: ""
         icon_filename: globe.svg
         categories:
-          - data-collection.synthetic-checks
+          - data-collection.synthetic-testing
       keywords: []
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/postfix/metadata.yaml
+++ b/src/go/plugin/go.d/collector/postfix/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Postfix
         link: https://www.postfix.org/
         categories:
-          - data-collection.mail-servers
+          - data-collection.applications
         icon_filename: "postfix.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/postgres/metadata.yaml
+++ b/src/go/plugin/go.d/collector/postgres/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: PostgreSQL
         link: https://www.postgresql.org/
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
         icon_filename: postgres.svg
       related_resources:
         integrations:
@@ -16,7 +16,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       alternative_monitored_instances: []
       info_provided_to_referring_integrations:
         description: ""

--- a/src/go/plugin/go.d/collector/powerdns/metadata.yaml
+++ b/src/go/plugin/go.d/collector/powerdns/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://doc.powerdns.com/authoritative/
         icon_filename: powerdns.svg
         categories:
-          - data-collection.dns-and-dhcp-servers
+          - data-collection.networking
       keywords:
         - powerdns
         - dns

--- a/src/go/plugin/go.d/collector/powerdns_recursor/metadata.yaml
+++ b/src/go/plugin/go.d/collector/powerdns_recursor/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://doc.powerdns.com/recursor/
         icon_filename: powerdns.svg
         categories:
-          - data-collection.dns-and-dhcp-servers
+          - data-collection.networking
       keywords:
         - powerdns
         - dns

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -10,8 +10,7 @@ modules:
         link: https://prometheus.io/
         icon_filename: prometheus.svg
         categories:
-          - data-collection.generic-data-collection
-          # - data-collection.apm
+          - data-collection.applications
       keywords:
         - prometheus
         - openmetrics
@@ -319,7 +318,7 @@ modules:
         link: https://github.com/O1ahmad/aws_ec2_exporter
         icon_filename: aws-ec2.png
         categories:
-          - data-collection.cloud-provider-managed
+          - data-collection.cloud-and-devops
       keywords:
         - cloud services
         - cloud computing
@@ -349,7 +348,7 @@ modules:
         link: https://github.com/prometheus/blackbox_exporter
         icon_filename: prometheus.svg
         categories:
-          - data-collection.synthetic-checks
+          - data-collection.synthetic-testing
       keywords:
         - blackbox
     overview:
@@ -377,7 +376,7 @@ modules:
         link: https://github.com/cilium/cilium
         icon_filename: cilium.png
         categories:
-          - data-collection.kubernetes
+          - data-collection.containers-and-orchestration
       keywords: [ ]
     overview:
       <<: *overview
@@ -404,7 +403,7 @@ modules:
         link: https://github.com/cilium/cilium
         icon_filename: cilium.png
         categories:
-          - data-collection.kubernetes
+          - data-collection.containers-and-orchestration
       keywords: [ ]
     overview:
       <<: *overview
@@ -431,7 +430,7 @@ modules:
         link: https://github.com/cilium/proxy
         icon_filename: cilium.png
         categories:
-          - data-collection.kubernetes
+          - data-collection.containers-and-orchestration
       keywords: [ ]
     overview:
       <<: *overview
@@ -458,7 +457,7 @@ modules:
         link: https://github.com/prometheus/cloudwatch_exporter
         icon_filename: aws-cloudwatch.png
         categories:
-          - data-collection.cloud-provider-managed
+          - data-collection.cloud-and-devops
       keywords:
         - cloud services
         - cloud computing
@@ -488,7 +487,7 @@ modules:
         link: https://concourse-ci.org
         icon_filename: concourse.png
         categories:
-          - data-collection.ci-cd-systems
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview
@@ -515,7 +514,7 @@ modules:
         link: https://www.scylladb.com/
         icon_filename: scylladb.png
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -535,7 +534,7 @@ modules:
         link: https://docs.crowdsec.net/docs/observability/prometheus
         icon_filename: crowdsec.png
         categories:
-          - data-collection.security-systems
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -562,7 +561,7 @@ modules:
         link: https://github.com/discourse/discourse-prometheus
         icon_filename: discourse.svg
         categories:
-          - data-collection.media-streaming-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -589,7 +588,7 @@ modules:
         link: https://github.com/Apside-TOP/dynatrace_exporter
         icon_filename: dynatrace.svg
         categories:
-          - data-collection.observability
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview
@@ -616,7 +615,7 @@ modules:
         link: https://eos-web.web.cern.ch/eos-web/
         icon_filename: eos.png
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords: [ ]
     overview:
       <<: *overview
@@ -643,7 +642,7 @@ modules:
         link: https://etcd.io/
         icon_filename: etcd.svg
         categories:
-          - data-collection.service-discovery-registry
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -663,7 +662,7 @@ modules:
         link: https://github.com/Axcient/freebsd-nfs-exporter
         icon_filename: freebsd.svg
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
       keywords: [ ]
     overview:
       <<: *overview
@@ -690,7 +689,7 @@ modules:
         link: https://github.com/yo000/rctl_exporter
         icon_filename: freebsd.svg
         categories:
-          - data-collection.freebsd
+          - data-collection.operating-systems
       keywords: [ ]
     overview:
       <<: *overview
@@ -717,7 +716,7 @@ modules:
         link: https://github.com/O1ahmad/gcp-gce-exporter
         icon_filename: gcp-gce.svg
         categories:
-          - data-collection.cloud-provider-managed
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview
@@ -744,7 +743,7 @@ modules:
         link: https://github.com/githubexporter/github-exporter
         icon_filename: github.svg
         categories:
-          - data-collection.other
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -771,7 +770,7 @@ modules:
         link: https://gitlab.com/gitlab-org/gitlab-runner
         icon_filename: gitlab.png
         categories:
-          - data-collection.ci-cd-systems
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview
@@ -798,7 +797,7 @@ modules:
         link: https://github.com/yyyar/gobetween
         icon_filename: gobetween.svg
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
       keywords: [ ]
     overview:
       <<: *overview
@@ -818,7 +817,7 @@ modules:
         link: https://github.com/DazWilkin/gcp-exporter
         icon_filename: gcp.png
         categories:
-          - data-collection.cloud-provider-managed
+          - data-collection.cloud-and-devops
       keywords:
         - cloud services
         - cloud computing
@@ -848,7 +847,7 @@ modules:
         link: https://github.com/prometheus-community/stackdriver_exporter
         icon_filename: gcp-stackdriver.svg
         categories:
-          - data-collection.cloud-provider-managed
+          - data-collection.cloud-and-devops
       keywords:
         - cloud services
         - cloud computing
@@ -878,7 +877,7 @@ modules:
         link: https://grafana.com/
         icon_filename: grafana.png
         categories:
-          - data-collection.observability
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview
@@ -898,7 +897,7 @@ modules:
         link: https://github.com/Graylog2/graylog2-server/
         icon_filename: graylog.svg
         categories:
-          - data-collection.logs-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -926,7 +925,7 @@ modules:
         link: https://github.com/jenningsloy318/hana_exporter
         icon_filename: sap.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -953,7 +952,7 @@ modules:
         link: https://github.com/Intrinsec/honeypot_exporter
         icon_filename: intrinsec.svg
         categories:
-          - data-collection.security-systems
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -980,7 +979,7 @@ modules:
         link: https://github.com/cilium/hubble
         icon_filename: hubble.png
         categories:
-          - data-collection.observability
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview
@@ -1007,7 +1006,7 @@ modules:
         link: https://github.com/topine/ibm-spectrum-exporter
         icon_filename: ibm.svg
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords: [ ]
     overview:
       <<: *overview
@@ -1034,7 +1033,7 @@ modules:
         link: https://github.com/prometheus/influxdb_exporter
         icon_filename: influxdb.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords:
         - database
         - dbms
@@ -1064,7 +1063,7 @@ modules:
         link: https://www.jenkins.io/
         icon_filename: jenkins.svg
         categories:
-          - data-collection.ci-cd-systems
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview
@@ -1091,7 +1090,7 @@ modules:
         link: https://github.com/prometheus/jmx_exporter
         icon_filename: java.svg
         categories:
-          - data-collection.apm
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -1118,7 +1117,7 @@ modules:
         link: https://github.com/omarsmak/kafka-consumer-lag-monitoring
         icon_filename: kafka.svg
         categories:
-          - data-collection.service-discovery-registry
+          - data-collection.applications
       keywords:
         - big data
         - stream processing
@@ -1148,7 +1147,7 @@ modules:
         link: https://github.com/danielqsj/kafka_exporter/
         icon_filename: kafka.svg
         categories:
-          - data-collection.message-brokers
+          - data-collection.databases
       keywords:
         - big data
         - stream processing
@@ -1178,7 +1177,7 @@ modules:
         link: https://github.com/cloudflare/kafka_zookeeper_exporter
         icon_filename: kafka.svg
         categories:
-          - data-collection.message-brokers
+          - data-collection.databases
       keywords:
         - big data
         - stream processing
@@ -1208,7 +1207,7 @@ modules:
         link: https://github.com/DazWilkin/linode-exporter
         icon_filename: linode.svg
         categories:
-          - data-collection.cloud-provider-managed
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview
@@ -1235,7 +1234,7 @@ modules:
         link: https://github.com/grafana/loki
         icon_filename: loki.png
         categories:
-          - data-collection.logs-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -1262,7 +1261,7 @@ modules:
         link: https://github.com/sladkoff/minecraft-prometheus-exporter
         icon_filename: minecraft.png
         categories:
-          - data-collection.gaming
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -1289,7 +1288,7 @@ modules:
         link: https://github.com/sapcc/mosquitto-exporter
         icon_filename: mosquitto.svg
         categories:
-          - data-collection.message-brokers
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -1316,7 +1315,7 @@ modules:
         link: https://github.com/agebhar1/mq_exporter
         icon_filename: ibm.svg
         categories:
-          - data-collection.message-brokers
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -1343,7 +1342,7 @@ modules:
         link: https://github.com/inovex/mqtt_blackbox_exporter
         icon_filename: mqtt.svg
         categories:
-          - data-collection.message-brokers
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -1370,7 +1369,7 @@ modules:
         link: https://github.com/sapcc/netapp-api-exporter
         icon_filename: netapp.svg
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords:
         - network monitoring
         - network performance
@@ -1400,7 +1399,7 @@ modules:
         link: https://github.com/mjavier2k/solidfire-exporter
         icon_filename: netapp.svg
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords:
         - network monitoring
         - network performance
@@ -1430,7 +1429,7 @@ modules:
         link: https://github.com/digitalocean/openvswitch_exporter
         icon_filename: ovs.png
         categories:
-          - data-collection.networking-stack-and-network-interfaces
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -1457,7 +1456,7 @@ modules:
         link: https://github.com/foomo/pagespeed_exporter
         icon_filename: google.svg
         categories:
-          - data-collection.apm
+          - data-collection.applications
       keywords:
         - cloud services
         - cloud computing
@@ -1487,7 +1486,7 @@ modules:
         link: https://github.com/aexel90/hue_exporter
         icon_filename: hue.svg
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -1514,7 +1513,7 @@ modules:
         link: https://github.com/containers/prometheus-podman-exporter
         icon_filename: podman.png
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords: [ ]
     overview:
       <<: *overview
@@ -1541,7 +1540,7 @@ modules:
         link: https://github.com/prometheus-pve/prometheus-pve-exporter
         icon_filename: proxmox.png
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords: [ ]
     overview:
       <<: *overview
@@ -1568,7 +1567,7 @@ modules:
         link: https://github.com/devon-mar/radius-exporter
         icon_filename: radius.png
         categories:
-          - data-collection.authentication-and-authorization
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -1595,7 +1594,7 @@ modules:
         link: https://github.com/percona/rds_exporter
         icon_filename: aws-rds.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords:
         - cloud services
         - cloud computing
@@ -1625,7 +1624,7 @@ modules:
         link: https://github.com/czerwonk/atlas_exporter
         icon_filename: ripe.png
         categories:
-          - data-collection.networking-stack-and-network-interfaces
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -1652,8 +1651,7 @@ modules:
         link: https://github.com/SckyzO/slurm_exporter
         icon_filename: slurm.png
         categories:
-          - data-collection.task-queues
-          #- data-collection.provisioning-systems
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -1680,7 +1678,7 @@ modules:
         link: https://github.com/spacelift-io/prometheus-exporter
         icon_filename: spacelift.png
         categories:
-          - data-collection.provisioning-systems
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview
@@ -1707,7 +1705,7 @@ modules:
         link: https://github.com/danopstech/starlink_exporter
         icon_filename: starlink.svg
         categories:
-          - data-collection.networking-stack-and-network-interfaces
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -1734,7 +1732,7 @@ modules:
         link: https://github.com/vladvasiliu/statuspage-exporter
         icon_filename: statuspage.png
         categories:
-          - data-collection.notifications
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -1761,7 +1759,7 @@ modules:
         link: https://github.com/devon-mar/tacacs-exporter
         icon_filename: tacacs.png
         categories:
-          - data-collection.authentication-and-authorization
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -1788,7 +1786,7 @@ modules:
         link: https://github.com/wywywywy/tesla-prometheus-exporter
         icon_filename: tesla.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -1815,7 +1813,7 @@ modules:
         link: https://github.com/damoun/twitch_exporter
         icon_filename: twitch.svg
         categories:
-          - data-collection.media-streaming-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -1842,7 +1840,7 @@ modules:
         link: https://github.com/swoga/ufiber-exporter
         icon_filename: ubiquiti.png
         categories:
-          - data-collection.networking-stack-and-network-interfaces
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -1869,7 +1867,7 @@ modules:
         link: https://github.com/wosc/prometheus-uptimerobot
         icon_filename: uptimerobot.svg
         categories:
-          - data-collection.synthetic-checks
+          - data-collection.synthetic-testing
       keywords: [ ]
     overview:
       <<: *overview
@@ -1896,7 +1894,7 @@ modules:
         link: https://github.com/aarnaud/vault-pki-exporter
         icon_filename: vault.svg
         categories:
-          - data-collection.security-systems
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -1923,7 +1921,7 @@ modules:
         link: https://github.com/vertica/vertica-prometheus-exporter
         icon_filename: vertica.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -1950,7 +1948,7 @@ modules:
         link: https://github.com/guicaulada/vscode-exporter
         icon_filename: vscode.svg
         categories:
-          - data-collection.apm
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -1977,7 +1975,7 @@ modules:
         link: https://github.com/ThomasMaul/Prometheus_4D_Exporter
         icon_filename: 4d_server.png
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -2004,7 +2002,7 @@ modules:
         link: https://github.com/dernasherbrezon/8430ft_exporter
         icon_filename: mtc.svg
         categories:
-          - data-collection.networking-stack-and-network-interfaces
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -2031,7 +2029,7 @@ modules:
         link: https://github.com/armsnyder/a2s-exporter
         icon_filename: a2s.png
         categories:
-          - data-collection.gaming
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -2058,7 +2056,7 @@ modules:
         link: https://github.com/codemonauts/prometheus-fe2-exporter
         icon_filename: alamos_fe2.png
         categories:
-          - data-collection.apm
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -2085,7 +2083,7 @@ modules:
         link: https://github.com/amd/amd_smi_exporter
         icon_filename: amd.svg
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -2112,7 +2110,7 @@ modules:
         link: https://github.com/3scale/apicast
         icon_filename: apicast.png
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
       keywords: [ ]
     overview:
       <<: *overview
@@ -2139,7 +2137,7 @@ modules:
         link: https://github.com/woblerr/authlog_exporter
         icon_filename: linux.png
         categories:
-          - data-collection.logs-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -2166,7 +2164,7 @@ modules:
         link: https://github.com/emylincon/aws_quota_exporter
         icon_filename: aws.svg
         categories:
-          - data-collection.cloud-provider-managed
+          - data-collection.cloud-and-devops
       keywords:
         - cloud services
         - cloud computing
@@ -2196,7 +2194,7 @@ modules:
         link: https://github.com/bosh-prometheus/bosh_exporter
         icon_filename: bosh.png
         categories:
-          - data-collection.provisioning-systems
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview
@@ -2223,7 +2221,7 @@ modules:
         link: https://github.com/weihao/bungeecord-prometheus-exporter
         icon_filename: bungee.png
         categories:
-          - data-collection.gaming
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -2250,7 +2248,7 @@ modules:
         link: https://github.com/ZeitOnline/celery_redis_prometheus
         icon_filename: celery.png
         categories:
-          - data-collection.task-queues
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -2277,7 +2275,7 @@ modules:
         link: https://github.com/chia-network/chia-exporter
         icon_filename: chia.png
         categories:
-          - data-collection.blockchain-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -2304,7 +2302,7 @@ modules:
         link: https://github.com/christmann/clm5ip_exporter/
         icon_filename: christelec.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -2331,7 +2329,7 @@ modules:
         link: https://github.com/sergeymakinen/clamav_exporter
         icon_filename: clamav.png
         categories:
-          - data-collection.security-systems
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -2358,7 +2356,7 @@ modules:
         link: https://github.com/FortnoxAB/clamscan-exporter
         icon_filename: clamav.png
         categories:
-          - data-collection.security-systems
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -2385,7 +2383,7 @@ modules:
         link: https://github.com/elonzh/clash_exporter
         icon_filename: clash.png
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
       keywords: [ ]
     overview:
       <<: *overview
@@ -2412,7 +2410,7 @@ modules:
         link: https://github.com/bosh-prometheus/cf_exporter
         icon_filename: cloud-foundry.svg
         categories:
-          - data-collection.provisioning-systems
+          - data-collection.cloud-and-devops
       keywords:
         - cloud services
         - cloud computing
@@ -2442,7 +2440,7 @@ modules:
         link: https://github.com/bosh-prometheus/firehose_exporter
         icon_filename: cloud-foundry.svg
         categories:
-          - data-collection.provisioning-systems
+          - data-collection.cloud-and-devops
       keywords:
         - cloud services
         - cloud computing
@@ -2472,7 +2470,7 @@ modules:
         link: https://github.com/GSI-HPC/prometheus-cluster-exporter
         icon_filename: lustre.png
         categories:
-          - data-collection.cloud-provider-managed
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview
@@ -2499,7 +2497,7 @@ modules:
         link: https://github.com/severalnines/cmon_exporter
         icon_filename: cluster-control.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -2526,7 +2524,7 @@ modules:
         link: https://github.com/prometheus/collectd_exporter
         icon_filename: collectd.png
         categories:
-          - data-collection.observability
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview
@@ -2553,7 +2551,7 @@ modules:
         link: https://github.com/jo-hannes/craftbeerpi_exporter
         icon_filename: craftbeer.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -2580,7 +2578,7 @@ modules:
         link: https://github.com/nbarrientos/cryptowat_exporter
         icon_filename: cryptowatch.png
         categories:
-          - data-collection.blockchain-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -2607,7 +2605,7 @@ modules:
         link: https://github.com/jgosmann/dmarc-metrics-exporter
         icon_filename: dmarc.png
         categories:
-          - data-collection.mail-servers
+          - data-collection.applications
       keywords:
         - email authentication
         - policy
@@ -2637,7 +2635,7 @@ modules:
         link: https://github.com/Luzilla/dnsbl_exporter/
         icon_filename: dnsbl.png
         categories:
-          - data-collection.dns-and-dhcp-servers
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -2666,7 +2664,7 @@ modules:
         link: https://github.com/czerwonk/bird_exporter
         icon_filename: bird.png
         categories:
-          - data-collection.networking-stack-and-network-interfaces
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -2693,7 +2691,7 @@ modules:
         link: https://github.com/mdlayher/keylight_exporter
         icon_filename: elgato.svg
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -2720,7 +2718,7 @@ modules:
         link: https://github.com/peak-load/energomera_exporter
         icon_filename: energomera.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -2747,7 +2745,7 @@ modules:
         link: https://github.com/freifunk-darmstadt/fastd-exporter
         icon_filename: fastd.png
         categories:
-          - data-collection.vpns
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -2774,7 +2772,7 @@ modules:
         link: https://github.com/xperimental/freifunk-exporter
         icon_filename: freifunk.png
         categories:
-          - data-collection.networking-stack-and-network-interfaces
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -2801,7 +2799,7 @@ modules:
         link: https://github.com/tynany/frr_exporter
         icon_filename: frrouting.png
         categories:
-          - data-collection.networking-stack-and-network-interfaces
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -2828,7 +2826,7 @@ modules:
         link: https://github.com/lunarway/github-ratelimit-exporter
         icon_filename: github.svg
         categories:
-          - data-collection.other
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -2856,7 +2854,7 @@ modules:
         link: https://github.com/natesales/gpsd-exporter
         icon_filename: gpsd.png
         categories:
-          - data-collection.apm
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -2883,7 +2881,7 @@ modules:
         link: https://github.com/tobiasbp/halon_exporter
         icon_filename: halon.svg
         categories:
-          - data-collection.mail-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -2910,7 +2908,7 @@ modules:
         link: https://github.com/hairyhenderson/hitron_coda_exporter
         icon_filename: hitron.svg
         categories:
-          - data-collection.networking-stack-and-network-interfaces
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -2937,7 +2935,7 @@ modules:
         link: https://github.com/lstrojny/homebridge-prometheus-exporter
         icon_filename: homebridge.svg
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -2964,7 +2962,7 @@ modules:
         link: https://github.com/rickardp/homey-prometheus-exporter
         icon_filename: homey.svg
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -2991,7 +2989,7 @@ modules:
         link: https://github.com/ibm-s390-cloud/k8s-cex-dev-plugin
         icon_filename: ibm.svg
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -3018,7 +3016,7 @@ modules:
         link: https://github.com/zhmcclient/zhmc-prometheus-exporter
         icon_filename: ibm.svg
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -3045,7 +3043,7 @@ modules:
         link: https://github.com/hairyhenderson/jarvis_exporter/
         icon_filename: jarvis.jpg
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -3073,7 +3071,7 @@ modules:
         link: https://github.com/Gandi/jbod-rs
         icon_filename: storage-enclosure.svg
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords: [ ]
     overview:
       <<: *overview
@@ -3100,7 +3098,7 @@ modules:
         link: https://github.com/dead-claudia/journald-exporter
         icon_filename: linux.png
         categories:
-          - data-collection.logs-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -3127,7 +3125,7 @@ modules:
         link: https://github.com/apostvav/kannel_exporter
         icon_filename: kannel.png
         categories:
-          - data-collection.telephony-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -3154,7 +3152,7 @@ modules:
         link: https://github.com/gen2brain/keepalived_exporter
         icon_filename: keepalived.png
         categories:
-          - data-collection.networking-stack-and-network-interfaces
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -3181,7 +3179,7 @@ modules:
         link: https://github.com/MauveSoftware/lynis_exporter
         icon_filename: lynis.png
         categories:
-          - data-collection.security-systems
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -3208,7 +3206,7 @@ modules:
         link: https://github.com/scottaglia/meilisearch_exporter
         icon_filename: meilisearch.svg
         categories:
-          - data-collection.search-engines
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -3235,8 +3233,7 @@ modules:
         link: http://github.com/mesosphere/mesos_exporter
         icon_filename: mesos.svg
         categories:
-          #- data-collection.provisioning-systems
-          - data-collection.task-queues
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -3263,7 +3260,7 @@ modules:
         link: https://github.com/xperimental/flowercare-exporter
         icon_filename: xiaomi.svg
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -3290,7 +3287,7 @@ modules:
         link: https://github.com/dernasherbrezon/modbusrtu_exporter
         icon_filename: modbus.svg
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords:
         - database
         - dbms
@@ -3320,7 +3317,7 @@ modules:
         link: https://github.com/KKBOX/mogilefs-exporter
         icon_filename: filesystem.svg
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords: [ ]
     overview:
       <<: *overview
@@ -3347,7 +3344,7 @@ modules:
         link: https://github.com/google/mtail
         icon_filename: mtail.png
         categories:
-          - data-collection.logs-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -3374,7 +3371,7 @@ modules:
         link: https://github.com/wbollock/nagios_exporter
         icon_filename: nagios.png
         categories:
-          - data-collection.observability
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview
@@ -3402,7 +3399,7 @@ modules:
         link: https://github.com/kenfdev/remo-exporter
         icon_filename: nature-remo.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -3429,7 +3426,7 @@ modules:
         link: https://github.com/xperimental/netatmo-exporter
         icon_filename: netatmo.svg
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords:
         - network monitoring
         - network performance
@@ -3459,7 +3456,7 @@ modules:
         link: https://github.com/xperimental/nextcloud-exporter
         icon_filename: nextcloud.png
         categories:
-          - data-collection.cloud-provider-managed
+          - data-collection.cloud-and-devops
       keywords:
         - cloud services
         - cloud computing
@@ -3489,7 +3486,7 @@ modules:
         link: https://github.com/raylas/nextdns-exporter
         icon_filename: nextdns.png
         categories:
-          - data-collection.dns-and-dhcp-servers
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -3516,7 +3513,7 @@ modules:
         link: https://github.com/crooks/njmon_exporter
         icon_filename: ibm.svg
         categories:
-          - data-collection.apm
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -3543,7 +3540,7 @@ modules:
         link: https://github.com/canonical/nrpe_exporter
         icon_filename: nrpelinux.png
         categories:
-          - data-collection.apm
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -3570,7 +3567,7 @@ modules:
         link: https://github.com/lukegb/obs_studio_exporter
         icon_filename: obs-studio.png
         categories:
-          - data-collection.media-streaming-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -3597,7 +3594,7 @@ modules:
         link: https://git.sr.ht/~tomleb/openrc-exporter
         icon_filename: linux.png
         categories:
-          - data-collection.linux-systems
+          - data-collection.operating-systems
       keywords: [ ]
     overview:
       <<: *overview
@@ -3624,7 +3621,7 @@ modules:
         link: https://github.com/utdal/openroadm_exporter
         icon_filename: openroadm.png
         categories:
-          - data-collection.networking-stack-and-network-interfaces
+          - data-collection.networking
       keywords:
         - network monitoring
         - network performance
@@ -3654,7 +3651,7 @@ modules:
         link: https://github.com/billykwooten/openweather-exporter
         icon_filename: openweather.png
         categories:
-          - data-collection.generic-data-collection
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -3681,7 +3678,7 @@ modules:
         link: https://github.com/TobiasDeBruijn/prometheus-p1-exporter
         icon_filename: dutch-electricity.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -3709,7 +3706,7 @@ modules:
         link: https://github.com/gopaytech/patroni_exporter
         icon_filename: patroni.png
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -3736,7 +3733,7 @@ modules:
         link: https://github.com/JohnOrthoefer/pws-exporter
         icon_filename: wunderground.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -3763,7 +3760,7 @@ modules:
         link: https://github.com/woblerr/pgbackrest_exporter
         icon_filename: pgbackrest.png
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -3790,7 +3787,7 @@ modules:
         link: https://github.com/pgpool/pgpool2_exporter
         icon_filename: pgpool2.png
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -3817,7 +3814,7 @@ modules:
         link: https://github.com/terradolor/prometheus-enviro-exporter
         icon_filename: pimorino.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -3844,7 +3841,7 @@ modules:
         link: https://github.com/aashley/powerpal_exporter
         icon_filename: powerpal.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -3871,7 +3868,7 @@ modules:
         link: https://github.com/transnano/proftpd_exporter
         icon_filename: proftpd.png
         categories:
-          - data-collection.ftp-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -3898,7 +3895,7 @@ modules:
         link: https://github.com/mdawar/rq-exporter
         icon_filename: rq.png
         categories:
-          - data-collection.message-brokers
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -3925,7 +3922,7 @@ modules:
         link: https://github.com/andrewlow/radio-thermostat-exporter
         icon_filename: radiots.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -3952,7 +3949,7 @@ modules:
         link: https://github.com/psyinfra/prometheus-raritan-pdu-exporter
         icon_filename: raritan.svg
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -3979,7 +3976,7 @@ modules:
         link: https://github.com/msroest/sabnzbd_exporter
         icon_filename: sabnzbd.png
         categories:
-          - data-collection.media-streaming-servers
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -4006,7 +4003,7 @@ modules:
         link: https://github.com/alejandroscf/prometheus_salicru_exporter
         icon_filename: salicru.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -4033,7 +4030,7 @@ modules:
         link: https://github.com/ejsuncy/sense_energy_prometheus_exporter
         icon_filename: sense.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -4060,7 +4057,7 @@ modules:
         link: https://github.com/aexel90/shelly_exporter
         icon_filename: shelly.jpg
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -4087,7 +4084,7 @@ modules:
         link: https://github.com/MarcusCalidus/s7-plc-exporter
         icon_filename: siemens.svg
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -4114,7 +4111,7 @@ modules:
         link: https://github.com/svenstaro/site24x7_exporter
         icon_filename: site24x7.svg
         categories:
-          - data-collection.synthetic-checks
+          - data-collection.synthetic-testing
       keywords: [ ]
     overview:
       <<: *overview
@@ -4141,7 +4138,7 @@ modules:
         link: https://github.com/dr0ps/sma_inverter_exporter
         icon_filename: sma.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -4168,7 +4165,7 @@ modules:
         link: https://github.com/mweinelt/sml-exporter
         icon_filename: sml.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -4195,7 +4192,7 @@ modules:
         link: https://github.com/dalance/softether_exporter
         icon_filename: softether.svg
         categories:
-          - data-collection.vpns
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -4222,7 +4219,7 @@ modules:
         link: https://gitlab.com/bhavin192/lsx-exporter
         icon_filename: solar.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -4249,7 +4246,7 @@ modules:
         link: https://github.com/candlerb/solis_exporter
         icon_filename: solis.jpg
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -4276,7 +4273,7 @@ modules:
         link: https://github.com/kamelnetworks/sonic_exporter
         icon_filename: sonic.png
         categories:
-          - data-collection.networking-stack-and-network-interfaces
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -4303,7 +4300,7 @@ modules:
         link: https://github.com/bluecmd/spectrum_virtualize_exporter
         icon_filename: ibm.svg
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords: [ ]
     overview:
       <<: *overview
@@ -4330,7 +4327,7 @@ modules:
         link: https://github.com/foxdalas/sphinx_exporter
         icon_filename: sphinx.png
         categories:
-          - data-collection.search-engines
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -4357,7 +4354,7 @@ modules:
         link: https://github.com/Storidge/cio-user-docs/blob/master/integrations/prometheus.md
         icon_filename: storidge.png
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords: [ ]
     overview:
       <<: *overview
@@ -4384,7 +4381,7 @@ modules:
         link: https://github.com/jlti-dev/ipsec_exporter
         icon_filename: strongswan.svg
         categories:
-          - data-collection.vpns
+          - data-collection.networking
       keywords: [ ]
     overview:
       <<: *overview
@@ -4411,7 +4408,7 @@ modules:
         link: https://github.com/inosion/prometheus-sunspec-exporter
         icon_filename: sunspec.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -4438,7 +4435,7 @@ modules:
         link: https://github.com/corelight/suricata_exporter
         icon_filename: suricata.png
         categories:
-          - data-collection.security-systems
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -4467,7 +4464,7 @@ modules:
         link: https://github.com/codemonauts/activebackup-prometheus-exporter
         icon_filename: synology.png
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords: [ ]
     overview:
       <<: *overview
@@ -4494,7 +4491,7 @@ modules:
         link: https://github.com/egmc/sysload_exporter
         icon_filename: sysload.png
         categories:
-          - data-collection.apm
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -4521,7 +4518,7 @@ modules:
         link: https://github.com/eko/tado-exporter
         icon_filename: tado.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -4549,7 +4546,7 @@ modules:
         link: https://github.com/lukasmalkmus/tankerkoenig_exporter
         icon_filename: tanker.png
         categories:
-          - data-collection.generic-data-collection
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -4576,7 +4573,7 @@ modules:
         link: https://github.com/benclapp/tesla_wall_connector_exporter
         icon_filename: tesla.png
         categories:
-          - data-collection.iot-devices
+          - data-collection.hardware-and-iot
       keywords: [ ]
     overview:
       <<: *overview
@@ -4603,7 +4600,7 @@ modules:
         link: https://github.com/centreon/warp10-sensision-exporter
         icon_filename: warp10.svg
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords: [ ]
     overview:
       <<: *overview
@@ -4631,7 +4628,7 @@ modules:
         link: https://github.com/just1not2/prometheus-exporter-yourls
         icon_filename: yourls.png
         categories:
-          - data-collection.apm
+          - data-collection.applications
       keywords: [ ]
     overview:
       <<: *overview
@@ -4658,7 +4655,7 @@ modules:
         link: https://github.com/claranet/zerto-exporter
         icon_filename: zerto.png
         categories:
-          - data-collection.cloud-provider-managed
+          - data-collection.cloud-and-devops
       keywords: [ ]
     overview:
       <<: *overview

--- a/src/go/plugin/go.d/collector/proxysql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/proxysql/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.proxysql.com/
         icon_filename: proxysql.png
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
       keywords:
         - proxysql
         - databases

--- a/src/go/plugin/go.d/collector/pulsar/metadata.yaml
+++ b/src/go/plugin/go.d/collector/pulsar/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://pulsar.apache.org/
         icon_filename: pulsar.svg
         categories:
-          - data-collection.message-brokers
+          - data-collection.databases
       keywords:
         - pulsar
       related_resources:

--- a/src/go/plugin/go.d/collector/puppet/metadata.yaml
+++ b/src/go/plugin/go.d/collector/puppet/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Puppet
         link: "https://www.puppet.com/"
         categories:
-          - data-collection.ci-cd-systems
+          - data-collection.cloud-and-devops
         icon_filename: "puppet.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/rabbitmq/metadata.yaml
+++ b/src/go/plugin/go.d/collector/rabbitmq/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.rabbitmq.com/
         icon_filename: rabbitmq.svg
         categories:
-          - data-collection.message-brokers
+          - data-collection.databases
       keywords:
         - rabbitmq
         - message brokers

--- a/src/go/plugin/go.d/collector/redis/metadata.yaml
+++ b/src/go/plugin/go.d/collector/redis/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Redis
         link: https://redis.com/
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
         icon_filename: redis.svg
       related_resources:
         integrations:
@@ -16,7 +16,8 @@ modules:
             - plugin_name: apps.plugin
               module_name: apps
             - plugin_name: cgroups.plugin
-              module_name: cgroups
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: Containers
       alternative_monitored_instances: []
       info_provided_to_referring_integrations:
         description: ""

--- a/src/go/plugin/go.d/collector/rethinkdb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/rethinkdb/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: RethinkDB
         link: https://rethinkdb.com
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
         icon_filename: "rethinkdb.png"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/riakkv/metadata.yaml
+++ b/src/go/plugin/go.d/collector/riakkv/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Riak KV
         link: https://riak.com/products/riak-kv/index.html
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
         icon_filename: "riak.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/rspamd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/rspamd/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Rspamd
         link: https://rspamd.com/
         categories:
-          - data-collection.security-systems
+          - data-collection.applications
         icon_filename: globe.svg
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/samba/metadata.yaml
+++ b/src/go/plugin/go.d/collector/samba/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: "https://www.samba.org/samba/"
         icon_filename: 'samba.svg'
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords:
         - samba
         - smb

--- a/src/go/plugin/go.d/collector/scaleio/metadata.yaml
+++ b/src/go/plugin/go.d/collector/scaleio/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.dell.com/en-ca/dt/storage/scaleio/scaleioreadynode.htm
         icon_filename: dell.svg
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords:
         - scaleio
       related_resources:

--- a/src/go/plugin/go.d/collector/sensors/metadata.yaml
+++ b/src/go/plugin/go.d/collector/sensors/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://hwmon.wiki.kernel.org/lm_sensors
         icon_filename: "microchip.svg"
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
       keywords:
         - sensors
         - temperature

--- a/src/go/plugin/go.d/collector/smartctl/metadata.yaml
+++ b/src/go/plugin/go.d/collector/smartctl/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: "https://linux.die.net/man/8/smartd"
         icon_filename: "smart.png"
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
       keywords:
         - smart
         - S.M.A.R.T.

--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: ""
         icon_filename: snmp.png
         categories:
-          - data-collection.generic-data-collection
+          - data-collection.applications
       keywords:
         # Protocol/generic
         - snmp

--- a/src/go/plugin/go.d/collector/spigotmc/metadata.yaml
+++ b/src/go/plugin/go.d/collector/spigotmc/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: SpigotMC
         link: https://www.spigotmc.org/
         categories:
-          - data-collection.gaming
+          - data-collection.applications
         icon_filename: "spigot.jfif"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/sql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/sql/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: SQL databases (generic)
         link: https://en.wikipedia.org/wiki/SQL
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
         icon_filename: sql.svg
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/squid/metadata.yaml
+++ b/src/go/plugin/go.d/collector/squid/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Squid
         link: "https://www.squid-cache.org/"
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
         icon_filename: "squid.png"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/squidlog/metadata.yaml
+++ b/src/go/plugin/go.d/collector/squidlog/metadata.yaml
@@ -6,10 +6,10 @@ modules:
       module_name: squidlog
       monitored_instance:
         name: Squid log files
-        link: https://www.lighttpd.net/
+        link: http://www.squid-cache.org/
         icon_filename: squid.png
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
       keywords:
         - squid
         - logs

--- a/src/go/plugin/go.d/collector/storcli/metadata.yaml
+++ b/src/go/plugin/go.d/collector/storcli/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: "https://docs.broadcom.com/doc/12352476"
         icon_filename: "hard-drive.svg"
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords:
         - storage
         - raid-controller

--- a/src/go/plugin/go.d/collector/supervisord/metadata.yaml
+++ b/src/go/plugin/go.d/collector/supervisord/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: http://supervisord.org/
         icon_filename: supervisord.png
         categories:
-          - data-collection.processes-and-system-services
+          - data-collection.operating-systems
       keywords:
         - supervisor
       related_resources:

--- a/src/go/plugin/go.d/collector/systemdunits/metadata.yaml
+++ b/src/go/plugin/go.d/collector/systemdunits/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.freedesktop.org/wiki/Software/systemd/
         icon_filename: systemd.svg
         categories:
-          - data-collection.systemd
+          - data-collection.operating-systems
       keywords:
         - systemd
       related_resources:

--- a/src/go/plugin/go.d/collector/tengine/metadata.yaml
+++ b/src/go/plugin/go.d/collector/tengine/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://tengine.taobao.org/
         icon_filename: tengine.jpeg
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
       keywords:
         - tengine
         - web

--- a/src/go/plugin/go.d/collector/tomcat/metadata.yaml
+++ b/src/go/plugin/go.d/collector/tomcat/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Tomcat
         link: "https://tomcat.apache.org/"
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
         icon_filename: "tomcat.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/tor/metadata.yaml
+++ b/src/go/plugin/go.d/collector/tor/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Tor
         link: https://www.torproject.org/
         categories:
-          - data-collection.vpns
+          - data-collection.networking
         icon_filename: "tor.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/traefik/metadata.yaml
+++ b/src/go/plugin/go.d/collector/traefik/metadata.yaml
@@ -6,10 +6,10 @@ modules:
       module_name: traefik
       monitored_instance:
         name: Traefik
-        link: Traefik
+        link: https://traefik.io/
         icon_filename: traefik.svg
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
       keywords:
         - traefik
         - proxy

--- a/src/go/plugin/go.d/collector/typesense/metadata.yaml
+++ b/src/go/plugin/go.d/collector/typesense/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Typesense
         link: https://typesense.org/
         categories:
-          - data-collection.search-engines
+          - data-collection.databases
         icon_filename: typesense.svg
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/unbound/metadata.yaml
+++ b/src/go/plugin/go.d/collector/unbound/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://nlnetlabs.nl/projects/unbound/about/
         icon_filename: unbound.png
         categories:
-          - data-collection.dns-and-dhcp-servers
+          - data-collection.networking
       keywords:
         - unbound
         - dns

--- a/src/go/plugin/go.d/collector/upsd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/upsd/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: ""
         icon_filename: plug-circle-bolt.svg
         categories:
-          - data-collection.ups
+          - data-collection.hardware-and-iot
       keywords:
         - ups
         - nut

--- a/src/go/plugin/go.d/collector/uwsgi/metadata.yaml
+++ b/src/go/plugin/go.d/collector/uwsgi/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: uWSGI
         link: https://uwsgi-docs.readthedocs.io/en/latest/
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
         icon_filename: "uwsgi.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/varnish/metadata.yaml
+++ b/src/go/plugin/go.d/collector/varnish/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: Varnish
         link: https://varnish-cache.org/
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
         icon_filename: "varnish.svg"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/vcsa/metadata.yaml
+++ b/src/go/plugin/go.d/collector/vcsa/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcsa.doc/GUID-223C2821-BD98-4C7A-936B-7DBE96291BA4.html
         icon_filename: vmware.svg
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - vmware
       related_resources:

--- a/src/go/plugin/go.d/collector/vernemq/metadata.yaml
+++ b/src/go/plugin/go.d/collector/vernemq/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://vernemq.com
         icon_filename: vernemq.svg
         categories:
-          - data-collection.message-brokers
+          - data-collection.databases
       keywords:
         - vernemq
         - message brokers

--- a/src/go/plugin/go.d/collector/vsphere/metadata.yaml
+++ b/src/go/plugin/go.d/collector/vsphere/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.vmware.com/products/vcenter-server.html
         icon_filename: vmware.svg
         categories:
-          - data-collection.containers-and-vms
+          - data-collection.containers-and-orchestration
       keywords:
         - vmware
         - esxi

--- a/src/go/plugin/go.d/collector/w1sensor/metadata.yaml
+++ b/src/go/plugin/go.d/collector/w1sensor/metadata.yaml
@@ -7,7 +7,7 @@ modules:
         name: 1-Wire Sensors
         link: "https://www.analog.com/en/product-category/1wire-temperature-sensors.html"
         categories:
-          - data-collection.hardware-devices-and-sensors
+          - data-collection.hardware-and-iot
         icon_filename: "1-wire.png"
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/weblog/metadata.yaml
+++ b/src/go/plugin/go.d/collector/weblog/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: Web server log files
         link: ""
         categories:
-          - data-collection.web-servers-and-web-proxies
+          - data-collection.web-servers-and-proxies
         icon_filename: webservers.svg
       keywords:
         - webserver

--- a/src/go/plugin/go.d/collector/whoisquery/metadata.yaml
+++ b/src/go/plugin/go.d/collector/whoisquery/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: ""
         icon_filename: globe.svg
         categories:
-          - data-collection.synthetic-checks
+          - data-collection.synthetic-testing
       keywords:
         - whois
       related_resources:

--- a/src/go/plugin/go.d/collector/wireguard/metadata.yaml
+++ b/src/go/plugin/go.d/collector/wireguard/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: WireGuard
         link: https://www.wireguard.com/
         categories:
-          - data-collection.vpns
+          - data-collection.networking
         icon_filename: wireguard.svg
       keywords:
         - wireguard

--- a/src/go/plugin/go.d/collector/x509check/metadata.yaml
+++ b/src/go/plugin/go.d/collector/x509check/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: X.509 certificate
         link: ""
         categories:
-          - data-collection.synthetic-checks
+          - data-collection.synthetic-testing
         icon_filename: lock.svg
       keywords:
         - x509

--- a/src/go/plugin/go.d/collector/yugabytedb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/yugabytedb/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: YugabyteDB
         link: https://www.yugabyte.com/yugabytedb
         categories:
-          - data-collection.database-servers
+          - data-collection.databases
         icon_filename: yugabytedb.svg
       related_resources:
         integrations:

--- a/src/go/plugin/go.d/collector/zfspool/metadata.yaml
+++ b/src/go/plugin/go.d/collector/zfspool/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: ""
         icon_filename: filesystem.svg
         categories:
-          - data-collection.storage-mount-points-and-filesystems
+          - data-collection.storage
       keywords:
         - zfs pools
         - pools

--- a/src/go/plugin/go.d/collector/zookeeper/metadata.yaml
+++ b/src/go/plugin/go.d/collector/zookeeper/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         name: ZooKeeper
         link: https://zookeeper.apache.org/
         categories:
-          - data-collection.service-discovery-registry
+          - data-collection.applications
         icon_filename: zookeeper.svg
       keywords:
         - zookeeper


### PR DESCRIPTION
## Summary

- **Restructure integration categories**: Consolidate 74 categories (42 under data-collection) into 10 clean, flat categories. Remove 19 unused categories and 4-level deep nesting. Update all 151 metadata.yaml files.
- **Fix broken related_resources lookup**: The mechanism that links related integrations (e.g., nginx → web_log) was completely non-functional — references never matched actual IDs. Implement a 3-level cascading lookup and fix 22 broken references across 10 metadata.yaml files.
- **Fix schema validation**: Add `heatmap` chart type to collector.json schema (used by k8s_apiserver).
- **Add guides infrastructure + Proxmox guide**: New `src/collectors/guides/` directory for multi-collector integration guides. First guide: Proxmox VE monitoring — ties together cgroups, proc, apps, ZFS, Ceph, SMART, and sensors collectors.

### Category restructuring

The previous `data-collection` category had 42 children, many with 1–3 integrations, and nesting up to 4 levels deep (e.g., `data-collection.linux-systems.filesystem-metrics.btrfs` for a single integration). 19 defined categories had zero collectors assigned.

New flat structure (10 categories):

| Category | Count |
|---|---:|
| Operating Systems | 121 |
| Applications | 65 |
| Databases | 51 |
| Hardware & IoT | 44 |
| Networking | 36 |
| Containers & Orchestration | 32 |
| Cloud & DevOps | 23 |
| Web Servers & Proxies | 22 |
| Storage | 22 |
| Synthetic Testing | 11 |

### related_resources fix

The `related_resources` mechanism was broken since its inception — `make_id()` produced IDs like `plugin-module-000_unknown` for references (which lack a monitored instance name), but actual integration IDs use the real instance name (e.g., `plugin-module-HTTP_Endpoints`). They never matched. The fix:

- Implement cascading lookup: plugin+module+instance → plugin+module → plugin-only
- Make `module_name` optional in schema, add `monitored_instance_name` for precise references
- Fix 19 cases of `module_name: cgroups` → `/sys/fs/cgroup` and 3 cases of `weblog` → `web_log`

### Guides infrastructure

New `src/collectors/guides/{name}/metadata.yaml` structure for integration guides that combine multiple collectors. The generator picks these up via `COLLECTOR_SOURCES`. First guide: Proxmox VE monitoring with 12 related integrations.

## Test plan

- [ ] `gen_integrations.py` runs with zero warnings
- [ ] All category IDs in metadata.yaml files map to valid categories in categories.yaml
- [ ] Proxmox guide appears in generated integrations output
- [ ] Related resources links resolve correctly for nginx, apache, lighttpd, etc.
- [ ] CI integration regeneration succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restruct assign data-collection categories into 10 flat groups for simpler navigation and updated all integration metadata to the Parsons IDs. Fix sop related_resources with a cascading, multi‑match lookup and schema updates, and added a Pro doubl downstream guide.

- **New Features**
  - Added guides infrastructure ( logistic/collectors/g Tenides/, included in COLLECTOR_SOURCES) and a Proxmox VE guide linking cgroups, proc, apps, ZFS, Ceph, SMART, and sensors.

- **Bug Fixes**
  - related_resources: cascading lookup (plugin+module+instance → plugin+module), supports multiple matches, skips plugin‑only fallback when module_name is set, and ignores self/duplicates. Schema: module_name optional, monitored_instance_name added. Fixed 22 bad references (e.g., cgroups → /sys/fs/cgroup, weblog → web_log).
  - Added heatmap to collector.json chart_type enum to clear k8s_apiserver validation warnings.

<sup>Written for commit 06091af98a3d0fce12830bc3a33d7b2a868742e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

