### PR TITLE
feat(health): add azure monitor alerts

### DIFF
--- a/src/health/health.d/azure_monitor_aks.conf
+++ b/src/health/health.d/azure_monitor_aks.conf
@@ -1,0 +1,207 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- API Server ---
+
+ template: am_aks_apiserver_cpu
+       on: azure_monitor.aks.apiserver_cpu
+    class: Utilization
+     type: Kubernetes
+component: AKS
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (80))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: AKS API server CPU on ${label:resource_name}
+     info: Average API server CPU utilization on AKS cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_aks_apiserver_memory
+       on: azure_monitor.aks.apiserver_memory
+    class: Utilization
+     type: Kubernetes
+component: AKS
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (80))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: AKS API server memory on ${label:resource_name}
+     info: Average API server memory utilization on AKS cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_aks_apiserver_inflight_requests
+       on: azure_monitor.aks.apiserver_inflight_requests
+    class: Workload
+     type: Kubernetes
+component: AKS
+   lookup: average -5m unaligned of average
+    units: requests
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (400) : (600))
+     crit: $this > (($status == $CRITICAL) ? (600) : (800))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: AKS API server inflight requests on ${label:resource_name}
+     info: Average number of inflight requests to the API server on AKS cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- etcd ---
+
+ template: am_aks_etcd_cpu
+       on: azure_monitor.aks.etcd_cpu
+    class: Utilization
+     type: Kubernetes
+component: AKS
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (80))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: AKS etcd CPU on ${label:resource_name}
+     info: Average etcd CPU utilization on AKS cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_aks_etcd_memory
+       on: azure_monitor.aks.etcd_memory
+    class: Utilization
+     type: Kubernetes
+component: AKS
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (80))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: AKS etcd memory on ${label:resource_name}
+     info: Average etcd memory utilization on AKS cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_aks_etcd_database
+       on: azure_monitor.aks.etcd_database
+    class: Utilization
+     type: Kubernetes
+component: AKS
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (80))
+     crit: $this > (($status == $CRITICAL) ? (85) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: AKS etcd database usage on ${label:resource_name}
+     info: Average etcd database utilization on AKS cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High etcd database usage can lead to cluster instability.
+       to: sysadmin
+
+# --- Autoscaler ---
+
+ template: am_aks_autoscaler_safe_to_autoscale
+       on: azure_monitor.aks.autoscaler_health
+    class: Availability
+     type: Kubernetes
+component: AKS
+   lookup: average -5m unaligned of safe_to_autoscale
+    units: state
+    every: 1m
+     warn: $this != nan AND $this < 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: AKS autoscaler unsafe on ${label:resource_name}
+     info: Cluster autoscaler reports the cluster is not safe to autoscale on AKS cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_aks_autoscaler_unschedulable_pods
+       on: azure_monitor.aks.autoscaler_unschedulable_pods
+    class: Errors
+     type: Kubernetes
+component: AKS
+   lookup: average -5m unaligned of average
+    units: pods
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: AKS unschedulable pods on ${label:resource_name}
+     info: Number of pods that cannot be scheduled by the cluster autoscaler on AKS cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Indicates insufficient cluster capacity.
+       to: sysadmin
+
+# --- Node CPU ---
+
+ template: am_aks_node_cpu
+       on: azure_monitor.aks.node_cpu_percentage
+    class: Utilization
+     type: Kubernetes
+component: AKS
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: AKS node CPU on ${label:resource_name}
+     info: Average node CPU utilization on AKS cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Node Memory ---
+
+ template: am_aks_node_memory_working_set
+       on: azure_monitor.aks.node_memory_working_set_percentage
+    class: Utilization
+     type: Kubernetes
+component: AKS
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: AKS node memory working set on ${label:resource_name}
+     info: Average node memory working set utilization on AKS cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_aks_node_memory_rss
+       on: azure_monitor.aks.node_memory_rss_percentage
+    class: Utilization
+     type: Kubernetes
+component: AKS
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: AKS node memory RSS on ${label:resource_name}
+     info: Average node memory RSS utilization on AKS cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Node Disk ---
+
+ template: am_aks_node_disk
+       on: azure_monitor.aks.node_disk_percentage
+    class: Utilization
+     type: Kubernetes
+component: AKS
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (80))
+     crit: $this > (($status == $CRITICAL) ? (85) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: AKS node disk usage on ${label:resource_name}
+     info: Average node disk utilization on AKS cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High disk usage can cause pod evictions.
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_api_management.conf
+++ b/src/health/health.d/azure_monitor_api_management.conf
@@ -1,0 +1,182 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Capacity / Utilization ---
+
+ template: am_api_management_capacity
+       on: azure_monitor.api_management.capacity
+    class: Utilization
+     type: Web Server
+component: API Management
+   lookup: average -5m unaligned of capacity
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: APIM capacity on ${label:resource_name}
+     info: Average capacity utilization of API Management service ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High capacity indicates the service is approaching its scaling limits
+       to: sysadmin
+
+ template: am_api_management_gateway_cpu
+       on: azure_monitor.api_management.gateway_cpu
+    class: Utilization
+     type: Web Server
+component: API Management
+   lookup: average -5m unaligned of cpu
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: APIM gateway CPU on ${label:resource_name}
+     info: Average gateway CPU utilization of API Management service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_api_management_gateway_memory
+       on: azure_monitor.api_management.gateway_memory
+    class: Utilization
+     type: Web Server
+component: API Management
+   lookup: average -5m unaligned of memory
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: APIM gateway memory on ${label:resource_name}
+     info: Average gateway memory utilization of API Management service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Request Latency ---
+
+ template: am_api_management_request_duration
+       on: azure_monitor.api_management.request_duration
+    class: Latency
+     type: Web Server
+component: API Management
+   lookup: average -5m unaligned of overall
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: APIM request duration on ${label:resource_name}
+     info: Average overall request duration of API Management service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_api_management_backend_duration
+       on: azure_monitor.api_management.request_duration
+    class: Latency
+     type: Web Server
+component: API Management
+   lookup: average -5m unaligned of backend
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: APIM backend duration on ${label:resource_name}
+     info: Average backend request duration of API Management service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Network Connectivity ---
+
+ template: am_api_management_network_connectivity
+       on: azure_monitor.api_management.network_connectivity
+    class: Availability
+     type: Web Server
+component: API Management
+   lookup: average -5m unaligned of connectivity
+    units: status
+    every: 1m
+     crit: $this < (($status == $CRITICAL) ? (1) : (0.5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: APIM network connectivity on ${label:resource_name}
+     info: Network connectivity status of API Management service ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Values below 1 indicate connectivity problems to backend dependencies
+       to: sysadmin
+
+# --- EventHub Errors ---
+
+ template: am_api_management_eventhub_failed_events
+       on: azure_monitor.api_management.eventhub_events
+    class: Errors
+     type: Web Server
+component: API Management
+   lookup: average -5m unaligned of failed
+    units: events/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: APIM EventHub failed events on ${label:resource_name}
+     info: Rate of failed EventHub events for API Management service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_api_management_eventhub_dropped_events
+       on: azure_monitor.api_management.eventhub_events
+    class: Errors
+     type: Web Server
+component: API Management
+   lookup: average -5m unaligned of dropped
+    units: events/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: APIM EventHub dropped events on ${label:resource_name}
+     info: Rate of dropped EventHub events for API Management service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_api_management_eventhub_rejected_events
+       on: azure_monitor.api_management.eventhub_events
+    class: Errors
+     type: Web Server
+component: API Management
+   lookup: average -5m unaligned of rejected
+    units: events/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: APIM EventHub rejected events on ${label:resource_name}
+     info: Rate of rejected EventHub events for API Management service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_api_management_eventhub_throttled_events
+       on: azure_monitor.api_management.eventhub_events
+    class: Errors
+     type: Web Server
+component: API Management
+   lookup: average -5m unaligned of throttled
+    units: events/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: APIM EventHub throttled events on ${label:resource_name}
+     info: Rate of throttled EventHub events for API Management service ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Throttling indicates EventHub throughput limits are being reached
+       to: sysadmin
+
+ template: am_api_management_eventhub_timedout_events
+       on: azure_monitor.api_management.eventhub_events
+    class: Errors
+     type: Web Server
+component: API Management
+   lookup: average -5m unaligned of timed_out
+    units: events/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: APIM EventHub timed out events on ${label:resource_name}
+     info: Rate of timed out EventHub events for API Management service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_app_service.conf
+++ b/src/health/health.d/azure_monitor_app_service.conf
@@ -1,0 +1,148 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# Health check status (0-100%). Low is bad.
+# AMBA: HealthCheckStatus < 100 is Sev1 (critical)
+
+ template: am_app_service_health_check
+       on: azure_monitor.app_service.health
+    class: Availability
+     type: Web Server
+component: App Service
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (100) : (80))
+     crit: $this < (($status == $CRITICAL) ? (80)  : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Service health on ${label:resource_name}
+     info: Health check status of App Service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# HTTP 5xx server errors (rate).
+# AMBA: Http5xx > 10 is Sev1
+
+ template: am_app_service_http_5xx_rate
+       on: azure_monitor.app_service.http_status
+    class: Errors
+     type: Web Server
+component: App Service
+   lookup: average -5m unaligned of 5xx
+    units: responses/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (5)  : (10))
+     crit: $this > (($status == $CRITICAL) ? (10) : (25))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Service 5xx errors on ${label:resource_name}
+     info: HTTP 5xx server error rate on App Service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# HTTP response time (seconds). High is bad.
+# AMBA: HttpResponseTime average > 5s is Sev2
+
+ template: am_app_service_response_time
+       on: azure_monitor.app_service.response_time
+    class: Latency
+     type: Web Server
+component: App Service
+   lookup: average -5m unaligned of average
+    units: seconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Service response time on ${label:resource_name}
+     info: Average HTTP response time of App Service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# CPU utilization (percentage). High is bad.
+# AMBA: CpuPercentage > 90 is Sev2
+
+ template: am_app_service_cpu_utilization
+       on: azure_monitor.app_service.cpu
+    class: Utilization
+     type: Web Server
+component: App Service
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Service CPU on ${label:resource_name}
+     info: CPU utilization of App Service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# Request queue depth (absolute). High means saturation.
+# AMBA: RequestsInApplicationQueue > 10 is Sev2
+
+ template: am_app_service_request_queue
+       on: azure_monitor.app_service.request_queue
+    class: Workload
+     type: Web Server
+component: App Service
+   lookup: average -5m unaligned of queued
+    units: requests
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (10) : (25))
+     crit: $this > (($status == $CRITICAL) ? (25) : (100))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Service request queue on ${label:resource_name}
+     info: Requests queued in application queue of App Service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# HTTP 4xx client errors (rate). Sustained high rates may indicate
+# broken clients, missing endpoints, or auth problems.
+
+ template: am_app_service_http_4xx_rate
+       on: azure_monitor.app_service.http_status
+    class: Errors
+     type: Web Server
+component: App Service
+   lookup: average -5m unaligned of 4xx
+    units: responses/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (50) : (100))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Service 4xx errors on ${label:resource_name}
+     info: HTTP 4xx client error rate on App Service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# HTTP 403 Forbidden spikes — may indicate WAF blocks or permission issues
+
+ template: am_app_service_http_403_rate
+       on: azure_monitor.app_service.http_error_detail
+    class: Errors
+     type: Web Server
+component: App Service
+   lookup: average -5m unaligned of 403_forbidden
+    units: responses/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (10) : (25))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Service 403 forbidden on ${label:resource_name}
+     info: HTTP 403 Forbidden response rate on App Service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# HTTP 401 Unauthorized spikes — may indicate auth service failures
+
+ template: am_app_service_http_401_rate
+       on: azure_monitor.app_service.http_error_detail
+    class: Errors
+     type: Web Server
+component: App Service
+   lookup: average -5m unaligned of 401_unauthorized
+    units: responses/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (10) : (25))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Service 401 unauthorized on ${label:resource_name}
+     info: HTTP 401 Unauthorized response rate on App Service ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_application_gateway.conf
+++ b/src/health/health.d/azure_monitor_application_gateway.conf
@@ -1,0 +1,153 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Errors: Failed Requests ---
+
+# helper: total requests over 5m (no alarm, value only)
+ template: am_appgw_total_requests
+       on: azure_monitor.application_gateway.requests
+    class: Workload
+     type: Web Server
+component: Application Gateway
+   lookup: sum -5m unaligned of total
+    units: requests/s
+    every: 1m
+     info: Total requests on Application Gateway ${label:resource_name}
+
+# failed request ratio — fires only when traffic is meaningful
+ template: am_appgw_failed_requests
+       on: azure_monitor.application_gateway.requests
+    class: Errors
+     type: Web Server
+component: Application Gateway
+   lookup: sum -5m unaligned of failed
+     calc: ($am_appgw_total_requests > 10) ? ($this * 100 / $am_appgw_total_requests) : (0)
+    units: %
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (5)  : (10))
+     crit: $this > (($status == $CRITICAL) ? (10) : (25))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Gateway failed requests on ${label:resource_name}
+     info: Percentage of failed requests on Application Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Availability: Backend Health ---
+
+ template: am_appgw_unhealthy_hosts
+       on: azure_monitor.application_gateway.backend_health
+    class: Errors
+     type: Web Server
+component: Application Gateway
+   lookup: average -5m unaligned of unhealthy
+    units: hosts
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (2))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Gateway unhealthy backends on ${label:resource_name}
+     info: Unhealthy backend hosts on Application Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Latency: Backend Connect Time ---
+
+ template: am_appgw_backend_connect_time
+       on: azure_monitor.application_gateway.backend_latency
+    class: Latency
+     type: Web Server
+component: Application Gateway
+   lookup: average -5m unaligned of connect
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (100) : (250))
+     crit: $this > (($status == $CRITICAL) ? (250) : (500))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Gateway backend connect time on ${label:resource_name}
+     info: Average backend connection time on Application Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Latency: Backend First Byte ---
+
+ template: am_appgw_backend_first_byte
+       on: azure_monitor.application_gateway.backend_latency
+    class: Latency
+     type: Web Server
+component: Application Gateway
+   lookup: average -5m unaligned of first_byte
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (2000) : (4000))
+     crit: $this > (($status == $CRITICAL) ? (4000) : (8000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Gateway backend TTFB on ${label:resource_name}
+     info: Average backend time to first byte on Application Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Latency: Total Client Request Time ---
+
+ template: am_appgw_total_time
+       on: azure_monitor.application_gateway.client_latency
+    class: Latency
+     type: Web Server
+component: Application Gateway
+   lookup: average -5m unaligned of total_time
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Gateway total request time on ${label:resource_name}
+     info: Average total client request time on Application Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Utilization: CPU ---
+
+ template: am_appgw_cpu_utilization
+       on: azure_monitor.application_gateway.cpu
+    class: Utilization
+     type: Web Server
+component: Application Gateway
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Gateway CPU utilization on ${label:resource_name}
+     info: CPU utilization on Application Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Errors: WAF Blocked Request Ratio ---
+
+# helper: total WAF requests over 5m (no alarm, value only)
+ template: am_appgw_waf_total_requests
+       on: azure_monitor.application_gateway.waf_requests
+    class: Workload
+     type: Web Server
+component: Application Gateway
+   lookup: sum -5m unaligned of total
+    units: requests/s
+    every: 1m
+     info: Total WAF requests on Application Gateway ${label:resource_name}
+
+# WAF blocked ratio — fires only when WAF has meaningful traffic
+ template: am_appgw_waf_blocked_ratio
+       on: azure_monitor.application_gateway.waf_requests
+    class: Errors
+     type: Web Server
+component: Application Gateway
+   lookup: sum -5m unaligned of blocked
+     calc: ($am_appgw_waf_total_requests > 10) ? ($this * 100 / $am_appgw_waf_total_requests) : (0)
+    units: %
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (25) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Gateway WAF block ratio on ${label:resource_name}
+     info: Percentage of requests blocked by WAF on Application Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High values may indicate an attack or WAF misconfiguration
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_application_insights.conf
+++ b/src/health/health.d/azure_monitor_application_insights.conf
@@ -1,0 +1,269 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# ── Availability ─────────────────────────────────────────────────────────────
+
+ template: am_appinsights_availability
+       on: azure_monitor.application_insights.availability_percentage
+    class: Availability
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99.9) : (99))
+     crit: $this < (($status == $CRITICAL) ? (99)   : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights availability on ${label:resource_name}
+     info: Availability test success rate for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_appinsights_availability_duration
+       on: azure_monitor.application_insights.availability_duration
+    class: Latency
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights availability test duration on ${label:resource_name}
+     info: Average availability test duration for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# ── Server Requests ──────────────────────────────────────────────────────────
+
+# Helper: total request rate over 5 minutes (used for minimum-data guard)
+ template: am_appinsights_request_rate
+       on: azure_monitor.application_insights.server_requests
+    class: Workload
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of total
+    units: requests/s
+    every: 1m
+  summary: App Insights request rate on ${label:resource_name}
+     info: Average server request rate for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: silent
+
+ template: am_appinsights_failed_requests
+       on: azure_monitor.application_insights.server_requests
+    class: Errors
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned percentage of failed
+    units: %
+    every: 1m
+     warn: ($am_appinsights_request_rate > 0.5) ? ($this > (($status >= $WARNING) ? (3) : (5))) : (0)
+     crit: ($am_appinsights_request_rate > 0.5) ? ($this > (($status == $CRITICAL) ? (10) : (15))) : (0)
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights failed requests on ${label:resource_name}
+     info: Percentage of failed server requests for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_appinsights_response_time
+       on: azure_monitor.application_insights.server_response_time
+    class: Latency
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights server response time on ${label:resource_name}
+     info: Average server response time for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# ── Dependencies ─────────────────────────────────────────────────────────────
+
+# Helper: total dependency call rate over 5 minutes
+ template: am_appinsights_dependency_rate
+       on: azure_monitor.application_insights.dependency_calls
+    class: Workload
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of total
+    units: calls/s
+    every: 1m
+  summary: App Insights dependency call rate on ${label:resource_name}
+     info: Average dependency call rate for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: silent
+
+ template: am_appinsights_failed_dependencies
+       on: azure_monitor.application_insights.dependency_calls
+    class: Errors
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned percentage of failed
+    units: %
+    every: 1m
+     warn: ($am_appinsights_dependency_rate > 0.5) ? ($this > (($status >= $WARNING) ? (5) : (10))) : (0)
+     crit: ($am_appinsights_dependency_rate > 0.5) ? ($this > (($status == $CRITICAL) ? (15) : (25))) : (0)
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights failed dependencies on ${label:resource_name}
+     info: Percentage of failed dependency calls for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_appinsights_dependency_duration
+       on: azure_monitor.application_insights.dependency_duration
+    class: Latency
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights dependency duration on ${label:resource_name}
+     info: Average dependency call duration for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# ── Exceptions ───────────────────────────────────────────────────────────────
+
+ template: am_appinsights_exception_rate
+       on: azure_monitor.application_insights.exception_rate
+    class: Errors
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of average
+    units: exceptions/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (5) : (10))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (25) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights exception rate on ${label:resource_name}
+     info: Server exception rate for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_appinsights_server_exceptions
+       on: azure_monitor.application_insights.exceptions
+    class: Errors
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of server
+    units: exceptions/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (5) : (10))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (25) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights server exceptions on ${label:resource_name}
+     info: Server-side exception rate for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# ── Browser Performance ──────────────────────────────────────────────────────
+
+ template: am_appinsights_browser_page_load_time
+       on: azure_monitor.application_insights.browser_page_load_time
+    class: Latency
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of total
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (5000)  : (10000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (10000) : (20000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights browser page load time on ${label:resource_name}
+     info: Average browser page load time for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# ── Performance - CPU ────────────────────────────────────────────────────────
+
+ template: am_appinsights_process_cpu
+       on: azure_monitor.application_insights.cpu_utilization
+    class: Utilization
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of process
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights process CPU on ${label:resource_name}
+     info: Application process CPU utilization for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_appinsights_processor_cpu
+       on: azure_monitor.application_insights.cpu_utilization
+    class: Utilization
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of processor
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights processor CPU on ${label:resource_name}
+     info: Host processor CPU utilization for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# ── Performance - HTTP Pipeline ──────────────────────────────────────────────
+
+ template: am_appinsights_http_execution_time
+       on: azure_monitor.application_insights.http_request_execution_time
+    class: Latency
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights HTTP execution time on ${label:resource_name}
+     info: Average HTTP request execution time for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_appinsights_http_queue_length
+       on: azure_monitor.application_insights.http_request_queue
+    class: Utilization
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of queued
+    units: requests
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (50)  : (100))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (100) : (250))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights HTTP request queue on ${label:resource_name}
+     info: Number of HTTP requests waiting in the application queue for Application Insights resource \
+           ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# ── Usage - Page Views ───────────────────────────────────────────────────────
+
+ template: am_appinsights_page_view_load_time
+       on: azure_monitor.application_insights.page_view_load_time
+    class: Latency
+     type: Other
+component: Application Insights
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (5000)  : (10000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (10000) : (20000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: App Insights page view load time on ${label:resource_name}
+     info: Average page view load time for Application Insights resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_cognitive_services.conf
+++ b/src/health/health.d/azure_monitor_cognitive_services.conf
@@ -1,0 +1,302 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Cognitive Services - Availability ---
+
+ template: am_cognitive_services_availability
+       on: azure_monitor.cognitive_services.availability
+    class: Availability
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of availability
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99.9) : (99))
+     crit: $this < (($status == $CRITICAL) ? (99)   : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cognitive Services availability on ${label:resource_name}
+     info: Success rate of Cognitive Services resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Cognitive Services - Errors ---
+
+ template: am_cognitive_services_server_errors
+       on: azure_monitor.cognitive_services.errors
+    class: Errors
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of server
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cognitive Services server errors on ${label:resource_name}
+     info: Rate of server errors (5xx) from Cognitive Services resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_cognitive_services_client_errors
+       on: azure_monitor.cognitive_services.errors
+    class: Errors
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of client
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cognitive Services client errors on ${label:resource_name}
+     info: Rate of client errors (4xx) from Cognitive Services resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High client error rates may indicate misconfigured API calls or invalid requests
+       to: sysadmin
+
+# --- Cognitive Services - Latency ---
+
+ template: am_cognitive_services_latency
+       on: azure_monitor.cognitive_services.latency
+    class: Latency
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cognitive Services latency on ${label:resource_name}
+     info: Average API latency of Cognitive Services resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Cognitive Services - Rate Limiting ---
+
+ template: am_cognitive_services_rate_limit
+       on: azure_monitor.cognitive_services.rate_limit
+    class: Workload
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of rate_limit
+    units: requests/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cognitive Services rate limiting on ${label:resource_name}
+     info: Rate of throttled requests due to rate limiting on Cognitive Services resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Indicates the service is hitting its API call quota
+       to: sysadmin
+
+# --- Cognitive Services - Blocked Calls ---
+
+ template: am_cognitive_services_blocked_calls
+       on: azure_monitor.cognitive_services.calls
+    class: Errors
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of blocked
+    units: calls/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cognitive Services blocked calls on ${label:resource_name}
+     info: Rate of blocked API calls on Cognitive Services resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Blocked calls indicate authorization or policy violations
+       to: sysadmin
+
+# --- Azure OpenAI - Availability ---
+
+ template: am_cognitive_services_openai_availability
+       on: azure_monitor.cognitive_services.openai_availability
+    class: Availability
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of availability
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this < (($status >= $WARNING)  ? (99.9) : (99))
+     crit: $this != nan AND $this < (($status == $CRITICAL) ? (99)   : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Azure OpenAI availability on ${label:resource_name}
+     info: Availability rate of Azure OpenAI service on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Azure OpenAI - Latency ---
+
+ template: am_cognitive_services_openai_time_to_response
+       on: azure_monitor.cognitive_services.openai_latency
+    class: Latency
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of time_to_response
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (5000)  : (10000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (10000) : (30000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Azure OpenAI time to response on ${label:resource_name}
+     info: Average time to response for Azure OpenAI requests on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_cognitive_services_openai_time_to_first_token
+       on: azure_monitor.cognitive_services.openai_latency
+    class: Latency
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of time_to_first_token
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Azure OpenAI time to first token on ${label:resource_name}
+     info: Average normalized time to first token for Azure OpenAI requests on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Azure OpenAI - Provisioned Utilization ---
+
+ template: am_cognitive_services_openai_provisioned_utilization
+       on: azure_monitor.cognitive_services.openai_provisioned_utilization
+    class: Utilization
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of utilization
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Azure OpenAI provisioned utilization on ${label:resource_name}
+     info: Provisioned-managed utilization of Azure OpenAI deployment on ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High utilization means requests may be throttled or rejected
+       to: sysadmin
+
+# --- Models - Availability ---
+
+ template: am_cognitive_services_model_availability
+       on: azure_monitor.cognitive_services.model_availability
+    class: Availability
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of availability
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this < (($status >= $WARNING)  ? (99.9) : (99))
+     crit: $this != nan AND $this < (($status == $CRITICAL) ? (99)   : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Model availability on ${label:resource_name}
+     info: Model availability rate on Cognitive Services resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Models - Latency ---
+
+ template: am_cognitive_services_model_time_to_response
+       on: azure_monitor.cognitive_services.model_latency
+    class: Latency
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of time_to_response
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (5000)  : (10000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (10000) : (30000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Model time to response on ${label:resource_name}
+     info: Average time to response for model requests on Cognitive Services resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_cognitive_services_model_time_to_first_token
+       on: azure_monitor.cognitive_services.model_latency
+    class: Latency
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of time_to_first_token
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Model time to first token on ${label:resource_name}
+     info: Average normalized time to first token for model requests on Cognitive Services resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Models - Provisioned Utilization ---
+
+ template: am_cognitive_services_model_provisioned_utilization
+       on: azure_monitor.cognitive_services.model_provisioned_utilization
+    class: Utilization
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of utilization
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Model provisioned utilization on ${label:resource_name}
+     info: Provisioned utilization of model deployment on Cognitive Services resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High utilization means requests may be throttled or rejected
+       to: sysadmin
+
+# --- Content Safety - Harmful Requests ---
+
+ template: am_cognitive_services_harmful_requests
+       on: azure_monitor.cognitive_services.content_safety_requests
+    class: Errors
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of harmful
+    units: requests/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (5) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Harmful content requests on ${label:resource_name}
+     info: Rate of requests flagged as harmful by content safety on Cognitive Services resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High rates may indicate abuse or prompt injection attempts
+       to: sysadmin
+
+ template: am_cognitive_services_blocked_content_requests
+       on: azure_monitor.cognitive_services.content_safety_requests
+    class: Errors
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of blocked
+    units: requests/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (1) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Blocked content requests on ${label:resource_name}
+     info: Rate of requests rejected by content safety on Cognitive Services resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Content Safety - Abusive Users ---
+
+ template: am_cognitive_services_abusive_users
+       on: azure_monitor.cognitive_services.content_safety_abusive_users
+    class: Errors
+     type: Other
+component: Cognitive Services
+   lookup: average -5m unaligned of abusive_users
+    units: users/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Abusive users detected on ${label:resource_name}
+     info: Rate of potentially abusive users detected on Cognitive Services resource ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_container_apps.conf
+++ b/src/health/health.d/azure_monitor_container_apps.conf
@@ -1,0 +1,195 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# CPU utilization
+
+ template: am_container_apps_cpu_utilization
+       on: azure_monitor.container_apps.cpu_percentage
+    class: Utilization
+     type: Containers
+component: Container Apps
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container Apps CPU on ${label:resource_name}
+     info: Average CPU utilization of Container App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# Memory utilization
+
+ template: am_container_apps_memory_utilization
+       on: azure_monitor.container_apps.memory_percentage
+    class: Utilization
+     type: Containers
+component: Container Apps
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container Apps memory on ${label:resource_name}
+     info: Average memory utilization of Container App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# Replica restarts
+
+ template: am_container_apps_restarts
+       on: azure_monitor.container_apps.restart_count
+    class: Errors
+     type: Containers
+component: Container Apps
+   lookup: sum -5m unaligned of restarts
+    units: restarts
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3) : (5))
+     crit: $this > (($status == $CRITICAL) ? (10) : (15))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container Apps restarts on ${label:resource_name}
+     info: Number of replica restarts in the last 5 minutes for Container App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# Response time (latency)
+
+ template: am_container_apps_response_time
+       on: azure_monitor.container_apps.response_time
+    class: Latency
+     type: Containers
+component: Container Apps
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container Apps response time on ${label:resource_name}
+     info: Average response time of Container App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# Resiliency - timeouts
+
+ template: am_container_apps_resiliency_timeouts
+       on: azure_monitor.container_apps.resiliency_timeouts
+    class: Errors
+     type: Containers
+component: Container Apps
+   lookup: sum -5m unaligned
+    units: timeouts
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (3) : (5))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (10) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container Apps resiliency timeouts on ${label:resource_name}
+     info: Connection and request timeouts in the last 5 minutes for Container App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# Resiliency - retries
+
+ template: am_container_apps_resiliency_retries
+       on: azure_monitor.container_apps.resiliency_retries
+    class: Errors
+     type: Containers
+component: Container Apps
+   lookup: sum -5m unaligned of retries
+    units: retries
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (10) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container Apps resiliency retries on ${label:resource_name}
+     info: Request retries in the last 5 minutes for Container App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# Resiliency - pending connection pool
+
+ template: am_container_apps_pending_connections
+       on: azure_monitor.container_apps.resiliency_pending_connections
+    class: Workload
+     type: Containers
+component: Container Apps
+   lookup: sum -5m unaligned of pending
+    units: requests
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (50) : (100))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container Apps pending connections on ${label:resource_name}
+     info: Requests pending in the connection pool in the last 5 minutes for Container App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# Resiliency - host ejections
+
+ template: am_container_apps_host_ejections
+       on: azure_monitor.container_apps.resiliency_ejections
+    class: Errors
+     type: Containers
+component: Container Apps
+   lookup: sum -5m unaligned of ejected
+    units: ejections
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container Apps host ejections on ${label:resource_name}
+     info: Upstream hosts ejected from the load balancing pool in the last 5 minutes for Container App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# Replica count — zero replicas means the app is scaled down or crashed
+
+ template: am_container_apps_replica_count
+       on: azure_monitor.container_apps.replicas
+    class: Availability
+     type: Containers
+component: Container Apps
+   lookup: average -5m unaligned of average
+    units: replicas
+    every: 1m
+     crit: $this != nan AND $this < 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container Apps replicas on ${label:resource_name}
+     info: Average replica count for Container App ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Zero replicas means the app is either scaled to zero or all replicas have crashed
+       to: sysadmin
+
+# GPU utilization (optional - only present when GPU workload profiles are used)
+
+ template: am_container_apps_gpu_utilization
+       on: azure_monitor.container_apps.gpu_utilization
+    class: Utilization
+     type: Containers
+component: Container Apps
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container Apps GPU on ${label:resource_name}
+     info: Average GPU utilization of Container App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# JVM GC duration (optional - only present for Java workloads)
+
+ template: am_container_apps_jvm_gc_duration
+       on: azure_monitor.container_apps.jvm_gc_duration
+    class: Latency
+     type: Containers
+component: Container Apps
+   lookup: sum -1m unaligned of duration
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container Apps JVM GC duration on ${label:resource_name}
+     info: Time spent in JVM garbage collection in the last minute for Container App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_container_instances.conf
+++ b/src/health/health.d/azure_monitor_container_instances.conf
@@ -1,0 +1,76 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- CPU ---
+# CPU usage in millicores. Default thresholds assume a 1 vCPU (1000 millicores) allocation.
+# Adjust warn/crit values to match your container group CPU allocation:
+#   2 vCPU = 2000 millicores, 4 vCPU = 4000 millicores, etc.
+
+ template: am_container_instances_cpu_usage
+       on: azure_monitor.container_instances.cpu_usage
+    class: Utilization
+     type: Containers
+component: Azure Container Instances
+   lookup: average -5m unaligned of average
+    units: millicores
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (850) : (900))
+     crit: $this > (($status == $CRITICAL) ? (900) : (950))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container CPU on ${label:resource_name}
+     info: Average CPU usage of container group ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Memory ---
+# Memory usage in bytes. Default thresholds assume a 1.5 GiB memory allocation.
+# Adjust warn/crit values to match your container group memory allocation.
+#   1.5 GiB: warn ~1.3 GiB (1395864371), crit ~1.4 GiB (1503238553)
+#   4.0 GiB: warn ~3.4 GiB (3650722201), crit ~3.6 GiB (3865470566)
+
+ template: am_container_instances_memory_usage
+       on: azure_monitor.container_instances.memory_usage
+    class: Utilization
+     type: Containers
+component: Azure Container Instances
+   lookup: average -5m unaligned of average
+    units: bytes
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1288490189) : (1395864371))
+     crit: $this > (($status == $CRITICAL) ? (1395864371) : (1503238553))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container memory on ${label:resource_name}
+     info: Average memory usage of container group ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Network ---
+
+ template: am_container_instances_network_rx
+       on: azure_monitor.container_instances.network
+    class: Workload
+     type: Containers
+component: Azure Container Instances
+   lookup: average -5m unaligned of received
+    units: bytes/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (100000000) : (125000000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container inbound traffic on ${label:resource_name}
+     info: High inbound network traffic on container group ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_container_instances_network_tx
+       on: azure_monitor.container_instances.network
+    class: Workload
+     type: Containers
+component: Azure Container Instances
+   lookup: average -5m unaligned of sent
+    units: bytes/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (100000000) : (125000000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Container outbound traffic on ${label:resource_name}
+     info: High outbound network traffic on container group ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_container_registry.conf
+++ b/src/health/health.d/azure_monitor_container_registry.conf
@@ -1,0 +1,63 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# helper: total pull rate over 5 minutes (used as denominator for failure ratio)
+
+ template: am_container_registry_pull_total
+       on: azure_monitor.container_registry.pull_count
+    class: Workload
+     type: Containers
+component: Azure ACR
+   lookup: average -5m unaligned of total
+    units: pulls/s
+    every: 1m
+     info: Total image pull rate on ACR ${label:resource_name}
+
+# Pull failure ratio: fires only when there is meaningful pull traffic
+
+ template: am_container_registry_pull_failures
+       on: azure_monitor.container_registry.pull_count
+    class: Errors
+     type: Containers
+component: Azure ACR
+   lookup: average -5m unaligned of successful
+     calc: ($am_container_registry_pull_total > 0.01) ? (($am_container_registry_pull_total - $this) * 100 / $am_container_registry_pull_total) : (0)
+    units: %
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (15))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ACR pull failures on ${label:resource_name}
+     info: Percentage of failed image pulls on ACR ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# helper: total push rate over 5 minutes (used as denominator for failure ratio)
+
+ template: am_container_registry_push_total
+       on: azure_monitor.container_registry.push_count
+    class: Workload
+     type: Containers
+component: Azure ACR
+   lookup: average -5m unaligned of total
+    units: pushes/s
+    every: 1m
+     info: Total image push rate on ACR ${label:resource_name}
+
+# Push failure ratio: fires only when there is meaningful push traffic
+
+ template: am_container_registry_push_failures
+       on: azure_monitor.container_registry.push_count
+    class: Errors
+     type: Containers
+component: Azure ACR
+   lookup: average -5m unaligned of successful
+     calc: ($am_container_registry_push_total > 0.01) ? (($am_container_registry_push_total - $this) * 100 / $am_container_registry_push_total) : (0)
+    units: %
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (15))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ACR push failures on ${label:resource_name}
+     info: Percentage of failed image pushes on ACR ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_cosmos_db.conf
+++ b/src/health/health.d/azure_monitor_cosmos_db.conf
@@ -1,0 +1,175 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Availability ---
+
+ template: am_cosmos_db_availability
+       on: azure_monitor.cosmos_db.availability
+    class: Availability
+     type: Database
+component: Cosmos DB
+   lookup: average -10m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99.99) : (99.9))
+     crit: $this < (($status == $CRITICAL) ? (99.9)  : (99))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cosmos DB availability on ${label:resource_name}
+     info: Service availability of Cosmos DB account ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- Utilization ---
+
+ template: am_cosmos_db_normalized_ru_consumption
+       on: azure_monitor.cosmos_db.normalized_ru_consumption
+    class: Utilization
+     type: Database
+component: Cosmos DB
+   lookup: average -5m unaligned of maximum
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cosmos DB RU consumption on ${label:resource_name}
+     info: Normalized request unit consumption on Cosmos DB account ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High values indicate approaching provisioned throughput limit and risk of throttling
+       to: dba
+
+ template: am_cosmos_db_storage_utilization
+       on: azure_monitor.cosmos_db.storage
+    class: Utilization
+     type: Database
+component: Cosmos DB
+     calc: ($quota > 0) ? (($data + $index) * 100 / $quota) : (0)
+    units: %
+    every: 5m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cosmos DB storage utilization on ${label:resource_name}
+     info: Data and index storage as a percentage of document quota on Cosmos DB account ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- Latency ---
+
+ template: am_cosmos_db_server_side_latency_direct
+       on: azure_monitor.cosmos_db.server_side_latency
+    class: Latency
+     type: Database
+component: Cosmos DB
+   lookup: average -5m unaligned of direct
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (8) : (10))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (10) : (15))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cosmos DB direct latency on ${label:resource_name}
+     info: Average server-side latency for direct connections on Cosmos DB account ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+ template: am_cosmos_db_server_side_latency_gateway
+       on: azure_monitor.cosmos_db.server_side_latency
+    class: Latency
+     type: Database
+component: Cosmos DB
+   lookup: average -5m unaligned of gateway
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (40) : (50))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (60) : (80))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cosmos DB gateway latency on ${label:resource_name}
+     info: Average server-side latency for gateway connections on Cosmos DB account ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+ template: am_cosmos_db_replication_latency
+       on: azure_monitor.cosmos_db.replication_latency
+    class: Latency
+     type: Database
+component: Cosmos DB
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (100) : (200))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (200) : (500))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cosmos DB replication latency on ${label:resource_name}
+     info: Average geo-replication latency (P99) on Cosmos DB account ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant when multi-region writes are configured
+       to: dba
+
+# --- Dedicated Gateway ---
+
+ template: am_cosmos_db_dedicated_gateway_cpu
+       on: azure_monitor.cosmos_db.dedicated_gateway_cpu
+    class: Utilization
+     type: Database
+component: Cosmos DB
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cosmos DB dedicated gateway CPU on ${label:resource_name}
+     info: CPU utilization of the dedicated gateway on Cosmos DB account ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- Integrated Cache ---
+
+ template: am_cosmos_db_integrated_cache_item_hit_rate
+       on: azure_monitor.cosmos_db.integrated_cache_hit_rate
+    class: Utilization
+     type: Database
+component: Cosmos DB
+   lookup: average -10m unaligned of item
+    units: percentage
+    every: 5m
+     warn: $this != nan AND $this < (($status >= $WARNING) ? (60) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cosmos DB cache item hit rate on ${label:resource_name}
+     info: Integrated cache item hit rate on Cosmos DB account ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Low hit rates indicate cache is not effectively reducing RU consumption
+       to: dba
+
+ template: am_cosmos_db_integrated_cache_query_hit_rate
+       on: azure_monitor.cosmos_db.integrated_cache_hit_rate
+    class: Utilization
+     type: Database
+component: Cosmos DB
+   lookup: average -10m unaligned of query
+    units: percentage
+    every: 5m
+     warn: $this != nan AND $this < (($status >= $WARNING) ? (60) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cosmos DB cache query hit rate on ${label:resource_name}
+     info: Integrated cache query hit rate on Cosmos DB account ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Low hit rates indicate cache is not effectively reducing RU consumption
+       to: dba
+
+# --- Cassandra API ---
+
+ template: am_cosmos_db_cassandra_connection_closures
+       on: azure_monitor.cosmos_db.cassandra_connections
+    class: Errors
+     type: Database
+component: Cosmos DB
+   lookup: average -5m unaligned of total
+    units: connections/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Cosmos DB Cassandra connection closures on ${label:resource_name}
+     info: Rate of Cassandra connection closures on Cosmos DB account ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant for accounts using the Cassandra API
+       to: dba

--- a/src/health/health.d/azure_monitor_data_explorer.conf
+++ b/src/health/health.d/azure_monitor_data_explorer.conf
@@ -1,0 +1,365 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Cluster Health ---
+
+ template: am_data_explorer_keep_alive
+       on: azure_monitor.data_explorer.keep_alive
+    class: Availability
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of average
+    units: count
+    every: 1m
+     crit: $this < (($status == $CRITICAL) ? (1) : (0.5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer keep alive on ${label:resource_name}
+     info: Cluster keep-alive health signal for Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           A value below 1 indicates the cluster is not responding properly.
+       to: sysadmin
+
+ template: am_data_explorer_cpu
+       on: azure_monitor.data_explorer.cpu_utilization
+    class: Utilization
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer CPU on ${label:resource_name}
+     info: Average CPU utilization of Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_data_explorer_ingestion_utilization
+       on: azure_monitor.data_explorer.utilization
+    class: Utilization
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of ingestion
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer ingestion utilization on ${label:resource_name}
+     info: Average ingestion utilization of Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High utilization indicates the cluster is approaching ingestion capacity.
+       to: sysadmin
+
+ template: am_data_explorer_cache_utilization
+       on: azure_monitor.data_explorer.utilization
+    class: Utilization
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of cache
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (80))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer cache utilization on ${label:resource_name}
+     info: Average cache utilization factor of Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High cache utilization may cause queries to read from cold storage.
+       to: sysadmin
+
+ template: am_data_explorer_throttled_commands
+       on: azure_monitor.data_explorer.throttled_commands
+    class: Errors
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of total
+    units: commands/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer throttled commands on ${label:resource_name}
+     info: Rate of throttled commands on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Throttling indicates the cluster is overloaded.
+       to: sysadmin
+
+# --- Query Performance ---
+
+ template: am_data_explorer_query_duration
+       on: azure_monitor.data_explorer.query_duration
+    class: Latency
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (15000) : (30000))
+     crit: $this > (($status == $CRITICAL) ? (30000) : (60000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer query duration on ${label:resource_name}
+     info: Average query duration on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_data_explorer_throttled_queries
+       on: azure_monitor.data_explorer.throttled_queries
+    class: Errors
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of total
+    units: queries/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer throttled queries on ${label:resource_name}
+     info: Rate of throttled queries on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Throttling indicates insufficient query capacity.
+       to: sysadmin
+
+# --- Ingestion Health ---
+
+ template: am_data_explorer_ingestion_latency
+       on: azure_monitor.data_explorer.ingestion_latency
+    class: Latency
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of average
+    units: seconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (300) : (600))
+     crit: $this > (($status == $CRITICAL) ? (600) : (1800))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer ingestion latency on ${label:resource_name}
+     info: Average ingestion latency on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High latency means data takes longer to become queryable.
+       to: sysadmin
+
+ template: am_data_explorer_events_dropped
+       on: azure_monitor.data_explorer.events
+    class: Errors
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of dropped
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer events dropped on ${label:resource_name}
+     info: Rate of dropped ingestion events on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Dropped events indicate data loss during ingestion.
+       to: sysadmin
+
+ template: am_data_explorer_blobs_dropped
+       on: azure_monitor.data_explorer.blobs
+    class: Errors
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of dropped
+    units: blobs/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer blobs dropped on ${label:resource_name}
+     info: Rate of dropped blobs during ingestion on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Dropped blobs indicate data loss during ingestion.
+       to: sysadmin
+
+ template: am_data_explorer_ingestion_queue_length
+       on: azure_monitor.data_explorer.ingestion_queue
+    class: Workload
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of length
+    units: messages
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (500) : (1000))
+     crit: $this > (($status == $CRITICAL) ? (1000) : (5000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer ingestion queue on ${label:resource_name}
+     info: Average ingestion queue length on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           A growing queue indicates ingestion is not keeping up with incoming data.
+       to: sysadmin
+
+ template: am_data_explorer_queue_oldest_message
+       on: azure_monitor.data_explorer.queue_oldest_message
+    class: Latency
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of age
+    units: seconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (300) : (600))
+     crit: $this > (($status == $CRITICAL) ? (600) : (1800))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer queue oldest message age on ${label:resource_name}
+     info: Age of the oldest message in the ingestion queue of Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Old messages indicate a significant ingestion backlog.
+       to: sysadmin
+
+# --- Export Health ---
+
+ template: am_data_explorer_export_utilization
+       on: azure_monitor.data_explorer.export_utilization
+    class: Utilization
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of maximum
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer export utilization on ${label:resource_name}
+     info: Export utilization of Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High export utilization may cause export jobs to be delayed or fail.
+       to: sysadmin
+
+ template: am_data_explorer_continuous_export_pending
+       on: azure_monitor.data_explorer.continuous_export_pending
+    class: Workload
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of maximum
+    units: jobs
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (5) : (10))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer continuous export pending on ${label:resource_name}
+     info: Number of pending continuous export jobs on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_data_explorer_continuous_export_lateness
+       on: azure_monitor.data_explorer.continuous_export_lateness
+    class: Latency
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of maximum
+    units: minutes
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (10) : (30))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (30) : (60))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer continuous export lateness on ${label:resource_name}
+     info: Maximum continuous export lateness on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High lateness means exported data is significantly behind real-time.
+       to: sysadmin
+
+# --- Streaming Ingest ---
+
+ template: am_data_explorer_streaming_ingest_utilization
+       on: azure_monitor.data_explorer.streaming_ingest_utilization
+    class: Utilization
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer streaming ingest utilization on ${label:resource_name}
+     info: Average streaming ingest utilization on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High utilization indicates the cluster is approaching streaming ingest capacity.
+       to: sysadmin
+
+ template: am_data_explorer_streaming_ingest_duration
+       on: azure_monitor.data_explorer.streaming_ingest_duration
+    class: Latency
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (500) : (1000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (1000) : (5000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer streaming ingest duration on ${label:resource_name}
+     info: Average streaming ingest duration on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Materialized Views ---
+
+ template: am_data_explorer_materialized_view_health
+       on: azure_monitor.data_explorer.materialized_view_health
+    class: Availability
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of health
+    units: status
+    every: 1m
+     crit: $this != nan AND $this < 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer materialized view health on ${label:resource_name}
+     info: Materialized view health status on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           A value below 1 indicates the materialized view is unhealthy.
+       to: sysadmin
+
+ template: am_data_explorer_materialized_view_age
+       on: azure_monitor.data_explorer.materialized_view_age
+    class: Latency
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of minutes
+    units: minutes
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (30) : (60))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (60) : (120))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer materialized view age on ${label:resource_name}
+     info: Age of the materialized view on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High age means the view is significantly behind the source data.
+       to: sysadmin
+
+ template: am_data_explorer_materialized_view_data_loss
+       on: azure_monitor.data_explorer.materialized_view_data_loss
+    class: Errors
+     type: Database
+component: Data Explorer
+   lookup: max -5m unaligned of maximum
+    units: status
+    every: 1m
+     crit: $this != nan AND $this > 0
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer materialized view data loss on ${label:resource_name}
+     info: Materialized view is reporting data loss on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           This indicates potential data inconsistency in the view.
+       to: sysadmin
+
+# --- Follower Latency ---
+
+ template: am_data_explorer_follower_latency
+       on: azure_monitor.data_explorer.follower_latency
+    class: Latency
+     type: Database
+component: Data Explorer
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (30000) : (60000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (60000) : (300000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Explorer follower latency on ${label:resource_name}
+     info: Average follower replication latency on Azure Data Explorer cluster ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High latency means follower databases are behind the leader.
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_data_factory.conf
+++ b/src/health/health.d/azure_monitor_data_factory.conf
@@ -1,0 +1,442 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Pipeline Runs ---
+
+ template: am_data_factory_pipeline_failed_runs
+       on: azure_monitor.data_factory.pipeline_runs
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of failed
+    units: runs
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory pipeline failures on ${label:resource_name}
+     info: Failed pipeline runs on Data Factory ${label:resource_name} \
+           in ${label:resource_group} (${label:region}) over the last 5 minutes
+       to: sysadmin
+
+ template: am_data_factory_pipeline_cancelled_runs
+       on: azure_monitor.data_factory.pipeline_runs
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -10m unaligned of cancelled
+    units: runs
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory pipeline cancellations on ${label:resource_name}
+     info: Cancelled pipeline runs on Data Factory ${label:resource_name} \
+           in ${label:resource_group} (${label:region}) over the last 10 minutes. \
+           Frequent cancellations may indicate configuration or dependency issues
+       to: sysadmin
+
+# --- Activity Runs ---
+
+ template: am_data_factory_activity_failed_runs
+       on: azure_monitor.data_factory.activity_runs
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of failed
+    units: runs
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory activity failures on ${label:resource_name}
+     info: Failed activity runs on Data Factory ${label:resource_name} \
+           in ${label:resource_group} (${label:region}) over the last 5 minutes
+       to: sysadmin
+
+# --- Trigger Runs ---
+
+ template: am_data_factory_trigger_failed_runs
+       on: azure_monitor.data_factory.trigger_runs
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of failed
+    units: runs
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory trigger failures on ${label:resource_name}
+     info: Failed trigger runs on Data Factory ${label:resource_name} \
+           in ${label:resource_group} (${label:region}) over the last 5 minutes
+       to: sysadmin
+
+# --- SSIS Integration Runtime ---
+
+ template: am_data_factory_ssis_ir_start_failures
+       on: azure_monitor.data_factory.ssis_ir_starts
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of failed
+    units: runs
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory SSIS IR start failures on ${label:resource_name}
+     info: Failed SSIS Integration Runtime start operations on Data Factory \
+           ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_data_factory_ssis_ir_stop_stuck
+       on: azure_monitor.data_factory.ssis_ir_stops
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of stuck
+    units: runs
+    every: 1m
+     warn: $this != nan AND $this > 0
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory SSIS IR stuck stops on ${label:resource_name}
+     info: SSIS Integration Runtime stop operations stuck on Data Factory \
+           ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_data_factory_ssis_package_failures
+       on: azure_monitor.data_factory.ssis_package_executions
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of failed
+    units: executions
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory SSIS package failures on ${label:resource_name}
+     info: Failed SSIS package executions on Data Factory ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Integration Runtime Resources ---
+
+ template: am_data_factory_ir_cpu
+       on: azure_monitor.data_factory.ir_cpu
+    class: Utilization
+     type: Other
+component: Azure Data Factory
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory IR CPU on ${label:resource_name}
+     info: Integration Runtime CPU utilization on Data Factory ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_data_factory_ir_queue_length
+       on: azure_monitor.data_factory.ir_queue
+    class: Workload
+     type: Other
+component: Azure Data Factory
+   lookup: average -5m unaligned of queue_length
+    units: tasks
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (10) : (20))
+     crit: $this > (($status == $CRITICAL) ? (20) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory IR queue depth on ${label:resource_name}
+     info: Integration Runtime queue length on Data Factory ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Growing queues indicate the runtime cannot keep up with submitted work
+       to: sysadmin
+
+ template: am_data_factory_ir_task_pickup_delay
+       on: azure_monitor.data_factory.ir_task_pickup_delay
+    class: Latency
+     type: Other
+component: Azure Data Factory
+   lookup: average -5m unaligned of average
+    units: seconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (30) : (60))
+     crit: $this > (($status == $CRITICAL) ? (60) : (120))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory IR task pickup delay on ${label:resource_name}
+     info: Average task pickup delay for Integration Runtime on Data Factory \
+           ${label:resource_name} in ${label:resource_group} (${label:region}). \
+           High delay indicates insufficient runtime capacity
+       to: sysadmin
+
+# --- Factory Capacity ---
+
+ template: am_data_factory_size_utilization
+       on: azure_monitor.data_factory.factory_size
+    class: Utilization
+     type: Other
+component: Azure Data Factory
+     calc: ($max_allowed > 0) ? ($current * 100 / $max_allowed) : (0)
+    units: %
+    every: 5m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory size utilization on ${label:resource_name}
+     info: Factory size as percentage of maximum allowed on Data Factory \
+           ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_data_factory_entity_utilization
+       on: azure_monitor.data_factory.entity_count
+    class: Utilization
+     type: Other
+component: Azure Data Factory
+     calc: ($max_allowed > 0) ? ($current * 100 / $max_allowed) : (0)
+    units: %
+    every: 5m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory entity count on ${label:resource_name}
+     info: Entity count (pipelines, datasets, etc.) as percentage of maximum allowed \
+           on Data Factory ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- MVNet IR Capacity ---
+
+ template: am_data_factory_mvnet_ir_copy_utilization
+       on: azure_monitor.data_factory.mvnet_ir_copy_capacity
+    class: Utilization
+     type: Other
+component: Azure Data Factory
+   lookup: average -5m unaligned of utilization
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory MVNet IR copy utilization on ${label:resource_name}
+     info: Managed VNet Integration Runtime copy capacity utilization on Data Factory \
+           ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_data_factory_mvnet_ir_external_utilization
+       on: azure_monitor.data_factory.mvnet_ir_external_capacity
+    class: Utilization
+     type: Other
+component: Azure Data Factory
+   lookup: average -5m unaligned of utilization
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory MVNet IR external utilization on ${label:resource_name}
+     info: Managed VNet Integration Runtime external activity capacity utilization \
+           on Data Factory ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_data_factory_mvnet_ir_pipeline_utilization
+       on: azure_monitor.data_factory.mvnet_ir_pipeline_capacity
+    class: Utilization
+     type: Other
+component: Azure Data Factory
+   lookup: average -5m unaligned of utilization
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory MVNet IR pipeline utilization on ${label:resource_name}
+     info: Managed VNet Integration Runtime pipeline capacity utilization \
+           on Data Factory ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Airflow IR Resources ---
+
+ template: am_data_factory_airflow_ir_cpu
+       on: azure_monitor.data_factory.airflow_ir_cpu
+    class: Utilization
+     type: Other
+component: Azure Data Factory
+   lookup: average -5m unaligned of percentage
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory Airflow IR CPU on ${label:resource_name}
+     info: Airflow Integration Runtime CPU utilization on Data Factory \
+           ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_data_factory_airflow_ir_memory
+       on: azure_monitor.data_factory.airflow_ir_memory
+    class: Utilization
+     type: Other
+component: Azure Data Factory
+   lookup: average -5m unaligned of percentage
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory Airflow IR memory on ${label:resource_name}
+     info: Airflow Integration Runtime memory utilization on Data Factory \
+           ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Airflow IR DAG Errors ---
+
+ template: am_data_factory_airflow_ir_dag_errors
+       on: azure_monitor.data_factory.airflow_ir_dag_errors
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of callback_exceptions,file_refresh,import
+    units: errors
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory Airflow DAG errors on ${label:resource_name}
+     info: DAG processing errors (callback exceptions, file refresh errors, import errors) \
+           on Airflow IR of Data Factory ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Airflow IR Operators ---
+
+ template: am_data_factory_airflow_ir_operator_failures
+       on: azure_monitor.data_factory.airflow_ir_operators
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of failures
+    units: operations
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory Airflow operator failures on ${label:resource_name}
+     info: Failed Airflow operator executions on Data Factory ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Airflow IR Jobs ---
+
+ template: am_data_factory_airflow_ir_job_heartbeat_failures
+       on: azure_monitor.data_factory.airflow_ir_jobs
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of heartbeat_failures
+    units: failures
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory Airflow job heartbeat failures on ${label:resource_name}
+     info: Airflow job heartbeat failures on Data Factory ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Heartbeat failures indicate scheduler or worker health issues
+       to: sysadmin
+
+# --- Airflow IR Pool Starvation ---
+
+ template: am_data_factory_airflow_ir_pool_starving
+       on: azure_monitor.data_factory.airflow_ir_pool_starving
+    class: Workload
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of starving
+    units: tasks
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory Airflow pool starvation on ${label:resource_name}
+     info: Starving tasks in Airflow pool on Data Factory ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Tasks are waiting for pool slots, consider increasing pool size
+       to: sysadmin
+
+# --- Airflow IR Scheduler Tasks ---
+
+ template: am_data_factory_airflow_ir_tasks_killed_externally
+       on: azure_monitor.data_factory.airflow_ir_scheduler_tasks
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of killed_externally
+    units: tasks
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (3))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory Airflow tasks killed externally on ${label:resource_name}
+     info: Tasks killed externally by the Airflow scheduler on Data Factory \
+           ${label:resource_name} in ${label:resource_group} (${label:region}). \
+           May indicate OOM kills or infrastructure issues
+       to: sysadmin
+
+ template: am_data_factory_airflow_ir_tasks_starving
+       on: azure_monitor.data_factory.airflow_ir_scheduler_tasks
+    class: Workload
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of starving
+    units: tasks
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory Airflow scheduler starving tasks on ${label:resource_name}
+     info: Starving tasks reported by Airflow scheduler on Data Factory \
+           ${label:resource_name} in ${label:resource_group} (${label:region}). \
+           Tasks cannot be scheduled due to resource constraints
+       to: sysadmin
+
+# --- Airflow IR Task Instances ---
+
+ template: am_data_factory_airflow_ir_task_instance_failures
+       on: azure_monitor.data_factory.airflow_ir_task_instances
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of failed
+    units: instances
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory Airflow task failures on ${label:resource_name}
+     info: Failed Airflow task instances on Data Factory ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Airflow IR Trigger Issues ---
+
+ template: am_data_factory_airflow_ir_trigger_issues
+       on: azure_monitor.data_factory.airflow_ir_trigger_issues
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of blocked_main_thread,celery_timeout_errors
+    units: events
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (3))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory Airflow trigger issues on ${label:resource_name}
+     info: Trigger issues (blocked main thread, Celery timeouts) on Airflow IR \
+           of Data Factory ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Airflow IR Zombies ---
+
+ template: am_data_factory_airflow_ir_zombies
+       on: azure_monitor.data_factory.airflow_ir_zombies
+    class: Errors
+     type: Other
+component: Azure Data Factory
+   lookup: sum -5m unaligned of killed
+    units: tasks
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (3))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Data Factory Airflow zombie tasks on ${label:resource_name}
+     info: Zombie tasks killed by Airflow on Data Factory ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Zombies occur when tasks are marked running but no process is executing them
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_event_grid.conf
+++ b/src/health/health.d/azure_monitor_event_grid.conf
@@ -1,0 +1,110 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Publish Failures ---
+
+ template: am_event_grid_publish_failures
+       on: azure_monitor.event_grid.publish_rate
+    class: Errors
+     type: Messaging
+component: Event Grid
+   lookup: average -5m unaligned of failed
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Grid publish failures on ${label:resource_name}
+     info: Rate of failed event publish operations on Event Grid topic ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Failed publishes indicate authentication, authorization, or schema validation errors
+       to: sysadmin
+
+# --- Delivery Failures ---
+
+ template: am_event_grid_delivery_failures
+       on: azure_monitor.event_grid.delivery
+    class: Errors
+     type: Messaging
+component: Event Grid
+   lookup: average -5m unaligned of failed
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Grid delivery failures on ${label:resource_name}
+     info: Rate of failed event delivery attempts on Event Grid topic ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Persistent delivery failures indicate subscriber endpoint issues
+       to: sysadmin
+
+ template: am_event_grid_dropped_events
+       on: azure_monitor.event_grid.delivery
+    class: Errors
+     type: Messaging
+component: Event Grid
+   lookup: average -5m unaligned of dropped
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Grid dropped events on ${label:resource_name}
+     info: Rate of dropped events on Event Grid topic ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Dropped events are permanently lost and indicate exhausted retry attempts \
+           without a dead-letter destination configured
+       to: sysadmin
+
+ template: am_event_grid_dead_lettered_events
+       on: azure_monitor.event_grid.delivery
+    class: Errors
+     type: Messaging
+component: Event Grid
+   lookup: average -5m unaligned of dead_lettered
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Grid dead-lettered events on ${label:resource_name}
+     info: Rate of events sent to the dead-letter destination on Event Grid topic ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Dead-lettered events failed all delivery retries and require manual investigation
+       to: sysadmin
+
+# --- Routing ---
+
+ template: am_event_grid_unmatched_events
+       on: azure_monitor.event_grid.routing
+    class: Errors
+     type: Messaging
+component: Event Grid
+   lookup: average -5m unaligned of unmatched
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Grid unmatched events on ${label:resource_name}
+     info: Rate of events that did not match any subscription on Event Grid topic ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Unmatched events indicate missing or misconfigured event subscriptions
+       to: sysadmin
+
+# --- Latency ---
+
+ template: am_event_grid_destination_processing_duration
+       on: azure_monitor.event_grid.destination_processing_duration
+    class: Latency
+     type: Messaging
+component: Event Grid
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Grid destination processing duration on ${label:resource_name}
+     info: Average time taken by the subscriber endpoint to process events from Event Grid topic ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High processing duration indicates slow or overloaded event subscribers
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_event_hubs.conf
+++ b/src/health/health.d/azure_monitor_event_hubs.conf
@@ -1,0 +1,185 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Errors ---
+
+ template: am_event_hubs_server_errors
+       on: azure_monitor.event_hubs.errors
+    class: Errors
+     type: Messaging
+component: Azure Event Hubs
+   lookup: average -5m unaligned of server
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Hubs server errors on ${label:resource_name}
+     info: Server-side errors on Event Hubs namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_event_hubs_throttled_requests
+       on: azure_monitor.event_hubs.errors
+    class: Errors
+     type: Messaging
+component: Azure Event Hubs
+   lookup: average -5m unaligned of throttled
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Hubs throttled requests on ${label:resource_name}
+     info: Requests being throttled on Event Hubs namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_event_hubs_quota_exceeded
+       on: azure_monitor.event_hubs.errors
+    class: Errors
+     type: Messaging
+component: Azure Event Hubs
+   lookup: average -5m unaligned of quota_exceeded
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Hubs quota exceeded on ${label:resource_name}
+     info: Quota exceeded errors on Event Hubs namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Quota errors indicate the namespace has exceeded its throughput unit limits
+       to: sysadmin
+
+# User errors (400-class) at sustained high rate may indicate
+# client misconfiguration or malformed messages.
+
+ template: am_event_hubs_user_errors
+       on: azure_monitor.event_hubs.errors
+    class: Errors
+     type: Messaging
+component: Azure Event Hubs
+   lookup: average -5m unaligned of user
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (10) : (25))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Hubs user errors on ${label:resource_name}
+     info: Rate of user (client-side) errors on Event Hubs namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Request Success Rate ---
+
+ template: am_event_hubs_incoming_requests
+       on: azure_monitor.event_hubs.requests
+    class: Workload
+     type: Messaging
+component: Azure Event Hubs
+   lookup: sum -5m unaligned of incoming
+    units: requests/s
+    every: 1m
+     info: Total incoming requests to Event Hubs namespace ${label:resource_name}
+
+ template: am_event_hubs_success_rate
+       on: azure_monitor.event_hubs.requests
+    class: Errors
+     type: Messaging
+component: Azure Event Hubs
+   lookup: sum -5m unaligned of successful
+     calc: ($am_event_hubs_incoming_requests > 0) ? ($this * 100 / $am_event_hubs_incoming_requests) : (100)
+    units: %
+    every: 1m
+     warn: ($am_event_hubs_incoming_requests > 120) ? ($this < (($status >= $WARNING) ? (99) : (95))) : (0)
+     crit: ($am_event_hubs_incoming_requests > 120) ? ($this < (($status == $CRITICAL) ? (95) : (85))) : (0)
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Hubs request success rate on ${label:resource_name}
+     info: Percentage of successful requests on Event Hubs namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Utilization (Premium tier) ---
+
+ template: am_event_hubs_namespace_cpu
+       on: azure_monitor.event_hubs.namespace_resources
+    class: Utilization
+     type: Messaging
+component: Azure Event Hubs
+   lookup: average -5m unaligned of cpu
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Hubs namespace CPU on ${label:resource_name}
+     info: CPU utilization of Event Hubs Premium namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_event_hubs_namespace_memory
+       on: azure_monitor.event_hubs.namespace_resources
+    class: Utilization
+     type: Messaging
+component: Azure Event Hubs
+   lookup: average -5m unaligned of memory
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Hubs namespace memory on ${label:resource_name}
+     info: Memory utilization of Event Hubs Premium namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Capture ---
+
+ template: am_event_hubs_capture_backlog
+       on: azure_monitor.event_hubs.capture_backlog
+    class: Workload
+     type: Messaging
+component: Azure Event Hubs
+   lookup: average -5m unaligned of backlog
+    units: messages
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (500000) : (1000000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (1000000) : (5000000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Hubs capture backlog on ${label:resource_name}
+     info: Messages waiting to be captured on Event Hubs namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Geo-Replication ---
+
+ template: am_event_hubs_replication_lag
+       on: azure_monitor.event_hubs.replication_lag
+    class: Latency
+     type: Messaging
+component: Azure Event Hubs
+   lookup: average -5m unaligned of messages
+    units: messages
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (100) : (500))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (500) : (1000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Hubs replication lag on ${label:resource_name}
+     info: Geo-replication message lag on Event Hubs namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_event_hubs_replication_lag_duration
+       on: azure_monitor.event_hubs.replication_lag_duration
+    class: Latency
+     type: Messaging
+component: Azure Event Hubs
+   lookup: average -5m unaligned of duration
+    units: seconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (30) : (60))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (60) : (120))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Event Hubs replication lag duration on ${label:resource_name}
+     info: Geo-replication time lag on Event Hubs namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_express_route_circuit.conf
+++ b/src/health/health.d/azure_monitor_express_route_circuit.conf
@@ -1,0 +1,109 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Availability ---
+
+ template: am_express_route_circuit_arp_availability
+       on: azure_monitor.express_route_circuit.arp_availability
+    class: Availability
+     type: Other
+component: ExpressRoute
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99) : (95))
+     crit: $this < (($status == $CRITICAL) ? (95) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ExpressRoute ARP availability on ${label:resource_name}
+     info: ARP availability of ExpressRoute circuit ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Low ARP availability indicates layer 2 connectivity problems between \
+           the Microsoft edge and the provider/customer edge
+       to: sysadmin
+
+ template: am_express_route_circuit_bgp_availability
+       on: azure_monitor.express_route_circuit.bgp_availability
+    class: Availability
+     type: Other
+component: ExpressRoute
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99) : (95))
+     crit: $this < (($status == $CRITICAL) ? (95) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ExpressRoute BGP availability on ${label:resource_name}
+     info: BGP availability of ExpressRoute circuit ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Low BGP availability indicates routing session problems that can \
+           cause traffic disruption
+       to: sysadmin
+
+# --- Bandwidth Utilization ---
+
+ template: am_express_route_circuit_ingress_bandwidth_utilization
+       on: azure_monitor.express_route_circuit.bandwidth_utilization
+    class: Utilization
+     type: Other
+component: ExpressRoute
+   lookup: average -5m unaligned of ingress
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ExpressRoute ingress bandwidth on ${label:resource_name}
+     info: Ingress bandwidth utilization of ExpressRoute circuit ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High utilization can cause packet drops and increased latency
+       to: sysadmin
+
+ template: am_express_route_circuit_egress_bandwidth_utilization
+       on: azure_monitor.express_route_circuit.bandwidth_utilization
+    class: Utilization
+     type: Other
+component: ExpressRoute
+   lookup: average -5m unaligned of egress
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ExpressRoute egress bandwidth on ${label:resource_name}
+     info: Egress bandwidth utilization of ExpressRoute circuit ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High utilization can cause packet drops and increased latency
+       to: sysadmin
+
+# --- QoS Drops ---
+
+ template: am_express_route_circuit_qos_drop_in
+       on: azure_monitor.express_route_circuit.qos_dropped_bits
+    class: Errors
+     type: Other
+component: ExpressRoute
+   lookup: average -5m unaligned of in
+    units: bits/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (1000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ExpressRoute QoS ingress drops on ${label:resource_name}
+     info: Rate of QoS-dropped ingress bits on ExpressRoute circuit ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Non-zero QoS drops indicate traffic is exceeding configured QoS policies
+       to: sysadmin
+
+ template: am_express_route_circuit_qos_drop_out
+       on: azure_monitor.express_route_circuit.qos_dropped_bits
+    class: Errors
+     type: Other
+component: ExpressRoute
+   lookup: average -5m unaligned of out
+    units: bits/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (1000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ExpressRoute QoS egress drops on ${label:resource_name}
+     info: Rate of QoS-dropped egress bits on ExpressRoute circuit ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Non-zero QoS drops indicate traffic is exceeding configured QoS policies
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_express_route_gateway.conf
+++ b/src/health/health.d/azure_monitor_express_route_gateway.conf
@@ -1,0 +1,174 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- CPU Utilization ---
+
+ template: am_express_route_gateway_cpu
+       on: azure_monitor.express_route_gateway.cpu_utilization
+    class: Utilization
+     type: Other
+component: ExpressRoute Gateway
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ExpressRoute GW CPU on ${label:resource_name}
+     info: Average CPU utilization of ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High CPU may cause degraded forwarding performance
+       to: sysadmin
+
+# --- Gateway Throughput ---
+
+ template: am_express_route_gateway_throughput
+       on: azure_monitor.express_route_gateway.gateway_throughput
+    class: Workload
+     type: Other
+component: ExpressRoute Gateway
+   lookup: average -5m unaligned of average
+    units: bits/s
+    every: 1m
+     info: Average throughput of ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: silent
+
+# --- Connection Throughput ---
+
+ template: am_express_route_gateway_connection_in
+       on: azure_monitor.express_route_gateway.connection_throughput
+    class: Workload
+     type: Other
+component: ExpressRoute Gateway
+   lookup: average -5m unaligned of in
+    units: bits/s
+    every: 1m
+     info: Average inbound connection throughput of ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: silent
+
+ template: am_express_route_gateway_connection_out
+       on: azure_monitor.express_route_gateway.connection_throughput
+    class: Workload
+     type: Other
+component: ExpressRoute Gateway
+   lookup: average -5m unaligned of out
+    units: bits/s
+    every: 1m
+     info: Average outbound connection throughput of ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: silent
+
+# --- Packets ---
+
+ template: am_express_route_gateway_packets
+       on: azure_monitor.express_route_gateway.packets
+    class: Workload
+     type: Other
+component: ExpressRoute Gateway
+   lookup: average -5m unaligned of average
+    units: packets/s
+    every: 1m
+     info: Average packet rate through ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: silent
+
+# --- Active Flows ---
+
+ template: am_express_route_gateway_active_flows
+       on: azure_monitor.express_route_gateway.active_flows
+    class: Workload
+     type: Other
+component: ExpressRoute Gateway
+   lookup: average -5m unaligned of average
+    units: flows
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (200000) : (250000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ExpressRoute GW active flows on ${label:resource_name}
+     info: Average number of active flows on ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High flow counts may indicate approaching scalability limits
+       to: sysadmin
+
+# --- Route Changes ---
+
+ template: am_express_route_gateway_route_changes
+       on: azure_monitor.express_route_gateway.route_changes
+    class: Errors
+     type: Other
+component: ExpressRoute Gateway
+   lookup: average -5m unaligned of total
+    units: changes/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ExpressRoute GW route churn on ${label:resource_name}
+     info: Rate of BGP route changes on ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Frequent route changes may indicate BGP instability
+       to: sysadmin
+
+# --- Routes Advertised ---
+
+ template: am_express_route_gateway_routes_advertised
+       on: azure_monitor.express_route_gateway.routes_advertised
+    class: Workload
+     type: Other
+component: ExpressRoute Gateway
+   lookup: average -5m unaligned of maximum
+    units: routes
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (900) : (950))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ExpressRoute GW routes advertised on ${label:resource_name}
+     info: Number of routes advertised to peer by ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Azure limits advertised routes to 1000 per peering
+       to: sysadmin
+
+# --- Routes Learned ---
+
+ template: am_express_route_gateway_routes_learned
+       on: azure_monitor.express_route_gateway.routes_learned
+    class: Workload
+     type: Other
+component: ExpressRoute Gateway
+   lookup: average -5m unaligned of maximum
+    units: routes
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (3800) : (3900))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ExpressRoute GW routes learned on ${label:resource_name}
+     info: Number of routes learned from peer by ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Azure limits learned routes to 4000 per peering
+       to: sysadmin
+
+# --- Max Flow Creation Rate ---
+
+ template: am_express_route_gateway_flow_creation_rate
+       on: azure_monitor.express_route_gateway.max_flows_creation_rate
+    class: Workload
+     type: Other
+component: ExpressRoute Gateway
+   lookup: average -5m unaligned of maximum
+    units: flows/s
+    every: 1m
+     info: Maximum flow creation rate on ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: silent
+
+# --- VMs in VNet ---
+
+ template: am_express_route_gateway_vm_count
+       on: azure_monitor.express_route_gateway.vm_count
+    class: Workload
+     type: Other
+component: ExpressRoute Gateway
+   lookup: average -5m unaligned of maximum
+    units: VMs
+    every: 1m
+     info: Number of VMs in the VNet behind ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: silent

--- a/src/health/health.d/azure_monitor_firewall.conf
+++ b/src/health/health.d/azure_monitor_firewall.conf
@@ -1,0 +1,58 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Health ---
+
+ template: am_firewall_health
+       on: azure_monitor.firewall.health
+    class: Availability
+     type: Other
+component: Azure Firewall
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99) : (90))
+     crit: $this < (($status == $CRITICAL) ? (90) : (80))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Firewall health on ${label:resource_name}
+     info: Health state of Azure Firewall ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           AMBA threshold is 90%. Values below 100% indicate partial degradation
+       to: sysadmin
+
+# --- Latency ---
+
+ template: am_firewall_latency
+       on: azure_monitor.firewall.latency
+    class: Latency
+     type: Other
+component: Azure Firewall
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (10) : (20))
+     crit: $this > (($status == $CRITICAL) ? (20) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Firewall latency on ${label:resource_name}
+     info: Average latency probe of Azure Firewall ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High latency indicates firewall processing delays
+       to: sysadmin
+
+# --- SNAT Port Utilization ---
+
+ template: am_firewall_snat_port_utilization
+       on: azure_monitor.firewall.snat_port_utilization
+    class: Utilization
+     type: Other
+component: Azure Firewall
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (60) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Firewall SNAT port utilization on ${label:resource_name}
+     info: SNAT port utilization of Azure Firewall ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           AMBA threshold is 80%. Exhaustion causes outbound connection failures
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_front_door.conf
+++ b/src/health/health.d/azure_monitor_front_door.conf
@@ -1,0 +1,129 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Origin Health ---
+
+ template: am_front_door_origin_health
+       on: azure_monitor.front_door.origin_health
+    class: Availability
+     type: Web Server
+component: Azure Front Door
+   lookup: average -5m unaligned of health
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99) : (95))
+     crit: $this < (($status == $CRITICAL) ? (95) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Front Door origin health on ${label:resource_name}
+     info: Origin health percentage for Azure Front Door ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Low origin health indicates backends are failing health probes
+       to: sysadmin
+
+# --- Latency ---
+
+ template: am_front_door_total_latency
+       on: azure_monitor.front_door.latency
+    class: Latency
+     type: Web Server
+component: Azure Front Door
+   lookup: average -5m unaligned of total
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3000) : (4000))
+     crit: $this > (($status == $CRITICAL) ? (5000) : (8000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Front Door total latency on ${label:resource_name}
+     info: Average total request latency (client to Front Door to origin and back) \
+           for Azure Front Door ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_front_door_origin_latency
+       on: azure_monitor.front_door.latency
+    class: Latency
+     type: Web Server
+component: Azure Front Door
+   lookup: average -5m unaligned of origin
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Front Door origin latency on ${label:resource_name}
+     info: Average origin response latency for Azure Front Door ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High origin latency indicates slow backends
+       to: sysadmin
+
+# --- Error Rates ---
+
+ template: am_front_door_5xx_error_rate
+       on: azure_monitor.front_door.error_rate
+    class: Errors
+     type: Web Server
+component: Azure Front Door
+   lookup: average -5m unaligned of 5xx
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Front Door 5xx error rate on ${label:resource_name}
+     info: Percentage of requests resulting in 5xx server errors \
+           for Azure Front Door ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_front_door_4xx_error_rate
+       on: azure_monitor.front_door.error_rate
+    class: Errors
+     type: Web Server
+component: Azure Front Door
+   lookup: average -5m unaligned of 4xx
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (15) : (25))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Front Door 4xx error rate on ${label:resource_name}
+     info: Percentage of requests resulting in 4xx client errors \
+           for Azure Front Door ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Sustained high 4xx rates may indicate misconfigured routing or abusive clients
+       to: sysadmin
+
+# --- Cache Performance ---
+
+ template: am_front_door_byte_hit_ratio
+       on: azure_monitor.front_door.byte_hit_ratio
+    class: Utilization
+     type: Web Server
+component: Azure Front Door
+   lookup: average -10m unaligned of hit_ratio
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this < (($status >= $WARNING) ? (50) : (40))
+    delay: down 15m multiplier 1.5 max 1h
+  summary: Front Door cache hit ratio on ${label:resource_name}
+     info: Byte hit ratio (percentage of bytes served from cache) \
+           for Azure Front Door ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Low cache hit ratio means most traffic goes to origin, increasing latency and origin load
+       to: sysadmin
+
+# --- WAF ---
+
+ template: am_front_door_waf_rate_limited
+       on: azure_monitor.front_door.origin_shield_requests
+    class: Errors
+     type: Web Server
+component: Azure Front Door
+   lookup: average -5m unaligned of rate_limited
+    units: requests/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (50) : (100))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Front Door origin shield rate limiting on ${label:resource_name}
+     info: Rate of origin shield requests being rate limited \
+           for Azure Front Door ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_iot_hub.conf
+++ b/src/health/health.d/azure_monitor_iot_hub.conf
@@ -1,0 +1,313 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- D2C Telemetry Throttling ---
+
+ template: am_iot_hub_d2c_telemetry_throttle
+       on: azure_monitor.iot_hub.d2c_telemetry_throttle
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of throttled
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub telemetry throttling on ${label:resource_name}
+     info: Device-to-cloud telemetry throttling errors on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Throttling indicates the hub is exceeding its message rate limits
+       to: sysadmin
+
+# --- C2D Messages Expired ---
+
+ template: am_iot_hub_c2d_messages_expired
+       on: azure_monitor.iot_hub.c2d_messages_expired
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of expired
+    units: messages/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub C2D messages expiring on ${label:resource_name}
+     info: Cloud-to-device messages expiring before delivery on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Expired messages indicate devices are not receiving commands in time
+       to: sysadmin
+
+# --- C2D Direct Method Failures ---
+
+ template: am_iot_hub_c2d_methods_failed
+       on: azure_monitor.iot_hub.c2d_methods
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of failed
+    units: invocations/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub direct method failures on ${label:resource_name}
+     info: Failed cloud-to-device direct method invocations on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- C2D Twin Read Failures ---
+
+ template: am_iot_hub_c2d_twin_read_failures
+       on: azure_monitor.iot_hub.c2d_twin_reads
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of failed
+    units: operations/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub backend twin read failures on ${label:resource_name}
+     info: Failed backend twin read operations on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- C2D Twin Update Failures ---
+
+ template: am_iot_hub_c2d_twin_update_failures
+       on: azure_monitor.iot_hub.c2d_twin_updates
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of failed
+    units: operations/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub backend twin update failures on ${label:resource_name}
+     info: Failed backend twin update operations on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- D2C Twin Read Failures ---
+
+ template: am_iot_hub_d2c_twin_read_failures
+       on: azure_monitor.iot_hub.d2c_twin_reads
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of failed
+    units: operations/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub device twin read failures on ${label:resource_name}
+     info: Failed device-initiated twin read operations on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- D2C Twin Update Failures ---
+
+ template: am_iot_hub_d2c_twin_update_failures
+       on: azure_monitor.iot_hub.d2c_twin_updates
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of failed
+    units: operations/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub device twin update failures on ${label:resource_name}
+     info: Failed device-initiated twin update operations on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Routing Dropped Messages ---
+
+ template: am_iot_hub_routing_dropped
+       on: azure_monitor.iot_hub.routing_deliveries
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of dropped
+    units: messages/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub routing dropped messages on ${label:resource_name}
+     info: Messages dropped by the routing engine on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Dropped messages indicate dead endpoints or misconfigured routes
+       to: sysadmin
+
+# --- Routing Orphaned Messages ---
+
+ template: am_iot_hub_routing_orphaned
+       on: azure_monitor.iot_hub.routing_deliveries
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of orphaned
+    units: messages/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub routing orphaned messages on ${label:resource_name}
+     info: Orphaned messages with no matching routing rule on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Orphaned messages indicate missing or incomplete routing configuration
+       to: sysadmin
+
+# --- Routing Invalid Messages ---
+
+ template: am_iot_hub_routing_invalid
+       on: azure_monitor.iot_hub.routing_deliveries
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of invalid
+    units: messages/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub routing invalid messages on ${label:resource_name}
+     info: Invalid messages rejected by the routing engine on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Routing Latency ---
+
+ template: am_iot_hub_routing_latency
+       on: azure_monitor.iot_hub.routing_latency
+    class: Latency
+     type: Messaging
+component: IoT Hub
+   lookup: max -5m unaligned
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub routing latency on ${label:resource_name}
+     info: Maximum message routing latency across all endpoints on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Event Grid Latency ---
+
+ template: am_iot_hub_event_grid_latency
+       on: azure_monitor.iot_hub.event_grid_latency
+    class: Latency
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub Event Grid latency on ${label:resource_name}
+     info: Average Event Grid delivery latency on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Job Failures ---
+
+ template: am_iot_hub_jobs_failed
+       on: azure_monitor.iot_hub.jobs_status
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of failed
+    units: operations/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub job failures on ${label:resource_name}
+     info: Failed jobs on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Twin Query Failures ---
+
+ template: am_iot_hub_twin_query_failures
+       on: azure_monitor.iot_hub.twin_queries
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of failed
+    units: queries/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub twin query failures on ${label:resource_name}
+     info: Failed twin queries on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- C2D Commands Abandoned ---
+
+ template: am_iot_hub_c2d_commands_abandoned
+       on: azure_monitor.iot_hub.c2d_commands
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of abandoned
+    units: messages/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub C2D commands abandoned on ${label:resource_name}
+     info: Cloud-to-device commands abandoned by devices on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Abandoned commands indicate devices are not properly handling received messages
+       to: sysadmin
+
+# --- C2D Commands Rejected ---
+
+ template: am_iot_hub_c2d_commands_rejected
+       on: azure_monitor.iot_hub.c2d_commands
+    class: Errors
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of rejected
+    units: messages/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub C2D commands rejected on ${label:resource_name}
+     info: Cloud-to-device commands rejected by devices on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Rejected commands indicate devices are explicitly refusing messages
+       to: sysadmin
+
+# --- Routing Delivery Latency (Preview) ---
+
+ template: am_iot_hub_routing_delivery_latency_preview
+       on: azure_monitor.iot_hub.routing_delivery_latency_preview
+    class: Latency
+     type: Messaging
+component: IoT Hub
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (3000) : (5000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: IoT Hub routing delivery latency on ${label:resource_name}
+     info: Average routing delivery latency (preview metric) on IoT Hub ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_key_vault.conf
+++ b/src/health/health.d/azure_monitor_key_vault.conf
@@ -1,0 +1,58 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Availability ---
+
+ template: am_key_vault_availability
+       on: azure_monitor.key_vault.availability
+    class: Availability
+     type: Certificates
+component: Azure Key Vault
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99.9) : (99))
+     crit: $this < (($status == $CRITICAL) ? (99)   : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Key Vault availability on ${label:resource_name}
+     info: Overall vault availability of Azure Key Vault ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Azure SLA guarantees 99.99% availability
+       to: sysadmin
+
+# --- Latency ---
+
+ template: am_key_vault_api_latency
+       on: azure_monitor.key_vault.api_latency
+    class: Latency
+     type: Certificates
+component: Azure Key Vault
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (500)  : (1000))
+     crit: $this > (($status == $CRITICAL) ? (1000) : (2000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Key Vault API latency on ${label:resource_name}
+     info: Average API latency of Azure Key Vault ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High latency may indicate throttling or service degradation
+       to: sysadmin
+
+# --- Saturation ---
+
+ template: am_key_vault_saturation
+       on: azure_monitor.key_vault.saturation
+    class: Utilization
+     type: Certificates
+component: Azure Key Vault
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (60) : (75))
+     crit: $this > (($status == $CRITICAL) ? (75) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Key Vault saturation on ${label:resource_name}
+     info: Vault saturation of Azure Key Vault ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High saturation means the vault is approaching its transaction limits
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_load_balancers.conf
+++ b/src/health/health.d/azure_monitor_load_balancers.conf
@@ -1,0 +1,73 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Availability ---
+
+ template: am_load_balancers_vip_availability
+       on: azure_monitor.load_balancers.vip_availability
+    class: Availability
+     type: Other
+component: Azure Load Balancer
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99.9) : (99))
+     crit: $this < (($status == $CRITICAL) ? (99)   : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: LB data path availability on ${label:resource_name}
+     info: Data path availability of Azure Load Balancer ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Low values indicate the load balancer is unable to forward traffic
+       to: sysadmin
+
+ template: am_load_balancers_dip_availability
+       on: azure_monitor.load_balancers.dip_availability
+    class: Availability
+     type: Other
+component: Azure Load Balancer
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99.9) : (99))
+     crit: $this < (($status == $CRITICAL) ? (99)   : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: LB health probe status on ${label:resource_name}
+     info: Health probe availability of Azure Load Balancer ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Low values indicate backend instances are failing health probes
+       to: sysadmin
+
+ template: am_load_balancers_global_backend_availability
+       on: azure_monitor.load_balancers.global_backend_availability
+    class: Availability
+     type: Other
+component: Azure Load Balancer
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this < (($status >= $WARNING)  ? (99.9) : (99))
+     crit: $this != nan AND $this < (($status == $CRITICAL) ? (99)   : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: LB global backend availability on ${label:resource_name}
+     info: Global backend availability of Azure Load Balancer ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Applies to cross-region load balancers only
+       to: sysadmin
+
+# --- SNAT Port Exhaustion ---
+
+ template: am_load_balancers_snat_port_utilization
+       on: azure_monitor.load_balancers.snat_ports
+    class: Utilization
+     type: Other
+component: Azure Load Balancer
+     calc: ($allocated > 0) ? ($used * 100 / $allocated) : (0)
+    units: %
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: LB SNAT port utilization on ${label:resource_name}
+     info: Percentage of allocated SNAT ports in use on Azure Load Balancer ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           SNAT port exhaustion causes outbound connection failures
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_log_analytics.conf
+++ b/src/health/health.d/azure_monitor_log_analytics.conf
@@ -1,0 +1,293 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Workspace SLI: Availability ---
+
+# Query availability (0-100%). Low is bad.
+# Azure SLA: 99.9% for Log Analytics queries.
+
+ template: am_log_analytics_query_availability
+       on: azure_monitor.log_analytics.query_availability
+    class: Availability
+     type: Other
+component: Log Analytics
+   lookup: average -5m unaligned of availability
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99.9) : (99))
+     crit: $this < (($status == $CRITICAL) ? (99)   : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Log Analytics query availability on ${label:resource_name}
+     info: Query availability of Log Analytics workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Workspace SLI: Ingestion ---
+
+# Ingestion latency (seconds). High is bad.
+# AMBA: average ingestion latency > 300s (5 min) is concerning.
+
+ template: am_log_analytics_ingestion_latency
+       on: azure_monitor.log_analytics.ingestion_latency
+    class: Latency
+     type: Other
+component: Log Analytics
+   lookup: average -5m unaligned of average
+    units: seconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (180) : (300))
+     crit: $this > (($status == $CRITICAL) ? (300) : (600))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Log Analytics ingestion latency on ${label:resource_name}
+     info: Average data ingestion latency for Log Analytics workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High latency means data takes longer to become queryable.
+       to: sysadmin
+
+# --- User Queries: Failures ---
+
+# Helper: total query count over 5 minutes
+ template: am_log_analytics_query_total
+       on: azure_monitor.log_analytics.queries
+    class: Workload
+     type: Other
+component: Log Analytics
+   lookup: sum -5m unaligned of total
+    units: queries
+    every: 1m
+     info: Total queries on Log Analytics workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+
+# Query failure rate as percentage of total queries.
+# Any sustained query failures indicate workspace or query problems.
+
+ template: am_log_analytics_query_failure_rate
+       on: azure_monitor.log_analytics.queries
+    class: Errors
+     type: Other
+component: Log Analytics
+   lookup: sum -5m unaligned of failed
+     calc: ($am_log_analytics_query_total > 0) ? ($this * 100 / $am_log_analytics_query_total) : (0)
+    units: %
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (15))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Log Analytics query failures on ${label:resource_name}
+     info: Percentage of failed queries on Log Analytics workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Data Export ---
+
+# Export failures (rate). Any sustained export failures need attention.
+
+ template: am_log_analytics_export_failures
+       on: azure_monitor.log_analytics.export_failures
+    class: Errors
+     type: Other
+component: Log Analytics
+   lookup: average -5m unaligned of failed
+    units: exports/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Log Analytics export failures on ${label:resource_name}
+     info: Data export failure rate for Log Analytics workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Failures mean exported data is not reaching the destination.
+       to: sysadmin
+
+# --- Legacy Agent: CPU ---
+
+# CPU utilization from legacy Log Analytics agents.
+
+ template: am_log_analytics_legacy_cpu
+       on: azure_monitor.log_analytics.legacy_cpu_utilization
+    class: Utilization
+     type: Other
+component: Log Analytics
+   lookup: average -5m unaligned of processor
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Legacy agent CPU on ${label:resource_name}
+     info: Processor time reported by legacy Log Analytics agent on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Legacy Agent: Memory ---
+
+# Memory utilization from legacy Log Analytics agents. High is bad.
+
+ template: am_log_analytics_legacy_memory
+       on: azure_monitor.log_analytics.legacy_memory_utilization
+    class: Utilization
+     type: Other
+component: Log Analytics
+   lookup: average -5m unaligned of used
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Legacy agent memory on ${label:resource_name}
+     info: Memory utilization reported by legacy Log Analytics agent on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Legacy Agent: Swap ---
+
+# Swap utilization from legacy Log Analytics agents. High is bad.
+
+ template: am_log_analytics_legacy_swap
+       on: azure_monitor.log_analytics.legacy_swap_utilization
+    class: Utilization
+     type: Other
+component: Log Analytics
+   lookup: average -5m unaligned of used
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (50) : (70))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (70) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Legacy agent swap usage on ${label:resource_name}
+     info: Swap utilization reported by legacy Log Analytics agent on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Legacy Agent: Disk Space ---
+
+# Disk space utilization from legacy Log Analytics agents. High is bad.
+
+ template: am_log_analytics_legacy_disk_space
+       on: azure_monitor.log_analytics.legacy_disk_space_utilization
+    class: Utilization
+     type: Other
+component: Log Analytics
+   lookup: average -5m unaligned of used
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (85))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Legacy agent disk space on ${label:resource_name}
+     info: Disk space utilization reported by legacy Log Analytics agent on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Legacy Agent: Disk Inodes ---
+
+# Inode utilization from legacy Log Analytics agents. High is bad.
+
+ template: am_log_analytics_legacy_disk_inodes
+       on: azure_monitor.log_analytics.legacy_disk_inodes
+    class: Utilization
+     type: Other
+component: Log Analytics
+   lookup: average -5m unaligned of used
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (85))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Legacy agent inode usage on ${label:resource_name}
+     info: Inode utilization reported by legacy Log Analytics agent on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Legacy Agent: Disk I/O Latency ---
+
+# Disk I/O latency from legacy Log Analytics agents. High is bad.
+# Read and write latency in seconds per operation.
+
+ template: am_log_analytics_legacy_disk_read_latency
+       on: azure_monitor.log_analytics.legacy_disk_io_latency
+    class: Latency
+     type: Other
+component: Log Analytics
+   lookup: average -5m unaligned of read
+    units: seconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (0.05) : (0.1))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (0.1)  : (0.5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Legacy agent disk read latency on ${label:resource_name}
+     info: Average disk read latency reported by legacy Log Analytics agent on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_log_analytics_legacy_disk_write_latency
+       on: azure_monitor.log_analytics.legacy_disk_io_latency
+    class: Latency
+     type: Other
+component: Log Analytics
+   lookup: average -5m unaligned of write
+    units: seconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (0.05) : (0.1))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (0.1)  : (0.5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Legacy agent disk write latency on ${label:resource_name}
+     info: Average disk write latency reported by legacy Log Analytics agent on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Legacy Agent: Disk Queue ---
+
+# Disk queue length from legacy Log Analytics agents. High means I/O saturation.
+
+ template: am_log_analytics_legacy_disk_queue
+       on: azure_monitor.log_analytics.legacy_disk_queue
+    class: Workload
+     type: Other
+component: Log Analytics
+   lookup: average -5m unaligned of queue_length
+    units: operations
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (2) : (5))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Legacy agent disk queue on ${label:resource_name}
+     info: Current disk queue length reported by legacy Log Analytics agent on ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High queue length indicates I/O saturation.
+       to: sysadmin
+
+# --- Legacy Agent: Network Errors ---
+
+# Network errors from legacy Log Analytics agents.
+
+ template: am_log_analytics_legacy_network_rx_errors
+       on: azure_monitor.log_analytics.legacy_network_errors
+    class: Errors
+     type: Other
+component: Log Analytics
+   lookup: average -5m unaligned of rx
+    units: errors
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (5)  : (10))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Legacy agent network RX errors on ${label:resource_name}
+     info: Network receive errors reported by legacy Log Analytics agent on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_log_analytics_legacy_network_tx_errors
+       on: azure_monitor.log_analytics.legacy_network_errors
+    class: Errors
+     type: Other
+component: Log Analytics
+   lookup: average -5m unaligned of tx
+    units: errors
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (5)  : (10))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Legacy agent network TX errors on ${label:resource_name}
+     info: Network transmit errors reported by legacy Log Analytics agent on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_logic_apps.conf
+++ b/src/health/health.d/azure_monitor_logic_apps.conf
@@ -1,0 +1,248 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Run Failure Rate ---
+
+# Run failure percentage (0-100%). High is bad.
+# AMBA: RunFailurePercentage > 0 is Sev1
+
+ template: am_logic_apps_run_failure_rate
+       on: azure_monitor.logic_apps.run_failure_rate
+    class: Errors
+     type: Other
+component: Logic Apps
+   lookup: average -5m unaligned of failure_rate
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Logic Apps run failure rate on ${label:resource_name}
+     info: Percentage of workflow runs failing on Logic App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Run Failures (absolute count) ---
+
+# Failed runs rate. Any sustained failures need attention.
+
+ template: am_logic_apps_runs_failed
+       on: azure_monitor.logic_apps.run_lifecycle
+    class: Errors
+     type: Other
+component: Logic Apps
+   lookup: average -5m unaligned of failed
+    units: runs/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Logic Apps failed runs on ${label:resource_name}
+     info: Rate of failed workflow runs on Logic App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Run Latency ---
+
+# Overall run latency (seconds). High latency indicates slow workflows.
+
+ template: am_logic_apps_run_latency
+       on: azure_monitor.logic_apps.run_latency
+    class: Latency
+     type: Other
+component: Logic Apps
+   lookup: average -5m unaligned of all
+    units: seconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (30) : (60))
+     crit: $this > (($status == $CRITICAL) ? (60) : (120))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Logic Apps run latency on ${label:resource_name}
+     info: Average workflow run latency on Logic App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Run Throttling ---
+
+# Throttled run events indicate the workflow is hitting
+# Azure rate limits.
+
+ template: am_logic_apps_run_throttled
+       on: azure_monitor.logic_apps.run_throttling
+    class: Errors
+     type: Other
+component: Logic Apps
+   lookup: average -5m unaligned
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Logic Apps run throttling on ${label:resource_name}
+     info: Rate of throttled run events on Logic App ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Throttling indicates Azure rate limits are being hit
+       to: sysadmin
+
+# --- Action Failures ---
+
+# Failed actions rate. Failing actions cause workflow failures.
+
+ template: am_logic_apps_actions_failed
+       on: azure_monitor.logic_apps.action_lifecycle
+    class: Errors
+     type: Other
+component: Logic Apps
+   lookup: average -5m unaligned of failed
+    units: actions/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Logic Apps failed actions on ${label:resource_name}
+     info: Rate of failed actions on Logic App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Action Latency ---
+
+# Average action latency. High values indicate slow connectors
+# or backend dependencies.
+
+ template: am_logic_apps_action_latency
+       on: azure_monitor.logic_apps.action_latency
+    class: Latency
+     type: Other
+component: Logic Apps
+   lookup: average -5m unaligned of all
+    units: seconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (15) : (30))
+     crit: $this > (($status == $CRITICAL) ? (30) : (60))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Logic Apps action latency on ${label:resource_name}
+     info: Average action latency on Logic App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Action Throttling ---
+
+# Throttled action events indicate connectors or actions
+# are hitting Azure rate limits.
+
+ template: am_logic_apps_action_throttled
+       on: azure_monitor.logic_apps.action_throttling
+    class: Errors
+     type: Other
+component: Logic Apps
+   lookup: average -5m unaligned of total
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Logic Apps action throttling on ${label:resource_name}
+     info: Rate of throttled action events on Logic App ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Throttling indicates connector rate limits are being hit
+       to: sysadmin
+
+# --- Trigger Failures ---
+
+# Failed triggers prevent workflows from starting.
+
+ template: am_logic_apps_triggers_failed
+       on: azure_monitor.logic_apps.trigger_lifecycle
+    class: Errors
+     type: Other
+component: Logic Apps
+   lookup: average -5m unaligned of failed
+    units: triggers/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Logic Apps failed triggers on ${label:resource_name}
+     info: Rate of failed triggers on Logic App ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Failed triggers prevent workflows from executing
+       to: sysadmin
+
+# --- Trigger Latency ---
+
+# Overall trigger latency. High values indicate slow polling
+# or webhook delays.
+
+ template: am_logic_apps_trigger_latency
+       on: azure_monitor.logic_apps.trigger_latency
+    class: Latency
+     type: Other
+component: Logic Apps
+   lookup: average -5m unaligned of all
+    units: seconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (15) : (30))
+     crit: $this > (($status == $CRITICAL) ? (30) : (60))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Logic Apps trigger latency on ${label:resource_name}
+     info: Average trigger latency on Logic App ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Trigger Throttling ---
+
+# Throttled trigger events indicate polling or webhook triggers
+# are hitting Azure rate limits.
+
+ template: am_logic_apps_trigger_throttled
+       on: azure_monitor.logic_apps.trigger_throttling
+    class: Errors
+     type: Other
+component: Logic Apps
+   lookup: average -5m unaligned of total
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Logic Apps trigger throttling on ${label:resource_name}
+     info: Rate of throttled trigger events on Logic App ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Throttling indicates trigger rate limits are being hit
+       to: sysadmin
+
+# --- AI Agent Token Overflow ---
+
+# Completion token overflow events indicate AI agent responses
+# are exceeding token limits (AI-enabled Logic Apps only).
+
+ template: am_logic_apps_completion_token_overflow
+       on: azure_monitor.logic_apps.agent
+    class: Errors
+     type: Other
+component: Logic Apps
+   lookup: average -5m unaligned of completion_overflow
+    units: events/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Logic Apps completion token overflow on ${label:resource_name}
+     info: Rate of completion token overflow events on Logic App ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Indicates AI agent responses are exceeding token limits
+       to: sysadmin
+
+# Prompt token overflow events indicate AI agent prompts
+# are exceeding token limits (AI-enabled Logic Apps only).
+
+ template: am_logic_apps_prompt_token_overflow
+       on: azure_monitor.logic_apps.agent
+    class: Errors
+     type: Other
+component: Logic Apps
+   lookup: average -5m unaligned of prompt_overflow
+    units: events/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Logic Apps prompt token overflow on ${label:resource_name}
+     info: Rate of prompt token overflow events on Logic App ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Indicates AI agent prompts are exceeding token limits
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_machine_learning.conf
+++ b/src/health/health.d/azure_monitor_machine_learning.conf
@@ -1,0 +1,284 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Quota ---
+
+ template: am_ml_quota_utilization
+       on: azure_monitor.machine_learning.quota_utilization
+    class: Utilization
+     type: Other
+component: Azure ML
+   lookup: average -5m unaligned of utilization
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML quota utilization on ${label:resource_name}
+     info: Average compute quota utilization on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High quota utilization may prevent new jobs from starting.
+       to: sysadmin
+
+# --- Cluster Cores ---
+
+ template: am_ml_unusable_cores
+       on: azure_monitor.machine_learning.cluster_cores
+    class: Errors
+     type: Other
+component: Azure ML
+   lookup: average -5m unaligned of unusable
+    units: cores
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (2))
+     crit: $this > (($status == $CRITICAL) ? (2) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML unusable cores on ${label:resource_name}
+     info: Number of unusable compute cores on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Unusable cores indicate hardware or configuration failures.
+       to: sysadmin
+
+ template: am_ml_preempted_cores
+       on: azure_monitor.machine_learning.cluster_cores
+    class: Workload
+     type: Other
+component: Azure ML
+   lookup: average -5m unaligned of preempted
+    units: cores
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML preempted cores on ${label:resource_name}
+     info: Number of preempted compute cores on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Preempted cores may cause training job interruptions.
+       to: sysadmin
+
+# --- Cluster Nodes ---
+
+ template: am_ml_unusable_nodes
+       on: azure_monitor.machine_learning.cluster_nodes
+    class: Errors
+     type: Other
+component: Azure ML
+   lookup: average -5m unaligned of unusable
+    units: nodes
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML unusable nodes on ${label:resource_name}
+     info: Number of unusable compute nodes on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Unusable nodes indicate hardware or configuration failures.
+       to: sysadmin
+
+# --- CPU Utilization ---
+
+ template: am_ml_cpu_utilization
+       on: azure_monitor.machine_learning.cpu_utilization
+    class: Utilization
+     type: Other
+component: Azure ML
+   lookup: average -5m unaligned of cluster_cpu
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML CPU utilization on ${label:resource_name}
+     info: Average cluster CPU utilization on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- CPU Memory Utilization ---
+
+ template: am_ml_cpu_memory_utilization
+       on: azure_monitor.machine_learning.cpu_memory_utilization
+    class: Utilization
+     type: Other
+component: Azure ML
+   lookup: average -5m unaligned of utilization
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML CPU memory utilization on ${label:resource_name}
+     info: Average CPU memory utilization on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- GPU Utilization ---
+
+ template: am_ml_gpu_utilization
+       on: azure_monitor.machine_learning.gpu_utilization
+    class: Utilization
+     type: Other
+component: Azure ML
+   lookup: average -5m unaligned of cluster_gpu
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (85) : (95))
+     crit: $this > (($status == $CRITICAL) ? (95) : (99))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML GPU utilization on ${label:resource_name}
+     info: Average cluster GPU utilization on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- GPU Memory Utilization ---
+
+ template: am_ml_gpu_memory_utilization
+       on: azure_monitor.machine_learning.gpu_memory_utilization
+    class: Utilization
+     type: Other
+component: Azure ML
+   lookup: average -5m unaligned of cluster_gpu_memory
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML GPU memory utilization on ${label:resource_name}
+     info: Average cluster GPU memory utilization on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High GPU memory usage may cause out-of-memory training failures.
+       to: sysadmin
+
+# --- Disk Usage ---
+
+ template: am_ml_disk_utilization
+       on: azure_monitor.machine_learning.disk_usage
+    class: Utilization
+     type: Other
+component: Azure ML
+     calc: ($used + $available > 0) ? ($used * 100 / ($used + $available)) : (0)
+    units: %
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML disk utilization on ${label:resource_name}
+     info: Disk utilization percentage on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High disk usage can cause training job failures.
+       to: sysadmin
+
+# --- Model Deployments ---
+
+ template: am_ml_model_deploy_failures
+       on: azure_monitor.machine_learning.model_deployments
+    class: Errors
+     type: Other
+component: Azure ML
+   lookup: sum -5m unaligned of failed
+    units: deployments
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML model deployment failures on ${label:resource_name}
+     info: Number of failed model deployments over the last 5 minutes on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Model Registrations ---
+
+ template: am_ml_model_register_failures
+       on: azure_monitor.machine_learning.model_registrations
+    class: Errors
+     type: Other
+component: Azure ML
+   lookup: sum -5m unaligned of failed
+    units: registrations
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML model registration failures on ${label:resource_name}
+     info: Number of failed model registrations over the last 5 minutes on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Run Completion ---
+
+ template: am_ml_failed_runs
+       on: azure_monitor.machine_learning.run_completion
+    class: Errors
+     type: Other
+component: Azure ML
+   lookup: sum -5m unaligned of failed
+    units: runs
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (3))
+     crit: $this > (($status == $CRITICAL) ? (3) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML failed runs on ${label:resource_name}
+     info: Number of failed training/experiment runs over the last 5 minutes on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_ml_not_responding_runs
+       on: azure_monitor.machine_learning.run_completion
+    class: Availability
+     type: Other
+component: Azure ML
+   lookup: sum -5m unaligned of not_responding
+    units: runs
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML not-responding runs on ${label:resource_name}
+     info: Number of runs that stopped responding over the last 5 minutes on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Not-responding runs indicate compute or infrastructure issues.
+       to: sysadmin
+
+# --- Run Issues ---
+
+ template: am_ml_run_errors
+       on: azure_monitor.machine_learning.run_issues
+    class: Errors
+     type: Other
+component: Azure ML
+   lookup: sum -5m unaligned of errors
+    units: errors
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML run errors on ${label:resource_name}
+     info: Number of run errors over the last 5 minutes on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Storage API ---
+
+ template: am_ml_storage_api_total
+       on: azure_monitor.machine_learning.storage_api_calls
+    class: Workload
+     type: Other
+component: Azure ML
+   lookup: sum -5m unaligned of success,failure
+    units: calls
+    every: 1m
+     info: Total storage API calls over the last 5 minutes on Azure ML workspace ${label:resource_name}
+
+ template: am_ml_storage_api_failures
+       on: azure_monitor.machine_learning.storage_api_calls
+    class: Errors
+     type: Other
+component: Azure ML
+   lookup: sum -5m unaligned of failure
+     calc: ($am_ml_storage_api_total > 10) ? ($this * 100 / $am_ml_storage_api_total) : (0)
+    units: %
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (15))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ML storage API failure rate on ${label:resource_name}
+     info: Percentage of failed storage API calls over the last 5 minutes on Azure ML workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_mysql_flexible.conf
+++ b/src/health/health.d/azure_monitor_mysql_flexible.conf
@@ -1,0 +1,329 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Utilization ---
+
+ template: am_mysql_flexible_cpu
+       on: azure_monitor.mysql_flexible.cpu
+    class: Utilization
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible CPU on ${label:resource_name}
+     info: Average CPU utilization on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+ template: am_mysql_flexible_memory
+       on: azure_monitor.mysql_flexible.memory
+    class: Utilization
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible memory on ${label:resource_name}
+     info: Average memory utilization on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+ template: am_mysql_flexible_io_utilization
+       on: azure_monitor.mysql_flexible.io_utilization
+    class: Utilization
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible I/O utilization on ${label:resource_name}
+     info: Average storage I/O utilization on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Sustained high I/O can cause query performance degradation
+       to: dba
+
+ template: am_mysql_flexible_storage_utilization
+       on: azure_monitor.mysql_flexible.storage_utilization
+    class: Utilization
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (80))
+     crit: $this > (($status == $CRITICAL) ? (85) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible storage on ${label:resource_name}
+     info: Storage utilization on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           When storage reaches 100% the server becomes read-only
+       to: dba
+
+ template: am_mysql_flexible_serverlog_storage_utilization
+       on: azure_monitor.mysql_flexible.serverlog_storage_utilization
+    class: Utilization
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible server log storage on ${label:resource_name}
+     info: Server log storage utilization on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+ template: am_mysql_flexible_cpu_credits_remaining
+       on: azure_monitor.mysql_flexible.cpu_credits
+    class: Utilization
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of remaining
+    units: credits
+    every: 1m
+     warn: $this != nan AND $this < (($status >= $WARNING) ? (30) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible CPU credits low on ${label:resource_name}
+     info: Remaining CPU credits on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only applicable to burstable tier; exhaustion causes CPU throttling
+       to: dba
+
+# --- Availability ---
+
+ template: am_mysql_flexible_ha_io_status
+       on: azure_monitor.mysql_flexible.ha_status
+    class: Availability
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of io
+    units: status
+    every: 1m
+     crit: $this != nan AND $this < 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible HA IO thread down on ${label:resource_name}
+     info: HA replication IO thread is not running on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant when high availability is configured
+       to: dba
+
+ template: am_mysql_flexible_ha_sql_status
+       on: azure_monitor.mysql_flexible.ha_status
+    class: Availability
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of sql
+    units: status
+    every: 1m
+     crit: $this != nan AND $this < 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible HA SQL thread down on ${label:resource_name}
+     info: HA replication SQL thread is not running on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant when high availability is configured
+       to: dba
+
+ template: am_mysql_flexible_replica_io_status
+       on: azure_monitor.mysql_flexible.replica_status
+    class: Availability
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of io
+    units: status
+    every: 1m
+     crit: $this != nan AND $this < 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible replica IO thread down on ${label:resource_name}
+     info: Read replica IO thread is not running on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant when read replicas are configured
+       to: dba
+
+ template: am_mysql_flexible_replica_sql_status
+       on: azure_monitor.mysql_flexible.replica_status
+    class: Availability
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of sql
+    units: status
+    every: 1m
+     crit: $this != nan AND $this < 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible replica SQL thread down on ${label:resource_name}
+     info: Read replica SQL thread is not running on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant when read replicas are configured
+       to: dba
+
+# --- Replication ---
+
+ template: am_mysql_flexible_replication_lag
+       on: azure_monitor.mysql_flexible.replication_lag
+    class: Latency
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of replica
+    units: seconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (20) : (30))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (30) : (60))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible replica lag on ${label:resource_name}
+     info: Read replica replication lag on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant when read replicas are configured
+       to: dba
+
+ template: am_mysql_flexible_ha_replication_lag
+       on: azure_monitor.mysql_flexible.replication_lag
+    class: Latency
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of ha
+    units: seconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (10) : (20))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (20) : (30))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible HA replication lag on ${label:resource_name}
+     info: HA standby replication lag on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High lag increases data loss risk during failover. \
+           Only relevant when high availability is configured
+       to: dba
+
+# --- Latency / Contention ---
+
+ template: am_mysql_flexible_innodb_row_lock_time
+       on: azure_monitor.mysql_flexible.innodb_row_lock_time
+    class: Latency
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (200) : (500))
+     crit: $this > (($status == $CRITICAL) ? (500) : (1000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible row lock wait time on ${label:resource_name}
+     info: Average InnoDB row lock wait time on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High values indicate significant lock contention between transactions
+       to: dba
+
+ template: am_mysql_flexible_lock_deadlocks
+       on: azure_monitor.mysql_flexible.lock_deadlocks
+    class: Errors
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of total
+    units: deadlocks/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible deadlocks on ${label:resource_name}
+     info: Rate of InnoDB deadlocks on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Deadlocks cause transactions to be rolled back
+       to: dba
+
+ template: am_mysql_flexible_lock_timeouts
+       on: azure_monitor.mysql_flexible.lock_timeouts
+    class: Errors
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of total
+    units: timeouts/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible lock timeouts on ${label:resource_name}
+     info: Rate of lock wait timeouts on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Timeouts indicate long-held locks blocking other transactions
+       to: dba
+
+# --- Errors ---
+
+ template: am_mysql_flexible_aborted_connections
+       on: azure_monitor.mysql_flexible.aborted_connections
+    class: Errors
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of total
+    units: connections/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (3) : (5))
+     crit: $this > (($status == $CRITICAL) ? (10) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible aborted connections on ${label:resource_name}
+     info: Rate of aborted connections on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Common causes include authentication failures, connection timeouts, and client errors
+       to: dba
+
+# --- Performance ---
+
+ template: am_mysql_flexible_slow_queries
+       on: azure_monitor.mysql_flexible.queries
+    class: Workload
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of slow
+    units: queries/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (5) : (10))
+     crit: $this > (($status == $CRITICAL) ? (10) : (25))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible slow queries on ${label:resource_name}
+     info: Rate of slow queries on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Review slow query log for optimization opportunities
+       to: dba
+
+ template: am_mysql_flexible_innodb_row_lock_waits
+       on: azure_monitor.mysql_flexible.innodb_row_lock_waits
+    class: Latency
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of total
+    units: waits/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (50) : (100))
+     crit: $this > (($status == $CRITICAL) ? (100) : (200))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible row lock waits on ${label:resource_name}
+     info: Rate of InnoDB row lock waits on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High lock waits degrade query throughput and increase response times
+       to: dba
+
+ template: am_mysql_flexible_history_list_length
+       on: azure_monitor.mysql_flexible.history_list_length
+    class: Utilization
+     type: Database
+component: Azure MySQL Flexible
+   lookup: average -5m unaligned of maximum
+    units: entries
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (50000) : (100000))
+     crit: $this > (($status == $CRITICAL) ? (100000) : (1000000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MySQL Flexible history list length on ${label:resource_name}
+     info: InnoDB history list length (undo log entries) on Azure MySQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           A growing history list indicates long-running transactions preventing purge
+       to: dba

--- a/src/health/health.d/azure_monitor_nat_gateway.conf
+++ b/src/health/health.d/azure_monitor_nat_gateway.conf
@@ -1,0 +1,86 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Availability ---
+
+# AMBA Sev4: DatapathAvailability < 90% (30m window)
+# NAT Gateway datapath availability below 100% means the service is degraded.
+# Below 90% indicates significant packet loss through the gateway.
+
+ template: am_nat_gateway_datapath_availability
+       on: azure_monitor.nat_gateway.datapath_availability
+    class: Availability
+     type: Other
+component: Azure NAT Gateway
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99) : (95))
+     crit: $this < (($status == $CRITICAL) ? (95) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: NAT Gateway availability on ${label:resource_name}
+     info: Datapath availability of NAT Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Values below 100% indicate packet loss through the gateway.
+       to: sysadmin
+
+# --- Errors ---
+
+# AMBA Sev1 (Critical): PacketDropCount > 5 packets/s (5m window)
+# Dropped packets indicate SNAT port exhaustion, flow timeouts, or
+# exceeding the connection limit of the NAT gateway.
+
+ template: am_nat_gateway_dropped_packets
+       on: azure_monitor.nat_gateway.dropped_packets
+    class: Errors
+     type: Other
+component: Azure NAT Gateway
+   lookup: average -5m unaligned of total
+    units: packets/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: NAT Gateway packet drops on ${label:resource_name}
+     info: Packets being dropped by NAT Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Drops indicate SNAT port exhaustion or connection limit reached.
+       to: sysadmin
+
+# --- Connections ---
+
+# Azure NAT Gateway supports up to 2 million total SNAT connections.
+# Azure recommends alerting at 80% (1.6M). We warn at 60% (1.2M).
+
+ template: am_nat_gateway_snat_connections
+       on: azure_monitor.nat_gateway.snat_connections
+    class: Utilization
+     type: Other
+component: Azure NAT Gateway
+   lookup: average -5m unaligned of total
+    units: connections
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1000000) : (1200000))
+     crit: $this > (($status == $CRITICAL) ? (1200000) : (1600000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: NAT Gateway SNAT connections on ${label:resource_name}
+     info: SNAT connection count on NAT Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Azure limit is 2 million connections per gateway.
+       to: sysadmin
+
+ template: am_nat_gateway_total_connections
+       on: azure_monitor.nat_gateway.total_connections
+    class: Utilization
+     type: Other
+component: Azure NAT Gateway
+   lookup: average -5m unaligned of total
+    units: connections
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1000000) : (1200000))
+     crit: $this > (($status == $CRITICAL) ? (1200000) : (1600000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: NAT Gateway total connections on ${label:resource_name}
+     info: Total SNAT connection count on NAT Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Azure limit is 2 million connections per gateway.
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_postgres_flexible.conf
+++ b/src/health/health.d/azure_monitor_postgres_flexible.conf
@@ -1,0 +1,344 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Availability ---
+
+ template: am_postgres_flexible_availability
+       on: azure_monitor.postgres_flexible.availability
+    class: Availability
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of maximum
+    units: state
+    every: 1m
+     crit: $this < 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible Server down on ${label:resource_name}
+     info: Database is not alive on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- Utilization ---
+
+ template: am_postgres_flexible_cpu
+       on: azure_monitor.postgres_flexible.cpu
+    class: Utilization
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible CPU on ${label:resource_name}
+     info: Average CPU utilization on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+ template: am_postgres_flexible_memory
+       on: azure_monitor.postgres_flexible.memory
+    class: Utilization
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible memory on ${label:resource_name}
+     info: Average memory utilization on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- Storage ---
+
+ template: am_postgres_flexible_storage_utilization
+       on: azure_monitor.postgres_flexible.storage_utilization
+    class: Utilization
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible storage on ${label:resource_name}
+     info: Storage utilization on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Running out of storage causes the server to become read-only
+       to: dba
+
+# --- I/O ---
+
+ template: am_postgres_flexible_disk_bandwidth_saturation
+       on: azure_monitor.postgres_flexible.disk_saturation
+    class: Utilization
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible disk bandwidth saturation on ${label:resource_name}
+     info: Disk bandwidth consumed percentage on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Sustained high values indicate I/O throttling
+       to: dba
+
+ template: am_postgres_flexible_disk_iops_saturation
+       on: azure_monitor.postgres_flexible.disk_saturation
+    class: Utilization
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of iops
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible disk IOPS saturation on ${label:resource_name}
+     info: Disk IOPS consumed percentage on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Sustained high values indicate I/O throttling
+       to: dba
+
+ template: am_postgres_flexible_disk_queue_depth
+       on: azure_monitor.postgres_flexible.disk_queue_depth
+    class: Workload
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of average
+    units: operations
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (32) : (64))
+     crit: $this > (($status == $CRITICAL) ? (64) : (128))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible disk queue depth on ${label:resource_name}
+     info: Disk queue depth on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High queue depth indicates I/O subsystem is saturated
+       to: dba
+
+# --- Connections ---
+
+ template: am_postgres_flexible_failed_connections
+       on: azure_monitor.postgres_flexible.connection_rate
+    class: Errors
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of failed
+    units: connections/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible failed connections on ${label:resource_name}
+     info: Rate of failed connection attempts on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           May indicate authentication failures, connection limit exhaustion, or network issues
+       to: dba
+
+ template: am_postgres_flexible_tcp_connection_backlog
+       on: azure_monitor.postgres_flexible.tcp_connection_backlog
+    class: Workload
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of maximum
+    units: connections
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (50) : (100))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (100) : (200))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible TCP connection backlog on ${label:resource_name}
+     info: TCP connection backlog on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High backlog indicates the server cannot accept connections fast enough
+       to: dba
+
+# --- Transactions ---
+
+ template: am_postgres_flexible_deadlocks
+       on: azure_monitor.postgres_flexible.deadlocks
+    class: Errors
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of total
+    units: deadlocks/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible deadlocks on ${label:resource_name}
+     info: Deadlock rate on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Deadlocks indicate conflicting lock acquisition patterns in concurrent transactions
+       to: dba
+
+ template: am_postgres_flexible_rollback_ratio
+       on: azure_monitor.postgres_flexible.transactions
+    class: Errors
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: sum -5m unaligned of committed,rolled_back
+     calc: ($this > 100) ? ($rolled_back * 100 / $this) : (0)
+    units: %
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (3) : (5))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (10) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible rollback ratio on ${label:resource_name}
+     info: Percentage of rolled back transactions on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High rollback rates indicate application errors or excessive contention
+       to: dba
+
+# --- Latency / Long Running ---
+
+ template: am_postgres_flexible_longest_query
+       on: azure_monitor.postgres_flexible.long_running
+    class: Latency
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: max -5m unaligned of query
+    units: seconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (300) : (600))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (600) : (1800))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible long running query on ${label:resource_name}
+     info: Longest running query duration on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Long running queries can hold locks and bloat WAL
+       to: dba
+
+ template: am_postgres_flexible_longest_transaction
+       on: azure_monitor.postgres_flexible.long_running
+    class: Latency
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: max -5m unaligned of transaction
+    units: seconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (300) : (600))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (600) : (1800))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible long running transaction on ${label:resource_name}
+     info: Longest running transaction duration on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Long running transactions prevent autovacuum from reclaiming dead tuples
+       to: dba
+
+# --- Safety (Transaction ID wraparound) ---
+
+ template: am_postgres_flexible_xid_usage
+       on: azure_monitor.postgres_flexible.xid_usage
+    class: Utilization
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of max_used
+    units: transactions
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (500000000) : (1000000000))
+     crit: $this > (($status == $CRITICAL) ? (1000000000) : (1500000000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible transaction ID usage on ${label:resource_name}
+     info: Maximum used transaction IDs on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           PostgreSQL wraps around at ~2.1 billion XIDs. High values require urgent VACUUM FREEZE
+       to: dba
+
+ template: am_postgres_flexible_xmin_age
+       on: azure_monitor.postgres_flexible.xmin_age
+    class: Utilization
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of maximum
+    units: transactions
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (200000000) : (500000000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (500000000) : (1000000000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible backend xmin age on ${label:resource_name}
+     info: Oldest backend xmin age on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           A large xmin age prevents autovacuum from cleaning dead tuples and increases XID wraparound risk
+       to: dba
+
+# --- Bloat ---
+
+ template: am_postgres_flexible_bloat
+       on: azure_monitor.postgres_flexible.bloat
+    class: Utilization
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of maximum
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (40) : (50))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (60) : (70))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible table bloat on ${label:resource_name}
+     info: Table bloat percentage on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High bloat wastes storage and degrades query performance. Consider running VACUUM FULL
+       to: dba
+
+# --- Replication ---
+
+ template: am_postgres_flexible_replication_lag
+       on: azure_monitor.postgres_flexible.replication_lag_time
+    class: Latency
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of average
+    units: seconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (10) : (30))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (30) : (60))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible replication lag on ${label:resource_name}
+     info: Physical replication lag on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High lag means replicas serve stale data
+       to: dba
+
+# --- CPU Credits (burstable tiers) ---
+
+ template: am_postgres_flexible_cpu_credits_remaining
+       on: azure_monitor.postgres_flexible.cpu_credits
+    class: Utilization
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of remaining
+    units: credits
+    every: 1m
+     warn: $this != nan AND $this < (($status >= $WARNING)  ? (30) : (20))
+     crit: $this != nan AND $this < (($status == $CRITICAL) ? (20) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible CPU credits low on ${label:resource_name}
+     info: Remaining CPU credits on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only applicable to burstable tiers. When credits are exhausted, CPU is capped at baseline
+       to: dba
+
+# --- Temp Files ---
+
+ template: am_postgres_flexible_temp_bytes
+       on: azure_monitor.postgres_flexible.temp_bytes
+    class: Workload
+     type: Database
+component: Azure PostgreSQL Flexible
+   lookup: average -5m unaligned of total
+    units: bytes/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (52428800) : (104857600))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (104857600) : (209715200))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: PostgreSQL Flexible temp file I/O on ${label:resource_name}
+     info: Rate of temporary file bytes written on Azure PostgreSQL Flexible Server ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Excessive temp file usage indicates queries spilling to disk due to insufficient work_mem
+       to: dba

