### PR TITLE
Fix potential use after free in RAM mode

### DIFF
--- a/src/database/ram/rrddim_mem.c
+++ b/src/database/ram/rrddim_mem.c
@@ -154,6 +154,7 @@ bool rrddim_metric_retention_by_uuid(STORAGE_INSTANCE *si __maybe_unused, nd_uui
 
     *first_entry_s = rrddim_query_oldest_time_s(smh);
     *last_entry_s = rrddim_query_latest_time_s(smh);
+    rrddim_metric_release(smh);
 
     return true;
 }
@@ -165,6 +166,7 @@ bool rrddim_metric_retention_by_id(STORAGE_INSTANCE *si __maybe_unused, UUIDMAP_
 
     *first_entry_s = rrddim_query_oldest_time_s(smh);
     *last_entry_s = rrddim_query_latest_time_s(smh);
+    rrddim_metric_release(smh);
 
     return true;
 }


### PR DESCRIPTION
##### Summary
- cache uuid in mem_metric_handle to avoid de-referencing potentially freed RRDDIM during metric release (ram mode)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache RRDDIM UUID in mem_metric_handle and use it during release in RAM mode to prevent use-after-free when deleting Judy entries. Also release the metric handle after retention queries (oldest/latest time) to avoid resource leaks.

<sup>Written for commit 4d8f39ecfb5b2f18bc71e767beb9ae8be2a6003d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

