### PR TITLE
docs(go.d/snmp): add multi-device SNMPv3 config example with YAML anchors

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -485,17 +485,18 @@ modules:
               description: |
                 This example monitors multiple SNMP devices that share the same SNMPv3 credentials.
 
-                It uses [YAML anchors](https://yaml.org/spec/1.2.2/#3222-anchors-and-aliases) (`&snmp_v3` to define, `*snmp_v3` to reuse) so you only
-                write the credentials once. To add another device, copy any job block
-                and change `name` and `hostname` — no need to duplicate the `user` section.
+                It uses [YAML anchors](https://yaml.org/spec/1.2.2/#3222-anchors-and-aliases) to define the
+                full job once (`&snmp_v3_job`) and then reuse it with `<<: *snmp_v3_job`,
+                overriding only `name` and `hostname` for each additional device.
               config: |
                 jobs:
-                  - name: switch1
+                  - &snmp_v3_job
+                    name: switch1
                     update_every: 10
                     hostname: 192.0.2.1
-                    options: &snmp_v3
+                    options:
                       version: 3
-                    user: &snmp_v3_user
+                    user:
                       name: username
                       level: authPriv
                       auth_proto: sha256
@@ -503,17 +504,13 @@ modules:
                       priv_proto: aes256
                       priv_key: priv_protocol_passphrase
 
-                  - name: switch2
-                    update_every: 10
+                  - <<: *snmp_v3_job
+                    name: switch2
                     hostname: 192.0.2.2
-                    options: *snmp_v3
-                    user: *snmp_v3_user
 
-                  - name: switch3
-                    update_every: 10
+                  - <<: *snmp_v3_job
+                    name: switch3
                     hostname: 192.0.2.3
-                    options: *snmp_v3
-                    user: *snmp_v3_user
     alerts: []
     functions:
       description: |


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

- [ ] AI-generated or AI-assisted content has been manually verified (examples/instructions tested where applicable).

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a SNMPv3 multi-device configuration example to the `go.d/snmp` docs using YAML anchors and the merge key. It shows how to reuse a base job and override only `name` and `hostname` to monitor multiple devices that share credentials.

<sup>Written for commit bfb0f1b959aa6c0a735259b733552f4492d8f0f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

