### PR TITLE
Fix crash when processing a corrupted journalfile

### DIFF
--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -831,7 +831,7 @@ static uint64_t journalfile_iterate_transactions(struct rrdengine_instance *ctx,
         for (pos_i = 0; pos_i < size_bytes;) {
             unsigned max_size;
 
-            max_size = pos + size_bytes - pos_i;
+            max_size = size_bytes - pos_i;
             ret = journalfile_replay_transaction(ctx, journalfile, buf + pos_i, &id, max_size);
             if (!ret)
                 /* unknown transaction size, move on to the next block */


### PR DESCRIPTION
##### Summary
- Fix incorrect calculation of `max_size` in journal transaction replay logic


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when replaying transactions from corrupted journalfiles by correcting the max_size calculation. We now use the remaining bytes in the block (size_bytes - pos_i), preventing oversized reads in journalfile_replay_transaction and avoiding out-of-bounds access.

<sup>Written for commit debfc7257565267847f8f4168d867afe20b41101. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

