### PR TITLE
ML: Reserve cluster centers

### DIFF
--- a/src/ml/ml_kmeans.cc
+++ b/src/ml/ml_kmeans.cc
@@ -41,7 +41,7 @@ ml_kmeans_train(ml_kmeans_t *kmeans, const ml_features_t *features, unsigned max
     // reallocation during lazy evaluation. dlib uses expression templates that hold
     // references to vector elements, and reallocation would invalidate those references,
     // causing heap-use-after-free when multiple threads train models concurrently.
-    //kmeans->cluster_centers.reserve(2);
+    kmeans->cluster_centers.reserve(2);
 
     dlib::pick_initial_centers(2, kmeans->cluster_centers, features->preprocessed_features);
     dlib::find_clusters_using_kmeans(features->preprocessed_features, kmeans->cluster_centers, max_iters);


### PR DESCRIPTION
##### Summary
-  prevent heap-use-after-free in k-means training



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserve capacity for kmeans->cluster_centers to avoid vector reallocation during dlib k-means training. This prevents heap-use-after-free in concurrent runs and improves training stability.

<sup>Written for commit 757672581be4edade3393528ad97e0da3be451e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

