### PR TITLE
Optimize EBPF memory handling and PID indexing.

### DIFF
--- a/src/collectors/collectors-ipc/ebpf-ipc.c
+++ b/src/collectors/collectors-ipc/ebpf-ipc.c
@@ -9,21 +9,29 @@ sem_t *shm_mutex_ebpf_integration = SEM_FAILED;
 static Pvoid_t ebpf_ipc_JudyL = NULL;
 ebpf_user_mem_stat_t ebpf_stat_values;
 
-static uint32_t *ebpf_shm_find_index_unsafe(uint32_t pid)
+// Judy stores index+1 directly in the pointer slot to avoid heap allocation.
+// 0 means "not found" (Judy returns NULL for missing keys),
+// so we offset by 1: stored = index+1, retrieved = stored-1.
+#define IDX_TO_JVALUE(idx) ((Pvoid_t)((Word_t)(idx) + 1))
+#define JVALUE_TO_IDX(pv)  ((uint32_t)((Word_t)(pv) - 1))
+#define JVALUE_IS_VALID(pv) ((pv) != NULL)
+
+static bool ebpf_shm_find_index_unsafe(uint32_t pid, uint32_t *result)
 {
     Pvoid_t *Pvalue = JudyLGet(ebpf_ipc_JudyL, (Word_t)pid, PJE0);
-    if (Pvalue)
-        return *Pvalue;
-    return NULL;
+    if (Pvalue && JVALUE_IS_VALID(*Pvalue)) {
+        *result = JVALUE_TO_IDX(*Pvalue);
+        return true;
+    }
+    return false;
 }
 
 static bool ebpf_find_pid_shm_del_unsafe(uint32_t pid, enum ebpf_pids_index shm_idx)
 {
-    uint32_t *lpid = ebpf_shm_find_index_unsafe(pid);
-    if (!lpid)
+    uint32_t idx;
+    if (!ebpf_shm_find_index_unsafe(pid, &idx))
         return false;
 
-    uint32_t idx = *lpid;
     if (idx >= ebpf_stat_values.current)
         return false;
 
@@ -35,17 +43,17 @@ static bool ebpf_find_pid_shm_del_unsafe(uint32_t pid, enum ebpf_pids_index shm_
     if (ptr->threads)
         return true;
 
-    freez(lpid);
     (void)JudyLDel(&ebpf_ipc_JudyL, (Word_t)pid, PJE0);
     ebpf_stat_values.current--;
 
     if (idx == ebpf_stat_values.current)
         return false;
 
+    // Compact: move last entry into the freed slot
     uint32_t last_pid = integration_shm[ebpf_stat_values.current].pid;
-    uint32_t *last_lpid = ebpf_shm_find_index_unsafe(last_pid);
-    if (last_lpid) {
-        *last_lpid = idx;
+    Pvoid_t *Pvalue = JudyLGet(ebpf_ipc_JudyL, (Word_t)last_pid, PJE0);
+    if (Pvalue && JVALUE_IS_VALID(*Pvalue)) {
+        *Pvalue = IDX_TO_JVALUE(idx);
         memcpy(ptr, &integration_shm[ebpf_stat_values.current], sizeof(*ptr));
     }
 
@@ -54,9 +62,9 @@ static bool ebpf_find_pid_shm_del_unsafe(uint32_t pid, enum ebpf_pids_index shm_
 
 static uint32_t ebpf_find_or_create_index_pid(uint32_t pid)
 {
-    uint32_t *idx = ebpf_shm_find_index_unsafe(pid);
-    if (idx)
-        return *idx;
+    uint32_t idx;
+    if (ebpf_shm_find_index_unsafe(pid, &idx))
+        return idx;
 
     if (ebpf_stat_values.current >= ebpf_stat_values.total)
         return UINT32_MAX;
@@ -65,9 +73,7 @@ static uint32_t ebpf_find_or_create_index_pid(uint32_t pid)
     internal_fatal(!Pvalue || Pvalue == PJERR, "EBPF: pid judy index");
 
     uint32_t new_idx = ebpf_stat_values.current++;
-    uint32_t *stored_idx = callocz(1, sizeof(uint32_t));
-    *stored_idx = new_idx;
-    *Pvalue = stored_idx;
+    *Pvalue = IDX_TO_JVALUE(new_idx);
 
     return new_idx;
 }
@@ -108,16 +114,8 @@ void netdata_integration_cleanup_shm()
         integration_shm = NULL;
     }
 
-    Word_t index = 0;
-    Word_t next_index;
-    PPvoid_t pid_ptr;
-    while ((pid_ptr = JudyLFirst(ebpf_ipc_JudyL, &index, PJE0)) != NULL) {
-        uint32_t *pid = *(uint32_t **)pid_ptr;
-        next_index = index;
-        freez(pid);
-        JudyLDel(&ebpf_ipc_JudyL, next_index, PJE0);
-        index = next_index;
-    }
+    // Values are stored inline (no heap allocation), just free the Judy array
+    (void)JudyLFreeArray(&ebpf_ipc_JudyL, PJE0);
     ebpf_ipc_JudyL = NULL;
 
     if (shm_fd_ebpf_integration > 0) {

--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -2299,6 +2299,19 @@ static void ebpf_signal_stop_handler(int sig)
  */
 int main(int argc, char **argv)
 {
+    // Reduce memory footprint:
+    // - Single malloc arena avoids fragmentation across 24+ threads
+    // - Allocations >1MB use mmap so they're returned to OS on free,
+    //   preventing 30MB+ of brk heap holes from libbpf's temp buffers
+    // - THP disabled prevents 2MB huge page waste in sparse allocations
+#if defined(HAVE_C_MALLOPT)
+    mallopt(M_ARENA_MAX, 1);
+    mallopt(M_MMAP_THRESHOLD, 1024 * 1024);
+#endif
+#if defined(HAVE_SYS_PRCTL_H) && defined(PR_SET_THP_DISABLE)
+    prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
+#endif
+
     nd_log_initialize_for_external_plugins(NETDATA_EBPF_PLUGIN_NAME);
     netdata_threads_init_for_external_plugins(0);
 
@@ -2372,6 +2385,12 @@ int main(int argc, char **argv)
             em->lifetime = EBPF_DEFAULT_LIFETIME;
         }
     }
+
+    // BPF loading allocated ~50MB then freed most of it.
+    // glibc keeps freed pages in its free list; trim returns them to the OS.
+#if defined(HAVE_C_MALLOC_TRIM)
+    malloc_trim(0);
+#endif
 
     heartbeat_t hb;
     heartbeat_init(&hb, USEC_PER_SEC);


### PR DESCRIPTION
##### Summary
- Replace heap allocations with inline Judy array storage for efficiency.
- Add macros for value conversion, ensuring safer and more compact logic.
- Reduce fragmentation and improve memory reuse in allocator settings.
- Trim unused memory after BPF initialization to minimize memory footprint.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize EBPF memory usage and PID indexing by storing Judy values inline and tuning allocator behavior. This removes per-PID heap allocations, reduces fragmentation, and releases freed pages after BPF load.

- **Refactors**
  - Store `index+1` directly in Judy values; added `IDX_TO_JVALUE`, `JVALUE_TO_IDX`, and `JVALUE_IS_VALID`.
  - Change PID lookup to a bool + out-param; on delete, compact by moving the last entry and updating its Judy value.
  - Simplify cleanup by freeing the Judy array once (no per-entry frees).

- **Performance**
  - Set `mallopt(M_ARENA_MAX, 1)` and `mallopt(M_MMAP_THRESHOLD, 1MB)` to limit arenas and mmap large allocs.
  - Disable THP with `prctl(PR_SET_THP_DISABLE)` to avoid sparse huge pages.
  - Call `malloc_trim(0)` after BPF initialization to return freed memory to the OS.

<sup>Written for commit c4d973722ed1a9cd9289029d6d80ce9a86af1707. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