--- a/src/health/health.d/azure_monitor_redis_cache.conf
+++ b/src/health/health.d/azure_monitor_redis_cache.conf
@@ -1,0 +1,206 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Server Load ---
+
+ template: am_redis_cache_server_load
+       on: azure_monitor.redis_cache.server_load
+    class: Utilization
+     type: Database
+component: Azure Redis
+   lookup: average -5m unaligned of maximum
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Redis server load on ${label:resource_name}
+     info: Maximum server load on Azure Cache for Redis ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Sustained high server load causes timeouts and increased latency
+       to: dba
+
+# --- CPU ---
+
+ template: am_redis_cache_cpu
+       on: azure_monitor.redis_cache.cpu
+    class: Utilization
+     type: Database
+component: Azure Redis
+   lookup: average -5m unaligned of maximum
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Redis CPU on ${label:resource_name}
+     info: Maximum CPU utilization on Azure Cache for Redis ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- Memory Utilization ---
+
+ template: am_redis_cache_memory_utilization
+       on: azure_monitor.redis_cache.memory_utilization
+    class: Utilization
+     type: Database
+component: Azure Redis
+   lookup: average -5m unaligned of maximum
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Redis memory utilization on ${label:resource_name}
+     info: Maximum memory utilization on Azure Cache for Redis ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High memory causes evictions and potential data loss
+       to: dba
+
+# --- Cache Miss Rate ---
+
+ template: am_redis_cache_miss_rate
+       on: azure_monitor.redis_cache.miss_rate
+    class: Utilization
+     type: Database
+component: Azure Redis
+   lookup: average -10m unaligned of miss_rate
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (40) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Redis cache miss rate on ${label:resource_name}
+     info: Cache miss rate on Azure Cache for Redis ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High miss rates indicate the cache is not effectively serving requests
+       to: dba
+
+# --- Errors ---
+
+ template: am_redis_cache_errors
+       on: azure_monitor.redis_cache.errors
+    class: Errors
+     type: Database
+component: Azure Redis
+   lookup: average -5m unaligned of maximum
+    units: errors
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (5))
+     crit: $this > (($status == $CRITICAL) ? (5) : (20))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Redis errors on ${label:resource_name}
+     info: Errors on Azure Cache for Redis ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Includes authentication failures, maxmemory errors, and connection issues
+       to: dba
+
+# --- Latency (average) ---
+
+ template: am_redis_cache_latency
+       on: azure_monitor.redis_cache.latency
+    class: Latency
+     type: Database
+component: Azure Redis
+   lookup: average -5m unaligned of average
+    units: microseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (5000) : (10000))
+     crit: $this > (($status == $CRITICAL) ? (10000) : (30000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Redis average latency on ${label:resource_name}
+     info: Average cache latency on Azure Cache for Redis ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- Latency P99 ---
+
+ template: am_redis_cache_latency_p99
+       on: azure_monitor.redis_cache.latency_p99
+    class: Latency
+     type: Database
+component: Azure Redis
+   lookup: average -5m unaligned of p99
+    units: microseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (10000) : (20000))
+     crit: $this > (($status == $CRITICAL) ? (20000) : (50000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Redis P99 latency on ${label:resource_name}
+     info: P99 latency on Azure Cache for Redis ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Tail latency spikes indicate resource pressure or network issues
+       to: dba
+
+# --- Key Evictions ---
+
+ template: am_redis_cache_evicted_keys
+       on: azure_monitor.redis_cache.key_events
+    class: Errors
+     type: Database
+component: Azure Redis
+   lookup: average -5m unaligned of evicted
+    units: keys/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (50) : (100))
+     crit: $this > (($status == $CRITICAL) ? (100) : (500))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Redis key evictions on ${label:resource_name}
+     info: Rate of evicted keys on Azure Cache for Redis ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Key evictions indicate the cache is running out of memory
+       to: dba
+
+# --- Geo-Replication Health (optional — only present when geo-replication is configured) ---
+
+ template: am_redis_cache_geo_replication_health
+       on: azure_monitor.redis_cache.geo_replication_health
+    class: Availability
+     type: Database
+component: Azure Redis
+   lookup: average -5m unaligned of average
+    units: status
+    every: 1m
+     crit: $this != nan AND $this < 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Redis geo-replication health on ${label:resource_name}
+     info: Geo-replication link health on Azure Cache for Redis ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           A value below 1 indicates the replication link is unhealthy
+       to: dba
+
+# --- Geo-Replication Lag (optional — only present when geo-replication is configured) ---
+
+ template: am_redis_cache_geo_replication_lag
+       on: azure_monitor.redis_cache.geo_replication_lag
+    class: Latency
+     type: Database
+component: Azure Redis
+   lookup: average -5m unaligned of average
+    units: seconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (5) : (10))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (10) : (30))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Redis geo-replication lag on ${label:resource_name}
+     info: Geo-replication connectivity lag on Azure Cache for Redis ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High lag indicates network issues between primary and secondary regions
+       to: dba
+
+# --- Geo-Replication Sync Offset (optional — only present when geo-replication is configured) ---
+
+ template: am_redis_cache_geo_replication_sync_offset
+       on: azure_monitor.redis_cache.geo_replication_sync_offset
+    class: Latency
+     type: Database
+component: Azure Redis
+   lookup: average -5m unaligned of average
+    units: bytes
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (1048576) : (5242880))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (5242880) : (52428800))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Redis geo-replication sync offset on ${label:resource_name}
+     info: Geo-replication data sync offset on Azure Cache for Redis ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Large offset indicates the secondary is falling behind the primary
+       to: dba

