### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/exporting/graphite/graphite.c
+++ b/src/exporting/graphite/graphite.c
@@ -149,7 +149,7 @@ int format_dimension_collected_graphite_plaintext(struct instance *instance, RRD
             chart_name,
             dimension_name,
             (instance->labels_buffer) ? buffer_tostring(instance->labels_buffer) : "",
-            rrddim_last_collected_raw_int(rd),
+            (collected_number)rrddim_last_collected_raw_int(rd),
             (unsigned long long)rd->collector.last_collected_time.tv_sec);
 
     return 0;

--- a/src/exporting/json/json.c
+++ b/src/exporting/json/json.c
@@ -182,7 +182,7 @@ int format_dimension_collected_json_plaintext(struct instance *instance, RRDDIM 
     if(rrddim_is_float(rd))
         buffer_sprintf(instance->buffer, NETDATA_DOUBLE_FORMAT, rrddim_last_collected_as_double(rd));
     else
-        buffer_sprintf(instance->buffer, COLLECTED_NUMBER_FORMAT, rrddim_last_collected_raw_int(rd));
+        buffer_sprintf(instance->buffer, COLLECTED_NUMBER_FORMAT, (collected_number)rrddim_last_collected_raw_int(rd));
 
     buffer_sprintf(instance->buffer, ",\"timestamp\":%llu}",
         (unsigned long long)rd->collector.last_collected_time.tv_sec);

--- a/src/exporting/opentsdb/opentsdb.c
+++ b/src/exporting/opentsdb/opentsdb.c
@@ -199,7 +199,7 @@ int format_dimension_collected_opentsdb_telnet(struct instance *instance, RRDDIM
             chart_name,
             dimension_name,
             (unsigned long long)rd->collector.last_collected_time.tv_sec,
-            rrddim_last_collected_raw_int(rd),
+            (collected_number)rrddim_last_collected_raw_int(rd),
             (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
             (instance->labels_buffer) ? buffer_tostring(instance->labels_buffer) : "");
 
@@ -337,7 +337,7 @@ int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *
     if(rrddim_is_float(rd))
         buffer_sprintf(instance->buffer, NETDATA_DOUBLE_FORMAT, rrddim_last_collected_as_double(rd));
     else
-        buffer_sprintf(instance->buffer, COLLECTED_NUMBER_FORMAT, rrddim_last_collected_raw_int(rd));
+        buffer_sprintf(instance->buffer, COLLECTED_NUMBER_FORMAT, (collected_number)rrddim_last_collected_raw_int(rd));
 
     buffer_sprintf(
         instance->buffer,


### PR DESCRIPTION
##### Summary
- Fix compilation warnings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes build warnings by casting rrddim_last_collected_raw_int to collected_number where integers are formatted. Applies to Graphite plaintext, JSON, and OpenTSDB (telnet and HTTP) exporters to align types with COLLECTED_NUMBER_FORMAT and prevent format-mismatch warnings.

<sup>Written for commit e52c95456ff4700df62054bbbade989ae8b07d24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

