### PR TITLE
Add Fedora 44 to CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -216,7 +216,7 @@ include:
 
   - &fedora
     distro: fedora
-    version: "43"
+    version: "44"
     support_type: Core
     notes: ''
     eol_check: true
@@ -225,11 +225,18 @@ include:
       dnf remove -y json-c-devel
     packages: &fedora_packages
       type: rpm
-      repo_distro: fedora/43
+      repo_distro: fedora/44
       builder_rev: *def_builder_rev
       arches:
         - x86_64
         - aarch64
+    test:
+      ebpf-core: true
+  - <<: *fedora
+    version: "43"
+    packages:
+      <<: *fedora_packages
+      repo_distro: fedora/43
     test:
       ebpf-core: true
   - <<: *fedora

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -75,6 +75,7 @@ Our [static builds](#static-builds) are expected to work on these platforms if a
 | Debian                   | 13.x           | x86\_64, i386, ARMv7, AArch64 |                                                                                                                |
 | Debian                   | 12.x           | x86\_64, i386, ARMv7, AArch64 |                                                                                                                |
 | Debian                   | 11.x           | x86\_64, i386, ARMv7, AArch64 |                                                                                                                |
+| Fedora                   | 44             | x86\_64, AArch64              |                                                                                                                |
 | Fedora                   | 43             | x86\_64, AArch64              |                                                                                                                |
 | Fedora                   | 42             | x86\_64, AArch64              |                                                                                                                |
 | openSUSE                 | Tumbleweed     | x86\_64, AArch64              |                                                                                                                |


### PR DESCRIPTION
##### Summary

Expected release date is 2026-04-14.

##### Test Plan

Fedora 44 CI jobs pass on this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Fedora 44 to CI and RPM package builds, targeting the 2026-04-14 release. Fedora 43 remains supported and is now pinned explicitly.

- **New Features**
  - Made Fedora 44 the default in `.github/data/distros.yml`; added an explicit Fedora 43 entry and updated `repo_distro` to `fedora/44`.
  - Updated `packaging/PLATFORM_SUPPORT.md` to list Fedora 44 (x86_64, AArch64).

<sup>Written for commit 2d68d85881001fc218721e99614877f607f9b9f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