--- a/src/health/health.d/azure_monitor_service_bus.conf
+++ b/src/health/health.d/azure_monitor_service_bus.conf
@@ -1,0 +1,265 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Errors ---
+
+# Server-side errors indicate Service Bus infrastructure problems.
+# AMBA: ServerErrors > 0 is Sev1
+
+ template: am_service_bus_server_errors
+       on: azure_monitor.service_bus.errors
+    class: Errors
+     type: Messaging
+component: Azure Service Bus
+   lookup: average -5m unaligned of server
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Service Bus server errors on ${label:resource_name}
+     info: Server-side error rate on Service Bus namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# Throttled requests mean the namespace has exceeded its messaging unit quotas.
+# AMBA: ThrottledRequests > 0 is Sev1
+
+ template: am_service_bus_throttled_requests
+       on: azure_monitor.service_bus.errors
+    class: Errors
+     type: Messaging
+component: Azure Service Bus
+   lookup: average -5m unaligned of throttled
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Service Bus throttled requests on ${label:resource_name}
+     info: Rate of throttled requests on Service Bus namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Indicates the namespace is exceeding its messaging unit quotas
+       to: sysadmin
+
+# User errors (400-class) at sustained high rate may indicate
+# client misconfiguration or malformed messages.
+
+ template: am_service_bus_user_errors
+       on: azure_monitor.service_bus.errors
+    class: Errors
+     type: Messaging
+component: Azure Service Bus
+   lookup: average -5m unaligned of user
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (10) : (25))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Service Bus user errors on ${label:resource_name}
+     info: Rate of user (client-side) errors on Service Bus namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Utilization (Premium tier only) ---
+
+# CPU utilization of Premium namespace messaging units.
+# AMBA: NamespaceCpuUsage > 70 is Sev2
+
+ template: am_service_bus_namespace_cpu
+       on: azure_monitor.service_bus.namespace_resources
+    class: Utilization
+     type: Messaging
+component: Azure Service Bus
+   lookup: average -5m unaligned of cpu
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Service Bus namespace CPU on ${label:resource_name}
+     info: CPU utilization of Premium Service Bus namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only available on Premium tier namespaces
+       to: sysadmin
+
+# Memory utilization of Premium namespace messaging units.
+# AMBA: NamespaceMemoryUsage > 70 is Sev2
+
+ template: am_service_bus_namespace_memory
+       on: azure_monitor.service_bus.namespace_resources
+    class: Utilization
+     type: Messaging
+component: Azure Service Bus
+   lookup: average -5m unaligned of memory
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Service Bus namespace memory on ${label:resource_name}
+     info: Memory utilization of Premium Service Bus namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only available on Premium tier namespaces
+       to: sysadmin
+
+# --- Latency ---
+
+# Server send latency measures how long Service Bus takes to complete
+# send operations. High latency indicates performance degradation.
+
+ template: am_service_bus_send_latency
+       on: azure_monitor.service_bus.send_latency
+    class: Latency
+     type: Messaging
+component: Azure Service Bus
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (500)  : (1000))
+     crit: $this > (($status == $CRITICAL) ? (1000) : (3000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Service Bus send latency on ${label:resource_name}
+     info: Average server send latency on Service Bus namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Saturation ---
+
+# Dead-lettered messages accumulate when messages cannot be processed
+# after max delivery attempts or when they expire. Growing dead letter
+# queues indicate consumer failures or poison messages.
+# AMBA: DeadletteredMessages > 0 is Sev2
+
+ template: am_service_bus_dead_lettered_messages
+       on: azure_monitor.service_bus.problem_messages
+    class: Errors
+     type: Messaging
+component: Azure Service Bus
+   lookup: average -5m unaligned of dead_lettered
+    units: messages
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0)  : (1))
+     crit: $this > (($status == $CRITICAL) ? (10) : (100))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Service Bus dead-lettered messages on ${label:resource_name}
+     info: Dead-lettered messages in Service Bus namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Messages land in dead letter queue after exceeding max delivery attempts or expiring
+       to: sysadmin
+
+# Active message queue depth. Sustained growth means consumers
+# are not keeping up with producers.
+# AMBA: ActiveMessages > 100 is Sev2
+
+ template: am_service_bus_active_messages
+       on: azure_monitor.service_bus.queue_depth
+    class: Workload
+     type: Messaging
+component: Azure Service Bus
+   lookup: average -10m unaligned of active
+    units: messages
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (5000)  : (10000))
+     crit: $this > (($status == $CRITICAL) ? (10000) : (50000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Service Bus queue depth on ${label:resource_name}
+     info: Active messages queued in Service Bus namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Sustained growth means consumers are not keeping up with producers
+       to: sysadmin
+
+# --- Request Success ---
+
+# Helper: total incoming requests over 5 minutes (no alarm, just a value)
+
+ template: am_service_bus_incoming_requests
+       on: azure_monitor.service_bus.requests
+    class: Workload
+     type: Messaging
+component: Azure Service Bus
+   lookup: sum -5m unaligned of incoming
+    units: requests/s
+    every: 1m
+     info: Total incoming requests on Service Bus namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+
+# Request success rate. Only fires when there is meaningful traffic
+# to avoid false positives during idle periods.
+
+ template: am_service_bus_request_success_rate
+       on: azure_monitor.service_bus.requests
+    class: Errors
+     type: Messaging
+component: Azure Service Bus
+   lookup: sum -5m unaligned of successful
+     calc: ($am_service_bus_incoming_requests > 0) ? ($this * 100 / $am_service_bus_incoming_requests) : (100)
+    units: %
+    every: 1m
+     warn: ($am_service_bus_incoming_requests > 120) ? ($this < (($status >= $WARNING)  ? (99) : (95))) : (0)
+     crit: ($am_service_bus_incoming_requests > 120) ? ($this < (($status == $CRITICAL) ? (95) : (80))) : (0)
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Service Bus request success rate on ${label:resource_name}
+     info: Percentage of successful requests on Service Bus namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Message Operations ---
+
+# Abandoned messages indicate consumers receiving but not processing messages.
+# Sustained abandonment suggests poison messages or consumer failures.
+
+ template: am_service_bus_abandoned_messages
+       on: azure_monitor.service_bus.message_operations
+    class: Errors
+     type: Messaging
+component: Azure Service Bus
+   lookup: average -5m unaligned of abandoned
+    units: messages/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Service Bus abandoned messages on ${label:resource_name}
+     info: Rate of abandoned messages on Service Bus namespace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Consumers are receiving but failing to process messages
+       to: sysadmin
+
+# --- Replication (Geo-DR only) ---
+
+# Replication lag count measures how many messages are pending replication
+# to the secondary namespace. Only relevant with Geo-DR configured.
+
+ template: am_service_bus_replication_lag
+       on: azure_monitor.service_bus.replication_lag
+    class: Latency
+     type: Messaging
+component: Azure Service Bus
+   lookup: average -5m unaligned of messages
+    units: messages
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (100)  : (1000))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (1000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Service Bus replication lag on ${label:resource_name}
+     info: Messages pending replication to secondary namespace on Service Bus ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant when Geo-DR is configured
+       to: sysadmin
+
+# Replication lag duration measures time behind the primary.
+
+ template: am_service_bus_replication_lag_duration
+       on: azure_monitor.service_bus.replication_lag_duration
+    class: Latency
+     type: Messaging
+component: Azure Service Bus
+   lookup: average -5m unaligned of duration
+    units: seconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (30) : (60))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (60) : (120))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Service Bus replication lag duration on ${label:resource_name}
+     info: Replication lag duration to secondary namespace on Service Bus ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant when Geo-DR is configured
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_sql_database.conf
+++ b/src/health/health.d/azure_monitor_sql_database.conf
@@ -1,0 +1,339 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Availability ---
+
+ template: am_sql_database_availability
+       on: azure_monitor.sql_database.availability
+    class: Availability
+     type: Database
+component: Azure SQL
+   lookup: average -10m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99.99) : (99.9))
+     crit: $this < (($status == $CRITICAL) ? (99.9)  : (99))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database availability on ${label:resource_name}
+     info: Database availability of Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- CPU Utilization ---
+
+ template: am_sql_database_cpu
+       on: azure_monitor.sql_database.cpu
+    class: Utilization
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database CPU on ${label:resource_name}
+     info: Average CPU utilization of Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+ template: am_sql_database_instance_cpu
+       on: azure_monitor.sql_database.instance_cpu
+    class: Utilization
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database instance CPU on ${label:resource_name}
+     info: SQL process CPU utilization (including background tasks) on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- Memory Utilization ---
+
+ template: am_sql_database_instance_memory
+       on: azure_monitor.sql_database.instance_memory
+    class: Utilization
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database instance memory on ${label:resource_name}
+     info: SQL process memory utilization on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- DTU Consumption ---
+
+ template: am_sql_database_dtu_consumption
+       on: azure_monitor.sql_database.dtu_consumption
+    class: Utilization
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database DTU consumption on ${label:resource_name}
+     info: DTU consumption on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant for DTU-based service tiers
+       to: dba
+
+# --- I/O Utilization ---
+
+ template: am_sql_database_data_io
+       on: azure_monitor.sql_database.io_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of data_read
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database data I/O on ${label:resource_name}
+     info: Physical data read I/O utilization on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+ template: am_sql_database_log_write
+       on: azure_monitor.sql_database.io_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of log_write
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database log write I/O on ${label:resource_name}
+     info: Transaction log write I/O utilization on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- Resource Limits (Workers / Sessions) ---
+
+ template: am_sql_database_workers
+       on: azure_monitor.sql_database.resource_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of workers
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database worker utilization on ${label:resource_name}
+     info: Worker thread utilization on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Exhausting workers causes query failures
+       to: dba
+
+ template: am_sql_database_sessions
+       on: azure_monitor.sql_database.resource_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of sessions
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database session utilization on ${label:resource_name}
+     info: Session utilization on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Exhausting sessions prevents new connections
+       to: dba
+
+# --- Connection Errors ---
+
+ template: am_sql_database_connection_failures
+       on: azure_monitor.sql_database.connections
+    class: Errors
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of failed_system
+    units: connections/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database system connection failures on ${label:resource_name}
+     info: Rate of system-caused connection failures on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+ template: am_sql_database_firewall_blocks
+       on: azure_monitor.sql_database.connections
+    class: Errors
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of firewall_blocked
+    units: connections/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database firewall blocks on ${label:resource_name}
+     info: Rate of connections blocked by firewall on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           May indicate misconfigured firewall rules or unauthorized access attempts
+       to: dba
+
+# --- Deadlocks ---
+
+ template: am_sql_database_deadlocks
+       on: azure_monitor.sql_database.deadlocks
+    class: Errors
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of total
+    units: deadlocks/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database deadlocks on ${label:resource_name}
+     info: Deadlock rate on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- Storage ---
+
+ template: am_sql_database_storage_utilization
+       on: azure_monitor.sql_database.storage_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database storage utilization on ${label:resource_name}
+     info: Data storage utilization on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- In-Memory OLTP ---
+
+ template: am_sql_database_xtp_storage
+       on: azure_monitor.sql_database.xtp_storage
+    class: Utilization
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database In-Memory OLTP storage on ${label:resource_name}
+     info: In-Memory OLTP storage utilization on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant when In-Memory OLTP is enabled
+       to: dba
+
+# --- Tempdb ---
+
+ template: am_sql_database_tempdb_log_utilization
+       on: azure_monitor.sql_database.tempdb_log_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database tempdb log utilization on ${label:resource_name}
+     info: Tempdb transaction log utilization on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High utilization may indicate long-running transactions or excessive version store usage
+       to: dba
+
+# --- Replication ---
+
+ template: am_sql_database_replication_lag
+       on: azure_monitor.sql_database.replication_lag
+    class: Latency
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of average
+    units: seconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (5) : (10))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (10) : (30))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database replication lag on ${label:resource_name}
+     info: Geo-replication lag on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant when geo-replication is configured
+       to: dba
+
+# --- Serverless ---
+
+ template: am_sql_database_serverless_cpu
+       on: azure_monitor.sql_database.serverless_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of cpu
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database serverless CPU on ${label:resource_name}
+     info: App-level CPU utilization on serverless Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant for serverless tier databases
+       to: dba
+
+ template: am_sql_database_serverless_memory
+       on: azure_monitor.sql_database.serverless_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of memory
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database serverless memory on ${label:resource_name}
+     info: App-level memory utilization on serverless Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant for serverless tier databases
+       to: dba
+
+# --- Ledger ---
+
+ template: am_sql_database_ledger_digest_failures
+       on: azure_monitor.sql_database.ledger_digest
+    class: Errors
+     type: Database
+component: Azure SQL
+   lookup: average -5m unaligned of failed
+    units: events/s
+    every: 1m
+     warn: $this != nan AND $this > 0
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Database ledger digest failures on ${label:resource_name}
+     info: Failed ledger digest uploads on Azure SQL Database ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant when database ledger is enabled
+       to: dba

