### PR TITLE
Fix lock order during ctx processing to avoid deadlock

### DIFF
--- a/src/database/contexts/rrdcontext-queues.c
+++ b/src/database/contexts/rrdcontext-queues.c
@@ -312,12 +312,28 @@ void rrdcontext_dispatch_queued_contexts_to_hub(RRDHOST *host, usec_t now_ut) {
 
         const DICTIONARY_ITEM *item = dictionary_get_and_acquire_item(host->rrdctx.contexts, string2str(lookup_id));
         bool do_it = item && (dictionary_acquired_item_value(item) == rc);
+        bool dispatch_ready = false;
 
         if(item) {
             if (do_it) {
-                worker_is_busy(WORKER_JOB_QUEUED);
-                usec_t dispatch_ut = rrdcontext_calculate_queued_dispatch_time_ut(rc, now_ut);
-                if(unlikely(now_ut >= dispatch_ut) && claim_id_is_set(claim_id)) {
+                spinlock_lock(&host->rrdctx.hub_queue.spinlock);
+
+                if(likely(service_running(SERVICE_CONTEXT))) {
+                    RRDCONTEXT *rc_at_idx = RRDCONTEXT_QUEUE_GET(&host->rrdctx.hub_queue, idx);
+                    if(rc_at_idx == rc) {
+                        worker_is_busy(WORKER_JOB_QUEUED);
+                        usec_t dispatch_ut = rrdcontext_calculate_queued_dispatch_time_ut(rc, now_ut);
+                        dispatch_ready = unlikely(now_ut >= dispatch_ut) && claim_id_is_set(claim_id);
+                    }
+                    else
+                        do_it = false;
+                }
+                else
+                    do_it = false;
+
+                spinlock_unlock(&host->rrdctx.hub_queue.spinlock);
+
+                if(dispatch_ready) {
                     worker_is_busy(WORKER_JOB_CHECK);
 
                     rrdcontext_lock(rc);


### PR DESCRIPTION
##### Summary
- Adjust locks to avoid a deadlock while processing context updates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deadlocks and race conditions in context queue processing by adjusting spinlock scope, duplicating IDs for safe dictionary access, and checking the queue index before dequeue. Also guards dispatch on service state, handles mid-processing updates, prevents a shutdown-time leak, and uses duplicated IDs during dictionary deletion.

- **Bug Fixes**
  - Unlock `hub_queue`/`pp_queue` before dictionary lookups; duplicate `rc->id` into `lookup_id`, snapshot `queued_ut`, then re-lock and free after use.
  - Keep the acquired item until processing completes; after re-lock, re-check `SERVICE_CONTEXT` and verify `RRDCONTEXT_QUEUE_GET(...) == rc` before dequeue/post-process/dispatch; on shutdown, release and return early.
  - Add null checks and index verification in prune/post-process/hub dispatch paths; during hub dispatch, recheck service state and `rc_at_idx == rc` before marking `dispatch_ready` and dequeue; use `delete_id` for `dictionary_del(...)`.

<sup>Written for commit 813d24042c3e059097ca8c0a89aad1bef30332ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

