### PR TITLE
Add Ubuntu 26.04 to CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -356,7 +356,7 @@ include:
 
   - &ubuntu
     distro: ubuntu
-    version: "24.04"
+    version: "26.04"
     support_type: Core
     notes: ''
     eol_check: true
@@ -369,7 +369,7 @@ include:
       apt-get remove -y libjson-c-dev
     packages: &ubuntu_packages
       type: deb
-      repo_distro: ubuntu/noble
+      repo_distro: ubuntu/resolute
       builder_rev: v2
       arches:
         - amd64
@@ -382,6 +382,11 @@ include:
     packages:
       <<: *ubuntu_packages
       repo_distro: ubuntu/questing
+  - <<: *ubuntu
+    version: "24.04"
+    packages:
+      <<: *ubuntu_packages
+      repo_distro: ubuntu/noble
   - <<: *ubuntu
     version: "22.04"
     packages:

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -89,6 +89,7 @@ Our [static builds](#static-builds) are expected to work on these platforms if a
 | Rocky Linux              | 10.x           | x86\_64, AArch64              | Also includes support for Alma Linux and other ABI compatible RHEL derivatives                                 |
 | Rocky Linux              | 9.x            | x86\_64, AArch64              | Also includes support for Alma Linux and other ABI compatible RHEL derivatives                                 |
 | Rocky Linux              | 8.x            | x86\_64, AArch64              | Also includes support for Alma Linux and other ABI compatible RHEL derivatives                                 |
+| Ubuntu                   | 26.04          | x86\_64, AArch64, ARMv7       |                                                                                                                |
 | Ubuntu                   | 25.10          | x86\_64, AArch64, ARMv7       |                                                                                                                |
 | Ubuntu                   | 24.04          | x86\_64, AArch64, ARMv7       |                                                                                                                |
 | Ubuntu                   | 22.04          | x86\_64, ARMv7, AArch64       |                                                                                                                |


### PR DESCRIPTION
##### Summary

Expected release date is 2026-04-23.

##### Test Plan

CI passes on this PR.

##### Additional Info

Relevant to #21912 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Ubuntu 26.04 as the default Ubuntu target in CI and package builds, and document support. Prepares for the 2026-04-23 Ubuntu release.

- **New Features**
  - CI/builds: switch default Ubuntu to 26.04 with `ubuntu/resolute`; keep 24.04 as an explicit target with `ubuntu/noble`.
  - Docs: add Ubuntu 26.04 to PLATFORM_SUPPORT.

<sup>Written for commit fdbfbaa20ff5f3f042439fec1b8e1fe5e0dc8533. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

