### PR TITLE
apps.plugin: add per-Windows-service process tree grouping

### DIFF
--- a/src/collectors/apps.plugin/apps_aggregations.c
+++ b/src/collectors/apps.plugin/apps_aggregations.c
@@ -180,8 +180,54 @@ static void assign_a_target_to_all_processes(void) {
     }
 }
 
+#if (PROCESSES_HAVE_SERVICE == 1)
+static STRING *other_service_name = NULL;
+
+static void assign_service_to_all_processes(void) {
+    if(!other_service_name)
+        other_service_name = string_strdupz("Other");
+
+    // Clear walk-up assigned service_names from previous iteration.
+    // Direct matches (got_service) are kept — they persist per process lifetime.
+    for(struct pid_stat *p = root_of_pids(); p ; p = p->next) {
+        if(!p->got_service && p->service_name) {
+            string_freez(p->service_name);
+            p->service_name = NULL;
+        }
+    }
+
+    // Phase 1: direct match — GetServiceNames() already tagged service root PIDs
+    // with p->service_name during data collection.
+
+    // Phase 2: untagged processes walk up to find a service-tagged ancestor
+    for(struct pid_stat *p = root_of_pids(); p ; p = p->next) {
+        if(!p->service_name) {
+            if(!p->is_manager) {
+                for(struct pid_stat *pp = p->parent; pp ; pp = pp->parent) {
+                    if(pp->is_manager) break;
+
+                    if(pp->service_name) {
+                        p->service_name = string_dup(pp->service_name);
+                        break;
+                    }
+                }
+            }
+
+            // Phase 3: fallback — no service ancestor found
+            if(!p->service_name)
+                p->service_name = string_dup(other_service_name);
+        }
+    }
+}
+#endif
+
 void aggregate_processes_to_targets(void) {
     assign_a_target_to_all_processes();
+
+#if (PROCESSES_HAVE_SERVICE == 1)
+    if(enable_services_charts)
+        assign_service_to_all_processes();
+#endif
     apps_groups_targets_count = zero_all_targets(apps_groups_root_target);
 
 #if (PROCESSES_HAVE_UID == 1)
@@ -192,6 +238,10 @@ void aggregate_processes_to_targets(void) {
 #endif
 #if (PROCESSES_HAVE_SID == 1)
     zero_all_targets(sids_root_target);
+#endif
+#if (PROCESSES_HAVE_SERVICE == 1)
+    if(enable_services_charts)
+        zero_all_targets(services_root_target);
 #endif
 
     // this has to be done, before the cleanup
@@ -266,6 +316,21 @@ void aggregate_processes_to_targets(void) {
             w = p->sid_target = get_sid_target(p->sid_name);
 
         aggregate_pid_on_target(w, p, o);
+#endif
+
+        // --------------------------------------------------------------------
+        // service target
+
+#if (PROCESSES_HAVE_SERVICE == 1)
+        if(enable_services_charts) {
+            o = p->service_target;
+            if(likely(p->service_target && p->service_target->service_name == p->service_name))
+                w = p->service_target;
+            else
+                w = p->service_target = get_service_target(p->service_name);
+
+            aggregate_pid_on_target(w, p, o);
+        }
 #endif
 
         // --------------------------------------------------------------------

--- a/src/collectors/apps.plugin/apps_aggregations.c
+++ b/src/collectors/apps.plugin/apps_aggregations.c
@@ -185,7 +185,7 @@ static STRING *other_service_name = NULL;
 
 static void assign_service_to_all_processes(void) {
     if(!other_service_name)
-        other_service_name = string_strdupz("Other");
+        other_service_name = string_strdupz("not-services");
 
     // Clear walk-up assigned service_names from previous iteration.
     // Direct matches (got_service) are kept — they persist per process lifetime.

--- a/src/collectors/apps.plugin/apps_os_windows.c
+++ b/src/collectors/apps.plugin/apps_os_windows.c
@@ -823,7 +823,7 @@ static inline kernel_uint_t perflib_cpu_utilization(COUNTER_DATA *d) {
      */
 
     LONGLONG dt = time1 - time0;
-    if(dt > 0)
+    if(dt > 0 && data1 >= data0)
         return NSEC_PER_SEC * (data1 - data0) / dt;
     else
         return 0;
@@ -836,7 +836,7 @@ static inline kernel_uint_t perflib_rate(COUNTER_DATA *d) {
     LONGLONG time0 = d->previous.Time;
 
     LONGLONG dt = (time1 - time0);
-    if(dt > 0)
+    if(dt > 0 && data1 >= data0)
         return (RATES_DETAIL * (data1 - data0)) / dt;
     else
         return 0;
@@ -949,6 +949,69 @@ bool apps_os_collect_all_pids_windows(void) {
         if(failed) {
             pid_collection_failed(p);
             continue;
+        }
+
+        // Detect PID reuse: if the process creation time changed, the PID was recycled
+        // by a different process. Without this check, the unsigned subtraction in
+        // perflib_cpu_utilization() and perflib_rate() would underflow, producing
+        // massive bogus values (e.g., 184725% CPU).
+        if(p->perflib[PDF_UPTIME].previous.Data != 0 &&
+           p->perflib[PDF_UPTIME].current.Data != p->perflib[PDF_UPTIME].previous.Data) {
+
+            nd_log(NDLS_COLLECTORS, NDLP_WARNING,
+                   "APPS: PID %d (%s) creation time changed "
+                   "(0x%" PRIx64 " -> 0x%" PRIx64 "), "
+                   "PID reuse detected, resetting counters",
+                   (int)p->pid, pid_stat_comm(p),
+                   (uint64_t)p->perflib[PDF_UPTIME].previous.Data,
+                   (uint64_t)p->perflib[PDF_UPTIME].current.Data);
+
+            // Reset all counter history to prevent unsigned underflow in rate calculations
+            for(PID_FIELD f = 0; f < PDF_MAX; f++) {
+                if(p->perflib[f].key)
+                    p->perflib[f].previous = RAW_DATA_EMPTY;
+            }
+
+            // Reset process identity so GetAllProcessesInfo() re-reads everything
+            p->got_info = false;
+            p->got_service = false;
+
+            string_freez(p->sid_name);
+            p->sid_name = NULL;
+
+            string_freez(p->service_name);
+            p->service_name = NULL;
+
+            string_freez(p->name);
+            p->name = NULL;
+
+            string_freez(p->cmdline);
+            p->cmdline = NULL;
+
+            // Re-read comm name from the perflib instance
+            {
+                char reuse_comm[MAX_PATH];
+                if(getInstanceName(d.pDataBlock, d.pObjectType, d.pi, reuse_comm, sizeof(reuse_comm)))
+                    fix_windows_comm(p, reuse_comm);
+                else
+                    strncpyz(reuse_comm, "unknown", sizeof(reuse_comm) - 1);
+
+                update_pid_comm(p, reuse_comm);
+            }
+
+            // Update parent PID
+            {
+                COUNTER_DATA ppid = {.key = "Creating Process ID"};
+                perflibGetInstanceCounter(d.pDataBlock, d.pObjectType, d.pi, &ppid);
+                p->ppid = (pid_t)ppid.current.Data;
+            }
+
+            // Reset target assignment — the new process may belong to a different group
+            p->target = NULL;
+            p->matched_by_config = false;
+
+            // Trigger GetAllProcessesInfo() to re-read cmdline, name, SID, service
+            added++;
         }
 
         // CPU time

--- a/src/collectors/apps.plugin/apps_os_windows.c
+++ b/src/collectors/apps.plugin/apps_os_windows.c
@@ -630,6 +630,10 @@ static void GetServiceNames(void) {
                 sanitize_apps_plugin_chart_meta(name);
                 string_freez(p->name);
                 p->name = string_strdupz(name);
+#if (PROCESSES_HAVE_SERVICE == 1)
+                string_freez(p->service_name);
+                p->service_name = string_strdupz(name);
+#endif
             }
         }
     }

--- a/src/collectors/apps.plugin/apps_pid.c
+++ b/src/collectors/apps.plugin/apps_pid.c
@@ -151,6 +151,10 @@ void del_pid_entry(pid_t pid) {
     string_freez(p->sid_name);
 #endif
 
+#if (PROCESSES_HAVE_SERVICE == 1)
+    string_freez(p->service_name);
+#endif
+
     string_freez(p->comm_orig);
     string_freez(p->comm);
     string_freez(p->cmdline);

--- a/src/collectors/apps.plugin/apps_plugin.c
+++ b/src/collectors/apps.plugin/apps_plugin.c
@@ -26,6 +26,9 @@ bool debug_enabled = false;
 bool enable_detailed_uptime_charts = false;
 bool enable_users_charts = true;
 bool enable_groups_charts = true;
+#if (PROCESSES_HAVE_SERVICE == 1)
+bool enable_services_charts = true;
+#endif
 bool include_exited_childs = true;
 bool proc_pid_cmdline_is_needed = true; // true when we need to read /proc/cmdline
 
@@ -518,6 +521,13 @@ static void parse_args(int argc, char **argv)
         }
 #endif
 
+#if (PROCESSES_HAVE_SERVICE == 1)
+        if(strcmp("no-services", argv[i]) == 0 || strcmp("without-services", argv[i]) == 0) {
+            enable_services_charts = false;
+            continue;
+        }
+#endif
+
         if(strcmp("with-detailed-uptime", argv[i]) == 0) {
             enable_detailed_uptime_charts = 1;
             continue;
@@ -573,6 +583,10 @@ static void parse_args(int argc, char **argv)
 #endif
 #if (PROCESSES_HAVE_GID == 1)
                     " without-groups         disable reporting per user group charts\n"
+                    "\n"
+#endif
+#if (PROCESSES_HAVE_SERVICE == 1)
+                    " without-services       disable reporting per Windows service charts\n"
                     "\n"
 #endif
                     " with-detailed-uptime   enable reporting min/avg/max uptime charts\n"
@@ -874,6 +888,13 @@ int main(int argc, char **argv) {
         if (enable_users_charts) {
             send_charts_updates_to_netdata(sids_root_target, "user", "user", "User Processes");
             send_collected_data_to_netdata(sids_root_target, "user", dt);
+        }
+#endif
+
+#if (PROCESSES_HAVE_SERVICE == 1)
+        if (enable_services_charts) {
+            send_charts_updates_to_netdata(services_root_target, "service", "service", "Windows Service");
+            send_collected_data_to_netdata(services_root_target, "service", dt);
         }
 #endif
 

--- a/src/collectors/apps.plugin/apps_plugin.h
+++ b/src/collectors/apps.plugin/apps_plugin.h
@@ -101,6 +101,7 @@ struct pid_info {
 #define PROCESSES_HAVE_UID                   0
 #define PROCESSES_HAVE_GID                   0
 #define PROCESSES_HAVE_SID                   1
+#define PROCESSES_HAVE_SERVICE               1
 #define PROCESSES_HAVE_MAJFLT                0
 #define PROCESSES_HAVE_CHILDREN_FLTS         0
 #define PROCESSES_HAVE_VMSWAP                1
@@ -294,6 +295,9 @@ typedef enum __attribute__((packed)) {
 #if (PROCESSES_HAVE_SID == 1)
     TARGET_TYPE_SID,
 #endif
+#if (PROCESSES_HAVE_SERVICE == 1)
+    TARGET_TYPE_SERVICE,
+#endif
     TARGET_TYPE_TREE,
 } TARGET_TYPE;
 
@@ -407,6 +411,9 @@ struct target {
 #if (PROCESSES_HAVE_SID == 1)
     STRING *sid_name;
 #endif
+#if (PROCESSES_HAVE_SERVICE == 1)
+    STRING *service_name;
+#endif
 
     kernel_uint_t values[PDF_MAX];
 
@@ -516,6 +523,9 @@ struct pid_stat {
 #if (PROCESSES_HAVE_SID == 1)
     struct target *sid_target;      // sid based targets
 #endif
+#if (PROCESSES_HAVE_SERVICE == 1)
+    struct target *service_target;  // service based targets
+#endif
 
     STRING *comm_orig;              // the command, as-collected
     STRING *comm;                   // the command, sanitized
@@ -538,6 +548,9 @@ struct pid_stat {
 #endif
 #if (PROCESSES_HAVE_SID == 1)
     STRING *sid_name;
+#endif
+#if (PROCESSES_HAVE_SERVICE == 1)
+    STRING *service_name;
 #endif
 
 #if (ALL_PIDS_ARE_READ_INSTANTLY == 0)
@@ -730,6 +743,12 @@ struct target *get_gid_target(gid_t gid);
 #if (PROCESSES_HAVE_SID == 1)
 extern struct target *sids_root_target;
 struct target *get_sid_target(STRING *sid_name);
+#endif
+
+#if (PROCESSES_HAVE_SERVICE == 1)
+extern bool enable_services_charts;
+extern struct target *services_root_target;
+struct target *get_service_target(STRING *service_name);
 #endif
 
 extern struct target *apps_groups_root_target;

--- a/src/collectors/apps.plugin/apps_targets.c
+++ b/src/collectors/apps.plugin/apps_targets.c
@@ -302,6 +302,33 @@ struct target *get_sid_target(STRING *sid_name) {
 #endif
 
 // --------------------------------------------------------------------------------------------------------------------
+// Service
+
+#if (PROCESSES_HAVE_SERVICE == 1)
+struct target *services_root_target = NULL;
+
+struct target *get_service_target(STRING *service_name) {
+    struct target *w;
+    for(w = services_root_target ; w ; w = w->next)
+        if(w->service_name == service_name) return w;
+
+    w = callocz(sizeof(struct target), 1);
+    w->type = TARGET_TYPE_SERVICE;
+    w->service_name = string_dup(service_name);
+    w->id = string_dup(service_name);
+    w->name = string_dup(service_name);
+    w->clean_name = get_clean_name(w->name);
+
+    w->next = services_root_target;
+    services_root_target = w;
+
+    debug_log("added service '%s' target", string2str(w->service_name));
+
+    return w;
+}
+#endif
+
+// --------------------------------------------------------------------------------------------------------------------
 // apps_groups.conf
 
 struct target *apps_groups_root_target = NULL;

--- a/src/collectors/apps.plugin/metadata.yaml
+++ b/src/collectors/apps.plugin/metadata.yaml
@@ -590,7 +590,7 @@ modules:
     overview:
       data_collection:
         metrics_description: "This integration monitors resource utilization grouped by Windows Service."
-        method_description: "It auto-discovers running Windows services via the Service Control Manager and groups each service's process tree to aggregate CPU, memory, I/O, and other metrics per service. Processes not belonging to any service are grouped under 'Other'."
+        method_description: "It auto-discovers running Windows services via the Service Control Manager and groups each service's process tree to aggregate CPU, memory, I/O, and other metrics per service. Processes not belonging to any service are grouped under 'not-services'."
       supported_platforms:
         include:
           - windows
@@ -604,7 +604,7 @@ modules:
         limits:
           description: ""
         performance_impact:
-          description: "Zero additional overhead. The service list is already queried by apps.plugin for process naming."
+          description: "No additional SCM query overhead. The service list is already queried by apps.plugin for process naming. Per-iteration work involves walking parent chains to assign service names."
     setup:
       prerequisites:
         list: []
@@ -613,7 +613,7 @@ modules:
           name: ""
           description: ""
         options:
-          description: "Service charts are enabled by default. Use the `without-services` command line option to disable them."
+          description: "Service charts are enabled by default. Use the `without-services` (or `no-services`) command line option to disable them."
           folding:
             title: ""
             enabled: true

--- a/src/collectors/apps.plugin/metadata.yaml
+++ b/src/collectors/apps.plugin/metadata.yaml
@@ -567,3 +567,147 @@ modules:
                 - name: min
                 - name: avg
                 - name: max
+  - meta:
+      plugin_name: apps.plugin
+      module_name: services
+      monitored_instance:
+        name: Windows Services
+        link: ""
+        categories:
+          - data-collection.operating-systems
+        icon_filename: "windows.svg"
+      related_resources:
+        integrations:
+          list: []
+      info_provided_to_referring_integrations:
+        description: ""
+      keywords:
+        - windows
+        - services
+        - processes
+        - os
+        - host monitoring
+    overview:
+      data_collection:
+        metrics_description: "This integration monitors resource utilization grouped by Windows Service."
+        method_description: "It auto-discovers running Windows services via the Service Control Manager and groups each service's process tree to aggregate CPU, memory, I/O, and other metrics per service. Processes not belonging to any service are grouped under 'Other'."
+      supported_platforms:
+        include:
+          - windows
+        exclude: []
+      multi_instance: true
+      additional_permissions:
+        description: ""
+      default_behavior:
+        auto_detection:
+          description: "All running Windows services are automatically discovered. No configuration is needed."
+        limits:
+          description: ""
+        performance_impact:
+          description: "Zero additional overhead. The service list is already queried by apps.plugin for process naming."
+    setup:
+      prerequisites:
+        list: []
+      configuration:
+        file:
+          name: ""
+          description: ""
+        options:
+          description: "Service charts are enabled by default. Use the `without-services` command line option to disable them."
+          folding:
+            title: ""
+            enabled: true
+          list: []
+        examples:
+          folding:
+            enabled: true
+            title: ""
+          list: []
+    troubleshooting:
+      problems:
+        list: []
+    alerts: []
+    metrics:
+      folding:
+        title: Metrics
+        enabled: false
+      description: ""
+      availability:
+        - windows
+      scopes:
+        - name: windows service
+          description: These metrics refer to the Windows Service.
+          labels:
+            - name: service
+              description: The display name of the Windows service.
+          metrics:
+            - name: service.cpu_utilization
+              description: Windows Service CPU utilization (100% = 1 core)
+              unit: percentage
+              chart_type: stacked
+              dimensions:
+                - name: user
+                - name: system
+            - name: service.mem_usage
+              description: Windows Service memory RSS usage
+              unit: MiB
+              chart_type: area
+              dimensions:
+                - name: rss
+            - name: service.vmem_usage
+              description: Windows Service virtual memory size
+              unit: MiB
+              chart_type: line
+              dimensions:
+                - name: vmem
+            - name: service.mem_page_faults
+              description: Windows Service memory page faults
+              unit: pgfaults/s
+              chart_type: stacked
+              dimensions:
+                - name: minor
+            - name: service.swap_usage
+              description: Windows Service swap usage
+              unit: MiB
+              chart_type: area
+              dimensions:
+                - name: swap
+            - name: service.disk_logical_io
+              description: Windows Service disk logical IO
+              unit: KiB/s
+              chart_type: area
+              dimensions:
+                - name: reads
+                - name: writes
+            - name: service.fds_open
+              description: Windows Service open handles
+              unit: fds
+              chart_type: stacked
+              dimensions:
+                - name: handles
+            - name: service.processes
+              description: Windows Service processes
+              unit: processes
+              chart_type: line
+              dimensions:
+                - name: processes
+            - name: service.threads
+              description: Windows Service threads
+              unit: threads
+              chart_type: line
+              dimensions:
+                - name: threads
+            - name: service.uptime
+              description: Windows Service uptime
+              unit: seconds
+              chart_type: line
+              dimensions:
+                - name: uptime
+            - name: service.uptime_summary
+              description: Windows Service uptime summary
+              unit: seconds
+              chart_type: area
+              dimensions:
+                - name: min
+                - name: avg
+                - name: max


### PR DESCRIPTION
## Summary

- Add a new grouping dimension to apps.plugin on Windows that groups processes by their owning Windows Service
- Service root PIDs are auto-discovered via the Service Control Manager (EnumServicesStatusEx, already called for process naming — zero additional overhead)
- Untagged child processes walk up the process tree to inherit their ancestor's service; non-service processes fall back to "not-services"
- Charts use type `service` and label `service` to naturally group with existing windows.plugin `service_state` charts
- Enabled by default; disable with `--without-services`
- No config file needed — fully auto-discovered from SCM
- **Fix: detect Windows PID reuse to prevent bogus CPU spikes** — when Windows recycles a PID, the unsigned subtraction in rate calculations would underflow (e.g., 184725% CPU). Now detects PID reuse via process creation time changes, resets counter history, and re-reads process identity.

## Files changed

| File | Changes |
|------|---------|
| `apps_plugin.h` | `PROCESSES_HAVE_SERVICE` flag, `TARGET_TYPE_SERVICE`, struct fields, externs |
| `apps_targets.c` | `services_root_target`, `get_service_target()` |
| `apps_os_windows.c` | Set `p->service_name` in `GetServiceNames()`; PID reuse detection via creation time; underflow guards in `perflib_cpu_utilization()` and `perflib_rate()` |
| `apps_aggregations.c` | `assign_service_to_all_processes()` with 3-phase walk-up, zero/aggregate blocks; fallback group renamed to "not-services" |
| `apps_plugin.c` | `enable_services_charts`, CLI flag, chart generation |
| `apps_pid.c` | Cleanup `service_name` on process deletion |
| `metadata.yaml` | New services module with Windows-only metrics |

## PID reuse fix details

Windows aggressively recycles PIDs. When a PID is reused:
1. The `pid_stat` entry still exists with counter data from the old process
2. The new process has less accumulated CPU time than the old one
3. `perflib_cpu_utilization()` computes `NSEC_PER_SEC * (data1 - data0) / dt` where `data1 < data0` (ULONGLONG), causing unsigned underflow → massive bogus value

The fix:
- **Detection**: Compare the `Elapsed Time` counter's `Data` field (process creation FILETIME) between cycles. If it changed, the PID was recycled.
- **Reset**: Zero out all `COUNTER_DATA.previous` for the process so the first cycle after reuse produces ~0 (safe)
- **Re-identify**: Re-read comm, ppid, and clear cmdline/SID/service so `GetAllProcessesInfo()` re-reads them
- **Safety guard**: Added `data1 >= data0` check in `perflib_cpu_utilization()` and `perflib_rate()` as defense-in-depth

## Test plan

- [x] Windows build compiles with `PROCESSES_HAVE_SERVICE`
- [x] Running services appear as targets with correct display names
- [x] Child processes of services grouped under parent service
- [x] svchost services correctly named via `-s ServiceName`
- [x] Non-service processes appear under "not-services"
- [ ] `--without-services` disables service charts
- [ ] Service start/stop: new PID gets correct service name
- [ ] Label `service` matches between windows.plugin and apps.plugin
- [ ] Linux/macOS/FreeBSD builds unaffected (all behind `#if` guards)
- [x] PID reuse during compilation burst: no CPU spikes (verified 0-3% range)