### PR TITLE
Fix windows config editor

### DIFF
--- a/packaging/windows/package-windows.sh
+++ b/packaging/windows/package-windows.sh
@@ -45,7 +45,7 @@ rm -rf /opt/netdata/msys64/
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
 ${GITHUB_ACTIONS+echo "::group::Configure Editor"}
-if [ ! -f "/opt/netdata/etc/profile" ]; then
+if [ -f "/opt/netdata/etc/profile" ]; then
     echo 'EDITOR="/usr/bin/nano.exe"' >> /opt/netdata/etc/profile
 fi
 ${GITHUB_ACTIONS+echo "::endgroup::"}
@@ -56,4 +56,3 @@ ${GITHUB_ACTIONS+echo "::endgroup::"}
 #cp "${build}/usr/bin/netdata_driver.*" "${build}/driver"
 #powershell.exe -ExecutionPolicy Bypass -File "${repo_root}/packaging/windows/generate-driver-catalog.ps1"
 #${GITHUB_ACTIONS+echo "::endgroup::"}
-


### PR DESCRIPTION
##### Summary
- Specify default editor


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows packaging to set the default editor correctly. Only appends `EDITOR="/usr/bin/nano.exe"` when `/opt/netdata/etc/profile` exists, avoiding accidental file creation and ensuring the editor is configured as intended.

<sup>Written for commit a717bbfb695b5307f34fd9b4b7a0143670f3e3fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

