### PR TITLE
Improve context snapshots needed on ACLK connect

### DIFF
--- a/src/database/contexts/rrdcontext-worker.c
+++ b/src/database/contexts/rrdcontext-worker.c
@@ -1085,9 +1085,8 @@ void rrdcontext_main(void *ptr) {
             pp_queued_contexts_for_all_hosts += rrdcontext_queue_entries(&host->rrdctx.pp_queue);
             rrdcontext_post_process_queued_contexts(host);
 
-            // if post-processing drained the queue, replay any deferred checkpoint
-            if(rrdcontext_queue_entries(&host->rrdctx.pp_queue) <= 0)
-                rrdcontext_hub_pending_checkpoint_replay(host);
+            // replay deferred checkpoint if post-processing drained the queue, or on timeout
+            rrdcontext_hub_pending_checkpoint_replay(host);
 
             hub_queued_contexts_for_all_hosts += rrdcontext_queue_entries(&host->rrdctx.hub_queue);
             rrdcontext_dispatch_queued_contexts_to_hub(host, now_ut);

--- a/src/database/contexts/rrdcontext-worker.c
+++ b/src/database/contexts/rrdcontext-worker.c
@@ -1085,6 +1085,10 @@ void rrdcontext_main(void *ptr) {
             pp_queued_contexts_for_all_hosts += rrdcontext_queue_entries(&host->rrdctx.pp_queue);
             rrdcontext_post_process_queued_contexts(host);
 
+            // if post-processing drained the queue, replay any deferred checkpoint
+            if(rrdcontext_queue_entries(&host->rrdctx.pp_queue) <= 0)
+                rrdcontext_hub_pending_checkpoint_replay(host);
+
             hub_queued_contexts_for_all_hosts += rrdcontext_queue_entries(&host->rrdctx.hub_queue);
             rrdcontext_dispatch_queued_contexts_to_hub(host, now_ut);
 

--- a/src/database/contexts/rrdcontext-worker.c
+++ b/src/database/contexts/rrdcontext-worker.c
@@ -1072,6 +1072,9 @@ void rrdcontext_main(void *ptr) {
         dfe_start_reentrant(rrdhost_root_index, host) {
             if(unlikely(!service_running(SERVICE_CONTEXT))) break;
 
+            // Allow timed-out deferred checkpoints to replay even if context loading is stuck.
+            rrdcontext_hub_pending_checkpoint_replay(host);
+
             if(rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD))
                 continue;
 

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -201,7 +201,7 @@ int rrdcontext_foreach_instance_with_rrdset_in_context(RRDHOST *host, const char
 // ----------------------------------------------------------------------------
 // ACLK interface
 
-static inline const char *aclk_ctx_defer_reason_to_string(uint8_t reason) {
+static inline const char *aclk_ctx_defer_reason_to_string(ACLK_CTX_DEFER_REASON reason) {
     switch(reason) {
         case ACLK_CTX_DEFER_REASON_PENDING_CONTEXT_LOAD:
             return "pending_context_load";
@@ -210,6 +210,42 @@ static inline const char *aclk_ctx_defer_reason_to_string(uint8_t reason) {
         default:
             return "unknown";
     }
+}
+
+// Record a deferred checkpoint and queue a node info update.
+// Returns true if the checkpoint should be deferred, false if the deferral limit has been reached
+// and the checkpoint should proceed anyway.
+static bool rrdcontext_checkpoint_defer(RRDHOST *host, ACLK_CTX_DEFER_REASON reason) {
+    time_t now_s = now_realtime_sec();
+
+    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_RELAXED);
+    if(aclk_host_config) {
+        uint32_t count = __atomic_add_fetch(&aclk_host_config->context_checkpoint_deferred_count, 1, __ATOMIC_RELAXED);
+        __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_reason, reason, __ATOMIC_RELAXED);
+        __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_last_time_s, now_s, __ATOMIC_RELAXED);
+
+        // set first deferral time if this is the first one
+        time_t first_time_s = __atomic_load_n(&aclk_host_config->context_checkpoint_deferred_first_time_s, __ATOMIC_RELAXED);
+        if(!first_time_s) {
+            __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_first_time_s, now_s, __ATOMIC_RELAXED);
+            first_time_s = now_s;
+        }
+
+        // check if we exceeded the deferral limits
+        if(count >= ACLK_CTX_CHECKPOINT_MAX_DEFERRALS ||
+           (first_time_s > 0 && now_s - first_time_s >= ACLK_CTX_CHECKPOINT_DEFER_MAX_TIME_S)) {
+            nd_log(NDLS_DAEMON, NDLP_WARNING,
+                   "RRDCONTEXT: host '%s' exceeded deferral limits (%u deferrals, %lld sec since first). "
+                   "Proceeding with checkpoint despite '%s'.",
+                   rrdhost_hostname(host), count,
+                   (first_time_s > 0) ? (long long)(now_s - first_time_s) : 0LL,
+                   aclk_ctx_defer_reason_to_string(reason));
+            return false;
+        }
+    }
+
+    aclk_queue_node_info(host, false);
+    return true;
 }
 
 void rrdcontext_hub_checkpoint_command(void *ptr) {
@@ -242,17 +278,8 @@ void rrdcontext_hub_checkpoint_command(void *ptr) {
                "but host '%s' is still loading contexts. Deferring hash check and snapshot decision.",
                cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
 
-        struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_RELAXED);
-        if(aclk_host_config) {
-            __atomic_add_fetch(&aclk_host_config->context_checkpoint_deferred_count, 1, __ATOMIC_RELAXED);
-            __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_reason,
-                             ACLK_CTX_DEFER_REASON_PENDING_CONTEXT_LOAD, __ATOMIC_RELAXED);
-            __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_last_time_s, now_realtime_sec(), __ATOMIC_RELAXED);
-        }
-
-        aclk_queue_node_info(host, false);
-
-        return;
+        if(rrdcontext_checkpoint_defer(host, ACLK_CTX_DEFER_REASON_PENDING_CONTEXT_LOAD))
+            return;
     }
 
     if(rrdcontext_queue_entries(&host->rrdctx.pp_queue) > 0) {
@@ -261,17 +288,8 @@ void rrdcontext_hub_checkpoint_command(void *ptr) {
                "but host '%s' still has pending context post-processing. Deferring hash check and snapshot decision.",
                cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
 
-        struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_RELAXED);
-        if(aclk_host_config) {
-            __atomic_add_fetch(&aclk_host_config->context_checkpoint_deferred_count, 1, __ATOMIC_RELAXED);
-            __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_reason,
-                             ACLK_CTX_DEFER_REASON_PENDING_POST_PROCESSING, __ATOMIC_RELAXED);
-            __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_last_time_s, now_realtime_sec(), __ATOMIC_RELAXED);
-        }
-
-        aclk_queue_node_info(host, false);
-
-        return;
+        if(rrdcontext_checkpoint_defer(host, ACLK_CTX_DEFER_REASON_PENDING_POST_PROCESSING))
+            return;
     }
 
     if(rrdhost_flag_check(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS)) {
@@ -319,17 +337,18 @@ void rrdcontext_hub_checkpoint_command(void *ptr) {
     struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_RELAXED);
     if(aclk_host_config) {
         uint32_t deferred_count = __atomic_exchange_n(&aclk_host_config->context_checkpoint_deferred_count, 0, __ATOMIC_RELAXED);
-        uint8_t deferred_reason = __atomic_exchange_n(&aclk_host_config->context_checkpoint_deferred_reason,
-                                                       ACLK_CTX_DEFER_REASON_NONE, __ATOMIC_RELAXED);
+        ACLK_CTX_DEFER_REASON deferred_reason = __atomic_exchange_n(&aclk_host_config->context_checkpoint_deferred_reason,
+                                                                     ACLK_CTX_DEFER_REASON_NONE, __ATOMIC_RELAXED);
         time_t deferred_last_time_s = __atomic_exchange_n(&aclk_host_config->context_checkpoint_deferred_last_time_s, 0, __ATOMIC_RELAXED);
+        __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_first_time_s, 0, __ATOMIC_RELAXED);
         if(deferred_count) {
-        time_t now_s = now_realtime_sec();
-        long long age_s = (deferred_last_time_s > 0 && now_s >= deferred_last_time_s) ? (long long)(now_s - deferred_last_time_s) : -1;
-        nd_log(NDLS_DAEMON, NDLP_NOTICE,
-               "RRDCONTEXT: host '%s' Activated context streaming after %u deferred checkpoint(s), "
-               "last reason '%s', last deferred at %lld (age %lld sec).",
-               rrdhost_hostname(host), deferred_count, aclk_ctx_defer_reason_to_string(deferred_reason),
-               (long long)deferred_last_time_s, age_s);
+            time_t now_s = now_realtime_sec();
+            long long age_s = (deferred_last_time_s > 0 && now_s >= deferred_last_time_s) ? (long long)(now_s - deferred_last_time_s) : -1;
+            nd_log(NDLS_DAEMON, NDLP_NOTICE,
+                   "RRDCONTEXT: host '%s' activated context streaming after %u deferred checkpoint(s), "
+                   "last reason '%s', last deferred at %lld (age %lld sec).",
+                   rrdhost_hostname(host), deferred_count, aclk_ctx_defer_reason_to_string(deferred_reason),
+                   (long long)deferred_last_time_s, age_s);
         }
     }
 

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -202,10 +202,11 @@ int rrdcontext_foreach_instance_with_rrdset_in_context(RRDHOST *host, const char
 // ACLK interface
 
 // Save a pending checkpoint to be replayed when context processing completes.
-static void rrdcontext_checkpoint_save_pending(RRDHOST *host, struct ctxs_checkpoint *cmd) {
+// Returns true if saved successfully, false if save failed (caller should execute immediately).
+static bool rrdcontext_checkpoint_save_pending(RRDHOST *host, struct ctxs_checkpoint *cmd) {
     struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_RELAXED);
     if(!aclk_host_config)
-        return;
+        return false;
 
     spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
     freez(aclk_host_config->pending_ctx_claim_id);
@@ -213,8 +214,10 @@ static void rrdcontext_checkpoint_save_pending(RRDHOST *host, struct ctxs_checkp
     aclk_host_config->pending_ctx_claim_id = strdupz(cmd->claim_id);
     aclk_host_config->pending_ctx_node_id = strdupz(cmd->node_id);
     aclk_host_config->pending_ctx_version_hash = cmd->version_hash;
-    aclk_host_config->pending_ctx_checkpoint = true;
+    aclk_host_config->pending_ctx_saved_time_s = now_realtime_sec();
+    __atomic_store_n(&aclk_host_config->pending_ctx_checkpoint, true, __ATOMIC_RELEASE);
     spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
+    return true;
 }
 
 // Execute the checkpoint: compare version hash, send snapshot if needed, enable streaming.
@@ -299,8 +302,12 @@ void rrdcontext_hub_checkpoint_command(void *ptr) {
                "but host '%s' has pending context work. Saving checkpoint for replay after processing completes.",
                cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
 
-        rrdcontext_checkpoint_save_pending(host, cmd);
-        return;
+        if(rrdcontext_checkpoint_save_pending(host, cmd))
+            return;
+
+        nd_log(NDLS_DAEMON, NDLP_WARNING,
+               "RRDCONTEXT: failed to save pending checkpoint for host '%s' (no aclk config). Executing immediately.",
+               rrdhost_hostname(host));
     }
 
     rrdcontext_checkpoint_execute(host, cmd->claim_id, cmd->node_id, cmd->version_hash);
@@ -346,18 +353,28 @@ void rrdcontext_hub_stop_streaming_command(void *ptr) {
     rrdhost_flag_clear(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
 }
 
+#define PENDING_CTX_CHECKPOINT_MAX_AGE_S 300
+
 void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host) {
     struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_RELAXED);
-    if(!aclk_host_config || !aclk_host_config->pending_ctx_checkpoint)
+    if(!aclk_host_config || !__atomic_load_n(&aclk_host_config->pending_ctx_checkpoint, __ATOMIC_ACQUIRE))
         return;
 
+    bool pp_queue_empty = rrdcontext_queue_entries(&host->rrdctx.pp_queue) <= 0;
+
     spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
-    if(!aclk_host_config->pending_ctx_checkpoint) {
+    if(!__atomic_load_n(&aclk_host_config->pending_ctx_checkpoint, __ATOMIC_RELAXED)) {
         spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
         return;
     }
 
-    aclk_host_config->pending_ctx_checkpoint = false;
+    // replay when pp_queue is empty, or force replay on timeout
+    time_t now_s = now_realtime_sec();
+    bool timed_out = (now_s - aclk_host_config->pending_ctx_saved_time_s >= PENDING_CTX_CHECKPOINT_MAX_AGE_S);
+    if(!pp_queue_empty && !timed_out) {
+        spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
+        return;
+    }
 
     char *claim_id = aclk_host_config->pending_ctx_claim_id;
     char *node_id = aclk_host_config->pending_ctx_node_id;
@@ -366,7 +383,14 @@ void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host) {
     aclk_host_config->pending_ctx_claim_id = NULL;
     aclk_host_config->pending_ctx_node_id = NULL;
     aclk_host_config->pending_ctx_version_hash = 0;
+    aclk_host_config->pending_ctx_saved_time_s = 0;
+    __atomic_store_n(&aclk_host_config->pending_ctx_checkpoint, false, __ATOMIC_RELEASE);
     spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
+
+    if(timed_out && !pp_queue_empty)
+        nd_log(NDLS_DAEMON, NDLP_WARNING,
+               "RRDCONTEXT: pending checkpoint for host '%s' timed out after %d sec with pp_queue still active. Forcing replay.",
+               rrdhost_hostname(host), PENDING_CTX_CHECKPOINT_MAX_AGE_S);
 
     if(!claim_id || !node_id) {
         freez(claim_id);

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "rrdcontext-internal.h"
+#include "../sqlite/sqlite_aclk.h"
 
 // ----------------------------------------------------------------------------
 // visualizing flags
@@ -200,6 +201,17 @@ int rrdcontext_foreach_instance_with_rrdset_in_context(RRDHOST *host, const char
 // ----------------------------------------------------------------------------
 // ACLK interface
 
+static inline const char *aclk_ctx_defer_reason_to_string(uint8_t reason) {
+    switch(reason) {
+        case ACLK_CTX_DEFER_REASON_PENDING_CONTEXT_LOAD:
+            return "pending_context_load";
+        case ACLK_CTX_DEFER_REASON_PENDING_POST_PROCESSING:
+            return "pending_post_processing";
+        default:
+            return "unknown";
+    }
+}
+
 void rrdcontext_hub_checkpoint_command(void *ptr) {
     struct ctxs_checkpoint *cmd = ptr;
 
@@ -220,6 +232,44 @@ void rrdcontext_hub_checkpoint_command(void *ptr) {
                "RRDCONTEXT: received checkpoint command for claim id '%s', node id '%s', "
                "but there is no node with such node id here. Ignoring command.",
                cmd->claim_id, cmd->node_id);
+
+        return;
+    }
+
+    if(rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD)) {
+        nd_log(NDLS_DAEMON, NDLP_NOTICE,
+               "RRDCONTEXT: received checkpoint command for claim id '%s', node id '%s', "
+               "but host '%s' is still loading contexts. Deferring hash check and snapshot decision.",
+               cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
+
+        struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_RELAXED);
+        if(aclk_host_config) {
+            __atomic_add_fetch(&aclk_host_config->context_checkpoint_deferred_count, 1, __ATOMIC_RELAXED);
+            __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_reason,
+                             ACLK_CTX_DEFER_REASON_PENDING_CONTEXT_LOAD, __ATOMIC_RELAXED);
+            __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_last_time_s, now_realtime_sec(), __ATOMIC_RELAXED);
+        }
+
+        aclk_queue_node_info(host, false);
+
+        return;
+    }
+
+    if(rrdcontext_queue_entries(&host->rrdctx.pp_queue) > 0) {
+        nd_log(NDLS_DAEMON, NDLP_NOTICE,
+               "RRDCONTEXT: received checkpoint command for claim id '%s', node id '%s', "
+               "but host '%s' still has pending context post-processing. Deferring hash check and snapshot decision.",
+               cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
+
+        struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_RELAXED);
+        if(aclk_host_config) {
+            __atomic_add_fetch(&aclk_host_config->context_checkpoint_deferred_count, 1, __ATOMIC_RELAXED);
+            __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_reason,
+                             ACLK_CTX_DEFER_REASON_PENDING_POST_PROCESSING, __ATOMIC_RELAXED);
+            __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_last_time_s, now_realtime_sec(), __ATOMIC_RELAXED);
+        }
+
+        aclk_queue_node_info(host, false);
 
         return;
     }
