### PR TITLE
Fix eBPF socket documentation to clarify module must be enabled first

### DIFF
--- a/src/collectors/ebpf.plugin/metadata.yaml
+++ b/src/collectors/ebpf.plugin/metadata.yaml
@@ -1580,7 +1580,7 @@ modules:
       configuration:
         file:
           name: "ebpf.d/network.conf"
-          description: "Overwrite default configuration helping to reduce memory usage. You can also select charts visible on dashboard."
+          description: "Overwrite default configuration helping to reduce memory usage. You can also select charts visible on dashboard. Note: You must first enable the socket module in ebpf.d.conf by setting `socket = yes` in the `[ebpf programs]` section."
         options:
           description: |
             All options are defined inside section `[global]`. Options inside `network connections` are ignored for while.


### PR DESCRIPTION
Fixes #16986. Clarifies that users must enable the socket module in ebpf.d.conf before configuring it in ebpf.d/network.conf. This resolves the confusion where the plugin was looking for ebpf.d.conf with the socket module enabled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies eBPF socket setup: you must enable the socket module in ebpf.d.conf before configuring ebpf.d/network.conf. Adds a note to set socket = yes under [ebpf programs] to prevent misconfiguration and related plugin errors.

<sup>Written for commit 9f052f1645acb8ef33d0b90aa2e38c06a2feec55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