--- a/src/health/health.d/azure_monitor_sql_elastic_pool.conf
+++ b/src/health/health.d/azure_monitor_sql_elastic_pool.conf
@@ -1,0 +1,252 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- CPU Utilization ---
+
+ template: am_sql_elastic_pool_cpu
+       on: azure_monitor.sql_elastic_pool.cpu
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool CPU on ${label:resource_name}
+     info: Average CPU utilization of SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+ template: am_sql_elastic_pool_instance_cpu
+       on: azure_monitor.sql_elastic_pool.instance_cpu
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool instance CPU on ${label:resource_name}
+     info: SQL instance CPU utilization of SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Includes overhead beyond user workloads
+       to: dba
+
+# --- Memory Utilization ---
+
+ template: am_sql_elastic_pool_instance_memory
+       on: azure_monitor.sql_elastic_pool.instance_memory
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool instance memory on ${label:resource_name}
+     info: SQL instance memory utilization of SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- DTU Utilization ---
+
+ template: am_sql_elastic_pool_dtu_consumption
+       on: azure_monitor.sql_elastic_pool.dtu_consumption
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool DTU consumption on ${label:resource_name}
+     info: DTU consumption percentage of SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High DTU usage indicates approaching the pool performance limit
+       to: dba
+
+# --- I/O Utilization ---
+
+ template: am_sql_elastic_pool_data_io
+       on: azure_monitor.sql_elastic_pool.io_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of data_read
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool data I/O on ${label:resource_name}
+     info: Physical data read I/O utilization of SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+ template: am_sql_elastic_pool_log_write
+       on: azure_monitor.sql_elastic_pool.io_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of log_write
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool log write on ${label:resource_name}
+     info: Transaction log write utilization of SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: dba
+
+# --- Resource Limits ---
+
+ template: am_sql_elastic_pool_workers
+       on: azure_monitor.sql_elastic_pool.resource_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of workers
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool workers on ${label:resource_name}
+     info: Worker thread utilization of SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Exhausting workers causes query failures
+       to: dba
+
+ template: am_sql_elastic_pool_sessions
+       on: azure_monitor.sql_elastic_pool.resource_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of sessions
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool sessions on ${label:resource_name}
+     info: Session utilization of SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Exhausting sessions prevents new connections
+       to: dba
+
+# --- Storage Utilization ---
+
+ template: am_sql_elastic_pool_storage_used
+       on: azure_monitor.sql_elastic_pool.storage_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of used
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool storage used on ${label:resource_name}
+     info: Data storage utilization of SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Reaching the storage limit prevents data inserts and updates
+       to: dba
+
+ template: am_sql_elastic_pool_storage_allocated
+       on: azure_monitor.sql_elastic_pool.storage_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of allocated
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool storage allocated on ${label:resource_name}
+     info: Allocated data storage utilization of SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Allocated space can exceed used space due to database file growth settings
+       to: dba
+
+# --- In-Memory OLTP ---
+
+ template: am_sql_elastic_pool_xtp_storage
+       on: azure_monitor.sql_elastic_pool.xtp_storage
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool In-Memory OLTP storage on ${label:resource_name}
+     info: In-Memory OLTP storage utilization of SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant when In-Memory OLTP is enabled
+       to: dba
+
+# --- Tempdb ---
+
+ template: am_sql_elastic_pool_tempdb_log
+       on: azure_monitor.sql_elastic_pool.tempdb_log_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool tempdb log on ${label:resource_name}
+     info: Tempdb transaction log utilization of SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High tempdb log usage can block transactions
+       to: dba
+
+# --- Serverless ---
+
+ template: am_sql_elastic_pool_serverless_cpu
+       on: azure_monitor.sql_elastic_pool.serverless_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of cpu
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool serverless CPU on ${label:resource_name}
+     info: App CPU utilization of serverless SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant for serverless tier elastic pools
+       to: dba
+
+ template: am_sql_elastic_pool_serverless_memory
+       on: azure_monitor.sql_elastic_pool.serverless_utilization
+    class: Utilization
+     type: Database
+component: Azure SQL Elastic Pool
+   lookup: average -5m unaligned of memory
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Elastic Pool serverless memory on ${label:resource_name}
+     info: App memory utilization of serverless SQL Elastic Pool ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant for serverless tier elastic pools
+       to: dba

