### PR TITLE
chore(go.d/azure_monitor): format profiles and fix IO family

### DIFF
--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/aks.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/aks.yaml
@@ -3,457 +3,457 @@ id: aks
 name: Azure Kubernetes Service Cluster
 resource_type: Microsoft.ContainerService/managedClusters
 metrics:
-- id: apiserver_cpu_usage_percentage
-  azure_name: apiserver_cpu_usage_percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: apiserver_memory_usage_percentage
-  azure_name: apiserver_memory_usage_percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: apiserver_current_inflight_requests
-  azure_name: apiserver_current_inflight_requests
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: etcd_cpu_usage_percentage
-  azure_name: etcd_cpu_usage_percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: etcd_memory_usage_percentage
-  azure_name: etcd_memory_usage_percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: etcd_database_usage_percentage
-  azure_name: etcd_database_usage_percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: kube_pod_status_phase
-  azure_name: kube_pod_status_phase
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: kube_pod_status_ready
-  azure_name: kube_pod_status_ready
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: kube_node_status_allocatable_cpu_cores
-  azure_name: kube_node_status_allocatable_cpu_cores
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: kube_node_status_allocatable_memory_bytes
-  azure_name: kube_node_status_allocatable_memory_bytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: kube_node_status_condition
-  azure_name: kube_node_status_condition
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cluster_autoscaler_cluster_safe_to_autoscale
-  azure_name: cluster_autoscaler_cluster_safe_to_autoscale
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cluster_autoscaler_unschedulable_pods_count
-  azure_name: cluster_autoscaler_unschedulable_pods_count
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cluster_autoscaler_unneeded_nodes_count
-  azure_name: cluster_autoscaler_unneeded_nodes_count
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cluster_autoscaler_scale_down_in_cooldown
-  azure_name: cluster_autoscaler_scale_down_in_cooldown
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: node_cpu_usage_millicores
-  azure_name: node_cpu_usage_millicores
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: node_cpu_usage_percentage
-  azure_name: node_cpu_usage_percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: node_memory_working_set_bytes
-  azure_name: node_memory_working_set_bytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: node_memory_working_set_percentage
-  azure_name: node_memory_working_set_percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: node_memory_rss_bytes
-  azure_name: node_memory_rss_bytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: node_memory_rss_percentage
-  azure_name: node_memory_rss_percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: node_disk_usage_bytes
-  azure_name: node_disk_usage_bytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: node_disk_usage_percentage
-  azure_name: node_disk_usage_percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: node_network_in_bytes
-  azure_name: node_network_in_bytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: node_network_out_bytes
-  azure_name: node_network_out_bytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
+  - id: apiserver_cpu_usage_percentage
+    azure_name: apiserver_cpu_usage_percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: apiserver_memory_usage_percentage
+    azure_name: apiserver_memory_usage_percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: apiserver_current_inflight_requests
+    azure_name: apiserver_current_inflight_requests
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: etcd_cpu_usage_percentage
+    azure_name: etcd_cpu_usage_percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: etcd_memory_usage_percentage
+    azure_name: etcd_memory_usage_percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: etcd_database_usage_percentage
+    azure_name: etcd_database_usage_percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: kube_pod_status_phase
+    azure_name: kube_pod_status_phase
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: kube_pod_status_ready
+    azure_name: kube_pod_status_ready
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: kube_node_status_allocatable_cpu_cores
+    azure_name: kube_node_status_allocatable_cpu_cores
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: kube_node_status_allocatable_memory_bytes
+    azure_name: kube_node_status_allocatable_memory_bytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: kube_node_status_condition
+    azure_name: kube_node_status_condition
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cluster_autoscaler_cluster_safe_to_autoscale
+    azure_name: cluster_autoscaler_cluster_safe_to_autoscale
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cluster_autoscaler_unschedulable_pods_count
+    azure_name: cluster_autoscaler_unschedulable_pods_count
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cluster_autoscaler_unneeded_nodes_count
+    azure_name: cluster_autoscaler_unneeded_nodes_count
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cluster_autoscaler_scale_down_in_cooldown
+    azure_name: cluster_autoscaler_scale_down_in_cooldown
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: node_cpu_usage_millicores
+    azure_name: node_cpu_usage_millicores
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: node_cpu_usage_percentage
+    azure_name: node_cpu_usage_percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: node_memory_working_set_bytes
+    azure_name: node_memory_working_set_bytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: node_memory_working_set_percentage
+    azure_name: node_memory_working_set_percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: node_memory_rss_bytes
+    azure_name: node_memory_rss_bytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: node_memory_rss_percentage
+    azure_name: node_memory_rss_percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: node_disk_usage_bytes
+    azure_name: node_disk_usage_bytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: node_disk_usage_percentage
+    azure_name: node_disk_usage_percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: node_network_in_bytes
+    azure_name: node_network_in_bytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: node_network_out_bytes
+    azure_name: node_network_out_bytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
 template:
   family: Azure Kubernetes Service Cluster
   context_namespace: aks
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_aks__apiserver_cpu
-    title: AKS API Server CPU Utilization
-    context: apiserver_cpu
-    family: API Server
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: aks.apiserver_cpu_usage_percentage_average
-      name: average
-    - selector: aks.apiserver_cpu_usage_percentage_maximum
-      name: maximum
-  - id: am_azure_aks__apiserver_memory
-    title: AKS API Server Memory Utilization
-    context: apiserver_memory
-    family: API Server
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: aks.apiserver_memory_usage_percentage_average
-      name: average
-    - selector: aks.apiserver_memory_usage_percentage_maximum
-      name: maximum
-  - id: am_azure_aks__apiserver_inflight_requests
-    title: AKS API Server Inflight Requests
-    context: apiserver_inflight_requests
-    family: API Server
-    type: line
-    units: requests
-    algorithm: absolute
-    dimensions:
-    - selector: aks.apiserver_current_inflight_requests_average
-      name: average
-  - id: am_azure_aks__etcd_cpu
-    title: AKS etcd CPU Utilization
-    context: etcd_cpu
-    family: Control Plane
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: aks.etcd_cpu_usage_percentage_average
-      name: average
-    - selector: aks.etcd_cpu_usage_percentage_maximum
-      name: maximum
-  - id: am_azure_aks__etcd_memory
-    title: AKS etcd Memory Utilization
-    context: etcd_memory
-    family: Control Plane
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: aks.etcd_memory_usage_percentage_average
-      name: average
-    - selector: aks.etcd_memory_usage_percentage_maximum
-      name: maximum
-  - id: am_azure_aks__etcd_database
-    title: AKS etcd Database Utilization
-    context: etcd_database
-    family: Control Plane
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: aks.etcd_database_usage_percentage_average
-      name: average
-    - selector: aks.etcd_database_usage_percentage_maximum
-      name: maximum
-  - id: am_azure_aks__pod_status_phase
-    title: AKS Pods by Phase
-    context: pod_status_phase
-    family: Pods
-    type: line
-    units: pods
-    algorithm: absolute
-    dimensions:
-    - selector: aks.kube_pod_status_phase_average
-      name: average
-  - id: am_azure_aks__pod_status_ready
-    title: AKS Pods in Ready State
-    context: pod_status_ready
-    family: Pods
-    type: line
-    units: pods
-    algorithm: absolute
-    dimensions:
-    - selector: aks.kube_pod_status_ready_average
-      name: average
-  - id: am_azure_aks__allocatable_cpu
-    title: AKS Allocatable CPU Cores
-    context: allocatable_cpu
-    family: Capacity
-    type: line
-    units: cores
-    algorithm: absolute
-    dimensions:
-    - selector: aks.kube_node_status_allocatable_cpu_cores_average
-      name: average
-  - id: am_azure_aks__allocatable_memory
-    title: AKS Allocatable Memory
-    context: allocatable_memory
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: aks.kube_node_status_allocatable_memory_bytes_average
-      name: average
-  - id: am_azure_aks__node_conditions
-    title: AKS Node Conditions
-    context: node_conditions
-    family: Capacity
-    type: line
-    units: nodes
-    algorithm: absolute
-    dimensions:
-    - selector: aks.kube_node_status_condition_average
-      name: average
-  - id: am_azure_aks__autoscaler_health
-    title: AKS Cluster Autoscaler Health
-    context: autoscaler_health
-    family: Autoscaler
-    type: line
-    units: state
-    algorithm: absolute
-    dimensions:
-    - selector: aks.cluster_autoscaler_cluster_safe_to_autoscale_average
-      name: safe_to_autoscale
-    - selector: aks.cluster_autoscaler_scale_down_in_cooldown_average
-      name: cooldown
-  - id: am_azure_aks__autoscaler_unschedulable_pods
-    title: AKS Autoscaler Unschedulable Pods
-    context: autoscaler_unschedulable_pods
-    family: Autoscaler
-    type: line
-    units: pods
-    algorithm: absolute
-    dimensions:
-    - selector: aks.cluster_autoscaler_unschedulable_pods_count_average
-      name: average
-  - id: am_azure_aks__autoscaler_unneeded_nodes
-    title: AKS Autoscaler Unneeded Nodes
-    context: autoscaler_unneeded_nodes
-    family: Autoscaler
-    type: line
-    units: nodes
-    algorithm: absolute
-    dimensions:
-    - selector: aks.cluster_autoscaler_unneeded_nodes_count_average
-      name: average
-  - id: am_azure_aks__node_cpu_millicores
-    title: AKS Node CPU Usage
-    context: node_cpu_millicores
-    family: Nodes
-    type: line
-    units: millicores
-    algorithm: absolute
-    dimensions:
-    - selector: aks.node_cpu_usage_millicores_average
-      name: average
-    - selector: aks.node_cpu_usage_millicores_maximum
-      name: maximum
-  - id: am_azure_aks__node_cpu_percentage
-    title: AKS Node CPU Percentage
-    context: node_cpu_percentage
-    family: Nodes
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: aks.node_cpu_usage_percentage_average
-      name: average
-    - selector: aks.node_cpu_usage_percentage_maximum
-      name: maximum
-  - id: am_azure_aks__node_memory_working_set
-    title: AKS Node Memory Working Set
-    context: node_memory_working_set
-    family: Nodes
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: aks.node_memory_working_set_bytes_average
-      name: average
-    - selector: aks.node_memory_working_set_bytes_maximum
-      name: maximum
-  - id: am_azure_aks__node_memory_working_set_percentage
-    title: AKS Node Memory Working Set Percentage
-    context: node_memory_working_set_percentage
-    family: Nodes
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: aks.node_memory_working_set_percentage_average
-      name: average
-    - selector: aks.node_memory_working_set_percentage_maximum
-      name: maximum
-  - id: am_azure_aks__node_memory_rss
-    title: AKS Node Memory RSS
-    context: node_memory_rss
-    family: Nodes
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: aks.node_memory_rss_bytes_average
-      name: average
-    - selector: aks.node_memory_rss_bytes_maximum
-      name: maximum
-  - id: am_azure_aks__node_memory_rss_percentage
-    title: AKS Node Memory RSS Percentage
-    context: node_memory_rss_percentage
-    family: Nodes
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: aks.node_memory_rss_percentage_average
-      name: average
-    - selector: aks.node_memory_rss_percentage_maximum
-      name: maximum
-  - id: am_azure_aks__node_disk_usage
-    title: AKS Node Disk Usage
-    context: node_disk_usage
-    family: Nodes
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: aks.node_disk_usage_bytes_average
-      name: average
-    - selector: aks.node_disk_usage_bytes_maximum
-      name: maximum
-  - id: am_azure_aks__node_disk_percentage
-    title: AKS Node Disk Usage Percentage
-    context: node_disk_percentage
-    family: Nodes
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: aks.node_disk_usage_percentage_average
-      name: average
-    - selector: aks.node_disk_usage_percentage_maximum
-      name: maximum
-  - id: am_azure_aks__node_network
-    title: AKS Node Network Traffic
-    context: node_network
-    family: Network
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: aks.node_network_in_bytes_average
-      name: in
-    - selector: aks.node_network_out_bytes_average
-      name: out
+    - id: am_azure_aks__apiserver_cpu
+      title: AKS API Server CPU Utilization
+      context: apiserver_cpu
+      family: API Server
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: aks.apiserver_cpu_usage_percentage_average
+          name: average
+        - selector: aks.apiserver_cpu_usage_percentage_maximum
+          name: maximum
+    - id: am_azure_aks__apiserver_memory
+      title: AKS API Server Memory Utilization
+      context: apiserver_memory
+      family: API Server
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: aks.apiserver_memory_usage_percentage_average
+          name: average
+        - selector: aks.apiserver_memory_usage_percentage_maximum
+          name: maximum
+    - id: am_azure_aks__apiserver_inflight_requests
+      title: AKS API Server Inflight Requests
+      context: apiserver_inflight_requests
+      family: API Server
+      type: line
+      units: requests
+      algorithm: absolute
+      dimensions:
+        - selector: aks.apiserver_current_inflight_requests_average
+          name: average
+    - id: am_azure_aks__etcd_cpu
+      title: AKS etcd CPU Utilization
+      context: etcd_cpu
+      family: Control Plane
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: aks.etcd_cpu_usage_percentage_average
+          name: average
+        - selector: aks.etcd_cpu_usage_percentage_maximum
+          name: maximum
+    - id: am_azure_aks__etcd_memory
+      title: AKS etcd Memory Utilization
+      context: etcd_memory
+      family: Control Plane
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: aks.etcd_memory_usage_percentage_average
+          name: average
+        - selector: aks.etcd_memory_usage_percentage_maximum
+          name: maximum
+    - id: am_azure_aks__etcd_database
+      title: AKS etcd Database Utilization
+      context: etcd_database
+      family: Control Plane
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: aks.etcd_database_usage_percentage_average
+          name: average
+        - selector: aks.etcd_database_usage_percentage_maximum
+          name: maximum
+    - id: am_azure_aks__pod_status_phase
+      title: AKS Pods by Phase
+      context: pod_status_phase
+      family: Pods
+      type: line
+      units: pods
+      algorithm: absolute
+      dimensions:
+        - selector: aks.kube_pod_status_phase_average
+          name: average
+    - id: am_azure_aks__pod_status_ready
+      title: AKS Pods in Ready State
+      context: pod_status_ready
+      family: Pods
+      type: line
+      units: pods
+      algorithm: absolute
+      dimensions:
+        - selector: aks.kube_pod_status_ready_average
+          name: average
+    - id: am_azure_aks__allocatable_cpu
+      title: AKS Allocatable CPU Cores
+      context: allocatable_cpu
+      family: Capacity
+      type: line
+      units: cores
+      algorithm: absolute
+      dimensions:
+        - selector: aks.kube_node_status_allocatable_cpu_cores_average
+          name: average
+    - id: am_azure_aks__allocatable_memory
+      title: AKS Allocatable Memory
+      context: allocatable_memory
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: aks.kube_node_status_allocatable_memory_bytes_average
+          name: average
+    - id: am_azure_aks__node_conditions
+      title: AKS Node Conditions
+      context: node_conditions
+      family: Capacity
+      type: line
+      units: nodes
+      algorithm: absolute
+      dimensions:
+        - selector: aks.kube_node_status_condition_average
+          name: average
+    - id: am_azure_aks__autoscaler_health
+      title: AKS Cluster Autoscaler Health
+      context: autoscaler_health
+      family: Autoscaler
+      type: line
+      units: state
+      algorithm: absolute
+      dimensions:
+        - selector: aks.cluster_autoscaler_cluster_safe_to_autoscale_average
+          name: safe_to_autoscale
+        - selector: aks.cluster_autoscaler_scale_down_in_cooldown_average
+          name: cooldown
+    - id: am_azure_aks__autoscaler_unschedulable_pods
+      title: AKS Autoscaler Unschedulable Pods
+      context: autoscaler_unschedulable_pods
+      family: Autoscaler
+      type: line
+      units: pods
+      algorithm: absolute
+      dimensions:
+        - selector: aks.cluster_autoscaler_unschedulable_pods_count_average
+          name: average
+    - id: am_azure_aks__autoscaler_unneeded_nodes
+      title: AKS Autoscaler Unneeded Nodes
+      context: autoscaler_unneeded_nodes
+      family: Autoscaler
+      type: line
+      units: nodes
+      algorithm: absolute
+      dimensions:
+        - selector: aks.cluster_autoscaler_unneeded_nodes_count_average
+          name: average
+    - id: am_azure_aks__node_cpu_millicores
+      title: AKS Node CPU Usage
+      context: node_cpu_millicores
+      family: Nodes
+      type: line
+      units: millicores
+      algorithm: absolute
+      dimensions:
+        - selector: aks.node_cpu_usage_millicores_average
+          name: average
+        - selector: aks.node_cpu_usage_millicores_maximum
+          name: maximum
+    - id: am_azure_aks__node_cpu_percentage
+      title: AKS Node CPU Percentage
+      context: node_cpu_percentage
+      family: Nodes
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: aks.node_cpu_usage_percentage_average
+          name: average
+        - selector: aks.node_cpu_usage_percentage_maximum
+          name: maximum
+    - id: am_azure_aks__node_memory_working_set
+      title: AKS Node Memory Working Set
+      context: node_memory_working_set
+      family: Nodes
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: aks.node_memory_working_set_bytes_average
+          name: average
+        - selector: aks.node_memory_working_set_bytes_maximum
+          name: maximum
+    - id: am_azure_aks__node_memory_working_set_percentage
+      title: AKS Node Memory Working Set Percentage
+      context: node_memory_working_set_percentage
+      family: Nodes
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: aks.node_memory_working_set_percentage_average
+          name: average
+        - selector: aks.node_memory_working_set_percentage_maximum
+          name: maximum
+    - id: am_azure_aks__node_memory_rss
+      title: AKS Node Memory RSS
+      context: node_memory_rss
+      family: Nodes
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: aks.node_memory_rss_bytes_average
+          name: average
+        - selector: aks.node_memory_rss_bytes_maximum
+          name: maximum
+    - id: am_azure_aks__node_memory_rss_percentage
+      title: AKS Node Memory RSS Percentage
+      context: node_memory_rss_percentage
+      family: Nodes
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: aks.node_memory_rss_percentage_average
+          name: average
+        - selector: aks.node_memory_rss_percentage_maximum
+          name: maximum
+    - id: am_azure_aks__node_disk_usage
+      title: AKS Node Disk Usage
+      context: node_disk_usage
+      family: Nodes
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: aks.node_disk_usage_bytes_average
+          name: average
+        - selector: aks.node_disk_usage_bytes_maximum
+          name: maximum
+    - id: am_azure_aks__node_disk_percentage
+      title: AKS Node Disk Usage Percentage
+      context: node_disk_percentage
+      family: Nodes
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: aks.node_disk_usage_percentage_average
+          name: average
+        - selector: aks.node_disk_usage_percentage_maximum
+          name: maximum
+    - id: am_azure_aks__node_network
+      title: AKS Node Network Traffic
+      context: node_network
+      family: Network
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: aks.node_network_in_bytes_average
+          name: in
+        - selector: aks.node_network_out_bytes_average
+          name: out

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/api_management.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/api_management.yaml
@@ -3,233 +3,233 @@ id: api_management
 name: Azure API Management
 resource_type: Microsoft.ApiManagement/service
 metrics:
-- id: capacity
-  azure_name: Capacity
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_percent_gateway
-  azure_name: CpuPercent_Gateway
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: memory_percent_gateway
-  azure_name: MemoryPercent_Gateway
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: requests
-  azure_name: Requests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: backend_duration
-  azure_name: BackendDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: duration
-  azure_name: Duration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: event_hub_total_events
-  azure_name: EventHubTotalEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: event_hub_successful_events
-  azure_name: EventHubSuccessfulEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: event_hub_total_failed_events
-  azure_name: EventHubTotalFailedEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: event_hub_dropped_events
-  azure_name: EventHubDroppedEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: event_hub_rejected_events
-  azure_name: EventHubRejectedEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: event_hub_throttled_events
-  azure_name: EventHubThrottledEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: event_hub_timedout_events
-  azure_name: EventHubTimedoutEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: event_hub_total_bytes_sent
-  azure_name: EventHubTotalBytesSent
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: connection_attempts
-  azure_name: ConnectionAttempts
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: web_socket_messages
-  azure_name: WebSocketMessages
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: network_connectivity
-  azure_name: NetworkConnectivity
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: capacity
+    azure_name: Capacity
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_percent_gateway
+    azure_name: CpuPercent_Gateway
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: memory_percent_gateway
+    azure_name: MemoryPercent_Gateway
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: requests
+    azure_name: Requests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: backend_duration
+    azure_name: BackendDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: duration
+    azure_name: Duration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: event_hub_total_events
+    azure_name: EventHubTotalEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: event_hub_successful_events
+    azure_name: EventHubSuccessfulEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: event_hub_total_failed_events
+    azure_name: EventHubTotalFailedEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: event_hub_dropped_events
+    azure_name: EventHubDroppedEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: event_hub_rejected_events
+    azure_name: EventHubRejectedEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: event_hub_throttled_events
+    azure_name: EventHubThrottledEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: event_hub_timedout_events
+    azure_name: EventHubTimedoutEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: event_hub_total_bytes_sent
+    azure_name: EventHubTotalBytesSent
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: connection_attempts
+    azure_name: ConnectionAttempts
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: web_socket_messages
+    azure_name: WebSocketMessages
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: network_connectivity
+    azure_name: NetworkConnectivity
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure API Management
   context_namespace: api_management
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_api_management__capacity
-    title: Azure API Management Capacity Utilization
-    context: capacity
-    family: Capacity
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: api_management.capacity_average
-      name: capacity
-  - id: am_azure_api_management__gateway_cpu
-    title: Azure API Management Gateway CPU
-    context: gateway_cpu
-    family: Capacity
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: api_management.cpu_percent_gateway_average
-      name: cpu
-  - id: am_azure_api_management__gateway_memory
-    title: Azure API Management Gateway Memory
-    context: gateway_memory
-    family: Capacity
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: api_management.memory_percent_gateway_average
-      name: memory
-  - id: am_azure_api_management__requests
-    title: Azure API Management Gateway Requests
-    context: requests
-    family: Requests
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: api_management.requests_total
-      name: requests
-  - id: am_azure_api_management__request_duration
-    title: Azure API Management Request Duration
-    context: request_duration
-    family: Requests
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: api_management.duration_average
-      name: overall
-    - selector: api_management.backend_duration_average
-      name: backend
-  - id: am_azure_api_management__eventhub_events
-    title: Azure API Management EventHub Events
-    context: eventhub_events
-    family: EventHub
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: api_management.event_hub_total_events_total
-      name: total
-    - selector: api_management.event_hub_successful_events_total
-      name: successful
-    - selector: api_management.event_hub_total_failed_events_total
-      name: failed
-    - selector: api_management.event_hub_dropped_events_total
-      name: dropped
-    - selector: api_management.event_hub_rejected_events_total
-      name: rejected
-    - selector: api_management.event_hub_throttled_events_total
-      name: throttled
-    - selector: api_management.event_hub_timedout_events_total
-      name: timed_out
-  - id: am_azure_api_management__eventhub_bytes
-    title: Azure API Management EventHub Bytes Sent
-    context: eventhub_bytes
-    family: EventHub
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: api_management.event_hub_total_bytes_sent_total
-      name: sent
-  - id: am_azure_api_management__websocket_connections
-    title: Azure API Management WebSocket Connection Attempts
-    context: websocket_connections
-    family: WebSocket
-    type: line
-    units: attempts/s
-    algorithm: incremental
-    dimensions:
-    - selector: api_management.connection_attempts_total
-      name: connection_attempts
-  - id: am_azure_api_management__websocket_messages
-    title: Azure API Management WebSocket Messages
-    context: websocket_messages
-    family: WebSocket
-    type: line
-    units: messages/s
-    algorithm: incremental
-    dimensions:
-    - selector: api_management.web_socket_messages_total
-      name: messages
-  - id: am_azure_api_management__network_connectivity
-    title: Azure API Management Network Connectivity Status
-    context: network_connectivity
-    family: Network
-    type: line
-    units: status
-    algorithm: absolute
-    dimensions:
-    - selector: api_management.network_connectivity_average
-      name: connectivity
+    - id: am_azure_api_management__capacity
+      title: Azure API Management Capacity Utilization
+      context: capacity
+      family: Capacity
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: api_management.capacity_average
+          name: capacity
+    - id: am_azure_api_management__gateway_cpu
+      title: Azure API Management Gateway CPU
+      context: gateway_cpu
+      family: Capacity
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: api_management.cpu_percent_gateway_average
+          name: cpu
+    - id: am_azure_api_management__gateway_memory
+      title: Azure API Management Gateway Memory
+      context: gateway_memory
+      family: Capacity
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: api_management.memory_percent_gateway_average
+          name: memory
+    - id: am_azure_api_management__requests
+      title: Azure API Management Gateway Requests
+      context: requests
+      family: Requests
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: api_management.requests_total
+          name: requests
+    - id: am_azure_api_management__request_duration
+      title: Azure API Management Request Duration
+      context: request_duration
+      family: Requests
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: api_management.duration_average
+          name: overall
+        - selector: api_management.backend_duration_average
+          name: backend
+    - id: am_azure_api_management__eventhub_events
+      title: Azure API Management EventHub Events
+      context: eventhub_events
+      family: EventHub
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: api_management.event_hub_total_events_total
+          name: total
+        - selector: api_management.event_hub_successful_events_total
+          name: successful
+        - selector: api_management.event_hub_total_failed_events_total
+          name: failed
+        - selector: api_management.event_hub_dropped_events_total
+          name: dropped
+        - selector: api_management.event_hub_rejected_events_total
+          name: rejected
+        - selector: api_management.event_hub_throttled_events_total
+          name: throttled
+        - selector: api_management.event_hub_timedout_events_total
+          name: timed_out
+    - id: am_azure_api_management__eventhub_bytes
+      title: Azure API Management EventHub Bytes Sent
+      context: eventhub_bytes
+      family: EventHub
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: api_management.event_hub_total_bytes_sent_total
+          name: sent
+    - id: am_azure_api_management__websocket_connections
+      title: Azure API Management WebSocket Connection Attempts
+      context: websocket_connections
+      family: WebSocket
+      type: line
+      units: attempts/s
+      algorithm: incremental
+      dimensions:
+        - selector: api_management.connection_attempts_total
+          name: connection_attempts
+    - id: am_azure_api_management__websocket_messages
+      title: Azure API Management WebSocket Messages
+      context: websocket_messages
+      family: WebSocket
+      type: line
+      units: messages/s
+      algorithm: incremental
+      dimensions:
+        - selector: api_management.web_socket_messages_total
+          name: messages
+    - id: am_azure_api_management__network_connectivity
+      title: Azure API Management Network Connectivity Status
+      context: network_connectivity
+      family: Network
+      type: line
+      units: status
+      algorithm: absolute
+      dimensions:
+        - selector: api_management.network_connectivity_average
+          name: connectivity

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/app_service.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/app_service.yaml
@@ -3,569 +3,569 @@ id: app_service
 name: Azure App Service
 resource_type: Microsoft.Web/sites
 metrics:
-- id: requests
-  azure_name: Requests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: http_response_time
-  azure_name: HttpResponseTime
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: http2xx
-  azure_name: Http2xx
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: http3xx
-  azure_name: Http3xx
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: http4xx
-  azure_name: Http4xx
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: http5xx
-  azure_name: Http5xx
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: cpu_percentage
-  azure_name: CpuPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_time
-  azure_name: CpuTime
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: average_memory_working_set
-  azure_name: AverageMemoryWorkingSet
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: memory_working_set
-  azure_name: MemoryWorkingSet
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: private_bytes
-  azure_name: PrivateBytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: bytes_received
-  azure_name: BytesReceived
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: bytes_sent
-  azure_name: BytesSent
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: health_check_status
-  azure_name: HealthCheckStatus
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: app_connections
-  azure_name: AppConnections
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: io_read_bytes_per_second
-  azure_name: IoReadBytesPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: io_write_bytes_per_second
-  azure_name: IoWriteBytesPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: io_read_operations_per_second
-  azure_name: IoReadOperationsPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: io_write_operations_per_second
-  azure_name: IoWriteOperationsPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: io_other_bytes_per_second
-  azure_name: IoOtherBytesPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: io_other_operations_per_second
-  azure_name: IoOtherOperationsPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: threads
-  azure_name: Threads
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: handles
-  azure_name: Handles
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: gen0_collections
-  azure_name: Gen0Collections
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: gen1_collections
-  azure_name: Gen1Collections
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: gen2_collections
-  azure_name: Gen2Collections
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: http101
-  azure_name: Http101
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: http401
-  azure_name: Http401
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: http403
-  azure_name: Http403
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: http404
-  azure_name: Http404
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: http406
-  azure_name: Http406
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: requests_in_application_queue
-  azure_name: RequestsInApplicationQueue
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: instance_count
-  azure_name: InstanceCount
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: current_assemblies
-  azure_name: CurrentAssemblies
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: total_app_domains
-  azure_name: TotalAppDomains
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: total_app_domains_unloaded
-  azure_name: TotalAppDomainsUnloaded
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: function_execution_count
-  azure_name: FunctionExecutionCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: function_execution_units
-  azure_name: FunctionExecutionUnits
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: always_ready_function_execution_count
-  azure_name: AlwaysReadyFunctionExecutionCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: always_ready_function_execution_units
-  azure_name: AlwaysReadyFunctionExecutionUnits
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: always_ready_units
-  azure_name: AlwaysReadyUnits
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: on_demand_function_execution_count
-  azure_name: OnDemandFunctionExecutionCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: on_demand_function_execution_units
-  azure_name: OnDemandFunctionExecutionUnits
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
+  - id: requests
+    azure_name: Requests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: http_response_time
+    azure_name: HttpResponseTime
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: http2xx
+    azure_name: Http2xx
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: http3xx
+    azure_name: Http3xx
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: http4xx
+    azure_name: Http4xx
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: http5xx
+    azure_name: Http5xx
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: cpu_percentage
+    azure_name: CpuPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_time
+    azure_name: CpuTime
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: average_memory_working_set
+    azure_name: AverageMemoryWorkingSet
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: memory_working_set
+    azure_name: MemoryWorkingSet
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: private_bytes
+    azure_name: PrivateBytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: bytes_received
+    azure_name: BytesReceived
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: bytes_sent
+    azure_name: BytesSent
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: health_check_status
+    azure_name: HealthCheckStatus
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: app_connections
+    azure_name: AppConnections
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: io_read_bytes_per_second
+    azure_name: IoReadBytesPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: io_write_bytes_per_second
+    azure_name: IoWriteBytesPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: io_read_operations_per_second
+    azure_name: IoReadOperationsPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: io_write_operations_per_second
+    azure_name: IoWriteOperationsPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: io_other_bytes_per_second
+    azure_name: IoOtherBytesPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: io_other_operations_per_second
+    azure_name: IoOtherOperationsPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: threads
+    azure_name: Threads
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: handles
+    azure_name: Handles
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: gen0_collections
+    azure_name: Gen0Collections
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: gen1_collections
+    azure_name: Gen1Collections
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: gen2_collections
+    azure_name: Gen2Collections
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: http101
+    azure_name: Http101
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: http401
+    azure_name: Http401
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: http403
+    azure_name: Http403
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: http404
+    azure_name: Http404
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: http406
+    azure_name: Http406
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: requests_in_application_queue
+    azure_name: RequestsInApplicationQueue
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: instance_count
+    azure_name: InstanceCount
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: current_assemblies
+    azure_name: CurrentAssemblies
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: total_app_domains
+    azure_name: TotalAppDomains
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: total_app_domains_unloaded
+    azure_name: TotalAppDomainsUnloaded
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: function_execution_count
+    azure_name: FunctionExecutionCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: function_execution_units
+    azure_name: FunctionExecutionUnits
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: always_ready_function_execution_count
+    azure_name: AlwaysReadyFunctionExecutionCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: always_ready_function_execution_units
+    azure_name: AlwaysReadyFunctionExecutionUnits
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: always_ready_units
+    azure_name: AlwaysReadyUnits
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: on_demand_function_execution_count
+    azure_name: OnDemandFunctionExecutionCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: on_demand_function_execution_units
+    azure_name: OnDemandFunctionExecutionUnits
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
 template:
   family: Azure App Service
   context_namespace: app_service
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_app_service__requests
-    title: Azure App Service Requests
-    context: requests
-    family: HTTP
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.requests_total
-      name: requests
-  - id: am_azure_app_service__response_time
-    title: Azure App Service Response Time
-    context: response_time
-    family: HTTP
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: app_service.http_response_time_average
-      name: average
-  - id: am_azure_app_service__http_status
-    title: Azure App Service HTTP Status Codes
-    context: http_status
-    family: HTTP
-    type: line
-    units: responses/s
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.http2xx_total
-      name: 2xx
-    - selector: app_service.http3xx_total
-      name: 3xx
-    - selector: app_service.http4xx_total
-      name: 4xx
-    - selector: app_service.http5xx_total
-      name: 5xx
-  - id: am_azure_app_service__http_error_detail
-    title: Azure App Service HTTP Error Detail
-    context: http_error_detail
-    family: HTTP
-    type: line
-    units: responses/s
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.http101_total
-      name: 101_websocket
-    - selector: app_service.http401_total
-      name: 401_unauthorized
-    - selector: app_service.http403_total
-      name: 403_forbidden
-    - selector: app_service.http404_total
-      name: 404_not_found
-    - selector: app_service.http406_total
-      name: 406_not_acceptable
-  - id: am_azure_app_service__cpu
-    title: Azure App Service CPU Utilization
-    context: cpu
-    family: Compute
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: app_service.cpu_percentage_average
-      name: average
-  - id: am_azure_app_service__cpu_time
-    title: Azure App Service CPU Time
-    context: cpu_time
-    family: Compute
-    type: line
-    units: seconds
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.cpu_time_total
-      name: total
-  - id: am_azure_app_service__memory_usage
-    title: Azure App Service Memory Usage
-    context: memory_usage
-    family: Compute
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: app_service.average_memory_working_set_average
-      name: average_working_set
-    - selector: app_service.memory_working_set_average
-      name: working_set
-    - selector: app_service.private_bytes_average
-      name: private
-  - id: am_azure_app_service__health
-    title: Azure App Service Health Check Status
-    context: health
-    family: Health
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: app_service.health_check_status_average
-      name: average
-  - id: am_azure_app_service__network_traffic
-    title: Azure App Service Network Traffic
-    context: network_traffic
-    family: Network
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.bytes_received_total
-      name: received
-    - selector: app_service.bytes_sent_total
-      name: sent
-  - id: am_azure_app_service__connections
-    title: Azure App Service Connections
-    context: connections
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: app_service.app_connections_average
-      name: average
-  - id: am_azure_app_service__io_throughput
-    title: Azure App Service IO Throughput
-    context: io_throughput
-    family: IO
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.io_read_bytes_per_second_total
-      name: read
-    - selector: app_service.io_write_bytes_per_second_total
-      name: write
-    - selector: app_service.io_other_bytes_per_second_total
-      name: other
-  - id: am_azure_app_service__io_operations
-    title: Azure App Service IO Operations
-    context: io_operations
-    family: IO
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.io_read_operations_per_second_total
-      name: read
-    - selector: app_service.io_write_operations_per_second_total
-      name: write
-    - selector: app_service.io_other_operations_per_second_total
-      name: other
-  - id: am_azure_app_service__threads
-    title: Azure App Service Threads
-    context: threads
-    family: Runtime
-    type: line
-    units: threads
-    algorithm: absolute
-    dimensions:
-    - selector: app_service.threads_average
-      name: average
-  - id: am_azure_app_service__handles
-    title: Azure App Service Handles
-    context: handles
-    family: Runtime
-    type: line
-    units: handles
-    algorithm: absolute
-    dimensions:
-    - selector: app_service.handles_average
-      name: average
-  - id: am_azure_app_service__gc_collections
-    title: Azure App Service .NET GC Collections
-    context: gc_collections
-    family: Runtime
-    type: line
-    units: collections/s
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.gen0_collections_total
-      name: gen0
-    - selector: app_service.gen1_collections_total
-      name: gen1
-    - selector: app_service.gen2_collections_total
-      name: gen2
-  - id: am_azure_app_service__function_executions
-    title: Azure App Service Function Executions
-    context: function_executions
-    family: Functions
-    type: line
-    units: executions/s
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.function_execution_count_total
-      name: total
-  - id: am_azure_app_service__function_execution_units
-    title: Azure App Service Function Execution Units
-    context: function_execution_units
-    family: Functions
-    type: line
-    units: MB-milliseconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.function_execution_units_total
-      name: total
-  - id: am_azure_app_service__always_ready_function_executions
-    title: Azure App Service Always Ready Function Executions
-    context: always_ready_function_executions
-    family: Functions
-    type: line
-    units: executions/s
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.always_ready_function_execution_count_total
-      name: total
-  - id: am_azure_app_service__always_ready_function_execution_units
-    title: Azure App Service Always Ready Function Execution Units
-    context: always_ready_function_execution_units
-    family: Functions
-    type: line
-    units: MB-milliseconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.always_ready_function_execution_units_total
-      name: total
-  - id: am_azure_app_service__always_ready_units
-    title: Azure App Service Always Ready Units
-    context: always_ready_units
-    family: Functions
-    type: line
-    units: units
-    algorithm: absolute
-    dimensions:
-    - selector: app_service.always_ready_units_total
-      name: total
-  - id: am_azure_app_service__on_demand_function_executions
-    title: Azure App Service On Demand Function Executions
-    context: on_demand_function_executions
-    family: Functions
-    type: line
-    units: executions/s
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.on_demand_function_execution_count_total
-      name: total
-  - id: am_azure_app_service__on_demand_function_execution_units
-    title: Azure App Service On Demand Function Execution Units
-    context: on_demand_function_execution_units
-    family: Functions
-    type: line
-    units: MB-milliseconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: app_service.on_demand_function_execution_units_total
-      name: total
-  - id: am_azure_app_service__request_queue
-    title: Azure App Service Request Queue
-    context: request_queue
-    family: Health
-    type: line
-    units: requests
-    algorithm: absolute
-    dimensions:
-    - selector: app_service.requests_in_application_queue_average
-      name: queued
-  - id: am_azure_app_service__instances
-    title: Azure App Service Instance Count
-    context: instances
-    family: Scaling
-    type: line
-    units: instances
-    algorithm: absolute
-    dimensions:
-    - selector: app_service.instance_count_average
-      name: running
-  - id: am_azure_app_service__assemblies
-    title: Azure App Service .NET Assemblies
-    context: assemblies
-    family: Runtime
-    type: line
-    units: assemblies
-    algorithm: absolute
-    dimensions:
-    - selector: app_service.current_assemblies_average
-      name: loaded
-  - id: am_azure_app_service__app_domains
-    title: Azure App Service App Domains
-    context: app_domains
-    family: Runtime
-    type: line
-    units: domains
-    algorithm: absolute
-    dimensions:
-    - selector: app_service.total_app_domains_average
-      name: loaded
-    - selector: app_service.total_app_domains_unloaded_average
-      name: unloaded
+    - id: am_azure_app_service__requests
+      title: Azure App Service Requests
+      context: requests
+      family: HTTP
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.requests_total
+          name: requests
+    - id: am_azure_app_service__response_time
+      title: Azure App Service Response Time
+      context: response_time
+      family: HTTP
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: app_service.http_response_time_average
+          name: average
+    - id: am_azure_app_service__http_status
+      title: Azure App Service HTTP Status Codes
+      context: http_status
+      family: HTTP
+      type: line
+      units: responses/s
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.http2xx_total
+          name: 2xx
+        - selector: app_service.http3xx_total
+          name: 3xx
+        - selector: app_service.http4xx_total
+          name: 4xx
+        - selector: app_service.http5xx_total
+          name: 5xx
+    - id: am_azure_app_service__http_error_detail
+      title: Azure App Service HTTP Error Detail
+      context: http_error_detail
+      family: HTTP
+      type: line
+      units: responses/s
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.http101_total
+          name: 101_websocket
+        - selector: app_service.http401_total
+          name: 401_unauthorized
+        - selector: app_service.http403_total
+          name: 403_forbidden
+        - selector: app_service.http404_total
+          name: 404_not_found
+        - selector: app_service.http406_total
+          name: 406_not_acceptable
+    - id: am_azure_app_service__cpu
+      title: Azure App Service CPU Utilization
+      context: cpu
+      family: Compute
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: app_service.cpu_percentage_average
+          name: average
+    - id: am_azure_app_service__cpu_time
+      title: Azure App Service CPU Time
+      context: cpu_time
+      family: Compute
+      type: line
+      units: seconds
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.cpu_time_total
+          name: total
+    - id: am_azure_app_service__memory_usage
+      title: Azure App Service Memory Usage
+      context: memory_usage
+      family: Compute
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: app_service.average_memory_working_set_average
+          name: average_working_set
+        - selector: app_service.memory_working_set_average
+          name: working_set
+        - selector: app_service.private_bytes_average
+          name: private
+    - id: am_azure_app_service__health
+      title: Azure App Service Health Check Status
+      context: health
+      family: Health
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: app_service.health_check_status_average
+          name: average
+    - id: am_azure_app_service__network_traffic
+      title: Azure App Service Network Traffic
+      context: network_traffic
+      family: Network
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.bytes_received_total
+          name: received
+        - selector: app_service.bytes_sent_total
+          name: sent
+    - id: am_azure_app_service__connections
+      title: Azure App Service Connections
+      context: connections
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: app_service.app_connections_average
+          name: average
+    - id: am_azure_app_service__io_throughput
+      title: Azure App Service IO Throughput
+      context: io_throughput
+      family: IO
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.io_read_bytes_per_second_total
+          name: read
+        - selector: app_service.io_write_bytes_per_second_total
+          name: write
+        - selector: app_service.io_other_bytes_per_second_total
+          name: other
+    - id: am_azure_app_service__io_operations
+      title: Azure App Service IO Operations
+      context: io_operations
+      family: IO
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.io_read_operations_per_second_total
+          name: read
+        - selector: app_service.io_write_operations_per_second_total
+          name: write
+        - selector: app_service.io_other_operations_per_second_total
+          name: other
+    - id: am_azure_app_service__threads
+      title: Azure App Service Threads
+      context: threads
+      family: Runtime
+      type: line
+      units: threads
+      algorithm: absolute
+      dimensions:
+        - selector: app_service.threads_average
+          name: average
+    - id: am_azure_app_service__handles
+      title: Azure App Service Handles
+      context: handles
+      family: Runtime
+      type: line
+      units: handles
+      algorithm: absolute
+      dimensions:
+        - selector: app_service.handles_average
+          name: average
+    - id: am_azure_app_service__gc_collections
+      title: Azure App Service .NET GC Collections
+      context: gc_collections
+      family: Runtime
+      type: line
+      units: collections/s
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.gen0_collections_total
+          name: gen0
+        - selector: app_service.gen1_collections_total
+          name: gen1
+        - selector: app_service.gen2_collections_total
+          name: gen2
+    - id: am_azure_app_service__function_executions
+      title: Azure App Service Function Executions
+      context: function_executions
+      family: Functions
+      type: line
+      units: executions/s
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.function_execution_count_total
+          name: total
+    - id: am_azure_app_service__function_execution_units
+      title: Azure App Service Function Execution Units
+      context: function_execution_units
+      family: Functions
+      type: line
+      units: MB-milliseconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.function_execution_units_total
+          name: total
+    - id: am_azure_app_service__always_ready_function_executions
+      title: Azure App Service Always Ready Function Executions
+      context: always_ready_function_executions
+      family: Functions
+      type: line
+      units: executions/s
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.always_ready_function_execution_count_total
+          name: total
+    - id: am_azure_app_service__always_ready_function_execution_units
+      title: Azure App Service Always Ready Function Execution Units
+      context: always_ready_function_execution_units
+      family: Functions
+      type: line
+      units: MB-milliseconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.always_ready_function_execution_units_total
+          name: total
+    - id: am_azure_app_service__always_ready_units
+      title: Azure App Service Always Ready Units
+      context: always_ready_units
+      family: Functions
+      type: line
+      units: units
+      algorithm: absolute
+      dimensions:
+        - selector: app_service.always_ready_units_total
+          name: total
+    - id: am_azure_app_service__on_demand_function_executions
+      title: Azure App Service On Demand Function Executions
+      context: on_demand_function_executions
+      family: Functions
+      type: line
+      units: executions/s
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.on_demand_function_execution_count_total
+          name: total
+    - id: am_azure_app_service__on_demand_function_execution_units
+      title: Azure App Service On Demand Function Execution Units
+      context: on_demand_function_execution_units
+      family: Functions
+      type: line
+      units: MB-milliseconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: app_service.on_demand_function_execution_units_total
+          name: total
+    - id: am_azure_app_service__request_queue
+      title: Azure App Service Request Queue
+      context: request_queue
+      family: Health
+      type: line
+      units: requests
+      algorithm: absolute
+      dimensions:
+        - selector: app_service.requests_in_application_queue_average
+          name: queued
+    - id: am_azure_app_service__instances
+      title: Azure App Service Instance Count
+      context: instances
+      family: Scaling
+      type: line
+      units: instances
+      algorithm: absolute
+      dimensions:
+        - selector: app_service.instance_count_average
+          name: running
+    - id: am_azure_app_service__assemblies
+      title: Azure App Service .NET Assemblies
+      context: assemblies
+      family: Runtime
+      type: line
+      units: assemblies
+      algorithm: absolute
+      dimensions:
+        - selector: app_service.current_assemblies_average
+          name: loaded
+    - id: am_azure_app_service__app_domains
+      title: Azure App Service App Domains
+      context: app_domains
+      family: Runtime
+      type: line
+      units: domains
+      algorithm: absolute
+      dimensions:
+        - selector: app_service.total_app_domains_average
+          name: loaded
+        - selector: app_service.total_app_domains_unloaded_average
+          name: unloaded

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/application_gateway.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/application_gateway.yaml
@@ -3,457 +3,457 @@ id: application_gateway
 name: Azure Application Gateway
 resource_type: Microsoft.Network/applicationGateways
 metrics:
-- id: throughput
-  azure_name: Throughput
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: bytes_received
-  azure_name: BytesReceived
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: bytes_sent
-  azure_name: BytesSent
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: total_requests
-  azure_name: TotalRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: failed_requests
-  azure_name: FailedRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: response_status
-  azure_name: ResponseStatus
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: backend_response_status
-  azure_name: BackendResponseStatus
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: healthy_host_count
-  azure_name: HealthyHostCount
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: unhealthy_host_count
-  azure_name: UnhealthyHostCount
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: avg_request_count_per_healthy_host
-  azure_name: AvgRequestCountPerHealthyHost
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: application_gateway_total_time
-  azure_name: ApplicationGatewayTotalTime
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: backend_connect_time
-  azure_name: BackendConnectTime
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: backend_first_byte_response_time
-  azure_name: BackendFirstByteResponseTime
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: backend_last_byte_response_time
-  azure_name: BackendLastByteResponseTime
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: client_rtt
-  azure_name: ClientRtt
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: current_connections
-  azure_name: CurrentConnections
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: new_connections_per_second
-  azure_name: NewConnectionsPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: capacity_units
-  azure_name: CapacityUnits
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: compute_units
-  azure_name: ComputeUnits
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: estimated_billed_capacity_units
-  azure_name: EstimatedBilledCapacityUnits
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: fixed_billable_capacity_units
-  azure_name: FixedBillableCapacityUnits
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_utilization
-  azure_name: CpuUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: tls_protocol
-  azure_name: TlsProtocol
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: web_socket_active_connections
-  azure_name: WebSocketActiveConnections
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: websocket_specific_close_status_code
-  azure_name: WebsocketSpecificCloseStatusCode
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: azwaf_total_requests
-  azure_name: AzwafTotalRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: blocked_count
-  azure_name: BlockedCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: matched_count
-  azure_name: MatchedCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: azwaf_bot_protection
-  azure_name: AzwafBotProtection
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: azwaf_custom_rule
-  azure_name: AzwafCustomRule
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: azwaf_sec_rule
-  azure_name: AzwafSecRule
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: az_waf_captcha_challenge_request_count
-  azure_name: AzWAFCaptchaChallengeRequestCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: az_wafjs_challenge_request_count
-  azure_name: AzWAFJSChallengeRequestCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: azwaf_penalty_box_hits
-  azure_name: AzwafPenaltyBoxHits
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: azwaf_penalty_box_size
-  azure_name: AzwafPenaltyBoxSize
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: throughput
+    azure_name: Throughput
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: bytes_received
+    azure_name: BytesReceived
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: bytes_sent
+    azure_name: BytesSent
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: total_requests
+    azure_name: TotalRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: failed_requests
+    azure_name: FailedRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: response_status
+    azure_name: ResponseStatus
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: backend_response_status
+    azure_name: BackendResponseStatus
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: healthy_host_count
+    azure_name: HealthyHostCount
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: unhealthy_host_count
+    azure_name: UnhealthyHostCount
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: avg_request_count_per_healthy_host
+    azure_name: AvgRequestCountPerHealthyHost
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: application_gateway_total_time
+    azure_name: ApplicationGatewayTotalTime
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: backend_connect_time
+    azure_name: BackendConnectTime
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: backend_first_byte_response_time
+    azure_name: BackendFirstByteResponseTime
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: backend_last_byte_response_time
+    azure_name: BackendLastByteResponseTime
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: client_rtt
+    azure_name: ClientRtt
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: current_connections
+    azure_name: CurrentConnections
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: new_connections_per_second
+    azure_name: NewConnectionsPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: capacity_units
+    azure_name: CapacityUnits
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: compute_units
+    azure_name: ComputeUnits
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: estimated_billed_capacity_units
+    azure_name: EstimatedBilledCapacityUnits
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: fixed_billable_capacity_units
+    azure_name: FixedBillableCapacityUnits
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_utilization
+    azure_name: CpuUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: tls_protocol
+    azure_name: TlsProtocol
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: web_socket_active_connections
+    azure_name: WebSocketActiveConnections
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: websocket_specific_close_status_code
+    azure_name: WebsocketSpecificCloseStatusCode
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: azwaf_total_requests
+    azure_name: AzwafTotalRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: blocked_count
+    azure_name: BlockedCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: matched_count
+    azure_name: MatchedCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: azwaf_bot_protection
+    azure_name: AzwafBotProtection
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: azwaf_custom_rule
+    azure_name: AzwafCustomRule
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: azwaf_sec_rule
+    azure_name: AzwafSecRule
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: az_waf_captcha_challenge_request_count
+    azure_name: AzWAFCaptchaChallengeRequestCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: az_wafjs_challenge_request_count
+    azure_name: AzWAFJSChallengeRequestCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: azwaf_penalty_box_hits
+    azure_name: AzwafPenaltyBoxHits
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: azwaf_penalty_box_size
+    azure_name: AzwafPenaltyBoxSize
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Application Gateway
   context_namespace: application_gateway
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_application_gateway__throughput
-    title: Azure Application Gateway Throughput
-    context: throughput
-    family: Traffic
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: application_gateway.throughput_average
-      name: average
-  - id: am_azure_application_gateway__traffic_volume
-    title: Azure Application Gateway Traffic Volume
-    context: traffic_volume
-    family: Traffic
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_gateway.bytes_received_total
-      name: received
-    - selector: application_gateway.bytes_sent_total
-      name: sent
-  - id: am_azure_application_gateway__requests
-    title: Azure Application Gateway Requests
-    context: requests
-    family: Traffic
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_gateway.total_requests_total
-      name: total
-    - selector: application_gateway.failed_requests_total
-      name: failed
-  - id: am_azure_application_gateway__response_status
-    title: Azure Application Gateway Response Status
-    context: response_status
-    family: Traffic
-    type: line
-    units: responses/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_gateway.response_status_total
-      name: gateway
-    - selector: application_gateway.backend_response_status_total
-      name: backend
-  - id: am_azure_application_gateway__backend_health
-    title: Azure Application Gateway Backend Health
-    context: backend_health
-    family: Backend
-    type: line
-    units: hosts
-    algorithm: absolute
-    dimensions:
-    - selector: application_gateway.healthy_host_count_average
-      name: healthy
-    - selector: application_gateway.unhealthy_host_count_average
-      name: unhealthy
-  - id: am_azure_application_gateway__backend_request_load
-    title: Azure Application Gateway Backend Request Load
-    context: backend_request_load
-    family: Backend
-    type: line
-    units: requests
-    algorithm: absolute
-    dimensions:
-    - selector: application_gateway.avg_request_count_per_healthy_host_average
-      name: per_healthy_host
-  - id: am_azure_application_gateway__backend_latency
-    title: Azure Application Gateway Backend Latency
-    context: backend_latency
-    family: Backend
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: application_gateway.backend_connect_time_average
-      name: connect
-    - selector: application_gateway.backend_first_byte_response_time_average
-      name: first_byte
-    - selector: application_gateway.backend_last_byte_response_time_average
-      name: last_byte
-  - id: am_azure_application_gateway__client_latency
-    title: Azure Application Gateway Client Latency
-    context: client_latency
-    family: Latency
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: application_gateway.application_gateway_total_time_average
-      name: total_time
-    - selector: application_gateway.client_rtt_average
-      name: client_rtt
-  - id: am_azure_application_gateway__current_connections
-    title: Azure Application Gateway Current Connections
-    context: current_connections
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: application_gateway.current_connections_total
-      name: current
-  - id: am_azure_application_gateway__new_connections
-    title: Azure Application Gateway New Connections
-    context: new_connections
-    family: Connections
-    type: line
-    units: connections/s
-    algorithm: absolute
-    dimensions:
-    - selector: application_gateway.new_connections_per_second_average
-      name: average
-  - id: am_azure_application_gateway__websocket_connections
-    title: Azure Application Gateway WebSocket Connections
-    context: websocket_connections
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: application_gateway.web_socket_active_connections_total
-      name: active
-  - id: am_azure_application_gateway__websocket_close_codes
-    title: Azure Application Gateway WebSocket Close Codes
-    context: websocket_close_codes
-    family: Connections
-    type: line
-    units: connections/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_gateway.websocket_specific_close_status_code_total
-      name: total
-  - id: am_azure_application_gateway__capacity
-    title: Azure Application Gateway Capacity
-    context: capacity
-    family: Capacity
-    type: line
-    units: units
-    algorithm: absolute
-    dimensions:
-    - selector: application_gateway.capacity_units_average
-      name: capacity
-    - selector: application_gateway.compute_units_average
-      name: compute
-    - selector: application_gateway.estimated_billed_capacity_units_average
-      name: billed
-    - selector: application_gateway.fixed_billable_capacity_units_average
-      name: fixed_billed
-  - id: am_azure_application_gateway__cpu
-    title: Azure Application Gateway CPU Utilization
-    context: cpu
-    family: Capacity
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: application_gateway.cpu_utilization_average
-      name: average
-  - id: am_azure_application_gateway__tls_connections
-    title: Azure Application Gateway TLS Connections
-    context: tls_connections
-    family: Security
-    type: line
-    units: connections/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_gateway.tls_protocol_total
-      name: total
-  - id: am_azure_application_gateway__waf_requests
-    title: Azure Application Gateway WAF Requests
-    context: waf_requests
-    family: WAF
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_gateway.azwaf_total_requests_total
-      name: total
-    - selector: application_gateway.blocked_count_total
-      name: blocked
-    - selector: application_gateway.matched_count_total
-      name: matched
-  - id: am_azure_application_gateway__waf_rule_matches
-    title: Azure Application Gateway WAF Rule Matches
-    context: waf_rule_matches
-    family: WAF
-    type: line
-    units: matches/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_gateway.azwaf_sec_rule_total
-      name: managed
-    - selector: application_gateway.azwaf_custom_rule_total
-      name: custom
-    - selector: application_gateway.azwaf_bot_protection_total
-      name: bot
-  - id: am_azure_application_gateway__waf_challenges
-    title: Azure Application Gateway WAF Challenges
-    context: waf_challenges
-    family: WAF
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_gateway.az_waf_captcha_challenge_request_count_total
-      name: captcha
-    - selector: application_gateway.az_wafjs_challenge_request_count_total
-      name: js_challenge
-  - id: am_azure_application_gateway__waf_penalty_box
-    title: Azure Application Gateway WAF Penalty Box
-    context: waf_penalty_box
-    family: WAF
-    type: line
-    units: IPs
-    algorithm: absolute
-    dimensions:
-    - selector: application_gateway.azwaf_penalty_box_size_average
-      name: size
-  - id: am_azure_application_gateway__waf_penalty_box_hits
-    title: Azure Application Gateway WAF Penalty Box Hits
-    context: waf_penalty_box_hits
-    family: WAF
-    type: line
-    units: hits/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_gateway.azwaf_penalty_box_hits_total
-      name: total
+    - id: am_azure_application_gateway__throughput
+      title: Azure Application Gateway Throughput
+      context: throughput
+      family: Traffic
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: application_gateway.throughput_average
+          name: average
+    - id: am_azure_application_gateway__traffic_volume
+      title: Azure Application Gateway Traffic Volume
+      context: traffic_volume
+      family: Traffic
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_gateway.bytes_received_total
+          name: received
+        - selector: application_gateway.bytes_sent_total
+          name: sent
+    - id: am_azure_application_gateway__requests
+      title: Azure Application Gateway Requests
+      context: requests
+      family: Traffic
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_gateway.total_requests_total
+          name: total
+        - selector: application_gateway.failed_requests_total
+          name: failed
+    - id: am_azure_application_gateway__response_status
+      title: Azure Application Gateway Response Status
+      context: response_status
+      family: Traffic
+      type: line
+      units: responses/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_gateway.response_status_total
+          name: gateway
+        - selector: application_gateway.backend_response_status_total
+          name: backend
+    - id: am_azure_application_gateway__backend_health
+      title: Azure Application Gateway Backend Health
+      context: backend_health
+      family: Backend
+      type: line
+      units: hosts
+      algorithm: absolute
+      dimensions:
+        - selector: application_gateway.healthy_host_count_average
+          name: healthy
+        - selector: application_gateway.unhealthy_host_count_average
+          name: unhealthy
+    - id: am_azure_application_gateway__backend_request_load
+      title: Azure Application Gateway Backend Request Load
+      context: backend_request_load
+      family: Backend
+      type: line
+      units: requests
+      algorithm: absolute
+      dimensions:
+        - selector: application_gateway.avg_request_count_per_healthy_host_average
+          name: per_healthy_host
+    - id: am_azure_application_gateway__backend_latency
+      title: Azure Application Gateway Backend Latency
+      context: backend_latency
+      family: Backend
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: application_gateway.backend_connect_time_average
+          name: connect
+        - selector: application_gateway.backend_first_byte_response_time_average
+          name: first_byte
+        - selector: application_gateway.backend_last_byte_response_time_average
+          name: last_byte
+    - id: am_azure_application_gateway__client_latency
+      title: Azure Application Gateway Client Latency
+      context: client_latency
+      family: Latency
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: application_gateway.application_gateway_total_time_average
+          name: total_time
+        - selector: application_gateway.client_rtt_average
+          name: client_rtt
+    - id: am_azure_application_gateway__current_connections
+      title: Azure Application Gateway Current Connections
+      context: current_connections
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: application_gateway.current_connections_total
+          name: current
+    - id: am_azure_application_gateway__new_connections
+      title: Azure Application Gateway New Connections
+      context: new_connections
+      family: Connections
+      type: line
+      units: connections/s
+      algorithm: absolute
+      dimensions:
+        - selector: application_gateway.new_connections_per_second_average
+          name: average
+    - id: am_azure_application_gateway__websocket_connections
+      title: Azure Application Gateway WebSocket Connections
+      context: websocket_connections
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: application_gateway.web_socket_active_connections_total
+          name: active
+    - id: am_azure_application_gateway__websocket_close_codes
+      title: Azure Application Gateway WebSocket Close Codes
+      context: websocket_close_codes
+      family: Connections
+      type: line
+      units: connections/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_gateway.websocket_specific_close_status_code_total
+          name: total
+    - id: am_azure_application_gateway__capacity
+      title: Azure Application Gateway Capacity
+      context: capacity
+      family: Capacity
+      type: line
+      units: units
+      algorithm: absolute
+      dimensions:
+        - selector: application_gateway.capacity_units_average
+          name: capacity
+        - selector: application_gateway.compute_units_average
+          name: compute
+        - selector: application_gateway.estimated_billed_capacity_units_average
+          name: billed
+        - selector: application_gateway.fixed_billable_capacity_units_average
+          name: fixed_billed
+    - id: am_azure_application_gateway__cpu
+      title: Azure Application Gateway CPU Utilization
+      context: cpu
+      family: Capacity
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: application_gateway.cpu_utilization_average
+          name: average
+    - id: am_azure_application_gateway__tls_connections
+      title: Azure Application Gateway TLS Connections
+      context: tls_connections
+      family: Security
+      type: line
+      units: connections/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_gateway.tls_protocol_total
+          name: total
+    - id: am_azure_application_gateway__waf_requests
+      title: Azure Application Gateway WAF Requests
+      context: waf_requests
+      family: WAF
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_gateway.azwaf_total_requests_total
+          name: total
+        - selector: application_gateway.blocked_count_total
+          name: blocked
+        - selector: application_gateway.matched_count_total
+          name: matched
+    - id: am_azure_application_gateway__waf_rule_matches
+      title: Azure Application Gateway WAF Rule Matches
+      context: waf_rule_matches
+      family: WAF
+      type: line
+      units: matches/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_gateway.azwaf_sec_rule_total
+          name: managed
+        - selector: application_gateway.azwaf_custom_rule_total
+          name: custom
+        - selector: application_gateway.azwaf_bot_protection_total
+          name: bot
+    - id: am_azure_application_gateway__waf_challenges
+      title: Azure Application Gateway WAF Challenges
+      context: waf_challenges
+      family: WAF
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_gateway.az_waf_captcha_challenge_request_count_total
+          name: captcha
+        - selector: application_gateway.az_wafjs_challenge_request_count_total
+          name: js_challenge
+    - id: am_azure_application_gateway__waf_penalty_box
+      title: Azure Application Gateway WAF Penalty Box
+      context: waf_penalty_box
+      family: WAF
+      type: line
+      units: IPs
+      algorithm: absolute
+      dimensions:
+        - selector: application_gateway.azwaf_penalty_box_size_average
+          name: size
+    - id: am_azure_application_gateway__waf_penalty_box_hits
+      title: Azure Application Gateway WAF Penalty Box Hits
+      context: waf_penalty_box_hits
+      family: WAF
+      type: line
+      units: hits/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_gateway.azwaf_penalty_box_hits_total
+          name: total

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/application_insights.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/application_insights.yaml
@@ -3,425 +3,425 @@ id: application_insights
 name: Azure Application Insights
 resource_type: Microsoft.Insights/components
 metrics:
-- id: availability_results_availability_percentage
-  azure_name: availabilityResults/availabilityPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: availability_results_count
-  azure_name: availabilityResults/count
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: availability_results_duration
-  azure_name: availabilityResults/duration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: browser_timings_network_duration
-  azure_name: browserTimings/networkDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: browser_timings_processing_duration
-  azure_name: browserTimings/processingDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: browser_timings_receive_duration
-  azure_name: browserTimings/receiveDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: browser_timings_send_duration
-  azure_name: browserTimings/sendDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: browser_timings_total_duration
-  azure_name: browserTimings/totalDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: requests_count
-  azure_name: requests/count
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: requests_duration
-  azure_name: requests/duration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: requests_failed
-  azure_name: requests/failed
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: requests_rate
-  azure_name: requests/rate
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: dependencies_count
-  azure_name: dependencies/count
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: dependencies_duration
-  azure_name: dependencies/duration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: dependencies_failed
-  azure_name: dependencies/failed
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: exceptions_count
-  azure_name: exceptions/count
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: exceptions_browser
-  azure_name: exceptions/browser
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: exceptions_server
-  azure_name: exceptions/server
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: performance_counters_process_cpu_percentage
-  azure_name: performanceCounters/processCpuPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: performance_counters_processor_cpu_percentage
-  azure_name: performanceCounters/processorCpuPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: performance_counters_memory_available_bytes
-  azure_name: performanceCounters/memoryAvailableBytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: performance_counters_process_private_bytes
-  azure_name: performanceCounters/processPrivateBytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: performance_counters_process_io_bytes_per_second
-  azure_name: performanceCounters/processIOBytesPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: performance_counters_exceptions_per_second
-  azure_name: performanceCounters/exceptionsPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: performance_counters_request_execution_time
-  azure_name: performanceCounters/requestExecutionTime
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: performance_counters_requests_in_queue
-  azure_name: performanceCounters/requestsInQueue
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: performance_counters_requests_per_second
-  azure_name: performanceCounters/requestsPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: page_views_count
-  azure_name: pageViews/count
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: page_views_duration
-  azure_name: pageViews/duration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: traces_count
-  azure_name: traces/count
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
+  - id: availability_results_availability_percentage
+    azure_name: availabilityResults/availabilityPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: availability_results_count
+    azure_name: availabilityResults/count
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: availability_results_duration
+    azure_name: availabilityResults/duration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: browser_timings_network_duration
+    azure_name: browserTimings/networkDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: browser_timings_processing_duration
+    azure_name: browserTimings/processingDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: browser_timings_receive_duration
+    azure_name: browserTimings/receiveDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: browser_timings_send_duration
+    azure_name: browserTimings/sendDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: browser_timings_total_duration
+    azure_name: browserTimings/totalDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: requests_count
+    azure_name: requests/count
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: requests_duration
+    azure_name: requests/duration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: requests_failed
+    azure_name: requests/failed
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: requests_rate
+    azure_name: requests/rate
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: dependencies_count
+    azure_name: dependencies/count
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: dependencies_duration
+    azure_name: dependencies/duration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: dependencies_failed
+    azure_name: dependencies/failed
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: exceptions_count
+    azure_name: exceptions/count
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: exceptions_browser
+    azure_name: exceptions/browser
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: exceptions_server
+    azure_name: exceptions/server
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: performance_counters_process_cpu_percentage
+    azure_name: performanceCounters/processCpuPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: performance_counters_processor_cpu_percentage
+    azure_name: performanceCounters/processorCpuPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: performance_counters_memory_available_bytes
+    azure_name: performanceCounters/memoryAvailableBytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: performance_counters_process_private_bytes
+    azure_name: performanceCounters/processPrivateBytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: performance_counters_process_io_bytes_per_second
+    azure_name: performanceCounters/processIOBytesPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: performance_counters_exceptions_per_second
+    azure_name: performanceCounters/exceptionsPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: performance_counters_request_execution_time
+    azure_name: performanceCounters/requestExecutionTime
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: performance_counters_requests_in_queue
+    azure_name: performanceCounters/requestsInQueue
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: performance_counters_requests_per_second
+    azure_name: performanceCounters/requestsPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: page_views_count
+    azure_name: pageViews/count
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: page_views_duration
+    azure_name: pageViews/duration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: traces_count
+    azure_name: traces/count
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
 template:
   family: Azure Application Insights
   context_namespace: application_insights
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_application_insights__availability_percentage
-    title: Azure Application Insights Availability
-    context: availability_percentage
-    family: Availability
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.availability_results_availability_percentage_average
-      name: average
-  - id: am_azure_application_insights__availability_tests
-    title: Azure Application Insights Availability Tests
-    context: availability_tests
-    family: Availability
-    type: line
-    units: tests/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_insights.availability_results_count_count
-      name: tests
-  - id: am_azure_application_insights__availability_duration
-    title: Azure Application Insights Availability Test Duration
-    context: availability_duration
-    family: Availability
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.availability_results_duration_average
-      name: average
-  - id: am_azure_application_insights__server_requests
-    title: Azure Application Insights Server Requests
-    context: server_requests
-    family: Requests
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_insights.requests_count_count
-      name: total
-    - selector: application_insights.requests_failed_count
-      name: failed
-  - id: am_azure_application_insights__server_request_rate
-    title: Azure Application Insights Server Request Rate
-    context: server_request_rate
-    family: Requests
-    type: line
-    units: requests/s
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.requests_rate_average
-      name: average
-  - id: am_azure_application_insights__server_response_time
-    title: Azure Application Insights Server Response Time
-    context: server_response_time
-    family: Requests
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.requests_duration_average
-      name: average
-  - id: am_azure_application_insights__dependency_calls
-    title: Azure Application Insights Dependency Calls
-    context: dependency_calls
-    family: Dependencies
-    type: line
-    units: calls/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_insights.dependencies_count_count
-      name: total
-    - selector: application_insights.dependencies_failed_count
-      name: failed
-  - id: am_azure_application_insights__dependency_duration
-    title: Azure Application Insights Dependency Duration
-    context: dependency_duration
-    family: Dependencies
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.dependencies_duration_average
-      name: average
-  - id: am_azure_application_insights__exceptions
-    title: Azure Application Insights Exceptions
-    context: exceptions
-    family: Exceptions
-    type: line
-    units: exceptions/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_insights.exceptions_count_count
-      name: total
-    - selector: application_insights.exceptions_browser_count
-      name: browser
-    - selector: application_insights.exceptions_server_count
-      name: server
-  - id: am_azure_application_insights__browser_page_load_time
-    title: Azure Application Insights Browser Page Load Time
-    context: browser_page_load_time
-    family: Browser
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.browser_timings_total_duration_average
-      name: total
-  - id: am_azure_application_insights__browser_timing_breakdown
-    title: Azure Application Insights Browser Timing Breakdown
-    context: browser_timing_breakdown
-    family: Browser
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.browser_timings_network_duration_average
-      name: network
-    - selector: application_insights.browser_timings_send_duration_average
-      name: send
-    - selector: application_insights.browser_timings_receive_duration_average
-      name: receive
-    - selector: application_insights.browser_timings_processing_duration_average
-      name: processing
-  - id: am_azure_application_insights__cpu_utilization
-    title: Azure Application Insights CPU Utilization
-    context: cpu_utilization
-    family: Performance
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.performance_counters_process_cpu_percentage_average
-      name: process
-    - selector: application_insights.performance_counters_processor_cpu_percentage_average
-      name: processor
-  - id: am_azure_application_insights__memory
-    title: Azure Application Insights Memory
-    context: memory
-    family: Performance
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.performance_counters_memory_available_bytes_average
-      name: available
-    - selector: application_insights.performance_counters_process_private_bytes_average
-      name: private
-  - id: am_azure_application_insights__process_io_rate
-    title: Azure Application Insights Process IO Rate
-    context: process_io_rate
-    family: Performance
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.performance_counters_process_io_bytes_per_second_average
-      name: average
-  - id: am_azure_application_insights__exception_rate
-    title: Azure Application Insights Exception Rate
-    context: exception_rate
-    family: Performance
-    type: line
-    units: exceptions/s
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.performance_counters_exceptions_per_second_average
-      name: average
-  - id: am_azure_application_insights__http_request_execution_time
-    title: Azure Application Insights HTTP Request Execution Time
-    context: http_request_execution_time
-    family: Performance
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.performance_counters_request_execution_time_average
-      name: average
-  - id: am_azure_application_insights__http_request_queue
-    title: Azure Application Insights HTTP Requests in Queue
-    context: http_request_queue
-    family: Performance
-    type: line
-    units: requests
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.performance_counters_requests_in_queue_average
-      name: queued
-  - id: am_azure_application_insights__http_request_rate
-    title: Azure Application Insights HTTP Request Rate
-    context: http_request_rate
-    family: Performance
-    type: line
-    units: requests/s
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.performance_counters_requests_per_second_average
-      name: average
-  - id: am_azure_application_insights__page_views
-    title: Azure Application Insights Page Views
-    context: page_views
-    family: Usage
-    type: line
-    units: views/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_insights.page_views_count_count
-      name: views
-  - id: am_azure_application_insights__page_view_load_time
-    title: Azure Application Insights Page View Load Time
-    context: page_view_load_time
-    family: Usage
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: application_insights.page_views_duration_average
-      name: average
-  - id: am_azure_application_insights__traces
-    title: Azure Application Insights Traces
-    context: traces
-    family: Usage
-    type: line
-    units: traces/s
-    algorithm: incremental
-    dimensions:
-    - selector: application_insights.traces_count_count
-      name: traces
+    - id: am_azure_application_insights__availability_percentage
+      title: Azure Application Insights Availability
+      context: availability_percentage
+      family: Availability
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.availability_results_availability_percentage_average
+          name: average
+    - id: am_azure_application_insights__availability_tests
+      title: Azure Application Insights Availability Tests
+      context: availability_tests
+      family: Availability
+      type: line
+      units: tests/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_insights.availability_results_count_count
+          name: tests
+    - id: am_azure_application_insights__availability_duration
+      title: Azure Application Insights Availability Test Duration
+      context: availability_duration
+      family: Availability
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.availability_results_duration_average
+          name: average
+    - id: am_azure_application_insights__server_requests
+      title: Azure Application Insights Server Requests
+      context: server_requests
+      family: Requests
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_insights.requests_count_count
+          name: total
+        - selector: application_insights.requests_failed_count
+          name: failed
+    - id: am_azure_application_insights__server_request_rate
+      title: Azure Application Insights Server Request Rate
+      context: server_request_rate
+      family: Requests
+      type: line
+      units: requests/s
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.requests_rate_average
+          name: average
+    - id: am_azure_application_insights__server_response_time
+      title: Azure Application Insights Server Response Time
+      context: server_response_time
+      family: Requests
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.requests_duration_average
+          name: average
+    - id: am_azure_application_insights__dependency_calls
+      title: Azure Application Insights Dependency Calls
+      context: dependency_calls
+      family: Dependencies
+      type: line
+      units: calls/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_insights.dependencies_count_count
+          name: total
+        - selector: application_insights.dependencies_failed_count
+          name: failed
+    - id: am_azure_application_insights__dependency_duration
+      title: Azure Application Insights Dependency Duration
+      context: dependency_duration
+      family: Dependencies
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.dependencies_duration_average
+          name: average
+    - id: am_azure_application_insights__exceptions
+      title: Azure Application Insights Exceptions
+      context: exceptions
+      family: Exceptions
+      type: line
+      units: exceptions/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_insights.exceptions_count_count
+          name: total
+        - selector: application_insights.exceptions_browser_count
+          name: browser
+        - selector: application_insights.exceptions_server_count
+          name: server
+    - id: am_azure_application_insights__browser_page_load_time
+      title: Azure Application Insights Browser Page Load Time
+      context: browser_page_load_time
+      family: Browser
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.browser_timings_total_duration_average
+          name: total
+    - id: am_azure_application_insights__browser_timing_breakdown
+      title: Azure Application Insights Browser Timing Breakdown
+      context: browser_timing_breakdown
+      family: Browser
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.browser_timings_network_duration_average
+          name: network
+        - selector: application_insights.browser_timings_send_duration_average
+          name: send
+        - selector: application_insights.browser_timings_receive_duration_average
+          name: receive
+        - selector: application_insights.browser_timings_processing_duration_average
+          name: processing
+    - id: am_azure_application_insights__cpu_utilization
+      title: Azure Application Insights CPU Utilization
+      context: cpu_utilization
+      family: Performance
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.performance_counters_process_cpu_percentage_average
+          name: process
+        - selector: application_insights.performance_counters_processor_cpu_percentage_average
+          name: processor
+    - id: am_azure_application_insights__memory
+      title: Azure Application Insights Memory
+      context: memory
+      family: Performance
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.performance_counters_memory_available_bytes_average
+          name: available
+        - selector: application_insights.performance_counters_process_private_bytes_average
+          name: private
+    - id: am_azure_application_insights__process_io_rate
+      title: Azure Application Insights Process IO Rate
+      context: process_io_rate
+      family: Performance
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.performance_counters_process_io_bytes_per_second_average
+          name: average
+    - id: am_azure_application_insights__exception_rate
+      title: Azure Application Insights Exception Rate
+      context: exception_rate
+      family: Performance
+      type: line
+      units: exceptions/s
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.performance_counters_exceptions_per_second_average
+          name: average
+    - id: am_azure_application_insights__http_request_execution_time
+      title: Azure Application Insights HTTP Request Execution Time
+      context: http_request_execution_time
+      family: Performance
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.performance_counters_request_execution_time_average
+          name: average
+    - id: am_azure_application_insights__http_request_queue
+      title: Azure Application Insights HTTP Requests in Queue
+      context: http_request_queue
+      family: Performance
+      type: line
+      units: requests
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.performance_counters_requests_in_queue_average
+          name: queued
+    - id: am_azure_application_insights__http_request_rate
+      title: Azure Application Insights HTTP Request Rate
+      context: http_request_rate
+      family: Performance
+      type: line
+      units: requests/s
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.performance_counters_requests_per_second_average
+          name: average
+    - id: am_azure_application_insights__page_views
+      title: Azure Application Insights Page Views
+      context: page_views
+      family: Usage
+      type: line
+      units: views/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_insights.page_views_count_count
+          name: views
+    - id: am_azure_application_insights__page_view_load_time
+      title: Azure Application Insights Page View Load Time
+      context: page_view_load_time
+      family: Usage
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: application_insights.page_views_duration_average
+          name: average
+    - id: am_azure_application_insights__traces
+      title: Azure Application Insights Traces
+      context: traces
+      family: Usage
+      type: line
+      units: traces/s
+      algorithm: incremental
+      dimensions:
+        - selector: application_insights.traces_count_count
+          name: traces

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/cognitive_services.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/cognitive_services.yaml
@@ -3,1689 +3,1689 @@ id: cognitive_services
 name: Azure Cognitive Services
 resource_type: Microsoft.CognitiveServices/accounts
 metrics:
-- id: success_rate
-  azure_name: SuccessRate
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: total_calls
-  azure_name: TotalCalls
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: successful_calls
-  azure_name: SuccessfulCalls
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: blocked_calls
-  azure_name: BlockedCalls
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: total_errors
-  azure_name: TotalErrors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: client_errors
-  azure_name: ClientErrors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: server_errors
-  azure_name: ServerErrors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: total_token_calls
-  azure_name: TotalTokenCalls
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: latency
-  azure_name: Latency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_in
-  azure_name: DataIn
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: data_out
-  azure_name: DataOut
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ratelimit
-  azure_name: Ratelimit
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: azure_open_ai_availability_rate
-  azure_name: AzureOpenAIAvailabilityRate
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: azure_open_ai_requests
-  azure_name: AzureOpenAIRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: azure_open_ai_normalized_tbt_in_ms
-  azure_name: AzureOpenAINormalizedTBTInMS
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: azure_open_ai_normalized_ttft_in_ms
-  azure_name: AzureOpenAINormalizedTTFTInMS
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: azure_open_ai_time_to_response
-  azure_name: AzureOpenAITimeToResponse
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: azure_open_ai_token_per_second
-  azure_name: AzureOpenAITokenPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: azure_open_aittlt_in_ms
-  azure_name: AzureOpenAITTLTInMS
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: active_tokens
-  azure_name: ActiveTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: audio_completion_tokens
-  azure_name: AudioCompletionTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: audio_prompt_tokens
-  azure_name: AudioPromptTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: azure_open_ai_context_tokens_cache_match_rate
-  azure_name: AzureOpenAIContextTokensCacheMatchRate
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: azure_open_ai_provisioned_managed_utilization_v2
-  azure_name: AzureOpenAIProvisionedManagedUtilizationV2
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: fine_tuned_training_hours
-  azure_name: FineTunedTrainingHours
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: generated_tokens
-  azure_name: GeneratedTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: processed_prompt_tokens
-  azure_name: ProcessedPromptTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: realtime_usage_time
-  azure_name: RealtimeUsageTime
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: token_transaction
-  azure_name: TokenTransaction
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: model_availability_rate
-  azure_name: ModelAvailabilityRate
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: model_requests
-  azure_name: ModelRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: normalized_time_between_tokens
-  azure_name: NormalizedTimeBetweenTokens
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: normalized_time_to_first_token
-  azure_name: NormalizedTimeToFirstToken
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: time_to_last_byte
-  azure_name: TimeToLastByte
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: time_to_response
-  azure_name: TimeToResponse
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: tokens_per_second
-  azure_name: TokensPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: annotated_pages
-  azure_name: AnnotatedPages
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: audio_input_tokens
-  azure_name: AudioInputTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: audio_output_tokens
-  azure_name: AudioOutputTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: cache_read_input_tokens
-  azure_name: cacheReadInputTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ephemeral1h_input_tokens
-  azure_name: ephemeral1hInputTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ephemeral5m_input_tokens
-  azure_name: ephemeral5mInputTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: generated_images
-  azure_name: GeneratedImages
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: input_tokens
-  azure_name: InputTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: output_tokens
-  azure_name: OutputTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: provisioned_utilization
-  azure_name: ProvisionedUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: total_pages
-  azure_name: TotalPages
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: total_tokens
-  azure_name: TotalTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: rai_abusive_users_count
-  azure_name: RAIAbusiveUsersCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: rai_harmful_requests
-  azure_name: RAIHarmfulRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: rai_rejected_requests
-  azure_name: RAIRejectedRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: rai_system_event
-  azure_name: RAISystemEvent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: rai_total_requests
-  azure_name: RAITotalRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: content_safety_image_analyze_request_count
-  azure_name: ContentSafetyImageAnalyzeRequestCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: content_safety_text_analyze_request_count
-  azure_name: ContentSafetyTextAnalyzeRequestCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: job_duration
-  azure_name: JobDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: action_id_occurrences
-  azure_name: ActionIdOccurrences
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: actions_per_event
-  azure_name: ActionsPerEvent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: action_feature_id_occurrences
-  azure_name: ActionFeatureIdOccurrences
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: context_feature_id_occurrences
-  azure_name: ContextFeatureIdOccurrences
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: slot_feature_id_occurrences
-  azure_name: SlotFeatureIdOccurrences
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: feature_cardinality_action
-  azure_name: FeatureCardinality_Action
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: feature_cardinality_context
-  azure_name: FeatureCardinality_Context
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: feature_cardinality_slot
-  azure_name: FeatureCardinality_Slot
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: action_features_per_event
-  azure_name: ActionFeaturesPerEvent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: context_features_per_event
-  azure_name: ContextFeaturesPerEvent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: slot_features_per_event
-  azure_name: SlotFeaturesPerEvent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: action_namespaces_per_event
-  azure_name: ActionNamespacesPerEvent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: context_namespaces_per_event
-  azure_name: ContextNamespacesPerEvent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: slot_namespaces_per_event
-  azure_name: SlotNamespacesPerEvent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: reward
-  azure_name: Reward
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: slot_reward
-  azure_name: SlotReward
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: baseline_estimator_overall_reward
-  azure_name: BaselineEstimatorOverallReward
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: baseline_estimator_slot_reward
-  azure_name: BaselineEstimatorSlotReward
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: baseline_random_estimator_overall_reward
-  azure_name: BaselineRandomEstimatorOverallReward
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: baseline_random_estimator_slot_reward
-  azure_name: BaselineRandomEstimatorSlotReward
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: number_of_slots
-  azure_name: NumberOfSlots
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: online_estimator_overall_reward
-  azure_name: OnlineEstimatorOverallReward
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: online_estimator_slot_reward
-  azure_name: OnlineEstimatorSlotReward
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: slot_id_occurrences
-  azure_name: SlotIdOccurrences
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: baseline_random_event_count
-  azure_name: BaselineRandomEventCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: baseline_random_reward
-  azure_name: BaselineRandomReward
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: online_event_count
-  azure_name: OnlineEventCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: online_reward
-  azure_name: OnlineReward
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: user_baseline_event_count
-  azure_name: UserBaselineEventCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: user_baseline_reward
-  azure_name: UserBaselineReward
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: audio_seconds_transcribed
-  azure_name: AudioSecondsTranscribed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: audio_seconds_batch_transcribed
-  azure_name: AudioSecondsBatchTranscribed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: audio_seconds_batch_whisper_transcribed
-  azure_name: AudioSecondsBatchWhisperTranscribed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: audio_seconds_fast_transcribed
-  azure_name: AudioSecondsFastTranscribed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: audio_seconds_fast_whisper_transcribed
-  azure_name: AudioSecondsFastWhisperTranscribed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: audio_seconds_translated
-  azure_name: AudioSecondsTranslated
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: avatar_model_hosting_seconds
-  azure_name: AvatarModelHostingSeconds
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: avatar_model_training_seconds
-  azure_name: AvatarModelTrainingSeconds
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: numberof_speaker_profiles
-  azure_name: NumberofSpeakerProfiles
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: speaker_recognition_transactions
-  azure_name: SpeakerRecognitionTransactions
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: speech_model_hosting_hours
-  azure_name: SpeechModelHostingHours
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: synthesized_characters
-  azure_name: SynthesizedCharacters
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: video_seconds_synthesized
-  azure_name: VideoSecondsSynthesized
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: voice_live_audio_input_tokens
-  azure_name: VoiceLiveAudioInputTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: voice_live_audio_output_tokens
-  azure_name: VoiceLiveAudioOutputTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: voice_live_cached_audio_input_tokens
-  azure_name: VoiceLiveCachedAudioInputTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: voice_live_cached_text_input_tokens
-  azure_name: VoiceLiveCachedTextInputTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: voice_live_text_input_tokens
-  azure_name: VoiceLiveTextInputTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: voice_live_text_output_tokens
-  azure_name: VoiceLiveTextOutputTokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: voice_model_hosting_hours
-  azure_name: VoiceModelHostingHours
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: voice_model_training_minutes
-  azure_name: VoiceModelTrainingMinutes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: document_characters_translated
-  azure_name: DocumentCharactersTranslated
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: document_custom_characters_translated
-  azure_name: DocumentCustomCharactersTranslated
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: one_document_characters_translated
-  azure_name: OneDocumentCharactersTranslated
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: one_document_custom_characters_translated
-  azure_name: OneDocumentCustomCharactersTranslated
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: text_characters_translated
-  azure_name: TextCharactersTranslated
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: text_custom_characters_translated
-  azure_name: TextCustomCharactersTranslated
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: text_trained_characters
-  azure_name: TextTrainedCharacters
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: translator_pro_app_seconds
-  azure_name: TranslatorProAppSeconds
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: carnegie_inference_count
-  azure_name: CarnegieInferenceCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: computer_vision_transactions
-  azure_name: ComputerVisionTransactions
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: custom_vision_training_time
-  azure_name: CustomVisionTrainingTime
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: custom_vision_transactions
-  azure_name: CustomVisionTransactions
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: face_images_trained
-  azure_name: FaceImagesTrained
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: faces_stored
-  azure_name: FacesStored
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: face_transactions
-  azure_name: FaceTransactions
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: images_stored
-  azure_name: ImagesStored
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: learned_events
-  azure_name: LearnedEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: luis_speech_requests
-  azure_name: LUISSpeechRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: luis_text_requests
-  azure_name: LUISTextRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: matched_rewards
-  azure_name: MatchedRewards
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: non_activated_events
-  azure_name: NonActivatedEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: observed_rewards
-  azure_name: ObservedRewards
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: processed_characters
-  azure_name: ProcessedCharacters
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: processed_health_text_records
-  azure_name: ProcessedHealthTextRecords
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: processed_images
-  azure_name: ProcessedImages
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: processed_pages
-  azure_name: ProcessedPages
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: processed_text_records
-  azure_name: ProcessedTextRecords
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: question_answering_text_records
-  azure_name: QuestionAnsweringTextRecords
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: total_events
-  azure_name: TotalEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
+  - id: success_rate
+    azure_name: SuccessRate
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: total_calls
+    azure_name: TotalCalls
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: successful_calls
+    azure_name: SuccessfulCalls
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: blocked_calls
+    azure_name: BlockedCalls
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: total_errors
+    azure_name: TotalErrors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: client_errors
+    azure_name: ClientErrors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: server_errors
+    azure_name: ServerErrors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: total_token_calls
+    azure_name: TotalTokenCalls
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: latency
+    azure_name: Latency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_in
+    azure_name: DataIn
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: data_out
+    azure_name: DataOut
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ratelimit
+    azure_name: Ratelimit
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: azure_open_ai_availability_rate
+    azure_name: AzureOpenAIAvailabilityRate
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: azure_open_ai_requests
+    azure_name: AzureOpenAIRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: azure_open_ai_normalized_tbt_in_ms
+    azure_name: AzureOpenAINormalizedTBTInMS
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: azure_open_ai_normalized_ttft_in_ms
+    azure_name: AzureOpenAINormalizedTTFTInMS
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: azure_open_ai_time_to_response
+    azure_name: AzureOpenAITimeToResponse
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: azure_open_ai_token_per_second
+    azure_name: AzureOpenAITokenPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: azure_open_aittlt_in_ms
+    azure_name: AzureOpenAITTLTInMS
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: active_tokens
+    azure_name: ActiveTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: audio_completion_tokens
+    azure_name: AudioCompletionTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: audio_prompt_tokens
+    azure_name: AudioPromptTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: azure_open_ai_context_tokens_cache_match_rate
+    azure_name: AzureOpenAIContextTokensCacheMatchRate
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: azure_open_ai_provisioned_managed_utilization_v2
+    azure_name: AzureOpenAIProvisionedManagedUtilizationV2
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: fine_tuned_training_hours
+    azure_name: FineTunedTrainingHours
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: generated_tokens
+    azure_name: GeneratedTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: processed_prompt_tokens
+    azure_name: ProcessedPromptTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: realtime_usage_time
+    azure_name: RealtimeUsageTime
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: token_transaction
+    azure_name: TokenTransaction
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: model_availability_rate
+    azure_name: ModelAvailabilityRate
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: model_requests
+    azure_name: ModelRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: normalized_time_between_tokens
+    azure_name: NormalizedTimeBetweenTokens
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: normalized_time_to_first_token
+    azure_name: NormalizedTimeToFirstToken
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: time_to_last_byte
+    azure_name: TimeToLastByte
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: time_to_response
+    azure_name: TimeToResponse
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: tokens_per_second
+    azure_name: TokensPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: annotated_pages
+    azure_name: AnnotatedPages
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: audio_input_tokens
+    azure_name: AudioInputTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: audio_output_tokens
+    azure_name: AudioOutputTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: cache_read_input_tokens
+    azure_name: cacheReadInputTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ephemeral1h_input_tokens
+    azure_name: ephemeral1hInputTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ephemeral5m_input_tokens
+    azure_name: ephemeral5mInputTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: generated_images
+    azure_name: GeneratedImages
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: input_tokens
+    azure_name: InputTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: output_tokens
+    azure_name: OutputTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: provisioned_utilization
+    azure_name: ProvisionedUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: total_pages
+    azure_name: TotalPages
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: total_tokens
+    azure_name: TotalTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: rai_abusive_users_count
+    azure_name: RAIAbusiveUsersCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: rai_harmful_requests
+    azure_name: RAIHarmfulRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: rai_rejected_requests
+    azure_name: RAIRejectedRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: rai_system_event
+    azure_name: RAISystemEvent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: rai_total_requests
+    azure_name: RAITotalRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: content_safety_image_analyze_request_count
+    azure_name: ContentSafetyImageAnalyzeRequestCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: content_safety_text_analyze_request_count
+    azure_name: ContentSafetyTextAnalyzeRequestCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: job_duration
+    azure_name: JobDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: action_id_occurrences
+    azure_name: ActionIdOccurrences
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: actions_per_event
+    azure_name: ActionsPerEvent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: action_feature_id_occurrences
+    azure_name: ActionFeatureIdOccurrences
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: context_feature_id_occurrences
+    azure_name: ContextFeatureIdOccurrences
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: slot_feature_id_occurrences
+    azure_name: SlotFeatureIdOccurrences
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: feature_cardinality_action
+    azure_name: FeatureCardinality_Action
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: feature_cardinality_context
+    azure_name: FeatureCardinality_Context
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: feature_cardinality_slot
+    azure_name: FeatureCardinality_Slot
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: action_features_per_event
+    azure_name: ActionFeaturesPerEvent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: context_features_per_event
+    azure_name: ContextFeaturesPerEvent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: slot_features_per_event
+    azure_name: SlotFeaturesPerEvent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: action_namespaces_per_event
+    azure_name: ActionNamespacesPerEvent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: context_namespaces_per_event
+    azure_name: ContextNamespacesPerEvent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: slot_namespaces_per_event
+    azure_name: SlotNamespacesPerEvent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: reward
+    azure_name: Reward
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: slot_reward
+    azure_name: SlotReward
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: baseline_estimator_overall_reward
+    azure_name: BaselineEstimatorOverallReward
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: baseline_estimator_slot_reward
+    azure_name: BaselineEstimatorSlotReward
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: baseline_random_estimator_overall_reward
+    azure_name: BaselineRandomEstimatorOverallReward
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: baseline_random_estimator_slot_reward
+    azure_name: BaselineRandomEstimatorSlotReward
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: number_of_slots
+    azure_name: NumberOfSlots
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: online_estimator_overall_reward
+    azure_name: OnlineEstimatorOverallReward
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: online_estimator_slot_reward
+    azure_name: OnlineEstimatorSlotReward
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: slot_id_occurrences
+    azure_name: SlotIdOccurrences
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: baseline_random_event_count
+    azure_name: BaselineRandomEventCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: baseline_random_reward
+    azure_name: BaselineRandomReward
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: online_event_count
+    azure_name: OnlineEventCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: online_reward
+    azure_name: OnlineReward
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: user_baseline_event_count
+    azure_name: UserBaselineEventCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: user_baseline_reward
+    azure_name: UserBaselineReward
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: audio_seconds_transcribed
+    azure_name: AudioSecondsTranscribed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: audio_seconds_batch_transcribed
+    azure_name: AudioSecondsBatchTranscribed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: audio_seconds_batch_whisper_transcribed
+    azure_name: AudioSecondsBatchWhisperTranscribed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: audio_seconds_fast_transcribed
+    azure_name: AudioSecondsFastTranscribed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: audio_seconds_fast_whisper_transcribed
+    azure_name: AudioSecondsFastWhisperTranscribed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: audio_seconds_translated
+    azure_name: AudioSecondsTranslated
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: avatar_model_hosting_seconds
+    azure_name: AvatarModelHostingSeconds
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: avatar_model_training_seconds
+    azure_name: AvatarModelTrainingSeconds
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: numberof_speaker_profiles
+    azure_name: NumberofSpeakerProfiles
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: speaker_recognition_transactions
+    azure_name: SpeakerRecognitionTransactions
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: speech_model_hosting_hours
+    azure_name: SpeechModelHostingHours
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: synthesized_characters
+    azure_name: SynthesizedCharacters
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: video_seconds_synthesized
+    azure_name: VideoSecondsSynthesized
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: voice_live_audio_input_tokens
+    azure_name: VoiceLiveAudioInputTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: voice_live_audio_output_tokens
+    azure_name: VoiceLiveAudioOutputTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: voice_live_cached_audio_input_tokens
+    azure_name: VoiceLiveCachedAudioInputTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: voice_live_cached_text_input_tokens
+    azure_name: VoiceLiveCachedTextInputTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: voice_live_text_input_tokens
+    azure_name: VoiceLiveTextInputTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: voice_live_text_output_tokens
+    azure_name: VoiceLiveTextOutputTokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: voice_model_hosting_hours
+    azure_name: VoiceModelHostingHours
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: voice_model_training_minutes
+    azure_name: VoiceModelTrainingMinutes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: document_characters_translated
+    azure_name: DocumentCharactersTranslated
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: document_custom_characters_translated
+    azure_name: DocumentCustomCharactersTranslated
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: one_document_characters_translated
+    azure_name: OneDocumentCharactersTranslated
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: one_document_custom_characters_translated
+    azure_name: OneDocumentCustomCharactersTranslated
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: text_characters_translated
+    azure_name: TextCharactersTranslated
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: text_custom_characters_translated
+    azure_name: TextCustomCharactersTranslated
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: text_trained_characters
+    azure_name: TextTrainedCharacters
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: translator_pro_app_seconds
+    azure_name: TranslatorProAppSeconds
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: carnegie_inference_count
+    azure_name: CarnegieInferenceCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: computer_vision_transactions
+    azure_name: ComputerVisionTransactions
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: custom_vision_training_time
+    azure_name: CustomVisionTrainingTime
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: custom_vision_transactions
+    azure_name: CustomVisionTransactions
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: face_images_trained
+    azure_name: FaceImagesTrained
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: faces_stored
+    azure_name: FacesStored
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: face_transactions
+    azure_name: FaceTransactions
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: images_stored
+    azure_name: ImagesStored
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: learned_events
+    azure_name: LearnedEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: luis_speech_requests
+    azure_name: LUISSpeechRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: luis_text_requests
+    azure_name: LUISTextRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: matched_rewards
+    azure_name: MatchedRewards
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: non_activated_events
+    azure_name: NonActivatedEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: observed_rewards
+    azure_name: ObservedRewards
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: processed_characters
+    azure_name: ProcessedCharacters
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: processed_health_text_records
+    azure_name: ProcessedHealthTextRecords
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: processed_images
+    azure_name: ProcessedImages
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: processed_pages
+    azure_name: ProcessedPages
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: processed_text_records
+    azure_name: ProcessedTextRecords
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: question_answering_text_records
+    azure_name: QuestionAnsweringTextRecords
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: total_events
+    azure_name: TotalEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
 template:
   family: Azure Cognitive Services
   context_namespace: cognitive_services
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_cognitive_services__availability
-    title: Azure Cognitive Services Availability
-    context: availability
-    family: Availability
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.success_rate_average
-      name: availability
-  - id: am_azure_cognitive_services__calls
-    title: Azure Cognitive Services Calls
-    context: calls
-    family: HTTP Requests
-    type: line
-    units: calls/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.total_calls_total
-      name: total
-    - selector: cognitive_services.successful_calls_total
-      name: successful
-    - selector: cognitive_services.blocked_calls_total
-      name: blocked
-    - selector: cognitive_services.total_token_calls_total
-      name: token
-  - id: am_azure_cognitive_services__errors
-    title: Azure Cognitive Services Errors
-    context: errors
-    family: HTTP Requests
-    type: line
-    units: errors/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.total_errors_total
-      name: total
-    - selector: cognitive_services.client_errors_total
-      name: client
-    - selector: cognitive_services.server_errors_total
-      name: server
-  - id: am_azure_cognitive_services__latency
-    title: Azure Cognitive Services Latency
-    context: latency
-    family: Performance
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.latency_average
-      name: average
-  - id: am_azure_cognitive_services__data_transfer
-    title: Azure Cognitive Services Data Transfer
-    context: data_transfer
-    family: HTTP Requests
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.data_in_total
-      name: in
-    - selector: cognitive_services.data_out_total
-      name: out
-  - id: am_azure_cognitive_services__rate_limit
-    title: Azure Cognitive Services Rate Limit
-    context: rate_limit
-    family: HTTP Requests
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.ratelimit_total
-      name: rate_limit
-  - id: am_azure_cognitive_services__openai_availability
-    title: Azure OpenAI Availability
-    context: openai_availability
-    family: Azure OpenAI
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.azure_open_ai_availability_rate_average
-      name: availability
-  - id: am_azure_cognitive_services__openai_requests
-    title: Azure OpenAI Requests
-    context: openai_requests
-    family: Azure OpenAI
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.azure_open_ai_requests_total
-      name: requests
-  - id: am_azure_cognitive_services__openai_latency
-    title: Azure OpenAI Latency
-    context: openai_latency
-    family: Azure OpenAI
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.azure_open_ai_time_to_response_average
-      name: time_to_response
-    - selector: cognitive_services.azure_open_ai_normalized_ttft_in_ms_average
-      name: time_to_first_token
-    - selector: cognitive_services.azure_open_ai_normalized_tbt_in_ms_average
-      name: time_between_tokens
-    - selector: cognitive_services.azure_open_aittlt_in_ms_average
-      name: time_to_last_byte
-  - id: am_azure_cognitive_services__openai_generation_speed
-    title: Azure OpenAI Token Generation Speed
-    context: openai_generation_speed
-    family: Azure OpenAI
-    type: line
-    units: tokens/s
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.azure_open_ai_token_per_second_average
-      name: tokens_per_second
-  - id: am_azure_cognitive_services__openai_token_usage
-    title: Azure OpenAI Token Usage
-    context: openai_token_usage
-    family: Azure OpenAI
-    type: line
-    units: tokens/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.token_transaction_total
-      name: total
-    - selector: cognitive_services.processed_prompt_tokens_total
-      name: prompt
-    - selector: cognitive_services.generated_tokens_total
-      name: generated
-    - selector: cognitive_services.active_tokens_total
-      name: active
-  - id: am_azure_cognitive_services__openai_audio_tokens
-    title: Azure OpenAI Audio Tokens
-    context: openai_audio_tokens
-    family: Azure OpenAI
-    type: line
-    units: tokens/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.audio_prompt_tokens_total
-      name: prompt
-    - selector: cognitive_services.audio_completion_tokens_total
-      name: completion
-  - id: am_azure_cognitive_services__openai_cache_match_rate
-    title: Azure OpenAI Prompt Token Cache Match Rate
-    context: openai_cache_match_rate
-    family: Azure OpenAI
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.azure_open_ai_context_tokens_cache_match_rate_average
-      name: cache_match_rate
-  - id: am_azure_cognitive_services__openai_provisioned_utilization
-    title: Azure OpenAI Provisioned-managed Utilization
-    context: openai_provisioned_utilization
-    family: Azure OpenAI
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.azure_open_ai_provisioned_managed_utilization_v2_average
-      name: utilization
-  - id: am_azure_cognitive_services__openai_finetuning
-    title: Azure OpenAI Fine-Tuning Training Hours
-    context: openai_finetuning
-    family: Azure OpenAI
-    type: line
-    units: hours/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.fine_tuned_training_hours_total
-      name: training_hours
-  - id: am_azure_cognitive_services__openai_realtime_usage
-    title: Azure OpenAI Realtime API Usage
-    context: openai_realtime_usage
-    family: Azure OpenAI
-    type: line
-    units: seconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.realtime_usage_time_total
-      name: seconds_used
-  - id: am_azure_cognitive_services__model_availability
-    title: Azure Cognitive Services Model Availability
-    context: model_availability
-    family: Models
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.model_availability_rate_average
-      name: availability
-  - id: am_azure_cognitive_services__model_requests
-    title: Azure Cognitive Services Model Requests
-    context: model_requests
-    family: Models
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.model_requests_total
-      name: requests
-  - id: am_azure_cognitive_services__model_latency
-    title: Azure Cognitive Services Model Latency
-    context: model_latency
-    family: Models
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.time_to_response_average
-      name: time_to_response
-    - selector: cognitive_services.normalized_time_to_first_token_average
-      name: time_to_first_token
-    - selector: cognitive_services.normalized_time_between_tokens_average
-      name: time_between_tokens
-    - selector: cognitive_services.time_to_last_byte_average
-      name: time_to_last_byte
-  - id: am_azure_cognitive_services__model_generation_speed
-    title: Azure Cognitive Services Model Token Generation Speed
-    context: model_generation_speed
-    family: Models
-    type: line
-    units: tokens/s
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.tokens_per_second_average
-      name: tokens_per_second
-  - id: am_azure_cognitive_services__model_token_usage
-    title: Azure Cognitive Services Model Token Usage
-    context: model_token_usage
-    family: Models
-    type: line
-    units: tokens/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.total_tokens_total
-      name: total
-    - selector: cognitive_services.input_tokens_total
-      name: input
-    - selector: cognitive_services.output_tokens_total
-      name: output
-  - id: am_azure_cognitive_services__model_audio_tokens
-    title: Azure Cognitive Services Model Audio Tokens
-    context: model_audio_tokens
-    family: Models
-    type: line
-    units: tokens/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.audio_input_tokens_total
-      name: input
-    - selector: cognitive_services.audio_output_tokens_total
-      name: output
-  - id: am_azure_cognitive_services__model_cache_tokens
-    title: Azure Cognitive Services Model Cache Tokens
-    context: model_cache_tokens
-    family: Models
-    type: line
-    units: tokens/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.cache_read_input_tokens_total
-      name: cache_read
-    - selector: cognitive_services.ephemeral1h_input_tokens_total
-      name: cache_write_1h
-    - selector: cognitive_services.ephemeral5m_input_tokens_total
-      name: cache_write_5m
-  - id: am_azure_cognitive_services__model_provisioned_utilization
-    title: Azure Cognitive Services Model Provisioned Utilization
-    context: model_provisioned_utilization
-    family: Models
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.provisioned_utilization_average
-      name: utilization
-  - id: am_azure_cognitive_services__model_pages
-    title: Azure Cognitive Services Model Pages Processed
-    context: model_pages
-    family: Models
-    type: line
-    units: pages/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.total_pages_total
-      name: total
-    - selector: cognitive_services.annotated_pages_total
-      name: annotated
-  - id: am_azure_cognitive_services__model_generated_images
-    title: Azure Cognitive Services Generated Images
-    context: model_generated_images
-    family: Models
-    type: line
-    units: images/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.generated_images_total
-      name: generated
-  - id: am_azure_cognitive_services__content_safety_requests
-    title: Azure Cognitive Services Content Safety Requests
-    context: content_safety_requests
-    family: Content Safety
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.rai_total_requests_total
-      name: total
-    - selector: cognitive_services.rai_harmful_requests_total
-      name: harmful
-    - selector: cognitive_services.rai_rejected_requests_total
-      name: blocked
-  - id: am_azure_cognitive_services__content_safety_abusive_users
-    title: Azure Cognitive Services Potentially Abusive Users
-    context: content_safety_abusive_users
-    family: Content Safety
-    type: line
-    units: users/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.rai_abusive_users_count_total
-      name: abusive_users
-  - id: am_azure_cognitive_services__content_safety_system_events
-    title: Azure Cognitive Services Safety System Events
-    context: content_safety_system_events
-    family: Content Safety
-    type: line
-    units: events
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.rai_system_event_average
-      name: events
-  - id: am_azure_cognitive_services__content_safety_moderation
-    title: Azure Cognitive Services Content Moderation Calls
-    context: content_safety_moderation
-    family: Content Safety
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.content_safety_text_analyze_request_count_total
-      name: text
-    - selector: cognitive_services.content_safety_image_analyze_request_count_total
-      name: image
-  - id: am_azure_cognitive_services__job_duration
-    title: Azure Cognitive Services Job Duration
-    context: job_duration
-    family: Language
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.job_duration_average
-      name: average
-  - id: am_azure_cognitive_services__personalizer_actions
-    title: Azure Cognitive Services Personalizer Action Occurrences
-    context: personalizer_actions
-    family: Personalizer
-    type: line
-    units: occurrences/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.action_id_occurrences_total
-      name: occurrences
-  - id: am_azure_cognitive_services__personalizer_actions_per_event
-    title: Azure Cognitive Services Personalizer Actions Per Event
-    context: personalizer_actions_per_event
-    family: Personalizer
-    type: line
-    units: actions
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.actions_per_event_average
-      name: average
-  - id: am_azure_cognitive_services__personalizer_feature_occurrences
-    title: Azure Cognitive Services Personalizer Feature Occurrences
-    context: personalizer_feature_occurrences
-    family: Personalizer
-    type: line
-    units: occurrences/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.action_feature_id_occurrences_total
-      name: action
-    - selector: cognitive_services.context_feature_id_occurrences_total
-      name: context
-    - selector: cognitive_services.slot_feature_id_occurrences_total
-      name: slot
-  - id: am_azure_cognitive_services__personalizer_feature_cardinality
-    title: Azure Cognitive Services Personalizer Feature Cardinality
-    context: personalizer_feature_cardinality
-    family: Personalizer
-    type: line
-    units: features
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.feature_cardinality_action_average
-      name: action
-    - selector: cognitive_services.feature_cardinality_context_average
-      name: context
-    - selector: cognitive_services.feature_cardinality_slot_average
-      name: slot
-  - id: am_azure_cognitive_services__personalizer_features_per_event
-    title: Azure Cognitive Services Personalizer Features Per Event
-    context: personalizer_features_per_event
-    family: Personalizer
-    type: line
-    units: features
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.action_features_per_event_average
-      name: action
-    - selector: cognitive_services.context_features_per_event_average
-      name: context
-    - selector: cognitive_services.slot_features_per_event_average
-      name: slot
-  - id: am_azure_cognitive_services__personalizer_namespaces_per_event
-    title: Azure Cognitive Services Personalizer Namespaces Per Event
-    context: personalizer_namespaces_per_event
-    family: Personalizer
-    type: line
-    units: namespaces
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.action_namespaces_per_event_average
-      name: action
-    - selector: cognitive_services.context_namespaces_per_event_average
-      name: context
-    - selector: cognitive_services.slot_namespaces_per_event_average
-      name: slot
-  - id: am_azure_cognitive_services__personalizer_rewards
-    title: Azure Cognitive Services Personalizer Rewards
-    context: personalizer_rewards
-    family: Personalizer
-    type: line
-    units: reward
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.reward_average
-      name: average
-    - selector: cognitive_services.slot_reward_average
-      name: slot
-  - id: am_azure_cognitive_services__personalizer_estimator_rewards
-    title: Azure Cognitive Services Personalizer Estimator Rewards
-    context: personalizer_estimator_rewards
-    family: Personalizer
-    type: line
-    units: reward
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.online_estimator_overall_reward_average
-      name: online
-    - selector: cognitive_services.baseline_estimator_overall_reward_average
-      name: baseline
-    - selector: cognitive_services.baseline_random_estimator_overall_reward_average
-      name: baseline_random
-  - id: am_azure_cognitive_services__personalizer_estimator_slot_rewards
-    title: Azure Cognitive Services Personalizer Estimator Slot Rewards
-    context: personalizer_estimator_slot_rewards
-    family: Personalizer
-    type: line
-    units: reward
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.online_estimator_slot_reward_average
-      name: online
-    - selector: cognitive_services.baseline_estimator_slot_reward_average
-      name: baseline
-    - selector: cognitive_services.baseline_random_estimator_slot_reward_average
-      name: baseline_random
-  - id: am_azure_cognitive_services__personalizer_slots
-    title: Azure Cognitive Services Personalizer Slots
-    context: personalizer_slots
-    family: Personalizer
-    type: line
-    units: slots
-    algorithm: absolute
-    dimensions:
-    - selector: cognitive_services.number_of_slots_average
-      name: average
-  - id: am_azure_cognitive_services__personalizer_slot_occurrences
-    title: Azure Cognitive Services Personalizer Slot Occurrences
-    context: personalizer_slot_occurrences
-    family: Personalizer
-    type: line
-    units: occurrences/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.slot_id_occurrences_total
-      name: occurrences
-  - id: am_azure_cognitive_services__personalizer_event_counts
-    title: Azure Cognitive Services Personalizer Event Counts
-    context: personalizer_event_counts
-    family: Personalizer
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.online_event_count_total
-      name: online
-    - selector: cognitive_services.baseline_random_event_count_total
-      name: baseline_random
-    - selector: cognitive_services.user_baseline_event_count_total
-      name: user_baseline
-  - id: am_azure_cognitive_services__personalizer_estimated_rewards
-    title: Azure Cognitive Services Personalizer Estimated Rewards
-    context: personalizer_estimated_rewards
-    family: Personalizer
-    type: line
-    units: reward/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.online_reward_total
-      name: online
-    - selector: cognitive_services.baseline_random_reward_total
-      name: baseline_random
-    - selector: cognitive_services.user_baseline_reward_total
-      name: user_baseline
-  - id: am_azure_cognitive_services__speech_transcription
-    title: Azure Cognitive Services Speech Transcription
-    context: speech_transcription
-    family: Speech Services
-    type: line
-    units: seconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.audio_seconds_transcribed_total
-      name: realtime
-    - selector: cognitive_services.audio_seconds_batch_transcribed_total
-      name: batch
-    - selector: cognitive_services.audio_seconds_batch_whisper_transcribed_total
-      name: batch_whisper
-    - selector: cognitive_services.audio_seconds_fast_transcribed_total
-      name: fast
-    - selector: cognitive_services.audio_seconds_fast_whisper_transcribed_total
-      name: fast_whisper
-  - id: am_azure_cognitive_services__speech_translation
-    title: Azure Cognitive Services Speech Translation
-    context: speech_translation
-    family: Speech Services
-    type: line
-    units: seconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.audio_seconds_translated_total
-      name: translated
-  - id: am_azure_cognitive_services__speech_synthesis
-    title: Azure Cognitive Services Speech Synthesis
-    context: speech_synthesis
-    family: Speech Services
-    type: line
-    units: characters/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.synthesized_characters_total
-      name: synthesized
-  - id: am_azure_cognitive_services__speech_video_synthesis
-    title: Azure Cognitive Services Video Synthesis
-    context: speech_video_synthesis
-    family: Speech Services
-    type: line
-    units: seconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.video_seconds_synthesized_total
-      name: synthesized
-  - id: am_azure_cognitive_services__speech_avatar
-    title: Azure Cognitive Services Avatar Usage
-    context: speech_avatar
-    family: Speech Services
-    type: line
-    units: seconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.avatar_model_hosting_seconds_total
-      name: hosting
-    - selector: cognitive_services.avatar_model_training_seconds_total
-      name: training
-  - id: am_azure_cognitive_services__speech_speaker_recognition
-    title: Azure Cognitive Services Speaker Recognition
-    context: speech_speaker_recognition
-    family: Speech Services
-    type: line
-    units: transactions/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.speaker_recognition_transactions_total
-      name: transactions
-  - id: am_azure_cognitive_services__speech_speaker_profiles
-    title: Azure Cognitive Services Speaker Profiles
-    context: speech_speaker_profiles
-    family: Speech Services
-    type: line
-    units: profiles/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.numberof_speaker_profiles_total
-      name: profiles
-  - id: am_azure_cognitive_services__speech_model_hosting
-    title: Azure Cognitive Services Speech Model Hosting
-    context: speech_model_hosting
-    family: Speech Services
-    type: line
-    units: hours/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.speech_model_hosting_hours_total
-      name: hosting
-  - id: am_azure_cognitive_services__speech_voice_live_tokens
-    title: Azure Cognitive Services Voice Live Tokens
-    context: speech_voice_live_tokens
-    family: Speech Services
-    type: line
-    units: tokens/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.voice_live_audio_input_tokens_total
-      name: audio_input
-    - selector: cognitive_services.voice_live_audio_output_tokens_total
-      name: audio_output
-    - selector: cognitive_services.voice_live_cached_audio_input_tokens_total
-      name: cached_audio_input
-    - selector: cognitive_services.voice_live_text_input_tokens_total
-      name: text_input
-    - selector: cognitive_services.voice_live_text_output_tokens_total
-      name: text_output
-    - selector: cognitive_services.voice_live_cached_text_input_tokens_total
-      name: cached_text_input
-  - id: am_azure_cognitive_services__speech_voice_model
-    title: Azure Cognitive Services Voice Model Usage
-    context: speech_voice_model
-    family: Speech Services
-    type: line
-    units: hours/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.voice_model_hosting_hours_total
-      name: hosting
-  - id: am_azure_cognitive_services__speech_voice_training
-    title: Azure Cognitive Services Voice Model Training
-    context: speech_voice_training
-    family: Speech Services
-    type: line
-    units: minutes/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.voice_model_training_minutes_total
-      name: training
-  - id: am_azure_cognitive_services__translator_text
-    title: Azure Cognitive Services Translator Text Characters
-    context: translator_text
-    family: Translator
-    type: line
-    units: characters/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.text_characters_translated_total
-      name: standard
-    - selector: cognitive_services.text_custom_characters_translated_total
-      name: custom
-    - selector: cognitive_services.text_trained_characters_total
-      name: trained
-  - id: am_azure_cognitive_services__translator_document
-    title: Azure Cognitive Services Translator Document Characters
-    context: translator_document
-    family: Translator
-    type: line
-    units: characters/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.document_characters_translated_total
-      name: standard
-    - selector: cognitive_services.document_custom_characters_translated_total
-      name: custom
-  - id: am_azure_cognitive_services__translator_document_sync
-    title: Azure Cognitive Services Translator Document Sync Characters
-    context: translator_document_sync
-    family: Translator
-    type: line
-    units: characters/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.one_document_characters_translated_total
-      name: standard
-    - selector: cognitive_services.one_document_custom_characters_translated_total
-      name: custom
-  - id: am_azure_cognitive_services__translator_pro_app
-    title: Azure Cognitive Services Translator Pro App Usage
-    context: translator_pro_app
-    family: Translator
-    type: line
-    units: seconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.translator_pro_app_seconds_total
-      name: seconds
-  - id: am_azure_cognitive_services__vision_transactions
-    title: Azure Cognitive Services Vision Transactions
-    context: vision_transactions
-    family: Vision
-    type: line
-    units: transactions/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.computer_vision_transactions_total
-      name: computer_vision
-    - selector: cognitive_services.custom_vision_transactions_total
-      name: custom_vision
-  - id: am_azure_cognitive_services__vision_training
-    title: Azure Cognitive Services Custom Vision Training
-    context: vision_training
-    family: Vision
-    type: line
-    units: seconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.custom_vision_training_time_total
-      name: training_time
-  - id: am_azure_cognitive_services__vision_images_stored
-    title: Azure Cognitive Services Images Stored
-    context: vision_images_stored
-    family: Vision
-    type: line
-    units: images/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.images_stored_total
-      name: stored
-  - id: am_azure_cognitive_services__face_transactions
-    title: Azure Cognitive Services Face Transactions
-    context: face_transactions
-    family: Face
-    type: line
-    units: transactions/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.face_transactions_total
-      name: transactions
-  - id: am_azure_cognitive_services__face_images_trained
-    title: Azure Cognitive Services Face Images Trained
-    context: face_images_trained
-    family: Face
-    type: line
-    units: images/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.face_images_trained_total
-      name: trained
-  - id: am_azure_cognitive_services__faces_stored
-    title: Azure Cognitive Services Faces Stored
-    context: faces_stored
-    family: Face
-    type: line
-    units: faces/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.faces_stored_total
-      name: stored
-  - id: am_azure_cognitive_services__luis_requests
-    title: Azure Cognitive Services LUIS Requests
-    context: luis_requests
-    family: LUIS
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.luis_speech_requests_total
-      name: speech
-    - selector: cognitive_services.luis_text_requests_total
-      name: text
-  - id: am_azure_cognitive_services__text_processing
-    title: Azure Cognitive Services Text Processing
-    context: text_processing
-    family: Text Processing
-    type: line
-    units: records/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.processed_text_records_total
-      name: text
-    - selector: cognitive_services.processed_health_text_records_total
-      name: health_text
-    - selector: cognitive_services.question_answering_text_records_total
-      name: question_answering
-  - id: am_azure_cognitive_services__processed_characters
-    title: Azure Cognitive Services Processed Characters
-    context: processed_characters
-    family: Text Processing
-    type: line
-    units: characters/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.processed_characters_total
-      name: characters
-  - id: am_azure_cognitive_services__processed_images
-    title: Azure Cognitive Services Processed Images
-    context: processed_images
-    family: Text Processing
-    type: line
-    units: images/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.processed_images_total
-      name: images
-  - id: am_azure_cognitive_services__processed_pages
-    title: Azure Cognitive Services Processed Pages
-    context: processed_pages
-    family: Text Processing
-    type: line
-    units: pages/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.processed_pages_total
-      name: pages
-  - id: am_azure_cognitive_services__carnegie_inference
-    title: Azure Cognitive Services Carnegie Inference
-    context: carnegie_inference
-    family: Content Safety
-    type: line
-    units: inferences/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.carnegie_inference_count_total
-      name: inferences
-  - id: am_azure_cognitive_services__personalizer_events
-    title: Azure Cognitive Services Personalizer Events
-    context: personalizer_events
-    family: Personalizer
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.total_events_total
-      name: total
-    - selector: cognitive_services.learned_events_total
-      name: learned
-    - selector: cognitive_services.non_activated_events_total
-      name: non_activated
-  - id: am_azure_cognitive_services__personalizer_reward_tracking
-    title: Azure Cognitive Services Personalizer Reward Tracking
-    context: personalizer_reward_tracking
-    family: Personalizer
-    type: line
-    units: rewards/s
-    algorithm: incremental
-    dimensions:
-    - selector: cognitive_services.matched_rewards_total
-      name: matched
-    - selector: cognitive_services.observed_rewards_total
-      name: observed
+    - id: am_azure_cognitive_services__availability
+      title: Azure Cognitive Services Availability
+      context: availability
+      family: Availability
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.success_rate_average
+          name: availability
+    - id: am_azure_cognitive_services__calls
+      title: Azure Cognitive Services Calls
+      context: calls
+      family: HTTP Requests
+      type: line
+      units: calls/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.total_calls_total
+          name: total
+        - selector: cognitive_services.successful_calls_total
+          name: successful
+        - selector: cognitive_services.blocked_calls_total
+          name: blocked
+        - selector: cognitive_services.total_token_calls_total
+          name: token
+    - id: am_azure_cognitive_services__errors
+      title: Azure Cognitive Services Errors
+      context: errors
+      family: HTTP Requests
+      type: line
+      units: errors/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.total_errors_total
+          name: total
+        - selector: cognitive_services.client_errors_total
+          name: client
+        - selector: cognitive_services.server_errors_total
+          name: server
+    - id: am_azure_cognitive_services__latency
+      title: Azure Cognitive Services Latency
+      context: latency
+      family: Performance
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.latency_average
+          name: average
+    - id: am_azure_cognitive_services__data_transfer
+      title: Azure Cognitive Services Data Transfer
+      context: data_transfer
+      family: HTTP Requests
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.data_in_total
+          name: in
+        - selector: cognitive_services.data_out_total
+          name: out
+    - id: am_azure_cognitive_services__rate_limit
+      title: Azure Cognitive Services Rate Limit
+      context: rate_limit
+      family: HTTP Requests
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.ratelimit_total
+          name: rate_limit
+    - id: am_azure_cognitive_services__openai_availability
+      title: Azure OpenAI Availability
+      context: openai_availability
+      family: Azure OpenAI
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.azure_open_ai_availability_rate_average
+          name: availability
+    - id: am_azure_cognitive_services__openai_requests
+      title: Azure OpenAI Requests
+      context: openai_requests
+      family: Azure OpenAI
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.azure_open_ai_requests_total
+          name: requests
+    - id: am_azure_cognitive_services__openai_latency
+      title: Azure OpenAI Latency
+      context: openai_latency
+      family: Azure OpenAI
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.azure_open_ai_time_to_response_average
+          name: time_to_response
+        - selector: cognitive_services.azure_open_ai_normalized_ttft_in_ms_average
+          name: time_to_first_token
+        - selector: cognitive_services.azure_open_ai_normalized_tbt_in_ms_average
+          name: time_between_tokens
+        - selector: cognitive_services.azure_open_aittlt_in_ms_average
+          name: time_to_last_byte
+    - id: am_azure_cognitive_services__openai_generation_speed
+      title: Azure OpenAI Token Generation Speed
+      context: openai_generation_speed
+      family: Azure OpenAI
+      type: line
+      units: tokens/s
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.azure_open_ai_token_per_second_average
+          name: tokens_per_second
+    - id: am_azure_cognitive_services__openai_token_usage
+      title: Azure OpenAI Token Usage
+      context: openai_token_usage
+      family: Azure OpenAI
+      type: line
+      units: tokens/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.token_transaction_total
+          name: total
+        - selector: cognitive_services.processed_prompt_tokens_total
+          name: prompt
+        - selector: cognitive_services.generated_tokens_total
+          name: generated
+        - selector: cognitive_services.active_tokens_total
+          name: active
+    - id: am_azure_cognitive_services__openai_audio_tokens
+      title: Azure OpenAI Audio Tokens
+      context: openai_audio_tokens
+      family: Azure OpenAI
+      type: line
+      units: tokens/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.audio_prompt_tokens_total
+          name: prompt
+        - selector: cognitive_services.audio_completion_tokens_total
+          name: completion
+    - id: am_azure_cognitive_services__openai_cache_match_rate
+      title: Azure OpenAI Prompt Token Cache Match Rate
+      context: openai_cache_match_rate
+      family: Azure OpenAI
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.azure_open_ai_context_tokens_cache_match_rate_average
+          name: cache_match_rate
+    - id: am_azure_cognitive_services__openai_provisioned_utilization
+      title: Azure OpenAI Provisioned-managed Utilization
+      context: openai_provisioned_utilization
+      family: Azure OpenAI
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.azure_open_ai_provisioned_managed_utilization_v2_average
+          name: utilization
+    - id: am_azure_cognitive_services__openai_finetuning
+      title: Azure OpenAI Fine-Tuning Training Hours
+      context: openai_finetuning
+      family: Azure OpenAI
+      type: line
+      units: hours/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.fine_tuned_training_hours_total
+          name: training_hours
+    - id: am_azure_cognitive_services__openai_realtime_usage
+      title: Azure OpenAI Realtime API Usage
+      context: openai_realtime_usage
+      family: Azure OpenAI
+      type: line
+      units: seconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.realtime_usage_time_total
+          name: seconds_used
+    - id: am_azure_cognitive_services__model_availability
+      title: Azure Cognitive Services Model Availability
+      context: model_availability
+      family: Models
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.model_availability_rate_average
+          name: availability
+    - id: am_azure_cognitive_services__model_requests
+      title: Azure Cognitive Services Model Requests
+      context: model_requests
+      family: Models
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.model_requests_total
+          name: requests
+    - id: am_azure_cognitive_services__model_latency
+      title: Azure Cognitive Services Model Latency
+      context: model_latency
+      family: Models
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.time_to_response_average
+          name: time_to_response
+        - selector: cognitive_services.normalized_time_to_first_token_average
+          name: time_to_first_token
+        - selector: cognitive_services.normalized_time_between_tokens_average
+          name: time_between_tokens
+        - selector: cognitive_services.time_to_last_byte_average
+          name: time_to_last_byte
+    - id: am_azure_cognitive_services__model_generation_speed
+      title: Azure Cognitive Services Model Token Generation Speed
+      context: model_generation_speed
+      family: Models
+      type: line
+      units: tokens/s
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.tokens_per_second_average
+          name: tokens_per_second
+    - id: am_azure_cognitive_services__model_token_usage
+      title: Azure Cognitive Services Model Token Usage
+      context: model_token_usage
+      family: Models
+      type: line
+      units: tokens/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.total_tokens_total
+          name: total
+        - selector: cognitive_services.input_tokens_total
+          name: input
+        - selector: cognitive_services.output_tokens_total
+          name: output
+    - id: am_azure_cognitive_services__model_audio_tokens
+      title: Azure Cognitive Services Model Audio Tokens
+      context: model_audio_tokens
+      family: Models
+      type: line
+      units: tokens/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.audio_input_tokens_total
+          name: input
+        - selector: cognitive_services.audio_output_tokens_total
+          name: output
+    - id: am_azure_cognitive_services__model_cache_tokens
+      title: Azure Cognitive Services Model Cache Tokens
+      context: model_cache_tokens
+      family: Models
+      type: line
+      units: tokens/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.cache_read_input_tokens_total
+          name: cache_read
+        - selector: cognitive_services.ephemeral1h_input_tokens_total
+          name: cache_write_1h
+        - selector: cognitive_services.ephemeral5m_input_tokens_total
+          name: cache_write_5m
+    - id: am_azure_cognitive_services__model_provisioned_utilization
+      title: Azure Cognitive Services Model Provisioned Utilization
+      context: model_provisioned_utilization
+      family: Models
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.provisioned_utilization_average
+          name: utilization
+    - id: am_azure_cognitive_services__model_pages
+      title: Azure Cognitive Services Model Pages Processed
+      context: model_pages
+      family: Models
+      type: line
+      units: pages/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.total_pages_total
+          name: total
+        - selector: cognitive_services.annotated_pages_total
+          name: annotated
+    - id: am_azure_cognitive_services__model_generated_images
+      title: Azure Cognitive Services Generated Images
+      context: model_generated_images
+      family: Models
+      type: line
+      units: images/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.generated_images_total
+          name: generated
+    - id: am_azure_cognitive_services__content_safety_requests
+      title: Azure Cognitive Services Content Safety Requests
+      context: content_safety_requests
+      family: Content Safety
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.rai_total_requests_total
+          name: total
+        - selector: cognitive_services.rai_harmful_requests_total
+          name: harmful
+        - selector: cognitive_services.rai_rejected_requests_total
+          name: blocked
+    - id: am_azure_cognitive_services__content_safety_abusive_users
+      title: Azure Cognitive Services Potentially Abusive Users
+      context: content_safety_abusive_users
+      family: Content Safety
+      type: line
+      units: users/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.rai_abusive_users_count_total
+          name: abusive_users
+    - id: am_azure_cognitive_services__content_safety_system_events
+      title: Azure Cognitive Services Safety System Events
+      context: content_safety_system_events
+      family: Content Safety
+      type: line
+      units: events
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.rai_system_event_average
+          name: events
+    - id: am_azure_cognitive_services__content_safety_moderation
+      title: Azure Cognitive Services Content Moderation Calls
+      context: content_safety_moderation
+      family: Content Safety
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.content_safety_text_analyze_request_count_total
+          name: text
+        - selector: cognitive_services.content_safety_image_analyze_request_count_total
+          name: image
+    - id: am_azure_cognitive_services__job_duration
+      title: Azure Cognitive Services Job Duration
+      context: job_duration
+      family: Language
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.job_duration_average
+          name: average
+    - id: am_azure_cognitive_services__personalizer_actions
+      title: Azure Cognitive Services Personalizer Action Occurrences
+      context: personalizer_actions
+      family: Personalizer
+      type: line
+      units: occurrences/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.action_id_occurrences_total
+          name: occurrences
+    - id: am_azure_cognitive_services__personalizer_actions_per_event
+      title: Azure Cognitive Services Personalizer Actions Per Event
+      context: personalizer_actions_per_event
+      family: Personalizer
+      type: line
+      units: actions
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.actions_per_event_average
+          name: average
+    - id: am_azure_cognitive_services__personalizer_feature_occurrences
+      title: Azure Cognitive Services Personalizer Feature Occurrences
+      context: personalizer_feature_occurrences
+      family: Personalizer
+      type: line
+      units: occurrences/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.action_feature_id_occurrences_total
+          name: action
+        - selector: cognitive_services.context_feature_id_occurrences_total
+          name: context
+        - selector: cognitive_services.slot_feature_id_occurrences_total
+          name: slot
+    - id: am_azure_cognitive_services__personalizer_feature_cardinality
+      title: Azure Cognitive Services Personalizer Feature Cardinality
+      context: personalizer_feature_cardinality
+      family: Personalizer
+      type: line
+      units: features
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.feature_cardinality_action_average
+          name: action
+        - selector: cognitive_services.feature_cardinality_context_average
+          name: context
+        - selector: cognitive_services.feature_cardinality_slot_average
+          name: slot
+    - id: am_azure_cognitive_services__personalizer_features_per_event
+      title: Azure Cognitive Services Personalizer Features Per Event
+      context: personalizer_features_per_event
+      family: Personalizer
+      type: line
+      units: features
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.action_features_per_event_average
+          name: action
+        - selector: cognitive_services.context_features_per_event_average
+          name: context
+        - selector: cognitive_services.slot_features_per_event_average
+          name: slot
+    - id: am_azure_cognitive_services__personalizer_namespaces_per_event
+      title: Azure Cognitive Services Personalizer Namespaces Per Event
+      context: personalizer_namespaces_per_event
+      family: Personalizer
+      type: line
+      units: namespaces
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.action_namespaces_per_event_average
+          name: action
+        - selector: cognitive_services.context_namespaces_per_event_average
+          name: context
+        - selector: cognitive_services.slot_namespaces_per_event_average
+          name: slot
+    - id: am_azure_cognitive_services__personalizer_rewards
+      title: Azure Cognitive Services Personalizer Rewards
+      context: personalizer_rewards
+      family: Personalizer
+      type: line
+      units: reward
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.reward_average
+          name: average
+        - selector: cognitive_services.slot_reward_average
+          name: slot
+    - id: am_azure_cognitive_services__personalizer_estimator_rewards
+      title: Azure Cognitive Services Personalizer Estimator Rewards
+      context: personalizer_estimator_rewards
+      family: Personalizer
+      type: line
+      units: reward
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.online_estimator_overall_reward_average
+          name: online
+        - selector: cognitive_services.baseline_estimator_overall_reward_average
+          name: baseline
+        - selector: cognitive_services.baseline_random_estimator_overall_reward_average
+          name: baseline_random
+    - id: am_azure_cognitive_services__personalizer_estimator_slot_rewards
+      title: Azure Cognitive Services Personalizer Estimator Slot Rewards
+      context: personalizer_estimator_slot_rewards
+      family: Personalizer
+      type: line
+      units: reward
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.online_estimator_slot_reward_average
+          name: online
+        - selector: cognitive_services.baseline_estimator_slot_reward_average
+          name: baseline
+        - selector: cognitive_services.baseline_random_estimator_slot_reward_average
+          name: baseline_random
+    - id: am_azure_cognitive_services__personalizer_slots
+      title: Azure Cognitive Services Personalizer Slots
+      context: personalizer_slots
+      family: Personalizer
+      type: line
+      units: slots
+      algorithm: absolute
+      dimensions:
+        - selector: cognitive_services.number_of_slots_average
+          name: average
+    - id: am_azure_cognitive_services__personalizer_slot_occurrences
+      title: Azure Cognitive Services Personalizer Slot Occurrences
+      context: personalizer_slot_occurrences
+      family: Personalizer
+      type: line
+      units: occurrences/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.slot_id_occurrences_total
+          name: occurrences
+    - id: am_azure_cognitive_services__personalizer_event_counts
+      title: Azure Cognitive Services Personalizer Event Counts
+      context: personalizer_event_counts
+      family: Personalizer
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.online_event_count_total
+          name: online
+        - selector: cognitive_services.baseline_random_event_count_total
+          name: baseline_random
+        - selector: cognitive_services.user_baseline_event_count_total
+          name: user_baseline
+    - id: am_azure_cognitive_services__personalizer_estimated_rewards
+      title: Azure Cognitive Services Personalizer Estimated Rewards
+      context: personalizer_estimated_rewards
+      family: Personalizer
+      type: line
+      units: reward/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.online_reward_total
+          name: online
+        - selector: cognitive_services.baseline_random_reward_total
+          name: baseline_random
+        - selector: cognitive_services.user_baseline_reward_total
+          name: user_baseline
+    - id: am_azure_cognitive_services__speech_transcription
+      title: Azure Cognitive Services Speech Transcription
+      context: speech_transcription
+      family: Speech Services
+      type: line
+      units: seconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.audio_seconds_transcribed_total
+          name: realtime
+        - selector: cognitive_services.audio_seconds_batch_transcribed_total
+          name: batch
+        - selector: cognitive_services.audio_seconds_batch_whisper_transcribed_total
+          name: batch_whisper
+        - selector: cognitive_services.audio_seconds_fast_transcribed_total
+          name: fast
+        - selector: cognitive_services.audio_seconds_fast_whisper_transcribed_total
+          name: fast_whisper
+    - id: am_azure_cognitive_services__speech_translation
+      title: Azure Cognitive Services Speech Translation
+      context: speech_translation
+      family: Speech Services
+      type: line
+      units: seconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.audio_seconds_translated_total
+          name: translated
+    - id: am_azure_cognitive_services__speech_synthesis
+      title: Azure Cognitive Services Speech Synthesis
+      context: speech_synthesis
+      family: Speech Services
+      type: line
+      units: characters/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.synthesized_characters_total
+          name: synthesized
+    - id: am_azure_cognitive_services__speech_video_synthesis
+      title: Azure Cognitive Services Video Synthesis
+      context: speech_video_synthesis
+      family: Speech Services
+      type: line
+      units: seconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.video_seconds_synthesized_total
+          name: synthesized
+    - id: am_azure_cognitive_services__speech_avatar
+      title: Azure Cognitive Services Avatar Usage
+      context: speech_avatar
+      family: Speech Services
+      type: line
+      units: seconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.avatar_model_hosting_seconds_total
+          name: hosting
+        - selector: cognitive_services.avatar_model_training_seconds_total
+          name: training
+    - id: am_azure_cognitive_services__speech_speaker_recognition
+      title: Azure Cognitive Services Speaker Recognition
+      context: speech_speaker_recognition
+      family: Speech Services
+      type: line
+      units: transactions/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.speaker_recognition_transactions_total
+          name: transactions
+    - id: am_azure_cognitive_services__speech_speaker_profiles
+      title: Azure Cognitive Services Speaker Profiles
+      context: speech_speaker_profiles
+      family: Speech Services
+      type: line
+      units: profiles/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.numberof_speaker_profiles_total
+          name: profiles
+    - id: am_azure_cognitive_services__speech_model_hosting
+      title: Azure Cognitive Services Speech Model Hosting
+      context: speech_model_hosting
+      family: Speech Services
+      type: line
+      units: hours/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.speech_model_hosting_hours_total
+          name: hosting
+    - id: am_azure_cognitive_services__speech_voice_live_tokens
+      title: Azure Cognitive Services Voice Live Tokens
+      context: speech_voice_live_tokens
+      family: Speech Services
+      type: line
+      units: tokens/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.voice_live_audio_input_tokens_total
+          name: audio_input
+        - selector: cognitive_services.voice_live_audio_output_tokens_total
+          name: audio_output
+        - selector: cognitive_services.voice_live_cached_audio_input_tokens_total
+          name: cached_audio_input
+        - selector: cognitive_services.voice_live_text_input_tokens_total
+          name: text_input
+        - selector: cognitive_services.voice_live_text_output_tokens_total
+          name: text_output
+        - selector: cognitive_services.voice_live_cached_text_input_tokens_total
+          name: cached_text_input
+    - id: am_azure_cognitive_services__speech_voice_model
+      title: Azure Cognitive Services Voice Model Usage
+      context: speech_voice_model
+      family: Speech Services
+      type: line
+      units: hours/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.voice_model_hosting_hours_total
+          name: hosting
+    - id: am_azure_cognitive_services__speech_voice_training
+      title: Azure Cognitive Services Voice Model Training
+      context: speech_voice_training
+      family: Speech Services
+      type: line
+      units: minutes/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.voice_model_training_minutes_total
+          name: training
+    - id: am_azure_cognitive_services__translator_text
+      title: Azure Cognitive Services Translator Text Characters
+      context: translator_text
+      family: Translator
+      type: line
+      units: characters/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.text_characters_translated_total
+          name: standard
+        - selector: cognitive_services.text_custom_characters_translated_total
+          name: custom
+        - selector: cognitive_services.text_trained_characters_total
+          name: trained
+    - id: am_azure_cognitive_services__translator_document
+      title: Azure Cognitive Services Translator Document Characters
+      context: translator_document
+      family: Translator
+      type: line
+      units: characters/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.document_characters_translated_total
+          name: standard
+        - selector: cognitive_services.document_custom_characters_translated_total
+          name: custom
+    - id: am_azure_cognitive_services__translator_document_sync
+      title: Azure Cognitive Services Translator Document Sync Characters
+      context: translator_document_sync
+      family: Translator
+      type: line
+      units: characters/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.one_document_characters_translated_total
+          name: standard
+        - selector: cognitive_services.one_document_custom_characters_translated_total
+          name: custom
+    - id: am_azure_cognitive_services__translator_pro_app
+      title: Azure Cognitive Services Translator Pro App Usage
+      context: translator_pro_app
+      family: Translator
+      type: line
+      units: seconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.translator_pro_app_seconds_total
+          name: seconds
+    - id: am_azure_cognitive_services__vision_transactions
+      title: Azure Cognitive Services Vision Transactions
+      context: vision_transactions
+      family: Vision
+      type: line
+      units: transactions/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.computer_vision_transactions_total
+          name: computer_vision
+        - selector: cognitive_services.custom_vision_transactions_total
+          name: custom_vision
+    - id: am_azure_cognitive_services__vision_training
+      title: Azure Cognitive Services Custom Vision Training
+      context: vision_training
+      family: Vision
+      type: line
+      units: seconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.custom_vision_training_time_total
+          name: training_time
+    - id: am_azure_cognitive_services__vision_images_stored
+      title: Azure Cognitive Services Images Stored
+      context: vision_images_stored
+      family: Vision
+      type: line
+      units: images/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.images_stored_total
+          name: stored
+    - id: am_azure_cognitive_services__face_transactions
+      title: Azure Cognitive Services Face Transactions
+      context: face_transactions
+      family: Face
+      type: line
+      units: transactions/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.face_transactions_total
+          name: transactions
+    - id: am_azure_cognitive_services__face_images_trained
+      title: Azure Cognitive Services Face Images Trained
+      context: face_images_trained
+      family: Face
+      type: line
+      units: images/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.face_images_trained_total
+          name: trained
+    - id: am_azure_cognitive_services__faces_stored
+      title: Azure Cognitive Services Faces Stored
+      context: faces_stored
+      family: Face
+      type: line
+      units: faces/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.faces_stored_total
+          name: stored
+    - id: am_azure_cognitive_services__luis_requests
+      title: Azure Cognitive Services LUIS Requests
+      context: luis_requests
+      family: LUIS
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.luis_speech_requests_total
+          name: speech
+        - selector: cognitive_services.luis_text_requests_total
+          name: text
+    - id: am_azure_cognitive_services__text_processing
+      title: Azure Cognitive Services Text Processing
+      context: text_processing
+      family: Text Processing
+      type: line
+      units: records/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.processed_text_records_total
+          name: text
+        - selector: cognitive_services.processed_health_text_records_total
+          name: health_text
+        - selector: cognitive_services.question_answering_text_records_total
+          name: question_answering
+    - id: am_azure_cognitive_services__processed_characters
+      title: Azure Cognitive Services Processed Characters
+      context: processed_characters
+      family: Text Processing
+      type: line
+      units: characters/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.processed_characters_total
+          name: characters
+    - id: am_azure_cognitive_services__processed_images
+      title: Azure Cognitive Services Processed Images
+      context: processed_images
+      family: Text Processing
+      type: line
+      units: images/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.processed_images_total
+          name: images
+    - id: am_azure_cognitive_services__processed_pages
+      title: Azure Cognitive Services Processed Pages
+      context: processed_pages
+      family: Text Processing
+      type: line
+      units: pages/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.processed_pages_total
+          name: pages
+    - id: am_azure_cognitive_services__carnegie_inference
+      title: Azure Cognitive Services Carnegie Inference
+      context: carnegie_inference
+      family: Content Safety
+      type: line
+      units: inferences/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.carnegie_inference_count_total
+          name: inferences
+    - id: am_azure_cognitive_services__personalizer_events
+      title: Azure Cognitive Services Personalizer Events
+      context: personalizer_events
+      family: Personalizer
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.total_events_total
+          name: total
+        - selector: cognitive_services.learned_events_total
+          name: learned
+        - selector: cognitive_services.non_activated_events_total
+          name: non_activated
+    - id: am_azure_cognitive_services__personalizer_reward_tracking
+      title: Azure Cognitive Services Personalizer Reward Tracking
+      context: personalizer_reward_tracking
+      family: Personalizer
+      type: line
+      units: rewards/s
+      algorithm: incremental
+      dimensions:
+        - selector: cognitive_services.matched_rewards_total
+          name: matched
+        - selector: cognitive_services.observed_rewards_total
+          name: observed

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/container_apps.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/container_apps.yaml
@@ -3,461 +3,461 @@ id: container_apps
 name: Azure Container Apps
 resource_type: Microsoft.App/containerApps
 metrics:
-- id: usage_nano_cores
-  azure_name: UsageNanoCores
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: cpu_percentage
-  azure_name: CpuPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: working_set_bytes
-  azure_name: WorkingSetBytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: memory_percentage
-  azure_name: MemoryPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: replicas
-  azure_name: Replicas
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cores_quota_used
-  azure_name: CoresQuotaUsed
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: total_cores_quota_used
-  azure_name: TotalCoresQuotaUsed
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: restart_count
-  azure_name: RestartCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: requests
-  azure_name: Requests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: response_time
-  azure_name: ResponseTime
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: rx_bytes
-  azure_name: RxBytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tx_bytes
-  azure_name: TxBytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: resiliency_connect_timeouts
-  azure_name: ResiliencyConnectTimeouts
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: resiliency_request_timeouts
-  azure_name: ResiliencyRequestTimeouts
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: resiliency_request_retries
-  azure_name: ResiliencyRequestRetries
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: resiliency_requests_pending_connection_pool
-  azure_name: ResiliencyRequestsPendingConnectionPool
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: resiliency_ejected_hosts
-  azure_name: ResiliencyEjectedHosts
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: resiliency_ejections_aborted
-  azure_name: ResiliencyEjectionsAborted
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: gpu_utilization_percentage
-  azure_name: GpuUtilizationPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: jvm_buffer_count
-  azure_name: JvmBufferCount
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: jvm_buffer_memory_limit
-  azure_name: JvmBufferMemoryLimit
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: jvm_buffer_memory_usage
-  azure_name: JvmBufferMemoryUsage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: jvm_gc_count
-  azure_name: JvmGcCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: jvm_gc_duration
-  azure_name: JvmGcDuration
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: jvm_memory_committed
-  azure_name: JvmMemoryCommitted
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: jvm_memory_limit
-  azure_name: JvmMemoryLimit
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: jvm_memory_used
-  azure_name: JvmMemoryUsed
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: jvm_memory_total_committed
-  azure_name: JvmMemoryTotalCommitted
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: jvm_memory_total_limit
-  azure_name: JvmMemoryTotalLimit
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: jvm_memory_total_used
-  azure_name: JvmMemoryTotalUsed
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: jvm_thread_count
-  azure_name: JvmThreadCount
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: usage_nano_cores
+    azure_name: UsageNanoCores
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: cpu_percentage
+    azure_name: CpuPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: working_set_bytes
+    azure_name: WorkingSetBytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: memory_percentage
+    azure_name: MemoryPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: replicas
+    azure_name: Replicas
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cores_quota_used
+    azure_name: CoresQuotaUsed
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: total_cores_quota_used
+    azure_name: TotalCoresQuotaUsed
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: restart_count
+    azure_name: RestartCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: requests
+    azure_name: Requests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: response_time
+    azure_name: ResponseTime
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: rx_bytes
+    azure_name: RxBytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tx_bytes
+    azure_name: TxBytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: resiliency_connect_timeouts
+    azure_name: ResiliencyConnectTimeouts
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: resiliency_request_timeouts
+    azure_name: ResiliencyRequestTimeouts
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: resiliency_request_retries
+    azure_name: ResiliencyRequestRetries
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: resiliency_requests_pending_connection_pool
+    azure_name: ResiliencyRequestsPendingConnectionPool
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: resiliency_ejected_hosts
+    azure_name: ResiliencyEjectedHosts
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: resiliency_ejections_aborted
+    azure_name: ResiliencyEjectionsAborted
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: gpu_utilization_percentage
+    azure_name: GpuUtilizationPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: jvm_buffer_count
+    azure_name: JvmBufferCount
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: jvm_buffer_memory_limit
+    azure_name: JvmBufferMemoryLimit
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: jvm_buffer_memory_usage
+    azure_name: JvmBufferMemoryUsage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: jvm_gc_count
+    azure_name: JvmGcCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: jvm_gc_duration
+    azure_name: JvmGcDuration
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: jvm_memory_committed
+    azure_name: JvmMemoryCommitted
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: jvm_memory_limit
+    azure_name: JvmMemoryLimit
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: jvm_memory_used
+    azure_name: JvmMemoryUsed
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: jvm_memory_total_committed
+    azure_name: JvmMemoryTotalCommitted
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: jvm_memory_total_limit
+    azure_name: JvmMemoryTotalLimit
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: jvm_memory_total_used
+    azure_name: JvmMemoryTotalUsed
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: jvm_thread_count
+    azure_name: JvmThreadCount
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Container Apps
   context_namespace: container_apps
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_container_apps__cpu_usage
-    title: Azure Container Apps CPU Usage
-    context: cpu_usage
-    family: CPU
-    type: line
-    units: nanocores
-    algorithm: absolute
-    dimensions:
-    - selector: container_apps.usage_nano_cores_average
-      name: average
-    - selector: container_apps.usage_nano_cores_maximum
-      name: maximum
-  - id: am_azure_container_apps__cpu_percentage
-    title: Azure Container Apps CPU Percentage
-    context: cpu_percentage
-    family: CPU
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: container_apps.cpu_percentage_average
-      name: average
-    - selector: container_apps.cpu_percentage_maximum
-      name: maximum
-  - id: am_azure_container_apps__memory_working_set
-    title: Azure Container Apps Memory Working Set
-    context: memory_working_set
-    family: Memory
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: container_apps.working_set_bytes_average
-      name: average
-    - selector: container_apps.working_set_bytes_maximum
-      name: maximum
-  - id: am_azure_container_apps__memory_percentage
-    title: Azure Container Apps Memory Percentage
-    context: memory_percentage
-    family: Memory
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: container_apps.memory_percentage_average
-      name: average
-    - selector: container_apps.memory_percentage_maximum
-      name: maximum
-  - id: am_azure_container_apps__replicas
-    title: Azure Container Apps Replica Count
-    context: replicas
-    family: Scaling
-    type: line
-    units: replicas
-    algorithm: absolute
-    dimensions:
-    - selector: container_apps.replicas_average
-      name: average
-  - id: am_azure_container_apps__reserved_cores
-    title: Azure Container Apps Reserved Cores
-    context: reserved_cores
-    family: Scaling
-    type: line
-    units: cores
-    algorithm: absolute
-    dimensions:
-    - selector: container_apps.cores_quota_used_maximum
-      name: per_revision
-    - selector: container_apps.total_cores_quota_used_average
-      name: total
-  - id: am_azure_container_apps__restart_count
-    title: Azure Container Apps Replica Restarts
-    context: restart_count
-    family: Scaling
-    type: line
-    units: restarts/s
-    algorithm: incremental
-    dimensions:
-    - selector: container_apps.restart_count_total
-      name: restarts
-  - id: am_azure_container_apps__requests
-    title: Azure Container Apps Requests
-    context: requests
-    family: Requests
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: container_apps.requests_total
-      name: requests
-  - id: am_azure_container_apps__response_time
-    title: Azure Container Apps Response Time
-    context: response_time
-    family: Requests
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: container_apps.response_time_average
-      name: average
-  - id: am_azure_container_apps__network
-    title: Azure Container Apps Network Traffic
-    context: network
-    family: Network
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: container_apps.rx_bytes_total
-      name: received
-    - selector: container_apps.tx_bytes_total
-      name: sent
-  - id: am_azure_container_apps__resiliency_timeouts
-    title: Azure Container Apps Resiliency Timeouts
-    context: resiliency_timeouts
-    family: Resiliency
-    type: line
-    units: timeouts/s
-    algorithm: incremental
-    dimensions:
-    - selector: container_apps.resiliency_connect_timeouts_total
-      name: connection
-    - selector: container_apps.resiliency_request_timeouts_total
-      name: request
-  - id: am_azure_container_apps__resiliency_retries
-    title: Azure Container Apps Resiliency Request Retries
-    context: resiliency_retries
-    family: Resiliency
-    type: line
-    units: retries/s
-    algorithm: incremental
-    dimensions:
-    - selector: container_apps.resiliency_request_retries_total
-      name: retries
-  - id: am_azure_container_apps__resiliency_pending_connections
-    title: Azure Container Apps Resiliency Pending Connection Pool
-    context: resiliency_pending_connections
-    family: Resiliency
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: container_apps.resiliency_requests_pending_connection_pool_total
-      name: pending
-  - id: am_azure_container_apps__resiliency_ejections
-    title: Azure Container Apps Resiliency Host Ejections
-    context: resiliency_ejections
-    family: Resiliency
-    type: line
-    units: ejections/s
-    algorithm: incremental
-    dimensions:
-    - selector: container_apps.resiliency_ejected_hosts_total
-      name: ejected
-    - selector: container_apps.resiliency_ejections_aborted_total
-      name: aborted
-  - id: am_azure_container_apps__gpu_utilization
-    title: Azure Container Apps GPU Utilization
-    context: gpu_utilization
-    family: GPU
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: container_apps.gpu_utilization_percentage_average
-      name: average
-    - selector: container_apps.gpu_utilization_percentage_maximum
-      name: maximum
-  - id: am_azure_container_apps__jvm_buffer_count
-    title: Azure Container Apps JVM Buffer Count
-    context: jvm_buffer_count
-    family: JVM Buffers
-    type: line
-    units: buffers
-    algorithm: absolute
-    dimensions:
-    - selector: container_apps.jvm_buffer_count_average
-      name: average
-  - id: am_azure_container_apps__jvm_buffer_memory
-    title: Azure Container Apps JVM Buffer Memory
-    context: jvm_buffer_memory
-    family: JVM Buffers
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: container_apps.jvm_buffer_memory_usage_average
-      name: used
-    - selector: container_apps.jvm_buffer_memory_limit_average
-      name: limit
-  - id: am_azure_container_apps__jvm_gc_count
-    title: Azure Container Apps JVM Garbage Collections
-    context: jvm_gc_count
-    family: JVM GC
-    type: line
-    units: collections/s
-    algorithm: incremental
-    dimensions:
-    - selector: container_apps.jvm_gc_count_total
-      name: collections
-  - id: am_azure_container_apps__jvm_gc_duration
-    title: Azure Container Apps JVM GC Duration
-    context: jvm_gc_duration
-    family: JVM GC
-    type: line
-    units: milliseconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: container_apps.jvm_gc_duration_total
-      name: duration
-  - id: am_azure_container_apps__jvm_memory_pool
-    title: Azure Container Apps JVM Memory per Pool
-    context: jvm_memory_pool
-    family: JVM Memory
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: container_apps.jvm_memory_used_average
-      name: used
-    - selector: container_apps.jvm_memory_committed_average
-      name: committed
-    - selector: container_apps.jvm_memory_limit_average
-      name: limit
-  - id: am_azure_container_apps__jvm_memory_total
-    title: Azure Container Apps JVM Memory Total
-    context: jvm_memory_total
-    family: JVM Memory
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: container_apps.jvm_memory_total_used_average
-      name: used
-    - selector: container_apps.jvm_memory_total_committed_average
-      name: committed
-    - selector: container_apps.jvm_memory_total_limit_average
-      name: limit
-  - id: am_azure_container_apps__jvm_thread_count
-    title: Azure Container Apps JVM Thread Count
-    context: jvm_thread_count
-    family: JVM Threads
-    type: line
-    units: threads
-    algorithm: absolute
-    dimensions:
-    - selector: container_apps.jvm_thread_count_average
-      name: average
+    - id: am_azure_container_apps__cpu_usage
+      title: Azure Container Apps CPU Usage
+      context: cpu_usage
+      family: CPU
+      type: line
+      units: nanocores
+      algorithm: absolute
+      dimensions:
+        - selector: container_apps.usage_nano_cores_average
+          name: average
+        - selector: container_apps.usage_nano_cores_maximum
+          name: maximum
+    - id: am_azure_container_apps__cpu_percentage
+      title: Azure Container Apps CPU Percentage
+      context: cpu_percentage
+      family: CPU
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: container_apps.cpu_percentage_average
+          name: average
+        - selector: container_apps.cpu_percentage_maximum
+          name: maximum
+    - id: am_azure_container_apps__memory_working_set
+      title: Azure Container Apps Memory Working Set
+      context: memory_working_set
+      family: Memory
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: container_apps.working_set_bytes_average
+          name: average
+        - selector: container_apps.working_set_bytes_maximum
+          name: maximum
+    - id: am_azure_container_apps__memory_percentage
+      title: Azure Container Apps Memory Percentage
+      context: memory_percentage
+      family: Memory
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: container_apps.memory_percentage_average
+          name: average
+        - selector: container_apps.memory_percentage_maximum
+          name: maximum
+    - id: am_azure_container_apps__replicas
+      title: Azure Container Apps Replica Count
+      context: replicas
+      family: Scaling
+      type: line
+      units: replicas
+      algorithm: absolute
+      dimensions:
+        - selector: container_apps.replicas_average
+          name: average
+    - id: am_azure_container_apps__reserved_cores
+      title: Azure Container Apps Reserved Cores
+      context: reserved_cores
+      family: Scaling
+      type: line
+      units: cores
+      algorithm: absolute
+      dimensions:
+        - selector: container_apps.cores_quota_used_maximum
+          name: per_revision
+        - selector: container_apps.total_cores_quota_used_average
+          name: total
+    - id: am_azure_container_apps__restart_count
+      title: Azure Container Apps Replica Restarts
+      context: restart_count
+      family: Scaling
+      type: line
+      units: restarts/s
+      algorithm: incremental
+      dimensions:
+        - selector: container_apps.restart_count_total
+          name: restarts
+    - id: am_azure_container_apps__requests
+      title: Azure Container Apps Requests
+      context: requests
+      family: Requests
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: container_apps.requests_total
+          name: requests
+    - id: am_azure_container_apps__response_time
+      title: Azure Container Apps Response Time
+      context: response_time
+      family: Requests
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: container_apps.response_time_average
+          name: average
+    - id: am_azure_container_apps__network
+      title: Azure Container Apps Network Traffic
+      context: network
+      family: Network
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: container_apps.rx_bytes_total
+          name: received
+        - selector: container_apps.tx_bytes_total
+          name: sent
+    - id: am_azure_container_apps__resiliency_timeouts
+      title: Azure Container Apps Resiliency Timeouts
+      context: resiliency_timeouts
+      family: Resiliency
+      type: line
+      units: timeouts/s
+      algorithm: incremental
+      dimensions:
+        - selector: container_apps.resiliency_connect_timeouts_total
+          name: connection
+        - selector: container_apps.resiliency_request_timeouts_total
+          name: request
+    - id: am_azure_container_apps__resiliency_retries
+      title: Azure Container Apps Resiliency Request Retries
+      context: resiliency_retries
+      family: Resiliency
+      type: line
+      units: retries/s
+      algorithm: incremental
+      dimensions:
+        - selector: container_apps.resiliency_request_retries_total
+          name: retries
+    - id: am_azure_container_apps__resiliency_pending_connections
+      title: Azure Container Apps Resiliency Pending Connection Pool
+      context: resiliency_pending_connections
+      family: Resiliency
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: container_apps.resiliency_requests_pending_connection_pool_total
+          name: pending
+    - id: am_azure_container_apps__resiliency_ejections
+      title: Azure Container Apps Resiliency Host Ejections
+      context: resiliency_ejections
+      family: Resiliency
+      type: line
+      units: ejections/s
+      algorithm: incremental
+      dimensions:
+        - selector: container_apps.resiliency_ejected_hosts_total
+          name: ejected
+        - selector: container_apps.resiliency_ejections_aborted_total
+          name: aborted
+    - id: am_azure_container_apps__gpu_utilization
+      title: Azure Container Apps GPU Utilization
+      context: gpu_utilization
+      family: GPU
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: container_apps.gpu_utilization_percentage_average
+          name: average
+        - selector: container_apps.gpu_utilization_percentage_maximum
+          name: maximum
+    - id: am_azure_container_apps__jvm_buffer_count
+      title: Azure Container Apps JVM Buffer Count
+      context: jvm_buffer_count
+      family: JVM Buffers
+      type: line
+      units: buffers
+      algorithm: absolute
+      dimensions:
+        - selector: container_apps.jvm_buffer_count_average
+          name: average
+    - id: am_azure_container_apps__jvm_buffer_memory
+      title: Azure Container Apps JVM Buffer Memory
+      context: jvm_buffer_memory
+      family: JVM Buffers
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: container_apps.jvm_buffer_memory_usage_average
+          name: used
+        - selector: container_apps.jvm_buffer_memory_limit_average
+          name: limit
+    - id: am_azure_container_apps__jvm_gc_count
+      title: Azure Container Apps JVM Garbage Collections
+      context: jvm_gc_count
+      family: JVM GC
+      type: line
+      units: collections/s
+      algorithm: incremental
+      dimensions:
+        - selector: container_apps.jvm_gc_count_total
+          name: collections
+    - id: am_azure_container_apps__jvm_gc_duration
+      title: Azure Container Apps JVM GC Duration
+      context: jvm_gc_duration
+      family: JVM GC
+      type: line
+      units: milliseconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: container_apps.jvm_gc_duration_total
+          name: duration
+    - id: am_azure_container_apps__jvm_memory_pool
+      title: Azure Container Apps JVM Memory per Pool
+      context: jvm_memory_pool
+      family: JVM Memory
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: container_apps.jvm_memory_used_average
+          name: used
+        - selector: container_apps.jvm_memory_committed_average
+          name: committed
+        - selector: container_apps.jvm_memory_limit_average
+          name: limit
+    - id: am_azure_container_apps__jvm_memory_total
+      title: Azure Container Apps JVM Memory Total
+      context: jvm_memory_total
+      family: JVM Memory
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: container_apps.jvm_memory_total_used_average
+          name: used
+        - selector: container_apps.jvm_memory_total_committed_average
+          name: committed
+        - selector: container_apps.jvm_memory_total_limit_average
+          name: limit
+    - id: am_azure_container_apps__jvm_thread_count
+      title: Azure Container Apps JVM Thread Count
+      context: jvm_thread_count
+      family: JVM Threads
+      type: line
+      units: threads
+      algorithm: absolute
+      dimensions:
+        - selector: container_apps.jvm_thread_count_average
+          name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/container_instances.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/container_instances.yaml
@@ -3,81 +3,81 @@ id: container_instances
 name: Azure Container Instances
 resource_type: Microsoft.ContainerInstance/containerGroups
 metrics:
-- id: cpu_usage
-  azure_name: CpuUsage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: memory_usage
-  azure_name: MemoryUsage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: network_bytes_received_per_second
-  azure_name: NetworkBytesReceivedPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: network_bytes_transmitted_per_second
-  azure_name: NetworkBytesTransmittedPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: cpu_usage
+    azure_name: CpuUsage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: memory_usage
+    azure_name: MemoryUsage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: network_bytes_received_per_second
+    azure_name: NetworkBytesReceivedPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: network_bytes_transmitted_per_second
+    azure_name: NetworkBytesTransmittedPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Container Instances
   context_namespace: container_instances
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_container_instances__cpu_usage
-    title: Azure Container Instances CPU Usage
-    context: cpu_usage
-    family: CPU
-    type: line
-    units: millicores
-    algorithm: absolute
-    dimensions:
-    - selector: container_instances.cpu_usage_average
-      name: average
-    - selector: container_instances.cpu_usage_maximum
-      name: maximum
-  - id: am_azure_container_instances__memory_usage
-    title: Azure Container Instances Memory Usage
-    context: memory_usage
-    family: Memory
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: container_instances.memory_usage_average
-      name: average
-    - selector: container_instances.memory_usage_maximum
-      name: maximum
-  - id: am_azure_container_instances__network
-    title: Azure Container Instances Network Traffic
-    context: network
-    family: Network
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: container_instances.network_bytes_received_per_second_average
-      name: received
-    - selector: container_instances.network_bytes_transmitted_per_second_average
-      name: sent
+    - id: am_azure_container_instances__cpu_usage
+      title: Azure Container Instances CPU Usage
+      context: cpu_usage
+      family: CPU
+      type: line
+      units: millicores
+      algorithm: absolute
+      dimensions:
+        - selector: container_instances.cpu_usage_average
+          name: average
+        - selector: container_instances.cpu_usage_maximum
+          name: maximum
+    - id: am_azure_container_instances__memory_usage
+      title: Azure Container Instances Memory Usage
+      context: memory_usage
+      family: Memory
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: container_instances.memory_usage_average
+          name: average
+        - selector: container_instances.memory_usage_maximum
+          name: maximum
+    - id: am_azure_container_instances__network
+      title: Azure Container Instances Network Traffic
+      context: network
+      family: Network
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: container_instances.network_bytes_received_per_second_average
+          name: received
+        - selector: container_instances.network_bytes_transmitted_per_second_average
+          name: sent

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/container_registry.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/container_registry.yaml
@@ -3,113 +3,113 @@ id: container_registry
 name: Azure Container Registry
 resource_type: Microsoft.ContainerRegistry/registries
 metrics:
-- id: storage_used
-  azure_name: StorageUsed
-  time_grain: PT1H
-  series:
-  - aggregation: average
-    kind: gauge
-- id: successful_pull_count
-  azure_name: SuccessfulPullCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: successful_push_count
-  azure_name: SuccessfulPushCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: total_pull_count
-  azure_name: TotalPullCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: total_push_count
-  azure_name: TotalPushCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: agent_pool_cpu_time
-  azure_name: AgentPoolCPUTime
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: run_duration
-  azure_name: RunDuration
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
+  - id: storage_used
+    azure_name: StorageUsed
+    time_grain: PT1H
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: successful_pull_count
+    azure_name: SuccessfulPullCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: successful_push_count
+    azure_name: SuccessfulPushCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: total_pull_count
+    azure_name: TotalPullCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: total_push_count
+    azure_name: TotalPushCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: agent_pool_cpu_time
+    azure_name: AgentPoolCPUTime
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: run_duration
+    azure_name: RunDuration
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
 template:
   family: Azure Container Registry
   context_namespace: container_registry
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_container_registry__storage_used
-    title: Azure Container Registry Storage Used
-    context: storage_used
-    family: Storage
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: container_registry.storage_used_average
-      name: used
-  - id: am_azure_container_registry__pull_count
-    title: Azure Container Registry Image Pulls
-    context: pull_count
-    family: Operations
-    type: line
-    units: pulls/s
-    algorithm: incremental
-    dimensions:
-    - selector: container_registry.successful_pull_count_total
-      name: successful
-    - selector: container_registry.total_pull_count_total
-      name: total
-  - id: am_azure_container_registry__push_count
-    title: Azure Container Registry Image Pushes
-    context: push_count
-    family: Operations
-    type: line
-    units: pushes/s
-    algorithm: incremental
-    dimensions:
-    - selector: container_registry.successful_push_count_total
-      name: successful
-    - selector: container_registry.total_push_count_total
-      name: total
-  - id: am_azure_container_registry__agentpool_cpu_time
-    title: Azure Container Registry AgentPool CPU Time
-    context: agentpool_cpu_time
-    family: Tasks
-    type: line
-    units: seconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: container_registry.agent_pool_cpu_time_total
-      name: cpu_time
-  - id: am_azure_container_registry__run_duration
-    title: Azure Container Registry Task Run Duration
-    context: run_duration
-    family: Tasks
-    type: line
-    units: milliseconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: container_registry.run_duration_total
-      name: duration
+    - id: am_azure_container_registry__storage_used
+      title: Azure Container Registry Storage Used
+      context: storage_used
+      family: Storage
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: container_registry.storage_used_average
+          name: used
+    - id: am_azure_container_registry__pull_count
+      title: Azure Container Registry Image Pulls
+      context: pull_count
+      family: Operations
+      type: line
+      units: pulls/s
+      algorithm: incremental
+      dimensions:
+        - selector: container_registry.successful_pull_count_total
+          name: successful
+        - selector: container_registry.total_pull_count_total
+          name: total
+    - id: am_azure_container_registry__push_count
+      title: Azure Container Registry Image Pushes
+      context: push_count
+      family: Operations
+      type: line
+      units: pushes/s
+      algorithm: incremental
+      dimensions:
+        - selector: container_registry.successful_push_count_total
+          name: successful
+        - selector: container_registry.total_push_count_total
+          name: total
+    - id: am_azure_container_registry__agentpool_cpu_time
+      title: Azure Container Registry AgentPool CPU Time
+      context: agentpool_cpu_time
+      family: Tasks
+      type: line
+      units: seconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: container_registry.agent_pool_cpu_time_total
+          name: cpu_time
+    - id: am_azure_container_registry__run_duration
+      title: Azure Container Registry Task Run Duration
+      context: run_duration
+      family: Tasks
+      type: line
+      units: milliseconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: container_registry.run_duration_total
+          name: duration

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/cosmos_db.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/cosmos_db.yaml
@@ -3,417 +3,417 @@ id: cosmos_db
 name: Azure Cosmos DB Account
 resource_type: Microsoft.DocumentDB/databaseAccounts
 metrics:
-- id: total_requests
-  azure_name: TotalRequests
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: total_request_units
-  azure_name: TotalRequestUnits
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: normalized_ru_consumption
-  azure_name: NormalizedRUConsumption
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: metadata_requests
-  azure_name: MetadataRequests
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: server_side_latency_direct
-  azure_name: ServerSideLatencyDirect
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: server_side_latency_gateway
-  azure_name: ServerSideLatencyGateway
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: replication_latency
-  azure_name: ReplicationLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_usage
-  azure_name: DataUsage
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: index_usage
-  azure_name: IndexUsage
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: document_quota
-  azure_name: DocumentQuota
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: document_count
-  azure_name: DocumentCount
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: physical_partition_size_info
-  azure_name: PhysicalPartitionSizeInfo
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: physical_partition_count
-  azure_name: PhysicalPartitionCount
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: physical_partition_throughput_info
-  azure_name: PhysicalPartitionThroughputInfo
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: autoscaled_ru
-  azure_name: AutoscaledRU
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: provisioned_throughput
-  azure_name: ProvisionedThroughput
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: autoscale_max_throughput
-  azure_name: AutoscaleMaxThroughput
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: service_availability
-  azure_name: ServiceAvailability
-  time_grain: PT1H
-  series:
-  - aggregation: average
-    kind: gauge
-- id: mongo_requests
-  azure_name: MongoRequests
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: cassandra_requests
-  azure_name: CassandraRequests
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: gremlin_requests
-  azure_name: GremlinRequests
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: mongo_request_charge
-  azure_name: MongoRequestCharge
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: cassandra_request_charges
-  azure_name: CassandraRequestCharges
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: gremlin_request_charges
-  azure_name: GremlinRequestCharges
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: dedicated_gateway_cpu_usage
-  azure_name: DedicatedGatewayCPUUsage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: dedicated_gateway_memory_usage
-  azure_name: DedicatedGatewayMemoryUsage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: dedicated_gateway_requests
-  azure_name: DedicatedGatewayRequests
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: integrated_cache_item_hit_rate
-  azure_name: IntegratedCacheItemHitRate
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: integrated_cache_query_hit_rate
-  azure_name: IntegratedCacheQueryHitRate
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cassandra_connection_closures
-  azure_name: CassandraConnectionClosures
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
+  - id: total_requests
+    azure_name: TotalRequests
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: total_request_units
+    azure_name: TotalRequestUnits
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: normalized_ru_consumption
+    azure_name: NormalizedRUConsumption
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: metadata_requests
+    azure_name: MetadataRequests
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: server_side_latency_direct
+    azure_name: ServerSideLatencyDirect
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: server_side_latency_gateway
+    azure_name: ServerSideLatencyGateway
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: replication_latency
+    azure_name: ReplicationLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_usage
+    azure_name: DataUsage
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: index_usage
+    azure_name: IndexUsage
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: document_quota
+    azure_name: DocumentQuota
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: document_count
+    azure_name: DocumentCount
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: physical_partition_size_info
+    azure_name: PhysicalPartitionSizeInfo
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: physical_partition_count
+    azure_name: PhysicalPartitionCount
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: physical_partition_throughput_info
+    azure_name: PhysicalPartitionThroughputInfo
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: autoscaled_ru
+    azure_name: AutoscaledRU
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: provisioned_throughput
+    azure_name: ProvisionedThroughput
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: autoscale_max_throughput
+    azure_name: AutoscaleMaxThroughput
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: service_availability
+    azure_name: ServiceAvailability
+    time_grain: PT1H
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: mongo_requests
+    azure_name: MongoRequests
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: cassandra_requests
+    azure_name: CassandraRequests
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: gremlin_requests
+    azure_name: GremlinRequests
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: mongo_request_charge
+    azure_name: MongoRequestCharge
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: cassandra_request_charges
+    azure_name: CassandraRequestCharges
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: gremlin_request_charges
+    azure_name: GremlinRequestCharges
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: dedicated_gateway_cpu_usage
+    azure_name: DedicatedGatewayCPUUsage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: dedicated_gateway_memory_usage
+    azure_name: DedicatedGatewayMemoryUsage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: dedicated_gateway_requests
+    azure_name: DedicatedGatewayRequests
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: integrated_cache_item_hit_rate
+    azure_name: IntegratedCacheItemHitRate
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: integrated_cache_query_hit_rate
+    azure_name: IntegratedCacheQueryHitRate
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cassandra_connection_closures
+    azure_name: CassandraConnectionClosures
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
 template:
   family: Azure Cosmos DB Account
   context_namespace: cosmos_db
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_cosmos_db__total_requests
-    title: Azure Cosmos DB Total Requests
-    context: total_requests
-    family: Throughput
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: cosmos_db.total_requests_count
-      name: count
-  - id: am_azure_cosmos_db__request_units
-    title: Azure Cosmos DB Request Units Consumed
-    context: request_units
-    family: Throughput
-    type: line
-    units: RU/s
-    algorithm: incremental
-    dimensions:
-    - selector: cosmos_db.total_request_units_total
-      name: total
-  - id: am_azure_cosmos_db__normalized_ru_consumption
-    title: Azure Cosmos DB Normalized RU Consumption
-    context: normalized_ru_consumption
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: cosmos_db.normalized_ru_consumption_maximum
-      name: maximum
-  - id: am_azure_cosmos_db__server_side_latency
-    title: Azure Cosmos DB Server-Side Latency
-    context: server_side_latency
-    family: Latency
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: cosmos_db.server_side_latency_direct_average
-      name: direct
-    - selector: cosmos_db.server_side_latency_gateway_average
-      name: gateway
-  - id: am_azure_cosmos_db__replication_latency
-    title: Azure Cosmos DB Replication Latency
-    context: replication_latency
-    family: Latency
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: cosmos_db.replication_latency_average
-      name: average
-  - id: am_azure_cosmos_db__storage
-    title: Azure Cosmos DB Storage
-    context: storage
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: cosmos_db.data_usage_maximum
-      name: data
-    - selector: cosmos_db.index_usage_maximum
-      name: index
-    - selector: cosmos_db.document_quota_total
-      name: quota
-  - id: am_azure_cosmos_db__document_count
-    title: Azure Cosmos DB Document Count
-    context: document_count
-    family: Capacity
-    type: line
-    units: documents
-    algorithm: absolute
-    dimensions:
-    - selector: cosmos_db.document_count_average
-      name: average
-  - id: am_azure_cosmos_db__partition_size
-    title: Azure Cosmos DB Physical Partition Size
-    context: partition_size
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: cosmos_db.physical_partition_size_info_maximum
-      name: maximum
-  - id: am_azure_cosmos_db__partition_count
-    title: Azure Cosmos DB Physical Partition Count
-    context: partition_count
-    family: Capacity
-    type: line
-    units: partitions
-    algorithm: absolute
-    dimensions:
-    - selector: cosmos_db.physical_partition_count_maximum
-      name: maximum
-  - id: am_azure_cosmos_db__provisioned_throughput
-    title: Azure Cosmos DB Provisioned Throughput
-    context: provisioned_throughput
-    family: Throughput
-    type: line
-    units: RU/s
-    algorithm: absolute
-    dimensions:
-    - selector: cosmos_db.provisioned_throughput_maximum
-      name: provisioned
-    - selector: cosmos_db.autoscale_max_throughput_maximum
-      name: autoscale_max
-    - selector: cosmos_db.autoscaled_ru_maximum
-      name: autoscaled
-  - id: am_azure_cosmos_db__partition_throughput
-    title: Azure Cosmos DB Physical Partition Throughput
-    context: partition_throughput
-    family: Throughput
-    type: line
-    units: RU/s
-    algorithm: absolute
-    dimensions:
-    - selector: cosmos_db.physical_partition_throughput_info_maximum
-      name: maximum
-  - id: am_azure_cosmos_db__availability
-    title: Azure Cosmos DB Service Availability
-    context: availability
-    family: Availability
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: cosmos_db.service_availability_average
-      name: average
-  - id: am_azure_cosmos_db__metadata_requests
-    title: Azure Cosmos DB Metadata Requests
-    context: metadata_requests
-    family: Throughput
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: cosmos_db.metadata_requests_count
-      name: count
-  - id: am_azure_cosmos_db__api_requests
-    title: Azure Cosmos DB API Requests
-    context: api_requests
-    family: API
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: cosmos_db.mongo_requests_count
-      name: mongo
-    - selector: cosmos_db.cassandra_requests_count
-      name: cassandra
-    - selector: cosmos_db.gremlin_requests_count
-      name: gremlin
-  - id: am_azure_cosmos_db__api_request_charges
-    title: Azure Cosmos DB API Request Charges
-    context: api_request_charges
-    family: API
-    type: line
-    units: RU/s
-    algorithm: incremental
-    dimensions:
-    - selector: cosmos_db.mongo_request_charge_total
-      name: mongo
-    - selector: cosmos_db.cassandra_request_charges_total
-      name: cassandra
-    - selector: cosmos_db.gremlin_request_charges_total
-      name: gremlin
-  - id: am_azure_cosmos_db__cassandra_connections
-    title: Azure Cosmos DB Cassandra Connection Closures
-    context: cassandra_connections
-    family: API
-    type: line
-    units: connections/s
-    algorithm: incremental
-    dimensions:
-    - selector: cosmos_db.cassandra_connection_closures_total
-      name: total
-  - id: am_azure_cosmos_db__dedicated_gateway_cpu
-    title: Azure Cosmos DB Dedicated Gateway CPU Usage
-    context: dedicated_gateway_cpu
-    family: Dedicated Gateway
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: cosmos_db.dedicated_gateway_cpu_usage_average
-      name: average
-  - id: am_azure_cosmos_db__dedicated_gateway_memory
-    title: Azure Cosmos DB Dedicated Gateway Memory Usage
-    context: dedicated_gateway_memory
-    family: Dedicated Gateway
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: cosmos_db.dedicated_gateway_memory_usage_average
-      name: average
-  - id: am_azure_cosmos_db__dedicated_gateway_requests
-    title: Azure Cosmos DB Dedicated Gateway Requests
-    context: dedicated_gateway_requests
-    family: Dedicated Gateway
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: cosmos_db.dedicated_gateway_requests_count
-      name: count
-  - id: am_azure_cosmos_db__integrated_cache_hit_rate
-    title: Azure Cosmos DB Integrated Cache Hit Rate
-    context: integrated_cache_hit_rate
-    family: Integrated Cache
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: cosmos_db.integrated_cache_item_hit_rate_average
-      name: item
-    - selector: cosmos_db.integrated_cache_query_hit_rate_average
-      name: query
+    - id: am_azure_cosmos_db__total_requests
+      title: Azure Cosmos DB Total Requests
+      context: total_requests
+      family: Throughput
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: cosmos_db.total_requests_count
+          name: count
+    - id: am_azure_cosmos_db__request_units
+      title: Azure Cosmos DB Request Units Consumed
+      context: request_units
+      family: Throughput
+      type: line
+      units: RU/s
+      algorithm: incremental
+      dimensions:
+        - selector: cosmos_db.total_request_units_total
+          name: total
+    - id: am_azure_cosmos_db__normalized_ru_consumption
+      title: Azure Cosmos DB Normalized RU Consumption
+      context: normalized_ru_consumption
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: cosmos_db.normalized_ru_consumption_maximum
+          name: maximum
+    - id: am_azure_cosmos_db__server_side_latency
+      title: Azure Cosmos DB Server-Side Latency
+      context: server_side_latency
+      family: Latency
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: cosmos_db.server_side_latency_direct_average
+          name: direct
+        - selector: cosmos_db.server_side_latency_gateway_average
+          name: gateway
+    - id: am_azure_cosmos_db__replication_latency
+      title: Azure Cosmos DB Replication Latency
+      context: replication_latency
+      family: Latency
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: cosmos_db.replication_latency_average
+          name: average
+    - id: am_azure_cosmos_db__storage
+      title: Azure Cosmos DB Storage
+      context: storage
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: cosmos_db.data_usage_maximum
+          name: data
+        - selector: cosmos_db.index_usage_maximum
+          name: index
+        - selector: cosmos_db.document_quota_total
+          name: quota
+    - id: am_azure_cosmos_db__document_count
+      title: Azure Cosmos DB Document Count
+      context: document_count
+      family: Capacity
+      type: line
+      units: documents
+      algorithm: absolute
+      dimensions:
+        - selector: cosmos_db.document_count_average
+          name: average
+    - id: am_azure_cosmos_db__partition_size
+      title: Azure Cosmos DB Physical Partition Size
+      context: partition_size
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: cosmos_db.physical_partition_size_info_maximum
+          name: maximum
+    - id: am_azure_cosmos_db__partition_count
+      title: Azure Cosmos DB Physical Partition Count
+      context: partition_count
+      family: Capacity
+      type: line
+      units: partitions
+      algorithm: absolute
+      dimensions:
+        - selector: cosmos_db.physical_partition_count_maximum
+          name: maximum
+    - id: am_azure_cosmos_db__provisioned_throughput
+      title: Azure Cosmos DB Provisioned Throughput
+      context: provisioned_throughput
+      family: Throughput
+      type: line
+      units: RU/s
+      algorithm: absolute
+      dimensions:
+        - selector: cosmos_db.provisioned_throughput_maximum
+          name: provisioned
+        - selector: cosmos_db.autoscale_max_throughput_maximum
+          name: autoscale_max
+        - selector: cosmos_db.autoscaled_ru_maximum
+          name: autoscaled
+    - id: am_azure_cosmos_db__partition_throughput
+      title: Azure Cosmos DB Physical Partition Throughput
+      context: partition_throughput
+      family: Throughput
+      type: line
+      units: RU/s
+      algorithm: absolute
+      dimensions:
+        - selector: cosmos_db.physical_partition_throughput_info_maximum
+          name: maximum
+    - id: am_azure_cosmos_db__availability
+      title: Azure Cosmos DB Service Availability
+      context: availability
+      family: Availability
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: cosmos_db.service_availability_average
+          name: average
+    - id: am_azure_cosmos_db__metadata_requests
+      title: Azure Cosmos DB Metadata Requests
+      context: metadata_requests
+      family: Throughput
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: cosmos_db.metadata_requests_count
+          name: count
+    - id: am_azure_cosmos_db__api_requests
+      title: Azure Cosmos DB API Requests
+      context: api_requests
+      family: API
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: cosmos_db.mongo_requests_count
+          name: mongo
+        - selector: cosmos_db.cassandra_requests_count
+          name: cassandra
+        - selector: cosmos_db.gremlin_requests_count
+          name: gremlin
+    - id: am_azure_cosmos_db__api_request_charges
+      title: Azure Cosmos DB API Request Charges
+      context: api_request_charges
+      family: API
+      type: line
+      units: RU/s
+      algorithm: incremental
+      dimensions:
+        - selector: cosmos_db.mongo_request_charge_total
+          name: mongo
+        - selector: cosmos_db.cassandra_request_charges_total
+          name: cassandra
+        - selector: cosmos_db.gremlin_request_charges_total
+          name: gremlin
+    - id: am_azure_cosmos_db__cassandra_connections
+      title: Azure Cosmos DB Cassandra Connection Closures
+      context: cassandra_connections
+      family: API
+      type: line
+      units: connections/s
+      algorithm: incremental
+      dimensions:
+        - selector: cosmos_db.cassandra_connection_closures_total
+          name: total
+    - id: am_azure_cosmos_db__dedicated_gateway_cpu
+      title: Azure Cosmos DB Dedicated Gateway CPU Usage
+      context: dedicated_gateway_cpu
+      family: Dedicated Gateway
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: cosmos_db.dedicated_gateway_cpu_usage_average
+          name: average
+    - id: am_azure_cosmos_db__dedicated_gateway_memory
+      title: Azure Cosmos DB Dedicated Gateway Memory Usage
+      context: dedicated_gateway_memory
+      family: Dedicated Gateway
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: cosmos_db.dedicated_gateway_memory_usage_average
+          name: average
+    - id: am_azure_cosmos_db__dedicated_gateway_requests
+      title: Azure Cosmos DB Dedicated Gateway Requests
+      context: dedicated_gateway_requests
+      family: Dedicated Gateway
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: cosmos_db.dedicated_gateway_requests_count
+          name: count
+    - id: am_azure_cosmos_db__integrated_cache_hit_rate
+      title: Azure Cosmos DB Integrated Cache Hit Rate
+      context: integrated_cache_hit_rate
+      family: Integrated Cache
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: cosmos_db.integrated_cache_item_hit_rate_average
+          name: item
+        - selector: cosmos_db.integrated_cache_query_hit_rate_average
+          name: query

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/data_explorer.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/data_explorer.yaml
@@ -3,781 +3,781 @@ id: data_explorer
 name: Azure Data Explorer Cluster
 resource_type: Microsoft.Kusto/clusters
 metrics:
-- id: cpu
-  azure_name: CPU
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: ingestion_utilization
-  azure_name: IngestionUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cache_utilization_factor
-  azure_name: CacheUtilizationFactor
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: keep_alive
-  azure_name: KeepAlive
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: instance_count
-  azure_name: InstanceCount
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-  - aggregation: minimum
-    kind: gauge
-- id: total_number_of_extents
-  azure_name: TotalNumberOfExtents
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: total_number_of_throttled_commands
-  azure_name: TotalNumberOfThrottledCommands
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: follower_latency
-  azure_name: FollowerLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: query_duration
-  azure_name: QueryDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: query_result
-  azure_name: QueryResult
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: total_number_of_concurrent_queries
-  azure_name: TotalNumberOfConcurrentQueries
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: total_number_of_throttled_queries
-  azure_name: TotalNumberOfThrottledQueries
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: weak_consistency_latency
-  azure_name: WeakConsistencyLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: ingestion_result
-  azure_name: IngestionResult
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ingestion_volume_in_mb
-  azure_name: IngestionVolumeInMB
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ingestion_latency_in_seconds
-  azure_name: IngestionLatencyInSeconds
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: events_processed
-  azure_name: EventsProcessed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: events_received
-  azure_name: EventsReceived
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: events_dropped
-  azure_name: EventsDropped
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: blobs_processed
-  azure_name: BlobsProcessed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: blobs_received
-  azure_name: BlobsReceived
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: blobs_dropped
-  azure_name: BlobsDropped
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: discovery_latency
-  azure_name: DiscoveryLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: stage_latency
-  azure_name: StageLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: queue_length
-  azure_name: QueueLength
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: queue_oldest_message
-  azure_name: QueueOldestMessage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: received_data_size_bytes
-  azure_name: ReceivedDataSizeBytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: batches_processed
-  azure_name: BatchesProcessed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: batch_blob_count
-  azure_name: BatchBlobCount
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: batch_size
-  azure_name: BatchSize
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: batch_duration
-  azure_name: BatchDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: export_utilization
-  azure_name: ExportUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: continuous_export_num_of_records_exported
-  azure_name: ContinuousExportNumOfRecordsExported
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: continuous_export_result
-  azure_name: ContinuousExportResult
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: continuous_export_pending_count
-  azure_name: ContinuousExportPendingCount
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: continuous_export_max_lateness_minutes
-  azure_name: ContinuousExportMaxLatenessMinutes
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: streaming_ingest_data_rate
-  azure_name: StreamingIngestDataRate
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: streaming_ingest_duration
-  azure_name: StreamingIngestDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: streaming_ingest_results
-  azure_name: StreamingIngestResults
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: streaming_ingest_utilization
-  azure_name: StreamingIngestUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: materialized_view_health
-  azure_name: MaterializedViewHealth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: materialized_view_age_minutes
-  azure_name: MaterializedViewAgeMinutes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: materialized_view_age_seconds
-  azure_name: MaterializedViewAgeSeconds
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: materialized_view_records_in_delta
-  azure_name: MaterializedViewRecordsInDelta
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: materialized_view_extents_rebuild
-  azure_name: MaterializedViewExtentsRebuild
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: materialized_view_data_loss
-  azure_name: MaterializedViewDataLoss
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: materialized_view_result
-  azure_name: MaterializedViewResult
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: partitioning_percentage
-  azure_name: PartitioningPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: partitioning_percentage_hot
-  azure_name: PartitioningPercentageHot
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: processed_partitioned_records
-  azure_name: ProcessedPartitionedRecords
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: cpu
+    azure_name: CPU
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: ingestion_utilization
+    azure_name: IngestionUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cache_utilization_factor
+    azure_name: CacheUtilizationFactor
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: keep_alive
+    azure_name: KeepAlive
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: instance_count
+    azure_name: InstanceCount
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+      - aggregation: minimum
+        kind: gauge
+  - id: total_number_of_extents
+    azure_name: TotalNumberOfExtents
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: total_number_of_throttled_commands
+    azure_name: TotalNumberOfThrottledCommands
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: follower_latency
+    azure_name: FollowerLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: query_duration
+    azure_name: QueryDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: query_result
+    azure_name: QueryResult
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: total_number_of_concurrent_queries
+    azure_name: TotalNumberOfConcurrentQueries
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: total_number_of_throttled_queries
+    azure_name: TotalNumberOfThrottledQueries
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: weak_consistency_latency
+    azure_name: WeakConsistencyLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: ingestion_result
+    azure_name: IngestionResult
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ingestion_volume_in_mb
+    azure_name: IngestionVolumeInMB
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ingestion_latency_in_seconds
+    azure_name: IngestionLatencyInSeconds
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: events_processed
+    azure_name: EventsProcessed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: events_received
+    azure_name: EventsReceived
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: events_dropped
+    azure_name: EventsDropped
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: blobs_processed
+    azure_name: BlobsProcessed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: blobs_received
+    azure_name: BlobsReceived
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: blobs_dropped
+    azure_name: BlobsDropped
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: discovery_latency
+    azure_name: DiscoveryLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: stage_latency
+    azure_name: StageLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: queue_length
+    azure_name: QueueLength
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: queue_oldest_message
+    azure_name: QueueOldestMessage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: received_data_size_bytes
+    azure_name: ReceivedDataSizeBytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: batches_processed
+    azure_name: BatchesProcessed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: batch_blob_count
+    azure_name: BatchBlobCount
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: batch_size
+    azure_name: BatchSize
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: batch_duration
+    azure_name: BatchDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: export_utilization
+    azure_name: ExportUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: continuous_export_num_of_records_exported
+    azure_name: ContinuousExportNumOfRecordsExported
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: continuous_export_result
+    azure_name: ContinuousExportResult
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: continuous_export_pending_count
+    azure_name: ContinuousExportPendingCount
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: continuous_export_max_lateness_minutes
+    azure_name: ContinuousExportMaxLatenessMinutes
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: streaming_ingest_data_rate
+    azure_name: StreamingIngestDataRate
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: streaming_ingest_duration
+    azure_name: StreamingIngestDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: streaming_ingest_results
+    azure_name: StreamingIngestResults
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: streaming_ingest_utilization
+    azure_name: StreamingIngestUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: materialized_view_health
+    azure_name: MaterializedViewHealth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: materialized_view_age_minutes
+    azure_name: MaterializedViewAgeMinutes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: materialized_view_age_seconds
+    azure_name: MaterializedViewAgeSeconds
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: materialized_view_records_in_delta
+    azure_name: MaterializedViewRecordsInDelta
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: materialized_view_extents_rebuild
+    azure_name: MaterializedViewExtentsRebuild
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: materialized_view_data_loss
+    azure_name: MaterializedViewDataLoss
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: materialized_view_result
+    azure_name: MaterializedViewResult
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: partitioning_percentage
+    azure_name: PartitioningPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: partitioning_percentage_hot
+    azure_name: PartitioningPercentageHot
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: processed_partitioned_records
+    azure_name: ProcessedPartitionedRecords
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Data Explorer Cluster
   context_namespace: data_explorer
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_data_explorer__cpu_utilization
-    title: Azure Data Explorer CPU Utilization
-    context: cpu_utilization
-    family: Compute
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.cpu_average
-      name: average
-  - id: am_azure_data_explorer__utilization
-    title: Azure Data Explorer Utilization
-    context: utilization
-    family: Compute
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.ingestion_utilization_average
-      name: ingestion
-    - selector: data_explorer.cache_utilization_factor_average
-      name: cache
-  - id: am_azure_data_explorer__keep_alive
-    title: Azure Data Explorer Keep Alive
-    context: keep_alive
-    family: Compute
-    type: line
-    units: count
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.keep_alive_average
-      name: average
-  - id: am_azure_data_explorer__instance_count
-    title: Azure Data Explorer Instance Count
-    context: instance_count
-    family: Compute
-    type: line
-    units: instances
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.instance_count_average
-      name: average
-    - selector: data_explorer.instance_count_maximum
-      name: maximum
-    - selector: data_explorer.instance_count_minimum
-      name: minimum
-  - id: am_azure_data_explorer__extents
-    title: Azure Data Explorer Total Extents
-    context: extents
-    family: Compute
-    type: line
-    units: extents
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.total_number_of_extents_average
-      name: average
-  - id: am_azure_data_explorer__throttled_commands
-    title: Azure Data Explorer Throttled Commands
-    context: throttled_commands
-    family: Compute
-    type: line
-    units: commands/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_explorer.total_number_of_throttled_commands_total
-      name: total
-  - id: am_azure_data_explorer__follower_latency
-    title: Azure Data Explorer Follower Latency
-    context: follower_latency
-    family: Compute
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.follower_latency_average
-      name: average
-  - id: am_azure_data_explorer__query_duration
-    title: Azure Data Explorer Query Duration
-    context: query_duration
-    family: Query
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.query_duration_average
-      name: average
-  - id: am_azure_data_explorer__query_count
-    title: Azure Data Explorer Query Count
-    context: query_count
-    family: Query
-    type: line
-    units: queries/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_explorer.query_result_count
-      name: count
-  - id: am_azure_data_explorer__concurrent_queries
-    title: Azure Data Explorer Concurrent Queries
-    context: concurrent_queries
-    family: Query
-    type: line
-    units: queries
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.total_number_of_concurrent_queries_average
-      name: average
-    - selector: data_explorer.total_number_of_concurrent_queries_maximum
-      name: maximum
-  - id: am_azure_data_explorer__throttled_queries
-    title: Azure Data Explorer Throttled Queries
-    context: throttled_queries
-    family: Query
-    type: line
-    units: queries/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_explorer.total_number_of_throttled_queries_total
-      name: total
-  - id: am_azure_data_explorer__weak_consistency_latency
-    title: Azure Data Explorer Weak Consistency Latency
-    context: weak_consistency_latency
-    family: Query
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.weak_consistency_latency_average
-      name: average
-  - id: am_azure_data_explorer__ingestion_result
-    title: Azure Data Explorer Ingestion Result
-    context: ingestion_result
-    family: Ingestion
-    type: line
-    units: sources/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_explorer.ingestion_result_total
-      name: total
-  - id: am_azure_data_explorer__ingestion_volume
-    title: Azure Data Explorer Ingestion Volume
-    context: ingestion_volume
-    family: Ingestion
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_explorer.ingestion_volume_in_mb_total
-      name: total
-  - id: am_azure_data_explorer__ingestion_latency
-    title: Azure Data Explorer Ingestion Latency
-    context: ingestion_latency
-    family: Ingestion
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.ingestion_latency_in_seconds_average
-      name: average
-  - id: am_azure_data_explorer__events
-    title: Azure Data Explorer Events
-    context: events
-    family: Ingestion
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_explorer.events_received_total
-      name: received
-    - selector: data_explorer.events_processed_total
-      name: processed
-    - selector: data_explorer.events_dropped_total
-      name: dropped
-  - id: am_azure_data_explorer__blobs
-    title: Azure Data Explorer Blobs
-    context: blobs
-    family: Ingestion
-    type: line
-    units: blobs/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_explorer.blobs_received_total
-      name: received
-    - selector: data_explorer.blobs_processed_total
-      name: processed
-    - selector: data_explorer.blobs_dropped_total
-      name: dropped
-  - id: am_azure_data_explorer__discovery_latency
-    title: Azure Data Explorer Discovery Latency
-    context: discovery_latency
-    family: Ingestion
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.discovery_latency_average
-      name: average
-  - id: am_azure_data_explorer__stage_latency
-    title: Azure Data Explorer Stage Latency
-    context: stage_latency
-    family: Ingestion
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.stage_latency_average
-      name: average
-  - id: am_azure_data_explorer__ingestion_queue
-    title: Azure Data Explorer Ingestion Queue
-    context: ingestion_queue
-    family: Ingestion
-    type: line
-    units: messages
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.queue_length_average
-      name: length
-  - id: am_azure_data_explorer__queue_oldest_message
-    title: Azure Data Explorer Queue Oldest Message Age
-    context: queue_oldest_message
-    family: Ingestion
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.queue_oldest_message_average
-      name: age
-  - id: am_azure_data_explorer__received_data_size
-    title: Azure Data Explorer Received Data Size
-    context: received_data_size
-    family: Ingestion
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_explorer.received_data_size_bytes_total
-      name: total
-  - id: am_azure_data_explorer__batches_processed
-    title: Azure Data Explorer Batches Processed
-    context: batches_processed
-    family: Ingestion
-    type: line
-    units: batches/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_explorer.batches_processed_total
-      name: total
-  - id: am_azure_data_explorer__batch_blob_count
-    title: Azure Data Explorer Batch Blob Count
-    context: batch_blob_count
-    family: Ingestion
-    type: line
-    units: blobs
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.batch_blob_count_average
-      name: average
-  - id: am_azure_data_explorer__batch_size
-    title: Azure Data Explorer Batch Size
-    context: batch_size
-    family: Ingestion
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.batch_size_average
-      name: average
-  - id: am_azure_data_explorer__batch_duration
-    title: Azure Data Explorer Batch Duration
-    context: batch_duration
-    family: Ingestion
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.batch_duration_average
-      name: average
-  - id: am_azure_data_explorer__export_utilization
-    title: Azure Data Explorer Export Utilization
-    context: export_utilization
-    family: Export
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.export_utilization_maximum
-      name: maximum
-  - id: am_azure_data_explorer__continuous_export_records
-    title: Azure Data Explorer Continuous Export Records
-    context: continuous_export_records
-    family: Export
-    type: line
-    units: records/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_explorer.continuous_export_num_of_records_exported_total
-      name: total
-  - id: am_azure_data_explorer__continuous_export_result
-    title: Azure Data Explorer Continuous Export Result
-    context: continuous_export_result
-    family: Export
-    type: line
-    units: results/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_explorer.continuous_export_result_count
-      name: count
-  - id: am_azure_data_explorer__continuous_export_pending
-    title: Azure Data Explorer Continuous Export Pending Jobs
-    context: continuous_export_pending
-    family: Export
-    type: line
-    units: jobs
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.continuous_export_pending_count_maximum
-      name: maximum
-  - id: am_azure_data_explorer__continuous_export_lateness
-    title: Azure Data Explorer Continuous Export Lateness
-    context: continuous_export_lateness
-    family: Export
-    type: line
-    units: minutes
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.continuous_export_max_lateness_minutes_maximum
-      name: maximum
-  - id: am_azure_data_explorer__streaming_ingest_data_rate
-    title: Azure Data Explorer Streaming Ingest Data Rate
-    context: streaming_ingest_data_rate
-    family: Streaming
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.streaming_ingest_data_rate_average
-      name: average
-  - id: am_azure_data_explorer__streaming_ingest_duration
-    title: Azure Data Explorer Streaming Ingest Duration
-    context: streaming_ingest_duration
-    family: Streaming
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.streaming_ingest_duration_average
-      name: average
-  - id: am_azure_data_explorer__streaming_ingest_result
-    title: Azure Data Explorer Streaming Ingest Result
-    context: streaming_ingest_result
-    family: Streaming
-    type: line
-    units: results/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_explorer.streaming_ingest_results_count
-      name: count
-  - id: am_azure_data_explorer__streaming_ingest_utilization
-    title: Azure Data Explorer Streaming Ingest Utilization
-    context: streaming_ingest_utilization
-    family: Streaming
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.streaming_ingest_utilization_average
-      name: average
-  - id: am_azure_data_explorer__materialized_view_health
-    title: Azure Data Explorer Materialized View Health
-    context: materialized_view_health
-    family: Materialized Views
-    type: line
-    units: status
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.materialized_view_health_average
-      name: health
-  - id: am_azure_data_explorer__materialized_view_age
-    title: Azure Data Explorer Materialized View Age
-    context: materialized_view_age
-    family: Materialized Views
-    type: line
-    units: minutes
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.materialized_view_age_minutes_average
-      name: minutes
-  - id: am_azure_data_explorer__materialized_view_age_seconds
-    title: Azure Data Explorer Materialized View Age (Seconds)
-    context: materialized_view_age_seconds
-    family: Materialized Views
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.materialized_view_age_seconds_average
-      name: average
-  - id: am_azure_data_explorer__materialized_view_records_in_delta
-    title: Azure Data Explorer Materialized View Records in Delta
-    context: materialized_view_records_in_delta
-    family: Materialized Views
-    type: line
-    units: records
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.materialized_view_records_in_delta_average
-      name: average
-  - id: am_azure_data_explorer__materialized_view_extents_rebuild
-    title: Azure Data Explorer Materialized View Extents Rebuild
-    context: materialized_view_extents_rebuild
-    family: Materialized Views
-    type: line
-    units: extents
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.materialized_view_extents_rebuild_average
-      name: average
-  - id: am_azure_data_explorer__materialized_view_data_loss
-    title: Azure Data Explorer Materialized View Data Loss
-    context: materialized_view_data_loss
-    family: Materialized Views
-    type: line
-    units: status
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.materialized_view_data_loss_maximum
-      name: maximum
-  - id: am_azure_data_explorer__materialized_view_result
-    title: Azure Data Explorer Materialized View Result
-    context: materialized_view_result
-    family: Materialized Views
-    type: line
-    units: status
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.materialized_view_result_average
-      name: average
-  - id: am_azure_data_explorer__partitioning_percentage
-    title: Azure Data Explorer Partitioning Percentage
-    context: partitioning_percentage
-    family: Partitioning
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.partitioning_percentage_average
-      name: total
-    - selector: data_explorer.partitioning_percentage_hot_average
-      name: hot
-  - id: am_azure_data_explorer__partitioned_records
-    title: Azure Data Explorer Processed Partitioned Records
-    context: partitioned_records
-    family: Partitioning
-    type: line
-    units: records
-    algorithm: absolute
-    dimensions:
-    - selector: data_explorer.processed_partitioned_records_average
-      name: average
+    - id: am_azure_data_explorer__cpu_utilization
+      title: Azure Data Explorer CPU Utilization
+      context: cpu_utilization
+      family: Compute
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.cpu_average
+          name: average
+    - id: am_azure_data_explorer__utilization
+      title: Azure Data Explorer Utilization
+      context: utilization
+      family: Compute
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.ingestion_utilization_average
+          name: ingestion
+        - selector: data_explorer.cache_utilization_factor_average
+          name: cache
+    - id: am_azure_data_explorer__keep_alive
+      title: Azure Data Explorer Keep Alive
+      context: keep_alive
+      family: Compute
+      type: line
+      units: count
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.keep_alive_average
+          name: average
+    - id: am_azure_data_explorer__instance_count
+      title: Azure Data Explorer Instance Count
+      context: instance_count
+      family: Compute
+      type: line
+      units: instances
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.instance_count_average
+          name: average
+        - selector: data_explorer.instance_count_maximum
+          name: maximum
+        - selector: data_explorer.instance_count_minimum
+          name: minimum
+    - id: am_azure_data_explorer__extents
+      title: Azure Data Explorer Total Extents
+      context: extents
+      family: Compute
+      type: line
+      units: extents
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.total_number_of_extents_average
+          name: average
+    - id: am_azure_data_explorer__throttled_commands
+      title: Azure Data Explorer Throttled Commands
+      context: throttled_commands
+      family: Compute
+      type: line
+      units: commands/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_explorer.total_number_of_throttled_commands_total
+          name: total
+    - id: am_azure_data_explorer__follower_latency
+      title: Azure Data Explorer Follower Latency
+      context: follower_latency
+      family: Compute
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.follower_latency_average
+          name: average
+    - id: am_azure_data_explorer__query_duration
+      title: Azure Data Explorer Query Duration
+      context: query_duration
+      family: Query
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.query_duration_average
+          name: average
+    - id: am_azure_data_explorer__query_count
+      title: Azure Data Explorer Query Count
+      context: query_count
+      family: Query
+      type: line
+      units: queries/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_explorer.query_result_count
+          name: count
+    - id: am_azure_data_explorer__concurrent_queries
+      title: Azure Data Explorer Concurrent Queries
+      context: concurrent_queries
+      family: Query
+      type: line
+      units: queries
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.total_number_of_concurrent_queries_average
+          name: average
+        - selector: data_explorer.total_number_of_concurrent_queries_maximum
+          name: maximum
+    - id: am_azure_data_explorer__throttled_queries
+      title: Azure Data Explorer Throttled Queries
+      context: throttled_queries
+      family: Query
+      type: line
+      units: queries/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_explorer.total_number_of_throttled_queries_total
+          name: total
+    - id: am_azure_data_explorer__weak_consistency_latency
+      title: Azure Data Explorer Weak Consistency Latency
+      context: weak_consistency_latency
+      family: Query
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.weak_consistency_latency_average
+          name: average
+    - id: am_azure_data_explorer__ingestion_result
+      title: Azure Data Explorer Ingestion Result
+      context: ingestion_result
+      family: Ingestion
+      type: line
+      units: sources/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_explorer.ingestion_result_total
+          name: total
+    - id: am_azure_data_explorer__ingestion_volume
+      title: Azure Data Explorer Ingestion Volume
+      context: ingestion_volume
+      family: Ingestion
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_explorer.ingestion_volume_in_mb_total
+          name: total
+    - id: am_azure_data_explorer__ingestion_latency
+      title: Azure Data Explorer Ingestion Latency
+      context: ingestion_latency
+      family: Ingestion
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.ingestion_latency_in_seconds_average
+          name: average
+    - id: am_azure_data_explorer__events
+      title: Azure Data Explorer Events
+      context: events
+      family: Ingestion
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_explorer.events_received_total
+          name: received
+        - selector: data_explorer.events_processed_total
+          name: processed
+        - selector: data_explorer.events_dropped_total
+          name: dropped
+    - id: am_azure_data_explorer__blobs
+      title: Azure Data Explorer Blobs
+      context: blobs
+      family: Ingestion
+      type: line
+      units: blobs/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_explorer.blobs_received_total
+          name: received
+        - selector: data_explorer.blobs_processed_total
+          name: processed
+        - selector: data_explorer.blobs_dropped_total
+          name: dropped
+    - id: am_azure_data_explorer__discovery_latency
+      title: Azure Data Explorer Discovery Latency
+      context: discovery_latency
+      family: Ingestion
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.discovery_latency_average
+          name: average
+    - id: am_azure_data_explorer__stage_latency
+      title: Azure Data Explorer Stage Latency
+      context: stage_latency
+      family: Ingestion
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.stage_latency_average
+          name: average
+    - id: am_azure_data_explorer__ingestion_queue
+      title: Azure Data Explorer Ingestion Queue
+      context: ingestion_queue
+      family: Ingestion
+      type: line
+      units: messages
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.queue_length_average
+          name: length
+    - id: am_azure_data_explorer__queue_oldest_message
+      title: Azure Data Explorer Queue Oldest Message Age
+      context: queue_oldest_message
+      family: Ingestion
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.queue_oldest_message_average
+          name: age
+    - id: am_azure_data_explorer__received_data_size
+      title: Azure Data Explorer Received Data Size
+      context: received_data_size
+      family: Ingestion
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_explorer.received_data_size_bytes_total
+          name: total
+    - id: am_azure_data_explorer__batches_processed
+      title: Azure Data Explorer Batches Processed
+      context: batches_processed
+      family: Ingestion
+      type: line
+      units: batches/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_explorer.batches_processed_total
+          name: total
+    - id: am_azure_data_explorer__batch_blob_count
+      title: Azure Data Explorer Batch Blob Count
+      context: batch_blob_count
+      family: Ingestion
+      type: line
+      units: blobs
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.batch_blob_count_average
+          name: average
+    - id: am_azure_data_explorer__batch_size
+      title: Azure Data Explorer Batch Size
+      context: batch_size
+      family: Ingestion
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.batch_size_average
+          name: average
+    - id: am_azure_data_explorer__batch_duration
+      title: Azure Data Explorer Batch Duration
+      context: batch_duration
+      family: Ingestion
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.batch_duration_average
+          name: average
+    - id: am_azure_data_explorer__export_utilization
+      title: Azure Data Explorer Export Utilization
+      context: export_utilization
+      family: Export
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.export_utilization_maximum
+          name: maximum
+    - id: am_azure_data_explorer__continuous_export_records
+      title: Azure Data Explorer Continuous Export Records
+      context: continuous_export_records
+      family: Export
+      type: line
+      units: records/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_explorer.continuous_export_num_of_records_exported_total
+          name: total
+    - id: am_azure_data_explorer__continuous_export_result
+      title: Azure Data Explorer Continuous Export Result
+      context: continuous_export_result
+      family: Export
+      type: line
+      units: results/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_explorer.continuous_export_result_count
+          name: count
+    - id: am_azure_data_explorer__continuous_export_pending
+      title: Azure Data Explorer Continuous Export Pending Jobs
+      context: continuous_export_pending
+      family: Export
+      type: line
+      units: jobs
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.continuous_export_pending_count_maximum
+          name: maximum
+    - id: am_azure_data_explorer__continuous_export_lateness
+      title: Azure Data Explorer Continuous Export Lateness
+      context: continuous_export_lateness
+      family: Export
+      type: line
+      units: minutes
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.continuous_export_max_lateness_minutes_maximum
+          name: maximum
+    - id: am_azure_data_explorer__streaming_ingest_data_rate
+      title: Azure Data Explorer Streaming Ingest Data Rate
+      context: streaming_ingest_data_rate
+      family: Streaming
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.streaming_ingest_data_rate_average
+          name: average
+    - id: am_azure_data_explorer__streaming_ingest_duration
+      title: Azure Data Explorer Streaming Ingest Duration
+      context: streaming_ingest_duration
+      family: Streaming
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.streaming_ingest_duration_average
+          name: average
+    - id: am_azure_data_explorer__streaming_ingest_result
+      title: Azure Data Explorer Streaming Ingest Result
+      context: streaming_ingest_result
+      family: Streaming
+      type: line
+      units: results/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_explorer.streaming_ingest_results_count
+          name: count
+    - id: am_azure_data_explorer__streaming_ingest_utilization
+      title: Azure Data Explorer Streaming Ingest Utilization
+      context: streaming_ingest_utilization
+      family: Streaming
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.streaming_ingest_utilization_average
+          name: average
+    - id: am_azure_data_explorer__materialized_view_health
+      title: Azure Data Explorer Materialized View Health
+      context: materialized_view_health
+      family: Materialized Views
+      type: line
+      units: status
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.materialized_view_health_average
+          name: health
+    - id: am_azure_data_explorer__materialized_view_age
+      title: Azure Data Explorer Materialized View Age
+      context: materialized_view_age
+      family: Materialized Views
+      type: line
+      units: minutes
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.materialized_view_age_minutes_average
+          name: minutes
+    - id: am_azure_data_explorer__materialized_view_age_seconds
+      title: Azure Data Explorer Materialized View Age (Seconds)
+      context: materialized_view_age_seconds
+      family: Materialized Views
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.materialized_view_age_seconds_average
+          name: average
+    - id: am_azure_data_explorer__materialized_view_records_in_delta
+      title: Azure Data Explorer Materialized View Records in Delta
+      context: materialized_view_records_in_delta
+      family: Materialized Views
+      type: line
+      units: records
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.materialized_view_records_in_delta_average
+          name: average
+    - id: am_azure_data_explorer__materialized_view_extents_rebuild
+      title: Azure Data Explorer Materialized View Extents Rebuild
+      context: materialized_view_extents_rebuild
+      family: Materialized Views
+      type: line
+      units: extents
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.materialized_view_extents_rebuild_average
+          name: average
+    - id: am_azure_data_explorer__materialized_view_data_loss
+      title: Azure Data Explorer Materialized View Data Loss
+      context: materialized_view_data_loss
+      family: Materialized Views
+      type: line
+      units: status
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.materialized_view_data_loss_maximum
+          name: maximum
+    - id: am_azure_data_explorer__materialized_view_result
+      title: Azure Data Explorer Materialized View Result
+      context: materialized_view_result
+      family: Materialized Views
+      type: line
+      units: status
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.materialized_view_result_average
+          name: average
+    - id: am_azure_data_explorer__partitioning_percentage
+      title: Azure Data Explorer Partitioning Percentage
+      context: partitioning_percentage
+      family: Partitioning
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.partitioning_percentage_average
+          name: total
+        - selector: data_explorer.partitioning_percentage_hot_average
+          name: hot
+    - id: am_azure_data_explorer__partitioned_records
+      title: Azure Data Explorer Processed Partitioned Records
+      context: partitioned_records
+      family: Partitioning
+      type: line
+      units: records
+      algorithm: absolute
+      dimensions:
+        - selector: data_explorer.processed_partitioned_records_average
+          name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/data_factory.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/data_factory.yaml
@@ -3,1153 +3,1153 @@ id: data_factory
 name: Azure Data Factory
 resource_type: Microsoft.DataFactory/factories
 metrics:
-- id: pipeline_succeeded_runs
-  azure_name: PipelineSucceededRuns
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: pipeline_failed_runs
-  azure_name: PipelineFailedRuns
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: pipeline_cancelled_runs
-  azure_name: PipelineCancelledRuns
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: pipeline_elapsed_time_runs
-  azure_name: PipelineElapsedTimeRuns
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: activity_succeeded_runs
-  azure_name: ActivitySucceededRuns
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: activity_failed_runs
-  azure_name: ActivityFailedRuns
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: activity_cancelled_runs
-  azure_name: ActivityCancelledRuns
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: trigger_succeeded_runs
-  azure_name: TriggerSucceededRuns
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: trigger_failed_runs
-  azure_name: TriggerFailedRuns
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: trigger_cancelled_runs
-  azure_name: TriggerCancelledRuns
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ssis_integration_runtime_start_succeeded
-  azure_name: SSISIntegrationRuntimeStartSucceeded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ssis_integration_runtime_start_failed
-  azure_name: SSISIntegrationRuntimeStartFailed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ssis_integration_runtime_start_cancel
-  azure_name: SSISIntegrationRuntimeStartCancel
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ssis_integration_runtime_stop_succeeded
-  azure_name: SSISIntegrationRuntimeStopSucceeded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ssis_integration_runtime_stop_stuck
-  azure_name: SSISIntegrationRuntimeStopStuck
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ssis_package_execution_succeeded
-  azure_name: SSISPackageExecutionSucceeded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ssis_package_execution_failed
-  azure_name: SSISPackageExecutionFailed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ssis_package_execution_cancel
-  azure_name: SSISPackageExecutionCancel
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: integration_runtime_cpu_percentage
-  azure_name: IntegrationRuntimeCpuPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: integration_runtime_available_memory
-  azure_name: IntegrationRuntimeAvailableMemory
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: integration_runtime_available_node_number
-  azure_name: IntegrationRuntimeAvailableNodeNumber
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: integration_runtime_queue_length
-  azure_name: IntegrationRuntimeQueueLength
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: integration_runtime_average_task_pickup_delay
-  azure_name: IntegrationRuntimeAverageTaskPickupDelay
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: factory_size_in_gb_units
-  azure_name: FactorySizeInGbUnits
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: max_allowed_factory_size_in_gb_units
-  azure_name: MaxAllowedFactorySizeInGbUnits
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: resource_count
-  azure_name: ResourceCount
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: max_allowed_resource_count
-  azure_name: MaxAllowedResourceCount
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: mv_net_ir_copy_available_capacity_pct
-  azure_name: MVNetIRCopyAvailableCapacityPCT
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: mv_net_ir_copy_capacity_utilization
-  azure_name: MVNetIRCopyCapacityUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: mv_net_ir_copy_waiting_queue_length
-  azure_name: MVNetIRCopyWaitingQueueLength
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: mv_net_ir_external_available_capacity_pct
-  azure_name: MVNetIRExternalAvailableCapacityPCT
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: mv_net_ir_external_capacity_utilization
-  azure_name: MVNetIRExternalCapacityUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: mv_net_ir_external_waiting_queue_length
-  azure_name: MVNetIRExternalWaitingQueueLength
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: mv_net_ir_pipeline_available_capacity_pct
-  azure_name: MVNetIRPipelineAvailableCapacityPCT
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: mv_net_ir_pipeline_capacity_utilization
-  azure_name: MVNetIRPipelineCapacityUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: mv_net_ir_pipeline_waiting_queue_length
-  azure_name: MVNetIRPipelineWaitingQueueLength
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_cpu_percentage
-  azure_name: AirflowIntegrationRuntimeCpuPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_cpu_usage
-  azure_name: AirflowIntegrationRuntimeCpuUsage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_memory_percentage
-  azure_name: AirflowIntegrationRuntimeMemoryPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_memory_usage
-  azure_name: AirflowIntegrationRuntimeMemoryUsage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_node_count
-  azure_name: AirflowIntegrationRuntimeNodeCount
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_collect_db_dags
-  azure_name: AirflowIntegrationRuntimeCollectDBDags
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_dag_bag_size
-  azure_name: AirflowIntegrationRuntimeDagBagSize
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_dag_callback_exceptions
-  azure_name: AirflowIntegrationRuntimeDagCallbackExceptions
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_dag_file_refresh_error
-  azure_name: AirflowIntegrationRuntimeDAGFileRefreshError
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_dag_processing_import_errors
-  azure_name: AirflowIntegrationRuntimeDAGProcessingImportErrors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_dag_processing_last_duration
-  azure_name: AirflowIntegrationRuntimeDAGProcessingLastDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_dag_processing_last_run_seconds_ago
-  azure_name: AirflowIntegrationRuntimeDAGProcessingLastRunSecondsAgo
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_dag_processing_manager_stalls
-  azure_name: AirflowIntegrationRuntimeDAGProcessingManagerStalls
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_dag_processing_processes
-  azure_name: AirflowIntegrationRuntimeDAGProcessingProcesses
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_dag_processing_processor_timeouts
-  azure_name: AirflowIntegrationRuntimeDAGProcessingProcessorTimeouts
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_dag_processing_total_parse_time
-  azure_name: AirflowIntegrationRuntimeDAGProcessingTotalParseTime
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_dag_run_dependency_check
-  azure_name: AirflowIntegrationRuntimeDAGRunDependencyCheck
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_dag_run_duration_failed
-  azure_name: AirflowIntegrationRuntimeDAGRunDurationFailed
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_dag_run_duration_success
-  azure_name: AirflowIntegrationRuntimeDAGRunDurationSuccess
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_dag_run_first_task_scheduling_delay
-  azure_name: AirflowIntegrationRuntimeDAGRunFirstTaskSchedulingDelay
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_dag_run_schedule_delay
-  azure_name: AirflowIntegrationRuntimeDAGRunScheduleDelay
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_executor_open_slots
-  azure_name: AirflowIntegrationRuntimeExecutorOpenSlots
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_executor_queued_tasks
-  azure_name: AirflowIntegrationRuntimeExecutorQueuedTasks
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_executor_running_tasks
-  azure_name: AirflowIntegrationRuntimeExecutorRunningTasks
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_job_start
-  azure_name: AirflowIntegrationRuntimeJobStart
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_job_end
-  azure_name: AirflowIntegrationRuntimeJobEnd
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_job_heartbeat_failure
-  azure_name: AirflowIntegrationRuntimeJobHeartbeatFailure
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_operator_successes
-  azure_name: AirflowIntegrationRuntimeOperatorSuccesses
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_operator_failures
-  azure_name: AirflowIntegrationRuntimeOperatorFailures
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_pool_open_slots
-  azure_name: AirflowIntegrationRuntimePoolOpenSlots
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_pool_queued_slots
-  azure_name: AirflowIntegrationRuntimePoolQueuedSlots
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_pool_running_slots
-  azure_name: AirflowIntegrationRuntimePoolRunningSlots
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_pool_starving_tasks
-  azure_name: AirflowIntegrationRuntimePoolStarvingTasks
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_scheduler_critical_section_busy
-  azure_name: AirflowIntegrationRuntimeSchedulerCriticalSectionBusy
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_scheduler_critical_section_duration
-  azure_name: AirflowIntegrationRuntimeSchedulerCriticalSectionDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_scheduler_failed_sla_email_attempts
-  azure_name: AirflowIntegrationRuntimeSchedulerFailedSLAEmailAttempts
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_scheduler_heartbeat
-  azure_name: AirflowIntegrationRuntimeSchedulerHeartbeat
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_scheduler_orphaned_tasks_adopted
-  azure_name: AirflowIntegrationRuntimeSchedulerOrphanedTasksAdopted
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_scheduler_orphaned_tasks_cleared
-  azure_name: AirflowIntegrationRuntimeSchedulerOrphanedTasksCleared
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_scheduler_tasks_executable
-  azure_name: AirflowIntegrationRuntimeSchedulerTasksExecutable
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_scheduler_tasks_killed_externally
-  azure_name: AirflowIntegrationRuntimeSchedulerTasksKilledExternally
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_scheduler_tasks_running
-  azure_name: AirflowIntegrationRuntimeSchedulerTasksRunning
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_scheduler_tasks_starving
-  azure_name: AirflowIntegrationRuntimeSchedulerTasksStarving
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_started_task_instances
-  azure_name: AirflowIntegrationRuntimeStartedTaskInstances
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_task_instance_created_using_operator
-  azure_name: AirflowIntegrationRuntimeTaskInstanceCreatedUsingOperator
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_task_instance_duration
-  azure_name: AirflowIntegrationRuntimeTaskInstanceDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: airflow_integration_runtime_task_instance_successes
-  azure_name: AirflowIntegrationRuntimeTaskInstanceSuccesses
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_task_instance_failures
-  azure_name: AirflowIntegrationRuntimeTaskInstanceFailures
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_task_instance_finished
-  azure_name: AirflowIntegrationRuntimeTaskInstanceFinished
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_task_instance_previously_succeeded
-  azure_name: AirflowIntegrationRuntimeTaskInstancePreviouslySucceeded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_task_removed_from_dag
-  azure_name: AirflowIntegrationRuntimeTaskRemovedFromDAG
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_task_restored_to_dag
-  azure_name: AirflowIntegrationRuntimeTaskRestoredToDAG
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_celery_task_timeout_error
-  azure_name: AirflowIntegrationRuntimeCeleryTaskTimeoutError
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_triggers_blocked_main_thread
-  azure_name: AirflowIntegrationRuntimeTriggersBlockedMainThread
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_triggers_failed
-  azure_name: AirflowIntegrationRuntimeTriggersFailed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_triggers_running
-  azure_name: AirflowIntegrationRuntimeTriggersRunning
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_triggers_succeeded
-  azure_name: AirflowIntegrationRuntimeTriggersSucceeded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: airflow_integration_runtime_zombies_killed
-  azure_name: AirflowIntegrationRuntimeZombiesKilled
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
+  - id: pipeline_succeeded_runs
+    azure_name: PipelineSucceededRuns
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: pipeline_failed_runs
+    azure_name: PipelineFailedRuns
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: pipeline_cancelled_runs
+    azure_name: PipelineCancelledRuns
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: pipeline_elapsed_time_runs
+    azure_name: PipelineElapsedTimeRuns
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: activity_succeeded_runs
+    azure_name: ActivitySucceededRuns
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: activity_failed_runs
+    azure_name: ActivityFailedRuns
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: activity_cancelled_runs
+    azure_name: ActivityCancelledRuns
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: trigger_succeeded_runs
+    azure_name: TriggerSucceededRuns
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: trigger_failed_runs
+    azure_name: TriggerFailedRuns
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: trigger_cancelled_runs
+    azure_name: TriggerCancelledRuns
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ssis_integration_runtime_start_succeeded
+    azure_name: SSISIntegrationRuntimeStartSucceeded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ssis_integration_runtime_start_failed
+    azure_name: SSISIntegrationRuntimeStartFailed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ssis_integration_runtime_start_cancel
+    azure_name: SSISIntegrationRuntimeStartCancel
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ssis_integration_runtime_stop_succeeded
+    azure_name: SSISIntegrationRuntimeStopSucceeded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ssis_integration_runtime_stop_stuck
+    azure_name: SSISIntegrationRuntimeStopStuck
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ssis_package_execution_succeeded
+    azure_name: SSISPackageExecutionSucceeded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ssis_package_execution_failed
+    azure_name: SSISPackageExecutionFailed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ssis_package_execution_cancel
+    azure_name: SSISPackageExecutionCancel
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: integration_runtime_cpu_percentage
+    azure_name: IntegrationRuntimeCpuPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: integration_runtime_available_memory
+    azure_name: IntegrationRuntimeAvailableMemory
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: integration_runtime_available_node_number
+    azure_name: IntegrationRuntimeAvailableNodeNumber
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: integration_runtime_queue_length
+    azure_name: IntegrationRuntimeQueueLength
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: integration_runtime_average_task_pickup_delay
+    azure_name: IntegrationRuntimeAverageTaskPickupDelay
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: factory_size_in_gb_units
+    azure_name: FactorySizeInGbUnits
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: max_allowed_factory_size_in_gb_units
+    azure_name: MaxAllowedFactorySizeInGbUnits
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: resource_count
+    azure_name: ResourceCount
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: max_allowed_resource_count
+    azure_name: MaxAllowedResourceCount
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: mv_net_ir_copy_available_capacity_pct
+    azure_name: MVNetIRCopyAvailableCapacityPCT
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: mv_net_ir_copy_capacity_utilization
+    azure_name: MVNetIRCopyCapacityUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: mv_net_ir_copy_waiting_queue_length
+    azure_name: MVNetIRCopyWaitingQueueLength
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: mv_net_ir_external_available_capacity_pct
+    azure_name: MVNetIRExternalAvailableCapacityPCT
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: mv_net_ir_external_capacity_utilization
+    azure_name: MVNetIRExternalCapacityUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: mv_net_ir_external_waiting_queue_length
+    azure_name: MVNetIRExternalWaitingQueueLength
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: mv_net_ir_pipeline_available_capacity_pct
+    azure_name: MVNetIRPipelineAvailableCapacityPCT
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: mv_net_ir_pipeline_capacity_utilization
+    azure_name: MVNetIRPipelineCapacityUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: mv_net_ir_pipeline_waiting_queue_length
+    azure_name: MVNetIRPipelineWaitingQueueLength
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_cpu_percentage
+    azure_name: AirflowIntegrationRuntimeCpuPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_cpu_usage
+    azure_name: AirflowIntegrationRuntimeCpuUsage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_memory_percentage
+    azure_name: AirflowIntegrationRuntimeMemoryPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_memory_usage
+    azure_name: AirflowIntegrationRuntimeMemoryUsage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_node_count
+    azure_name: AirflowIntegrationRuntimeNodeCount
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_collect_db_dags
+    azure_name: AirflowIntegrationRuntimeCollectDBDags
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_dag_bag_size
+    azure_name: AirflowIntegrationRuntimeDagBagSize
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_dag_callback_exceptions
+    azure_name: AirflowIntegrationRuntimeDagCallbackExceptions
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_dag_file_refresh_error
+    azure_name: AirflowIntegrationRuntimeDAGFileRefreshError
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_dag_processing_import_errors
+    azure_name: AirflowIntegrationRuntimeDAGProcessingImportErrors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_dag_processing_last_duration
+    azure_name: AirflowIntegrationRuntimeDAGProcessingLastDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_dag_processing_last_run_seconds_ago
+    azure_name: AirflowIntegrationRuntimeDAGProcessingLastRunSecondsAgo
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_dag_processing_manager_stalls
+    azure_name: AirflowIntegrationRuntimeDAGProcessingManagerStalls
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_dag_processing_processes
+    azure_name: AirflowIntegrationRuntimeDAGProcessingProcesses
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_dag_processing_processor_timeouts
+    azure_name: AirflowIntegrationRuntimeDAGProcessingProcessorTimeouts
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_dag_processing_total_parse_time
+    azure_name: AirflowIntegrationRuntimeDAGProcessingTotalParseTime
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_dag_run_dependency_check
+    azure_name: AirflowIntegrationRuntimeDAGRunDependencyCheck
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_dag_run_duration_failed
+    azure_name: AirflowIntegrationRuntimeDAGRunDurationFailed
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_dag_run_duration_success
+    azure_name: AirflowIntegrationRuntimeDAGRunDurationSuccess
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_dag_run_first_task_scheduling_delay
+    azure_name: AirflowIntegrationRuntimeDAGRunFirstTaskSchedulingDelay
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_dag_run_schedule_delay
+    azure_name: AirflowIntegrationRuntimeDAGRunScheduleDelay
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_executor_open_slots
+    azure_name: AirflowIntegrationRuntimeExecutorOpenSlots
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_executor_queued_tasks
+    azure_name: AirflowIntegrationRuntimeExecutorQueuedTasks
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_executor_running_tasks
+    azure_name: AirflowIntegrationRuntimeExecutorRunningTasks
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_job_start
+    azure_name: AirflowIntegrationRuntimeJobStart
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_job_end
+    azure_name: AirflowIntegrationRuntimeJobEnd
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_job_heartbeat_failure
+    azure_name: AirflowIntegrationRuntimeJobHeartbeatFailure
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_operator_successes
+    azure_name: AirflowIntegrationRuntimeOperatorSuccesses
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_operator_failures
+    azure_name: AirflowIntegrationRuntimeOperatorFailures
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_pool_open_slots
+    azure_name: AirflowIntegrationRuntimePoolOpenSlots
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_pool_queued_slots
+    azure_name: AirflowIntegrationRuntimePoolQueuedSlots
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_pool_running_slots
+    azure_name: AirflowIntegrationRuntimePoolRunningSlots
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_pool_starving_tasks
+    azure_name: AirflowIntegrationRuntimePoolStarvingTasks
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_scheduler_critical_section_busy
+    azure_name: AirflowIntegrationRuntimeSchedulerCriticalSectionBusy
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_scheduler_critical_section_duration
+    azure_name: AirflowIntegrationRuntimeSchedulerCriticalSectionDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_scheduler_failed_sla_email_attempts
+    azure_name: AirflowIntegrationRuntimeSchedulerFailedSLAEmailAttempts
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_scheduler_heartbeat
+    azure_name: AirflowIntegrationRuntimeSchedulerHeartbeat
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_scheduler_orphaned_tasks_adopted
+    azure_name: AirflowIntegrationRuntimeSchedulerOrphanedTasksAdopted
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_scheduler_orphaned_tasks_cleared
+    azure_name: AirflowIntegrationRuntimeSchedulerOrphanedTasksCleared
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_scheduler_tasks_executable
+    azure_name: AirflowIntegrationRuntimeSchedulerTasksExecutable
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_scheduler_tasks_killed_externally
+    azure_name: AirflowIntegrationRuntimeSchedulerTasksKilledExternally
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_scheduler_tasks_running
+    azure_name: AirflowIntegrationRuntimeSchedulerTasksRunning
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_scheduler_tasks_starving
+    azure_name: AirflowIntegrationRuntimeSchedulerTasksStarving
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_started_task_instances
+    azure_name: AirflowIntegrationRuntimeStartedTaskInstances
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_task_instance_created_using_operator
+    azure_name: AirflowIntegrationRuntimeTaskInstanceCreatedUsingOperator
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_task_instance_duration
+    azure_name: AirflowIntegrationRuntimeTaskInstanceDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: airflow_integration_runtime_task_instance_successes
+    azure_name: AirflowIntegrationRuntimeTaskInstanceSuccesses
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_task_instance_failures
+    azure_name: AirflowIntegrationRuntimeTaskInstanceFailures
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_task_instance_finished
+    azure_name: AirflowIntegrationRuntimeTaskInstanceFinished
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_task_instance_previously_succeeded
+    azure_name: AirflowIntegrationRuntimeTaskInstancePreviouslySucceeded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_task_removed_from_dag
+    azure_name: AirflowIntegrationRuntimeTaskRemovedFromDAG
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_task_restored_to_dag
+    azure_name: AirflowIntegrationRuntimeTaskRestoredToDAG
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_celery_task_timeout_error
+    azure_name: AirflowIntegrationRuntimeCeleryTaskTimeoutError
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_triggers_blocked_main_thread
+    azure_name: AirflowIntegrationRuntimeTriggersBlockedMainThread
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_triggers_failed
+    azure_name: AirflowIntegrationRuntimeTriggersFailed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_triggers_running
+    azure_name: AirflowIntegrationRuntimeTriggersRunning
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_triggers_succeeded
+    azure_name: AirflowIntegrationRuntimeTriggersSucceeded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: airflow_integration_runtime_zombies_killed
+    azure_name: AirflowIntegrationRuntimeZombiesKilled
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
 template:
   family: Azure Data Factory
   context_namespace: data_factory
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_data_factory__pipeline_runs
-    title: Azure Data Factory Pipeline Runs
-    context: pipeline_runs
-    family: Pipelines
-    type: line
-    units: runs/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.pipeline_succeeded_runs_total
-      name: succeeded
-    - selector: data_factory.pipeline_failed_runs_total
-      name: failed
-    - selector: data_factory.pipeline_cancelled_runs_total
-      name: cancelled
-  - id: am_azure_data_factory__pipeline_elapsed_time
-    title: Azure Data Factory Pipeline Elapsed Time Runs
-    context: pipeline_elapsed_time
-    family: Pipelines
-    type: line
-    units: runs/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.pipeline_elapsed_time_runs_total
-      name: elapsed_time
-  - id: am_azure_data_factory__activity_runs
-    title: Azure Data Factory Activity Runs
-    context: activity_runs
-    family: Activities
-    type: line
-    units: runs/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.activity_succeeded_runs_total
-      name: succeeded
-    - selector: data_factory.activity_failed_runs_total
-      name: failed
-    - selector: data_factory.activity_cancelled_runs_total
-      name: cancelled
-  - id: am_azure_data_factory__trigger_runs
-    title: Azure Data Factory Trigger Runs
-    context: trigger_runs
-    family: Triggers
-    type: line
-    units: runs/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.trigger_succeeded_runs_total
-      name: succeeded
-    - selector: data_factory.trigger_failed_runs_total
-      name: failed
-    - selector: data_factory.trigger_cancelled_runs_total
-      name: cancelled
-  - id: am_azure_data_factory__ssis_ir_starts
-    title: Azure Data Factory SSIS IR Start Operations
-    context: ssis_ir_starts
-    family: SSIS
-    type: line
-    units: runs/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.ssis_integration_runtime_start_succeeded_total
-      name: succeeded
-    - selector: data_factory.ssis_integration_runtime_start_failed_total
-      name: failed
-    - selector: data_factory.ssis_integration_runtime_start_cancel_total
-      name: cancelled
-  - id: am_azure_data_factory__ssis_ir_stops
-    title: Azure Data Factory SSIS IR Stop Operations
-    context: ssis_ir_stops
-    family: SSIS
-    type: line
-    units: runs/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.ssis_integration_runtime_stop_succeeded_total
-      name: succeeded
-    - selector: data_factory.ssis_integration_runtime_stop_stuck_total
-      name: stuck
-  - id: am_azure_data_factory__ssis_package_executions
-    title: Azure Data Factory SSIS Package Executions
-    context: ssis_package_executions
-    family: SSIS
-    type: line
-    units: executions/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.ssis_package_execution_succeeded_total
-      name: succeeded
-    - selector: data_factory.ssis_package_execution_failed_total
-      name: failed
-    - selector: data_factory.ssis_package_execution_cancel_total
-      name: cancelled
-  - id: am_azure_data_factory__ir_cpu
-    title: Azure Data Factory Integration Runtime CPU
-    context: ir_cpu
-    family: Integration Runtime
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.integration_runtime_cpu_percentage_average
-      name: average
-  - id: am_azure_data_factory__ir_memory
-    title: Azure Data Factory Integration Runtime Available Memory
-    context: ir_memory
-    family: Integration Runtime
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.integration_runtime_available_memory_average
-      name: available
-  - id: am_azure_data_factory__ir_nodes
-    title: Azure Data Factory Integration Runtime Available Nodes
-    context: ir_nodes
-    family: Integration Runtime
-    type: line
-    units: nodes
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.integration_runtime_available_node_number_average
-      name: available
-  - id: am_azure_data_factory__ir_queue
-    title: Azure Data Factory Integration Runtime Queue
-    context: ir_queue
-    family: Integration Runtime
-    type: line
-    units: tasks
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.integration_runtime_queue_length_average
-      name: queue_length
-  - id: am_azure_data_factory__ir_task_pickup_delay
-    title: Azure Data Factory Integration Runtime Task Pickup Delay
-    context: ir_task_pickup_delay
-    family: Integration Runtime
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.integration_runtime_average_task_pickup_delay_average
-      name: average
-  - id: am_azure_data_factory__factory_size
-    title: Azure Data Factory Factory Size
-    context: factory_size
-    family: Capacity
-    type: line
-    units: GiB
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.factory_size_in_gb_units_maximum
-      name: current
-    - selector: data_factory.max_allowed_factory_size_in_gb_units_maximum
-      name: max_allowed
-  - id: am_azure_data_factory__entity_count
-    title: Azure Data Factory Entity Count
-    context: entity_count
-    family: Capacity
-    type: line
-    units: entities
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.resource_count_maximum
-      name: current
-    - selector: data_factory.max_allowed_resource_count_maximum
-      name: max_allowed
-  - id: am_azure_data_factory__mvnet_ir_copy_capacity
-    title: Azure Data Factory MVNet IR Copy Capacity
-    context: mvnet_ir_copy_capacity
-    family: MVNet IR
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.mv_net_ir_copy_capacity_utilization_maximum
-      name: utilization
-    - selector: data_factory.mv_net_ir_copy_available_capacity_pct_maximum
-      name: available
-  - id: am_azure_data_factory__mvnet_ir_copy_queue
-    title: Azure Data Factory MVNet IR Copy Queue
-    context: mvnet_ir_copy_queue
-    family: MVNet IR
-    type: line
-    units: tasks
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.mv_net_ir_copy_waiting_queue_length_average
-      name: waiting
-  - id: am_azure_data_factory__mvnet_ir_external_capacity
-    title: Azure Data Factory MVNet IR External Capacity
-    context: mvnet_ir_external_capacity
-    family: MVNet IR
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.mv_net_ir_external_capacity_utilization_maximum
-      name: utilization
-    - selector: data_factory.mv_net_ir_external_available_capacity_pct_maximum
-      name: available
-  - id: am_azure_data_factory__mvnet_ir_external_queue
-    title: Azure Data Factory MVNet IR External Queue
-    context: mvnet_ir_external_queue
-    family: MVNet IR
-    type: line
-    units: tasks
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.mv_net_ir_external_waiting_queue_length_average
-      name: waiting
-  - id: am_azure_data_factory__mvnet_ir_pipeline_capacity
-    title: Azure Data Factory MVNet IR Pipeline Capacity
-    context: mvnet_ir_pipeline_capacity
-    family: MVNet IR
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.mv_net_ir_pipeline_capacity_utilization_maximum
-      name: utilization
-    - selector: data_factory.mv_net_ir_pipeline_available_capacity_pct_maximum
-      name: available
-  - id: am_azure_data_factory__mvnet_ir_pipeline_queue
-    title: Azure Data Factory MVNet IR Pipeline Queue
-    context: mvnet_ir_pipeline_queue
-    family: MVNet IR
-    type: line
-    units: tasks
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.mv_net_ir_pipeline_waiting_queue_length_average
-      name: waiting
-  - id: am_azure_data_factory__airflow_ir_cpu
-    title: Azure Data Factory Airflow IR CPU
-    context: airflow_ir_cpu
-    family: Airflow IR
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_cpu_percentage_average
-      name: percentage
-  - id: am_azure_data_factory__airflow_ir_cpu_usage
-    title: Azure Data Factory Airflow IR CPU Usage
-    context: airflow_ir_cpu_usage
-    family: Airflow IR
-    type: line
-    units: millicores
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_cpu_usage_average
-      name: average
-  - id: am_azure_data_factory__airflow_ir_memory
-    title: Azure Data Factory Airflow IR Memory
-    context: airflow_ir_memory
-    family: Airflow IR
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_memory_percentage_average
-      name: percentage
-  - id: am_azure_data_factory__airflow_ir_memory_usage
-    title: Azure Data Factory Airflow IR Memory Usage
-    context: airflow_ir_memory_usage
-    family: Airflow IR
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_memory_usage_average
-      name: average
-  - id: am_azure_data_factory__airflow_ir_nodes
-    title: Azure Data Factory Airflow IR Node Count
-    context: airflow_ir_nodes
-    family: Airflow IR
-    type: line
-    units: nodes
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_node_count_average
-      name: average
-  - id: am_azure_data_factory__airflow_ir_dag_collection
-    title: Azure Data Factory Airflow IR DAG DB Collection Time
-    context: airflow_ir_dag_collection
-    family: Airflow DAG Processing
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_collect_db_dags_average
-      name: average
-  - id: am_azure_data_factory__airflow_ir_dag_bag
-    title: Azure Data Factory Airflow IR DAG Bag Size
-    context: airflow_ir_dag_bag
-    family: Airflow DAG Processing
-    type: line
-    units: dags/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_dag_bag_size_total
-      name: total
-  - id: am_azure_data_factory__airflow_ir_dag_errors
-    title: Azure Data Factory Airflow IR DAG Errors
-    context: airflow_ir_dag_errors
-    family: Airflow DAG Processing
-    type: line
-    units: errors/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_dag_callback_exceptions_total
-      name: callback_exceptions
-    - selector: data_factory.airflow_integration_runtime_dag_file_refresh_error_total
-      name: file_refresh
-    - selector: data_factory.airflow_integration_runtime_dag_processing_import_errors_total
-      name: import
-  - id: am_azure_data_factory__airflow_ir_dag_processing_duration
-    title: Azure Data Factory Airflow IR DAG Processing Duration
-    context: airflow_ir_dag_processing_duration
-    family: Airflow DAG Processing
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_dag_processing_last_duration_average
-      name: last_duration
-  - id: am_azure_data_factory__airflow_ir_dag_processing_lag
-    title: Azure Data Factory Airflow IR DAG Processing Lag
-    context: airflow_ir_dag_processing_lag
-    family: Airflow DAG Processing
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_dag_processing_last_run_seconds_ago_average
-      name: last_run_seconds_ago
-    - selector: data_factory.airflow_integration_runtime_dag_processing_processor_timeouts_average
-      name: processor_timeouts
-    - selector: data_factory.airflow_integration_runtime_dag_processing_total_parse_time_average
-      name: total_parse_time
-  - id: am_azure_data_factory__airflow_ir_dag_processing_activity
-    title: Azure Data Factory Airflow IR DAG Processing Activity
-    context: airflow_ir_dag_processing_activity
-    family: Airflow DAG Processing
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_dag_processing_manager_stalls_total
-      name: manager_stalls
-    - selector: data_factory.airflow_integration_runtime_dag_processing_processes_total
-      name: processes
-  - id: am_azure_data_factory__airflow_ir_dag_run_duration
-    title: Azure Data Factory Airflow IR DAG Run Duration
-    context: airflow_ir_dag_run_duration
-    family: Airflow DAG Runs
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_dag_run_duration_success_average
-      name: success
-    - selector: data_factory.airflow_integration_runtime_dag_run_duration_failed_average
-      name: failed
-  - id: am_azure_data_factory__airflow_ir_dag_run_scheduling
-    title: Azure Data Factory Airflow IR DAG Run Scheduling Delays
-    context: airflow_ir_dag_run_scheduling
-    family: Airflow DAG Runs
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_dag_run_dependency_check_average
-      name: dependency_check
-    - selector: data_factory.airflow_integration_runtime_dag_run_first_task_scheduling_delay_average
-      name: first_task_delay
-    - selector: data_factory.airflow_integration_runtime_dag_run_schedule_delay_average
-      name: schedule_delay
-  - id: am_azure_data_factory__airflow_ir_executor
-    title: Azure Data Factory Airflow IR Executor
-    context: airflow_ir_executor
-    family: Airflow Executor
-    type: line
-    units: slots/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_executor_open_slots_total
-      name: open_slots
-    - selector: data_factory.airflow_integration_runtime_executor_queued_tasks_total
-      name: queued_tasks
-    - selector: data_factory.airflow_integration_runtime_executor_running_tasks_total
-      name: running_tasks
-  - id: am_azure_data_factory__airflow_ir_jobs
-    title: Azure Data Factory Airflow IR Jobs
-    context: airflow_ir_jobs
-    family: Airflow Jobs
-    type: line
-    units: jobs/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_job_start_total
-      name: started
-    - selector: data_factory.airflow_integration_runtime_job_end_total
-      name: ended
-    - selector: data_factory.airflow_integration_runtime_job_heartbeat_failure_total
-      name: heartbeat_failures
-  - id: am_azure_data_factory__airflow_ir_operators
-    title: Azure Data Factory Airflow IR Operators
-    context: airflow_ir_operators
-    family: Airflow Operators
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_operator_successes_total
-      name: successes
-    - selector: data_factory.airflow_integration_runtime_operator_failures_total
-      name: failures
-  - id: am_azure_data_factory__airflow_ir_pool_slots
-    title: Azure Data Factory Airflow IR Pool Slots
-    context: airflow_ir_pool_slots
-    family: Airflow Pools
-    type: line
-    units: slots/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_pool_open_slots_total
-      name: open
-    - selector: data_factory.airflow_integration_runtime_pool_queued_slots_total
-      name: queued
-    - selector: data_factory.airflow_integration_runtime_pool_running_slots_total
-      name: running
-  - id: am_azure_data_factory__airflow_ir_pool_starving
-    title: Azure Data Factory Airflow IR Pool Starving Tasks
-    context: airflow_ir_pool_starving
-    family: Airflow Pools
-    type: line
-    units: tasks/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_pool_starving_tasks_total
-      name: starving
-  - id: am_azure_data_factory__airflow_ir_scheduler_critical_section
-    title: Azure Data Factory Airflow IR Scheduler Critical Section
-    context: airflow_ir_scheduler_critical_section
-    family: Airflow Scheduler
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_scheduler_critical_section_duration_average
-      name: duration
-  - id: am_azure_data_factory__airflow_ir_scheduler_activity
-    title: Azure Data Factory Airflow IR Scheduler Activity
-    context: airflow_ir_scheduler_activity
-    family: Airflow Scheduler
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_scheduler_critical_section_busy_total
-      name: critical_section_busy
-    - selector: data_factory.airflow_integration_runtime_scheduler_heartbeat_total
-      name: heartbeats
-    - selector: data_factory.airflow_integration_runtime_scheduler_failed_sla_email_attempts_total
-      name: failed_sla_emails
-  - id: am_azure_data_factory__airflow_ir_scheduler_orphaned_tasks
-    title: Azure Data Factory Airflow IR Scheduler Orphaned Tasks
-    context: airflow_ir_scheduler_orphaned_tasks
-    family: Airflow Scheduler
-    type: line
-    units: tasks/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_scheduler_orphaned_tasks_adopted_total
-      name: adopted
-    - selector: data_factory.airflow_integration_runtime_scheduler_orphaned_tasks_cleared_total
-      name: cleared
-  - id: am_azure_data_factory__airflow_ir_scheduler_tasks
-    title: Azure Data Factory Airflow IR Scheduler Tasks
-    context: airflow_ir_scheduler_tasks
-    family: Airflow Scheduler
-    type: line
-    units: tasks/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_scheduler_tasks_executable_total
-      name: executable
-    - selector: data_factory.airflow_integration_runtime_scheduler_tasks_running_total
-      name: running
-    - selector: data_factory.airflow_integration_runtime_scheduler_tasks_starving_total
-      name: starving
-    - selector: data_factory.airflow_integration_runtime_scheduler_tasks_killed_externally_total
-      name: killed_externally
-  - id: am_azure_data_factory__airflow_ir_task_instances
-    title: Azure Data Factory Airflow IR Task Instances
-    context: airflow_ir_task_instances
-    family: Airflow Tasks
-    type: line
-    units: instances/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_started_task_instances_total
-      name: started
-    - selector: data_factory.airflow_integration_runtime_task_instance_successes_total
-      name: succeeded
-    - selector: data_factory.airflow_integration_runtime_task_instance_failures_total
-      name: failed
-    - selector: data_factory.airflow_integration_runtime_task_instance_finished_total
-      name: finished
-    - selector: data_factory.airflow_integration_runtime_task_instance_previously_succeeded_total
-      name: previously_succeeded
-    - selector: data_factory.airflow_integration_runtime_task_instance_created_using_operator_total
-      name: created_via_operator
-  - id: am_azure_data_factory__airflow_ir_task_instance_duration
-    title: Azure Data Factory Airflow IR Task Instance Duration
-    context: airflow_ir_task_instance_duration
-    family: Airflow Tasks
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_task_instance_duration_average
-      name: average
-  - id: am_azure_data_factory__airflow_ir_task_dag_changes
-    title: Azure Data Factory Airflow IR Task DAG Changes
-    context: airflow_ir_task_dag_changes
-    family: Airflow Tasks
-    type: line
-    units: tasks/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_task_removed_from_dag_total
-      name: removed
-    - selector: data_factory.airflow_integration_runtime_task_restored_to_dag_total
-      name: restored
-  - id: am_azure_data_factory__airflow_ir_triggers
-    title: Azure Data Factory Airflow IR Triggers
-    context: airflow_ir_triggers
-    family: Airflow Triggers
-    type: line
-    units: triggers/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_triggers_succeeded_total
-      name: succeeded
-    - selector: data_factory.airflow_integration_runtime_triggers_failed_total
-      name: failed
-    - selector: data_factory.airflow_integration_runtime_triggers_running_total
-      name: running
-  - id: am_azure_data_factory__airflow_ir_trigger_issues
-    title: Azure Data Factory Airflow IR Trigger Issues
-    context: airflow_ir_trigger_issues
-    family: Airflow Triggers
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_triggers_blocked_main_thread_total
-      name: blocked_main_thread
-    - selector: data_factory.airflow_integration_runtime_celery_task_timeout_error_total
-      name: celery_timeout_errors
-  - id: am_azure_data_factory__airflow_ir_zombies
-    title: Azure Data Factory Airflow IR Zombie Tasks Killed
-    context: airflow_ir_zombies
-    family: Airflow Triggers
-    type: line
-    units: tasks/s
-    algorithm: incremental
-    dimensions:
-    - selector: data_factory.airflow_integration_runtime_zombies_killed_total
-      name: killed
+    - id: am_azure_data_factory__pipeline_runs
+      title: Azure Data Factory Pipeline Runs
+      context: pipeline_runs
+      family: Pipelines
+      type: line
+      units: runs/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.pipeline_succeeded_runs_total
+          name: succeeded
+        - selector: data_factory.pipeline_failed_runs_total
+          name: failed
+        - selector: data_factory.pipeline_cancelled_runs_total
+          name: cancelled
+    - id: am_azure_data_factory__pipeline_elapsed_time
+      title: Azure Data Factory Pipeline Elapsed Time Runs
+      context: pipeline_elapsed_time
+      family: Pipelines
+      type: line
+      units: runs/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.pipeline_elapsed_time_runs_total
+          name: elapsed_time
+    - id: am_azure_data_factory__activity_runs
+      title: Azure Data Factory Activity Runs
+      context: activity_runs
+      family: Activities
+      type: line
+      units: runs/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.activity_succeeded_runs_total
+          name: succeeded
+        - selector: data_factory.activity_failed_runs_total
+          name: failed
+        - selector: data_factory.activity_cancelled_runs_total
+          name: cancelled
+    - id: am_azure_data_factory__trigger_runs
+      title: Azure Data Factory Trigger Runs
+      context: trigger_runs
+      family: Triggers
+      type: line
+      units: runs/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.trigger_succeeded_runs_total
+          name: succeeded
+        - selector: data_factory.trigger_failed_runs_total
+          name: failed
+        - selector: data_factory.trigger_cancelled_runs_total
+          name: cancelled
+    - id: am_azure_data_factory__ssis_ir_starts
+      title: Azure Data Factory SSIS IR Start Operations
+      context: ssis_ir_starts
+      family: SSIS
+      type: line
+      units: runs/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.ssis_integration_runtime_start_succeeded_total
+          name: succeeded
+        - selector: data_factory.ssis_integration_runtime_start_failed_total
+          name: failed
+        - selector: data_factory.ssis_integration_runtime_start_cancel_total
+          name: cancelled
+    - id: am_azure_data_factory__ssis_ir_stops
+      title: Azure Data Factory SSIS IR Stop Operations
+      context: ssis_ir_stops
+      family: SSIS
+      type: line
+      units: runs/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.ssis_integration_runtime_stop_succeeded_total
+          name: succeeded
+        - selector: data_factory.ssis_integration_runtime_stop_stuck_total
+          name: stuck
+    - id: am_azure_data_factory__ssis_package_executions
+      title: Azure Data Factory SSIS Package Executions
+      context: ssis_package_executions
+      family: SSIS
+      type: line
+      units: executions/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.ssis_package_execution_succeeded_total
+          name: succeeded
+        - selector: data_factory.ssis_package_execution_failed_total
+          name: failed
+        - selector: data_factory.ssis_package_execution_cancel_total
+          name: cancelled
+    - id: am_azure_data_factory__ir_cpu
+      title: Azure Data Factory Integration Runtime CPU
+      context: ir_cpu
+      family: Integration Runtime
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.integration_runtime_cpu_percentage_average
+          name: average
+    - id: am_azure_data_factory__ir_memory
+      title: Azure Data Factory Integration Runtime Available Memory
+      context: ir_memory
+      family: Integration Runtime
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.integration_runtime_available_memory_average
+          name: available
+    - id: am_azure_data_factory__ir_nodes
+      title: Azure Data Factory Integration Runtime Available Nodes
+      context: ir_nodes
+      family: Integration Runtime
+      type: line
+      units: nodes
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.integration_runtime_available_node_number_average
+          name: available
+    - id: am_azure_data_factory__ir_queue
+      title: Azure Data Factory Integration Runtime Queue
+      context: ir_queue
+      family: Integration Runtime
+      type: line
+      units: tasks
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.integration_runtime_queue_length_average
+          name: queue_length
+    - id: am_azure_data_factory__ir_task_pickup_delay
+      title: Azure Data Factory Integration Runtime Task Pickup Delay
+      context: ir_task_pickup_delay
+      family: Integration Runtime
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.integration_runtime_average_task_pickup_delay_average
+          name: average
+    - id: am_azure_data_factory__factory_size
+      title: Azure Data Factory Factory Size
+      context: factory_size
+      family: Capacity
+      type: line
+      units: GiB
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.factory_size_in_gb_units_maximum
+          name: current
+        - selector: data_factory.max_allowed_factory_size_in_gb_units_maximum
+          name: max_allowed
+    - id: am_azure_data_factory__entity_count
+      title: Azure Data Factory Entity Count
+      context: entity_count
+      family: Capacity
+      type: line
+      units: entities
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.resource_count_maximum
+          name: current
+        - selector: data_factory.max_allowed_resource_count_maximum
+          name: max_allowed
+    - id: am_azure_data_factory__mvnet_ir_copy_capacity
+      title: Azure Data Factory MVNet IR Copy Capacity
+      context: mvnet_ir_copy_capacity
+      family: MVNet IR
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.mv_net_ir_copy_capacity_utilization_maximum
+          name: utilization
+        - selector: data_factory.mv_net_ir_copy_available_capacity_pct_maximum
+          name: available
+    - id: am_azure_data_factory__mvnet_ir_copy_queue
+      title: Azure Data Factory MVNet IR Copy Queue
+      context: mvnet_ir_copy_queue
+      family: MVNet IR
+      type: line
+      units: tasks
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.mv_net_ir_copy_waiting_queue_length_average
+          name: waiting
+    - id: am_azure_data_factory__mvnet_ir_external_capacity
+      title: Azure Data Factory MVNet IR External Capacity
+      context: mvnet_ir_external_capacity
+      family: MVNet IR
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.mv_net_ir_external_capacity_utilization_maximum
+          name: utilization
+        - selector: data_factory.mv_net_ir_external_available_capacity_pct_maximum
+          name: available
+    - id: am_azure_data_factory__mvnet_ir_external_queue
+      title: Azure Data Factory MVNet IR External Queue
+      context: mvnet_ir_external_queue
+      family: MVNet IR
+      type: line
+      units: tasks
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.mv_net_ir_external_waiting_queue_length_average
+          name: waiting
+    - id: am_azure_data_factory__mvnet_ir_pipeline_capacity
+      title: Azure Data Factory MVNet IR Pipeline Capacity
+      context: mvnet_ir_pipeline_capacity
+      family: MVNet IR
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.mv_net_ir_pipeline_capacity_utilization_maximum
+          name: utilization
+        - selector: data_factory.mv_net_ir_pipeline_available_capacity_pct_maximum
+          name: available
+    - id: am_azure_data_factory__mvnet_ir_pipeline_queue
+      title: Azure Data Factory MVNet IR Pipeline Queue
+      context: mvnet_ir_pipeline_queue
+      family: MVNet IR
+      type: line
+      units: tasks
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.mv_net_ir_pipeline_waiting_queue_length_average
+          name: waiting
+    - id: am_azure_data_factory__airflow_ir_cpu
+      title: Azure Data Factory Airflow IR CPU
+      context: airflow_ir_cpu
+      family: Airflow IR
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_cpu_percentage_average
+          name: percentage
+    - id: am_azure_data_factory__airflow_ir_cpu_usage
+      title: Azure Data Factory Airflow IR CPU Usage
+      context: airflow_ir_cpu_usage
+      family: Airflow IR
+      type: line
+      units: millicores
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_cpu_usage_average
+          name: average
+    - id: am_azure_data_factory__airflow_ir_memory
+      title: Azure Data Factory Airflow IR Memory
+      context: airflow_ir_memory
+      family: Airflow IR
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_memory_percentage_average
+          name: percentage
+    - id: am_azure_data_factory__airflow_ir_memory_usage
+      title: Azure Data Factory Airflow IR Memory Usage
+      context: airflow_ir_memory_usage
+      family: Airflow IR
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_memory_usage_average
+          name: average
+    - id: am_azure_data_factory__airflow_ir_nodes
+      title: Azure Data Factory Airflow IR Node Count
+      context: airflow_ir_nodes
+      family: Airflow IR
+      type: line
+      units: nodes
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_node_count_average
+          name: average
+    - id: am_azure_data_factory__airflow_ir_dag_collection
+      title: Azure Data Factory Airflow IR DAG DB Collection Time
+      context: airflow_ir_dag_collection
+      family: Airflow DAG Processing
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_collect_db_dags_average
+          name: average
+    - id: am_azure_data_factory__airflow_ir_dag_bag
+      title: Azure Data Factory Airflow IR DAG Bag Size
+      context: airflow_ir_dag_bag
+      family: Airflow DAG Processing
+      type: line
+      units: dags/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_dag_bag_size_total
+          name: total
+    - id: am_azure_data_factory__airflow_ir_dag_errors
+      title: Azure Data Factory Airflow IR DAG Errors
+      context: airflow_ir_dag_errors
+      family: Airflow DAG Processing
+      type: line
+      units: errors/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_dag_callback_exceptions_total
+          name: callback_exceptions
+        - selector: data_factory.airflow_integration_runtime_dag_file_refresh_error_total
+          name: file_refresh
+        - selector: data_factory.airflow_integration_runtime_dag_processing_import_errors_total
+          name: import
+    - id: am_azure_data_factory__airflow_ir_dag_processing_duration
+      title: Azure Data Factory Airflow IR DAG Processing Duration
+      context: airflow_ir_dag_processing_duration
+      family: Airflow DAG Processing
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_dag_processing_last_duration_average
+          name: last_duration
+    - id: am_azure_data_factory__airflow_ir_dag_processing_lag
+      title: Azure Data Factory Airflow IR DAG Processing Lag
+      context: airflow_ir_dag_processing_lag
+      family: Airflow DAG Processing
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_dag_processing_last_run_seconds_ago_average
+          name: last_run_seconds_ago
+        - selector: data_factory.airflow_integration_runtime_dag_processing_processor_timeouts_average
+          name: processor_timeouts
+        - selector: data_factory.airflow_integration_runtime_dag_processing_total_parse_time_average
+          name: total_parse_time
+    - id: am_azure_data_factory__airflow_ir_dag_processing_activity
+      title: Azure Data Factory Airflow IR DAG Processing Activity
+      context: airflow_ir_dag_processing_activity
+      family: Airflow DAG Processing
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_dag_processing_manager_stalls_total
+          name: manager_stalls
+        - selector: data_factory.airflow_integration_runtime_dag_processing_processes_total
+          name: processes
+    - id: am_azure_data_factory__airflow_ir_dag_run_duration
+      title: Azure Data Factory Airflow IR DAG Run Duration
+      context: airflow_ir_dag_run_duration
+      family: Airflow DAG Runs
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_dag_run_duration_success_average
+          name: success
+        - selector: data_factory.airflow_integration_runtime_dag_run_duration_failed_average
+          name: failed
+    - id: am_azure_data_factory__airflow_ir_dag_run_scheduling
+      title: Azure Data Factory Airflow IR DAG Run Scheduling Delays
+      context: airflow_ir_dag_run_scheduling
+      family: Airflow DAG Runs
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_dag_run_dependency_check_average
+          name: dependency_check
+        - selector: data_factory.airflow_integration_runtime_dag_run_first_task_scheduling_delay_average
+          name: first_task_delay
+        - selector: data_factory.airflow_integration_runtime_dag_run_schedule_delay_average
+          name: schedule_delay
+    - id: am_azure_data_factory__airflow_ir_executor
+      title: Azure Data Factory Airflow IR Executor
+      context: airflow_ir_executor
+      family: Airflow Executor
+      type: line
+      units: slots/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_executor_open_slots_total
+          name: open_slots
+        - selector: data_factory.airflow_integration_runtime_executor_queued_tasks_total
+          name: queued_tasks
+        - selector: data_factory.airflow_integration_runtime_executor_running_tasks_total
+          name: running_tasks
+    - id: am_azure_data_factory__airflow_ir_jobs
+      title: Azure Data Factory Airflow IR Jobs
+      context: airflow_ir_jobs
+      family: Airflow Jobs
+      type: line
+      units: jobs/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_job_start_total
+          name: started
+        - selector: data_factory.airflow_integration_runtime_job_end_total
+          name: ended
+        - selector: data_factory.airflow_integration_runtime_job_heartbeat_failure_total
+          name: heartbeat_failures
+    - id: am_azure_data_factory__airflow_ir_operators
+      title: Azure Data Factory Airflow IR Operators
+      context: airflow_ir_operators
+      family: Airflow Operators
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_operator_successes_total
+          name: successes
+        - selector: data_factory.airflow_integration_runtime_operator_failures_total
+          name: failures
+    - id: am_azure_data_factory__airflow_ir_pool_slots
+      title: Azure Data Factory Airflow IR Pool Slots
+      context: airflow_ir_pool_slots
+      family: Airflow Pools
+      type: line
+      units: slots/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_pool_open_slots_total
+          name: open
+        - selector: data_factory.airflow_integration_runtime_pool_queued_slots_total
+          name: queued
+        - selector: data_factory.airflow_integration_runtime_pool_running_slots_total
+          name: running
+    - id: am_azure_data_factory__airflow_ir_pool_starving
+      title: Azure Data Factory Airflow IR Pool Starving Tasks
+      context: airflow_ir_pool_starving
+      family: Airflow Pools
+      type: line
+      units: tasks/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_pool_starving_tasks_total
+          name: starving
+    - id: am_azure_data_factory__airflow_ir_scheduler_critical_section
+      title: Azure Data Factory Airflow IR Scheduler Critical Section
+      context: airflow_ir_scheduler_critical_section
+      family: Airflow Scheduler
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_scheduler_critical_section_duration_average
+          name: duration
+    - id: am_azure_data_factory__airflow_ir_scheduler_activity
+      title: Azure Data Factory Airflow IR Scheduler Activity
+      context: airflow_ir_scheduler_activity
+      family: Airflow Scheduler
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_scheduler_critical_section_busy_total
+          name: critical_section_busy
+        - selector: data_factory.airflow_integration_runtime_scheduler_heartbeat_total
+          name: heartbeats
+        - selector: data_factory.airflow_integration_runtime_scheduler_failed_sla_email_attempts_total
+          name: failed_sla_emails
+    - id: am_azure_data_factory__airflow_ir_scheduler_orphaned_tasks
+      title: Azure Data Factory Airflow IR Scheduler Orphaned Tasks
+      context: airflow_ir_scheduler_orphaned_tasks
+      family: Airflow Scheduler
+      type: line
+      units: tasks/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_scheduler_orphaned_tasks_adopted_total
+          name: adopted
+        - selector: data_factory.airflow_integration_runtime_scheduler_orphaned_tasks_cleared_total
+          name: cleared
+    - id: am_azure_data_factory__airflow_ir_scheduler_tasks
+      title: Azure Data Factory Airflow IR Scheduler Tasks
+      context: airflow_ir_scheduler_tasks
+      family: Airflow Scheduler
+      type: line
+      units: tasks/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_scheduler_tasks_executable_total
+          name: executable
+        - selector: data_factory.airflow_integration_runtime_scheduler_tasks_running_total
+          name: running
+        - selector: data_factory.airflow_integration_runtime_scheduler_tasks_starving_total
+          name: starving
+        - selector: data_factory.airflow_integration_runtime_scheduler_tasks_killed_externally_total
+          name: killed_externally
+    - id: am_azure_data_factory__airflow_ir_task_instances
+      title: Azure Data Factory Airflow IR Task Instances
+      context: airflow_ir_task_instances
+      family: Airflow Tasks
+      type: line
+      units: instances/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_started_task_instances_total
+          name: started
+        - selector: data_factory.airflow_integration_runtime_task_instance_successes_total
+          name: succeeded
+        - selector: data_factory.airflow_integration_runtime_task_instance_failures_total
+          name: failed
+        - selector: data_factory.airflow_integration_runtime_task_instance_finished_total
+          name: finished
+        - selector: data_factory.airflow_integration_runtime_task_instance_previously_succeeded_total
+          name: previously_succeeded
+        - selector: data_factory.airflow_integration_runtime_task_instance_created_using_operator_total
+          name: created_via_operator
+    - id: am_azure_data_factory__airflow_ir_task_instance_duration
+      title: Azure Data Factory Airflow IR Task Instance Duration
+      context: airflow_ir_task_instance_duration
+      family: Airflow Tasks
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_task_instance_duration_average
+          name: average
+    - id: am_azure_data_factory__airflow_ir_task_dag_changes
+      title: Azure Data Factory Airflow IR Task DAG Changes
+      context: airflow_ir_task_dag_changes
+      family: Airflow Tasks
+      type: line
+      units: tasks/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_task_removed_from_dag_total
+          name: removed
+        - selector: data_factory.airflow_integration_runtime_task_restored_to_dag_total
+          name: restored
+    - id: am_azure_data_factory__airflow_ir_triggers
+      title: Azure Data Factory Airflow IR Triggers
+      context: airflow_ir_triggers
+      family: Airflow Triggers
+      type: line
+      units: triggers/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_triggers_succeeded_total
+          name: succeeded
+        - selector: data_factory.airflow_integration_runtime_triggers_failed_total
+          name: failed
+        - selector: data_factory.airflow_integration_runtime_triggers_running_total
+          name: running
+    - id: am_azure_data_factory__airflow_ir_trigger_issues
+      title: Azure Data Factory Airflow IR Trigger Issues
+      context: airflow_ir_trigger_issues
+      family: Airflow Triggers
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_triggers_blocked_main_thread_total
+          name: blocked_main_thread
+        - selector: data_factory.airflow_integration_runtime_celery_task_timeout_error_total
+          name: celery_timeout_errors
+    - id: am_azure_data_factory__airflow_ir_zombies
+      title: Azure Data Factory Airflow IR Zombie Tasks Killed
+      context: airflow_ir_zombies
+      family: Airflow Triggers
+      type: line
+      units: tasks/s
+      algorithm: incremental
+      dimensions:
+        - selector: data_factory.airflow_integration_runtime_zombies_killed_total
+          name: killed

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/event_grid.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/event_grid.yaml
@@ -3,153 +3,153 @@ id: event_grid
 name: Azure Event Grid Topic
 resource_type: Microsoft.EventGrid/topics
 metrics:
-- id: publish_success_count
-  azure_name: PublishSuccessCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: publish_fail_count
-  azure_name: PublishFailCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: publish_success_latency_in_ms
-  azure_name: PublishSuccessLatencyInMs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: matched_event_count
-  azure_name: MatchedEventCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: unmatched_event_count
-  azure_name: UnmatchedEventCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: advanced_filter_evaluation_count
-  azure_name: AdvancedFilterEvaluationCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: delivery_success_count
-  azure_name: DeliverySuccessCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: delivery_attempt_fail_count
-  azure_name: DeliveryAttemptFailCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: dropped_event_count
-  azure_name: DroppedEventCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: dead_lettered_count
-  azure_name: DeadLetteredCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: destination_processing_duration_in_ms
-  azure_name: DestinationProcessingDurationInMs
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: publish_success_count
+    azure_name: PublishSuccessCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: publish_fail_count
+    azure_name: PublishFailCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: publish_success_latency_in_ms
+    azure_name: PublishSuccessLatencyInMs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: matched_event_count
+    azure_name: MatchedEventCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: unmatched_event_count
+    azure_name: UnmatchedEventCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: advanced_filter_evaluation_count
+    azure_name: AdvancedFilterEvaluationCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: delivery_success_count
+    azure_name: DeliverySuccessCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: delivery_attempt_fail_count
+    azure_name: DeliveryAttemptFailCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: dropped_event_count
+    azure_name: DroppedEventCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: dead_lettered_count
+    azure_name: DeadLetteredCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: destination_processing_duration_in_ms
+    azure_name: DestinationProcessingDurationInMs
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Event Grid Topic
   context_namespace: event_grid
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_event_grid__publish_rate
-    title: Azure Event Grid Publish Rate
-    context: publish_rate
-    family: Publishing
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: event_grid.publish_success_count_total
-      name: success
-    - selector: event_grid.publish_fail_count_total
-      name: failed
-  - id: am_azure_event_grid__publish_latency
-    title: Azure Event Grid Publish Latency
-    context: publish_latency
-    family: Publishing
-    type: line
-    units: milliseconds
-    algorithm: incremental
-    dimensions:
-    - selector: event_grid.publish_success_latency_in_ms_total
-      name: latency
-  - id: am_azure_event_grid__routing
-    title: Azure Event Grid Event Routing
-    context: routing
-    family: Routing
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: event_grid.matched_event_count_total
-      name: matched
-    - selector: event_grid.unmatched_event_count_total
-      name: unmatched
-  - id: am_azure_event_grid__advanced_filter_evaluations
-    title: Azure Event Grid Advanced Filter Evaluations
-    context: advanced_filter_evaluations
-    family: Routing
-    type: line
-    units: evaluations/s
-    algorithm: incremental
-    dimensions:
-    - selector: event_grid.advanced_filter_evaluation_count_total
-      name: evaluations
-  - id: am_azure_event_grid__delivery
-    title: Azure Event Grid Event Delivery
-    context: delivery
-    family: Delivery
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: event_grid.delivery_success_count_total
-      name: delivered
-    - selector: event_grid.delivery_attempt_fail_count_total
-      name: failed
-    - selector: event_grid.dropped_event_count_total
-      name: dropped
-    - selector: event_grid.dead_lettered_count_total
-      name: dead_lettered
-  - id: am_azure_event_grid__destination_processing_duration
-    title: Azure Event Grid Destination Processing Duration
-    context: destination_processing_duration
-    family: Performance
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: event_grid.destination_processing_duration_in_ms_average
-      name: average
+    - id: am_azure_event_grid__publish_rate
+      title: Azure Event Grid Publish Rate
+      context: publish_rate
+      family: Publishing
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: event_grid.publish_success_count_total
+          name: success
+        - selector: event_grid.publish_fail_count_total
+          name: failed
+    - id: am_azure_event_grid__publish_latency
+      title: Azure Event Grid Publish Latency
+      context: publish_latency
+      family: Publishing
+      type: line
+      units: milliseconds
+      algorithm: incremental
+      dimensions:
+        - selector: event_grid.publish_success_latency_in_ms_total
+          name: latency
+    - id: am_azure_event_grid__routing
+      title: Azure Event Grid Event Routing
+      context: routing
+      family: Routing
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: event_grid.matched_event_count_total
+          name: matched
+        - selector: event_grid.unmatched_event_count_total
+          name: unmatched
+    - id: am_azure_event_grid__advanced_filter_evaluations
+      title: Azure Event Grid Advanced Filter Evaluations
+      context: advanced_filter_evaluations
+      family: Routing
+      type: line
+      units: evaluations/s
+      algorithm: incremental
+      dimensions:
+        - selector: event_grid.advanced_filter_evaluation_count_total
+          name: evaluations
+    - id: am_azure_event_grid__delivery
+      title: Azure Event Grid Event Delivery
+      context: delivery
+      family: Delivery
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: event_grid.delivery_success_count_total
+          name: delivered
+        - selector: event_grid.delivery_attempt_fail_count_total
+          name: failed
+        - selector: event_grid.dropped_event_count_total
+          name: dropped
+        - selector: event_grid.dead_lettered_count_total
+          name: dead_lettered
+    - id: am_azure_event_grid__destination_processing_duration
+      title: Azure Event Grid Destination Processing Duration
+      context: destination_processing_duration
+      family: Performance
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: event_grid.destination_processing_duration_in_ms_average
+          name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/event_hubs.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/event_hubs.yaml
@@ -3,289 +3,289 @@ id: event_hubs
 name: Azure Event Hubs Namespace
 resource_type: Microsoft.EventHub/Namespaces
 metrics:
-- id: incoming_messages
-  azure_name: IncomingMessages
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: outgoing_messages
-  azure_name: OutgoingMessages
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: incoming_bytes
-  azure_name: IncomingBytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: outgoing_bytes
-  azure_name: OutgoingBytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: incoming_requests
-  azure_name: IncomingRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: successful_requests
-  azure_name: SuccessfulRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: throttled_requests
-  azure_name: ThrottledRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: server_errors
-  azure_name: ServerErrors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: user_errors
-  azure_name: UserErrors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: quota_exceeded_errors
-  azure_name: QuotaExceededErrors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: active_connections
-  azure_name: ActiveConnections
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: connections_opened
-  azure_name: ConnectionsOpened
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: connections_closed
-  azure_name: ConnectionsClosed
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: captured_messages
-  azure_name: CapturedMessages
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: captured_bytes
-  azure_name: CapturedBytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: capture_backlog
-  azure_name: CaptureBacklog
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: namespace_cpu_usage
-  azure_name: NamespaceCpuUsage
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: namespace_memory_usage
-  azure_name: NamespaceMemoryUsage
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: replication_lag_count
-  azure_name: ReplicationLagCount
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: replication_lag_duration
-  azure_name: ReplicationLagDuration
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: size
-  azure_name: Size
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: incoming_messages
+    azure_name: IncomingMessages
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: outgoing_messages
+    azure_name: OutgoingMessages
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: incoming_bytes
+    azure_name: IncomingBytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: outgoing_bytes
+    azure_name: OutgoingBytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: incoming_requests
+    azure_name: IncomingRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: successful_requests
+    azure_name: SuccessfulRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: throttled_requests
+    azure_name: ThrottledRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: server_errors
+    azure_name: ServerErrors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: user_errors
+    azure_name: UserErrors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: quota_exceeded_errors
+    azure_name: QuotaExceededErrors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: active_connections
+    azure_name: ActiveConnections
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: connections_opened
+    azure_name: ConnectionsOpened
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: connections_closed
+    azure_name: ConnectionsClosed
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: captured_messages
+    azure_name: CapturedMessages
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: captured_bytes
+    azure_name: CapturedBytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: capture_backlog
+    azure_name: CaptureBacklog
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: namespace_cpu_usage
+    azure_name: NamespaceCpuUsage
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: namespace_memory_usage
+    azure_name: NamespaceMemoryUsage
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: replication_lag_count
+    azure_name: ReplicationLagCount
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: replication_lag_duration
+    azure_name: ReplicationLagDuration
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: size
+    azure_name: Size
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Event Hubs Namespace
   context_namespace: event_hubs
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_event_hubs__message_flow
-    title: Azure Event Hubs Message Flow
-    context: message_flow
-    family: Messages
-    type: line
-    units: messages/s
-    algorithm: incremental
-    dimensions:
-    - selector: event_hubs.incoming_messages_total
-      name: in
-    - selector: event_hubs.outgoing_messages_total
-      name: out
-  - id: am_azure_event_hubs__data_throughput
-    title: Azure Event Hubs Data Throughput
-    context: data_throughput
-    family: Messages
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: event_hubs.incoming_bytes_total
-      name: in
-    - selector: event_hubs.outgoing_bytes_total
-      name: out
-  - id: am_azure_event_hubs__requests
-    title: Azure Event Hubs Requests
-    context: requests
-    family: Requests
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: event_hubs.incoming_requests_total
-      name: incoming
-    - selector: event_hubs.successful_requests_total
-      name: successful
-  - id: am_azure_event_hubs__errors
-    title: Azure Event Hubs Errors
-    context: errors
-    family: Errors
-    type: line
-    units: errors/s
-    algorithm: incremental
-    dimensions:
-    - selector: event_hubs.server_errors_total
-      name: server
-    - selector: event_hubs.user_errors_total
-      name: user
-    - selector: event_hubs.throttled_requests_total
-      name: throttled
-    - selector: event_hubs.quota_exceeded_errors_total
-      name: quota_exceeded
-  - id: am_azure_event_hubs__connections
-    title: Azure Event Hubs Active Connections
-    context: connections
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: event_hubs.active_connections_average
-      name: active
-  - id: am_azure_event_hubs__connection_events
-    title: Azure Event Hubs Connection Events
-    context: connection_events
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: event_hubs.connections_opened_maximum
-      name: opened
-    - selector: event_hubs.connections_closed_maximum
-      name: closed
-  - id: am_azure_event_hubs__captured_messages
-    title: Azure Event Hubs Captured Messages
-    context: captured_messages
-    family: Capture
-    type: line
-    units: messages/s
-    algorithm: incremental
-    dimensions:
-    - selector: event_hubs.captured_messages_total
-      name: total
-  - id: am_azure_event_hubs__captured_data
-    title: Azure Event Hubs Captured Data
-    context: captured_data
-    family: Capture
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: event_hubs.captured_bytes_total
-      name: total
-  - id: am_azure_event_hubs__namespace_size
-    title: Azure Event Hubs Namespace Size
-    context: namespace_size
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: event_hubs.size_average
-      name: average
-  - id: am_azure_event_hubs__capture_backlog
-    title: Azure Event Hubs Capture Backlog
-    context: capture_backlog
-    family: Capture
-    type: line
-    units: messages
-    algorithm: absolute
-    dimensions:
-    - selector: event_hubs.capture_backlog_total
-      name: backlog
-  - id: am_azure_event_hubs__namespace_resources
-    title: Azure Event Hubs Namespace Resources
-    context: namespace_resources
-    family: Capacity
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: event_hubs.namespace_cpu_usage_maximum
-      name: cpu
-    - selector: event_hubs.namespace_memory_usage_maximum
-      name: memory
-  - id: am_azure_event_hubs__replication_lag
-    title: Azure Event Hubs Replication Lag
-    context: replication_lag
-    family: Replication
-    type: line
-    units: messages
-    algorithm: absolute
-    dimensions:
-    - selector: event_hubs.replication_lag_count_maximum
-      name: messages
-  - id: am_azure_event_hubs__replication_lag_duration
-    title: Azure Event Hubs Replication Lag Duration
-    context: replication_lag_duration
-    family: Replication
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: event_hubs.replication_lag_duration_maximum
-      name: duration
+    - id: am_azure_event_hubs__message_flow
+      title: Azure Event Hubs Message Flow
+      context: message_flow
+      family: Messages
+      type: line
+      units: messages/s
+      algorithm: incremental
+      dimensions:
+        - selector: event_hubs.incoming_messages_total
+          name: in
+        - selector: event_hubs.outgoing_messages_total
+          name: out
+    - id: am_azure_event_hubs__data_throughput
+      title: Azure Event Hubs Data Throughput
+      context: data_throughput
+      family: Messages
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: event_hubs.incoming_bytes_total
+          name: in
+        - selector: event_hubs.outgoing_bytes_total
+          name: out
+    - id: am_azure_event_hubs__requests
+      title: Azure Event Hubs Requests
+      context: requests
+      family: Requests
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: event_hubs.incoming_requests_total
+          name: incoming
+        - selector: event_hubs.successful_requests_total
+          name: successful
+    - id: am_azure_event_hubs__errors
+      title: Azure Event Hubs Errors
+      context: errors
+      family: Errors
+      type: line
+      units: errors/s
+      algorithm: incremental
+      dimensions:
+        - selector: event_hubs.server_errors_total
+          name: server
+        - selector: event_hubs.user_errors_total
+          name: user
+        - selector: event_hubs.throttled_requests_total
+          name: throttled
+        - selector: event_hubs.quota_exceeded_errors_total
+          name: quota_exceeded
+    - id: am_azure_event_hubs__connections
+      title: Azure Event Hubs Active Connections
+      context: connections
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: event_hubs.active_connections_average
+          name: active
+    - id: am_azure_event_hubs__connection_events
+      title: Azure Event Hubs Connection Events
+      context: connection_events
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: event_hubs.connections_opened_maximum
+          name: opened
+        - selector: event_hubs.connections_closed_maximum
+          name: closed
+    - id: am_azure_event_hubs__captured_messages
+      title: Azure Event Hubs Captured Messages
+      context: captured_messages
+      family: Capture
+      type: line
+      units: messages/s
+      algorithm: incremental
+      dimensions:
+        - selector: event_hubs.captured_messages_total
+          name: total
+    - id: am_azure_event_hubs__captured_data
+      title: Azure Event Hubs Captured Data
+      context: captured_data
+      family: Capture
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: event_hubs.captured_bytes_total
+          name: total
+    - id: am_azure_event_hubs__namespace_size
+      title: Azure Event Hubs Namespace Size
+      context: namespace_size
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: event_hubs.size_average
+          name: average
+    - id: am_azure_event_hubs__capture_backlog
+      title: Azure Event Hubs Capture Backlog
+      context: capture_backlog
+      family: Capture
+      type: line
+      units: messages
+      algorithm: absolute
+      dimensions:
+        - selector: event_hubs.capture_backlog_total
+          name: backlog
+    - id: am_azure_event_hubs__namespace_resources
+      title: Azure Event Hubs Namespace Resources
+      context: namespace_resources
+      family: Capacity
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: event_hubs.namespace_cpu_usage_maximum
+          name: cpu
+        - selector: event_hubs.namespace_memory_usage_maximum
+          name: memory
+    - id: am_azure_event_hubs__replication_lag
+      title: Azure Event Hubs Replication Lag
+      context: replication_lag
+      family: Replication
+      type: line
+      units: messages
+      algorithm: absolute
+      dimensions:
+        - selector: event_hubs.replication_lag_count_maximum
+          name: messages
+    - id: am_azure_event_hubs__replication_lag_duration
+      title: Azure Event Hubs Replication Lag Duration
+      context: replication_lag_duration
+      family: Replication
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: event_hubs.replication_lag_duration_maximum
+          name: duration

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/express_route_circuit.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/express_route_circuit.yaml
@@ -3,161 +3,161 @@ id: express_route_circuit
 name: Azure ExpressRoute Circuit
 resource_type: Microsoft.Network/expressRouteCircuits
 metrics:
-- id: arp_availability
-  azure_name: ArpAvailability
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: bgp_availability
-  azure_name: BgpAvailability
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: bits_in_per_second
-  azure_name: BitsInPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: bits_out_per_second
-  azure_name: BitsOutPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: ingress_bandwidth_utilization
-  azure_name: IngressBandwidthUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: egress_bandwidth_utilization
-  azure_name: EgressBandwidthUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: qos_drop_bits_in_per_second
-  azure_name: QosDropBitsInPerSecond
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: qos_drop_bits_out_per_second
-  azure_name: QosDropBitsOutPerSecond
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: fast_path_routes_count_for_circuit
-  azure_name: FastPathRoutesCountForCircuit
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: global_reach_bits_in_per_second
-  azure_name: GlobalReachBitsInPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: global_reach_bits_out_per_second
-  azure_name: GlobalReachBitsOutPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: arp_availability
+    azure_name: ArpAvailability
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: bgp_availability
+    azure_name: BgpAvailability
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: bits_in_per_second
+    azure_name: BitsInPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: bits_out_per_second
+    azure_name: BitsOutPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: ingress_bandwidth_utilization
+    azure_name: IngressBandwidthUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: egress_bandwidth_utilization
+    azure_name: EgressBandwidthUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: qos_drop_bits_in_per_second
+    azure_name: QosDropBitsInPerSecond
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: qos_drop_bits_out_per_second
+    azure_name: QosDropBitsOutPerSecond
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: fast_path_routes_count_for_circuit
+    azure_name: FastPathRoutesCountForCircuit
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: global_reach_bits_in_per_second
+    azure_name: GlobalReachBitsInPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: global_reach_bits_out_per_second
+    azure_name: GlobalReachBitsOutPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure ExpressRoute Circuit
   context_namespace: express_route_circuit
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_express_route_circuit__arp_availability
-    title: Azure ExpressRoute Circuit ARP Availability
-    context: arp_availability
-    family: Availability
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_circuit.arp_availability_average
-      name: average
-  - id: am_azure_express_route_circuit__bgp_availability
-    title: Azure ExpressRoute Circuit BGP Availability
-    context: bgp_availability
-    family: Availability
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_circuit.bgp_availability_average
-      name: average
-  - id: am_azure_express_route_circuit__throughput
-    title: Azure ExpressRoute Circuit Throughput
-    context: throughput
-    family: Traffic
-    type: line
-    units: bits/s
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_circuit.bits_in_per_second_average
-      name: in
-    - selector: express_route_circuit.bits_out_per_second_average
-      name: out
-  - id: am_azure_express_route_circuit__bandwidth_utilization
-    title: Azure ExpressRoute Circuit Bandwidth Utilization
-    context: bandwidth_utilization
-    family: Traffic
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_circuit.ingress_bandwidth_utilization_maximum
-      name: ingress
-    - selector: express_route_circuit.egress_bandwidth_utilization_maximum
-      name: egress
-  - id: am_azure_express_route_circuit__qos_dropped_bits
-    title: Azure ExpressRoute Circuit QoS Dropped Bits
-    context: qos_dropped_bits
-    family: QoS
-    type: line
-    units: bits/s
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_circuit.qos_drop_bits_in_per_second_average
-      name: in
-    - selector: express_route_circuit.qos_drop_bits_out_per_second_average
-      name: out
-  - id: am_azure_express_route_circuit__fastpath_routes
-    title: Azure ExpressRoute Circuit FastPath Routes
-    context: fastpath_routes
-    family: FastPath
-    type: line
-    units: routes
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_circuit.fast_path_routes_count_for_circuit_maximum
-      name: maximum
-  - id: am_azure_express_route_circuit__global_reach_throughput
-    title: Azure ExpressRoute Circuit GlobalReach Throughput
-    context: global_reach_throughput
-    family: GlobalReach
-    type: line
-    units: bits/s
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_circuit.global_reach_bits_in_per_second_average
-      name: in
-    - selector: express_route_circuit.global_reach_bits_out_per_second_average
-      name: out
+    - id: am_azure_express_route_circuit__arp_availability
+      title: Azure ExpressRoute Circuit ARP Availability
+      context: arp_availability
+      family: Availability
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_circuit.arp_availability_average
+          name: average
+    - id: am_azure_express_route_circuit__bgp_availability
+      title: Azure ExpressRoute Circuit BGP Availability
+      context: bgp_availability
+      family: Availability
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_circuit.bgp_availability_average
+          name: average
+    - id: am_azure_express_route_circuit__throughput
+      title: Azure ExpressRoute Circuit Throughput
+      context: throughput
+      family: Traffic
+      type: line
+      units: bits/s
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_circuit.bits_in_per_second_average
+          name: in
+        - selector: express_route_circuit.bits_out_per_second_average
+          name: out
+    - id: am_azure_express_route_circuit__bandwidth_utilization
+      title: Azure ExpressRoute Circuit Bandwidth Utilization
+      context: bandwidth_utilization
+      family: Traffic
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_circuit.ingress_bandwidth_utilization_maximum
+          name: ingress
+        - selector: express_route_circuit.egress_bandwidth_utilization_maximum
+          name: egress
+    - id: am_azure_express_route_circuit__qos_dropped_bits
+      title: Azure ExpressRoute Circuit QoS Dropped Bits
+      context: qos_dropped_bits
+      family: QoS
+      type: line
+      units: bits/s
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_circuit.qos_drop_bits_in_per_second_average
+          name: in
+        - selector: express_route_circuit.qos_drop_bits_out_per_second_average
+          name: out
+    - id: am_azure_express_route_circuit__fastpath_routes
+      title: Azure ExpressRoute Circuit FastPath Routes
+      context: fastpath_routes
+      family: FastPath
+      type: line
+      units: routes
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_circuit.fast_path_routes_count_for_circuit_maximum
+          name: maximum
+    - id: am_azure_express_route_circuit__global_reach_throughput
+      title: Azure ExpressRoute Circuit GlobalReach Throughput
+      context: global_reach_throughput
+      family: GlobalReach
+      type: line
+      units: bits/s
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_circuit.global_reach_bits_in_per_second_average
+          name: in
+        - selector: express_route_circuit.global_reach_bits_out_per_second_average
+          name: out

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/express_route_gateway.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/express_route_gateway.yaml
@@ -3,201 +3,201 @@ id: express_route_gateway
 name: Azure ExpressRoute Gateway
 resource_type: Microsoft.Network/expressRouteGateways
 metrics:
-- id: er_gateway_connection_bits_in_per_second
-  azure_name: ErGatewayConnectionBitsInPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: er_gateway_connection_bits_out_per_second
-  azure_name: ErGatewayConnectionBitsOutPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: express_route_gateway_bits_per_second
-  azure_name: ExpressRouteGatewayBitsPerSecond
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: minimum
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: express_route_gateway_cpu_utilization
-  azure_name: ExpressRouteGatewayCpuUtilization
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: minimum
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: express_route_gateway_packets_per_second
-  azure_name: ExpressRouteGatewayPacketsPerSecond
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: minimum
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: express_route_gateway_active_flows
-  azure_name: ExpressRouteGatewayActiveFlows
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: minimum
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: express_route_gateway_count_of_routes_advertised_to_peer
-  azure_name: ExpressRouteGatewayCountOfRoutesAdvertisedToPeer
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: express_route_gateway_count_of_routes_learned_from_peer
-  azure_name: ExpressRouteGatewayCountOfRoutesLearnedFromPeer
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: express_route_gateway_frequency_of_routes_changed
-  azure_name: ExpressRouteGatewayFrequencyOfRoutesChanged
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: express_route_gateway_max_flows_creation_rate
-  azure_name: ExpressRouteGatewayMaxFlowsCreationRate
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: express_route_gateway_number_of_vm_in_vnet
-  azure_name: ExpressRouteGatewayNumberOfVmInVnet
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
+  - id: er_gateway_connection_bits_in_per_second
+    azure_name: ErGatewayConnectionBitsInPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: er_gateway_connection_bits_out_per_second
+    azure_name: ErGatewayConnectionBitsOutPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: express_route_gateway_bits_per_second
+    azure_name: ExpressRouteGatewayBitsPerSecond
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: minimum
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: express_route_gateway_cpu_utilization
+    azure_name: ExpressRouteGatewayCpuUtilization
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: minimum
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: express_route_gateway_packets_per_second
+    azure_name: ExpressRouteGatewayPacketsPerSecond
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: minimum
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: express_route_gateway_active_flows
+    azure_name: ExpressRouteGatewayActiveFlows
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: minimum
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: express_route_gateway_count_of_routes_advertised_to_peer
+    azure_name: ExpressRouteGatewayCountOfRoutesAdvertisedToPeer
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: express_route_gateway_count_of_routes_learned_from_peer
+    azure_name: ExpressRouteGatewayCountOfRoutesLearnedFromPeer
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: express_route_gateway_frequency_of_routes_changed
+    azure_name: ExpressRouteGatewayFrequencyOfRoutesChanged
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: express_route_gateway_max_flows_creation_rate
+    azure_name: ExpressRouteGatewayMaxFlowsCreationRate
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: express_route_gateway_number_of_vm_in_vnet
+    azure_name: ExpressRouteGatewayNumberOfVmInVnet
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
 template:
   family: Azure ExpressRoute Gateway
   context_namespace: express_route_gateway
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_express_route_gateway__connection_throughput
-    title: Azure ExpressRoute Gateway Connection Throughput
-    context: connection_throughput
-    family: Traffic
-    type: line
-    units: bits/s
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_gateway.er_gateway_connection_bits_in_per_second_average
-      name: in
-    - selector: express_route_gateway.er_gateway_connection_bits_out_per_second_average
-      name: out
-  - id: am_azure_express_route_gateway__gateway_throughput
-    title: Azure ExpressRoute Gateway Throughput
-    context: gateway_throughput
-    family: Performance
-    type: line
-    units: bits/s
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_gateway.express_route_gateway_bits_per_second_average
-      name: average
-  - id: am_azure_express_route_gateway__cpu_utilization
-    title: Azure ExpressRoute Gateway CPU Utilization
-    context: cpu_utilization
-    family: Performance
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_gateway.express_route_gateway_cpu_utilization_average
-      name: average
-  - id: am_azure_express_route_gateway__packets
-    title: Azure ExpressRoute Gateway Packets
-    context: packets
-    family: Performance
-    type: line
-    units: packets/s
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_gateway.express_route_gateway_packets_per_second_average
-      name: average
-  - id: am_azure_express_route_gateway__active_flows
-    title: Azure ExpressRoute Gateway Active Flows
-    context: active_flows
-    family: Scalability
-    type: line
-    units: flows
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_gateway.express_route_gateway_active_flows_average
-      name: average
-  - id: am_azure_express_route_gateway__routes_advertised
-    title: Azure ExpressRoute Gateway Routes Advertised to Peer
-    context: routes_advertised
-    family: Scalability
-    type: line
-    units: routes
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_gateway.express_route_gateway_count_of_routes_advertised_to_peer_maximum
-      name: maximum
-  - id: am_azure_express_route_gateway__routes_learned
-    title: Azure ExpressRoute Gateway Routes Learned from Peer
-    context: routes_learned
-    family: Scalability
-    type: line
-    units: routes
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_gateway.express_route_gateway_count_of_routes_learned_from_peer_maximum
-      name: maximum
-  - id: am_azure_express_route_gateway__route_changes
-    title: Azure ExpressRoute Gateway Route Changes
-    context: route_changes
-    family: Scalability
-    type: line
-    units: changes/s
-    algorithm: incremental
-    dimensions:
-    - selector: express_route_gateway.express_route_gateway_frequency_of_routes_changed_total
-      name: total
-  - id: am_azure_express_route_gateway__max_flows_creation_rate
-    title: Azure ExpressRoute Gateway Max Flow Creation Rate
-    context: max_flows_creation_rate
-    family: Scalability
-    type: line
-    units: flows/s
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_gateway.express_route_gateway_max_flows_creation_rate_maximum
-      name: maximum
-  - id: am_azure_express_route_gateway__vm_count
-    title: Azure ExpressRoute Gateway VMs in VNet
-    context: vm_count
-    family: Scalability
-    type: line
-    units: VMs
-    algorithm: absolute
-    dimensions:
-    - selector: express_route_gateway.express_route_gateway_number_of_vm_in_vnet_maximum
-      name: maximum
+    - id: am_azure_express_route_gateway__connection_throughput
+      title: Azure ExpressRoute Gateway Connection Throughput
+      context: connection_throughput
+      family: Traffic
+      type: line
+      units: bits/s
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_gateway.er_gateway_connection_bits_in_per_second_average
+          name: in
+        - selector: express_route_gateway.er_gateway_connection_bits_out_per_second_average
+          name: out
+    - id: am_azure_express_route_gateway__gateway_throughput
+      title: Azure ExpressRoute Gateway Throughput
+      context: gateway_throughput
+      family: Performance
+      type: line
+      units: bits/s
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_gateway.express_route_gateway_bits_per_second_average
+          name: average
+    - id: am_azure_express_route_gateway__cpu_utilization
+      title: Azure ExpressRoute Gateway CPU Utilization
+      context: cpu_utilization
+      family: Performance
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_gateway.express_route_gateway_cpu_utilization_average
+          name: average
+    - id: am_azure_express_route_gateway__packets
+      title: Azure ExpressRoute Gateway Packets
+      context: packets
+      family: Performance
+      type: line
+      units: packets/s
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_gateway.express_route_gateway_packets_per_second_average
+          name: average
+    - id: am_azure_express_route_gateway__active_flows
+      title: Azure ExpressRoute Gateway Active Flows
+      context: active_flows
+      family: Scalability
+      type: line
+      units: flows
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_gateway.express_route_gateway_active_flows_average
+          name: average
+    - id: am_azure_express_route_gateway__routes_advertised
+      title: Azure ExpressRoute Gateway Routes Advertised to Peer
+      context: routes_advertised
+      family: Scalability
+      type: line
+      units: routes
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_gateway.express_route_gateway_count_of_routes_advertised_to_peer_maximum
+          name: maximum
+    - id: am_azure_express_route_gateway__routes_learned
+      title: Azure ExpressRoute Gateway Routes Learned from Peer
+      context: routes_learned
+      family: Scalability
+      type: line
+      units: routes
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_gateway.express_route_gateway_count_of_routes_learned_from_peer_maximum
+          name: maximum
+    - id: am_azure_express_route_gateway__route_changes
+      title: Azure ExpressRoute Gateway Route Changes
+      context: route_changes
+      family: Scalability
+      type: line
+      units: changes/s
+      algorithm: incremental
+      dimensions:
+        - selector: express_route_gateway.express_route_gateway_frequency_of_routes_changed_total
+          name: total
+    - id: am_azure_express_route_gateway__max_flows_creation_rate
+      title: Azure ExpressRoute Gateway Max Flow Creation Rate
+      context: max_flows_creation_rate
+      family: Scalability
+      type: line
+      units: flows/s
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_gateway.express_route_gateway_max_flows_creation_rate_maximum
+          name: maximum
+    - id: am_azure_express_route_gateway__vm_count
+      title: Azure ExpressRoute Gateway VMs in VNet
+      context: vm_count
+      family: Scalability
+      type: line
+      units: VMs
+      algorithm: absolute
+      dimensions:
+        - selector: express_route_gateway.express_route_gateway_number_of_vm_in_vnet_maximum
+          name: maximum

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/firewall.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/firewall.yaml
@@ -3,137 +3,137 @@ id: firewall
 name: Azure Firewall
 resource_type: Microsoft.Network/azureFirewalls
 metrics:
-- id: firewall_health
-  azure_name: FirewallHealth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: firewall_latency_png
-  azure_name: FirewallLatencyPng
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: throughput
-  azure_name: Throughput
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_processed
-  azure_name: DataProcessed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: application_rule_hit
-  azure_name: ApplicationRuleHit
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: network_rule_hit
-  azure_name: NetworkRuleHit
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: snat_port_utilization
-  azure_name: SNATPortUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: observed_capacity
-  azure_name: ObservedCapacity
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: firewall_health
+    azure_name: FirewallHealth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: firewall_latency_png
+    azure_name: FirewallLatencyPng
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: throughput
+    azure_name: Throughput
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_processed
+    azure_name: DataProcessed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: application_rule_hit
+    azure_name: ApplicationRuleHit
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: network_rule_hit
+    azure_name: NetworkRuleHit
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: snat_port_utilization
+    azure_name: SNATPortUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: observed_capacity
+    azure_name: ObservedCapacity
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Firewall
   context_namespace: firewall
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_firewall__health
-    title: Azure Firewall Health State
-    context: health
-    family: Health
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: firewall.firewall_health_average
-      name: average
-  - id: am_azure_firewall__latency
-    title: Azure Firewall Latency Probe
-    context: latency
-    family: Performance
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: firewall.firewall_latency_png_average
-      name: average
-  - id: am_azure_firewall__throughput
-    title: Azure Firewall Throughput
-    context: throughput
-    family: Traffic
-    type: line
-    units: bits/s
-    algorithm: absolute
-    dimensions:
-    - selector: firewall.throughput_average
-      name: average
-  - id: am_azure_firewall__data_processed
-    title: Azure Firewall Data Processed
-    context: data_processed
-    family: Traffic
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: firewall.data_processed_total
-      name: total
-  - id: am_azure_firewall__rule_hits
-    title: Azure Firewall Rule Hits
-    context: rule_hits
-    family: Rules
-    type: line
-    units: hits/s
-    algorithm: incremental
-    dimensions:
-    - selector: firewall.application_rule_hit_total
-      name: application
-    - selector: firewall.network_rule_hit_total
-      name: network
-  - id: am_azure_firewall__snat_port_utilization
-    title: Azure Firewall SNAT Port Utilization
-    context: snat_port_utilization
-    family: SNAT
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: firewall.snat_port_utilization_average
-      name: average
-  - id: am_azure_firewall__capacity
-    title: Azure Firewall Observed Capacity Units
-    context: capacity
-    family: Capacity
-    type: line
-    units: units
-    algorithm: absolute
-    dimensions:
-    - selector: firewall.observed_capacity_average
-      name: average
+    - id: am_azure_firewall__health
+      title: Azure Firewall Health State
+      context: health
+      family: Health
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: firewall.firewall_health_average
+          name: average
+    - id: am_azure_firewall__latency
+      title: Azure Firewall Latency Probe
+      context: latency
+      family: Performance
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: firewall.firewall_latency_png_average
+          name: average
+    - id: am_azure_firewall__throughput
+      title: Azure Firewall Throughput
+      context: throughput
+      family: Traffic
+      type: line
+      units: bits/s
+      algorithm: absolute
+      dimensions:
+        - selector: firewall.throughput_average
+          name: average
+    - id: am_azure_firewall__data_processed
+      title: Azure Firewall Data Processed
+      context: data_processed
+      family: Traffic
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: firewall.data_processed_total
+          name: total
+    - id: am_azure_firewall__rule_hits
+      title: Azure Firewall Rule Hits
+      context: rule_hits
+      family: Rules
+      type: line
+      units: hits/s
+      algorithm: incremental
+      dimensions:
+        - selector: firewall.application_rule_hit_total
+          name: application
+        - selector: firewall.network_rule_hit_total
+          name: network
+    - id: am_azure_firewall__snat_port_utilization
+      title: Azure Firewall SNAT Port Utilization
+      context: snat_port_utilization
+      family: SNAT
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: firewall.snat_port_utilization_average
+          name: average
+    - id: am_azure_firewall__capacity
+      title: Azure Firewall Observed Capacity Units
+      context: capacity
+      family: Capacity
+      type: line
+      units: units
+      algorithm: absolute
+      dimensions:
+        - selector: firewall.observed_capacity_average
+          name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/front_door.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/front_door.yaml
@@ -3,273 +3,273 @@ id: front_door
 name: Azure Front Door
 resource_type: Microsoft.Cdn/profiles
 metrics:
-- id: total_latency
-  azure_name: TotalLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: origin_latency
-  azure_name: OriginLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: origin_health_percentage
-  azure_name: OriginHealthPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: byte_hit_ratio
-  azure_name: ByteHitRatio
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: percentage4xx
-  azure_name: Percentage4XX
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: percentage5xx
-  azure_name: Percentage5XX
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: request_count
-  azure_name: RequestCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: origin_request_count
-  azure_name: OriginRequestCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: request_size
-  azure_name: RequestSize
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: response_size
-  azure_name: ResponseSize
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: origin_shield_request_count
-  azure_name: OriginShieldRequestCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: origin_shield_origin_request_count
-  azure_name: OriginShieldOriginRequestCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: origin_shield_rate_limit_request_count
-  azure_name: OriginShieldRateLimitRequestCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: origin_shield_request_size
-  azure_name: OriginShieldRequestSize
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: web_application_firewall_request_count
-  azure_name: WebApplicationFirewallRequestCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: web_application_firewall_captcha_request_count
-  azure_name: WebApplicationFirewallCaptchaRequestCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: web_application_firewall_js_request_count
-  azure_name: WebApplicationFirewallJsRequestCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: web_socket_connections
-  azure_name: WebSocketConnections
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: active_web_socket_connections
-  azure_name: ActiveWebSocketConnections
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: average_web_socket_connection_duration
-  azure_name: AverageWebSocketConnectionDuration
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: total_latency
+    azure_name: TotalLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: origin_latency
+    azure_name: OriginLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: origin_health_percentage
+    azure_name: OriginHealthPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: byte_hit_ratio
+    azure_name: ByteHitRatio
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: percentage4xx
+    azure_name: Percentage4XX
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: percentage5xx
+    azure_name: Percentage5XX
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: request_count
+    azure_name: RequestCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: origin_request_count
+    azure_name: OriginRequestCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: request_size
+    azure_name: RequestSize
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: response_size
+    azure_name: ResponseSize
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: origin_shield_request_count
+    azure_name: OriginShieldRequestCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: origin_shield_origin_request_count
+    azure_name: OriginShieldOriginRequestCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: origin_shield_rate_limit_request_count
+    azure_name: OriginShieldRateLimitRequestCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: origin_shield_request_size
+    azure_name: OriginShieldRequestSize
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: web_application_firewall_request_count
+    azure_name: WebApplicationFirewallRequestCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: web_application_firewall_captcha_request_count
+    azure_name: WebApplicationFirewallCaptchaRequestCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: web_application_firewall_js_request_count
+    azure_name: WebApplicationFirewallJsRequestCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: web_socket_connections
+    azure_name: WebSocketConnections
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: active_web_socket_connections
+    azure_name: ActiveWebSocketConnections
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: average_web_socket_connection_duration
+    azure_name: AverageWebSocketConnectionDuration
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Front Door
   context_namespace: front_door
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_front_door__latency
-    title: Azure Front Door Latency
-    context: latency
-    family: Latency
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: front_door.total_latency_average
-      name: total
-    - selector: front_door.origin_latency_average
-      name: origin
-  - id: am_azure_front_door__origin_health
-    title: Azure Front Door Origin Health
-    context: origin_health
-    family: Origin Health
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: front_door.origin_health_percentage_average
-      name: health
-  - id: am_azure_front_door__byte_hit_ratio
-    title: Azure Front Door Byte Hit Ratio
-    context: byte_hit_ratio
-    family: Cache
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: front_door.byte_hit_ratio_average
-      name: hit_ratio
-  - id: am_azure_front_door__error_rate
-    title: Azure Front Door Error Rate
-    context: error_rate
-    family: Errors
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: front_door.percentage4xx_average
-      name: 4xx
-    - selector: front_door.percentage5xx_average
-      name: 5xx
-  - id: am_azure_front_door__requests
-    title: Azure Front Door Requests
-    context: requests
-    family: Traffic
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: front_door.request_count_total
-      name: client
-    - selector: front_door.origin_request_count_total
-      name: origin
-  - id: am_azure_front_door__data_transfer
-    title: Azure Front Door Data Transfer
-    context: data_transfer
-    family: Traffic
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: front_door.request_size_total
-      name: request
-    - selector: front_door.response_size_total
-      name: response
-  - id: am_azure_front_door__origin_shield_requests
-    title: Azure Front Door Origin Shield Requests
-    context: origin_shield_requests
-    family: Origin Shield
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: front_door.origin_shield_request_count_total
-      name: to_shield
-    - selector: front_door.origin_shield_origin_request_count_total
-      name: to_origin
-    - selector: front_door.origin_shield_rate_limit_request_count_total
-      name: rate_limited
-  - id: am_azure_front_door__origin_shield_data_transfer
-    title: Azure Front Door Origin Shield Data Transfer
-    context: origin_shield_data_transfer
-    family: Origin Shield
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: front_door.origin_shield_request_size_total
-      name: request
-  - id: am_azure_front_door__waf_requests
-    title: Azure Front Door WAF Requests
-    context: waf_requests
-    family: WAF
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: front_door.web_application_firewall_request_count_total
-      name: total
-  - id: am_azure_front_door__waf_challenges
-    title: Azure Front Door WAF Challenges
-    context: waf_challenges
-    family: WAF
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: front_door.web_application_firewall_captcha_request_count_total
-      name: captcha
-    - selector: front_door.web_application_firewall_js_request_count_total
-      name: js_challenge
-  - id: am_azure_front_door__websocket_connections
-    title: Azure Front Door WebSocket Connections
-    context: websocket_connections
-    family: WebSocket
-    type: line
-    units: connections/s
-    algorithm: incremental
-    dimensions:
-    - selector: front_door.web_socket_connections_total
-      name: requested
-    - selector: front_door.active_web_socket_connections_total
-      name: active
-  - id: am_azure_front_door__websocket_duration
-    title: Azure Front Door WebSocket Connection Duration
-    context: websocket_duration
-    family: WebSocket
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: front_door.average_web_socket_connection_duration_average
-      name: average
+    - id: am_azure_front_door__latency
+      title: Azure Front Door Latency
+      context: latency
+      family: Latency
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: front_door.total_latency_average
+          name: total
+        - selector: front_door.origin_latency_average
+          name: origin
+    - id: am_azure_front_door__origin_health
+      title: Azure Front Door Origin Health
+      context: origin_health
+      family: Origin Health
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: front_door.origin_health_percentage_average
+          name: health
+    - id: am_azure_front_door__byte_hit_ratio
+      title: Azure Front Door Byte Hit Ratio
+      context: byte_hit_ratio
+      family: Cache
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: front_door.byte_hit_ratio_average
+          name: hit_ratio
+    - id: am_azure_front_door__error_rate
+      title: Azure Front Door Error Rate
+      context: error_rate
+      family: Errors
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: front_door.percentage4xx_average
+          name: 4xx
+        - selector: front_door.percentage5xx_average
+          name: 5xx
+    - id: am_azure_front_door__requests
+      title: Azure Front Door Requests
+      context: requests
+      family: Traffic
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: front_door.request_count_total
+          name: client
+        - selector: front_door.origin_request_count_total
+          name: origin
+    - id: am_azure_front_door__data_transfer
+      title: Azure Front Door Data Transfer
+      context: data_transfer
+      family: Traffic
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: front_door.request_size_total
+          name: request
+        - selector: front_door.response_size_total
+          name: response
+    - id: am_azure_front_door__origin_shield_requests
+      title: Azure Front Door Origin Shield Requests
+      context: origin_shield_requests
+      family: Origin Shield
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: front_door.origin_shield_request_count_total
+          name: to_shield
+        - selector: front_door.origin_shield_origin_request_count_total
+          name: to_origin
+        - selector: front_door.origin_shield_rate_limit_request_count_total
+          name: rate_limited
+    - id: am_azure_front_door__origin_shield_data_transfer
+      title: Azure Front Door Origin Shield Data Transfer
+      context: origin_shield_data_transfer
+      family: Origin Shield
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: front_door.origin_shield_request_size_total
+          name: request
+    - id: am_azure_front_door__waf_requests
+      title: Azure Front Door WAF Requests
+      context: waf_requests
+      family: WAF
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: front_door.web_application_firewall_request_count_total
+          name: total
+    - id: am_azure_front_door__waf_challenges
+      title: Azure Front Door WAF Challenges
+      context: waf_challenges
+      family: WAF
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: front_door.web_application_firewall_captcha_request_count_total
+          name: captcha
+        - selector: front_door.web_application_firewall_js_request_count_total
+          name: js_challenge
+    - id: am_azure_front_door__websocket_connections
+      title: Azure Front Door WebSocket Connections
+      context: websocket_connections
+      family: WebSocket
+      type: line
+      units: connections/s
+      algorithm: incremental
+      dimensions:
+        - selector: front_door.web_socket_connections_total
+          name: requested
+        - selector: front_door.active_web_socket_connections_total
+          name: active
+    - id: am_azure_front_door__websocket_duration
+      title: Azure Front Door WebSocket Connection Duration
+      context: websocket_duration
+      family: WebSocket
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: front_door.average_web_socket_connection_duration_average
+          name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/iot_hub.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/iot_hub.yaml
@@ -3,865 +3,865 @@ id: iot_hub
 name: Azure IoT Hub
 resource_type: Microsoft.Devices/IotHubs
 metrics:
-- id: c2d_commands_egress_abandon_success
-  azure_name: c2d.commands.egress.abandon.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: c2d_commands_egress_complete_success
-  azure_name: c2d.commands.egress.complete.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: c2d_commands_egress_reject_success
-  azure_name: c2d.commands.egress.reject.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: c2d_messages_expired
-  azure_name: C2DMessagesExpired
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: c2d_methods_success
-  azure_name: c2d.methods.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: c2d_methods_failure
-  azure_name: c2d.methods.failure
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: c2d_methods_request_size
-  azure_name: c2d.methods.requestSize
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: c2d_methods_response_size
-  azure_name: c2d.methods.responseSize
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: c2d_twin_read_success
-  azure_name: c2d.twin.read.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: c2d_twin_read_failure
-  azure_name: c2d.twin.read.failure
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: c2d_twin_read_size
-  azure_name: c2d.twin.read.size
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: c2d_twin_update_success
-  azure_name: c2d.twin.update.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: c2d_twin_update_failure
-  azure_name: c2d.twin.update.failure
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: c2d_twin_update_size
-  azure_name: c2d.twin.update.size
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: d2c_telemetry_ingress_all_protocol
-  azure_name: d2c.telemetry.ingress.allProtocol
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_telemetry_ingress_success
-  azure_name: d2c.telemetry.ingress.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_telemetry_ingress_send_throttle
-  azure_name: d2c.telemetry.ingress.sendThrottle
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_twin_read_success
-  azure_name: d2c.twin.read.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_twin_read_failure
-  azure_name: d2c.twin.read.failure
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_twin_read_size
-  azure_name: d2c.twin.read.size
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: d2c_twin_update_success
-  azure_name: d2c.twin.update.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_twin_update_failure
-  azure_name: d2c.twin.update.failure
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_twin_update_size
-  azure_name: d2c.twin.update.size
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: d2c_endpoints_egress_built_in_events
-  azure_name: d2c.endpoints.egress.builtIn.events
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_endpoints_egress_event_hubs
-  azure_name: d2c.endpoints.egress.eventHubs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_endpoints_egress_service_bus_queues
-  azure_name: d2c.endpoints.egress.serviceBusQueues
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_endpoints_egress_service_bus_topics
-  azure_name: d2c.endpoints.egress.serviceBusTopics
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_endpoints_egress_storage
-  azure_name: d2c.endpoints.egress.storage
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_endpoints_egress_storage_blobs
-  azure_name: d2c.endpoints.egress.storage.blobs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_endpoints_egress_storage_bytes
-  azure_name: d2c.endpoints.egress.storage.bytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_endpoints_latency_built_in_events
-  azure_name: d2c.endpoints.latency.builtIn.events
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: d2c_endpoints_latency_event_hubs
-  azure_name: d2c.endpoints.latency.eventHubs
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: d2c_endpoints_latency_service_bus_queues
-  azure_name: d2c.endpoints.latency.serviceBusQueues
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: d2c_endpoints_latency_service_bus_topics
-  azure_name: d2c.endpoints.latency.serviceBusTopics
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: d2c_endpoints_latency_storage
-  azure_name: d2c.endpoints.latency.storage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: d2c_telemetry_egress_success
-  azure_name: d2c.telemetry.egress.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_telemetry_egress_dropped
-  azure_name: d2c.telemetry.egress.dropped
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_telemetry_egress_orphaned
-  azure_name: d2c.telemetry.egress.orphaned
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_telemetry_egress_invalid
-  azure_name: d2c.telemetry.egress.invalid
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: d2c_telemetry_egress_fallback
-  azure_name: d2c.telemetry.egress.fallback
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: routing_deliveries
-  azure_name: RoutingDeliveries
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: routing_delivery_latency
-  azure_name: RoutingDeliveryLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: routing_data_size_in_bytes_delivered
-  azure_name: RoutingDataSizeInBytesDelivered
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: connect_success
-  azure_name: connect.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: connected_device_count
-  azure_name: connectedDeviceCount
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: total_device_count
-  azure_name: totalDeviceCount
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: daily_message_quota_used
-  azure_name: dailyMessageQuotaUsed
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: device_data_usage
-  azure_name: deviceDataUsage
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: device_data_usage_v2
-  azure_name: deviceDataUsageV2
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: configurations
-  azure_name: configurations
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: event_grid_deliveries
-  azure_name: EventGridDeliveries
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: event_grid_latency
-  azure_name: EventGridLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: jobs_completed
-  azure_name: jobs.completed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: jobs_failed
-  azure_name: jobs.failed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: jobs_cancel_job_success
-  azure_name: jobs.cancelJob.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: jobs_cancel_job_failure
-  azure_name: jobs.cancelJob.failure
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: jobs_create_direct_method_job_success
-  azure_name: jobs.createDirectMethodJob.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: jobs_create_direct_method_job_failure
-  azure_name: jobs.createDirectMethodJob.failure
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: jobs_create_twin_update_job_success
-  azure_name: jobs.createTwinUpdateJob.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: jobs_create_twin_update_job_failure
-  azure_name: jobs.createTwinUpdateJob.failure
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: jobs_list_jobs_success
-  azure_name: jobs.listJobs.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: jobs_list_jobs_failure
-  azure_name: jobs.listJobs.failure
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: jobs_query_jobs_success
-  azure_name: jobs.queryJobs.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: jobs_query_jobs_failure
-  azure_name: jobs.queryJobs.failure
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: twin_queries_success
-  azure_name: twinQueries.success
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: twin_queries_failure
-  azure_name: twinQueries.failure
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: twin_queries_result_size
-  azure_name: twinQueries.resultSize
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: c2d_commands_egress_abandon_success
+    azure_name: c2d.commands.egress.abandon.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: c2d_commands_egress_complete_success
+    azure_name: c2d.commands.egress.complete.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: c2d_commands_egress_reject_success
+    azure_name: c2d.commands.egress.reject.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: c2d_messages_expired
+    azure_name: C2DMessagesExpired
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: c2d_methods_success
+    azure_name: c2d.methods.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: c2d_methods_failure
+    azure_name: c2d.methods.failure
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: c2d_methods_request_size
+    azure_name: c2d.methods.requestSize
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: c2d_methods_response_size
+    azure_name: c2d.methods.responseSize
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: c2d_twin_read_success
+    azure_name: c2d.twin.read.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: c2d_twin_read_failure
+    azure_name: c2d.twin.read.failure
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: c2d_twin_read_size
+    azure_name: c2d.twin.read.size
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: c2d_twin_update_success
+    azure_name: c2d.twin.update.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: c2d_twin_update_failure
+    azure_name: c2d.twin.update.failure
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: c2d_twin_update_size
+    azure_name: c2d.twin.update.size
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: d2c_telemetry_ingress_all_protocol
+    azure_name: d2c.telemetry.ingress.allProtocol
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_telemetry_ingress_success
+    azure_name: d2c.telemetry.ingress.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_telemetry_ingress_send_throttle
+    azure_name: d2c.telemetry.ingress.sendThrottle
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_twin_read_success
+    azure_name: d2c.twin.read.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_twin_read_failure
+    azure_name: d2c.twin.read.failure
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_twin_read_size
+    azure_name: d2c.twin.read.size
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: d2c_twin_update_success
+    azure_name: d2c.twin.update.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_twin_update_failure
+    azure_name: d2c.twin.update.failure
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_twin_update_size
+    azure_name: d2c.twin.update.size
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: d2c_endpoints_egress_built_in_events
+    azure_name: d2c.endpoints.egress.builtIn.events
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_endpoints_egress_event_hubs
+    azure_name: d2c.endpoints.egress.eventHubs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_endpoints_egress_service_bus_queues
+    azure_name: d2c.endpoints.egress.serviceBusQueues
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_endpoints_egress_service_bus_topics
+    azure_name: d2c.endpoints.egress.serviceBusTopics
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_endpoints_egress_storage
+    azure_name: d2c.endpoints.egress.storage
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_endpoints_egress_storage_blobs
+    azure_name: d2c.endpoints.egress.storage.blobs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_endpoints_egress_storage_bytes
+    azure_name: d2c.endpoints.egress.storage.bytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_endpoints_latency_built_in_events
+    azure_name: d2c.endpoints.latency.builtIn.events
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: d2c_endpoints_latency_event_hubs
+    azure_name: d2c.endpoints.latency.eventHubs
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: d2c_endpoints_latency_service_bus_queues
+    azure_name: d2c.endpoints.latency.serviceBusQueues
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: d2c_endpoints_latency_service_bus_topics
+    azure_name: d2c.endpoints.latency.serviceBusTopics
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: d2c_endpoints_latency_storage
+    azure_name: d2c.endpoints.latency.storage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: d2c_telemetry_egress_success
+    azure_name: d2c.telemetry.egress.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_telemetry_egress_dropped
+    azure_name: d2c.telemetry.egress.dropped
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_telemetry_egress_orphaned
+    azure_name: d2c.telemetry.egress.orphaned
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_telemetry_egress_invalid
+    azure_name: d2c.telemetry.egress.invalid
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: d2c_telemetry_egress_fallback
+    azure_name: d2c.telemetry.egress.fallback
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: routing_deliveries
+    azure_name: RoutingDeliveries
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: routing_delivery_latency
+    azure_name: RoutingDeliveryLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: routing_data_size_in_bytes_delivered
+    azure_name: RoutingDataSizeInBytesDelivered
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: connect_success
+    azure_name: connect.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: connected_device_count
+    azure_name: connectedDeviceCount
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: total_device_count
+    azure_name: totalDeviceCount
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: daily_message_quota_used
+    azure_name: dailyMessageQuotaUsed
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: device_data_usage
+    azure_name: deviceDataUsage
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: device_data_usage_v2
+    azure_name: deviceDataUsageV2
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: configurations
+    azure_name: configurations
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: event_grid_deliveries
+    azure_name: EventGridDeliveries
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: event_grid_latency
+    azure_name: EventGridLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: jobs_completed
+    azure_name: jobs.completed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: jobs_failed
+    azure_name: jobs.failed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: jobs_cancel_job_success
+    azure_name: jobs.cancelJob.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: jobs_cancel_job_failure
+    azure_name: jobs.cancelJob.failure
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: jobs_create_direct_method_job_success
+    azure_name: jobs.createDirectMethodJob.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: jobs_create_direct_method_job_failure
+    azure_name: jobs.createDirectMethodJob.failure
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: jobs_create_twin_update_job_success
+    azure_name: jobs.createTwinUpdateJob.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: jobs_create_twin_update_job_failure
+    azure_name: jobs.createTwinUpdateJob.failure
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: jobs_list_jobs_success
+    azure_name: jobs.listJobs.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: jobs_list_jobs_failure
+    azure_name: jobs.listJobs.failure
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: jobs_query_jobs_success
+    azure_name: jobs.queryJobs.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: jobs_query_jobs_failure
+    azure_name: jobs.queryJobs.failure
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: twin_queries_success
+    azure_name: twinQueries.success
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: twin_queries_failure
+    azure_name: twinQueries.failure
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: twin_queries_result_size
+    azure_name: twinQueries.resultSize
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure IoT Hub
   context_namespace: iot_hub
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_iot_hub__c2d_commands
-    title: Azure IoT Hub Cloud-to-Device Commands
-    context: c2d_commands
-    family: C2D Messages
-    type: line
-    units: messages/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.c2d_commands_egress_complete_success_total
-      name: completed
-    - selector: iot_hub.c2d_commands_egress_abandon_success_total
-      name: abandoned
-    - selector: iot_hub.c2d_commands_egress_reject_success_total
-      name: rejected
-  - id: am_azure_iot_hub__c2d_messages_expired
-    title: Azure IoT Hub Cloud-to-Device Messages Expired
-    context: c2d_messages_expired
-    family: C2D Messages
-    type: line
-    units: messages/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.c2d_messages_expired_total
-      name: expired
-  - id: am_azure_iot_hub__c2d_methods
-    title: Azure IoT Hub Direct Method Invocations
-    context: c2d_methods
-    family: C2D Methods
-    type: line
-    units: invocations/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.c2d_methods_success_total
-      name: successful
-    - selector: iot_hub.c2d_methods_failure_total
-      name: failed
-  - id: am_azure_iot_hub__c2d_methods_request_size
-    title: Azure IoT Hub Direct Method Request Size
-    context: c2d_methods_request_size
-    family: C2D Methods
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: iot_hub.c2d_methods_request_size_average
-      name: average
-  - id: am_azure_iot_hub__c2d_methods_response_size
-    title: Azure IoT Hub Direct Method Response Size
-    context: c2d_methods_response_size
-    family: C2D Methods
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: iot_hub.c2d_methods_response_size_average
-      name: average
-  - id: am_azure_iot_hub__c2d_twin_reads
-    title: Azure IoT Hub Backend Twin Reads
-    context: c2d_twin_reads
-    family: C2D Twins
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.c2d_twin_read_success_total
-      name: successful
-    - selector: iot_hub.c2d_twin_read_failure_total
-      name: failed
-  - id: am_azure_iot_hub__c2d_twin_read_size
-    title: Azure IoT Hub Backend Twin Read Size
-    context: c2d_twin_read_size
-    family: C2D Twins
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: iot_hub.c2d_twin_read_size_average
-      name: average
-  - id: am_azure_iot_hub__c2d_twin_updates
-    title: Azure IoT Hub Backend Twin Updates
-    context: c2d_twin_updates
-    family: C2D Twins
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.c2d_twin_update_success_total
-      name: successful
-    - selector: iot_hub.c2d_twin_update_failure_total
-      name: failed
-  - id: am_azure_iot_hub__c2d_twin_update_size
-    title: Azure IoT Hub Backend Twin Update Size
-    context: c2d_twin_update_size
-    family: C2D Twins
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: iot_hub.c2d_twin_update_size_average
-      name: average
-  - id: am_azure_iot_hub__d2c_telemetry
-    title: Azure IoT Hub Device Telemetry
-    context: d2c_telemetry
-    family: D2C Telemetry
-    type: line
-    units: messages/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.d2c_telemetry_ingress_all_protocol_total
-      name: attempted
-    - selector: iot_hub.d2c_telemetry_ingress_success_total
-      name: sent
-  - id: am_azure_iot_hub__d2c_telemetry_throttle
-    title: Azure IoT Hub Telemetry Throttling Errors
-    context: d2c_telemetry_throttle
-    family: D2C Telemetry
-    type: line
-    units: errors/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.d2c_telemetry_ingress_send_throttle_total
-      name: throttled
-  - id: am_azure_iot_hub__d2c_twin_reads
-    title: Azure IoT Hub Device Twin Reads
-    context: d2c_twin_reads
-    family: D2C Twins
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.d2c_twin_read_success_total
-      name: successful
-    - selector: iot_hub.d2c_twin_read_failure_total
-      name: failed
-  - id: am_azure_iot_hub__d2c_twin_read_size
-    title: Azure IoT Hub Device Twin Read Size
-    context: d2c_twin_read_size
-    family: D2C Twins
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: iot_hub.d2c_twin_read_size_average
-      name: average
-  - id: am_azure_iot_hub__d2c_twin_updates
-    title: Azure IoT Hub Device Twin Updates
-    context: d2c_twin_updates
-    family: D2C Twins
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.d2c_twin_update_success_total
-      name: successful
-    - selector: iot_hub.d2c_twin_update_failure_total
-      name: failed
-  - id: am_azure_iot_hub__d2c_twin_update_size
-    title: Azure IoT Hub Device Twin Update Size
-    context: d2c_twin_update_size
-    family: D2C Twins
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: iot_hub.d2c_twin_update_size_average
-      name: average
-  - id: am_azure_iot_hub__routing_deliveries
-    title: Azure IoT Hub Routing Message Deliveries
-    context: routing_deliveries
-    family: Routing
-    type: line
-    units: messages/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.d2c_telemetry_egress_success_total
-      name: delivered
-    - selector: iot_hub.d2c_telemetry_egress_dropped_total
-      name: dropped
-    - selector: iot_hub.d2c_telemetry_egress_orphaned_total
-      name: orphaned
-    - selector: iot_hub.d2c_telemetry_egress_invalid_total
-      name: invalid
-    - selector: iot_hub.d2c_telemetry_egress_fallback_total
-      name: fallback
-  - id: am_azure_iot_hub__routing_delivery_by_endpoint
-    title: Azure IoT Hub Routing Deliveries by Endpoint
-    context: routing_delivery_by_endpoint
-    family: Routing
-    type: line
-    units: messages/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.d2c_endpoints_egress_built_in_events_total
-      name: builtin_events
-    - selector: iot_hub.d2c_endpoints_egress_event_hubs_total
-      name: event_hubs
-    - selector: iot_hub.d2c_endpoints_egress_service_bus_queues_total
-      name: service_bus_queues
-    - selector: iot_hub.d2c_endpoints_egress_service_bus_topics_total
-      name: service_bus_topics
-    - selector: iot_hub.d2c_endpoints_egress_storage_total
-      name: storage
-  - id: am_azure_iot_hub__routing_storage_blobs
-    title: Azure IoT Hub Routing Blobs Delivered to Storage
-    context: routing_storage_blobs
-    family: Routing
-    type: line
-    units: blobs/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.d2c_endpoints_egress_storage_blobs_total
-      name: blobs
-  - id: am_azure_iot_hub__routing_storage_data
-    title: Azure IoT Hub Routing Data Delivered to Storage
-    context: routing_storage_data
-    family: Routing
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.d2c_endpoints_egress_storage_bytes_total
-      name: bytes
-  - id: am_azure_iot_hub__routing_latency
-    title: Azure IoT Hub Routing Latency
-    context: routing_latency
-    family: Routing
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: iot_hub.d2c_endpoints_latency_built_in_events_average
-      name: builtin_events
-    - selector: iot_hub.d2c_endpoints_latency_event_hubs_average
-      name: event_hubs
-    - selector: iot_hub.d2c_endpoints_latency_service_bus_queues_average
-      name: service_bus_queues
-    - selector: iot_hub.d2c_endpoints_latency_service_bus_topics_average
-      name: service_bus_topics
-    - selector: iot_hub.d2c_endpoints_latency_storage_average
-      name: storage
-  - id: am_azure_iot_hub__routing_deliveries_preview
-    title: Azure IoT Hub Routing Deliveries (Preview)
-    context: routing_deliveries_preview
-    family: Routing
-    type: line
-    units: deliveries/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.routing_deliveries_total
-      name: deliveries
-  - id: am_azure_iot_hub__routing_delivery_latency_preview
-    title: Azure IoT Hub Routing Delivery Latency (Preview)
-    context: routing_delivery_latency_preview
-    family: Routing
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: iot_hub.routing_delivery_latency_average
-      name: average
-  - id: am_azure_iot_hub__routing_data_size_preview
-    title: Azure IoT Hub Routing Delivery Message Size (Preview)
-    context: routing_data_size_preview
-    family: Routing
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.routing_data_size_in_bytes_delivered_total
-      name: bytes
-  - id: am_azure_iot_hub__connections
-    title: Azure IoT Hub Successful Connections
-    context: connections
-    family: Connections
-    type: line
-    units: connections/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.connect_success_total
-      name: successful
-  - id: am_azure_iot_hub__connected_devices
-    title: Azure IoT Hub Connected Devices
-    context: connected_devices
-    family: Connections
-    type: line
-    units: devices
-    algorithm: absolute
-    dimensions:
-    - selector: iot_hub.connected_device_count_average
-      name: connected
-  - id: am_azure_iot_hub__total_devices
-    title: Azure IoT Hub Total Devices
-    context: total_devices
-    family: Devices
-    type: line
-    units: devices
-    algorithm: absolute
-    dimensions:
-    - selector: iot_hub.total_device_count_average
-      name: total
-  - id: am_azure_iot_hub__daily_message_quota
-    title: Azure IoT Hub Daily Message Quota Used
-    context: daily_message_quota
-    family: Quota
-    type: line
-    units: messages
-    algorithm: absolute
-    dimensions:
-    - selector: iot_hub.daily_message_quota_used_average
-      name: used
-  - id: am_azure_iot_hub__data_usage
-    title: Azure IoT Hub Device Data Usage
-    context: data_usage
-    family: Data Usage
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.device_data_usage_total
-      name: data_usage
-    - selector: iot_hub.device_data_usage_v2_total
-      name: data_usage_v2
-  - id: am_azure_iot_hub__configurations
-    title: Azure IoT Hub Configuration Operations
-    context: configurations
-    family: Configuration
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.configurations_total
-      name: operations
-  - id: am_azure_iot_hub__event_grid_deliveries
-    title: Azure IoT Hub Event Grid Deliveries
-    context: event_grid_deliveries
-    family: Event Grid
-    type: line
-    units: deliveries/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.event_grid_deliveries_total
-      name: deliveries
-  - id: am_azure_iot_hub__event_grid_latency
-    title: Azure IoT Hub Event Grid Latency
-    context: event_grid_latency
-    family: Event Grid
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: iot_hub.event_grid_latency_average
-      name: average
-  - id: am_azure_iot_hub__jobs_status
-    title: Azure IoT Hub Job Completions
-    context: jobs_status
-    family: Jobs
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.jobs_completed_total
-      name: completed
-    - selector: iot_hub.jobs_failed_total
-      name: failed
-  - id: am_azure_iot_hub__jobs_cancel
-    title: Azure IoT Hub Job Cancellations
-    context: jobs_cancel
-    family: Jobs
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.jobs_cancel_job_success_total
-      name: successful
-    - selector: iot_hub.jobs_cancel_job_failure_total
-      name: failed
-  - id: am_azure_iot_hub__jobs_create_method
-    title: Azure IoT Hub Direct Method Job Creations
-    context: jobs_create_method
-    family: Jobs
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.jobs_create_direct_method_job_success_total
-      name: successful
-    - selector: iot_hub.jobs_create_direct_method_job_failure_total
-      name: failed
-  - id: am_azure_iot_hub__jobs_create_twin_update
-    title: Azure IoT Hub Twin Update Job Creations
-    context: jobs_create_twin_update
-    family: Jobs
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.jobs_create_twin_update_job_success_total
-      name: successful
-    - selector: iot_hub.jobs_create_twin_update_job_failure_total
-      name: failed
-  - id: am_azure_iot_hub__jobs_list
-    title: Azure IoT Hub Job List Calls
-    context: jobs_list
-    family: Jobs
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.jobs_list_jobs_success_total
-      name: successful
-    - selector: iot_hub.jobs_list_jobs_failure_total
-      name: failed
-  - id: am_azure_iot_hub__jobs_query
-    title: Azure IoT Hub Job Queries
-    context: jobs_query
-    family: Jobs
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.jobs_query_jobs_success_total
-      name: successful
-    - selector: iot_hub.jobs_query_jobs_failure_total
-      name: failed
-  - id: am_azure_iot_hub__twin_queries
-    title: Azure IoT Hub Twin Queries
-    context: twin_queries
-    family: Twin Queries
-    type: line
-    units: queries/s
-    algorithm: incremental
-    dimensions:
-    - selector: iot_hub.twin_queries_success_total
-      name: successful
-    - selector: iot_hub.twin_queries_failure_total
-      name: failed
-  - id: am_azure_iot_hub__twin_queries_result_size
-    title: Azure IoT Hub Twin Query Result Size
-    context: twin_queries_result_size
-    family: Twin Queries
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: iot_hub.twin_queries_result_size_average
-      name: average
+    - id: am_azure_iot_hub__c2d_commands
+      title: Azure IoT Hub Cloud-to-Device Commands
+      context: c2d_commands
+      family: C2D Messages
+      type: line
+      units: messages/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.c2d_commands_egress_complete_success_total
+          name: completed
+        - selector: iot_hub.c2d_commands_egress_abandon_success_total
+          name: abandoned
+        - selector: iot_hub.c2d_commands_egress_reject_success_total
+          name: rejected
+    - id: am_azure_iot_hub__c2d_messages_expired
+      title: Azure IoT Hub Cloud-to-Device Messages Expired
+      context: c2d_messages_expired
+      family: C2D Messages
+      type: line
+      units: messages/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.c2d_messages_expired_total
+          name: expired
+    - id: am_azure_iot_hub__c2d_methods
+      title: Azure IoT Hub Direct Method Invocations
+      context: c2d_methods
+      family: C2D Methods
+      type: line
+      units: invocations/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.c2d_methods_success_total
+          name: successful
+        - selector: iot_hub.c2d_methods_failure_total
+          name: failed
+    - id: am_azure_iot_hub__c2d_methods_request_size
+      title: Azure IoT Hub Direct Method Request Size
+      context: c2d_methods_request_size
+      family: C2D Methods
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: iot_hub.c2d_methods_request_size_average
+          name: average
+    - id: am_azure_iot_hub__c2d_methods_response_size
+      title: Azure IoT Hub Direct Method Response Size
+      context: c2d_methods_response_size
+      family: C2D Methods
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: iot_hub.c2d_methods_response_size_average
+          name: average
+    - id: am_azure_iot_hub__c2d_twin_reads
+      title: Azure IoT Hub Backend Twin Reads
+      context: c2d_twin_reads
+      family: C2D Twins
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.c2d_twin_read_success_total
+          name: successful
+        - selector: iot_hub.c2d_twin_read_failure_total
+          name: failed
+    - id: am_azure_iot_hub__c2d_twin_read_size
+      title: Azure IoT Hub Backend Twin Read Size
+      context: c2d_twin_read_size
+      family: C2D Twins
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: iot_hub.c2d_twin_read_size_average
+          name: average
+    - id: am_azure_iot_hub__c2d_twin_updates
+      title: Azure IoT Hub Backend Twin Updates
+      context: c2d_twin_updates
+      family: C2D Twins
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.c2d_twin_update_success_total
+          name: successful
+        - selector: iot_hub.c2d_twin_update_failure_total
+          name: failed
+    - id: am_azure_iot_hub__c2d_twin_update_size
+      title: Azure IoT Hub Backend Twin Update Size
+      context: c2d_twin_update_size
+      family: C2D Twins
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: iot_hub.c2d_twin_update_size_average
+          name: average
+    - id: am_azure_iot_hub__d2c_telemetry
+      title: Azure IoT Hub Device Telemetry
+      context: d2c_telemetry
+      family: D2C Telemetry
+      type: line
+      units: messages/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.d2c_telemetry_ingress_all_protocol_total
+          name: attempted
+        - selector: iot_hub.d2c_telemetry_ingress_success_total
+          name: sent
+    - id: am_azure_iot_hub__d2c_telemetry_throttle
+      title: Azure IoT Hub Telemetry Throttling Errors
+      context: d2c_telemetry_throttle
+      family: D2C Telemetry
+      type: line
+      units: errors/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.d2c_telemetry_ingress_send_throttle_total
+          name: throttled
+    - id: am_azure_iot_hub__d2c_twin_reads
+      title: Azure IoT Hub Device Twin Reads
+      context: d2c_twin_reads
+      family: D2C Twins
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.d2c_twin_read_success_total
+          name: successful
+        - selector: iot_hub.d2c_twin_read_failure_total
+          name: failed
+    - id: am_azure_iot_hub__d2c_twin_read_size
+      title: Azure IoT Hub Device Twin Read Size
+      context: d2c_twin_read_size
+      family: D2C Twins
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: iot_hub.d2c_twin_read_size_average
+          name: average
+    - id: am_azure_iot_hub__d2c_twin_updates
+      title: Azure IoT Hub Device Twin Updates
+      context: d2c_twin_updates
+      family: D2C Twins
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.d2c_twin_update_success_total
+          name: successful
+        - selector: iot_hub.d2c_twin_update_failure_total
+          name: failed
+    - id: am_azure_iot_hub__d2c_twin_update_size
+      title: Azure IoT Hub Device Twin Update Size
+      context: d2c_twin_update_size
+      family: D2C Twins
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: iot_hub.d2c_twin_update_size_average
+          name: average
+    - id: am_azure_iot_hub__routing_deliveries
+      title: Azure IoT Hub Routing Message Deliveries
+      context: routing_deliveries
+      family: Routing
+      type: line
+      units: messages/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.d2c_telemetry_egress_success_total
+          name: delivered
+        - selector: iot_hub.d2c_telemetry_egress_dropped_total
+          name: dropped
+        - selector: iot_hub.d2c_telemetry_egress_orphaned_total
+          name: orphaned
+        - selector: iot_hub.d2c_telemetry_egress_invalid_total
+          name: invalid
+        - selector: iot_hub.d2c_telemetry_egress_fallback_total
+          name: fallback
+    - id: am_azure_iot_hub__routing_delivery_by_endpoint
+      title: Azure IoT Hub Routing Deliveries by Endpoint
+      context: routing_delivery_by_endpoint
+      family: Routing
+      type: line
+      units: messages/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.d2c_endpoints_egress_built_in_events_total
+          name: builtin_events
+        - selector: iot_hub.d2c_endpoints_egress_event_hubs_total
+          name: event_hubs
+        - selector: iot_hub.d2c_endpoints_egress_service_bus_queues_total
+          name: service_bus_queues
+        - selector: iot_hub.d2c_endpoints_egress_service_bus_topics_total
+          name: service_bus_topics
+        - selector: iot_hub.d2c_endpoints_egress_storage_total
+          name: storage
+    - id: am_azure_iot_hub__routing_storage_blobs
+      title: Azure IoT Hub Routing Blobs Delivered to Storage
+      context: routing_storage_blobs
+      family: Routing
+      type: line
+      units: blobs/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.d2c_endpoints_egress_storage_blobs_total
+          name: blobs
+    - id: am_azure_iot_hub__routing_storage_data
+      title: Azure IoT Hub Routing Data Delivered to Storage
+      context: routing_storage_data
+      family: Routing
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.d2c_endpoints_egress_storage_bytes_total
+          name: bytes
+    - id: am_azure_iot_hub__routing_latency
+      title: Azure IoT Hub Routing Latency
+      context: routing_latency
+      family: Routing
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: iot_hub.d2c_endpoints_latency_built_in_events_average
+          name: builtin_events
+        - selector: iot_hub.d2c_endpoints_latency_event_hubs_average
+          name: event_hubs
+        - selector: iot_hub.d2c_endpoints_latency_service_bus_queues_average
+          name: service_bus_queues
+        - selector: iot_hub.d2c_endpoints_latency_service_bus_topics_average
+          name: service_bus_topics
+        - selector: iot_hub.d2c_endpoints_latency_storage_average
+          name: storage
+    - id: am_azure_iot_hub__routing_deliveries_preview
+      title: Azure IoT Hub Routing Deliveries (Preview)
+      context: routing_deliveries_preview
+      family: Routing
+      type: line
+      units: deliveries/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.routing_deliveries_total
+          name: deliveries
+    - id: am_azure_iot_hub__routing_delivery_latency_preview
+      title: Azure IoT Hub Routing Delivery Latency (Preview)
+      context: routing_delivery_latency_preview
+      family: Routing
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: iot_hub.routing_delivery_latency_average
+          name: average
+    - id: am_azure_iot_hub__routing_data_size_preview
+      title: Azure IoT Hub Routing Delivery Message Size (Preview)
+      context: routing_data_size_preview
+      family: Routing
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.routing_data_size_in_bytes_delivered_total
+          name: bytes
+    - id: am_azure_iot_hub__connections
+      title: Azure IoT Hub Successful Connections
+      context: connections
+      family: Connections
+      type: line
+      units: connections/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.connect_success_total
+          name: successful
+    - id: am_azure_iot_hub__connected_devices
+      title: Azure IoT Hub Connected Devices
+      context: connected_devices
+      family: Connections
+      type: line
+      units: devices
+      algorithm: absolute
+      dimensions:
+        - selector: iot_hub.connected_device_count_average
+          name: connected
+    - id: am_azure_iot_hub__total_devices
+      title: Azure IoT Hub Total Devices
+      context: total_devices
+      family: Devices
+      type: line
+      units: devices
+      algorithm: absolute
+      dimensions:
+        - selector: iot_hub.total_device_count_average
+          name: total
+    - id: am_azure_iot_hub__daily_message_quota
+      title: Azure IoT Hub Daily Message Quota Used
+      context: daily_message_quota
+      family: Quota
+      type: line
+      units: messages
+      algorithm: absolute
+      dimensions:
+        - selector: iot_hub.daily_message_quota_used_average
+          name: used
+    - id: am_azure_iot_hub__data_usage
+      title: Azure IoT Hub Device Data Usage
+      context: data_usage
+      family: Data Usage
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.device_data_usage_total
+          name: data_usage
+        - selector: iot_hub.device_data_usage_v2_total
+          name: data_usage_v2
+    - id: am_azure_iot_hub__configurations
+      title: Azure IoT Hub Configuration Operations
+      context: configurations
+      family: Configuration
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.configurations_total
+          name: operations
+    - id: am_azure_iot_hub__event_grid_deliveries
+      title: Azure IoT Hub Event Grid Deliveries
+      context: event_grid_deliveries
+      family: Event Grid
+      type: line
+      units: deliveries/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.event_grid_deliveries_total
+          name: deliveries
+    - id: am_azure_iot_hub__event_grid_latency
+      title: Azure IoT Hub Event Grid Latency
+      context: event_grid_latency
+      family: Event Grid
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: iot_hub.event_grid_latency_average
+          name: average
+    - id: am_azure_iot_hub__jobs_status
+      title: Azure IoT Hub Job Completions
+      context: jobs_status
+      family: Jobs
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.jobs_completed_total
+          name: completed
+        - selector: iot_hub.jobs_failed_total
+          name: failed
+    - id: am_azure_iot_hub__jobs_cancel
+      title: Azure IoT Hub Job Cancellations
+      context: jobs_cancel
+      family: Jobs
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.jobs_cancel_job_success_total
+          name: successful
+        - selector: iot_hub.jobs_cancel_job_failure_total
+          name: failed
+    - id: am_azure_iot_hub__jobs_create_method
+      title: Azure IoT Hub Direct Method Job Creations
+      context: jobs_create_method
+      family: Jobs
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.jobs_create_direct_method_job_success_total
+          name: successful
+        - selector: iot_hub.jobs_create_direct_method_job_failure_total
+          name: failed
+    - id: am_azure_iot_hub__jobs_create_twin_update
+      title: Azure IoT Hub Twin Update Job Creations
+      context: jobs_create_twin_update
+      family: Jobs
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.jobs_create_twin_update_job_success_total
+          name: successful
+        - selector: iot_hub.jobs_create_twin_update_job_failure_total
+          name: failed
+    - id: am_azure_iot_hub__jobs_list
+      title: Azure IoT Hub Job List Calls
+      context: jobs_list
+      family: Jobs
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.jobs_list_jobs_success_total
+          name: successful
+        - selector: iot_hub.jobs_list_jobs_failure_total
+          name: failed
+    - id: am_azure_iot_hub__jobs_query
+      title: Azure IoT Hub Job Queries
+      context: jobs_query
+      family: Jobs
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.jobs_query_jobs_success_total
+          name: successful
+        - selector: iot_hub.jobs_query_jobs_failure_total
+          name: failed
+    - id: am_azure_iot_hub__twin_queries
+      title: Azure IoT Hub Twin Queries
+      context: twin_queries
+      family: Twin Queries
+      type: line
+      units: queries/s
+      algorithm: incremental
+      dimensions:
+        - selector: iot_hub.twin_queries_success_total
+          name: successful
+        - selector: iot_hub.twin_queries_failure_total
+          name: failed
+    - id: am_azure_iot_hub__twin_queries_result_size
+      title: Azure IoT Hub Twin Query Result Size
+      context: twin_queries_result_size
+      family: Twin Queries
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: iot_hub.twin_queries_result_size_average
+          name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/key_vault.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/key_vault.yaml
@@ -3,89 +3,89 @@ id: key_vault
 name: Azure Key Vault
 resource_type: Microsoft.KeyVault/vaults
 metrics:
-- id: availability
-  azure_name: Availability
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: service_api_latency
-  azure_name: ServiceApiLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: saturation_shoebox
-  azure_name: SaturationShoebox
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: service_api_hit
-  azure_name: ServiceApiHit
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: service_api_result
-  azure_name: ServiceApiResult
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
+  - id: availability
+    azure_name: Availability
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: service_api_latency
+    azure_name: ServiceApiLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: saturation_shoebox
+    azure_name: SaturationShoebox
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: service_api_hit
+    azure_name: ServiceApiHit
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: service_api_result
+    azure_name: ServiceApiResult
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
 template:
   family: Azure Key Vault
   context_namespace: key_vault
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_key_vault__availability
-    title: Azure Key Vault Availability
-    context: availability
-    family: Availability
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: key_vault.availability_average
-      name: average
-  - id: am_azure_key_vault__api_latency
-    title: Azure Key Vault API Latency
-    context: api_latency
-    family: Performance
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: key_vault.service_api_latency_average
-      name: average
-  - id: am_azure_key_vault__saturation
-    title: Azure Key Vault Saturation
-    context: saturation
-    family: Capacity
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: key_vault.saturation_shoebox_average
-      name: average
-  - id: am_azure_key_vault__api_activity
-    title: Azure Key Vault API Activity
-    context: api_activity
-    family: Operations
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: key_vault.service_api_hit_count
-      name: hits
-    - selector: key_vault.service_api_result_count
-      name: results
+    - id: am_azure_key_vault__availability
+      title: Azure Key Vault Availability
+      context: availability
+      family: Availability
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: key_vault.availability_average
+          name: average
+    - id: am_azure_key_vault__api_latency
+      title: Azure Key Vault API Latency
+      context: api_latency
+      family: Performance
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: key_vault.service_api_latency_average
+          name: average
+    - id: am_azure_key_vault__saturation
+      title: Azure Key Vault Saturation
+      context: saturation
+      family: Capacity
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: key_vault.saturation_shoebox_average
+          name: average
+    - id: am_azure_key_vault__api_activity
+      title: Azure Key Vault API Activity
+      context: api_activity
+      family: Operations
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: key_vault.service_api_hit_count
+          name: hits
+        - selector: key_vault.service_api_result_count
+          name: results

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/load_balancers.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/load_balancers.yaml
@@ -3,153 +3,153 @@ id: load_balancers
 name: Azure Load Balancer
 resource_type: Microsoft.Network/loadBalancers
 metrics:
-- id: vip_availability
-  azure_name: VipAvailability
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: dip_availability
-  azure_name: DipAvailability
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: global_backend_availability
-  azure_name: GlobalBackendAvailability
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: byte_count
-  azure_name: ByteCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: packet_count
-  azure_name: PacketCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: syn_count
-  azure_name: SYNCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: snat_connection_count
-  azure_name: SnatConnectionCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: allocated_snat_ports
-  azure_name: AllocatedSnatPorts
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: used_snat_ports
-  azure_name: UsedSnatPorts
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: vip_availability
+    azure_name: VipAvailability
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: dip_availability
+    azure_name: DipAvailability
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: global_backend_availability
+    azure_name: GlobalBackendAvailability
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: byte_count
+    azure_name: ByteCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: packet_count
+    azure_name: PacketCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: syn_count
+    azure_name: SYNCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: snat_connection_count
+    azure_name: SnatConnectionCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: allocated_snat_ports
+    azure_name: AllocatedSnatPorts
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: used_snat_ports
+    azure_name: UsedSnatPorts
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Load Balancer
   context_namespace: load_balancers
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_load_balancers__vip_availability
-    title: Azure Load Balancer Data Path Availability
-    context: vip_availability
-    family: Availability
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: load_balancers.vip_availability_average
-      name: average
-  - id: am_azure_load_balancers__dip_availability
-    title: Azure Load Balancer Health Probe Status
-    context: dip_availability
-    family: Availability
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: load_balancers.dip_availability_average
-      name: average
-  - id: am_azure_load_balancers__global_backend_availability
-    title: Azure Load Balancer Global Backend Availability
-    context: global_backend_availability
-    family: Availability
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: load_balancers.global_backend_availability_average
-      name: average
-  - id: am_azure_load_balancers__byte_throughput
-    title: Azure Load Balancer Byte Throughput
-    context: byte_throughput
-    family: Throughput
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: load_balancers.byte_count_total
-      name: total
-  - id: am_azure_load_balancers__packet_throughput
-    title: Azure Load Balancer Packet Throughput
-    context: packet_throughput
-    family: Throughput
-    type: line
-    units: packets/s
-    algorithm: incremental
-    dimensions:
-    - selector: load_balancers.packet_count_total
-      name: total
-  - id: am_azure_load_balancers__syn_count
-    title: Azure Load Balancer SYN Packets
-    context: syn_count
-    family: Throughput
-    type: line
-    units: packets/s
-    algorithm: incremental
-    dimensions:
-    - selector: load_balancers.syn_count_total
-      name: total
-  - id: am_azure_load_balancers__snat_connections
-    title: Azure Load Balancer SNAT Connections
-    context: snat_connections
-    family: SNAT
-    type: line
-    units: connections/s
-    algorithm: incremental
-    dimensions:
-    - selector: load_balancers.snat_connection_count_total
-      name: total
-  - id: am_azure_load_balancers__snat_ports
-    title: Azure Load Balancer SNAT Port Usage
-    context: snat_ports
-    family: SNAT
-    type: line
-    units: ports
-    algorithm: absolute
-    dimensions:
-    - selector: load_balancers.allocated_snat_ports_average
-      name: allocated
-    - selector: load_balancers.used_snat_ports_average
-      name: used
+    - id: am_azure_load_balancers__vip_availability
+      title: Azure Load Balancer Data Path Availability
+      context: vip_availability
+      family: Availability
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: load_balancers.vip_availability_average
+          name: average
+    - id: am_azure_load_balancers__dip_availability
+      title: Azure Load Balancer Health Probe Status
+      context: dip_availability
+      family: Availability
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: load_balancers.dip_availability_average
+          name: average
+    - id: am_azure_load_balancers__global_backend_availability
+      title: Azure Load Balancer Global Backend Availability
+      context: global_backend_availability
+      family: Availability
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: load_balancers.global_backend_availability_average
+          name: average
+    - id: am_azure_load_balancers__byte_throughput
+      title: Azure Load Balancer Byte Throughput
+      context: byte_throughput
+      family: Throughput
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: load_balancers.byte_count_total
+          name: total
+    - id: am_azure_load_balancers__packet_throughput
+      title: Azure Load Balancer Packet Throughput
+      context: packet_throughput
+      family: Throughput
+      type: line
+      units: packets/s
+      algorithm: incremental
+      dimensions:
+        - selector: load_balancers.packet_count_total
+          name: total
+    - id: am_azure_load_balancers__syn_count
+      title: Azure Load Balancer SYN Packets
+      context: syn_count
+      family: Throughput
+      type: line
+      units: packets/s
+      algorithm: incremental
+      dimensions:
+        - selector: load_balancers.syn_count_total
+          name: total
+    - id: am_azure_load_balancers__snat_connections
+      title: Azure Load Balancer SNAT Connections
+      context: snat_connections
+      family: SNAT
+      type: line
+      units: connections/s
+      algorithm: incremental
+      dimensions:
+        - selector: load_balancers.snat_connection_count_total
+          name: total
+    - id: am_azure_load_balancers__snat_ports
+      title: Azure Load Balancer SNAT Port Usage
+      context: snat_ports
+      family: SNAT
+      type: line
+      units: ports
+      algorithm: absolute
+      dimensions:
+        - selector: load_balancers.allocated_snat_ports_average
+          name: allocated
+        - selector: load_balancers.used_snat_ports_average
+          name: used

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/log_analytics.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/log_analytics.yaml
@@ -3,889 +3,889 @@ id: log_analytics
 name: Azure Log Analytics Workspace
 resource_type: Microsoft.OperationalInsights/workspaces
 metrics:
-- id: availability_rate_query
-  azure_name: AvailabilityRate_Query
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: ingestion_time
-  azure_name: Ingestion Time
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-  - aggregation: minimum
-    kind: gauge
-- id: ingestion_volume
-  azure_name: Ingestion Volume
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: query_count
-  azure_name: Query Count
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: query_failure_count
-  azure_name: Query Failure Count
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: bytes_exported
-  azure_name: BytesExported
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: records_exported
-  azure_name: RecordsExported
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: export_failed
-  azure_name: ExportFailed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: average_processor_time
-  azure_name: Average_% Processor Time
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_privileged_time
-  azure_name: Average_% Privileged Time
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_user_time
-  azure_name: Average_% User Time
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_dpc_time
-  azure_name: Average_% DPC Time
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_interrupt_time
-  azure_name: Average_% Interrupt Time
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_idle_time
-  azure_name: Average_% Idle Time
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_io_wait_time
-  azure_name: Average_% IO Wait Time
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_nice_time
-  azure_name: Average_% Nice Time
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_pct_privileged_time
-  azure_name: Average_Pct Privileged Time
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_pct_user_time
-  azure_name: Average_Pct User Time
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_available_memory
-  azure_name: Average_% Available Memory
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_used_memory
-  azure_name: Average_% Used Memory
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_committed_bytes_in_use
-  azure_name: Average_% Committed Bytes In Use
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_available_m_bytes
-  azure_name: Average_Available MBytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_available_m_bytes_memory
-  azure_name: Average_Available MBytes Memory
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_used_memory_k_bytes
-  azure_name: Average_Used Memory kBytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_used_memory_m_bytes
-  azure_name: Average_Used Memory MBytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_free_physical_memory
-  azure_name: Average_Free Physical Memory
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_free_virtual_memory
-  azure_name: Average_Free Virtual Memory
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_virtual_shared_memory
-  azure_name: Average_Virtual Shared Memory
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_available_swap_space
-  azure_name: Average_% Available Swap Space
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_used_swap_space
-  azure_name: Average_% Used Swap Space
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_available_m_bytes_swap
-  azure_name: Average_Available MBytes Swap
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_used_m_bytes_swap_space
-  azure_name: Average_Used MBytes Swap Space
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_free_space
-  azure_name: Average_% Free Space
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_used_space
-  azure_name: Average_% Used Space
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_free_inodes
-  azure_name: Average_% Free Inodes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_used_inodes
-  azure_name: Average_% Used Inodes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_free_megabytes
-  azure_name: Average_Free Megabytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_disk_read_bytes_sec
-  azure_name: Average_Disk Read Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_disk_write_bytes_sec
-  azure_name: Average_Disk Write Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_disk_reads_sec
-  azure_name: Average_Disk Reads/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_disk_writes_sec
-  azure_name: Average_Disk Writes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_disk_transfers_sec
-  azure_name: Average_Disk Transfers/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_logical_disk_bytes_sec
-  azure_name: Average_Logical Disk Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_physical_disk_bytes_sec
-  azure_name: Average_Physical Disk Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_avg_disk_sec_read
-  azure_name: Average_Avg. Disk sec/Read
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_avg_disk_sec_write
-  azure_name: Average_Avg. Disk sec/Write
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_avg_disk_sec_transfer
-  azure_name: Average_Avg. Disk sec/Transfer
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_current_disk_queue_length
-  azure_name: Average_Current Disk Queue Length
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_page_reads_sec
-  azure_name: Average_Page Reads/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_page_writes_sec
-  azure_name: Average_Page Writes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_pages_sec
-  azure_name: Average_Pages/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_free_space_in_paging_files
-  azure_name: Average_Free Space in Paging Files
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_size_stored_in_paging_files
-  azure_name: Average_Size Stored In Paging Files
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_bytes_received_sec
-  azure_name: Average_Bytes Received/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_bytes_sent_sec
-  azure_name: Average_Bytes Sent/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_bytes_total_sec
-  azure_name: Average_Bytes Total/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_total_bytes
-  azure_name: Average_Total Bytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_total_bytes_received
-  azure_name: Average_Total Bytes Received
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_total_bytes_transmitted
-  azure_name: Average_Total Bytes Transmitted
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_total_packets_received
-  azure_name: Average_Total Packets Received
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_total_packets_transmitted
-  azure_name: Average_Total Packets Transmitted
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_total_collisions
-  azure_name: Average_Total Collisions
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_total_rx_errors
-  azure_name: Average_Total Rx Errors
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_total_tx_errors
-  azure_name: Average_Total Tx Errors
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_processes
-  azure_name: Average_Processes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_processor_queue_length
-  azure_name: Average_Processor Queue Length
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_uptime
-  azure_name: Average_Uptime
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: average_users
-  azure_name: Average_Users
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: event
-  azure_name: Event
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: heartbeat
-  azure_name: Heartbeat
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: update
-  azure_name: Update
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: availability_rate_query
+    azure_name: AvailabilityRate_Query
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: ingestion_time
+    azure_name: Ingestion Time
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+      - aggregation: minimum
+        kind: gauge
+  - id: ingestion_volume
+    azure_name: Ingestion Volume
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: query_count
+    azure_name: Query Count
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: query_failure_count
+    azure_name: Query Failure Count
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: bytes_exported
+    azure_name: BytesExported
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: records_exported
+    azure_name: RecordsExported
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: export_failed
+    azure_name: ExportFailed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: average_processor_time
+    azure_name: Average_% Processor Time
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_privileged_time
+    azure_name: Average_% Privileged Time
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_user_time
+    azure_name: Average_% User Time
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_dpc_time
+    azure_name: Average_% DPC Time
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_interrupt_time
+    azure_name: Average_% Interrupt Time
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_idle_time
+    azure_name: Average_% Idle Time
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_io_wait_time
+    azure_name: Average_% IO Wait Time
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_nice_time
+    azure_name: Average_% Nice Time
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_pct_privileged_time
+    azure_name: Average_Pct Privileged Time
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_pct_user_time
+    azure_name: Average_Pct User Time
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_available_memory
+    azure_name: Average_% Available Memory
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_used_memory
+    azure_name: Average_% Used Memory
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_committed_bytes_in_use
+    azure_name: Average_% Committed Bytes In Use
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_available_m_bytes
+    azure_name: Average_Available MBytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_available_m_bytes_memory
+    azure_name: Average_Available MBytes Memory
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_used_memory_k_bytes
+    azure_name: Average_Used Memory kBytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_used_memory_m_bytes
+    azure_name: Average_Used Memory MBytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_free_physical_memory
+    azure_name: Average_Free Physical Memory
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_free_virtual_memory
+    azure_name: Average_Free Virtual Memory
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_virtual_shared_memory
+    azure_name: Average_Virtual Shared Memory
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_available_swap_space
+    azure_name: Average_% Available Swap Space
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_used_swap_space
+    azure_name: Average_% Used Swap Space
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_available_m_bytes_swap
+    azure_name: Average_Available MBytes Swap
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_used_m_bytes_swap_space
+    azure_name: Average_Used MBytes Swap Space
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_free_space
+    azure_name: Average_% Free Space
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_used_space
+    azure_name: Average_% Used Space
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_free_inodes
+    azure_name: Average_% Free Inodes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_used_inodes
+    azure_name: Average_% Used Inodes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_free_megabytes
+    azure_name: Average_Free Megabytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_disk_read_bytes_sec
+    azure_name: Average_Disk Read Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_disk_write_bytes_sec
+    azure_name: Average_Disk Write Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_disk_reads_sec
+    azure_name: Average_Disk Reads/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_disk_writes_sec
+    azure_name: Average_Disk Writes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_disk_transfers_sec
+    azure_name: Average_Disk Transfers/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_logical_disk_bytes_sec
+    azure_name: Average_Logical Disk Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_physical_disk_bytes_sec
+    azure_name: Average_Physical Disk Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_avg_disk_sec_read
+    azure_name: Average_Avg. Disk sec/Read
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_avg_disk_sec_write
+    azure_name: Average_Avg. Disk sec/Write
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_avg_disk_sec_transfer
+    azure_name: Average_Avg. Disk sec/Transfer
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_current_disk_queue_length
+    azure_name: Average_Current Disk Queue Length
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_page_reads_sec
+    azure_name: Average_Page Reads/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_page_writes_sec
+    azure_name: Average_Page Writes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_pages_sec
+    azure_name: Average_Pages/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_free_space_in_paging_files
+    azure_name: Average_Free Space in Paging Files
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_size_stored_in_paging_files
+    azure_name: Average_Size Stored In Paging Files
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_bytes_received_sec
+    azure_name: Average_Bytes Received/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_bytes_sent_sec
+    azure_name: Average_Bytes Sent/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_bytes_total_sec
+    azure_name: Average_Bytes Total/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_total_bytes
+    azure_name: Average_Total Bytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_total_bytes_received
+    azure_name: Average_Total Bytes Received
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_total_bytes_transmitted
+    azure_name: Average_Total Bytes Transmitted
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_total_packets_received
+    azure_name: Average_Total Packets Received
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_total_packets_transmitted
+    azure_name: Average_Total Packets Transmitted
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_total_collisions
+    azure_name: Average_Total Collisions
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_total_rx_errors
+    azure_name: Average_Total Rx Errors
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_total_tx_errors
+    azure_name: Average_Total Tx Errors
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_processes
+    azure_name: Average_Processes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_processor_queue_length
+    azure_name: Average_Processor Queue Length
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_uptime
+    azure_name: Average_Uptime
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: average_users
+    azure_name: Average_Users
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: event
+    azure_name: Event
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: heartbeat
+    azure_name: Heartbeat
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: update
+    azure_name: Update
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Log Analytics Workspace
   context_namespace: log_analytics
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_log_analytics__query_availability
-    title: Azure Log Analytics Query Availability
-    context: query_availability
-    family: Availability
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.availability_rate_query_average
-      name: availability
-  - id: am_azure_log_analytics__ingestion_latency
-    title: Azure Log Analytics Ingestion Latency
-    context: ingestion_latency
-    family: Ingestion
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.ingestion_time_average
-      name: average
-    - selector: log_analytics.ingestion_time_maximum
-      name: maximum
-    - selector: log_analytics.ingestion_time_minimum
-      name: minimum
-  - id: am_azure_log_analytics__ingestion_volume
-    title: Azure Log Analytics Ingestion Volume
-    context: ingestion_volume
-    family: Ingestion
-    type: line
-    units: records/s
-    algorithm: incremental
-    dimensions:
-    - selector: log_analytics.ingestion_volume_count
-      name: records
-  - id: am_azure_log_analytics__queries
-    title: Azure Log Analytics Queries
-    context: queries
-    family: Queries
-    type: line
-    units: queries/s
-    algorithm: incremental
-    dimensions:
-    - selector: log_analytics.query_count_count
-      name: total
-    - selector: log_analytics.query_failure_count_count
-      name: failed
-  - id: am_azure_log_analytics__export_data
-    title: Azure Log Analytics Exported Data
-    context: export_data
-    family: DataExport
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: log_analytics.bytes_exported_total
-      name: exported
-  - id: am_azure_log_analytics__export_records
-    title: Azure Log Analytics Exported Records
-    context: export_records
-    family: DataExport
-    type: line
-    units: records/s
-    algorithm: incremental
-    dimensions:
-    - selector: log_analytics.records_exported_total
-      name: exported
-  - id: am_azure_log_analytics__export_failures
-    title: Azure Log Analytics Export Failures
-    context: export_failures
-    family: DataExport
-    type: line
-    units: exports/s
-    algorithm: incremental
-    dimensions:
-    - selector: log_analytics.export_failed_total
-      name: failed
-  - id: am_azure_log_analytics__legacy_cpu_utilization
-    title: Azure Log Analytics Legacy CPU Utilization
-    context: legacy_cpu_utilization
-    family: 'Legacy: CPU'
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_processor_time_average
-      name: processor
-    - selector: log_analytics.average_privileged_time_average
-      name: privileged
-    - selector: log_analytics.average_user_time_average
-      name: user
-    - selector: log_analytics.average_idle_time_average
-      name: idle
-  - id: am_azure_log_analytics__legacy_cpu_detailed
-    title: Azure Log Analytics Legacy CPU Detailed
-    context: legacy_cpu_detailed
-    family: 'Legacy: CPU'
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_dpc_time_average
-      name: dpc
-    - selector: log_analytics.average_interrupt_time_average
-      name: interrupt
-    - selector: log_analytics.average_io_wait_time_average
-      name: io_wait
-    - selector: log_analytics.average_nice_time_average
-      name: nice
-  - id: am_azure_log_analytics__legacy_cpu_pct
-    title: Azure Log Analytics Legacy CPU Pct Time
-    context: legacy_cpu_pct
-    family: 'Legacy: CPU'
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_pct_privileged_time_average
-      name: privileged
-    - selector: log_analytics.average_pct_user_time_average
-      name: user
-  - id: am_azure_log_analytics__legacy_memory_utilization
-    title: Azure Log Analytics Legacy Memory Utilization
-    context: legacy_memory_utilization
-    family: 'Legacy: Memory'
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_available_memory_average
-      name: available
-    - selector: log_analytics.average_used_memory_average
-      name: used
-    - selector: log_analytics.average_committed_bytes_in_use_average
-      name: committed
-  - id: am_azure_log_analytics__legacy_memory_available
-    title: Azure Log Analytics Legacy Available Memory
-    context: legacy_memory_available
-    family: 'Legacy: Memory'
-    type: line
-    units: megabytes
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_available_m_bytes_average
-      name: available_mbytes
-    - selector: log_analytics.average_available_m_bytes_memory_average
-      name: available_mbytes_memory
-  - id: am_azure_log_analytics__legacy_memory_used_kbytes
-    title: Azure Log Analytics Legacy Used Memory (kBytes)
-    context: legacy_memory_used_kbytes
-    family: 'Legacy: Memory'
-    type: line
-    units: kilobytes
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_used_memory_k_bytes_average
-      name: used
-  - id: am_azure_log_analytics__legacy_memory_used_mbytes
-    title: Azure Log Analytics Legacy Used Memory (MBytes)
-    context: legacy_memory_used_mbytes
-    family: 'Legacy: Memory'
-    type: line
-    units: megabytes
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_used_memory_m_bytes_average
-      name: used
-  - id: am_azure_log_analytics__legacy_memory_free
-    title: Azure Log Analytics Legacy Free Memory
-    context: legacy_memory_free
-    family: 'Legacy: Memory'
-    type: line
-    units: megabytes
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_free_physical_memory_average
-      name: physical
-    - selector: log_analytics.average_free_virtual_memory_average
-      name: virtual
-    - selector: log_analytics.average_virtual_shared_memory_average
-      name: shared
-  - id: am_azure_log_analytics__legacy_swap_utilization
-    title: Azure Log Analytics Legacy Swap Utilization
-    context: legacy_swap_utilization
-    family: 'Legacy: Swap'
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_available_swap_space_average
-      name: available
-    - selector: log_analytics.average_used_swap_space_average
-      name: used
-  - id: am_azure_log_analytics__legacy_swap_size
-    title: Azure Log Analytics Legacy Swap Size
-    context: legacy_swap_size
-    family: 'Legacy: Swap'
-    type: line
-    units: megabytes
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_available_m_bytes_swap_average
-      name: available
-    - selector: log_analytics.average_used_m_bytes_swap_space_average
-      name: used
-  - id: am_azure_log_analytics__legacy_disk_space_utilization
-    title: Azure Log Analytics Legacy Disk Space Utilization
-    context: legacy_disk_space_utilization
-    family: 'Legacy: Disk'
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_free_space_average
-      name: free
-    - selector: log_analytics.average_used_space_average
-      name: used
-  - id: am_azure_log_analytics__legacy_disk_inodes
-    title: Azure Log Analytics Legacy Disk Inodes
-    context: legacy_disk_inodes
-    family: 'Legacy: Disk'
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_free_inodes_average
-      name: free
-    - selector: log_analytics.average_used_inodes_average
-      name: used
-  - id: am_azure_log_analytics__legacy_disk_free
-    title: Azure Log Analytics Legacy Disk Free Space
-    context: legacy_disk_free
-    family: 'Legacy: Disk'
-    type: line
-    units: megabytes
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_free_megabytes_average
-      name: free
-  - id: am_azure_log_analytics__legacy_disk_io_throughput
-    title: Azure Log Analytics Legacy Disk I/O Throughput
-    context: legacy_disk_io_throughput
-    family: 'Legacy: Disk'
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_disk_read_bytes_sec_average
-      name: read
-    - selector: log_analytics.average_disk_write_bytes_sec_average
-      name: write
-    - selector: log_analytics.average_logical_disk_bytes_sec_average
-      name: logical
-    - selector: log_analytics.average_physical_disk_bytes_sec_average
-      name: physical
-  - id: am_azure_log_analytics__legacy_disk_io_operations
-    title: Azure Log Analytics Legacy Disk I/O Operations
-    context: legacy_disk_io_operations
-    family: 'Legacy: Disk'
-    type: line
-    units: operations/s
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_disk_reads_sec_average
-      name: reads
-    - selector: log_analytics.average_disk_writes_sec_average
-      name: writes
-    - selector: log_analytics.average_disk_transfers_sec_average
-      name: transfers
-  - id: am_azure_log_analytics__legacy_disk_io_latency
-    title: Azure Log Analytics Legacy Disk I/O Latency
-    context: legacy_disk_io_latency
-    family: 'Legacy: Disk'
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_avg_disk_sec_read_average
-      name: read
-    - selector: log_analytics.average_avg_disk_sec_write_average
-      name: write
-    - selector: log_analytics.average_avg_disk_sec_transfer_average
-      name: transfer
-  - id: am_azure_log_analytics__legacy_disk_queue
-    title: Azure Log Analytics Legacy Disk Queue Length
-    context: legacy_disk_queue
-    family: 'Legacy: Disk'
-    type: line
-    units: operations
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_current_disk_queue_length_average
-      name: queue_length
-  - id: am_azure_log_analytics__legacy_paging
-    title: Azure Log Analytics Legacy Paging Activity
-    context: legacy_paging
-    family: 'Legacy: Memory'
-    type: line
-    units: pages/s
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_page_reads_sec_average
-      name: reads
-    - selector: log_analytics.average_page_writes_sec_average
-      name: writes
-    - selector: log_analytics.average_pages_sec_average
-      name: total
-  - id: am_azure_log_analytics__legacy_paging_files
-    title: Azure Log Analytics Legacy Paging Files
-    context: legacy_paging_files
-    family: 'Legacy: Memory'
-    type: line
-    units: megabytes
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_free_space_in_paging_files_average
-      name: free
-    - selector: log_analytics.average_size_stored_in_paging_files_average
-      name: stored
-  - id: am_azure_log_analytics__legacy_network_throughput_win
-    title: Azure Log Analytics Legacy Network Throughput (Windows)
-    context: legacy_network_throughput_win
-    family: 'Legacy: Network'
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_bytes_received_sec_average
-      name: received
-    - selector: log_analytics.average_bytes_sent_sec_average
-      name: sent
-    - selector: log_analytics.average_bytes_total_sec_average
-      name: total
-  - id: am_azure_log_analytics__legacy_network_traffic
-    title: Azure Log Analytics Legacy Network Traffic
-    context: legacy_network_traffic
-    family: 'Legacy: Network'
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_total_bytes_average
-      name: total
-    - selector: log_analytics.average_total_bytes_received_average
-      name: received
-    - selector: log_analytics.average_total_bytes_transmitted_average
-      name: transmitted
-  - id: am_azure_log_analytics__legacy_network_packets
-    title: Azure Log Analytics Legacy Network Packets
-    context: legacy_network_packets
-    family: 'Legacy: Network'
-    type: line
-    units: packets
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_total_packets_received_average
-      name: received
-    - selector: log_analytics.average_total_packets_transmitted_average
-      name: transmitted
-  - id: am_azure_log_analytics__legacy_network_errors
-    title: Azure Log Analytics Legacy Network Errors
-    context: legacy_network_errors
-    family: 'Legacy: Network'
-    type: line
-    units: errors
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_total_rx_errors_average
-      name: rx
-    - selector: log_analytics.average_total_tx_errors_average
-      name: tx
-    - selector: log_analytics.average_total_collisions_average
-      name: collisions
-  - id: am_azure_log_analytics__legacy_system
-    title: Azure Log Analytics Legacy System
-    context: legacy_system
-    family: 'Legacy: System'
-    type: line
-    units: processes
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_processes_average
-      name: processes
-  - id: am_azure_log_analytics__legacy_processor_queue
-    title: Azure Log Analytics Legacy Processor Queue
-    context: legacy_processor_queue
-    family: 'Legacy: System'
-    type: line
-    units: threads
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_processor_queue_length_average
-      name: queue_length
-  - id: am_azure_log_analytics__legacy_uptime
-    title: Azure Log Analytics Legacy Uptime
-    context: legacy_uptime
-    family: 'Legacy: System'
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_uptime_average
-      name: uptime
-  - id: am_azure_log_analytics__legacy_users
-    title: Azure Log Analytics Legacy Users
-    context: legacy_users
-    family: 'Legacy: System'
-    type: line
-    units: users
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.average_users_average
-      name: users
-  - id: am_azure_log_analytics__legacy_events
-    title: Azure Log Analytics Legacy Events
-    context: legacy_events
-    family: 'Legacy: Events'
-    type: line
-    units: events/s
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.event_average
-      name: events
-  - id: am_azure_log_analytics__legacy_heartbeat
-    title: Azure Log Analytics Legacy Heartbeat
-    context: legacy_heartbeat
-    family: 'Legacy: Events'
-    type: line
-    units: heartbeats/s
-    algorithm: incremental
-    dimensions:
-    - selector: log_analytics.heartbeat_total
-      name: heartbeats
-  - id: am_azure_log_analytics__legacy_updates
-    title: Azure Log Analytics Legacy Updates
-    context: legacy_updates
-    family: 'Legacy: Events'
-    type: line
-    units: updates
-    algorithm: absolute
-    dimensions:
-    - selector: log_analytics.update_average
-      name: updates
+    - id: am_azure_log_analytics__query_availability
+      title: Azure Log Analytics Query Availability
+      context: query_availability
+      family: Availability
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.availability_rate_query_average
+          name: availability
+    - id: am_azure_log_analytics__ingestion_latency
+      title: Azure Log Analytics Ingestion Latency
+      context: ingestion_latency
+      family: Ingestion
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.ingestion_time_average
+          name: average
+        - selector: log_analytics.ingestion_time_maximum
+          name: maximum
+        - selector: log_analytics.ingestion_time_minimum
+          name: minimum
+    - id: am_azure_log_analytics__ingestion_volume
+      title: Azure Log Analytics Ingestion Volume
+      context: ingestion_volume
+      family: Ingestion
+      type: line
+      units: records/s
+      algorithm: incremental
+      dimensions:
+        - selector: log_analytics.ingestion_volume_count
+          name: records
+    - id: am_azure_log_analytics__queries
+      title: Azure Log Analytics Queries
+      context: queries
+      family: Queries
+      type: line
+      units: queries/s
+      algorithm: incremental
+      dimensions:
+        - selector: log_analytics.query_count_count
+          name: total
+        - selector: log_analytics.query_failure_count_count
+          name: failed
+    - id: am_azure_log_analytics__export_data
+      title: Azure Log Analytics Exported Data
+      context: export_data
+      family: DataExport
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: log_analytics.bytes_exported_total
+          name: exported
+    - id: am_azure_log_analytics__export_records
+      title: Azure Log Analytics Exported Records
+      context: export_records
+      family: DataExport
+      type: line
+      units: records/s
+      algorithm: incremental
+      dimensions:
+        - selector: log_analytics.records_exported_total
+          name: exported
+    - id: am_azure_log_analytics__export_failures
+      title: Azure Log Analytics Export Failures
+      context: export_failures
+      family: DataExport
+      type: line
+      units: exports/s
+      algorithm: incremental
+      dimensions:
+        - selector: log_analytics.export_failed_total
+          name: failed
+    - id: am_azure_log_analytics__legacy_cpu_utilization
+      title: Azure Log Analytics Legacy CPU Utilization
+      context: legacy_cpu_utilization
+      family: 'Legacy: CPU'
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_processor_time_average
+          name: processor
+        - selector: log_analytics.average_privileged_time_average
+          name: privileged
+        - selector: log_analytics.average_user_time_average
+          name: user
+        - selector: log_analytics.average_idle_time_average
+          name: idle
+    - id: am_azure_log_analytics__legacy_cpu_detailed
+      title: Azure Log Analytics Legacy CPU Detailed
+      context: legacy_cpu_detailed
+      family: 'Legacy: CPU'
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_dpc_time_average
+          name: dpc
+        - selector: log_analytics.average_interrupt_time_average
+          name: interrupt
+        - selector: log_analytics.average_io_wait_time_average
+          name: io_wait
+        - selector: log_analytics.average_nice_time_average
+          name: nice
+    - id: am_azure_log_analytics__legacy_cpu_pct
+      title: Azure Log Analytics Legacy CPU Pct Time
+      context: legacy_cpu_pct
+      family: 'Legacy: CPU'
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_pct_privileged_time_average
+          name: privileged
+        - selector: log_analytics.average_pct_user_time_average
+          name: user
+    - id: am_azure_log_analytics__legacy_memory_utilization
+      title: Azure Log Analytics Legacy Memory Utilization
+      context: legacy_memory_utilization
+      family: 'Legacy: Memory'
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_available_memory_average
+          name: available
+        - selector: log_analytics.average_used_memory_average
+          name: used
+        - selector: log_analytics.average_committed_bytes_in_use_average
+          name: committed
+    - id: am_azure_log_analytics__legacy_memory_available
+      title: Azure Log Analytics Legacy Available Memory
+      context: legacy_memory_available
+      family: 'Legacy: Memory'
+      type: line
+      units: megabytes
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_available_m_bytes_average
+          name: available_mbytes
+        - selector: log_analytics.average_available_m_bytes_memory_average
+          name: available_mbytes_memory
+    - id: am_azure_log_analytics__legacy_memory_used_kbytes
+      title: Azure Log Analytics Legacy Used Memory (kBytes)
+      context: legacy_memory_used_kbytes
+      family: 'Legacy: Memory'
+      type: line
+      units: kilobytes
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_used_memory_k_bytes_average
+          name: used
+    - id: am_azure_log_analytics__legacy_memory_used_mbytes
+      title: Azure Log Analytics Legacy Used Memory (MBytes)
+      context: legacy_memory_used_mbytes
+      family: 'Legacy: Memory'
+      type: line
+      units: megabytes
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_used_memory_m_bytes_average
+          name: used
+    - id: am_azure_log_analytics__legacy_memory_free
+      title: Azure Log Analytics Legacy Free Memory
+      context: legacy_memory_free
+      family: 'Legacy: Memory'
+      type: line
+      units: megabytes
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_free_physical_memory_average
+          name: physical
+        - selector: log_analytics.average_free_virtual_memory_average
+          name: virtual
+        - selector: log_analytics.average_virtual_shared_memory_average
+          name: shared
+    - id: am_azure_log_analytics__legacy_swap_utilization
+      title: Azure Log Analytics Legacy Swap Utilization
+      context: legacy_swap_utilization
+      family: 'Legacy: Swap'
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_available_swap_space_average
+          name: available
+        - selector: log_analytics.average_used_swap_space_average
+          name: used
+    - id: am_azure_log_analytics__legacy_swap_size
+      title: Azure Log Analytics Legacy Swap Size
+      context: legacy_swap_size
+      family: 'Legacy: Swap'
+      type: line
+      units: megabytes
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_available_m_bytes_swap_average
+          name: available
+        - selector: log_analytics.average_used_m_bytes_swap_space_average
+          name: used
+    - id: am_azure_log_analytics__legacy_disk_space_utilization
+      title: Azure Log Analytics Legacy Disk Space Utilization
+      context: legacy_disk_space_utilization
+      family: 'Legacy: Disk'
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_free_space_average
+          name: free
+        - selector: log_analytics.average_used_space_average
+          name: used
+    - id: am_azure_log_analytics__legacy_disk_inodes
+      title: Azure Log Analytics Legacy Disk Inodes
+      context: legacy_disk_inodes
+      family: 'Legacy: Disk'
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_free_inodes_average
+          name: free
+        - selector: log_analytics.average_used_inodes_average
+          name: used
+    - id: am_azure_log_analytics__legacy_disk_free
+      title: Azure Log Analytics Legacy Disk Free Space
+      context: legacy_disk_free
+      family: 'Legacy: Disk'
+      type: line
+      units: megabytes
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_free_megabytes_average
+          name: free
+    - id: am_azure_log_analytics__legacy_disk_io_throughput
+      title: Azure Log Analytics Legacy Disk I/O Throughput
+      context: legacy_disk_io_throughput
+      family: 'Legacy: Disk'
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_disk_read_bytes_sec_average
+          name: read
+        - selector: log_analytics.average_disk_write_bytes_sec_average
+          name: write
+        - selector: log_analytics.average_logical_disk_bytes_sec_average
+          name: logical
+        - selector: log_analytics.average_physical_disk_bytes_sec_average
+          name: physical
+    - id: am_azure_log_analytics__legacy_disk_io_operations
+      title: Azure Log Analytics Legacy Disk I/O Operations
+      context: legacy_disk_io_operations
+      family: 'Legacy: Disk'
+      type: line
+      units: operations/s
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_disk_reads_sec_average
+          name: reads
+        - selector: log_analytics.average_disk_writes_sec_average
+          name: writes
+        - selector: log_analytics.average_disk_transfers_sec_average
+          name: transfers
+    - id: am_azure_log_analytics__legacy_disk_io_latency
+      title: Azure Log Analytics Legacy Disk I/O Latency
+      context: legacy_disk_io_latency
+      family: 'Legacy: Disk'
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_avg_disk_sec_read_average
+          name: read
+        - selector: log_analytics.average_avg_disk_sec_write_average
+          name: write
+        - selector: log_analytics.average_avg_disk_sec_transfer_average
+          name: transfer
+    - id: am_azure_log_analytics__legacy_disk_queue
+      title: Azure Log Analytics Legacy Disk Queue Length
+      context: legacy_disk_queue
+      family: 'Legacy: Disk'
+      type: line
+      units: operations
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_current_disk_queue_length_average
+          name: queue_length
+    - id: am_azure_log_analytics__legacy_paging
+      title: Azure Log Analytics Legacy Paging Activity
+      context: legacy_paging
+      family: 'Legacy: Memory'
+      type: line
+      units: pages/s
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_page_reads_sec_average
+          name: reads
+        - selector: log_analytics.average_page_writes_sec_average
+          name: writes
+        - selector: log_analytics.average_pages_sec_average
+          name: total
+    - id: am_azure_log_analytics__legacy_paging_files
+      title: Azure Log Analytics Legacy Paging Files
+      context: legacy_paging_files
+      family: 'Legacy: Memory'
+      type: line
+      units: megabytes
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_free_space_in_paging_files_average
+          name: free
+        - selector: log_analytics.average_size_stored_in_paging_files_average
+          name: stored
+    - id: am_azure_log_analytics__legacy_network_throughput_win
+      title: Azure Log Analytics Legacy Network Throughput (Windows)
+      context: legacy_network_throughput_win
+      family: 'Legacy: Network'
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_bytes_received_sec_average
+          name: received
+        - selector: log_analytics.average_bytes_sent_sec_average
+          name: sent
+        - selector: log_analytics.average_bytes_total_sec_average
+          name: total
+    - id: am_azure_log_analytics__legacy_network_traffic
+      title: Azure Log Analytics Legacy Network Traffic
+      context: legacy_network_traffic
+      family: 'Legacy: Network'
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_total_bytes_average
+          name: total
+        - selector: log_analytics.average_total_bytes_received_average
+          name: received
+        - selector: log_analytics.average_total_bytes_transmitted_average
+          name: transmitted
+    - id: am_azure_log_analytics__legacy_network_packets
+      title: Azure Log Analytics Legacy Network Packets
+      context: legacy_network_packets
+      family: 'Legacy: Network'
+      type: line
+      units: packets
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_total_packets_received_average
+          name: received
+        - selector: log_analytics.average_total_packets_transmitted_average
+          name: transmitted
+    - id: am_azure_log_analytics__legacy_network_errors
+      title: Azure Log Analytics Legacy Network Errors
+      context: legacy_network_errors
+      family: 'Legacy: Network'
+      type: line
+      units: errors
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_total_rx_errors_average
+          name: rx
+        - selector: log_analytics.average_total_tx_errors_average
+          name: tx
+        - selector: log_analytics.average_total_collisions_average
+          name: collisions
+    - id: am_azure_log_analytics__legacy_system
+      title: Azure Log Analytics Legacy System
+      context: legacy_system
+      family: 'Legacy: System'
+      type: line
+      units: processes
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_processes_average
+          name: processes
+    - id: am_azure_log_analytics__legacy_processor_queue
+      title: Azure Log Analytics Legacy Processor Queue
+      context: legacy_processor_queue
+      family: 'Legacy: System'
+      type: line
+      units: threads
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_processor_queue_length_average
+          name: queue_length
+    - id: am_azure_log_analytics__legacy_uptime
+      title: Azure Log Analytics Legacy Uptime
+      context: legacy_uptime
+      family: 'Legacy: System'
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_uptime_average
+          name: uptime
+    - id: am_azure_log_analytics__legacy_users
+      title: Azure Log Analytics Legacy Users
+      context: legacy_users
+      family: 'Legacy: System'
+      type: line
+      units: users
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.average_users_average
+          name: users
+    - id: am_azure_log_analytics__legacy_events
+      title: Azure Log Analytics Legacy Events
+      context: legacy_events
+      family: 'Legacy: Events'
+      type: line
+      units: events/s
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.event_average
+          name: events
+    - id: am_azure_log_analytics__legacy_heartbeat
+      title: Azure Log Analytics Legacy Heartbeat
+      context: legacy_heartbeat
+      family: 'Legacy: Events'
+      type: line
+      units: heartbeats/s
+      algorithm: incremental
+      dimensions:
+        - selector: log_analytics.heartbeat_total
+          name: heartbeats
+    - id: am_azure_log_analytics__legacy_updates
+      title: Azure Log Analytics Legacy Updates
+      context: legacy_updates
+      family: 'Legacy: Events'
+      type: line
+      units: updates
+      algorithm: absolute
+      dimensions:
+        - selector: log_analytics.update_average
+          name: updates

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/logic_apps.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/logic_apps.yaml
@@ -3,417 +3,417 @@ id: logic_apps
 name: Azure Logic Apps Workflow
 resource_type: Microsoft.Logic/workflows
 metrics:
-- id: runs_started
-  azure_name: RunsStarted
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: runs_completed
-  azure_name: RunsCompleted
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: runs_succeeded
-  azure_name: RunsSucceeded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: runs_failed
-  azure_name: RunsFailed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: runs_cancelled
-  azure_name: RunsCancelled
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: run_latency
-  azure_name: RunLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: run_success_latency
-  azure_name: RunSuccessLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: run_failure_percentage
-  azure_name: RunFailurePercentage
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: run_throttled_events
-  azure_name: RunThrottledEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: run_start_throttled_events
-  azure_name: RunStartThrottledEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: actions_started
-  azure_name: ActionsStarted
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: actions_completed
-  azure_name: ActionsCompleted
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: actions_succeeded
-  azure_name: ActionsSucceeded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: actions_failed
-  azure_name: ActionsFailed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: actions_skipped
-  azure_name: ActionsSkipped
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: action_latency
-  azure_name: ActionLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: action_success_latency
-  azure_name: ActionSuccessLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: action_throttled_events
-  azure_name: ActionThrottledEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: triggers_started
-  azure_name: TriggersStarted
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: triggers_completed
-  azure_name: TriggersCompleted
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: triggers_succeeded
-  azure_name: TriggersSucceeded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: triggers_fired
-  azure_name: TriggersFired
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: triggers_failed
-  azure_name: TriggersFailed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: triggers_skipped
-  azure_name: TriggersSkipped
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: trigger_latency
-  azure_name: TriggerLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: trigger_fire_latency
-  azure_name: TriggerFireLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: trigger_success_latency
-  azure_name: TriggerSuccessLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: trigger_throttled_events
-  azure_name: TriggerThrottledEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: total_billable_executions
-  azure_name: TotalBillableExecutions
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: billable_action_executions
-  azure_name: BillableActionExecutions
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: billable_trigger_executions
-  azure_name: BillableTriggerExecutions
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: billing_usage_native_operation
-  azure_name: BillingUsageNativeOperation
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: billing_usage_standard_connector
-  azure_name: BillingUsageStandardConnector
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: billing_usage_storage_consumption
-  azure_name: BillingUsageStorageConsumption
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: agent_loop_execution
-  azure_name: AgentLoopExecution
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: completion_token_overflow_usage
-  azure_name: CompletionTokenOverflowUsage
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: prompt_token_overflow_usage
-  azure_name: PromptTokenOverflowUsage
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
+  - id: runs_started
+    azure_name: RunsStarted
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: runs_completed
+    azure_name: RunsCompleted
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: runs_succeeded
+    azure_name: RunsSucceeded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: runs_failed
+    azure_name: RunsFailed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: runs_cancelled
+    azure_name: RunsCancelled
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: run_latency
+    azure_name: RunLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: run_success_latency
+    azure_name: RunSuccessLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: run_failure_percentage
+    azure_name: RunFailurePercentage
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: run_throttled_events
+    azure_name: RunThrottledEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: run_start_throttled_events
+    azure_name: RunStartThrottledEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: actions_started
+    azure_name: ActionsStarted
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: actions_completed
+    azure_name: ActionsCompleted
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: actions_succeeded
+    azure_name: ActionsSucceeded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: actions_failed
+    azure_name: ActionsFailed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: actions_skipped
+    azure_name: ActionsSkipped
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: action_latency
+    azure_name: ActionLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: action_success_latency
+    azure_name: ActionSuccessLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: action_throttled_events
+    azure_name: ActionThrottledEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: triggers_started
+    azure_name: TriggersStarted
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: triggers_completed
+    azure_name: TriggersCompleted
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: triggers_succeeded
+    azure_name: TriggersSucceeded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: triggers_fired
+    azure_name: TriggersFired
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: triggers_failed
+    azure_name: TriggersFailed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: triggers_skipped
+    azure_name: TriggersSkipped
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: trigger_latency
+    azure_name: TriggerLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: trigger_fire_latency
+    azure_name: TriggerFireLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: trigger_success_latency
+    azure_name: TriggerSuccessLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: trigger_throttled_events
+    azure_name: TriggerThrottledEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: total_billable_executions
+    azure_name: TotalBillableExecutions
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: billable_action_executions
+    azure_name: BillableActionExecutions
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: billable_trigger_executions
+    azure_name: BillableTriggerExecutions
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: billing_usage_native_operation
+    azure_name: BillingUsageNativeOperation
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: billing_usage_standard_connector
+    azure_name: BillingUsageStandardConnector
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: billing_usage_storage_consumption
+    azure_name: BillingUsageStorageConsumption
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: agent_loop_execution
+    azure_name: AgentLoopExecution
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: completion_token_overflow_usage
+    azure_name: CompletionTokenOverflowUsage
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: prompt_token_overflow_usage
+    azure_name: PromptTokenOverflowUsage
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
 template:
   family: Azure Logic Apps Workflow
   context_namespace: logic_apps
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_logic_apps__run_lifecycle
-    title: Azure Logic Apps Run Lifecycle
-    context: run_lifecycle
-    family: Runs
-    type: line
-    units: runs/s
-    algorithm: incremental
-    dimensions:
-    - selector: logic_apps.runs_started_total
-      name: started
-    - selector: logic_apps.runs_completed_total
-      name: completed
-    - selector: logic_apps.runs_succeeded_total
-      name: succeeded
-    - selector: logic_apps.runs_failed_total
-      name: failed
-    - selector: logic_apps.runs_cancelled_total
-      name: cancelled
-  - id: am_azure_logic_apps__run_latency
-    title: Azure Logic Apps Run Latency
-    context: run_latency
-    family: Runs
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: logic_apps.run_latency_average
-      name: all
-    - selector: logic_apps.run_success_latency_average
-      name: success
-  - id: am_azure_logic_apps__run_failure_rate
-    title: Azure Logic Apps Run Failure Rate
-    context: run_failure_rate
-    family: Runs
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: logic_apps.run_failure_percentage_total
-      name: failure_rate
-  - id: am_azure_logic_apps__run_throttling
-    title: Azure Logic Apps Run Throttling
-    context: run_throttling
-    family: Runs
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: logic_apps.run_throttled_events_total
-      name: during_run
-    - selector: logic_apps.run_start_throttled_events_total
-      name: at_start
-  - id: am_azure_logic_apps__action_lifecycle
-    title: Azure Logic Apps Action Lifecycle
-    context: action_lifecycle
-    family: Actions
-    type: line
-    units: actions/s
-    algorithm: incremental
-    dimensions:
-    - selector: logic_apps.actions_started_total
-      name: started
-    - selector: logic_apps.actions_completed_total
-      name: completed
-    - selector: logic_apps.actions_succeeded_total
-      name: succeeded
-    - selector: logic_apps.actions_failed_total
-      name: failed
-    - selector: logic_apps.actions_skipped_total
-      name: skipped
-  - id: am_azure_logic_apps__action_latency
-    title: Azure Logic Apps Action Latency
-    context: action_latency
-    family: Actions
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: logic_apps.action_latency_average
-      name: all
-    - selector: logic_apps.action_success_latency_average
-      name: success
-  - id: am_azure_logic_apps__action_throttling
-    title: Azure Logic Apps Action Throttling
-    context: action_throttling
-    family: Actions
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: logic_apps.action_throttled_events_total
-      name: total
-  - id: am_azure_logic_apps__trigger_lifecycle
-    title: Azure Logic Apps Trigger Lifecycle
-    context: trigger_lifecycle
-    family: Triggers
-    type: line
-    units: triggers/s
-    algorithm: incremental
-    dimensions:
-    - selector: logic_apps.triggers_started_total
-      name: started
-    - selector: logic_apps.triggers_completed_total
-      name: completed
-    - selector: logic_apps.triggers_succeeded_total
-      name: succeeded
-    - selector: logic_apps.triggers_fired_total
-      name: fired
-    - selector: logic_apps.triggers_failed_total
-      name: failed
-    - selector: logic_apps.triggers_skipped_total
-      name: skipped
-  - id: am_azure_logic_apps__trigger_latency
-    title: Azure Logic Apps Trigger Latency
-    context: trigger_latency
-    family: Triggers
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: logic_apps.trigger_latency_average
-      name: all
-    - selector: logic_apps.trigger_fire_latency_average
-      name: fire
-    - selector: logic_apps.trigger_success_latency_average
-      name: success
-  - id: am_azure_logic_apps__trigger_throttling
-    title: Azure Logic Apps Trigger Throttling
-    context: trigger_throttling
-    family: Triggers
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: logic_apps.trigger_throttled_events_total
-      name: total
-  - id: am_azure_logic_apps__billable_executions
-    title: Azure Logic Apps Billable Executions
-    context: billable_executions
-    family: Billing
-    type: line
-    units: executions/s
-    algorithm: incremental
-    dimensions:
-    - selector: logic_apps.total_billable_executions_total
-      name: total
-    - selector: logic_apps.billable_action_executions_total
-      name: actions
-    - selector: logic_apps.billable_trigger_executions_total
-      name: triggers
-  - id: am_azure_logic_apps__billing_by_type
-    title: Azure Logic Apps Billing by Type
-    context: billing_by_type
-    family: Billing
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: logic_apps.billing_usage_native_operation_total
-      name: native
-    - selector: logic_apps.billing_usage_standard_connector_total
-      name: standard_connector
-    - selector: logic_apps.billing_usage_storage_consumption_total
-      name: storage
-  - id: am_azure_logic_apps__agent
-    title: Azure Logic Apps AI Agent Activity
-    context: agent
-    family: Agent
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: logic_apps.agent_loop_execution_total
-      name: loop_executions
-    - selector: logic_apps.completion_token_overflow_usage_total
-      name: completion_overflow
-    - selector: logic_apps.prompt_token_overflow_usage_total
-      name: prompt_overflow
+    - id: am_azure_logic_apps__run_lifecycle
+      title: Azure Logic Apps Run Lifecycle
+      context: run_lifecycle
+      family: Runs
+      type: line
+      units: runs/s
+      algorithm: incremental
+      dimensions:
+        - selector: logic_apps.runs_started_total
+          name: started
+        - selector: logic_apps.runs_completed_total
+          name: completed
+        - selector: logic_apps.runs_succeeded_total
+          name: succeeded
+        - selector: logic_apps.runs_failed_total
+          name: failed
+        - selector: logic_apps.runs_cancelled_total
+          name: cancelled
+    - id: am_azure_logic_apps__run_latency
+      title: Azure Logic Apps Run Latency
+      context: run_latency
+      family: Runs
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: logic_apps.run_latency_average
+          name: all
+        - selector: logic_apps.run_success_latency_average
+          name: success
+    - id: am_azure_logic_apps__run_failure_rate
+      title: Azure Logic Apps Run Failure Rate
+      context: run_failure_rate
+      family: Runs
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: logic_apps.run_failure_percentage_total
+          name: failure_rate
+    - id: am_azure_logic_apps__run_throttling
+      title: Azure Logic Apps Run Throttling
+      context: run_throttling
+      family: Runs
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: logic_apps.run_throttled_events_total
+          name: during_run
+        - selector: logic_apps.run_start_throttled_events_total
+          name: at_start
+    - id: am_azure_logic_apps__action_lifecycle
+      title: Azure Logic Apps Action Lifecycle
+      context: action_lifecycle
+      family: Actions
+      type: line
+      units: actions/s
+      algorithm: incremental
+      dimensions:
+        - selector: logic_apps.actions_started_total
+          name: started
+        - selector: logic_apps.actions_completed_total
+          name: completed
+        - selector: logic_apps.actions_succeeded_total
+          name: succeeded
+        - selector: logic_apps.actions_failed_total
+          name: failed
+        - selector: logic_apps.actions_skipped_total
+          name: skipped
+    - id: am_azure_logic_apps__action_latency
+      title: Azure Logic Apps Action Latency
+      context: action_latency
+      family: Actions
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: logic_apps.action_latency_average
+          name: all
+        - selector: logic_apps.action_success_latency_average
+          name: success
+    - id: am_azure_logic_apps__action_throttling
+      title: Azure Logic Apps Action Throttling
+      context: action_throttling
+      family: Actions
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: logic_apps.action_throttled_events_total
+          name: total
+    - id: am_azure_logic_apps__trigger_lifecycle
+      title: Azure Logic Apps Trigger Lifecycle
+      context: trigger_lifecycle
+      family: Triggers
+      type: line
+      units: triggers/s
+      algorithm: incremental
+      dimensions:
+        - selector: logic_apps.triggers_started_total
+          name: started
+        - selector: logic_apps.triggers_completed_total
+          name: completed
+        - selector: logic_apps.triggers_succeeded_total
+          name: succeeded
+        - selector: logic_apps.triggers_fired_total
+          name: fired
+        - selector: logic_apps.triggers_failed_total
+          name: failed
+        - selector: logic_apps.triggers_skipped_total
+          name: skipped
+    - id: am_azure_logic_apps__trigger_latency
+      title: Azure Logic Apps Trigger Latency
+      context: trigger_latency
+      family: Triggers
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: logic_apps.trigger_latency_average
+          name: all
+        - selector: logic_apps.trigger_fire_latency_average
+          name: fire
+        - selector: logic_apps.trigger_success_latency_average
+          name: success
+    - id: am_azure_logic_apps__trigger_throttling
+      title: Azure Logic Apps Trigger Throttling
+      context: trigger_throttling
+      family: Triggers
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: logic_apps.trigger_throttled_events_total
+          name: total
+    - id: am_azure_logic_apps__billable_executions
+      title: Azure Logic Apps Billable Executions
+      context: billable_executions
+      family: Billing
+      type: line
+      units: executions/s
+      algorithm: incremental
+      dimensions:
+        - selector: logic_apps.total_billable_executions_total
+          name: total
+        - selector: logic_apps.billable_action_executions_total
+          name: actions
+        - selector: logic_apps.billable_trigger_executions_total
+          name: triggers
+    - id: am_azure_logic_apps__billing_by_type
+      title: Azure Logic Apps Billing by Type
+      context: billing_by_type
+      family: Billing
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: logic_apps.billing_usage_native_operation_total
+          name: native
+        - selector: logic_apps.billing_usage_standard_connector_total
+          name: standard_connector
+        - selector: logic_apps.billing_usage_storage_consumption_total
+          name: storage
+    - id: am_azure_logic_apps__agent
+      title: Azure Logic Apps AI Agent Activity
+      context: agent
+      family: Agent
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: logic_apps.agent_loop_execution_total
+          name: loop_executions
+        - selector: logic_apps.completion_token_overflow_usage_total
+          name: completion_overflow
+        - selector: logic_apps.prompt_token_overflow_usage_total
+          name: prompt_overflow

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/machine_learning.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/machine_learning.yaml
@@ -3,777 +3,777 @@ id: machine_learning
 name: Azure Machine Learning Workspace
 resource_type: Microsoft.MachineLearningServices/workspaces
 metrics:
-- id: agents
-  azure_name: Agents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: indexed_files
-  azure_name: IndexedFiles
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: messages
-  azure_name: Messages
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: runs
-  azure_name: Runs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: threads
-  azure_name: Threads
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tokens
-  azure_name: Tokens
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tool_calls
-  azure_name: ToolCalls
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: model_deploy_failed
-  azure_name: Model Deploy Failed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: model_deploy_started
-  azure_name: Model Deploy Started
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: model_deploy_succeeded
-  azure_name: Model Deploy Succeeded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: model_register_failed
-  azure_name: Model Register Failed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: model_register_succeeded
-  azure_name: Model Register Succeeded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: active_cores
-  azure_name: Active Cores
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: idle_cores
-  azure_name: Idle Cores
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: leaving_cores
-  azure_name: Leaving Cores
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: preempted_cores
-  azure_name: Preempted Cores
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: unusable_cores
-  azure_name: Unusable Cores
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: total_cores
-  azure_name: Total Cores
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: active_nodes
-  azure_name: Active Nodes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: idle_nodes
-  azure_name: Idle Nodes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: leaving_nodes
-  azure_name: Leaving Nodes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: preempted_nodes
-  azure_name: Preempted Nodes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: unusable_nodes
-  azure_name: Unusable Nodes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: total_nodes
-  azure_name: Total Nodes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: quota_utilization_percentage
-  azure_name: Quota Utilization Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_utilization
-  azure_name: CpuUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_utilization_percentage
-  azure_name: CpuUtilizationPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_utilization_millicores
-  azure_name: CpuUtilizationMillicores
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_capacity_millicores
-  azure_name: CpuCapacityMillicores
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_memory_utilization_percentage
-  azure_name: CpuMemoryUtilizationPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_memory_utilization_megabytes
-  azure_name: CpuMemoryUtilizationMegabytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_memory_capacity_megabytes
-  azure_name: CpuMemoryCapacityMegabytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: gpu_utilization
-  azure_name: GpuUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: gpu_utilization_percentage
-  azure_name: GpuUtilizationPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: gpu_utilization_milli_gpus
-  azure_name: GpuUtilizationMilliGPUs
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: gpu_capacity_milli_gpus
-  azure_name: GpuCapacityMilliGPUs
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: gpu_memory_utilization
-  azure_name: GpuMemoryUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: gpu_memory_utilization_percentage
-  azure_name: GpuMemoryUtilizationPercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: gpu_memory_utilization_megabytes
-  azure_name: GpuMemoryUtilizationMegabytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: gpu_memory_capacity_megabytes
-  azure_name: GpuMemoryCapacityMegabytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: gpu_energy_joules
-  azure_name: GpuEnergyJoules
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: disk_used_megabytes
-  azure_name: DiskUsedMegabytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: disk_avail_megabytes
-  azure_name: DiskAvailMegabytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: disk_read_megabytes
-  azure_name: DiskReadMegabytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: disk_write_megabytes
-  azure_name: DiskWriteMegabytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: network_input_megabytes
-  azure_name: NetworkInputMegabytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: network_output_megabytes
-  azure_name: NetworkOutputMegabytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ib_receive_megabytes
-  azure_name: IBReceiveMegabytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ib_transmit_megabytes
-  azure_name: IBTransmitMegabytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: storage_api_success_count
-  azure_name: StorageAPISuccessCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: storage_api_failure_count
-  azure_name: StorageAPIFailureCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: not_started_runs
-  azure_name: Not Started Runs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: starting_runs
-  azure_name: Starting Runs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: preparing_runs
-  azure_name: Preparing Runs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: provisioning_runs
-  azure_name: Provisioning Runs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: queued_runs
-  azure_name: Queued Runs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: started_runs
-  azure_name: Started Runs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: completed_runs
-  azure_name: Completed Runs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: failed_runs
-  azure_name: Failed Runs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: cancelled_runs
-  azure_name: Cancelled Runs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: cancel_requested_runs
-  azure_name: Cancel Requested Runs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: finalizing_runs
-  azure_name: Finalizing Runs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: not_responding_runs
-  azure_name: Not Responding Runs
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: errors
-  azure_name: Errors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: warnings
-  azure_name: Warnings
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
+  - id: agents
+    azure_name: Agents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: indexed_files
+    azure_name: IndexedFiles
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: messages
+    azure_name: Messages
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: runs
+    azure_name: Runs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: threads
+    azure_name: Threads
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tokens
+    azure_name: Tokens
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tool_calls
+    azure_name: ToolCalls
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: model_deploy_failed
+    azure_name: Model Deploy Failed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: model_deploy_started
+    azure_name: Model Deploy Started
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: model_deploy_succeeded
+    azure_name: Model Deploy Succeeded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: model_register_failed
+    azure_name: Model Register Failed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: model_register_succeeded
+    azure_name: Model Register Succeeded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: active_cores
+    azure_name: Active Cores
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: idle_cores
+    azure_name: Idle Cores
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: leaving_cores
+    azure_name: Leaving Cores
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: preempted_cores
+    azure_name: Preempted Cores
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: unusable_cores
+    azure_name: Unusable Cores
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: total_cores
+    azure_name: Total Cores
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: active_nodes
+    azure_name: Active Nodes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: idle_nodes
+    azure_name: Idle Nodes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: leaving_nodes
+    azure_name: Leaving Nodes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: preempted_nodes
+    azure_name: Preempted Nodes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: unusable_nodes
+    azure_name: Unusable Nodes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: total_nodes
+    azure_name: Total Nodes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: quota_utilization_percentage
+    azure_name: Quota Utilization Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_utilization
+    azure_name: CpuUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_utilization_percentage
+    azure_name: CpuUtilizationPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_utilization_millicores
+    azure_name: CpuUtilizationMillicores
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_capacity_millicores
+    azure_name: CpuCapacityMillicores
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_memory_utilization_percentage
+    azure_name: CpuMemoryUtilizationPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_memory_utilization_megabytes
+    azure_name: CpuMemoryUtilizationMegabytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_memory_capacity_megabytes
+    azure_name: CpuMemoryCapacityMegabytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: gpu_utilization
+    azure_name: GpuUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: gpu_utilization_percentage
+    azure_name: GpuUtilizationPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: gpu_utilization_milli_gpus
+    azure_name: GpuUtilizationMilliGPUs
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: gpu_capacity_milli_gpus
+    azure_name: GpuCapacityMilliGPUs
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: gpu_memory_utilization
+    azure_name: GpuMemoryUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: gpu_memory_utilization_percentage
+    azure_name: GpuMemoryUtilizationPercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: gpu_memory_utilization_megabytes
+    azure_name: GpuMemoryUtilizationMegabytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: gpu_memory_capacity_megabytes
+    azure_name: GpuMemoryCapacityMegabytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: gpu_energy_joules
+    azure_name: GpuEnergyJoules
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: disk_used_megabytes
+    azure_name: DiskUsedMegabytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: disk_avail_megabytes
+    azure_name: DiskAvailMegabytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: disk_read_megabytes
+    azure_name: DiskReadMegabytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: disk_write_megabytes
+    azure_name: DiskWriteMegabytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: network_input_megabytes
+    azure_name: NetworkInputMegabytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: network_output_megabytes
+    azure_name: NetworkOutputMegabytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ib_receive_megabytes
+    azure_name: IBReceiveMegabytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ib_transmit_megabytes
+    azure_name: IBTransmitMegabytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: storage_api_success_count
+    azure_name: StorageAPISuccessCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: storage_api_failure_count
+    azure_name: StorageAPIFailureCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: not_started_runs
+    azure_name: Not Started Runs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: starting_runs
+    azure_name: Starting Runs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: preparing_runs
+    azure_name: Preparing Runs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: provisioning_runs
+    azure_name: Provisioning Runs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: queued_runs
+    azure_name: Queued Runs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: started_runs
+    azure_name: Started Runs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: completed_runs
+    azure_name: Completed Runs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: failed_runs
+    azure_name: Failed Runs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: cancelled_runs
+    azure_name: Cancelled Runs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: cancel_requested_runs
+    azure_name: Cancel Requested Runs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: finalizing_runs
+    azure_name: Finalizing Runs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: not_responding_runs
+    azure_name: Not Responding Runs
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: errors
+    azure_name: Errors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: warnings
+    azure_name: Warnings
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
 template:
   family: Azure Machine Learning Workspace
   context_namespace: machine_learning
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_machine_learning__agent_events
-    title: Azure Machine Learning Agent Events
-    context: agent_events
-    family: Agents
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.agents_total
-      name: agent_events
-    - selector: machine_learning.threads_total
-      name: thread_events
-  - id: am_azure_machine_learning__agent_messages
-    title: Azure Machine Learning Agent Messages
-    context: agent_messages
-    family: Agents
-    type: line
-    units: messages/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.messages_total
-      name: messages
-  - id: am_azure_machine_learning__agent_runs
-    title: Azure Machine Learning Agent Runs
-    context: agent_runs
-    family: Agents
-    type: line
-    units: runs/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.runs_total
-      name: runs
-  - id: am_azure_machine_learning__agent_tokens
-    title: Azure Machine Learning Agent Tokens
-    context: agent_tokens
-    family: Agents
-    type: line
-    units: tokens/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.tokens_total
-      name: tokens
-  - id: am_azure_machine_learning__agent_tool_calls
-    title: Azure Machine Learning Agent Tool Calls
-    context: agent_tool_calls
-    family: Agents
-    type: line
-    units: calls/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.tool_calls_total
-      name: tool_calls
-  - id: am_azure_machine_learning__agent_indexed_files
-    title: Azure Machine Learning Agent Indexed Files
-    context: agent_indexed_files
-    family: Agents
-    type: line
-    units: files/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.indexed_files_total
-      name: indexed_files
-  - id: am_azure_machine_learning__model_deployments
-    title: Azure Machine Learning Model Deployments
-    context: model_deployments
-    family: Model
-    type: line
-    units: deployments/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.model_deploy_started_total
-      name: started
-    - selector: machine_learning.model_deploy_succeeded_total
-      name: succeeded
-    - selector: machine_learning.model_deploy_failed_total
-      name: failed
-  - id: am_azure_machine_learning__model_registrations
-    title: Azure Machine Learning Model Registrations
-    context: model_registrations
-    family: Model
-    type: line
-    units: registrations/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.model_register_succeeded_total
-      name: succeeded
-    - selector: machine_learning.model_register_failed_total
-      name: failed
-  - id: am_azure_machine_learning__cluster_cores
-    title: Azure Machine Learning Cluster Cores
-    context: cluster_cores
-    family: Quota
-    type: stacked
-    units: cores
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.active_cores_average
-      name: active
-    - selector: machine_learning.idle_cores_average
-      name: idle
-    - selector: machine_learning.leaving_cores_average
-      name: leaving
-    - selector: machine_learning.preempted_cores_average
-      name: preempted
-    - selector: machine_learning.unusable_cores_average
-      name: unusable
-  - id: am_azure_machine_learning__total_cores
-    title: Azure Machine Learning Total Cores
-    context: total_cores
-    family: Quota
-    type: line
-    units: cores
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.total_cores_average
-      name: total
-  - id: am_azure_machine_learning__cluster_nodes
-    title: Azure Machine Learning Cluster Nodes
-    context: cluster_nodes
-    family: Quota
-    type: stacked
-    units: nodes
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.active_nodes_average
-      name: active
-    - selector: machine_learning.idle_nodes_average
-      name: idle
-    - selector: machine_learning.leaving_nodes_average
-      name: leaving
-    - selector: machine_learning.preempted_nodes_average
-      name: preempted
-    - selector: machine_learning.unusable_nodes_average
-      name: unusable
-  - id: am_azure_machine_learning__total_nodes
-    title: Azure Machine Learning Total Nodes
-    context: total_nodes
-    family: Quota
-    type: line
-    units: nodes
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.total_nodes_average
-      name: total
-  - id: am_azure_machine_learning__quota_utilization
-    title: Azure Machine Learning Quota Utilization
-    context: quota_utilization
-    family: Quota
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.quota_utilization_percentage_average
-      name: utilization
-  - id: am_azure_machine_learning__cpu_utilization
-    title: Azure Machine Learning CPU Utilization
-    context: cpu_utilization
-    family: Compute
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.cpu_utilization_average
-      name: cluster_cpu
-    - selector: machine_learning.cpu_utilization_percentage_average
-      name: node_cpu
-  - id: am_azure_machine_learning__cpu_millicores
-    title: Azure Machine Learning CPU Millicores
-    context: cpu_millicores
-    family: Compute
-    type: line
-    units: millicores
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.cpu_utilization_millicores_average
-      name: used
-    - selector: machine_learning.cpu_capacity_millicores_average
-      name: capacity
-  - id: am_azure_machine_learning__cpu_memory_utilization
-    title: Azure Machine Learning CPU Memory Utilization
-    context: cpu_memory_utilization
-    family: Compute
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.cpu_memory_utilization_percentage_average
-      name: utilization
-  - id: am_azure_machine_learning__cpu_memory_megabytes
-    title: Azure Machine Learning CPU Memory
-    context: cpu_memory_megabytes
-    family: Compute
-    type: line
-    units: megabytes
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.cpu_memory_utilization_megabytes_average
-      name: used
-    - selector: machine_learning.cpu_memory_capacity_megabytes_average
-      name: capacity
-  - id: am_azure_machine_learning__gpu_utilization
-    title: Azure Machine Learning GPU Utilization
-    context: gpu_utilization
-    family: Compute
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.gpu_utilization_average
-      name: cluster_gpu
-    - selector: machine_learning.gpu_utilization_percentage_average
-      name: node_gpu
-  - id: am_azure_machine_learning__gpu_milligpus
-    title: Azure Machine Learning GPU MilliGPUs
-    context: gpu_milligpus
-    family: Compute
-    type: line
-    units: milliGPUs
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.gpu_utilization_milli_gpus_average
-      name: used
-    - selector: machine_learning.gpu_capacity_milli_gpus_average
-      name: capacity
-  - id: am_azure_machine_learning__gpu_memory_utilization
-    title: Azure Machine Learning GPU Memory Utilization
-    context: gpu_memory_utilization
-    family: Compute
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.gpu_memory_utilization_average
-      name: cluster_gpu_memory
-    - selector: machine_learning.gpu_memory_utilization_percentage_average
-      name: node_gpu_memory
-  - id: am_azure_machine_learning__gpu_memory_megabytes
-    title: Azure Machine Learning GPU Memory
-    context: gpu_memory_megabytes
-    family: Compute
-    type: line
-    units: megabytes
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.gpu_memory_utilization_megabytes_average
-      name: used
-    - selector: machine_learning.gpu_memory_capacity_megabytes_average
-      name: capacity
-  - id: am_azure_machine_learning__gpu_energy
-    title: Azure Machine Learning GPU Energy
-    context: gpu_energy
-    family: Compute
-    type: line
-    units: joules/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.gpu_energy_joules_total
-      name: energy
-  - id: am_azure_machine_learning__disk_usage
-    title: Azure Machine Learning Disk Usage
-    context: disk_usage
-    family: Compute
-    type: line
-    units: megabytes
-    algorithm: absolute
-    dimensions:
-    - selector: machine_learning.disk_used_megabytes_average
-      name: used
-    - selector: machine_learning.disk_avail_megabytes_average
-      name: available
-  - id: am_azure_machine_learning__disk_io
-    title: Azure Machine Learning Disk I/O
-    context: disk_io
-    family: Compute
-    type: line
-    units: megabytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.disk_read_megabytes_total
-      name: read
-    - selector: machine_learning.disk_write_megabytes_total
-      name: write
-  - id: am_azure_machine_learning__network_traffic
-    title: Azure Machine Learning Network Traffic
-    context: network_traffic
-    family: Network
-    type: line
-    units: megabytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.network_input_megabytes_total
-      name: in
-    - selector: machine_learning.network_output_megabytes_total
-      name: out
-  - id: am_azure_machine_learning__infiniband_traffic
-    title: Azure Machine Learning InfiniBand Traffic
-    context: infiniband_traffic
-    family: Network
-    type: line
-    units: megabytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.ib_receive_megabytes_total
-      name: receive
-    - selector: machine_learning.ib_transmit_megabytes_total
-      name: transmit
-  - id: am_azure_machine_learning__storage_api_calls
-    title: Azure Machine Learning Storage API Calls
-    context: storage_api_calls
-    family: Compute
-    type: line
-    units: calls/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.storage_api_success_count_total
-      name: success
-    - selector: machine_learning.storage_api_failure_count_total
-      name: failure
-  - id: am_azure_machine_learning__run_lifecycle
-    title: Azure Machine Learning Run Lifecycle
-    context: run_lifecycle
-    family: Runs
-    type: line
-    units: runs/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.not_started_runs_total
-      name: not_started
-    - selector: machine_learning.starting_runs_total
-      name: starting
-    - selector: machine_learning.preparing_runs_total
-      name: preparing
-    - selector: machine_learning.provisioning_runs_total
-      name: provisioning
-    - selector: machine_learning.queued_runs_total
-      name: queued
-    - selector: machine_learning.started_runs_total
-      name: started
-  - id: am_azure_machine_learning__run_completion
-    title: Azure Machine Learning Run Completion
-    context: run_completion
-    family: Runs
-    type: line
-    units: runs/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.completed_runs_total
-      name: completed
-    - selector: machine_learning.failed_runs_total
-      name: failed
-    - selector: machine_learning.finalizing_runs_total
-      name: finalizing
-    - selector: machine_learning.cancelled_runs_total
-      name: cancelled
-    - selector: machine_learning.cancel_requested_runs_total
-      name: cancel_requested
-    - selector: machine_learning.not_responding_runs_total
-      name: not_responding
-  - id: am_azure_machine_learning__run_issues
-    title: Azure Machine Learning Run Issues
-    context: run_issues
-    family: Runs
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: machine_learning.errors_total
-      name: errors
-    - selector: machine_learning.warnings_total
-      name: warnings
+    - id: am_azure_machine_learning__agent_events
+      title: Azure Machine Learning Agent Events
+      context: agent_events
+      family: Agents
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.agents_total
+          name: agent_events
+        - selector: machine_learning.threads_total
+          name: thread_events
+    - id: am_azure_machine_learning__agent_messages
+      title: Azure Machine Learning Agent Messages
+      context: agent_messages
+      family: Agents
+      type: line
+      units: messages/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.messages_total
+          name: messages
+    - id: am_azure_machine_learning__agent_runs
+      title: Azure Machine Learning Agent Runs
+      context: agent_runs
+      family: Agents
+      type: line
+      units: runs/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.runs_total
+          name: runs
+    - id: am_azure_machine_learning__agent_tokens
+      title: Azure Machine Learning Agent Tokens
+      context: agent_tokens
+      family: Agents
+      type: line
+      units: tokens/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.tokens_total
+          name: tokens
+    - id: am_azure_machine_learning__agent_tool_calls
+      title: Azure Machine Learning Agent Tool Calls
+      context: agent_tool_calls
+      family: Agents
+      type: line
+      units: calls/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.tool_calls_total
+          name: tool_calls
+    - id: am_azure_machine_learning__agent_indexed_files
+      title: Azure Machine Learning Agent Indexed Files
+      context: agent_indexed_files
+      family: Agents
+      type: line
+      units: files/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.indexed_files_total
+          name: indexed_files
+    - id: am_azure_machine_learning__model_deployments
+      title: Azure Machine Learning Model Deployments
+      context: model_deployments
+      family: Model
+      type: line
+      units: deployments/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.model_deploy_started_total
+          name: started
+        - selector: machine_learning.model_deploy_succeeded_total
+          name: succeeded
+        - selector: machine_learning.model_deploy_failed_total
+          name: failed
+    - id: am_azure_machine_learning__model_registrations
+      title: Azure Machine Learning Model Registrations
+      context: model_registrations
+      family: Model
+      type: line
+      units: registrations/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.model_register_succeeded_total
+          name: succeeded
+        - selector: machine_learning.model_register_failed_total
+          name: failed
+    - id: am_azure_machine_learning__cluster_cores
+      title: Azure Machine Learning Cluster Cores
+      context: cluster_cores
+      family: Quota
+      type: stacked
+      units: cores
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.active_cores_average
+          name: active
+        - selector: machine_learning.idle_cores_average
+          name: idle
+        - selector: machine_learning.leaving_cores_average
+          name: leaving
+        - selector: machine_learning.preempted_cores_average
+          name: preempted
+        - selector: machine_learning.unusable_cores_average
+          name: unusable
+    - id: am_azure_machine_learning__total_cores
+      title: Azure Machine Learning Total Cores
+      context: total_cores
+      family: Quota
+      type: line
+      units: cores
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.total_cores_average
+          name: total
+    - id: am_azure_machine_learning__cluster_nodes
+      title: Azure Machine Learning Cluster Nodes
+      context: cluster_nodes
+      family: Quota
+      type: stacked
+      units: nodes
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.active_nodes_average
+          name: active
+        - selector: machine_learning.idle_nodes_average
+          name: idle
+        - selector: machine_learning.leaving_nodes_average
+          name: leaving
+        - selector: machine_learning.preempted_nodes_average
+          name: preempted
+        - selector: machine_learning.unusable_nodes_average
+          name: unusable
+    - id: am_azure_machine_learning__total_nodes
+      title: Azure Machine Learning Total Nodes
+      context: total_nodes
+      family: Quota
+      type: line
+      units: nodes
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.total_nodes_average
+          name: total
+    - id: am_azure_machine_learning__quota_utilization
+      title: Azure Machine Learning Quota Utilization
+      context: quota_utilization
+      family: Quota
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.quota_utilization_percentage_average
+          name: utilization
+    - id: am_azure_machine_learning__cpu_utilization
+      title: Azure Machine Learning CPU Utilization
+      context: cpu_utilization
+      family: Compute
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.cpu_utilization_average
+          name: cluster_cpu
+        - selector: machine_learning.cpu_utilization_percentage_average
+          name: node_cpu
+    - id: am_azure_machine_learning__cpu_millicores
+      title: Azure Machine Learning CPU Millicores
+      context: cpu_millicores
+      family: Compute
+      type: line
+      units: millicores
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.cpu_utilization_millicores_average
+          name: used
+        - selector: machine_learning.cpu_capacity_millicores_average
+          name: capacity
+    - id: am_azure_machine_learning__cpu_memory_utilization
+      title: Azure Machine Learning CPU Memory Utilization
+      context: cpu_memory_utilization
+      family: Compute
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.cpu_memory_utilization_percentage_average
+          name: utilization
+    - id: am_azure_machine_learning__cpu_memory_megabytes
+      title: Azure Machine Learning CPU Memory
+      context: cpu_memory_megabytes
+      family: Compute
+      type: line
+      units: megabytes
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.cpu_memory_utilization_megabytes_average
+          name: used
+        - selector: machine_learning.cpu_memory_capacity_megabytes_average
+          name: capacity
+    - id: am_azure_machine_learning__gpu_utilization
+      title: Azure Machine Learning GPU Utilization
+      context: gpu_utilization
+      family: Compute
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.gpu_utilization_average
+          name: cluster_gpu
+        - selector: machine_learning.gpu_utilization_percentage_average
+          name: node_gpu
+    - id: am_azure_machine_learning__gpu_milligpus
+      title: Azure Machine Learning GPU MilliGPUs
+      context: gpu_milligpus
+      family: Compute
+      type: line
+      units: milliGPUs
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.gpu_utilization_milli_gpus_average
+          name: used
+        - selector: machine_learning.gpu_capacity_milli_gpus_average
+          name: capacity
+    - id: am_azure_machine_learning__gpu_memory_utilization
+      title: Azure Machine Learning GPU Memory Utilization
+      context: gpu_memory_utilization
+      family: Compute
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.gpu_memory_utilization_average
+          name: cluster_gpu_memory
+        - selector: machine_learning.gpu_memory_utilization_percentage_average
+          name: node_gpu_memory
+    - id: am_azure_machine_learning__gpu_memory_megabytes
+      title: Azure Machine Learning GPU Memory
+      context: gpu_memory_megabytes
+      family: Compute
+      type: line
+      units: megabytes
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.gpu_memory_utilization_megabytes_average
+          name: used
+        - selector: machine_learning.gpu_memory_capacity_megabytes_average
+          name: capacity
+    - id: am_azure_machine_learning__gpu_energy
+      title: Azure Machine Learning GPU Energy
+      context: gpu_energy
+      family: Compute
+      type: line
+      units: joules/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.gpu_energy_joules_total
+          name: energy
+    - id: am_azure_machine_learning__disk_usage
+      title: Azure Machine Learning Disk Usage
+      context: disk_usage
+      family: Compute
+      type: line
+      units: megabytes
+      algorithm: absolute
+      dimensions:
+        - selector: machine_learning.disk_used_megabytes_average
+          name: used
+        - selector: machine_learning.disk_avail_megabytes_average
+          name: available
+    - id: am_azure_machine_learning__disk_io
+      title: Azure Machine Learning Disk I/O
+      context: disk_io
+      family: Compute
+      type: line
+      units: megabytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.disk_read_megabytes_total
+          name: read
+        - selector: machine_learning.disk_write_megabytes_total
+          name: write
+    - id: am_azure_machine_learning__network_traffic
+      title: Azure Machine Learning Network Traffic
+      context: network_traffic
+      family: Network
+      type: line
+      units: megabytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.network_input_megabytes_total
+          name: in
+        - selector: machine_learning.network_output_megabytes_total
+          name: out
+    - id: am_azure_machine_learning__infiniband_traffic
+      title: Azure Machine Learning InfiniBand Traffic
+      context: infiniband_traffic
+      family: Network
+      type: line
+      units: megabytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.ib_receive_megabytes_total
+          name: receive
+        - selector: machine_learning.ib_transmit_megabytes_total
+          name: transmit
+    - id: am_azure_machine_learning__storage_api_calls
+      title: Azure Machine Learning Storage API Calls
+      context: storage_api_calls
+      family: Compute
+      type: line
+      units: calls/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.storage_api_success_count_total
+          name: success
+        - selector: machine_learning.storage_api_failure_count_total
+          name: failure
+    - id: am_azure_machine_learning__run_lifecycle
+      title: Azure Machine Learning Run Lifecycle
+      context: run_lifecycle
+      family: Runs
+      type: line
+      units: runs/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.not_started_runs_total
+          name: not_started
+        - selector: machine_learning.starting_runs_total
+          name: starting
+        - selector: machine_learning.preparing_runs_total
+          name: preparing
+        - selector: machine_learning.provisioning_runs_total
+          name: provisioning
+        - selector: machine_learning.queued_runs_total
+          name: queued
+        - selector: machine_learning.started_runs_total
+          name: started
+    - id: am_azure_machine_learning__run_completion
+      title: Azure Machine Learning Run Completion
+      context: run_completion
+      family: Runs
+      type: line
+      units: runs/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.completed_runs_total
+          name: completed
+        - selector: machine_learning.failed_runs_total
+          name: failed
+        - selector: machine_learning.finalizing_runs_total
+          name: finalizing
+        - selector: machine_learning.cancelled_runs_total
+          name: cancelled
+        - selector: machine_learning.cancel_requested_runs_total
+          name: cancel_requested
+        - selector: machine_learning.not_responding_runs_total
+          name: not_responding
+    - id: am_azure_machine_learning__run_issues
+      title: Azure Machine Learning Run Issues
+      context: run_issues
+      family: Runs
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: machine_learning.errors_total
+          name: errors
+        - selector: machine_learning.warnings_total
+          name: warnings

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/mysql_flexible.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/mysql_flexible.yaml
@@ -3,721 +3,721 @@ id: mysql_flexible
 name: Azure MySQL Flexible Server
 resource_type: Microsoft.DBforMySQL/flexibleServers
 metrics:
-- id: ha_io_status
-  azure_name: HA_IO_status
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: ha_sql_status
-  azure_name: HA_SQL_status
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: replica_io_running
-  azure_name: Replica_IO_Running
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: replica_sql_running
-  azure_name: Replica_SQL_Running
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: aborted_connections
-  azure_name: aborted_connections
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ha_replication_lag
-  azure_name: HA_replication_lag
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: innodb_row_lock_time
-  azure_name: Innodb_row_lock_time
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: innodb_row_lock_waits
-  azure_name: Innodb_row_lock_waits
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: replication_lag
-  azure_name: replication_lag
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: uptime
-  azure_name: Uptime
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: cpu_percent
-  azure_name: cpu_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: memory_percent
-  azure_name: memory_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: io_consumption_percent
-  azure_name: io_consumption_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_credits_consumed
-  azure_name: cpu_credits_consumed
-  time_grain: PT15M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_credits_remaining
-  azure_name: cpu_credits_remaining
-  time_grain: PT15M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: storage_used
-  azure_name: storage_used
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: storage_limit
-  azure_name: storage_limit
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: storage_percent
-  azure_name: storage_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_storage_used
-  azure_name: data_storage_used
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: ibdata1_storage_used
-  azure_name: ibdata1_storage_used
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: binlog_storage_used
-  azure_name: binlog_storage_used
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: others_storage_used
-  azure_name: others_storage_used
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: backup_storage_used
-  azure_name: backup_storage_used
-  time_grain: PT15M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: serverlog_storage_usage
-  azure_name: serverlog_storage_usage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: serverlog_storage_limit
-  azure_name: serverlog_storage_limit
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: serverlog_storage_percent
-  azure_name: serverlog_storage_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: innodb_buffer_pool_pages_data
-  azure_name: Innodb_buffer_pool_pages_data
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: innodb_buffer_pool_pages_dirty
-  azure_name: Innodb_buffer_pool_pages_dirty
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: innodb_buffer_pool_pages_free
-  azure_name: Innodb_buffer_pool_pages_free
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: innodb_buffer_pool_read_requests
-  azure_name: Innodb_buffer_pool_read_requests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: innodb_buffer_pool_reads
-  azure_name: Innodb_buffer_pool_reads
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: sort_merge_passes
-  azure_name: Sort_merge_passes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: threads_running
-  azure_name: Threads_running
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: active_connections
-  azure_name: active_connections
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: total_connections
-  azure_name: total_connections
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: active_transactions
-  azure_name: active_transactions
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: queries
-  azure_name: Queries
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: slow_queries
-  azure_name: Slow_queries
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: com_select
-  azure_name: Com_select
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: com_insert
-  azure_name: Com_insert
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: com_update
-  azure_name: Com_update
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: com_delete
-  azure_name: Com_delete
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: com_create_table
-  azure_name: Com_create_table
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: com_alter_table
-  azure_name: Com_alter_table
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: com_drop_table
-  azure_name: Com_drop_table
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: com_create_db
-  azure_name: Com_create_db
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: com_drop_db
-  azure_name: Com_drop_db
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: innodb_buffer_pool_pages_flushed
-  azure_name: Innodb_buffer_pool_pages_flushed
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: innodb_data_writes
-  azure_name: Innodb_data_writes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: lock_deadlocks
-  azure_name: lock_deadlocks
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: lock_timeouts
-  azure_name: lock_timeouts
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: network_bytes_ingress
-  azure_name: network_bytes_ingress
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: network_bytes_egress
-  azure_name: network_bytes_egress
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: storage_io_count
-  azure_name: storage_io_count
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: trx_rseg_history_len
-  azure_name: trx_rseg_history_len
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
+  - id: ha_io_status
+    azure_name: HA_IO_status
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: ha_sql_status
+    azure_name: HA_SQL_status
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: replica_io_running
+    azure_name: Replica_IO_Running
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: replica_sql_running
+    azure_name: Replica_SQL_Running
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: aborted_connections
+    azure_name: aborted_connections
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ha_replication_lag
+    azure_name: HA_replication_lag
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: innodb_row_lock_time
+    azure_name: Innodb_row_lock_time
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: innodb_row_lock_waits
+    azure_name: Innodb_row_lock_waits
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: replication_lag
+    azure_name: replication_lag
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: uptime
+    azure_name: Uptime
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: cpu_percent
+    azure_name: cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: memory_percent
+    azure_name: memory_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: io_consumption_percent
+    azure_name: io_consumption_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_credits_consumed
+    azure_name: cpu_credits_consumed
+    time_grain: PT15M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_credits_remaining
+    azure_name: cpu_credits_remaining
+    time_grain: PT15M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: storage_used
+    azure_name: storage_used
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: storage_limit
+    azure_name: storage_limit
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: storage_percent
+    azure_name: storage_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_storage_used
+    azure_name: data_storage_used
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: ibdata1_storage_used
+    azure_name: ibdata1_storage_used
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: binlog_storage_used
+    azure_name: binlog_storage_used
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: others_storage_used
+    azure_name: others_storage_used
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: backup_storage_used
+    azure_name: backup_storage_used
+    time_grain: PT15M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: serverlog_storage_usage
+    azure_name: serverlog_storage_usage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: serverlog_storage_limit
+    azure_name: serverlog_storage_limit
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: serverlog_storage_percent
+    azure_name: serverlog_storage_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: innodb_buffer_pool_pages_data
+    azure_name: Innodb_buffer_pool_pages_data
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: innodb_buffer_pool_pages_dirty
+    azure_name: Innodb_buffer_pool_pages_dirty
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: innodb_buffer_pool_pages_free
+    azure_name: Innodb_buffer_pool_pages_free
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: innodb_buffer_pool_read_requests
+    azure_name: Innodb_buffer_pool_read_requests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: innodb_buffer_pool_reads
+    azure_name: Innodb_buffer_pool_reads
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: sort_merge_passes
+    azure_name: Sort_merge_passes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: threads_running
+    azure_name: Threads_running
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: active_connections
+    azure_name: active_connections
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: total_connections
+    azure_name: total_connections
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: active_transactions
+    azure_name: active_transactions
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: queries
+    azure_name: Queries
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: slow_queries
+    azure_name: Slow_queries
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: com_select
+    azure_name: Com_select
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: com_insert
+    azure_name: Com_insert
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: com_update
+    azure_name: Com_update
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: com_delete
+    azure_name: Com_delete
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: com_create_table
+    azure_name: Com_create_table
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: com_alter_table
+    azure_name: Com_alter_table
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: com_drop_table
+    azure_name: Com_drop_table
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: com_create_db
+    azure_name: Com_create_db
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: com_drop_db
+    azure_name: Com_drop_db
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: innodb_buffer_pool_pages_flushed
+    azure_name: Innodb_buffer_pool_pages_flushed
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: innodb_data_writes
+    azure_name: Innodb_data_writes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: lock_deadlocks
+    azure_name: lock_deadlocks
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: lock_timeouts
+    azure_name: lock_timeouts
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: network_bytes_ingress
+    azure_name: network_bytes_ingress
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: network_bytes_egress
+    azure_name: network_bytes_egress
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: storage_io_count
+    azure_name: storage_io_count
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: trx_rseg_history_len
+    azure_name: trx_rseg_history_len
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
 template:
   family: Azure MySQL Flexible Server
   context_namespace: mysql_flexible
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_mysql_flexible__cpu
-    title: Azure MySQL Flexible Server CPU Utilization
-    context: cpu
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.cpu_percent_average
-      name: average
-  - id: am_azure_mysql_flexible__memory
-    title: Azure MySQL Flexible Server Memory Utilization
-    context: memory
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.memory_percent_average
-      name: average
-  - id: am_azure_mysql_flexible__io_utilization
-    title: Azure MySQL Flexible Server Storage I/O Utilization
-    context: io_utilization
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.io_consumption_percent_average
-      name: average
-  - id: am_azure_mysql_flexible__cpu_credits
-    title: Azure MySQL Flexible Server CPU Credits
-    context: cpu_credits
-    family: Utilization
-    type: line
-    units: credits
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.cpu_credits_consumed_average
-      name: consumed
-    - selector: mysql_flexible.cpu_credits_remaining_average
-      name: remaining
-  - id: am_azure_mysql_flexible__ha_status
-    title: Azure MySQL Flexible Server HA Replication Status
-    context: ha_status
-    family: Availability
-    type: line
-    units: status
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.ha_io_status_maximum
-      name: io
-    - selector: mysql_flexible.ha_sql_status_maximum
-      name: sql
-  - id: am_azure_mysql_flexible__replica_status
-    title: Azure MySQL Flexible Server Replica Status
-    context: replica_status
-    family: Availability
-    type: line
-    units: status
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.replica_io_running_maximum
-      name: io
-    - selector: mysql_flexible.replica_sql_running_maximum
-      name: sql
-  - id: am_azure_mysql_flexible__uptime
-    title: Azure MySQL Flexible Server Uptime
-    context: uptime
-    family: Availability
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.uptime_maximum
-      name: uptime
-  - id: am_azure_mysql_flexible__replication_lag
-    title: Azure MySQL Flexible Server Replication Lag
-    context: replication_lag
-    family: Replication
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.replication_lag_average
-      name: replica
-    - selector: mysql_flexible.ha_replication_lag_average
-      name: ha
-  - id: am_azure_mysql_flexible__innodb_row_lock_time
-    title: Azure MySQL Flexible Server InnoDB Row Lock Time
-    context: innodb_row_lock_time
-    family: Contention
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.innodb_row_lock_time_average
-      name: average
-  - id: am_azure_mysql_flexible__innodb_row_lock_waits
-    title: Azure MySQL Flexible Server InnoDB Row Lock Waits
-    context: innodb_row_lock_waits
-    family: Contention
-    type: line
-    units: waits/s
-    algorithm: incremental
-    dimensions:
-    - selector: mysql_flexible.innodb_row_lock_waits_total
-      name: total
-  - id: am_azure_mysql_flexible__aborted_connections
-    title: Azure MySQL Flexible Server Aborted Connections
-    context: aborted_connections
-    family: Errors
-    type: line
-    units: connections/s
-    algorithm: incremental
-    dimensions:
-    - selector: mysql_flexible.aborted_connections_total
-      name: total
-  - id: am_azure_mysql_flexible__active_connections
-    title: Azure MySQL Flexible Server Active Connections
-    context: active_connections
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.active_connections_average
-      name: average
-  - id: am_azure_mysql_flexible__total_connections
-    title: Azure MySQL Flexible Server Total Connections
-    context: total_connections
-    family: Connections
-    type: line
-    units: connections/s
-    algorithm: incremental
-    dimensions:
-    - selector: mysql_flexible.total_connections_total
-      name: total
-  - id: am_azure_mysql_flexible__active_transactions
-    title: Azure MySQL Flexible Server Active Transactions
-    context: active_transactions
-    family: Connections
-    type: line
-    units: transactions
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.active_transactions_average
-      name: average
-  - id: am_azure_mysql_flexible__threads_running
-    title: Azure MySQL Flexible Server Threads Running
-    context: threads_running
-    family: Connections
-    type: line
-    units: threads
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.threads_running_maximum
-      name: maximum
-  - id: am_azure_mysql_flexible__queries
-    title: Azure MySQL Flexible Server Queries
-    context: queries
-    family: Throughput
-    type: line
-    units: queries/s
-    algorithm: incremental
-    dimensions:
-    - selector: mysql_flexible.queries_total
-      name: total
-    - selector: mysql_flexible.slow_queries_total
-      name: slow
-  - id: am_azure_mysql_flexible__dml_statements
-    title: Azure MySQL Flexible Server DML Statements
-    context: dml_statements
-    family: Throughput
-    type: line
-    units: statements/s
-    algorithm: incremental
-    dimensions:
-    - selector: mysql_flexible.com_select_total
-      name: select
-    - selector: mysql_flexible.com_insert_total
-      name: insert
-    - selector: mysql_flexible.com_update_total
-      name: update
-    - selector: mysql_flexible.com_delete_total
-      name: delete
-  - id: am_azure_mysql_flexible__ddl_statements
-    title: Azure MySQL Flexible Server DDL Statements
-    context: ddl_statements
-    family: Throughput
-    type: line
-    units: statements/s
-    algorithm: incremental
-    dimensions:
-    - selector: mysql_flexible.com_create_table_total
-      name: create_table
-    - selector: mysql_flexible.com_alter_table_total
-      name: alter_table
-    - selector: mysql_flexible.com_drop_table_total
-      name: drop_table
-    - selector: mysql_flexible.com_create_db_total
-      name: create_db
-    - selector: mysql_flexible.com_drop_db_total
-      name: drop_db
-  - id: am_azure_mysql_flexible__lock_deadlocks
-    title: Azure MySQL Flexible Server Deadlocks
-    context: lock_deadlocks
-    family: Contention
-    type: line
-    units: deadlocks/s
-    algorithm: incremental
-    dimensions:
-    - selector: mysql_flexible.lock_deadlocks_total
-      name: total
-  - id: am_azure_mysql_flexible__lock_timeouts
-    title: Azure MySQL Flexible Server Lock Timeouts
-    context: lock_timeouts
-    family: Contention
-    type: line
-    units: timeouts/s
-    algorithm: incremental
-    dimensions:
-    - selector: mysql_flexible.lock_timeouts_total
-      name: total
-  - id: am_azure_mysql_flexible__innodb_buffer_pool_pages
-    title: Azure MySQL Flexible Server InnoDB Buffer Pool Pages
-    context: innodb_buffer_pool_pages
-    family: InnoDB
-    type: line
-    units: pages
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.innodb_buffer_pool_pages_data_maximum
-      name: data
-    - selector: mysql_flexible.innodb_buffer_pool_pages_dirty_maximum
-      name: dirty
-    - selector: mysql_flexible.innodb_buffer_pool_pages_free_maximum
-      name: free
-    - selector: mysql_flexible.innodb_buffer_pool_pages_flushed_average
-      name: flushed
-  - id: am_azure_mysql_flexible__innodb_buffer_pool_io
-    title: Azure MySQL Flexible Server InnoDB Buffer Pool I/O
-    context: innodb_buffer_pool_io
-    family: InnoDB
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: mysql_flexible.innodb_buffer_pool_read_requests_total
-      name: read_requests
-    - selector: mysql_flexible.innodb_buffer_pool_reads_total
-      name: disk_reads
-  - id: am_azure_mysql_flexible__innodb_data_writes
-    title: Azure MySQL Flexible Server InnoDB Data Writes
-    context: innodb_data_writes
-    family: InnoDB
-    type: line
-    units: writes/s
-    algorithm: incremental
-    dimensions:
-    - selector: mysql_flexible.innodb_data_writes_total
-      name: total
-  - id: am_azure_mysql_flexible__sort_merge_passes
-    title: Azure MySQL Flexible Server Sort Merge Passes
-    context: sort_merge_passes
-    family: Performance
-    type: line
-    units: passes/s
-    algorithm: incremental
-    dimensions:
-    - selector: mysql_flexible.sort_merge_passes_total
-      name: total
-  - id: am_azure_mysql_flexible__network
-    title: Azure MySQL Flexible Server Network Traffic
-    context: network
-    family: Network
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: mysql_flexible.network_bytes_ingress_total
-      name: in
-    - selector: mysql_flexible.network_bytes_egress_total
-      name: out
-  - id: am_azure_mysql_flexible__storage_io
-    title: Azure MySQL Flexible Server Storage I/O
-    context: storage_io
-    family: I/O
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: mysql_flexible.storage_io_count_total
-      name: total
-  - id: am_azure_mysql_flexible__storage
-    title: Azure MySQL Flexible Server Storage
-    context: storage
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.storage_used_average
-      name: used
-    - selector: mysql_flexible.storage_limit_maximum
-      name: limit
-  - id: am_azure_mysql_flexible__storage_utilization
-    title: Azure MySQL Flexible Server Storage Utilization
-    context: storage_utilization
-    family: Capacity
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.storage_percent_average
-      name: average
-  - id: am_azure_mysql_flexible__storage_breakdown
-    title: Azure MySQL Flexible Server Storage Breakdown
-    context: storage_breakdown
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.data_storage_used_average
-      name: data
-    - selector: mysql_flexible.ibdata1_storage_used_average
-      name: ibdata1
-    - selector: mysql_flexible.binlog_storage_used_average
-      name: binlog
-    - selector: mysql_flexible.others_storage_used_average
-      name: others
-  - id: am_azure_mysql_flexible__backup_storage
-    title: Azure MySQL Flexible Server Backup Storage
-    context: backup_storage
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.backup_storage_used_average
-      name: used
-  - id: am_azure_mysql_flexible__serverlog_storage
-    title: Azure MySQL Flexible Server Server Log Storage
-    context: serverlog_storage
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.serverlog_storage_usage_average
-      name: used
-    - selector: mysql_flexible.serverlog_storage_limit_maximum
-      name: limit
-  - id: am_azure_mysql_flexible__serverlog_storage_utilization
-    title: Azure MySQL Flexible Server Server Log Storage Utilization
-    context: serverlog_storage_utilization
-    family: Capacity
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.serverlog_storage_percent_average
-      name: average
-  - id: am_azure_mysql_flexible__history_list_length
-    title: Azure MySQL Flexible Server History List Length
-    context: history_list_length
-    family: InnoDB
-    type: line
-    units: entries
-    algorithm: absolute
-    dimensions:
-    - selector: mysql_flexible.trx_rseg_history_len_maximum
-      name: maximum
+    - id: am_azure_mysql_flexible__cpu
+      title: Azure MySQL Flexible Server CPU Utilization
+      context: cpu
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.cpu_percent_average
+          name: average
+    - id: am_azure_mysql_flexible__memory
+      title: Azure MySQL Flexible Server Memory Utilization
+      context: memory
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.memory_percent_average
+          name: average
+    - id: am_azure_mysql_flexible__io_utilization
+      title: Azure MySQL Flexible Server Storage I/O Utilization
+      context: io_utilization
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.io_consumption_percent_average
+          name: average
+    - id: am_azure_mysql_flexible__cpu_credits
+      title: Azure MySQL Flexible Server CPU Credits
+      context: cpu_credits
+      family: Utilization
+      type: line
+      units: credits
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.cpu_credits_consumed_average
+          name: consumed
+        - selector: mysql_flexible.cpu_credits_remaining_average
+          name: remaining
+    - id: am_azure_mysql_flexible__ha_status
+      title: Azure MySQL Flexible Server HA Replication Status
+      context: ha_status
+      family: Availability
+      type: line
+      units: status
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.ha_io_status_maximum
+          name: io
+        - selector: mysql_flexible.ha_sql_status_maximum
+          name: sql
+    - id: am_azure_mysql_flexible__replica_status
+      title: Azure MySQL Flexible Server Replica Status
+      context: replica_status
+      family: Availability
+      type: line
+      units: status
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.replica_io_running_maximum
+          name: io
+        - selector: mysql_flexible.replica_sql_running_maximum
+          name: sql
+    - id: am_azure_mysql_flexible__uptime
+      title: Azure MySQL Flexible Server Uptime
+      context: uptime
+      family: Availability
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.uptime_maximum
+          name: uptime
+    - id: am_azure_mysql_flexible__replication_lag
+      title: Azure MySQL Flexible Server Replication Lag
+      context: replication_lag
+      family: Replication
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.replication_lag_average
+          name: replica
+        - selector: mysql_flexible.ha_replication_lag_average
+          name: ha
+    - id: am_azure_mysql_flexible__innodb_row_lock_time
+      title: Azure MySQL Flexible Server InnoDB Row Lock Time
+      context: innodb_row_lock_time
+      family: Contention
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.innodb_row_lock_time_average
+          name: average
+    - id: am_azure_mysql_flexible__innodb_row_lock_waits
+      title: Azure MySQL Flexible Server InnoDB Row Lock Waits
+      context: innodb_row_lock_waits
+      family: Contention
+      type: line
+      units: waits/s
+      algorithm: incremental
+      dimensions:
+        - selector: mysql_flexible.innodb_row_lock_waits_total
+          name: total
+    - id: am_azure_mysql_flexible__aborted_connections
+      title: Azure MySQL Flexible Server Aborted Connections
+      context: aborted_connections
+      family: Errors
+      type: line
+      units: connections/s
+      algorithm: incremental
+      dimensions:
+        - selector: mysql_flexible.aborted_connections_total
+          name: total
+    - id: am_azure_mysql_flexible__active_connections
+      title: Azure MySQL Flexible Server Active Connections
+      context: active_connections
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.active_connections_average
+          name: average
+    - id: am_azure_mysql_flexible__total_connections
+      title: Azure MySQL Flexible Server Total Connections
+      context: total_connections
+      family: Connections
+      type: line
+      units: connections/s
+      algorithm: incremental
+      dimensions:
+        - selector: mysql_flexible.total_connections_total
+          name: total
+    - id: am_azure_mysql_flexible__active_transactions
+      title: Azure MySQL Flexible Server Active Transactions
+      context: active_transactions
+      family: Connections
+      type: line
+      units: transactions
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.active_transactions_average
+          name: average
+    - id: am_azure_mysql_flexible__threads_running
+      title: Azure MySQL Flexible Server Threads Running
+      context: threads_running
+      family: Connections
+      type: line
+      units: threads
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.threads_running_maximum
+          name: maximum
+    - id: am_azure_mysql_flexible__queries
+      title: Azure MySQL Flexible Server Queries
+      context: queries
+      family: Throughput
+      type: line
+      units: queries/s
+      algorithm: incremental
+      dimensions:
+        - selector: mysql_flexible.queries_total
+          name: total
+        - selector: mysql_flexible.slow_queries_total
+          name: slow
+    - id: am_azure_mysql_flexible__dml_statements
+      title: Azure MySQL Flexible Server DML Statements
+      context: dml_statements
+      family: Throughput
+      type: line
+      units: statements/s
+      algorithm: incremental
+      dimensions:
+        - selector: mysql_flexible.com_select_total
+          name: select
+        - selector: mysql_flexible.com_insert_total
+          name: insert
+        - selector: mysql_flexible.com_update_total
+          name: update
+        - selector: mysql_flexible.com_delete_total
+          name: delete
+    - id: am_azure_mysql_flexible__ddl_statements
+      title: Azure MySQL Flexible Server DDL Statements
+      context: ddl_statements
+      family: Throughput
+      type: line
+      units: statements/s
+      algorithm: incremental
+      dimensions:
+        - selector: mysql_flexible.com_create_table_total
+          name: create_table
+        - selector: mysql_flexible.com_alter_table_total
+          name: alter_table
+        - selector: mysql_flexible.com_drop_table_total
+          name: drop_table
+        - selector: mysql_flexible.com_create_db_total
+          name: create_db
+        - selector: mysql_flexible.com_drop_db_total
+          name: drop_db
+    - id: am_azure_mysql_flexible__lock_deadlocks
+      title: Azure MySQL Flexible Server Deadlocks
+      context: lock_deadlocks
+      family: Contention
+      type: line
+      units: deadlocks/s
+      algorithm: incremental
+      dimensions:
+        - selector: mysql_flexible.lock_deadlocks_total
+          name: total
+    - id: am_azure_mysql_flexible__lock_timeouts
+      title: Azure MySQL Flexible Server Lock Timeouts
+      context: lock_timeouts
+      family: Contention
+      type: line
+      units: timeouts/s
+      algorithm: incremental
+      dimensions:
+        - selector: mysql_flexible.lock_timeouts_total
+          name: total
+    - id: am_azure_mysql_flexible__innodb_buffer_pool_pages
+      title: Azure MySQL Flexible Server InnoDB Buffer Pool Pages
+      context: innodb_buffer_pool_pages
+      family: InnoDB
+      type: line
+      units: pages
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.innodb_buffer_pool_pages_data_maximum
+          name: data
+        - selector: mysql_flexible.innodb_buffer_pool_pages_dirty_maximum
+          name: dirty
+        - selector: mysql_flexible.innodb_buffer_pool_pages_free_maximum
+          name: free
+        - selector: mysql_flexible.innodb_buffer_pool_pages_flushed_average
+          name: flushed
+    - id: am_azure_mysql_flexible__innodb_buffer_pool_io
+      title: Azure MySQL Flexible Server InnoDB Buffer Pool I/O
+      context: innodb_buffer_pool_io
+      family: InnoDB
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: mysql_flexible.innodb_buffer_pool_read_requests_total
+          name: read_requests
+        - selector: mysql_flexible.innodb_buffer_pool_reads_total
+          name: disk_reads
+    - id: am_azure_mysql_flexible__innodb_data_writes
+      title: Azure MySQL Flexible Server InnoDB Data Writes
+      context: innodb_data_writes
+      family: InnoDB
+      type: line
+      units: writes/s
+      algorithm: incremental
+      dimensions:
+        - selector: mysql_flexible.innodb_data_writes_total
+          name: total
+    - id: am_azure_mysql_flexible__sort_merge_passes
+      title: Azure MySQL Flexible Server Sort Merge Passes
+      context: sort_merge_passes
+      family: Performance
+      type: line
+      units: passes/s
+      algorithm: incremental
+      dimensions:
+        - selector: mysql_flexible.sort_merge_passes_total
+          name: total
+    - id: am_azure_mysql_flexible__network
+      title: Azure MySQL Flexible Server Network Traffic
+      context: network
+      family: Network
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: mysql_flexible.network_bytes_ingress_total
+          name: in
+        - selector: mysql_flexible.network_bytes_egress_total
+          name: out
+    - id: am_azure_mysql_flexible__storage_io
+      title: Azure MySQL Flexible Server Storage I/O
+      context: storage_io
+      family: IO
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: mysql_flexible.storage_io_count_total
+          name: total
+    - id: am_azure_mysql_flexible__storage
+      title: Azure MySQL Flexible Server Storage
+      context: storage
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.storage_used_average
+          name: used
+        - selector: mysql_flexible.storage_limit_maximum
+          name: limit
+    - id: am_azure_mysql_flexible__storage_utilization
+      title: Azure MySQL Flexible Server Storage Utilization
+      context: storage_utilization
+      family: Capacity
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.storage_percent_average
+          name: average
+    - id: am_azure_mysql_flexible__storage_breakdown
+      title: Azure MySQL Flexible Server Storage Breakdown
+      context: storage_breakdown
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.data_storage_used_average
+          name: data
+        - selector: mysql_flexible.ibdata1_storage_used_average
+          name: ibdata1
+        - selector: mysql_flexible.binlog_storage_used_average
+          name: binlog
+        - selector: mysql_flexible.others_storage_used_average
+          name: others
+    - id: am_azure_mysql_flexible__backup_storage
+      title: Azure MySQL Flexible Server Backup Storage
+      context: backup_storage
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.backup_storage_used_average
+          name: used
+    - id: am_azure_mysql_flexible__serverlog_storage
+      title: Azure MySQL Flexible Server Server Log Storage
+      context: serverlog_storage
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.serverlog_storage_usage_average
+          name: used
+        - selector: mysql_flexible.serverlog_storage_limit_maximum
+          name: limit
+    - id: am_azure_mysql_flexible__serverlog_storage_utilization
+      title: Azure MySQL Flexible Server Server Log Storage Utilization
+      context: serverlog_storage_utilization
+      family: Capacity
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.serverlog_storage_percent_average
+          name: average
+    - id: am_azure_mysql_flexible__history_list_length
+      title: Azure MySQL Flexible Server History List Length
+      context: history_list_length
+      family: InnoDB
+      type: line
+      units: entries
+      algorithm: absolute
+      dimensions:
+        - selector: mysql_flexible.trx_rseg_history_len_maximum
+          name: maximum

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/nat_gateway.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/nat_gateway.yaml
@@ -3,113 +3,113 @@ id: nat_gateway
 name: Azure NAT Gateway
 resource_type: Microsoft.Network/natGateways
 metrics:
-- id: datapath_availability
-  azure_name: DatapathAvailability
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: byte_count
-  azure_name: ByteCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: packet_count
-  azure_name: PacketCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: packet_drop_count
-  azure_name: PacketDropCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: snat_connection_count
-  azure_name: SNATConnectionCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: total_connection_count
-  azure_name: TotalConnectionCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: gauge
+  - id: datapath_availability
+    azure_name: DatapathAvailability
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: byte_count
+    azure_name: ByteCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: packet_count
+    azure_name: PacketCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: packet_drop_count
+    azure_name: PacketDropCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: snat_connection_count
+    azure_name: SNATConnectionCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: total_connection_count
+    azure_name: TotalConnectionCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: gauge
 template:
   family: Azure NAT Gateway
   context_namespace: nat_gateway
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_nat_gateway__datapath_availability
-    title: Azure NAT Gateway Datapath Availability
-    context: datapath_availability
-    family: Availability
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: nat_gateway.datapath_availability_average
-      name: average
-  - id: am_azure_nat_gateway__byte_throughput
-    title: Azure NAT Gateway Byte Throughput
-    context: byte_throughput
-    family: Throughput
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: nat_gateway.byte_count_total
-      name: total
-  - id: am_azure_nat_gateway__packet_throughput
-    title: Azure NAT Gateway Packet Throughput
-    context: packet_throughput
-    family: Throughput
-    type: line
-    units: packets/s
-    algorithm: incremental
-    dimensions:
-    - selector: nat_gateway.packet_count_total
-      name: total
-  - id: am_azure_nat_gateway__dropped_packets
-    title: Azure NAT Gateway Dropped Packets
-    context: dropped_packets
-    family: Errors
-    type: line
-    units: packets/s
-    algorithm: incremental
-    dimensions:
-    - selector: nat_gateway.packet_drop_count_total
-      name: total
-  - id: am_azure_nat_gateway__snat_connections
-    title: Azure NAT Gateway SNAT Connections
-    context: snat_connections
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: nat_gateway.snat_connection_count_total
-      name: total
-  - id: am_azure_nat_gateway__total_connections
-    title: Azure NAT Gateway Total SNAT Connections
-    context: total_connections
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: nat_gateway.total_connection_count_total
-      name: total
+    - id: am_azure_nat_gateway__datapath_availability
+      title: Azure NAT Gateway Datapath Availability
+      context: datapath_availability
+      family: Availability
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: nat_gateway.datapath_availability_average
+          name: average
+    - id: am_azure_nat_gateway__byte_throughput
+      title: Azure NAT Gateway Byte Throughput
+      context: byte_throughput
+      family: Throughput
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: nat_gateway.byte_count_total
+          name: total
+    - id: am_azure_nat_gateway__packet_throughput
+      title: Azure NAT Gateway Packet Throughput
+      context: packet_throughput
+      family: Throughput
+      type: line
+      units: packets/s
+      algorithm: incremental
+      dimensions:
+        - selector: nat_gateway.packet_count_total
+          name: total
+    - id: am_azure_nat_gateway__dropped_packets
+      title: Azure NAT Gateway Dropped Packets
+      context: dropped_packets
+      family: Errors
+      type: line
+      units: packets/s
+      algorithm: incremental
+      dimensions:
+        - selector: nat_gateway.packet_drop_count_total
+          name: total
+    - id: am_azure_nat_gateway__snat_connections
+      title: Azure NAT Gateway SNAT Connections
+      context: snat_connections
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: nat_gateway.snat_connection_count_total
+          name: total
+    - id: am_azure_nat_gateway__total_connections
+      title: Azure NAT Gateway Total SNAT Connections
+      context: total_connections
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: nat_gateway.total_connection_count_total
+          name: total

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/postgres_flexible.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/postgres_flexible.yaml
@@ -3,929 +3,929 @@ id: postgres_flexible
 name: Azure PostgreSQL Flexible Server
 resource_type: Microsoft.DBforPostgreSQL/flexibleServers
 metrics:
-- id: cpu_percent
-  azure_name: cpu_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: memory_percent
-  azure_name: memory_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: is_db_alive
-  azure_name: is_db_alive
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: iops
-  azure_name: iops
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: read_iops
-  azure_name: read_iops
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: write_iops
-  azure_name: write_iops
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: read_throughput
-  azure_name: read_throughput
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: write_throughput
-  azure_name: write_throughput
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: disk_bandwidth_consumed_percentage
-  azure_name: disk_bandwidth_consumed_percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: disk_iops_consumed_percentage
-  azure_name: disk_iops_consumed_percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: disk_queue_depth
-  azure_name: disk_queue_depth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: blks_hit
-  azure_name: blks_hit
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: blks_read
-  azure_name: blks_read
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: active_connections
-  azure_name: active_connections
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: connections_succeeded
-  azure_name: connections_succeeded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: connections_failed
-  azure_name: connections_failed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tps
-  azure_name: tps
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: xact_commit
-  azure_name: xact_commit
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: xact_rollback
-  azure_name: xact_rollback
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: deadlocks
-  azure_name: deadlocks
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tup_returned
-  azure_name: tup_returned
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tup_fetched
-  azure_name: tup_fetched
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tup_inserted
-  azure_name: tup_inserted
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tup_updated
-  azure_name: tup_updated
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tup_deleted
-  azure_name: tup_deleted
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: temp_files
-  azure_name: temp_files
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: temp_bytes
-  azure_name: temp_bytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: longest_query_time_sec
-  azure_name: longest_query_time_sec
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: longest_transaction_time_sec
-  azure_name: longest_transaction_time_sec
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: maximum_used_transaction_ids
-  azure_name: maximum_used_transactionIDs
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: oldest_backend_xmin_age
-  azure_name: oldest_backend_xmin_age
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: network_bytes_egress
-  azure_name: network_bytes_egress
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: network_bytes_ingress
-  azure_name: network_bytes_ingress
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: storage_used
-  azure_name: storage_used
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: storage_free
-  azure_name: storage_free
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: storage_percent
-  azure_name: storage_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: txlogs_storage_used
-  azure_name: txlogs_storage_used
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: database_size_bytes
-  azure_name: database_size_bytes
-  time_grain: PT30M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: backup_storage_used
-  azure_name: backup_storage_used
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: oldest_backend_xmin
-  azure_name: oldest_backend_xmin
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: sessions_by_state
-  azure_name: sessions_by_state
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: sessions_by_wait_event_type
-  azure_name: sessions_by_wait_event_type
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: analyze_count_user_tables
-  azure_name: analyze_count_user_tables
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: autoanalyze_count_user_tables
-  azure_name: autoanalyze_count_user_tables
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: autovacuum_count_user_tables
-  azure_name: autovacuum_count_user_tables
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: bloat_percent
-  azure_name: bloat_percent
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: n_dead_tup_user_tables
-  azure_name: n_dead_tup_user_tables
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: n_live_tup_user_tables
-  azure_name: n_live_tup_user_tables
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: n_mod_since_analyze_user_tables
-  azure_name: n_mod_since_analyze_user_tables
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: tables_analyzed_user_tables
-  azure_name: tables_analyzed_user_tables
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: tables_autoanalyzed_user_tables
-  azure_name: tables_autoanalyzed_user_tables
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: tables_autovacuumed_user_tables
-  azure_name: tables_autovacuumed_user_tables
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: tables_counter_user_tables
-  azure_name: tables_counter_user_tables
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: tables_vacuumed_user_tables
-  azure_name: tables_vacuumed_user_tables
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: vacuum_count_user_tables
-  azure_name: vacuum_count_user_tables
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: numbackends
-  azure_name: numbackends
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: xact_total
-  azure_name: xact_total
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: client_connections_active
-  azure_name: client_connections_active
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: client_connections_waiting
-  azure_name: client_connections_waiting
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: num_pools
-  azure_name: num_pools
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: server_connections_active
-  azure_name: server_connections_active
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: server_connections_idle
-  azure_name: server_connections_idle
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: total_pooled_connections
-  azure_name: total_pooled_connections
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: cpu_credits_consumed
-  azure_name: cpu_credits_consumed
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_credits_remaining
-  azure_name: cpu_credits_remaining
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: postmaster_process_cpu_usage_percent
-  azure_name: postmaster_process_cpu_usage_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: max_connections
-  azure_name: max_connections
-  time_grain: PT30M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: tcp_connection_backlog
-  azure_name: tcp_connection_backlog
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: physical_replication_delay_in_seconds
-  azure_name: physical_replication_delay_in_seconds
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: physical_replication_delay_in_bytes
-  azure_name: physical_replication_delay_in_bytes
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: logical_replication_delay_in_bytes
-  azure_name: logical_replication_delay_in_bytes
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
+  - id: cpu_percent
+    azure_name: cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: memory_percent
+    azure_name: memory_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: is_db_alive
+    azure_name: is_db_alive
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: iops
+    azure_name: iops
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: read_iops
+    azure_name: read_iops
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: write_iops
+    azure_name: write_iops
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: read_throughput
+    azure_name: read_throughput
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: write_throughput
+    azure_name: write_throughput
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: disk_bandwidth_consumed_percentage
+    azure_name: disk_bandwidth_consumed_percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: disk_iops_consumed_percentage
+    azure_name: disk_iops_consumed_percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: disk_queue_depth
+    azure_name: disk_queue_depth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: blks_hit
+    azure_name: blks_hit
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: blks_read
+    azure_name: blks_read
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: active_connections
+    azure_name: active_connections
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: connections_succeeded
+    azure_name: connections_succeeded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: connections_failed
+    azure_name: connections_failed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tps
+    azure_name: tps
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: xact_commit
+    azure_name: xact_commit
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: xact_rollback
+    azure_name: xact_rollback
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: deadlocks
+    azure_name: deadlocks
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tup_returned
+    azure_name: tup_returned
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tup_fetched
+    azure_name: tup_fetched
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tup_inserted
+    azure_name: tup_inserted
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tup_updated
+    azure_name: tup_updated
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tup_deleted
+    azure_name: tup_deleted
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: temp_files
+    azure_name: temp_files
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: temp_bytes
+    azure_name: temp_bytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: longest_query_time_sec
+    azure_name: longest_query_time_sec
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: longest_transaction_time_sec
+    azure_name: longest_transaction_time_sec
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: maximum_used_transaction_ids
+    azure_name: maximum_used_transactionIDs
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: oldest_backend_xmin_age
+    azure_name: oldest_backend_xmin_age
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: network_bytes_egress
+    azure_name: network_bytes_egress
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: network_bytes_ingress
+    azure_name: network_bytes_ingress
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: storage_used
+    azure_name: storage_used
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: storage_free
+    azure_name: storage_free
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: storage_percent
+    azure_name: storage_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: txlogs_storage_used
+    azure_name: txlogs_storage_used
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: database_size_bytes
+    azure_name: database_size_bytes
+    time_grain: PT30M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: backup_storage_used
+    azure_name: backup_storage_used
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: oldest_backend_xmin
+    azure_name: oldest_backend_xmin
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: sessions_by_state
+    azure_name: sessions_by_state
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: sessions_by_wait_event_type
+    azure_name: sessions_by_wait_event_type
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: analyze_count_user_tables
+    azure_name: analyze_count_user_tables
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: autoanalyze_count_user_tables
+    azure_name: autoanalyze_count_user_tables
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: autovacuum_count_user_tables
+    azure_name: autovacuum_count_user_tables
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: bloat_percent
+    azure_name: bloat_percent
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: n_dead_tup_user_tables
+    azure_name: n_dead_tup_user_tables
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: n_live_tup_user_tables
+    azure_name: n_live_tup_user_tables
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: n_mod_since_analyze_user_tables
+    azure_name: n_mod_since_analyze_user_tables
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: tables_analyzed_user_tables
+    azure_name: tables_analyzed_user_tables
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: tables_autoanalyzed_user_tables
+    azure_name: tables_autoanalyzed_user_tables
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: tables_autovacuumed_user_tables
+    azure_name: tables_autovacuumed_user_tables
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: tables_counter_user_tables
+    azure_name: tables_counter_user_tables
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: tables_vacuumed_user_tables
+    azure_name: tables_vacuumed_user_tables
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: vacuum_count_user_tables
+    azure_name: vacuum_count_user_tables
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: numbackends
+    azure_name: numbackends
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: xact_total
+    azure_name: xact_total
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: client_connections_active
+    azure_name: client_connections_active
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: client_connections_waiting
+    azure_name: client_connections_waiting
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: num_pools
+    azure_name: num_pools
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: server_connections_active
+    azure_name: server_connections_active
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: server_connections_idle
+    azure_name: server_connections_idle
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: total_pooled_connections
+    azure_name: total_pooled_connections
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: cpu_credits_consumed
+    azure_name: cpu_credits_consumed
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_credits_remaining
+    azure_name: cpu_credits_remaining
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: postmaster_process_cpu_usage_percent
+    azure_name: postmaster_process_cpu_usage_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: max_connections
+    azure_name: max_connections
+    time_grain: PT30M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: tcp_connection_backlog
+    azure_name: tcp_connection_backlog
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: physical_replication_delay_in_seconds
+    azure_name: physical_replication_delay_in_seconds
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: physical_replication_delay_in_bytes
+    azure_name: physical_replication_delay_in_bytes
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: logical_replication_delay_in_bytes
+    azure_name: logical_replication_delay_in_bytes
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
 template:
   family: Azure PostgreSQL Flexible Server
   context_namespace: postgres_flexible
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_postgres_flexible__cpu
-    title: Azure PostgreSQL Flexible Server CPU Utilization
-    context: cpu
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.cpu_percent_average
-      name: average
-  - id: am_azure_postgres_flexible__memory
-    title: Azure PostgreSQL Flexible Server Memory Utilization
-    context: memory
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.memory_percent_average
-      name: average
-  - id: am_azure_postgres_flexible__availability
-    title: Azure PostgreSQL Flexible Server Database Alive
-    context: availability
-    family: Availability
-    type: line
-    units: state
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.is_db_alive_maximum
-      name: maximum
-  - id: am_azure_postgres_flexible__iops
-    title: Azure PostgreSQL Flexible Server IOPS
-    context: iops
-    family: I/O
-    type: line
-    units: operations/s
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.iops_average
-      name: total
-    - selector: postgres_flexible.read_iops_average
-      name: read
-    - selector: postgres_flexible.write_iops_average
-      name: write
-  - id: am_azure_postgres_flexible__disk_throughput
-    title: Azure PostgreSQL Flexible Server Disk Throughput
-    context: disk_throughput
-    family: I/O
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.read_throughput_average
-      name: read
-    - selector: postgres_flexible.write_throughput_average
-      name: write
-  - id: am_azure_postgres_flexible__disk_saturation
-    title: Azure PostgreSQL Flexible Server Disk Saturation
-    context: disk_saturation
-    family: I/O
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.disk_bandwidth_consumed_percentage_average
-      name: bandwidth
-    - selector: postgres_flexible.disk_iops_consumed_percentage_average
-      name: iops
-  - id: am_azure_postgres_flexible__disk_queue_depth
-    title: Azure PostgreSQL Flexible Server Disk Queue Depth
-    context: disk_queue_depth
-    family: I/O
-    type: line
-    units: operations
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.disk_queue_depth_average
-      name: average
-  - id: am_azure_postgres_flexible__buffer_cache
-    title: Azure PostgreSQL Flexible Server Buffer Cache
-    context: buffer_cache
-    family: Performance
-    type: line
-    units: blocks/s
-    algorithm: incremental
-    dimensions:
-    - selector: postgres_flexible.blks_hit_total
-      name: hits
-    - selector: postgres_flexible.blks_read_total
-      name: reads
-  - id: am_azure_postgres_flexible__active_connections
-    title: Azure PostgreSQL Flexible Server Active Connections
-    context: active_connections
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.active_connections_average
-      name: average
-  - id: am_azure_postgres_flexible__connection_rate
-    title: Azure PostgreSQL Flexible Server Connection Rate
-    context: connection_rate
-    family: Connections
-    type: line
-    units: connections/s
-    algorithm: incremental
-    dimensions:
-    - selector: postgres_flexible.connections_succeeded_total
-      name: succeeded
-    - selector: postgres_flexible.connections_failed_total
-      name: failed
-  - id: am_azure_postgres_flexible__transactions
-    title: Azure PostgreSQL Flexible Server Transactions
-    context: transactions
-    family: Throughput
-    type: line
-    units: transactions/s
-    algorithm: incremental
-    dimensions:
-    - selector: postgres_flexible.xact_commit_total
-      name: committed
-    - selector: postgres_flexible.xact_rollback_total
-      name: rolled_back
-  - id: am_azure_postgres_flexible__transaction_rate
-    title: Azure PostgreSQL Flexible Server Transaction Rate
-    context: transaction_rate
-    family: Throughput
-    type: line
-    units: transactions/s
-    algorithm: incremental
-    dimensions:
-    - selector: postgres_flexible.tps_total
-      name: total
-    - selector: postgres_flexible.xact_total_total
-      name: xact_total
-  - id: am_azure_postgres_flexible__deadlocks
-    title: Azure PostgreSQL Flexible Server Deadlocks
-    context: deadlocks
-    family: Contention
-    type: line
-    units: deadlocks/s
-    algorithm: incremental
-    dimensions:
-    - selector: postgres_flexible.deadlocks_total
-      name: total
-  - id: am_azure_postgres_flexible__tuple_reads
-    title: Azure PostgreSQL Flexible Server Tuple Reads
-    context: tuple_reads
-    family: Throughput
-    type: line
-    units: tuples/s
-    algorithm: incremental
-    dimensions:
-    - selector: postgres_flexible.tup_returned_total
-      name: returned
-    - selector: postgres_flexible.tup_fetched_total
-      name: fetched
-  - id: am_azure_postgres_flexible__tuple_writes
-    title: Azure PostgreSQL Flexible Server Tuple Writes
-    context: tuple_writes
-    family: Throughput
-    type: line
-    units: tuples/s
-    algorithm: incremental
-    dimensions:
-    - selector: postgres_flexible.tup_inserted_total
-      name: inserted
-    - selector: postgres_flexible.tup_updated_total
-      name: updated
-    - selector: postgres_flexible.tup_deleted_total
-      name: deleted
-  - id: am_azure_postgres_flexible__temp_files
-    title: Azure PostgreSQL Flexible Server Temp Files Created
-    context: temp_files
-    family: Performance
-    type: line
-    units: files/s
-    algorithm: incremental
-    dimensions:
-    - selector: postgres_flexible.temp_files_total
-      name: total
-  - id: am_azure_postgres_flexible__temp_bytes
-    title: Azure PostgreSQL Flexible Server Temp Bytes Written
-    context: temp_bytes
-    family: Performance
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: postgres_flexible.temp_bytes_total
-      name: total
-  - id: am_azure_postgres_flexible__long_running
-    title: Azure PostgreSQL Flexible Server Long Running Operations
-    context: long_running
-    family: Activity
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.longest_query_time_sec_maximum
-      name: query
-    - selector: postgres_flexible.longest_transaction_time_sec_maximum
-      name: transaction
-  - id: am_azure_postgres_flexible__xid_usage
-    title: Azure PostgreSQL Flexible Server Transaction ID Usage
-    context: xid_usage
-    family: Safety
-    type: line
-    units: transactions
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.maximum_used_transaction_ids_average
-      name: max_used
-    - selector: postgres_flexible.oldest_backend_xmin_maximum
-      name: oldest_xmin
-  - id: am_azure_postgres_flexible__xmin_age
-    title: Azure PostgreSQL Flexible Server Backend XID Age
-    context: xmin_age
-    family: Safety
-    type: line
-    units: transactions
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.oldest_backend_xmin_age_maximum
-      name: maximum
-  - id: am_azure_postgres_flexible__network
-    title: Azure PostgreSQL Flexible Server Network Traffic
-    context: network
-    family: Network
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: postgres_flexible.network_bytes_ingress_total
-      name: in
-    - selector: postgres_flexible.network_bytes_egress_total
-      name: out
-  - id: am_azure_postgres_flexible__storage
-    title: Azure PostgreSQL Flexible Server Storage
-    context: storage
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.storage_used_average
-      name: used
-    - selector: postgres_flexible.storage_free_average
-      name: free
-  - id: am_azure_postgres_flexible__storage_utilization
-    title: Azure PostgreSQL Flexible Server Storage Utilization
-    context: storage_utilization
-    family: Capacity
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.storage_percent_average
-      name: average
-  - id: am_azure_postgres_flexible__wal_storage
-    title: Azure PostgreSQL Flexible Server WAL Storage
-    context: wal_storage
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.txlogs_storage_used_average
-      name: used
-  - id: am_azure_postgres_flexible__database_size
-    title: Azure PostgreSQL Flexible Server Database Size
-    context: database_size
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.database_size_bytes_average
-      name: average
-  - id: am_azure_postgres_flexible__backup_storage
-    title: Azure PostgreSQL Flexible Server Backup Storage
-    context: backup_storage
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.backup_storage_used_average
-      name: used
-  - id: am_azure_postgres_flexible__replication_lag_time
-    title: Azure PostgreSQL Flexible Server Replication Lag
-    context: replication_lag_time
-    family: Replication
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.physical_replication_delay_in_seconds_average
-      name: average
-  - id: am_azure_postgres_flexible__replication_lag_bytes
-    title: Azure PostgreSQL Flexible Server Replication Lag Bytes
-    context: replication_lag_bytes
-    family: Replication
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.physical_replication_delay_in_bytes_maximum
-      name: physical
-    - selector: postgres_flexible.logical_replication_delay_in_bytes_maximum
-      name: logical
-  - id: am_azure_postgres_flexible__sessions_by_state
-    title: Azure PostgreSQL Flexible Server Sessions by State
-    context: sessions_by_state
-    family: Activity
-    type: line
-    units: sessions
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.sessions_by_state_maximum
-      name: maximum
-  - id: am_azure_postgres_flexible__sessions_by_wait_event_type
-    title: Azure PostgreSQL Flexible Server Sessions by Wait Event Type
-    context: sessions_by_wait_event_type
-    family: Activity
-    type: line
-    units: sessions
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.sessions_by_wait_event_type_maximum
-      name: maximum
-  - id: am_azure_postgres_flexible__autovacuum_operations
-    title: Azure PostgreSQL Flexible Server Autovacuum Operations
-    context: autovacuum_operations
-    family: Autovacuum
-    type: line
-    units: operations
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.vacuum_count_user_tables_maximum
-      name: vacuum
-    - selector: postgres_flexible.autovacuum_count_user_tables_maximum
-      name: autovacuum
-    - selector: postgres_flexible.analyze_count_user_tables_maximum
-      name: analyze
-    - selector: postgres_flexible.autoanalyze_count_user_tables_maximum
-      name: autoanalyze
-  - id: am_azure_postgres_flexible__autovacuum_table_coverage
-    title: Azure PostgreSQL Flexible Server Autovacuum Table Coverage
-    context: autovacuum_table_coverage
-    family: Autovacuum
-    type: line
-    units: tables
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.tables_vacuumed_user_tables_maximum
-      name: vacuumed
-    - selector: postgres_flexible.tables_autovacuumed_user_tables_maximum
-      name: autovacuumed
-    - selector: postgres_flexible.tables_analyzed_user_tables_maximum
-      name: analyzed
-    - selector: postgres_flexible.tables_autoanalyzed_user_tables_maximum
-      name: autoanalyzed
-    - selector: postgres_flexible.tables_counter_user_tables_maximum
-      name: total
-  - id: am_azure_postgres_flexible__tuple_liveness
-    title: Azure PostgreSQL Flexible Server Tuple Liveness
-    context: tuple_liveness
-    family: Autovacuum
-    type: line
-    units: tuples
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.n_live_tup_user_tables_maximum
-      name: live
-    - selector: postgres_flexible.n_dead_tup_user_tables_maximum
-      name: dead
-    - selector: postgres_flexible.n_mod_since_analyze_user_tables_maximum
-      name: modified_since_analyze
-  - id: am_azure_postgres_flexible__bloat
-    title: Azure PostgreSQL Flexible Server Table Bloat
-    context: bloat
-    family: Autovacuum
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.bloat_percent_maximum
-      name: maximum
-  - id: am_azure_postgres_flexible__backend_count
-    title: Azure PostgreSQL Flexible Server Backend Count
-    context: backend_count
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.numbackends_maximum
-      name: maximum
-  - id: am_azure_postgres_flexible__pgbouncer_client_connections
-    title: Azure PostgreSQL Flexible Server PgBouncer Client Connections
-    context: pgbouncer_client_connections
-    family: PgBouncer
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.client_connections_active_maximum
-      name: active
-    - selector: postgres_flexible.client_connections_waiting_maximum
-      name: waiting
-  - id: am_azure_postgres_flexible__pgbouncer_server_connections
-    title: Azure PostgreSQL Flexible Server PgBouncer Server Connections
-    context: pgbouncer_server_connections
-    family: PgBouncer
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.server_connections_active_maximum
-      name: active
-    - selector: postgres_flexible.server_connections_idle_maximum
-      name: idle
-  - id: am_azure_postgres_flexible__pgbouncer_pool_count
-    title: Azure PostgreSQL Flexible Server PgBouncer Pool Count
-    context: pgbouncer_pool_count
-    family: PgBouncer
-    type: line
-    units: pools
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.num_pools_maximum
-      name: pools
-  - id: am_azure_postgres_flexible__pgbouncer_pooled_connections
-    title: Azure PostgreSQL Flexible Server PgBouncer Pooled Connections
-    context: pgbouncer_pooled_connections
-    family: PgBouncer
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.total_pooled_connections_maximum
-      name: pooled_connections
-  - id: am_azure_postgres_flexible__cpu_credits
-    title: Azure PostgreSQL Flexible Server CPU Credits
-    context: cpu_credits
-    family: Saturation
-    type: line
-    units: credits
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.cpu_credits_consumed_average
-      name: consumed
-    - selector: postgres_flexible.cpu_credits_remaining_average
-      name: remaining
-  - id: am_azure_postgres_flexible__postmaster_cpu
-    title: Azure PostgreSQL Flexible Server Postmaster CPU Usage
-    context: postmaster_cpu
-    family: Saturation
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.postmaster_process_cpu_usage_percent_average
-      name: average
-  - id: am_azure_postgres_flexible__max_connections
-    title: Azure PostgreSQL Flexible Server Max Connections
-    context: max_connections
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.max_connections_maximum
-      name: maximum
-  - id: am_azure_postgres_flexible__tcp_connection_backlog
-    title: Azure PostgreSQL Flexible Server TCP Connection Backlog
-    context: tcp_connection_backlog
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: postgres_flexible.tcp_connection_backlog_maximum
-      name: maximum
+    - id: am_azure_postgres_flexible__cpu
+      title: Azure PostgreSQL Flexible Server CPU Utilization
+      context: cpu
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.cpu_percent_average
+          name: average
+    - id: am_azure_postgres_flexible__memory
+      title: Azure PostgreSQL Flexible Server Memory Utilization
+      context: memory
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.memory_percent_average
+          name: average
+    - id: am_azure_postgres_flexible__availability
+      title: Azure PostgreSQL Flexible Server Database Alive
+      context: availability
+      family: Availability
+      type: line
+      units: state
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.is_db_alive_maximum
+          name: maximum
+    - id: am_azure_postgres_flexible__iops
+      title: Azure PostgreSQL Flexible Server IOPS
+      context: iops
+      family: IO
+      type: line
+      units: operations/s
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.iops_average
+          name: total
+        - selector: postgres_flexible.read_iops_average
+          name: read
+        - selector: postgres_flexible.write_iops_average
+          name: write
+    - id: am_azure_postgres_flexible__disk_throughput
+      title: Azure PostgreSQL Flexible Server Disk Throughput
+      context: disk_throughput
+      family: IO
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.read_throughput_average
+          name: read
+        - selector: postgres_flexible.write_throughput_average
+          name: write
+    - id: am_azure_postgres_flexible__disk_saturation
+      title: Azure PostgreSQL Flexible Server Disk Saturation
+      context: disk_saturation
+      family: IO
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.disk_bandwidth_consumed_percentage_average
+          name: bandwidth
+        - selector: postgres_flexible.disk_iops_consumed_percentage_average
+          name: iops
+    - id: am_azure_postgres_flexible__disk_queue_depth
+      title: Azure PostgreSQL Flexible Server Disk Queue Depth
+      context: disk_queue_depth
+      family: IO
+      type: line
+      units: operations
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.disk_queue_depth_average
+          name: average
+    - id: am_azure_postgres_flexible__buffer_cache
+      title: Azure PostgreSQL Flexible Server Buffer Cache
+      context: buffer_cache
+      family: Performance
+      type: line
+      units: blocks/s
+      algorithm: incremental
+      dimensions:
+        - selector: postgres_flexible.blks_hit_total
+          name: hits
+        - selector: postgres_flexible.blks_read_total
+          name: reads
+    - id: am_azure_postgres_flexible__active_connections
+      title: Azure PostgreSQL Flexible Server Active Connections
+      context: active_connections
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.active_connections_average
+          name: average
+    - id: am_azure_postgres_flexible__connection_rate
+      title: Azure PostgreSQL Flexible Server Connection Rate
+      context: connection_rate
+      family: Connections
+      type: line
+      units: connections/s
+      algorithm: incremental
+      dimensions:
+        - selector: postgres_flexible.connections_succeeded_total
+          name: succeeded
+        - selector: postgres_flexible.connections_failed_total
+          name: failed
+    - id: am_azure_postgres_flexible__transactions
+      title: Azure PostgreSQL Flexible Server Transactions
+      context: transactions
+      family: Throughput
+      type: line
+      units: transactions/s
+      algorithm: incremental
+      dimensions:
+        - selector: postgres_flexible.xact_commit_total
+          name: committed
+        - selector: postgres_flexible.xact_rollback_total
+          name: rolled_back
+    - id: am_azure_postgres_flexible__transaction_rate
+      title: Azure PostgreSQL Flexible Server Transaction Rate
+      context: transaction_rate
+      family: Throughput
+      type: line
+      units: transactions/s
+      algorithm: incremental
+      dimensions:
+        - selector: postgres_flexible.tps_total
+          name: total
+        - selector: postgres_flexible.xact_total_total
+          name: xact_total
+    - id: am_azure_postgres_flexible__deadlocks
+      title: Azure PostgreSQL Flexible Server Deadlocks
+      context: deadlocks
+      family: Contention
+      type: line
+      units: deadlocks/s
+      algorithm: incremental
+      dimensions:
+        - selector: postgres_flexible.deadlocks_total
+          name: total
+    - id: am_azure_postgres_flexible__tuple_reads
+      title: Azure PostgreSQL Flexible Server Tuple Reads
+      context: tuple_reads
+      family: Throughput
+      type: line
+      units: tuples/s
+      algorithm: incremental
+      dimensions:
+        - selector: postgres_flexible.tup_returned_total
+          name: returned
+        - selector: postgres_flexible.tup_fetched_total
+          name: fetched
+    - id: am_azure_postgres_flexible__tuple_writes
+      title: Azure PostgreSQL Flexible Server Tuple Writes
+      context: tuple_writes
+      family: Throughput
+      type: line
+      units: tuples/s
+      algorithm: incremental
+      dimensions:
+        - selector: postgres_flexible.tup_inserted_total
+          name: inserted
+        - selector: postgres_flexible.tup_updated_total
+          name: updated
+        - selector: postgres_flexible.tup_deleted_total
+          name: deleted
+    - id: am_azure_postgres_flexible__temp_files
+      title: Azure PostgreSQL Flexible Server Temp Files Created
+      context: temp_files
+      family: Performance
+      type: line
+      units: files/s
+      algorithm: incremental
+      dimensions:
+        - selector: postgres_flexible.temp_files_total
+          name: total
+    - id: am_azure_postgres_flexible__temp_bytes
+      title: Azure PostgreSQL Flexible Server Temp Bytes Written
+      context: temp_bytes
+      family: Performance
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: postgres_flexible.temp_bytes_total
+          name: total
+    - id: am_azure_postgres_flexible__long_running
+      title: Azure PostgreSQL Flexible Server Long Running Operations
+      context: long_running
+      family: Activity
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.longest_query_time_sec_maximum
+          name: query
+        - selector: postgres_flexible.longest_transaction_time_sec_maximum
+          name: transaction
+    - id: am_azure_postgres_flexible__xid_usage
+      title: Azure PostgreSQL Flexible Server Transaction ID Usage
+      context: xid_usage
+      family: Safety
+      type: line
+      units: transactions
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.maximum_used_transaction_ids_average
+          name: max_used
+        - selector: postgres_flexible.oldest_backend_xmin_maximum
+          name: oldest_xmin
+    - id: am_azure_postgres_flexible__xmin_age
+      title: Azure PostgreSQL Flexible Server Backend XID Age
+      context: xmin_age
+      family: Safety
+      type: line
+      units: transactions
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.oldest_backend_xmin_age_maximum
+          name: maximum
+    - id: am_azure_postgres_flexible__network
+      title: Azure PostgreSQL Flexible Server Network Traffic
+      context: network
+      family: Network
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: postgres_flexible.network_bytes_ingress_total
+          name: in
+        - selector: postgres_flexible.network_bytes_egress_total
+          name: out
+    - id: am_azure_postgres_flexible__storage
+      title: Azure PostgreSQL Flexible Server Storage
+      context: storage
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.storage_used_average
+          name: used
+        - selector: postgres_flexible.storage_free_average
+          name: free
+    - id: am_azure_postgres_flexible__storage_utilization
+      title: Azure PostgreSQL Flexible Server Storage Utilization
+      context: storage_utilization
+      family: Capacity
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.storage_percent_average
+          name: average
+    - id: am_azure_postgres_flexible__wal_storage
+      title: Azure PostgreSQL Flexible Server WAL Storage
+      context: wal_storage
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.txlogs_storage_used_average
+          name: used
+    - id: am_azure_postgres_flexible__database_size
+      title: Azure PostgreSQL Flexible Server Database Size
+      context: database_size
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.database_size_bytes_average
+          name: average
+    - id: am_azure_postgres_flexible__backup_storage
+      title: Azure PostgreSQL Flexible Server Backup Storage
+      context: backup_storage
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.backup_storage_used_average
+          name: used
+    - id: am_azure_postgres_flexible__replication_lag_time
+      title: Azure PostgreSQL Flexible Server Replication Lag
+      context: replication_lag_time
+      family: Replication
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.physical_replication_delay_in_seconds_average
+          name: average
+    - id: am_azure_postgres_flexible__replication_lag_bytes
+      title: Azure PostgreSQL Flexible Server Replication Lag Bytes
+      context: replication_lag_bytes
+      family: Replication
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.physical_replication_delay_in_bytes_maximum
+          name: physical
+        - selector: postgres_flexible.logical_replication_delay_in_bytes_maximum
+          name: logical
+    - id: am_azure_postgres_flexible__sessions_by_state
+      title: Azure PostgreSQL Flexible Server Sessions by State
+      context: sessions_by_state
+      family: Activity
+      type: line
+      units: sessions
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.sessions_by_state_maximum
+          name: maximum
+    - id: am_azure_postgres_flexible__sessions_by_wait_event_type
+      title: Azure PostgreSQL Flexible Server Sessions by Wait Event Type
+      context: sessions_by_wait_event_type
+      family: Activity
+      type: line
+      units: sessions
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.sessions_by_wait_event_type_maximum
+          name: maximum
+    - id: am_azure_postgres_flexible__autovacuum_operations
+      title: Azure PostgreSQL Flexible Server Autovacuum Operations
+      context: autovacuum_operations
+      family: Autovacuum
+      type: line
+      units: operations
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.vacuum_count_user_tables_maximum
+          name: vacuum
+        - selector: postgres_flexible.autovacuum_count_user_tables_maximum
+          name: autovacuum
+        - selector: postgres_flexible.analyze_count_user_tables_maximum
+          name: analyze
+        - selector: postgres_flexible.autoanalyze_count_user_tables_maximum
+          name: autoanalyze
+    - id: am_azure_postgres_flexible__autovacuum_table_coverage
+      title: Azure PostgreSQL Flexible Server Autovacuum Table Coverage
+      context: autovacuum_table_coverage
+      family: Autovacuum
+      type: line
+      units: tables
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.tables_vacuumed_user_tables_maximum
+          name: vacuumed
+        - selector: postgres_flexible.tables_autovacuumed_user_tables_maximum
+          name: autovacuumed
+        - selector: postgres_flexible.tables_analyzed_user_tables_maximum
+          name: analyzed
+        - selector: postgres_flexible.tables_autoanalyzed_user_tables_maximum
+          name: autoanalyzed
+        - selector: postgres_flexible.tables_counter_user_tables_maximum
+          name: total
+    - id: am_azure_postgres_flexible__tuple_liveness
+      title: Azure PostgreSQL Flexible Server Tuple Liveness
+      context: tuple_liveness
+      family: Autovacuum
+      type: line
+      units: tuples
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.n_live_tup_user_tables_maximum
+          name: live
+        - selector: postgres_flexible.n_dead_tup_user_tables_maximum
+          name: dead
+        - selector: postgres_flexible.n_mod_since_analyze_user_tables_maximum
+          name: modified_since_analyze
+    - id: am_azure_postgres_flexible__bloat
+      title: Azure PostgreSQL Flexible Server Table Bloat
+      context: bloat
+      family: Autovacuum
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.bloat_percent_maximum
+          name: maximum
+    - id: am_azure_postgres_flexible__backend_count
+      title: Azure PostgreSQL Flexible Server Backend Count
+      context: backend_count
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.numbackends_maximum
+          name: maximum
+    - id: am_azure_postgres_flexible__pgbouncer_client_connections
+      title: Azure PostgreSQL Flexible Server PgBouncer Client Connections
+      context: pgbouncer_client_connections
+      family: PgBouncer
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.client_connections_active_maximum
+          name: active
+        - selector: postgres_flexible.client_connections_waiting_maximum
+          name: waiting
+    - id: am_azure_postgres_flexible__pgbouncer_server_connections
+      title: Azure PostgreSQL Flexible Server PgBouncer Server Connections
+      context: pgbouncer_server_connections
+      family: PgBouncer
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.server_connections_active_maximum
+          name: active
+        - selector: postgres_flexible.server_connections_idle_maximum
+          name: idle
+    - id: am_azure_postgres_flexible__pgbouncer_pool_count
+      title: Azure PostgreSQL Flexible Server PgBouncer Pool Count
+      context: pgbouncer_pool_count
+      family: PgBouncer
+      type: line
+      units: pools
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.num_pools_maximum
+          name: pools
+    - id: am_azure_postgres_flexible__pgbouncer_pooled_connections
+      title: Azure PostgreSQL Flexible Server PgBouncer Pooled Connections
+      context: pgbouncer_pooled_connections
+      family: PgBouncer
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.total_pooled_connections_maximum
+          name: pooled_connections
+    - id: am_azure_postgres_flexible__cpu_credits
+      title: Azure PostgreSQL Flexible Server CPU Credits
+      context: cpu_credits
+      family: Saturation
+      type: line
+      units: credits
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.cpu_credits_consumed_average
+          name: consumed
+        - selector: postgres_flexible.cpu_credits_remaining_average
+          name: remaining
+    - id: am_azure_postgres_flexible__postmaster_cpu
+      title: Azure PostgreSQL Flexible Server Postmaster CPU Usage
+      context: postmaster_cpu
+      family: Saturation
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.postmaster_process_cpu_usage_percent_average
+          name: average
+    - id: am_azure_postgres_flexible__max_connections
+      title: Azure PostgreSQL Flexible Server Max Connections
+      context: max_connections
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.max_connections_maximum
+          name: maximum
+    - id: am_azure_postgres_flexible__tcp_connection_backlog
+      title: Azure PostgreSQL Flexible Server TCP Connection Backlog
+      context: tcp_connection_backlog
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: postgres_flexible.tcp_connection_backlog_maximum
+          name: maximum

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/redis_cache.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/redis_cache.yaml
@@ -3,641 +3,641 @@ id: redis_cache
 name: Azure Cache for Redis
 resource_type: Microsoft.Cache/redis
 metrics:
-- id: cachehits
-  azure_name: cachehits
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: cachemisses
-  azure_name: cachemisses
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: cache_read
-  azure_name: cacheRead
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: cache_write
-  azure_name: cacheWrite
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: server_load
-  azure_name: serverLoad
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: percent_processor_time
-  azure_name: percentProcessorTime
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: usedmemory
-  azure_name: usedmemory
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: usedmemorypercentage
-  azure_name: usedmemorypercentage
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: usedmemory_rss
-  azure_name: usedmemoryRss
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: connectedclients
-  azure_name: connectedclients
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: operations_per_second
-  azure_name: operationsPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: totalcommandsprocessed
-  azure_name: totalcommandsprocessed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: getcommands
-  azure_name: getcommands
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: setcommands
-  azure_name: setcommands
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: cache_latency
-  azure_name: cacheLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: totalkeys
-  azure_name: totalkeys
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: evictedkeys
-  azure_name: evictedkeys
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: expiredkeys
-  azure_name: expiredkeys
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: errors
-  azure_name: errors
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: cachemissrate
-  azure_name: cachemissrate
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: latency_p99
-  azure_name: LatencyP99
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: all_connections_closed_per_second
-  azure_name: allConnectionsClosedPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: all_connections_created_per_second
-  azure_name: allConnectionsCreatedPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: connected_clients_using_aad_token
-  azure_name: ConnectedClientsUsingAADToken
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: allcachehits
-  azure_name: allcachehits
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: allcachemisses
-  azure_name: allcachemisses
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: allcache_read
-  azure_name: allcacheRead
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: allcache_write
-  azure_name: allcacheWrite
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: allserver_load
-  azure_name: allserverLoad
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: allpercentprocessortime
-  azure_name: allpercentprocessortime
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: allusedmemory
-  azure_name: allusedmemory
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: allusedmemorypercentage
-  azure_name: allusedmemorypercentage
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: allusedmemory_rss
-  azure_name: allusedmemoryRss
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: allconnectedclients
-  azure_name: allconnectedclients
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: alloperations_per_second
-  azure_name: alloperationsPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: alltotalcommandsprocessed
-  azure_name: alltotalcommandsprocessed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: allgetcommands
-  azure_name: allgetcommands
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: allsetcommands
-  azure_name: allsetcommands
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: alltotalkeys
-  azure_name: alltotalkeys
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: allevictedkeys
-  azure_name: allevictedkeys
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: allexpiredkeys
-  azure_name: allexpiredkeys
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: geo_replication_connectivity_lag
-  azure_name: GeoReplicationConnectivityLag
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: geo_replication_data_sync_offset
-  azure_name: GeoReplicationDataSyncOffset
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: geo_replication_full_sync_event_finished
-  azure_name: GeoReplicationFullSyncEventFinished
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: geo_replication_full_sync_event_started
-  azure_name: GeoReplicationFullSyncEventStarted
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: geo_replication_healthy
-  azure_name: GeoReplicationHealthy
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: cachehits
+    azure_name: cachehits
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: cachemisses
+    azure_name: cachemisses
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: cache_read
+    azure_name: cacheRead
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: cache_write
+    azure_name: cacheWrite
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: server_load
+    azure_name: serverLoad
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: percent_processor_time
+    azure_name: percentProcessorTime
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: usedmemory
+    azure_name: usedmemory
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: usedmemorypercentage
+    azure_name: usedmemorypercentage
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: usedmemory_rss
+    azure_name: usedmemoryRss
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: connectedclients
+    azure_name: connectedclients
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: operations_per_second
+    azure_name: operationsPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: totalcommandsprocessed
+    azure_name: totalcommandsprocessed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: getcommands
+    azure_name: getcommands
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: setcommands
+    azure_name: setcommands
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: cache_latency
+    azure_name: cacheLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: totalkeys
+    azure_name: totalkeys
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: evictedkeys
+    azure_name: evictedkeys
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: expiredkeys
+    azure_name: expiredkeys
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: errors
+    azure_name: errors
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: cachemissrate
+    azure_name: cachemissrate
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: latency_p99
+    azure_name: LatencyP99
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: all_connections_closed_per_second
+    azure_name: allConnectionsClosedPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: all_connections_created_per_second
+    azure_name: allConnectionsCreatedPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: connected_clients_using_aad_token
+    azure_name: ConnectedClientsUsingAADToken
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: allcachehits
+    azure_name: allcachehits
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: allcachemisses
+    azure_name: allcachemisses
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: allcache_read
+    azure_name: allcacheRead
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: allcache_write
+    azure_name: allcacheWrite
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: allserver_load
+    azure_name: allserverLoad
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: allpercentprocessortime
+    azure_name: allpercentprocessortime
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: allusedmemory
+    azure_name: allusedmemory
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: allusedmemorypercentage
+    azure_name: allusedmemorypercentage
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: allusedmemory_rss
+    azure_name: allusedmemoryRss
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: allconnectedclients
+    azure_name: allconnectedclients
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: alloperations_per_second
+    azure_name: alloperationsPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: alltotalcommandsprocessed
+    azure_name: alltotalcommandsprocessed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: allgetcommands
+    azure_name: allgetcommands
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: allsetcommands
+    azure_name: allsetcommands
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: alltotalkeys
+    azure_name: alltotalkeys
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: allevictedkeys
+    azure_name: allevictedkeys
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: allexpiredkeys
+    azure_name: allexpiredkeys
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: geo_replication_connectivity_lag
+    azure_name: GeoReplicationConnectivityLag
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: geo_replication_data_sync_offset
+    azure_name: GeoReplicationDataSyncOffset
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: geo_replication_full_sync_event_finished
+    azure_name: GeoReplicationFullSyncEventFinished
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: geo_replication_full_sync_event_started
+    azure_name: GeoReplicationFullSyncEventStarted
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: geo_replication_healthy
+    azure_name: GeoReplicationHealthy
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Cache for Redis
   context_namespace: redis_cache
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_redis_cache__cache_hits
-    title: Azure Cache for Redis Hit Rate
-    context: cache_hits
-    family: Cache
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: redis_cache.cachehits_total
-      name: hits
-    - selector: redis_cache.cachemisses_total
-      name: misses
-  - id: am_azure_redis_cache__throughput
-    title: Azure Cache for Redis Throughput
-    context: throughput
-    family: Cache
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.cache_read_maximum
-      name: read
-    - selector: redis_cache.cache_write_maximum
-      name: write
-  - id: am_azure_redis_cache__server_load
-    title: Azure Cache for Redis Server Load
-    context: server_load
-    family: Server
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.server_load_maximum
-      name: maximum
-  - id: am_azure_redis_cache__cpu
-    title: Azure Cache for Redis CPU Utilization
-    context: cpu
-    family: Server
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.percent_processor_time_maximum
-      name: maximum
-  - id: am_azure_redis_cache__memory_usage
-    title: Azure Cache for Redis Memory Usage
-    context: memory_usage
-    family: Memory
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.usedmemory_maximum
-      name: used
-    - selector: redis_cache.usedmemory_rss_maximum
-      name: rss
-  - id: am_azure_redis_cache__memory_utilization
-    title: Azure Cache for Redis Memory Utilization
-    context: memory_utilization
-    family: Memory
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.usedmemorypercentage_maximum
-      name: maximum
-  - id: am_azure_redis_cache__clients
-    title: Azure Cache for Redis Connected Clients
-    context: clients
-    family: Clients
-    type: line
-    units: clients
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.connectedclients_maximum
-      name: maximum
-  - id: am_azure_redis_cache__operations
-    title: Azure Cache for Redis Operations
-    context: operations
-    family: Operations
-    type: line
-    units: operations/s
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.operations_per_second_maximum
-      name: maximum
-  - id: am_azure_redis_cache__commands
-    title: Azure Cache for Redis Commands Processed
-    context: commands
-    family: Operations
-    type: line
-    units: commands/s
-    algorithm: incremental
-    dimensions:
-    - selector: redis_cache.totalcommandsprocessed_total
-      name: total
-  - id: am_azure_redis_cache__command_types
-    title: Azure Cache for Redis Command Types
-    context: command_types
-    family: Operations
-    type: line
-    units: commands/s
-    algorithm: incremental
-    dimensions:
-    - selector: redis_cache.getcommands_total
-      name: get
-    - selector: redis_cache.setcommands_total
-      name: set
-  - id: am_azure_redis_cache__latency
-    title: Azure Cache for Redis Latency
-    context: latency
-    family: Latency
-    type: line
-    units: microseconds
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.cache_latency_average
-      name: average
-  - id: am_azure_redis_cache__key_events
-    title: Azure Cache for Redis Key Events
-    context: key_events
-    family: Keys
-    type: line
-    units: keys/s
-    algorithm: incremental
-    dimensions:
-    - selector: redis_cache.evictedkeys_total
-      name: evicted
-    - selector: redis_cache.expiredkeys_total
-      name: expired
-  - id: am_azure_redis_cache__total_keys
-    title: Azure Cache for Redis Total Keys
-    context: total_keys
-    family: Keys
-    type: line
-    units: keys
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.totalkeys_maximum
-      name: maximum
-  - id: am_azure_redis_cache__errors
-    title: Azure Cache for Redis Errors
-    context: errors
-    family: Errors
-    type: line
-    units: errors
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.errors_maximum
-      name: maximum
-  - id: am_azure_redis_cache__miss_rate
-    title: Azure Cache for Redis Miss Rate
-    context: miss_rate
-    family: Cache
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.cachemissrate_total
-      name: miss_rate
-  - id: am_azure_redis_cache__latency_p99
-    title: Azure Cache for Redis P99 Latency
-    context: latency_p99
-    family: Latency
-    type: line
-    units: microseconds
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.latency_p99_average
-      name: p99
-  - id: am_azure_redis_cache__connection_rate
-    title: Azure Cache for Redis Connection Rate
-    context: connection_rate
-    family: Clients
-    type: line
-    units: connections/s
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.all_connections_created_per_second_maximum
-      name: created
-    - selector: redis_cache.all_connections_closed_per_second_maximum
-      name: closed
-  - id: am_azure_redis_cache__aad_clients
-    title: Azure Cache for Redis Entra Token Clients
-    context: aad_clients
-    family: Clients
-    type: line
-    units: clients
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.connected_clients_using_aad_token_maximum
-      name: maximum
-  - id: am_azure_redis_cache__instance_cache_hits
-    title: Azure Cache for Redis Instance Hit Rate
-    context: instance_cache_hits
-    family: Instance Cache
-    type: line
-    units: operations/s
-    algorithm: incremental
-    dimensions:
-    - selector: redis_cache.allcachehits_total
-      name: hits
-    - selector: redis_cache.allcachemisses_total
-      name: misses
-  - id: am_azure_redis_cache__instance_throughput
-    title: Azure Cache for Redis Instance Throughput
-    context: instance_throughput
-    family: Instance Cache
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.allcache_read_maximum
-      name: read
-    - selector: redis_cache.allcache_write_maximum
-      name: write
-  - id: am_azure_redis_cache__instance_server_load
-    title: Azure Cache for Redis Instance Server Load
-    context: instance_server_load
-    family: Instance Server
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.allserver_load_maximum
-      name: server_load
-    - selector: redis_cache.allpercentprocessortime_maximum
-      name: cpu
-  - id: am_azure_redis_cache__instance_memory_usage
-    title: Azure Cache for Redis Instance Memory Usage
-    context: instance_memory_usage
-    family: Instance Memory
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.allusedmemory_maximum
-      name: used
-    - selector: redis_cache.allusedmemory_rss_maximum
-      name: rss
-  - id: am_azure_redis_cache__instance_memory_utilization
-    title: Azure Cache for Redis Instance Memory Utilization
-    context: instance_memory_utilization
-    family: Instance Memory
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.allusedmemorypercentage_maximum
-      name: maximum
-  - id: am_azure_redis_cache__instance_clients
-    title: Azure Cache for Redis Instance Connected Clients
-    context: instance_clients
-    family: Instance Clients
-    type: line
-    units: clients
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.allconnectedclients_maximum
-      name: maximum
-  - id: am_azure_redis_cache__instance_operations
-    title: Azure Cache for Redis Instance Operations
-    context: instance_operations
-    family: Instance Operations
-    type: line
-    units: operations/s
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.alloperations_per_second_maximum
-      name: maximum
-  - id: am_azure_redis_cache__instance_commands
-    title: Azure Cache for Redis Instance Commands Processed
-    context: instance_commands
-    family: Instance Operations
-    type: line
-    units: commands/s
-    algorithm: incremental
-    dimensions:
-    - selector: redis_cache.alltotalcommandsprocessed_total
-      name: total
-    - selector: redis_cache.allgetcommands_total
-      name: get
-    - selector: redis_cache.allsetcommands_total
-      name: set
-  - id: am_azure_redis_cache__instance_total_keys
-    title: Azure Cache for Redis Instance Total Keys
-    context: instance_total_keys
-    family: Instance Keys
-    type: line
-    units: keys
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.alltotalkeys_maximum
-      name: maximum
-  - id: am_azure_redis_cache__instance_key_events
-    title: Azure Cache for Redis Instance Key Events
-    context: instance_key_events
-    family: Instance Keys
-    type: line
-    units: keys/s
-    algorithm: incremental
-    dimensions:
-    - selector: redis_cache.allevictedkeys_total
-      name: evicted
-    - selector: redis_cache.allexpiredkeys_total
-      name: expired
-  - id: am_azure_redis_cache__geo_replication_lag
-    title: Azure Cache for Redis Geo-Replication Connectivity Lag
-    context: geo_replication_lag
-    family: Geo-Replication
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.geo_replication_connectivity_lag_average
-      name: average
-  - id: am_azure_redis_cache__geo_replication_sync_offset
-    title: Azure Cache for Redis Geo-Replication Data Sync Offset
-    context: geo_replication_sync_offset
-    family: Geo-Replication
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.geo_replication_data_sync_offset_average
-      name: average
-  - id: am_azure_redis_cache__geo_replication_sync_events
-    title: Azure Cache for Redis Geo-Replication Sync Events
-    context: geo_replication_sync_events
-    family: Geo-Replication
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: redis_cache.geo_replication_full_sync_event_started_count
-      name: started
-    - selector: redis_cache.geo_replication_full_sync_event_finished_count
-      name: finished
-  - id: am_azure_redis_cache__geo_replication_health
-    title: Azure Cache for Redis Geo-Replication Health
-    context: geo_replication_health
-    family: Geo-Replication
-    type: line
-    units: status
-    algorithm: absolute
-    dimensions:
-    - selector: redis_cache.geo_replication_healthy_average
-      name: average
+    - id: am_azure_redis_cache__cache_hits
+      title: Azure Cache for Redis Hit Rate
+      context: cache_hits
+      family: Cache
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: redis_cache.cachehits_total
+          name: hits
+        - selector: redis_cache.cachemisses_total
+          name: misses
+    - id: am_azure_redis_cache__throughput
+      title: Azure Cache for Redis Throughput
+      context: throughput
+      family: Cache
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.cache_read_maximum
+          name: read
+        - selector: redis_cache.cache_write_maximum
+          name: write
+    - id: am_azure_redis_cache__server_load
+      title: Azure Cache for Redis Server Load
+      context: server_load
+      family: Server
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.server_load_maximum
+          name: maximum
+    - id: am_azure_redis_cache__cpu
+      title: Azure Cache for Redis CPU Utilization
+      context: cpu
+      family: Server
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.percent_processor_time_maximum
+          name: maximum
+    - id: am_azure_redis_cache__memory_usage
+      title: Azure Cache for Redis Memory Usage
+      context: memory_usage
+      family: Memory
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.usedmemory_maximum
+          name: used
+        - selector: redis_cache.usedmemory_rss_maximum
+          name: rss
+    - id: am_azure_redis_cache__memory_utilization
+      title: Azure Cache for Redis Memory Utilization
+      context: memory_utilization
+      family: Memory
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.usedmemorypercentage_maximum
+          name: maximum
+    - id: am_azure_redis_cache__clients
+      title: Azure Cache for Redis Connected Clients
+      context: clients
+      family: Clients
+      type: line
+      units: clients
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.connectedclients_maximum
+          name: maximum
+    - id: am_azure_redis_cache__operations
+      title: Azure Cache for Redis Operations
+      context: operations
+      family: Operations
+      type: line
+      units: operations/s
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.operations_per_second_maximum
+          name: maximum
+    - id: am_azure_redis_cache__commands
+      title: Azure Cache for Redis Commands Processed
+      context: commands
+      family: Operations
+      type: line
+      units: commands/s
+      algorithm: incremental
+      dimensions:
+        - selector: redis_cache.totalcommandsprocessed_total
+          name: total
+    - id: am_azure_redis_cache__command_types
+      title: Azure Cache for Redis Command Types
+      context: command_types
+      family: Operations
+      type: line
+      units: commands/s
+      algorithm: incremental
+      dimensions:
+        - selector: redis_cache.getcommands_total
+          name: get
+        - selector: redis_cache.setcommands_total
+          name: set
+    - id: am_azure_redis_cache__latency
+      title: Azure Cache for Redis Latency
+      context: latency
+      family: Latency
+      type: line
+      units: microseconds
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.cache_latency_average
+          name: average
+    - id: am_azure_redis_cache__key_events
+      title: Azure Cache for Redis Key Events
+      context: key_events
+      family: Keys
+      type: line
+      units: keys/s
+      algorithm: incremental
+      dimensions:
+        - selector: redis_cache.evictedkeys_total
+          name: evicted
+        - selector: redis_cache.expiredkeys_total
+          name: expired
+    - id: am_azure_redis_cache__total_keys
+      title: Azure Cache for Redis Total Keys
+      context: total_keys
+      family: Keys
+      type: line
+      units: keys
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.totalkeys_maximum
+          name: maximum
+    - id: am_azure_redis_cache__errors
+      title: Azure Cache for Redis Errors
+      context: errors
+      family: Errors
+      type: line
+      units: errors
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.errors_maximum
+          name: maximum
+    - id: am_azure_redis_cache__miss_rate
+      title: Azure Cache for Redis Miss Rate
+      context: miss_rate
+      family: Cache
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.cachemissrate_total
+          name: miss_rate
+    - id: am_azure_redis_cache__latency_p99
+      title: Azure Cache for Redis P99 Latency
+      context: latency_p99
+      family: Latency
+      type: line
+      units: microseconds
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.latency_p99_average
+          name: p99
+    - id: am_azure_redis_cache__connection_rate
+      title: Azure Cache for Redis Connection Rate
+      context: connection_rate
+      family: Clients
+      type: line
+      units: connections/s
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.all_connections_created_per_second_maximum
+          name: created
+        - selector: redis_cache.all_connections_closed_per_second_maximum
+          name: closed
+    - id: am_azure_redis_cache__aad_clients
+      title: Azure Cache for Redis Entra Token Clients
+      context: aad_clients
+      family: Clients
+      type: line
+      units: clients
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.connected_clients_using_aad_token_maximum
+          name: maximum
+    - id: am_azure_redis_cache__instance_cache_hits
+      title: Azure Cache for Redis Instance Hit Rate
+      context: instance_cache_hits
+      family: Instance Cache
+      type: line
+      units: operations/s
+      algorithm: incremental
+      dimensions:
+        - selector: redis_cache.allcachehits_total
+          name: hits
+        - selector: redis_cache.allcachemisses_total
+          name: misses
+    - id: am_azure_redis_cache__instance_throughput
+      title: Azure Cache for Redis Instance Throughput
+      context: instance_throughput
+      family: Instance Cache
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.allcache_read_maximum
+          name: read
+        - selector: redis_cache.allcache_write_maximum
+          name: write
+    - id: am_azure_redis_cache__instance_server_load
+      title: Azure Cache for Redis Instance Server Load
+      context: instance_server_load
+      family: Instance Server
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.allserver_load_maximum
+          name: server_load
+        - selector: redis_cache.allpercentprocessortime_maximum
+          name: cpu
+    - id: am_azure_redis_cache__instance_memory_usage
+      title: Azure Cache for Redis Instance Memory Usage
+      context: instance_memory_usage
+      family: Instance Memory
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.allusedmemory_maximum
+          name: used
+        - selector: redis_cache.allusedmemory_rss_maximum
+          name: rss
+    - id: am_azure_redis_cache__instance_memory_utilization
+      title: Azure Cache for Redis Instance Memory Utilization
+      context: instance_memory_utilization
+      family: Instance Memory
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.allusedmemorypercentage_maximum
+          name: maximum
+    - id: am_azure_redis_cache__instance_clients
+      title: Azure Cache for Redis Instance Connected Clients
+      context: instance_clients
+      family: Instance Clients
+      type: line
+      units: clients
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.allconnectedclients_maximum
+          name: maximum
+    - id: am_azure_redis_cache__instance_operations
+      title: Azure Cache for Redis Instance Operations
+      context: instance_operations
+      family: Instance Operations
+      type: line
+      units: operations/s
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.alloperations_per_second_maximum
+          name: maximum
+    - id: am_azure_redis_cache__instance_commands
+      title: Azure Cache for Redis Instance Commands Processed
+      context: instance_commands
+      family: Instance Operations
+      type: line
+      units: commands/s
+      algorithm: incremental
+      dimensions:
+        - selector: redis_cache.alltotalcommandsprocessed_total
+          name: total
+        - selector: redis_cache.allgetcommands_total
+          name: get
+        - selector: redis_cache.allsetcommands_total
+          name: set
+    - id: am_azure_redis_cache__instance_total_keys
+      title: Azure Cache for Redis Instance Total Keys
+      context: instance_total_keys
+      family: Instance Keys
+      type: line
+      units: keys
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.alltotalkeys_maximum
+          name: maximum
+    - id: am_azure_redis_cache__instance_key_events
+      title: Azure Cache for Redis Instance Key Events
+      context: instance_key_events
+      family: Instance Keys
+      type: line
+      units: keys/s
+      algorithm: incremental
+      dimensions:
+        - selector: redis_cache.allevictedkeys_total
+          name: evicted
+        - selector: redis_cache.allexpiredkeys_total
+          name: expired
+    - id: am_azure_redis_cache__geo_replication_lag
+      title: Azure Cache for Redis Geo-Replication Connectivity Lag
+      context: geo_replication_lag
+      family: Geo-Replication
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.geo_replication_connectivity_lag_average
+          name: average
+    - id: am_azure_redis_cache__geo_replication_sync_offset
+      title: Azure Cache for Redis Geo-Replication Data Sync Offset
+      context: geo_replication_sync_offset
+      family: Geo-Replication
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.geo_replication_data_sync_offset_average
+          name: average
+    - id: am_azure_redis_cache__geo_replication_sync_events
+      title: Azure Cache for Redis Geo-Replication Sync Events
+      context: geo_replication_sync_events
+      family: Geo-Replication
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: redis_cache.geo_replication_full_sync_event_started_count
+          name: started
+        - selector: redis_cache.geo_replication_full_sync_event_finished_count
+          name: finished
+    - id: am_azure_redis_cache__geo_replication_health
+      title: Azure Cache for Redis Geo-Replication Health
+      context: geo_replication_health
+      family: Geo-Replication
+      type: line
+      units: status
+      algorithm: absolute
+      dimensions:
+        - selector: redis_cache.geo_replication_healthy_average
+          name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/service_bus.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/service_bus.yaml
@@ -3,345 +3,345 @@ id: service_bus
 name: Azure Service Bus Namespace
 resource_type: Microsoft.ServiceBus/Namespaces
 metrics:
-- id: incoming_messages
-  azure_name: IncomingMessages
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: outgoing_messages
-  azure_name: OutgoingMessages
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: complete_message
-  azure_name: CompleteMessage
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: abandon_message
-  azure_name: AbandonMessage
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: active_messages
-  azure_name: ActiveMessages
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: deadlettered_messages
-  azure_name: DeadletteredMessages
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: scheduled_messages
-  azure_name: ScheduledMessages
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: incoming_requests
-  azure_name: IncomingRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: successful_requests
-  azure_name: SuccessfulRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: server_errors
-  azure_name: ServerErrors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: user_errors
-  azure_name: UserErrors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: throttled_requests
-  azure_name: ThrottledRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: active_connections
-  azure_name: ActiveConnections
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: connections_opened
-  azure_name: ConnectionsOpened
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: connections_closed
-  azure_name: ConnectionsClosed
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: incoming_bytes
-  azure_name: IncomingBytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: outgoing_bytes
-  azure_name: OutgoingBytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: messages
-  azure_name: Messages
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: namespace_cpu_usage
-  azure_name: NamespaceCpuUsage
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: namespace_memory_usage
-  azure_name: NamespaceMemoryUsage
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: server_send_latency
-  azure_name: ServerSendLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: pending_checkpoint_operation_count
-  azure_name: PendingCheckpointOperationCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: replication_lag_count
-  azure_name: ReplicationLagCount
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: replication_lag_duration
-  azure_name: ReplicationLagDuration
-  time_grain: PT1M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: size
-  azure_name: Size
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: incoming_messages
+    azure_name: IncomingMessages
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: outgoing_messages
+    azure_name: OutgoingMessages
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: complete_message
+    azure_name: CompleteMessage
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: abandon_message
+    azure_name: AbandonMessage
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: active_messages
+    azure_name: ActiveMessages
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: deadlettered_messages
+    azure_name: DeadletteredMessages
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: scheduled_messages
+    azure_name: ScheduledMessages
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: incoming_requests
+    azure_name: IncomingRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: successful_requests
+    azure_name: SuccessfulRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: server_errors
+    azure_name: ServerErrors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: user_errors
+    azure_name: UserErrors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: throttled_requests
+    azure_name: ThrottledRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: active_connections
+    azure_name: ActiveConnections
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: connections_opened
+    azure_name: ConnectionsOpened
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: connections_closed
+    azure_name: ConnectionsClosed
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: incoming_bytes
+    azure_name: IncomingBytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: outgoing_bytes
+    azure_name: OutgoingBytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: messages
+    azure_name: Messages
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: namespace_cpu_usage
+    azure_name: NamespaceCpuUsage
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: namespace_memory_usage
+    azure_name: NamespaceMemoryUsage
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: server_send_latency
+    azure_name: ServerSendLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: pending_checkpoint_operation_count
+    azure_name: PendingCheckpointOperationCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: replication_lag_count
+    azure_name: ReplicationLagCount
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: replication_lag_duration
+    azure_name: ReplicationLagDuration
+    time_grain: PT1M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: size
+    azure_name: Size
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Service Bus Namespace
   context_namespace: service_bus
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_service_bus__message_flow
-    title: Azure Service Bus Message Flow
-    context: message_flow
-    family: Messages
-    type: line
-    units: messages/s
-    algorithm: incremental
-    dimensions:
-    - selector: service_bus.incoming_messages_total
-      name: in
-    - selector: service_bus.outgoing_messages_total
-      name: out
-  - id: am_azure_service_bus__message_operations
-    title: Azure Service Bus Message Operations
-    context: message_operations
-    family: Messages
-    type: line
-    units: messages/s
-    algorithm: incremental
-    dimensions:
-    - selector: service_bus.complete_message_total
-      name: completed
-    - selector: service_bus.abandon_message_total
-      name: abandoned
-  - id: am_azure_service_bus__queue_depth
-    title: Azure Service Bus Queue Depth
-    context: queue_depth
-    family: Queue
-    type: line
-    units: messages
-    algorithm: absolute
-    dimensions:
-    - selector: service_bus.active_messages_average
-      name: active
-  - id: am_azure_service_bus__problem_messages
-    title: Azure Service Bus Problem Messages
-    context: problem_messages
-    family: Queue
-    type: line
-    units: messages
-    algorithm: absolute
-    dimensions:
-    - selector: service_bus.deadlettered_messages_average
-      name: dead_lettered
-    - selector: service_bus.scheduled_messages_average
-      name: scheduled
-  - id: am_azure_service_bus__total_messages
-    title: Azure Service Bus Total Messages
-    context: total_messages
-    family: Queue
-    type: line
-    units: messages
-    algorithm: absolute
-    dimensions:
-    - selector: service_bus.messages_average
-      name: total
-  - id: am_azure_service_bus__requests
-    title: Azure Service Bus Requests
-    context: requests
-    family: Requests
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: service_bus.incoming_requests_total
-      name: incoming
-    - selector: service_bus.successful_requests_total
-      name: successful
-  - id: am_azure_service_bus__errors
-    title: Azure Service Bus Errors
-    context: errors
-    family: Errors
-    type: line
-    units: errors/s
-    algorithm: incremental
-    dimensions:
-    - selector: service_bus.server_errors_total
-      name: server
-    - selector: service_bus.user_errors_total
-      name: user
-    - selector: service_bus.throttled_requests_total
-      name: throttled
-  - id: am_azure_service_bus__connections
-    title: Azure Service Bus Active Connections
-    context: connections
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: service_bus.active_connections_total
-      name: active
-  - id: am_azure_service_bus__connection_events
-    title: Azure Service Bus Connection Events
-    context: connection_events
-    family: Connections
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: service_bus.connections_opened_average
-      name: opened
-    - selector: service_bus.connections_closed_average
-      name: closed
-  - id: am_azure_service_bus__namespace_size
-    title: Azure Service Bus Namespace Size
-    context: namespace_size
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: service_bus.size_average
-      name: average
-  - id: am_azure_service_bus__data_throughput
-    title: Azure Service Bus Data Throughput
-    context: data_throughput
-    family: Messages
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: service_bus.incoming_bytes_total
-      name: in
-    - selector: service_bus.outgoing_bytes_total
-      name: out
-  - id: am_azure_service_bus__namespace_resources
-    title: Azure Service Bus Namespace Resources
-    context: namespace_resources
-    family: Capacity
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: service_bus.namespace_cpu_usage_maximum
-      name: cpu
-    - selector: service_bus.namespace_memory_usage_maximum
-      name: memory
-  - id: am_azure_service_bus__send_latency
-    title: Azure Service Bus Send Latency
-    context: send_latency
-    family: Performance
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: service_bus.server_send_latency_average
-      name: average
-  - id: am_azure_service_bus__replication_lag
-    title: Azure Service Bus Replication Lag
-    context: replication_lag
-    family: Replication
-    type: line
-    units: messages
-    algorithm: absolute
-    dimensions:
-    - selector: service_bus.replication_lag_count_maximum
-      name: messages
-  - id: am_azure_service_bus__replication_lag_duration
-    title: Azure Service Bus Replication Lag Duration
-    context: replication_lag_duration
-    family: Replication
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: service_bus.replication_lag_duration_maximum
-      name: duration
-  - id: am_azure_service_bus__checkpoint_operations
-    title: Azure Service Bus Pending Checkpoint Operations
-    context: checkpoint_operations
-    family: Replication
-    type: line
-    units: operations
-    algorithm: absolute
-    dimensions:
-    - selector: service_bus.pending_checkpoint_operation_count_total
-      name: pending
+    - id: am_azure_service_bus__message_flow
+      title: Azure Service Bus Message Flow
+      context: message_flow
+      family: Messages
+      type: line
+      units: messages/s
+      algorithm: incremental
+      dimensions:
+        - selector: service_bus.incoming_messages_total
+          name: in
+        - selector: service_bus.outgoing_messages_total
+          name: out
+    - id: am_azure_service_bus__message_operations
+      title: Azure Service Bus Message Operations
+      context: message_operations
+      family: Messages
+      type: line
+      units: messages/s
+      algorithm: incremental
+      dimensions:
+        - selector: service_bus.complete_message_total
+          name: completed
+        - selector: service_bus.abandon_message_total
+          name: abandoned
+    - id: am_azure_service_bus__queue_depth
+      title: Azure Service Bus Queue Depth
+      context: queue_depth
+      family: Queue
+      type: line
+      units: messages
+      algorithm: absolute
+      dimensions:
+        - selector: service_bus.active_messages_average
+          name: active
+    - id: am_azure_service_bus__problem_messages
+      title: Azure Service Bus Problem Messages
+      context: problem_messages
+      family: Queue
+      type: line
+      units: messages
+      algorithm: absolute
+      dimensions:
+        - selector: service_bus.deadlettered_messages_average
+          name: dead_lettered
+        - selector: service_bus.scheduled_messages_average
+          name: scheduled
+    - id: am_azure_service_bus__total_messages
+      title: Azure Service Bus Total Messages
+      context: total_messages
+      family: Queue
+      type: line
+      units: messages
+      algorithm: absolute
+      dimensions:
+        - selector: service_bus.messages_average
+          name: total
+    - id: am_azure_service_bus__requests
+      title: Azure Service Bus Requests
+      context: requests
+      family: Requests
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: service_bus.incoming_requests_total
+          name: incoming
+        - selector: service_bus.successful_requests_total
+          name: successful
+    - id: am_azure_service_bus__errors
+      title: Azure Service Bus Errors
+      context: errors
+      family: Errors
+      type: line
+      units: errors/s
+      algorithm: incremental
+      dimensions:
+        - selector: service_bus.server_errors_total
+          name: server
+        - selector: service_bus.user_errors_total
+          name: user
+        - selector: service_bus.throttled_requests_total
+          name: throttled
+    - id: am_azure_service_bus__connections
+      title: Azure Service Bus Active Connections
+      context: connections
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: service_bus.active_connections_total
+          name: active
+    - id: am_azure_service_bus__connection_events
+      title: Azure Service Bus Connection Events
+      context: connection_events
+      family: Connections
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: service_bus.connections_opened_average
+          name: opened
+        - selector: service_bus.connections_closed_average
+          name: closed
+    - id: am_azure_service_bus__namespace_size
+      title: Azure Service Bus Namespace Size
+      context: namespace_size
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: service_bus.size_average
+          name: average
+    - id: am_azure_service_bus__data_throughput
+      title: Azure Service Bus Data Throughput
+      context: data_throughput
+      family: Messages
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: service_bus.incoming_bytes_total
+          name: in
+        - selector: service_bus.outgoing_bytes_total
+          name: out
+    - id: am_azure_service_bus__namespace_resources
+      title: Azure Service Bus Namespace Resources
+      context: namespace_resources
+      family: Capacity
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: service_bus.namespace_cpu_usage_maximum
+          name: cpu
+        - selector: service_bus.namespace_memory_usage_maximum
+          name: memory
+    - id: am_azure_service_bus__send_latency
+      title: Azure Service Bus Send Latency
+      context: send_latency
+      family: Performance
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: service_bus.server_send_latency_average
+          name: average
+    - id: am_azure_service_bus__replication_lag
+      title: Azure Service Bus Replication Lag
+      context: replication_lag
+      family: Replication
+      type: line
+      units: messages
+      algorithm: absolute
+      dimensions:
+        - selector: service_bus.replication_lag_count_maximum
+          name: messages
+    - id: am_azure_service_bus__replication_lag_duration
+      title: Azure Service Bus Replication Lag Duration
+      context: replication_lag_duration
+      family: Replication
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: service_bus.replication_lag_duration_maximum
+          name: duration
+    - id: am_azure_service_bus__checkpoint_operations
+      title: Azure Service Bus Pending Checkpoint Operations
+      context: checkpoint_operations
+      family: Replication
+      type: line
+      units: operations
+      algorithm: absolute
+      dimensions:
+        - selector: service_bus.pending_checkpoint_operation_count_total
+          name: pending

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/sql_database.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/sql_database.yaml
@@ -3,477 +3,477 @@ id: sql_database
 name: Azure SQL Database
 resource_type: Microsoft.Sql/servers/databases
 metrics:
-- id: cpu_percent
-  azure_name: cpu_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: dtu_consumption_percent
-  azure_name: dtu_consumption_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: sql_instance_cpu_percent
-  azure_name: sql_instance_cpu_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: sql_instance_memory_percent
-  azure_name: sql_instance_memory_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: physical_data_read_percent
-  azure_name: physical_data_read_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: log_write_percent
-  azure_name: log_write_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: workers_percent
-  azure_name: workers_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: sessions_percent
-  azure_name: sessions_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: sessions_count
-  azure_name: sessions_count
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: availability
-  azure_name: availability
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: connection_successful
-  azure_name: connection_successful
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: connection_failed
-  azure_name: connection_failed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: connection_failed_user_error
-  azure_name: connection_failed_user_error
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: blocked_by_firewall
-  azure_name: blocked_by_firewall
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: deadlock
-  azure_name: deadlock
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: storage
-  azure_name: storage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: allocated_data_storage
-  azure_name: allocated_data_storage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: storage_percent
-  azure_name: storage_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: xtp_storage_percent
-  azure_name: xtp_storage_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: tempdb_data_size
-  azure_name: tempdb_data_size
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: tempdb_log_size
-  azure_name: tempdb_log_size
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: tempdb_log_used_percent
-  azure_name: tempdb_log_used_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_used
-  azure_name: cpu_used
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_limit
-  azure_name: cpu_limit
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: dtu_used
-  azure_name: dtu_used
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: dtu_limit
-  azure_name: dtu_limit
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: replication_lag_seconds
-  azure_name: replication_lag_seconds
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: app_cpu_percent
-  azure_name: app_cpu_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: app_memory_percent
-  azure_name: app_memory_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: app_cpu_billed
-  azure_name: app_cpu_billed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: app_cpu_billed_ha_replicas
-  azure_name: app_cpu_billed_ha_replicas
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: free_amount_consumed
-  azure_name: free_amount_consumed
-  time_grain: PT15M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: free_amount_remaining
-  azure_name: free_amount_remaining
-  time_grain: PT15M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: ledger_digest_upload_failed
-  azure_name: ledger_digest_upload_failed
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
-- id: ledger_digest_upload_success
-  azure_name: ledger_digest_upload_success
-  time_grain: PT1M
-  series:
-  - aggregation: count
-    kind: counter
+  - id: cpu_percent
+    azure_name: cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: dtu_consumption_percent
+    azure_name: dtu_consumption_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: sql_instance_cpu_percent
+    azure_name: sql_instance_cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: sql_instance_memory_percent
+    azure_name: sql_instance_memory_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: physical_data_read_percent
+    azure_name: physical_data_read_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: log_write_percent
+    azure_name: log_write_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: workers_percent
+    azure_name: workers_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: sessions_percent
+    azure_name: sessions_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: sessions_count
+    azure_name: sessions_count
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: availability
+    azure_name: availability
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: connection_successful
+    azure_name: connection_successful
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: connection_failed
+    azure_name: connection_failed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: connection_failed_user_error
+    azure_name: connection_failed_user_error
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: blocked_by_firewall
+    azure_name: blocked_by_firewall
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: deadlock
+    azure_name: deadlock
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: storage
+    azure_name: storage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: allocated_data_storage
+    azure_name: allocated_data_storage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: storage_percent
+    azure_name: storage_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: xtp_storage_percent
+    azure_name: xtp_storage_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: tempdb_data_size
+    azure_name: tempdb_data_size
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: tempdb_log_size
+    azure_name: tempdb_log_size
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: tempdb_log_used_percent
+    azure_name: tempdb_log_used_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_used
+    azure_name: cpu_used
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_limit
+    azure_name: cpu_limit
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: dtu_used
+    azure_name: dtu_used
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: dtu_limit
+    azure_name: dtu_limit
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: replication_lag_seconds
+    azure_name: replication_lag_seconds
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: app_cpu_percent
+    azure_name: app_cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: app_memory_percent
+    azure_name: app_memory_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: app_cpu_billed
+    azure_name: app_cpu_billed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: app_cpu_billed_ha_replicas
+    azure_name: app_cpu_billed_ha_replicas
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: free_amount_consumed
+    azure_name: free_amount_consumed
+    time_grain: PT15M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: free_amount_remaining
+    azure_name: free_amount_remaining
+    time_grain: PT15M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: ledger_digest_upload_failed
+    azure_name: ledger_digest_upload_failed
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
+  - id: ledger_digest_upload_success
+    azure_name: ledger_digest_upload_success
+    time_grain: PT1M
+    series:
+      - aggregation: count
+        kind: counter
 template:
   family: Azure SQL Database
   context_namespace: sql_database
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_sql_database__cpu
-    title: Azure SQL Database CPU Utilization
-    context: cpu
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.cpu_percent_average
-      name: average
-    - selector: sql_database.cpu_percent_maximum
-      name: maximum
-  - id: am_azure_sql_database__instance_cpu
-    title: Azure SQL Database Instance CPU Utilization
-    context: instance_cpu
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.sql_instance_cpu_percent_average
-      name: average
-  - id: am_azure_sql_database__instance_memory
-    title: Azure SQL Database Instance Memory Utilization
-    context: instance_memory
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.sql_instance_memory_percent_average
-      name: average
-  - id: am_azure_sql_database__dtu_consumption
-    title: Azure SQL Database DTU Consumption
-    context: dtu_consumption
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.dtu_consumption_percent_average
-      name: average
-  - id: am_azure_sql_database__io_utilization
-    title: Azure SQL Database I/O Utilization
-    context: io_utilization
-    family: I/O
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.physical_data_read_percent_average
-      name: data_read
-    - selector: sql_database.log_write_percent_average
-      name: log_write
-  - id: am_azure_sql_database__resource_utilization
-    title: Azure SQL Database Resource Utilization
-    context: resource_utilization
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.workers_percent_average
-      name: workers
-    - selector: sql_database.sessions_percent_average
-      name: sessions
-  - id: am_azure_sql_database__availability
-    title: Azure SQL Database Availability
-    context: availability
-    family: Availability
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.availability_average
-      name: average
-  - id: am_azure_sql_database__connections
-    title: Azure SQL Database Connection Events
-    context: connections
-    family: Connections
-    type: line
-    units: connections/s
-    algorithm: incremental
-    dimensions:
-    - selector: sql_database.connection_successful_total
-      name: successful
-    - selector: sql_database.connection_failed_total
-      name: failed_system
-    - selector: sql_database.connection_failed_user_error_total
-      name: failed_user
-    - selector: sql_database.blocked_by_firewall_total
-      name: firewall_blocked
-  - id: am_azure_sql_database__deadlocks
-    title: Azure SQL Database Deadlocks
-    context: deadlocks
-    family: Locking
-    type: line
-    units: deadlocks/s
-    algorithm: incremental
-    dimensions:
-    - selector: sql_database.deadlock_total
-      name: total
-  - id: am_azure_sql_database__storage
-    title: Azure SQL Database Storage
-    context: storage
-    family: Storage
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.storage_average
-      name: used
-    - selector: sql_database.allocated_data_storage_average
-      name: allocated
-  - id: am_azure_sql_database__storage_utilization
-    title: Azure SQL Database Storage Utilization
-    context: storage_utilization
-    family: Storage
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.storage_percent_average
-      name: average
-  - id: am_azure_sql_database__tempdb_size
-    title: Azure SQL Database Tempdb Size
-    context: tempdb_size
-    family: Tempdb
-    type: line
-    units: KiB
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.tempdb_data_size_average
-      name: data
-    - selector: sql_database.tempdb_log_size_average
-      name: log
-  - id: am_azure_sql_database__tempdb_log_utilization
-    title: Azure SQL Database Tempdb Log Utilization
-    context: tempdb_log_utilization
-    family: Tempdb
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.tempdb_log_used_percent_average
-      name: average
-  - id: am_azure_sql_database__vcore_usage
-    title: Azure SQL Database vCore Usage
-    context: vcore_usage
-    family: Capacity
-    type: line
-    units: vCores
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.cpu_used_average
-      name: used
-    - selector: sql_database.cpu_limit_average
-      name: limit
-  - id: am_azure_sql_database__dtu_usage
-    title: Azure SQL Database DTU Usage
-    context: dtu_usage
-    family: Capacity
-    type: line
-    units: DTU
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.dtu_used_average
-      name: used
-    - selector: sql_database.dtu_limit_average
-      name: limit
-  - id: am_azure_sql_database__sessions_count
-    title: Azure SQL Database Sessions Count
-    context: sessions_count
-    family: Capacity
-    type: line
-    units: sessions
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.sessions_count_average
-      name: average
-  - id: am_azure_sql_database__replication_lag
-    title: Azure SQL Database Replication Lag
-    context: replication_lag
-    family: Replication
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.replication_lag_seconds_average
-      name: average
-  - id: am_azure_sql_database__xtp_storage
-    title: Azure SQL Database In-Memory OLTP Storage
-    context: xtp_storage
-    family: In-Memory OLTP
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.xtp_storage_percent_average
-      name: average
-  - id: am_azure_sql_database__serverless_utilization
-    title: Azure SQL Database Serverless Utilization
-    context: serverless_utilization
-    family: Serverless
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.app_cpu_percent_average
-      name: cpu
-    - selector: sql_database.app_memory_percent_average
-      name: memory
-  - id: am_azure_sql_database__serverless_billing
-    title: Azure SQL Database Serverless Billing
-    context: serverless_billing
-    family: Serverless
-    type: line
-    units: vCore-seconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: sql_database.app_cpu_billed_total
-      name: total
-    - selector: sql_database.app_cpu_billed_ha_replicas_total
-      name: ha_replicas
-  - id: am_azure_sql_database__free_tier_usage
-    title: Azure SQL Database Free Tier Usage
-    context: free_tier_usage
-    family: Free Tier
-    type: line
-    units: vCore-seconds
-    algorithm: absolute
-    dimensions:
-    - selector: sql_database.free_amount_consumed_average
-      name: consumed
-    - selector: sql_database.free_amount_remaining_average
-      name: remaining
-  - id: am_azure_sql_database__ledger_digest
-    title: Azure SQL Database Ledger Digest Uploads
-    context: ledger_digest
-    family: Ledger
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: sql_database.ledger_digest_upload_success_count
-      name: success
-    - selector: sql_database.ledger_digest_upload_failed_count
-      name: failed
+    - id: am_azure_sql_database__cpu
+      title: Azure SQL Database CPU Utilization
+      context: cpu
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.cpu_percent_average
+          name: average
+        - selector: sql_database.cpu_percent_maximum
+          name: maximum
+    - id: am_azure_sql_database__instance_cpu
+      title: Azure SQL Database Instance CPU Utilization
+      context: instance_cpu
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.sql_instance_cpu_percent_average
+          name: average
+    - id: am_azure_sql_database__instance_memory
+      title: Azure SQL Database Instance Memory Utilization
+      context: instance_memory
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.sql_instance_memory_percent_average
+          name: average
+    - id: am_azure_sql_database__dtu_consumption
+      title: Azure SQL Database DTU Consumption
+      context: dtu_consumption
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.dtu_consumption_percent_average
+          name: average
+    - id: am_azure_sql_database__io_utilization
+      title: Azure SQL Database I/O Utilization
+      context: io_utilization
+      family: IO
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.physical_data_read_percent_average
+          name: data_read
+        - selector: sql_database.log_write_percent_average
+          name: log_write
+    - id: am_azure_sql_database__resource_utilization
+      title: Azure SQL Database Resource Utilization
+      context: resource_utilization
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.workers_percent_average
+          name: workers
+        - selector: sql_database.sessions_percent_average
+          name: sessions
+    - id: am_azure_sql_database__availability
+      title: Azure SQL Database Availability
+      context: availability
+      family: Availability
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.availability_average
+          name: average
+    - id: am_azure_sql_database__connections
+      title: Azure SQL Database Connection Events
+      context: connections
+      family: Connections
+      type: line
+      units: connections/s
+      algorithm: incremental
+      dimensions:
+        - selector: sql_database.connection_successful_total
+          name: successful
+        - selector: sql_database.connection_failed_total
+          name: failed_system
+        - selector: sql_database.connection_failed_user_error_total
+          name: failed_user
+        - selector: sql_database.blocked_by_firewall_total
+          name: firewall_blocked
+    - id: am_azure_sql_database__deadlocks
+      title: Azure SQL Database Deadlocks
+      context: deadlocks
+      family: Locking
+      type: line
+      units: deadlocks/s
+      algorithm: incremental
+      dimensions:
+        - selector: sql_database.deadlock_total
+          name: total
+    - id: am_azure_sql_database__storage
+      title: Azure SQL Database Storage
+      context: storage
+      family: Storage
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.storage_average
+          name: used
+        - selector: sql_database.allocated_data_storage_average
+          name: allocated
+    - id: am_azure_sql_database__storage_utilization
+      title: Azure SQL Database Storage Utilization
+      context: storage_utilization
+      family: Storage
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.storage_percent_average
+          name: average
+    - id: am_azure_sql_database__tempdb_size
+      title: Azure SQL Database Tempdb Size
+      context: tempdb_size
+      family: Tempdb
+      type: line
+      units: KiB
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.tempdb_data_size_average
+          name: data
+        - selector: sql_database.tempdb_log_size_average
+          name: log
+    - id: am_azure_sql_database__tempdb_log_utilization
+      title: Azure SQL Database Tempdb Log Utilization
+      context: tempdb_log_utilization
+      family: Tempdb
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.tempdb_log_used_percent_average
+          name: average
+    - id: am_azure_sql_database__vcore_usage
+      title: Azure SQL Database vCore Usage
+      context: vcore_usage
+      family: Capacity
+      type: line
+      units: vCores
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.cpu_used_average
+          name: used
+        - selector: sql_database.cpu_limit_average
+          name: limit
+    - id: am_azure_sql_database__dtu_usage
+      title: Azure SQL Database DTU Usage
+      context: dtu_usage
+      family: Capacity
+      type: line
+      units: DTU
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.dtu_used_average
+          name: used
+        - selector: sql_database.dtu_limit_average
+          name: limit
+    - id: am_azure_sql_database__sessions_count
+      title: Azure SQL Database Sessions Count
+      context: sessions_count
+      family: Capacity
+      type: line
+      units: sessions
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.sessions_count_average
+          name: average
+    - id: am_azure_sql_database__replication_lag
+      title: Azure SQL Database Replication Lag
+      context: replication_lag
+      family: Replication
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.replication_lag_seconds_average
+          name: average
+    - id: am_azure_sql_database__xtp_storage
+      title: Azure SQL Database In-Memory OLTP Storage
+      context: xtp_storage
+      family: In-Memory OLTP
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.xtp_storage_percent_average
+          name: average
+    - id: am_azure_sql_database__serverless_utilization
+      title: Azure SQL Database Serverless Utilization
+      context: serverless_utilization
+      family: Serverless
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.app_cpu_percent_average
+          name: cpu
+        - selector: sql_database.app_memory_percent_average
+          name: memory
+    - id: am_azure_sql_database__serverless_billing
+      title: Azure SQL Database Serverless Billing
+      context: serverless_billing
+      family: Serverless
+      type: line
+      units: vCore-seconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: sql_database.app_cpu_billed_total
+          name: total
+        - selector: sql_database.app_cpu_billed_ha_replicas_total
+          name: ha_replicas
+    - id: am_azure_sql_database__free_tier_usage
+      title: Azure SQL Database Free Tier Usage
+      context: free_tier_usage
+      family: Free Tier
+      type: line
+      units: vCore-seconds
+      algorithm: absolute
+      dimensions:
+        - selector: sql_database.free_amount_consumed_average
+          name: consumed
+        - selector: sql_database.free_amount_remaining_average
+          name: remaining
+    - id: am_azure_sql_database__ledger_digest
+      title: Azure SQL Database Ledger Digest Uploads
+      context: ledger_digest
+      family: Ledger
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: sql_database.ledger_digest_upload_success_count
+          name: success
+        - selector: sql_database.ledger_digest_upload_failed_count
+          name: failed

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/sql_elastic_pool.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/sql_elastic_pool.yaml
@@ -3,349 +3,349 @@ id: sql_elastic_pool
 name: Azure SQL Elastic Pool
 resource_type: Microsoft.Sql/servers/elasticPools
 metrics:
-- id: cpu_percent
-  azure_name: cpu_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: cpu_used
-  azure_name: cpu_used
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_limit
-  azure_name: cpu_limit
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: dtu_consumption_percent
-  azure_name: dtu_consumption_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: e_dtu_used
-  azure_name: eDTU_used
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: e_dtu_limit
-  azure_name: eDTU_limit
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: sql_instance_cpu_percent
-  azure_name: sql_instance_cpu_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: sql_instance_memory_percent
-  azure_name: sql_instance_memory_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: physical_data_read_percent
-  azure_name: physical_data_read_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: log_write_percent
-  azure_name: log_write_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: workers_percent
-  azure_name: workers_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: sessions_percent
-  azure_name: sessions_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: sessions_count
-  azure_name: sessions_count
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: allocated_data_storage
-  azure_name: allocated_data_storage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: allocated_data_storage_percent
-  azure_name: allocated_data_storage_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: storage_used
-  azure_name: storage_used
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: storage_percent
-  azure_name: storage_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: storage_limit
-  azure_name: storage_limit
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: xtp_storage_percent
-  azure_name: xtp_storage_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: tempdb_data_size
-  azure_name: tempdb_data_size
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: tempdb_log_size
-  azure_name: tempdb_log_size
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: tempdb_log_used_percent
-  azure_name: tempdb_log_used_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: app_cpu_percent
-  azure_name: app_cpu_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: app_memory_percent
-  azure_name: app_memory_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: app_cpu_billed
-  azure_name: app_cpu_billed
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
+  - id: cpu_percent
+    azure_name: cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: cpu_used
+    azure_name: cpu_used
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_limit
+    azure_name: cpu_limit
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: dtu_consumption_percent
+    azure_name: dtu_consumption_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: e_dtu_used
+    azure_name: eDTU_used
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: e_dtu_limit
+    azure_name: eDTU_limit
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: sql_instance_cpu_percent
+    azure_name: sql_instance_cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: sql_instance_memory_percent
+    azure_name: sql_instance_memory_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: physical_data_read_percent
+    azure_name: physical_data_read_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: log_write_percent
+    azure_name: log_write_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: workers_percent
+    azure_name: workers_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: sessions_percent
+    azure_name: sessions_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: sessions_count
+    azure_name: sessions_count
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: allocated_data_storage
+    azure_name: allocated_data_storage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: allocated_data_storage_percent
+    azure_name: allocated_data_storage_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: storage_used
+    azure_name: storage_used
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: storage_percent
+    azure_name: storage_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: storage_limit
+    azure_name: storage_limit
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: xtp_storage_percent
+    azure_name: xtp_storage_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: tempdb_data_size
+    azure_name: tempdb_data_size
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: tempdb_log_size
+    azure_name: tempdb_log_size
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: tempdb_log_used_percent
+    azure_name: tempdb_log_used_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: app_cpu_percent
+    azure_name: app_cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: app_memory_percent
+    azure_name: app_memory_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: app_cpu_billed
+    azure_name: app_cpu_billed
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
 template:
   family: Azure SQL Elastic Pool
   context_namespace: sql_elastic_pool
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_sql_elastic_pool__cpu
-    title: Azure SQL Elastic Pool CPU Utilization
-    context: cpu
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.cpu_percent_average
-      name: average
-    - selector: sql_elastic_pool.cpu_percent_maximum
-      name: maximum
-  - id: am_azure_sql_elastic_pool__instance_cpu
-    title: Azure SQL Elastic Pool Instance CPU Utilization
-    context: instance_cpu
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.sql_instance_cpu_percent_average
-      name: average
-  - id: am_azure_sql_elastic_pool__instance_memory
-    title: Azure SQL Elastic Pool Instance Memory Utilization
-    context: instance_memory
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.sql_instance_memory_percent_average
-      name: average
-  - id: am_azure_sql_elastic_pool__dtu_consumption
-    title: Azure SQL Elastic Pool DTU Consumption
-    context: dtu_consumption
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.dtu_consumption_percent_average
-      name: average
-  - id: am_azure_sql_elastic_pool__io_utilization
-    title: Azure SQL Elastic Pool I/O Utilization
-    context: io_utilization
-    family: I/O
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.physical_data_read_percent_average
-      name: data_read
-    - selector: sql_elastic_pool.log_write_percent_average
-      name: log_write
-  - id: am_azure_sql_elastic_pool__resource_utilization
-    title: Azure SQL Elastic Pool Resource Utilization
-    context: resource_utilization
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.workers_percent_average
-      name: workers
-    - selector: sql_elastic_pool.sessions_percent_average
-      name: sessions
-  - id: am_azure_sql_elastic_pool__sessions_count
-    title: Azure SQL Elastic Pool Sessions Count
-    context: sessions_count
-    family: Capacity
-    type: line
-    units: sessions
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.sessions_count_average
-      name: average
-  - id: am_azure_sql_elastic_pool__storage
-    title: Azure SQL Elastic Pool Storage
-    context: storage
-    family: Storage
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.storage_used_average
-      name: used
-    - selector: sql_elastic_pool.allocated_data_storage_average
-      name: allocated
-    - selector: sql_elastic_pool.storage_limit_average
-      name: limit
-  - id: am_azure_sql_elastic_pool__storage_utilization
-    title: Azure SQL Elastic Pool Storage Utilization
-    context: storage_utilization
-    family: Storage
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.storage_percent_average
-      name: used
-    - selector: sql_elastic_pool.allocated_data_storage_percent_average
-      name: allocated
-  - id: am_azure_sql_elastic_pool__xtp_storage
-    title: Azure SQL Elastic Pool In-Memory OLTP Storage
-    context: xtp_storage
-    family: In-Memory OLTP
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.xtp_storage_percent_average
-      name: average
-  - id: am_azure_sql_elastic_pool__tempdb_size
-    title: Azure SQL Elastic Pool Tempdb Size
-    context: tempdb_size
-    family: Tempdb
-    type: line
-    units: KiB
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.tempdb_data_size_average
-      name: data
-    - selector: sql_elastic_pool.tempdb_log_size_average
-      name: log
-  - id: am_azure_sql_elastic_pool__tempdb_log_utilization
-    title: Azure SQL Elastic Pool Tempdb Log Utilization
-    context: tempdb_log_utilization
-    family: Tempdb
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.tempdb_log_used_percent_average
-      name: average
-  - id: am_azure_sql_elastic_pool__vcore_usage
-    title: Azure SQL Elastic Pool vCore Usage
-    context: vcore_usage
-    family: Capacity
-    type: line
-    units: vCores
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.cpu_used_average
-      name: used
-    - selector: sql_elastic_pool.cpu_limit_average
-      name: limit
-  - id: am_azure_sql_elastic_pool__edtu_usage
-    title: Azure SQL Elastic Pool eDTU Usage
-    context: edtu_usage
-    family: Capacity
-    type: line
-    units: eDTU
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.e_dtu_used_average
-      name: used
-    - selector: sql_elastic_pool.e_dtu_limit_average
-      name: limit
-  - id: am_azure_sql_elastic_pool__serverless_utilization
-    title: Azure SQL Elastic Pool Serverless Utilization
-    context: serverless_utilization
-    family: Serverless
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_elastic_pool.app_cpu_percent_average
-      name: cpu
-    - selector: sql_elastic_pool.app_memory_percent_average
-      name: memory
-  - id: am_azure_sql_elastic_pool__serverless_billing
-    title: Azure SQL Elastic Pool Serverless Billing
-    context: serverless_billing
-    family: Serverless
-    type: line
-    units: vCore-seconds/s
-    algorithm: incremental
-    dimensions:
-    - selector: sql_elastic_pool.app_cpu_billed_total
-      name: total
+    - id: am_azure_sql_elastic_pool__cpu
+      title: Azure SQL Elastic Pool CPU Utilization
+      context: cpu
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.cpu_percent_average
+          name: average
+        - selector: sql_elastic_pool.cpu_percent_maximum
+          name: maximum
+    - id: am_azure_sql_elastic_pool__instance_cpu
+      title: Azure SQL Elastic Pool Instance CPU Utilization
+      context: instance_cpu
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.sql_instance_cpu_percent_average
+          name: average
+    - id: am_azure_sql_elastic_pool__instance_memory
+      title: Azure SQL Elastic Pool Instance Memory Utilization
+      context: instance_memory
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.sql_instance_memory_percent_average
+          name: average
+    - id: am_azure_sql_elastic_pool__dtu_consumption
+      title: Azure SQL Elastic Pool DTU Consumption
+      context: dtu_consumption
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.dtu_consumption_percent_average
+          name: average
+    - id: am_azure_sql_elastic_pool__io_utilization
+      title: Azure SQL Elastic Pool I/O Utilization
+      context: io_utilization
+      family: IO
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.physical_data_read_percent_average
+          name: data_read
+        - selector: sql_elastic_pool.log_write_percent_average
+          name: log_write
+    - id: am_azure_sql_elastic_pool__resource_utilization
+      title: Azure SQL Elastic Pool Resource Utilization
+      context: resource_utilization
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.workers_percent_average
+          name: workers
+        - selector: sql_elastic_pool.sessions_percent_average
+          name: sessions
+    - id: am_azure_sql_elastic_pool__sessions_count
+      title: Azure SQL Elastic Pool Sessions Count
+      context: sessions_count
+      family: Capacity
+      type: line
+      units: sessions
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.sessions_count_average
+          name: average
+    - id: am_azure_sql_elastic_pool__storage
+      title: Azure SQL Elastic Pool Storage
+      context: storage
+      family: Storage
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.storage_used_average
+          name: used
+        - selector: sql_elastic_pool.allocated_data_storage_average
+          name: allocated
+        - selector: sql_elastic_pool.storage_limit_average
+          name: limit
+    - id: am_azure_sql_elastic_pool__storage_utilization
+      title: Azure SQL Elastic Pool Storage Utilization
+      context: storage_utilization
+      family: Storage
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.storage_percent_average
+          name: used
+        - selector: sql_elastic_pool.allocated_data_storage_percent_average
+          name: allocated
+    - id: am_azure_sql_elastic_pool__xtp_storage
+      title: Azure SQL Elastic Pool In-Memory OLTP Storage
+      context: xtp_storage
+      family: In-Memory OLTP
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.xtp_storage_percent_average
+          name: average
+    - id: am_azure_sql_elastic_pool__tempdb_size
+      title: Azure SQL Elastic Pool Tempdb Size
+      context: tempdb_size
+      family: Tempdb
+      type: line
+      units: KiB
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.tempdb_data_size_average
+          name: data
+        - selector: sql_elastic_pool.tempdb_log_size_average
+          name: log
+    - id: am_azure_sql_elastic_pool__tempdb_log_utilization
+      title: Azure SQL Elastic Pool Tempdb Log Utilization
+      context: tempdb_log_utilization
+      family: Tempdb
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.tempdb_log_used_percent_average
+          name: average
+    - id: am_azure_sql_elastic_pool__vcore_usage
+      title: Azure SQL Elastic Pool vCore Usage
+      context: vcore_usage
+      family: Capacity
+      type: line
+      units: vCores
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.cpu_used_average
+          name: used
+        - selector: sql_elastic_pool.cpu_limit_average
+          name: limit
+    - id: am_azure_sql_elastic_pool__edtu_usage
+      title: Azure SQL Elastic Pool eDTU Usage
+      context: edtu_usage
+      family: Capacity
+      type: line
+      units: eDTU
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.e_dtu_used_average
+          name: used
+        - selector: sql_elastic_pool.e_dtu_limit_average
+          name: limit
+    - id: am_azure_sql_elastic_pool__serverless_utilization
+      title: Azure SQL Elastic Pool Serverless Utilization
+      context: serverless_utilization
+      family: Serverless
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_elastic_pool.app_cpu_percent_average
+          name: cpu
+        - selector: sql_elastic_pool.app_memory_percent_average
+          name: memory
+    - id: am_azure_sql_elastic_pool__serverless_billing
+      title: Azure SQL Elastic Pool Serverless Billing
+      context: serverless_billing
+      family: Serverless
+      type: line
+      units: vCore-seconds/s
+      algorithm: incremental
+      dimensions:
+        - selector: sql_elastic_pool.app_cpu_billed_total
+          name: total

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/sql_managed_instance.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/sql_managed_instance.yaml
@@ -3,117 +3,117 @@ id: sql_managed_instance
 name: Azure SQL Managed Instance
 resource_type: Microsoft.Sql/managedInstances
 metrics:
-- id: avg_cpu_percent
-  azure_name: avg_cpu_percent
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: io_bytes_read
-  azure_name: io_bytes_read
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: io_bytes_written
-  azure_name: io_bytes_written
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: io_requests
-  azure_name: io_requests
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: reserved_storage_mb
-  azure_name: reserved_storage_mb
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: storage_space_used_mb
-  azure_name: storage_space_used_mb
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: virtual_core_count
-  azure_name: virtual_core_count
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: avg_cpu_percent
+    azure_name: avg_cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: io_bytes_read
+    azure_name: io_bytes_read
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: io_bytes_written
+    azure_name: io_bytes_written
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: io_requests
+    azure_name: io_requests
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: reserved_storage_mb
+    azure_name: reserved_storage_mb
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: storage_space_used_mb
+    azure_name: storage_space_used_mb
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: virtual_core_count
+    azure_name: virtual_core_count
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure SQL Managed Instance
   context_namespace: sql_managed_instance
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_sql_managed_instance__cpu
-    title: Azure SQL Managed Instance CPU Utilization
-    context: cpu
-    family: Utilization
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: sql_managed_instance.avg_cpu_percent_average
-      name: average
-    - selector: sql_managed_instance.avg_cpu_percent_maximum
-      name: maximum
-  - id: am_azure_sql_managed_instance__io_throughput
-    title: Azure SQL Managed Instance I/O Throughput
-    context: io_throughput
-    family: I/O
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: sql_managed_instance.io_bytes_read_average
-      name: read
-    - selector: sql_managed_instance.io_bytes_written_average
-      name: written
-  - id: am_azure_sql_managed_instance__io_requests
-    title: Azure SQL Managed Instance I/O Requests
-    context: io_requests
-    family: I/O
-    type: line
-    units: requests/s
-    algorithm: absolute
-    dimensions:
-    - selector: sql_managed_instance.io_requests_average
-      name: average
-  - id: am_azure_sql_managed_instance__storage
-    title: Azure SQL Managed Instance Storage
-    context: storage
-    family: Capacity
-    type: line
-    units: MiB
-    algorithm: absolute
-    dimensions:
-    - selector: sql_managed_instance.reserved_storage_mb_average
-      name: reserved
-    - selector: sql_managed_instance.storage_space_used_mb_average
-      name: used
-  - id: am_azure_sql_managed_instance__virtual_core_count
-    title: Azure SQL Managed Instance Virtual Core Count
-    context: virtual_core_count
-    family: Capacity
-    type: line
-    units: cores
-    algorithm: absolute
-    dimensions:
-    - selector: sql_managed_instance.virtual_core_count_average
-      name: average
+    - id: am_azure_sql_managed_instance__cpu
+      title: Azure SQL Managed Instance CPU Utilization
+      context: cpu
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: sql_managed_instance.avg_cpu_percent_average
+          name: average
+        - selector: sql_managed_instance.avg_cpu_percent_maximum
+          name: maximum
+    - id: am_azure_sql_managed_instance__io_throughput
+      title: Azure SQL Managed Instance I/O Throughput
+      context: io_throughput
+      family: IO
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: sql_managed_instance.io_bytes_read_average
+          name: read
+        - selector: sql_managed_instance.io_bytes_written_average
+          name: written
+    - id: am_azure_sql_managed_instance__io_requests
+      title: Azure SQL Managed Instance I/O Requests
+      context: io_requests
+      family: IO
+      type: line
+      units: requests/s
+      algorithm: absolute
+      dimensions:
+        - selector: sql_managed_instance.io_requests_average
+          name: average
+    - id: am_azure_sql_managed_instance__storage
+      title: Azure SQL Managed Instance Storage
+      context: storage
+      family: Capacity
+      type: line
+      units: MiB
+      algorithm: absolute
+      dimensions:
+        - selector: sql_managed_instance.reserved_storage_mb_average
+          name: reserved
+        - selector: sql_managed_instance.storage_space_used_mb_average
+          name: used
+    - id: am_azure_sql_managed_instance__virtual_core_count
+      title: Azure SQL Managed Instance Virtual Core Count
+      context: virtual_core_count
+      family: Capacity
+      type: line
+      units: cores
+      algorithm: absolute
+      dimensions:
+        - selector: sql_managed_instance.virtual_core_count_average
+          name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/storage_accounts.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/storage_accounts.yaml
@@ -3,129 +3,129 @@ id: storage_accounts
 name: Azure Storage Account
 resource_type: Microsoft.Storage/storageAccounts
 metrics:
-- id: availability
-  azure_name: Availability
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: transactions
-  azure_name: Transactions
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: ingress
-  azure_name: Ingress
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: egress
-  azure_name: Egress
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: success_e2e_latency
-  azure_name: SuccessE2ELatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: success_server_latency
-  azure_name: SuccessServerLatency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-- id: used_capacity
-  azure_name: UsedCapacity
-  time_grain: PT1H
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: availability
+    azure_name: Availability
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: transactions
+    azure_name: Transactions
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: ingress
+    azure_name: Ingress
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: egress
+    azure_name: Egress
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: success_e2e_latency
+    azure_name: SuccessE2ELatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: success_server_latency
+    azure_name: SuccessServerLatency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+  - id: used_capacity
+    azure_name: UsedCapacity
+    time_grain: PT1H
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Storage Account
   context_namespace: storage_accounts
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_storage_accounts__availability
-    title: Azure Storage Account Availability
-    context: availability
-    family: Availability
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: storage_accounts.availability_average
-      name: average
-  - id: am_azure_storage_accounts__transactions
-    title: Azure Storage Account Transactions
-    context: transactions
-    family: Throughput
-    type: line
-    units: transactions/s
-    algorithm: incremental
-    dimensions:
-    - selector: storage_accounts.transactions_total
-      name: total
-  - id: am_azure_storage_accounts__throughput
-    title: Azure Storage Account Throughput
-    context: throughput
-    family: Throughput
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: storage_accounts.ingress_total
-      name: ingress
-    - selector: storage_accounts.egress_total
-      name: egress
-  - id: am_azure_storage_accounts__e2e_latency
-    title: Azure Storage Account End-to-End Latency
-    context: e2e_latency
-    family: Latency
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: storage_accounts.success_e2e_latency_average
-      name: average
-    - selector: storage_accounts.success_e2e_latency_maximum
-      name: maximum
-  - id: am_azure_storage_accounts__server_latency
-    title: Azure Storage Account Server Latency
-    context: server_latency
-    family: Latency
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: storage_accounts.success_server_latency_average
-      name: average
-    - selector: storage_accounts.success_server_latency_maximum
-      name: maximum
-  - id: am_azure_storage_accounts__used_capacity
-    title: Azure Storage Account Used Capacity
-    context: used_capacity
-    family: Capacity
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: storage_accounts.used_capacity_average
-      name: average
+    - id: am_azure_storage_accounts__availability
+      title: Azure Storage Account Availability
+      context: availability
+      family: Availability
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: storage_accounts.availability_average
+          name: average
+    - id: am_azure_storage_accounts__transactions
+      title: Azure Storage Account Transactions
+      context: transactions
+      family: Throughput
+      type: line
+      units: transactions/s
+      algorithm: incremental
+      dimensions:
+        - selector: storage_accounts.transactions_total
+          name: total
+    - id: am_azure_storage_accounts__throughput
+      title: Azure Storage Account Throughput
+      context: throughput
+      family: Throughput
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: storage_accounts.ingress_total
+          name: ingress
+        - selector: storage_accounts.egress_total
+          name: egress
+    - id: am_azure_storage_accounts__e2e_latency
+      title: Azure Storage Account End-to-End Latency
+      context: e2e_latency
+      family: Latency
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: storage_accounts.success_e2e_latency_average
+          name: average
+        - selector: storage_accounts.success_e2e_latency_maximum
+          name: maximum
+    - id: am_azure_storage_accounts__server_latency
+      title: Azure Storage Account Server Latency
+      context: server_latency
+      family: Latency
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: storage_accounts.success_server_latency_average
+          name: average
+        - selector: storage_accounts.success_server_latency_maximum
+          name: maximum
+    - id: am_azure_storage_accounts__used_capacity
+      title: Azure Storage Account Used Capacity
+      context: used_capacity
+      family: Capacity
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: storage_accounts.used_capacity_average
+          name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/stream_analytics.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/stream_analytics.yaml
@@ -3,249 +3,249 @@ id: stream_analytics
 name: Azure Stream Analytics Job
 resource_type: Microsoft.StreamAnalytics/streamingjobs
 metrics:
-- id: input_events
-  azure_name: InputEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: input_event_bytes
-  azure_name: InputEventBytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: input_events_sources_per_second
-  azure_name: InputEventsSourcesPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: output_events
-  azure_name: OutputEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: late_input_events
-  azure_name: LateInputEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: early_input_events
-  azure_name: EarlyInputEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: dropped_or_adjusted_events
-  azure_name: DroppedOrAdjustedEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: input_events_sources_backlogged
-  azure_name: InputEventsSourcesBacklogged
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-  - aggregation: minimum
-    kind: gauge
-- id: output_watermark_delay_seconds
-  azure_name: OutputWatermarkDelaySeconds
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-  - aggregation: minimum
-    kind: gauge
-- id: conversion_errors
-  azure_name: ConversionErrors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: deserialization_error
-  azure_name: DeserializationError
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: errors
-  azure_name: Errors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: aml_callout_requests
-  azure_name: AMLCalloutRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: aml_callout_failed_requests
-  azure_name: AMLCalloutFailedRequests
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: aml_callout_input_events
-  azure_name: AMLCalloutInputEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: process_cpu_usage_percentage
-  azure_name: ProcessCPUUsagePercentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-  - aggregation: minimum
-    kind: gauge
-- id: resource_utilization
-  azure_name: ResourceUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-  - aggregation: minimum
-    kind: gauge
+  - id: input_events
+    azure_name: InputEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: input_event_bytes
+    azure_name: InputEventBytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: input_events_sources_per_second
+    azure_name: InputEventsSourcesPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: output_events
+    azure_name: OutputEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: late_input_events
+    azure_name: LateInputEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: early_input_events
+    azure_name: EarlyInputEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: dropped_or_adjusted_events
+    azure_name: DroppedOrAdjustedEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: input_events_sources_backlogged
+    azure_name: InputEventsSourcesBacklogged
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+      - aggregation: minimum
+        kind: gauge
+  - id: output_watermark_delay_seconds
+    azure_name: OutputWatermarkDelaySeconds
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+      - aggregation: minimum
+        kind: gauge
+  - id: conversion_errors
+    azure_name: ConversionErrors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: deserialization_error
+    azure_name: DeserializationError
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: errors
+    azure_name: Errors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: aml_callout_requests
+    azure_name: AMLCalloutRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: aml_callout_failed_requests
+    azure_name: AMLCalloutFailedRequests
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: aml_callout_input_events
+    azure_name: AMLCalloutInputEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: process_cpu_usage_percentage
+    azure_name: ProcessCPUUsagePercentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+      - aggregation: minimum
+        kind: gauge
+  - id: resource_utilization
+    azure_name: ResourceUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+      - aggregation: minimum
+        kind: gauge
 template:
   family: Azure Stream Analytics Job
   context_namespace: stream_analytics
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_stream_analytics__event_flow
-    title: Azure Stream Analytics Event Flow
-    context: event_flow
-    family: Events
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: stream_analytics.input_events_total
-      name: in
-    - selector: stream_analytics.output_events_total
-      name: out
-  - id: am_azure_stream_analytics__input_data_throughput
-    title: Azure Stream Analytics Input Data Throughput
-    context: input_data_throughput
-    family: Events
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: stream_analytics.input_event_bytes_total
-      name: received
-  - id: am_azure_stream_analytics__input_sources_received
-    title: Azure Stream Analytics Input Sources Received
-    context: input_sources_received
-    family: Events
-    type: line
-    units: sources/s
-    algorithm: incremental
-    dimensions:
-    - selector: stream_analytics.input_events_sources_per_second_total
-      name: received
-  - id: am_azure_stream_analytics__event_timing
-    title: Azure Stream Analytics Event Timing Issues
-    context: event_timing
-    family: Events
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: stream_analytics.late_input_events_total
-      name: late
-    - selector: stream_analytics.early_input_events_total
-      name: early
-    - selector: stream_analytics.dropped_or_adjusted_events_total
-      name: out_of_order
-  - id: am_azure_stream_analytics__backlogged_events
-    title: Azure Stream Analytics Backlogged Events
-    context: backlogged_events
-    family: Backlog
-    type: line
-    units: events
-    algorithm: absolute
-    dimensions:
-    - selector: stream_analytics.input_events_sources_backlogged_average
-      name: backlogged
-  - id: am_azure_stream_analytics__watermark_delay
-    title: Azure Stream Analytics Watermark Delay
-    context: watermark_delay
-    family: Watermark
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: stream_analytics.output_watermark_delay_seconds_maximum
-      name: delay
-  - id: am_azure_stream_analytics__errors
-    title: Azure Stream Analytics Errors
-    context: errors
-    family: Errors
-    type: line
-    units: errors/s
-    algorithm: incremental
-    dimensions:
-    - selector: stream_analytics.errors_total
-      name: runtime
-    - selector: stream_analytics.conversion_errors_total
-      name: data_conversion
-    - selector: stream_analytics.deserialization_error_total
-      name: deserialization
-  - id: am_azure_stream_analytics__function_requests
-    title: Azure Stream Analytics Function Requests
-    context: function_requests
-    family: Functions
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: stream_analytics.aml_callout_requests_total
-      name: total
-    - selector: stream_analytics.aml_callout_failed_requests_total
-      name: failed
-  - id: am_azure_stream_analytics__function_events
-    title: Azure Stream Analytics Function Events
-    context: function_events
-    family: Functions
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: stream_analytics.aml_callout_input_events_total
-      name: input
-  - id: am_azure_stream_analytics__resource_utilization
-    title: Azure Stream Analytics Resource Utilization
-    context: resource_utilization
-    family: Resources
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: stream_analytics.process_cpu_usage_percentage_average
-      name: cpu
-    - selector: stream_analytics.resource_utilization_average
-      name: su_memory
+    - id: am_azure_stream_analytics__event_flow
+      title: Azure Stream Analytics Event Flow
+      context: event_flow
+      family: Events
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: stream_analytics.input_events_total
+          name: in
+        - selector: stream_analytics.output_events_total
+          name: out
+    - id: am_azure_stream_analytics__input_data_throughput
+      title: Azure Stream Analytics Input Data Throughput
+      context: input_data_throughput
+      family: Events
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: stream_analytics.input_event_bytes_total
+          name: received
+    - id: am_azure_stream_analytics__input_sources_received
+      title: Azure Stream Analytics Input Sources Received
+      context: input_sources_received
+      family: Events
+      type: line
+      units: sources/s
+      algorithm: incremental
+      dimensions:
+        - selector: stream_analytics.input_events_sources_per_second_total
+          name: received
+    - id: am_azure_stream_analytics__event_timing
+      title: Azure Stream Analytics Event Timing Issues
+      context: event_timing
+      family: Events
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: stream_analytics.late_input_events_total
+          name: late
+        - selector: stream_analytics.early_input_events_total
+          name: early
+        - selector: stream_analytics.dropped_or_adjusted_events_total
+          name: out_of_order
+    - id: am_azure_stream_analytics__backlogged_events
+      title: Azure Stream Analytics Backlogged Events
+      context: backlogged_events
+      family: Backlog
+      type: line
+      units: events
+      algorithm: absolute
+      dimensions:
+        - selector: stream_analytics.input_events_sources_backlogged_average
+          name: backlogged
+    - id: am_azure_stream_analytics__watermark_delay
+      title: Azure Stream Analytics Watermark Delay
+      context: watermark_delay
+      family: Watermark
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: stream_analytics.output_watermark_delay_seconds_maximum
+          name: delay
+    - id: am_azure_stream_analytics__errors
+      title: Azure Stream Analytics Errors
+      context: errors
+      family: Errors
+      type: line
+      units: errors/s
+      algorithm: incremental
+      dimensions:
+        - selector: stream_analytics.errors_total
+          name: runtime
+        - selector: stream_analytics.conversion_errors_total
+          name: data_conversion
+        - selector: stream_analytics.deserialization_error_total
+          name: deserialization
+    - id: am_azure_stream_analytics__function_requests
+      title: Azure Stream Analytics Function Requests
+      context: function_requests
+      family: Functions
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: stream_analytics.aml_callout_requests_total
+          name: total
+        - selector: stream_analytics.aml_callout_failed_requests_total
+          name: failed
+    - id: am_azure_stream_analytics__function_events
+      title: Azure Stream Analytics Function Events
+      context: function_events
+      family: Functions
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: stream_analytics.aml_callout_input_events_total
+          name: input
+    - id: am_azure_stream_analytics__resource_utilization
+      title: Azure Stream Analytics Resource Utilization
+      context: resource_utilization
+      family: Resources
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: stream_analytics.process_cpu_usage_percentage_average
+          name: cpu
+        - selector: stream_analytics.resource_utilization_average
+          name: su_memory

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/synapse.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/synapse.yaml
@@ -3,365 +3,365 @@ id: synapse
 name: Azure Synapse Analytics Workspace
 resource_type: Microsoft.Synapse/workspaces
 metrics:
-- id: builtin_sql_pool_data_processed_bytes
-  azure_name: BuiltinSqlPoolDataProcessedBytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: builtin_sql_pool_login_attempts
-  azure_name: BuiltinSqlPoolLoginAttempts
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: builtin_sql_pool_requests_ended
-  azure_name: BuiltinSqlPoolRequestsEnded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: integration_activity_runs_ended
-  azure_name: IntegrationActivityRunsEnded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: integration_link_connection_events
-  azure_name: IntegrationLinkConnectionEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: integration_link_processed_changed_rows
-  azure_name: IntegrationLinkProcessedChangedRows
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: integration_link_processed_data_volume
-  azure_name: IntegrationLinkProcessedDataVolume
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: integration_link_processing_latency_in_seconds
-  azure_name: IntegrationLinkProcessingLatencyInSeconds
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-  - aggregation: minimum
-    kind: gauge
-- id: integration_link_table_events
-  azure_name: IntegrationLinkTableEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: integration_pipeline_runs_ended
-  azure_name: IntegrationPipelineRunsEnded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: integration_trigger_runs_ended
-  azure_name: IntegrationTriggerRunsEnded
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: sql_streaming_input_events
-  azure_name: SQLStreamingInputEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: sql_streaming_input_event_bytes
-  azure_name: SQLStreamingInputEventBytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: sql_streaming_input_events_sources_per_second
-  azure_name: SQLStreamingInputEventsSourcesPerSecond
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: sql_streaming_output_events
-  azure_name: SQLStreamingOutputEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: sql_streaming_backlogged_input_event_sources
-  azure_name: SQLStreamingBackloggedInputEventSources
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: sql_streaming_early_input_events
-  azure_name: SQLStreamingEarlyInputEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: sql_streaming_late_input_events
-  azure_name: SQLStreamingLateInputEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: sql_streaming_out_of_order_events
-  azure_name: SQLStreamingOutOfOrderEvents
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: sql_streaming_output_watermark_delay_seconds
-  azure_name: SQLStreamingOutputWatermarkDelaySeconds
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-  - aggregation: minimum
-    kind: gauge
-- id: sql_streaming_conversion_errors
-  azure_name: SQLStreamingConversionErrors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: sql_streaming_deserialization_error
-  azure_name: SQLStreamingDeserializationError
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: sql_streaming_runtime_errors
-  azure_name: SQLStreamingRuntimeErrors
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: sql_streaming_resource_utilization
-  azure_name: SQLStreamingResourceUtilization
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-  - aggregation: maximum
-    kind: gauge
-  - aggregation: minimum
-    kind: gauge
+  - id: builtin_sql_pool_data_processed_bytes
+    azure_name: BuiltinSqlPoolDataProcessedBytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: builtin_sql_pool_login_attempts
+    azure_name: BuiltinSqlPoolLoginAttempts
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: builtin_sql_pool_requests_ended
+    azure_name: BuiltinSqlPoolRequestsEnded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: integration_activity_runs_ended
+    azure_name: IntegrationActivityRunsEnded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: integration_link_connection_events
+    azure_name: IntegrationLinkConnectionEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: integration_link_processed_changed_rows
+    azure_name: IntegrationLinkProcessedChangedRows
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: integration_link_processed_data_volume
+    azure_name: IntegrationLinkProcessedDataVolume
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: integration_link_processing_latency_in_seconds
+    azure_name: IntegrationLinkProcessingLatencyInSeconds
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+      - aggregation: minimum
+        kind: gauge
+  - id: integration_link_table_events
+    azure_name: IntegrationLinkTableEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: integration_pipeline_runs_ended
+    azure_name: IntegrationPipelineRunsEnded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: integration_trigger_runs_ended
+    azure_name: IntegrationTriggerRunsEnded
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: sql_streaming_input_events
+    azure_name: SQLStreamingInputEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: sql_streaming_input_event_bytes
+    azure_name: SQLStreamingInputEventBytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: sql_streaming_input_events_sources_per_second
+    azure_name: SQLStreamingInputEventsSourcesPerSecond
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: sql_streaming_output_events
+    azure_name: SQLStreamingOutputEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: sql_streaming_backlogged_input_event_sources
+    azure_name: SQLStreamingBackloggedInputEventSources
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: sql_streaming_early_input_events
+    azure_name: SQLStreamingEarlyInputEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: sql_streaming_late_input_events
+    azure_name: SQLStreamingLateInputEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: sql_streaming_out_of_order_events
+    azure_name: SQLStreamingOutOfOrderEvents
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: sql_streaming_output_watermark_delay_seconds
+    azure_name: SQLStreamingOutputWatermarkDelaySeconds
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+      - aggregation: minimum
+        kind: gauge
+  - id: sql_streaming_conversion_errors
+    azure_name: SQLStreamingConversionErrors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: sql_streaming_deserialization_error
+    azure_name: SQLStreamingDeserializationError
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: sql_streaming_runtime_errors
+    azure_name: SQLStreamingRuntimeErrors
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: sql_streaming_resource_utilization
+    azure_name: SQLStreamingResourceUtilization
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+      - aggregation: maximum
+        kind: gauge
+      - aggregation: minimum
+        kind: gauge
 template:
   family: Azure Synapse Analytics Workspace
   context_namespace: synapse
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_synapse__builtin_sql_pool_data_processed
-    title: Azure Synapse Built-in SQL Pool Data Processed
-    context: builtin_sql_pool_data_processed
-    family: Built-in SQL Pool
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.builtin_sql_pool_data_processed_bytes_total
-      name: processed
-  - id: am_azure_synapse__builtin_sql_pool_login_attempts
-    title: Azure Synapse Built-in SQL Pool Login Attempts
-    context: builtin_sql_pool_login_attempts
-    family: Built-in SQL Pool
-    type: line
-    units: attempts/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.builtin_sql_pool_login_attempts_total
-      name: login_attempts
-  - id: am_azure_synapse__builtin_sql_pool_requests
-    title: Azure Synapse Built-in SQL Pool Requests Ended
-    context: builtin_sql_pool_requests
-    family: Built-in SQL Pool
-    type: line
-    units: requests/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.builtin_sql_pool_requests_ended_total
-      name: requests
-  - id: am_azure_synapse__activity_runs
-    title: Azure Synapse Activity Runs
-    context: activity_runs
-    family: Integration
-    type: line
-    units: runs/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.integration_activity_runs_ended_total
-      name: ended
-  - id: am_azure_synapse__pipeline_runs
-    title: Azure Synapse Pipeline Runs
-    context: pipeline_runs
-    family: Integration
-    type: line
-    units: runs/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.integration_pipeline_runs_ended_total
-      name: ended
-  - id: am_azure_synapse__trigger_runs
-    title: Azure Synapse Trigger Runs
-    context: trigger_runs
-    family: Integration
-    type: line
-    units: runs/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.integration_trigger_runs_ended_total
-      name: ended
-  - id: am_azure_synapse__link_connection_events
-    title: Azure Synapse Link Connection Events
-    context: link_connection_events
-    family: Link
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.integration_link_connection_events_total
-      name: events
-  - id: am_azure_synapse__link_table_events
-    title: Azure Synapse Link Table Events
-    context: link_table_events
-    family: Link
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.integration_link_table_events_total
-      name: events
-  - id: am_azure_synapse__link_processed_rows
-    title: Azure Synapse Link Processed Changed Rows
-    context: link_processed_rows
-    family: Link
-    type: line
-    units: rows/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.integration_link_processed_changed_rows_total
-      name: changed_rows
-  - id: am_azure_synapse__link_data_volume
-    title: Azure Synapse Link Processed Data Volume
-    context: link_data_volume
-    family: Link
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.integration_link_processed_data_volume_total
-      name: processed
-  - id: am_azure_synapse__link_processing_latency
-    title: Azure Synapse Link Processing Latency
-    context: link_processing_latency
-    family: Link
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: synapse.integration_link_processing_latency_in_seconds_average
-      name: average
-  - id: am_azure_synapse__streaming_event_flow
-    title: Azure Synapse Streaming Event Flow
-    context: streaming_event_flow
-    family: Streaming Job
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.sql_streaming_input_events_total
-      name: in
-    - selector: synapse.sql_streaming_output_events_total
-      name: out
-  - id: am_azure_synapse__streaming_input_throughput
-    title: Azure Synapse Streaming Input Data Throughput
-    context: streaming_input_throughput
-    family: Streaming Job
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.sql_streaming_input_event_bytes_total
-      name: received
-  - id: am_azure_synapse__streaming_input_sources
-    title: Azure Synapse Streaming Input Sources Received
-    context: streaming_input_sources
-    family: Streaming Job
-    type: line
-    units: sources/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.sql_streaming_input_events_sources_per_second_total
-      name: received
-  - id: am_azure_synapse__streaming_event_timing
-    title: Azure Synapse Streaming Event Timing Issues
-    context: streaming_event_timing
-    family: Streaming Job
-    type: line
-    units: events/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.sql_streaming_late_input_events_total
-      name: late
-    - selector: synapse.sql_streaming_early_input_events_total
-      name: early
-    - selector: synapse.sql_streaming_out_of_order_events_total
-      name: out_of_order
-    - selector: synapse.sql_streaming_backlogged_input_event_sources_total
-      name: backlogged
-  - id: am_azure_synapse__streaming_watermark_delay
-    title: Azure Synapse Streaming Watermark Delay
-    context: streaming_watermark_delay
-    family: Streaming Job
-    type: line
-    units: seconds
-    algorithm: absolute
-    dimensions:
-    - selector: synapse.sql_streaming_output_watermark_delay_seconds_maximum
-      name: delay
-  - id: am_azure_synapse__streaming_errors
-    title: Azure Synapse Streaming Errors
-    context: streaming_errors
-    family: Streaming Job
-    type: line
-    units: errors/s
-    algorithm: incremental
-    dimensions:
-    - selector: synapse.sql_streaming_runtime_errors_total
-      name: runtime
-    - selector: synapse.sql_streaming_conversion_errors_total
-      name: data_conversion
-    - selector: synapse.sql_streaming_deserialization_error_total
-      name: deserialization
-  - id: am_azure_synapse__streaming_resource_utilization
-    title: Azure Synapse Streaming Resource Utilization
-    context: streaming_resource_utilization
-    family: Streaming Job
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: synapse.sql_streaming_resource_utilization_average
-      name: utilization
+    - id: am_azure_synapse__builtin_sql_pool_data_processed
+      title: Azure Synapse Built-in SQL Pool Data Processed
+      context: builtin_sql_pool_data_processed
+      family: Built-in SQL Pool
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.builtin_sql_pool_data_processed_bytes_total
+          name: processed
+    - id: am_azure_synapse__builtin_sql_pool_login_attempts
+      title: Azure Synapse Built-in SQL Pool Login Attempts
+      context: builtin_sql_pool_login_attempts
+      family: Built-in SQL Pool
+      type: line
+      units: attempts/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.builtin_sql_pool_login_attempts_total
+          name: login_attempts
+    - id: am_azure_synapse__builtin_sql_pool_requests
+      title: Azure Synapse Built-in SQL Pool Requests Ended
+      context: builtin_sql_pool_requests
+      family: Built-in SQL Pool
+      type: line
+      units: requests/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.builtin_sql_pool_requests_ended_total
+          name: requests
+    - id: am_azure_synapse__activity_runs
+      title: Azure Synapse Activity Runs
+      context: activity_runs
+      family: Integration
+      type: line
+      units: runs/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.integration_activity_runs_ended_total
+          name: ended
+    - id: am_azure_synapse__pipeline_runs
+      title: Azure Synapse Pipeline Runs
+      context: pipeline_runs
+      family: Integration
+      type: line
+      units: runs/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.integration_pipeline_runs_ended_total
+          name: ended
+    - id: am_azure_synapse__trigger_runs
+      title: Azure Synapse Trigger Runs
+      context: trigger_runs
+      family: Integration
+      type: line
+      units: runs/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.integration_trigger_runs_ended_total
+          name: ended
+    - id: am_azure_synapse__link_connection_events
+      title: Azure Synapse Link Connection Events
+      context: link_connection_events
+      family: Link
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.integration_link_connection_events_total
+          name: events
+    - id: am_azure_synapse__link_table_events
+      title: Azure Synapse Link Table Events
+      context: link_table_events
+      family: Link
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.integration_link_table_events_total
+          name: events
+    - id: am_azure_synapse__link_processed_rows
+      title: Azure Synapse Link Processed Changed Rows
+      context: link_processed_rows
+      family: Link
+      type: line
+      units: rows/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.integration_link_processed_changed_rows_total
+          name: changed_rows
+    - id: am_azure_synapse__link_data_volume
+      title: Azure Synapse Link Processed Data Volume
+      context: link_data_volume
+      family: Link
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.integration_link_processed_data_volume_total
+          name: processed
+    - id: am_azure_synapse__link_processing_latency
+      title: Azure Synapse Link Processing Latency
+      context: link_processing_latency
+      family: Link
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: synapse.integration_link_processing_latency_in_seconds_average
+          name: average
+    - id: am_azure_synapse__streaming_event_flow
+      title: Azure Synapse Streaming Event Flow
+      context: streaming_event_flow
+      family: Streaming Job
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.sql_streaming_input_events_total
+          name: in
+        - selector: synapse.sql_streaming_output_events_total
+          name: out
+    - id: am_azure_synapse__streaming_input_throughput
+      title: Azure Synapse Streaming Input Data Throughput
+      context: streaming_input_throughput
+      family: Streaming Job
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.sql_streaming_input_event_bytes_total
+          name: received
+    - id: am_azure_synapse__streaming_input_sources
+      title: Azure Synapse Streaming Input Sources Received
+      context: streaming_input_sources
+      family: Streaming Job
+      type: line
+      units: sources/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.sql_streaming_input_events_sources_per_second_total
+          name: received
+    - id: am_azure_synapse__streaming_event_timing
+      title: Azure Synapse Streaming Event Timing Issues
+      context: streaming_event_timing
+      family: Streaming Job
+      type: line
+      units: events/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.sql_streaming_late_input_events_total
+          name: late
+        - selector: synapse.sql_streaming_early_input_events_total
+          name: early
+        - selector: synapse.sql_streaming_out_of_order_events_total
+          name: out_of_order
+        - selector: synapse.sql_streaming_backlogged_input_event_sources_total
+          name: backlogged
+    - id: am_azure_synapse__streaming_watermark_delay
+      title: Azure Synapse Streaming Watermark Delay
+      context: streaming_watermark_delay
+      family: Streaming Job
+      type: line
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: synapse.sql_streaming_output_watermark_delay_seconds_maximum
+          name: delay
+    - id: am_azure_synapse__streaming_errors
+      title: Azure Synapse Streaming Errors
+      context: streaming_errors
+      family: Streaming Job
+      type: line
+      units: errors/s
+      algorithm: incremental
+      dimensions:
+        - selector: synapse.sql_streaming_runtime_errors_total
+          name: runtime
+        - selector: synapse.sql_streaming_conversion_errors_total
+          name: data_conversion
+        - selector: synapse.sql_streaming_deserialization_error_total
+          name: deserialization
+    - id: am_azure_synapse__streaming_resource_utilization
+      title: Azure Synapse Streaming Resource Utilization
+      context: streaming_resource_utilization
+      family: Streaming Job
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: synapse.sql_streaming_resource_utilization_average
+          name: utilization

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/virtual_machines.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/virtual_machines.yaml
@@ -3,801 +3,801 @@ id: virtual_machines
 name: Azure Virtual Machine
 resource_type: Microsoft.Compute/virtualMachines
 metrics:
-- id: percentage_cpu
-  azure_name: Percentage CPU
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_credits_consumed
-  azure_name: CPU Credits Consumed
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_credits_remaining
-  azure_name: CPU Credits Remaining
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: available_memory_bytes
-  azure_name: Available Memory Bytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: available_memory_percentage
-  azure_name: Available Memory Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_availability_metric
-  azure_name: VmAvailabilityMetric
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: network_in_total
-  azure_name: Network In Total
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: network_out_total
-  azure_name: Network Out Total
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: inbound_flows
-  azure_name: Inbound Flows
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: outbound_flows
-  azure_name: Outbound Flows
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: inbound_flows_maximum_creation_rate
-  azure_name: Inbound Flows Maximum Creation Rate
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: outbound_flows_maximum_creation_rate
-  azure_name: Outbound Flows Maximum Creation Rate
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: disk_read_bytes
-  azure_name: Disk Read Bytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: disk_write_bytes
-  azure_name: Disk Write Bytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: disk_read_operations_sec
-  azure_name: Disk Read Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: disk_write_operations_sec
-  azure_name: Disk Write Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_read_bytes_sec
-  azure_name: OS Disk Read Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_write_bytes_sec
-  azure_name: OS Disk Write Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_read_operations_sec
-  azure_name: OS Disk Read Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_write_operations_sec
-  azure_name: OS Disk Write Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_queue_depth
-  azure_name: OS Disk Queue Depth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_latency
-  azure_name: OS Disk Latency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_bandwidth_consumed_percentage
-  azure_name: OS Disk Bandwidth Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_iops_consumed_percentage
-  azure_name: OS Disk IOPS Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_max_burst_bandwidth
-  azure_name: OS Disk Max Burst Bandwidth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_max_burst_iops
-  azure_name: OS Disk Max Burst IOPS
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_target_bandwidth
-  azure_name: OS Disk Target Bandwidth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_target_iops
-  azure_name: OS Disk Target IOPS
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_used_burst_bps_credits_percentage
-  azure_name: OS Disk Used Burst BPS Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_used_burst_io_credits_percentage
-  azure_name: OS Disk Used Burst IO Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_read_bytes_sec
-  azure_name: Data Disk Read Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_write_bytes_sec
-  azure_name: Data Disk Write Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_read_operations_sec
-  azure_name: Data Disk Read Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_write_operations_sec
-  azure_name: Data Disk Write Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_queue_depth
-  azure_name: Data Disk Queue Depth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_latency
-  azure_name: Data Disk Latency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_bandwidth_consumed_percentage
-  azure_name: Data Disk Bandwidth Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_iops_consumed_percentage
-  azure_name: Data Disk IOPS Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_max_burst_bandwidth
-  azure_name: Data Disk Max Burst Bandwidth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_max_burst_iops
-  azure_name: Data Disk Max Burst IOPS
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_target_bandwidth
-  azure_name: Data Disk Target Bandwidth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_target_iops
-  azure_name: Data Disk Target IOPS
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_used_burst_bps_credits_percentage
-  azure_name: Data Disk Used Burst BPS Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_used_burst_io_credits_percentage
-  azure_name: Data Disk Used Burst IO Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: temp_disk_read_bytes_sec
-  azure_name: Temp Disk Read Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: temp_disk_write_bytes_sec
-  azure_name: Temp Disk Write Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: temp_disk_read_operations_sec
-  azure_name: Temp Disk Read Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: temp_disk_write_operations_sec
-  azure_name: Temp Disk Write Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: temp_disk_queue_depth
-  azure_name: Temp Disk Queue Depth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: temp_disk_latency
-  azure_name: Temp Disk Latency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: premium_data_disk_cache_read_hit
-  azure_name: Premium Data Disk Cache Read Hit
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: premium_data_disk_cache_read_miss
-  azure_name: Premium Data Disk Cache Read Miss
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: premium_os_disk_cache_read_hit
-  azure_name: Premium OS Disk Cache Read Hit
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: premium_os_disk_cache_read_miss
-  azure_name: Premium OS Disk Cache Read Miss
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_cached_bandwidth_consumed_percentage
-  azure_name: VM Cached Bandwidth Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_cached_iops_consumed_percentage
-  azure_name: VM Cached IOPS Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_uncached_bandwidth_consumed_percentage
-  azure_name: VM Uncached Bandwidth Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_uncached_iops_consumed_percentage
-  azure_name: VM Uncached IOPS Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_local_used_burst_bps_credits_percentage
-  azure_name: VM Local Used Burst BPS Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_local_used_burst_io_credits_percentage
-  azure_name: VM Local Used Burst IO Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_remote_used_burst_bps_credits_percentage
-  azure_name: VM Remote Used Burst BPS Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_remote_used_burst_io_credits_percentage
-  azure_name: VM Remote Used Burst IO Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: percentage_cpu
+    azure_name: Percentage CPU
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_credits_consumed
+    azure_name: CPU Credits Consumed
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_credits_remaining
+    azure_name: CPU Credits Remaining
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: available_memory_bytes
+    azure_name: Available Memory Bytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: available_memory_percentage
+    azure_name: Available Memory Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_availability_metric
+    azure_name: VmAvailabilityMetric
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: network_in_total
+    azure_name: Network In Total
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: network_out_total
+    azure_name: Network Out Total
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: inbound_flows
+    azure_name: Inbound Flows
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: outbound_flows
+    azure_name: Outbound Flows
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: inbound_flows_maximum_creation_rate
+    azure_name: Inbound Flows Maximum Creation Rate
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: outbound_flows_maximum_creation_rate
+    azure_name: Outbound Flows Maximum Creation Rate
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: disk_read_bytes
+    azure_name: Disk Read Bytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: disk_write_bytes
+    azure_name: Disk Write Bytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: disk_read_operations_sec
+    azure_name: Disk Read Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: disk_write_operations_sec
+    azure_name: Disk Write Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_read_bytes_sec
+    azure_name: OS Disk Read Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_write_bytes_sec
+    azure_name: OS Disk Write Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_read_operations_sec
+    azure_name: OS Disk Read Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_write_operations_sec
+    azure_name: OS Disk Write Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_queue_depth
+    azure_name: OS Disk Queue Depth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_latency
+    azure_name: OS Disk Latency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_bandwidth_consumed_percentage
+    azure_name: OS Disk Bandwidth Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_iops_consumed_percentage
+    azure_name: OS Disk IOPS Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_max_burst_bandwidth
+    azure_name: OS Disk Max Burst Bandwidth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_max_burst_iops
+    azure_name: OS Disk Max Burst IOPS
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_target_bandwidth
+    azure_name: OS Disk Target Bandwidth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_target_iops
+    azure_name: OS Disk Target IOPS
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_used_burst_bps_credits_percentage
+    azure_name: OS Disk Used Burst BPS Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_used_burst_io_credits_percentage
+    azure_name: OS Disk Used Burst IO Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_read_bytes_sec
+    azure_name: Data Disk Read Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_write_bytes_sec
+    azure_name: Data Disk Write Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_read_operations_sec
+    azure_name: Data Disk Read Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_write_operations_sec
+    azure_name: Data Disk Write Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_queue_depth
+    azure_name: Data Disk Queue Depth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_latency
+    azure_name: Data Disk Latency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_bandwidth_consumed_percentage
+    azure_name: Data Disk Bandwidth Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_iops_consumed_percentage
+    azure_name: Data Disk IOPS Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_max_burst_bandwidth
+    azure_name: Data Disk Max Burst Bandwidth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_max_burst_iops
+    azure_name: Data Disk Max Burst IOPS
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_target_bandwidth
+    azure_name: Data Disk Target Bandwidth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_target_iops
+    azure_name: Data Disk Target IOPS
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_used_burst_bps_credits_percentage
+    azure_name: Data Disk Used Burst BPS Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_used_burst_io_credits_percentage
+    azure_name: Data Disk Used Burst IO Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: temp_disk_read_bytes_sec
+    azure_name: Temp Disk Read Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: temp_disk_write_bytes_sec
+    azure_name: Temp Disk Write Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: temp_disk_read_operations_sec
+    azure_name: Temp Disk Read Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: temp_disk_write_operations_sec
+    azure_name: Temp Disk Write Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: temp_disk_queue_depth
+    azure_name: Temp Disk Queue Depth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: temp_disk_latency
+    azure_name: Temp Disk Latency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: premium_data_disk_cache_read_hit
+    azure_name: Premium Data Disk Cache Read Hit
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: premium_data_disk_cache_read_miss
+    azure_name: Premium Data Disk Cache Read Miss
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: premium_os_disk_cache_read_hit
+    azure_name: Premium OS Disk Cache Read Hit
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: premium_os_disk_cache_read_miss
+    azure_name: Premium OS Disk Cache Read Miss
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_cached_bandwidth_consumed_percentage
+    azure_name: VM Cached Bandwidth Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_cached_iops_consumed_percentage
+    azure_name: VM Cached IOPS Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_uncached_bandwidth_consumed_percentage
+    azure_name: VM Uncached Bandwidth Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_uncached_iops_consumed_percentage
+    azure_name: VM Uncached IOPS Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_local_used_burst_bps_credits_percentage
+    azure_name: VM Local Used Burst BPS Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_local_used_burst_io_credits_percentage
+    azure_name: VM Local Used Burst IO Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_remote_used_burst_bps_credits_percentage
+    azure_name: VM Remote Used Burst BPS Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_remote_used_burst_io_credits_percentage
+    azure_name: VM Remote Used Burst IO Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Virtual Machine
   context_namespace: virtual_machines
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_virtual_machines__cpu
-    title: Azure Virtual Machine CPU Utilization
-    context: cpu
-    family: CPU
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.percentage_cpu_average
-      name: average
-  - id: am_azure_virtual_machines__cpu_credits
-    title: Azure Virtual Machine CPU Credits
-    context: cpu_credits
-    family: CPU
-    type: line
-    units: credits
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.cpu_credits_consumed_average
-      name: consumed
-    - selector: virtual_machines.cpu_credits_remaining_average
-      name: remaining
-  - id: am_azure_virtual_machines__memory
-    title: Azure Virtual Machine Available Memory
-    context: memory
-    family: Memory
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.available_memory_bytes_average
-      name: available
-  - id: am_azure_virtual_machines__memory_percentage
-    title: Azure Virtual Machine Available Memory Percentage
-    context: memory_percentage
-    family: Memory
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.available_memory_percentage_average
-      name: available
-  - id: am_azure_virtual_machines__availability
-    title: Azure Virtual Machine Availability
-    context: availability
-    family: Availability
-    type: line
-    units: state
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.vm_availability_metric_average
-      name: average
-  - id: am_azure_virtual_machines__network_traffic
-    title: Azure Virtual Machine Network Traffic
-    context: network_traffic
-    family: Network
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: virtual_machines.network_in_total_total
-      name: in
-    - selector: virtual_machines.network_out_total_total
-      name: out
-  - id: am_azure_virtual_machines__network_flows
-    title: Azure Virtual Machine Network Flows
-    context: network_flows
-    family: Network
-    type: line
-    units: flows
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.inbound_flows_average
-      name: in
-    - selector: virtual_machines.outbound_flows_average
-      name: out
-  - id: am_azure_virtual_machines__network_flow_creation_rate
-    title: Azure Virtual Machine Network Flow Creation Rate
-    context: network_flow_creation_rate
-    family: Network
-    type: line
-    units: flows/s
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.inbound_flows_maximum_creation_rate_average
-      name: in
-    - selector: virtual_machines.outbound_flows_maximum_creation_rate_average
-      name: out
-  - id: am_azure_virtual_machines__disk_throughput
-    title: Azure Virtual Machine Disk Throughput
-    context: disk_throughput
-    family: Disk
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: virtual_machines.disk_read_bytes_total
-      name: read
-    - selector: virtual_machines.disk_write_bytes_total
-      name: write
-  - id: am_azure_virtual_machines__disk_iops
-    title: Azure Virtual Machine Disk IOPS
-    context: disk_iops
-    family: Disk
-    type: line
-    units: operations/s
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.disk_read_operations_sec_average
-      name: read
-    - selector: virtual_machines.disk_write_operations_sec_average
-      name: write
-  - id: am_azure_virtual_machines__os_disk_throughput
-    title: Azure Virtual Machine OS Disk Throughput
-    context: os_disk_throughput
-    family: OS Disk
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.os_disk_read_bytes_sec_average
-      name: read
-    - selector: virtual_machines.os_disk_write_bytes_sec_average
-      name: write
-  - id: am_azure_virtual_machines__os_disk_iops
-    title: Azure Virtual Machine OS Disk IOPS
-    context: os_disk_iops
-    family: OS Disk
-    type: line
-    units: operations/s
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.os_disk_read_operations_sec_average
-      name: read
-    - selector: virtual_machines.os_disk_write_operations_sec_average
-      name: write
-  - id: am_azure_virtual_machines__os_disk_latency
-    title: Azure Virtual Machine OS Disk Latency
-    context: os_disk_latency
-    family: OS Disk
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.os_disk_latency_average
-      name: average
-  - id: am_azure_virtual_machines__os_disk_queue_depth
-    title: Azure Virtual Machine OS Disk Queue Depth
-    context: os_disk_queue_depth
-    family: OS Disk
-    type: line
-    units: operations
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.os_disk_queue_depth_average
-      name: average
-  - id: am_azure_virtual_machines__os_disk_throttling
-    title: Azure Virtual Machine OS Disk Throttling
-    context: os_disk_throttling
-    family: OS Disk
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.os_disk_bandwidth_consumed_percentage_average
-      name: bandwidth
-    - selector: virtual_machines.os_disk_iops_consumed_percentage_average
-      name: iops
-  - id: am_azure_virtual_machines__os_disk_burst_capacity
-    title: Azure Virtual Machine OS Disk Burst Capacity
-    context: os_disk_burst_capacity
-    family: OS Disk
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.os_disk_max_burst_bandwidth_average
-      name: max_burst
-    - selector: virtual_machines.os_disk_target_bandwidth_average
-      name: target
-  - id: am_azure_virtual_machines__os_disk_burst_iops_capacity
-    title: Azure Virtual Machine OS Disk Burst IOPS Capacity
-    context: os_disk_burst_iops_capacity
-    family: OS Disk
-    type: line
-    units: iops
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.os_disk_max_burst_iops_average
-      name: max_burst
-    - selector: virtual_machines.os_disk_target_iops_average
-      name: target
-  - id: am_azure_virtual_machines__os_disk_burst_credits
-    title: Azure Virtual Machine OS Disk Burst Credits Used
-    context: os_disk_burst_credits
-    family: OS Disk
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.os_disk_used_burst_bps_credits_percentage_average
-      name: bandwidth
-    - selector: virtual_machines.os_disk_used_burst_io_credits_percentage_average
-      name: io
-  - id: am_azure_virtual_machines__data_disk_throughput
-    title: Azure Virtual Machine Data Disk Throughput
-    context: data_disk_throughput
-    family: Data Disk
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.data_disk_read_bytes_sec_average
-      name: read
-    - selector: virtual_machines.data_disk_write_bytes_sec_average
-      name: write
-  - id: am_azure_virtual_machines__data_disk_iops
-    title: Azure Virtual Machine Data Disk IOPS
-    context: data_disk_iops
-    family: Data Disk
-    type: line
-    units: operations/s
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.data_disk_read_operations_sec_average
-      name: read
-    - selector: virtual_machines.data_disk_write_operations_sec_average
-      name: write
-  - id: am_azure_virtual_machines__data_disk_latency
-    title: Azure Virtual Machine Data Disk Latency
-    context: data_disk_latency
-    family: Data Disk
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.data_disk_latency_average
-      name: average
-  - id: am_azure_virtual_machines__data_disk_queue_depth
-    title: Azure Virtual Machine Data Disk Queue Depth
-    context: data_disk_queue_depth
-    family: Data Disk
-    type: line
-    units: operations
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.data_disk_queue_depth_average
-      name: average
-  - id: am_azure_virtual_machines__data_disk_throttling
-    title: Azure Virtual Machine Data Disk Throttling
-    context: data_disk_throttling
-    family: Data Disk
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.data_disk_bandwidth_consumed_percentage_average
-      name: bandwidth
-    - selector: virtual_machines.data_disk_iops_consumed_percentage_average
-      name: iops
-  - id: am_azure_virtual_machines__data_disk_burst_capacity
-    title: Azure Virtual Machine Data Disk Burst Capacity
-    context: data_disk_burst_capacity
-    family: Data Disk
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.data_disk_max_burst_bandwidth_average
-      name: max_burst
-    - selector: virtual_machines.data_disk_target_bandwidth_average
-      name: target
-  - id: am_azure_virtual_machines__data_disk_burst_iops_capacity
-    title: Azure Virtual Machine Data Disk Burst IOPS Capacity
-    context: data_disk_burst_iops_capacity
-    family: Data Disk
-    type: line
-    units: iops
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.data_disk_max_burst_iops_average
-      name: max_burst
-    - selector: virtual_machines.data_disk_target_iops_average
-      name: target
-  - id: am_azure_virtual_machines__data_disk_burst_credits
-    title: Azure Virtual Machine Data Disk Burst Credits Used
-    context: data_disk_burst_credits
-    family: Data Disk
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.data_disk_used_burst_bps_credits_percentage_average
-      name: bandwidth
-    - selector: virtual_machines.data_disk_used_burst_io_credits_percentage_average
-      name: io
-  - id: am_azure_virtual_machines__temp_disk_throughput
-    title: Azure Virtual Machine Temp Disk Throughput
-    context: temp_disk_throughput
-    family: Temp Disk
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.temp_disk_read_bytes_sec_average
-      name: read
-    - selector: virtual_machines.temp_disk_write_bytes_sec_average
-      name: write
-  - id: am_azure_virtual_machines__temp_disk_iops
-    title: Azure Virtual Machine Temp Disk IOPS
-    context: temp_disk_iops
-    family: Temp Disk
-    type: line
-    units: operations/s
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.temp_disk_read_operations_sec_average
-      name: read
-    - selector: virtual_machines.temp_disk_write_operations_sec_average
-      name: write
-  - id: am_azure_virtual_machines__temp_disk_latency
-    title: Azure Virtual Machine Temp Disk Latency
-    context: temp_disk_latency
-    family: Temp Disk
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.temp_disk_latency_average
-      name: average
-  - id: am_azure_virtual_machines__temp_disk_queue_depth
-    title: Azure Virtual Machine Temp Disk Queue Depth
-    context: temp_disk_queue_depth
-    family: Temp Disk
-    type: line
-    units: operations
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.temp_disk_queue_depth_average
-      name: average
-  - id: am_azure_virtual_machines__premium_data_disk_cache
-    title: Azure Virtual Machine Premium Data Disk Cache
-    context: premium_data_disk_cache
-    family: Premium Cache
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.premium_data_disk_cache_read_hit_average
-      name: hit
-    - selector: virtual_machines.premium_data_disk_cache_read_miss_average
-      name: miss
-  - id: am_azure_virtual_machines__premium_os_disk_cache
-    title: Azure Virtual Machine Premium OS Disk Cache
-    context: premium_os_disk_cache
-    family: Premium Cache
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.premium_os_disk_cache_read_hit_average
-      name: hit
-    - selector: virtual_machines.premium_os_disk_cache_read_miss_average
-      name: miss
-  - id: am_azure_virtual_machines__vm_cached_throttling
-    title: Azure Virtual Machine Cached IO Throttling
-    context: vm_cached_throttling
-    family: VM Throttling
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.vm_cached_bandwidth_consumed_percentage_average
-      name: bandwidth
-    - selector: virtual_machines.vm_cached_iops_consumed_percentage_average
-      name: iops
-  - id: am_azure_virtual_machines__vm_uncached_throttling
-    title: Azure Virtual Machine Uncached IO Throttling
-    context: vm_uncached_throttling
-    family: VM Throttling
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.vm_uncached_bandwidth_consumed_percentage_average
-      name: bandwidth
-    - selector: virtual_machines.vm_uncached_iops_consumed_percentage_average
-      name: iops
-  - id: am_azure_virtual_machines__vm_cached_burst_credits
-    title: Azure Virtual Machine Cached Burst Credits Used
-    context: vm_cached_burst_credits
-    family: VM Throttling
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.vm_local_used_burst_bps_credits_percentage_average
-      name: bandwidth
-    - selector: virtual_machines.vm_local_used_burst_io_credits_percentage_average
-      name: io
-  - id: am_azure_virtual_machines__vm_uncached_burst_credits
-    title: Azure Virtual Machine Uncached Burst Credits Used
-    context: vm_uncached_burst_credits
-    family: VM Throttling
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: virtual_machines.vm_remote_used_burst_bps_credits_percentage_average
-      name: bandwidth
-    - selector: virtual_machines.vm_remote_used_burst_io_credits_percentage_average
-      name: io
+    - id: am_azure_virtual_machines__cpu
+      title: Azure Virtual Machine CPU Utilization
+      context: cpu
+      family: CPU
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.percentage_cpu_average
+          name: average
+    - id: am_azure_virtual_machines__cpu_credits
+      title: Azure Virtual Machine CPU Credits
+      context: cpu_credits
+      family: CPU
+      type: line
+      units: credits
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.cpu_credits_consumed_average
+          name: consumed
+        - selector: virtual_machines.cpu_credits_remaining_average
+          name: remaining
+    - id: am_azure_virtual_machines__memory
+      title: Azure Virtual Machine Available Memory
+      context: memory
+      family: Memory
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.available_memory_bytes_average
+          name: available
+    - id: am_azure_virtual_machines__memory_percentage
+      title: Azure Virtual Machine Available Memory Percentage
+      context: memory_percentage
+      family: Memory
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.available_memory_percentage_average
+          name: available
+    - id: am_azure_virtual_machines__availability
+      title: Azure Virtual Machine Availability
+      context: availability
+      family: Availability
+      type: line
+      units: state
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.vm_availability_metric_average
+          name: average
+    - id: am_azure_virtual_machines__network_traffic
+      title: Azure Virtual Machine Network Traffic
+      context: network_traffic
+      family: Network
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: virtual_machines.network_in_total_total
+          name: in
+        - selector: virtual_machines.network_out_total_total
+          name: out
+    - id: am_azure_virtual_machines__network_flows
+      title: Azure Virtual Machine Network Flows
+      context: network_flows
+      family: Network
+      type: line
+      units: flows
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.inbound_flows_average
+          name: in
+        - selector: virtual_machines.outbound_flows_average
+          name: out
+    - id: am_azure_virtual_machines__network_flow_creation_rate
+      title: Azure Virtual Machine Network Flow Creation Rate
+      context: network_flow_creation_rate
+      family: Network
+      type: line
+      units: flows/s
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.inbound_flows_maximum_creation_rate_average
+          name: in
+        - selector: virtual_machines.outbound_flows_maximum_creation_rate_average
+          name: out
+    - id: am_azure_virtual_machines__disk_throughput
+      title: Azure Virtual Machine Disk Throughput
+      context: disk_throughput
+      family: Disk
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: virtual_machines.disk_read_bytes_total
+          name: read
+        - selector: virtual_machines.disk_write_bytes_total
+          name: write
+    - id: am_azure_virtual_machines__disk_iops
+      title: Azure Virtual Machine Disk IOPS
+      context: disk_iops
+      family: Disk
+      type: line
+      units: operations/s
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.disk_read_operations_sec_average
+          name: read
+        - selector: virtual_machines.disk_write_operations_sec_average
+          name: write
+    - id: am_azure_virtual_machines__os_disk_throughput
+      title: Azure Virtual Machine OS Disk Throughput
+      context: os_disk_throughput
+      family: OS Disk
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.os_disk_read_bytes_sec_average
+          name: read
+        - selector: virtual_machines.os_disk_write_bytes_sec_average
+          name: write
+    - id: am_azure_virtual_machines__os_disk_iops
+      title: Azure Virtual Machine OS Disk IOPS
+      context: os_disk_iops
+      family: OS Disk
+      type: line
+      units: operations/s
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.os_disk_read_operations_sec_average
+          name: read
+        - selector: virtual_machines.os_disk_write_operations_sec_average
+          name: write
+    - id: am_azure_virtual_machines__os_disk_latency
+      title: Azure Virtual Machine OS Disk Latency
+      context: os_disk_latency
+      family: OS Disk
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.os_disk_latency_average
+          name: average
+    - id: am_azure_virtual_machines__os_disk_queue_depth
+      title: Azure Virtual Machine OS Disk Queue Depth
+      context: os_disk_queue_depth
+      family: OS Disk
+      type: line
+      units: operations
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.os_disk_queue_depth_average
+          name: average
+    - id: am_azure_virtual_machines__os_disk_throttling
+      title: Azure Virtual Machine OS Disk Throttling
+      context: os_disk_throttling
+      family: OS Disk
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.os_disk_bandwidth_consumed_percentage_average
+          name: bandwidth
+        - selector: virtual_machines.os_disk_iops_consumed_percentage_average
+          name: iops
+    - id: am_azure_virtual_machines__os_disk_burst_capacity
+      title: Azure Virtual Machine OS Disk Burst Capacity
+      context: os_disk_burst_capacity
+      family: OS Disk
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.os_disk_max_burst_bandwidth_average
+          name: max_burst
+        - selector: virtual_machines.os_disk_target_bandwidth_average
+          name: target
+    - id: am_azure_virtual_machines__os_disk_burst_iops_capacity
+      title: Azure Virtual Machine OS Disk Burst IOPS Capacity
+      context: os_disk_burst_iops_capacity
+      family: OS Disk
+      type: line
+      units: iops
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.os_disk_max_burst_iops_average
+          name: max_burst
+        - selector: virtual_machines.os_disk_target_iops_average
+          name: target
+    - id: am_azure_virtual_machines__os_disk_burst_credits
+      title: Azure Virtual Machine OS Disk Burst Credits Used
+      context: os_disk_burst_credits
+      family: OS Disk
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.os_disk_used_burst_bps_credits_percentage_average
+          name: bandwidth
+        - selector: virtual_machines.os_disk_used_burst_io_credits_percentage_average
+          name: io
+    - id: am_azure_virtual_machines__data_disk_throughput
+      title: Azure Virtual Machine Data Disk Throughput
+      context: data_disk_throughput
+      family: Data Disk
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.data_disk_read_bytes_sec_average
+          name: read
+        - selector: virtual_machines.data_disk_write_bytes_sec_average
+          name: write
+    - id: am_azure_virtual_machines__data_disk_iops
+      title: Azure Virtual Machine Data Disk IOPS
+      context: data_disk_iops
+      family: Data Disk
+      type: line
+      units: operations/s
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.data_disk_read_operations_sec_average
+          name: read
+        - selector: virtual_machines.data_disk_write_operations_sec_average
+          name: write
+    - id: am_azure_virtual_machines__data_disk_latency
+      title: Azure Virtual Machine Data Disk Latency
+      context: data_disk_latency
+      family: Data Disk
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.data_disk_latency_average
+          name: average
+    - id: am_azure_virtual_machines__data_disk_queue_depth
+      title: Azure Virtual Machine Data Disk Queue Depth
+      context: data_disk_queue_depth
+      family: Data Disk
+      type: line
+      units: operations
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.data_disk_queue_depth_average
+          name: average
+    - id: am_azure_virtual_machines__data_disk_throttling
+      title: Azure Virtual Machine Data Disk Throttling
+      context: data_disk_throttling
+      family: Data Disk
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.data_disk_bandwidth_consumed_percentage_average
+          name: bandwidth
+        - selector: virtual_machines.data_disk_iops_consumed_percentage_average
+          name: iops
+    - id: am_azure_virtual_machines__data_disk_burst_capacity
+      title: Azure Virtual Machine Data Disk Burst Capacity
+      context: data_disk_burst_capacity
+      family: Data Disk
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.data_disk_max_burst_bandwidth_average
+          name: max_burst
+        - selector: virtual_machines.data_disk_target_bandwidth_average
+          name: target
+    - id: am_azure_virtual_machines__data_disk_burst_iops_capacity
+      title: Azure Virtual Machine Data Disk Burst IOPS Capacity
+      context: data_disk_burst_iops_capacity
+      family: Data Disk
+      type: line
+      units: iops
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.data_disk_max_burst_iops_average
+          name: max_burst
+        - selector: virtual_machines.data_disk_target_iops_average
+          name: target
+    - id: am_azure_virtual_machines__data_disk_burst_credits
+      title: Azure Virtual Machine Data Disk Burst Credits Used
+      context: data_disk_burst_credits
+      family: Data Disk
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.data_disk_used_burst_bps_credits_percentage_average
+          name: bandwidth
+        - selector: virtual_machines.data_disk_used_burst_io_credits_percentage_average
+          name: io
+    - id: am_azure_virtual_machines__temp_disk_throughput
+      title: Azure Virtual Machine Temp Disk Throughput
+      context: temp_disk_throughput
+      family: Temp Disk
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.temp_disk_read_bytes_sec_average
+          name: read
+        - selector: virtual_machines.temp_disk_write_bytes_sec_average
+          name: write
+    - id: am_azure_virtual_machines__temp_disk_iops
+      title: Azure Virtual Machine Temp Disk IOPS
+      context: temp_disk_iops
+      family: Temp Disk
+      type: line
+      units: operations/s
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.temp_disk_read_operations_sec_average
+          name: read
+        - selector: virtual_machines.temp_disk_write_operations_sec_average
+          name: write
+    - id: am_azure_virtual_machines__temp_disk_latency
+      title: Azure Virtual Machine Temp Disk Latency
+      context: temp_disk_latency
+      family: Temp Disk
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.temp_disk_latency_average
+          name: average
+    - id: am_azure_virtual_machines__temp_disk_queue_depth
+      title: Azure Virtual Machine Temp Disk Queue Depth
+      context: temp_disk_queue_depth
+      family: Temp Disk
+      type: line
+      units: operations
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.temp_disk_queue_depth_average
+          name: average
+    - id: am_azure_virtual_machines__premium_data_disk_cache
+      title: Azure Virtual Machine Premium Data Disk Cache
+      context: premium_data_disk_cache
+      family: Premium Cache
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.premium_data_disk_cache_read_hit_average
+          name: hit
+        - selector: virtual_machines.premium_data_disk_cache_read_miss_average
+          name: miss
+    - id: am_azure_virtual_machines__premium_os_disk_cache
+      title: Azure Virtual Machine Premium OS Disk Cache
+      context: premium_os_disk_cache
+      family: Premium Cache
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.premium_os_disk_cache_read_hit_average
+          name: hit
+        - selector: virtual_machines.premium_os_disk_cache_read_miss_average
+          name: miss
+    - id: am_azure_virtual_machines__vm_cached_throttling
+      title: Azure Virtual Machine Cached IO Throttling
+      context: vm_cached_throttling
+      family: VM Throttling
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.vm_cached_bandwidth_consumed_percentage_average
+          name: bandwidth
+        - selector: virtual_machines.vm_cached_iops_consumed_percentage_average
+          name: iops
+    - id: am_azure_virtual_machines__vm_uncached_throttling
+      title: Azure Virtual Machine Uncached IO Throttling
+      context: vm_uncached_throttling
+      family: VM Throttling
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.vm_uncached_bandwidth_consumed_percentage_average
+          name: bandwidth
+        - selector: virtual_machines.vm_uncached_iops_consumed_percentage_average
+          name: iops
+    - id: am_azure_virtual_machines__vm_cached_burst_credits
+      title: Azure Virtual Machine Cached Burst Credits Used
+      context: vm_cached_burst_credits
+      family: VM Throttling
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.vm_local_used_burst_bps_credits_percentage_average
+          name: bandwidth
+        - selector: virtual_machines.vm_local_used_burst_io_credits_percentage_average
+          name: io
+    - id: am_azure_virtual_machines__vm_uncached_burst_credits
+      title: Azure Virtual Machine Uncached Burst Credits Used
+      context: vm_uncached_burst_credits
+      family: VM Throttling
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: virtual_machines.vm_remote_used_burst_bps_credits_percentage_average
+          name: bandwidth
+        - selector: virtual_machines.vm_remote_used_burst_io_credits_percentage_average
+          name: io

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/vmss.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/vmss.yaml
@@ -3,801 +3,801 @@ id: vmss
 name: Azure Virtual Machine Scale Set
 resource_type: Microsoft.Compute/virtualMachineScaleSets
 metrics:
-- id: percentage_cpu
-  azure_name: Percentage CPU
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_credits_consumed
-  azure_name: CPU Credits Consumed
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: cpu_credits_remaining
-  azure_name: CPU Credits Remaining
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: available_memory_bytes
-  azure_name: Available Memory Bytes
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: available_memory_percentage
-  azure_name: Available Memory Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_availability_metric
-  azure_name: VmAvailabilityMetric
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: network_in_total
-  azure_name: Network In Total
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: network_out_total
-  azure_name: Network Out Total
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: inbound_flows
-  azure_name: Inbound Flows
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: outbound_flows
-  azure_name: Outbound Flows
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: inbound_flows_maximum_creation_rate
-  azure_name: Inbound Flows Maximum Creation Rate
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: outbound_flows_maximum_creation_rate
-  azure_name: Outbound Flows Maximum Creation Rate
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: disk_read_bytes
-  azure_name: Disk Read Bytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: disk_write_bytes
-  azure_name: Disk Write Bytes
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: counter
-- id: disk_read_operations_sec
-  azure_name: Disk Read Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: disk_write_operations_sec
-  azure_name: Disk Write Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_read_bytes_sec
-  azure_name: OS Disk Read Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_write_bytes_sec
-  azure_name: OS Disk Write Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_read_operations_sec
-  azure_name: OS Disk Read Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_write_operations_sec
-  azure_name: OS Disk Write Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_queue_depth
-  azure_name: OS Disk Queue Depth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_latency
-  azure_name: OS Disk Latency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_bandwidth_consumed_percentage
-  azure_name: OS Disk Bandwidth Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_iops_consumed_percentage
-  azure_name: OS Disk IOPS Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_max_burst_bandwidth
-  azure_name: OS Disk Max Burst Bandwidth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_max_burst_iops
-  azure_name: OS Disk Max Burst IOPS
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_target_bandwidth
-  azure_name: OS Disk Target Bandwidth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_target_iops
-  azure_name: OS Disk Target IOPS
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_used_burst_bps_credits_percentage
-  azure_name: OS Disk Used Burst BPS Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: os_disk_used_burst_io_credits_percentage
-  azure_name: OS Disk Used Burst IO Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_read_bytes_sec
-  azure_name: Data Disk Read Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_write_bytes_sec
-  azure_name: Data Disk Write Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_read_operations_sec
-  azure_name: Data Disk Read Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_write_operations_sec
-  azure_name: Data Disk Write Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_queue_depth
-  azure_name: Data Disk Queue Depth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_latency
-  azure_name: Data Disk Latency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_bandwidth_consumed_percentage
-  azure_name: Data Disk Bandwidth Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_iops_consumed_percentage
-  azure_name: Data Disk IOPS Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_max_burst_bandwidth
-  azure_name: Data Disk Max Burst Bandwidth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_max_burst_iops
-  azure_name: Data Disk Max Burst IOPS
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_target_bandwidth
-  azure_name: Data Disk Target Bandwidth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_target_iops
-  azure_name: Data Disk Target IOPS
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_used_burst_bps_credits_percentage
-  azure_name: Data Disk Used Burst BPS Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: data_disk_used_burst_io_credits_percentage
-  azure_name: Data Disk Used Burst IO Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: temp_disk_read_bytes_sec
-  azure_name: Temp Disk Read Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: temp_disk_write_bytes_sec
-  azure_name: Temp Disk Write Bytes/sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: temp_disk_read_operations_sec
-  azure_name: Temp Disk Read Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: temp_disk_write_operations_sec
-  azure_name: Temp Disk Write Operations/Sec
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: temp_disk_queue_depth
-  azure_name: Temp Disk Queue Depth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: temp_disk_latency
-  azure_name: Temp Disk Latency
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: premium_data_disk_cache_read_hit
-  azure_name: Premium Data Disk Cache Read Hit
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: premium_data_disk_cache_read_miss
-  azure_name: Premium Data Disk Cache Read Miss
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: premium_os_disk_cache_read_hit
-  azure_name: Premium OS Disk Cache Read Hit
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: premium_os_disk_cache_read_miss
-  azure_name: Premium OS Disk Cache Read Miss
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_cached_bandwidth_consumed_percentage
-  azure_name: VM Cached Bandwidth Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_cached_iops_consumed_percentage
-  azure_name: VM Cached IOPS Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_uncached_bandwidth_consumed_percentage
-  azure_name: VM Uncached Bandwidth Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_uncached_iops_consumed_percentage
-  azure_name: VM Uncached IOPS Consumed Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_local_used_burst_bps_credits_percentage
-  azure_name: VM Local Used Burst BPS Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_local_used_burst_io_credits_percentage
-  azure_name: VM Local Used Burst IO Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_remote_used_burst_bps_credits_percentage
-  azure_name: VM Remote Used Burst BPS Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: vm_remote_used_burst_io_credits_percentage
-  azure_name: VM Remote Used Burst IO Credits Percentage
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
+  - id: percentage_cpu
+    azure_name: Percentage CPU
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_credits_consumed
+    azure_name: CPU Credits Consumed
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: cpu_credits_remaining
+    azure_name: CPU Credits Remaining
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: available_memory_bytes
+    azure_name: Available Memory Bytes
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: available_memory_percentage
+    azure_name: Available Memory Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_availability_metric
+    azure_name: VmAvailabilityMetric
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: network_in_total
+    azure_name: Network In Total
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: network_out_total
+    azure_name: Network Out Total
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: inbound_flows
+    azure_name: Inbound Flows
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: outbound_flows
+    azure_name: Outbound Flows
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: inbound_flows_maximum_creation_rate
+    azure_name: Inbound Flows Maximum Creation Rate
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: outbound_flows_maximum_creation_rate
+    azure_name: Outbound Flows Maximum Creation Rate
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: disk_read_bytes
+    azure_name: Disk Read Bytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: disk_write_bytes
+    azure_name: Disk Write Bytes
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: disk_read_operations_sec
+    azure_name: Disk Read Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: disk_write_operations_sec
+    azure_name: Disk Write Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_read_bytes_sec
+    azure_name: OS Disk Read Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_write_bytes_sec
+    azure_name: OS Disk Write Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_read_operations_sec
+    azure_name: OS Disk Read Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_write_operations_sec
+    azure_name: OS Disk Write Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_queue_depth
+    azure_name: OS Disk Queue Depth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_latency
+    azure_name: OS Disk Latency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_bandwidth_consumed_percentage
+    azure_name: OS Disk Bandwidth Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_iops_consumed_percentage
+    azure_name: OS Disk IOPS Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_max_burst_bandwidth
+    azure_name: OS Disk Max Burst Bandwidth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_max_burst_iops
+    azure_name: OS Disk Max Burst IOPS
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_target_bandwidth
+    azure_name: OS Disk Target Bandwidth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_target_iops
+    azure_name: OS Disk Target IOPS
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_used_burst_bps_credits_percentage
+    azure_name: OS Disk Used Burst BPS Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: os_disk_used_burst_io_credits_percentage
+    azure_name: OS Disk Used Burst IO Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_read_bytes_sec
+    azure_name: Data Disk Read Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_write_bytes_sec
+    azure_name: Data Disk Write Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_read_operations_sec
+    azure_name: Data Disk Read Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_write_operations_sec
+    azure_name: Data Disk Write Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_queue_depth
+    azure_name: Data Disk Queue Depth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_latency
+    azure_name: Data Disk Latency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_bandwidth_consumed_percentage
+    azure_name: Data Disk Bandwidth Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_iops_consumed_percentage
+    azure_name: Data Disk IOPS Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_max_burst_bandwidth
+    azure_name: Data Disk Max Burst Bandwidth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_max_burst_iops
+    azure_name: Data Disk Max Burst IOPS
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_target_bandwidth
+    azure_name: Data Disk Target Bandwidth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_target_iops
+    azure_name: Data Disk Target IOPS
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_used_burst_bps_credits_percentage
+    azure_name: Data Disk Used Burst BPS Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: data_disk_used_burst_io_credits_percentage
+    azure_name: Data Disk Used Burst IO Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: temp_disk_read_bytes_sec
+    azure_name: Temp Disk Read Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: temp_disk_write_bytes_sec
+    azure_name: Temp Disk Write Bytes/sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: temp_disk_read_operations_sec
+    azure_name: Temp Disk Read Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: temp_disk_write_operations_sec
+    azure_name: Temp Disk Write Operations/Sec
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: temp_disk_queue_depth
+    azure_name: Temp Disk Queue Depth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: temp_disk_latency
+    azure_name: Temp Disk Latency
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: premium_data_disk_cache_read_hit
+    azure_name: Premium Data Disk Cache Read Hit
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: premium_data_disk_cache_read_miss
+    azure_name: Premium Data Disk Cache Read Miss
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: premium_os_disk_cache_read_hit
+    azure_name: Premium OS Disk Cache Read Hit
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: premium_os_disk_cache_read_miss
+    azure_name: Premium OS Disk Cache Read Miss
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_cached_bandwidth_consumed_percentage
+    azure_name: VM Cached Bandwidth Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_cached_iops_consumed_percentage
+    azure_name: VM Cached IOPS Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_uncached_bandwidth_consumed_percentage
+    azure_name: VM Uncached Bandwidth Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_uncached_iops_consumed_percentage
+    azure_name: VM Uncached IOPS Consumed Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_local_used_burst_bps_credits_percentage
+    azure_name: VM Local Used Burst BPS Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_local_used_burst_io_credits_percentage
+    azure_name: VM Local Used Burst IO Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_remote_used_burst_bps_credits_percentage
+    azure_name: VM Remote Used Burst BPS Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: vm_remote_used_burst_io_credits_percentage
+    azure_name: VM Remote Used Burst IO Credits Percentage
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
 template:
   family: Azure Virtual Machine Scale Set
   context_namespace: vmss
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_vmss__cpu
-    title: Azure VMSS CPU Utilization
-    context: cpu
-    family: CPU
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.percentage_cpu_average
-      name: average
-  - id: am_azure_vmss__cpu_credits
-    title: Azure VMSS CPU Credits
-    context: cpu_credits
-    family: CPU
-    type: line
-    units: credits
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.cpu_credits_consumed_average
-      name: consumed
-    - selector: vmss.cpu_credits_remaining_average
-      name: remaining
-  - id: am_azure_vmss__memory
-    title: Azure VMSS Available Memory
-    context: memory
-    family: Memory
-    type: line
-    units: bytes
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.available_memory_bytes_average
-      name: available
-  - id: am_azure_vmss__memory_percentage
-    title: Azure VMSS Available Memory Percentage
-    context: memory_percentage
-    family: Memory
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.available_memory_percentage_average
-      name: available
-  - id: am_azure_vmss__availability
-    title: Azure VMSS Availability
-    context: availability
-    family: Availability
-    type: line
-    units: state
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.vm_availability_metric_average
-      name: average
-  - id: am_azure_vmss__network_traffic
-    title: Azure VMSS Network Traffic
-    context: network_traffic
-    family: Network
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: vmss.network_in_total_total
-      name: in
-    - selector: vmss.network_out_total_total
-      name: out
-  - id: am_azure_vmss__network_flows
-    title: Azure VMSS Network Flows
-    context: network_flows
-    family: Network
-    type: line
-    units: flows
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.inbound_flows_average
-      name: in
-    - selector: vmss.outbound_flows_average
-      name: out
-  - id: am_azure_vmss__network_flow_creation_rate
-    title: Azure VMSS Network Flow Creation Rate
-    context: network_flow_creation_rate
-    family: Network
-    type: line
-    units: flows/s
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.inbound_flows_maximum_creation_rate_average
-      name: in
-    - selector: vmss.outbound_flows_maximum_creation_rate_average
-      name: out
-  - id: am_azure_vmss__disk_throughput
-    title: Azure VMSS Disk Throughput
-    context: disk_throughput
-    family: Disk
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: vmss.disk_read_bytes_total
-      name: read
-    - selector: vmss.disk_write_bytes_total
-      name: write
-  - id: am_azure_vmss__disk_iops
-    title: Azure VMSS Disk IOPS
-    context: disk_iops
-    family: Disk
-    type: line
-    units: operations/s
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.disk_read_operations_sec_average
-      name: read
-    - selector: vmss.disk_write_operations_sec_average
-      name: write
-  - id: am_azure_vmss__os_disk_throughput
-    title: Azure VMSS OS Disk Throughput
-    context: os_disk_throughput
-    family: OS Disk
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.os_disk_read_bytes_sec_average
-      name: read
-    - selector: vmss.os_disk_write_bytes_sec_average
-      name: write
-  - id: am_azure_vmss__os_disk_iops
-    title: Azure VMSS OS Disk IOPS
-    context: os_disk_iops
-    family: OS Disk
-    type: line
-    units: operations/s
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.os_disk_read_operations_sec_average
-      name: read
-    - selector: vmss.os_disk_write_operations_sec_average
-      name: write
-  - id: am_azure_vmss__os_disk_latency
-    title: Azure VMSS OS Disk Latency
-    context: os_disk_latency
-    family: OS Disk
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.os_disk_latency_average
-      name: average
-  - id: am_azure_vmss__os_disk_queue_depth
-    title: Azure VMSS OS Disk Queue Depth
-    context: os_disk_queue_depth
-    family: OS Disk
-    type: line
-    units: operations
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.os_disk_queue_depth_average
-      name: average
-  - id: am_azure_vmss__os_disk_throttling
-    title: Azure VMSS OS Disk Throttling
-    context: os_disk_throttling
-    family: OS Disk
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.os_disk_bandwidth_consumed_percentage_average
-      name: bandwidth
-    - selector: vmss.os_disk_iops_consumed_percentage_average
-      name: iops
-  - id: am_azure_vmss__os_disk_burst_capacity
-    title: Azure VMSS OS Disk Burst Capacity
-    context: os_disk_burst_capacity
-    family: OS Disk
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.os_disk_max_burst_bandwidth_average
-      name: max_burst
-    - selector: vmss.os_disk_target_bandwidth_average
-      name: target
-  - id: am_azure_vmss__os_disk_burst_iops_capacity
-    title: Azure VMSS OS Disk Burst IOPS Capacity
-    context: os_disk_burst_iops_capacity
-    family: OS Disk
-    type: line
-    units: iops
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.os_disk_max_burst_iops_average
-      name: max_burst
-    - selector: vmss.os_disk_target_iops_average
-      name: target
-  - id: am_azure_vmss__os_disk_burst_credits
-    title: Azure VMSS OS Disk Burst Credits Used
-    context: os_disk_burst_credits
-    family: OS Disk
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.os_disk_used_burst_bps_credits_percentage_average
-      name: bandwidth
-    - selector: vmss.os_disk_used_burst_io_credits_percentage_average
-      name: io
-  - id: am_azure_vmss__data_disk_throughput
-    title: Azure VMSS Data Disk Throughput
-    context: data_disk_throughput
-    family: Data Disk
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.data_disk_read_bytes_sec_average
-      name: read
-    - selector: vmss.data_disk_write_bytes_sec_average
-      name: write
-  - id: am_azure_vmss__data_disk_iops
-    title: Azure VMSS Data Disk IOPS
-    context: data_disk_iops
-    family: Data Disk
-    type: line
-    units: operations/s
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.data_disk_read_operations_sec_average
-      name: read
-    - selector: vmss.data_disk_write_operations_sec_average
-      name: write
-  - id: am_azure_vmss__data_disk_latency
-    title: Azure VMSS Data Disk Latency
-    context: data_disk_latency
-    family: Data Disk
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.data_disk_latency_average
-      name: average
-  - id: am_azure_vmss__data_disk_queue_depth
-    title: Azure VMSS Data Disk Queue Depth
-    context: data_disk_queue_depth
-    family: Data Disk
-    type: line
-    units: operations
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.data_disk_queue_depth_average
-      name: average
-  - id: am_azure_vmss__data_disk_throttling
-    title: Azure VMSS Data Disk Throttling
-    context: data_disk_throttling
-    family: Data Disk
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.data_disk_bandwidth_consumed_percentage_average
-      name: bandwidth
-    - selector: vmss.data_disk_iops_consumed_percentage_average
-      name: iops
-  - id: am_azure_vmss__data_disk_burst_capacity
-    title: Azure VMSS Data Disk Burst Capacity
-    context: data_disk_burst_capacity
-    family: Data Disk
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.data_disk_max_burst_bandwidth_average
-      name: max_burst
-    - selector: vmss.data_disk_target_bandwidth_average
-      name: target
-  - id: am_azure_vmss__data_disk_burst_iops_capacity
-    title: Azure VMSS Data Disk Burst IOPS Capacity
-    context: data_disk_burst_iops_capacity
-    family: Data Disk
-    type: line
-    units: iops
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.data_disk_max_burst_iops_average
-      name: max_burst
-    - selector: vmss.data_disk_target_iops_average
-      name: target
-  - id: am_azure_vmss__data_disk_burst_credits
-    title: Azure VMSS Data Disk Burst Credits Used
-    context: data_disk_burst_credits
-    family: Data Disk
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.data_disk_used_burst_bps_credits_percentage_average
-      name: bandwidth
-    - selector: vmss.data_disk_used_burst_io_credits_percentage_average
-      name: io
-  - id: am_azure_vmss__temp_disk_throughput
-    title: Azure VMSS Temp Disk Throughput
-    context: temp_disk_throughput
-    family: Temp Disk
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.temp_disk_read_bytes_sec_average
-      name: read
-    - selector: vmss.temp_disk_write_bytes_sec_average
-      name: write
-  - id: am_azure_vmss__temp_disk_iops
-    title: Azure VMSS Temp Disk IOPS
-    context: temp_disk_iops
-    family: Temp Disk
-    type: line
-    units: operations/s
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.temp_disk_read_operations_sec_average
-      name: read
-    - selector: vmss.temp_disk_write_operations_sec_average
-      name: write
-  - id: am_azure_vmss__temp_disk_latency
-    title: Azure VMSS Temp Disk Latency
-    context: temp_disk_latency
-    family: Temp Disk
-    type: line
-    units: milliseconds
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.temp_disk_latency_average
-      name: average
-  - id: am_azure_vmss__temp_disk_queue_depth
-    title: Azure VMSS Temp Disk Queue Depth
-    context: temp_disk_queue_depth
-    family: Temp Disk
-    type: line
-    units: operations
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.temp_disk_queue_depth_average
-      name: average
-  - id: am_azure_vmss__premium_data_disk_cache
-    title: Azure VMSS Premium Data Disk Cache
-    context: premium_data_disk_cache
-    family: Premium Cache
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.premium_data_disk_cache_read_hit_average
-      name: hit
-    - selector: vmss.premium_data_disk_cache_read_miss_average
-      name: miss
-  - id: am_azure_vmss__premium_os_disk_cache
-    title: Azure VMSS Premium OS Disk Cache
-    context: premium_os_disk_cache
-    family: Premium Cache
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.premium_os_disk_cache_read_hit_average
-      name: hit
-    - selector: vmss.premium_os_disk_cache_read_miss_average
-      name: miss
-  - id: am_azure_vmss__vm_cached_throttling
-    title: Azure VMSS Cached IO Throttling
-    context: vm_cached_throttling
-    family: VM Throttling
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.vm_cached_bandwidth_consumed_percentage_average
-      name: bandwidth
-    - selector: vmss.vm_cached_iops_consumed_percentage_average
-      name: iops
-  - id: am_azure_vmss__vm_uncached_throttling
-    title: Azure VMSS Uncached IO Throttling
-    context: vm_uncached_throttling
-    family: VM Throttling
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.vm_uncached_bandwidth_consumed_percentage_average
-      name: bandwidth
-    - selector: vmss.vm_uncached_iops_consumed_percentage_average
-      name: iops
-  - id: am_azure_vmss__vm_cached_burst_credits
-    title: Azure VMSS Cached Burst Credits Used
-    context: vm_cached_burst_credits
-    family: VM Throttling
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.vm_local_used_burst_bps_credits_percentage_average
-      name: bandwidth
-    - selector: vmss.vm_local_used_burst_io_credits_percentage_average
-      name: io
-  - id: am_azure_vmss__vm_uncached_burst_credits
-    title: Azure VMSS Uncached Burst Credits Used
-    context: vm_uncached_burst_credits
-    family: VM Throttling
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vmss.vm_remote_used_burst_bps_credits_percentage_average
-      name: bandwidth
-    - selector: vmss.vm_remote_used_burst_io_credits_percentage_average
-      name: io
+    - id: am_azure_vmss__cpu
+      title: Azure VMSS CPU Utilization
+      context: cpu
+      family: CPU
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.percentage_cpu_average
+          name: average
+    - id: am_azure_vmss__cpu_credits
+      title: Azure VMSS CPU Credits
+      context: cpu_credits
+      family: CPU
+      type: line
+      units: credits
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.cpu_credits_consumed_average
+          name: consumed
+        - selector: vmss.cpu_credits_remaining_average
+          name: remaining
+    - id: am_azure_vmss__memory
+      title: Azure VMSS Available Memory
+      context: memory
+      family: Memory
+      type: line
+      units: bytes
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.available_memory_bytes_average
+          name: available
+    - id: am_azure_vmss__memory_percentage
+      title: Azure VMSS Available Memory Percentage
+      context: memory_percentage
+      family: Memory
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.available_memory_percentage_average
+          name: available
+    - id: am_azure_vmss__availability
+      title: Azure VMSS Availability
+      context: availability
+      family: Availability
+      type: line
+      units: state
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.vm_availability_metric_average
+          name: average
+    - id: am_azure_vmss__network_traffic
+      title: Azure VMSS Network Traffic
+      context: network_traffic
+      family: Network
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: vmss.network_in_total_total
+          name: in
+        - selector: vmss.network_out_total_total
+          name: out
+    - id: am_azure_vmss__network_flows
+      title: Azure VMSS Network Flows
+      context: network_flows
+      family: Network
+      type: line
+      units: flows
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.inbound_flows_average
+          name: in
+        - selector: vmss.outbound_flows_average
+          name: out
+    - id: am_azure_vmss__network_flow_creation_rate
+      title: Azure VMSS Network Flow Creation Rate
+      context: network_flow_creation_rate
+      family: Network
+      type: line
+      units: flows/s
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.inbound_flows_maximum_creation_rate_average
+          name: in
+        - selector: vmss.outbound_flows_maximum_creation_rate_average
+          name: out
+    - id: am_azure_vmss__disk_throughput
+      title: Azure VMSS Disk Throughput
+      context: disk_throughput
+      family: Disk
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: vmss.disk_read_bytes_total
+          name: read
+        - selector: vmss.disk_write_bytes_total
+          name: write
+    - id: am_azure_vmss__disk_iops
+      title: Azure VMSS Disk IOPS
+      context: disk_iops
+      family: Disk
+      type: line
+      units: operations/s
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.disk_read_operations_sec_average
+          name: read
+        - selector: vmss.disk_write_operations_sec_average
+          name: write
+    - id: am_azure_vmss__os_disk_throughput
+      title: Azure VMSS OS Disk Throughput
+      context: os_disk_throughput
+      family: OS Disk
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.os_disk_read_bytes_sec_average
+          name: read
+        - selector: vmss.os_disk_write_bytes_sec_average
+          name: write
+    - id: am_azure_vmss__os_disk_iops
+      title: Azure VMSS OS Disk IOPS
+      context: os_disk_iops
+      family: OS Disk
+      type: line
+      units: operations/s
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.os_disk_read_operations_sec_average
+          name: read
+        - selector: vmss.os_disk_write_operations_sec_average
+          name: write
+    - id: am_azure_vmss__os_disk_latency
+      title: Azure VMSS OS Disk Latency
+      context: os_disk_latency
+      family: OS Disk
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.os_disk_latency_average
+          name: average
+    - id: am_azure_vmss__os_disk_queue_depth
+      title: Azure VMSS OS Disk Queue Depth
+      context: os_disk_queue_depth
+      family: OS Disk
+      type: line
+      units: operations
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.os_disk_queue_depth_average
+          name: average
+    - id: am_azure_vmss__os_disk_throttling
+      title: Azure VMSS OS Disk Throttling
+      context: os_disk_throttling
+      family: OS Disk
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.os_disk_bandwidth_consumed_percentage_average
+          name: bandwidth
+        - selector: vmss.os_disk_iops_consumed_percentage_average
+          name: iops
+    - id: am_azure_vmss__os_disk_burst_capacity
+      title: Azure VMSS OS Disk Burst Capacity
+      context: os_disk_burst_capacity
+      family: OS Disk
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.os_disk_max_burst_bandwidth_average
+          name: max_burst
+        - selector: vmss.os_disk_target_bandwidth_average
+          name: target
+    - id: am_azure_vmss__os_disk_burst_iops_capacity
+      title: Azure VMSS OS Disk Burst IOPS Capacity
+      context: os_disk_burst_iops_capacity
+      family: OS Disk
+      type: line
+      units: iops
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.os_disk_max_burst_iops_average
+          name: max_burst
+        - selector: vmss.os_disk_target_iops_average
+          name: target
+    - id: am_azure_vmss__os_disk_burst_credits
+      title: Azure VMSS OS Disk Burst Credits Used
+      context: os_disk_burst_credits
+      family: OS Disk
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.os_disk_used_burst_bps_credits_percentage_average
+          name: bandwidth
+        - selector: vmss.os_disk_used_burst_io_credits_percentage_average
+          name: io
+    - id: am_azure_vmss__data_disk_throughput
+      title: Azure VMSS Data Disk Throughput
+      context: data_disk_throughput
+      family: Data Disk
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.data_disk_read_bytes_sec_average
+          name: read
+        - selector: vmss.data_disk_write_bytes_sec_average
+          name: write
+    - id: am_azure_vmss__data_disk_iops
+      title: Azure VMSS Data Disk IOPS
+      context: data_disk_iops
+      family: Data Disk
+      type: line
+      units: operations/s
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.data_disk_read_operations_sec_average
+          name: read
+        - selector: vmss.data_disk_write_operations_sec_average
+          name: write
+    - id: am_azure_vmss__data_disk_latency
+      title: Azure VMSS Data Disk Latency
+      context: data_disk_latency
+      family: Data Disk
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.data_disk_latency_average
+          name: average
+    - id: am_azure_vmss__data_disk_queue_depth
+      title: Azure VMSS Data Disk Queue Depth
+      context: data_disk_queue_depth
+      family: Data Disk
+      type: line
+      units: operations
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.data_disk_queue_depth_average
+          name: average
+    - id: am_azure_vmss__data_disk_throttling
+      title: Azure VMSS Data Disk Throttling
+      context: data_disk_throttling
+      family: Data Disk
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.data_disk_bandwidth_consumed_percentage_average
+          name: bandwidth
+        - selector: vmss.data_disk_iops_consumed_percentage_average
+          name: iops
+    - id: am_azure_vmss__data_disk_burst_capacity
+      title: Azure VMSS Data Disk Burst Capacity
+      context: data_disk_burst_capacity
+      family: Data Disk
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.data_disk_max_burst_bandwidth_average
+          name: max_burst
+        - selector: vmss.data_disk_target_bandwidth_average
+          name: target
+    - id: am_azure_vmss__data_disk_burst_iops_capacity
+      title: Azure VMSS Data Disk Burst IOPS Capacity
+      context: data_disk_burst_iops_capacity
+      family: Data Disk
+      type: line
+      units: iops
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.data_disk_max_burst_iops_average
+          name: max_burst
+        - selector: vmss.data_disk_target_iops_average
+          name: target
+    - id: am_azure_vmss__data_disk_burst_credits
+      title: Azure VMSS Data Disk Burst Credits Used
+      context: data_disk_burst_credits
+      family: Data Disk
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.data_disk_used_burst_bps_credits_percentage_average
+          name: bandwidth
+        - selector: vmss.data_disk_used_burst_io_credits_percentage_average
+          name: io
+    - id: am_azure_vmss__temp_disk_throughput
+      title: Azure VMSS Temp Disk Throughput
+      context: temp_disk_throughput
+      family: Temp Disk
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.temp_disk_read_bytes_sec_average
+          name: read
+        - selector: vmss.temp_disk_write_bytes_sec_average
+          name: write
+    - id: am_azure_vmss__temp_disk_iops
+      title: Azure VMSS Temp Disk IOPS
+      context: temp_disk_iops
+      family: Temp Disk
+      type: line
+      units: operations/s
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.temp_disk_read_operations_sec_average
+          name: read
+        - selector: vmss.temp_disk_write_operations_sec_average
+          name: write
+    - id: am_azure_vmss__temp_disk_latency
+      title: Azure VMSS Temp Disk Latency
+      context: temp_disk_latency
+      family: Temp Disk
+      type: line
+      units: milliseconds
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.temp_disk_latency_average
+          name: average
+    - id: am_azure_vmss__temp_disk_queue_depth
+      title: Azure VMSS Temp Disk Queue Depth
+      context: temp_disk_queue_depth
+      family: Temp Disk
+      type: line
+      units: operations
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.temp_disk_queue_depth_average
+          name: average
+    - id: am_azure_vmss__premium_data_disk_cache
+      title: Azure VMSS Premium Data Disk Cache
+      context: premium_data_disk_cache
+      family: Premium Cache
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.premium_data_disk_cache_read_hit_average
+          name: hit
+        - selector: vmss.premium_data_disk_cache_read_miss_average
+          name: miss
+    - id: am_azure_vmss__premium_os_disk_cache
+      title: Azure VMSS Premium OS Disk Cache
+      context: premium_os_disk_cache
+      family: Premium Cache
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.premium_os_disk_cache_read_hit_average
+          name: hit
+        - selector: vmss.premium_os_disk_cache_read_miss_average
+          name: miss
+    - id: am_azure_vmss__vm_cached_throttling
+      title: Azure VMSS Cached IO Throttling
+      context: vm_cached_throttling
+      family: VM Throttling
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.vm_cached_bandwidth_consumed_percentage_average
+          name: bandwidth
+        - selector: vmss.vm_cached_iops_consumed_percentage_average
+          name: iops
+    - id: am_azure_vmss__vm_uncached_throttling
+      title: Azure VMSS Uncached IO Throttling
+      context: vm_uncached_throttling
+      family: VM Throttling
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.vm_uncached_bandwidth_consumed_percentage_average
+          name: bandwidth
+        - selector: vmss.vm_uncached_iops_consumed_percentage_average
+          name: iops
+    - id: am_azure_vmss__vm_cached_burst_credits
+      title: Azure VMSS Cached Burst Credits Used
+      context: vm_cached_burst_credits
+      family: VM Throttling
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.vm_local_used_burst_bps_credits_percentage_average
+          name: bandwidth
+        - selector: vmss.vm_local_used_burst_io_credits_percentage_average
+          name: io
+    - id: am_azure_vmss__vm_uncached_burst_credits
+      title: Azure VMSS Uncached Burst Credits Used
+      context: vm_uncached_burst_credits
+      family: VM Throttling
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vmss.vm_remote_used_burst_bps_credits_percentage_average
+          name: bandwidth
+        - selector: vmss.vm_remote_used_burst_io_credits_percentage_average
+          name: io

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/vpn_gateway.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/vpn_gateway.yaml
@@ -3,721 +3,721 @@ id: vpn_gateway
 name: Azure VPN Gateway
 resource_type: Microsoft.Network/virtualNetworkGateways
 metrics:
-- id: average_bandwidth
-  azure_name: AverageBandwidth
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: p2s_bandwidth
-  azure_name: P2SBandwidth
-  time_grain: PT1M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: p2s_connection_count
-  azure_name: P2SConnectionCount
-  time_grain: PT1M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: inbound_flows_count
-  azure_name: InboundFlowsCount
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: outbound_flows_count
-  azure_name: OutboundFlowsCount
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: tunnel_average_bandwidth
-  azure_name: TunnelAverageBandwidth
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: tunnel_egress_bytes
-  azure_name: TunnelEgressBytes
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_ingress_bytes
-  azure_name: TunnelIngressBytes
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_egress_packets
-  azure_name: TunnelEgressPackets
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_ingress_packets
-  azure_name: TunnelIngressPackets
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_peak_packets
-  azure_name: TunnelPeakPackets
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: tunnel_total_flow_count
-  azure_name: TunnelTotalFlowCount
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_nat_allocations
-  azure_name: TunnelNatAllocations
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_nated_bytes
-  azure_name: TunnelNatedBytes
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_reverse_nated_bytes
-  azure_name: TunnelReverseNatedBytes
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_nated_packets
-  azure_name: TunnelNatedPackets
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_reverse_nated_packets
-  azure_name: TunnelReverseNatedPackets
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_nat_flow_count
-  azure_name: TunnelNatFlowCount
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_egress_packet_drop_count
-  azure_name: TunnelEgressPacketDropCount
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_ingress_packet_drop_count
-  azure_name: TunnelIngressPacketDropCount
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_egress_packet_drop_ts_mismatch
-  azure_name: TunnelEgressPacketDropTSMismatch
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_ingress_packet_drop_ts_mismatch
-  azure_name: TunnelIngressPacketDropTSMismatch
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: tunnel_nat_packet_drop
-  azure_name: TunnelNatPacketDrop
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: mmsa_count
-  azure_name: MmsaCount
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: qmsa_count
-  azure_name: QmsaCount
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: bgp_peer_status
-  azure_name: BgpPeerStatus
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: bgp_routes_advertised
-  azure_name: BgpRoutesAdvertised
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: bgp_routes_learned
-  azure_name: BgpRoutesLearned
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: user_vpn_route_count
-  azure_name: UserVpnRouteCount
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: vnet_address_prefix_count
-  azure_name: VnetAddressPrefixCount
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: gauge
-- id: express_route_gateway_bits_per_second
-  azure_name: ExpressRouteGatewayBitsPerSecond
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: express_route_gateway_cpu_utilization
-  azure_name: ExpressRouteGatewayCpuUtilization
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: express_route_gateway_packets_per_second
-  azure_name: ExpressRouteGatewayPacketsPerSecond
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: express_route_gateway_active_flows
-  azure_name: ExpressRouteGatewayActiveFlows
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: express_route_gateway_count_of_routes_advertised_to_peer
-  azure_name: ExpressRouteGatewayCountOfRoutesAdvertisedToPeer
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: express_route_gateway_count_of_routes_learned_from_peer
-  azure_name: ExpressRouteGatewayCountOfRoutesLearnedFromPeer
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: express_route_gateway_frequency_of_routes_changed
-  azure_name: ExpressRouteGatewayFrequencyOfRoutesChanged
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: express_route_gateway_max_flows_creation_rate
-  azure_name: ExpressRouteGatewayMaxFlowsCreationRate
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: express_route_gateway_number_of_vm_in_vnet
-  azure_name: ExpressRouteGatewayNumberOfVmInVnet
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: scalable_express_route_gateway_bits_per_second
-  azure_name: ScalableExpressRouteGatewayBitsPerSecond
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: scalable_express_route_gateway_cpu_utilization
-  azure_name: ScalableExpressRouteGatewayCpuUtilization
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: scalable_express_route_gateway_packets_per_second
-  azure_name: ScalableExpressRouteGatewayPacketsPerSecond
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: scalable_express_route_gateway_active_flows
-  azure_name: ScalableExpressRouteGatewayActiveFlows
-  time_grain: PT5M
-  series:
-  - aggregation: average
-    kind: gauge
-- id: scalable_express_route_gateway_count_of_routes_advertised_to_peer
-  azure_name: ScalableExpressRouteGatewayCountOfRoutesAdvertisedToPeer
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: scalable_express_route_gateway_count_of_routes_learned_from_peer
-  azure_name: ScalableExpressRouteGatewayCountOfRoutesLearnedFromPeer
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: scalable_express_route_gateway_frequency_of_routes_changed
-  azure_name: ScalableExpressRouteGatewayFrequencyOfRoutesChanged
-  time_grain: PT5M
-  series:
-  - aggregation: total
-    kind: counter
-- id: scalable_express_route_gateway_max_flows_creation_rate
-  azure_name: ScalableExpressRouteGatewayMaxFlowsCreationRate
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: scalable_express_route_gateway_number_of_vm_in_vnet
-  azure_name: ScalableExpressRouteGatewayNumberOfVmInVnet
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
-- id: scalable_express_route_gateway_scale_unit
-  azure_name: ScalableExpressRouteGatewayScaleUnit
-  time_grain: PT5M
-  series:
-  - aggregation: maximum
-    kind: gauge
+  - id: average_bandwidth
+    azure_name: AverageBandwidth
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: p2s_bandwidth
+    azure_name: P2SBandwidth
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: p2s_connection_count
+    azure_name: P2SConnectionCount
+    time_grain: PT1M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: inbound_flows_count
+    azure_name: InboundFlowsCount
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: outbound_flows_count
+    azure_name: OutboundFlowsCount
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: tunnel_average_bandwidth
+    azure_name: TunnelAverageBandwidth
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: tunnel_egress_bytes
+    azure_name: TunnelEgressBytes
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_ingress_bytes
+    azure_name: TunnelIngressBytes
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_egress_packets
+    azure_name: TunnelEgressPackets
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_ingress_packets
+    azure_name: TunnelIngressPackets
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_peak_packets
+    azure_name: TunnelPeakPackets
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: tunnel_total_flow_count
+    azure_name: TunnelTotalFlowCount
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_nat_allocations
+    azure_name: TunnelNatAllocations
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_nated_bytes
+    azure_name: TunnelNatedBytes
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_reverse_nated_bytes
+    azure_name: TunnelReverseNatedBytes
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_nated_packets
+    azure_name: TunnelNatedPackets
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_reverse_nated_packets
+    azure_name: TunnelReverseNatedPackets
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_nat_flow_count
+    azure_name: TunnelNatFlowCount
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_egress_packet_drop_count
+    azure_name: TunnelEgressPacketDropCount
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_ingress_packet_drop_count
+    azure_name: TunnelIngressPacketDropCount
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_egress_packet_drop_ts_mismatch
+    azure_name: TunnelEgressPacketDropTSMismatch
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_ingress_packet_drop_ts_mismatch
+    azure_name: TunnelIngressPacketDropTSMismatch
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: tunnel_nat_packet_drop
+    azure_name: TunnelNatPacketDrop
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: mmsa_count
+    azure_name: MmsaCount
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: qmsa_count
+    azure_name: QmsaCount
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: bgp_peer_status
+    azure_name: BgpPeerStatus
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: bgp_routes_advertised
+    azure_name: BgpRoutesAdvertised
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: bgp_routes_learned
+    azure_name: BgpRoutesLearned
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: user_vpn_route_count
+    azure_name: UserVpnRouteCount
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: vnet_address_prefix_count
+    azure_name: VnetAddressPrefixCount
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: gauge
+  - id: express_route_gateway_bits_per_second
+    azure_name: ExpressRouteGatewayBitsPerSecond
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: express_route_gateway_cpu_utilization
+    azure_name: ExpressRouteGatewayCpuUtilization
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: express_route_gateway_packets_per_second
+    azure_name: ExpressRouteGatewayPacketsPerSecond
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: express_route_gateway_active_flows
+    azure_name: ExpressRouteGatewayActiveFlows
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: express_route_gateway_count_of_routes_advertised_to_peer
+    azure_name: ExpressRouteGatewayCountOfRoutesAdvertisedToPeer
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: express_route_gateway_count_of_routes_learned_from_peer
+    azure_name: ExpressRouteGatewayCountOfRoutesLearnedFromPeer
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: express_route_gateway_frequency_of_routes_changed
+    azure_name: ExpressRouteGatewayFrequencyOfRoutesChanged
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: express_route_gateway_max_flows_creation_rate
+    azure_name: ExpressRouteGatewayMaxFlowsCreationRate
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: express_route_gateway_number_of_vm_in_vnet
+    azure_name: ExpressRouteGatewayNumberOfVmInVnet
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: scalable_express_route_gateway_bits_per_second
+    azure_name: ScalableExpressRouteGatewayBitsPerSecond
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: scalable_express_route_gateway_cpu_utilization
+    azure_name: ScalableExpressRouteGatewayCpuUtilization
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: scalable_express_route_gateway_packets_per_second
+    azure_name: ScalableExpressRouteGatewayPacketsPerSecond
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: scalable_express_route_gateway_active_flows
+    azure_name: ScalableExpressRouteGatewayActiveFlows
+    time_grain: PT5M
+    series:
+      - aggregation: average
+        kind: gauge
+  - id: scalable_express_route_gateway_count_of_routes_advertised_to_peer
+    azure_name: ScalableExpressRouteGatewayCountOfRoutesAdvertisedToPeer
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: scalable_express_route_gateway_count_of_routes_learned_from_peer
+    azure_name: ScalableExpressRouteGatewayCountOfRoutesLearnedFromPeer
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: scalable_express_route_gateway_frequency_of_routes_changed
+    azure_name: ScalableExpressRouteGatewayFrequencyOfRoutesChanged
+    time_grain: PT5M
+    series:
+      - aggregation: total
+        kind: counter
+  - id: scalable_express_route_gateway_max_flows_creation_rate
+    azure_name: ScalableExpressRouteGatewayMaxFlowsCreationRate
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: scalable_express_route_gateway_number_of_vm_in_vnet
+    azure_name: ScalableExpressRouteGatewayNumberOfVmInVnet
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
+  - id: scalable_express_route_gateway_scale_unit
+    azure_name: ScalableExpressRouteGatewayScaleUnit
+    time_grain: PT5M
+    series:
+      - aggregation: maximum
+        kind: gauge
 template:
   family: Azure VPN Gateway
   context_namespace: vpn_gateway
   chart_defaults:
     label_promotion:
-    - resource_name
-    - resource_group
-    - region
-    - resource_type
-    - profile
+      - resource_name
+      - resource_group
+      - region
+      - resource_type
+      - profile
     instances:
       by_labels:
-      - resource_uid
+        - resource_uid
   charts:
-  - id: am_azure_vpn_gateway__s2s_bandwidth
-    title: Azure VPN Gateway S2S Bandwidth
-    context: s2s_bandwidth
-    family: Traffic
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.average_bandwidth_average
-      name: average
-  - id: am_azure_vpn_gateway__p2s_bandwidth
-    title: Azure VPN Gateway P2S Bandwidth
-    context: p2s_bandwidth
-    family: Traffic
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.p2s_bandwidth_average
-      name: average
-  - id: am_azure_vpn_gateway__p2s_connections
-    title: Azure VPN Gateway P2S Connection Count
-    context: p2s_connections
-    family: Traffic
-    type: line
-    units: connections
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.p2s_connection_count_total
-      name: total
-  - id: am_azure_vpn_gateway__gateway_flows
-    title: Azure VPN Gateway Flows
-    context: gateway_flows
-    family: Traffic
-    type: line
-    units: flows
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.inbound_flows_count_maximum
-      name: inbound
-    - selector: vpn_gateway.outbound_flows_count_maximum
-      name: outbound
-  - id: am_azure_vpn_gateway__tunnel_bandwidth
-    title: Azure VPN Gateway Tunnel Bandwidth
-    context: tunnel_bandwidth
-    family: Tunnel Traffic
-    type: line
-    units: bytes/s
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.tunnel_average_bandwidth_average
-      name: average
-  - id: am_azure_vpn_gateway__tunnel_bytes
-    title: Azure VPN Gateway Tunnel Bytes
-    context: tunnel_bytes
-    family: Tunnel Traffic
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: vpn_gateway.tunnel_egress_bytes_total
-      name: egress
-    - selector: vpn_gateway.tunnel_ingress_bytes_total
-      name: ingress
-  - id: am_azure_vpn_gateway__tunnel_packets
-    title: Azure VPN Gateway Tunnel Packets
-    context: tunnel_packets
-    family: Tunnel Traffic
-    type: line
-    units: packets/s
-    algorithm: incremental
-    dimensions:
-    - selector: vpn_gateway.tunnel_egress_packets_total
-      name: egress
-    - selector: vpn_gateway.tunnel_ingress_packets_total
-      name: ingress
-  - id: am_azure_vpn_gateway__tunnel_peak_pps
-    title: Azure VPN Gateway Tunnel Peak PPS
-    context: tunnel_peak_pps
-    family: Tunnel Traffic
-    type: line
-    units: packets/s
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.tunnel_peak_packets_maximum
-      name: peak
-  - id: am_azure_vpn_gateway__tunnel_total_flows
-    title: Azure VPN Gateway Tunnel Total Flows
-    context: tunnel_total_flows
-    family: Tunnel Traffic
-    type: line
-    units: flows/s
-    algorithm: incremental
-    dimensions:
-    - selector: vpn_gateway.tunnel_total_flow_count_total
-      name: total
-  - id: am_azure_vpn_gateway__tunnel_nat_allocations
-    title: Azure VPN Gateway Tunnel NAT Allocations
-    context: tunnel_nat_allocations
-    family: Tunnel NAT
-    type: line
-    units: allocations/s
-    algorithm: incremental
-    dimensions:
-    - selector: vpn_gateway.tunnel_nat_allocations_total
-      name: total
-  - id: am_azure_vpn_gateway__tunnel_nated_bytes
-    title: Azure VPN Gateway Tunnel NATed Bytes
-    context: tunnel_nated_bytes
-    family: Tunnel NAT
-    type: line
-    units: bytes/s
-    algorithm: incremental
-    dimensions:
-    - selector: vpn_gateway.tunnel_nated_bytes_total
-      name: nated
-    - selector: vpn_gateway.tunnel_reverse_nated_bytes_total
-      name: reverse_nated
-  - id: am_azure_vpn_gateway__tunnel_nated_packets
-    title: Azure VPN Gateway Tunnel NATed Packets
-    context: tunnel_nated_packets
-    family: Tunnel NAT
-    type: line
-    units: packets/s
-    algorithm: incremental
-    dimensions:
-    - selector: vpn_gateway.tunnel_nated_packets_total
-      name: nated
-    - selector: vpn_gateway.tunnel_reverse_nated_packets_total
-      name: reverse_nated
-  - id: am_azure_vpn_gateway__tunnel_nat_flows
-    title: Azure VPN Gateway Tunnel NAT Flows
-    context: tunnel_nat_flows
-    family: Tunnel NAT
-    type: line
-    units: flows/s
-    algorithm: incremental
-    dimensions:
-    - selector: vpn_gateway.tunnel_nat_flow_count_total
-      name: total
-  - id: am_azure_vpn_gateway__tunnel_packet_drops
-    title: Azure VPN Gateway Tunnel Packet Drops
-    context: tunnel_packet_drops
-    family: Errors
-    type: line
-    units: packets/s
-    algorithm: incremental
-    dimensions:
-    - selector: vpn_gateway.tunnel_egress_packet_drop_count_total
-      name: egress
-    - selector: vpn_gateway.tunnel_ingress_packet_drop_count_total
-      name: ingress
-  - id: am_azure_vpn_gateway__tunnel_ts_mismatch_drops
-    title: Azure VPN Gateway Tunnel TS Mismatch Drops
-    context: tunnel_ts_mismatch_drops
-    family: Errors
-    type: line
-    units: packets/s
-    algorithm: incremental
-    dimensions:
-    - selector: vpn_gateway.tunnel_egress_packet_drop_ts_mismatch_total
-      name: egress
-    - selector: vpn_gateway.tunnel_ingress_packet_drop_ts_mismatch_total
-      name: ingress
-  - id: am_azure_vpn_gateway__tunnel_nat_packet_drops
-    title: Azure VPN Gateway Tunnel NAT Packet Drops
-    context: tunnel_nat_packet_drops
-    family: Errors
-    type: line
-    units: packets/s
-    algorithm: incremental
-    dimensions:
-    - selector: vpn_gateway.tunnel_nat_packet_drop_total
-      name: total
-  - id: am_azure_vpn_gateway__ipsec_sa
-    title: Azure VPN Gateway IPsec Security Associations
-    context: ipsec_sa
-    family: IPsec
-    type: line
-    units: associations
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.mmsa_count_total
-      name: mmsa
-    - selector: vpn_gateway.qmsa_count_total
-      name: qmsa
-  - id: am_azure_vpn_gateway__bgp_peer_status
-    title: Azure VPN Gateway BGP Peer Status
-    context: bgp_peer_status
-    family: Routing
-    type: line
-    units: status
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.bgp_peer_status_average
-      name: average
-  - id: am_azure_vpn_gateway__bgp_routes
-    title: Azure VPN Gateway BGP Routes
-    context: bgp_routes
-    family: Routing
-    type: line
-    units: routes/s
-    algorithm: incremental
-    dimensions:
-    - selector: vpn_gateway.bgp_routes_advertised_total
-      name: advertised
-    - selector: vpn_gateway.bgp_routes_learned_total
-      name: learned
-  - id: am_azure_vpn_gateway__route_counts
-    title: Azure VPN Gateway Route Counts
-    context: route_counts
-    family: Routing
-    type: line
-    units: routes
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.user_vpn_route_count_total
-      name: user_vpn
-    - selector: vpn_gateway.vnet_address_prefix_count_total
-      name: vnet_prefix
-  - id: am_azure_vpn_gateway__er_gateway_bandwidth
-    title: Azure VPN Gateway ExpressRoute Bandwidth
-    context: er_gateway_bandwidth
-    family: ExpressRoute
-    type: line
-    units: bits/s
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.express_route_gateway_bits_per_second_average
-      name: average
-  - id: am_azure_vpn_gateway__er_gateway_cpu
-    title: Azure VPN Gateway ExpressRoute CPU Utilization
-    context: er_gateway_cpu
-    family: ExpressRoute
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.express_route_gateway_cpu_utilization_average
-      name: average
-  - id: am_azure_vpn_gateway__er_gateway_packets
-    title: Azure VPN Gateway ExpressRoute Packets
-    context: er_gateway_packets
-    family: ExpressRoute
-    type: line
-    units: packets/s
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.express_route_gateway_packets_per_second_average
-      name: average
-  - id: am_azure_vpn_gateway__er_gateway_active_flows
-    title: Azure VPN Gateway ExpressRoute Active Flows
-    context: er_gateway_active_flows
-    family: ExpressRoute
-    type: line
-    units: flows
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.express_route_gateway_active_flows_average
-      name: average
-  - id: am_azure_vpn_gateway__er_gateway_routes_advertised
-    title: Azure VPN Gateway ExpressRoute Routes Advertised to Peer
-    context: er_gateway_routes_advertised
-    family: ExpressRoute
-    type: line
-    units: routes
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.express_route_gateway_count_of_routes_advertised_to_peer_maximum
-      name: maximum
-  - id: am_azure_vpn_gateway__er_gateway_routes_learned
-    title: Azure VPN Gateway ExpressRoute Routes Learned from Peer
-    context: er_gateway_routes_learned
-    family: ExpressRoute
-    type: line
-    units: routes
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.express_route_gateway_count_of_routes_learned_from_peer_maximum
-      name: maximum
-  - id: am_azure_vpn_gateway__er_gateway_route_changes
-    title: Azure VPN Gateway ExpressRoute Route Changes
-    context: er_gateway_route_changes
-    family: ExpressRoute
-    type: line
-    units: changes/s
-    algorithm: incremental
-    dimensions:
-    - selector: vpn_gateway.express_route_gateway_frequency_of_routes_changed_total
-      name: total
-  - id: am_azure_vpn_gateway__er_gateway_max_flows_rate
-    title: Azure VPN Gateway ExpressRoute Max Flow Creation Rate
-    context: er_gateway_max_flows_rate
-    family: ExpressRoute
-    type: line
-    units: flows/s
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.express_route_gateway_max_flows_creation_rate_maximum
-      name: maximum
-  - id: am_azure_vpn_gateway__er_gateway_vm_count
-    title: Azure VPN Gateway ExpressRoute VMs in VNet
-    context: er_gateway_vm_count
-    family: ExpressRoute
-    type: line
-    units: VMs
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.express_route_gateway_number_of_vm_in_vnet_maximum
-      name: maximum
-  - id: am_azure_vpn_gateway__scalable_er_bandwidth
-    title: Azure VPN Gateway Scalable ExpressRoute Bandwidth
-    context: scalable_er_bandwidth
-    family: Scalable ExpressRoute
-    type: line
-    units: bits/s
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.scalable_express_route_gateway_bits_per_second_average
-      name: average
-  - id: am_azure_vpn_gateway__scalable_er_cpu
-    title: Azure VPN Gateway Scalable ExpressRoute CPU Utilization
-    context: scalable_er_cpu
-    family: Scalable ExpressRoute
-    type: line
-    units: percentage
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.scalable_express_route_gateway_cpu_utilization_average
-      name: average
-  - id: am_azure_vpn_gateway__scalable_er_packets
-    title: Azure VPN Gateway Scalable ExpressRoute Packets
-    context: scalable_er_packets
-    family: Scalable ExpressRoute
-    type: line
-    units: packets/s
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.scalable_express_route_gateway_packets_per_second_average
-      name: average
-  - id: am_azure_vpn_gateway__scalable_er_active_flows
-    title: Azure VPN Gateway Scalable ExpressRoute Active Flows
-    context: scalable_er_active_flows
-    family: Scalable ExpressRoute
-    type: line
-    units: flows
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.scalable_express_route_gateway_active_flows_average
-      name: average
-  - id: am_azure_vpn_gateway__scalable_er_routes_advertised
-    title: Azure VPN Gateway Scalable ExpressRoute Routes Advertised
-    context: scalable_er_routes_advertised
-    family: Scalable ExpressRoute
-    type: line
-    units: routes
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.scalable_express_route_gateway_count_of_routes_advertised_to_peer_maximum
-      name: maximum
-  - id: am_azure_vpn_gateway__scalable_er_routes_learned
-    title: Azure VPN Gateway Scalable ExpressRoute Routes Learned
-    context: scalable_er_routes_learned
-    family: Scalable ExpressRoute
-    type: line
-    units: routes
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.scalable_express_route_gateway_count_of_routes_learned_from_peer_maximum
-      name: maximum
-  - id: am_azure_vpn_gateway__scalable_er_route_changes
-    title: Azure VPN Gateway Scalable ExpressRoute Route Changes
-    context: scalable_er_route_changes
-    family: Scalable ExpressRoute
-    type: line
-    units: changes/s
-    algorithm: incremental
-    dimensions:
-    - selector: vpn_gateway.scalable_express_route_gateway_frequency_of_routes_changed_total
-      name: total
-  - id: am_azure_vpn_gateway__scalable_er_max_flows_rate
-    title: Azure VPN Gateway Scalable ExpressRoute Max Flow Creation Rate
-    context: scalable_er_max_flows_rate
-    family: Scalable ExpressRoute
-    type: line
-    units: flows/s
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.scalable_express_route_gateway_max_flows_creation_rate_maximum
-      name: maximum
-  - id: am_azure_vpn_gateway__scalable_er_vm_count
-    title: Azure VPN Gateway Scalable ExpressRoute VMs in VNet
-    context: scalable_er_vm_count
-    family: Scalable ExpressRoute
-    type: line
-    units: VMs
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.scalable_express_route_gateway_number_of_vm_in_vnet_maximum
-      name: maximum
-  - id: am_azure_vpn_gateway__scalable_er_scale_units
-    title: Azure VPN Gateway Scalable ExpressRoute Scale Units
-    context: scalable_er_scale_units
-    family: Scalable ExpressRoute
-    type: line
-    units: units
-    algorithm: absolute
-    dimensions:
-    - selector: vpn_gateway.scalable_express_route_gateway_scale_unit_maximum
-      name: maximum
+    - id: am_azure_vpn_gateway__s2s_bandwidth
+      title: Azure VPN Gateway S2S Bandwidth
+      context: s2s_bandwidth
+      family: Traffic
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.average_bandwidth_average
+          name: average
+    - id: am_azure_vpn_gateway__p2s_bandwidth
+      title: Azure VPN Gateway P2S Bandwidth
+      context: p2s_bandwidth
+      family: Traffic
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.p2s_bandwidth_average
+          name: average
+    - id: am_azure_vpn_gateway__p2s_connections
+      title: Azure VPN Gateway P2S Connection Count
+      context: p2s_connections
+      family: Traffic
+      type: line
+      units: connections
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.p2s_connection_count_total
+          name: total
+    - id: am_azure_vpn_gateway__gateway_flows
+      title: Azure VPN Gateway Flows
+      context: gateway_flows
+      family: Traffic
+      type: line
+      units: flows
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.inbound_flows_count_maximum
+          name: inbound
+        - selector: vpn_gateway.outbound_flows_count_maximum
+          name: outbound
+    - id: am_azure_vpn_gateway__tunnel_bandwidth
+      title: Azure VPN Gateway Tunnel Bandwidth
+      context: tunnel_bandwidth
+      family: Tunnel Traffic
+      type: line
+      units: bytes/s
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.tunnel_average_bandwidth_average
+          name: average
+    - id: am_azure_vpn_gateway__tunnel_bytes
+      title: Azure VPN Gateway Tunnel Bytes
+      context: tunnel_bytes
+      family: Tunnel Traffic
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: vpn_gateway.tunnel_egress_bytes_total
+          name: egress
+        - selector: vpn_gateway.tunnel_ingress_bytes_total
+          name: ingress
+    - id: am_azure_vpn_gateway__tunnel_packets
+      title: Azure VPN Gateway Tunnel Packets
+      context: tunnel_packets
+      family: Tunnel Traffic
+      type: line
+      units: packets/s
+      algorithm: incremental
+      dimensions:
+        - selector: vpn_gateway.tunnel_egress_packets_total
+          name: egress
+        - selector: vpn_gateway.tunnel_ingress_packets_total
+          name: ingress
+    - id: am_azure_vpn_gateway__tunnel_peak_pps
+      title: Azure VPN Gateway Tunnel Peak PPS
+      context: tunnel_peak_pps
+      family: Tunnel Traffic
+      type: line
+      units: packets/s
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.tunnel_peak_packets_maximum
+          name: peak
+    - id: am_azure_vpn_gateway__tunnel_total_flows
+      title: Azure VPN Gateway Tunnel Total Flows
+      context: tunnel_total_flows
+      family: Tunnel Traffic
+      type: line
+      units: flows/s
+      algorithm: incremental
+      dimensions:
+        - selector: vpn_gateway.tunnel_total_flow_count_total
+          name: total
+    - id: am_azure_vpn_gateway__tunnel_nat_allocations
+      title: Azure VPN Gateway Tunnel NAT Allocations
+      context: tunnel_nat_allocations
+      family: Tunnel NAT
+      type: line
+      units: allocations/s
+      algorithm: incremental
+      dimensions:
+        - selector: vpn_gateway.tunnel_nat_allocations_total
+          name: total
+    - id: am_azure_vpn_gateway__tunnel_nated_bytes
+      title: Azure VPN Gateway Tunnel NATed Bytes
+      context: tunnel_nated_bytes
+      family: Tunnel NAT
+      type: line
+      units: bytes/s
+      algorithm: incremental
+      dimensions:
+        - selector: vpn_gateway.tunnel_nated_bytes_total
+          name: nated
+        - selector: vpn_gateway.tunnel_reverse_nated_bytes_total
+          name: reverse_nated
+    - id: am_azure_vpn_gateway__tunnel_nated_packets
+      title: Azure VPN Gateway Tunnel NATed Packets
+      context: tunnel_nated_packets
+      family: Tunnel NAT
+      type: line
+      units: packets/s
+      algorithm: incremental
+      dimensions:
+        - selector: vpn_gateway.tunnel_nated_packets_total
+          name: nated
+        - selector: vpn_gateway.tunnel_reverse_nated_packets_total
+          name: reverse_nated
+    - id: am_azure_vpn_gateway__tunnel_nat_flows
+      title: Azure VPN Gateway Tunnel NAT Flows
+      context: tunnel_nat_flows
+      family: Tunnel NAT
+      type: line
+      units: flows/s
+      algorithm: incremental
+      dimensions:
+        - selector: vpn_gateway.tunnel_nat_flow_count_total
+          name: total
+    - id: am_azure_vpn_gateway__tunnel_packet_drops
+      title: Azure VPN Gateway Tunnel Packet Drops
+      context: tunnel_packet_drops
+      family: Errors
+      type: line
+      units: packets/s
+      algorithm: incremental
+      dimensions:
+        - selector: vpn_gateway.tunnel_egress_packet_drop_count_total
+          name: egress
+        - selector: vpn_gateway.tunnel_ingress_packet_drop_count_total
+          name: ingress
+    - id: am_azure_vpn_gateway__tunnel_ts_mismatch_drops
+      title: Azure VPN Gateway Tunnel TS Mismatch Drops
+      context: tunnel_ts_mismatch_drops
+      family: Errors
+      type: line
+      units: packets/s
+      algorithm: incremental
+      dimensions:
+        - selector: vpn_gateway.tunnel_egress_packet_drop_ts_mismatch_total
+          name: egress
+        - selector: vpn_gateway.tunnel_ingress_packet_drop_ts_mismatch_total
+          name: ingress
+    - id: am_azure_vpn_gateway__tunnel_nat_packet_drops
+      title: Azure VPN Gateway Tunnel NAT Packet Drops
+      context: tunnel_nat_packet_drops
+      family: Errors
+      type: line
+      units: packets/s
+      algorithm: incremental
+      dimensions:
+        - selector: vpn_gateway.tunnel_nat_packet_drop_total
+          name: total
+    - id: am_azure_vpn_gateway__ipsec_sa
+      title: Azure VPN Gateway IPsec Security Associations
+      context: ipsec_sa
+      family: IPsec
+      type: line
+      units: associations
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.mmsa_count_total
+          name: mmsa
+        - selector: vpn_gateway.qmsa_count_total
+          name: qmsa
+    - id: am_azure_vpn_gateway__bgp_peer_status
+      title: Azure VPN Gateway BGP Peer Status
+      context: bgp_peer_status
+      family: Routing
+      type: line
+      units: status
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.bgp_peer_status_average
+          name: average
+    - id: am_azure_vpn_gateway__bgp_routes
+      title: Azure VPN Gateway BGP Routes
+      context: bgp_routes
+      family: Routing
+      type: line
+      units: routes/s
+      algorithm: incremental
+      dimensions:
+        - selector: vpn_gateway.bgp_routes_advertised_total
+          name: advertised
+        - selector: vpn_gateway.bgp_routes_learned_total
+          name: learned
+    - id: am_azure_vpn_gateway__route_counts
+      title: Azure VPN Gateway Route Counts
+      context: route_counts
+      family: Routing
+      type: line
+      units: routes
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.user_vpn_route_count_total
+          name: user_vpn
+        - selector: vpn_gateway.vnet_address_prefix_count_total
+          name: vnet_prefix
+    - id: am_azure_vpn_gateway__er_gateway_bandwidth
+      title: Azure VPN Gateway ExpressRoute Bandwidth
+      context: er_gateway_bandwidth
+      family: ExpressRoute
+      type: line
+      units: bits/s
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.express_route_gateway_bits_per_second_average
+          name: average
+    - id: am_azure_vpn_gateway__er_gateway_cpu
+      title: Azure VPN Gateway ExpressRoute CPU Utilization
+      context: er_gateway_cpu
+      family: ExpressRoute
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.express_route_gateway_cpu_utilization_average
+          name: average
+    - id: am_azure_vpn_gateway__er_gateway_packets
+      title: Azure VPN Gateway ExpressRoute Packets
+      context: er_gateway_packets
+      family: ExpressRoute
+      type: line
+      units: packets/s
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.express_route_gateway_packets_per_second_average
+          name: average
+    - id: am_azure_vpn_gateway__er_gateway_active_flows
+      title: Azure VPN Gateway ExpressRoute Active Flows
+      context: er_gateway_active_flows
+      family: ExpressRoute
+      type: line
+      units: flows
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.express_route_gateway_active_flows_average
+          name: average
+    - id: am_azure_vpn_gateway__er_gateway_routes_advertised
+      title: Azure VPN Gateway ExpressRoute Routes Advertised to Peer
+      context: er_gateway_routes_advertised
+      family: ExpressRoute
+      type: line
+      units: routes
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.express_route_gateway_count_of_routes_advertised_to_peer_maximum
+          name: maximum
+    - id: am_azure_vpn_gateway__er_gateway_routes_learned
+      title: Azure VPN Gateway ExpressRoute Routes Learned from Peer
+      context: er_gateway_routes_learned
+      family: ExpressRoute
+      type: line
+      units: routes
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.express_route_gateway_count_of_routes_learned_from_peer_maximum
+          name: maximum
+    - id: am_azure_vpn_gateway__er_gateway_route_changes
+      title: Azure VPN Gateway ExpressRoute Route Changes
+      context: er_gateway_route_changes
+      family: ExpressRoute
+      type: line
+      units: changes/s
+      algorithm: incremental
+      dimensions:
+        - selector: vpn_gateway.express_route_gateway_frequency_of_routes_changed_total
+          name: total
+    - id: am_azure_vpn_gateway__er_gateway_max_flows_rate
+      title: Azure VPN Gateway ExpressRoute Max Flow Creation Rate
+      context: er_gateway_max_flows_rate
+      family: ExpressRoute
+      type: line
+      units: flows/s
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.express_route_gateway_max_flows_creation_rate_maximum
+          name: maximum
+    - id: am_azure_vpn_gateway__er_gateway_vm_count
+      title: Azure VPN Gateway ExpressRoute VMs in VNet
+      context: er_gateway_vm_count
+      family: ExpressRoute
+      type: line
+      units: VMs
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.express_route_gateway_number_of_vm_in_vnet_maximum
+          name: maximum
+    - id: am_azure_vpn_gateway__scalable_er_bandwidth
+      title: Azure VPN Gateway Scalable ExpressRoute Bandwidth
+      context: scalable_er_bandwidth
+      family: Scalable ExpressRoute
+      type: line
+      units: bits/s
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.scalable_express_route_gateway_bits_per_second_average
+          name: average
+    - id: am_azure_vpn_gateway__scalable_er_cpu
+      title: Azure VPN Gateway Scalable ExpressRoute CPU Utilization
+      context: scalable_er_cpu
+      family: Scalable ExpressRoute
+      type: line
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.scalable_express_route_gateway_cpu_utilization_average
+          name: average
+    - id: am_azure_vpn_gateway__scalable_er_packets
+      title: Azure VPN Gateway Scalable ExpressRoute Packets
+      context: scalable_er_packets
+      family: Scalable ExpressRoute
+      type: line
+      units: packets/s
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.scalable_express_route_gateway_packets_per_second_average
+          name: average
+    - id: am_azure_vpn_gateway__scalable_er_active_flows
+      title: Azure VPN Gateway Scalable ExpressRoute Active Flows
+      context: scalable_er_active_flows
+      family: Scalable ExpressRoute
+      type: line
+      units: flows
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.scalable_express_route_gateway_active_flows_average
+          name: average
+    - id: am_azure_vpn_gateway__scalable_er_routes_advertised
+      title: Azure VPN Gateway Scalable ExpressRoute Routes Advertised
+      context: scalable_er_routes_advertised
+      family: Scalable ExpressRoute
+      type: line
+      units: routes
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.scalable_express_route_gateway_count_of_routes_advertised_to_peer_maximum
+          name: maximum
+    - id: am_azure_vpn_gateway__scalable_er_routes_learned
+      title: Azure VPN Gateway Scalable ExpressRoute Routes Learned
+      context: scalable_er_routes_learned
+      family: Scalable ExpressRoute
+      type: line
+      units: routes
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.scalable_express_route_gateway_count_of_routes_learned_from_peer_maximum
+          name: maximum
+    - id: am_azure_vpn_gateway__scalable_er_route_changes
+      title: Azure VPN Gateway Scalable ExpressRoute Route Changes
+      context: scalable_er_route_changes
+      family: Scalable ExpressRoute
+      type: line
+      units: changes/s
+      algorithm: incremental
+      dimensions:
+        - selector: vpn_gateway.scalable_express_route_gateway_frequency_of_routes_changed_total
+          name: total
+    - id: am_azure_vpn_gateway__scalable_er_max_flows_rate
+      title: Azure VPN Gateway Scalable ExpressRoute Max Flow Creation Rate
+      context: scalable_er_max_flows_rate
+      family: Scalable ExpressRoute
+      type: line
+      units: flows/s
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.scalable_express_route_gateway_max_flows_creation_rate_maximum
+          name: maximum
+    - id: am_azure_vpn_gateway__scalable_er_vm_count
+      title: Azure VPN Gateway Scalable ExpressRoute VMs in VNet
+      context: scalable_er_vm_count
+      family: Scalable ExpressRoute
+      type: line
+      units: VMs
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.scalable_express_route_gateway_number_of_vm_in_vnet_maximum
+          name: maximum
+    - id: am_azure_vpn_gateway__scalable_er_scale_units
+      title: Azure VPN Gateway Scalable ExpressRoute Scale Units
+      context: scalable_er_scale_units
+      family: Scalable ExpressRoute
+      type: line
+      units: units
+      algorithm: absolute
+      dimensions:
+        - selector: vpn_gateway.scalable_express_route_gateway_scale_unit_maximum
+          name: maximum


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the Azure Monitor default profile YAMLs and fixed the I/O chart family mapping so metrics display under the correct charts. No metric IDs or aggregations were changed.

- **Bug Fixes**
  - Correct I/O chart family mapping to ensure proper chart grouping and visualization.

- **Refactors**
  - Reformatted all default profiles for consistent indentation and series structure across services.

<sup>Written for commit 34204d4c0b1243d60855c0110e9fcb29474bc78c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

