### PR TITLE
Improve streaming

### DIFF
--- a/src/daemon/daemon-service.c
+++ b/src/daemon/daemon-service.c
@@ -213,7 +213,7 @@ bool service_wait_exit(SERVICE_TYPE service, usec_t timeout_ut) {
         }
 
         ended_ut = now_monotonic_usec();
-    } while(running && ended_ut - started_ut < timeout_ut);
+    } while(running && ((ended_ut - started_ut) < timeout_ut));
 
     if(running) {
         buffer_flush(service_list);


### PR DESCRIPTION
##### Summary
This PR reduces issues with streaming reported by an agent:

```sh
info:  shutdown steps timings
#1 'close webrtc connections': 3ms 779us
#2 'disable maintenance, new queries, new web requests, new streaming connections and aclk': 3ms 368us
#3 'stop maintenance thread': 3ms 120us
#4 'stop exporters, health and web servers threads': 140ms 309us
```

##### Test Plan
1. Compile this branch;
2. Stop parent while having a child connect and try to recreate it;
3. Do the previous step in inverse other;

In these scenarios, we should not have core dumps again.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve streaming shutdown reliability by fixing the service exit wait logic. Prevents rare core dumps during parent/child disconnects and reconnects.

- **Bug Fixes**
  - Simplified `service_wait_exit` to use only total elapsed timeout; removed stale-time tracking and the unused `stale_time_ut` to streamline shutdown checks.

<sup>Written for commit 0d0241fd3d228b2d8d2b767c3846aee54179b317. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