--- a/src/health/health.d/azure_monitor_sql_managed_instance.conf
+++ b/src/health/health.d/azure_monitor_sql_managed_instance.conf
@@ -1,0 +1,56 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Utilization ---
+
+ template: am_sql_managed_instance_cpu
+       on: azure_monitor.sql_managed_instance.cpu
+    class: Utilization
+     type: Database
+component: Azure SQL MI
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL MI CPU utilization on ${label:resource_name}
+     info: Average CPU utilization of SQL Managed Instance ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Sustained high CPU indicates insufficient compute tier or query optimization needed
+       to: dba
+
+ template: am_sql_managed_instance_storage_utilization
+       on: azure_monitor.sql_managed_instance.storage
+    class: Utilization
+     type: Database
+component: Azure SQL MI
+     calc: ($reserved > 0) ? ($used * 100 / $reserved) : (0)
+    units: %
+    every: 5m
+     warn: $this > (($status >= $WARNING)  ? (80) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL MI storage utilization on ${label:resource_name}
+     info: Storage used as a percentage of reserved storage on SQL Managed Instance ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Approaching reserved storage limit may cause write failures
+       to: dba
+
+# --- Workload ---
+
+ template: am_sql_managed_instance_io_requests
+       on: azure_monitor.sql_managed_instance.io_requests
+    class: Workload
+     type: Database
+component: Azure SQL MI
+   lookup: average -5m unaligned of average
+    units: requests/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (4000) : (5000))
+     crit: $this > (($status == $CRITICAL) ? (5000) : (7500))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL MI I/O requests on ${label:resource_name}
+     info: Average I/O requests per second on SQL Managed Instance ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High I/O request rates may indicate I/O bottleneck or unoptimized queries
+       to: dba

