### PR TITLE
docs: fix Top tab leftovers

### DIFF
--- a/src/go/plugin/go.d/collector/docker/metadata.yaml
+++ b/src/go/plugin/go.d/collector/docker/metadata.yaml
@@ -130,7 +130,7 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/docker.conf
     functions:
       description: |
-        This collector exposes real-time functions for interactive troubleshooting in the Top tab.
+        This collector exposes real-time functions for interactive troubleshooting in the Live tab.
       list:
         - id: container-ls
           name: Containers

--- a/src/go/plugin/go.d/collector/sql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/sql/metadata.yaml
@@ -606,7 +606,7 @@ modules:
                 PostgreSQL example that provides an interactive slow query analysis view
                 without collecting any time-series metrics.
 
-                This is useful for ad-hoc troubleshooting via the Netdata **Top** tab.
+                This is useful for ad-hoc troubleshooting via the Netdata **Live** tab.
                 The function queries `pg_stat_statements` to show the slowest queries
                 sorted by total execution time.
               config: |
@@ -707,7 +707,7 @@ modules:
     functions:
       description: |
         This collector supports user-defined SQL functions that expose query results as
-        interactive table views in Netdata's **Top** tab. Functions are configured per job
+        interactive table views in Netdata's **Live** tab. Functions are configured per job
         in the `functions` section of the job configuration. Since functions are entirely
         user-defined, no predefined functions are listed here.
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan


<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs to replace references to the “Top” tab with the “Live” tab in Docker and SQL collector metadata to match the current UI.
No code or behavior changes; this clarifies where real-time functions and interactive tables appear.

<sup>Written for commit d3aa9984408e75b0cc819c85d36680ee8e95850e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

