### PR TITLE
Fix uninitialized string assignment in `json-c-parser-inline.h`

### DIFF
--- a/src/libnetdata/json/json-c-parser-inline.h
+++ b/src/libnetdata/json/json-c-parser-inline.h
@@ -117,6 +117,8 @@
             buffer_sprintf(error, "cannot convert to string for '%s.%s'", path, member);                        \
             return false;                                                                                       \
         }                                                                                                       \
+        else                                                                                                    \
+            dst[0] = '\0';                                                                                      \
     }                                                                                                           \
     else {                                                                                                      \
         dst[0] = '\0';                                                                                          \


### PR DESCRIPTION
##### Summary
-  Fix CID 501701:       Uninitialized variables  (UNINIT)
  /src/health/health_dyncfg.c: 188           in parse_prototype()



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set dst[0] = '\0' on the failure path in json-c-parser-inline.h so callers always get an initialized string. Fixes the uninitialized read flagged by Coverity (CID 501701) in health_dyncfg.c:parse_prototype.

<sup>Written for commit 3b42b5ba6d911f40e1c132ddcc6f4b2a082ec4b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

