### PR TITLE
fix(jobmgr): register collector static functions on first job start

### DIFF
--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -94,6 +94,7 @@ func New(cfg Config) *Manager {
 		runtimeService:     cfg.RuntimeService,
 
 		moduleFuncs:       newModuleFuncRegistry(),
+		staticMethodsSeen: make(map[string]struct{}),
 		discoveredConfigs: newDiscoveredConfigsCache(),
 		seen:              seen,
 		exposed:           exposed,
@@ -166,6 +167,9 @@ type Manager struct {
 
 	fileStatus  *fileStatus
 	moduleFuncs *moduleFuncRegistry
+	// staticMethodsSeen tracks modules whose static methods were already exposed.
+	// Registration is delayed until the first started job for a module.
+	staticMethodsSeen map[string]struct{}
 
 	discoveredConfigs *discoveredConfigs
 	seen              *dyncfg.SeenCache[confgroup.Config]
@@ -217,41 +221,7 @@ func (m *Manager) Run(ctx context.Context, in chan []*confgroup.Group) {
 			m.moduleFuncs.registerModule(name, creator)
 		}
 
-		// Register static module-level functions
-		if creator.Methods != nil {
-			methods := creator.Methods()
-			for _, method := range methods {
-				if method.ID == "" {
-					m.Warningf("skipping function registration for module '%s': empty method ID", name)
-					continue
-				}
-				funcName := fmt.Sprintf("%s:%s", name, method.ID)
-				m.fnReg.Register(funcName, m.makeMethodFuncHandler(name, method.ID))
-
-				// Notify Netdata about this function so it appears in the functions API
-				help := method.Help
-				if help == "" {
-					help = fmt.Sprintf("%s %s data function", name, method.ID)
-				}
-
-				// https://github.com/netdata/netdata/blob/1bc1775a17590b3c0fe3a4fe547dc6146d07be89/src/libnetdata/user-auth/http-access.h#L21
-				const cloudAccess = "0x0013" // SIGNED_ID | SAME_SPACE | SENSITIVE_DATA
-				access := "0x0000"
-				if method.RequireCloud {
-					access = cloudAccess
-				}
-				m.dyncfgApi.FunctionGlobal(netdataapi.FunctionGlobalOpts{
-					Name:     funcName,
-					Timeout:  60,
-					Help:     help,
-					Tags:     "top",
-					Access:   access,
-					Priority: 100,
-					Version:  3,
-				})
-			}
-		}
-		// Note: Per-job methods (JobMethods) are registered in startRunningJob
+		// Note: Static module methods and per-job methods are registered in startRunningJob.
 	}
 
 	m.loadFileStatus()
@@ -435,6 +405,7 @@ func (m *Manager) startRunningJob(job runtimeJob) {
 
 	// Track job for module function routing.
 	m.moduleFuncs.addJob(job.ModuleName(), job.Name(), job)
+	m.registerModuleMethodsOnFirstJobStart(job.ModuleName())
 
 	// Register job-specific methods if module provides JobMethods callback
 	creator, ok := m.modules.Lookup(job.ModuleName())
@@ -460,6 +431,9 @@ func (m *Manager) stopRunningJob(name string) {
 		m.unregisterJobMethods(job)
 		// Remove job from module function registry.
 		m.moduleFuncs.removeJob(job.ModuleName(), job.Name())
+		// Static module methods remain registered for now. Once Netdata supports
+		// function removal, this should unregister static methods when the last
+		// running job for the module is removed.
 		job.Stop()
 	}
 }
@@ -500,6 +474,50 @@ func (m *Manager) waitCmdTestWorkers() {
 	case <-time.After(cmdTestWorkerDrainWait):
 		m.Warningf("dyncfg: timeout waiting %s for command test workers to drain", cmdTestWorkerDrainWait)
 	}
+}
+
+func (m *Manager) registerModuleMethodsOnFirstJobStart(moduleName string) {
+	if _, ok := m.staticMethodsSeen[moduleName]; ok {
+		return
+	}
+
+	creator, ok := m.modules.Lookup(moduleName)
+	if !ok || creator.Methods == nil {
+		return
+	}
+
+	methods := creator.Methods()
+	for _, method := range methods {
+		if method.ID == "" {
+			m.Warningf("skipping function registration for module '%s': empty method ID", moduleName)
+			continue
+		}
+		funcName := fmt.Sprintf("%s:%s", moduleName, method.ID)
+		m.fnReg.Register(funcName, m.makeMethodFuncHandler(moduleName, method.ID))
+
+		help := method.Help
+		if help == "" {
+			help = fmt.Sprintf("%s %s data function", moduleName, method.ID)
+		}
+
+		// https://github.com/netdata/netdata/blob/1bc1775a17590b3c0fe3a4fe547dc6146d07be89/src/libnetdata/user-auth/http-access.h#L21
+		const cloudAccess = "0x0013" // SIGNED_ID | SAME_SPACE | SENSITIVE_DATA
+		access := "0x0000"
+		if method.RequireCloud {
+			access = cloudAccess
+		}
+		m.dyncfgApi.FunctionGlobal(netdataapi.FunctionGlobalOpts{
+			Name:     funcName,
+			Timeout:  60,
+			Help:     help,
+			Tags:     "top",
+			Access:   access,
+			Priority: 100,
+			Version:  3,
+		})
+	}
+
+	m.staticMethodsSeen[moduleName] = struct{}{}
 }
 
 // registerJobMethods registers methods for a specific job with Netdata

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -170,6 +170,83 @@ func TestRunNotifyRunningJobs_TickOutsideLock(t *testing.T) {
 	}
 }
 
