### PR TITLE
docs: fix integration name collision

### DIFF
--- a/src/collectors/windows.plugin/metadata.yaml
+++ b/src/collectors/windows.plugin/metadata.yaml
@@ -109,7 +109,7 @@ modules:
       plugin_name: windows.plugin
       module_name: PerflibMemory
       monitored_instance:
-        name: Memory statistics
+        name: Memory Statistics (Win)
         link: "https://learn.microsoft.com/en-us/windows/win32/Memory/memory-management"
         categories:
           - data-collection.operating-systems
@@ -1069,7 +1069,7 @@ modules:
       plugin_name: windows.plugin
       module_name: GetPowerSupply
       monitored_instance:
-        name: Power supply
+        name: Power Supply (Win)
         link: "https://learn.microsoft.com/en-us/windows/win32/power/power-management-portal"
         categories:
           - data-collection.hardware-and-sensors


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

- [ ] AI-generated or AI-assisted content has been manually verified (examples/instructions tested where applicable).

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed two Windows integration entries in docs to prevent name collisions with similarly named integrations. This clarifies Memory and Power Supply pages without changing functionality.

- **Bug Fixes**
  - Memory: renamed to "Memory Statistics (Win)"
  - Power Supply: renamed to "Power Supply (Win)"
  - Docs metadata only; no runtime impact

<sup>Written for commit a71447e6dba738e65d9b25cae7a708f891a96310. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

