### PR TITLE
Strip intermediate objects from flattened JSON

### DIFF
--- a/src/crates/netdata-otel/flatten_otel/src/lib.rs
+++ b/src/crates/netdata-otel/flatten_otel/src/lib.rs
@@ -13,6 +13,10 @@ pub use logs::{json_from_export_logs_service_request, json_from_log_record};
 pub use metrics::flatten_metrics_request;
 
 pub fn json_from_key_value_list(kvl: &Vec<KeyValue>) -> JsonMap<String, JsonValue> {
+    flatten_and_strip(&json_map_from_key_value_list(kvl))
+}
+
+fn json_map_from_key_value_list(kvl: &Vec<KeyValue>) -> JsonMap<String, JsonValue> {
     let mut map = JsonMap::new();
 
     for kv in kvl {
@@ -23,7 +27,14 @@ pub fn json_from_key_value_list(kvl: &Vec<KeyValue>) -> JsonMap<String, JsonValu
         }
     }
 
-    flatten_serde_json::flatten(&map)
+    map
+}
+
+pub(crate) fn flatten_and_strip(map: &JsonMap<String, JsonValue>) -> JsonMap<String, JsonValue> {
+    flatten_serde_json::flatten(map)
+        .into_iter()
+        .filter(|(_k, v)| !v.is_object())
+        .collect()
 }
 
 fn json_from_any_value(any_value: &AnyValue) -> JsonValue {
@@ -42,7 +53,9 @@ fn json_from_any_value(any_value: &AnyValue) -> JsonValue {
             let values: Vec<JsonValue> = array.values.iter().map(json_from_any_value).collect();
             JsonValue::Array(values)
         }
-        Some(Value::KvlistValue(kvl)) => JsonValue::Object(json_from_key_value_list(&kvl.values)),
+        Some(Value::KvlistValue(kvl)) => {
+            JsonValue::Object(json_map_from_key_value_list(&kvl.values))
+        }
         Some(Value::BytesValue(bytes)) => JsonValue::String(BASE64.encode(bytes)),
         None => JsonValue::Null,
     }

--- a/src/crates/netdata-otel/flatten_otel/src/logs.rs
+++ b/src/crates/netdata-otel/flatten_otel/src/logs.rs
@@ -5,8 +5,8 @@ use opentelemetry_proto::tonic::{
 };
 
 use crate::{
-    json_from_any_value, json_from_instrumentation_scope, json_from_key_value_list,
-    json_from_resource,
+    flatten_and_strip, json_from_any_value, json_from_instrumentation_scope,
+    json_from_key_value_list, json_from_resource,
 };
 
 pub fn json_from_log_record(jm: &mut JsonMap<String, JsonValue>, log_record: &LogRecord) {
@@ -43,7 +43,7 @@ pub fn json_from_log_record(jm: &mut JsonMap<String, JsonValue>, log_record: &Lo
                         let mut temp_map = JsonMap::new();
                         temp_map.insert("body".to_string(), parsed);
 
-                        let flattened_body = flatten_serde_json::flatten(&temp_map);
+                        let flattened_body = flatten_and_strip(&temp_map);
                         for (key, value) in flattened_body {
                             jm.insert(format!("log.{}", key), value);
                         }
@@ -66,7 +66,7 @@ pub fn json_from_log_record(jm: &mut JsonMap<String, JsonValue>, log_record: &Lo
                 let mut temp_map = JsonMap::new();
                 temp_map.insert("body".to_string(), body_json);
 
-                let flattened_body = flatten_serde_json::flatten(&temp_map);
+                let flattened_body = flatten_and_strip(&temp_map);
                 for (key, value) in flattened_body {
                     jm.insert(format!("log.{}", key), value);
                 }


### PR DESCRIPTION
flatten_serde_json::flatten() preserves intermediate object nodes alongside leaf values, causing space waste. For example, flattening nested structures produced both the flattened leaves AND the parent objects as serialized JSON blobs, with leaf values duplicated into arrays.

Introduce flatten_and_strip() that filters out intermediate objects after flattening. Split json_map_from_key_value_list (raw builder) from json_from_key_value_list (flatten+strip) to avoid double-flattening nested KvlistValues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop duplicating data in flattened JSON by stripping intermediate objects after flattening. This reduces payload size and removes redundant parent objects.

- **Bug Fixes**
  - Added `flatten_and_strip()` to drop object nodes returned by `flatten_serde_json::flatten()`.
  - Split json_map_from_key_value_list (raw) from json_from_key_value_list (build + flatten+strip) to avoid double-flattening nested Kvlist values.
  - Updated log body flattening to use flatten_and_strip.

<sup>Written for commit e197baebd6341c8c617cc1b76ad2f4c77b8a9ace. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