--- a/src/health/health.d/azure_monitor_storage_accounts.conf
+++ b/src/health/health.d/azure_monitor_storage_accounts.conf
@@ -1,0 +1,104 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Availability ---
+
+# Storage account availability (0-100%). Low is bad.
+# Azure SLA guarantees >=99.9% for RA-GRS/RA-GZRS, >=99.9% for most tiers.
+# AMBA: Availability < 99% is Sev1 (critical)
+
+ template: am_storage_accounts_availability
+       on: azure_monitor.storage_accounts.availability
+    class: Availability
+     type: Storage
+component: Azure Storage
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (99.9) : (99))
+     crit: $this < (($status == $CRITICAL) ? (99)   : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Storage availability on ${label:resource_name}
+     info: Overall availability of Azure Storage Account ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Azure SLA guarantees 99.9% or higher depending on redundancy tier
+       to: sysadmin
+
+# --- Latency ---
+
+# End-to-end latency measures the full round-trip including network.
+# AMBA: SuccessE2ELatency average > 1000ms is Sev2
+
+ template: am_storage_accounts_e2e_latency
+       on: azure_monitor.storage_accounts.e2e_latency
+    class: Latency
+     type: Storage
+component: Azure Storage
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (500)  : (1000))
+     crit: $this > (($status == $CRITICAL) ? (1000) : (2000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Storage E2E latency on ${label:resource_name}
+     info: Average end-to-end latency of successful requests to Azure Storage Account \
+           ${label:resource_name} in ${label:resource_group} (${label:region}). \
+           Includes network round-trip time
+       to: sysadmin
+
+# Peak end-to-end latency — catches extreme spikes even when average looks normal.
+
+ template: am_storage_accounts_e2e_latency_peak
+       on: azure_monitor.storage_accounts.e2e_latency
+    class: Latency
+     type: Storage
+component: Azure Storage
+   lookup: max -5m unaligned of maximum
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (2000) : (5000))
+     crit: $this > (($status == $CRITICAL) ? (5000) : (10000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Storage E2E latency peak on ${label:resource_name}
+     info: Peak end-to-end latency of successful requests to Azure Storage Account \
+           ${label:resource_name} in ${label:resource_group} (${label:region}). \
+           Spikes may indicate throttling or network congestion
+       to: sysadmin
+
+# Server-side latency excludes network — pure Azure processing time.
+# AMBA: SuccessServerLatency average > 1000ms is Sev2
+
+ template: am_storage_accounts_server_latency
+       on: azure_monitor.storage_accounts.server_latency
+    class: Latency
+     type: Storage
+component: Azure Storage
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (300) : (500))
+     crit: $this > (($status == $CRITICAL) ? (500) : (1000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Storage server latency on ${label:resource_name}
+     info: Average server-side latency of successful requests to Azure Storage Account \
+           ${label:resource_name} in ${label:resource_group} (${label:region}). \
+           Excludes network time — high values indicate Azure-side processing delays
+       to: sysadmin
+
+# Peak server-side latency — catches extreme server-side spikes.
+
+ template: am_storage_accounts_server_latency_peak
+       on: azure_monitor.storage_accounts.server_latency
+    class: Latency
+     type: Storage
+component: Azure Storage
+   lookup: max -5m unaligned of maximum
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1000) : (2000))
+     crit: $this > (($status == $CRITICAL) ? (2000) : (5000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Storage server latency peak on ${label:resource_name}
+     info: Peak server-side latency of successful requests to Azure Storage Account \
+           ${label:resource_name} in ${label:resource_group} (${label:region}). \
+           Spikes may indicate throttling at the storage partition level
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_stream_analytics.conf
+++ b/src/health/health.d/azure_monitor_stream_analytics.conf
@@ -1,0 +1,192 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# ── Resource Utilization ────────────────────────────────────────────────────
+
+ template: am_stream_analytics_su_utilization
+       on: azure_monitor.stream_analytics.resource_utilization
+    class: Utilization
+     type: Other
+component: Azure Stream Analytics
+   lookup: average -5m unaligned of su_memory
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Stream Analytics SU utilization on ${label:resource_name}
+     info: Average streaming unit (memory) utilization of Stream Analytics job ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Sustained high SU utilization indicates the job needs more streaming units.
+       to: sysadmin
+
+ template: am_stream_analytics_cpu_utilization
+       on: azure_monitor.stream_analytics.resource_utilization
+    class: Utilization
+     type: Other
+component: Azure Stream Analytics
+   lookup: average -5m unaligned of cpu
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (80))
+     crit: $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Stream Analytics CPU on ${label:resource_name}
+     info: Average CPU utilization of Stream Analytics job ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High CPU indicates complex query processing or insufficient streaming units.
+       to: sysadmin
+
+# ── Watermark Delay ─────────────────────────────────────────────────────────
+
+ template: am_stream_analytics_watermark_delay
+       on: azure_monitor.stream_analytics.watermark_delay
+    class: Latency
+     type: Other
+component: Azure Stream Analytics
+   lookup: average -5m unaligned of delay
+    units: seconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (60)  : (120))
+     crit: $this > (($status == $CRITICAL) ? (120) : (300))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Stream Analytics watermark delay on ${label:resource_name}
+     info: Output watermark delay of Stream Analytics job ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Growing delay means the job is falling behind processing input data.
+       to: sysadmin
+
+# ── Errors ──────────────────────────────────────────────────────────────────
+
+ template: am_stream_analytics_runtime_errors
+       on: azure_monitor.stream_analytics.errors
+    class: Errors
+     type: Other
+component: Azure Stream Analytics
+   lookup: average -5m unaligned of runtime
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Stream Analytics runtime errors on ${label:resource_name}
+     info: Runtime errors on Stream Analytics job ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Runtime errors indicate issues with query execution or resource constraints.
+       to: sysadmin
+
+ template: am_stream_analytics_data_conversion_errors
+       on: azure_monitor.stream_analytics.errors
+    class: Errors
+     type: Other
+component: Azure Stream Analytics
+   lookup: average -5m unaligned of data_conversion
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Stream Analytics conversion errors on ${label:resource_name}
+     info: Data conversion errors on Stream Analytics job ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           These occur when output events cannot be converted to the expected output schema.
+       to: sysadmin
+
+ template: am_stream_analytics_deserialization_errors
+       on: azure_monitor.stream_analytics.errors
+    class: Errors
+     type: Other
+component: Azure Stream Analytics
+   lookup: average -5m unaligned of deserialization
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (0) : (1))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Stream Analytics deserialization errors on ${label:resource_name}
+     info: Input deserialization errors on Stream Analytics job ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           These occur when input events cannot be parsed (malformed JSON, CSV, Avro).
+       to: sysadmin
+
+# ── Event Timing ────────────────────────────────────────────────────────────
+
+ template: am_stream_analytics_out_of_order_events
+       on: azure_monitor.stream_analytics.event_timing
+    class: Errors
+     type: Other
+component: Azure Stream Analytics
+   lookup: average -5m unaligned of out_of_order
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Stream Analytics out-of-order events on ${label:resource_name}
+     info: Rate of dropped or adjusted out-of-order events on Stream Analytics job \
+           ${label:resource_name} in ${label:resource_group} (${label:region}). \
+           High rates may indicate clock skew in event sources.
+       to: sysadmin
+
+ template: am_stream_analytics_late_events
+       on: azure_monitor.stream_analytics.event_timing
+    class: Errors
+     type: Other
+component: Azure Stream Analytics
+   lookup: average -5m unaligned of late
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Stream Analytics late events on ${label:resource_name}
+     info: Rate of late-arriving input events on Stream Analytics job ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Late events arrive after the late arrival tolerance window.
+       to: sysadmin
+
+# ── Backlog ─────────────────────────────────────────────────────────────────
+
+ template: am_stream_analytics_backlogged_events
+       on: azure_monitor.stream_analytics.backlogged_events
+    class: Utilization
+     type: Other
+component: Azure Stream Analytics
+   lookup: average -5m unaligned of backlogged
+    units: events
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (5000) : (10000))
+     crit: $this > (($status == $CRITICAL) ? (10000) : (50000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Stream Analytics backlog on ${label:resource_name}
+     info: Number of backlogged input events on Stream Analytics job ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           A growing backlog means the job cannot keep up with the input rate.
+       to: sysadmin
+
+# ── Function Requests ───────────────────────────────────────────────────────
+
+# Helper: total ML function request rate (used for minimum-data guard)
+ template: am_stream_analytics_function_request_rate
+       on: azure_monitor.stream_analytics.function_requests
+    class: Workload
+     type: Other
+component: Azure Stream Analytics
+   lookup: average -5m unaligned of total
+    units: requests/s
+    every: 1m
+  summary: Stream Analytics function call rate on ${label:resource_name}
+     info: Average Azure ML function call rate for Stream Analytics job ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: silent
+
+ template: am_stream_analytics_function_failures
+       on: azure_monitor.stream_analytics.function_requests
+    class: Errors
+     type: Other
+component: Azure Stream Analytics
+   lookup: average -5m unaligned of failed
+     calc: ($am_stream_analytics_function_request_rate > 0) ? ($this * 100 / $am_stream_analytics_function_request_rate) : (0)
+    units: %
+    every: 1m
+     warn: $this != nan AND ($am_stream_analytics_function_request_rate > 0.5) ? ($this > (($status >= $WARNING) ? (5) : (10))) : (0)
+     crit: $this != nan AND ($am_stream_analytics_function_request_rate > 0.5) ? ($this > (($status == $CRITICAL) ? (15) : (25))) : (0)
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Stream Analytics ML function failures on ${label:resource_name}
+     info: Percentage of failed Azure ML function requests for Stream Analytics job \
+           ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_synapse.conf
+++ b/src/health/health.d/azure_monitor_synapse.conf
@@ -1,0 +1,143 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# ── Streaming Job - Resource Utilization ────────────────────────────────────
+
+ template: am_synapse_streaming_resource_utilization
+       on: azure_monitor.synapse.streaming_resource_utilization
+    class: Utilization
+     type: Database
+component: Azure Synapse
+   lookup: average -5m unaligned of utilization
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (75) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Synapse streaming SU utilization on ${label:resource_name}
+     info: Streaming job resource utilization on Azure Synapse workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High values indicate the streaming job is approaching capacity
+       to: sysadmin
+
+# ── Streaming Job - Errors ──────────────────────────────────────────────────
+
+ template: am_synapse_streaming_runtime_errors
+       on: azure_monitor.synapse.streaming_errors
+    class: Errors
+     type: Database
+component: Azure Synapse
+   lookup: average -5m unaligned of runtime
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (1) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Synapse streaming runtime errors on ${label:resource_name}
+     info: Streaming job runtime errors on Azure Synapse workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_synapse_streaming_data_errors
+       on: azure_monitor.synapse.streaming_errors
+    class: Errors
+     type: Database
+component: Azure Synapse
+   lookup: average -5m unaligned of data_conversion,deserialization
+    units: errors/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (0) : (1))
+     crit: $this > (($status == $CRITICAL) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Synapse streaming data errors on ${label:resource_name}
+     info: Streaming job data conversion and deserialization errors on Azure Synapse workspace \
+           ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# ── Streaming Job - Watermark Delay ─────────────────────────────────────────
+
+ template: am_synapse_streaming_watermark_delay
+       on: azure_monitor.synapse.streaming_watermark_delay
+    class: Latency
+     type: Database
+component: Azure Synapse
+   lookup: average -5m unaligned of delay
+    units: seconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (30) : (60))
+     crit: $this > (($status == $CRITICAL) ? (60) : (120))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Synapse streaming watermark delay on ${label:resource_name}
+     info: Output watermark delay of the streaming job on Azure Synapse workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High delay indicates the streaming job is falling behind real-time processing
+       to: sysadmin
+
+# ── Streaming Job - Event Timing Issues ─────────────────────────────────────
+
+ template: am_synapse_streaming_late_events
+       on: azure_monitor.synapse.streaming_event_timing
+    class: Errors
+     type: Database
+component: Azure Synapse
+   lookup: average -5m unaligned of late
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (5) : (10))
+     crit: $this > (($status == $CRITICAL) ? (25) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Synapse streaming late events on ${label:resource_name}
+     info: Rate of late-arriving input events in the streaming job on Azure Synapse workspace \
+           ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_synapse_streaming_out_of_order_events
+       on: azure_monitor.synapse.streaming_event_timing
+    class: Errors
+     type: Database
+component: Azure Synapse
+   lookup: average -5m unaligned of out_of_order
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (5) : (10))
+     crit: $this > (($status == $CRITICAL) ? (25) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Synapse streaming out-of-order events on ${label:resource_name}
+     info: Rate of out-of-order input events in the streaming job on Azure Synapse workspace \
+           ${label:resource_name} in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_synapse_streaming_backlogged_events
+       on: azure_monitor.synapse.streaming_event_timing
+    class: Workload
+     type: Database
+component: Azure Synapse
+   lookup: average -5m unaligned of backlogged
+    units: events/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (50) : (100))
+     crit: $this > (($status == $CRITICAL) ? (100) : (500))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Synapse streaming backlogged events on ${label:resource_name}
+     info: Rate of backlogged input event sources in the streaming job on Azure Synapse workspace \
+           ${label:resource_name} in ${label:resource_group} (${label:region}). \
+           Backlog growth indicates input rate exceeds processing capacity
+       to: sysadmin
+
+# ── Integration - Link Processing Latency ───────────────────────────────────
+
+ template: am_synapse_link_processing_latency
+       on: azure_monitor.synapse.link_processing_latency
+    class: Latency
+     type: Database
+component: Azure Synapse
+   lookup: average -5m unaligned of average
+    units: seconds
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (30) : (60))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (60) : (120))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: Synapse Link processing latency on ${label:resource_name}
+     info: Average Synapse Link processing latency on Azure Synapse workspace ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Only relevant when Synapse Link connections are configured
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_virtual_machines.conf
+++ b/src/health/health.d/azure_monitor_virtual_machines.conf
@@ -1,0 +1,446 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- CPU ---
+
+ template: am_vm_cpu
+       on: azure_monitor.virtual_machines.cpu
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (85) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM CPU on ${label:resource_name}
+     info: Average CPU utilization on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# CPU credits are only available on burstable B-series VMs.
+# NaN guard: remaining is NaN on non-burstable VM sizes.
+
+ template: am_vm_cpu_credits_remaining
+       on: azure_monitor.virtual_machines.cpu_credits
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of remaining
+    units: credits
+    every: 1m
+     warn: $this != nan AND $this < (($status >= $WARNING)  ? (30) : (20))
+     crit: $this != nan AND $this < (($status == $CRITICAL) ? (20) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM CPU credits low on ${label:resource_name}
+     info: CPU credits remaining on burstable Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           When credits are exhausted, CPU performance is capped.
+       to: sysadmin
+
+# --- Memory ---
+# Available Memory Percentage: low is bad.
+
+ template: am_vm_memory_available
+       on: azure_monitor.virtual_machines.memory_percentage
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of available
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (15) : (10))
+     crit: $this < (($status == $CRITICAL) ? (10) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM available memory on ${label:resource_name}
+     info: Available memory percentage on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Availability ---
+# VmAvailabilityMetric: 1 = available, < 1 = degraded/unavailable.
+
+ template: am_vm_availability
+       on: azure_monitor.virtual_machines.availability
+    class: Availability
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of average
+    units: state
+    every: 1m
+     crit: $this < 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM unavailable ${label:resource_name}
+     info: Azure VM ${label:resource_name} in ${label:resource_group} (${label:region}) \
+           is reporting degraded or unavailable state
+       to: sysadmin
+
+# --- OS Disk Latency ---
+
+ template: am_vm_os_disk_latency
+       on: azure_monitor.virtual_machines.os_disk_latency
+    class: Latency
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (30) : (50))
+     crit: $this > (($status == $CRITICAL) ? (50) : (100))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM OS disk latency on ${label:resource_name}
+     info: Average OS disk latency on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High latency indicates disk I/O bottleneck.
+       to: sysadmin
+
+# --- OS Disk Queue Depth ---
+
+ template: am_vm_os_disk_queue_depth
+       on: azure_monitor.virtual_machines.os_disk_queue_depth
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of average
+    units: operations
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (16) : (32))
+     crit: $this > (($status == $CRITICAL) ? (32) : (64))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM OS disk queue depth on ${label:resource_name}
+     info: Average OS disk queue depth on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High queue depth indicates I/O saturation.
+       to: sysadmin
+
+# --- OS Disk Throttling ---
+# Bandwidth and IOPS consumed percentage. High values mean the disk
+# is approaching its provisioned performance limit and may be throttled.
+
+ template: am_vm_os_disk_bandwidth_throttling
+       on: azure_monitor.virtual_machines.os_disk_throttling
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM OS disk bandwidth throttling on ${label:resource_name}
+     info: OS disk bandwidth consumed percentage on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Approaching the provisioned bandwidth limit causes throttling.
+       to: sysadmin
+
+ template: am_vm_os_disk_iops_throttling
+       on: azure_monitor.virtual_machines.os_disk_throttling
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of iops
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM OS disk IOPS throttling on ${label:resource_name}
+     info: OS disk IOPS consumed percentage on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Approaching the provisioned IOPS limit causes throttling.
+       to: sysadmin
+
+# --- OS Disk Burst Credits ---
+# Burst credit usage: high means credits are being depleted.
+# NaN guard: burst credits are only available on eligible disk tiers.
+
+ template: am_vm_os_disk_burst_bps_credits
+       on: azure_monitor.virtual_machines.os_disk_burst_credits
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM OS disk burst bandwidth credits on ${label:resource_name}
+     info: OS disk burst bandwidth credits consumed on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           When credits are exhausted, disk throughput drops to baseline.
+       to: sysadmin
+
+ template: am_vm_os_disk_burst_io_credits
+       on: azure_monitor.virtual_machines.os_disk_burst_credits
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of io
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM OS disk burst IO credits on ${label:resource_name}
+     info: OS disk burst IO credits consumed on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           When credits are exhausted, disk IOPS drops to baseline.
+       to: sysadmin
+
+# --- Data Disk Latency ---
+
+ template: am_vm_data_disk_latency
+       on: azure_monitor.virtual_machines.data_disk_latency
+    class: Latency
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (30) : (50))
+     crit: $this > (($status == $CRITICAL) ? (50) : (100))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM data disk latency on ${label:resource_name}
+     info: Average data disk latency on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High latency indicates disk I/O bottleneck.
+       to: sysadmin
+
+# --- Data Disk Queue Depth ---
+
+ template: am_vm_data_disk_queue_depth
+       on: azure_monitor.virtual_machines.data_disk_queue_depth
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of average
+    units: operations
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (16) : (32))
+     crit: $this > (($status == $CRITICAL) ? (32) : (64))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM data disk queue depth on ${label:resource_name}
+     info: Average data disk queue depth on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High queue depth indicates I/O saturation.
+       to: sysadmin
+
+# --- Data Disk Throttling ---
+
+ template: am_vm_data_disk_bandwidth_throttling
+       on: azure_monitor.virtual_machines.data_disk_throttling
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM data disk bandwidth throttling on ${label:resource_name}
+     info: Data disk bandwidth consumed percentage on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Approaching the provisioned bandwidth limit causes throttling.
+       to: sysadmin
+
+ template: am_vm_data_disk_iops_throttling
+       on: azure_monitor.virtual_machines.data_disk_throttling
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of iops
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM data disk IOPS throttling on ${label:resource_name}
+     info: Data disk IOPS consumed percentage on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Approaching the provisioned IOPS limit causes throttling.
+       to: sysadmin
+
+# --- Data Disk Burst Credits ---
+# NaN guard: burst credits are only available on eligible disk tiers.
+
+ template: am_vm_data_disk_burst_bps_credits
+       on: azure_monitor.virtual_machines.data_disk_burst_credits
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM data disk burst bandwidth credits on ${label:resource_name}
+     info: Data disk burst bandwidth credits consumed on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           When credits are exhausted, disk throughput drops to baseline.
+       to: sysadmin
+
+ template: am_vm_data_disk_burst_io_credits
+       on: azure_monitor.virtual_machines.data_disk_burst_credits
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of io
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM data disk burst IO credits on ${label:resource_name}
+     info: Data disk burst IO credits consumed on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           When credits are exhausted, disk IOPS drops to baseline.
+       to: sysadmin
+
+# --- VM-Level Cached IO Throttling ---
+# VM-level limits are separate from individual disk limits.
+# The VM can be throttled even when individual disks are not.
+
+ template: am_vm_cached_bandwidth_throttling
+       on: azure_monitor.virtual_machines.vm_cached_throttling
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM cached bandwidth throttling on ${label:resource_name}
+     info: VM-level cached bandwidth consumed percentage on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           VM-level throttling affects all disks on the VM.
+       to: sysadmin
+
+ template: am_vm_cached_iops_throttling
+       on: azure_monitor.virtual_machines.vm_cached_throttling
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of iops
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM cached IOPS throttling on ${label:resource_name}
+     info: VM-level cached IOPS consumed percentage on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           VM-level throttling affects all disks on the VM.
+       to: sysadmin
+
+# --- VM-Level Uncached IO Throttling ---
+
+ template: am_vm_uncached_bandwidth_throttling
+       on: azure_monitor.virtual_machines.vm_uncached_throttling
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM uncached bandwidth throttling on ${label:resource_name}
+     info: VM-level uncached bandwidth consumed percentage on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           VM-level throttling affects all disks on the VM.
+       to: sysadmin
+
+ template: am_vm_uncached_iops_throttling
+       on: azure_monitor.virtual_machines.vm_uncached_throttling
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of iops
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM uncached IOPS throttling on ${label:resource_name}
+     info: VM-level uncached IOPS consumed percentage on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           VM-level throttling affects all disks on the VM.
+       to: sysadmin
+
+# --- VM-Level Burst Credits ---
+# NaN guard: burst credits are only available on burstable VM sizes.
+
+ template: am_vm_cached_burst_bps_credits
+       on: azure_monitor.virtual_machines.vm_cached_burst_credits
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM cached burst bandwidth credits on ${label:resource_name}
+     info: VM-level cached burst bandwidth credits consumed on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           When credits are exhausted, cached I/O throughput drops to baseline.
+       to: sysadmin
+
+ template: am_vm_cached_burst_io_credits
+       on: azure_monitor.virtual_machines.vm_cached_burst_credits
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of io
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM cached burst IO credits on ${label:resource_name}
+     info: VM-level cached burst IO credits consumed on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           When credits are exhausted, cached IOPS drops to baseline.
+       to: sysadmin
+
+ template: am_vm_uncached_burst_bps_credits
+       on: azure_monitor.virtual_machines.vm_uncached_burst_credits
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM uncached burst bandwidth credits on ${label:resource_name}
+     info: VM-level uncached burst bandwidth credits consumed on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           When credits are exhausted, uncached I/O throughput drops to baseline.
+       to: sysadmin
+
+ template: am_vm_uncached_burst_io_credits
+       on: azure_monitor.virtual_machines.vm_uncached_burst_credits
+    class: Utilization
+     type: System
+component: Azure VM
+   lookup: average -5m unaligned of io
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VM uncached burst IO credits on ${label:resource_name}
+     info: VM-level uncached burst IO credits consumed on Azure VM ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           When credits are exhausted, uncached IOPS drops to baseline.
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_vmss.conf
+++ b/src/health/health.d/azure_monitor_vmss.conf
@@ -1,0 +1,453 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- CPU ---
+
+ template: am_vmss_cpu
+       on: azure_monitor.vmss.cpu
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (85) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS CPU utilization on ${label:resource_name}
+     info: Average CPU utilization of VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_vmss_cpu_credits_remaining
+       on: azure_monitor.vmss.cpu_credits
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of remaining
+    units: credits
+    every: 1m
+     warn: $this != nan AND $this < (($status >= $WARNING)  ? (30) : (20))
+     crit: $this != nan AND $this < (($status == $CRITICAL) ? (20) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS CPU credits low on ${label:resource_name}
+     info: Remaining CPU credits on burstable VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Running out of credits will cap performance to baseline.
+       to: sysadmin
+
+# --- Memory ---
+
+ template: am_vmss_memory_available
+       on: azure_monitor.vmss.memory_percentage
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of available
+    units: percentage
+    every: 1m
+     warn: $this < (($status >= $WARNING)  ? (15) : (10))
+     crit: $this < (($status == $CRITICAL) ? (10) : (5))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS available memory low on ${label:resource_name}
+     info: Average available memory percentage on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+# --- Availability ---
+
+ template: am_vmss_availability
+       on: azure_monitor.vmss.availability
+    class: Availability
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of average
+    units: state
+    every: 1m
+     crit: $this < 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS availability degraded on ${label:resource_name}
+     info: VM availability state on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Values below 1 indicate instances are unavailable.
+       to: sysadmin
+
+# --- OS Disk ---
+
+ template: am_vmss_os_disk_latency
+       on: azure_monitor.vmss.os_disk_latency
+    class: Latency
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (30) : (50))
+     crit: $this > (($status == $CRITICAL) ? (50) : (100))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS OS disk latency on ${label:resource_name}
+     info: Average OS disk latency on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_vmss_os_disk_queue_depth
+       on: azure_monitor.vmss.os_disk_queue_depth
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of average
+    units: operations
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (16) : (32))
+     crit: $this > (($status == $CRITICAL) ? (32) : (64))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS OS disk queue depth on ${label:resource_name}
+     info: Average OS disk queue depth on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High queue depth indicates disk I/O saturation.
+       to: sysadmin
+
+ template: am_vmss_os_disk_bandwidth_throttling
+       on: azure_monitor.vmss.os_disk_throttling
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS OS disk bandwidth consumed on ${label:resource_name}
+     info: OS disk bandwidth consumed percentage on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Approaching 100% means disk throughput is being throttled.
+       to: sysadmin
+
+ template: am_vmss_os_disk_iops_throttling
+       on: azure_monitor.vmss.os_disk_throttling
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of iops
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS OS disk IOPS consumed on ${label:resource_name}
+     info: OS disk IOPS consumed percentage on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Approaching 100% means disk IOPS is being throttled.
+       to: sysadmin
+
+ template: am_vmss_os_disk_burst_bps_credits
+       on: azure_monitor.vmss.os_disk_burst_credits
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS OS disk burst BPS credits depleting on ${label:resource_name}
+     info: OS disk burst bandwidth credits consumed on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Exhausting burst credits will throttle disk throughput to baseline.
+       to: sysadmin
+
+ template: am_vmss_os_disk_burst_io_credits
+       on: azure_monitor.vmss.os_disk_burst_credits
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of io
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS OS disk burst IO credits depleting on ${label:resource_name}
+     info: OS disk burst IO credits consumed on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Exhausting burst credits will throttle disk IOPS to baseline.
+       to: sysadmin
+
+# --- Data Disk ---
+
+ template: am_vmss_data_disk_latency
+       on: azure_monitor.vmss.data_disk_latency
+    class: Latency
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (30) : (50))
+     crit: $this > (($status == $CRITICAL) ? (50) : (100))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS data disk latency on ${label:resource_name}
+     info: Average data disk latency on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_vmss_data_disk_queue_depth
+       on: azure_monitor.vmss.data_disk_queue_depth
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of average
+    units: operations
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (16) : (32))
+     crit: $this > (($status == $CRITICAL) ? (32) : (64))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS data disk queue depth on ${label:resource_name}
+     info: Average data disk queue depth on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High queue depth indicates disk I/O saturation.
+       to: sysadmin
+
+ template: am_vmss_data_disk_bandwidth_throttling
+       on: azure_monitor.vmss.data_disk_throttling
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS data disk bandwidth consumed on ${label:resource_name}
+     info: Data disk bandwidth consumed percentage on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Approaching 100% means disk throughput is being throttled.
+       to: sysadmin
+
+ template: am_vmss_data_disk_iops_throttling
+       on: azure_monitor.vmss.data_disk_throttling
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of iops
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS data disk IOPS consumed on ${label:resource_name}
+     info: Data disk IOPS consumed percentage on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Approaching 100% means disk IOPS is being throttled.
+       to: sysadmin
+
+ template: am_vmss_data_disk_burst_bps_credits
+       on: azure_monitor.vmss.data_disk_burst_credits
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS data disk burst BPS credits depleting on ${label:resource_name}
+     info: Data disk burst bandwidth credits consumed on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Exhausting burst credits will throttle disk throughput to baseline.
+       to: sysadmin
+
+ template: am_vmss_data_disk_burst_io_credits
+       on: azure_monitor.vmss.data_disk_burst_credits
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of io
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS data disk burst IO credits depleting on ${label:resource_name}
+     info: Data disk burst IO credits consumed on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Exhausting burst credits will throttle disk IOPS to baseline.
+       to: sysadmin
+
+# --- Temp Disk ---
+
+ template: am_vmss_temp_disk_latency
+       on: azure_monitor.vmss.temp_disk_latency
+    class: Latency
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of average
+    units: milliseconds
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (30) : (50))
+     crit: $this > (($status == $CRITICAL) ? (50) : (100))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS temp disk latency on ${label:resource_name}
+     info: Average temp disk latency on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: sysadmin
+
+ template: am_vmss_temp_disk_queue_depth
+       on: azure_monitor.vmss.temp_disk_queue_depth
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of average
+    units: operations
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (16) : (32))
+     crit: $this > (($status == $CRITICAL) ? (32) : (64))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS temp disk queue depth on ${label:resource_name}
+     info: Average temp disk queue depth on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High queue depth indicates disk I/O saturation.
+       to: sysadmin
+
+# --- VM-Level IO Throttling ---
+
+ template: am_vmss_vm_cached_bandwidth_throttling
+       on: azure_monitor.vmss.vm_cached_throttling
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS cached bandwidth consumed on ${label:resource_name}
+     info: VM-level cached bandwidth consumed percentage on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Approaching 100% means the VM is being throttled at the host level.
+       to: sysadmin
+
+ template: am_vmss_vm_cached_iops_throttling
+       on: azure_monitor.vmss.vm_cached_throttling
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of iops
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS cached IOPS consumed on ${label:resource_name}
+     info: VM-level cached IOPS consumed percentage on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Approaching 100% means the VM is being throttled at the host level.
+       to: sysadmin
+
+ template: am_vmss_vm_uncached_bandwidth_throttling
+       on: azure_monitor.vmss.vm_uncached_throttling
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS uncached bandwidth consumed on ${label:resource_name}
+     info: VM-level uncached bandwidth consumed percentage on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Approaching 100% means the VM is being throttled at the host level.
+       to: sysadmin
+
+ template: am_vmss_vm_uncached_iops_throttling
+       on: azure_monitor.vmss.vm_uncached_throttling
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of iops
+    units: percentage
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS uncached IOPS consumed on ${label:resource_name}
+     info: VM-level uncached IOPS consumed percentage on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Approaching 100% means the VM is being throttled at the host level.
+       to: sysadmin
+
+# --- VM-Level Burst Credits ---
+
+ template: am_vmss_vm_cached_burst_bps_credits
+       on: azure_monitor.vmss.vm_cached_burst_credits
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS cached burst BPS credits depleting on ${label:resource_name}
+     info: VM-level cached burst bandwidth credits consumed on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Exhausting credits will throttle cached IO throughput to baseline.
+       to: sysadmin
+
+ template: am_vmss_vm_cached_burst_io_credits
+       on: azure_monitor.vmss.vm_cached_burst_credits
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of io
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS cached burst IO credits depleting on ${label:resource_name}
+     info: VM-level cached burst IO credits consumed on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Exhausting credits will throttle cached IOPS to baseline.
+       to: sysadmin
+
+ template: am_vmss_vm_uncached_burst_bps_credits
+       on: azure_monitor.vmss.vm_uncached_burst_credits
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of bandwidth
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS uncached burst BPS credits depleting on ${label:resource_name}
+     info: VM-level uncached burst bandwidth credits consumed on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Exhausting credits will throttle uncached IO throughput to baseline.
+       to: sysadmin
+
+ template: am_vmss_vm_uncached_burst_io_credits
+       on: azure_monitor.vmss.vm_uncached_burst_credits
+    class: Utilization
+     type: System
+component: Azure VMSS
+   lookup: average -5m unaligned of io
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (80) : (90))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (90) : (95))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VMSS uncached burst IO credits depleting on ${label:resource_name}
+     info: VM-level uncached burst IO credits consumed on VMSS ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Exhausting credits will throttle uncached IOPS to baseline.
+       to: sysadmin

