### PR TITLE
Support environment variable expansion in host labels

### DIFF
--- a/docs/netdata-agent/configuration/organize-systems-metrics-and-alerts.md
+++ b/docs/netdata-agent/configuration/organize-systems-metrics-and-alerts.md
@@ -143,13 +143,30 @@ Add your own labels to categorize systems by any criteria you need.
     - Values cannot contain: `!` ` ` `'` `"` `*`
       :::
 
-3. Enable your labels without restarting Netdata:
+3. You can use environment variables in label values:
+
+    ```text
+    [host labels]
+        region = ${REGION}
+        rack = ${RACK:-unknown}
+        env = ${DEPLOYMENT_ENV:-production}
+        location = ${DC}-${RACK:-default}
+    ```
+
+    | Syntax | Behavior |
+    |--------|----------|
+    | `${VAR}` | Replaced with the value of `VAR`. If unset or empty, the label value becomes `[none]` |
+    | `${VAR:-default}` | Replaced with the value of `VAR`. If unset or empty, uses `default` |
+
+    Environment variables are resolved when labels are loaded or reloaded. You can mix them with literal text (e.g., `${DC}-${RACK}`).
+
+4. Enable your labels without restarting Netdata:
 
     ```bash
     netdatacli reload-labels
     ```
 
-4. Verify your labels at `http://HOST-IP:19999/api/v1/info`
+5. Verify your labels at `http://HOST-IP:19999/api/v1/info`
 
 ### Stream labels from Child to Parent
 

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -403,6 +403,7 @@ int netdata_main(int argc, char **argv) {
                             if (dictionary_unittest(10000)) return 1;
                             if (aral_unittest(10000)) return 1;
                             if (rrdlabels_unittest()) return 1;
+                            if (rrdhost_labels_unittest()) return 1;
                             if (ctx_unittest()) return 1;
                             if (uuid_unittest()) return 1;
                             if (dyncfg_unittest()) return 1;

--- a/src/database/rrdhost-labels.c
+++ b/src/database/rrdhost-labels.c
@@ -16,8 +16,86 @@ void rrdhost_set_is_parent_label(void) {
     }
 }
 
+// expand ${VAR} and ${VAR:-default} patterns in src, writing result to dst
+static void env_expand_labels_value(const char *src, char *dst, size_t dst_size) {
+    if(!src || !dst || dst_size < 1) return;
+
+    const char *s = src;
+    char *d = dst;
+    char *end = dst + dst_size - 1;
+
+    while(*s && d < end) {
+        if(s[0] == '$' && s[1] == '{') {
+            const char *closing = strchr(s + 2, '}');
+            if(!closing) {
+                // no closing brace — copy rest literally
+                while(*s && d < end)
+                    *d++ = *s++;
+                break;
+            }
+
+            size_t content_len = closing - (s + 2);
+            char *var_name = mallocz(content_len + 1);
+            memcpy(var_name, s + 2, content_len);
+            var_name[content_len] = '\0';
+
+            // check for :- default separator
+            char *default_val = NULL;
+            char *sep = strstr(var_name, ":-");
+            if(sep) {
+                *sep = '\0';
+                default_val = sep + 2;
+            }
+
+            const char *env_val = getenv(var_name);
+            const char *resolved;
+
+            if(env_val && *env_val)
+                resolved = env_val;
+            else if(default_val)
+                resolved = default_val;
+            else {
+                nd_log(NDLS_DAEMON, NDLP_WARNING,
+                       "RRDLABEL: environment variable '%s' is not set and no default provided", var_name);
+                resolved = "";
+            }
+
+            size_t rlen = strlen(resolved);
+            size_t available = end - d;
+            size_t to_copy = rlen < available ? rlen : available;
+            memcpy(d, resolved, to_copy);
+            d += to_copy;
+
+            freez(var_name);
+            s = closing + 1;
+        }
+        else {
+            *d++ = *s++;
+        }
+    }
+
+    *d = '\0';
+}
+
+// check if value contains any ${...} pattern worth expanding
+static bool value_has_env_variables(const char *value) {
+    const char *p = value;
+    while((p = strchr(p, '$')) != NULL) {
+        if(p[1] == '{') return true;
+        p++;
+    }
+    return false;
+}
+
 static bool config_label_cb(void *data __maybe_unused, const char *name, const char *value) {
-    rrdlabels_add(localhost->rrdlabels, name, value, RRDLABEL_SRC_CONFIG);
+    if(value_has_env_variables(value)) {
+        char expanded[RRDLABELS_MAX_VALUE_LENGTH + 1];
+        env_expand_labels_value(value, expanded, sizeof(expanded));
+        rrdlabels_add(localhost->rrdlabels, name, expanded, RRDLABEL_SRC_CONFIG);
+    }
+    else
+        rrdlabels_add(localhost->rrdlabels, name, value, RRDLABEL_SRC_CONFIG);
+
     return true;
 }
 
