### PR TITLE
fix(scripts.d): reduce nagios perfdata chart registration log spam

### DIFF
--- a/src/go/plugin/scripts.d/modules/nagios/module.go
+++ b/src/go/plugin/scripts.d/modules/nagios/module.go
@@ -294,7 +294,6 @@ func (c *Collector) registerPerfdataChart(job spec.JobSpec, datum output.PerfDat
 	labelID := ids.Sanitize(label)
 	scale := units.NewScale(datum.Unit)
 	key := fmt.Sprintf("%s|%s", meta.JobKey, labelID)
-	c.Infof("nagios: registering perfdata chart scheduler=%s job=%s label=%s unit=%s", meta.Scheduler, job.Name, label, datum.Unit)
 	c.chartMu.Lock()
 	defer c.chartMu.Unlock()
 	if existing, ok := c.perfCharts[key]; ok {
@@ -306,6 +305,7 @@ func (c *Collector) registerPerfdataChart(job spec.JobSpec, datum output.PerfDat
 			chart.MarkRemove()
 		}
 	}
+	c.Infof("nagios: registering perfdata chart scheduler=%s job=%s label=%s unit=%s", meta.Scheduler, job.Name, label, datum.Unit)
 	chart := charts.PerfdataChart(meta, label, scale, 200)
 	if err := c.charts.Add(chart); err != nil {
 		c.Errorf("failed to add perfdata chart for job %s label %s: %v", job.Name, label, err)


### PR DESCRIPTION
Move the info log in registerPerfdataChart after the dedup check so it only fires when a chart is actually being created, not on every collection cycle.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce Nagios perfdata chart registration log spam by logging only when a chart is actually created. Moved the info log in registerPerfdataChart after the dedup check to avoid messages on every collection cycle.

<sup>Written for commit f19216d5bd65d8ba4a337b49e1b9c9806bf56f87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

