### PR TITLE
Rename function from otel-signal-viewer to otel-logs

### DIFF
--- a/src/crates/netdata-log-viewer/otel-signal-viewer-plugin/src/catalog.rs
+++ b/src/crates/netdata-log-viewer/otel-signal-viewer-plugin/src/catalog.rs
@@ -697,10 +697,8 @@ impl FunctionHandler for CatalogFunction {
         // calls in a consistent way. If you rename this function, you should
         // update the `rt` crate as well.
 
-        let mut func_decl = FunctionDeclaration::new(
-            "otel-signal-viewer",
-            "Query and visualize OpenTelemetry logs",
-        );
+        let mut func_decl =
+            FunctionDeclaration::new("otel-logs", "Query and visualize OpenTelemetry logs");
         func_decl.global = true;
         func_decl.tags = Some(String::from("logs"));
         func_decl.access =

--- a/src/crates/netdata-plugin/rt/src/lib.rs
+++ b/src/crates/netdata-plugin/rt/src/lib.rs
@@ -1000,7 +1000,7 @@ impl<R: AsyncRead + Unpin + Send, W: AsyncWrite + Unpin + Send> PluginRuntime<R,
         // we convert the frontend request from a GET to POST.
         let mut function_call = function_call;
         {
-            if function_call.name == "otel-signal-viewer" {
+            if function_call.name == "otel-logs" {
                 if !function_call.args.is_empty() {
                     let mut map = serde_json::Map::new();
                     map.insert("info".to_string(), serde_json::json!(true));


### PR DESCRIPTION
In theory, the same function can/should be used for querying traces/profiles, etc.

However, we can't be sure at this point if this will be possible. Pick the most
specific function name and use it to keep our options open.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the function from "otel-signal-viewer" to "otel-logs" to reflect its current scope (logs only). Updated the runtime to handle the new name; no behavior change.

- **Migration**
  - Update any references to "otel-signal-viewer" to "otel-logs" in callers/tests/config.

<sup>Written for commit b9572fc189bf73b303b20c5735de23065d09f84c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

