### PR TITLE
Fix handling of control files for DEB packages.

### DIFF
--- a/packaging/cmake/Modules/Packaging.cmake
+++ b/packaging/cmake/Modules/Packaging.cmake
@@ -148,7 +148,7 @@ endif()
 
 list(JOIN _main_deps ", " CPACK_DEBIAN_NETDATA_PACKAGE_DEPENDS)
 
-set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
+set(CPACK_DEBIAN_NETDATA_PACKAGE_CONTROL_EXTRA
 	  "${PKG_FILES_PATH}/deb/netdata/conffiles;"
 	  "${PKG_FILES_PATH}/deb/netdata/postinst"
 	  "${PKG_FILES_PATH}/deb/netdata/prerm"


### PR DESCRIPTION
##### Summary

Due to a typo in the CPack configuration, the main `netdata` package control files were being included in any package that did not explicitly define own control files, causing uninstallation of those packages to mask the netdata service.

Fix this so that we set the control files for the main package itself instead of specifying them as the default for any package that doesn’t define it’s own control files.

##### Test Plan

Requires manual verification of the packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CPack config to apply `netdata` DEB control files only to the `netdata` package. Prevents other DEB packages from inheriting these scripts and masking the `netdata` service on uninstall.

- **Bug Fixes**
  - Use `CPACK_DEBIAN_NETDATA_PACKAGE_CONTROL_EXTRA` instead of `CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA` to scope control files to the main package.

<sup>Written for commit 9e20013d4967e5f715da37fab62843afc673866c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

