### PR TITLE
docs(go.d/mssql): add Windows Authentication setup guide

### DIFF
--- a/src/go/plugin/go.d/collector/mssql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mssql/metadata.yaml
@@ -123,6 +123,45 @@ modules:
               - `SELECT on distribution.dbo.MSreplication_monitordata` - Replication monitoring
               - `SELECT on distribution.dbo.MSpublications` - Publication information
               - `SELECT on distribution.dbo.MSsubscriptions` - Subscription counts
+          - title: Grant Windows Authentication access (optional)
+            description: |
+              If you prefer Windows integrated authentication instead of SQL authentication, grant the
+              Netdata service account access to SQL Server.
+
+              By default, the Netdata service runs as `Local System`. The identity it presents to
+              SQL Server depends on your environment:
+
+              **Domain-joined machine (Active Directory):**
+
+              `Local System` authenticates as the computer account (`DOMAIN\COMPUTERNAME$`).
+              Replace `DOMAIN\COMPUTERNAME$` with your actual values
+              (e.g., `MYDOM\SQLBOX01$`).
+
+              ```sql
+              CREATE LOGIN [DOMAIN\COMPUTERNAME$] FROM WINDOWS;
+              GRANT VIEW SERVER STATE TO [DOMAIN\COMPUTERNAME$];
+              GRANT VIEW ANY DEFINITION TO [DOMAIN\COMPUTERNAME$];
+              USE msdb;
+              CREATE USER [DOMAIN\COMPUTERNAME$] FOR LOGIN [DOMAIN\COMPUTERNAME$];
+              GRANT SELECT ON dbo.sysjobs TO [DOMAIN\COMPUTERNAME$];
+              ```
+
+              **Workgroup machine (no Active Directory, localhost only):**
+
+              `Local System` authenticates as `NT AUTHORITY\SYSTEM`.
+              This only works when SQL Server runs on the same machine.
+
+              ```sql
+              CREATE LOGIN [NT AUTHORITY\SYSTEM] FROM WINDOWS;
+              GRANT VIEW SERVER STATE TO [NT AUTHORITY\SYSTEM];
+              GRANT VIEW ANY DEFINITION TO [NT AUTHORITY\SYSTEM];
+              USE msdb;
+              CREATE USER [NT AUTHORITY\SYSTEM] FOR LOGIN [NT AUTHORITY\SYSTEM];
+              GRANT SELECT ON dbo.sysjobs TO [NT AUTHORITY\SYSTEM];
+              ```
+
+              > **Note**: To verify which account SQL Server sees, connect with Windows Authentication
+              > and run `SELECT SYSTEM_USER`.
       configuration:
         file:
           name: go.d/mssql.conf
@@ -262,11 +301,19 @@ modules:
                   - name: local
                     dsn: "sqlserver://netdata_user:password@localhost:1433"
             - name: Windows Authentication
-              description: Connect using Windows integrated authentication.
+              description: |
+                Connect using Windows integrated authentication (Windows only).
+
+                When no username/password is provided in the DSN, the driver uses the Netdata service account's
+                Windows credentials. By default, the Netdata service runs as `Local System`, which authenticates
+                to SQL Server as the computer account (`DOMAIN\COMPUTERNAME$`).
+
+                See the [Grant Windows Authentication access](#grant-windows-authentication-access-optional) prerequisite
+                to configure SQL Server for this.
               config: |
                 jobs:
                   - name: local
-                    dsn: "sqlserver://localhost:1433?trusted_connection=yes"
+                    dsn: "sqlserver://localhost:1433"
             - name: Named instance
               description: Connect to a named SQL Server instance.
               config: |


### PR DESCRIPTION
Add prerequisite section for Windows integrated authentication covering both AD domain-joined and workgroup environments. Update the Windows Authentication example to remove the unused trusted_connection parameter.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

- [ ] AI-generated or AI-assisted content has been manually verified (examples/instructions tested where applicable).

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Windows integrated authentication setup guide for `go.d/mssql`, covering AD domain-joined and workgroup machines with exact SQL grants. Update the Windows Authentication example to drop the unused `trusted_connection` parameter and clarify that the driver uses the Netdata service account when no username/password is provided.

<sup>Written for commit 76293f8d5ad092dd4377565c2c5d08e50d9cc333. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

