### PR TITLE
Fix PID cleanup loop in EBPF to avoid use-after-free errors

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -829,10 +829,12 @@ void ebpf_del_pid_entry(pid_t pid)
 static void ebpf_cleanup_exited_pids()
 {
     ebpf_pid_data_t *p = NULL;
-    for (p = ebpf_pids_link_list; p; p = p->next) {
+    for (p = ebpf_pids_link_list; p;) {
+        ebpf_pid_data_t *next = p->next;
         if (!p->has_proc_file) {
             ebpf_reset_specific_pid_data(p);
         }
+        p = next;
     }
 }
 


### PR DESCRIPTION
##### Summary
- Updated the `ebpf_cleanup_exited_pids` function to correctly handle the iterator by storing the next pointer before resetting PID data.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix PID cleanup in the eBPF plugin to prevent use-after-free while iterating the PID list. The loop now saves the next pointer before resetting PID data, ensuring safe traversal.

<sup>Written for commit 80687e3005a79974446c44a823fc0f92faad6ca7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

