### PR TITLE
Fix data race in ML training during host stop

### DIFF
--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -620,6 +620,13 @@ static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim)
 
     spinlock_lock(&dim->slock);
 
+    ml_host_t *host = (ml_host_t *) dim->rd->rrdset->rrdhost->ml_host;
+    if (!host || !host->ml_running) {
+        dim->training_in_progress = false;
+        spinlock_unlock(&dim->slock);
+        return;
+    }
+
     if (dim->km_contexts.size() < Cfg.num_models_to_use) {
         dim->km_contexts.emplace_back(dim->kmeans);
     } else {
@@ -1133,6 +1140,8 @@ static enum ml_worker_result ml_worker_add_existing_model(ml_worker_t *worker, m
     }
     spinlock_unlock(&Dim->slock);
 
+    // Safe without Dim->slock: per-host work is serialized through a single worker queue,
+    // and stop/reset no longer writes Dim->kmeans from non-worker threads.
     Dim->kmeans = req.inlined_km;
     ml_dimension_update_models(worker, Dim);
     pulse_ml_models_received();

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -79,6 +79,9 @@ void ml_host_stop(RRDHOST *rh) {
     if (!host || !host->ml_running)
         return;
 
+    // Prevent new ML activity from publishing while we reset host/dimension state.
+    host->ml_running = false;
+
     netdata_mutex_lock(&host->mutex);
 
     // reset host stats
@@ -112,8 +115,7 @@ void ml_host_stop(RRDHOST *rh) {
             dim->suppression_anomaly_counter = 0;
             dim->suppression_window_counter = 0;
             dim->cns.clear();
-
-            ml_kmeans_init(&dim->kmeans);
+            dim->km_contexts.clear();
 
             spinlock_unlock(&dim->slock);
         }
@@ -122,8 +124,6 @@ void ml_host_stop(RRDHOST *rh) {
     rrdset_foreach_done(rsp);
 
     netdata_mutex_unlock(&host->mutex);
-
-    host->ml_running = false;
 }
 
 void ml_host_get_info(RRDHOST *rh, BUFFER *wb)


### PR DESCRIPTION
##### Summary
- Prevent concurrent ML activity during host reset and improve thread safety in k-means dimension handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block new ML work during host stop and guard k-means updates to fix a data race. Prevents crashes and inconsistent models on shutdown.

- **Bug Fixes**
  - Disable ML at the start of ml_host_stop; clear km_contexts instead of reinitializing kmeans.
  - In ml_dimension_update_models, bail out when the host isn’t running and reset training_in_progress.
  - Move Dim->kmeans assignment outside the lock; rely on the serialized worker queue to avoid cross-thread writes.

<sup>Written for commit 6b9f8b4975b4ad8412639ae42086f9fd1bee9602. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