@@ -265,6 +315,24 @@ void rrdcontext_hub_checkpoint_command(void *ptr) {
            rrdhost_hostname(host));
 
     rrdhost_flag_set(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
+
+    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_RELAXED);
+    if(aclk_host_config) {
+        uint32_t deferred_count = __atomic_exchange_n(&aclk_host_config->context_checkpoint_deferred_count, 0, __ATOMIC_RELAXED);
+        uint8_t deferred_reason = __atomic_exchange_n(&aclk_host_config->context_checkpoint_deferred_reason,
+                                                       ACLK_CTX_DEFER_REASON_NONE, __ATOMIC_RELAXED);
+        time_t deferred_last_time_s = __atomic_exchange_n(&aclk_host_config->context_checkpoint_deferred_last_time_s, 0, __ATOMIC_RELAXED);
+        if(deferred_count) {
+        time_t now_s = now_realtime_sec();
+        long long age_s = (deferred_last_time_s > 0 && now_s >= deferred_last_time_s) ? (long long)(now_s - deferred_last_time_s) : -1;
+        nd_log(NDLS_DAEMON, NDLP_NOTICE,
+               "RRDCONTEXT: host '%s' Activated context streaming after %u deferred checkpoint(s), "
+               "last reason '%s', last deferred at %lld (age %lld sec).",
+               rrdhost_hostname(host), deferred_count, aclk_ctx_defer_reason_to_string(deferred_reason),
+               (long long)deferred_last_time_s, age_s);
+        }
+    }
+
     char node_str[UUID_STR_LEN];
     uuid_unparse_lower(host->node_id.uuid, node_str);
     nd_log(NDLS_ACCESS, NDLP_DEBUG,

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -207,13 +207,14 @@ static void rrdcontext_checkpoint_save_pending(RRDHOST *host, struct ctxs_checkp
     if(!aclk_host_config)
         return;
 
+    spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
     freez(aclk_host_config->pending_ctx_claim_id);
     freez(aclk_host_config->pending_ctx_node_id);
-
     aclk_host_config->pending_ctx_claim_id = strdupz(cmd->claim_id);
     aclk_host_config->pending_ctx_node_id = strdupz(cmd->node_id);
     aclk_host_config->pending_ctx_version_hash = cmd->version_hash;
     aclk_host_config->pending_ctx_checkpoint = true;
+    spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
 }
 
 // Execute the checkpoint: compare version hash, send snapshot if needed, enable streaming.
@@ -350,7 +351,12 @@ void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host) {
     if(!aclk_host_config || !aclk_host_config->pending_ctx_checkpoint)
         return;
 
-    // clear the pending flag first to avoid re-entry
+    spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
+    if(!aclk_host_config->pending_ctx_checkpoint) {
+        spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
+        return;
+    }
+
     aclk_host_config->pending_ctx_checkpoint = false;
 
     char *claim_id = aclk_host_config->pending_ctx_claim_id;
@@ -360,6 +366,7 @@ void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host) {
     aclk_host_config->pending_ctx_claim_id = NULL;
     aclk_host_config->pending_ctx_node_id = NULL;
     aclk_host_config->pending_ctx_version_hash = 0;
+    spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
 
     if(!claim_id || !node_id) {
         freez(claim_id);

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -201,51 +201,70 @@ int rrdcontext_foreach_instance_with_rrdset_in_context(RRDHOST *host, const char
 // ----------------------------------------------------------------------------
 // ACLK interface
 
-static inline const char *aclk_ctx_defer_reason_to_string(ACLK_CTX_DEFER_REASON reason) {
-    switch(reason) {
-        case ACLK_CTX_DEFER_REASON_PENDING_CONTEXT_LOAD:
-            return "pending_context_load";
-        case ACLK_CTX_DEFER_REASON_PENDING_POST_PROCESSING:
-            return "pending_post_processing";
-        default:
-            return "unknown";
-    }
+// Save a pending checkpoint to be replayed when context processing completes.
+static void rrdcontext_checkpoint_save_pending(RRDHOST *host, struct ctxs_checkpoint *cmd) {
+    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_RELAXED);
+    if(!aclk_host_config)
+        return;
+
+    freez(aclk_host_config->pending_ctx_claim_id);
+    freez(aclk_host_config->pending_ctx_node_id);
+
+    aclk_host_config->pending_ctx_claim_id = strdupz(cmd->claim_id);
+    aclk_host_config->pending_ctx_node_id = strdupz(cmd->node_id);
+    aclk_host_config->pending_ctx_version_hash = cmd->version_hash;
+    aclk_host_config->pending_ctx_checkpoint = true;
 }
 
-// Record a deferred checkpoint and queue a node info update.
-// Returns true if the checkpoint should be deferred, false if the deferral limit has been reached
-// and the checkpoint should proceed anyway.
-static bool rrdcontext_checkpoint_defer(RRDHOST *host, ACLK_CTX_DEFER_REASON reason) {
-    time_t now_s = now_realtime_sec();
+// Execute the checkpoint: compare version hash, send snapshot if needed, enable streaming.
+static void rrdcontext_checkpoint_execute(RRDHOST *host, const char *claim_id, const char *node_id, uint64_t version_hash) {
+    if(rrdhost_flag_check(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS)) {
+        nd_log(NDLS_DAEMON, NDLP_NOTICE,
+               "RRDCONTEXT: checkpoint for claim id '%s', node id '%s', "
+               "while node '%s' has an active context streaming.",
+               claim_id, node_id, rrdhost_hostname(host));
 
-    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_RELAXED);
-    if(aclk_host_config) {
-        uint32_t count = __atomic_add_fetch(&aclk_host_config->context_checkpoint_deferred_count, 1, __ATOMIC_RELAXED);
-        __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_reason, reason, __ATOMIC_RELAXED);
-        __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_last_time_s, now_s, __ATOMIC_RELAXED);
-
-        // set first deferral time if this is the first one
-        time_t first_time_s = __atomic_load_n(&aclk_host_config->context_checkpoint_deferred_first_time_s, __ATOMIC_RELAXED);
-        if(!first_time_s) {
-            __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_first_time_s, now_s, __ATOMIC_RELAXED);
-            first_time_s = now_s;
-        }
-
-        // check if we exceeded the deferral limits
-        if(count >= ACLK_CTX_CHECKPOINT_MAX_DEFERRALS ||
-           (first_time_s > 0 && now_s - first_time_s >= ACLK_CTX_CHECKPOINT_DEFER_MAX_TIME_S)) {
-            nd_log(NDLS_DAEMON, NDLP_WARNING,
-                   "RRDCONTEXT: host '%s' exceeded deferral limits (%u deferrals, %lld sec since first). "
-                   "Proceeding with checkpoint despite '%s'.",
-                   rrdhost_hostname(host), count,
-                   (first_time_s > 0) ? (long long)(now_s - first_time_s) : 0LL,
-                   aclk_ctx_defer_reason_to_string(reason));
-            return false;
-        }
+        // disable it temporarily, so that our worker will not attempt to send messages in parallel
+        rrdhost_flag_clear(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
     }
 
-    aclk_queue_node_info(host, false);
-    return true;
+    uint64_t our_version_hash = rrdcontext_version_hash(host);
+
+    if(version_hash != our_version_hash) {
+        nd_log(NDLS_DAEMON, NDLP_NOTICE,
+               "RRDCONTEXT: received version hash %"PRIu64" for host '%s', does not match our version hash %"PRIu64". "
+               "Sending snapshot of all contexts.",
+               version_hash, rrdhost_hostname(host), our_version_hash);
+
+        // prepare the snapshot
+        char uuid_str[UUID_STR_LEN];
+        uuid_unparse_lower(host->node_id.uuid, uuid_str);
+        contexts_snapshot_t bundle = contexts_snapshot_new(claim_id, uuid_str, our_version_hash);
+
+        // do a deep scan on every metric of the host to make sure all our data are updated
+        rrdcontext_recalculate_host_retention(host, RRD_FLAG_NONE, false);
+
+        // calculate version hash and pack all the messages together in one go
+        our_version_hash = rrdcontext_version_hash_with_callback(host, rrdcontext_message_send_unsafe, true, bundle);
+
+        // update the version
+        contexts_snapshot_set_version(bundle, our_version_hash);
+
+        // send it
+        aclk_send_contexts_snapshot(bundle);
+    }
+
+    nd_log(NDLS_DAEMON, NDLP_DEBUG,
+           "RRDCONTEXT: host '%s' enabling streaming of contexts",
+           rrdhost_hostname(host));
+
+    rrdhost_flag_set(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
+
+    char node_str[UUID_STR_LEN];
+    uuid_unparse_lower(host->node_id.uuid, node_str);
+    nd_log(NDLS_ACCESS, NDLP_DEBUG,
+           "ACLK REQ [%s (%s)]: STREAM CONTEXTS ENABLED",
+           node_str, rrdhost_hostname(host));
 }
 
 void rrdcontext_hub_checkpoint_command(void *ptr) {
@@ -272,91 +291,18 @@ void rrdcontext_hub_checkpoint_command(void *ptr) {
         return;
     }
 
-    if(rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD)) {
+    if(rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD) ||
+       rrdcontext_queue_entries(&host->rrdctx.pp_queue) > 0) {
         nd_log(NDLS_DAEMON, NDLP_NOTICE,
                "RRDCONTEXT: received checkpoint command for claim id '%s', node id '%s', "
-               "but host '%s' is still loading contexts. Deferring hash check and snapshot decision.",
+               "but host '%s' has pending context work. Saving checkpoint for replay after processing completes.",
                cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
 
-        if(rrdcontext_checkpoint_defer(host, ACLK_CTX_DEFER_REASON_PENDING_CONTEXT_LOAD))
-            return;
+        rrdcontext_checkpoint_save_pending(host, cmd);
+        return;
     }
 
-    if(rrdcontext_queue_entries(&host->rrdctx.pp_queue) > 0) {
-        nd_log(NDLS_DAEMON, NDLP_NOTICE,
-               "RRDCONTEXT: received checkpoint command for claim id '%s', node id '%s', "
-               "but host '%s' still has pending context post-processing. Deferring hash check and snapshot decision.",
-               cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
-
-        if(rrdcontext_checkpoint_defer(host, ACLK_CTX_DEFER_REASON_PENDING_POST_PROCESSING))
-            return;
-    }
-
-    if(rrdhost_flag_check(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS)) {
-        nd_log(NDLS_DAEMON, NDLP_NOTICE,
-               "RRDCONTEXT: received checkpoint command for claim id '%s', node id '%s', "
-               "while node '%s' has an active context streaming.",
-               cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
-
-        // disable it temporarily, so that our worker will not attempt to send messages in parallel
-        rrdhost_flag_clear(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
-    }
-
-    uint64_t our_version_hash = rrdcontext_version_hash(host);
-
-    if(cmd->version_hash != our_version_hash) {
-        nd_log(NDLS_DAEMON, NDLP_NOTICE,
-               "RRDCONTEXT: received version hash %"PRIu64" for host '%s', does not match our version hash %"PRIu64". "
-               "Sending snapshot of all contexts.",
-               cmd->version_hash, rrdhost_hostname(host), our_version_hash);
-
-        // prepare the snapshot
-        char uuid_str[UUID_STR_LEN];
-        uuid_unparse_lower(host->node_id.uuid, uuid_str);
-        contexts_snapshot_t bundle = contexts_snapshot_new(cmd->claim_id, uuid_str, our_version_hash);
-
-        // do a deep scan on every metric of the host to make sure all our data are updated
-        rrdcontext_recalculate_host_retention(host, RRD_FLAG_NONE, false);
-
-        // calculate version hash and pack all the messages together in one go
-        our_version_hash = rrdcontext_version_hash_with_callback(host, rrdcontext_message_send_unsafe, true, bundle);
-
-        // update the version
-        contexts_snapshot_set_version(bundle, our_version_hash);
-
-        // send it
-        aclk_send_contexts_snapshot(bundle);
-    }
-
-    nd_log(NDLS_DAEMON, NDLP_DEBUG,
-           "RRDCONTEXT: host '%s' enabling streaming of contexts",
-           rrdhost_hostname(host));
-
-    rrdhost_flag_set(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
-
-    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_RELAXED);
-    if(aclk_host_config) {
-        uint32_t deferred_count = __atomic_exchange_n(&aclk_host_config->context_checkpoint_deferred_count, 0, __ATOMIC_RELAXED);
-        ACLK_CTX_DEFER_REASON deferred_reason = __atomic_exchange_n(&aclk_host_config->context_checkpoint_deferred_reason,
-                                                                     ACLK_CTX_DEFER_REASON_NONE, __ATOMIC_RELAXED);
-        time_t deferred_last_time_s = __atomic_exchange_n(&aclk_host_config->context_checkpoint_deferred_last_time_s, 0, __ATOMIC_RELAXED);
-        __atomic_store_n(&aclk_host_config->context_checkpoint_deferred_first_time_s, 0, __ATOMIC_RELAXED);
-        if(deferred_count) {
-            time_t now_s = now_realtime_sec();
-            long long age_s = (deferred_last_time_s > 0 && now_s >= deferred_last_time_s) ? (long long)(now_s - deferred_last_time_s) : -1;
-            nd_log(NDLS_DAEMON, NDLP_NOTICE,
-                   "RRDCONTEXT: host '%s' activated context streaming after %u deferred checkpoint(s), "
-                   "last reason '%s', last deferred at %lld (age %lld sec).",
-                   rrdhost_hostname(host), deferred_count, aclk_ctx_defer_reason_to_string(deferred_reason),
-                   (long long)deferred_last_time_s, age_s);
-        }
-    }
-
-    char node_str[UUID_STR_LEN];
-    uuid_unparse_lower(host->node_id.uuid, node_str);
-    nd_log(NDLS_ACCESS, NDLP_DEBUG,
-           "ACLK REQ [%s (%s)]: STREAM CONTEXTS ENABLED",
-           node_str, rrdhost_hostname(host));
+    rrdcontext_checkpoint_execute(host, cmd->claim_id, cmd->node_id, cmd->version_hash);
 }
 
 void rrdcontext_hub_stop_streaming_command(void *ptr) {
@@ -397,6 +343,48 @@ void rrdcontext_hub_stop_streaming_command(void *ptr) {
            rrdhost_hostname(host));
 
     rrdhost_flag_clear(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
+}
+
+void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host) {
+    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_RELAXED);
+    if(!aclk_host_config || !aclk_host_config->pending_ctx_checkpoint)
+        return;
+
+    // clear the pending flag first to avoid re-entry
+    aclk_host_config->pending_ctx_checkpoint = false;
+
+    char *claim_id = aclk_host_config->pending_ctx_claim_id;
+    char *node_id = aclk_host_config->pending_ctx_node_id;
+    uint64_t version_hash = aclk_host_config->pending_ctx_version_hash;
+
+    aclk_host_config->pending_ctx_claim_id = NULL;
+    aclk_host_config->pending_ctx_node_id = NULL;
+    aclk_host_config->pending_ctx_version_hash = 0;
+
+    if(!claim_id || !node_id) {
+        freez(claim_id);
+        freez(node_id);
+        return;
+    }
+
+    // verify claim id is still valid
+    if(!claim_id_matches(claim_id)) {
+        nd_log(NDLS_DAEMON, NDLP_WARNING,
+               "RRDCONTEXT: pending checkpoint for host '%s' has stale claim id '%s'. Discarding.",
+               rrdhost_hostname(host), claim_id);
+        freez(claim_id);
+        freez(node_id);
+        return;
+    }
+
+    nd_log(NDLS_DAEMON, NDLP_NOTICE,
+           "RRDCONTEXT: replaying deferred checkpoint for host '%s', claim id '%s', node id '%s'.",
+           rrdhost_hostname(host), claim_id, node_id);
+
+    rrdcontext_checkpoint_execute(host, claim_id, node_id, version_hash);
+
+    freez(claim_id);
+    freez(node_id);
 }
 
 ALWAYS_INLINE

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -250,10 +250,11 @@ static bool rrdcontext_checkpoint_save_pending(RRDHOST *host, struct ctxs_checkp
     if(!aclk_host_config)
         return false;
 
+    spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
+
     // Pause incremental context streaming until the deferred checkpoint is replayed.
     rrdhost_flag_clear(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
 
-    spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
     __atomic_add_fetch(&aclk_host_config->pending_ctx_generation, 1, __ATOMIC_RELEASE);
     rrdcontext_checkpoint_clear_pending_unsafe(aclk_host_config);
     aclk_host_config->pending_ctx_claim_id = strdupz(cmd->claim_id);
@@ -269,6 +270,8 @@ static bool rrdcontext_checkpoint_save_pending(RRDHOST *host, struct ctxs_checkp
 static void rrdcontext_checkpoint_execute(RRDHOST *host, const char *claim_id, const char *node_id, uint64_t version_hash, uint64_t generation) {
     if(!rrdcontext_checkpoint_generation_is_current(host, claim_id, node_id, generation))
         return;
+
+    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
 
     if(rrdhost_flag_check(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS)) {
         nd_log(NDLS_DAEMON, NDLP_NOTICE,
@@ -318,7 +321,23 @@ static void rrdcontext_checkpoint_execute(RRDHOST *host, const char *claim_id, c
            "RRDCONTEXT: host '%s' enabling streaming of contexts",
            rrdhost_hostname(host));
 
-    rrdhost_flag_set(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
+    if(aclk_host_config) {
+        spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
+
+        bool can_enable =
+            __atomic_load_n(&aclk_host_config->pending_ctx_generation, __ATOMIC_ACQUIRE) == generation &&
+            !__atomic_load_n(&aclk_host_config->pending_ctx_checkpoint, __ATOMIC_ACQUIRE);
+
+        if(can_enable)
+            rrdhost_flag_set(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
+
+        spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
+
+        if(!can_enable)
+            return;
+    }
+    else
+        rrdhost_flag_set(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
 
     char node_str[UUID_STR_LEN];
     uuid_unparse_lower(host->node_id.uuid, node_str);

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -217,7 +217,7 @@ static uint64_t rrdcontext_checkpoint_invalidate_pending(RRDHOST *host) {
         return 0;
 
     spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
-    uint64_t generation = ++aclk_host_config->pending_ctx_generation;
+    uint64_t generation = __atomic_add_fetch(&aclk_host_config->pending_ctx_generation, 1, __ATOMIC_RELEASE);
     rrdcontext_checkpoint_clear_pending_unsafe(aclk_host_config);
     spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
 
@@ -254,7 +254,7 @@ static bool rrdcontext_checkpoint_save_pending(RRDHOST *host, struct ctxs_checkp
     rrdhost_flag_clear(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
 
     spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
-    ++aclk_host_config->pending_ctx_generation;
+    __atomic_add_fetch(&aclk_host_config->pending_ctx_generation, 1, __ATOMIC_RELEASE);
     rrdcontext_checkpoint_clear_pending_unsafe(aclk_host_config);
     aclk_host_config->pending_ctx_claim_id = strdupz(cmd->claim_id);
     aclk_host_config->pending_ctx_node_id = strdupz(cmd->node_id);
@@ -445,7 +445,7 @@ void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host) {
     char *claim_id = aclk_host_config->pending_ctx_claim_id;
     char *node_id = aclk_host_config->pending_ctx_node_id;
     uint64_t version_hash = aclk_host_config->pending_ctx_version_hash;
-    uint64_t generation = aclk_host_config->pending_ctx_generation;
+    uint64_t generation = __atomic_load_n(&aclk_host_config->pending_ctx_generation, __ATOMIC_RELAXED);
 
     aclk_host_config->pending_ctx_claim_id = NULL;
     aclk_host_config->pending_ctx_node_id = NULL;

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -201,6 +201,48 @@ int rrdcontext_foreach_instance_with_rrdset_in_context(RRDHOST *host, const char
 // ----------------------------------------------------------------------------
 // ACLK interface
 
+static void rrdcontext_checkpoint_clear_pending_unsafe(struct aclk_sync_cfg_t *aclk_host_config) {
+    freez(aclk_host_config->pending_ctx_claim_id);
+    freez(aclk_host_config->pending_ctx_node_id);
+    aclk_host_config->pending_ctx_claim_id = NULL;
+    aclk_host_config->pending_ctx_node_id = NULL;
+    aclk_host_config->pending_ctx_version_hash = 0;
+    aclk_host_config->pending_ctx_saved_monotonic_s = 0;
+    __atomic_store_n(&aclk_host_config->pending_ctx_checkpoint, false, __ATOMIC_RELEASE);
+}
+
+static uint64_t rrdcontext_checkpoint_invalidate_pending(RRDHOST *host) {
+    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
+    if(!aclk_host_config)
+        return 0;
+
+    spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
+    uint64_t generation = ++aclk_host_config->pending_ctx_generation;
+    rrdcontext_checkpoint_clear_pending_unsafe(aclk_host_config);
+    spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
+
+    return generation;
+}
+
+static bool rrdcontext_checkpoint_generation_is_current(RRDHOST *host, const char *claim_id, const char *node_id, uint64_t generation) {
+    if(!generation)
+        return true;
+
+    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
+    uint64_t current_generation = aclk_host_config ?
+                                  __atomic_load_n(&aclk_host_config->pending_ctx_generation, __ATOMIC_ACQUIRE) :
+                                  0;
+
+    if(likely(aclk_host_config && current_generation == generation))
+        return true;
+
+    nd_log(NDLS_DAEMON, NDLP_NOTICE,
+           "RRDCONTEXT: skipping stale checkpoint for host '%s', claim id '%s', node id '%s' "
+           "(generation %"PRIu64", current %"PRIu64").",
+           rrdhost_hostname(host), claim_id, node_id, generation, current_generation);
+    return false;
+}
+
 // Save a pending checkpoint to be replayed when context processing completes.
 // Returns true if saved successfully, false if save failed (caller should execute immediately).
 static bool rrdcontext_checkpoint_save_pending(RRDHOST *host, struct ctxs_checkpoint *cmd) {
@@ -212,19 +254,22 @@ static bool rrdcontext_checkpoint_save_pending(RRDHOST *host, struct ctxs_checkp
     rrdhost_flag_clear(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
 
     spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
-    freez(aclk_host_config->pending_ctx_claim_id);
-    freez(aclk_host_config->pending_ctx_node_id);
+    ++aclk_host_config->pending_ctx_generation;
+    rrdcontext_checkpoint_clear_pending_unsafe(aclk_host_config);
     aclk_host_config->pending_ctx_claim_id = strdupz(cmd->claim_id);
     aclk_host_config->pending_ctx_node_id = strdupz(cmd->node_id);
     aclk_host_config->pending_ctx_version_hash = cmd->version_hash;
-    aclk_host_config->pending_ctx_saved_time_s = now_realtime_sec();
+    aclk_host_config->pending_ctx_saved_monotonic_s = now_monotonic_sec();
     __atomic_store_n(&aclk_host_config->pending_ctx_checkpoint, true, __ATOMIC_RELEASE);
     spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
     return true;
 }
 
 // Execute the checkpoint: compare version hash, send snapshot if needed, enable streaming.
-static void rrdcontext_checkpoint_execute(RRDHOST *host, const char *claim_id, const char *node_id, uint64_t version_hash) {
+static void rrdcontext_checkpoint_execute(RRDHOST *host, const char *claim_id, const char *node_id, uint64_t version_hash, uint64_t generation) {
+    if(!rrdcontext_checkpoint_generation_is_current(host, claim_id, node_id, generation))
+        return;
+
     if(rrdhost_flag_check(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS)) {
         nd_log(NDLS_DAEMON, NDLP_NOTICE,
                "RRDCONTEXT: checkpoint for claim id '%s', node id '%s', "
@@ -254,12 +299,20 @@ static void rrdcontext_checkpoint_execute(RRDHOST *host, const char *claim_id, c
         // calculate version hash and pack all the messages together in one go
         our_version_hash = rrdcontext_version_hash_with_callback(host, rrdcontext_message_send_unsafe, true, bundle);
 
+        if(!rrdcontext_checkpoint_generation_is_current(host, claim_id, node_id, generation)) {
+            contexts_snapshot_delete(bundle);
+            return;
+        }
+
         // update the version
         contexts_snapshot_set_version(bundle, our_version_hash);
 
         // send it
         aclk_send_contexts_snapshot(bundle);
     }
+
+    if(!rrdcontext_checkpoint_generation_is_current(host, claim_id, node_id, generation))
+        return;
 
     nd_log(NDLS_DAEMON, NDLP_DEBUG,
            "RRDCONTEXT: host '%s' enabling streaming of contexts",
@@ -313,7 +366,8 @@ void rrdcontext_hub_checkpoint_command(void *ptr) {
                rrdhost_hostname(host));
     }
 
-    rrdcontext_checkpoint_execute(host, cmd->claim_id, cmd->node_id, cmd->version_hash);
+    uint64_t generation = rrdcontext_checkpoint_invalidate_pending(host);
+    rrdcontext_checkpoint_execute(host, cmd->claim_id, cmd->node_id, cmd->version_hash, generation);
 }
 
 void rrdcontext_hub_stop_streaming_command(void *ptr) {
@@ -340,11 +394,19 @@ void rrdcontext_hub_stop_streaming_command(void *ptr) {
         return;
     }
 
+    bool had_pending_checkpoint = false;
+    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
+    if(aclk_host_config)
+        had_pending_checkpoint = __atomic_load_n(&aclk_host_config->pending_ctx_checkpoint, __ATOMIC_ACQUIRE);
+
+    rrdcontext_checkpoint_invalidate_pending(host);
+
     if(!rrdhost_flag_check(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS)) {
         nd_log(NDLS_DAEMON, NDLP_NOTICE,
                "RRDCONTEXT: received stop streaming command for claim id '%s', node id '%s', "
-               "but node '%s' does not have active context streaming. Ignoring command.",
-               cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
+               "but node '%s' does not have active context streaming%s.",
+               cmd->claim_id, cmd->node_id, rrdhost_hostname(host),
+               had_pending_checkpoint ? "; invalidated deferred checkpoint" : "");
 
         return;
     }
@@ -373,8 +435,8 @@ void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host) {
     }
 
     // replay when pp_queue is empty, or force replay on timeout
-    time_t now_s = now_realtime_sec();
-    bool timed_out = (now_s - aclk_host_config->pending_ctx_saved_time_s >= PENDING_CTX_CHECKPOINT_MAX_AGE_S);
+    time_t now_s = now_monotonic_sec();
+    bool timed_out = (now_s - aclk_host_config->pending_ctx_saved_monotonic_s >= PENDING_CTX_CHECKPOINT_MAX_AGE_S);
     if((pending_context_load || !pp_queue_empty) && !timed_out) {
         spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
         return;
@@ -383,11 +445,12 @@ void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host) {
     char *claim_id = aclk_host_config->pending_ctx_claim_id;
     char *node_id = aclk_host_config->pending_ctx_node_id;
     uint64_t version_hash = aclk_host_config->pending_ctx_version_hash;
+    uint64_t generation = aclk_host_config->pending_ctx_generation;
 
     aclk_host_config->pending_ctx_claim_id = NULL;
     aclk_host_config->pending_ctx_node_id = NULL;
     aclk_host_config->pending_ctx_version_hash = 0;
-    aclk_host_config->pending_ctx_saved_time_s = 0;
+    aclk_host_config->pending_ctx_saved_monotonic_s = 0;
     __atomic_store_n(&aclk_host_config->pending_ctx_checkpoint, false, __ATOMIC_RELEASE);
     spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
 
@@ -416,7 +479,7 @@ void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host) {
            "RRDCONTEXT: replaying deferred checkpoint for host '%s', claim id '%s', node id '%s'.",
            rrdhost_hostname(host), claim_id, node_id);
 
-    rrdcontext_checkpoint_execute(host, claim_id, node_id, version_hash);
+    rrdcontext_checkpoint_execute(host, claim_id, node_id, version_hash, generation);
 
     freez(claim_id);
     freez(node_id);

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -208,6 +208,9 @@ static bool rrdcontext_checkpoint_save_pending(RRDHOST *host, struct ctxs_checkp
     if(!aclk_host_config)
         return false;
 
+    // Pause incremental context streaming until the deferred checkpoint is replayed.
+    rrdhost_flag_clear(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
+
     spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
     freez(aclk_host_config->pending_ctx_claim_id);
     freez(aclk_host_config->pending_ctx_node_id);
@@ -360,6 +363,7 @@ void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host) {
     if(!aclk_host_config || !__atomic_load_n(&aclk_host_config->pending_ctx_checkpoint, __ATOMIC_ACQUIRE))
         return;
 
+    bool pending_context_load = rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD);
     bool pp_queue_empty = rrdcontext_queue_entries(&host->rrdctx.pp_queue) <= 0;
 
     spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
@@ -371,7 +375,7 @@ void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host) {
     // replay when pp_queue is empty, or force replay on timeout
     time_t now_s = now_realtime_sec();
     bool timed_out = (now_s - aclk_host_config->pending_ctx_saved_time_s >= PENDING_CTX_CHECKPOINT_MAX_AGE_S);
-    if(!pp_queue_empty && !timed_out) {
+    if((pending_context_load || !pp_queue_empty) && !timed_out) {
         spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
         return;
     }
@@ -387,9 +391,9 @@ void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host) {
     __atomic_store_n(&aclk_host_config->pending_ctx_checkpoint, false, __ATOMIC_RELEASE);
     spinlock_unlock(&aclk_host_config->pending_ctx_spinlock);
 
-    if(timed_out && !pp_queue_empty)
+    if(timed_out && (pending_context_load || !pp_queue_empty))
         nd_log(NDLS_DAEMON, NDLP_WARNING,
-               "RRDCONTEXT: pending checkpoint for host '%s' timed out after %d sec with pp_queue still active. Forcing replay.",
+               "RRDCONTEXT: pending checkpoint for host '%s' timed out after %d sec with context work still active. Forcing replay.",
                rrdhost_hostname(host), PENDING_CTX_CHECKPOINT_MAX_AGE_S);
 
     if(!claim_id || !node_id) {

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -236,7 +236,7 @@ static bool rrdcontext_checkpoint_generation_is_current(RRDHOST *host, const cha
     if(likely(aclk_host_config && current_generation == generation))
         return true;
 
-    nd_log(NDLS_DAEMON, NDLP_NOTICE,
+    nd_log(NDLS_DAEMON, NDLP_DEBUG,
            "RRDCONTEXT: skipping stale checkpoint for host '%s', claim id '%s', node id '%s' "
            "(generation %"PRIu64", current %"PRIu64").",
            rrdhost_hostname(host), claim_id, node_id, generation, current_generation);

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -271,8 +271,6 @@ static void rrdcontext_checkpoint_execute(RRDHOST *host, const char *claim_id, c
     if(!rrdcontext_checkpoint_generation_is_current(host, claim_id, node_id, generation))
         return;
 
-    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
-
     if(rrdhost_flag_check(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS)) {
         nd_log(NDLS_DAEMON, NDLP_NOTICE,
                "RRDCONTEXT: checkpoint for claim id '%s', node id '%s', "
@@ -321,6 +319,7 @@ static void rrdcontext_checkpoint_execute(RRDHOST *host, const char *claim_id, c
            "RRDCONTEXT: host '%s' enabling streaming of contexts",
            rrdhost_hostname(host));
 
+    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
     if(aclk_host_config) {
         spinlock_lock(&aclk_host_config->pending_ctx_spinlock);
 

--- a/src/database/contexts/rrdcontext.h
+++ b/src/database/contexts/rrdcontext.h
@@ -121,6 +121,7 @@ int rrdcontext_find_chart_uuid(RRDSET *st, nd_uuid_t *store_uuid);
 
 void rrdcontext_hub_checkpoint_command(void *cmd);
 void rrdcontext_hub_stop_streaming_command(void *cmd);
+void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host);
 
 
 // ----------------------------------------------------------------------------

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -1222,8 +1222,18 @@ void destroy_aclk_config(RRDHOST *host)
     }
 
     struct aclk_sync_cfg_t *old_aclk_host_config = __atomic_exchange_n(&host->aclk_host_config, NULL, __ATOMIC_RELAXED);
-    freez(old_aclk_host_config->pending_ctx_claim_id);
-    freez(old_aclk_host_config->pending_ctx_node_id);
+
+    // detach pending checkpoint strings under lock, to avoid racing with save/replay
+    spinlock_lock(&old_aclk_host_config->pending_ctx_spinlock);
+    char *pending_claim_id = old_aclk_host_config->pending_ctx_claim_id;
+    char *pending_node_id = old_aclk_host_config->pending_ctx_node_id;
+    old_aclk_host_config->pending_ctx_claim_id = NULL;
+    old_aclk_host_config->pending_ctx_node_id = NULL;
+    __atomic_store_n(&old_aclk_host_config->pending_ctx_checkpoint, false, __ATOMIC_RELEASE);
+    spinlock_unlock(&old_aclk_host_config->pending_ctx_spinlock);
+
+    freez(pending_claim_id);
+    freez(pending_node_id);
     freez(old_aclk_host_config);
 }
 

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -992,6 +992,7 @@ void create_aclk_config(RRDHOST *host, nd_uuid_t *host_uuid __maybe_unused, nd_u
         return;
 
     struct aclk_sync_cfg_t *aclk_host_config = callocz(1, sizeof(struct aclk_sync_cfg_t));
+    spinlock_init(&aclk_host_config->pending_ctx_spinlock);
     if (node_id && !uuid_is_null(*node_id))
         uuid_unparse_lower(*node_id, aclk_host_config->node_id);
 

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -1231,6 +1231,8 @@ void destroy_aclk_config(RRDHOST *host)
     char *pending_node_id = old_aclk_host_config->pending_ctx_node_id;
     old_aclk_host_config->pending_ctx_claim_id = NULL;
     old_aclk_host_config->pending_ctx_node_id = NULL;
+    old_aclk_host_config->pending_ctx_version_hash = 0;
+    old_aclk_host_config->pending_ctx_saved_monotonic_s = 0;
     __atomic_store_n(&old_aclk_host_config->pending_ctx_checkpoint, false, __ATOMIC_RELEASE);
     spinlock_unlock(&old_aclk_host_config->pending_ctx_spinlock);
 

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -1221,6 +1221,8 @@ void destroy_aclk_config(RRDHOST *host)
     }
 
     struct aclk_sync_cfg_t *old_aclk_host_config = __atomic_exchange_n(&host->aclk_host_config, NULL, __ATOMIC_RELAXED);
+    freez(old_aclk_host_config->pending_ctx_claim_id);
+    freez(old_aclk_host_config->pending_ctx_node_id);
     freez(old_aclk_host_config);
 }
 

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -1222,6 +1222,8 @@ void destroy_aclk_config(RRDHOST *host)
     }
 
     struct aclk_sync_cfg_t *old_aclk_host_config = __atomic_exchange_n(&host->aclk_host_config, NULL, __ATOMIC_RELAXED);
+    if (!old_aclk_host_config)
+        return;
 
     // detach pending checkpoint strings under lock, to avoid racing with save/replay
     spinlock_lock(&old_aclk_host_config->pending_ctx_spinlock);

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -46,6 +46,7 @@ typedef struct aclk_sync_cfg_t {
     char *pending_ctx_claim_id;
     char *pending_ctx_node_id;
     uint64_t pending_ctx_version_hash;
+    time_t pending_ctx_saved_time_s;
 
     int8_t send_snapshot;
     bool stream_alerts;

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -38,6 +38,9 @@ typedef struct aclk_sync_cfg_t {
     RRDHOST *host;
     uv_timer_t timer;
     bool timer_initialized;
+    uint32_t context_checkpoint_deferred_count;
+    uint8_t context_checkpoint_deferred_reason;
+    time_t context_checkpoint_deferred_last_time_s;
     int8_t send_snapshot;
     bool stream_alerts;
     int alert_count;
@@ -47,6 +50,12 @@ typedef struct aclk_sync_cfg_t {
     time_t node_collectors_send;
     char node_id[UUID_STR_LEN];
 } aclk_sync_cfg_t;
+
+typedef enum {
+    ACLK_CTX_DEFER_REASON_NONE = 0,
+    ACLK_CTX_DEFER_REASON_PENDING_CONTEXT_LOAD = 1,
+    ACLK_CTX_DEFER_REASON_PENDING_POST_PROCESSING = 2,
+} ACLK_CTX_DEFER_REASON;
 
 void create_aclk_config(RRDHOST *host, nd_uuid_t *host_uuid, nd_uuid_t *node_id);
 void destroy_aclk_config(RRDHOST *host);

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -34,23 +34,17 @@ enum aclk_database_opcode {
     ACLK_MAX_ENUMERATIONS_DEFINED
 };
 
-typedef enum {
-    ACLK_CTX_DEFER_REASON_NONE = 0,
-    ACLK_CTX_DEFER_REASON_PENDING_CONTEXT_LOAD = 1,
-    ACLK_CTX_DEFER_REASON_PENDING_POST_PROCESSING = 2,
-} ACLK_CTX_DEFER_REASON;
-
-#define ACLK_CTX_CHECKPOINT_MAX_DEFERRALS 60
-#define ACLK_CTX_CHECKPOINT_DEFER_MAX_TIME_S 300
-
 typedef struct aclk_sync_cfg_t {
     RRDHOST *host;
     uv_timer_t timer;
     bool timer_initialized;
-    uint32_t context_checkpoint_deferred_count;
-    ACLK_CTX_DEFER_REASON context_checkpoint_deferred_reason;
-    time_t context_checkpoint_deferred_last_time_s;
-    time_t context_checkpoint_deferred_first_time_s;
+
+    // pending context checkpoint - saved when deferred during context load or post-processing
+    bool pending_ctx_checkpoint;
+    char *pending_ctx_claim_id;
+    char *pending_ctx_node_id;
+    uint64_t pending_ctx_version_hash;
+
     int8_t send_snapshot;
     bool stream_alerts;
     int alert_count;

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -34,13 +34,23 @@ enum aclk_database_opcode {
     ACLK_MAX_ENUMERATIONS_DEFINED
 };
 
+typedef enum {
+    ACLK_CTX_DEFER_REASON_NONE = 0,
+    ACLK_CTX_DEFER_REASON_PENDING_CONTEXT_LOAD = 1,
+    ACLK_CTX_DEFER_REASON_PENDING_POST_PROCESSING = 2,
+} ACLK_CTX_DEFER_REASON;
+
+#define ACLK_CTX_CHECKPOINT_MAX_DEFERRALS 60
+#define ACLK_CTX_CHECKPOINT_DEFER_MAX_TIME_S 300
+
 typedef struct aclk_sync_cfg_t {
     RRDHOST *host;
     uv_timer_t timer;
     bool timer_initialized;
     uint32_t context_checkpoint_deferred_count;
-    uint8_t context_checkpoint_deferred_reason;
+    ACLK_CTX_DEFER_REASON context_checkpoint_deferred_reason;
     time_t context_checkpoint_deferred_last_time_s;
+    time_t context_checkpoint_deferred_first_time_s;
     int8_t send_snapshot;
     bool stream_alerts;
     int alert_count;
@@ -50,12 +60,6 @@ typedef struct aclk_sync_cfg_t {
     time_t node_collectors_send;
     char node_id[UUID_STR_LEN];
 } aclk_sync_cfg_t;
-
-typedef enum {
-    ACLK_CTX_DEFER_REASON_NONE = 0,
-    ACLK_CTX_DEFER_REASON_PENDING_CONTEXT_LOAD = 1,
-    ACLK_CTX_DEFER_REASON_PENDING_POST_PROCESSING = 2,
-} ACLK_CTX_DEFER_REASON;
 
 void create_aclk_config(RRDHOST *host, nd_uuid_t *host_uuid, nd_uuid_t *node_id);
 void destroy_aclk_config(RRDHOST *host);

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -40,6 +40,8 @@ typedef struct aclk_sync_cfg_t {
     bool timer_initialized;
 
     // pending context checkpoint - saved when deferred during context load or post-processing
+    // protected by pending_ctx_spinlock (accessed from ACLK query thread and context worker thread)
+    SPINLOCK pending_ctx_spinlock;
     bool pending_ctx_checkpoint;
     char *pending_ctx_claim_id;
     char *pending_ctx_node_id;

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -42,11 +42,12 @@ typedef struct aclk_sync_cfg_t {
     // pending context checkpoint - saved when deferred during context load or post-processing
     // protected by pending_ctx_spinlock (accessed from ACLK query thread and context worker thread)
     SPINLOCK pending_ctx_spinlock;
+    uint64_t pending_ctx_generation;
     bool pending_ctx_checkpoint;
     char *pending_ctx_claim_id;
     char *pending_ctx_node_id;
     uint64_t pending_ctx_version_hash;
-    time_t pending_ctx_saved_time_s;
+    time_t pending_ctx_saved_monotonic_s;
 
     int8_t send_snapshot;
     bool stream_alerts;


### PR DESCRIPTION
##### Summary
- Defer context snapshots if version recalculation is pending (send snapshot when done)
  - This should reduce context snapshos sent to cloud 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers ACLK context checkpoint snapshots during context recalculation or post-processing, pauses incremental streaming, and replays when queues drain or after a 5‑minute monotonic timeout (even if context loading is stuck). This reduces duplicate snapshots and avoids races with active streaming.

- **New Features**
  - Track a pending checkpoint in `aclk_sync_cfg_t` (claim_id, node_id, version_hash, generation, saved monotonic time) guarded by `pending_ctx_spinlock`; clear `RRDHOST_FLAG_ACLK_STREAM_CONTEXTS` until replay.
  - Add `rrdcontext_hub_pending_checkpoint_replay()` and call it in the worker before the context-load check and after post-processing; replay when queues drain or on timeout; discard if claim_id is stale; force replay on timeout even if context load continues.
  - Centralize execution: validate a generation counter before/after snapshot creation to skip stale work; send a full snapshot on version hash mismatch; re‑enable streaming only if the checkpoint state hasn’t changed; invalidate pending checkpoints on immediate execution or stop‑streaming.

- **Bug Fixes**
  - Initialize `pending_ctx_spinlock` and atomically manage `pending_ctx_generation`; use atomic loads for `aclk_host_config`; adjust lock placement for pausing/enabling streaming; reorder atomic loads for proper sync.
  - Safely detach and free pending checkpoint data during ACLK config destruction (with null checks and locking) to prevent races and null derefs; downgrade stale-checkpoint skip logs to DEBUG.

<sup>Written for commit d336fb94cae88b1499bcbb141e27a3c7c53e4a42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

