### PR TITLE
Clarify retention in Parent with tiered storage examples

### DIFF
--- a/docs/deployment-guides/deployment-strategies.md
+++ b/docs/deployment-guides/deployment-strategies.md
@@ -74,7 +74,7 @@ Edit `stream.conf` on the Child using the [edit-config](/docs/netdata-agent/conf
 
 ### Parent with Tiered Storage
 
-This example helps you configure a Parent with multiple [tiers of metrics storage](/src/database/README.md#tiers) to store different time ranges at different resolutionsm, for 10 Children with about 2k metrics each. Retention in each tier is restricted both in time and storage space, whichever is met first. See [retention settings](/src/database/CONFIGURATION.md#retention-settings) for fine-tuning retention.
+This example helps you configure a Parent with multiple [tiers of metrics storage](/src/database/README.md#tiers) to store different time ranges at different resolutions, for 10 Children with about 2k metrics each. Retention in each tier is restricted both in time and storage space, whichever is met first. See [retention settings](/src/database/CONFIGURATION.md#retention-settings) for fine-tuning retention.
 
 **What this gives you:**
 


### PR DESCRIPTION
This clarifies the example configuration for a Parent with tiered storage
on how retention works, by explicitly showing retention in time (as suggested
by the prose above) as well, and referring to the documentation on retention
settings.

Also removes details tags to just show the examples the page is about.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the Parent with tiered storage example with per-tier retention times in addition to size limits, and linked to retention settings.
Made examples visible by default by removing details/summary, fixed a relative link, tightened wording to avoid repetition, and corrected a typo.

<sup>Written for commit 8ebab9e98dc4e31a31c85d1be28cd607693a954f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

