### PR TITLE
Remove most_popular from integrations

### DIFF
--- a/docs/.templates/integration/schema.json
+++ b/docs/.templates/integration/schema.json
@@ -21,10 +21,6 @@
                                 "type": "string",
                                 "description": "Text that will be presented below the category title, or that will be accompanying the category in the UI in any form."
                             },
-                            "priority": {
-                                "type": "integer",
-                                "description": "Priority of the category. A number expressing where the category should be in the menu. Currently, a static number gets assigned to all categories, with a higher priority one for the most-popular flagged categories."
-                            },
                             "children": {
                                 "type": "array",
                                 "description": "an array that recursively has the same elements as the parent.",
@@ -59,10 +55,6 @@
                                 "category_id": {
                                     "type": "string",
                                     "description": "The category_ID for this integration. This is the category ID mentioned inside integrations/category.yaml, for the respective category."
-                                },
-                                "priority": {
-                                    "type": "integer",
-                                    "description": "Priority for this specific category. Will control where the integration will be positioned in this category"
                                 }
                             }
                         }

--- a/integrations/categories.yaml
+++ b/integrations/categories.yaml
@@ -1,127 +1,85 @@
 - id: deploy
   name: Deploy
   description: ""
-  most_popular: true
-  priority: 1
   children:
     - id: deploy.operating-systems
       name: Operating Systems
       description: ""
-      most_popular: true
-      priority: 1
       children: []
     - id: deploy.docker-kubernetes
       name: Docker & Kubernetes
       description: ""
-      most_popular: true
-      priority: 2
       children: []
     - id: deploy.provisioning-systems
       name: Provisioning Systems
       description: ""
-      most_popular: false
-      priority: -1
       children: []
 - id: data-collection
   name: Data Collection
   description: ""
-  most_popular: true
-  priority: 2
   children:
     - id: data-collection.databases
       name: Databases
       description: ""
-      most_popular: true
-      priority: 1
       children: []
     - id: data-collection.web-servers-and-proxies
       name: Web Servers and Proxies
       description: ""
-      most_popular: true
-      priority: 2
       children: []
     - id: data-collection.containers-and-vms
       name: Containers and VMs
       description: ""
-      most_popular: true
-      priority: 3
       children: []
     - id: data-collection.operating-systems
       name: Operating Systems
       description: ""
-      most_popular: true
-      priority: 4
       children: []
     - id: data-collection.networking
       name: Networking
       description: ""
-      most_popular: true
-      priority: 5
       children: []
     - id: data-collection.cloud-and-devops
       name: Cloud and DevOps
       description: ""
-      most_popular: true
-      priority: 6
       children: []
     - id: data-collection.hardware-and-sensors
       name: Hardware and Sensors
       description: ""
-      most_popular: true
-      priority: 7
       children: []
     - id: data-collection.applications
       name: Applications
       description: ""
-      most_popular: true
-      priority: 8
       collector_default: true
       children: []
     - id: data-collection.storage
       name: Storage and Filesystems
       description: ""
-      most_popular: true
-      priority: 9
       children: []
     - id: data-collection.synthetic-testing
       name: Synthetic Testing
       description: ""
-      most_popular: true
-      priority: 10
       children: []
 - id: logs
   name: Logs
   description: "Monitoring logs on your infrastructure"
-  most_popular: true
-  priority: 3
   children: []
 - id: export
   name: exporters
   description: "Exporter Integrations"
-  most_popular: true
-  priority: 6
   children: []
 - id: notify
   name: notifications
   description: "Notification Integrations"
-  most_popular: true
-  priority: 4
   children:
     - id: notify.agent
       name: Agent Dispatched Notifications
       description: ""
-      most_popular: true
-      priority: 2
       children: []
     - id: notify.cloud
       name: Centralized Cloud Notifications
       description: ""
-      most_popular: true
-      priority: 1
       children: []
 - id: auth
   name: authentication
   description: "Authentication & Authorization"
-  most_popular: true
-  priority: 5
   children: []

--- a/integrations/deploy.yaml
+++ b/integrations/deploy.yaml
@@ -8,7 +8,6 @@
     icon_filename: "linux.svg"
   keywords:
     - linux
-  most_popular: true
   install_description: "Run the following command on your node to install and connnect Netdata to your Space:"
   methods:
     - &ks_wget
@@ -45,7 +44,6 @@
     name: Ubuntu
     link: https://ubuntu.com/
     icon_filename: "ubuntu.svg"
-  most_popular: false
   platform_info:
     group: "include"
     distro: "ubuntu"
@@ -57,7 +55,6 @@
     name: Debian
     link: https://www.debian.org/
     icon_filename: "debian.svg"
-  most_popular: false
   platform_info:
     group: "include"
     distro: "debian"
@@ -69,7 +66,6 @@
     name: Fedora
     link: https://www.fedoraproject.org/
     icon_filename: "fedora.png"
-  most_popular: false
   platform_info:
     group: "include"
     distro: "fedora"
@@ -81,7 +77,6 @@
     name: Red Hat Enterprise Linux
     link: https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux
     icon_filename: "rhel.png"
-  most_popular: false
   platform_info:
     group: "no_include"
     distro: "rhel"
@@ -93,7 +88,6 @@
     name: Rocky Linux
     link: https://rockylinux.org/
     icon_filename: "rocky.svg"
-  most_popular: false
   platform_info:
     group: "include"
     distro: "rockylinux"
@@ -105,7 +99,6 @@
     name: Alpine Linux
     link: https://www.alpinelinux.org/
     icon_filename: "alpine.svg"
-  most_popular: false
   platform_info:
     group: "include"
     distro: "alpinelinux"
@@ -117,7 +110,6 @@
     name: Amazon Linux
     link: https://aws.amazon.com/amazon-linux-2/
     icon_filename: "amazonlinux.png"
-  most_popular: false
   platform_info:
     group: "include"
     distro: "amazonlinux"
@@ -129,7 +121,6 @@
     name: Arch Linux
     link: https://archlinux.org/
     icon_filename: "archlinux.png"
-  most_popular: false
   platform_info:
     group: "include"
     distro: "archlinux"
@@ -141,7 +132,6 @@
     name: CentOS
     link: https://www.centos.org/
     icon_filename: "centos.svg"
-  most_popular: false
   platform_info:
     group: "include"
     distro: "centos"
@@ -153,7 +143,6 @@
     name: CentOS Stream
     link: https://www.centos.org/centos-stream
     icon_filename: "centos.svg"
-  most_popular: false
   platform_info:
     group: "include"
     distro: "centos-stream"
@@ -165,7 +154,6 @@
     name: Manjaro Linux
     link: https://manjaro.org/
     icon_filename: "manjaro.svg"
-  most_popular: false
   platform_info:
     group: "include"
     distro: "archlinux"
@@ -177,7 +165,6 @@
     name: Oracle Linux
     link: https://www.oracle.com/linux/
     icon_filename: "oraclelinux.svg"
-  most_popular: false
   platform_info:
     group: "include"
     distro: "oraclelinux"
@@ -189,7 +176,6 @@
     name: SUSE Linux
     link: https://www.suse.com/
     icon_filename: "openSUSE.svg"
-  most_popular: false
   platform_info:
     group: "include"
     distro: "opensuse"
@@ -201,7 +187,6 @@
     categories:
       - deploy.operating-systems
     icon_filename: "macos.svg"
-  most_popular: true
   keywords:
     - macOS
     - mac
@@ -223,7 +208,6 @@
     categories:
       - deploy.docker-kubernetes
     icon_filename: "docker.svg"
-  most_popular: true
   keywords:
     - docker
     - container
@@ -551,7 +535,6 @@
             {% /if %}
   additional_info: ""
   related_resources: {}
-  most_popular: true
   platform_info:
     group: ""
     distro: ""
@@ -606,7 +589,6 @@
     | `ROOMS=`     | Comma-separated list of Room IDs where you want your node to appear.                             |
     | `PROXY=`     | Sets the proxy server address if your network requires one.                                      |
   related_resources: {}
-  most_popular: true
   platform_info:
     group: ""
     distro: ""
@@ -618,7 +600,6 @@
     categories:
       - deploy.operating-systems
     icon_filename: "freebsd.svg"
-  most_popular: true
   keywords:
     - freebsd
   install_description: |

--- a/integrations/gen_docs_integrations.py
+++ b/integrations/gen_docs_integrations.py
@@ -194,7 +194,6 @@ def build_readme_from_integration(integration, categories, mode: str = ""):
             learn_rel_path = generate_category_from_name(
                 integration["meta"]["monitored_instance"]["categories"][0].split("."), categories
             ).replace("Data Collection", "Collecting Metrics")
-            most_popular = integration["meta"]["most_popular"]
             keywords = integration["meta"]["keywords"] if "keywords" in integration["meta"] else None
 
             md = f"""<!--startmeta
@@ -202,7 +201,6 @@ meta_yaml: "{meta_yaml}"
 sidebar_label: "{sidebar_label}"
 learn_status: "Published"
 learn_rel_path: "{learn_rel_path}"
-most_popular: {most_popular}
 """
             if keywords:
                 md += f"keywords: {keywords}\n"

--- a/integrations/schemas/categories.json
+++ b/integrations/schemas/categories.json
@@ -22,14 +22,6 @@
           "type": "string",
           "description": "A description of the category."
         },
