### PR TITLE
Fix initialization handling in `GetHardwareInfo` function

### DIFF
--- a/src/collectors/windows.plugin/GetHardwareInfo.c
+++ b/src/collectors/windows.plugin/GetHardwareInfo.c
@@ -366,6 +366,9 @@ static RRDSET *netdata_publish_cpu_chart(int update_every)
 
 static void netdata_loop_cpu_chart(int update_every)
 {
+    if (unlikely(!cpus_lock_initialized || !cpus))
+        return;
+
     RRDSET *chart = netdata_publish_cpu_chart(update_every);
 
     EnterCriticalSection(&cpus_lock);
@@ -391,11 +394,17 @@ static void netdata_loop_cpu_chart(int update_every)
 int do_GetHardwareInfo(int update_every, usec_t dt __maybe_unused)
 {
     static bool initialized = false;
+    static bool init_failed = false;
+
+    if (unlikely(init_failed))
+        return -1;
+
     if (unlikely(!initialized)) {
-        initialized = true;
         if (initialize()) {
+            init_failed = true;
             return -1;
         }
+        initialized = true;
     }
 
     netdata_loop_cpu_chart(update_every);


### PR DESCRIPTION
##### Summary
- Add checks for uninitialized `cpus` and `cpus_lock` in `netdata_loop_cpu_chart` to prevent potential issues.
- Introduce `init_failed` flag to handle initialization failures gracefully and prevent redundant attempts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix initialization handling in the Windows GetHardwareInfo collector to prevent crashes and redundant work. We short-circuit after a failed initialize() using an init_failed flag, and skip netdata_loop_cpu_chart if cpus_lock isn’t initialized or cpus is null.

<sup>Written for commit d4df18717d5394532c763464c9611daf83259866. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

