### PR TITLE
feat(integrations): link setup option names to detailed configuration sections

### DIFF
--- a/integrations/gen_integrations.py
+++ b/integrations/gen_integrations.py
@@ -191,7 +191,7 @@ def get_jinja_env():
             lstrip_blocks=True,
         )
 
-        _jinja_env.globals.update(strfy=strfy)
+        _jinja_env.globals.update(strfy=strfy, anchorfy=anchorfy)
 
     return _jinja_env
 
@@ -202,6 +202,17 @@ def strfy(value):
     if isinstance(value, str):
         return ' '.join([v.strip() for v in value.strip().split("\n") if v]).replace('|', '/')
     return value
+
+
+def anchorfy(value):
+    if value is None:
+        return ''
+
+    anchor = str(value).strip().lower()
+    anchor = re.sub(r'[^a-z0-9]+', '-', anchor)
+    anchor = re.sub(r'-{2,}', '-', anchor).strip('-')
+
+    return anchor
 
 
 def get_category_sets(categories):

--- a/integrations/templates/setup.md
+++ b/integrations/templates/setup.md
@@ -63,19 +63,25 @@ No action required.
 |:------|:-----|:------------|:--------|:---------:|
 [% set ns = namespace(last_group=None) %]
 [% for item in entry.setup.configuration.options.list %]
-| [[ ("**" ~ item.group ~ "**") if (item.group is defined and item.group != ns.last_group) else "" ]] | [[ strfy(item.name) ]] | [[ strfy(item.description) ]] | [[ strfy(item.default_value) ]] | [[ strfy(item.required) ]] |
+[% set anchor_source = (item.group ~ "-" ~ item.name) if (item.group is defined and item.group) else item.name %]
+[% set item_anchor = "option-" ~ anchorfy(anchor_source) %]
+| [[ ("**" ~ item.group ~ "**") if (item.group is defined and item.group != ns.last_group) else "" ]] | [[ ("[" ~ strfy(item.name) ~ "](#" ~ item_anchor ~ ")") if ('detailed_description' in item) else strfy(item.name) ]] | [[ strfy(item.description) ]] | [[ strfy(item.default_value) ]] | [[ strfy(item.required) ]] |
 [% set ns.last_group = item.group if item.group is defined else ns.last_group %]
 [% endfor %]
 [% else %]
 | Option | Description | Default | Required |
 |:-----|:------------|:--------|:---------:|
 [% for item in entry.setup.configuration.options.list %]
-| [[ strfy(item.name) ]] | [[ strfy(item.description) ]] | [[ strfy(item.default_value) ]] | [[ strfy(item.required) ]] |
+[% set anchor_source = (item.group ~ "-" ~ item.name) if (item.group is defined and item.group) else item.name %]
+[% set item_anchor = "option-" ~ anchorfy(anchor_source) %]
+| [[ ("[" ~ strfy(item.name) ~ "](#" ~ item_anchor ~ ")") if ('detailed_description' in item) else strfy(item.name) ]] | [[ strfy(item.description) ]] | [[ strfy(item.default_value) ]] | [[ strfy(item.required) ]] |
 [% endfor %]
 [% endif %]
 
 [% for item in entry.setup.configuration.options.list %]
 [% if 'detailed_description' in item %]
+[% set anchor_source = (item.group ~ "-" ~ item.name) if (item.group is defined and item.group) else item.name %]
+<a id="[[ "option-" ~ anchorfy(anchor_source) ]]"></a>
 ##### [[ item.name ]]
 
 [[ item.detailed_description ]]


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

- [x] AI-generated or AI-assisted content has been manually verified (examples/instructions tested where applicable).

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes setup option names clickable in generated integration docs, linking tables to their detailed configuration sections. Improves navigation for integrations with many options.

- **New Features**
  - Added anchorfy helper and exposed it to Jinja for stable, URL-safe anchors.
  - Updated setup.md to link option names to detail sections when a detailed_description exists and to insert matching anchors.
  - Anchors are prefixed with "option-" and use group-name (if present) for uniqueness.

<sup>Written for commit 0649e2f19294c14a639613b6779aa71c21b69ff9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

