### PR TITLE
Improve discoverability of Alerts Automation docs

### DIFF
--- a/docs/alerts-and-notifications/creating-alerts-with-netdata-alerts-configuration-manager.md
+++ b/docs/alerts-and-notifications/creating-alerts-with-netdata-alerts-configuration-manager.md
@@ -1,6 +1,12 @@
 # Creating Alerts with Netdata Alerts Configuration Manager
 
-The **Netdata Alerts Configuration Manager** lets you create and fine-tune alerts directly from the Netdata Cloud Dashboard.
+The **Netdata Alerts Configuration Manager** lets you create and fine-tune alerts directly from the Netdata Cloud Dashboard using a visual UI wizard.
+
+:::tip
+
+**Want AI to handle the configuration for you?** [Alerts Automation](/docs/netdata-ai/alerts-automation/alerts-automation.md) uses AI to suggest alerts, generate the configuration, and test it against historical data — so you can validate thresholds before deployment without writing any configuration manually.
+
+:::
 
 :::info
 
@@ -102,3 +108,4 @@ You control how and when alerts are triggered, escalated, or resolved:
 
 - You can apply alert definitions to **Parent Agents** or **Standalone Child Agents**
 - If you need help writing custom alerts, check the [full alert reference](/src/health/REFERENCE.md)
+- To create alerts using natural language instead of this manual wizard, see [Alerts Automation](/docs/netdata-ai/alerts-automation/alerts-automation.md)

--- a/docs/alerts-and-notifications/notifications/README.md
+++ b/docs/alerts-and-notifications/notifications/README.md
@@ -109,13 +109,16 @@ Choose the option that fits your needs:
 | Fine-tuned control per system/service | Netdata Agent |
 | Want both simplicity and flexibility  | Use **both**  |
 
+## Creating and configuring alerts
+
+Netdata ships with hundreds of pre-configured alerts. You can also create your own or tune existing ones:
+
+- **[Alerts Automation](/docs/netdata-ai/alerts-automation/alerts-automation.md)** — Describe what you want in plain English; AI suggests alerts, generates the configuration, and tests it against historical data before deployment
+- **[Alerts Configuration Manager](/docs/alerts-and-notifications/creating-alerts-with-netdata-alerts-configuration-manager.md)** — Visual UI wizard for creating and editing alerts
+- **[Manual configuration](/src/health/REFERENCE.md)** — Edit `health.d/*.conf` files directly for full control over alert syntax
+
 ## Next Steps
 
