### PR TITLE
fix: netdev_mutex deadlock when do_proc_net_dev() fails

### DIFF
--- a/src/collectors/proc.plugin/proc_net_dev.c
+++ b/src/collectors/proc.plugin/proc_net_dev.c
@@ -1742,8 +1742,9 @@ void netdev_main(void *ptr_is_null __maybe_unused)
         worker_is_busy(0);
 
         netdata_mutex_lock(&netdev_mutex);
-        if (do_proc_net_dev(localhost->rrd_update_every, hb_dt))
-            break;
+        int ret = do_proc_net_dev(localhost->rrd_update_every, hb_dt);
         netdata_mutex_unlock(&netdev_mutex);
+        if (ret)
+            break;
     }
 }


### PR DESCRIPTION
##### Summary

When `do_proc_net_dev()` returns an error (e.g. cannot open `/proc/net/dev`), the main loop in `netdev_main()` executes `break` while still holding `netdev_mutex`. The mutex is never unlocked, permanently deadlocking the NETDEV collector thread.

This causes the `network-interfaces` function to hang indefinitely, since `netdev_function_net_interfaces()` also needs to acquire `netdev_mutex`. On streaming setups, this blocks the parent's function call which then times out.

The fix moves `netdata_mutex_unlock()` before the error check, ensuring the mutex is always released regardless of whether `do_proc_net_dev()` succeeds or fails.

The mutex was introduced in PR #12996 (May 2022) when the netdev collector was moved to a separate thread. The deadlock has been latent since then, only manifesting when `procfile_open()` fails — which happens in container environments where `/host/proc/1/net/dev` is inaccessible (e.g. SELinux enforcing with `container_t` domain on openSUSE MicroOS / k3s).

##### Test Plan

Reproduced on a k3s cluster (7 nodes, openSUSE MicroOS with SELinux enforcing) where:
1. `/host/proc/1/net/dev` returns Permission Denied due to SELinux `dontaudit` rule blocking `container_t` from accessing `init_t` proc entries
2. `do_proc_net_dev()` fails on first call → `break` without unlock → permanent deadlock
3. All subsequent `network-interfaces` function calls hang forever waiting on `netdev_mutex`
4. Verified zero `net.*` charts were ever created (collector never completed a single cycle)

With the fix applied, the mutex is always released. The collector exits cleanly on failure, and the `network-interfaces` function returns immediately (empty result) instead of hanging.

##### Additional Information

The root cause chain:
1. SELinux `container_t` domain has a `dontaudit` rule: `dontaudit container_domain domain:dir { getattr open search }` — this **silently** denies access to `/proc/1/net/dev` without any audit log entry
2. `procfile_open()` returns NULL → `do_proc_net_dev()` returns 1 (error)
3. `netdev_main()` loop: `netdata_mutex_lock(); if(do_proc_net_dev(...)) break;` — breaks without unlocking
4. `netdev_function_net_interfaces()` tries `netdata_mutex_lock()` → deadlock forever

This affects any container environment where `/host/proc/1/net/dev` is not accessible, including systems with SELinux enforcing, `hidepid` on procfs, or restricted container runtimes.

<details> <summary>For users: How does this change affect me?</summary>

- **Area affected:** Network interface monitoring (proc.plugin netdev collector)
- **Visibility:** The `network-interfaces` function in the dashboard hangs forever / times out on affected systems. After this fix, it either works normally or returns an empty result cleanly.
- **Impact:** Users running Netdata in containers on SELinux-enforcing systems (e.g. openSUSE MicroOS, Fedora CoreOS, RHEL with SELinux) may experience the `network-interfaces` dashboard function hanging indefinitely. This also blocks the streaming thread on child nodes, potentially causing disconnections.
- **Benefit:** Eliminates a permanent deadlock in the netdev collector, improving stability in containerized deployments.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deadlock in the netdev collector by always releasing netdev_mutex when do_proc_net_dev() fails; the unlock now happens before the error check. Prevents network-interfaces from hanging on systems where /proc/net/dev cannot be opened (e.g., containers with SELinux or restricted procfs).

<sup>Written for commit 99c8cacb293f3ad47854b7c3059c383c9930c851. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

