### PR TITLE
Clarify default storage retention limits in docs

### DIFF
--- a/docs/impact-on-resources.md
+++ b/docs/impact-on-resources.md
@@ -42,7 +42,7 @@ When deployed on an empty VM, Netdata collects and visualizes critical system me
 - **Metrics storage is limited to 3 GiB by default** (configurable), using 1 GiB per tier × 3 tiers. In total, with SQLite databases, alert transitions, and other metadata, expect about **4 GiB** of disk usage under normal conditions.
 - Default retention limits: per-second data for 1 GiB or 14 days, per-minute data for 1 GiB or 3 months, per-hour data for 1 GiB or 2 years.
 - The number of metrics collected determines how far back in time retention extends within these limits.
-- In practice, with about 4,000 metrics per second, Netdata provides about 14 days of per-second data, 3 months of per-minute data, and more than 1 year of per-hour data.
+- In practice, with an ingestion rate of about 4,000 metrics per second, Netdata provides about 14 days of per-second data, 3 months of per-minute data, and more than 1 year of per-hour data.
 - These limits are [fully configurable](/src/database/CONFIGURATION.md#tiers).
 
 ### Resource Consumption

--- a/docs/netdata-agent/sizing-netdata-agents/disk-requirements-and-retention.md
+++ b/docs/netdata-agent/sizing-netdata-agents/disk-requirements-and-retention.md
@@ -45,7 +45,7 @@ Netdata Agent metrics storage is limited to 3 GiB by default (configurable), usi
 
 Data is deleted when it reaches **either** the size limit or the time limit, whichever comes first. The number of metrics collected determines how far back in time retention extends within the size limit.
 
-In practice, with default settings and about 4,000 metrics per second, Netdata provides about 14 days of high resolution (per-second) data, 3 months of medium resolution (per-minute) data, and more than 1 year of low resolution (per-hour) data.
+In practice, with default settings and an ingestion rate of about 4,000 metrics per second, Netdata provides about 14 days of high resolution (per-second) data, 3 months of medium resolution (per-minute) data, and more than 1 year of low resolution (per-hour) data.
 
 These limits are fully configurable. See [Changing how long Netdata stores metrics](/src/database/CONFIGURATION.md#tiers).
 

--- a/src/database/README.md
+++ b/src/database/README.md
@@ -30,7 +30,7 @@ Netdata Agent metrics storage is limited to 3 GiB by default (configurable), usi
 
 In total, with SQLite databases, alert transitions, and other metadata, expect about 4 GiB of disk usage under normal conditions.
 
-In practice, with default settings and about 4,000 metrics per second, Netdata provides about 14 days of high resolution (per-second) data, 3 months of medium resolution (per-minute) data, and more than 1 year of low resolution (per-hour) data.
+In practice, with default settings and an ingestion rate of about 4,000 metrics per second, Netdata provides about 14 days of high resolution (per-second) data, 3 months of medium resolution (per-minute) data, and more than 1 year of low resolution (per-hour) data.
 
 These limits are fully configurable. See [Changing how long Netdata stores metrics](/src/database/CONFIGURATION.md#tiers).
 


### PR DESCRIPTION
## Summary

- Clarified that Netdata metrics storage is **limited to 3 GiB by default** (1 GiB per tier × 3 tiers), and does not grow unbounded
- Added that total disk usage is about **4 GiB** under normal conditions (including SQLite databases, alert transitions, and other metadata)
- Added practical retention example: with ~4,000 time-series, expect ~14 days per-second, ~3 months per-minute, ~1 year per-hour data
- Added configuration links in all three locations

**Context:** Our AI support agent was telling users they need "3-5 GB/day for Tier 0" because the docs presented per-sample sizes without clearly explaining the default size caps. This led to wildly incorrect storage estimates.

### Files changed

- `docs/netdata-agent/sizing-netdata-agents/disk-requirements-and-retention.md` — added "Default Disk Footprint" section
- `src/database/README.md` — expanded the storage explanation
- `docs/impact-on-resources.md` — expanded Data Retention section, updated Storage references

## Test plan

- [ ] Verify rendered markdown looks correct on the docs site
- [ ] Confirm links to `/src/database/CONFIGURATION.md#tiers` resolve correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Netdata’s default metrics storage and retention so data is capped at 3 GiB (~4 GiB total with metadata) and does not grow unbounded. Tightens terminology to use “metrics per second” and explicitly define it as ingestion rate.

- **Documentation**
  - States default caps: 1 GiB per tier × 3 tiers; ~4 GiB total with metadata.
  - Explains retention: data is removed at the size or time limit; ingestion rate determines how much history fits.
  - Updates example using ~4,000 metrics/second: ~14 days per-second, ~3 months per-minute, >1 year per-hour.
  - Clarifies terminology: “metrics per second” = ingestion rate; replaces “unique time-series.”
  - Adds configuration link (/src/database/CONFIGURATION.md#tiers) and updates three pages: disk requirements and retention, database README, impact on resources.

<sup>Written for commit df47aae6e7b0cc36be32c69a13e939cbc0bd9be5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

