### PR TITLE
docs(secretstore): improve secret store backend documentation

### DIFF
--- a/integrations/gen_doc_secrets_page.py
+++ b/integrations/gen_doc_secrets_page.py
@@ -27,6 +27,7 @@ SECRETS_PAGE = {
     ],
     "jump_to": [
         {"label": "Resolver Quick Reference", "anchor": "resolver-quick-reference"},
+        {"label": "Choosing a Resolver", "anchor": "choosing-a-resolver"},
         {"label": "Environment Variables", "anchor": "environment-variables"},
         {"label": "Files", "anchor": "files"},
         {"label": "Commands", "anchor": "commands"},
@@ -61,6 +62,12 @@ SECRETS_PAGE = {
             "notes": "Configure the secretstore first, then reference it from collector configs.",
         },
     ],
+    "choosing_a_resolver": [
+        "Use `${env:...}` or `${file:...}` for simple setups where secrets are already available locally on the Netdata host.",
+        "Use `${cmd:...}` when you need dynamic secret retrieval via a trusted local command, such as 1Password CLI or a custom script.",
+        "Use `${store:...}` when your organization manages secrets centrally in a cloud provider or Vault and you want Netdata to pull from that source directly.",
+        "You can use different resolver types across different collectors, different jobs within the same collector, or even within the same configuration value. See [Mixing resolver types](#mixing-resolver-types).",
+    ],
     "sections": {
         "env": {
             "heading": "## Environment Variables",
@@ -87,6 +94,8 @@ jobs:
                 "The file path must be absolute.",
                 "Netdata trims leading and trailing whitespace from the file contents.",
                 "The file must exist on the Netdata host and be readable by the `netdata` user.",
+                "**Docker Secrets**: Docker mounts secrets as files under `/run/secrets/` inside the container. Use `${file:/run/secrets/<secret-name>}` to read them.",
+                "**Kubernetes Secrets**: If you mount Kubernetes Secrets as volume files in the Netdata pod, reference them with `${file:/path/to/mounted/secret}`.",
             ],
         },
         "cmd": {
@@ -130,6 +139,32 @@ jobs:
         ],
         "file_intro": "Each secretstore backend has its own file under `/etc/netdata/go.d/ss/`:",
         "file_note": "File-based secretstores are loaded at agent startup. If you edit these files, restart the Netdata Agent to apply the changes.",
+        "file_directory": (
+            "If the `/etc/netdata/go.d/ss/` directory does not exist, create it:\n\n"
+            "```bash\n"
+            "sudo mkdir -p /etc/netdata/go.d/ss\n"
+            "sudo chown netdata:netdata /etc/netdata/go.d/ss\n"
+            "sudo chmod 0750 /etc/netdata/go.d/ss\n"
+            "```\n\n"
+            "Secretstore configuration files may contain sensitive values such as tokens or client secrets. "
+            "Restrict directory and file permissions to the `netdata` user."
+        ),
+        "mixing": (
+            "You can mix different resolver types in the same configuration value or the same config file. "
+            "For example, you might read the username from an environment variable and the password from a secretstore:\n\n"
+            "```yaml\n"
+            "jobs:\n"
+            "  - name: mysql_prod\n"
+            '    dsn: "${env:MYSQL_USER}:${store:vault:vault_prod:secret/data/netdata/mysql#password}@tcp(127.0.0.1:3306)/"\n'
+            "```\n\n"
+            "Different jobs within the same collector config file can also use different resolver types."
+        ),
+        "multiple_stores": (
+            "Each secretstore config file can contain multiple `jobs` entries, each with a unique store name. "
+            "You can use different secretstore backends simultaneously. "
+            "For example, you might configure a Vault store for database credentials and an AWS Secrets Manager store for API keys, "
+            "then reference each one using its `${store:<kind>:<name>:<operand>}` syntax in the relevant collector configs."
+        ),
     },
     "secretstores": {
         "heading": "## Supported Secretstore Backends",
@@ -145,6 +180,7 @@ jobs:
     "security_notes": [
         "Prefer secret references over plain-text credentials in collector configs.",
         "Prefer platform-native identity modes for production when a backend supports them, such as instance roles, managed identities, or metadata-based credentials.",
+        "Secretstore configuration values (such as tokens and client secrets) also support `${env:...}`, `${file:...}`, and `${cmd:...}` resolvers. Use them to avoid storing backend credentials in plain text. Note that `${store:...}` references are not supported inside secretstore configurations.",
         "Keep local secret material readable only by the `netdata` user, including token files, service account files, and any files used with `${file:...}`.",
         "Use `${cmd:...}` only with trusted local commands and absolute paths.",
     ],
@@ -288,6 +324,7 @@ def build_page_context() -> Dict[str, Any]:
             f'[{jump["label"]}](#{jump["anchor"]})' for jump in SECRETS_PAGE["jump_to"]
         ),
         "quick_reference": SECRETS_PAGE["quick_reference"],
