### PR TITLE
chore(go/plugin/functions): change "not instances configured" resp code

### DIFF
--- a/src/go/plugin/agent/jobmgr/funcshandler.go
+++ b/src/go/plugin/agent/jobmgr/funcshandler.go
@@ -119,7 +119,7 @@ func (m *Manager) makeMethodFuncHandler(moduleName, methodID string) func(functi
 
 		jobs := m.moduleFuncs.getJobNames(moduleName)
 		if len(jobs) == 0 {
-			m.respondError(fn, 503, "no %s instances configured", moduleName)
+			m.respondError(fn, 422, "no %s instances configured", moduleName)
 			return
 		}
 		jobParam := buildJobParamConfig(jobs)


### PR DESCRIPTION
to 422

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 422 (Unprocessable Entity) instead of 503 when calling a module function with no instances configured. This clarifies the error and avoids retry loops that treat it like a server outage.

- **Bug Fixes**
  - Updated func handler to respond with 422 for “no instances configured.”
  - Improves HTTP semantics and client behavior on configuration errors.

<sup>Written for commit 3e30f2b0c372c481fc0dc61811201531161ad2d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

