### PR TITLE
:wrench: config(consul-autopilot-m): consul autopilot monitoring discove

### DIFF
--- a/src/go/plugin/go.d/collector/consul/metadata.yaml
+++ b/src/go/plugin/go.d/collector/consul/metadata.yaml
@@ -19,6 +19,8 @@ modules:
       keywords:
         - service networking platform
         - hashicorp
+        - autopilot
+        - operator
       most_popular: true
     overview:
       data_collection:


### PR DESCRIPTION
## Why this PR is opened
- Consul autopilot monitoring is fully implemented and documented across collector code, metadata, alerts, and health guides
- The documentation gap is solely a discoverability issue: 'autopilot' keyword is missing from metadata.yaml keywords list
- Previous search failure was caused by invalid RGrep path, not missing documentation

## What this PR fixes
- Add 'autopilot' keyword to netdata/src/go/plugin/go.d/collector/consul/metadata.yaml keywords list (lines 19-22)
- Optional: Add 'operator' keyword to improve discoverability of Consul operator-level monitoring features
- No regeneration needed - metadata.yaml is the source file for generated integration docs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add "autopilot" and "operator" to the Consul integration keywords so Autopilot monitoring is discoverable in docs search. No regeneration needed; src/go/plugin/go.d/collector/consul/metadata.yaml is the source for generated docs.

<sup>Written for commit d3da32fcd3455a65979bf08dc3c0b6f9d793676d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

