### PR TITLE
Fix uninitialized vnode stale timeout field in pluginsd parser

### DIFF
--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -125,6 +125,7 @@ static void pluginsd_host_define_cleanup(PARSER *parser) {
     parser->user.host_define.hostname = NULL;
     parser->user.host_define.rrdlabels = NULL;
     parser->user.host_define.parsing_host = false;
+    parser->user.host_define.node_stale_after_seconds = 0;
 }
 
 static inline bool pluginsd_validate_machine_guid(const char *guid, nd_uuid_t *uuid, char *output) {
@@ -153,6 +154,7 @@ static inline PARSER_RC pluginsd_host_define(char **words, size_t num_words, PAR
     parser->user.host_define.hostname = string_strdupz(hostname);
     parser->user.host_define.rrdlabels = rrdlabels_create();
     parser->user.host_define.parsing_host = true;
+    parser->user.host_define.node_stale_after_seconds = 0;
 
     return PARSER_RC_OK;
 }


### PR DESCRIPTION
##### Summary
- Initialize node_stale_after_seconds field in pluginsd_parser to prevent residual values from previous host definitions leaking into subsequent one


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize node_stale_after_seconds to 0 during host define and cleanup in the pluginsd parser to prevent stale timeout values leaking between hosts. This fixes hosts inheriting incorrect stale timeouts and avoids inconsistent node expiry behavior.

- **Bug Fixes**
  - Set node_stale_after_seconds = 0 in host define and cleanup to reset state between host definitions.

<sup>Written for commit d0f2e3cfc2f8c729665d02a62b6909943af14089. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

