### PR TITLE
Fix handling of package publishing detection in updater script.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -655,6 +655,45 @@ download() {
   fi
 }
 
+check_for_remote_file() {
+  url="${1}"
+  succeeded=0
+  checked=0
+
+  if echo "${url}" | grep -Eq "^file:///"; then
+    [ -e "${url#file://}" ] || return 1
+    return 0
+  elif [ -n "${NETDATA_ASSUME_REMOTE_FILES_ARE_PRESENT}" ]; then
+    return 0
+  fi
+
+  if [ -n "${curl}" ]; then
+    checked=1
+
+    if "${curl}" --output /dev/null --silent --head --fail "${url}"; then
+      succeeded=1
+    fi
+  fi
+
+  if [ "${checked}" -eq 0 ]; then
+    if command -v wget > /dev/null 2>&1; then
+      checked=1
+
+      if wget -S --spider "${url}" 2>&1 | grep -q 'HTTP/1.1 200 OK'; then
+        succeeded=1
+      fi
+    fi
+  fi
+
+  if [ "${succeeded}" -eq 1 ]; then
+    return 0
+  elif [ "${checked}" -eq 1 ]; then
+    return 1
+  else
+    return 255
+  fi
+}
+
 get_netdata_latest_tag() {
   url="${1}/latest"
 
@@ -1210,7 +1249,7 @@ update_binpkg() {
     info "Checking if native packages are still being published for this platform."
 
     set +e
-    _safe_download "${check_url}" /dev/null
+    check_for_remote_file "${check_url}"
     ret=$?
     set -e
 

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -667,6 +667,8 @@ check_for_remote_file() {
     return 0
   fi
 
+  check_for_curl
+
   if [ -n "${curl}" ]; then
     checked=1
 

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -677,7 +677,7 @@ check_for_remote_file() {
     fi
   fi
 
-  if [ "${checked}" -eq 0 ]; then
+  if [ "${succeeded}" -eq 0 ]; then
     if command -v wget > /dev/null 2>&1; then
       checked=1
 


### PR DESCRIPTION
##### Summary

This updates the remote file check to be consistent with how the kickstart script handles it, which should make it behave consistently (and thus correctly).

##### Test Plan

Requires manual testing. Simplest check is to install native packages on Ubutnu 20.04 and then try to run the updater script. It should fail with an error message indicating that we no longer publish packages for that system.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the updater’s detection of whether native packages are still published, aligning it with the kickstart script. This prevents updates on unsupported systems and shows a clear error instead.

- **Bug Fixes**
  - Added `check_for_remote_file` to probe URLs: supports `file://`, honors `NETDATA_ASSUME_REMOTE_FILES_ARE_PRESENT`, detects `curl` correctly and uses it (HEAD) or falls back to `wget --spider`; mirrors kickstart behavior and return codes.
  - Replaced `_safe_download` check in the native package path with the new helper.
  - Updater now exits with a clear message when packages aren’t published for the platform.

<sup>Written for commit e3f85d4529fb37583898876538cee332745be799. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