-        "most_popular": {
-          "type": "boolean",
-          "description": "Indicates if the category should show up in the initial list of categories, or only in the full expanded list."
-        },
-        "priority": {
-          "type": "integer",
-          "description": "Indicates sort order for categories that are marked as most popular."
-        },
         "collector_default": {
           "type": "boolean",
           "description": "Indicates that the category should be added to collector integrations that list no categories."
@@ -46,8 +38,6 @@
         "id",
         "name",
         "description",
-        "most_popular",
-        "priority",
         "children"
       ]
     }

--- a/integrations/schemas/collector.json
+++ b/integrations/schemas/collector.json
@@ -86,10 +86,6 @@
                   "description"
                 ]
               },
-              "most_popular": {
-                "type": "boolean",
-                "description": "Whether or not the integration is to be flagged as most-popular, meaning it will show up at the top of the menu."
-              },
               "community": {
                 "type": "boolean",
                 "description": "Whether or not the integration should be flagged as community."
@@ -100,10 +96,9 @@
               "module_name",
               "monitored_instance",
               "keywords",
-              "related_resources",
-              "info_provided_to_referring_integrations",
-              "most_popular"
-            ]
+                "related_resources",
+                "info_provided_to_referring_integrations"
+              ]
           },
           "overview": {
             "type": "object",

--- a/integrations/schemas/deploy.json
+++ b/integrations/schemas/deploy.json
@@ -15,10 +15,6 @@
       "keywords": {
         "$ref": "./shared.json#/$defs/keywords"
       },
-      "most_popular": {
-        "type": "boolean",
-        "description": "If true, the integration is sorted to the top of the list of integrations."
-      },
       "install_description": {
         "type": "string",
         "description": "Describes basic information about how to deploy on this platform."
@@ -108,7 +104,6 @@
       "id",
       "meta",
       "keywords",
-      "most_popular",
       "install_description",
       "methods",
       "additional_info",

--- a/src/collectors/apps.plugin/metadata.yaml
+++ b/src/collectors/apps.plugin/metadata.yaml
@@ -20,7 +20,6 @@ modules:
         - processes
         - os
         - host monitoring
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor Applications for optimal software performance and resource usage."
@@ -211,7 +210,6 @@ modules:
         - authorization
         - os
         - host monitoring
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration monitors resource utilization on a user groups context."
@@ -400,7 +398,6 @@ modules:
         - processes
         - os
         - host monitoring
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration monitors resource utilization on a user context."

--- a/src/collectors/cgroups.plugin/metadata.yaml
+++ b/src/collectors/cgroups.plugin/metadata.yaml
@@ -30,7 +30,6 @@ modules:
         - nspawn
         - cgroups
         - linux containers
-      most_popular: true
     overview: &overview
       data_collection: &data_collection
         metrics_description: "Monitor containers and virtual machines resource utilization — CPU, memory, disk I/O, and network — via Linux cgroups."
@@ -464,7 +463,6 @@ modules:
               module_name: k8s_kubeproxy
             - plugin_name: go.d.plugin
               module_name: coredns
-      most_popular: true
     overview:
       <<: *overview
       data-collection:

--- a/src/collectors/charts.d.plugin/libreswan/metadata.yaml
+++ b/src/collectors/charts.d.plugin/libreswan/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - libreswan
         - network
         - ipsec
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor Libreswan performance for optimal IPsec VPN operations. Improve your VPN operations with Netdata''s real-time metrics and built-in alerts."

--- a/src/collectors/charts.d.plugin/opensips/metadata.yaml
+++ b/src/collectors/charts.d.plugin/opensips/metadata.yaml
@@ -20,7 +20,6 @@ modules:
         - voice
         - video
         - stream
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Examine OpenSIPS metrics for insights into SIP server operations. Study call rates, error rates, and response times for reliable voice over IP services."

--- a/src/collectors/cups.plugin/metadata.yaml
+++ b/src/collectors/cups.plugin/metadata.yaml
@@ -15,7 +15,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor CUPS performance for achieving optimal printing system operations. Monitor job statuses, queue lengths, and error rates to ensure smooth printing tasks."

--- a/src/collectors/debugfs.plugin/metadata.yaml
+++ b/src/collectors/debugfs.plugin/metadata.yaml
@@ -18,7 +18,6 @@ modules:
         - extfrag
         - extfrag_threshold
         - memory fragmentation
-      most_popular: false
     overview:
       data_collection:
         metrics_description: 'Collects memory fragmentation statistics from the Linux kernel'
@@ -161,7 +160,6 @@ modules:
         - zswap
         - frontswap
         - swap cache
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >
@@ -304,7 +302,6 @@ modules:
       keywords:
         - power capping
         - energy
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/collectors/diskspace.plugin/metadata.yaml
+++ b/src/collectors/diskspace.plugin/metadata.yaml
@@ -21,7 +21,6 @@ modules:
         - I/O
         - space
         - inode
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor Disk space metrics for proficient storage management. Keep track of usage, free space, and error rates to prevent disk space issues."

--- a/src/collectors/ebpf.plugin/metadata.yaml
+++ b/src/collectors/ebpf.plugin/metadata.yaml
@@ -25,7 +25,6 @@ modules:
         - fd
         - open
         - close
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor calls for functions responsible to open or close a file descriptor and possible errors."
@@ -249,7 +248,6 @@ modules:
         - fork
         - process
         - eBPF
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor calls for function creating tasks (threads and processes) inside Linux kernel."
@@ -500,7 +498,6 @@ modules:
         - eBPF
         - latency
         - partition
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Measure latency for I/O events on disk."
@@ -606,7 +603,6 @@ modules:
       keywords:
         - HardIRQ
         - eBPF
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor latency for each HardIRQ available."
@@ -718,7 +714,6 @@ modules:
         - Page cache
         - Hit ratio
         - eBPF
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor Linux page cache events giving for users a general vision about how his kernel is manipulating files."
@@ -947,7 +942,6 @@ modules:
         - eBPF
         - hard disk
         - memory
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor syscall responsible to move data from memory to storage device."
@@ -1128,7 +1122,6 @@ modules:
         - MD
         - RAID
         - eBPF
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor when flush events happen between disks."
@@ -1238,7 +1231,6 @@ modules:
         - memory
         - eBPF
         - Hard Disk
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitors when swap has I/O events and applications executing events."
@@ -1417,7 +1409,6 @@ modules:
       keywords:
         - application
         - memory
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor applications that reach out of memory."
@@ -1550,7 +1541,6 @@ modules:
         - server
         - connection
         - socket
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor bandwidth consumption per application for protocols TCP and UDP."
@@ -1907,7 +1897,6 @@ modules:
         - Directory Cache
         - File system
         - eBPF
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor directory cache events per application given an overall vision about files on memory or storage device."
@@ -2131,7 +2120,6 @@ modules:
         - eBPF
         - latency
         - I/O
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor latency for main actions on filesystem like I/O events."
@@ -2292,7 +2280,6 @@ modules:
         - syscall
         - shared memory
         - eBPF
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor syscall responsible to manipulate shared memory."
@@ -2523,7 +2510,6 @@ modules:
       keywords:
         - SoftIRQ
         - eBPF
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor latency for each SoftIRQ available."
@@ -2631,7 +2617,6 @@ modules:
         - umount
         - device
         - eBPF
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor calls for mount and umount syscall."
@@ -2761,7 +2746,6 @@ modules:
         - eBPF
         - I/O
         - files
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor I/O events on Linux Virtual Filesystem."
@@ -3190,7 +3174,6 @@ modules:
         - Memory
         - plugin
         - eBPF
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor internal memory usage."

--- a/src/collectors/freebsd.plugin/metadata.yaml
+++ b/src/collectors/freebsd.plugin/metadata.yaml
@@ -15,7 +15,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "System Load Average"
@@ -114,7 +113,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect Virtual Memory information from host."
@@ -216,7 +214,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Total CPU utilization"
@@ -330,7 +327,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Get current CPU temperature"
@@ -407,7 +403,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Read current CPU Scaling frequency."
@@ -484,7 +479,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Get total number of interrupts"
@@ -567,7 +561,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Device interrupts"
@@ -644,7 +637,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Software Interrupt"
@@ -721,7 +713,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "CPU context switch"
@@ -804,7 +795,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect information about SWAP memory."
@@ -887,7 +877,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Show information about system memory usage."
@@ -996,7 +985,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "The metric swap amount of data read from and written to SWAP."
@@ -1079,7 +1067,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect memory page faults events."
@@ -1160,7 +1147,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect information about semaphore."
@@ -1253,7 +1239,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect shared memory information."
@@ -1336,7 +1321,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect number of IPC message Queues"
@@ -1426,7 +1410,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Show period of time server is up."
@@ -1503,7 +1486,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect information about system softnet stat."
@@ -1617,7 +1599,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect information per hard disk available on host."
@@ -1809,7 +1790,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: ""
@@ -1891,7 +1871,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect overall information about TCP connections."
@@ -2078,7 +2057,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect information about UDP connections."
@@ -2180,7 +2158,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect information about ICMP traffic."
@@ -2283,7 +2260,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect IP stats"
@@ -2402,7 +2378,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect information abou IPv6 stats."
@@ -2523,7 +2498,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect information abou IPv6 ICMP"
@@ -2689,7 +2663,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect information about FreeBSD firewall."
@@ -2799,7 +2772,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect traffic per network interface."
@@ -3019,7 +2991,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect information per mount point."
@@ -3132,7 +3103,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Collect metrics for ZFS filesystem"

--- a/src/collectors/freeipmi.plugin/metadata.yaml
+++ b/src/collectors/freeipmi.plugin/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - ipmi
         - freeipmi
         - ipmimonitoring
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/collectors/guides/proxmox/metadata.yaml
+++ b/src/collectors/guides/proxmox/metadata.yaml
@@ -58,7 +58,6 @@ modules:
               module_name: /proc/spl/kstat/zfs/arcstats
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/collectors/idlejitter.plugin/metadata.yaml
+++ b/src/collectors/idlejitter.plugin/metadata.yaml
@@ -17,7 +17,6 @@ modules:
       keywords:
         - latency
         - jitter
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/collectors/ioping.plugin/metadata.yaml
+++ b/src/collectors/ioping.plugin/metadata.yaml
@@ -15,7 +15,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor IOPing metrics for efficient disk I/O latency tracking. Keep track of read/write speeds, latency, and error rates for optimized disk operations."

--- a/src/collectors/macos.plugin/metadata.yaml
+++ b/src/collectors/macos.plugin/metadata.yaml
@@ -18,7 +18,6 @@ modules:
         - macos
         - apple
         - darwin
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor macOS metrics for efficient operating system performance."

--- a/src/collectors/network-viewer.plugin/metadata.yaml
+++ b/src/collectors/network-viewer.plugin/metadata.yaml
@@ -23,7 +23,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: ""

--- a/src/collectors/nfacct.plugin/metadata.yaml
+++ b/src/collectors/nfacct.plugin/metadata.yaml
@@ -15,7 +15,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: 'Monitor Netfilter metrics for optimal packet filtering and manipulation. Keep tabs on packet counts, dropped packets, and error rates to secure network operations.'

--- a/src/collectors/perf.plugin/metadata.yaml
+++ b/src/collectors/perf.plugin/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - cpu performance
         - cpu cache
         - perf.plugin
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This collector monitors CPU performance metrics about cycles, instructions, migrations, cache operations and more."

--- a/src/collectors/proc.plugin/metadata.yaml
+++ b/src/collectors/proc.plugin/metadata.yaml
@@ -17,7 +17,6 @@ modules:
       keywords:
         - cpu utilization
         - process counts
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -215,7 +214,6 @@ modules:
         description: ""
       keywords:
         - entropy
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -323,7 +321,6 @@ modules:
         description: ""
       keywords:
         - uptime
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -410,7 +407,6 @@ modules:
         - page faults
         - oom
         - numa
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -626,7 +622,6 @@ modules:
         description: ""
       keywords:
         - interrupts
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -742,7 +737,6 @@ modules:
       keywords:
         - load
         - load average
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -870,7 +864,6 @@ modules:
         description: ""
       keywords:
         - pressure
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -1045,7 +1038,6 @@ modules:
       keywords:
         - softirqs
         - interrupts
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -1152,7 +1144,6 @@ modules:
         description: ""
       keywords:
         - softnet
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -1280,7 +1271,6 @@ modules:
         - ram
         - available
         - committed
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -1519,7 +1509,6 @@ modules:
         description: ""
       keywords:
         - memory page types
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration provides metrics about the system's memory page types"
@@ -1612,7 +1601,6 @@ modules:
         - dimm
         - ram
         - hardware
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -1752,7 +1740,6 @@ modules:
         description: ""
       keywords:
         - numa
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -1846,7 +1833,6 @@ modules:
         - ksm
         - samepage
         - merging
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -1941,7 +1927,6 @@ modules:
         description: ""
       keywords:
         - zram
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -2042,7 +2027,6 @@ modules:
         - ipc
         - semaphores
         - shared memory
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -2172,7 +2156,6 @@ modules:
         - disks
         - io
         - block devices
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -2384,7 +2367,6 @@ modules:
         - cache
         - ssd
         - block devices
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -2533,7 +2515,6 @@ modules:
         - mdadm
         - mdstat
         - raid
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration monitors the status of MD RAID devices."
@@ -2671,7 +2652,6 @@ modules:
         description: ""
       keywords:
         - network interfaces
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor network interface metrics about bandwidth, state, errors and more."
@@ -2893,7 +2873,6 @@ modules:
         description: ""
       keywords:
         - wireless devices
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor wireless devices with metrics about status, link quality, signal level, noise level and more."
@@ -3004,7 +2983,6 @@ modules:
       keywords:
         - infiniband
         - rdma
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration monitors InfiniBand network inteface statistics."
@@ -3151,7 +3129,6 @@ modules:
         - icmp
         - netstat
         - snmp
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration provides metrics from the `netstat`, `snmp` and `snmp6` modules."
@@ -3731,7 +3708,6 @@ modules:
         description: ""
       keywords:
         - sockets
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration provides socket statistics."
@@ -3865,7 +3841,6 @@ modules:
         description: ""
       keywords:
         - ipv6 sockets
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration provides IPv6 socket statistics."
@@ -3962,7 +3937,6 @@ modules:
         description: ""
       keywords:
         - ip virtual server
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration monitors IP Virtual Server statistics"
@@ -4050,7 +4024,6 @@ modules:
       keywords:
         - nfs client
         - filesystem
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration provides statistics from the Linux kernel's NFS Client."
@@ -4151,7 +4124,6 @@ modules:
       keywords:
         - nfs server
         - filesystem
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration provides statistics from the Linux kernel's NFS Server."
@@ -4285,7 +4257,6 @@ modules:
       keywords:
         - sctp
         - stream control transmission protocol
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration provides statistics about the Stream Control Transmission Protocol (SCTP)."
@@ -4390,7 +4361,6 @@ modules:
         - connection tracking mechanism
         - netfilter
         - conntrack
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration monitors the connection tracking mechanism of Netfilter in the Linux Kernel."
@@ -4509,7 +4479,6 @@ modules:
         description: ""
       keywords:
         - synproxy
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration provides statistics about the Synproxy netfilter module."
@@ -4599,7 +4568,6 @@ modules:
         - arc
         - zfs
         - filesystem
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration monitors  ZFS Adadptive Replacement Cache (ARC) statistics."
@@ -4863,7 +4831,6 @@ modules:
       keywords:
         - btrfs
         - filesystem
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration provides usage and error statistics from the BTRFS filesystem."
@@ -5053,7 +5020,6 @@ modules:
       keywords:
         - psu
         - power supply
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration monitors Power supply metrics, such as battery status, AC power status and more."
@@ -5170,7 +5136,6 @@ modules:
         - amd
         - gpu
         - hardware
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This integration monitors AMD GPU metrics, such as utilization, clock frequency and memory usage."

--- a/src/collectors/python.d.plugin/am2320/metadata.yaml
+++ b/src/collectors/python.d.plugin/am2320/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - am2320
         - sensor
         - humidity
-      most_popular: false
     overview:
       data_collection:
         metrics_description: 'This collector monitors AM2320 sensor metrics about temperature and humidity.'

--- a/src/collectors/python.d.plugin/go_expvar/metadata.yaml
+++ b/src/collectors/python.d.plugin/go_expvar/metadata.yaml
@@ -18,7 +18,6 @@ modules:
         - go
         - expvar
         - application
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This collector monitors Go applications that expose their metrics with the use of the `expvar` package from the Go standard library. It produces charts for Go runtime memory statistics and optionally any number of custom charts."

--- a/src/collectors/python.d.plugin/haproxy/metadata.yaml
+++ b/src/collectors/python.d.plugin/haproxy/metadata.yaml
@@ -20,7 +20,6 @@
 #     - haproxy
 #     - tcp
 #     - balancer
-#   most_popular: false
 # overview:
 #   data_collection:
 #     metrics_description: 'This collector monitors HAProxy metrics about frontend servers, backend servers, responses and more.'

--- a/src/collectors/python.d.plugin/pandas/metadata.yaml
+++ b/src/collectors/python.d.plugin/pandas/metadata.yaml
@@ -17,7 +17,6 @@ modules:
       keywords:
         - pandas
         - python
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/collectors/python.d.plugin/traefik/metadata.yaml
+++ b/src/collectors/python.d.plugin/traefik/metadata.yaml
@@ -15,7 +15,6 @@
 #   info_provided_to_referring_integrations:
 #     description: ''
 #   keywords: []
-#   most_popular: false
 # overview:
 #   data_collection:
 #     metrics_description: ''

--- a/src/collectors/slabinfo.plugin/metadata.yaml
+++ b/src/collectors/slabinfo.plugin/metadata.yaml
@@ -20,7 +20,6 @@ modules:
         - slub
         - slob
         - slabinfo
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/collectors/tc.plugin/metadata.yaml
+++ b/src/collectors/tc.plugin/metadata.yaml
@@ -15,7 +15,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Examine tc metrics to gain insights into Linux traffic control operations. Study packet flow rates, queue lengths, and drop rates to optimize network traffic flow."

--- a/src/collectors/timex.plugin/metadata.yaml
+++ b/src/collectors/timex.plugin/metadata.yaml
@@ -15,7 +15,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Examine Timex metrics to gain insights into system clock operations. Study time sync status, clock drift, and adjustments to ensure accurate system timekeeping."

--- a/src/collectors/windows.plugin/metadata.yaml
+++ b/src/collectors/windows.plugin/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - microsoft
         - processor
         - CPU
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -123,7 +122,6 @@ modules:
       keywords:
         - memory
         - swap
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -227,7 +225,6 @@ modules:
         - process counts
         - threads
         - context switch
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -331,7 +328,6 @@ modules:
         - volume
         - physical
         - logical
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -514,7 +510,6 @@ modules:
         - udp
         - tcp
         - interface
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -834,7 +829,6 @@ modules:
       keywords:
         - ipc
         - semaphores
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -926,7 +920,6 @@ modules:
       keywords:
         - cpu
         - temperature
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -1008,7 +1001,6 @@ modules:
       keywords:
         - thermal
         - temperature
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -1089,7 +1081,6 @@ modules:
         description: ""
       keywords:
         - power supply
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -1183,7 +1174,6 @@ modules:
       keywords:
         - Sensors
         - Windows
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -1410,7 +1400,6 @@ modules:
         - IIS
         - HTTP
         - Web service
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -1729,7 +1718,6 @@ modules:
         - hyperv
         - virtualization
         - vm
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -2096,7 +2084,6 @@ modules:
         - microsoft
         - sql
         - queries
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -2719,7 +2706,6 @@ modules:
         - microsoft
         - netframework
         - dotnet
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -2985,7 +2971,6 @@ modules:
         - microsoft
         - active directory
         - ad
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -3152,7 +3137,6 @@ modules:
         - active directory
         - adcs
         - ad
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -3329,7 +3313,6 @@ modules:
         - active directory
         - adfs
         - ad
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -3605,7 +3588,6 @@ modules:
         - windows
         - microsoft
         - services
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -3698,7 +3680,6 @@ modules:
         - microsoft
         - exchange
         - mail
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -3962,7 +3943,6 @@ modules:
         - windows
         - NUMA
         - processor
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |
@@ -4048,7 +4028,6 @@ modules:
         - windows
         - ASP
         - webservice
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/collectors/xenstat.plugin/metadata.yaml
+++ b/src/collectors/xenstat.plugin/metadata.yaml
@@ -15,7 +15,6 @@ modules:
       info_provided_to_referring_integrations:
         description: ""
       keywords: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This collector monitors XenServer and XCP-ng host and domains statistics."

--- a/src/crates/netdata-otel/otel-plugin/metadata.yaml
+++ b/src/crates/netdata-otel/otel-plugin/metadata.yaml
@@ -24,7 +24,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/activemq/metadata.yaml
+++ b/src/go/plugin/go.d/collector/activemq/metadata.yaml
@@ -13,7 +13,6 @@ modules:
       alternative_monitored_instances: []
       keywords:
         - message broker
-      most_popular: false
       info_provided_to_referring_integrations:
         description: ""
       related_resources:

--- a/src/go/plugin/go.d/collector/adaptecraid/metadata.yaml
+++ b/src/go/plugin/go.d/collector/adaptecraid/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/ap/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ap/metadata.yaml
@@ -20,7 +20,6 @@ modules:
         - point
         - wireless
         - network
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/apache/metadata.yaml
+++ b/src/go/plugin/go.d/collector/apache/metadata.yaml
@@ -24,7 +24,6 @@ modules:
               module_name: apps
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/apcupsd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/apcupsd/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/beanstalk/metadata.yaml
+++ b/src/go/plugin/go.d/collector/beanstalk/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - beanstalk
         - beanstalkd
         - message
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/boinc/metadata.yaml
+++ b/src/go/plugin/go.d/collector/boinc/metadata.yaml
@@ -18,7 +18,6 @@ modules:
       keywords:
         - boinc
         - distributed
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/cassandra/metadata.yaml
+++ b/src/go/plugin/go.d/collector/cassandra/metadata.yaml
@@ -21,7 +21,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/ceph/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ceph/metadata.yaml
@@ -17,7 +17,6 @@ modules:
       keywords:
         - ceph
         - storage
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/chrony/metadata.yaml
+++ b/src/go/plugin/go.d/collector/chrony/metadata.yaml
@@ -17,7 +17,6 @@ modules:
       related_resources:
         integrations:
           list: []
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/clickhouse/metadata.yaml
+++ b/src/go/plugin/go.d/collector/clickhouse/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/cockroachdb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/cockroachdb/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/consul/metadata.yaml
+++ b/src/go/plugin/go.d/collector/consul/metadata.yaml
@@ -20,7 +20,6 @@ modules:
         - service networking platform
         - hashicorp
         - autopilot
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/coredns/metadata.yaml
+++ b/src/go/plugin/go.d/collector/coredns/metadata.yaml
@@ -30,7 +30,6 @@ modules:
               monitored_instance_name: "Kubernetes Containers"
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/couchbase/metadata.yaml
+++ b/src/go/plugin/go.d/collector/couchbase/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/couchdb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/couchdb/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/dcgm/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dcgm/metadata.yaml
@@ -22,7 +22,6 @@ modules:
               module_name: nvidia_smi
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/dmcache/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dmcache/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/go/plugin/go.d/collector/dnsdist/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dnsdist/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/dnsmasq/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dnsmasq/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/dnsmasq_dhcp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dnsmasq_dhcp/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/dnsquery/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dnsquery/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/docker/metadata.yaml
+++ b/src/go/plugin/go.d/collector/docker/metadata.yaml
@@ -18,7 +18,6 @@ modules:
         description: ""
       keywords:
         - container
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/docker_engine/metadata.yaml
+++ b/src/go/plugin/go.d/collector/docker_engine/metadata.yaml
@@ -19,7 +19,6 @@ modules:
       keywords:
         - docker
         - container
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/dockerhub/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dockerhub/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/dovecot/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dovecot/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - dovecot
         - imap
         - mail
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/elasticsearch/metadata.yaml
+++ b/src/go/plugin/go.d/collector/elasticsearch/metadata.yaml
@@ -26,7 +26,6 @@ modules:
               monitored_instance_name: Containers
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/envoy/metadata.yaml
+++ b/src/go/plugin/go.d/collector/envoy/metadata.yaml
@@ -20,7 +20,6 @@ modules:
               module_name: apps
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/ethtool/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ethtool/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/go/plugin/go.d/collector/exim/metadata.yaml
+++ b/src/go/plugin/go.d/collector/exim/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/go/plugin/go.d/collector/fail2ban/metadata.yaml
+++ b/src/go/plugin/go.d/collector/fail2ban/metadata.yaml
@@ -20,7 +20,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/go/plugin/go.d/collector/filecheck/metadata.yaml
+++ b/src/go/plugin/go.d/collector/filecheck/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/fluentd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/fluentd/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/freeradius/metadata.yaml
+++ b/src/go/plugin/go.d/collector/freeradius/metadata.yaml
@@ -13,7 +13,6 @@ modules:
       keywords:
         - freeradius
         - radius
-      most_popular: false
       info_provided_to_referring_integrations:
         description: ""
       related_resources:

--- a/src/go/plugin/go.d/collector/gearman/metadata.yaml
+++ b/src/go/plugin/go.d/collector/gearman/metadata.yaml
@@ -17,7 +17,6 @@ modules:
         description: ""
       keywords:
         - gearman
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/geth/metadata.yaml
+++ b/src/go/plugin/go.d/collector/geth/metadata.yaml
@@ -21,7 +21,6 @@ modules:
               module_name: apps
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/haproxy/metadata.yaml
+++ b/src/go/plugin/go.d/collector/haproxy/metadata.yaml
@@ -21,7 +21,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/hddtemp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/hddtemp/metadata.yaml
@@ -20,7 +20,6 @@ modules:
         - hdd temperature
         - disk temperature
         - temperature
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/hdfs/metadata.yaml
+++ b/src/go/plugin/go.d/collector/hdfs/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/hpssa/metadata.yaml
+++ b/src/go/plugin/go.d/collector/hpssa/metadata.yaml
@@ -21,7 +21,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/httpcheck/metadata.yaml
+++ b/src/go/plugin/go.d/collector/httpcheck/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/icecast/metadata.yaml
+++ b/src/go/plugin/go.d/collector/icecast/metadata.yaml
@@ -18,7 +18,6 @@ modules:
         - icecast
         - streaming
         - media
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This collector monitors Icecast listener counts."

--- a/src/go/plugin/go.d/collector/intelgpu/metadata.yaml
+++ b/src/go/plugin/go.d/collector/intelgpu/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/ipfs/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ipfs/metadata.yaml
@@ -18,7 +18,6 @@ modules:
       keywords:
         - ipfs
         - filesystem
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "This collector monitors IPFS daemon health and network activity."

--- a/src/go/plugin/go.d/collector/isc_dhcpd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/isc_dhcpd/metadata.yaml
@@ -13,7 +13,6 @@ modules:
       keywords:
         - dhcpd
         - dhcp
-      most_popular: false
       info_provided_to_referring_integrations:
         description: ""
       related_resources:

--- a/src/go/plugin/go.d/collector/k8s_apiserver/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_apiserver/metadata.yaml
@@ -31,7 +31,6 @@ modules:
               module_name: coredns
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/k8s_kubelet/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_kubelet/metadata.yaml
@@ -32,7 +32,6 @@ modules:
               module_name: coredns
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/k8s_kubeproxy/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_kubeproxy/metadata.yaml
@@ -32,7 +32,6 @@ modules:
               module_name: coredns
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/k8s_state/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_state/metadata.yaml
@@ -29,7 +29,6 @@ modules:
               module_name: coredns
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/lighttpd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/lighttpd/metadata.yaml
@@ -23,7 +23,6 @@ modules:
               module_name: apps
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/litespeed/metadata.yaml
+++ b/src/go/plugin/go.d/collector/litespeed/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - litespeed
         - web
         - server
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Examine Litespeed metrics for insights into web server operations. Analyze request rates, response times, and error rates for efficient web service delivery."

--- a/src/go/plugin/go.d/collector/logind/metadata.yaml
+++ b/src/go/plugin/go.d/collector/logind/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/logstash/metadata.yaml
+++ b/src/go/plugin/go.d/collector/logstash/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/lvm/metadata.yaml
+++ b/src/go/plugin/go.d/collector/lvm/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/go/plugin/go.d/collector/maxscale/metadata.yaml
+++ b/src/go/plugin/go.d/collector/maxscale/metadata.yaml
@@ -22,7 +22,6 @@ modules:
         - maxscale
         - database
         - db
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/megacli/metadata.yaml
+++ b/src/go/plugin/go.d/collector/megacli/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/memcached/metadata.yaml
+++ b/src/go/plugin/go.d/collector/memcached/metadata.yaml
@@ -20,7 +20,6 @@ modules:
         - memcache
         - cache
         - database
-      most_popular: false
     overview:
       data_collection:
         metrics_description: "Monitor Memcached metrics for proficient in-memory key-value store operations. Track cache hits, misses, and memory usage for efficient data caching."

--- a/src/go/plugin/go.d/collector/mongodb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mongodb/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/monit/metadata.yaml
+++ b/src/go/plugin/go.d/collector/monit/metadata.yaml
@@ -21,7 +21,6 @@ modules:
         - mmonit
         - supervision tool
         - monitrc
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/mssql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mssql/metadata.yaml
@@ -27,7 +27,6 @@ modules:
         - "mssql"
         - "sql server"
         - "microsoft"
-      most_popular: false
     overview:
       multi_instance: true
       data_collection:

--- a/src/go/plugin/go.d/collector/mysql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mysql/metadata.yaml
@@ -28,7 +28,6 @@ modules:
         - "maria"
         - "mariadb"
         - "sql"
-      most_popular: true
     overview:
       multi_instance: true
       data_collection:
@@ -1305,7 +1304,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-percona_mysql
-      most_popular: false
       monitored_instance:
         name: Percona MySQL
         link: https://www.percona.com/software/mysql-database/percona-server

--- a/src/go/plugin/go.d/collector/nats/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nats/metadata.yaml
@@ -20,7 +20,6 @@ modules:
         - nats
         - messaging
         - broker
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/nginx/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nginx/metadata.yaml
@@ -31,7 +31,6 @@ modules:
         - webserver
         - http
         - proxy
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/nginxplus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nginxplus/metadata.yaml
@@ -22,7 +22,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/nginxunit/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nginxunit/metadata.yaml
@@ -22,7 +22,6 @@ modules:
         - web
         - appserver
         - http
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/nginxvts/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nginxvts/metadata.yaml
@@ -23,7 +23,6 @@ modules:
               module_name: apps
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/nsd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nsd/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: [ ]
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/go/plugin/go.d/collector/ntpd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ntpd/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/go/plugin/go.d/collector/nvidia_smi/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nvidia_smi/metadata.yaml
@@ -21,7 +21,6 @@ modules:
               module_name: dcgm
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/nvme/metadata.yaml
+++ b/src/go/plugin/go.d/collector/nvme/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/go/plugin/go.d/collector/openldap/metadata.yaml
+++ b/src/go/plugin/go.d/collector/openldap/metadata.yaml
@@ -18,7 +18,6 @@ modules:
         - openldap
         - RBAC
         - Directory access
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/openvpn/metadata.yaml
+++ b/src/go/plugin/go.d/collector/openvpn/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/openvpn_status_log/metadata.yaml
+++ b/src/go/plugin/go.d/collector/openvpn_status_log/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/oracledb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/oracledb/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - database
         - oracle
         - sql
-      most_popular: false
     overview:
       multi_instance: true
       data_collection:

--- a/src/go/plugin/go.d/collector/pgbouncer/metadata.yaml
+++ b/src/go/plugin/go.d/collector/pgbouncer/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/phpdaemon/metadata.yaml
+++ b/src/go/plugin/go.d/collector/phpdaemon/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/phpfpm/metadata.yaml
+++ b/src/go/plugin/go.d/collector/phpfpm/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/pihole/metadata.yaml
+++ b/src/go/plugin/go.d/collector/pihole/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/pika/metadata.yaml
+++ b/src/go/plugin/go.d/collector/pika/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/ping/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ping/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/portcheck/metadata.yaml
+++ b/src/go/plugin/go.d/collector/portcheck/metadata.yaml
@@ -16,7 +16,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/postfix/metadata.yaml
+++ b/src/go/plugin/go.d/collector/postfix/metadata.yaml
@@ -18,7 +18,6 @@ modules:
         - postfix
         - mail
         - mail server
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/go/plugin/go.d/collector/postgres/metadata.yaml
+++ b/src/go/plugin/go.d/collector/postgres/metadata.yaml
@@ -27,7 +27,6 @@ modules:
         - postgres
         - postgresql
         - sql
-      most_popular: true
     overview:
       multi_instance: true
       data_collection:

--- a/src/go/plugin/go.d/collector/powerdns/metadata.yaml
+++ b/src/go/plugin/go.d/collector/powerdns/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/powerdns_recursor/metadata.yaml
+++ b/src/go/plugin/go.d/collector/powerdns_recursor/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: [ ]
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview: &overview
       data_collection:
         metrics_description: |
@@ -311,7 +310,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-aws_ec2
-      most_popular: false
       community: true
       monitored_instance:
         name: AWS EC2 Compute instances
@@ -341,7 +339,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-blackbox
-      most_popular: false
       community: true
       monitored_instance:
         name: Blackbox
@@ -369,7 +366,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-cilium_agent
-      most_popular: false
       community: true
       monitored_instance:
         name: Cilium Agent
@@ -396,7 +392,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-cilium_operator
-      most_popular: false
       community: true
       monitored_instance:
         name: Cilium Operator
@@ -423,7 +418,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-cilium_proxy
-      most_popular: false
       community: true
       monitored_instance:
         name: Cilium Proxy
@@ -450,7 +444,6 @@ modules:
     meta:
       id: collector-go.d.plugin-prometheus-aws_cloudwatch
       <<: *meta
-      most_popular: false
       community: true
       monitored_instance:
         name: CloudWatch
@@ -480,7 +473,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-concourse
-      most_popular: false
       community: true
       monitored_instance:
         name: Concourse
@@ -507,7 +499,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-scylladb
-      most_popular: false
       community: true
       monitored_instance:
         name: ScyllaDB
@@ -527,7 +518,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-crowdsec
-      most_popular: false
       community: true
       monitored_instance:
         name: Crowdsec
@@ -554,7 +544,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-discourse
-      most_popular: false
       community: true
       monitored_instance:
         name: Discourse
@@ -581,7 +570,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-dynatrace
-      most_popular: false
       community: true
       monitored_instance:
         name: Dynatrace
@@ -608,7 +596,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-eos_web
-      most_popular: false
       community: true
       monitored_instance:
         name: EOS
@@ -635,7 +622,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-etcd
-      most_popular: false
       community: true
       monitored_instance:
         name: etcd
@@ -655,7 +641,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-freebsd_nfs
-      most_popular: false
       community: true
       monitored_instance:
         name: FreeBSD NFS
@@ -682,7 +667,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-freebsd_rctl
-      most_popular: false
       community: true
       monitored_instance:
         name: FreeBSD RCTL-RACCT
@@ -709,7 +693,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-gcp_gce
-      most_popular: false
       community: true
       monitored_instance:
         name: GCP GCE
@@ -736,7 +719,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-github_repo
-      most_popular: false
       community: true
       monitored_instance:
         name: GitHub repository
@@ -763,7 +745,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-gitlab_runner
-      most_popular: false
       community: true
       monitored_instance:
         name: GitLab Runner
@@ -790,7 +771,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-gobetween
-      most_popular: false
       community: true
       monitored_instance:
         name: Gobetween
@@ -810,7 +790,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-gcp
-      most_popular: false
       community: true
       monitored_instance:
         name: Google Cloud Platform
@@ -840,7 +819,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-gcp_stackdriver
-      most_popular: false
       community: true
       monitored_instance:
         name: Google Stackdriver
@@ -870,7 +848,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-grafana
-      most_popular: false
       community: true
       monitored_instance:
         name: Grafana
@@ -890,7 +867,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-graylog
-      most_popular: false
       community: true
       monitored_instance:
         name: Graylog Server
@@ -918,7 +894,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-hana
-      most_popular: false
       community: true
       monitored_instance:
         name: HANA
@@ -945,7 +920,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-honeypot
-      most_popular: false
       community: true
       monitored_instance:
         name: Honeypot
@@ -972,7 +946,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-hubble
-      most_popular: false
       community: true
       monitored_instance:
         name: Hubble
@@ -999,7 +972,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-ibm_spectrum
-      most_popular: false
       community: true
       monitored_instance:
         name: IBM Spectrum
@@ -1026,7 +998,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-influxdb
-      most_popular: false
       community: true
       monitored_instance:
         name: InfluxDB
@@ -1056,7 +1027,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-jenkins
-      most_popular: false
       community: true
       monitored_instance:
         name: Jenkins
@@ -1083,7 +1053,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-jmx
-      most_popular: false
       community: true
       monitored_instance:
         name: JMX
@@ -1110,7 +1079,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-kafka_consumer_lag
-      most_popular: false
       community: true
       monitored_instance:
         name: Kafka Consumer Lag
@@ -1140,7 +1108,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-kafka
-      most_popular: false
       community: true
       monitored_instance:
         name: Kafka
@@ -1170,7 +1137,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-kafka_zookeeper
-      most_popular: false
       community: true
       monitored_instance:
         name: Kafka ZooKeeper
@@ -1200,7 +1166,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-linode
-      most_popular: false
       community: true
       monitored_instance:
         name: Linode
@@ -1227,7 +1192,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-loki
-      most_popular: false
       community: true
       monitored_instance:
         name: loki
@@ -1254,7 +1218,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-minecraft
-      most_popular: false
       community: true
       monitored_instance:
         name: Minecraft
@@ -1281,7 +1244,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-mosquitto
-      most_popular: false
       community: true
       monitored_instance:
         name: mosquitto
@@ -1308,7 +1270,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-ibm_mq
-      most_popular: false
       community: true
       monitored_instance:
         name: IBM MQ
@@ -1335,7 +1296,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-mqtt_blackbox
-      most_popular: false
       community: true
       monitored_instance:
         name: MQTT Blackbox
@@ -1362,7 +1322,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-netapp_ontap
-      most_popular: false
       community: true
       monitored_instance:
         name: Netapp ONTAP API
@@ -1392,7 +1351,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-netapp_solidfire
-      most_popular: false
       community: true
       monitored_instance:
         name: NetApp Solidfire
@@ -1422,7 +1380,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-openvswitch
-      most_popular: false
       community: true
       monitored_instance:
         name: Open vSwitch
@@ -1449,7 +1406,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-google_pagespeed
-      most_popular: false
       community: true
       monitored_instance:
         name: Google Pagespeed
@@ -1479,7 +1435,6 @@ modules:
     meta:
       id: collector-go.d.plugin-prometheus-philips_hue
       <<: *meta
-      most_popular: false
       community: true
       monitored_instance:
         name: Philips Hue
@@ -1506,7 +1461,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-podman
-      most_popular: false
       community: true
       monitored_instance:
         name: Podman
@@ -1533,7 +1487,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-proxmox
-      most_popular: false
       community: true
       monitored_instance:
         name: Proxmox VE
@@ -1560,7 +1513,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-radius
-      most_popular: false
       community: true
       monitored_instance:
         name: RADIUS
@@ -1587,7 +1539,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-aws_rds
-      most_popular: false
       community: true
       monitored_instance:
         name: AWS RDS
@@ -1617,7 +1568,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-ripe_atlas
-      most_popular: false
       community: true
       monitored_instance:
         name: RIPE Atlas
@@ -1644,7 +1594,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-slurm
-      most_popular: false
       community: true
       monitored_instance:
         name: Slurm
@@ -1671,7 +1620,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-spacelift
-      most_popular: false
       community: true
       monitored_instance:
         name: Spacelift
@@ -1698,7 +1646,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-starlink
-      most_popular: false
       community: true
       monitored_instance:
         name: Starlink (SpaceX)
@@ -1725,7 +1672,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-statuspage
-      most_popular: false
       community: true
       monitored_instance:
         name: StatusPage
@@ -1752,7 +1698,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-tacas
-      most_popular: false
       community: true
       monitored_instance:
         name: TACACS
@@ -1779,7 +1724,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-tesla_vehicle
-      most_popular: false
       community: true
       monitored_instance:
         name: Tesla vehicle
@@ -1806,7 +1750,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-twitch
-      most_popular: false
       community: true
       monitored_instance:
         name: Twitch
@@ -1833,7 +1776,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-ubiquity_ufiber
-      most_popular: false
       community: true
       monitored_instance:
         name: Ubiquiti UFiber OLT
@@ -1860,7 +1802,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-uptimerobot
-      most_popular: false
       community: true
       monitored_instance:
         name: Uptimerobot
@@ -1887,7 +1828,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-vault_pki
-      most_popular: false
       community: true
       monitored_instance:
         name: Vault PKI
@@ -1914,7 +1854,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-vertica
-      most_popular: false
       community: true
       monitored_instance:
         name: Vertica
@@ -1941,7 +1880,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-vscode
-      most_popular: false
       community: true
       monitored_instance:
         name: VSCode
@@ -1968,7 +1906,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-4d_server
-      most_popular: false
       community: true
       monitored_instance:
         name: 4D Server
@@ -1995,7 +1932,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-8430ft-modem
-      most_popular: false
       community: true
       monitored_instance:
         name: 8430FT modem
@@ -2022,7 +1958,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-steam_a2s
-      most_popular: false
       community: true
       monitored_instance:
         name: Steam
@@ -2049,7 +1984,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-alamos_fe2
-      most_popular: false
       community: true
       monitored_instance:
         name: Alamos FE2 server
@@ -2076,7 +2010,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-amd_smi
-      most_popular: false
       community: true
       monitored_instance:
         name: AMD CPU & GPU
@@ -2103,7 +2036,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-apicast
-      most_popular: false
       community: true
       monitored_instance:
         name: APIcast
@@ -2130,7 +2062,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-authlog
-      most_popular: false
       community: true
       monitored_instance:
         name: AuthLog
@@ -2157,7 +2088,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-aws_quota
-      most_popular: false
       community: true
       monitored_instance:
         name: AWS Quota
@@ -2187,7 +2117,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-bosh
-      most_popular: false
       community: true
       monitored_instance:
         name: BOSH
@@ -2214,7 +2143,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-bungeecord
-      most_popular: false
       community: true
       monitored_instance:
         name: BungeeCord
@@ -2241,7 +2169,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-celery
-      most_popular: false
       community: true
       monitored_instance:
         name: Celery
@@ -2268,7 +2195,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-chia
-      most_popular: false
       community: true
       monitored_instance:
         name: Chia
@@ -2295,7 +2221,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-clm5ip
-      most_popular: false
       community: true
       monitored_instance:
         name: Christ Elektronik CLM5IP power panel
@@ -2322,7 +2247,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-clamd
-      most_popular: false
       community: true
       monitored_instance:
         name: ClamAV daemon
@@ -2349,7 +2273,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-clamscan
-      most_popular: false
       community: true
       monitored_instance:
         name: Clamscan results
@@ -2376,7 +2299,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-clash
-      most_popular: false
       community: true
       monitored_instance:
         name: Clash
@@ -2403,7 +2325,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-cloud_foundry
-      most_popular: false
       community: true
       monitored_instance:
         name: Cloud Foundry
@@ -2433,7 +2354,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-cloud_foundry_firebase
-      most_popular: false
       community: true
       monitored_instance:
         name: Cloud Foundry Firehose
@@ -2463,7 +2383,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-lustre
-      most_popular: false
       community: true
       monitored_instance:
         name: Lustre metadata
@@ -2490,7 +2409,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-cmon
-      most_popular: false
       community: true
       monitored_instance:
         name: ClusterControl CMON
@@ -2517,7 +2435,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-collectd
-      most_popular: false
       community: true
       monitored_instance:
         name: Collectd
@@ -2544,7 +2461,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-ftbeerpi
-      most_popular: false
       community: true
       monitored_instance:
         name: CraftBeerPi
@@ -2571,7 +2487,6 @@ modules:
     meta:
       id: collector-go.d.plugin-prometheus-cryptowatch
       <<: *meta
-      most_popular: false
       community: true
       monitored_instance:
         name: Cryptowatch
@@ -2598,7 +2513,6 @@ modules:
     meta:
       id: collector-go.d.plugin-prometheus-dmarc
       <<: *meta
-      most_popular: false
       community: true
       monitored_instance:
         name: DMARC
@@ -2628,7 +2542,6 @@ modules:
     meta:
       id: collector-go.d.plugin-prometheus-dnsbl
       <<: *meta
-      most_popular: false
       community: true
       monitored_instance:
         name: DNSBL
@@ -2657,7 +2570,6 @@ modules:
     meta:
       id: collector-go.d.plugin-prometheus-bird
       <<: *meta
-      most_popular: false
       community: true
       monitored_instance:
         name: Bird Routing Daemon
@@ -2684,7 +2596,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-elgato_keylight
-      most_popular: false
       community: true
       monitored_instance:
         name: Elgato Key Light devices.
@@ -2711,7 +2622,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-energomera
-      most_popular: false
       community: true
       monitored_instance:
         name: Energomera smart power meters
@@ -2738,7 +2648,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-fastd
-      most_popular: false
       community: true
       monitored_instance:
         name: Fastd
@@ -2765,7 +2674,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-freifunk
-      most_popular: false
       community: true
       monitored_instance:
         name: Freifunk network
@@ -2792,7 +2700,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-frrouting
-      most_popular: false
       community: true
       monitored_instance:
         name: FRRouting
@@ -2819,7 +2726,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-github_ratelimit
-      most_popular: false
       community: true
       monitored_instance:
         name: GitHub API rate limit
@@ -2847,7 +2753,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-gpsd
-      most_popular: false
       community: true
       monitored_instance:
         name: gpsd
@@ -2874,7 +2779,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-halon
-      most_popular: false
       community: true
       monitored_instance:
         name: Halon
@@ -2901,7 +2805,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-hitron_coda
-      most_popular: false
       community: true
       monitored_instance:
         name: Hitron CODA Cable Modem
@@ -2928,7 +2831,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-homebridge
-      most_popular: false
       community: true
       monitored_instance:
         name: Homebridge
@@ -2955,7 +2857,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-homey
-      most_popular: false
       community: true
       monitored_instance:
         name: Homey
@@ -2982,7 +2883,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-ibm_cex
-      most_popular: false
       community: true
       monitored_instance:
         name: IBM CryptoExpress (CEX) cards
@@ -3009,7 +2909,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-ibm_zhmc
-      most_popular: false
       community: true
       monitored_instance:
         name: IBM Z Hardware Management Console
@@ -3036,7 +2935,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-jarvis
-      most_popular: false
       community: true
       monitored_instance:
         name: Jarvis Standing Desk
@@ -3064,7 +2962,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-enclosure
-      most_popular: false
       community: true
       monitored_instance:
         name: Generic storage enclosure tool
@@ -3091,7 +2988,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-journald
-      most_popular: false
       community: true
       monitored_instance:
         name: journald
@@ -3118,7 +3014,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-kannel
-      most_popular: false
       community: true
       monitored_instance:
         name: Kannel
@@ -3145,7 +3040,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-keepalived
-      most_popular: false
       community: true
       monitored_instance:
         name: Keepalived
@@ -3172,7 +3066,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-lynis
-      most_popular: false
       community: true
       monitored_instance:
         name: Lynis audit reports
@@ -3199,7 +3092,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-meilisearch
-      most_popular: false
       community: true
       monitored_instance:
         name: Meilisearch
@@ -3226,7 +3118,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-mesos
-      most_popular: false
       community: true
       monitored_instance:
         name: Mesos
@@ -3253,7 +3144,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-xiaomi_mi_flora
-      most_popular: false
       community: true
       monitored_instance:
         name: Xiaomi Mi Flora
@@ -3280,7 +3170,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-modbus_rtu
-      most_popular: false
       community: true
       monitored_instance:
         name: Modbus protocol
@@ -3310,7 +3199,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-mogilefs
-      most_popular: false
       community: true
       monitored_instance:
         name: MogileFS
@@ -3337,7 +3225,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-mtail
-      most_popular: false
       community: true
       monitored_instance:
         name: mtail
@@ -3364,7 +3251,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-nagios
-      most_popular: false
       community: true
       monitored_instance:
         name: Nagios
@@ -3392,7 +3278,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-nature_remo
-      most_popular: false
       community: true
       monitored_instance:
         name: Nature Remo E lite devices
@@ -3419,7 +3304,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-netatmo
-      most_popular: false
       community: true
       monitored_instance:
         name: Netatmo sensors
@@ -3449,7 +3333,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-nextcloud
-      most_popular: false
       community: true
       monitored_instance:
         name: Nextcloud servers
@@ -3479,7 +3362,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-nextdns
-      most_popular: false
       community: true
       monitored_instance:
         name: NextDNS
@@ -3506,7 +3388,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-ibm_aix_njmon
-      most_popular: false
       community: true
       monitored_instance:
         name: IBM AIX systems Njmon
@@ -3533,7 +3414,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-nrpe
-      most_popular: false
       community: true
       monitored_instance:
         name: NRPE daemon
@@ -3560,7 +3440,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-obs_studio
-      most_popular: false
       community: true
       monitored_instance:
         name: OBS Studio
@@ -3587,7 +3466,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-openrc
-      most_popular: false
       community: true
       monitored_instance:
         name: OpenRC
@@ -3614,7 +3492,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-openroadm
-      most_popular: false
       community: true
       monitored_instance:
         name: OpenROADM devices
@@ -3644,7 +3521,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-openweathermap
-      most_popular: false
       community: true
       monitored_instance:
         name: OpenWeatherMap
@@ -3671,7 +3547,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-dutch_electricity_smart_meter
-      most_popular: false
       community: true
       monitored_instance:
         name: Dutch Electricity Smart Meter
@@ -3699,7 +3574,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-patroni
-      most_popular: false
       community: true
       monitored_instance:
         name: Patroni
@@ -3726,7 +3600,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-pws
-      most_popular: false
       community: true
       monitored_instance:
         name: Personal Weather Station
@@ -3753,7 +3626,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-pgbackrest
-      most_popular: false
       community: true
       monitored_instance:
         name: pgBackRest
@@ -3780,7 +3652,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-pgpool2
-      most_popular: false
       community: true
       monitored_instance:
         name: Pgpool-II
@@ -3807,7 +3678,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-pimoroni_enviro_plus
-      most_popular: false
       community: true
       monitored_instance:
         name: Pimoroni Enviro+
@@ -3834,7 +3704,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-powerpal
-      most_popular: false
       community: true
       monitored_instance:
         name: Powerpal devices
@@ -3861,7 +3730,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-proftpd
-      most_popular: false
       community: true
       monitored_instance:
         name: ProFTPD
@@ -3888,7 +3756,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-redis_queue
-      most_popular: false
       community: true
       monitored_instance:
         name: Redis Queue
@@ -3915,7 +3782,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-radio_thermostat
-      most_popular: false
       community: true
       monitored_instance:
         name: Radio Thermostat
@@ -3942,7 +3808,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-raritan_pdu
-      most_popular: false
       community: true
       monitored_instance:
         name: Raritan PDU
@@ -3969,7 +3834,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-sabnzbd
-      most_popular: false
       community: true
       monitored_instance:
         name: SABnzbd
@@ -3996,7 +3860,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-salicru_eqx
-      most_popular: false
       community: true
       monitored_instance:
         name: Salicru EQX inverter
@@ -4023,7 +3886,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-sense_energy
-      most_popular: false
       community: true
       monitored_instance:
         name: Sense Energy
@@ -4050,7 +3912,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-shelly
-      most_popular: false
       community: true
       monitored_instance:
         name: Shelly humidity sensor
@@ -4077,7 +3938,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-s7_plc
-      most_popular: false
       community: true
       monitored_instance:
         name: Siemens S7 PLC
@@ -4104,7 +3964,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-site24x7
-      most_popular: false
       community: true
       monitored_instance:
         name: Site 24x7
@@ -4131,7 +3990,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-sma_inverter
-      most_popular: false
       community: true
       monitored_instance:
         name: SMA Inverters
@@ -4158,7 +4016,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-sml
-      most_popular: false
       community: true
       monitored_instance:
         name: Smart meters SML
@@ -4185,7 +4042,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-softether
-      most_popular: false
       community: true
       monitored_instance:
         name: SoftEther VPN Server
@@ -4212,7 +4068,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-lsx
-      most_popular: false
       community: true
       monitored_instance:
         name: Solar logging stick
@@ -4239,7 +4094,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-solis
-      most_popular: false
       community: true
       monitored_instance:
         name: Solis Ginlong 5G inverters
@@ -4266,7 +4120,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-sonic
-      most_popular: false
       community: true
       monitored_instance:
         name: SONiC NOS
@@ -4293,7 +4146,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-ibm_spectrum_virtualize
-      most_popular: false
       community: true
       monitored_instance:
         name: IBM Spectrum Virtualize
@@ -4320,7 +4172,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-sphinx
-      most_popular: false
       community: true
       monitored_instance:
         name: Sphinx
@@ -4347,7 +4198,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-storidge
-      most_popular: false
       community: true
       monitored_instance:
         name: Storidge
@@ -4374,7 +4224,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-strongswan
-      most_popular: false
       community: true
       monitored_instance:
         name: strongSwan
@@ -4401,7 +4250,6 @@ modules:
     meta:
       id: collector-go.d.plugin-prometheus-sunspec
       <<: *meta
-      most_popular: false
       community: true
       monitored_instance:
         name: Sunspec Solar Energy
@@ -4428,7 +4276,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-suricata
-      most_popular: false
       community: true
       monitored_instance:
         name: Suricata
@@ -4457,7 +4304,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-synology_activebackup
-      most_popular: false
       community: true
       monitored_instance:
         name: Synology ActiveBackup
@@ -4484,7 +4330,6 @@ modules:
     meta:
       id: collector-go.d.plugin-prometheus-sysload
       <<: *meta
-      most_popular: false
       community: true
       monitored_instance:
         name: Sysload
@@ -4511,7 +4356,6 @@ modules:
     meta:
       id: collector-go.d.plugin-prometheus-tado
       <<: *meta
-      most_popular: false
       community: true
       monitored_instance:
         name: Tado smart heating solution
@@ -4539,7 +4383,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-tankerkoenig
-      most_popular: false
       community: true
       monitored_instance:
         name: Tankerkoenig API
@@ -4566,7 +4409,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-tesla_wall_connector
-      most_popular: false
       community: true
       monitored_instance:
         name: Tesla Wall Connector
@@ -4593,7 +4435,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-warp10
-      most_popular: false
       community: true
       monitored_instance:
         name: Warp10
@@ -4621,7 +4462,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-yourls
-      most_popular: false
       community: true
       monitored_instance:
         name: YOURLS URL Shortener
@@ -4648,7 +4488,6 @@ modules:
     meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-zerto
-      most_popular: false
       community: true
       monitored_instance:
         name: Zerto

--- a/src/go/plugin/go.d/collector/proxysql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/proxysql/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/pulsar/metadata.yaml
+++ b/src/go/plugin/go.d/collector/pulsar/metadata.yaml
@@ -19,7 +19,6 @@ modules:
               module_name: apps
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/puppet/metadata.yaml
+++ b/src/go/plugin/go.d/collector/puppet/metadata.yaml
@@ -17,7 +17,6 @@ modules:
         description: ""
       keywords:
         - puppet
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/rabbitmq/metadata.yaml
+++ b/src/go/plugin/go.d/collector/rabbitmq/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/redis/metadata.yaml
+++ b/src/go/plugin/go.d/collector/redis/metadata.yaml
@@ -24,7 +24,6 @@ modules:
       keywords:
         - redis
         - databases
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/rethinkdb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/rethinkdb/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - rethinkdb
         - database
         - db
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/riakkv/metadata.yaml
+++ b/src/go/plugin/go.d/collector/riakkv/metadata.yaml
@@ -20,7 +20,6 @@ modules:
         - database
         - nosql
         - big data
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/rspamd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/rspamd/metadata.yaml
@@ -24,7 +24,6 @@ modules:
         - spam
         - rspamd
         - email
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/samba/metadata.yaml
+++ b/src/go/plugin/go.d/collector/samba/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/go/plugin/go.d/collector/scaleio/metadata.yaml
+++ b/src/go/plugin/go.d/collector/scaleio/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/sensors/metadata.yaml
+++ b/src/go/plugin/go.d/collector/sensors/metadata.yaml
@@ -25,7 +25,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/smartctl/metadata.yaml
+++ b/src/go/plugin/go.d/collector/smartctl/metadata.yaml
@@ -20,7 +20,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -162,7 +162,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/spigotmc/metadata.yaml
+++ b/src/go/plugin/go.d/collector/spigotmc/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - minecraft
         - spigotmc
         - spigot
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/sql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/sql/metadata.yaml
@@ -29,7 +29,6 @@ modules:
         - sqlserver
         - mssql
         - generic
-      most_popular: false
     overview:
       multi_instance: true
       data_collection:

--- a/src/go/plugin/go.d/collector/squid/metadata.yaml
+++ b/src/go/plugin/go.d/collector/squid/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - squid
         - web delivery
         - squid caching proxy
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/squidlog/metadata.yaml
+++ b/src/go/plugin/go.d/collector/squidlog/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/storcli/metadata.yaml
+++ b/src/go/plugin/go.d/collector/storcli/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/supervisord/metadata.yaml
+++ b/src/go/plugin/go.d/collector/supervisord/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/systemdunits/metadata.yaml
+++ b/src/go/plugin/go.d/collector/systemdunits/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/tengine/metadata.yaml
+++ b/src/go/plugin/go.d/collector/tengine/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/tomcat/metadata.yaml
+++ b/src/go/plugin/go.d/collector/tomcat/metadata.yaml
@@ -21,7 +21,6 @@ modules:
         - websocket
         - jakarta
         - javaEE
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/tor/metadata.yaml
+++ b/src/go/plugin/go.d/collector/tor/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - tor
         - traffic
         - vpn
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/traefik/metadata.yaml
+++ b/src/go/plugin/go.d/collector/traefik/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/typesense/metadata.yaml
+++ b/src/go/plugin/go.d/collector/typesense/metadata.yaml
@@ -19,7 +19,6 @@ modules:
       keywords:
         - typesense
         - search engine
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/unbound/metadata.yaml
+++ b/src/go/plugin/go.d/collector/unbound/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/upsd/metadata.yaml
+++ b/src/go/plugin/go.d/collector/upsd/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/uwsgi/metadata.yaml
+++ b/src/go/plugin/go.d/collector/uwsgi/metadata.yaml
@@ -19,7 +19,6 @@ modules:
         - application server
         - python
         - web applications
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/varnish/metadata.yaml
+++ b/src/go/plugin/go.d/collector/varnish/metadata.yaml
@@ -21,7 +21,6 @@ modules:
         - cache
         - web server
         - web cache
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/vcsa/metadata.yaml
+++ b/src/go/plugin/go.d/collector/vcsa/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/vernemq/metadata.yaml
+++ b/src/go/plugin/go.d/collector/vernemq/metadata.yaml
@@ -18,7 +18,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/vsphere/metadata.yaml
+++ b/src/go/plugin/go.d/collector/vsphere/metadata.yaml
@@ -19,7 +19,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: true
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/w1sensor/metadata.yaml
+++ b/src/go/plugin/go.d/collector/w1sensor/metadata.yaml
@@ -18,7 +18,6 @@ modules:
         - temperature
         - sensor
         - 1-wire
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/weblog/metadata.yaml
+++ b/src/go/plugin/go.d/collector/weblog/metadata.yaml
@@ -17,7 +17,6 @@ modules:
         - nginx
         - lighttpd
         - logs
-      most_popular: false
       info_provided_to_referring_integrations:
         description: ""
       related_resources:

--- a/src/go/plugin/go.d/collector/whoisquery/metadata.yaml
+++ b/src/go/plugin/go.d/collector/whoisquery/metadata.yaml
@@ -17,7 +17,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/wireguard/metadata.yaml
+++ b/src/go/plugin/go.d/collector/wireguard/metadata.yaml
@@ -14,7 +14,6 @@ modules:
         - wireguard
         - vpn
         - security
-      most_popular: false
       info_provided_to_referring_integrations:
         description: ""
       related_resources:

--- a/src/go/plugin/go.d/collector/x509check/metadata.yaml
+++ b/src/go/plugin/go.d/collector/x509check/metadata.yaml
@@ -13,7 +13,6 @@ modules:
       keywords:
         - x509
         - certificate
-      most_popular: false
       info_provided_to_referring_integrations:
         description: ""
       related_resources:

--- a/src/go/plugin/go.d/collector/yugabytedb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/yugabytedb/metadata.yaml
@@ -21,7 +21,6 @@ modules:
         - database
         - yb
         - yugabyte
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/go.d/collector/zfspool/metadata.yaml
+++ b/src/go/plugin/go.d/collector/zfspool/metadata.yaml
@@ -20,7 +20,6 @@ modules:
           list: []
       info_provided_to_referring_integrations:
         description: ""
-      most_popular: false
     overview:
       data_collection:
         metrics_description: >

--- a/src/go/plugin/go.d/collector/zookeeper/metadata.yaml
+++ b/src/go/plugin/go.d/collector/zookeeper/metadata.yaml
@@ -12,7 +12,6 @@ modules:
         icon_filename: zookeeper.svg
       keywords:
         - zookeeper
-      most_popular: false
       info_provided_to_referring_integrations:
         description: ""
       related_resources:

--- a/src/go/plugin/ibm.d/modules/as400/metadata.yaml
+++ b/src/go/plugin/ibm.d/modules/as400/metadata.yaml
@@ -17,7 +17,6 @@ modules:
         description: ""
       keywords:
         - as400
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/ibm.d/modules/db2/metadata.yaml
+++ b/src/go/plugin/ibm.d/modules/db2/metadata.yaml
@@ -17,7 +17,6 @@ modules:
         description: ""
       keywords:
         - db2
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/ibm.d/modules/mq/metadata.yaml
+++ b/src/go/plugin/ibm.d/modules/mq/metadata.yaml
@@ -17,7 +17,6 @@ modules:
         description: ""
       keywords:
         - mq
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/ibm.d/modules/websphere/jmx/metadata.yaml
+++ b/src/go/plugin/ibm.d/modules/websphere/jmx/metadata.yaml
@@ -17,7 +17,6 @@ modules:
         description: ""
       keywords:
         - websphere_jmx
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/ibm.d/modules/websphere/mp/metadata.yaml
+++ b/src/go/plugin/ibm.d/modules/websphere/mp/metadata.yaml
@@ -17,7 +17,6 @@ modules:
         description: ""
       keywords:
         - websphere_mp
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/ibm.d/modules/websphere/pmi/metadata.yaml
+++ b/src/go/plugin/ibm.d/modules/websphere/pmi/metadata.yaml
@@ -17,7 +17,6 @@ modules:
         description: ""
       keywords:
         - websphere_pmi
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/scripts.d/modules/nagios/metadata.yaml
+++ b/src/go/plugin/scripts.d/modules/nagios/metadata.yaml
@@ -21,7 +21,6 @@ modules:
         - checks
         - scripts
         - monitoring
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |

--- a/src/go/plugin/scripts.d/modules/scheduler/metadata.yaml
+++ b/src/go/plugin/scripts.d/modules/scheduler/metadata.yaml
@@ -22,7 +22,6 @@ modules:
       keywords:
         - scheduler
         - scripts
-      most_popular: false
     overview:
       data_collection:
         metrics_description: |


### PR DESCRIPTION
##### Summary
related to #21810 #21770


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes most_popular from all integrations and schemas, and drops category priority (per #21810). This cleans up the integration data model and removes unused sorting metadata.

- **Refactors**
  - Removed most_popular from collector, deploy, and category schemas and from all integration metadata YAMLs.
  - Removed category priority from schemas and categories.yaml; deleted related fields from docs integration schema and README frontmatter generation.
  - Updated gen_docs_integrations.py to stop emitting most_popular.

- **Migration**
  - Downstream integrations must remove most_popular and priority keys to pass schema validation.
  - Regenerate docs and update any custom sorting that previously relied on these fields.

<sup>Written for commit 909ae58222214c1961bb47fba1300f08e331f577. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

