### PR TITLE
Log missing user configuration directory at info level

### DIFF
--- a/src/crates/netdata-otel/otel-plugin/src/chart_config.rs
+++ b/src/crates/netdata-otel/otel-plugin/src/chart_config.rs
@@ -241,10 +241,11 @@ impl ChartConfigManager {
     pub fn load_user_configs<P: AsRef<std::path::Path>>(&mut self, config_dir: P) -> Result<()> {
         let config_path = config_dir.as_ref();
         if !config_path.exists() {
-            return Err(anyhow::anyhow!(
-                "Configuration directory does not exist: {}",
+            tracing::info!(
+                "user configuration directory does not exist: {} - using stock configs",
                 config_path.display()
-            ));
+            );
+            return Ok(());
         }
         if !config_path.is_dir() {
             return Err(anyhow::anyhow!(


### PR DESCRIPTION
We correctly fallback to stock configuration directory in such cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
When the user configuration directory is missing, we now log at info level and continue with stock configs instead of returning an error. This removes a noisy failure and preserves the intended fallback behavior.

<sup>Written for commit cbb8692f6fc254c07407e7fca5eab4a4cc82cf2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

