### PR TITLE
docs(go.d/mysql): add User Statistics prerequisite for per-user metrics

### DIFF
--- a/src/go/plugin/go.d/collector/mysql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mysql/metadata.yaml
@@ -93,8 +93,27 @@ modules:
                 FLUSH PRIVILEGES;
                 ```
 
-              The `netdata` user will have the ability to connect to the MySQL server on localhost without a password. 
+              The `netdata` user will have the ability to connect to the MySQL server on localhost without a password.
               It will only be able to gather statistics without being able to alter or affect operations in any way.
+          - title: Enable User Statistics (optional)
+            description: |
+              To collect per-user statistics, the [User Statistics](https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/query-optimizations/statistics-for-optimizing-queries/user-statistics) plugin must be enabled.
+              This is available for **MariaDB** and **Percona**, not for MySQL.
+
+              By default, statistics are not collected. To enable the plugin, set the `userstat` system variable.
+
+              - **In a configuration file** (persistent, requires restart):
+
+                ```ini
+                [mariadb]
+                userstat = 1
+                ```
+
+              - **Dynamically** (takes effect immediately, does not persist across restarts):
+
+                ```mysql
+                SET GLOBAL userstat=1;
+                ```
       configuration:
         file:
           name: go.d/mysql.conf


### PR DESCRIPTION
Add setup instructions for enabling the userstat plugin, which is required to collect per-user metrics on MariaDB and Percona.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docs for enabling the User Statistics (userstat) plugin required to collect per‑user metrics in the MySQL go.d collector. Clarifies this works on MariaDB and Percona only; not supported on MySQL.

- **Migration**
  - MariaDB/Percona: enable userstat (persistent: add userstat=1 in config; dynamic: SET GLOBAL userstat=1)
  - MySQL: per‑user metrics are not available

<sup>Written for commit 11956c4df7e5230814ff77dbe3e35aaa6ac1637b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

