### PR TITLE
Include corrosion's cargo build dir in the clean target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,12 @@ if(ENABLE_NETDATA_JOURNAL_FILE_READER OR ENABLE_PLUGIN_OTEL OR ENABLE_PLUGIN_OTE
     )
     FetchContent_MakeAvailable(Corrosion)
 
+    # Corrosion places cargo build artifacts under ${CMAKE_BINARY_DIR}/cargo/
+    # (see Corrosion.cmake cargo_target_dir). Register it for cleanup so that
+    # `ninja clean` removes it.  If a future Corrosion version changes this
+    # path, this line must be updated to match.
+    set_directory_properties(PROPERTIES ADDITIONAL_CLEAN_FILES "${CMAKE_BINARY_DIR}/cargo")
+
     if(ENABLE_NETDATA_JOURNAL_FILE_READER)
         corrosion_import_crate(MANIFEST_PATH src/crates/jf/Cargo.toml
                                CRATES journal_reader_ffi)


### PR DESCRIPTION
SSIA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `ninja clean` removes Corrosion’s cargo build artifacts by adding ${CMAKE_BINARY_DIR}/cargo to CMake’s ADDITIONAL_CLEAN_FILES.

<sup>Written for commit 8b5fe51fad914c85e9b86988842e762bdacf6d8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