--- a/src/health/health.d/azure_monitor_vpn_gateway.conf
+++ b/src/health/health.d/azure_monitor_vpn_gateway.conf
@@ -1,0 +1,315 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# --- Errors: Tunnel Packet Drops ---
+
+ template: am_vpn_gateway_tunnel_packet_drops
+       on: azure_monitor.vpn_gateway.tunnel_packet_drops
+    class: Errors
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of egress ingress
+    units: packets/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (10) : (50))
+     crit: $this > (($status == $CRITICAL) ? (50) : (200))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN Gateway tunnel packet drops on ${label:resource_name}
+     info: Packets being dropped across VPN tunnels on ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Drops indicate tunnel instability or capacity issues
+       to: sysadmin
+
+# --- Errors: Tunnel TS Mismatch Drops ---
+
+ template: am_vpn_gateway_tunnel_ts_mismatch_drops
+       on: azure_monitor.vpn_gateway.tunnel_ts_mismatch_drops
+    class: Errors
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of egress ingress
+    units: packets/s
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (1) : (10))
+     crit: $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN Gateway TS mismatch drops on ${label:resource_name}
+     info: Packets dropped due to traffic selector mismatch on ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           This typically indicates IPsec policy misconfiguration
+       to: sysadmin
+
+# --- Errors: Tunnel NAT Packet Drops ---
+
+ template: am_vpn_gateway_tunnel_nat_packet_drops
+       on: azure_monitor.vpn_gateway.tunnel_nat_packet_drops
+    class: Errors
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of total
+    units: packets/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (1) : (10))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (10) : (50))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN Gateway NAT packet drops on ${label:resource_name}
+     info: NAT-related packet drops on VPN Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           May indicate NAT rule misconfiguration or address exhaustion
+       to: sysadmin
+
+# --- Routing: BGP Peer Status ---
+# BGP is optional; metrics return NaN when BGP is not configured
+
+ template: am_vpn_gateway_bgp_peer_status
+       on: azure_monitor.vpn_gateway.bgp_peer_status
+    class: Availability
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of average
+    units: status
+    every: 1m
+     crit: $this != nan AND $this < 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN Gateway BGP peer down on ${label:resource_name}
+     info: BGP peer status on VPN Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Value below 1 indicates a BGP peer session is down
+       to: sysadmin
+
+# --- Utilization: ExpressRoute Gateway CPU ---
+
+ template: am_vpn_gateway_er_gateway_cpu
+       on: azure_monitor.vpn_gateway.er_gateway_cpu
+    class: Utilization
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN GW ExpressRoute CPU on ${label:resource_name}
+     info: CPU utilization of ExpressRoute Gateway on ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High CPU may degrade forwarding performance
+       to: sysadmin
+
+# --- Workload: ExpressRoute Gateway Active Flows ---
+
+ template: am_vpn_gateway_er_gateway_active_flows
+       on: azure_monitor.vpn_gateway.er_gateway_active_flows
+    class: Workload
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of average
+    units: flows
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (200000) : (250000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN GW ExpressRoute active flows on ${label:resource_name}
+     info: Active flows on ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High flow counts may indicate approaching scalability limits
+       to: sysadmin
+
+# --- Errors: ExpressRoute Gateway Route Changes ---
+
+ template: am_vpn_gateway_er_gateway_route_changes
+       on: azure_monitor.vpn_gateway.er_gateway_route_changes
+    class: Errors
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of total
+    units: changes/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN GW ExpressRoute route churn on ${label:resource_name}
+     info: Rate of BGP route changes on ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Frequent route changes may indicate BGP instability
+       to: sysadmin
+
+# --- Workload: ExpressRoute Routes Advertised ---
+
+ template: am_vpn_gateway_er_gateway_routes_advertised
+       on: azure_monitor.vpn_gateway.er_gateway_routes_advertised
+    class: Workload
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of maximum
+    units: routes
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (900) : (950))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN GW ExpressRoute routes advertised on ${label:resource_name}
+     info: Routes advertised to peer by ExpressRoute Gateway on ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Azure limits advertised routes to 1000 per peering
+       to: sysadmin
+
+# --- Workload: ExpressRoute Routes Learned ---
+
+ template: am_vpn_gateway_er_gateway_routes_learned
+       on: azure_monitor.vpn_gateway.er_gateway_routes_learned
+    class: Workload
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of maximum
+    units: routes
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (3800) : (3900))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN GW ExpressRoute routes learned on ${label:resource_name}
+     info: Routes learned from peer by ExpressRoute Gateway on ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Default Azure limit is 4000 routes per peering (varies by gateway SKU)
+       to: sysadmin
+
+# --- Utilization: Scalable ExpressRoute Gateway CPU ---
+
+ template: am_vpn_gateway_scalable_er_cpu
+       on: azure_monitor.vpn_gateway.scalable_er_cpu
+    class: Utilization
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of average
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this != nan AND $this > (($status == $CRITICAL) ? (80) : (90))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN GW Scalable ER CPU on ${label:resource_name}
+     info: CPU utilization of Scalable ExpressRoute Gateway on ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High CPU may degrade forwarding performance
+       to: sysadmin
+
+# --- Workload: Scalable ExpressRoute Gateway Active Flows ---
+
+ template: am_vpn_gateway_scalable_er_active_flows
+       on: azure_monitor.vpn_gateway.scalable_er_active_flows
+    class: Workload
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of average
+    units: flows
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (200000) : (250000))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN GW Scalable ER active flows on ${label:resource_name}
+     info: Active flows on Scalable ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           High flow counts may indicate approaching scalability limits
+       to: sysadmin
+
+# --- Errors: Scalable ExpressRoute Gateway Route Changes ---
+
+ template: am_vpn_gateway_scalable_er_route_changes
+       on: azure_monitor.vpn_gateway.scalable_er_route_changes
+    class: Errors
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of total
+    units: changes/s
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (5) : (10))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN GW Scalable ER route churn on ${label:resource_name}
+     info: Rate of BGP route changes on Scalable ExpressRoute Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Frequent route changes may indicate BGP instability
+       to: sysadmin
+
+# --- Workload: Scalable ExpressRoute Routes Advertised ---
+
+ template: am_vpn_gateway_scalable_er_routes_advertised
+       on: azure_monitor.vpn_gateway.scalable_er_routes_advertised
+    class: Workload
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of maximum
+    units: routes
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (900) : (950))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN GW Scalable ER routes advertised on ${label:resource_name}
+     info: Routes advertised to peer by Scalable ExpressRoute Gateway on ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Azure limits advertised routes to 1000 per peering
+       to: sysadmin
+
+# --- Workload: Scalable ExpressRoute Routes Learned ---
+
+ template: am_vpn_gateway_scalable_er_routes_learned
+       on: azure_monitor.vpn_gateway.scalable_er_routes_learned
+    class: Workload
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of maximum
+    units: routes
+    every: 1m
+     warn: $this != nan AND $this > (($status >= $WARNING) ? (3800) : (3900))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN GW Scalable ER routes learned on ${label:resource_name}
+     info: Routes learned from peer by Scalable ExpressRoute Gateway on ${label:resource_name} \
+           in ${label:resource_group} (${label:region}). \
+           Default Azure limit is 4000 routes per peering (varies by gateway SKU)
+       to: sysadmin
+
+# --- Workload: ExpressRoute Gateway Bandwidth (informational) ---
+
+ template: am_vpn_gateway_er_gateway_bandwidth
+       on: azure_monitor.vpn_gateway.er_gateway_bandwidth
+    class: Workload
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of average
+    units: bits/s
+    every: 1m
+     info: Average throughput of ExpressRoute Gateway on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: silent
+
+# --- Workload: Scalable ExpressRoute Gateway Bandwidth (informational) ---
+
+ template: am_vpn_gateway_scalable_er_bandwidth
+       on: azure_monitor.vpn_gateway.scalable_er_bandwidth
+    class: Workload
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of average
+    units: bits/s
+    every: 1m
+     info: Average throughput of Scalable ExpressRoute Gateway on ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: silent
+
+# --- Workload: S2S Bandwidth (informational) ---
+
+ template: am_vpn_gateway_s2s_bandwidth
+       on: azure_monitor.vpn_gateway.s2s_bandwidth
+    class: Workload
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of average
+    units: bytes/s
+    every: 1m
+     info: Average site-to-site bandwidth on VPN Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: silent
+
+# --- Workload: Tunnel Bandwidth (informational) ---
+
+ template: am_vpn_gateway_tunnel_bandwidth
+       on: azure_monitor.vpn_gateway.tunnel_bandwidth
+    class: Workload
+     type: Other
+component: Azure VPN Gateway
+   lookup: average -5m unaligned of average
+    units: bytes/s
+    every: 1m
+     info: Average tunnel bandwidth on VPN Gateway ${label:resource_name} \
+           in ${label:resource_group} (${label:region})
+       to: silent


