### PR TITLE
Fix cache (SIGSEGV)

### DIFF
--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -216,12 +216,18 @@ static inline size_t page_size_from_assumed_size(PGC *cache, size_t assumed_size
 // locking
 
 static inline size_t pgc_indexing_partition(PGC *cache, Word_t metric_id) {
+    static __thread PGC *last_cache = NULL;
+    static __thread size_t last_partitions = 0;
     static __thread Word_t last_metric_id = 0;
     static __thread size_t last_partition = 0;
 
-    if(metric_id == last_metric_id || cache->config.partitions == 1)
+    if(cache == last_cache &&
+       cache->config.partitions == last_partitions &&
+       (metric_id == last_metric_id || cache->config.partitions == 1))
         return last_partition;
 
+    last_cache = cache;
+    last_partitions = cache->config.partitions;
     last_metric_id = metric_id;
     last_partition = indexing_partition(metric_id, cache->config.partitions);
 
@@ -3141,6 +3147,32 @@ int pgc_unittest(void) {
     pgc_page_hot_to_dirty_and_release(cache, page3, false);
 
     pgc_destroy(cache, true);
+
+    {
+        PGC *cache_a = pgc_create("partition-cache-a",
+                                  32 * 1024 * 1024, unittest_free_clean_page_callback,
+                                  64, NULL, unittest_save_dirty_page_callback,
+                                  10, 10, 1000, 10,
+                                  PGC_OPTIONS_DEFAULT, 4, 0);
+        PGC *cache_b = pgc_create("partition-cache-b",
+                                  32 * 1024 * 1024, unittest_free_clean_page_callback,
+                                  64, NULL, unittest_save_dirty_page_callback,
+                                  10, 10, 1000, 10,
+                                  PGC_OPTIONS_DEFAULT, 5, 0);
+
+        Word_t metric_id = 5;
+        size_t partition_a = pgc_indexing_partition(cache_a, metric_id);
+        size_t partition_b = pgc_indexing_partition(cache_b, metric_id);
+
+        if(partition_a != indexing_partition(metric_id, cache_a->config.partitions))
+            fatal("pgc_indexing_partition() returned the wrong partition for cache_a");
+
+        if(partition_b != indexing_partition(metric_id, cache_b->config.partitions))
+            fatal("pgc_indexing_partition() returned the wrong partition for cache_b");
+
+        pgc_destroy(cache_a, true);
+        pgc_destroy(cache_b, true);
+    }
 
 #ifdef PGC_STRESS_TEST
     unittest_stress_test();


### PR DESCRIPTION
##### Summary
This PR fixes the following SIGSEGV detected on a host:

```sh
{"function":"aral_add_free_slot___no_lock_required","stack_trace":"
#0 <unknown> [0x7F00DB37241F]\n
#1 aral_add_free_slot___no_lock_required [0x559B10FFD2A5] (/src/libnetdata/aral/aral.c:899)\n
#2 aral_freez_internal [0x559B10FFD2A5] (/src/libnetdata/aral/aral.c:1005)\n
#3 pgc_open_cache_to_journal_v2 [0x559B11344FE1] (/src/database/engine/cache.c:2612)\n
#4 journal_v2_indexing_tp_worker [0x559B11376F6F] (/src/database/engine/rrdengine.c:1956)\n
#5 work_standard_worker [0x559B1137A073] (/src/database/engine/rrdengine.c:242)\n
#6 <unknown> [0x7F00DAB6F51D]\n
#7 <unknown> [0x7F00DB366608]\n
#8 <unknown> [0x7F00DB08E352]\n
#9 <unknown> [0xFFFFFFFFFFFFFFFF]","status":"running","thread":"UV_WORKER","thread_id":"1432","worker_job_id":"13"}
```

##### Test Plan

- Compile locally;
- Verify no issue is having with your data and netdata agent.

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a SIGSEGV in the cache/journal path by making `pgc_indexing_partition`’s thread-local memoization aware of the cache instance and partition count. Adds unit tests to ensure correct partitioning across different caches.

- **Bug Fixes**
  - Track `last_cache` and `last_partitions` alongside `last_metric_id`; only reuse the cached partition when both the cache and partition count match.
  - Add unit tests creating two caches with different partition counts to verify `pgc_indexing_partition` returns the correct partition for each.

<sup>Written for commit 7ab25853096b0c6864ec7f1fa8e32c2d6c69be4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

