### PR TITLE
Update docs to reference Cloud MCP alongside Agent/Parent MCP

### DIFF
--- a/docs/getting-started-netdata/guide.md
+++ b/docs/getting-started-netdata/guide.md
@@ -285,11 +285,11 @@ Transform troubleshooting from complex queries to natural conversation. Ask ques
 <details>
 <summary><strong>Model Context Protocol (MCP) Integration</strong></summary><br/>
 
-Every Netdata Agent and Parent is an MCP server, enabling seamless integration with AI assistants for natural language queries and automated analysis.
+MCP is available via Netdata Cloud for infrastructure-wide access (Business/Homelab plan) and on every Agent/Parent for direct local access (free, open-source), enabling seamless integration with AI assistants for natural language queries and automated analysis.
 
 **Why this matters:** Use your existing AI tools or our standalone web chat with choice of AI providers. Query live metrics, logs, processes, network connections, and system state securely.
 
-**Technical details:** MCP integration via WebSocket, choice of Claude, GPT-4, Gemini and others, two deployment options available, real-time data access, secure connection where LLM has access to your data via the LLM client.
+**Technical details:** MCP integration via WebSocket/HTTP, choice of Claude, GPT-4, Gemini and others, multiple deployment options (Cloud MCP, Agent MCP, Parent MCP), real-time data access, secure connection where LLM has access to your data via the LLM client.
 
 </details>
 

--- a/docs/netdata-enterprise-evaluation-corrected.md
+++ b/docs/netdata-enterprise-evaluation-corrected.md
@@ -179,7 +179,7 @@ For logs, standard systemd-journal practices apply.
 
 For alert notifications, Netdata supports PagerDuty, Slack, Teams, email (SMTP), Discord, Telegram, Jira, ServiceNow, and custom webhooks.
 
-For AI and Large Language Models, Netdata supports Model Context Protocol (MCP), supports AI DevOps/SRE Copilots like Claude Code and Gemini CLI, and provides an AI Chat application (access to Google, OpenAI, Anthropic LLMs is required).
+For AI and Large Language Models, Netdata supports Model Context Protocol (MCP) — available via Netdata Cloud for infrastructure-wide access (Business/Homelab plan) and on every Agent/Parent for direct local access (free, open-source). Netdata supports AI DevOps/SRE Copilots like Claude Code and Gemini CLI, and provides an AI Chat application (access to Google, OpenAI, Anthropic LLMs is required).
 
 ## Compliance and Security
 

--- a/docs/netdata-oss-limitations.md
+++ b/docs/netdata-oss-limitations.md
@@ -86,9 +86,12 @@ Functions provide on-demand, detailed information beyond standard metrics.
 
 ## MCP (Model Context Protocol)
 
-Netdata's MCP server is available directly at Netdata Agents and Parents, independent of Netdata Cloud authentication. This allows AI assistants and tools to query metrics and execute functions through the MCP protocol.
+Netdata provides MCP in two ways:
 
-When accessing Netdata via MCP:
+- **Netdata Cloud MCP** at `app.netdata.cloud/api/v1/mcp` — infrastructure-wide access to all your nodes (requires Business or Homelab plan)
+- **Agent/Parent MCP** — available directly at Netdata Agents and Parents, free and open-source
+
+When accessing Netdata via Agent/Parent MCP:
 
 - **Without Cloud connection**: MCP can access public functions and metrics, but sensitive functions follow the same restrictions as the dashboard
 - **With Cloud connection**: MCP inherits the user's Cloud permissions, enabling access to sensitive functions for authenticated users

--- a/docs/reporting.md
+++ b/docs/reporting.md
@@ -74,7 +74,12 @@ factors, and remediation recommendations.
 
 Connect your AI assistant directly to Netdata using the Model Context Protocol (MCP). Ask questions in natural language and receive answers based on live infrastructure data.
 
