### PR TITLE
Refactor UID/GID cache updates in apps plugin aggregation logic

### DIFF
--- a/src/collectors/apps.plugin/apps_aggregations.c
+++ b/src/collectors/apps.plugin/apps_aggregations.c
@@ -198,6 +198,13 @@ void aggregate_processes_to_targets(void) {
     struct target *w = NULL, *o = NULL;
     (void)w; (void)o;
 
+#if (PROCESSES_HAVE_UID == 1)
+    update_cached_host_users();
+#endif
+#if (PROCESSES_HAVE_GID == 1)
+    update_cached_host_groups();
+#endif
+
     // concentrate everything on the targets
     for(struct pid_stat *p = root_of_pids(); p ; p = p->next) {
 
@@ -217,8 +224,6 @@ void aggregate_processes_to_targets(void) {
         // user target
 
 #if (PROCESSES_HAVE_UID == 1)
-        update_cached_host_users();
-
         o = p->uid_target;
         if(likely(p->uid_target && p->uid_target->uid == p->uid))
             w = p->uid_target;
@@ -236,7 +241,6 @@ void aggregate_processes_to_targets(void) {
         // user group target
 
 #if (PROCESSES_HAVE_GID == 1)
-        update_cached_host_users();
 
         o = p->gid_target;
         if(likely(p->gid_target && p->gid_target->gid == p->gid))


### PR DESCRIPTION
##### Summary
- Relocate `update_cached_host_users()` and `update_cached_host_groups()` calls outside per-PID loops to optimize and simplify code structure.
- Remove redundant updates within conditional blocks.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored apps plugin aggregation to refresh UID/GID caches once per cycle instead of per process, removing redundant updates and reducing overhead. Simplifies control flow by moving cache updates before the PID loop.

- **Refactors**
  - Call update_cached_host_users() and update_cached_host_groups() once before iterating PIDs (guarded by PROCESSES_HAVE_UID/GID).
  - Removed duplicate updates inside UID/GID branches.
  - No change to target selection or aggregation behavior.

<sup>Written for commit e05beaa8a6f0fc6fc42b236da8034d3bb5233249. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

