### PR TITLE
Ensure thread safety and proper cleanup in `GetHardwareInfo`

### DIFF
--- a/src/collectors/windows.plugin/GetHardwareInfo.c
+++ b/src/collectors/windows.plugin/GetHardwareInfo.c
@@ -32,6 +32,7 @@ static int consecutive_errors = 0;
 static const int MAX_CONSECUTIVE_ERRORS = 5;
 static const int IOCTL_RETRIES = 3;
 static const int IOCTL_RETRY_DELAY_MS = 10;
+static const int THREAD_JOIN_FALLBACK_WAIT_MS = 2000;
 #define INVALID_TEMP ((collected_number)(-1))
 
 static void netdata_stop_driver()
@@ -516,14 +517,16 @@ void do_GetHardwareInfo_cleanup()
             // nd_thread_join() frees the ND_THREAD object even on failure,
             // so we cannot retry. The Windows/MSYS2 UV_EINVAL fast-exit case
             // is already handled inside nd_thread_join(). For any other error,
-            // wait briefly for the worker to report completion before tearing
-            // down local resources it may still be touching. If it never does,
-            // abort cleanup: leaking here is safer than racing a live worker
-            // or hanging plugin shutdown indefinitely.
+            // wait for up to one heartbeat interval plus slack for the worker
+            // to report completion before tearing down local resources it may
+            // still be touching. If it never does, abort cleanup: leaking here
+            // is safer than racing a live worker or hanging plugin shutdown
+            // indefinitely.
             nd_log_daemon(NDLP_ERR, "Failed to join Get Hardware Info thread");
 
             size_t retries = 0;
-            while (!InterlockedCompareExchange(&hardware_info_thread_finished, 1, 1) && retries < 1000) {
+            while (!InterlockedCompareExchange(&hardware_info_thread_finished, 1, 1) &&
+                   retries < (size_t)THREAD_JOIN_FALLBACK_WAIT_MS) {
                 Sleep(1);
                 retries++;
             }


### PR DESCRIPTION
##### Summary
- Add critical section locks for MSR device operations to prevent race conditions.
- Improve error handling during thread join and hardware info cleanup.
- Refine resource lifecycle management to avoid teardown races.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protect MSR device access with a critical section and add a bounded, deterministic cleanup path using a finished flag. This prevents races during IOCTL reads/reopens and ensures safe teardown on Windows.

- **Bug Fixes**
  - Serialize `netdata_reopen_device_if_needed` and `netdata_read_msr` with `device_lock`; hold the lock across IOCTL retries.
  - Track worker state with `hardware_info_thread_finished` (0 on init, 1 on exit).
  - On `nd_thread_join` failure, wait up to `THREAD_JOIN_FALLBACK_WAIT_MS` (2s) for `hardware_info_thread_finished`; if not set, skip teardown to avoid racing a live worker.
  - Close `msr_device` under `device_lock` when available; close directly otherwise.
  - Guard `netdata_read_msr` against `NULL` requests.

<sup>Written for commit 46b7c274e0ff2e1a9cd37da9ed75bf44f2491a21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

