### PR TITLE
Correctly prefetch IBM MQ libraries in DEB package build CI jobs.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -248,7 +248,7 @@ jobs:
             docker pull --platform ${{ matrix.platform }} netdata/package-builders:${{ matrix.distro }}${{ matrix.version }}-${{ matrix.builder_rev }}
       - name: Fetch IBM MQ libs
         id: fetch-ibm-mq
-        if: matrix.arch == 'x86_64' && needs.file-check.outputs.run == 'true'
+        if: (matrix.arch == 'amd64' || matrix.arch == 'x86_64') && needs.file-check.outputs.run == 'true'
         run: .github/scripts/prep-ibm-mq-libs.sh
       - name: Build Packages
         id: build


### PR DESCRIPTION
##### Summary

The initial implementation unintentionally excluded DEB package builds from the prefetching.

##### Test Plan

CI passes on this PR, and the ‘Fetch IBM MQ Libs’ step in the packaging workflow runs on 64-bit x86 DEB package builds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix packaging workflow so the IBM MQ libs prefetch runs for 64-bit DEB builds. The `Fetch IBM MQ libs` step now triggers when `matrix.arch` is `amd64` or `x86_64`, preventing missing libs in CI.

<sup>Written for commit f49740b592ba6dc5a5358e6c179f2620da3f3b7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

