### PR TITLE
icons

### DIFF
--- a/src/collectors/cgroups.plugin/metadata.yaml
+++ b/src/collectors/cgroups.plugin/metadata.yaml
@@ -1130,7 +1130,7 @@ modules:
       monitored_instance:
         name: Podman Containers
         link: https://podman.io/
-        icon_filename: podman.svg
+        icon_filename: podman.png
         categories:
           - data-collection.containers-and-vms
       keywords:
@@ -1171,7 +1171,7 @@ modules:
       monitored_instance:
         name: Nomad Containers
         link: https://www.nomadproject.io/
-        icon_filename: nomad.svg
+        icon_filename: nomad.png
         categories:
           - data-collection.containers-and-vms
       keywords:
@@ -1190,7 +1190,7 @@ modules:
       monitored_instance:
         name: containerd Containers
         link: https://containerd.io/
-        icon_filename: containerd.svg
+        icon_filename: containerd.png
         categories:
           - data-collection.containers-and-vms
       keywords:
@@ -1230,7 +1230,7 @@ modules:
       monitored_instance:
         name: OpenShift Containers
         link: https://www.redhat.com/en/technologies/cloud-computing/openshift
-        icon_filename: openshift.svg
+        icon_filename: openshift.png
         categories:
           - data-collection.containers-and-vms
       keywords:

--- a/src/exporting/prometheus/metadata.yaml
+++ b/src/exporting/prometheus/metadata.yaml
@@ -452,7 +452,7 @@
     <<: *meta
     name: GreptimeDB
     link: https://greptime.com/product/db
-    icon_filename: 'greptimedb.png'
+    icon_filename: 'greptimedb.svg'
     keywords:
       - export
       - GreptimeDB

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -512,7 +512,7 @@ modules:
       monitored_instance:
         name: ScyllaDB
         link: https://www.scylladb.com/
-        icon_filename: scylladb.png
+        icon_filename: scylladb.svg
         categories:
           - data-collection.databases
       keywords: [ ]
@@ -3150,7 +3150,7 @@ modules:
       monitored_instance:
         name: Keepalived
         link: https://github.com/gen2brain/keepalived_exporter
-        icon_filename: keepalived.png
+        icon_filename: Keepalived.png
         categories:
           - data-collection.networking
       keywords: [ ]

--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -7,7 +7,7 @@ modules:
       monitored_instance:
         name: SNMP devices
         link: ""
-        icon_filename: snmp.png
+        icon_filename: SNMP.png
         categories:
           - data-collection.networking
       keywords:

--- a/src/go/plugin/ibm.d/modules/as400/metadata.yaml
+++ b/src/go/plugin/ibm.d/modules/as400/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.ibm.com/products/power-systems
         categories:
           - data-collection.operating-systems
-        icon_filename: "ibm-i.svg"
+        icon_filename: "ibm-i.png"
       related_resources:
         integrations:
           list: []

--- a/src/go/plugin/ibm.d/modules/as400/module.yaml
+++ b/src/go/plugin/ibm.d/modules/as400/module.yaml
@@ -137,7 +137,7 @@ description: |
   values on pre-7.4 systems.
 
   Network interface metrics have a fixed internal limit of 50 instances, and HTTP server metrics are capped at 200 instances; these limits are currently not configurable.
-icon: ibm-i.svg
+icon: ibm-i.png
 categories:
   - data-collection.operating-systems
 link: https://www.ibm.com/products/power-systems

--- a/src/go/plugin/ibm.d/modules/mq/metadata.yaml
+++ b/src/go/plugin/ibm.d/modules/mq/metadata.yaml
@@ -9,7 +9,7 @@ modules:
         link: https://www.ibm.com/products/mq
         categories:
           - data-collection.applications
-        icon_filename: "ibm-mq.svg"
+        icon_filename: "ibm-mq.png"
       related_resources:
         integrations:
           list: []

--- a/src/go/plugin/ibm.d/modules/mq/module.yaml
+++ b/src/go/plugin/ibm.d/modules/mq/module.yaml
@@ -16,7 +16,7 @@ description: |
   groups. Parallel queue-group charts summarise depth, traffic, and backlog per naming
   prefix (first two dot-separated segments, collapsing all `SYSTEM.*` queues together), so
   high-level visibility is never lost even when detailed charts are trimmed.
-icon: ibm-mq.svg
+icon: ibm-mq.png
 categories:
   - data-collection.applications
 link: https://www.ibm.com/products/mq

--- a/src/go/plugin/scripts.d/modules/nagios/metadata.yaml
+++ b/src/go/plugin/scripts.d/modules/nagios/metadata.yaml
@@ -7,7 +7,7 @@ modules:
       monitored_instance:
         name: Nagios Plugins
         link: https://www.nagios-plugins.org/
-        icon_filename: nagios.svg
+        icon_filename: nagios.png
         categories:
           - data-collection.synthetic-testing
       related_resources:

--- a/src/go/plugin/scripts.d/modules/scheduler/metadata.yaml
+++ b/src/go/plugin/scripts.d/modules/scheduler/metadata.yaml
@@ -7,7 +7,7 @@ modules:
       monitored_instance:
         name: scripts.d Scheduler
         link: ""
-        icon_filename: netdata.svg
+        icon_filename: netdata-logomark.svg
         categories:
           - data-collection.applications
       related_resources:


### PR DESCRIPTION
##### Summary

Fix icons pointed by @ktsaou, this goes hand-in-hand with https://github.com/netdata/website/pull/1126 which actually adds the missing files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed incorrect icon filenames in integration metadata so icons render correctly. This aligns with netdata/website PR #1126, which adds the missing assets.

- **Bug Fixes**
  - Containers: Podman, Nomad, containerd, OpenShift → .png.
  - Other integrations: GreptimeDB → .svg; ScyllaDB → .svg; Keepalived filename case; SNMP → SNMP.png; Nagios → .png; Scheduler → netdata-logomark.svg; IBM i and MQ → .png.

<sup>Written for commit b86ed9e49298a69c4f12acecab19c74d0b2c4c98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

