### PR TITLE
fix: apps.plugin use-after-free crash on parent pointer dereference

### DIFF
--- a/src/collectors/apps.plugin/apps_pid.c
+++ b/src/collectors/apps.plugin/apps_pid.c
@@ -909,6 +909,7 @@ bool collect_data_for_all_pids(void) {
     for(struct pid_stat *p = root_of_pids(); p ; p = p->next) {
         p->read = p->updated = p->merged = false;
         p->children_count = 0;
+        p->parent = NULL; // clear stale parent pointers from previous iteration to prevent use-after-free
 
 #if (INCREMENTAL_DATA_COLLECTION == 0)
         p->last_stat_collected_usec = p->stat_collected_usec;


### PR DESCRIPTION
##### Summary

In `collect_data_for_all_pids()`, the parent pointers from the previous collection cycle can reference `pid_stat` entries that have since been freed (when a process exits and its entry is released via `aral_freez()` in `del_pid_entry()`). The subsequent `link_all_processes_to_their_parents()` call rebuilds parent pointers, but `collect_parents_before_children()` runs before that rebuild and dereferences `p->parent` while it still points to freed memory.

The fix clears all parent pointers to NULL at the start of each collection cycle, before `collect_parents_before_children()` can follow dangling pointers. The correct parent chain is rebuilt later by `link_all_processes_to_their_parents()`.

##### Test Plan

Reproduced consistently on a k3s cluster (7 nodes, 4 workers) where apps.plugin crashed with SIGSEGV (signal 11) after exactly 242 data collections on every worker node:

1. Iteration N: `cleanup_exited_pids()` calls `del_pid_entry(A)` → frees parent process A's `pid_stat` struct via `aral_freez()`. But children's `->parent` pointers still point to the freed memory.
2. Iteration N+1: `collect_parents_before_children()` traverses `for (struct pid_stat *pp = p; pp; pp = pp->parent)` → follows `pp->parent` → dereferences the dangling pointer → SIGSEGV.

The crash always occurred at collection 242 because it corresponded to the time until the first parent process exited on that specific k3s workload (same pods = same process lifecycle = same crash point).

After deploying the fix, all nodes ran well past the previous crash point with no SIGSEGV.

##### Additional Information

The crash manifested as:
- `processes` function returning HTTP 503 on the dashboard
- apps.plugin process terminating with signal 11
- Consistent reproduction across all worker nodes at the same collection count

The use-after-free occurs in the window between the start of `collect_data_for_all_pids()` and the `link_all_processes_to_their_parents()` call. During this window, `collect_parents_before_children()` walks parent chains that may contain freed entries.

<details> <summary>For users: How does this change affect me?</summary>

- **Area affected:** apps.plugin (process monitoring)
- **Visibility:** Under the hood — prevents a crash, no UI change
- **Impact:** Users running Netdata in environments with high process churn (especially Kubernetes) may experience apps.plugin crashes (SIGSEGV) causing the `processes` function to return 503 errors. This fix eliminates that crash.
- **Benefit:** Improved stability of apps.plugin in container/orchestration environments.

</details>