### PR TITLE
no such category

### DIFF
--- a/integrations/logs/metadata.yaml
+++ b/integrations/logs/metadata.yaml
@@ -42,7 +42,6 @@
     link: "https://github.com/netdata/netdata/blob/master/src/collectors/windows-events.plugin/README.md"
     categories:
       - logs
-      - data-collection.windows-systems
     icon_filename: "windows.svg"
   keywords:
     - windows


### PR DESCRIPTION
##### Summary

this is failing the website integrations generation, the category does not exist anymore after https://github.com/netdata/netdata/pull/21742/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the obsolete category "data-collection.windows-systems" from integrations/logs/metadata.yaml to fix the website build, since the category no longer exists.

<sup>Written for commit 5332f7686e12deb50020c09455d73e101a1ba8ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