+func TestRun_DoesNotRegisterModuleMethodsBeforeAnyJobStarts(t *testing.T) {
+	fnReg := &recordingFunctionRegistry{}
+	mgr := New(Config{PluginName: testPluginName, FnReg: fnReg})
+
+	mgr.modules = collectorapi.Registry{
+		"mod": collectorapi.Creator{
+			Methods: func() []funcapi.MethodConfig {
+				return []funcapi.MethodConfig{{ID: "a"}}
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		mgr.Run(ctx, in)
+		close(done)
+	}()
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx), "manager did not report started")
+
+	cancel()
+	close(in)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("manager did not stop after cancel")
+	}
+
+	assert.Empty(t, fnReg.registeredNames(), "static methods must not be registered before first started job")
+}
+
+func TestStartRunningJob_RegistersModuleMethodsOnFirstStartedJob(t *testing.T) {
+	fnReg := &recordingFunctionRegistry{}
+	mgr := New(Config{PluginName: testPluginName, FnReg: fnReg})
+	creator := collectorapi.Creator{
+		Methods: func() []funcapi.MethodConfig {
+			return []funcapi.MethodConfig{{ID: "a"}, {ID: "b"}}
+		},
+	}
+	mgr.modules = collectorapi.Registry{"mod": creator}
+	mgr.moduleFuncs.registerModule("mod", creator)
+
+	job := &lockProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1"}
+	mgr.startRunningJob(job)
+
+	assert.ElementsMatch(t, []string{"mod:a", "mod:b"}, fnReg.registeredNames())
+}
+
+func TestStartRunningJob_DoesNotReregisterModuleMethods(t *testing.T) {
+	fnReg := &recordingFunctionRegistry{}
+	mgr := New(Config{PluginName: testPluginName, FnReg: fnReg})
+	creator := collectorapi.Creator{
+		Methods: func() []funcapi.MethodConfig {
+			return []funcapi.MethodConfig{{ID: "a"}, {ID: "b"}}
+		},
+	}
+	mgr.modules = collectorapi.Registry{"mod": creator}
+	mgr.moduleFuncs.registerModule("mod", creator)
+
+	job1 := &lockProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1"}
+	mgr.startRunningJob(job1)
+
+	job2 := &lockProbeJob{fullName: "mod_job2", moduleName: "mod", name: "job2"}
+	mgr.startRunningJob(job2)
+
+	registered := fnReg.registeredNames()
+	assert.Len(t, registered, 2)
+	assert.ElementsMatch(t, []string{"mod:a", "mod:b"}, registered)
+}
+
 func TestRegisterJobMethods_FailFastOnCollisionWithStaticMethod(t *testing.T) {
 	fnReg := &recordingFunctionRegistry{}
 	mgr := New(Config{PluginName: testPluginName, FnReg: fnReg})

--- a/src/go/plugin/agent/jobmgr/sim_test.go
+++ b/src/go/plugin/agent/jobmgr/sim_test.go
@@ -130,13 +130,21 @@ func (s *runSim) run(t *testing.T) {
 	}
 
 	var lines []string
+	skipNextEmpty := false
 	for _, s := range strings.Split(out.String(), "\n") {
 		if strings.HasPrefix(s, "CONFIG") && strings.Contains(s, " template ") {
+			skipNextEmpty = false
 			continue
 		}
 		if strings.HasPrefix(s, "FUNCTION GLOBAL") {
+			skipNextEmpty = true
 			continue
 		}
+		if skipNextEmpty && s == "" {
+			skipNextEmpty = false
+			continue
+		}
+		skipNextEmpty = false
 		if strings.HasPrefix(s, "FUNCTION_RESULT_BEGIN") {
 			parts := strings.Fields(s)
 			s = strings.Join(parts[:len(parts)-1], " ") // remove timestamp


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan


<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Static collector functions are now registered on the first started job for a module, not at manager startup. This prevents premature function exposure and avoids duplicate registrations.

- **Bug Fixes**
  - Register static module methods in startRunningJob via registerModuleMethodsOnFirstJobStart.
  - Track seen modules with staticMethodsSeen to prevent re-registration.
  - Leave static methods registered after the last job stops until function removal is supported.
  - Tests added: no registration before any job, registration on first job, no duplicate registration; minor sim_test output filtering tweak.

<sup>Written for commit dbfcbb1c60a13646c439114eae4cd74d3809a845. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

