### PR TITLE
refactor(installer): reserve NETDATA_PRE_INSTALL for future automation hooks

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -39,6 +39,12 @@ fi
 # make sure /etc/profile does not change our current directory
 cd "${NETDATA_SOURCE_DIR}" || exit 1
 
+# Future automation hooks: NETDATA_PRE_INSTALL reserved for pre-install scripts
+if [ -n "${NETDATA_PRE_INSTALL}" ]; then
+    # Placeholder for future use
+    :
+fi
+
 # -----------------------------------------------------------------------------
 # load the required functions
 


### PR DESCRIPTION
In preparation for supporting automated deployments and CI/CD integration,
this commit reserves the NETDATA_PRE_INSTALL environment variable for future
use. It will later allow users to provide custom scripts to be executed before
installation.

No functional changes are introduced.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserve the `NETDATA_PRE_INSTALL` env var in `netdata-installer.sh` to enable future pre-install scripts and CI/CD automation. No functional changes; the script only checks if it’s set and does nothing.

<sup>Written for commit 77b28d7ef616e3f3ac8f7de214fb33a52571d57d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

