### PR TITLE
Make release profile optimize for speed vs. size

### DIFF
--- a/src/crates/Cargo.toml
+++ b/src/crates/Cargo.toml
@@ -166,10 +166,9 @@ debug-assertions = true
 
 [profile.release]
 debug = true
-# lto = true
-opt-level = "z"
-# strip = true
-# codegen-units = 1
+lto = "fat"
+opt-level = 3
+codegen-units = 1
 
 [profile.release-min]
 inherits = "release"


### PR DESCRIPTION
SSIA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch release builds to prioritize runtime speed over binary size. Enables fat LTO, sets opt-level=3, and sets codegen-units=1 for faster binaries, at the cost of larger size and longer compile times.

<sup>Written for commit 8209671d3b6d9be13c44edb04805ed65cbbaa867. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

