### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ On Linux, you can continuously monitor all kernel features and hardware sensors 
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/netdata-netdata-netdata).
+
 ## Getting Started
 
 You can install Netdata on all major operating systems. To begin:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/netdata-netdata-netdata)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Hosted deployment section to the README with a link to Fronteir for a ready-to-use hosted option. This makes it easier to try Netdata without installing locally.

<sup>Written for commit ed65de59052200b29811bc17fe4f7e80ed5531f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

