### PR TITLE
chore(scripts.d/nagios): add float flag to perfdata fields observation

### DIFF
--- a/src/go/plugin/scripts.d/collector/nagios/collect.go
+++ b/src/go/plugin/scripts.d/collector/nagios/collect.go
@@ -124,6 +124,7 @@ func (c *Collector) emitMetrics(execMetrics executionMetrics) {
 				metrix.WithMeasureSetFields(perfMeasureSetFieldSpecs()...),
 				metrix.WithChartFamily(perfdataFamily(measureSet.scriptName)),
 				metrix.WithUnit(measureSet.unit),
+				metrix.WithFloat(true),
 			).ObserveTotalFields(fields)
 		} else {
 			jobMeter.MeasureSetGauge(
@@ -131,6 +132,7 @@ func (c *Collector) emitMetrics(execMetrics executionMetrics) {
 				metrix.WithMeasureSetFields(perfMeasureSetFieldSpecs()...),
 				metrix.WithChartFamily(perfdataFamily(measureSet.scriptName)),
 				metrix.WithUnit(measureSet.unit),
+				metrix.WithFloat(true),
 			).ObserveFields(fields)
 		}
 	}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

- [ ] AI-generated or AI-assisted content has been manually verified (examples/instructions tested where applicable).

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark perfdata observations as float in the `scripts.d` Nagios collector by passing `metrix.WithFloat(true)`. This preserves decimal values for gauge and total metrics and prevents rounding.

- **Bug Fixes**
  - Apply the float flag for both `ObserveTotalFields` and `ObserveFields` to accurately record fractional perfdata values.

<sup>Written for commit fcb0eb9909dc679fd135e89311fa9764b15c4845. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

