### PR TITLE
Update documentation (Windows installer)

### DIFF
--- a/packaging/windows/WINDOWS_INSTALLER.md
+++ b/packaging/windows/WINDOWS_INSTALLER.md
@@ -100,7 +100,8 @@ By using silent installation, you agree to:
 
 When Netdata is installed on Windows, it automatically registers as a Windows Service and appears in
 **Add or remove programs** (also known as **Programs and Features** or **Apps & features** in newer Windows versions).
-The service can be managed through Windows Services (services.msc) or via the [Netdata Dashboard](http://localhost:19999).
+The service can be monitored through the [Netdata Dashboard](http://localhost:19999).
+To start, stop, or restart the service, use Windows Services (services.msc) or command-line tools
 
 ## Automatic Updates
 


### PR DESCRIPTION
##### Summary
To help users who cannot find Netdata in their environment, this PR adds a new section to our documentation to help them visualize where Netdata is.

##### Test Plan

- Check grammar

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a "Where is Netdata?" section to the Windows installer docs to help users find and manage the agent after install. It notes Netdata installs as a Windows Service, appears in Add or remove programs (Programs and Features / Apps & features), can be controlled via Services (services.msc) or command-line tools, and is monitored at http://localhost:19999.

<sup>Written for commit 34ccff22a31f0d25b512cd47bfdb79183c824a48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

