### PR TITLE
docs: clarify sum semantics for web_log rate alerts

### DIFF
--- a/src/go/plugin/go.d/collector/weblog/integrations/web_server_log_files.md
+++ b/src/go/plugin/go.d/collector/weblog/integrations/web_server_log_files.md
@@ -296,6 +296,11 @@ The following alerts are available:
 | [ web_log_web_slow ](https://github.com/netdata/netdata/blob/master/src/health/health.d/web_log.conf) | web_log.request_processing_time | average HTTP response time over the last 1 minute |
 | [ web_log_5m_requests_ratio ](https://github.com/netdata/netdata/blob/master/src/health/health.d/web_log.conf) | web_log.type_requests | ratio of successful HTTP requests over over the last 5 minutes, compared with the previous 5 minutes |
 
+> [!NOTE]
+> `web_log.requests`, `web_log.excluded_requests`, and `web_log.type_requests` are rate charts with `requests/s` units.
+> The bundled `lookup: sum` alerts report an exact request count only when the collector runs with `update_every: 1`.
+> If you increase `update_every`, multiply `$this` by `$update_every` in `calc` when you need the true request volume for the alert window.
+
 
 ## Metrics
 
@@ -449,5 +454,4 @@ If your Netdata runs in a Docker container named "netdata" (replace if different
 ```bash
 docker logs netdata 2>&1 | grep web_log
 ```
-
 

--- a/src/health/REFERENCE.md
+++ b/src/health/REFERENCE.md
@@ -1091,6 +1091,11 @@ template: apache_last_collected_secs
 <br/>
 </details>
 
+> [!NOTE]
+> `lookup: sum` adds the stored samples for the selected window.
+> On rate-based charts, such as `RRD_ALGORITHM_INCREMENTAL` dimensions stored in units like `requests/s`, this equals the true event volume only when the chart collects every second.
+> If `update_every` is greater than `1`, multiply `$this` by `$update_every` in `calc` when you need the total volume represented by the window.
+
 <details>
 <summary><strong>Example 2: Disk Space Monitoring</strong></summary><br/>
 

--- a/src/health/health.d/web_log.conf
+++ b/src/health/health.d/web_log.conf
@@ -7,6 +7,11 @@
 #  $1m_total_requests > 120
 #
 # i.e. when there are at least 120 requests during the last minute
+#
+# These charts are collected as requests/s. `lookup: sum` therefore returns
+# the expected request count only when the collector runs at `update_every: 1`.
+# If you increase `update_every`, multiply `$this` by `$update_every` in `calc`
+# when you need a true request volume over the window.
 
  template: web_log_1m_total_requests
        on: web_log.requests


### PR DESCRIPTION
## Summary

- document that `lookup: sum` on the `web_log` request charts only matches true request counts when `update_every: 1`
- point users to the `$this * $update_every` workaround when they need total request volume with a slower collection interval
- keep the explanation aligned across the shipped alert config, the collector integration guide, and the health reference

## Testing

- `git diff --check`

## Related

- Refs #22112


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that `lookup: sum` on `web_log` rate charts reports exact request counts only with `update_every: 1`, and shows how to get true volumes at higher intervals using `$this * $update_every` in `calc`. Aligns wording across the integration guide, health reference, and `web_log.conf` comments.

<sup>Written for commit 1f5dbd6154e2cbb0168701a99372a674df8e082e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

