### PR TITLE
Add cmake render-docs target for integration doc generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ docs/diagrams/plantuml.jar
 
 # python virtual environment
 venv/
+virtualenv/
 .python-version
 
 # debugging / profiling
@@ -145,6 +146,10 @@ test-driver
 **/tests/*_testdriver
 **/tests/*_testdriver.trs
 python.d/python-modules-installer.sh
+
+# integration generated files
+integrations/integrations.js
+integrations/integrations.json
 
 # documentation generated files
 docs/generator/src

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4010,6 +4010,12 @@ if(OS_WINDOWS)
 endif()
 
 #
+# Optional: render integration docs from metadata.yaml
+#
+
+include(NetdataRenderDocs)
+
+#
 # Include packaging logic
 #
 

--- a/integrations/pip.sh
+++ b/integrations/pip.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+# If you change these dependencies, also update the pip install command in
+# packaging/cmake/Modules/NetdataRenderDocs.cmake
 exec pip install jsonschema referencing jinja2 ruamel.yaml

--- a/packaging/cmake/Modules/NetdataRenderDocs.cmake
+++ b/packaging/cmake/Modules/NetdataRenderDocs.cmake
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Optional target for regenerating integration documentation from metadata.yaml files.
+#
+# Usage:
+#   ninja -C build render-docs
+#
+# This target is never part of ALL, so it has zero impact on normal builds.
+# On first invocation it creates a Python venv in the build directory and
+# installs the required packages. Subsequent runs reuse the existing venv.
+
+include_guard()
+
+set(_render_docs_venv_dir "${CMAKE_BINARY_DIR}/_render_docs_venv")
+set(_render_docs_venv_stamp "${_render_docs_venv_dir}/.stamp")
+set(_render_docs_scripts_dir "${CMAKE_SOURCE_DIR}/integrations")
+
+add_custom_command(
+        OUTPUT "${_render_docs_venv_stamp}"
+        DEPENDS "${_render_docs_scripts_dir}/pip.sh"
+        COMMAND python3 -m venv "${_render_docs_venv_dir}"
+        COMMAND "${_render_docs_venv_dir}/bin/pip" install -q jsonschema referencing jinja2 ruamel.yaml
+        COMMAND "${CMAKE_COMMAND}" -E touch "${_render_docs_venv_stamp}"
+        COMMENT "Creating Python venv for render-docs"
+)
+
+add_custom_target(render-docs
+        DEPENDS "${_render_docs_venv_stamp}"
+        COMMAND "${_render_docs_venv_dir}/bin/python3" "${_render_docs_scripts_dir}/gen_integrations.py"
+        COMMAND "${_render_docs_venv_dir}/bin/python3" "${_render_docs_scripts_dir}/gen_docs_integrations.py"
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        COMMENT "Generating integration documentation from metadata.yaml files"
+)


### PR DESCRIPTION
Add a `render-docs` build target that automates the metadata.yaml to markdown pipeline. The target manages its own Python venv in the build directory and is never part of ALL, so it has zero impact on normal builds. Also add generated integration files and virtualenv/ to .gitignore.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional CMake target render-docs to generate integration docs from metadata.yaml without impacting normal builds. It creates and reuses a build-local Python venv, and ignores generated outputs in Git.

- **New Features**
  - New CMake module NetdataRenderDocs.cmake; included from CMakeLists.txt.
  - Usage: run ninja -C build render-docs; not part of ALL.
  - Bootstraps a build-local venv on first run and installs jsonschema, referencing, jinja2, ruamel.yaml; reused on subsequent runs.
  - Executes integrations/gen_integrations.py and gen_docs_integrations.py to render docs.
  - .gitignore updated to ignore integrations.js, integrations.json, and virtualenv/.

<sup>Written for commit 27e2b0cb7db74578b214f9d87da2e50ac8587f28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

