### PR TITLE
Rename Top tab to Live tab across all documentation

### DIFF
--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -727,9 +727,9 @@ sidebar:
               edit_url: https://github.com/netdata/netdata/edit/master/docs/dashboards-and-charts/nodes-tab.md
               description: See charts from all your nodes in one pane of glass, then dive in to embedded dashboards for granular troubleshooting of ongoing issues.
           - meta:
-              label: Top
-              edit_url: https://github.com/netdata/netdata/edit/master/docs/dashboards-and-charts/top-tab.md
-              description: Instructions on how to use Functions
+              label: Live
+              edit_url: https://github.com/netdata/netdata/edit/master/docs/dashboards-and-charts/live-tab.md
+              description: Access live information from monitored nodes through Netdata Functions
       - meta:
           label: Theme
           edit_url: https://github.com/netdata/netdata/edit/master/docs/dashboards-and-charts/themes.md

--- a/docs/dashboards-and-charts/README.md
+++ b/docs/dashboards-and-charts/README.md
@@ -19,7 +19,7 @@ The Netdata dashboard consists of the following main sections:
 - [Nodes Tab](/docs/dashboards-and-charts/nodes-tab.md)
 - [Netdata Charts](/docs/dashboards-and-charts/netdata-charts.md)
 - [Metrics Tab and Single Node Tabs](/docs/dashboards-and-charts/metrics-tab-and-single-node-tabs.md)
-- [Top Tab](/docs/dashboards-and-charts/top-tab.md)
+- [Live Tab](/docs/dashboards-and-charts/live-tab.md)
 - [Logs Tab](/docs/dashboards-and-charts/logs-tab.md)
 - [Dashboards Tab](/docs/dashboards-and-charts/dashboards-tab.md)
 - [Alerts Tab](/docs/dashboards-and-charts/alerts-tab.md)

--- a/docs/dashboards-and-charts/live-tab.md
+++ b/docs/dashboards-and-charts/live-tab.md
@@ -1,6 +1,6 @@
-# Top Tab
+# Live Tab
 
-The **Top tab** gives you access to [Netdata Functions](/docs/top-monitoring-netdata-functions.md) that can be executed on any node running the Netdata Agent. These specialized routines, provided by various collectors, offer enhanced insights and allow you to trigger specific actions directly on the monitored node.
+The **Live tab** gives you real-time access to [Netdata Functions](/docs/top-monitoring-netdata-functions.md) that can be executed on any node running the Netdata Agent. These specialized routines, provided by various collectors, deliver live information from your monitored nodes—including database monitoring functions, network topology maps, process explorers, and more.
 
 You can **use these Functions to**:
 
