### PR TITLE
Fix the yaml map

### DIFF
--- a/docs/.map/map.csv
+++ b/docs/.map/map.csv
@@ -139,15 +139,15 @@ https://github.com/netdata/netdata/edit/master/src/web/api/exporters/shell/READM
 ,,,,,
 ,,,,,
 logs_integrations,,,,,
-https://github.com/netdata/netdata/edit/master/docs/logs/README.md,Journal Viewer Plugin,Published,Logs/Systemd Journal Logs,,View and analyze logs available in systemd journal
-https://github.com/netdata/netdata/edit/master/docs/logs/forward_secure_sealing.md,Forward Secure Sealing (FSS) in Systemd-Journal,Published,Logs/Systemd Journal Logs,,
+https://github.com/netdata/netdata/edit/master/src/collectors/systemd-journal.plugin/README.md,Systemd Journal Plugin Reference,Published,Logs/Systemd Journal Logs,,View and analyze logs available in systemd journal
+https://github.com/netdata/netdata/edit/master/src/collectors/systemd-journal.plugin/forward_secure_sealing.md,Forward Secure Sealing (FSS) in Systemd-Journal,Published,Logs/Systemd Journal Logs,,
 https://github.com/netdata/netdata/edit/master/src/collectors/windows-events.plugin/README.md,Windows Events Plugin Reference,Published,Logs/Windows Event Logs,,
 https://github.com/netdata/netdata/edit/master/src/collectors/log2journal/README.md,log2journal,Published,Logs/log2journal,,
 https://github.com/netdata/netdata/edit/master/src/libnetdata/log/systemd-cat-native.md,systemd-cat-native,Published,Logs/systemd-cat-native,,
 https://github.com/netdata/netdata/edit/master/docs/observability-centralization-points/logs-centralization-points-with-systemd-journald/README.md,Logs Centralization Points with systemd-journald,Published,Logs/Logs Centralization Points with systemd-journald,,
 https://github.com/netdata/netdata/edit/master/docs/observability-centralization-points/logs-centralization-points-with-systemd-journald/passive-journal-centralization-with-encryption-using-self-signed-certificates.md,Passive journal centralization with encryption using self-signed certificates,Published,Logs/Logs Centralization Points with systemd-journald,,
 https://github.com/netdata/netdata/edit/master/docs/observability-centralization-points/logs-centralization-points-with-systemd-journald/passive-journal-centralization-without-encryption.md,Passive journal centralization without encryption,Published,Logs/Logs Centralization Points with systemd-journald,,
-https://github.com/netdata/netdata/edit/master/docs/logs/active_journal_centralization_guide_no_encryption.md,Active journal source without encryption,Published,Logs/Logs Centralization Points with systemd-journald,,
+https://github.com/netdata/netdata/edit/master/src/collectors/systemd-journal.plugin/active_journal_centralization_guide_no_encryption.md,Active journal source without encryption,Published,Logs/Logs Centralization Points with systemd-journald,,
 ,,,,,
 ,,,,,
 https://github.com/netdata/netdata/edit/master/docs/top-monitoring-netdata-functions.md,Top Consumers,Published,Top Consumers,,Present the Netdata Functions what these are and why they should be used.
@@ -221,6 +221,7 @@ https://github.com/netdata/netdata/edit/master/docs/dashboards-and-charts/visual
 ,,,,,
 ,,,,,
 https://github.com/netdata/netdata/edit/master/docs/security-and-privacy-design/README.md,Security and Privacy Design,Published,Security and Privacy Design,,
+https://github.com/netdata/netdata/edit/master/docs/netdata-oss-limitations.md,Access Control and Feature Availability,Published,Security and Privacy Design,,Feature availability across Anonymous access Netdata Cloud Community and Business tiers
 https://github.com/netdata/netdata/edit/master/docs/security-and-privacy-design/netdata-agent-security.md,Netdata Agent,Published,Security and Privacy Design,,
 https://github.com/netdata/netdata/edit/master/docs/security-and-privacy-design/netdata-cloud-security.md,Netdata Cloud,Published,Security and Privacy Design,,
 ,,,,,


### PR DESCRIPTION
##### Summary

people reverted csv map but yaml lagged behind. @ilyam8 I wanna merge the ingest changes today, and we can remove the csv map forever


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the docs navigation YAML to fix stale Systemd Journal links and labels, and added the missing “Access Control and Feature Availability” page. This aligns the map with current file locations and prevents broken edit links.

- **Bug Fixes**
  - Renamed “Journal Viewer Plugin” to “Systemd Journal Plugin Reference”.
  - Pointed Systemd Journal docs and FSS guide to src/collectors/systemd-journal.plugin paths.
  - Fixed the “Active journal source without encryption” edit_url.

- **New Features**
  - Added “Access Control and Feature Availability” under Security and Privacy Design.

<sup>Written for commit 48b3fb53cc3b0dcc25674aef42c0f1a41ad0c9e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

