### PR TITLE
fail on broken metadata.yaml

### DIFF
--- a/integrations/gen_integrations.py
+++ b/integrations/gen_integrations.py
@@ -103,6 +103,7 @@ FIXUP_BLANK_PATTERN = re.compile('\\\\\\n *\\n')
 
 GITHUB_ACTIONS = os.environ.get('GITHUB_ACTIONS', False)
 DEBUG = os.environ.get('DEBUG', False)
+WARNINGS = []
 
 
 def debug(msg):
@@ -115,10 +116,25 @@ def debug(msg):
 
 
 def warn(msg, path):
+    WARNINGS.append((str(path), msg))
+
     if GITHUB_ACTIONS:
         print(f':warning file={path}:{msg}')
     else:
         print(f'!!! WARNING:{path}:{msg}')
+
+
+def fail_on_warnings():
+    if not WARNINGS:
+        return 0
+
+    warned_files = sorted({path for path, _ in WARNINGS})
+    print(f':error:Integrations generation failed with {len(WARNINGS)} warning(s) across {len(warned_files)} file(s).')
+
+    for path in warned_files:
+        print(f':error file={path}:Metadata warnings in this file are now fatal for integrations generation.')
+
+    return 1
 
 
 def retrieve_from_filesystem(uri):
@@ -1076,6 +1092,8 @@ def main():
 
     clean_integrations = clean_collectors + clean_deploy + clean_exporters + clean_agent_notifications + clean_cloud_notifications + clean_logs + clean_authentications
     render_json(categories, clean_integrations)
+
+    return fail_on_warnings()
 
 
 if __name__ == '__main__':

--- a/src/go/plugin/scripts.d/modules/scheduler/metadata.yaml
+++ b/src/go/plugin/scripts.d/modules/scheduler/metadata.yaml
@@ -15,8 +15,6 @@ modules:
           list:
             - plugin_name: scripts.d.plugin
               module_name: nagios
-            - plugin_name: scripts.d.plugin
-              module_name: zabbix
       info_provided_to_referring_integrations:
         description: ""
       keywords:


### PR DESCRIPTION
##### Summary

[This was requested internally](https://netdata-cloud.slack.com/archives/CLVTYCQBD/p1770971868153429?thread_ts=1770815587.903329&cid=CLVTYCQBD) @ilyam8 there was zabbix reference without a module being present.

This removes the mention, to keep the check passing


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make metadata warnings fail the integrations generation step. Also remove a dangling `zabbix` module reference in `scheduler` metadata so checks pass.

- **New Features**
  - Integrations generator now collects metadata warnings and exits with a non-zero status if any are found.
  - Prints GitHub Actions-friendly error annotations per affected file.

- **Bug Fixes**
  - Removed `zabbix` entry from `src/go/plugin/scripts.d/modules/scheduler/metadata.yaml` (module not present).

<sup>Written for commit db24439ac333c16a640bf16fc00744c4b176c693. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