-Every Netdata Agent and Parent (v2.6.0+) includes an MCP server. AI assistants can query metrics, alerts, logs, and live system information across your entire infrastructure.
+MCP is available in two ways:
+
+- **Netdata Cloud MCP** at `app.netdata.cloud/api/v1/mcp` — infrastructure-wide access to all your nodes (Business/Homelab plan)
+- **Agent/Parent MCP** on every Netdata Agent and Parent (v2.6.0+) — direct local access (free, open-source)
+
+AI assistants can query metrics, alerts, logs, and live system information across your entire infrastructure.
 
 ### Supported AI clients
 
@@ -112,9 +117,10 @@ Once connected, ask natural language questions:
 
 ### Availability
 
-- Available on all plans (v2.6.0+)
+- **Cloud MCP**: Available on Business and Homelab plans — infrastructure-wide access, zero local setup
+- **Agent/Parent MCP**: Available on all plans (v2.6.0+) — free, open-source, direct local access
 - Unlimited queries with no per-query charges
-- Requires API key for access to sensitive data
+- Requires API key (Cloud token or local API key) for access
 
 See [Netdata MCP](/docs/netdata-ai/mcp/README.md) for detailed setup instructions.
 

--- a/docs/welcome-to-netdata.md
+++ b/docs/welcome-to-netdata.md
@@ -226,7 +226,7 @@ Netdata thrives as part of a vibrant open-source community with 1.5 million down
 - **Metrics export**: Exports metrics to all open standards and commonly used time-series databases (Prometheus, Graphite, InfluxDB, OpenTSDB, and more)
 - **Logs**: Uses battle tested systemd journal files for storing logs, providing maximum interoperability
 - **Alert routing**: Delivers notifications to PagerDuty, Slack, email, webhooks, and 20+ platforms
-- **AI integration**: Supports AI assistants via Model Context Protocol (MCP)
+- **AI integration**: Supports AI assistants via Model Context Protocol (MCP) — available via Netdata Cloud (infrastructure-wide) and on every Agent/Parent (local access)
 - **Visualization**: Works with Grafana through native datasource plugin
 - **Container orchestration**: Integrates with Kubernetes, Docker Swarm, and Nomad
 
@@ -250,7 +250,7 @@ Netdata will automatically provide:
 3. Live and interactive exploration of running **processes**, **network connections**, **systemd units**, **systemd services**, **IMPI sensors**, and more
 4. Unsupervised **machine-learning based anomaly detection** for all metrics
 5. Hundreds of **pre-configured alerts** for systems and applications
-6. **AI insights** (reports) and **AI-assistant** (chat) connections via MCP
+6. **AI insights** (reports) and **AI-assistant** (chat) connections via MCP (Cloud MCP for infrastructure-wide access, Agent/Parent MCP for local access)
 
 :::tip
 


### PR DESCRIPTION
## Summary

- Updated 5 documentation pages to mention Netdata Cloud MCP (`app.netdata.cloud/api/v1/mcp`) alongside existing Agent/Parent MCP
- Cloud-first ordering: Cloud MCP (infrastructure-wide, Business/Homelab plan) is mentioned before Agent/Parent MCP (local, free, open-source)
- Follows the same pattern applied to the main MCP documentation in #21736

### Files changed

- `docs/reporting.md` — Added Cloud MCP and Agent/Parent MCP as two distinct options
- `docs/netdata-oss-limitations.md` — Rewrote MCP section to describe both access paths
- `docs/welcome-to-netdata.md` — Updated AI integration bullet and feature list
- `docs/getting-started-netdata/guide.md` — Updated MCP Integration collapsible section
- `docs/netdata-enterprise-evaluation-corrected.md` — Updated MCP description

## Test plan

- [x] Docusaurus build passes
- [x] Review updated pages on staging for messaging consistency

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated five docs to include Netdata Cloud MCP alongside Agent/Parent MCP, with cloud-first ordering. Adds the Cloud MCP endpoint (app.netdata.cloud/api/v1/mcp), clarifies plan requirements and access modes (Business/Homelab vs free local), and refreshes AI integration wording and technical details.

<sup>Written for commit 92db202052b8ee1891f528e628f702e2f215db2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

