### PR TITLE
Improve ML model loading

### DIFF
--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -175,8 +175,8 @@ const char *db_models_load =
     "c00, c01, c02, c03, c04, c05, "
     "c10, c11, c12, c13, c14, c15 FROM models "
     "WHERE dim_id = @dim_id AND after >= @after "
-    "ORDER BY before DESC, after DESC LIMIT @n"
-    ") ORDER BY before ASC, after ASC;";
+    "ORDER BY after DESC LIMIT @n"
+    ") ORDER BY after ASC;";
 
 const char *db_models_delete =
     "DELETE FROM models "


### PR DESCRIPTION
##### Summary
- Load the most recent models (up to the configured required models)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load only the most recent ML models up to the configured limit to speed up initialization and reduce DB work.

- **Refactors**
  - Rewrote `db_models_load` to select explicit columns, fetch the N newest via subquery (`ORDER BY after DESC LIMIT @n`), then return them sorted by `after` ASC.
  - Bind `Cfg.num_models_to_use` as `@n` and tidy `ml_dimension_stream_kmeans` indentation.

<sup>Written for commit 17c8239cf5679f1206c3f2592fcabf8f95233fd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

