### PR TITLE
Remove `.inf` extension from file filter in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,7 +389,7 @@ jobs:
           signing-account-name: Netdata
           certificate-profile-name: Netdata
           files-folder: ${{ github.workspace }}\build
-          files-folder-filter: exe,dll,sys,inf
+          files-folder-filter: exe,dll,sys
           files-folder-recurse: true
           file-digest: SHA256
           timestamp-rfc3161: "http://timestamp.acs.microsoft.com"


### PR DESCRIPTION
##### Summary
- Exclude inf files from signature

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude `.inf` files from Windows code signing by removing `inf` from the workflow’s `files-folder-filter`. This prevents invalid signing attempts and reduces failures in the installer signing step.

<sup>Written for commit ff9ec6dc0b4df3142018d7e3d3fdd66c2b784503. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

