### PR TITLE
ACLK: fix proxy timeout Y2K38 conversion

### DIFF
--- a/src/aclk/https_client.c
+++ b/src/aclk/https_client.c
@@ -806,8 +806,8 @@ https_client_resp_t https_request(https_req_t *request, https_req_response_t *re
         if (proxy_type == MQTT_WSS_DIRECT)
             proxy_type = MQTT_WSS_PROXY_HTTP;
 
-        int proxy_timeout_ms = (request->timeout_s > 0 && request->timeout_s <= 2000000)
-                                    ? (int)request->timeout_s * 1000
+        int proxy_timeout_ms = (request->timeout_s > 0 && request->timeout_s <= (time_t)(INT_MAX / 1000))
+                                    ? (int)(request->timeout_s * 1000)
                                     : 30000;
 
         if (aclk_proxy_negotiation_connect(ctx->sock, proxy_type, request->proxy_username, request->proxy_password,


### PR DESCRIPTION
##### Summary
- Handle CID 501829
  ** CID 501829:       High impact quality  (Y2K38_SAFETY)
  /src/aclk/https_client.c: 810           in https_request()


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Y2K38-related overflow when converting proxy timeouts from seconds to milliseconds. Prevents integer overflow on 32-bit builds and falls back to 30s when the value exceeds safe limits.

- Bug Fixes
  - Replace the hardcoded 2,000,000s cap with a check against (time_t)(INT_MAX/1000), multiply in a wide type, then cast to int. Keeps the 30s default for out-of-range values.

<sup>Written for commit 20efb76f1d2aa7d91ebf999f3e382cb3a42ba1a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