@@ -102,4 +180,154 @@ void reload_host_labels(void) {
     rrdhost_flag_set(localhost,RRDHOST_FLAG_METADATA_LABELS | RRDHOST_FLAG_METADATA_UPDATE);
 
     stream_send_host_labels(localhost);
+}
+
+// ----------------------------------------------------------------------------
+// unit tests
+
+static int env_expand_unittest_check(const char *src, const char *expected, const char *test_name) {
+    char buf[RRDLABELS_MAX_VALUE_LENGTH + 1];
+    env_expand_labels_value(src, buf, sizeof(buf));
+
+    int err = strcmp(buf, expected) != 0;
+    fprintf(stderr, "  env_expand(%s): %s, expected '%s', got '%s'\n",
+            test_name, err ? "FAILED" : "OK", expected, buf);
+    return err;
+}
+
+int rrdhost_labels_unittest(void) {
+    fprintf(stderr, "\n%s() tests\n", __FUNCTION__);
+    int errors = 0;
+
+    // --- set up test env vars ---
+    setenv("ND_TEST_VAR", "hello", 1);
+    setenv("ND_TEST_DC", "us-east", 1);
+    setenv("ND_TEST_RACK", "rack42", 1);
+    setenv("ND_TEST_EMPTY", "", 1);
+    unsetenv("ND_TEST_UNSET");
+
+    // no variables — pass through unchanged
+    errors += env_expand_unittest_check("plain value", "plain value", "plain text");
+    errors += env_expand_unittest_check("", "", "empty string");
+
+    // basic variable expansion
+    errors += env_expand_unittest_check("${ND_TEST_VAR}", "hello", "${VAR} set");
+    errors += env_expand_unittest_check("prefix-${ND_TEST_VAR}", "prefix-hello", "prefix + ${VAR}");
+    errors += env_expand_unittest_check("${ND_TEST_VAR}-suffix", "hello-suffix", "${VAR} + suffix");
+    errors += env_expand_unittest_check("pre-${ND_TEST_VAR}-post", "pre-hello-post", "prefix + ${VAR} + suffix");
+
+    // multiple variables
+    errors += env_expand_unittest_check("${ND_TEST_DC}-${ND_TEST_RACK}", "us-east-rack42", "two vars adjacent");
+    errors += env_expand_unittest_check("${ND_TEST_DC}/${ND_TEST_RACK}/${ND_TEST_VAR}", "us-east/rack42/hello", "three vars");
+    errors += env_expand_unittest_check("dc=${ND_TEST_DC} rack=${ND_TEST_RACK}", "dc=us-east rack=rack42", "vars with literal labels");
+
+    // default values — variable is set (default ignored)
+    errors += env_expand_unittest_check("${ND_TEST_VAR:-fallback}", "hello", "default ignored when var set");
+    errors += env_expand_unittest_check("${ND_TEST_DC:-other}", "us-east", "default ignored when var set (2)");
+
+    // default values — variable is unset
+    errors += env_expand_unittest_check("${ND_TEST_UNSET:-fallback}", "fallback", "default used when var unset");
+    errors += env_expand_unittest_check("pre-${ND_TEST_UNSET:-fallback}-post", "pre-fallback-post", "default with surrounding text");
+
+    // default values — variable is empty (treated same as unset)
+    errors += env_expand_unittest_check("${ND_TEST_EMPTY:-fallback}", "fallback", "default used when var empty");
+
+    // unset variable, no default — empty string
+    errors += env_expand_unittest_check("${ND_TEST_UNSET}", "", "unset var no default = empty");
+    errors += env_expand_unittest_check("pre-${ND_TEST_UNSET}-post", "pre--post", "unset var no default with text");
+
+    // empty default — should resolve to empty string
+    errors += env_expand_unittest_check("${ND_TEST_UNSET:-}", "", "empty default");
+    errors += env_expand_unittest_check("pre-${ND_TEST_UNSET:-}-post", "pre--post", "empty default with text");
+
+    // malformed syntax — no closing brace, copy literally
+    errors += env_expand_unittest_check("${ND_TEST_UNCLOSED", "${ND_TEST_UNCLOSED", "no closing brace");
+    errors += env_expand_unittest_check("pre-${ND_TEST_UNCLOSED", "pre-${ND_TEST_UNCLOSED", "no closing brace with prefix");
+
+    // dollar sign not followed by brace — literal
+    errors += env_expand_unittest_check("$notavar", "$notavar", "$ without {");
+    errors += env_expand_unittest_check("price is $5", "price is $5", "$ with digit");
+    errors += env_expand_unittest_check("$$", "$$", "double dollar");
+    errors += env_expand_unittest_check("$", "$", "lone dollar at end");
+
+    // empty variable name: ${} — getenv("") returns NULL, no default → empty
+    errors += env_expand_unittest_check("${}", "", "empty var name");
+    errors += env_expand_unittest_check("${:-fallback}", "fallback", "empty var name with default");
+
+    // default containing :- (only first :- is the separator)
+    errors += env_expand_unittest_check("${ND_TEST_UNSET:-a:-b}", "a:-b", "default containing :-");
+
+    // no recursive expansion — env value containing ${...} is NOT re-expanded
+    setenv("ND_TEST_NESTED", "${ND_TEST_VAR}", 1);
+    errors += env_expand_unittest_check("${ND_TEST_NESTED}", "${ND_TEST_VAR}", "no recursive expansion");
+
+    // default containing ${...} is NOT re-expanded
+    errors += env_expand_unittest_check("${ND_TEST_UNSET:-${ND_TEST_VAR}}", "${ND_TEST_VAR}", "no expansion in default");
+
+    // buffer overflow protection — expand into small buffer
+    {
+        char tiny[8];
+        env_expand_labels_value("${ND_TEST_DC}", tiny, sizeof(tiny));
+        // "us-east" is 7 chars, buffer is 8 (7+null) — should fit exactly
+        int err = strcmp(tiny, "us-east") != 0;
+        fprintf(stderr, "  env_expand(small buffer exact fit): %s, expected 'us-east', got '%s'\n",
+                err ? "FAILED" : "OK", tiny);
+        errors += err;
+    }
+    {
+        char tiny[5];
+        env_expand_labels_value("${ND_TEST_DC}", tiny, sizeof(tiny));
+        // "us-east" is 7 chars, buffer is 5 (4+null) — should truncate to "us-e"
+        int err = strcmp(tiny, "us-e") != 0;
+        fprintf(stderr, "  env_expand(small buffer truncation): %s, expected 'us-e', got '%s'\n",
+                err ? "FAILED" : "OK", tiny);
+        errors += err;
+    }
+    {
+        char tiny[5];
+        env_expand_labels_value("abcdefghij", tiny, sizeof(tiny));
+        // plain text truncation — should truncate to "abcd"
+        int err = strcmp(tiny, "abcd") != 0;
+        fprintf(stderr, "  env_expand(plain text truncation): %s, expected 'abcd', got '%s'\n",
+                err ? "FAILED" : "OK", tiny);
+        errors += err;
+    }
+
+    // value_has_env_variables() tests
+    {
+        struct {
+            const char *input;
+            bool expected;
+        } detect_tests[] = {
+            { "plain",                    false },
+            { "",                         false },
+            { "$notvar",                  false },
+            { "$",                        false },
+            { "${VAR}",                   true  },
+            { "pre${VAR}post",            true  },
+            { "${A}${B}",                 true  },
+            { "$${}",                     true  },  // second $ starts ${
+            { "${",                       true  },  // has ${ even without closing }
+            { NULL, false }
+        };
+        for(int i = 0; detect_tests[i].input; i++) {
+            bool result = value_has_env_variables(detect_tests[i].input);
+            int err = result != detect_tests[i].expected;
+            fprintf(stderr, "  value_has_env_variables('%s'): %s, expected %s, got %s\n",
+                    detect_tests[i].input, err ? "FAILED" : "OK",
+                    detect_tests[i].expected ? "true" : "false",
+                    result ? "true" : "false");
+            errors += err;
+        }
+    }
+
+    // --- cleanup test env vars ---
+    unsetenv("ND_TEST_VAR");
+    unsetenv("ND_TEST_DC");
+    unsetenv("ND_TEST_RACK");
+    unsetenv("ND_TEST_EMPTY");
+    unsetenv("ND_TEST_NESTED");
+
+    fprintf(stderr, "%s: %d errors\n", __FUNCTION__, errors);
+    return errors;
 }

