### PR TITLE
fix(packaging): add --no-same-owner to tar in Go toolchain install

### DIFF
--- a/packaging/check-for-go-toolchain.sh
+++ b/packaging/check-for-go-toolchain.sh
@@ -142,7 +142,7 @@ install_go_toolchain() {
     return 1
   fi
 
-  if ! tar -C /usr/local/ -xzf "${GOLANG_ARCHIVE_NAME}"; then
+  if ! tar -C /usr/local/ --no-same-owner -xzf "${GOLANG_ARCHIVE_NAME}"; then
     GOLANG_FAILURE_REASON="Failed to extract Go toolchain."
     return 1
   fi


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

- [x] AI-generated or AI-assisted content has been manually verified (examples/instructions tested where applicable).

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add --no-same-owner to tar during Go toolchain install to avoid preserving archive file ownership. This prevents permission errors when extracting to /usr/local and makes installs reliable in containers and non-root environments.

<sup>Written for commit 5499acc2277135c5179ff3b7eecc799543e5ad81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