### PR DESCRIPTION
##### Summary

Alerts from #21906

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Netdata Health alert templates for Azure Monitor, covering availability, utilization, errors, and latency across 35+ Azure services. This enables quick, out-of-the-box detection of outages, throttling, and capacity issues.

- **New Features**
  - Health rules added for: Compute (VMs, VMSS, AKS), Web (App Service, API Management, Application Gateway, Front Door), Data (SQL DB/MI/Elastic Pool, Cosmos DB, MySQL/Postgres Flexible, Redis, Data Explorer, Synapse, Data Factory, Log Analytics, Storage Accounts), Messaging (Service Bus, Event Hubs, Event Grid, IoT Hub), Networking (Load Balancer, NAT, VPN/ExpressRoute, Firewall), Containers (Container Apps, ACI, ACR), and Platform (Key Vault, Cognitive Services, Machine Learning, Logic Apps).
  - Thresholds tuned to Azure SLAs and common SRE practices; includes traffic-aware ratios and NaN guards to reduce noise.
  - Consistent 5–10m lookbacks with clear summaries/info and default recipients (`sysadmin`, `dba`).

- **Migration**
  - Ensure the `azure_monitor` collector is enabled and resources are discovered.
  - Reload health configs (restart the agent or run netdatacli reload-health) to apply the new alarms.

<sup>Written for commit 617f601a6fe85e550e9b99e1bce21209fa4ba60a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