--- a/src/database/rrdhost-labels.h
+++ b/src/database/rrdhost-labels.h
@@ -7,5 +7,6 @@
 
 void reload_host_labels(void);
 void rrdhost_set_is_parent_label(void);
+int rrdhost_labels_unittest(void);
 
 #endif //NETDATA_RRDHOST_LABELS_H


### PR DESCRIPTION
## Summary
- Allow `${VAR}` and `${VAR:-default}` syntax in `[host labels]` section of netdata.conf
- Variables are resolved from the environment at label load/reload time
- The raw `${VAR}` template is preserved in inicfg, so `netdata.conf` regeneration keeps the original syntax
- Unset variables with no default produce an empty value (sanitized to `[none]`) and log a warning

## Changes
- `src/database/rrdhost-labels.c` — added `env_expand_labels_value()` and `value_has_env_variables()`, modified `config_label_cb()` to expand before adding labels
- `src/database/rrdhost-labels.h` — declared `rrdhost_labels_unittest()`
- `src/daemon/main.c` — hooked unittest into `netdata -W unittest`
- `docs/netdata-agent/configuration/organize-systems-metrics-and-alerts.md` — documented the new syntax with examples

## Test plan
- [x] Unit tests: 38 test cases covering all corner cases (basic expansion, defaults, empty vars, malformed syntax, buffer overflow, no recursive expansion, detection function)
- [x] Build: compiles clean
- [x] `netdata -W unittest` passes
- [x] Manual: set env vars, configure labels with `${VAR}`, verify via `/api/v1/info`
- [x] Manual: test `reload-labels` picks up env changes
- [x] Manual: verify netdata.conf regeneration preserves `${VAR}` syntax

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add environment variable expansion to [host labels] in netdata.conf for dynamic label values. Labels resolve on load and reload, so you can update them without restarting.

- **New Features**
  - Expand ${VAR} and ${VAR:-default} in label values; unset/empty without default resolve to [none] with a warning. Supports mixing with literals (e.g., ${DC}-${RACK}); no recursive expansion.
  - Preserve the original ${...} text in the config store so regenerated netdata.conf keeps placeholders.
  - Add unit tests (hooked to netdata -W unittest) and update docs with examples.

- **Migration**
  - Set env vars and use ${VAR} or ${VAR:-default} in [host labels].
  - Run netdatacli reload-labels to apply changes.

<sup>Written for commit 6135911c5b34b83c070ba9e9411c33cb195ef0ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

