### PR TITLE
chore(go.d/agent): improve terminal-mode behavior

### DIFF
--- a/src/go/cmd/godplugin/main.go
+++ b/src/go/cmd/godplugin/main.go
@@ -78,6 +78,8 @@ func main() {
 	isInsideK8s := hostinfo.IsInsideK8sCluster()
 	moduleRegistry := moduleRegistryWithSystemdPolicy(collectorapi.DefaultRegistry, hostinfo.SystemdVersion)
 
+	runModePolicy := policy.Agent(isTerminal)
+
 	a := agent.New(agent.Config{
 		Name:                      executable.Name,
 		PluginConfigDir:           pluginconfig.ConfigDir(),
@@ -87,11 +89,7 @@ func main() {
 		VarLibDir:                 pluginconfig.VarLibDir(),
 		ModuleRegistry:            moduleRegistry,
 		IsInsideK8s:               isInsideK8s,
-		RunModePolicy: policy.RunModePolicy{
-			IsTerminal:               isTerminal,
-			AutoEnableDiscovered:     isTerminal,
-			UseFileStatusPersistence: !isTerminal,
-		},
+		RunModePolicy:             runModePolicy,
 		DiscoveryProviders: []discovery.ProviderFactory{
 			discoveryproviders.File(),
 			discoveryproviders.Dummy(),
@@ -202,13 +200,9 @@ func runFunctionCLI(opts *cli.Option) int {
 	defer cancel()
 
 	jobMgr := jobmgr.New(jobmgr.Config{
-		PluginName: executable.Name,
-		Out:        io.Discard,
-		RunModePolicy: policy.RunModePolicy{
-			IsTerminal:               false,
-			AutoEnableDiscovered:     true,
-			UseFileStatusPersistence: true,
-		},
+		PluginName:     executable.Name,
+		Out:            io.Discard,
+		RunModePolicy:  policy.FunctionCLI(),
 		VarLibDir:      pluginconfig.VarLibDir(),
 		Modules:        collectorapi.Registry{moduleName: creator},
 		ConfigDefaults: reg,

--- a/src/go/cmd/ibmdplugin/main.go
+++ b/src/go/cmd/ibmdplugin/main.go
@@ -120,11 +120,7 @@ func main() {
 		VarLibDir:           pluginconfig.VarLibDir(),
 		ModuleRegistry:      collectorapi.DefaultRegistry,
 		IsInsideK8s:         hostinfo.IsInsideK8sCluster(),
-		RunModePolicy: policy.RunModePolicy{
-			IsTerminal:               isTerminal,
-			AutoEnableDiscovered:     isTerminal,
-			UseFileStatusPersistence: !isTerminal,
-		},
+		RunModePolicy:       policy.Agent(isTerminal),
 		DiscoveryProviders: []discovery.ProviderFactory{
 			discoveryproviders.File(),
 			discoveryproviders.Dummy(),

--- a/src/go/cmd/scriptsdplugin/main.go
+++ b/src/go/cmd/scriptsdplugin/main.go
@@ -75,11 +75,7 @@ func main() {
 		VarLibDir:                 pluginconfig.VarLibDir(),
 		ModuleRegistry:            collectorapi.DefaultRegistry,
 		IsInsideK8s:               hostinfo.IsInsideK8sCluster(),
-		RunModePolicy: policy.RunModePolicy{
-			IsTerminal:               isTerminal,
-			AutoEnableDiscovered:     isTerminal,
-			UseFileStatusPersistence: !isTerminal,
-		},
+		RunModePolicy:             policy.Agent(isTerminal),
 		DiscoveryProviders: []discovery.ProviderFactory{
 			discoveryproviders.File(),
 			discoveryproviders.Dummy(),

--- a/src/go/plugin/agent/agent.go
+++ b/src/go/plugin/agent/agent.go
@@ -22,6 +22,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/metricsaudit"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/runtimecomp"
 )
 
 // Config is an Agent configuration.
@@ -227,9 +228,10 @@ func (a *Agent) run(ctx context.Context) {
 		return
 	}
 
-	runtimeSvc := runtimechartemit.New(a.Logger.With(slog.String("component", "runtime metrics service")))
-	runtimeSvc.Start(a.Name, a.Out)
-	defer runtimeSvc.Stop()
+	runtimeSvc, stopRuntimeSvc := a.setupRuntimeService()
+	if stopRuntimeSvc != nil {
+		defer stopRuntimeSvc()
+	}
 	fnMgr.SetRuntimeService(runtimeSvc)
 
 	var runJob []string
@@ -281,6 +283,23 @@ func (a *Agent) printMetricsAudit() {
 	} else {
 		a.auditAnalyzer.PrintReport()
 	}
+}
+
+func (a *Agent) serviceDiscoveryEnabled() bool {
+	if a == nil {
+		return false
+	}
+	return !a.DisableServiceDiscovery && a.runModePolicy.EnableServiceDiscovery
+}
+
+func (a *Agent) setupRuntimeService() (runtimecomp.Service, func()) {
+	if a == nil || !a.runModePolicy.EnableRuntimeCharts {
+		return nil, nil
+	}
+
+	svc := runtimechartemit.New(a.Logger.With(slog.String("component", "runtime metrics service")))
+	svc.Start(a.Name, a.Out)
+	return svc, svc.Stop
 }
 
 func (a *Agent) signalAuditComplete() {

--- a/src/go/plugin/agent/agent_test.go
+++ b/src/go/plugin/agent/agent_test.go
@@ -5,6 +5,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -31,6 +33,74 @@ func TestNew(t *testing.T) {
 	})
 }
 
+func TestAgent_serviceDiscoveryEnabled(t *testing.T) {
+	tests := map[string]struct {
+		agent *Agent
+		want  bool
+	}{
+		"non-terminal policy enables service discovery": {
+			agent: &Agent{runModePolicy: policy.Agent(false)},
+			want:  true,
+		},
+		"terminal policy disables service discovery": {
+			agent: &Agent{runModePolicy: policy.Agent(true)},
+			want:  false,
+		},
+		"plugin-level disable wins over policy": {
+			agent: &Agent{
+				runModePolicy:           policy.Agent(false),
+				DisableServiceDiscovery: true,
+			},
+			want: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NotNil(t, test.agent)
+			assert.Equal(t, test.want, test.agent.serviceDiscoveryEnabled())
+		})
+	}
+}
+
+func TestAgent_setupRuntimeService(t *testing.T) {
+	tests := map[string]struct {
+		policy      policy.RunModePolicy
+		wantEnabled bool
+	}{
+		"terminal mode disables runtime service": {
+			policy:      policy.Agent(true),
+			wantEnabled: false,
+		},
+		"non-terminal mode enables runtime service": {
+			policy:      policy.Agent(false),
+			wantEnabled: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			a := New(Config{
+				Name:          "test",
+				RunModePolicy: test.policy,
+			})
+			require.NotNil(t, a)
+			a.Out = io.Discard
+
+			svc, stop := a.setupRuntimeService()
+			if !test.wantEnabled {
+				assert.Nil(t, svc)
+				assert.Nil(t, stop)
+				return
+			}
+
+			require.NotNil(t, svc)
+			require.NotNil(t, stop)
+			stop()
+		})
+	}
+}
+
 func TestAgent_Run(t *testing.T) {
 	a := New(Config{
 		Name: "test",
@@ -38,6 +108,7 @@ func TestAgent_Run(t *testing.T) {
 			IsTerminal:               false,
 			AutoEnableDiscovered:     true,
 			UseFileStatusPersistence: true,
+			EnableRuntimeCharts:      true,
 		},
 		DiscoveryProviders: []discovery.ProviderFactory{
 			discovery.NewProviderFactory("dummy", func(ctx discovery.BuildContext) (discovery.Discoverer, bool, error) {

--- a/src/go/plugin/agent/policy/runmode.go
+++ b/src/go/plugin/agent/policy/runmode.go
@@ -7,4 +7,28 @@ type RunModePolicy struct {
 	IsTerminal               bool
 	AutoEnableDiscovered     bool
 	UseFileStatusPersistence bool
+	EnableServiceDiscovery   bool
+	EnableRuntimeCharts      bool
+}
+
+// Agent returns the shared defaults for long-lived agent processes.
+func Agent(isTerminal bool) RunModePolicy {
+	return RunModePolicy{
+		IsTerminal:               isTerminal,
+		AutoEnableDiscovered:     isTerminal,
+		UseFileStatusPersistence: !isTerminal,
+		EnableServiceDiscovery:   !isTerminal,
+		EnableRuntimeCharts:      !isTerminal,
+	}
+}
+
+// FunctionCLI returns the shared defaults for one-shot function execution.
+func FunctionCLI() RunModePolicy {
+	return RunModePolicy{
+		IsTerminal:               false,
+		AutoEnableDiscovered:     true,
+		UseFileStatusPersistence: true,
+		EnableServiceDiscovery:   false,
+		EnableRuntimeCharts:      false,
+	}
 }

--- a/src/go/plugin/agent/policy/runmode_test.go
+++ b/src/go/plugin/agent/policy/runmode_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunModeConstructors(t *testing.T) {
+	tests := map[string]struct {
+		makePolicy func() RunModePolicy
+		want       RunModePolicy
+	}{
+		"agent terminal": {
+			makePolicy: func() RunModePolicy { return Agent(true) },
+			want: RunModePolicy{
+				IsTerminal:               true,
+				AutoEnableDiscovered:     true,
+				UseFileStatusPersistence: false,
+				EnableServiceDiscovery:   false,
+				EnableRuntimeCharts:      false,
+			},
+		},
+		"agent daemon": {
+			makePolicy: func() RunModePolicy { return Agent(false) },
+			want: RunModePolicy{
+				IsTerminal:               false,
+				AutoEnableDiscovered:     false,
+				UseFileStatusPersistence: true,
+				EnableServiceDiscovery:   true,
+				EnableRuntimeCharts:      true,
+			},
+		},
+		"function cli": {
+			makePolicy: FunctionCLI,
+			want: RunModePolicy{
+				IsTerminal:               false,
+				AutoEnableDiscovered:     true,
+				UseFileStatusPersistence: true,
+				EnableServiceDiscovery:   false,
+				EnableRuntimeCharts:      false,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NotNil(t, test.makePolicy)
+			assert.Equal(t, test.want, test.makePolicy())
+		})
+	}
+}

--- a/src/go/plugin/agent/setup.go
+++ b/src/go/plugin/agent/setup.go
@@ -88,8 +88,7 @@ func (a *Agent) buildDiscoveryConf(enabled collectorapi.Registry, fnReg function
 
 	watchPaths := a.CollectorsConfigWatchPath
 	sdConfDir := a.ServiceDiscoveryConfigDir
-	if a.DisableServiceDiscovery {
-		dummyPaths = nil
+	if !a.serviceDiscoveryEnabled() {
 		sdConfDir = nil
 	}
 

--- a/src/go/plugin/agent/setup_test.go
+++ b/src/go/plugin/agent/setup_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/policy"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
@@ -299,4 +300,60 @@ func TestAgent_buildDiscoveryConf(t *testing.T) {
 		assert.False(t, cfg.BuildContext.Policy.IsInsideK8s)
 		assert.Len(t, cfg.Providers, 1)
 	})
+}
+
+func TestAgent_buildDiscoveryConf_serviceDiscoveryGating(t *testing.T) {
+	providers := []discovery.ProviderFactory{
+		discovery.NewProviderFactory("noop", nil),
+	}
+	enabled := collectorapi.Registry{
+		"module1": collectorapi.Creator{},
+	}
+
+	tests := map[string]struct {
+		agent         *Agent
+		wantSDDir     []string
+		wantWatchPath []string
+	}{
+		"terminal mode disables service discovery without changing collector watch paths": {
+			agent: &Agent{
+				runModePolicy:             policy.Agent(true),
+				ServiceDiscoveryConfigDir: []string{"sd"},
+				CollectorsConfDir:         []string{"collectors"},
+				CollectorsConfigWatchPath: []string{"watch/*.conf"},
+				DiscoveryProviders:        providers,
+			},
+			wantWatchPath: []string{"watch/*.conf"},
+		},
+		"plugin-level disable overrides non-terminal service discovery policy": {
+			agent: &Agent{
+				runModePolicy:             policy.Agent(false),
+				DisableServiceDiscovery:   true,
+				ServiceDiscoveryConfigDir: []string{"sd"},
+				CollectorsConfDir:         []string{"collectors"},
+				DiscoveryProviders:        providers,
+			},
+		},
+		"non-terminal mode keeps service discovery enabled": {
+			agent: &Agent{
+				runModePolicy:             policy.Agent(false),
+				ServiceDiscoveryConfigDir: []string{"sd"},
+				CollectorsConfDir:         []string{"collectors"},
+				CollectorsConfigWatchPath: []string{"watch/*.conf"},
+				DiscoveryProviders:        providers,
+			},
+			wantSDDir:     []string{"sd"},
+			wantWatchPath: []string{"watch/*.conf"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NotNil(t, test.agent)
+
+			cfg := test.agent.buildDiscoveryConf(enabled, nil)
+			assert.Equal(t, test.wantSDDir, []string(cfg.BuildContext.Paths.ServiceDiscoveryConfigDir))
+			assert.Equal(t, test.wantWatchPath, cfg.BuildContext.Paths.CollectorsConfigWatchPath)
+		})
+	}
 }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

- [ ] AI-generated or AI-assisted content has been manually verified (examples/instructions tested where applicable).

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate runtime features by run mode to improve terminal-mode behavior. Terminal sessions now disable service discovery and runtime charts; daemon mode keeps them enabled.

- **Refactors**
  - Added `EnableServiceDiscovery` and `EnableRuntimeCharts` to `policy.RunModePolicy`.
  - Introduced `policy.Agent(isTerminal)` and `policy.FunctionCLI()` for consistent defaults.
  - Gated setup through `Agent.serviceDiscoveryEnabled()` and `Agent.setupRuntimeService()`.
  - Switched `godplugin`, `ibmdplugin`, and `scriptsdplugin` to the new policy helpers.
  - Added tests for policy constructors, agent gating, and discovery config.

<sup>Written for commit 2b42ed29cda9c4c2e383a123a699afa4231bc99c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

