### PR TITLE
go.d/snmp: add tunnel_index to Check Point VPN tunnel tables

### DIFF
--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_checkpoint-vpn.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_checkpoint-vpn.yaml
@@ -136,6 +136,8 @@ metrics:
           1: alive
           2: dead
     metric_tags:
+      - tag: tunnel_index
+        index: 1
       - tag: tunnel_peer_name
         symbol:
           OID: 1.3.6.1.4.1.2620.500.9002.1.2
@@ -195,6 +197,8 @@ metrics:
           1: alive
           2: dead
     metric_tags:
+      - tag: tunnel_index
+        index: 1
       - tag: tunnel_peer_name
         symbol:
           OID: 1.3.6.1.4.1.2620.500.9003.1.2


### PR DESCRIPTION
Add explicit SNMP row index tag to tunnelTable and permanentTunnelTable for guaranteed chart ID uniqueness. A single peer can have multiple tunnels (different communities, interfaces, or source IPs), so tunnel_peer_name alone is not sufficient.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
