### PR TITLE
Fix  context hub cleanup

### DIFF
--- a/src/database/contexts/rrdcontext-queues.c
+++ b/src/database/contexts/rrdcontext-queues.c
@@ -99,6 +99,9 @@ static void rrdcontext_prune_hub_queue(RRDHOST *host, usec_t now_ut, bool force_
             dictionary_acquired_item_release(host->rrdctx.contexts, item);
 
         spinlock_lock(&host->rrdctx.hub_queue.spinlock);
+        if(unlikely(!service_running(SERVICE_CONTEXT)))
+            break;
+
         if(stale) {
             // Revalidate after re-lock: queue may have changed while lock was dropped.
             RRDCONTEXT *rc_at_idx = RRDCONTEXT_QUEUE_GET(&host->rrdctx.hub_queue, idx);

--- a/src/plugins.d/pluginsd_internals.h
+++ b/src/plugins.d/pluginsd_internals.h
@@ -157,6 +157,12 @@ static inline void pluginsd_rrddim_put_to_slot(PARSER *parser, RRDSET *st, RRDDI
             prd->id = NULL;
 
             prd->rda = rrddim_find_and_acquire(st, string2str(rd->id), true);
+            if(unlikely(!prd->rda)) {
+                netdata_log_error("PLUGINSD: failed to acquire dimension '%s' for chart '%s' while updating slot cache",
+                                  rrddim_id(rd), rrdset_id(st));
+                return;
+            }
+
             prd->rd = rrddim_acquired_to_rrddim(prd->rda);
             prd->id = string2str(prd->rd->id);
         }


### PR DESCRIPTION
##### Summary
- Introduce `rrdcontext_prune_hub_queue` for better queue management, including handling stale or over-limit entries.
- Add queue bounding and cleanup during unclaimed or non-dispatching states.
- Improve RRDCONTEXT hub-queue handling to prevent indefinite retention of entries.
- Enhance pluginsd resource cleanup by releasing and reacquiring `rrddim` resources appropriately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents RRDCONTEXT hub-queue growth and fixes pluginsd rrddim cleanup to avoid leaks and stuck GC. Adds pruning and guardrails so stale/offline entries are removed safely.

- **Bug Fixes**
  - Prune stale/over-limit hub-queue entries (15m, 10k), be claim/dispatch aware (skip enqueue and force-clear when unclaimed; bound queue when streaming is off), and stop processing when the context service is not running.
  - Revalidate under lock before removal; release old rrddim before reacquiring; on acquire failure, log an error and return to avoid leaks and stale pointers.

<sup>Written for commit f0f5bd3b33b4e17ffbf8c42ced7ad172a5f119b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

