### PR TITLE
Create journal directory if missing before watching

### DIFF
--- a/src/crates/netdata-log-viewer/otel-signal-viewer-plugin/src/main.rs
+++ b/src/crates/netdata-log-viewer/otel-signal-viewer-plugin/src/main.rs
@@ -81,6 +81,14 @@ async fn run_plugin() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     // Watch configured journal directories
     for path in &config.journal.paths {
+        // Create the directory if it doesn't exist so inotify can watch it.
+        // The otel plugin creates it too (via create_dir_all), but it may start later.
+        if !std::path::Path::new(path).exists() {
+            if let Err(e) = std::fs::create_dir_all(path) {
+                error!("failed to create directory {}: {}", path, e);
+            }
+        }
+
         if let Err(e) = catalog_function.watch_directory(path) {
             error!("failed to watch directory {}: {:#?}", path, e);
         }


### PR DESCRIPTION
##### Summary

If the otel-signal-viewer plugin starts before the otel plugin, the journal directory (e.g. /var/log/netdata/otel/v1) might not yet exist. This causes inotify watch setup to fail, and the viewer never picks up logs even after the otel plugin creates the directory and starts writing.

Create the directory with create_dir_all before setting up the watch. This is safe because the otel plugin also uses create_dir_all (to create a machine-id subdirectory inside it), which is idempotent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create the journal directory if missing before setting up the inotify watch in the otel-signal-viewer. This fixes a startup race with the otel plugin where the watch failed and logs were never picked up; uses `create_dir_all`, which is idempotent.

<sup>Written for commit 7699572f0fb0ada62c85aa66f34badc2533061ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

