### PR TITLE
docs: Update kickstart URL to canonical get.netdata.cloud

### DIFF
--- a/docs/getting-started-netdata/guide.md
+++ b/docs/getting-started-netdata/guide.md
@@ -100,7 +100,7 @@ Once logged into Netdata Cloud, you'll see connection instructions. There are th
 All methods will show you a command like this:
 
 ```bash
-bash <(curl -Ss https://my-netdata.io/kickstart.sh) --claim-token YOUR_TOKEN --claim-rooms YOUR_ROOMS --claim-url https://app.netdata.cloud
+bash <(curl -Ss https://get.netdata.cloud/kickstart.sh) --claim-token YOUR_TOKEN --claim-rooms YOUR_ROOMS --claim-url https://app.netdata.cloud
 ```
 
 :::
@@ -228,7 +228,7 @@ Click "Invite Users" in your Space sidebar to add team members. Set appropriate 
 **Organize by Your Needs:**
 
 | **Category**       | **Examples**                         |
-|--------------------|--------------------------------------|
+| ------------------ | ------------------------------------ |
 | **By Service**     | Web servers, databases, applications |
 | **By Location**    | Data centers, cloud regions          |
 | **By Team**        | DevOps, SRE, development teams       |
@@ -248,7 +248,7 @@ Click "Invite Users" in your Space sidebar to add team members. Set appropriate 
 ### Traditional Monitoring vs Netdata Business
 
 | **Traditional Monitoring**                       |        | **Netdata Business**                               |
-|--------------------------------------------------|:------:|----------------------------------------------------|
+| ------------------------------------------------ | :----: | -------------------------------------------------- |
 | **Navigate complex interfaces** during incidents |        | **Get instant analysis** with natural language     |
 | **Build dashboards** during incidents            | **VS** | **Automatic dashboards** with zero configuration   |
 | **Manually correlate data** across systems       |        | **AI-powered correlation** and root cause analysis |
@@ -262,7 +262,7 @@ Experience the future of infrastructure monitoring with AI that actually works. 
 **AI Features Overview:**
 
 | **Capability**           | **What It Does**                    | **Access**                           |
-|--------------------------|-------------------------------------|--------------------------------------|
+| ------------------------ | ----------------------------------- | ------------------------------------ |
 | **AI Chat with Netdata** | Ask questions in natural language   | Available now for all deployments    |
 | **AI DevOps Copilot**    | CLI-based AI automation             | Available now with MCP tools         |
 | **AI Insights**          | Professional reports in 2-3 minutes | Business plans get unlimited reports |

--- a/docs/learn/unclaim-reclaim-node.md
+++ b/docs/learn/unclaim-reclaim-node.md
@@ -5,7 +5,7 @@
 **What's the difference between unclaiming/reclaiming and removing a node?**
 
 | Action                | What it does                                          | Agent status                            |
-|-----------------------|-------------------------------------------------------|-----------------------------------------|
+| --------------------- | ----------------------------------------------------- | --------------------------------------- |
 | **Unclaim & Reclaim** | Disconnect from current Space, connect to a new Space | Agent keeps running                     |
 | **Remove**            | Permanently delete node from Netdata Cloud            | Agent may keep running but disconnected |
 
@@ -65,7 +65,7 @@ sudo systemctl restart netdata
 Run the standard claim command with your new Space's token:
 
 ```bash
-bash <(curl -Ss https://my-netdata.io/kickstart.sh) --claim-token YOUR_NEW_TOKEN --claim-rooms YOUR_ROOMS --claim-url https://app.netdata.cloud
+bash <(curl -Ss https://get.netdata.cloud/kickstart.sh) --claim-token YOUR_NEW_TOKEN --claim-rooms YOUR_ROOMS --claim-url https://app.netdata.cloud
 ```
 
 ### Option 2: Configuration File
@@ -109,9 +109,9 @@ After reclaiming, verify the node appears in:
 - Verify the claim token is correct for the new Space
 - Check `/var/lib/netdata/cloud.d/` was removed before reclaiming
 - Review agent logs using:
-    - `journalctl --namespace netdata -b 0 | grep -i CLAIM`
-    - or:
-    - `grep -i CLAIM /var/log/netdata/daemon.log`
+  - `journalctl --namespace netdata -b 0 | grep -i CLAIM`
+  - or:
+  - `grep -i CLAIM /var/log/netdata/daemon.log`
 
 **Reconnection fails:**
 


### PR DESCRIPTION
## Summary

This PR resolves a documentation inconsistency by updating the kickstart installation URL to use the canonical `https://get.netdata.cloud/kickstart.sh` instead of `https://my-netdata.io/kickstart.sh`.

## Changes

- Updated `docs/getting-started-netdata/guide.md` - Replaced kickstart URL in installation command
- Updated `docs/learn/unclaim-reclaim-node.md` - Replaced kickstart URL in reclaim command

## Context

The installation documentation was using different kickstart URLs across different files. The OneLineInstall component uses `get.netdata.cloud` while the Getting Started guide used `my-netdata.io`. This PR standardizes all documentation to use the canonical URL for consistency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the kickstart install URL to https://get.netdata.cloud/kickstart.sh across docs for consistency with OneLineInstall and to avoid confusion. Updates the Getting Started guide and the Unclaim/Reclaim guide.

<sup>Written for commit 5283f5a349cdf03c17446a14a734625bf3cf4aa9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

