### PR TITLE
Improve journal file logging

### DIFF
--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1374,7 +1374,7 @@ bool journalfile_migrate_to_v2_callback(Word_t section, unsigned datafile_fileno
     journalfile_v2_generate_path(datafile, path, sizeof(path));
 
     netdata_log_info("DBENGINE: tier %d: indexing " WALFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL WALFILE_EXTENSION_V2 ": extents %zu, metrics %zu, pages %zu",
-        datafile_ctx(datafile)->config.tier, datafile->tier, datafile->fileno,
+        ctx->config.tier, datafile->tier, datafile->fileno,
         number_of_extents,
         number_of_metrics,
         number_of_pages);


### PR DESCRIPTION

##### Summary
- Drop full path from journal file logging

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace full path logging for journal v2 files with structured file identifiers to standardize DBENGINE messages and avoid leaking absolute paths.

- **Refactors**
  - Updated “indexing” and “migrated” logs in `journalfile.c` to use WAL-style file IDs (`WALFILE_PREFIX` + `RRDENG_FILE_NUMBER_PRINT_TMPL` + `WALFILE_EXTENSION_V2`), reading the tier from `ctx->config.tier`.
  - Removed absolute paths from these messages.

<sup>Written for commit 9bd60437e068af175a32db3adec611113d859ab4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

