### PR TITLE
fix(go.d/sd): skip unsupported discoverer configs

### DIFF
--- a/src/go/plugin/agent/discovery/sd/sd.go
+++ b/src/go/plugin/agent/discovery/sd/sd.go
@@ -238,6 +238,12 @@ func (d *ServiceDiscovery) addPipeline(ctx context.Context, conf confFile) {
 		d.Errorf("config '%s' has no discoverer configured", conf.source)
 		return
 	}
+	if !d.hasDiscovererType(scfg.DiscovererType()) {
+		if scfg.SourceType() != confgroup.TypeStock {
+			d.Warningf("config '%s' uses unsupported discoverer type '%s', skipping", conf.source, scfg.DiscovererType())
+		}
+		return
+	}
 
 	if scfg.Name() == "" {
 		d.Errorf("config '%s' has no name configured", conf.source)

--- a/src/go/plugin/agent/discovery/sd/sd_test.go
+++ b/src/go/plugin/agent/discovery/sd/sd_test.go
@@ -83,8 +83,33 @@ func TestServiceDiscovery_Run(t *testing.T) {
 	}
 }
 
+func TestServiceDiscovery_UnsupportedDiscovererConfigIsIgnored(t *testing.T) {
+	sim := &discoverySimExt{
+		configs: []confFile{
+			prepareUnsupportedDiscovererConfigFile("/usr/lib/netdata/conf.d/sd/unsupported.conf", "unsupported"),
+		},
+		wantPipelines:    nil,
+		wantExposedCount: 0,
+	}
+	sim.run(t)
+}
+
 func prepareConfigFile(source, name string) confFile {
 	disc, _ := pipeline.NewDiscovererPayload(testDiscovererTypeNetListeners, testNetListenersConfig{})
+	cfg := pipeline.Config{
+		Name:       name,
+		Discoverer: disc,
+	}
+	bs, _ := yaml.Marshal(cfg)
+
+	return confFile{
+		source:  source,
+		content: bs,
+	}
+}
+
+func prepareUnsupportedDiscovererConfigFile(source, name string) confFile {
+	disc, _ := pipeline.NewDiscovererPayload("unsupported", map[string]any{})
 	cfg := pipeline.Config{
 		Name:       name,
 		Discoverer: disc,

--- a/src/go/plugin/agent/discovery/sd/sim_test.go
+++ b/src/go/plugin/agent/discovery/sd/sim_test.go
@@ -108,9 +108,7 @@ func (sim *discoverySimExt) run(t *testing.T) {
 
 	// Check exposed configs after SD goroutine has stopped (no race on entry.Status).
 	// Caches survive shutdown — StopAll only stops pipelines, doesn't clear caches.
-	if sim.wantExposedCount > 0 {
-		assert.Equal(t, sim.wantExposedCount, mgr.exposed.Count(), "exposed configs count")
-	}
+	assert.Equal(t, sim.wantExposedCount, mgr.exposed.Count(), "exposed configs count")
 	for _, want := range sim.wantExposed {
 		entry, ok := mgr.exposed.LookupByKey(want.discovererType + ":" + want.name)
 		if !assert.Truef(t, ok, "exposed config '%s:%s' not found", want.discovererType, want.name) {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Service discovery now skips configs that use unsupported discoverer types to prevent invalid pipelines and reduce noise. User configs log a warning; stock configs are silently ignored.

- **Bug Fixes**
  - Added a supported-type check in addPipeline; skip unknown discoverers.
  - Warn only for non-stock sources when skipping.
  - Added a test for unsupported discoverers and tightened exposed-count assertions.

<sup>Written for commit 606677624c814cbbfce4af87c257382a21ad33d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

