### PR TITLE
docs: remove Nagios from Prometheus meta

### DIFF
--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -3250,33 +3250,6 @@ modules:
   - <<: *module
     meta:
       <<: *meta
-      id: collector-go.d.plugin-prometheus-nagios
-      community: true
-      monitored_instance:
-        name: Nagios
-        link: https://github.com/wbollock/nagios_exporter
-        icon_filename: nagios.png
-        categories:
-          - data-collection.applications
-      keywords: [ ]
-    overview:
-      <<: *overview
-      data_collection:
-        metrics_description: |
-          Keep tabs on Nagios network monitoring metrics for efficient
-          IT infrastructure management and performance.
-        method_description: |
-          Metrics are gathered by periodically sending HTTP requests to [Nagios exporter](https://github.com/wbollock/nagios_exporter).
-    setup:
-      <<: *setup
-      prerequisites:
-        list:
-          - title: Install Exporter
-            description: |
-              Install [Nagios exporter](https://github.com/wbollock/nagios_exporter) by following the instructions mentioned in the exporter README.
-  - <<: *module
-    meta:
-      <<: *meta
       id: collector-go.d.plugin-prometheus-nature_remo
       community: true
       monitored_instance:


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

- [ ] AI-generated or AI-assisted content has been manually verified (examples/instructions tested where applicable).

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Nagios exporter entry from the Prometheus collector metadata to stop advertising an unsupported integration and clean up the docs. The Nagios block was deleted from src/go/plugin/go.d/collector/prometheus/metadata.yaml so it no longer shows up in generated docs or UI lists.

<sup>Written for commit a9e49e59a4f379017626bb1e4ded93827564cf86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

