### PR TITLE
Add cross-references between Kubernetes integrations

### DIFF
--- a/src/collectors/cgroups.plugin/integrations/kubernetes_containers.md
+++ b/src/collectors/cgroups.plugin/integrations/kubernetes_containers.md
@@ -33,6 +33,14 @@ This collector is only supported on the following platforms:
 This collector supports collecting metrics from multiple instances of this integration, including remote instances.
 
 
+Kubernetes Containers can be monitored further using the following other integrations:
+
+- {% relatedResource id="go.d.plugin-k8s_state-Kubernetes_Cluster_State" %}Kubernetes Cluster State{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_apiserver-Kubernetes_API_Server" %}Kubernetes API Server{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_kubelet-Kubelet" %}Kubelet{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_kubeproxy-Kubeproxy" %}Kubeproxy{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-coredns-CoreDNS" %}CoreDNS{% /relatedResource %}
+
 ### Default Behavior
 
 #### Auto-Detection

--- a/src/collectors/cgroups.plugin/metadata.yaml
+++ b/src/collectors/cgroups.plugin/metadata.yaml
@@ -451,6 +451,19 @@ modules:
         - cri-o
         - kubelet
         - kubepods
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: go.d.plugin
+              module_name: k8s_state
+            - plugin_name: go.d.plugin
+              module_name: k8s_apiserver
+            - plugin_name: go.d.plugin
+              module_name: k8s_kubelet
+            - plugin_name: go.d.plugin
+              module_name: k8s_kubeproxy
+            - plugin_name: go.d.plugin
+              module_name: coredns
       most_popular: true
     overview:
       <<: *overview

--- a/src/go/plugin/go.d/collector/coredns/integrations/coredns.md
+++ b/src/go/plugin/go.d/collector/coredns/integrations/coredns.md
@@ -32,6 +32,14 @@ This collector is supported on all platforms.
 This collector supports collecting metrics from multiple instances of this integration, including remote instances.
 
 