@@ -15,11 +15,11 @@ You can also execute a Function from the [Nodes tab](/docs/dashboards-and-charts
 
 :::note
 
-If you receive an error saying that your node can’t execute Functions, check the [prerequisites](/docs/top-monitoring-netdata-functions.md) to ensure your node is configured properly.
+If you receive an error saying that your node can't execute Functions, check the [prerequisites](/docs/top-monitoring-netdata-functions.md) to ensure your node is configured properly.
 
 :::
 
-## Top Tab Structure Overview
+## Live Tab Structure Overview
 
 ```mermaid
 flowchart TD
@@ -42,13 +42,13 @@ flowchart TD
 
 :::tip
 
-The diagram above shows how Function selection and execution work in the Top tab, helping you visualize the flow from choosing a Function to viewing the results.
+The diagram above shows how Function selection and execution work in the Live tab, helping you visualize the flow from choosing a Function to viewing the results.
 
 :::
 
-## Top Tab View
+## Live Tab View
 
-The main view of the Top tab provides two elements, depending on the selected Function:
+The main view of the Live tab provides two elements, depending on the selected Function:
 
 | Element           | Description                                                                                                                  |
 |-------------------|------------------------------------------------------------------------------------------------------------------------------|
@@ -66,7 +66,7 @@ You can control the data refresh and update settings in the top right-hand corne
 
 ## Functions Bar
 
-The **Functions bar**, located on the right-hand side of the Top tab, lets you select which Function to run, on which node, and apply filtering where available.
+The **Functions bar**, located on the right-hand side of the Live tab, lets you select which Function to run, on which node, and apply filtering where available.
 
 | Option              | Description                                                                                                                                                                  |
 |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/functions/databases.md
+++ b/docs/functions/databases.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Database query functions provide deep visibility into SQL and NoSQL database performance through Netdata's Top tab. They help you identify problematic queries, detect deadlocks, and understand error patterns—all from the Netdata dashboard.
+Database query functions provide deep visibility into SQL and NoSQL database performance through Netdata's Live tab. They help you identify problematic queries, detect deadlocks, and understand error patterns—all from the Netdata dashboard.
 
 | Capability | Description |
 |------------|-------------|

--- a/docs/netdata-oss-limitations.md
+++ b/docs/netdata-oss-limitations.md
@@ -37,7 +37,7 @@ Without authentication, anyone who can reach the Netdata dashboard could access 
 | Multi-node views | 5 nodes | 5 nodes | Unlimited |
 | Custom dashboards | 1 per agent | 1 per room | Unlimited |
 
-### Functions (Top Tab)
+### Functions (Live Tab)
 
 Functions provide on-demand, detailed information beyond standard metrics.
 

--- a/docs/observability-centralization-points/metrics-centralization-points/replication-of-past-samples.md
+++ b/docs/observability-centralization-points/metrics-centralization-points/replication-of-past-samples.md
@@ -117,7 +117,7 @@ You can monitor how replication is progressing through both your dashboard and A
 
 ### Dashboard Monitoring
 
-Check your replication progress right in your dashboard using the Netdata Function `Netdata-streaming`, under the `Top` tab.
+Check your replication progress right in your dashboard using the Netdata Function `Netdata-streaming`, under the `Live` tab.
 
 ### API Monitoring
 

--- a/src/go/plugin/go.d/collector/clickhouse/integrations/clickhouse.md
+++ b/src/go/plugin/go.d/collector/clickhouse/integrations/clickhouse.md
@@ -172,7 +172,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/clickhouse/metadata.yaml
+++ b/src/go/plugin/go.d/collector/clickhouse/metadata.yaml
@@ -269,7 +269,7 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/clickhouse.conf
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: top-queries
           name: Top Queries

--- a/src/go/plugin/go.d/collector/cockroachdb/integrations/cockroachdb.md
+++ b/src/go/plugin/go.d/collector/cockroachdb/integrations/cockroachdb.md
@@ -136,7 +136,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/cockroachdb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/cockroachdb/metadata.yaml
@@ -272,7 +272,7 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cockroachdb.conf
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: top-queries
           name: Top Queries

--- a/src/go/plugin/go.d/collector/couchbase/integrations/couchbase.md
+++ b/src/go/plugin/go.d/collector/couchbase/integrations/couchbase.md
@@ -76,7 +76,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/couchbase/metadata.yaml
+++ b/src/go/plugin/go.d/collector/couchbase/metadata.yaml
@@ -208,7 +208,7 @@ modules:
     alerts: []
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: top-queries
           name: Top Queries

--- a/src/go/plugin/go.d/collector/elasticsearch/integrations/elasticsearch.md
+++ b/src/go/plugin/go.d/collector/elasticsearch/integrations/elasticsearch.md
@@ -172,7 +172,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/elasticsearch/integrations/opensearch.md
+++ b/src/go/plugin/go.d/collector/elasticsearch/integrations/opensearch.md
@@ -172,7 +172,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/elasticsearch/metadata.yaml
+++ b/src/go/plugin/go.d/collector/elasticsearch/metadata.yaml
@@ -294,7 +294,7 @@ modules:
         info: node index $label:index health status is red.
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: top-queries
           name: Top Queries

--- a/src/go/plugin/go.d/collector/mongodb/integrations/mongodb.md
+++ b/src/go/plugin/go.d/collector/mongodb/integrations/mongodb.md
@@ -206,7 +206,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/mongodb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mongodb/metadata.yaml
@@ -182,7 +182,7 @@ modules:
     alerts: []
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: top-queries
           name: Top Queries

--- a/src/go/plugin/go.d/collector/mssql/integrations/microsoft_sql_server.md
+++ b/src/go/plugin/go.d/collector/mssql/integrations/microsoft_sql_server.md
@@ -241,7 +241,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/mssql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mssql/metadata.yaml
@@ -279,7 +279,7 @@ modules:
     alerts: []
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: top-queries
           name: Top Queries

--- a/src/go/plugin/go.d/collector/mysql/integrations/mariadb.md
+++ b/src/go/plugin/go.d/collector/mysql/integrations/mariadb.md
@@ -189,7 +189,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/mysql/integrations/mysql.md
+++ b/src/go/plugin/go.d/collector/mysql/integrations/mysql.md
@@ -189,7 +189,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/mysql/integrations/percona_mysql.md
+++ b/src/go/plugin/go.d/collector/mysql/integrations/percona_mysql.md
@@ -189,7 +189,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/mysql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mysql/metadata.yaml
@@ -288,7 +288,7 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/mysql.conf
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: top-queries
           name: Top Queries

--- a/src/go/plugin/go.d/collector/oracledb/integrations/oracle_db.md
+++ b/src/go/plugin/go.d/collector/oracledb/integrations/oracle_db.md
@@ -137,7 +137,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/oracledb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/oracledb/metadata.yaml
@@ -177,7 +177,7 @@ modules:
     alerts: []
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: top-queries
           name: Top Queries

--- a/src/go/plugin/go.d/collector/postgres/integrations/postgresql.md
+++ b/src/go/plugin/go.d/collector/postgres/integrations/postgresql.md
@@ -233,7 +233,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/postgres/metadata.yaml
+++ b/src/go/plugin/go.d/collector/postgres/metadata.yaml
@@ -240,7 +240,7 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/postgres.conf
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: top-queries
           name: Top Queries

--- a/src/go/plugin/go.d/collector/proxysql/integrations/proxysql.md
+++ b/src/go/plugin/go.d/collector/proxysql/integrations/proxysql.md
@@ -170,7 +170,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/proxysql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/proxysql/metadata.yaml
@@ -140,7 +140,7 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/proxysql.conf
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: top-queries
           name: Top Queries

--- a/src/go/plugin/go.d/collector/redis/integrations/redis.md
+++ b/src/go/plugin/go.d/collector/redis/integrations/redis.md
@@ -108,7 +108,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/redis/metadata.yaml
+++ b/src/go/plugin/go.d/collector/redis/metadata.yaml
@@ -202,7 +202,7 @@ modules:
         info: time elapsed since the link between master and slave is down
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: top-queries
           name: Top Queries

--- a/src/go/plugin/go.d/collector/rethinkdb/integrations/rethinkdb.md
+++ b/src/go/plugin/go.d/collector/rethinkdb/integrations/rethinkdb.md
@@ -98,7 +98,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Running Queries

--- a/src/go/plugin/go.d/collector/rethinkdb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/rethinkdb/metadata.yaml
@@ -145,7 +145,7 @@ modules:
     alerts: []
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: running-queries
           name: Running Queries

--- a/src/go/plugin/go.d/collector/snmp/integrations/snmp_devices.md
+++ b/src/go/plugin/go.d/collector/snmp/integrations/snmp_devices.md
@@ -126,7 +126,7 @@ If `ping.enabled` is true, ICMP latency/packet-loss charts are also provided (or
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Network Interfaces

--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -484,7 +484,7 @@ modules:
     alerts: []
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: interfaces
           name: Network Interfaces

--- a/src/go/plugin/go.d/collector/sql/integrations/sql_databases_generic.md
+++ b/src/go/plugin/go.d/collector/sql/integrations/sql_databases_generic.md
@@ -29,7 +29,7 @@ To see what a specific job collects, open that job's dashboard in Netdata
 and inspect the charts and dimensions it created.
 
 Jobs can also define **functions** that provide interactive table views in
-Netdata's Top tab. A job can have metrics only, functions only, or both.
+Netdata's Live tab. A job can have metrics only, functions only, or both.
 
 :::tip
 
@@ -53,7 +53,7 @@ For each metric block you define, it executes the SQL query (inline or via
 dimensions.
 
 Additionally, you can define **functions** that expose SQL query results as
-interactive table views in Netdata's Top tab. Functions support filtering,
+interactive table views in Netdata's Live tab. Functions support filtering,
 sorting, and searching without creating persistent metrics.
 
 ### Result Processing Modes
@@ -117,7 +117,7 @@ interactive table views in Netdata's **Top** tab. Functions are configured per j
 in the `functions` section of the job configuration. Since functions are entirely
 user-defined, no predefined functions are listed here.
 
-In the Top tab, functions appear in a hierarchical menu:
+In the Live tab, functions appear in a hierarchical menu:
 
 ```
 Databases
@@ -272,7 +272,7 @@ metrics:
 # Set function_only: true if this job only provides functions (no metrics).
 function_only: <true|false>                    # OPTIONAL. Default: false.
 
-# Expose SQL queries as interactive table views in Netdata's Top tab.
+# Expose SQL queries as interactive table views in Netdata's Live tab.
 functions:
   - id: <function_id>                          # REQUIRED. Unique identifier.
     name: <display_name>                       # OPTIONAL. Derived from id if not set.
@@ -307,7 +307,7 @@ functions:
 | **Labels** | static_labels | A map of static labels added to every chart created by this job. Useful for tagging charts with environment, region, or role. | {} | no |
 | **Queries & Metrics** | queries | A list of reusable queries. Metric blocks can reference these via `query_ref` to avoid repeating SQL. See [Configuration Structure](#configuration) for details. | [] | no |
 |  | metrics | A list of metric blocks. Each block defines how a query is executed and how its result is transformed into one or more charts. See [Configuration Structure](#configuration) for details. | [] | no |
-| **Functions** | functions | A list of SQL functions exposed as interactive table views in Netdata's Top tab. Each function runs a SQL query and displays results in a filterable, sortable table. See [Functions](#functions) for details. | [] | no |
+| **Functions** | functions | A list of SQL functions exposed as interactive table views in Netdata's Live tab. Each function runs a SQL query and displays results in a filterable, sortable table. See [Functions](#functions) for details. | [] | no |
 |  | functions[].id | Unique identifier for this function. |  | yes |
 |  | functions[].name | Display name shown in the UI. Auto-derived from ID if not set. |  | no |
 |  | functions[].description | Help text shown in the UI. |  | no |

--- a/src/go/plugin/go.d/collector/sql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/sql/metadata.yaml
@@ -41,7 +41,7 @@ modules:
           and inspect the charts and dimensions it created.
 
           Jobs can also define **functions** that provide interactive table views in
-          Netdata's Top tab. A job can have metrics only, functions only, or both.
+          Netdata's Live tab. A job can have metrics only, functions only, or both.
 
           :::tip
 
@@ -64,7 +64,7 @@ modules:
           dimensions.
 
           Additionally, you can define **functions** that expose SQL query results as
-          interactive table views in Netdata's Top tab. Functions support filtering,
+          interactive table views in Netdata's Live tab. Functions support filtering,
           sorting, and searching without creating persistent metrics.
 
           ### Result Processing Modes
@@ -215,7 +215,7 @@ modules:
             # Set function_only: true if this job only provides functions (no metrics).
             function_only: <true|false>                    # OPTIONAL. Default: false.
 
-            # Expose SQL queries as interactive table views in Netdata's Top tab.
+            # Expose SQL queries as interactive table views in Netdata's Live tab.
             functions:
               - id: <function_id>                          # REQUIRED. Unique identifier.
                 name: <display_name>                       # OPTIONAL. Derived from id if not set.
@@ -294,7 +294,7 @@ modules:
 
             - name: functions
               description: >
-                A list of SQL functions exposed as interactive table views in Netdata's Top tab.
+                A list of SQL functions exposed as interactive table views in Netdata's Live tab.
                 Each function runs a SQL query and displays results in a filterable, sortable table.
                 See [Functions](#functions) for details.
               default_value: "[]"
@@ -711,7 +711,7 @@ modules:
         in the `functions` section of the job configuration. Since functions are entirely
         user-defined, no predefined functions are listed here.
 
-        In the Top tab, functions appear in a hierarchical menu:
+        In the Live tab, functions appear in a hierarchical menu:
 
         ```
         Databases

--- a/src/go/plugin/go.d/collector/yugabytedb/integrations/yugabytedb.md
+++ b/src/go/plugin/go.d/collector/yugabytedb/integrations/yugabytedb.md
@@ -334,7 +334,7 @@ Metrics:
 
 ## Functions
 
-This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+This collector exposes real-time functions for interactive troubleshooting in the Live tab.
 
 
 ### Top Queries

--- a/src/go/plugin/go.d/collector/yugabytedb/metadata.yaml
+++ b/src/go/plugin/go.d/collector/yugabytedb/metadata.yaml
@@ -266,7 +266,7 @@ modules:
     alerts: []
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: top-queries
           name: Top Queries


### PR DESCRIPTION
Docs update 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the “Top” tab to “Live” across the docs to match the UI and emphasize real-time Functions. Links, labels, and copy now point to the Live tab.

- **Refactors**
  - Renamed top-tab.md to live-tab.md and updated the sidebar map and README.
  - Replaced “Top tab” with “Live tab” in docs and collector guides/metadata (e.g., SQL, ClickHouse, MySQL, Postgres, Redis, SNMP, etc.).
  - Tightened wording to highlight live information and real-time Functions; documentation-only changes.

<sup>Written for commit 4ce9c3c80581e1be916d1758f62b954baad7b60b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

