### PR TITLE
Remove DBENGINE Warnings (Linux compilation)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2506,8 +2506,6 @@ netdata_protoc_generate_cpp("${CMAKE_SOURCE_DIR}/src/aclk/aclk-schemas"
 
 list(APPEND ACLK_FILES ${ACLK_PROTO_BUILT_SRCS}
                        ${ACLK_PROTO_BUILT_HDRS})
-# Suppress false-positive -Wstringop-overflow from GCC 15 in protobuf-generated swap methods
-set_source_files_properties(${ACLK_PROTO_BUILT_SRCS} PROPERTIES COMPILE_OPTIONS "-Wno-stringop-overflow")
 
 #
 # nd-run helper program

--- a/src/aclk/aclk_util.c
+++ b/src/aclk/aclk_util.c
@@ -640,13 +640,6 @@ static int aclk_http_proxy_negotiate(int sockfd, const char *proxy_username, con
         char *creds_base64 = callocz(1, (size_t)creds_base64_len + 1);
         (void)netdata_base64_encode((unsigned char *)creds_base64, (unsigned char *)creds_plain, creds_plain_len);
 
-        // pre-validate: "Proxy-Authorization: Basic " (27) + base64 + "\r\n" (2) + NUL (1) = 30 + base64
-        size_t needed = 30 + (size_t)creds_base64_len;
-        if (sizeof(req) - off < needed) {
-            aclk_sensitive_free(&creds_plain);
-            aclk_sensitive_free(&creds_base64);
-            goto cleanup;
-        }
         rc = snprintf(req + off, sizeof(req) - off, "Proxy-Authorization: Basic %s\r\n", creds_base64);
         aclk_sensitive_free(&creds_plain);
         aclk_sensitive_free(&creds_base64);


### PR DESCRIPTION
##### Summary
This PR removes the following warnings on Linux environment:

<details> <summary>Warnings</summary>
/home/thiago/Netdata/tests_netdata/src/database/engine/mrg-unittest.c:9:53: warning: missing braces around initializer [-Wmissing-braces]
    9 | static struct rrdengine_instance test_ctx_tier[4] = { {0}, {0}, {0}, {0} }; // For stress test tiers
      |                                                     ^
      |                                                        {}   {}   {}   {}
/home/thiago/Netdata/tests_netdata/src/database/engine/mrg-unittest.c: In function 'mrg_unittest':
/home/thiago/Netdata/tests_netdata/src/database/engine/mrg-unittest.c:203:72: warning: format '%zu' expects argument of type 'size_t', but argument 4 has type 'ssize_t' {aka 'long int'} [-Wformat=]
  203 |     fprintf(stderr, "DBENGINE METRIC: final MRG state - %zu entries, %zu acquired\n",
      |                                                                      ~~^
      |                                                                        |
      |                                                                        long unsigned int
      |                                                                      %lu
  204 |                      final_stats.entries, final_stats.entries_acquired);
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
      |                                                      |
      |                                                      ssize_t {aka lon


/home/thiago/Netdata/tests_netdata/src/database/engine/rrdengine.c: In function 'datafile_delete':
/home/thiago/Netdata/tests_netdata/src/database/engine/rrdengine.c:1500:35: warning: format '%d' expects argument of type 'int', but argument 7 has type 'unsigned int' [-Wformat=]
 1500 |                 netdata_log_error("DBENGINE: tier %d: " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL
      |                                   ^~~~~~~~~~~~~~~~~~~~~
......
 1503 |                                   tier, datafile->tier, fileno, attempts, datafile->users.lockers);
      |                                   ~~~~
      |                                   |
      |                                   unsigned int
/home/thiago/Netdata/tests_netdata/src/libnetdata/log/nd_log.h:144:117: note: in definition of macro 'netdata_log_error'
  144 | #define netdata_log_error(args...)  netdata_logger(NDLS_DAEMON,     NDLP_ERR,   __FILE__, __FUNCTION__, __LINE__, ##args)
      |                                                                                                                     ^~~~
/home/thiago/Netdata/tests_netdata/src/database/engine/rrdengine.c:1500:52: note: format string is defined here
 1500 |                 netdata_log_error("DBENGINE: tier %d: " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL
      |                                                   ~^
      |                                                    |
      |                                                    int
      |                                                   %d

</details>

In rrdengine.c there are different warnings, but I copied only one group;

##### Test Plan

- [ ] AI-generated or AI-assisted content has been manually verified (examples/instructions tested where applicable).

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes DBENGINE compiler warnings on Linux by fixing array initialization and log format specifiers. mrg-unittest now uses {0} and %zd for ssize_t; rrdengine logs use %u for tier to match unsigned types, with no functional changes.

<sup>Written for commit 575c5db564cb185331e57490a2e3ca8520753602. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