+CoreDNS can be monitored further using the following other integrations:
+
+- {% relatedResource id="go.d.plugin-k8s_state-Kubernetes_Cluster_State" %}Kubernetes Cluster State{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_apiserver-Kubernetes_API_Server" %}Kubernetes API Server{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_kubelet-Kubelet" %}Kubelet{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_kubeproxy-Kubeproxy" %}Kubeproxy{% /relatedResource %}
+- {% relatedResource id="cgroups.plugin-/sys/fs/cgroup-Kubernetes_Containers" %}Kubernetes Containers{% /relatedResource %}
+
 ### Default Behavior
 
 #### Auto-Detection

--- a/src/go/plugin/go.d/collector/coredns/metadata.yaml
+++ b/src/go/plugin/go.d/collector/coredns/metadata.yaml
@@ -16,7 +16,18 @@ modules:
         - kubernetes
       related_resources:
         integrations:
-          list: []
+          list:
+            - plugin_name: go.d.plugin
+              module_name: k8s_state
+            - plugin_name: go.d.plugin
+              module_name: k8s_apiserver
+            - plugin_name: go.d.plugin
+              module_name: k8s_kubelet
+            - plugin_name: go.d.plugin
+              module_name: k8s_kubeproxy
+            - plugin_name: cgroups.plugin
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: "Kubernetes Containers"
       info_provided_to_referring_integrations:
         description: ""
       most_popular: false

--- a/src/go/plugin/go.d/collector/k8s_apiserver/integrations/kubernetes_api_server.md
+++ b/src/go/plugin/go.d/collector/k8s_apiserver/integrations/kubernetes_api_server.md
@@ -51,6 +51,8 @@ Kubernetes API Server can be monitored further using the following other integra
 - {% relatedResource id="go.d.plugin-k8s_kubelet-Kubelet" %}Kubelet{% /relatedResource %}
 - {% relatedResource id="go.d.plugin-k8s_kubeproxy-Kubeproxy" %}Kubeproxy{% /relatedResource %}
 - {% relatedResource id="go.d.plugin-k8s_state-Kubernetes_Cluster_State" %}Kubernetes Cluster State{% /relatedResource %}
+- {% relatedResource id="cgroups.plugin-/sys/fs/cgroup-Kubernetes_Containers" %}Kubernetes Containers{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-coredns-CoreDNS" %}CoreDNS{% /relatedResource %}
 
 ### Default Behavior
 

--- a/src/go/plugin/go.d/collector/k8s_apiserver/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_apiserver/metadata.yaml
@@ -24,6 +24,11 @@ modules:
               module_name: k8s_kubeproxy
             - plugin_name: go.d.plugin
               module_name: k8s_state
+            - plugin_name: cgroups.plugin
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: "Kubernetes Containers"
+            - plugin_name: go.d.plugin
+              module_name: coredns
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true

--- a/src/go/plugin/go.d/collector/k8s_kubelet/integrations/kubelet.md
+++ b/src/go/plugin/go.d/collector/k8s_kubelet/integrations/kubelet.md
@@ -35,6 +35,11 @@ This collector supports collecting metrics from multiple instances of this integ
 Kubelet can be monitored further using the following other integrations:
 
 - {% relatedResource id="apps.plugin-apps-Applications" %}Applications{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_state-Kubernetes_Cluster_State" %}Kubernetes Cluster State{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_apiserver-Kubernetes_API_Server" %}Kubernetes API Server{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_kubeproxy-Kubeproxy" %}Kubeproxy{% /relatedResource %}
+- {% relatedResource id="cgroups.plugin-/sys/fs/cgroup-Kubernetes_Containers" %}Kubernetes Containers{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-coredns-CoreDNS" %}CoreDNS{% /relatedResource %}
 
 ### Default Behavior
 

--- a/src/go/plugin/go.d/collector/k8s_kubelet/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_kubelet/metadata.yaml
@@ -19,6 +19,17 @@ modules:
           list:
             - plugin_name: apps.plugin
               module_name: apps
+            - plugin_name: go.d.plugin
+              module_name: k8s_state
+            - plugin_name: go.d.plugin
+              module_name: k8s_apiserver
+            - plugin_name: go.d.plugin
+              module_name: k8s_kubeproxy
+            - plugin_name: cgroups.plugin
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: "Kubernetes Containers"
+            - plugin_name: go.d.plugin
+              module_name: coredns
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true

--- a/src/go/plugin/go.d/collector/k8s_kubeproxy/integrations/kubeproxy.md
+++ b/src/go/plugin/go.d/collector/k8s_kubeproxy/integrations/kubeproxy.md
@@ -35,6 +35,11 @@ This collector supports collecting metrics from multiple instances of this integ
 Kubeproxy can be monitored further using the following other integrations:
 
 - {% relatedResource id="apps.plugin-apps-Applications" %}Applications{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_state-Kubernetes_Cluster_State" %}Kubernetes Cluster State{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_apiserver-Kubernetes_API_Server" %}Kubernetes API Server{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_kubelet-Kubelet" %}Kubelet{% /relatedResource %}
+- {% relatedResource id="cgroups.plugin-/sys/fs/cgroup-Kubernetes_Containers" %}Kubernetes Containers{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-coredns-CoreDNS" %}CoreDNS{% /relatedResource %}
 
 ### Default Behavior
 

--- a/src/go/plugin/go.d/collector/k8s_kubeproxy/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_kubeproxy/metadata.yaml
@@ -19,6 +19,17 @@ modules:
           list:
             - plugin_name: apps.plugin
               module_name: apps
+            - plugin_name: go.d.plugin
+              module_name: k8s_state
+            - plugin_name: go.d.plugin
+              module_name: k8s_apiserver
+            - plugin_name: go.d.plugin
+              module_name: k8s_kubelet
+            - plugin_name: cgroups.plugin
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: "Kubernetes Containers"
+            - plugin_name: go.d.plugin
+              module_name: coredns
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true

--- a/src/go/plugin/go.d/collector/k8s_state/integrations/kubernetes_cluster_state.md
+++ b/src/go/plugin/go.d/collector/k8s_state/integrations/kubernetes_cluster_state.md
@@ -32,6 +32,14 @@ This collector is supported on all platforms.
 This collector only supports collecting metrics from a single instance of this integration.
 
 
+Kubernetes Cluster State can be monitored further using the following other integrations:
+
+- {% relatedResource id="go.d.plugin-k8s_apiserver-Kubernetes_API_Server" %}Kubernetes API Server{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_kubelet-Kubelet" %}Kubelet{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-k8s_kubeproxy-Kubeproxy" %}Kubeproxy{% /relatedResource %}
+- {% relatedResource id="cgroups.plugin-/sys/fs/cgroup-Kubernetes_Containers" %}Kubernetes Containers{% /relatedResource %}
+- {% relatedResource id="go.d.plugin-coredns-CoreDNS" %}CoreDNS{% /relatedResource %}
+
 ### Default Behavior
 
 #### Auto-Detection

--- a/src/go/plugin/go.d/collector/k8s_state/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_state/metadata.yaml
@@ -15,7 +15,18 @@ modules:
         - k8s
       related_resources:
         integrations:
-          list: []
+          list:
+            - plugin_name: go.d.plugin
+              module_name: k8s_apiserver
+            - plugin_name: go.d.plugin
+              module_name: k8s_kubelet
+            - plugin_name: go.d.plugin
+              module_name: k8s_kubeproxy
+            - plugin_name: cgroups.plugin
+              module_name: /sys/fs/cgroup
+              monitored_instance_name: "Kubernetes Containers"
+            - plugin_name: go.d.plugin
+              module_name: coredns
       info_provided_to_referring_integrations:
         description: ""
       most_popular: true


### PR DESCRIPTION
## Summary
- Links k8s_state, k8s_apiserver, k8s_kubelet, k8s_kubeproxy, cgroups "Kubernetes Containers", and CoreDNS as related resources in their metadata.yaml files
- Each integration now references all the others, so users can discover the full K8s monitoring stack from any single integration page
- Regenerated integration docs to reflect the new cross-references

## Test plan
- [ ] Verify `python3 integrations/gen_integrations.py` runs without errors
- [ ] Verify `python3 integrations/gen_docs_integrations.py` runs without errors
- [ ] Verify each K8s integration page shows related resources section listing all others

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add cross-references across Kubernetes integrations so users can navigate the full K8s monitoring stack from any page. Updates metadata and docs to surface Related resources links for k8s_state, k8s_apiserver, k8s_kubelet, k8s_kubeproxy, CoreDNS, and Kubernetes Containers.

- **New Features**
  - Added related_resources entries across all K8s integrations listed above.
  - Updated integration pages to display the Related resources section linking the others.

<sup>Written for commit 01e947b11ee49e434af82bf8dd126e22c48bf2d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