-- 🔧 [Set up Cloud Notifications](/docs/alerts-and-notifications/notifications/centralized-cloud-notifications/centralized-cloud-notifications-reference.md)
-- ⚙️ [Set up Agent Notifications](/src/health/notifications/README.md)
-
-:::info
-
-For additional alert customization options including threshold adjustments, custom conditions, and notification routing, check out our [alert configuration reference](https://learn.netdata.cloud/docs/alerts-&-notifications/alert-configuration-reference).
-
-:::
+- [Set up Cloud Notifications](/docs/alerts-and-notifications/notifications/centralized-cloud-notifications/centralized-cloud-notifications-reference.md)
+- [Set up Agent Notifications](/src/health/notifications/README.md)
+- [Create alerts with AI](/docs/netdata-ai/alerts-automation/alerts-automation.md)

--- a/docs/category-overview-pages/machine-learning-and-assisted-troubleshooting.md
+++ b/docs/category-overview-pages/machine-learning-and-assisted-troubleshooting.md
@@ -42,7 +42,7 @@ See the [Troubleshooting overview](/docs/netdata-ai/troubleshooting/index.md).
 
 ### 5) Alerts Automation
 
-[Alerts Automation](/docs/netdata-ai/alerts-automation/alerts-automation.md) lets you describe alert conditions in plain English while AI handles the syntax. Create production-ready alerts, get intelligent suggestions based on your infrastructure, and explain existing alert definitions.
+[Alerts Automation](/docs/netdata-ai/alerts-automation/alerts-automation.md) uses AI to suggest, generate, and test alert configurations. Describe what you want to monitor in plain English, and the AI generates the complete alert definition, tests it against historical data to show how it would have triggered, and lets you deploy it to your nodes — no need to learn alert configuration syntax or manually tune thresholds.
 
 ### 6) Anomaly Detection
 

--- a/docs/dashboards-and-charts/alerts-tab.md
+++ b/docs/dashboards-and-charts/alerts-tab.md
@@ -67,6 +67,14 @@ In the **Raised Alerts** tab:
     - Create a new [silencing rule](/docs/alerts-and-notifications/notifications/centralized-cloud-notifications/centralized-cloud-notifications-reference.md#alert-notification-silencing-rules).
     - Ask AI to troubleshoot the alert.
 
+## Creating and Tuning Alerts
+
+From the Alerts tab, you can create new alerts or tune existing ones:
+
+- **[Alerts Automation](/docs/netdata-ai/alerts-automation/alerts-automation.md)** — Describe what you want in plain English and let AI generate the alert configuration, including thresholds and tuning parameters
+- **[Alerts Configuration Manager](/docs/alerts-and-notifications/creating-alerts-with-netdata-alerts-configuration-manager.md)** — Visual UI wizard for manual alert creation and fine-tuning
+- **[Manual configuration](/src/health/REFERENCE.md)** — Edit `health.d/*.conf` files directly for full control
+
 ## Alert Configurations Tab
 
 The **Alert Configurations** tab shows the configuration of all running alerts in your Room.

--- a/docs/netdata-ai/alerts-automation/alerts-automation.md
+++ b/docs/netdata-ai/alerts-automation/alerts-automation.md
@@ -1,89 +1,112 @@
 # Alerts Automation
 
-## Overview
+Alerts Automation uses AI to suggest, generate, and test alert configurations for you — no need to learn Netdata's alert syntax or manually tune thresholds. Describe what you want to monitor in plain English, review the generated configuration against historical data, and deploy it to your nodes.
 
-Netdata has an incredibly powerful alerting engine that offers immense flexibility to build specific, intelligent alerts. However, mastering its syntax can feel like learning a new language.
+## When to use it
 
-To ensure accessibility for every member on your engineering team, we created Alerts Automation. A bridge between your intent and Netdata's syntax, letting you describe conditions in plain English while the AI handles the rest.
+- You want to set up alerts without learning Netdata's alert configuration syntax
+- You need suggestions for what to alert on for a given service or use case
+- You want to validate an alert configuration against historical data before deploying it
+- You want to tune alert thresholds and reduce alert fatigue without trial and error
 
-## Capabilities
+## How it works
 
-### Creating production-ready alerts
+Alerts Automation provides three AI-powered capabilities that work together as a single workflow:
 
-All you have to do to create production-ready alerts is to simply describe your goal in plain English. For example, if you want to get ahead of a disk filling up:
+### Suggest
 
-**"Create an alert that warns me when a disk will be more than 85% full in the next 24 hours, and goes critical if it is more than 95% full."**
+Ask Netdata AI what alerts would be appropriate for your infrastructure, and it responds with suggestions described in plain English. Because suggestions are in natural language, anyone on the team can understand, discuss, and refine them before they become configurations.
 
-Netdata AI translates your request into a perfectly formatted, syntactically correct alert definition and presents it for your review.
+### Generate
 
-### Suggest what to alert on
+Once you decide what to alert on, Netdata AI generates the complete alert configuration automatically. It translates your intent into Netdata's alert syntax — handling lookups, thresholds, hysteresis, dimensions, and all other parameters — so you don't have to write or understand the configuration format.
 
-You can ask Netdata AI for intelligent suggestions based on the context of your infrastructure.
+### Test on historical data
 
-Netdata AI will suggest what would be a suitable alert for a specific use-case or context.
+Before deploying, Netdata AI tests the generated alert configuration against the historical metric data of any node you select. The test shows:
 
-### Explain what every alert does
+- How many times the alert **would have triggered**
+- How long each alert **would have lasted**
+- What **alert states** (warning, critical) would have been reached
 
-Netdata ships with hundreds of pre-configured alerts. To get masterfull insights of their underlying logic:
+This lets you evaluate whether the alert is too sensitive, too quiet, or just right — before it reaches production. You can then adjust the configuration and re-test until you are satisfied with the results.
 
-Click on any alert definition and ask Netdata AI to **Explain** this alert. It will break down the entire definition line by line.
+### Edit and deploy
+
+After testing, you can edit the alert definition through the UI and submit it to a single node or multiple nodes, depending on your needs.
+
+## How alert configuration works in Netdata
+
+Netdata provides multiple ways to configure alerts. All methods produce the same underlying alert definitions — they differ in how you author them.
+
+| Method | How it works | Best for |
+|--------|-------------|----------|
+| **AI Alerts Automation** (this page) | Describe what you want in plain English; AI suggests, generates, and tests the configuration | Getting started quickly, avoiding syntax errors, validating before deployment |
+| **[Alerts Configuration Manager](/docs/alerts-and-notifications/creating-alerts-with-netdata-alerts-configuration-manager.md)** | Visual UI wizard for creating and editing alerts | Manual control over every parameter via a guided interface |
+| **[Manual config files](/src/health/REFERENCE.md)** | Edit `health.d/*.conf` files directly | Advanced users, automation pipelines, version-controlled configurations |
+
+## How to access
+
+Alerts Automation is available directly within the alert configuration workflow in Netdata Cloud.
+
+### From any chart
+
+1. Click the **alert bell icon** on any chart
+2. Click **+ Add alert**
+3. Describe the alert you want to create, or ask for suggestions
+
+### From the Alerts tab
+
+Click **"New Alert"** from the Alerts tab to access the AI-powered alert creation workflow.
 
 ## AI credits consumption
 
-Just like other Netdata AI functionality, usage is based on AI credits. You get 10 monthly complementary credits with a Business subscription, and you can top up credits yourself based on your needs. You also get 10 free credits on the free trial to experiment with.
+Usage is based on AI credits. You get 10 monthly complementary credits with a Business subscription, and you can top up credits based on your needs. You also get 10 free credits on the free trial.
 
 - **Alert creation**: 0.2 credits per run (create up to 5 alerts per AI credit)
 - **Alert suggestion**: 0.2 credits per run (up to 5 suggestions per AI credit)
 - **Alert explanation**: Free to use
 
 :::info
-
 Track your AI credit usage from `Settings → Usage & Billing → AI Credits`.
-
 :::
 
-## How to access
+## Availability
 
-You'll find these new AI capabilities directly within the alert configuration workflow in Netdata Cloud.
-
-### From any chart
-
-**Step 1:** Click on the **alert bell icon** (locate it by navigating your cursor on any chart)
-**Step 2:** Click on **+ Add alert**
-**Step 3:** Describe the alert you want to create
-
-You can now seamlessly:
-
-- Create alerts using natural language
-- Get AI suggestions for what to monitor
-- Explain existing alerts
-
-### From the Alerts tab
-
-Click on **"New Alert"** from the alerts tab to access the AI-powered alert creation workflow.
-
-### Alternative: Manual configuration
-
-You can always use the manual dynamic configuration alert wizard, which gives you full control over every parameter.
-
-## Requirements
+Available for all users on a Business plan or free trial.
 
 - **Subscription:** Business plan or Free Trial
 - **Access:** Netdata Cloud account with appropriate permissions
 
-## Availability
+## FAQ
 
-This feature is available today for all users on a Business plan or a free trial.
+### Is alert configuration in Netdata manual or automated?
+
+Both. Alerts Automation provides a fully automated, AI-powered path where you describe what you want in plain English and the AI generates, tests, and helps you deploy the alert configuration. You can also configure alerts manually using the [Alerts Configuration Manager](/docs/alerts-and-notifications/creating-alerts-with-netdata-alerts-configuration-manager.md) UI or by [editing config files directly](/src/health/REFERENCE.md).
+
+### Can I automatically tune alert thresholds?
+
+Yes. Describe your goal (e.g., "warn me when CPU is consistently high but ignore short spikes") and the AI generates appropriate thresholds. You can then test the configuration against historical data to see how it would have behaved, adjust, and re-test until the thresholds are right.
+
+### Does Netdata use machine learning for alerts?
+
+Yes, in two ways:
+
+1. **ML-based anomaly detection** — Every Netdata Agent runs unsupervised machine learning models that learn normal metric behavior and score anomalies in real time. You can create alerts based on anomaly rates. See [ML Anomaly Detection](/docs/ml-ai/ml-anomaly-detection/ml-anomaly-detection.md).
+2. **AI-powered alert configuration** (this page) — Use natural language to suggest, generate, test, and deploy alert definitions.
+
+### How is this different from the Alerts Configuration Manager?
+
+The [Alerts Configuration Manager](/docs/alerts-and-notifications/creating-alerts-with-netdata-alerts-configuration-manager.md) is a visual UI wizard where you manually select metrics, set thresholds, and configure parameters field by field. Alerts Automation uses AI to generate the entire configuration from a natural language description and lets you validate it against historical data before deployment. Both produce the same alert definitions.
 
 ## See also
 
-- [Alert Troubleshooting](/docs/troubleshooting/troubleshoot.md) - AI-powered alert investigation
-- [Netdata AI Overview](/docs/category-overview-pages/machine-learning-and-assisted-troubleshooting.md) - Complete AI capabilities guide
-
-By letting Netdata AI handle the syntactic complexity, we're lowering the barrier to entry for effective alerting and freeing up your team to focus on what matters: building reliable, high-performance systems.
+- [Alert Configuration Reference](/src/health/REFERENCE.md) — full manual configuration syntax
+- [Alerts Configuration Manager](/docs/alerts-and-notifications/creating-alerts-with-netdata-alerts-configuration-manager.md) — visual UI wizard for alert configuration
+- [ML Anomaly Detection](/docs/ml-ai/ml-anomaly-detection/ml-anomaly-detection.md) — machine learning based anomaly scoring
+- [Alert Troubleshooting](/docs/troubleshooting/troubleshoot.md) — AI-powered alert investigation
+- [Netdata AI Overview](/docs/category-overview-pages/machine-learning-and-assisted-troubleshooting.md) — complete AI capabilities guide
 
 :::note
-
 Despite our best efforts to reduce inaccuracies, AI responses may sometimes be incorrect. Please review generated configurations before deploying to production systems.
-
 :::

--- a/src/health/REFERENCE.md
+++ b/src/health/REFERENCE.md
@@ -1,5 +1,13 @@
 # Configure Health Alerts
 
+:::tip
+
+**Don't want to write alert configs manually?** [Alerts Automation](/docs/netdata-ai/alerts-automation/alerts-automation.md) uses AI to suggest alerts, generate the configuration, and test it against historical data — so you can validate thresholds before deployment without learning the syntax. You can also use the visual [Alerts Configuration Manager](/docs/alerts-and-notifications/creating-alerts-with-netdata-alerts-configuration-manager.md).
+
+:::
+
+This page covers **manual alert configuration** — editing config files directly. For a comparison of all configuration methods, see [How alert configuration works in Netdata](/docs/netdata-ai/alerts-automation/alerts-automation.md#how-alert-configuration-works-in-netdata).
+
 ## Quick Start Guide
 
 :::tip
@@ -1568,5 +1576,12 @@ When seeking help, include:
 - [Netdata GitHub Issues](https://github.com/netdata/netdata/issues)
 - [Netdata Community Forum](https://community.netdata.cloud)
 - [Netdata Discord](https://discord.gg/mPZ6WZKKG2)
+
+## Related Pages
+
+- [Alerts Automation](/docs/netdata-ai/alerts-automation/alerts-automation.md) - Create and tune alerts using natural language with AI assistance (no manual configuration needed)
+- [Alerts Configuration Manager](/docs/alerts-and-notifications/creating-alerts-with-netdata-alerts-configuration-manager.md) - Visual UI wizard for creating alerts
+- [ML Anomaly Detection](/docs/ml-ai/ml-anomaly-detection/ml-anomaly-detection.md) - Machine learning based anomaly detection for all metrics
+- [Alert Troubleshooting](/docs/troubleshooting/troubleshoot.md) - AI-powered alert investigation and root-cause analysis
 
 **Next Steps:** You now have comprehensive knowledge of Netdata health configuration. Start with the [Quick Start Guide](#quick-start-guide) for immediate needs or dive into [Common Tasks](#common-tasks) for specific workflows.


### PR DESCRIPTION
## Summary

- **Rewrote `alerts-automation.md`** to accurately describe the three core capabilities: suggest alerts in plain English, auto-generate the configuration syntax, and test against historical data (trigger count, duration, alert states per node) before deployment
- **Added cross-references across 5 other alert-related docs** (`REFERENCE.md`, Alerts Configuration Manager, Alerts Tab, Notifications README, Netdata AI overview) so that any entry point leads to the automation page within one hop
- **Added FAQ section** to `alerts-automation.md` with naturally phrased questions matching common search patterns (e.g., "Is alert configuration manual or automated?", "Can I automatically tune alert thresholds?")

### Problem

Our docs agent (Nedi) could not find the Alerts Automation page when asked about whether alert configuration is manual or automated. The search for `automatic|auto-tune|dynamic.*threshold|adaptive` returned zero results because:
1. The automation page lacked these keywords
2. The Alert Configuration Reference (which was found and read) had no pointer to the automation page
3. The `alerts-and-notifications/` directory had no mention of AI-powered alert creation

### Changes (6 files)

| File | Change |
|------|--------|
| `docs/netdata-ai/alerts-automation/alerts-automation.md` | Full rewrite with accurate capabilities, comparison table, FAQ |
| `src/health/REFERENCE.md` | Added tip box at top + Related Pages section at bottom |
| `docs/alerts-and-notifications/creating-alerts-with-netdata-alerts-configuration-manager.md` | Added tip box + link in Final Notes |
| `docs/dashboards-and-charts/alerts-tab.md` | Added "Creating and Tuning Alerts" section |
| `docs/alerts-and-notifications/notifications/README.md` | Added "Creating and configuring alerts" section + link in Next Steps |
| `docs/category-overview-pages/machine-learning-and-assisted-troubleshooting.md` | Updated Alerts Automation description |

## Test plan

- [x] Verify all internal links resolve correctly (verified locally — all 12 link targets exist)
- [x] Verify markdown renders correctly (tables, admonitions, heading hierarchy)
- [ ] Confirm the automation page now surfaces when searching for: `automatic`, `auto-tune`, `threshold tuning`, `automated alert configuration`
- [ ] Confirm an agent reading the Alert Configuration Reference finds the automation page via the tip box

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve discoverability and clarity of Alerts Automation docs. Rewrites the main page to explain the suggest → generate → test workflow and adds one-hop links from related docs so users and search can find it quickly.

- **Refactors**
  - Rewrote `docs/netdata-ai/alerts-automation/alerts-automation.md` to detail the workflow, access paths, availability, and credit usage.
  - Added a concise comparison of alert configuration methods and an FAQ with search-friendly questions.
  - Added cross-links from `src/health/REFERENCE.md`, Alerts Configuration Manager, Alerts Tab, Notifications README, and the ML overview.
  - Improves search coverage for terms like “automatic,” “auto-tune,” “threshold tuning,” and “automated alert configuration.”

<sup>Written for commit 3197013c29311f3cfde1a4d68fd08c8794518b1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