+        "choosing_a_resolver": SECRETS_PAGE["choosing_a_resolver"],
         "sections": [
             SECRETS_PAGE["sections"]["env"],
             SECRETS_PAGE["sections"]["file"],

--- a/integrations/schemas/secretstore.json
+++ b/integrations/schemas/secretstore.json
@@ -167,7 +167,7 @@
           "properties": {
             "list": {
               "type": "array",
-              "minLength": 1,
+              "minItems": 1,
               "items": {
                 "$ref": "#/$defs/collector_configs_example"
               }

--- a/integrations/templates/collector_configs.md
+++ b/integrations/templates/collector_configs.md
@@ -20,7 +20,7 @@
 
 [[ example.description ]]
 
-```[[ example.language or 'text' ]]
+```[[ example.language or 'yaml' ]]
 [[ example.content ]]
 ```
 [% endfor %]

--- a/integrations/templates/secrets.md
+++ b/integrations/templates/secrets.md
@@ -17,6 +17,12 @@
 | [[ item.resolver ]] | [[ item.syntax ]] | [[ item.best_for ]] | [[ item.notes ]] |
 [% endfor %]
 
+## Choosing a Resolver
+
+[% for item in page.choosing_a_resolver %]
+- [[ item ]]
+[% endfor %]
+
 [% for section in page.sections %]
 [[ section.heading ]]
 
@@ -74,6 +80,16 @@ Each file contains a `jobs` array. The backend kind is determined by the filenam
 [[ page.store.file_note ]]
 
 :::
+
+[[ page.store.file_directory ]]
+
+### Multiple Secretstores
+
+[[ page.store.multiple_stores ]]
+
+### Mixing Resolver Types
+
+[[ page.store.mixing ]]
 
 [[ page.secretstores.heading ]]
 

--- a/src/collectors/SECRETS.md
+++ b/src/collectors/SECRETS.md
@@ -6,7 +6,7 @@ Netdata lets you reference secret values in collector configs instead of storing
 
 ### Jump To
 
-[Resolver Quick Reference](#resolver-quick-reference) • [Environment Variables](#environment-variables) • [Files](#files) • [Commands](#commands) • [Secretstores](#secretstores) • [Supported Secretstore Backends](#supported-secretstore-backends) • [How It Works](#how-it-works) • [Troubleshooting](#troubleshooting)
+[Resolver Quick Reference](#resolver-quick-reference) • [Choosing a Resolver](#choosing-a-resolver) • [Environment Variables](#environment-variables) • [Files](#files) • [Commands](#commands) • [Secretstores](#secretstores) • [Supported Secretstore Backends](#supported-secretstore-backends) • [How It Works](#how-it-works) • [Troubleshooting](#troubleshooting)
 
 
 ## Resolver Quick Reference
@@ -17,6 +17,13 @@ Netdata lets you reference secret values in collector configs instead of storing
 | File | `${file:/absolute/path}` | Secrets stored in local files on disk | The path must be absolute. File contents are trimmed. |
 | Command | `${cmd:/absolute/path/to/command args}` | Secrets returned by a trusted local command | The command path must be absolute. Netdata uses a 10-second timeout. |
 | Secretstore | `${store:<kind>:<name>:<operand>}` | Secrets stored in remote backends such as Vault, AWS, Azure, or GCP | Configure the secretstore first, then reference it from collector configs. |
+
+## Choosing a Resolver
+
+- Use `${env:...}` or `${file:...}` for simple setups where secrets are already available locally on the Netdata host.
+- Use `${cmd:...}` when you need dynamic secret retrieval via a trusted local command, such as 1Password CLI or a custom script.
+- Use `${store:...}` when your organization manages secrets centrally in a cloud provider or Vault and you want Netdata to pull from that source directly.
+- You can use different resolver types across different collectors, different jobs within the same collector, or even within the same configuration value. See [Mixing resolver types](#mixing-resolver-types).
 
 ## Environment Variables
 
@@ -44,6 +51,8 @@ jobs:
 - The file path must be absolute.
 - Netdata trims leading and trailing whitespace from the file contents.
 - The file must exist on the Netdata host and be readable by the `netdata` user.
+- **Docker Secrets**: Docker mounts secrets as files under `/run/secrets/` inside the container. Use `${file:/run/secrets/<secret-name>}` to read them.
+- **Kubernetes Secrets**: If you mount Kubernetes Secrets as volume files in the Netdata pod, reference them with `${file:/path/to/mounted/secret}`.
 
 ## Commands
 
@@ -114,6 +123,32 @@ File-based secretstores are loaded at agent startup. If you edit these files, re
 
 :::
 
+If the `/etc/netdata/go.d/ss/` directory does not exist, create it:
+
+```bash
+sudo mkdir -p /etc/netdata/go.d/ss
+sudo chown netdata:netdata /etc/netdata/go.d/ss
+sudo chmod 0750 /etc/netdata/go.d/ss
+```
+
+Secretstore configuration files may contain sensitive values such as tokens or client secrets. Restrict directory and file permissions to the `netdata` user.
+
+### Multiple Secretstores
+
+Each secretstore config file can contain multiple `jobs` entries, each with a unique store name. You can use different secretstore backends simultaneously. For example, you might configure a Vault store for database credentials and an AWS Secrets Manager store for API keys, then reference each one using its `${store:<kind>:<name>:<operand>}` syntax in the relevant collector configs.
+
+### Mixing Resolver Types
+
+You can mix different resolver types in the same configuration value or the same config file. For example, you might read the username from an environment variable and the password from a secretstore:
+
+```yaml
+jobs:
+  - name: mysql_prod
+    dsn: "${env:MYSQL_USER}:${store:vault:vault_prod:secret/data/netdata/mysql#password}@tcp(127.0.0.1:3306)/"
+```
+
+Different jobs within the same collector config file can also use different resolver types.
+
 ## Supported Secretstore Backends
 
 Use the backend README for provider-specific authentication, operand rules, configuration examples, and troubleshooting.
@@ -137,6 +172,7 @@ Use the backend README for provider-specific authentication, operand rules, conf
 
 - Prefer secret references over plain-text credentials in collector configs.
 - Prefer platform-native identity modes for production when a backend supports them, such as instance roles, managed identities, or metadata-based credentials.
+- Secretstore configuration values (such as tokens and client secrets) also support `${env:...}`, `${file:...}`, and `${cmd:...}` resolvers. Use them to avoid storing backend credentials in plain text. Note that `${store:...}` references are not supported inside secretstore configurations.
 - Keep local secret material readable only by the `netdata` user, including token files, service account files, and any files used with `${file:...}`.
 - Use `${cmd:...}` only with trusted local commands and absolute paths.
 

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/integrations/aws-sm.md
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/integrations/aws-sm.md
@@ -20,9 +20,9 @@ Kind: aws-sm
 
 ## Overview
 
-Use AWS Secrets Manager as a secretstore backend when you want Netdata collectors to read secrets from AWS at runtime instead of storing them in plain text in collector configuration files.
+Netdata can pull collector credentials directly from AWS Secrets Manager at runtime, so you never store passwords or tokens in plain-text configuration files.
 
-This page covers AWS Secrets Manager specific setup. For the shared resolver workflow and syntax, see [Secrets Management](https://github.com/netdata/netdata/blob/master/src/collectors/SECRETS.md).
+This page covers AWS Secrets Manager specific setup. For the full resolver overview and syntax reference, including simpler alternatives like `${env:...}`, `${file:...}`, and `${cmd:...}`, see [Secrets Management](https://github.com/netdata/netdata/blob/master/src/collectors/SECRETS.md).
 
 
 ### Limitations
@@ -54,7 +54,7 @@ For production on AWS, prefer `ecs` or `imds` over `env` so credentials are supp
 
 #### Allow access to Secrets Manager
 
-The AWS identity used by this secretstore must be allowed to read the secrets you reference in collector configs in the configured `region`.
+The AWS identity used by this secretstore must have the `secretsmanager:GetSecretValue` permission on the secrets you reference in collector configs. Scope the IAM policy to only the secret ARNs Netdata needs.
 
 
 #### Plan for file-based changes
@@ -75,7 +75,7 @@ The following options can be defined for this secretstore backend.
 | Option | Description | Default | Required |
 |:-----|:------------|:--------|:---------:|
 | [auth_mode](#option-auth-mode) | How Netdata obtains AWS credentials. | env | yes |
-| region | AWS region used for Secrets Manager requests. |  | yes |
+| region | AWS region used for Secrets Manager requests. There is no automatic region detection — you must always set this explicitly. |  | yes |
 
 <a id="option-auth-mode"></a>
 ##### auth_mode
@@ -148,13 +148,13 @@ jobs:
 
 ## Use in collector configs
 
-Reference AWS Secrets Manager secrets from collector configs with the `aws-sm` secretstore kind.
+Use the `${store:aws-sm:...}` syntax to reference AWS Secrets Manager secrets in any string field of a collector configuration file.
 
 
 The operand is `secret-name` or `secret-name#key`.
 
-- Use `secret-name` to return the whole `SecretString`.
-- Use `secret-name#key` to read one top-level field from a JSON `SecretString`.
+- Use `secret-name` to return the whole `SecretString`, for example: `${store:aws-sm:aws_prod:netdata/mysql/password}`.
+- Use `secret-name#key` to read one top-level field from a JSON `SecretString`, for example: `${store:aws-sm:aws_prod:netdata/mysql#password}`.
 - If you use `#key`, Netdata parses the secret value as JSON. Secret resolution fails if the value is not valid JSON or if the key does not exist.
 - Nested paths such as `parent.child` are not interpreted as nested JSON lookups.
 
@@ -168,28 +168,37 @@ ${store:aws-sm:<store-name>:<secret-name[#key]>}
 - `<secret-name[#key]>`: The AWS Secrets Manager secret name, optionally followed by `#key` to read one field from a JSON `SecretString`.
 
 ### Examples
-#### Whole secret value
+#### MySQL collector with password from AWS Secrets Manager
 
-Return the full `SecretString` stored under the `netdata/mysql/password` secret.
+This example configures a MySQL collector job in `/etc/netdata/go.d/mysql.conf`.
+The password in the DSN connection string is not stored in plain text. Instead,
+`${store:aws-sm:aws_prod:netdata/mysql#password}` tells Netdata to fetch the secret
+named `netdata/mysql` from the `aws_prod` store, extract the `password` field from
+its JSON value, and substitute it into the DSN at runtime.
 
-```text
-${store:aws-sm:aws_prod:netdata/mysql/password}
-```
-#### JSON field from SecretString
-
-Read the `password` field from a JSON `SecretString`.
-
-```text
-${store:aws-sm:aws_prod:netdata/mysql#password}
-```
-#### Collector config example
-
-Use an AWS-stored password in a collector DSN.
 
 ```yaml
+# /etc/netdata/go.d/mysql.conf
 jobs:
   - name: mysql_prod
     dsn: "netdata:${store:aws-sm:aws_prod:netdata/mysql#password}@tcp(127.0.0.1:3306)/"
+
+```
+#### Elasticsearch collector with HTTP basic auth
+
+This example configures an Elasticsearch collector job in `/etc/netdata/go.d/elasticsearch.conf`.
+The `password` field uses a secret reference instead of a plain-text password. Netdata fetches
+the secret named `netdata/elasticsearch/password` from the `aws_prod` store and substitutes
+its full value into the `password` field at runtime.
+
+
+```yaml
+# /etc/netdata/go.d/elasticsearch.conf
+jobs:
+  - name: es_prod
+    url: https://elasticsearch.example.com:9200
+    username: netdata
+    password: "${store:aws-sm:aws_prod:netdata/elasticsearch/password}"
 
 ```
 

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/metadata.yaml
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/metadata.yaml
@@ -14,9 +14,9 @@ keywords:
   - 'aws secrets manager'
 overview:
   description: |
-    Use AWS Secrets Manager as a secretstore backend when you want Netdata collectors to read secrets from AWS at runtime instead of storing them in plain text in collector configuration files.
+    Netdata can pull collector credentials directly from AWS Secrets Manager at runtime, so you never store passwords or tokens in plain-text configuration files.
 
-    This page covers AWS Secrets Manager specific setup. For the shared resolver workflow and syntax, see [Secrets Management](/src/collectors/SECRETS.md).
+    This page covers AWS Secrets Manager specific setup. For the full resolver overview and syntax reference, including simpler alternatives like `${env:...}`, `${file:...}`, and `${cmd:...}`, see [Secrets Management](/src/collectors/SECRETS.md).
   limitations: |
     Netdata reads existing secrets from AWS Secrets Manager. It does not create, rotate, or manage those secrets. If you use `secret-name#key`, the secret value must be stored as a JSON `SecretString`.
 setup:
@@ -33,7 +33,7 @@ setup:
           For production on AWS, prefer `ecs` or `imds` over `env` so credentials are supplied by the platform instead of being stored in the Netdata service environment.
       - title: 'Allow access to Secrets Manager'
         description: |
-          The AWS identity used by this secretstore must be allowed to read the secrets you reference in collector configs in the configured `region`.
+          The AWS identity used by this secretstore must have the `secretsmanager:GetSecretValue` permission on the secrets you reference in collector configs. Scope the IAM policy to only the secret ARNs Netdata needs.
       - title: 'Plan for file-based changes'
         description: |
           If you edit `/etc/netdata/go.d/ss/aws-sm.conf`, restart the Netdata Agent to load the updated secretstore definition.
@@ -59,7 +59,7 @@ setup:
 
             For production on AWS, prefer `ecs` or `imds` when Netdata runs on ECS or EC2. Use `env` when you intentionally manage credentials in the Netdata service environment.
         - name: 'region'
-          description: 'AWS region used for Secrets Manager requests.'
+          description: 'AWS region used for Secrets Manager requests. There is no automatic region detection — you must always set this explicitly.'
           default_value: ''
           required: true
     examples:
@@ -90,7 +90,7 @@ setup:
                 region: us-east-1
 collector_configs:
   description: |
-    Reference AWS Secrets Manager secrets from collector configs with the `aws-sm` secretstore kind.
+    Use the `${store:aws-sm:...}` syntax to reference AWS Secrets Manager secrets in any string field of a collector configuration file.
   summary:
     operand_format: 'secret-name[#key]'
     example_operand: 'netdata/mysql#password'
@@ -98,8 +98,8 @@ collector_configs:
     description: |
       The operand is `secret-name` or `secret-name#key`.
 
-      - Use `secret-name` to return the whole `SecretString`.
-      - Use `secret-name#key` to read one top-level field from a JSON `SecretString`.
+      - Use `secret-name` to return the whole `SecretString`, for example: `${store:aws-sm:aws_prod:netdata/mysql/password}`.
+      - Use `secret-name#key` to read one top-level field from a JSON `SecretString`, for example: `${store:aws-sm:aws_prod:netdata/mysql#password}`.
       - If you use `#key`, Netdata parses the secret value as JSON. Secret resolution fails if the value is not valid JSON or if the key does not exist.
       - Nested paths such as `parent.child` are not interpreted as nested JSON lookups.
     syntax: '${store:aws-sm:<store-name>:<secret-name[#key]>}'
@@ -113,21 +113,31 @@ collector_configs:
           description: 'The AWS Secrets Manager secret name, optionally followed by `#key` to read one field from a JSON `SecretString`.'
   examples:
     list:
-      - name: 'Whole secret value'
-        description: 'Return the full `SecretString` stored under the `netdata/mysql/password` secret.'
-        language: 'text'
-        content: '${store:aws-sm:aws_prod:netdata/mysql/password}'
-      - name: 'JSON field from SecretString'
-        description: 'Read the `password` field from a JSON `SecretString`.'
-        language: 'text'
-        content: '${store:aws-sm:aws_prod:netdata/mysql#password}'
-      - name: 'Collector config example'
-        description: 'Use an AWS-stored password in a collector DSN.'
-        language: 'yaml'
+      - name: 'MySQL collector with password from AWS Secrets Manager'
+        description: |
+          This example configures a MySQL collector job in `/etc/netdata/go.d/mysql.conf`.
+          The password in the DSN connection string is not stored in plain text. Instead,
+          `${store:aws-sm:aws_prod:netdata/mysql#password}` tells Netdata to fetch the secret
+          named `netdata/mysql` from the `aws_prod` store, extract the `password` field from
+          its JSON value, and substitute it into the DSN at runtime.
         content: |
+          # /etc/netdata/go.d/mysql.conf
           jobs:
             - name: mysql_prod
               dsn: "netdata:${store:aws-sm:aws_prod:netdata/mysql#password}@tcp(127.0.0.1:3306)/"
+      - name: 'Elasticsearch collector with HTTP basic auth'
+        description: |
+          This example configures an Elasticsearch collector job in `/etc/netdata/go.d/elasticsearch.conf`.
+          The `password` field uses a secret reference instead of a plain-text password. Netdata fetches
+          the secret named `netdata/elasticsearch/password` from the `aws_prod` store and substitutes
+          its full value into the `password` field at runtime.
+        content: |
+          # /etc/netdata/go.d/elasticsearch.conf
+          jobs:
+            - name: es_prod
+              url: https://elasticsearch.example.com:9200
+              username: netdata
+              password: "${store:aws-sm:aws_prod:netdata/elasticsearch/password}"
 troubleshooting:
   problems:
     list:

--- a/src/go/plugin/agent/secrets/secretstore/backends/azure/integrations/azure-kv.md
+++ b/src/go/plugin/agent/secrets/secretstore/backends/azure/integrations/azure-kv.md
@@ -20,9 +20,9 @@ Kind: azure-kv
 
 ## Overview
 
-Use Azure Key Vault as a secretstore backend when you want Netdata collectors to read secrets from Azure at runtime instead of storing them in plain text in collector configuration files.
+Netdata can pull collector credentials directly from Azure Key Vault at runtime, so you never store passwords or tokens in plain-text configuration files.
 
-This page covers Azure Key Vault specific setup. For the shared resolver workflow and syntax, see [Secrets Management](https://github.com/netdata/netdata/blob/master/src/collectors/SECRETS.md).
+This page covers Azure Key Vault specific setup. For the full resolver overview and syntax reference, including simpler alternatives like `${env:...}`, `${file:...}`, and `${cmd:...}`, see [Secrets Management](https://github.com/netdata/netdata/blob/master/src/collectors/SECRETS.md).
 
 
 ### Limitations
@@ -54,7 +54,7 @@ Prefer `managed_identity` for production on Azure when Netdata runs on an Azure 
 
 #### Allow secret read access
 
-The Azure identity used by this secretstore must be allowed to read secret values from the target vaults.
+The Azure identity used by this secretstore must be allowed to read secret values from the target vaults. Assign the `Key Vault Secrets User` built-in role scoped to the vault. Do not use broader roles like `Key Vault Administrator`.
 
 
 #### Plan for file-based changes
@@ -128,6 +128,20 @@ jobs:
       client_secret: your-client-secret
 
 ```
+###### Service principal with credentials from environment
+
+Use `${env:...}` resolvers for sensitive fields to avoid storing the client secret in plain text in the secretstore config file.
+
+```yaml
+jobs:
+  - name: azure_prod
+    mode: service_principal
+    mode_service_principal:
+      tenant_id: "${env:AZURE_TENANT_ID}"
+      client_id: "${env:AZURE_CLIENT_ID}"
+      client_secret: "${env:AZURE_CLIENT_SECRET}"
+
+```
 ###### Managed identity
 
 Use the managed identity attached to the Azure resource running Netdata.
@@ -154,10 +168,10 @@ jobs:
 
 ## Use in collector configs
 
-Reference Azure Key Vault secrets from collector configs with the `azure-kv` secretstore kind.
+Use the `${store:azure-kv:...}` syntax to reference Azure Key Vault secrets in any string field of a collector configuration file.
 
 
-The operand is `vault-name/secret-name`.
+The operand is `vault-name/secret-name`, for example: `${store:azure-kv:azure_prod:my-keyvault/mysql-password}`.
 
 Netdata requests the latest secret value from `https://<vault-name>.vault.azure.net/secrets/<secret-name>?api-version=7.4`.
 Both `vault-name` and `secret-name` must use only letters, numbers, and hyphens.
@@ -172,21 +186,35 @@ ${store:azure-kv:<store-name>:<vault-name/secret-name>}
 - `<vault-name/secret-name>`: The Azure Key Vault name and the secret name, separated by `/`.
 
 ### Examples
-#### Secret reference
+#### MySQL collector with password from Azure Key Vault
 
-Read the latest value of the `mysql-password` secret from the `my-keyvault` vault.
+This example configures a MySQL collector job in `/etc/netdata/go.d/mysql.conf`.
+The password in the DSN connection string is not stored in plain text. Instead,
+`${store:azure-kv:azure_prod:my-keyvault/mysql-password}` tells Netdata to fetch
+the secret named `mysql-password` from the `my-keyvault` vault using the `azure_prod`
+store, and substitute its value into the DSN at runtime.
 
-```text
-${store:azure-kv:azure_prod:my-keyvault/mysql-password}
-```
-#### Collector config example
-
-Use an Azure Key Vault secret in a collector DSN.
 
 ```yaml
+# /etc/netdata/go.d/mysql.conf
 jobs:
   - name: mysql_prod
     dsn: "netdata:${store:azure-kv:azure_prod:my-keyvault/mysql-password}@tcp(127.0.0.1:3306)/"
+
+```
+#### PostgreSQL collector with password from Azure Key Vault
+
+This example configures a PostgreSQL collector job in `/etc/netdata/go.d/postgres.conf`.
+The `password` field uses a secret reference instead of a plain-text value. Netdata fetches
+the secret named `postgres-password` from the `my-keyvault` vault and substitutes its value
+into the `password` field at runtime.
+
+
+```yaml
+# /etc/netdata/go.d/postgres.conf
+jobs:
+  - name: postgres_prod
+    dsn: "postgresql://netdata:${store:azure-kv:azure_prod:my-keyvault/postgres-password}@localhost:5432/postgres"
 
 ```
 

--- a/src/go/plugin/agent/secrets/secretstore/backends/azure/metadata.yaml
+++ b/src/go/plugin/agent/secrets/secretstore/backends/azure/metadata.yaml
@@ -14,9 +14,9 @@ keywords:
   - 'azure key vault'
 overview:
   description: |
-    Use Azure Key Vault as a secretstore backend when you want Netdata collectors to read secrets from Azure at runtime instead of storing them in plain text in collector configuration files.
+    Netdata can pull collector credentials directly from Azure Key Vault at runtime, so you never store passwords or tokens in plain-text configuration files.
 
-    This page covers Azure Key Vault specific setup. For the shared resolver workflow and syntax, see [Secrets Management](/src/collectors/SECRETS.md).
+    This page covers Azure Key Vault specific setup. For the full resolver overview and syntax reference, including simpler alternatives like `${env:...}`, `${file:...}`, and `${cmd:...}`, see [Secrets Management](/src/collectors/SECRETS.md).
   limitations: |
     Netdata reads the latest version of a secret value from Azure Key Vault. The operand format does not select a specific secret version.
 setup:
@@ -33,7 +33,7 @@ setup:
           Prefer `managed_identity` for production on Azure when Netdata runs on an Azure resource with an attached identity. Use `service_principal` for explicit application credentials. Use `default` for Azure SDK auto-discovery or local development convenience.
       - title: 'Allow secret read access'
         description: |
-          The Azure identity used by this secretstore must be allowed to read secret values from the target vaults.
+          The Azure identity used by this secretstore must be allowed to read secret values from the target vaults. Assign the `Key Vault Secrets User` built-in role scoped to the vault. Do not use broader roles like `Key Vault Administrator`.
       - title: 'Plan for file-based changes'
         description: |
           If you edit `/etc/netdata/go.d/ss/azure-kv.conf`, restart the Netdata Agent to load the updated secretstore definition.
@@ -93,6 +93,16 @@ setup:
                   tenant_id: 00000000-0000-0000-0000-000000000000
                   client_id: 00000000-0000-0000-0000-000000000000
                   client_secret: your-client-secret
+        - name: 'Service principal with credentials from environment'
+          description: 'Use `${env:...}` resolvers for sensitive fields to avoid storing the client secret in plain text in the secretstore config file.'
+          config: |
+            jobs:
+              - name: azure_prod
+                mode: service_principal
+                mode_service_principal:
+                  tenant_id: "${env:AZURE_TENANT_ID}"
+                  client_id: "${env:AZURE_CLIENT_ID}"
+                  client_secret: "${env:AZURE_CLIENT_SECRET}"
         - name: 'Managed identity'
           description: 'Use the managed identity attached to the Azure resource running Netdata.'
           config: |
@@ -109,13 +119,13 @@ setup:
                 mode: default
 collector_configs:
   description: |
-    Reference Azure Key Vault secrets from collector configs with the `azure-kv` secretstore kind.
+    Use the `${store:azure-kv:...}` syntax to reference Azure Key Vault secrets in any string field of a collector configuration file.
   summary:
     operand_format: 'vault-name/secret-name'
     example_operand: 'my-keyvault/mysql-password'
   format:
     description: |
-      The operand is `vault-name/secret-name`.
+      The operand is `vault-name/secret-name`, for example: `${store:azure-kv:azure_prod:my-keyvault/mysql-password}`.
 
       Netdata requests the latest secret value from `https://<vault-name>.vault.azure.net/secrets/<secret-name>?api-version=7.4`.
       Both `vault-name` and `secret-name` must use only letters, numbers, and hyphens.
@@ -130,17 +140,29 @@ collector_configs:
           description: 'The Azure Key Vault name and the secret name, separated by `/`.'
   examples:
     list:
-      - name: 'Secret reference'
-        description: 'Read the latest value of the `mysql-password` secret from the `my-keyvault` vault.'
-        language: 'text'
-        content: '${store:azure-kv:azure_prod:my-keyvault/mysql-password}'
-      - name: 'Collector config example'
-        description: 'Use an Azure Key Vault secret in a collector DSN.'
-        language: 'yaml'
+      - name: 'MySQL collector with password from Azure Key Vault'
+        description: |
+          This example configures a MySQL collector job in `/etc/netdata/go.d/mysql.conf`.
+          The password in the DSN connection string is not stored in plain text. Instead,
+          `${store:azure-kv:azure_prod:my-keyvault/mysql-password}` tells Netdata to fetch
+          the secret named `mysql-password` from the `my-keyvault` vault using the `azure_prod`
+          store, and substitute its value into the DSN at runtime.
         content: |
+          # /etc/netdata/go.d/mysql.conf
           jobs:
             - name: mysql_prod
               dsn: "netdata:${store:azure-kv:azure_prod:my-keyvault/mysql-password}@tcp(127.0.0.1:3306)/"
+      - name: 'PostgreSQL collector with password from Azure Key Vault'
+        description: |
+          This example configures a PostgreSQL collector job in `/etc/netdata/go.d/postgres.conf`.
+          The `password` field uses a secret reference instead of a plain-text value. Netdata fetches
+          the secret named `postgres-password` from the `my-keyvault` vault and substitutes its value
+          into the `password` field at runtime.
+        content: |
+          # /etc/netdata/go.d/postgres.conf
+          jobs:
+            - name: postgres_prod
+              dsn: "postgresql://netdata:${store:azure-kv:azure_prod:my-keyvault/postgres-password}@localhost:5432/postgres"
 troubleshooting:
   problems:
     list:

--- a/src/go/plugin/agent/secrets/secretstore/backends/gcp/integrations/gcp-sm.md
+++ b/src/go/plugin/agent/secrets/secretstore/backends/gcp/integrations/gcp-sm.md
@@ -20,14 +20,14 @@ Kind: gcp-sm
 
 ## Overview
 
-Use Google Secret Manager as a secretstore backend when you want Netdata collectors to read secrets from GCP at runtime instead of storing them in plain text in collector configuration files.
+Netdata can pull collector credentials directly from Google Secret Manager at runtime, so you never store passwords or tokens in plain-text configuration files.
 
-This page covers Google Secret Manager specific setup. For the shared resolver workflow and syntax, see [Secrets Management](https://github.com/netdata/netdata/blob/master/src/collectors/SECRETS.md).
+This page covers Google Secret Manager specific setup. For the full resolver overview and syntax reference, including simpler alternatives like `${env:...}`, `${file:...}`, and `${cmd:...}`, see [Secrets Management](https://github.com/netdata/netdata/blob/master/src/collectors/SECRETS.md).
 
 
 ### Limitations
 
-If you omit the version in the operand, Netdata reads the `latest` secret version automatically.
+Netdata reads existing secrets from Google Secret Manager. It does not create, rotate, or manage those secrets. If you omit the version in the operand, Netdata reads the `latest` secret version automatically.
 
 
 ## Setup
@@ -58,7 +58,7 @@ If you use `service_account_file`, the JSON file contains a private key. Keep it
 
 #### Allow Secret Manager access
 
-The Google identity used by this secretstore must be allowed to access the referenced secrets in Google Secret Manager.
+The Google identity used by this secretstore must have the `roles/secretmanager.secretAccessor` IAM role on the secrets you reference from collector configs. Do not use broader roles like `roles/secretmanager.admin`.
 
 
 #### Plan for file-based changes
@@ -79,14 +79,14 @@ The following options can be defined for this secretstore backend.
 | Group | Option | Description | Default | Required |
 |:------|:-----|:------------|:--------|:---------:|
 |  | [mode](#option-mode) | GCP authentication mode. | metadata | yes |
-| **Service Account File** | mode_service_account_file.path | Path to a service account JSON file. Required when `mode` is `service_account_file`. The file contains a private key and should be readable only by the `netdata` user or another tightly scoped owner. |  | yes |
+| **Service Account File** | mode_service_account_file.path | Absolute path to a service account JSON file. Required when `mode` is `service_account_file`. The file contains a private key and should be readable only by the `netdata` user or another tightly scoped owner. |  | yes |
 
 <a id="option-mode"></a>
 ##### mode
 
 Supported values:
 
-- `metadata`: get an access token from the Google metadata server.
+- `metadata`: get an access token from the Google metadata server. This works in GCE, GKE (with Workload Identity configured), Cloud Run, and other Google Cloud environments where the metadata server is reachable.
 - `service_account_file`: use a local service account JSON file.
 
 Prefer `metadata` for production when Netdata runs in a supported Google Cloud environment. Use `service_account_file` when you need explicit credentials or when the metadata server is not available.
@@ -140,14 +140,15 @@ jobs:
 
 ## Use in collector configs
 
-Reference Google Secret Manager secrets from collector configs with the `gcp-sm` secretstore kind.
+Use the `${store:gcp-sm:...}` syntax to reference Google Secret Manager secrets in any string field of a collector configuration file.
 
 
 The operand is `project/secret` or `project/secret/version`.
 
-If you omit the version, Netdata uses `latest`.
+- Use `project/secret` to read the latest version, for example: `${store:gcp-sm:gcp_prod:my-project/mysql-password}`.
+- Use `project/secret/version` to read a specific version, for example: `${store:gcp-sm:gcp_prod:my-project/mysql-password/3}`.
+
 Project IDs may use letters, numbers, `.`, `_`, `:`, or `-`. Secret names and versions may use letters, numbers, `_`, or `-`.
-When you specify a version, use the version name accepted by Secret Manager, such as `3`.
 
 
 ```text
@@ -159,28 +160,37 @@ ${store:gcp-sm:<store-name>:<project/secret[/version]>}
 - `<project/secret[/version]>`: The Google Cloud project ID, secret name, and optional version.
 
 ### Examples
-#### Latest version
+#### MySQL collector with password from Google Secret Manager
 
-Read the latest version of the `mysql-password` secret from the `my-project` project.
+This example configures a MySQL collector job in `/etc/netdata/go.d/mysql.conf`.
+The password in the DSN connection string is not stored in plain text. Instead,
+`${store:gcp-sm:gcp_prod:my-project/mysql-password}` tells Netdata to fetch the
+latest version of the `mysql-password` secret from the `my-project` project using
+the `gcp_prod` store, and substitute its value into the DSN at runtime.
 
-```text
-${store:gcp-sm:gcp_prod:my-project/mysql-password}
-```
-#### Specific version
-
-Read version `3` of the `mysql-password` secret.
-
-```text
-${store:gcp-sm:gcp_prod:my-project/mysql-password/3}
-```
-#### Collector config example
-
-Use a Google Secret Manager secret in a collector DSN.
 
 ```yaml
+# /etc/netdata/go.d/mysql.conf
 jobs:
   - name: mysql_prod
     dsn: "netdata:${store:gcp-sm:gcp_prod:my-project/mysql-password}@tcp(127.0.0.1:3306)/"
+
+```
+#### HTTP check collector with password from Google Secret Manager
+
+This example configures an HTTP check collector job in `/etc/netdata/go.d/httpcheck.conf`.
+The `password` field uses a secret reference instead of a plain-text value. Netdata fetches
+the `api-password` secret from the `my-project` project and substitutes its value into the
+`password` field at runtime.
+
+
+```yaml
+# /etc/netdata/go.d/httpcheck.conf
+jobs:
+  - name: internal_api
+    url: https://api.example.com/health
+    username: netdata
+    password: "${store:gcp-sm:gcp_prod:my-project/api-password}"
 
 ```
 

--- a/src/go/plugin/agent/secrets/secretstore/backends/gcp/metadata.yaml
+++ b/src/go/plugin/agent/secrets/secretstore/backends/gcp/metadata.yaml
@@ -14,11 +14,11 @@ keywords:
   - 'google secret manager'
 overview:
   description: |
-    Use Google Secret Manager as a secretstore backend when you want Netdata collectors to read secrets from GCP at runtime instead of storing them in plain text in collector configuration files.
+    Netdata can pull collector credentials directly from Google Secret Manager at runtime, so you never store passwords or tokens in plain-text configuration files.
 
-    This page covers Google Secret Manager specific setup. For the shared resolver workflow and syntax, see [Secrets Management](/src/collectors/SECRETS.md).
+    This page covers Google Secret Manager specific setup. For the full resolver overview and syntax reference, including simpler alternatives like `${env:...}`, `${file:...}`, and `${cmd:...}`, see [Secrets Management](/src/collectors/SECRETS.md).
   limitations: |
-    If you omit the version in the operand, Netdata reads the `latest` secret version automatically.
+    Netdata reads existing secrets from Google Secret Manager. It does not create, rotate, or manage those secrets. If you omit the version in the operand, Netdata reads the `latest` secret version automatically.
 setup:
   prerequisites:
     list:
@@ -35,7 +35,7 @@ setup:
           If you use `service_account_file`, the JSON file contains a private key. Keep it on the Netdata host, make it readable by the `netdata` user, and restrict access as tightly as possible. A common setup is `chmod 0600` with ownership that allows the `netdata` user to read the file.
       - title: 'Allow Secret Manager access'
         description: |
-          The Google identity used by this secretstore must be allowed to access the referenced secrets in Google Secret Manager.
+          The Google identity used by this secretstore must have the `roles/secretmanager.secretAccessor` IAM role on the secrets you reference from collector configs. Do not use broader roles like `roles/secretmanager.admin`.
       - title: 'Plan for file-based changes'
         description: |
           If you edit `/etc/netdata/go.d/ss/gcp-sm.conf`, restart the Netdata Agent to load the updated secretstore definition.
@@ -55,13 +55,13 @@ setup:
           detailed_description: |
             Supported values:
 
-            - `metadata`: get an access token from the Google metadata server.
+            - `metadata`: get an access token from the Google metadata server. This works in GCE, GKE (with Workload Identity configured), Cloud Run, and other Google Cloud environments where the metadata server is reachable.
             - `service_account_file`: use a local service account JSON file.
 
             Prefer `metadata` for production when Netdata runs in a supported Google Cloud environment. Use `service_account_file` when you need explicit credentials or when the metadata server is not available.
         - name: 'mode_service_account_file.path'
           group: 'Service Account File'
-          description: 'Path to a service account JSON file. Required when `mode` is `service_account_file`. The file contains a private key and should be readable only by the `netdata` user or another tightly scoped owner.'
+          description: 'Absolute path to a service account JSON file. Required when `mode` is `service_account_file`. The file contains a private key and should be readable only by the `netdata` user or another tightly scoped owner.'
           default_value: ''
           required: true
     examples:
@@ -85,7 +85,7 @@ setup:
                   path: /etc/netdata/gcp-service-account.json
 collector_configs:
   description: |
-    Reference Google Secret Manager secrets from collector configs with the `gcp-sm` secretstore kind.
+    Use the `${store:gcp-sm:...}` syntax to reference Google Secret Manager secrets in any string field of a collector configuration file.
   summary:
     operand_format: 'project/secret[/version]'
     example_operand: 'my-project/mysql-password'
@@ -93,9 +93,10 @@ collector_configs:
     description: |
       The operand is `project/secret` or `project/secret/version`.
 
-      If you omit the version, Netdata uses `latest`.
+      - Use `project/secret` to read the latest version, for example: `${store:gcp-sm:gcp_prod:my-project/mysql-password}`.
+      - Use `project/secret/version` to read a specific version, for example: `${store:gcp-sm:gcp_prod:my-project/mysql-password/3}`.
+
       Project IDs may use letters, numbers, `.`, `_`, `:`, or `-`. Secret names and versions may use letters, numbers, `_`, or `-`.
-      When you specify a version, use the version name accepted by Secret Manager, such as `3`.
     syntax: '${store:gcp-sm:<store-name>:<project/secret[/version]>}'
     parts:
       list:
@@ -107,21 +108,31 @@ collector_configs:
           description: 'The Google Cloud project ID, secret name, and optional version.'
   examples:
     list:
-      - name: 'Latest version'
-        description: 'Read the latest version of the `mysql-password` secret from the `my-project` project.'
-        language: 'text'
-        content: '${store:gcp-sm:gcp_prod:my-project/mysql-password}'
-      - name: 'Specific version'
-        description: 'Read version `3` of the `mysql-password` secret.'
-        language: 'text'
-        content: '${store:gcp-sm:gcp_prod:my-project/mysql-password/3}'
-      - name: 'Collector config example'
-        description: 'Use a Google Secret Manager secret in a collector DSN.'
-        language: 'yaml'
+      - name: 'MySQL collector with password from Google Secret Manager'
+        description: |
+          This example configures a MySQL collector job in `/etc/netdata/go.d/mysql.conf`.
+          The password in the DSN connection string is not stored in plain text. Instead,
+          `${store:gcp-sm:gcp_prod:my-project/mysql-password}` tells Netdata to fetch the
+          latest version of the `mysql-password` secret from the `my-project` project using
+          the `gcp_prod` store, and substitute its value into the DSN at runtime.
         content: |
+          # /etc/netdata/go.d/mysql.conf
           jobs:
             - name: mysql_prod
               dsn: "netdata:${store:gcp-sm:gcp_prod:my-project/mysql-password}@tcp(127.0.0.1:3306)/"
+      - name: 'HTTP check collector with password from Google Secret Manager'
+        description: |
+          This example configures an HTTP check collector job in `/etc/netdata/go.d/httpcheck.conf`.
+          The `password` field uses a secret reference instead of a plain-text value. Netdata fetches
+          the `api-password` secret from the `my-project` project and substitutes its value into the
+          `password` field at runtime.
+        content: |
+          # /etc/netdata/go.d/httpcheck.conf
+          jobs:
+            - name: internal_api
+              url: https://api.example.com/health
+              username: netdata
+              password: "${store:gcp-sm:gcp_prod:my-project/api-password}"
 troubleshooting:
   problems:
     list:

--- a/src/go/plugin/agent/secrets/secretstore/backends/vault/integrations/vault.md
+++ b/src/go/plugin/agent/secrets/secretstore/backends/vault/integrations/vault.md
@@ -20,14 +20,14 @@ Kind: vault
 
 ## Overview
 
-Use Vault as a secretstore backend when you want Netdata collectors to read secrets from HashiCorp Vault at runtime instead of storing them in plain text in collector configuration files.
+Netdata can pull collector credentials directly from HashiCorp Vault at runtime, so you never store passwords or tokens in plain-text configuration files.
 
-This page covers Vault specific setup. For the shared resolver workflow and syntax, see [Secrets Management](https://github.com/netdata/netdata/blob/master/src/collectors/SECRETS.md).
+This page covers Vault specific setup. For the full resolver overview and syntax reference, including simpler alternatives like `${env:...}`, `${file:...}`, and `${cmd:...}`, see [Secrets Management](https://github.com/netdata/netdata/blob/master/src/collectors/SECRETS.md).
 
 
 ### Limitations
 
-Netdata reads existing secrets from Vault. It does not create or renew Vault tokens. If the configured token expires or becomes invalid, secret resolution fails until Netdata can read a valid token again. For KV v2 secrets, Netdata does not add `/data/` to the path automatically.
+Netdata reads existing secrets from Vault. It does not create or renew Vault tokens. If the configured token expires or becomes invalid, secret resolution fails until Netdata can read a valid token again. If you use `token_file` mode, Netdata re-reads the file on every secret resolution, so an external process (e.g. Vault Agent, a cron job) can renew the token by writing to the file. For KV v2 secrets, Netdata does not add `/data/` to the path automatically.
 
 
 ## Setup
@@ -58,7 +58,7 @@ Prefer `token_file` for production so the Vault token is not embedded directly i
 
 #### Allow access to the referenced secret paths
 
-The Vault token used by this secretstore must be allowed to read the paths you reference from collector configs.
+The Vault token used by this secretstore must have a policy that grants `read` capability on the paths you reference from collector configs. Scope the policy to only the paths Netdata needs.
 
 
 #### Plan for file-based changes
@@ -135,13 +135,24 @@ jobs:
     mode_token:
       token: your-vault-token
     addr: https://vault.example
-    namespace: admin
-    tls_skip_verify: false
+
+```
+###### Token from environment variable
+
+Use a `${env:...}` resolver for the Vault token to avoid storing it in plain text in the secretstore config file.
+
+```yaml
+jobs:
+  - name: vault_prod
+    mode: token
+    mode_token:
+      token: "${env:VAULT_TOKEN}"
+    addr: https://vault.example
 
 ```
 ###### Token file
 
-Read the Vault token from a local file on the Netdata host.
+Read the Vault token from a local file on the Netdata host. Netdata re-reads the file on every secret resolution, so an external process can renew the token by writing to this file.
 
 ```yaml
 jobs:
@@ -152,17 +163,34 @@ jobs:
     addr: https://vault.example
 
 ```
+###### Vault Enterprise with namespace
+
+Connect to a Vault Enterprise server using a specific namespace.
+
+```yaml
+jobs:
+  - name: vault_enterprise
+    mode: token_file
+    mode_token_file:
+      path: /var/lib/netdata/vault.token
+    addr: https://vault.example
+    namespace: admin
+
+```
 
 
 ## Use in collector configs
 
-Reference Vault secrets from collector configs with the `vault` secretstore kind.
+Use the `${store:vault:...}` syntax to reference Vault secrets in any string field of a collector configuration file.
 
 
 The operand is `path#key`.
 
 Netdata sends the path to Vault as `/v1/<path>` exactly as you provide it. For KV v2 secrets, include `/data/` in the path yourself.
 The `path` must not be empty and must not contain `..`, `?`, or `#`.
+
+- KV v1 example: `${store:vault:vault_prod:secret/netdata/mysql#password}`.
+- KV v2 example: `${store:vault:vault_prod:secret/data/netdata/mysql#password}` — note the `/data/` segment, Netdata does not add it automatically.
 
 
 ```text
@@ -174,28 +202,37 @@ ${store:vault:<store-name>:<path#key>}
 - `<path#key>`: The Vault API path and the secret field name, separated by `#`.
 
 ### Examples
-#### KV v1 secret
+#### MySQL collector with password from Vault
 
-Read the `password` field from a KV v1 secret.
+This example configures a MySQL collector job in `/etc/netdata/go.d/mysql.conf`.
+The password in the DSN connection string is not stored in plain text. Instead,
+`${store:vault:vault_prod:secret/data/netdata/mysql#password}` tells Netdata to
+read the KV v2 secret at `secret/data/netdata/mysql` from the `vault_prod` store,
+extract the `password` field from the response, and substitute it into the DSN at runtime.
 
-```text
-${store:vault:vault_prod:secret/netdata/mysql#password}
-```
-#### KV v2 secret
-
-Read the `password` field from a KV v2 secret. Include `/data/` in the path.
-
-```text
-${store:vault:vault_prod:secret/data/netdata/mysql#password}
-```
-#### Collector config example
-
-Use a Vault secret in a collector DSN.
 
 ```yaml
+# /etc/netdata/go.d/mysql.conf
 jobs:
   - name: mysql_prod
     dsn: "netdata:${store:vault:vault_prod:secret/data/netdata/mysql#password}@tcp(127.0.0.1:3306)/"
+
+```
+#### Elasticsearch collector with HTTP basic auth from Vault
+
+This example configures an Elasticsearch collector job in `/etc/netdata/go.d/elasticsearch.conf`.
+The `password` field uses a secret reference instead of a plain-text value. Netdata reads the
+KV v2 secret at `secret/data/netdata/elasticsearch` from the `vault_prod` store, extracts the
+`password` field, and substitutes it at runtime.
+
+
+```yaml
+# /etc/netdata/go.d/elasticsearch.conf
+jobs:
+  - name: es_prod
+    url: https://elasticsearch.example.com:9200
+    username: netdata
+    password: "${store:vault:vault_prod:secret/data/netdata/elasticsearch#password}"
 
 ```
 

--- a/src/go/plugin/agent/secrets/secretstore/backends/vault/metadata.yaml
+++ b/src/go/plugin/agent/secrets/secretstore/backends/vault/metadata.yaml
@@ -13,11 +13,11 @@ keywords:
   - 'hashicorp vault'
 overview:
   description: |
-    Use Vault as a secretstore backend when you want Netdata collectors to read secrets from HashiCorp Vault at runtime instead of storing them in plain text in collector configuration files.
+    Netdata can pull collector credentials directly from HashiCorp Vault at runtime, so you never store passwords or tokens in plain-text configuration files.
 
-    This page covers Vault specific setup. For the shared resolver workflow and syntax, see [Secrets Management](/src/collectors/SECRETS.md).
+    This page covers Vault specific setup. For the full resolver overview and syntax reference, including simpler alternatives like `${env:...}`, `${file:...}`, and `${cmd:...}`, see [Secrets Management](/src/collectors/SECRETS.md).
   limitations: |
-    Netdata reads existing secrets from Vault. It does not create or renew Vault tokens. If the configured token expires or becomes invalid, secret resolution fails until Netdata can read a valid token again. For KV v2 secrets, Netdata does not add `/data/` to the path automatically.
+    Netdata reads existing secrets from Vault. It does not create or renew Vault tokens. If the configured token expires or becomes invalid, secret resolution fails until Netdata can read a valid token again. If you use `token_file` mode, Netdata re-reads the file on every secret resolution, so an external process (e.g. Vault Agent, a cron job) can renew the token by writing to the file. For KV v2 secrets, Netdata does not add `/data/` to the path automatically.
 setup:
   prerequisites:
     list:
@@ -34,7 +34,7 @@ setup:
           Prefer `token_file` for production so the Vault token is not embedded directly in the secretstore configuration.
       - title: 'Allow access to the referenced secret paths'
         description: |
-          The Vault token used by this secretstore must be allowed to read the paths you reference from collector configs.
+          The Vault token used by this secretstore must have a policy that grants `read` capability on the paths you reference from collector configs. Scope the policy to only the paths Netdata needs.
       - title: 'Plan for file-based changes'
         description: |
           If you edit `/etc/netdata/go.d/ss/vault.conf`, restart the Netdata Agent to load the updated secretstore definition.
@@ -96,10 +96,17 @@ setup:
                 mode_token:
                   token: your-vault-token
                 addr: https://vault.example
-                namespace: admin
-                tls_skip_verify: false
+        - name: 'Token from environment variable'
+          description: 'Use a `${env:...}` resolver for the Vault token to avoid storing it in plain text in the secretstore config file.'
+          config: |
+            jobs:
+              - name: vault_prod
+                mode: token
+                mode_token:
+                  token: "${env:VAULT_TOKEN}"
+                addr: https://vault.example
         - name: 'Token file'
-          description: 'Read the Vault token from a local file on the Netdata host.'
+          description: 'Read the Vault token from a local file on the Netdata host. Netdata re-reads the file on every secret resolution, so an external process can renew the token by writing to this file.'
           config: |
             jobs:
               - name: vault_prod_file_token
@@ -107,9 +114,19 @@ setup:
                 mode_token_file:
                   path: /var/lib/netdata/vault.token
                 addr: https://vault.example
+        - name: 'Vault Enterprise with namespace'
+          description: 'Connect to a Vault Enterprise server using a specific namespace.'
+          config: |
+            jobs:
+              - name: vault_enterprise
+                mode: token_file
+                mode_token_file:
+                  path: /var/lib/netdata/vault.token
+                addr: https://vault.example
+                namespace: admin
 collector_configs:
   description: |
-    Reference Vault secrets from collector configs with the `vault` secretstore kind.
+    Use the `${store:vault:...}` syntax to reference Vault secrets in any string field of a collector configuration file.
   summary:
     operand_format: 'path#key'
     example_operand: 'secret/data/netdata/mysql#password'
@@ -119,6 +136,9 @@ collector_configs:
 
       Netdata sends the path to Vault as `/v1/<path>` exactly as you provide it. For KV v2 secrets, include `/data/` in the path yourself.
       The `path` must not be empty and must not contain `..`, `?`, or `#`.
+
+      - KV v1 example: `${store:vault:vault_prod:secret/netdata/mysql#password}`.
+      - KV v2 example: `${store:vault:vault_prod:secret/data/netdata/mysql#password}` — note the `/data/` segment, Netdata does not add it automatically.
     syntax: '${store:vault:<store-name>:<path#key>}'
     parts:
       list:
@@ -130,21 +150,31 @@ collector_configs:
           description: 'The Vault API path and the secret field name, separated by `#`.'
   examples:
     list:
-      - name: 'KV v1 secret'
-        description: 'Read the `password` field from a KV v1 secret.'
-        language: 'text'
-        content: '${store:vault:vault_prod:secret/netdata/mysql#password}'
-      - name: 'KV v2 secret'
-        description: 'Read the `password` field from a KV v2 secret. Include `/data/` in the path.'
-        language: 'text'
-        content: '${store:vault:vault_prod:secret/data/netdata/mysql#password}'
-      - name: 'Collector config example'
-        description: 'Use a Vault secret in a collector DSN.'
-        language: 'yaml'
+      - name: 'MySQL collector with password from Vault'
+        description: |
+          This example configures a MySQL collector job in `/etc/netdata/go.d/mysql.conf`.
+          The password in the DSN connection string is not stored in plain text. Instead,
+          `${store:vault:vault_prod:secret/data/netdata/mysql#password}` tells Netdata to
+          read the KV v2 secret at `secret/data/netdata/mysql` from the `vault_prod` store,
+          extract the `password` field from the response, and substitute it into the DSN at runtime.
         content: |
+          # /etc/netdata/go.d/mysql.conf
           jobs:
             - name: mysql_prod
               dsn: "netdata:${store:vault:vault_prod:secret/data/netdata/mysql#password}@tcp(127.0.0.1:3306)/"
+      - name: 'Elasticsearch collector with HTTP basic auth from Vault'
+        description: |
+          This example configures an Elasticsearch collector job in `/etc/netdata/go.d/elasticsearch.conf`.
+          The `password` field uses a secret reference instead of a plain-text value. Netdata reads the
+          KV v2 secret at `secret/data/netdata/elasticsearch` from the `vault_prod` store, extracts the
+          `password` field, and substitutes it at runtime.
+        content: |
+          # /etc/netdata/go.d/elasticsearch.conf
+          jobs:
+            - name: es_prod
+              url: https://elasticsearch.example.com:9200
+              username: netdata
+              password: "${store:vault:vault_prod:secret/data/netdata/elasticsearch#password}"
 troubleshooting:
   problems:
     list:


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

- [ ] AI-generated or AI-assisted content has been manually verified (examples/instructions tested where applicable).

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves secrets management docs with clear, example-driven guidance and a resolver decision guide, plus fixes a schema validation bug and defaults code fences to YAML for better readability.

- **Documentation**
  - Added “Choosing a Resolver,” “Multiple Secretstores,” and “Mixing Resolver Types” to SECRETS.md.
  - Wrote realistic collector examples (MySQL, Elasticsearch, PostgreSQL, HTTP check) showing `${store:...}` substitution.
  - Documented that secretstore configs support `${env:...}`, `${file:...}`, and `${cmd:...}` (not `${store:...}` inside secretstores).
  - Added Docker Secrets and Kubernetes Secrets notes for `${file:...}` and directory setup steps for `/etc/netdata/go.d/ss/`.
  - Updated backend guides with minimum permissions and platform notes:
    - `aws-sm`: must set `region` explicitly; IAM needs `secretsmanager:GetSecretValue`.
    - `azure-kv`: use “Key Vault Secrets User” role; added `${env:...}` option for `client_secret`.
    - `gcp-sm`: clarified limitations; added GKE Workload Identity note; IAM needs `roles/secretmanager.secretAccessor`; absolute path for `service_account_file`.
    - `vault`: token file is re-read on each resolution; added Enterprise namespace example; `${env:...}` option for token; cleaned examples.

- **Bug Fixes**
  - Fixed schema: `minLength` → `minItems` for arrays in `secretstore.json`.
  - Defaulted code fences to `yaml` in `collector_configs.md` template.

<sup>Written for commit 64359ac5e85ce36ebb15c32def21e509fe8df068. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

