### PR TITLE
FIX SIGSEGV Judy array

### DIFF
--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1497,7 +1497,7 @@ void datafile_delete(
                 // pending_deletion is already set, blocking new acquires.
                 // Bail out and let the next rotation cycle retry - lockers
                 // will drain over time since no new ones can be added.
-                netdata_log_error("DBENGINE: tier %d: " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL
+                netdata_log_error("DBENGINE: tier %u: " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL
                                   " could not be acquired for deletion after %zu attempts (%u lockers remain)"
                                   " - will retry on next rotation",
                                   tier, datafile->tier, fileno, attempts, datafile->users.lockers);
@@ -1508,7 +1508,7 @@ void datafile_delete(
                 return;
             }
 
-            netdata_log_info("DBENGINE: tier %d: waiting for " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL
+            netdata_log_info("DBENGINE: tier %u: waiting for " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL
                          " to be available for deletion, in use by %u users.",
                  tier, datafile->tier, fileno, datafile->users.lockers);
 
@@ -1528,7 +1528,7 @@ void datafile_delete(
 //    }
 
     __atomic_add_fetch(&rrdeng_cache_efficiency_stats.datafile_deletion_started, 1, __ATOMIC_RELAXED);
-    netdata_log_info("DBENGINE: tier %d: deleting " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL " to maintain %s.",
+    netdata_log_info("DBENGINE: tier %u: deleting " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL " to maintain %s.",
                      tier, datafile->tier, fileno, disk_time ? "disk quota" : "time retention");
 
     if(worker)
@@ -1586,10 +1586,10 @@ void datafile_delete(
     bool exp_njfv2 = expected_journal_files & JOURNALFILE_DELETED_V2;
 
     if (del_ndf && del_njf && del_njfv2)
-        netdata_log_info("DBENGINE: tier %d: deleted " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL " (.ndf, .njf, .njfv2), reclaimed %s.",
+        netdata_log_info("DBENGINE: tier %u: deleted " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL " (.ndf, .njf, .njfv2), reclaimed %s.",
                          tier, datafile_tier, fileno, size_for_humans);
     else if (del_ndf && del_njf && !exp_njfv2)
-        netdata_log_info("DBENGINE: tier %d: deleted " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL " (.ndf, .njf), reclaimed %s.",
+        netdata_log_info("DBENGINE: tier %u: deleted " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL " (.ndf, .njf), reclaimed %s.",
                          tier, datafile_tier, fileno, size_for_humans);
     else if (del_ndf || del_njf || del_njfv2) {
         BUFFER *removed = buffer_create(0, NULL);
@@ -1607,18 +1607,18 @@ void datafile_delete(
         if (exp_njfv2 && !del_njfv2) { buffer_strcat(failed, sep); buffer_strcat(failed, ".njfv2"); }
 
         if(buffer_strlen(failed))
-            netdata_log_error("DBENGINE: tier %d: partial delete of " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL
+            netdata_log_error("DBENGINE: tier %u: partial delete of " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL
                               " - removed: %s, failed: %s, reclaimed %s.",
                               tier, datafile_tier, fileno,
                               buffer_tostring(removed), buffer_tostring(failed), size_for_humans);
         else
-            netdata_log_info("DBENGINE: tier %d: deleted " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL " (%s), reclaimed %s.",
+            netdata_log_info("DBENGINE: tier %u: deleted " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL " (%s), reclaimed %s.",
                              tier, datafile_tier, fileno, buffer_tostring(removed), size_for_humans);
         buffer_free(removed);
         buffer_free(failed);
     }
     else
-        netdata_log_error("DBENGINE: tier %d: failed to delete " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL " to maintain %s.",
+        netdata_log_error("DBENGINE: tier %u: failed to delete " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL " to maintain %s.",
                           tier, datafile_tier, fileno, disk_time ? "disk quota" : "time retention");
 }
 
@@ -1809,11 +1809,16 @@ static void *ctx_shutdown_tp_worker(struct rrdengine_instance *ctx __maybe_unuse
 
     bool logged = false;
     while(__atomic_load_n(&ctx->atomic.extents_currently_being_flushed, __ATOMIC_RELAXED) ||
-            __atomic_load_n(&ctx->atomic.inflight_queries, __ATOMIC_RELAXED)) {
+            __atomic_load_n(&ctx->atomic.inflight_queries, __ATOMIC_RELAXED) ||
+            __atomic_load_n(&ctx->atomic.collectors_running, __ATOMIC_RELAXED)) {
         if(!logged) {
             logged = true;
-            netdata_log_info("DBENGINE: waiting for %zu inflight queries to finish to shutdown tier %d...",
-                 __atomic_load_n(&ctx->atomic.inflight_queries, __ATOMIC_RELAXED), ctx->config.tier);
+            netdata_log_info("DBENGINE: waiting for shutdown preconditions on tier %d "
+                             "(collectors_running=%zu, inflight_queries=%zu, extents_currently_being_flushed=%u)...",
+                             ctx->config.tier,
+                             __atomic_load_n(&ctx->atomic.collectors_running, __ATOMIC_RELAXED),
+                             __atomic_load_n(&ctx->atomic.inflight_queries, __ATOMIC_RELAXED),
+                             __atomic_load_n(&ctx->atomic.extents_currently_being_flushed, __ATOMIC_RELAXED));
         }
         sleep_usec(1 * USEC_PER_MS);
     }

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -1226,6 +1226,25 @@ size_t rrdeng_collectors_running(struct rrdengine_instance *ctx) {
     return __atomic_load_n(&ctx->atomic.collectors_running, __ATOMIC_RELAXED);
 }
 
+#define RRDENG_SHUTDOWN_WAIT_SLEEP_MS 100
+#define RRDENG_SHUTDOWN_LOG_EVERY_SEC 5
+#define RRDENG_SHUTDOWN_COLLECTORS_TIMEOUT_SEC 30
+#define RRDENG_SHUTDOWN_COMPLETION_TIMEOUT_SEC 30
+
+NORETURN
+static void rrdeng_shutdown_watchdog_timeout(struct rrdengine_instance *ctx, const char *phase) {
+    netdata_log_error(
+        "DBENGINE: shutdown watchdog timeout (%d seconds) exceeded while %s tier %d "
+        "(collectors_running=%zu, inflight_queries=%zu, extents_currently_being_flushed=%u)",
+        RRDENG_SHUTDOWN_COLLECTORS_TIMEOUT_SEC,
+        phase,
+        ctx ? ctx->config.tier : 0,
+        ctx ? __atomic_load_n(&ctx->atomic.collectors_running, __ATOMIC_RELAXED) : 0,
+        ctx ? __atomic_load_n(&ctx->atomic.inflight_queries, __ATOMIC_RELAXED) : 0,
+        ctx ? __atomic_load_n(&ctx->atomic.extents_currently_being_flushed, __ATOMIC_RELAXED) : 0);
+    abort();
+}
+
 /*
  * Returns 0 on success, 1 on error
  */
@@ -1240,14 +1259,22 @@ int rrdeng_exit(struct rrdengine_instance *ctx) {
     // 4. then wait for completion
 
     bool logged = false;
-    size_t count = 10;
-    while(__atomic_load_n(&ctx->atomic.collectors_running, __ATOMIC_RELAXED) && count && !unittest_running) {
-        if(!logged) {
-            netdata_log_info("DBENGINE: waiting for collectors to finish on tier %d...", ctx->config.tier);
+    usec_t started_ut = now_monotonic_usec();
+    usec_t next_log_ut = started_ut;
+    while(__atomic_load_n(&ctx->atomic.collectors_running, __ATOMIC_RELAXED) && !unittest_running) {
+        usec_t now_ut = now_monotonic_usec();
+
+        if(now_ut - started_ut >= RRDENG_SHUTDOWN_COLLECTORS_TIMEOUT_SEC * USEC_PER_SEC)
+            rrdeng_shutdown_watchdog_timeout(ctx, "waiting for collectors to finish on");
+
+        if(!logged || now_ut >= next_log_ut) {
+            netdata_log_info("DBENGINE: waiting for %zu collectors to finish on tier %d...",
+                             __atomic_load_n(&ctx->atomic.collectors_running, __ATOMIC_RELAXED), ctx->config.tier);
             logged = true;
+            next_log_ut = now_ut + RRDENG_SHUTDOWN_LOG_EVERY_SEC * USEC_PER_SEC;
         }
-        sleep_usec(100 * USEC_PER_MS);
-        count--;
+
+        sleep_usec(RRDENG_SHUTDOWN_WAIT_SLEEP_MS * USEC_PER_MS);
     }
 
     pgc_flush_all_hot_and_dirty_pages(main_cache, (Word_t)ctx);
@@ -1256,7 +1283,9 @@ int rrdeng_exit(struct rrdengine_instance *ctx) {
     completion_init(&completion);
     rrdeng_enq_cmd(ctx, RRDENG_OPCODE_CTX_SHUTDOWN, NULL, &completion, STORAGE_PRIORITY_BEST_EFFORT, NULL, NULL);
 
-    completion_wait_for(&completion);
+    if(!completion_timedwait_for(&completion, RRDENG_SHUTDOWN_COMPLETION_TIMEOUT_SEC))
+        rrdeng_shutdown_watchdog_timeout(ctx, "waiting for ctx shutdown completion on");
+
     completion_destroy(&completion);
 
     if(unittest_running)


### PR DESCRIPTION
##### Summary

daemon-shutdown.c — the collector wait loop had no sleep. nd_log_limit is a rate-limited logger; it does NOT pause execution. The loop completed 50 iterations in microseconds and exited even with active collectors, allowing pgc_destroy to free Judy array memory while a collector thread was mid-call in JudyLIns → NULL dereference inside j__udySearchLeaf2 → SIGSEGV.


Core dump:

<details> <summary>Stacktrace</summary>
<pre>
SIGSEGV / SI_KERNEL / 0x0: Fatal Error: SIGSEGV / SI_KERNEL / 0x0
  netdata             0x649451dccf26 j__udySearchLeaf2 (JudyPrivate.h:1563)
  netdata             0x649451dccf26 j__udyInsWalk (JudyLIns.c:797)
  netdata             0x649451dcccbd j__udyInsWalk (JudyLIns.c:1650)
  netdata             0x649451dcccbd j__udyInsWalk (JudyLIns.c:1650)
  netdata             0x649451dd07d2 JudyLIns (JudyLIns.c:1847)
  netdata             0x64945199768d pgc_page_add.lto_priv.0 (cache.c:1449)
  netdata             0x64945197973f pgc_page_add_and_acquire (cache.c:2175)
  netdata             0x64945197973f rrdeng_store_metric_create_new_page.lto_priv.0 (rrdengineapi.c:393)
  netdata             0x6494512874a0 rrdeng_store_metric_append_point (rrdengineapi.c:522)
  netdata             0x6494512874a0 rrdeng_store_metric_next (rrdengineapi.c:656)
  netdata             0x6494512874a0 storage_engine_store_metric (storage-engine.h:178)
  netdata             0x6494512874a0 store_metric_at_tier_flush_last_completed (rrddim-collection.c:23)
  netdata             0x6494512874a0 store_metric_at_tier_save_last_completed (rrddim-collection.c:54)
  netdata             0x6494512874a0 store_metric_at_tier (rrddim-collection.c:75)
  netdata             0x6494512874a0 rrddim_store_metric (rrddim-collection.c:180)
</pre>
</details>

##### Test Plan

- Check CI

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve DB engine shutdown to reliably wait for collectors and inflight work, preventing Judy array frees during inserts and avoiding the SIGSEGV in JudyLIns/j__udySearchLeaf2.

- **Bug Fixes**
  - In `rrdeng_exit`: drain collectors with 100 ms sleeps, log every 5s, and enforce 30s watchdogs for both collector drain and shutdown completion (timed wait + abort on timeout).
  - In `ctx_shutdown_tp_worker`: also wait on `collectors_running` with 1 ms sleeps and log all preconditions; fix tier log formatting to `%u` in deletion logs.

<sup>Written for commit 4a8407ab33fa07a7f8721bd68a2ec6d77eab5a3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

