### PR TITLE
Add msys-yaml DLL to Windows install dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4016,6 +4016,7 @@ install(CODE "
 
 if(OS_WINDOWS)
         install(FILES /usr/bin/msys-protobuf-32.dll
+                      /usr/bin/msys-yaml-0-2.dll
                       /usr/bin/msys-uv-1.dll
                       DESTINATION "${BINDIR}")
 


### PR DESCRIPTION
##### Summary
- Fix windows install (yaml lib)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add msys-yaml-0-2.dll to the Windows install to fix missing YAML dependency at runtime on Windows. Updates the CMake OS_WINDOWS install list so the DLL is copied into BINDIR.

<sup>Written for commit c582c76eaf4eee3c5da8ca7976a11f47d29217a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

