### PR TITLE
Update units in ping RTT variance chart from `ms^2` to `ms²` for consistency

### DIFF
--- a/src/go/plugin/go.d/collector/ping/charts.yaml
+++ b/src/go/plugin/go.d/collector/ping/charts.yaml
@@ -65,7 +65,7 @@ groups:
       - id: host_rtt_variance
         title: Ping round-trip time variance
         context: host_rtt_variance
-        units: ms^2
+        units: ms²
         instances:
           by_labels: [host]
         dimensions:


### PR DESCRIPTION
##### Summary
- Adjust units

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed the unit label for ping RTT variance to “ms²” instead of “ms^2” for consistent formatting and clearer display across charts.

<sup>Written for commit d7127e3081d99b280b5a798aa604c58833cced3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

