### PR TITLE
fix(packaging): Reduce docker image size by setting the permission bits in the builder stage

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -24,7 +24,9 @@ ARG BUILD_ARCH
 ENV BUILD_ARCH=$BUILD_ARCH
 
 # Copy source
-COPY . /opt/netdata.git
+COPY --exclude='**/.git' \
+     --exclude='**/Dockerfile' \
+     . /opt/netdata.git
 WORKDIR /opt/netdata.git
 
 # Install from source
@@ -66,7 +68,29 @@ RUN mkdir -p /app/usr/sbin/ \
     mkdir -p /deps/etc && \
     cp -rp /deps/etc /app/usr/local/etc && \
     chmod -R o+rX /app && \
-    chmod +x /app/usr/sbin/run.sh
+    chmod +x /app/usr/sbin/run.sh && \
+    # Apply the permissions per https://learn.netdata.cloud/docs/collecting-metrics#file-permissions-and-ownership
+    # TODO: "5" is used for the "others" bit, not consistent with the documentation
+    chmod 0755 /app/usr/libexec/netdata/plugins.d/*.plugin && \
+    for name in cgroup-network \
+                local-listeners \
+                apps.plugin \
+                debugfs.plugin \
+                freeipmi.plugin \
+                go.d.plugin \
+                perf.plugin \
+                ndsudo \
+                slabinfo.plugin \
+                network-viewer.plugin \
+                otel-plugin \
+                otel-signal-viewer-plugin \
+                systemd-journal.plugin; do \
+        [ -f "/app/usr/libexec/netdata/plugins.d/$name" ] && chmod 4755 "/app/usr/libexec/netdata/plugins.d/$name"; \
+    done && \
+    # Group write permissions due to: https://github.com/netdata/netdata/pull/6543
+    find /app/var/lib/netdata /app/var/cache/netdata -type d -exec chmod 0770 {} \; && \
+    find /app/var/lib/netdata /app/var/cache/netdata -type f -exec chmod 0660 {} \; && \
+    chmod 0700 /app/var/lib/netdata/cloud.d
 
 #####################################################################
 # This image contains preinstalled dependencies
@@ -108,27 +132,31 @@ RUN mkdir -p /opt/src /var/log/netdata && \
     ln -sf /dev/stderr /var/log/netdata/error.log && \
     ln -sf /dev/stderr /var/log/netdata/daemon.log && \
     ln -sf /dev/stdout /var/log/netdata/collector.log && \
-    ln -sf /dev/stdout /var/log/netdata/health.log
+    ln -sf /dev/stdout /var/log/netdata/health.log && \
+    chown -R ${NETDATA_UID}:0 /var/log/netdata
 
-COPY --from=builder /app /
+# Using chmod/chown command with a "RUN" instruction to set the permission/ownership
+# would bloat the image significantly, so we set the permission bits in the builder stage
+# and then copy the files with the correct ownership.
+# Own everything by root group due to https://github.com/netdata/netdata/pull/6543
+COPY --from=builder --chown=0:0 --parents \
+    /app/./usr/sbin/ \
+    /app/./usr/share/netdata \
+    /app/./usr/libexec/netdata \
+    /app/./usr/local/etc \
+    /app/./etc/netdata \
+    /
+COPY --from=builder --chown=${NETDATA_UID}:0 --parents \
+    /app/./usr/lib/netdata \
+    /app/./var/cache/netdata \
+    /app/./var/lib/netdata \
+    /
 
-# Create netdata user and apply the permissions as described in
-# https://docs.netdata.cloud/docs/netdata-security/#netdata-directories, but own everything by root group due to https://github.com/netdata/netdata/pull/6543
+# Create netdata user
 # hadolint ignore=DL3013
 RUN addgroup --gid ${NETDATA_GID} --system "${DOCKER_GRP}" && \
     adduser --system --no-create-home --shell /usr/sbin/nologin --uid ${NETDATA_UID} --home /etc/netdata --group "${DOCKER_USR}" && \
-    chown -R root:root \
-        /etc/netdata \
-        /usr/share/netdata \
-        /usr/libexec/netdata && \
-    chown -R netdata:root \
-        /usr/lib/netdata \
-        /var/cache/netdata \
-        /var/lib/netdata \
-        /var/log/netdata && \
-    chown -R netdata:netdata /var/lib/netdata/cloud.d && \
-    chmod 0700 /var/lib/netdata/cloud.d && \
-    chmod 0755 /usr/libexec/netdata/plugins.d/*.plugin && \
+    chown -R ${NETDATA_UID}:${NETDATA_GID} /var/lib/netdata/cloud.d && \
     for name in cgroup-network \
                 local-listeners \
                 apps.plugin \
@@ -142,11 +170,8 @@ RUN addgroup --gid ${NETDATA_GID} --system "${DOCKER_GRP}" && \
                 otel-plugin \
                 otel-signal-viewer-plugin \
                 systemd-journal.plugin; do \
-        [ -f "/usr/libexec/netdata/plugins.d/$name" ] && chmod 4755 "/usr/libexec/netdata/plugins.d/$name"; \
+        [ -f "/usr/libexec/netdata/plugins.d/$name" ] && test $(stat -c %a "/usr/libexec/netdata/plugins.d/$name") = "4755"; \
     done && \
-    # Group write permissions due to: https://github.com/netdata/netdata/pull/6543
-    find /var/lib/netdata /var/cache/netdata -type d -exec chmod 0770 {} \; && \
-    find /var/lib/netdata /var/cache/netdata -type f -exec chmod 0660 {} \; && \
     cp -va /etc/netdata /etc/netdata.stock
 
 ENTRYPOINT ["/usr/sbin/run.sh"]


### PR DESCRIPTION
##### Summary

Using chmod/chown command with a "RUN" instruction to set the permission/ownership would bloat the image significantly, so we set the permission bits in the builder stage and then copy the files with the correct ownership.

##### Test Plan

- [x] AI-generated or AI-assisted content has been manually verified (examples/instructions tested where applicable).

Verified all the files are with the wanted permission bits and ownerships:
```bash
$ sudo docker run --rm -it --entrypoint="" netdata bash
root@d1b8e2d85e23:/# ls -lh /usr/sbin/netdata /usr/share/netdata /usr/libexec/netdata /usr/local/etc /etc/netdata
-rwxr-xr-x  1 root root 103M Mar  5 20:21 /usr/sbin/netdata

/etc/netdata:
total 48K
drwxr-xr-x 2 root root 4.0K Mar  5 20:21 charts.d
drwxr-xr-x 2 root root 4.0K Mar  5 20:21 custom-plugins.d
-rwxr-xr-x 1 root root 8.9K Jan  3 15:30 edit-config
drwxr-xr-x 2 root root 4.0K Mar  5 20:21 go.d
drwxr-xr-x 2 root root 4.0K Mar  5 20:21 health.d
-rw-r--r-- 1 root root  279 Mar  5 20:21 netdata.conf
lrwxrwxrwx 1 root root   24 Mar  5 20:21 orig -> //usr/lib/netdata/conf.d
drwxrwxr-x 3 root root 4.0K Mar  5 20:21 otel.d
drwxr-xr-x 2 root root 4.0K Mar  5 20:21 python.d
drwxr-xr-x 2 root root 4.0K Mar  5 20:21 ssl
drwxr-xr-x 2 root root 4.0K Mar  5 20:21 statsd.d

/usr/libexec/netdata:
total 108K
drwxr-xr-x 2 root root 4.0K Mar  5 20:21 charts.d
-rwxr-xr-x 1 root root  24K Mar  5 20:15 install-service.sh
-rwxr-xr-x 1 root root  22K Mar  5 20:21 netdata-uninstaller.sh
-rwxr-xr-x 1 root root  47K Mar  5 20:21 netdata-updater.sh
drwxr-xr-x 2 root root 4.0K Mar  5 20:21 plugins.d
drwxr-xr-x 3 root root 4.0K Mar  5 20:21 python.d

/usr/local/etc:
total 0

/usr/share/netdata:
total 20K
-rw-r--r-- 1 root root  13K Mar  5 20:21 build-info-cmake-cache.gz
drwxrwxr-x 4 root root 4.0K Mar  5 20:21 web
root@d1b8e2d85e23:/# ls -lh /usr/lib/netdata /var/cache/netdata /var/lib/netdata
/usr/lib/netdata:
total 8.0K
drwxr-xr-x 11 netdata root 4.0K Mar  5 20:21 conf.d
drwxrwxr-x 12 netdata root 4.0K Mar  5 20:21 system

/var/cache/netdata:
total 0

/var/lib/netdata:
total 12K
drwx------ 1 netdata netdata 4.0K Mar  5 20:21 cloud.d
-rw-rw---- 1 netdata root      17 Mar  5 20:21 netdata.tarball.checksum
drwxrwx--- 2 netdata root    4.0K Mar  5 20:21 registry
```

##### Additional Information

Before:
```bash
$ sudo docker image ls
IMAGE                                            ID             DISK USAGE   CONTENT SIZE   EXTRA
netdata/netdata:stable                           96eb00c6a327       1.18GB             0B        
$ sudo docker history netdata/netdata:stable
IMAGE          CREATED       CREATED BY                                      SIZE      COMMENT
96eb00c6a327   2 weeks ago   HEALTHCHECK &{["CMD-SHELL" "/usr/sbin/health…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   ENTRYPOINT ["/usr/sbin/run.sh"]                 0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   RUN |5 BUILD_DATE=2026-02-16T15:33:14Z BUILD…   392MB     buildkit.dockerfile.v0
<missing>      2 weeks ago   COPY /app / # buildkit                          535MB     buildkit.dockerfile.v0
<missing>      2 weeks ago   RUN |5 BUILD_DATE=2026-02-16T15:33:14Z BUILD…   77B       buildkit.dockerfile.v0
<missing>      2 weeks ago   ENV NETDATA_EXTRA_DEB_PACKAGES=                 0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   EXPOSE [19999/tcp]                              0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   ENV NETDATA_LISTENER_PORT=19999                 0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   ENV DOCKER_USR=netdata                          0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   ENV DOCKER_GRP=netdata                          0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   ARG NETDATA_GID=201                             0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   ARG NETDATA_UID=201                             0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   ENV NETDATA_OFFICIAL_IMAGE=true                 0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   ARG OFFICIAL_IMAGE=true                         0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   LABEL org.opencontainers.image.version=2.9.0    0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   LABEL org.opencontainers.image.created=2026-…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   LABEL org.opencontainers.image.vendor=Netdat…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   LABEL org.opencontainers.image.description=O…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   LABEL org.opencontainers.image.title=Netdata…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   LABEL org.opencontainers.image.source=https:…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   LABEL org.opencontainers.image.documentation…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   LABEL org.opencontainers.image.url=https://n…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   LABEL org.opencontainers.image.authors=Netda…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   ARG BUILD_VERSION=2.9.0                         0B        buildkit.dockerfile.v0
<missing>      2 weeks ago   ARG BUILD_DATE=2026-02-16T15:33:14Z             0B        buildkit.dockerfile.v0
<missing>      4 weeks ago   RUN /bin/sh -c DISTRO_CODENAME="$(awk -F= '/…   136MB     buildkit.dockerfile.v0
<missing>      4 weeks ago   ENV DEBIAN_FRONTEND=noninteractive              0B        buildkit.dockerfile.v0
<missing>      4 weeks ago   LABEL org.opencontainers.image.vendor=Netdat…   0B        buildkit.dockerfile.v0
<missing>      4 weeks ago   LABEL org.opencontainers.image.description=B…   0B        buildkit.dockerfile.v0
<missing>      4 weeks ago   LABEL org.opencontainers.image.title=Netdata…   0B        buildkit.dockerfile.v0
<missing>      4 weeks ago   LABEL org.opencontainers.image.source=https:…   0B        buildkit.dockerfile.v0
<missing>      4 weeks ago   LABEL org.opencontainers.image.authors=Netda…   0B        buildkit.dockerfile.v0
<missing>      4 weeks ago   # debian.sh --arch 'amd64' out/ 'trixie' '@1…   120MB     debuerreotype 0.17
```
After:
```bash
$ sudo docker image ls
IMAGE                                                                 ID             DISK USAGE   CONTENT SIZE   EXTRA
netdata:latest                                                        b5a31abc515b        798MB             0B
$ sudo docker history netdata
IMAGE          CREATED             CREATED BY                                      SIZE      COMMENT
b5a31abc515b   3 minutes ago       HEALTHCHECK &{["CMD-SHELL" "/usr/sbin/health…   0B        buildkit.dockerfile.v0
<missing>      3 minutes ago       ENTRYPOINT ["/usr/sbin/run.sh"]                 0B        buildkit.dockerfile.v0
<missing>      3 minutes ago       RUN |5 BUILD_DATE= BUILD_VERSION= OFFICIAL_I…   15.9kB    buildkit.dockerfile.v0
<missing>      3 minutes ago       COPY --parents --chown=201:0 /app/./usr/lib/…   3.26MB    buildkit.dockerfile.v0
<missing>      6 minutes ago       COPY --parents --chown=0:0 /app/./usr/sbin/ …   539MB     buildkit.dockerfile.v0
<missing>      About an hour ago   RUN |5 BUILD_DATE= BUILD_VERSION= OFFICIAL_I…   0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ENV NETDATA_EXTRA_DEB_PACKAGES=                 0B        buildkit.dockerfile.v0
<missing>      About an hour ago   EXPOSE [19999/tcp]                              0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ENV NETDATA_LISTENER_PORT=19999                 0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ENV DOCKER_USR=netdata                          0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ENV DOCKER_GRP=netdata                          0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ARG NETDATA_GID=201                             0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ARG NETDATA_UID=201                             0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ENV NETDATA_OFFICIAL_IMAGE=false                0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ARG OFFICIAL_IMAGE=false                        0B        buildkit.dockerfile.v0
<missing>      About an hour ago   LABEL org.opencontainers.image.version=         0B        buildkit.dockerfile.v0
<missing>      About an hour ago   LABEL org.opencontainers.image.created=         0B        buildkit.dockerfile.v0
<missing>      About an hour ago   LABEL org.opencontainers.image.vendor=Netdat…   0B        buildkit.dockerfile.v0
<missing>      About an hour ago   LABEL org.opencontainers.image.description=O…   0B        buildkit.dockerfile.v0
<missing>      About an hour ago   LABEL org.opencontainers.image.title=Netdata…   0B        buildkit.dockerfile.v0
<missing>      About an hour ago   LABEL org.opencontainers.image.source=https:…   0B        buildkit.dockerfile.v0
<missing>      About an hour ago   LABEL org.opencontainers.image.documentation…   0B        buildkit.dockerfile.v0
<missing>      About an hour ago   LABEL org.opencontainers.image.url=https://n…   0B        buildkit.dockerfile.v0
<missing>      About an hour ago   LABEL org.opencontainers.image.authors=Netda…   0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ARG BUILD_VERSION                               0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ARG BUILD_DATE                                  0B        buildkit.dockerfile.v0
<missing>      20 hours ago        RUN /bin/sh -c DISTRO_CODENAME="$(awk -F= '/…   136MB     buildkit.dockerfile.v0
<missing>      20 hours ago        ENV DEBIAN_FRONTEND=noninteractive              0B        buildkit.dockerfile.v0
<missing>      20 hours ago        LABEL org.opencontainers.image.vendor=Netdat…   0B        buildkit.dockerfile.v0
<missing>      20 hours ago        LABEL org.opencontainers.image.description=B…   0B        buildkit.dockerfile.v0
<missing>      20 hours ago        LABEL org.opencontainers.image.title=Netdata…   0B        buildkit.dockerfile.v0
<missing>      20 hours ago        LABEL org.opencontainers.image.source=https:…   0B        buildkit.dockerfile.v0
<missing>      20 hours ago        LABEL org.opencontainers.image.authors=Netda…   0B        buildkit.dockerfile.v0
<missing>      10 days ago         # debian.sh --arch 'amd64' out/ 'trixie' '@1…   120MB     debuerreotype 0.17
```

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce Docker image size by setting permissions in the builder stage and copying artifacts with the correct ownership. Drops the image from ~1.18GB to ~798MB while keeping required permissions and runtime behavior.

- **Refactors**
  - Plugin perms: 0755 for *.plugin; 4755 for required helpers (apps.plugin, go.d.plugin, ndsudo, etc.).
  - Group-writable perms for /var/lib/netdata and /var/cache/netdata; cloud.d set to 0700 and owned by netdata.
  - Logs symlinked to stdout/stderr; chown /var/log/netdata to NETDATA_UID:0.
  - Install files with correct ownership (root:0 for system dirs; netdata:0 for /usr/lib/netdata and state dirs). Excludes .git and Dockerfile from source copy.

<sup>Written for commit 2bd4f203e469c32a47c7af9b86b4cabe70624cb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

