### PR TITLE
fix(go.d/secretsctl): handle userconfig for job IDs

### DIFF
--- a/src/go/plugin/agent/jobmgr/dyncfg_secretstore_test.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_secretstore_test.go
@@ -48,7 +48,7 @@ func TestDyncfgSecretStoreSeqExec(t *testing.T) {
 				assert.Equal(t, dyncfg.StatusRunning, entry.Status)
 				_, ok = mustSecretStoreService(t, mgr).GetStatus(secretstore.StoreKey(secretstore.KindVault, "vault_prod"))
 				assert.True(t, ok)
-				assert.Contains(t, out.String(), "schema get update test remove")
+				assert.Contains(t, out.String(), "schema get update test userconfig remove")
 				assert.NotContains(t, out.String(), "enable")
 				assert.NotContains(t, out.String(), "disable")
 

--- a/src/go/plugin/agent/jobmgr/secretsctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/controller.go
@@ -92,6 +92,7 @@ func New(opts Options) *Controller {
 			dyncfg.CommandGet,
 			dyncfg.CommandUpdate,
 			dyncfg.CommandTest,
+			dyncfg.CommandUserconfig,
 		},
 	})
 	return c

--- a/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
@@ -106,19 +106,10 @@ func (c *Controller) dyncfgCmdAdd(fn dyncfg.Function) {
 }
 
 func (c *Controller) dyncfgCmdSchema(fn dyncfg.Function) {
-	kind, ok := c.dyncfgExtractSecretStoreKindFromTemplateID(fn.ID())
-	if !ok {
-		storeKey, ok := c.dyncfgExtractSecretStoreKey(fn.ID())
-		if !ok {
-			c.api.SendCodef(fn, 400, "Invalid ID format for secretstore schema: %s.", fn.ID())
-			return
-		}
-		entry, ok := c.lookup(storeKey)
-		if !ok {
-			c.api.SendCodef(fn, 404, "The specified secretstore '%s' is not configured.", storeKey)
-			return
-		}
-		kind = entry.Cfg.Kind()
+	kind, err := c.dyncfgResolveSecretStoreKind(fn.ID())
+	if err != nil {
+		c.api.SendCodef(fn, secretStoreErrorCode(err), "%v", err)
+		return
 	}
 
 	schema, ok := c.service.Schema(kind)
@@ -201,9 +192,9 @@ func (c *Controller) dyncfgCmdTest(fn dyncfg.Function) {
 }
 
 func (c *Controller) dyncfgCmdUserconfig(fn dyncfg.Function) {
-	kind, ok := c.dyncfgExtractSecretStoreKindFromTemplateID(fn.ID())
-	if !ok {
-		c.api.SendCodef(fn, 400, "Invalid template ID for secretstore userconfig: %s.", fn.ID())
+	kind, err := c.dyncfgResolveSecretStoreKind(fn.ID())
+	if err != nil {
+		c.api.SendCodef(fn, secretStoreErrorCode(err), "%v", err)
 		return
 	}
 	if err := fn.ValidateHasPayload(); err != nil {
@@ -288,6 +279,21 @@ func (c *Controller) dyncfgNewTypedConfig(kind secretstore.StoreKind) (any, erro
 		return nil, fmt.Errorf("secretstore kind '%s' does not provide configuration", kind)
 	}
 	return cfg, nil
+}
+
+func (c *Controller) dyncfgResolveSecretStoreKind(id string) (secretstore.StoreKind, error) {
+	if kind, ok := c.dyncfgExtractSecretStoreKindFromTemplateID(id); ok {
+		return kind, nil
+	}
+	storeKey, ok := c.dyncfgExtractSecretStoreKey(id)
+	if !ok {
+		return "", fmt.Errorf("invalid secretstore ID format: %s", id)
+	}
+	entry, ok := c.lookup(storeKey)
+	if !ok {
+		return "", fmt.Errorf("%w: %s", secretstore.ErrStoreNotFound, storeKey)
+	}
+	return entry.Cfg.Kind(), nil
 }
 
 func (c *Controller) dyncfgExtractSecretStoreKindFromTemplateID(id string) (secretstore.StoreKind, bool) {


### PR DESCRIPTION
- Fix dyncfgCmdUserconfig to handle both template IDs (go.d:secretstore:gcp) and job IDs (go.d:secretstore:gcp:gcp_service_account) by falling back to store key extraction when template ID parsing fails.
- Extract shared dyncfgResolveSecretStoreKind method to deduplicate the kind resolution logic used by both dyncfgCmdSchema and dyncfgCmdUserconfig.
- Add CommandUserconfig to the job dyncfg commands list.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

- [ ] AI-generated or AI-assisted content has been manually verified (examples/instructions tested where applicable).

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `go.d/secretsctl` userconfig to accept both template IDs and job IDs, and enables the `userconfig` command for job dyncfg. Centralizes kind resolution and improves error messages.

- **Bug Fixes**
  - `dyncfgCmdUserconfig` now supports both template IDs (e.g., `go.d:secretstore:gcp`) and job IDs (e.g., `go.d:secretstore:gcp:gcp_service_account`) by falling back to store key lookup.
  - Jobs now include `CommandUserconfig` in the dyncfg commands list.

- **Refactors**
  - Added `dyncfgResolveSecretStoreKind` and used it in both `dyncfgCmdSchema` and `dyncfgCmdUserconfig`, with unified error handling.

<sup>Written for commit dcedd39d5783e124e5cb5f155ddc07c8edcb6656. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

