### PR TITLE
Windows documentation

### DIFF
--- a/docs/category-overview-pages/working-with-netdata-on-windows.md
+++ b/docs/category-overview-pages/working-with-netdata-on-windows.md
@@ -77,7 +77,7 @@ When `edit-config` opens the file on Windows, it uses the `nano` editor.
 - Search: press `Ctrl + W`, type the text you want to find, then press `Enter`.
 - Save: press `Ctrl + O`, press `Enter` to confirm the filename, then wait for nano to write the file.
 - Exit: press `Ctrl + X`.
-- Exit without losing changes: if nano asks whether to save modified content, press `Y` to save or `N` to leave without saving.
+- Exit after editing: press `Ctrl + X`. If nano asks whether to save modified content, press `Y` to save your changes or `N` to discard them.
 
 ## Related Windows documentation
 


### PR DESCRIPTION
##### Summary

After different users showed misunderstanding about msys2 and the expected input in netdata.conf when running Netdata on Windows, this PR brings new documentation to help them edit configuration files

##### Test Plan

- Verify grammar.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful  there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new “Working with Netdata on Windows” doc to clarify how to use the bundled `msys2.exe`, write MSYS-style paths in configs, and edit files safely with `edit-config`. This aims to reduce confusion when configuring Netdata on Windows.

- **New Features**
  - New page: `docs/category-overview-pages/working-with-netdata-on-windows.md`.
  - How to launch `msys2.exe` (Run dialog, PowerShell, CMD).
  - Rules and examples for MSYS path format (e.g., `C:\` → `/c/`).
  - Edit configs via `/etc/netdata/edit-config`; defaults to `nano` with basic shortcuts.
  - Cross-link to Netdata Agent Configuration (full `edit-config` workflow) and related Windows docs.

<sup>Written for commit 40c850f9f7131edf693e92cfb96bc77a1cdd9acd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

