### PR TITLE
chore(go.d/azure_monitor): shorten stock profile selectors

### DIFF
--- a/src/go/plugin/go.d/collector/azure_monitor/azureprofiles/default_catalog_test.go
+++ b/src/go/plugin/go.d/collector/azure_monitor/azureprofiles/default_catalog_test.go
@@ -39,6 +39,42 @@ func TestLoadFromDefaultDirs_LoadsAllStockProfiles(t *testing.T) {
 	assert.Len(t, catalog.byBaseName, want)
 }
 
+func TestLoadFromDefaultDirs_StockProfilesUseSelectorShorthand(t *testing.T) {
+	dir := azureProfilesDirFromThisFile()
+	require.NotEmpty(t, dir)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		ext := strings.ToLower(filepath.Ext(name))
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		require.NoError(t, err)
+
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "- selector:") {
+				continue
+			}
+
+			selector := strings.TrimSpace(strings.TrimPrefix(line, "- selector:"))
+			if selector == "" || strings.HasPrefix(selector, "{") {
+				continue
+			}
+
+			assert.NotContainsf(t, selector, ".", "stock profile %q should use selector shorthand, found %q", name, selector)
+		}
+	}
+}
+
 func TestDefaultCatalog_CachesSuccessfulLoads(t *testing.T) {
 	calls := 0
 	restore := stubDefaultCatalog(t, func() bool { return true }, func() (Catalog, error) {

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/aks.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/aks.yaml
@@ -204,9 +204,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: aks.apiserver_cpu_usage_percentage_average
+        - selector: apiserver_cpu_usage_percentage_average
           name: average
-        - selector: aks.apiserver_cpu_usage_percentage_maximum
+        - selector: apiserver_cpu_usage_percentage_maximum
           name: maximum
     - id: am_azure_aks__apiserver_memory
       title: AKS API Server Memory Utilization
@@ -216,9 +216,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: aks.apiserver_memory_usage_percentage_average
+        - selector: apiserver_memory_usage_percentage_average
           name: average
-        - selector: aks.apiserver_memory_usage_percentage_maximum
+        - selector: apiserver_memory_usage_percentage_maximum
           name: maximum
     - id: am_azure_aks__apiserver_inflight_requests
       title: AKS API Server Inflight Requests
@@ -228,7 +228,7 @@ template:
       units: requests
       algorithm: absolute
       dimensions:
-        - selector: aks.apiserver_current_inflight_requests_average
+        - selector: apiserver_current_inflight_requests_average
           name: average
     - id: am_azure_aks__etcd_cpu
       title: AKS etcd CPU Utilization
@@ -238,9 +238,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: aks.etcd_cpu_usage_percentage_average
+        - selector: etcd_cpu_usage_percentage_average
           name: average
-        - selector: aks.etcd_cpu_usage_percentage_maximum
+        - selector: etcd_cpu_usage_percentage_maximum
           name: maximum
     - id: am_azure_aks__etcd_memory
       title: AKS etcd Memory Utilization
@@ -250,9 +250,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: aks.etcd_memory_usage_percentage_average
+        - selector: etcd_memory_usage_percentage_average
           name: average
-        - selector: aks.etcd_memory_usage_percentage_maximum
+        - selector: etcd_memory_usage_percentage_maximum
           name: maximum
     - id: am_azure_aks__etcd_database
       title: AKS etcd Database Utilization
@@ -262,9 +262,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: aks.etcd_database_usage_percentage_average
+        - selector: etcd_database_usage_percentage_average
           name: average
-        - selector: aks.etcd_database_usage_percentage_maximum
+        - selector: etcd_database_usage_percentage_maximum
           name: maximum
     - id: am_azure_aks__pod_status_phase
       title: AKS Pods by Phase
@@ -274,7 +274,7 @@ template:
       units: pods
       algorithm: absolute
       dimensions:
-        - selector: aks.kube_pod_status_phase_average
+        - selector: kube_pod_status_phase_average
           name: average
     - id: am_azure_aks__pod_status_ready
       title: AKS Pods in Ready State
@@ -284,7 +284,7 @@ template:
       units: pods
       algorithm: absolute
       dimensions:
-        - selector: aks.kube_pod_status_ready_average
+        - selector: kube_pod_status_ready_average
           name: average
     - id: am_azure_aks__allocatable_cpu
       title: AKS Allocatable CPU Cores
@@ -294,7 +294,7 @@ template:
       units: cores
       algorithm: absolute
       dimensions:
-        - selector: aks.kube_node_status_allocatable_cpu_cores_average
+        - selector: kube_node_status_allocatable_cpu_cores_average
           name: average
     - id: am_azure_aks__allocatable_memory
       title: AKS Allocatable Memory
@@ -304,7 +304,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: aks.kube_node_status_allocatable_memory_bytes_average
+        - selector: kube_node_status_allocatable_memory_bytes_average
           name: average
     - id: am_azure_aks__node_conditions
       title: AKS Node Conditions
@@ -314,7 +314,7 @@ template:
       units: nodes
       algorithm: absolute
       dimensions:
-        - selector: aks.kube_node_status_condition_average
+        - selector: kube_node_status_condition_average
           name: average
     - id: am_azure_aks__autoscaler_health
       title: AKS Cluster Autoscaler Health
@@ -324,9 +324,9 @@ template:
       units: state
       algorithm: absolute
       dimensions:
-        - selector: aks.cluster_autoscaler_cluster_safe_to_autoscale_average
+        - selector: cluster_autoscaler_cluster_safe_to_autoscale_average
           name: safe_to_autoscale
-        - selector: aks.cluster_autoscaler_scale_down_in_cooldown_average
+        - selector: cluster_autoscaler_scale_down_in_cooldown_average
           name: cooldown
     - id: am_azure_aks__autoscaler_unschedulable_pods
       title: AKS Autoscaler Unschedulable Pods
@@ -336,7 +336,7 @@ template:
       units: pods
       algorithm: absolute
       dimensions:
-        - selector: aks.cluster_autoscaler_unschedulable_pods_count_average
+        - selector: cluster_autoscaler_unschedulable_pods_count_average
           name: average
     - id: am_azure_aks__autoscaler_unneeded_nodes
       title: AKS Autoscaler Unneeded Nodes
@@ -346,7 +346,7 @@ template:
       units: nodes
       algorithm: absolute
       dimensions:
-        - selector: aks.cluster_autoscaler_unneeded_nodes_count_average
+        - selector: cluster_autoscaler_unneeded_nodes_count_average
           name: average
     - id: am_azure_aks__node_cpu_millicores
       title: AKS Node CPU Usage
@@ -356,9 +356,9 @@ template:
       units: millicores
       algorithm: absolute
       dimensions:
-        - selector: aks.node_cpu_usage_millicores_average
+        - selector: node_cpu_usage_millicores_average
           name: average
-        - selector: aks.node_cpu_usage_millicores_maximum
+        - selector: node_cpu_usage_millicores_maximum
           name: maximum
     - id: am_azure_aks__node_cpu_percentage
       title: AKS Node CPU Percentage
@@ -368,9 +368,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: aks.node_cpu_usage_percentage_average
+        - selector: node_cpu_usage_percentage_average
           name: average
-        - selector: aks.node_cpu_usage_percentage_maximum
+        - selector: node_cpu_usage_percentage_maximum
           name: maximum
     - id: am_azure_aks__node_memory_working_set
       title: AKS Node Memory Working Set
@@ -380,9 +380,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: aks.node_memory_working_set_bytes_average
+        - selector: node_memory_working_set_bytes_average
           name: average
-        - selector: aks.node_memory_working_set_bytes_maximum
+        - selector: node_memory_working_set_bytes_maximum
           name: maximum
     - id: am_azure_aks__node_memory_working_set_percentage
       title: AKS Node Memory Working Set Percentage
@@ -392,9 +392,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: aks.node_memory_working_set_percentage_average
+        - selector: node_memory_working_set_percentage_average
           name: average
-        - selector: aks.node_memory_working_set_percentage_maximum
+        - selector: node_memory_working_set_percentage_maximum
           name: maximum
     - id: am_azure_aks__node_memory_rss
       title: AKS Node Memory RSS
@@ -404,9 +404,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: aks.node_memory_rss_bytes_average
+        - selector: node_memory_rss_bytes_average
           name: average
-        - selector: aks.node_memory_rss_bytes_maximum
+        - selector: node_memory_rss_bytes_maximum
           name: maximum
     - id: am_azure_aks__node_memory_rss_percentage
       title: AKS Node Memory RSS Percentage
@@ -416,9 +416,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: aks.node_memory_rss_percentage_average
+        - selector: node_memory_rss_percentage_average
           name: average
-        - selector: aks.node_memory_rss_percentage_maximum
+        - selector: node_memory_rss_percentage_maximum
           name: maximum
     - id: am_azure_aks__node_disk_usage
       title: AKS Node Disk Usage
@@ -428,9 +428,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: aks.node_disk_usage_bytes_average
+        - selector: node_disk_usage_bytes_average
           name: average
-        - selector: aks.node_disk_usage_bytes_maximum
+        - selector: node_disk_usage_bytes_maximum
           name: maximum
     - id: am_azure_aks__node_disk_percentage
       title: AKS Node Disk Usage Percentage
@@ -440,9 +440,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: aks.node_disk_usage_percentage_average
+        - selector: node_disk_usage_percentage_average
           name: average
-        - selector: aks.node_disk_usage_percentage_maximum
+        - selector: node_disk_usage_percentage_maximum
           name: maximum
     - id: am_azure_aks__node_network
       title: AKS Node Network Traffic
@@ -452,7 +452,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: aks.node_network_in_bytes_average
+        - selector: node_network_in_bytes_average
           name: in
-        - selector: aks.node_network_out_bytes_average
+        - selector: node_network_out_bytes_average
           name: out

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/api_management.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/api_management.yaml
@@ -126,7 +126,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: api_management.capacity_average
+        - selector: capacity_average
           name: capacity
     - id: am_azure_api_management__gateway_cpu
       title: Azure API Management Gateway CPU
@@ -136,7 +136,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: api_management.cpu_percent_gateway_average
+        - selector: cpu_percent_gateway_average
           name: cpu
     - id: am_azure_api_management__gateway_memory
       title: Azure API Management Gateway Memory
@@ -146,7 +146,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: api_management.memory_percent_gateway_average
+        - selector: memory_percent_gateway_average
           name: memory
     - id: am_azure_api_management__requests
       title: Azure API Management Gateway Requests
@@ -156,7 +156,7 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: api_management.requests_total
+        - selector: requests_total
           name: requests
     - id: am_azure_api_management__request_duration
       title: Azure API Management Request Duration
@@ -166,9 +166,9 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: api_management.duration_average
+        - selector: duration_average
           name: overall
-        - selector: api_management.backend_duration_average
+        - selector: backend_duration_average
           name: backend
     - id: am_azure_api_management__eventhub_events
       title: Azure API Management EventHub Events
@@ -178,19 +178,19 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: api_management.event_hub_total_events_total
+        - selector: event_hub_total_events_total
           name: total
-        - selector: api_management.event_hub_successful_events_total
+        - selector: event_hub_successful_events_total
           name: successful
-        - selector: api_management.event_hub_total_failed_events_total
+        - selector: event_hub_total_failed_events_total
           name: failed
-        - selector: api_management.event_hub_dropped_events_total
+        - selector: event_hub_dropped_events_total
           name: dropped
-        - selector: api_management.event_hub_rejected_events_total
+        - selector: event_hub_rejected_events_total
           name: rejected
-        - selector: api_management.event_hub_throttled_events_total
+        - selector: event_hub_throttled_events_total
           name: throttled
-        - selector: api_management.event_hub_timedout_events_total
+        - selector: event_hub_timedout_events_total
           name: timed_out
     - id: am_azure_api_management__eventhub_bytes
       title: Azure API Management EventHub Bytes Sent
@@ -200,7 +200,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: api_management.event_hub_total_bytes_sent_total
+        - selector: event_hub_total_bytes_sent_total
           name: sent
     - id: am_azure_api_management__websocket_connections
       title: Azure API Management WebSocket Connection Attempts
@@ -210,7 +210,7 @@ template:
       units: attempts/s
       algorithm: incremental
       dimensions:
-        - selector: api_management.connection_attempts_total
+        - selector: connection_attempts_total
           name: connection_attempts
     - id: am_azure_api_management__websocket_messages
       title: Azure API Management WebSocket Messages
@@ -220,7 +220,7 @@ template:
       units: messages/s
       algorithm: incremental
       dimensions:
-        - selector: api_management.web_socket_messages_total
+        - selector: web_socket_messages_total
           name: messages
     - id: am_azure_api_management__network_connectivity
       title: Azure API Management Network Connectivity Status
@@ -230,5 +230,5 @@ template:
       units: status
       algorithm: absolute
       dimensions:
-        - selector: api_management.network_connectivity_average
+        - selector: network_connectivity_average
           name: connectivity

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/app_service.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/app_service.yaml
@@ -282,7 +282,7 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: app_service.requests_total
+        - selector: requests_total
           name: requests
     - id: am_azure_app_service__response_time
       title: Azure App Service Response Time
@@ -292,7 +292,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: app_service.http_response_time_average
+        - selector: http_response_time_average
           name: average
     - id: am_azure_app_service__http_status
       title: Azure App Service HTTP Status Codes
@@ -302,13 +302,13 @@ template:
       units: responses/s
       algorithm: incremental
       dimensions:
-        - selector: app_service.http2xx_total
+        - selector: http2xx_total
           name: 2xx
-        - selector: app_service.http3xx_total
+        - selector: http3xx_total
           name: 3xx
-        - selector: app_service.http4xx_total
+        - selector: http4xx_total
           name: 4xx
-        - selector: app_service.http5xx_total
+        - selector: http5xx_total
           name: 5xx
     - id: am_azure_app_service__http_error_detail
       title: Azure App Service HTTP Error Detail
@@ -318,15 +318,15 @@ template:
       units: responses/s
       algorithm: incremental
       dimensions:
-        - selector: app_service.http101_total
+        - selector: http101_total
           name: 101_websocket
-        - selector: app_service.http401_total
+        - selector: http401_total
           name: 401_unauthorized
-        - selector: app_service.http403_total
+        - selector: http403_total
           name: 403_forbidden
-        - selector: app_service.http404_total
+        - selector: http404_total
           name: 404_not_found
-        - selector: app_service.http406_total
+        - selector: http406_total
           name: 406_not_acceptable
     - id: am_azure_app_service__cpu
       title: Azure App Service CPU Utilization
@@ -336,7 +336,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: app_service.cpu_percentage_average
+        - selector: cpu_percentage_average
           name: average
     - id: am_azure_app_service__cpu_time
       title: Azure App Service CPU Time
@@ -346,7 +346,7 @@ template:
       units: seconds
       algorithm: incremental
       dimensions:
-        - selector: app_service.cpu_time_total
+        - selector: cpu_time_total
           name: total
     - id: am_azure_app_service__memory_usage
       title: Azure App Service Memory Usage
@@ -356,11 +356,11 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: app_service.average_memory_working_set_average
+        - selector: average_memory_working_set_average
           name: average_working_set
-        - selector: app_service.memory_working_set_average
+        - selector: memory_working_set_average
           name: working_set
-        - selector: app_service.private_bytes_average
+        - selector: private_bytes_average
           name: private
     - id: am_azure_app_service__health
       title: Azure App Service Health Check Status
@@ -370,7 +370,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: app_service.health_check_status_average
+        - selector: health_check_status_average
           name: average
     - id: am_azure_app_service__network_traffic
       title: Azure App Service Network Traffic
@@ -380,9 +380,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: app_service.bytes_received_total
+        - selector: bytes_received_total
           name: received
-        - selector: app_service.bytes_sent_total
+        - selector: bytes_sent_total
           name: sent
     - id: am_azure_app_service__connections
       title: Azure App Service Connections
@@ -392,7 +392,7 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: app_service.app_connections_average
+        - selector: app_connections_average
           name: average
     - id: am_azure_app_service__io_throughput
       title: Azure App Service IO Throughput
@@ -402,11 +402,11 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: app_service.io_read_bytes_per_second_total
+        - selector: io_read_bytes_per_second_total
           name: read
-        - selector: app_service.io_write_bytes_per_second_total
+        - selector: io_write_bytes_per_second_total
           name: write
-        - selector: app_service.io_other_bytes_per_second_total
+        - selector: io_other_bytes_per_second_total
           name: other
     - id: am_azure_app_service__io_operations
       title: Azure App Service IO Operations
@@ -416,11 +416,11 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: app_service.io_read_operations_per_second_total
+        - selector: io_read_operations_per_second_total
           name: read
-        - selector: app_service.io_write_operations_per_second_total
+        - selector: io_write_operations_per_second_total
           name: write
-        - selector: app_service.io_other_operations_per_second_total
+        - selector: io_other_operations_per_second_total
           name: other
     - id: am_azure_app_service__threads
       title: Azure App Service Threads
@@ -430,7 +430,7 @@ template:
       units: threads
       algorithm: absolute
       dimensions:
-        - selector: app_service.threads_average
+        - selector: threads_average
           name: average
     - id: am_azure_app_service__handles
       title: Azure App Service Handles
@@ -440,7 +440,7 @@ template:
       units: handles
       algorithm: absolute
       dimensions:
-        - selector: app_service.handles_average
+        - selector: handles_average
           name: average
     - id: am_azure_app_service__gc_collections
       title: Azure App Service .NET GC Collections
@@ -450,11 +450,11 @@ template:
       units: collections/s
       algorithm: incremental
       dimensions:
-        - selector: app_service.gen0_collections_total
+        - selector: gen0_collections_total
           name: gen0
-        - selector: app_service.gen1_collections_total
+        - selector: gen1_collections_total
           name: gen1
-        - selector: app_service.gen2_collections_total
+        - selector: gen2_collections_total
           name: gen2
     - id: am_azure_app_service__function_executions
       title: Azure App Service Function Executions
@@ -464,7 +464,7 @@ template:
       units: executions/s
       algorithm: incremental
       dimensions:
-        - selector: app_service.function_execution_count_total
+        - selector: function_execution_count_total
           name: total
     - id: am_azure_app_service__function_execution_units
       title: Azure App Service Function Execution Units
@@ -474,7 +474,7 @@ template:
       units: MB-milliseconds/s
       algorithm: incremental
       dimensions:
-        - selector: app_service.function_execution_units_total
+        - selector: function_execution_units_total
           name: total
     - id: am_azure_app_service__always_ready_function_executions
       title: Azure App Service Always Ready Function Executions
@@ -484,7 +484,7 @@ template:
       units: executions/s
       algorithm: incremental
       dimensions:
-        - selector: app_service.always_ready_function_execution_count_total
+        - selector: always_ready_function_execution_count_total
           name: total
     - id: am_azure_app_service__always_ready_function_execution_units
       title: Azure App Service Always Ready Function Execution Units
@@ -494,7 +494,7 @@ template:
       units: MB-milliseconds/s
       algorithm: incremental
       dimensions:
-        - selector: app_service.always_ready_function_execution_units_total
+        - selector: always_ready_function_execution_units_total
           name: total
     - id: am_azure_app_service__always_ready_units
       title: Azure App Service Always Ready Units
@@ -504,7 +504,7 @@ template:
       units: units
       algorithm: absolute
       dimensions:
-        - selector: app_service.always_ready_units_total
+        - selector: always_ready_units_total
           name: total
     - id: am_azure_app_service__on_demand_function_executions
       title: Azure App Service On Demand Function Executions
@@ -514,7 +514,7 @@ template:
       units: executions/s
       algorithm: incremental
       dimensions:
-        - selector: app_service.on_demand_function_execution_count_total
+        - selector: on_demand_function_execution_count_total
           name: total
     - id: am_azure_app_service__on_demand_function_execution_units
       title: Azure App Service On Demand Function Execution Units
@@ -524,7 +524,7 @@ template:
       units: MB-milliseconds/s
       algorithm: incremental
       dimensions:
-        - selector: app_service.on_demand_function_execution_units_total
+        - selector: on_demand_function_execution_units_total
           name: total
     - id: am_azure_app_service__request_queue
       title: Azure App Service Request Queue
@@ -534,7 +534,7 @@ template:
       units: requests
       algorithm: absolute
       dimensions:
-        - selector: app_service.requests_in_application_queue_average
+        - selector: requests_in_application_queue_average
           name: queued
     - id: am_azure_app_service__instances
       title: Azure App Service Instance Count
@@ -544,7 +544,7 @@ template:
       units: instances
       algorithm: absolute
       dimensions:
-        - selector: app_service.instance_count_average
+        - selector: instance_count_average
           name: running
     - id: am_azure_app_service__assemblies
       title: Azure App Service .NET Assemblies
@@ -554,7 +554,7 @@ template:
       units: assemblies
       algorithm: absolute
       dimensions:
-        - selector: app_service.current_assemblies_average
+        - selector: current_assemblies_average
           name: loaded
     - id: am_azure_app_service__app_domains
       title: Azure App Service App Domains
@@ -564,7 +564,7 @@ template:
       units: domains
       algorithm: absolute
       dimensions:
-        - selector: app_service.total_app_domains_average
+        - selector: total_app_domains_average
           name: loaded
-        - selector: app_service.total_app_domains_unloaded_average
+        - selector: total_app_domains_unloaded_average
           name: unloaded

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/application_gateway.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/application_gateway.yaml
@@ -234,7 +234,7 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: application_gateway.throughput_average
+        - selector: throughput_average
           name: average
     - id: am_azure_application_gateway__traffic_volume
       title: Azure Application Gateway Traffic Volume
@@ -244,9 +244,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: application_gateway.bytes_received_total
+        - selector: bytes_received_total
           name: received
-        - selector: application_gateway.bytes_sent_total
+        - selector: bytes_sent_total
           name: sent
     - id: am_azure_application_gateway__requests
       title: Azure Application Gateway Requests
@@ -256,9 +256,9 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: application_gateway.total_requests_total
+        - selector: total_requests_total
           name: total
-        - selector: application_gateway.failed_requests_total
+        - selector: failed_requests_total
           name: failed
     - id: am_azure_application_gateway__response_status
       title: Azure Application Gateway Response Status
@@ -268,9 +268,9 @@ template:
       units: responses/s
       algorithm: incremental
       dimensions:
-        - selector: application_gateway.response_status_total
+        - selector: response_status_total
           name: gateway
-        - selector: application_gateway.backend_response_status_total
+        - selector: backend_response_status_total
           name: backend
     - id: am_azure_application_gateway__backend_health
       title: Azure Application Gateway Backend Health
@@ -280,9 +280,9 @@ template:
       units: hosts
       algorithm: absolute
       dimensions:
-        - selector: application_gateway.healthy_host_count_average
+        - selector: healthy_host_count_average
           name: healthy
-        - selector: application_gateway.unhealthy_host_count_average
+        - selector: unhealthy_host_count_average
           name: unhealthy
     - id: am_azure_application_gateway__backend_request_load
       title: Azure Application Gateway Backend Request Load
@@ -292,7 +292,7 @@ template:
       units: requests
       algorithm: absolute
       dimensions:
-        - selector: application_gateway.avg_request_count_per_healthy_host_average
+        - selector: avg_request_count_per_healthy_host_average
           name: per_healthy_host
     - id: am_azure_application_gateway__backend_latency
       title: Azure Application Gateway Backend Latency
@@ -302,11 +302,11 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: application_gateway.backend_connect_time_average
+        - selector: backend_connect_time_average
           name: connect
-        - selector: application_gateway.backend_first_byte_response_time_average
+        - selector: backend_first_byte_response_time_average
           name: first_byte
-        - selector: application_gateway.backend_last_byte_response_time_average
+        - selector: backend_last_byte_response_time_average
           name: last_byte
     - id: am_azure_application_gateway__client_latency
       title: Azure Application Gateway Client Latency
@@ -316,9 +316,9 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: application_gateway.application_gateway_total_time_average
+        - selector: application_gateway_total_time_average
           name: total_time
-        - selector: application_gateway.client_rtt_average
+        - selector: client_rtt_average
           name: client_rtt
     - id: am_azure_application_gateway__current_connections
       title: Azure Application Gateway Current Connections
@@ -328,7 +328,7 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: application_gateway.current_connections_total
+        - selector: current_connections_total
           name: current
     - id: am_azure_application_gateway__new_connections
       title: Azure Application Gateway New Connections
@@ -338,7 +338,7 @@ template:
       units: connections/s
       algorithm: absolute
       dimensions:
-        - selector: application_gateway.new_connections_per_second_average
+        - selector: new_connections_per_second_average
           name: average
     - id: am_azure_application_gateway__websocket_connections
       title: Azure Application Gateway WebSocket Connections
@@ -348,7 +348,7 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: application_gateway.web_socket_active_connections_total
+        - selector: web_socket_active_connections_total
           name: active
     - id: am_azure_application_gateway__websocket_close_codes
       title: Azure Application Gateway WebSocket Close Codes
@@ -358,7 +358,7 @@ template:
       units: connections/s
       algorithm: incremental
       dimensions:
-        - selector: application_gateway.websocket_specific_close_status_code_total
+        - selector: websocket_specific_close_status_code_total
           name: total
     - id: am_azure_application_gateway__capacity
       title: Azure Application Gateway Capacity
@@ -368,13 +368,13 @@ template:
       units: units
       algorithm: absolute
       dimensions:
-        - selector: application_gateway.capacity_units_average
+        - selector: capacity_units_average
           name: capacity
-        - selector: application_gateway.compute_units_average
+        - selector: compute_units_average
           name: compute
-        - selector: application_gateway.estimated_billed_capacity_units_average
+        - selector: estimated_billed_capacity_units_average
           name: billed
-        - selector: application_gateway.fixed_billable_capacity_units_average
+        - selector: fixed_billable_capacity_units_average
           name: fixed_billed
     - id: am_azure_application_gateway__cpu
       title: Azure Application Gateway CPU Utilization
@@ -384,7 +384,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: application_gateway.cpu_utilization_average
+        - selector: cpu_utilization_average
           name: average
     - id: am_azure_application_gateway__tls_connections
       title: Azure Application Gateway TLS Connections
@@ -394,7 +394,7 @@ template:
       units: connections/s
       algorithm: incremental
       dimensions:
-        - selector: application_gateway.tls_protocol_total
+        - selector: tls_protocol_total
           name: total
     - id: am_azure_application_gateway__waf_requests
       title: Azure Application Gateway WAF Requests
@@ -404,11 +404,11 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: application_gateway.azwaf_total_requests_total
+        - selector: azwaf_total_requests_total
           name: total
-        - selector: application_gateway.blocked_count_total
+        - selector: blocked_count_total
           name: blocked
-        - selector: application_gateway.matched_count_total
+        - selector: matched_count_total
           name: matched
     - id: am_azure_application_gateway__waf_rule_matches
       title: Azure Application Gateway WAF Rule Matches
@@ -418,11 +418,11 @@ template:
       units: matches/s
       algorithm: incremental
       dimensions:
-        - selector: application_gateway.azwaf_sec_rule_total
+        - selector: azwaf_sec_rule_total
           name: managed
-        - selector: application_gateway.azwaf_custom_rule_total
+        - selector: azwaf_custom_rule_total
           name: custom
-        - selector: application_gateway.azwaf_bot_protection_total
+        - selector: azwaf_bot_protection_total
           name: bot
     - id: am_azure_application_gateway__waf_challenges
       title: Azure Application Gateway WAF Challenges
@@ -432,9 +432,9 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: application_gateway.az_waf_captcha_challenge_request_count_total
+        - selector: az_waf_captcha_challenge_request_count_total
           name: captcha
-        - selector: application_gateway.az_wafjs_challenge_request_count_total
+        - selector: az_wafjs_challenge_request_count_total
           name: js_challenge
     - id: am_azure_application_gateway__waf_penalty_box
       title: Azure Application Gateway WAF Penalty Box
@@ -444,7 +444,7 @@ template:
       units: IPs
       algorithm: absolute
       dimensions:
-        - selector: application_gateway.azwaf_penalty_box_size_average
+        - selector: azwaf_penalty_box_size_average
           name: size
     - id: am_azure_application_gateway__waf_penalty_box_hits
       title: Azure Application Gateway WAF Penalty Box Hits
@@ -454,5 +454,5 @@ template:
       units: hits/s
       algorithm: incremental
       dimensions:
-        - selector: application_gateway.azwaf_penalty_box_hits_total
+        - selector: azwaf_penalty_box_hits_total
           name: total

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/application_insights.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/application_insights.yaml
@@ -204,7 +204,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: application_insights.availability_results_availability_percentage_average
+        - selector: availability_results_availability_percentage_average
           name: average
     - id: am_azure_application_insights__availability_tests
       title: Azure Application Insights Availability Tests
@@ -214,7 +214,7 @@ template:
       units: tests/s
       algorithm: incremental
       dimensions:
-        - selector: application_insights.availability_results_count_count
+        - selector: availability_results_count_count
           name: tests
     - id: am_azure_application_insights__availability_duration
       title: Azure Application Insights Availability Test Duration
@@ -224,7 +224,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: application_insights.availability_results_duration_average
+        - selector: availability_results_duration_average
           name: average
     - id: am_azure_application_insights__server_requests
       title: Azure Application Insights Server Requests
@@ -234,9 +234,9 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: application_insights.requests_count_count
+        - selector: requests_count_count
           name: total
-        - selector: application_insights.requests_failed_count
+        - selector: requests_failed_count
           name: failed
     - id: am_azure_application_insights__server_request_rate
       title: Azure Application Insights Server Request Rate
@@ -246,7 +246,7 @@ template:
       units: requests/s
       algorithm: absolute
       dimensions:
-        - selector: application_insights.requests_rate_average
+        - selector: requests_rate_average
           name: average
     - id: am_azure_application_insights__server_response_time
       title: Azure Application Insights Server Response Time
@@ -256,7 +256,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: application_insights.requests_duration_average
+        - selector: requests_duration_average
           name: average
     - id: am_azure_application_insights__dependency_calls
       title: Azure Application Insights Dependency Calls
@@ -266,9 +266,9 @@ template:
       units: calls/s
       algorithm: incremental
       dimensions:
-        - selector: application_insights.dependencies_count_count
+        - selector: dependencies_count_count
           name: total
-        - selector: application_insights.dependencies_failed_count
+        - selector: dependencies_failed_count
           name: failed
     - id: am_azure_application_insights__dependency_duration
       title: Azure Application Insights Dependency Duration
@@ -278,7 +278,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: application_insights.dependencies_duration_average
+        - selector: dependencies_duration_average
           name: average
     - id: am_azure_application_insights__exceptions
       title: Azure Application Insights Exceptions
@@ -288,11 +288,11 @@ template:
       units: exceptions/s
       algorithm: incremental
       dimensions:
-        - selector: application_insights.exceptions_count_count
+        - selector: exceptions_count_count
           name: total
-        - selector: application_insights.exceptions_browser_count
+        - selector: exceptions_browser_count
           name: browser
-        - selector: application_insights.exceptions_server_count
+        - selector: exceptions_server_count
           name: server
     - id: am_azure_application_insights__browser_page_load_time
       title: Azure Application Insights Browser Page Load Time
@@ -302,7 +302,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: application_insights.browser_timings_total_duration_average
+        - selector: browser_timings_total_duration_average
           name: total
     - id: am_azure_application_insights__browser_timing_breakdown
       title: Azure Application Insights Browser Timing Breakdown
@@ -312,13 +312,13 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: application_insights.browser_timings_network_duration_average
+        - selector: browser_timings_network_duration_average
           name: network
-        - selector: application_insights.browser_timings_send_duration_average
+        - selector: browser_timings_send_duration_average
           name: send
-        - selector: application_insights.browser_timings_receive_duration_average
+        - selector: browser_timings_receive_duration_average
           name: receive
-        - selector: application_insights.browser_timings_processing_duration_average
+        - selector: browser_timings_processing_duration_average
           name: processing
     - id: am_azure_application_insights__cpu_utilization
       title: Azure Application Insights CPU Utilization
@@ -328,9 +328,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: application_insights.performance_counters_process_cpu_percentage_average
+        - selector: performance_counters_process_cpu_percentage_average
           name: process
-        - selector: application_insights.performance_counters_processor_cpu_percentage_average
+        - selector: performance_counters_processor_cpu_percentage_average
           name: processor
     - id: am_azure_application_insights__memory
       title: Azure Application Insights Memory
@@ -340,9 +340,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: application_insights.performance_counters_memory_available_bytes_average
+        - selector: performance_counters_memory_available_bytes_average
           name: available
-        - selector: application_insights.performance_counters_process_private_bytes_average
+        - selector: performance_counters_process_private_bytes_average
           name: private
     - id: am_azure_application_insights__process_io_rate
       title: Azure Application Insights Process IO Rate
@@ -352,7 +352,7 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: application_insights.performance_counters_process_io_bytes_per_second_average
+        - selector: performance_counters_process_io_bytes_per_second_average
           name: average
     - id: am_azure_application_insights__exception_rate
       title: Azure Application Insights Exception Rate
@@ -362,7 +362,7 @@ template:
       units: exceptions/s
       algorithm: absolute
       dimensions:
-        - selector: application_insights.performance_counters_exceptions_per_second_average
+        - selector: performance_counters_exceptions_per_second_average
           name: average
     - id: am_azure_application_insights__http_request_execution_time
       title: Azure Application Insights HTTP Request Execution Time
@@ -372,7 +372,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: application_insights.performance_counters_request_execution_time_average
+        - selector: performance_counters_request_execution_time_average
           name: average
     - id: am_azure_application_insights__http_request_queue
       title: Azure Application Insights HTTP Requests in Queue
@@ -382,7 +382,7 @@ template:
       units: requests
       algorithm: absolute
       dimensions:
-        - selector: application_insights.performance_counters_requests_in_queue_average
+        - selector: performance_counters_requests_in_queue_average
           name: queued
     - id: am_azure_application_insights__http_request_rate
       title: Azure Application Insights HTTP Request Rate
@@ -392,7 +392,7 @@ template:
       units: requests/s
       algorithm: absolute
       dimensions:
-        - selector: application_insights.performance_counters_requests_per_second_average
+        - selector: performance_counters_requests_per_second_average
           name: average
     - id: am_azure_application_insights__page_views
       title: Azure Application Insights Page Views
@@ -402,7 +402,7 @@ template:
       units: views/s
       algorithm: incremental
       dimensions:
-        - selector: application_insights.page_views_count_count
+        - selector: page_views_count_count
           name: views
     - id: am_azure_application_insights__page_view_load_time
       title: Azure Application Insights Page View Load Time
@@ -412,7 +412,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: application_insights.page_views_duration_average
+        - selector: page_views_duration_average
           name: average
     - id: am_azure_application_insights__traces
       title: Azure Application Insights Traces
@@ -422,5 +422,5 @@ template:
       units: traces/s
       algorithm: incremental
       dimensions:
-        - selector: application_insights.traces_count_count
+        - selector: traces_count_count
           name: traces

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/cognitive_services.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/cognitive_services.yaml
@@ -840,7 +840,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.success_rate_average
+        - selector: success_rate_average
           name: availability
     - id: am_azure_cognitive_services__calls
       title: Azure Cognitive Services Calls
@@ -850,13 +850,13 @@ template:
       units: calls/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.total_calls_total
+        - selector: total_calls_total
           name: total
-        - selector: cognitive_services.successful_calls_total
+        - selector: successful_calls_total
           name: successful
-        - selector: cognitive_services.blocked_calls_total
+        - selector: blocked_calls_total
           name: blocked
-        - selector: cognitive_services.total_token_calls_total
+        - selector: total_token_calls_total
           name: token
     - id: am_azure_cognitive_services__errors
       title: Azure Cognitive Services Errors
@@ -866,11 +866,11 @@ template:
       units: errors/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.total_errors_total
+        - selector: total_errors_total
           name: total
-        - selector: cognitive_services.client_errors_total
+        - selector: client_errors_total
           name: client
-        - selector: cognitive_services.server_errors_total
+        - selector: server_errors_total
           name: server
     - id: am_azure_cognitive_services__latency
       title: Azure Cognitive Services Latency
@@ -880,7 +880,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.latency_average
+        - selector: latency_average
           name: average
     - id: am_azure_cognitive_services__data_transfer
       title: Azure Cognitive Services Data Transfer
@@ -890,9 +890,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.data_in_total
+        - selector: data_in_total
           name: in
-        - selector: cognitive_services.data_out_total
+        - selector: data_out_total
           name: out
     - id: am_azure_cognitive_services__rate_limit
       title: Azure Cognitive Services Rate Limit
@@ -902,7 +902,7 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.ratelimit_total
+        - selector: ratelimit_total
           name: rate_limit
     - id: am_azure_cognitive_services__openai_availability
       title: Azure OpenAI Availability
@@ -912,7 +912,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.azure_open_ai_availability_rate_average
+        - selector: azure_open_ai_availability_rate_average
           name: availability
     - id: am_azure_cognitive_services__openai_requests
       title: Azure OpenAI Requests
@@ -922,7 +922,7 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.azure_open_ai_requests_total
+        - selector: azure_open_ai_requests_total
           name: requests
     - id: am_azure_cognitive_services__openai_latency
       title: Azure OpenAI Latency
@@ -932,13 +932,13 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.azure_open_ai_time_to_response_average
+        - selector: azure_open_ai_time_to_response_average
           name: time_to_response
-        - selector: cognitive_services.azure_open_ai_normalized_ttft_in_ms_average
+        - selector: azure_open_ai_normalized_ttft_in_ms_average
           name: time_to_first_token
-        - selector: cognitive_services.azure_open_ai_normalized_tbt_in_ms_average
+        - selector: azure_open_ai_normalized_tbt_in_ms_average
           name: time_between_tokens
-        - selector: cognitive_services.azure_open_aittlt_in_ms_average
+        - selector: azure_open_aittlt_in_ms_average
           name: time_to_last_byte
     - id: am_azure_cognitive_services__openai_generation_speed
       title: Azure OpenAI Token Generation Speed
@@ -948,7 +948,7 @@ template:
       units: tokens/s
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.azure_open_ai_token_per_second_average
+        - selector: azure_open_ai_token_per_second_average
           name: tokens_per_second
     - id: am_azure_cognitive_services__openai_token_usage
       title: Azure OpenAI Token Usage
@@ -958,13 +958,13 @@ template:
       units: tokens/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.token_transaction_total
+        - selector: token_transaction_total
           name: total
-        - selector: cognitive_services.processed_prompt_tokens_total
+        - selector: processed_prompt_tokens_total
           name: prompt
-        - selector: cognitive_services.generated_tokens_total
+        - selector: generated_tokens_total
           name: generated
-        - selector: cognitive_services.active_tokens_total
+        - selector: active_tokens_total
           name: active
     - id: am_azure_cognitive_services__openai_audio_tokens
       title: Azure OpenAI Audio Tokens
@@ -974,9 +974,9 @@ template:
       units: tokens/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.audio_prompt_tokens_total
+        - selector: audio_prompt_tokens_total
           name: prompt
-        - selector: cognitive_services.audio_completion_tokens_total
+        - selector: audio_completion_tokens_total
           name: completion
     - id: am_azure_cognitive_services__openai_cache_match_rate
       title: Azure OpenAI Prompt Token Cache Match Rate
@@ -986,7 +986,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.azure_open_ai_context_tokens_cache_match_rate_average
+        - selector: azure_open_ai_context_tokens_cache_match_rate_average
           name: cache_match_rate
     - id: am_azure_cognitive_services__openai_provisioned_utilization
       title: Azure OpenAI Provisioned-managed Utilization
@@ -996,7 +996,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.azure_open_ai_provisioned_managed_utilization_v2_average
+        - selector: azure_open_ai_provisioned_managed_utilization_v2_average
           name: utilization
     - id: am_azure_cognitive_services__openai_finetuning
       title: Azure OpenAI Fine-Tuning Training Hours
@@ -1006,7 +1006,7 @@ template:
       units: hours/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.fine_tuned_training_hours_total
+        - selector: fine_tuned_training_hours_total
           name: training_hours
     - id: am_azure_cognitive_services__openai_realtime_usage
       title: Azure OpenAI Realtime API Usage
@@ -1016,7 +1016,7 @@ template:
       units: seconds/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.realtime_usage_time_total
+        - selector: realtime_usage_time_total
           name: seconds_used
     - id: am_azure_cognitive_services__model_availability
       title: Azure Cognitive Services Model Availability
@@ -1026,7 +1026,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.model_availability_rate_average
+        - selector: model_availability_rate_average
           name: availability
     - id: am_azure_cognitive_services__model_requests
       title: Azure Cognitive Services Model Requests
@@ -1036,7 +1036,7 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.model_requests_total
+        - selector: model_requests_total
           name: requests
     - id: am_azure_cognitive_services__model_latency
       title: Azure Cognitive Services Model Latency
@@ -1046,13 +1046,13 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.time_to_response_average
+        - selector: time_to_response_average
           name: time_to_response
-        - selector: cognitive_services.normalized_time_to_first_token_average
+        - selector: normalized_time_to_first_token_average
           name: time_to_first_token
-        - selector: cognitive_services.normalized_time_between_tokens_average
+        - selector: normalized_time_between_tokens_average
           name: time_between_tokens
-        - selector: cognitive_services.time_to_last_byte_average
+        - selector: time_to_last_byte_average
           name: time_to_last_byte
     - id: am_azure_cognitive_services__model_generation_speed
       title: Azure Cognitive Services Model Token Generation Speed
@@ -1062,7 +1062,7 @@ template:
       units: tokens/s
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.tokens_per_second_average
+        - selector: tokens_per_second_average
           name: tokens_per_second
     - id: am_azure_cognitive_services__model_token_usage
       title: Azure Cognitive Services Model Token Usage
@@ -1072,11 +1072,11 @@ template:
       units: tokens/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.total_tokens_total
+        - selector: total_tokens_total
           name: total
-        - selector: cognitive_services.input_tokens_total
+        - selector: input_tokens_total
           name: input
-        - selector: cognitive_services.output_tokens_total
+        - selector: output_tokens_total
           name: output
     - id: am_azure_cognitive_services__model_audio_tokens
       title: Azure Cognitive Services Model Audio Tokens
@@ -1086,9 +1086,9 @@ template:
       units: tokens/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.audio_input_tokens_total
+        - selector: audio_input_tokens_total
           name: input
-        - selector: cognitive_services.audio_output_tokens_total
+        - selector: audio_output_tokens_total
           name: output
     - id: am_azure_cognitive_services__model_cache_tokens
       title: Azure Cognitive Services Model Cache Tokens
@@ -1098,11 +1098,11 @@ template:
       units: tokens/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.cache_read_input_tokens_total
+        - selector: cache_read_input_tokens_total
           name: cache_read
-        - selector: cognitive_services.ephemeral1h_input_tokens_total
+        - selector: ephemeral1h_input_tokens_total
           name: cache_write_1h
-        - selector: cognitive_services.ephemeral5m_input_tokens_total
+        - selector: ephemeral5m_input_tokens_total
           name: cache_write_5m
     - id: am_azure_cognitive_services__model_provisioned_utilization
       title: Azure Cognitive Services Model Provisioned Utilization
@@ -1112,7 +1112,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.provisioned_utilization_average
+        - selector: provisioned_utilization_average
           name: utilization
     - id: am_azure_cognitive_services__model_pages
       title: Azure Cognitive Services Model Pages Processed
@@ -1122,9 +1122,9 @@ template:
       units: pages/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.total_pages_total
+        - selector: total_pages_total
           name: total
-        - selector: cognitive_services.annotated_pages_total
+        - selector: annotated_pages_total
           name: annotated
     - id: am_azure_cognitive_services__model_generated_images
       title: Azure Cognitive Services Generated Images
@@ -1134,7 +1134,7 @@ template:
       units: images/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.generated_images_total
+        - selector: generated_images_total
           name: generated
     - id: am_azure_cognitive_services__content_safety_requests
       title: Azure Cognitive Services Content Safety Requests
@@ -1144,11 +1144,11 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.rai_total_requests_total
+        - selector: rai_total_requests_total
           name: total
-        - selector: cognitive_services.rai_harmful_requests_total
+        - selector: rai_harmful_requests_total
           name: harmful
-        - selector: cognitive_services.rai_rejected_requests_total
+        - selector: rai_rejected_requests_total
           name: blocked
     - id: am_azure_cognitive_services__content_safety_abusive_users
       title: Azure Cognitive Services Potentially Abusive Users
@@ -1158,7 +1158,7 @@ template:
       units: users/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.rai_abusive_users_count_total
+        - selector: rai_abusive_users_count_total
           name: abusive_users
     - id: am_azure_cognitive_services__content_safety_system_events
       title: Azure Cognitive Services Safety System Events
@@ -1168,7 +1168,7 @@ template:
       units: events
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.rai_system_event_average
+        - selector: rai_system_event_average
           name: events
     - id: am_azure_cognitive_services__content_safety_moderation
       title: Azure Cognitive Services Content Moderation Calls
@@ -1178,9 +1178,9 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.content_safety_text_analyze_request_count_total
+        - selector: content_safety_text_analyze_request_count_total
           name: text
-        - selector: cognitive_services.content_safety_image_analyze_request_count_total
+        - selector: content_safety_image_analyze_request_count_total
           name: image
     - id: am_azure_cognitive_services__job_duration
       title: Azure Cognitive Services Job Duration
@@ -1190,7 +1190,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.job_duration_average
+        - selector: job_duration_average
           name: average
     - id: am_azure_cognitive_services__personalizer_actions
       title: Azure Cognitive Services Personalizer Action Occurrences
@@ -1200,7 +1200,7 @@ template:
       units: occurrences/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.action_id_occurrences_total
+        - selector: action_id_occurrences_total
           name: occurrences
     - id: am_azure_cognitive_services__personalizer_actions_per_event
       title: Azure Cognitive Services Personalizer Actions Per Event
@@ -1210,7 +1210,7 @@ template:
       units: actions
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.actions_per_event_average
+        - selector: actions_per_event_average
           name: average
     - id: am_azure_cognitive_services__personalizer_feature_occurrences
       title: Azure Cognitive Services Personalizer Feature Occurrences
@@ -1220,11 +1220,11 @@ template:
       units: occurrences/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.action_feature_id_occurrences_total
+        - selector: action_feature_id_occurrences_total
           name: action
-        - selector: cognitive_services.context_feature_id_occurrences_total
+        - selector: context_feature_id_occurrences_total
           name: context
-        - selector: cognitive_services.slot_feature_id_occurrences_total
+        - selector: slot_feature_id_occurrences_total
           name: slot
     - id: am_azure_cognitive_services__personalizer_feature_cardinality
       title: Azure Cognitive Services Personalizer Feature Cardinality
@@ -1234,11 +1234,11 @@ template:
       units: features
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.feature_cardinality_action_average
+        - selector: feature_cardinality_action_average
           name: action
-        - selector: cognitive_services.feature_cardinality_context_average
+        - selector: feature_cardinality_context_average
           name: context
-        - selector: cognitive_services.feature_cardinality_slot_average
+        - selector: feature_cardinality_slot_average
           name: slot
     - id: am_azure_cognitive_services__personalizer_features_per_event
       title: Azure Cognitive Services Personalizer Features Per Event
@@ -1248,11 +1248,11 @@ template:
       units: features
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.action_features_per_event_average
+        - selector: action_features_per_event_average
           name: action
-        - selector: cognitive_services.context_features_per_event_average
+        - selector: context_features_per_event_average
           name: context
-        - selector: cognitive_services.slot_features_per_event_average
+        - selector: slot_features_per_event_average
           name: slot
     - id: am_azure_cognitive_services__personalizer_namespaces_per_event
       title: Azure Cognitive Services Personalizer Namespaces Per Event
@@ -1262,11 +1262,11 @@ template:
       units: namespaces
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.action_namespaces_per_event_average
+        - selector: action_namespaces_per_event_average
           name: action
-        - selector: cognitive_services.context_namespaces_per_event_average
+        - selector: context_namespaces_per_event_average
           name: context
-        - selector: cognitive_services.slot_namespaces_per_event_average
+        - selector: slot_namespaces_per_event_average
           name: slot
     - id: am_azure_cognitive_services__personalizer_rewards
       title: Azure Cognitive Services Personalizer Rewards
@@ -1276,9 +1276,9 @@ template:
       units: reward
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.reward_average
+        - selector: reward_average
           name: average
-        - selector: cognitive_services.slot_reward_average
+        - selector: slot_reward_average
           name: slot
     - id: am_azure_cognitive_services__personalizer_estimator_rewards
       title: Azure Cognitive Services Personalizer Estimator Rewards
@@ -1288,11 +1288,11 @@ template:
       units: reward
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.online_estimator_overall_reward_average
+        - selector: online_estimator_overall_reward_average
           name: online
-        - selector: cognitive_services.baseline_estimator_overall_reward_average
+        - selector: baseline_estimator_overall_reward_average
           name: baseline
-        - selector: cognitive_services.baseline_random_estimator_overall_reward_average
+        - selector: baseline_random_estimator_overall_reward_average
           name: baseline_random
     - id: am_azure_cognitive_services__personalizer_estimator_slot_rewards
       title: Azure Cognitive Services Personalizer Estimator Slot Rewards
@@ -1302,11 +1302,11 @@ template:
       units: reward
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.online_estimator_slot_reward_average
+        - selector: online_estimator_slot_reward_average
           name: online
-        - selector: cognitive_services.baseline_estimator_slot_reward_average
+        - selector: baseline_estimator_slot_reward_average
           name: baseline
-        - selector: cognitive_services.baseline_random_estimator_slot_reward_average
+        - selector: baseline_random_estimator_slot_reward_average
           name: baseline_random
     - id: am_azure_cognitive_services__personalizer_slots
       title: Azure Cognitive Services Personalizer Slots
@@ -1316,7 +1316,7 @@ template:
       units: slots
       algorithm: absolute
       dimensions:
-        - selector: cognitive_services.number_of_slots_average
+        - selector: number_of_slots_average
           name: average
     - id: am_azure_cognitive_services__personalizer_slot_occurrences
       title: Azure Cognitive Services Personalizer Slot Occurrences
@@ -1326,7 +1326,7 @@ template:
       units: occurrences/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.slot_id_occurrences_total
+        - selector: slot_id_occurrences_total
           name: occurrences
     - id: am_azure_cognitive_services__personalizer_event_counts
       title: Azure Cognitive Services Personalizer Event Counts
@@ -1336,11 +1336,11 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.online_event_count_total
+        - selector: online_event_count_total
           name: online
-        - selector: cognitive_services.baseline_random_event_count_total
+        - selector: baseline_random_event_count_total
           name: baseline_random
-        - selector: cognitive_services.user_baseline_event_count_total
+        - selector: user_baseline_event_count_total
           name: user_baseline
     - id: am_azure_cognitive_services__personalizer_estimated_rewards
       title: Azure Cognitive Services Personalizer Estimated Rewards
@@ -1350,11 +1350,11 @@ template:
       units: reward/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.online_reward_total
+        - selector: online_reward_total
           name: online
-        - selector: cognitive_services.baseline_random_reward_total
+        - selector: baseline_random_reward_total
           name: baseline_random
-        - selector: cognitive_services.user_baseline_reward_total
+        - selector: user_baseline_reward_total
           name: user_baseline
     - id: am_azure_cognitive_services__speech_transcription
       title: Azure Cognitive Services Speech Transcription
@@ -1364,15 +1364,15 @@ template:
       units: seconds/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.audio_seconds_transcribed_total
+        - selector: audio_seconds_transcribed_total
           name: realtime
-        - selector: cognitive_services.audio_seconds_batch_transcribed_total
+        - selector: audio_seconds_batch_transcribed_total
           name: batch
-        - selector: cognitive_services.audio_seconds_batch_whisper_transcribed_total
+        - selector: audio_seconds_batch_whisper_transcribed_total
           name: batch_whisper
-        - selector: cognitive_services.audio_seconds_fast_transcribed_total
+        - selector: audio_seconds_fast_transcribed_total
           name: fast
-        - selector: cognitive_services.audio_seconds_fast_whisper_transcribed_total
+        - selector: audio_seconds_fast_whisper_transcribed_total
           name: fast_whisper
     - id: am_azure_cognitive_services__speech_translation
       title: Azure Cognitive Services Speech Translation
@@ -1382,7 +1382,7 @@ template:
       units: seconds/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.audio_seconds_translated_total
+        - selector: audio_seconds_translated_total
           name: translated
     - id: am_azure_cognitive_services__speech_synthesis
       title: Azure Cognitive Services Speech Synthesis
@@ -1392,7 +1392,7 @@ template:
       units: characters/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.synthesized_characters_total
+        - selector: synthesized_characters_total
           name: synthesized
     - id: am_azure_cognitive_services__speech_video_synthesis
       title: Azure Cognitive Services Video Synthesis
@@ -1402,7 +1402,7 @@ template:
       units: seconds/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.video_seconds_synthesized_total
+        - selector: video_seconds_synthesized_total
           name: synthesized
     - id: am_azure_cognitive_services__speech_avatar
       title: Azure Cognitive Services Avatar Usage
@@ -1412,9 +1412,9 @@ template:
       units: seconds/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.avatar_model_hosting_seconds_total
+        - selector: avatar_model_hosting_seconds_total
           name: hosting
-        - selector: cognitive_services.avatar_model_training_seconds_total
+        - selector: avatar_model_training_seconds_total
           name: training
     - id: am_azure_cognitive_services__speech_speaker_recognition
       title: Azure Cognitive Services Speaker Recognition
@@ -1424,7 +1424,7 @@ template:
       units: transactions/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.speaker_recognition_transactions_total
+        - selector: speaker_recognition_transactions_total
           name: transactions
     - id: am_azure_cognitive_services__speech_speaker_profiles
       title: Azure Cognitive Services Speaker Profiles
@@ -1434,7 +1434,7 @@ template:
       units: profiles/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.numberof_speaker_profiles_total
+        - selector: numberof_speaker_profiles_total
           name: profiles
     - id: am_azure_cognitive_services__speech_model_hosting
       title: Azure Cognitive Services Speech Model Hosting
@@ -1444,7 +1444,7 @@ template:
       units: hours/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.speech_model_hosting_hours_total
+        - selector: speech_model_hosting_hours_total
           name: hosting
     - id: am_azure_cognitive_services__speech_voice_live_tokens
       title: Azure Cognitive Services Voice Live Tokens
@@ -1454,17 +1454,17 @@ template:
       units: tokens/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.voice_live_audio_input_tokens_total
+        - selector: voice_live_audio_input_tokens_total
           name: audio_input
-        - selector: cognitive_services.voice_live_audio_output_tokens_total
+        - selector: voice_live_audio_output_tokens_total
           name: audio_output
-        - selector: cognitive_services.voice_live_cached_audio_input_tokens_total
+        - selector: voice_live_cached_audio_input_tokens_total
           name: cached_audio_input
-        - selector: cognitive_services.voice_live_text_input_tokens_total
+        - selector: voice_live_text_input_tokens_total
           name: text_input
-        - selector: cognitive_services.voice_live_text_output_tokens_total
+        - selector: voice_live_text_output_tokens_total
           name: text_output
-        - selector: cognitive_services.voice_live_cached_text_input_tokens_total
+        - selector: voice_live_cached_text_input_tokens_total
           name: cached_text_input
     - id: am_azure_cognitive_services__speech_voice_model
       title: Azure Cognitive Services Voice Model Usage
@@ -1474,7 +1474,7 @@ template:
       units: hours/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.voice_model_hosting_hours_total
+        - selector: voice_model_hosting_hours_total
           name: hosting
     - id: am_azure_cognitive_services__speech_voice_training
       title: Azure Cognitive Services Voice Model Training
@@ -1484,7 +1484,7 @@ template:
       units: minutes/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.voice_model_training_minutes_total
+        - selector: voice_model_training_minutes_total
           name: training
     - id: am_azure_cognitive_services__translator_text
       title: Azure Cognitive Services Translator Text Characters
@@ -1494,11 +1494,11 @@ template:
       units: characters/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.text_characters_translated_total
+        - selector: text_characters_translated_total
           name: standard
-        - selector: cognitive_services.text_custom_characters_translated_total
+        - selector: text_custom_characters_translated_total
           name: custom
-        - selector: cognitive_services.text_trained_characters_total
+        - selector: text_trained_characters_total
           name: trained
     - id: am_azure_cognitive_services__translator_document
       title: Azure Cognitive Services Translator Document Characters
@@ -1508,9 +1508,9 @@ template:
       units: characters/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.document_characters_translated_total
+        - selector: document_characters_translated_total
           name: standard
-        - selector: cognitive_services.document_custom_characters_translated_total
+        - selector: document_custom_characters_translated_total
           name: custom
     - id: am_azure_cognitive_services__translator_document_sync
       title: Azure Cognitive Services Translator Document Sync Characters
@@ -1520,9 +1520,9 @@ template:
       units: characters/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.one_document_characters_translated_total
+        - selector: one_document_characters_translated_total
           name: standard
-        - selector: cognitive_services.one_document_custom_characters_translated_total
+        - selector: one_document_custom_characters_translated_total
           name: custom
     - id: am_azure_cognitive_services__translator_pro_app
       title: Azure Cognitive Services Translator Pro App Usage
@@ -1532,7 +1532,7 @@ template:
       units: seconds/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.translator_pro_app_seconds_total
+        - selector: translator_pro_app_seconds_total
           name: seconds
     - id: am_azure_cognitive_services__vision_transactions
       title: Azure Cognitive Services Vision Transactions
@@ -1542,9 +1542,9 @@ template:
       units: transactions/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.computer_vision_transactions_total
+        - selector: computer_vision_transactions_total
           name: computer_vision
-        - selector: cognitive_services.custom_vision_transactions_total
+        - selector: custom_vision_transactions_total
           name: custom_vision
     - id: am_azure_cognitive_services__vision_training
       title: Azure Cognitive Services Custom Vision Training
@@ -1554,7 +1554,7 @@ template:
       units: seconds/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.custom_vision_training_time_total
+        - selector: custom_vision_training_time_total
           name: training_time
     - id: am_azure_cognitive_services__vision_images_stored
       title: Azure Cognitive Services Images Stored
@@ -1564,7 +1564,7 @@ template:
       units: images/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.images_stored_total
+        - selector: images_stored_total
           name: stored
     - id: am_azure_cognitive_services__face_transactions
       title: Azure Cognitive Services Face Transactions
@@ -1574,7 +1574,7 @@ template:
       units: transactions/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.face_transactions_total
+        - selector: face_transactions_total
           name: transactions
     - id: am_azure_cognitive_services__face_images_trained
       title: Azure Cognitive Services Face Images Trained
@@ -1584,7 +1584,7 @@ template:
       units: images/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.face_images_trained_total
+        - selector: face_images_trained_total
           name: trained
     - id: am_azure_cognitive_services__faces_stored
       title: Azure Cognitive Services Faces Stored
@@ -1594,7 +1594,7 @@ template:
       units: faces/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.faces_stored_total
+        - selector: faces_stored_total
           name: stored
     - id: am_azure_cognitive_services__luis_requests
       title: Azure Cognitive Services LUIS Requests
@@ -1604,9 +1604,9 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.luis_speech_requests_total
+        - selector: luis_speech_requests_total
           name: speech
-        - selector: cognitive_services.luis_text_requests_total
+        - selector: luis_text_requests_total
           name: text
     - id: am_azure_cognitive_services__text_processing
       title: Azure Cognitive Services Text Processing
@@ -1616,11 +1616,11 @@ template:
       units: records/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.processed_text_records_total
+        - selector: processed_text_records_total
           name: text
-        - selector: cognitive_services.processed_health_text_records_total
+        - selector: processed_health_text_records_total
           name: health_text
-        - selector: cognitive_services.question_answering_text_records_total
+        - selector: question_answering_text_records_total
           name: question_answering
     - id: am_azure_cognitive_services__processed_characters
       title: Azure Cognitive Services Processed Characters
@@ -1630,7 +1630,7 @@ template:
       units: characters/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.processed_characters_total
+        - selector: processed_characters_total
           name: characters
     - id: am_azure_cognitive_services__processed_images
       title: Azure Cognitive Services Processed Images
@@ -1640,7 +1640,7 @@ template:
       units: images/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.processed_images_total
+        - selector: processed_images_total
           name: images
     - id: am_azure_cognitive_services__processed_pages
       title: Azure Cognitive Services Processed Pages
@@ -1650,7 +1650,7 @@ template:
       units: pages/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.processed_pages_total
+        - selector: processed_pages_total
           name: pages
     - id: am_azure_cognitive_services__carnegie_inference
       title: Azure Cognitive Services Carnegie Inference
@@ -1660,7 +1660,7 @@ template:
       units: inferences/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.carnegie_inference_count_total
+        - selector: carnegie_inference_count_total
           name: inferences
     - id: am_azure_cognitive_services__personalizer_events
       title: Azure Cognitive Services Personalizer Events
@@ -1670,11 +1670,11 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.total_events_total
+        - selector: total_events_total
           name: total
-        - selector: cognitive_services.learned_events_total
+        - selector: learned_events_total
           name: learned
-        - selector: cognitive_services.non_activated_events_total
+        - selector: non_activated_events_total
           name: non_activated
     - id: am_azure_cognitive_services__personalizer_reward_tracking
       title: Azure Cognitive Services Personalizer Reward Tracking
@@ -1684,7 +1684,7 @@ template:
       units: rewards/s
       algorithm: incremental
       dimensions:
-        - selector: cognitive_services.matched_rewards_total
+        - selector: matched_rewards_total
           name: matched
-        - selector: cognitive_services.observed_rewards_total
+        - selector: observed_rewards_total
           name: observed

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/container_apps.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/container_apps.yaml
@@ -220,9 +220,9 @@ template:
       units: nanocores
       algorithm: absolute
       dimensions:
-        - selector: container_apps.usage_nano_cores_average
+        - selector: usage_nano_cores_average
           name: average
-        - selector: container_apps.usage_nano_cores_maximum
+        - selector: usage_nano_cores_maximum
           name: maximum
     - id: am_azure_container_apps__cpu_percentage
       title: Azure Container Apps CPU Percentage
@@ -232,9 +232,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: container_apps.cpu_percentage_average
+        - selector: cpu_percentage_average
           name: average
-        - selector: container_apps.cpu_percentage_maximum
+        - selector: cpu_percentage_maximum
           name: maximum
     - id: am_azure_container_apps__memory_working_set
       title: Azure Container Apps Memory Working Set
@@ -244,9 +244,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: container_apps.working_set_bytes_average
+        - selector: working_set_bytes_average
           name: average
-        - selector: container_apps.working_set_bytes_maximum
+        - selector: working_set_bytes_maximum
           name: maximum
     - id: am_azure_container_apps__memory_percentage
       title: Azure Container Apps Memory Percentage
@@ -256,9 +256,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: container_apps.memory_percentage_average
+        - selector: memory_percentage_average
           name: average
-        - selector: container_apps.memory_percentage_maximum
+        - selector: memory_percentage_maximum
           name: maximum
     - id: am_azure_container_apps__replicas
       title: Azure Container Apps Replica Count
@@ -268,7 +268,7 @@ template:
       units: replicas
       algorithm: absolute
       dimensions:
-        - selector: container_apps.replicas_average
+        - selector: replicas_average
           name: average
     - id: am_azure_container_apps__reserved_cores
       title: Azure Container Apps Reserved Cores
@@ -278,9 +278,9 @@ template:
       units: cores
       algorithm: absolute
       dimensions:
-        - selector: container_apps.cores_quota_used_maximum
+        - selector: cores_quota_used_maximum
           name: per_revision
-        - selector: container_apps.total_cores_quota_used_average
+        - selector: total_cores_quota_used_average
           name: total
     - id: am_azure_container_apps__restart_count
       title: Azure Container Apps Replica Restarts
@@ -290,7 +290,7 @@ template:
       units: restarts/s
       algorithm: incremental
       dimensions:
-        - selector: container_apps.restart_count_total
+        - selector: restart_count_total
           name: restarts
     - id: am_azure_container_apps__requests
       title: Azure Container Apps Requests
@@ -300,7 +300,7 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: container_apps.requests_total
+        - selector: requests_total
           name: requests
     - id: am_azure_container_apps__response_time
       title: Azure Container Apps Response Time
@@ -310,7 +310,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: container_apps.response_time_average
+        - selector: response_time_average
           name: average
     - id: am_azure_container_apps__network
       title: Azure Container Apps Network Traffic
@@ -320,9 +320,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: container_apps.rx_bytes_total
+        - selector: rx_bytes_total
           name: received
-        - selector: container_apps.tx_bytes_total
+        - selector: tx_bytes_total
           name: sent
     - id: am_azure_container_apps__resiliency_timeouts
       title: Azure Container Apps Resiliency Timeouts
@@ -332,9 +332,9 @@ template:
       units: timeouts/s
       algorithm: incremental
       dimensions:
-        - selector: container_apps.resiliency_connect_timeouts_total
+        - selector: resiliency_connect_timeouts_total
           name: connection
-        - selector: container_apps.resiliency_request_timeouts_total
+        - selector: resiliency_request_timeouts_total
           name: request
     - id: am_azure_container_apps__resiliency_retries
       title: Azure Container Apps Resiliency Request Retries
@@ -344,7 +344,7 @@ template:
       units: retries/s
       algorithm: incremental
       dimensions:
-        - selector: container_apps.resiliency_request_retries_total
+        - selector: resiliency_request_retries_total
           name: retries
     - id: am_azure_container_apps__resiliency_pending_connections
       title: Azure Container Apps Resiliency Pending Connection Pool
@@ -354,7 +354,7 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: container_apps.resiliency_requests_pending_connection_pool_total
+        - selector: resiliency_requests_pending_connection_pool_total
           name: pending
     - id: am_azure_container_apps__resiliency_ejections
       title: Azure Container Apps Resiliency Host Ejections
@@ -364,9 +364,9 @@ template:
       units: ejections/s
       algorithm: incremental
       dimensions:
-        - selector: container_apps.resiliency_ejected_hosts_total
+        - selector: resiliency_ejected_hosts_total
           name: ejected
-        - selector: container_apps.resiliency_ejections_aborted_total
+        - selector: resiliency_ejections_aborted_total
           name: aborted
     - id: am_azure_container_apps__gpu_utilization
       title: Azure Container Apps GPU Utilization
@@ -376,9 +376,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: container_apps.gpu_utilization_percentage_average
+        - selector: gpu_utilization_percentage_average
           name: average
-        - selector: container_apps.gpu_utilization_percentage_maximum
+        - selector: gpu_utilization_percentage_maximum
           name: maximum
     - id: am_azure_container_apps__jvm_buffer_count
       title: Azure Container Apps JVM Buffer Count
@@ -388,7 +388,7 @@ template:
       units: buffers
       algorithm: absolute
       dimensions:
-        - selector: container_apps.jvm_buffer_count_average
+        - selector: jvm_buffer_count_average
           name: average
     - id: am_azure_container_apps__jvm_buffer_memory
       title: Azure Container Apps JVM Buffer Memory
@@ -398,9 +398,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: container_apps.jvm_buffer_memory_usage_average
+        - selector: jvm_buffer_memory_usage_average
           name: used
-        - selector: container_apps.jvm_buffer_memory_limit_average
+        - selector: jvm_buffer_memory_limit_average
           name: limit
     - id: am_azure_container_apps__jvm_gc_count
       title: Azure Container Apps JVM Garbage Collections
@@ -410,7 +410,7 @@ template:
       units: collections/s
       algorithm: incremental
       dimensions:
-        - selector: container_apps.jvm_gc_count_total
+        - selector: jvm_gc_count_total
           name: collections
     - id: am_azure_container_apps__jvm_gc_duration
       title: Azure Container Apps JVM GC Duration
@@ -420,7 +420,7 @@ template:
       units: milliseconds/s
       algorithm: incremental
       dimensions:
-        - selector: container_apps.jvm_gc_duration_total
+        - selector: jvm_gc_duration_total
           name: duration
     - id: am_azure_container_apps__jvm_memory_pool
       title: Azure Container Apps JVM Memory per Pool
@@ -430,11 +430,11 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: container_apps.jvm_memory_used_average
+        - selector: jvm_memory_used_average
           name: used
-        - selector: container_apps.jvm_memory_committed_average
+        - selector: jvm_memory_committed_average
           name: committed
-        - selector: container_apps.jvm_memory_limit_average
+        - selector: jvm_memory_limit_average
           name: limit
     - id: am_azure_container_apps__jvm_memory_total
       title: Azure Container Apps JVM Memory Total
@@ -444,11 +444,11 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: container_apps.jvm_memory_total_used_average
+        - selector: jvm_memory_total_used_average
           name: used
-        - selector: container_apps.jvm_memory_total_committed_average
+        - selector: jvm_memory_total_committed_average
           name: committed
-        - selector: container_apps.jvm_memory_total_limit_average
+        - selector: jvm_memory_total_limit_average
           name: limit
     - id: am_azure_container_apps__jvm_thread_count
       title: Azure Container Apps JVM Thread Count
@@ -458,5 +458,5 @@ template:
       units: threads
       algorithm: absolute
       dimensions:
-        - selector: container_apps.jvm_thread_count_average
+        - selector: jvm_thread_count_average
           name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/container_instances.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/container_instances.yaml
@@ -52,9 +52,9 @@ template:
       units: millicores
       algorithm: absolute
       dimensions:
-        - selector: container_instances.cpu_usage_average
+        - selector: cpu_usage_average
           name: average
-        - selector: container_instances.cpu_usage_maximum
+        - selector: cpu_usage_maximum
           name: maximum
     - id: am_azure_container_instances__memory_usage
       title: Azure Container Instances Memory Usage
@@ -64,9 +64,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: container_instances.memory_usage_average
+        - selector: memory_usage_average
           name: average
-        - selector: container_instances.memory_usage_maximum
+        - selector: memory_usage_maximum
           name: maximum
     - id: am_azure_container_instances__network
       title: Azure Container Instances Network Traffic
@@ -76,7 +76,7 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: container_instances.network_bytes_received_per_second_average
+        - selector: network_bytes_received_per_second_average
           name: received
-        - selector: container_instances.network_bytes_transmitted_per_second_average
+        - selector: network_bytes_transmitted_per_second_average
           name: sent

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/container_registry.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/container_registry.yaml
@@ -66,7 +66,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: container_registry.storage_used_average
+        - selector: storage_used_average
           name: used
     - id: am_azure_container_registry__pull_count
       title: Azure Container Registry Image Pulls
@@ -76,9 +76,9 @@ template:
       units: pulls/s
       algorithm: incremental
       dimensions:
-        - selector: container_registry.successful_pull_count_total
+        - selector: successful_pull_count_total
           name: successful
-        - selector: container_registry.total_pull_count_total
+        - selector: total_pull_count_total
           name: total
     - id: am_azure_container_registry__push_count
       title: Azure Container Registry Image Pushes
@@ -88,9 +88,9 @@ template:
       units: pushes/s
       algorithm: incremental
       dimensions:
-        - selector: container_registry.successful_push_count_total
+        - selector: successful_push_count_total
           name: successful
-        - selector: container_registry.total_push_count_total
+        - selector: total_push_count_total
           name: total
     - id: am_azure_container_registry__agentpool_cpu_time
       title: Azure Container Registry AgentPool CPU Time
@@ -100,7 +100,7 @@ template:
       units: seconds/s
       algorithm: incremental
       dimensions:
-        - selector: container_registry.agent_pool_cpu_time_total
+        - selector: agent_pool_cpu_time_total
           name: cpu_time
     - id: am_azure_container_registry__run_duration
       title: Azure Container Registry Task Run Duration
@@ -110,5 +110,5 @@ template:
       units: milliseconds/s
       algorithm: incremental
       dimensions:
-        - selector: container_registry.run_duration_total
+        - selector: run_duration_total
           name: duration

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/cosmos_db.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/cosmos_db.yaml
@@ -204,7 +204,7 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: cosmos_db.total_requests_count
+        - selector: total_requests_count
           name: count
     - id: am_azure_cosmos_db__request_units
       title: Azure Cosmos DB Request Units Consumed
@@ -214,7 +214,7 @@ template:
       units: RU/s
       algorithm: incremental
       dimensions:
-        - selector: cosmos_db.total_request_units_total
+        - selector: total_request_units_total
           name: total
     - id: am_azure_cosmos_db__normalized_ru_consumption
       title: Azure Cosmos DB Normalized RU Consumption
@@ -224,7 +224,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: cosmos_db.normalized_ru_consumption_maximum
+        - selector: normalized_ru_consumption_maximum
           name: maximum
     - id: am_azure_cosmos_db__server_side_latency
       title: Azure Cosmos DB Server-Side Latency
@@ -234,9 +234,9 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: cosmos_db.server_side_latency_direct_average
+        - selector: server_side_latency_direct_average
           name: direct
-        - selector: cosmos_db.server_side_latency_gateway_average
+        - selector: server_side_latency_gateway_average
           name: gateway
     - id: am_azure_cosmos_db__replication_latency
       title: Azure Cosmos DB Replication Latency
@@ -246,7 +246,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: cosmos_db.replication_latency_average
+        - selector: replication_latency_average
           name: average
     - id: am_azure_cosmos_db__storage
       title: Azure Cosmos DB Storage
@@ -256,11 +256,11 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: cosmos_db.data_usage_maximum
+        - selector: data_usage_maximum
           name: data
-        - selector: cosmos_db.index_usage_maximum
+        - selector: index_usage_maximum
           name: index
-        - selector: cosmos_db.document_quota_total
+        - selector: document_quota_total
           name: quota
     - id: am_azure_cosmos_db__document_count
       title: Azure Cosmos DB Document Count
@@ -270,7 +270,7 @@ template:
       units: documents
       algorithm: absolute
       dimensions:
-        - selector: cosmos_db.document_count_average
+        - selector: document_count_average
           name: average
     - id: am_azure_cosmos_db__partition_size
       title: Azure Cosmos DB Physical Partition Size
@@ -280,7 +280,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: cosmos_db.physical_partition_size_info_maximum
+        - selector: physical_partition_size_info_maximum
           name: maximum
     - id: am_azure_cosmos_db__partition_count
       title: Azure Cosmos DB Physical Partition Count
@@ -290,7 +290,7 @@ template:
       units: partitions
       algorithm: absolute
       dimensions:
-        - selector: cosmos_db.physical_partition_count_maximum
+        - selector: physical_partition_count_maximum
           name: maximum
     - id: am_azure_cosmos_db__provisioned_throughput
       title: Azure Cosmos DB Provisioned Throughput
@@ -300,11 +300,11 @@ template:
       units: RU/s
       algorithm: absolute
       dimensions:
-        - selector: cosmos_db.provisioned_throughput_maximum
+        - selector: provisioned_throughput_maximum
           name: provisioned
-        - selector: cosmos_db.autoscale_max_throughput_maximum
+        - selector: autoscale_max_throughput_maximum
           name: autoscale_max
-        - selector: cosmos_db.autoscaled_ru_maximum
+        - selector: autoscaled_ru_maximum
           name: autoscaled
     - id: am_azure_cosmos_db__partition_throughput
       title: Azure Cosmos DB Physical Partition Throughput
@@ -314,7 +314,7 @@ template:
       units: RU/s
       algorithm: absolute
       dimensions:
-        - selector: cosmos_db.physical_partition_throughput_info_maximum
+        - selector: physical_partition_throughput_info_maximum
           name: maximum
     - id: am_azure_cosmos_db__availability
       title: Azure Cosmos DB Service Availability
@@ -324,7 +324,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: cosmos_db.service_availability_average
+        - selector: service_availability_average
           name: average
     - id: am_azure_cosmos_db__metadata_requests
       title: Azure Cosmos DB Metadata Requests
@@ -334,7 +334,7 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: cosmos_db.metadata_requests_count
+        - selector: metadata_requests_count
           name: count
     - id: am_azure_cosmos_db__api_requests
       title: Azure Cosmos DB API Requests
@@ -344,11 +344,11 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: cosmos_db.mongo_requests_count
+        - selector: mongo_requests_count
           name: mongo
-        - selector: cosmos_db.cassandra_requests_count
+        - selector: cassandra_requests_count
           name: cassandra
-        - selector: cosmos_db.gremlin_requests_count
+        - selector: gremlin_requests_count
           name: gremlin
     - id: am_azure_cosmos_db__api_request_charges
       title: Azure Cosmos DB API Request Charges
@@ -358,11 +358,11 @@ template:
       units: RU/s
       algorithm: incremental
       dimensions:
-        - selector: cosmos_db.mongo_request_charge_total
+        - selector: mongo_request_charge_total
           name: mongo
-        - selector: cosmos_db.cassandra_request_charges_total
+        - selector: cassandra_request_charges_total
           name: cassandra
-        - selector: cosmos_db.gremlin_request_charges_total
+        - selector: gremlin_request_charges_total
           name: gremlin
     - id: am_azure_cosmos_db__cassandra_connections
       title: Azure Cosmos DB Cassandra Connection Closures
@@ -372,7 +372,7 @@ template:
       units: connections/s
       algorithm: incremental
       dimensions:
-        - selector: cosmos_db.cassandra_connection_closures_total
+        - selector: cassandra_connection_closures_total
           name: total
     - id: am_azure_cosmos_db__dedicated_gateway_cpu
       title: Azure Cosmos DB Dedicated Gateway CPU Usage
@@ -382,7 +382,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: cosmos_db.dedicated_gateway_cpu_usage_average
+        - selector: dedicated_gateway_cpu_usage_average
           name: average
     - id: am_azure_cosmos_db__dedicated_gateway_memory
       title: Azure Cosmos DB Dedicated Gateway Memory Usage
@@ -392,7 +392,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: cosmos_db.dedicated_gateway_memory_usage_average
+        - selector: dedicated_gateway_memory_usage_average
           name: average
     - id: am_azure_cosmos_db__dedicated_gateway_requests
       title: Azure Cosmos DB Dedicated Gateway Requests
@@ -402,7 +402,7 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: cosmos_db.dedicated_gateway_requests_count
+        - selector: dedicated_gateway_requests_count
           name: count
     - id: am_azure_cosmos_db__integrated_cache_hit_rate
       title: Azure Cosmos DB Integrated Cache Hit Rate
@@ -412,7 +412,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: cosmos_db.integrated_cache_item_hit_rate_average
+        - selector: integrated_cache_item_hit_rate_average
           name: item
-        - selector: cosmos_db.integrated_cache_query_hit_rate_average
+        - selector: integrated_cache_query_hit_rate_average
           name: query

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/data_explorer.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/data_explorer.yaml
@@ -330,7 +330,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.cpu_average
+        - selector: cpu_average
           name: average
     - id: am_azure_data_explorer__utilization
       title: Azure Data Explorer Utilization
@@ -340,9 +340,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.ingestion_utilization_average
+        - selector: ingestion_utilization_average
           name: ingestion
-        - selector: data_explorer.cache_utilization_factor_average
+        - selector: cache_utilization_factor_average
           name: cache
     - id: am_azure_data_explorer__keep_alive
       title: Azure Data Explorer Keep Alive
@@ -352,7 +352,7 @@ template:
       units: count
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.keep_alive_average
+        - selector: keep_alive_average
           name: average
     - id: am_azure_data_explorer__instance_count
       title: Azure Data Explorer Instance Count
@@ -362,11 +362,11 @@ template:
       units: instances
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.instance_count_average
+        - selector: instance_count_average
           name: average
-        - selector: data_explorer.instance_count_maximum
+        - selector: instance_count_maximum
           name: maximum
-        - selector: data_explorer.instance_count_minimum
+        - selector: instance_count_minimum
           name: minimum
     - id: am_azure_data_explorer__extents
       title: Azure Data Explorer Total Extents
@@ -376,7 +376,7 @@ template:
       units: extents
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.total_number_of_extents_average
+        - selector: total_number_of_extents_average
           name: average
     - id: am_azure_data_explorer__throttled_commands
       title: Azure Data Explorer Throttled Commands
@@ -386,7 +386,7 @@ template:
       units: commands/s
       algorithm: incremental
       dimensions:
-        - selector: data_explorer.total_number_of_throttled_commands_total
+        - selector: total_number_of_throttled_commands_total
           name: total
     - id: am_azure_data_explorer__follower_latency
       title: Azure Data Explorer Follower Latency
@@ -396,7 +396,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.follower_latency_average
+        - selector: follower_latency_average
           name: average
     - id: am_azure_data_explorer__query_duration
       title: Azure Data Explorer Query Duration
@@ -406,7 +406,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.query_duration_average
+        - selector: query_duration_average
           name: average
     - id: am_azure_data_explorer__query_count
       title: Azure Data Explorer Query Count
@@ -416,7 +416,7 @@ template:
       units: queries/s
       algorithm: incremental
       dimensions:
-        - selector: data_explorer.query_result_count
+        - selector: query_result_count
           name: count
     - id: am_azure_data_explorer__concurrent_queries
       title: Azure Data Explorer Concurrent Queries
@@ -426,9 +426,9 @@ template:
       units: queries
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.total_number_of_concurrent_queries_average
+        - selector: total_number_of_concurrent_queries_average
           name: average
-        - selector: data_explorer.total_number_of_concurrent_queries_maximum
+        - selector: total_number_of_concurrent_queries_maximum
           name: maximum
     - id: am_azure_data_explorer__throttled_queries
       title: Azure Data Explorer Throttled Queries
@@ -438,7 +438,7 @@ template:
       units: queries/s
       algorithm: incremental
       dimensions:
-        - selector: data_explorer.total_number_of_throttled_queries_total
+        - selector: total_number_of_throttled_queries_total
           name: total
     - id: am_azure_data_explorer__weak_consistency_latency
       title: Azure Data Explorer Weak Consistency Latency
@@ -448,7 +448,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.weak_consistency_latency_average
+        - selector: weak_consistency_latency_average
           name: average
     - id: am_azure_data_explorer__ingestion_result
       title: Azure Data Explorer Ingestion Result
@@ -458,7 +458,7 @@ template:
       units: sources/s
       algorithm: incremental
       dimensions:
-        - selector: data_explorer.ingestion_result_total
+        - selector: ingestion_result_total
           name: total
     - id: am_azure_data_explorer__ingestion_volume
       title: Azure Data Explorer Ingestion Volume
@@ -468,7 +468,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: data_explorer.ingestion_volume_in_mb_total
+        - selector: ingestion_volume_in_mb_total
           name: total
     - id: am_azure_data_explorer__ingestion_latency
       title: Azure Data Explorer Ingestion Latency
@@ -478,7 +478,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.ingestion_latency_in_seconds_average
+        - selector: ingestion_latency_in_seconds_average
           name: average
     - id: am_azure_data_explorer__events
       title: Azure Data Explorer Events
@@ -488,11 +488,11 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: data_explorer.events_received_total
+        - selector: events_received_total
           name: received
-        - selector: data_explorer.events_processed_total
+        - selector: events_processed_total
           name: processed
-        - selector: data_explorer.events_dropped_total
+        - selector: events_dropped_total
           name: dropped
     - id: am_azure_data_explorer__blobs
       title: Azure Data Explorer Blobs
@@ -502,11 +502,11 @@ template:
       units: blobs/s
       algorithm: incremental
       dimensions:
-        - selector: data_explorer.blobs_received_total
+        - selector: blobs_received_total
           name: received
-        - selector: data_explorer.blobs_processed_total
+        - selector: blobs_processed_total
           name: processed
-        - selector: data_explorer.blobs_dropped_total
+        - selector: blobs_dropped_total
           name: dropped
     - id: am_azure_data_explorer__discovery_latency
       title: Azure Data Explorer Discovery Latency
@@ -516,7 +516,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.discovery_latency_average
+        - selector: discovery_latency_average
           name: average
     - id: am_azure_data_explorer__stage_latency
       title: Azure Data Explorer Stage Latency
@@ -526,7 +526,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.stage_latency_average
+        - selector: stage_latency_average
           name: average
     - id: am_azure_data_explorer__ingestion_queue
       title: Azure Data Explorer Ingestion Queue
@@ -536,7 +536,7 @@ template:
       units: messages
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.queue_length_average
+        - selector: queue_length_average
           name: length
     - id: am_azure_data_explorer__queue_oldest_message
       title: Azure Data Explorer Queue Oldest Message Age
@@ -546,7 +546,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.queue_oldest_message_average
+        - selector: queue_oldest_message_average
           name: age
     - id: am_azure_data_explorer__received_data_size
       title: Azure Data Explorer Received Data Size
@@ -556,7 +556,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: data_explorer.received_data_size_bytes_total
+        - selector: received_data_size_bytes_total
           name: total
     - id: am_azure_data_explorer__batches_processed
       title: Azure Data Explorer Batches Processed
@@ -566,7 +566,7 @@ template:
       units: batches/s
       algorithm: incremental
       dimensions:
-        - selector: data_explorer.batches_processed_total
+        - selector: batches_processed_total
           name: total
     - id: am_azure_data_explorer__batch_blob_count
       title: Azure Data Explorer Batch Blob Count
@@ -576,7 +576,7 @@ template:
       units: blobs
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.batch_blob_count_average
+        - selector: batch_blob_count_average
           name: average
     - id: am_azure_data_explorer__batch_size
       title: Azure Data Explorer Batch Size
@@ -586,7 +586,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.batch_size_average
+        - selector: batch_size_average
           name: average
     - id: am_azure_data_explorer__batch_duration
       title: Azure Data Explorer Batch Duration
@@ -596,7 +596,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.batch_duration_average
+        - selector: batch_duration_average
           name: average
     - id: am_azure_data_explorer__export_utilization
       title: Azure Data Explorer Export Utilization
@@ -606,7 +606,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.export_utilization_maximum
+        - selector: export_utilization_maximum
           name: maximum
     - id: am_azure_data_explorer__continuous_export_records
       title: Azure Data Explorer Continuous Export Records
@@ -616,7 +616,7 @@ template:
       units: records/s
       algorithm: incremental
       dimensions:
-        - selector: data_explorer.continuous_export_num_of_records_exported_total
+        - selector: continuous_export_num_of_records_exported_total
           name: total
     - id: am_azure_data_explorer__continuous_export_result
       title: Azure Data Explorer Continuous Export Result
@@ -626,7 +626,7 @@ template:
       units: results/s
       algorithm: incremental
       dimensions:
-        - selector: data_explorer.continuous_export_result_count
+        - selector: continuous_export_result_count
           name: count
     - id: am_azure_data_explorer__continuous_export_pending
       title: Azure Data Explorer Continuous Export Pending Jobs
@@ -636,7 +636,7 @@ template:
       units: jobs
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.continuous_export_pending_count_maximum
+        - selector: continuous_export_pending_count_maximum
           name: maximum
     - id: am_azure_data_explorer__continuous_export_lateness
       title: Azure Data Explorer Continuous Export Lateness
@@ -646,7 +646,7 @@ template:
       units: minutes
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.continuous_export_max_lateness_minutes_maximum
+        - selector: continuous_export_max_lateness_minutes_maximum
           name: maximum
     - id: am_azure_data_explorer__streaming_ingest_data_rate
       title: Azure Data Explorer Streaming Ingest Data Rate
@@ -656,7 +656,7 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.streaming_ingest_data_rate_average
+        - selector: streaming_ingest_data_rate_average
           name: average
     - id: am_azure_data_explorer__streaming_ingest_duration
       title: Azure Data Explorer Streaming Ingest Duration
@@ -666,7 +666,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.streaming_ingest_duration_average
+        - selector: streaming_ingest_duration_average
           name: average
     - id: am_azure_data_explorer__streaming_ingest_result
       title: Azure Data Explorer Streaming Ingest Result
@@ -676,7 +676,7 @@ template:
       units: results/s
       algorithm: incremental
       dimensions:
-        - selector: data_explorer.streaming_ingest_results_count
+        - selector: streaming_ingest_results_count
           name: count
     - id: am_azure_data_explorer__streaming_ingest_utilization
       title: Azure Data Explorer Streaming Ingest Utilization
@@ -686,7 +686,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.streaming_ingest_utilization_average
+        - selector: streaming_ingest_utilization_average
           name: average
     - id: am_azure_data_explorer__materialized_view_health
       title: Azure Data Explorer Materialized View Health
@@ -696,7 +696,7 @@ template:
       units: status
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.materialized_view_health_average
+        - selector: materialized_view_health_average
           name: health
     - id: am_azure_data_explorer__materialized_view_age
       title: Azure Data Explorer Materialized View Age
@@ -706,7 +706,7 @@ template:
       units: minutes
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.materialized_view_age_minutes_average
+        - selector: materialized_view_age_minutes_average
           name: minutes
     - id: am_azure_data_explorer__materialized_view_age_seconds
       title: Azure Data Explorer Materialized View Age (Seconds)
@@ -716,7 +716,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.materialized_view_age_seconds_average
+        - selector: materialized_view_age_seconds_average
           name: average
     - id: am_azure_data_explorer__materialized_view_records_in_delta
       title: Azure Data Explorer Materialized View Records in Delta
@@ -726,7 +726,7 @@ template:
       units: records
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.materialized_view_records_in_delta_average
+        - selector: materialized_view_records_in_delta_average
           name: average
     - id: am_azure_data_explorer__materialized_view_extents_rebuild
       title: Azure Data Explorer Materialized View Extents Rebuild
@@ -736,7 +736,7 @@ template:
       units: extents
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.materialized_view_extents_rebuild_average
+        - selector: materialized_view_extents_rebuild_average
           name: average
     - id: am_azure_data_explorer__materialized_view_data_loss
       title: Azure Data Explorer Materialized View Data Loss
@@ -746,7 +746,7 @@ template:
       units: status
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.materialized_view_data_loss_maximum
+        - selector: materialized_view_data_loss_maximum
           name: maximum
     - id: am_azure_data_explorer__materialized_view_result
       title: Azure Data Explorer Materialized View Result
@@ -756,7 +756,7 @@ template:
       units: status
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.materialized_view_result_average
+        - selector: materialized_view_result_average
           name: average
     - id: am_azure_data_explorer__partitioning_percentage
       title: Azure Data Explorer Partitioning Percentage
@@ -766,9 +766,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.partitioning_percentage_average
+        - selector: partitioning_percentage_average
           name: total
-        - selector: data_explorer.partitioning_percentage_hot_average
+        - selector: partitioning_percentage_hot_average
           name: hot
     - id: am_azure_data_explorer__partitioned_records
       title: Azure Data Explorer Processed Partitioned Records
@@ -778,5 +778,5 @@ template:
       units: records
       algorithm: absolute
       dimensions:
-        - selector: data_explorer.processed_partitioned_records_average
+        - selector: processed_partitioned_records_average
           name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/data_factory.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/data_factory.yaml
@@ -588,11 +588,11 @@ template:
       units: runs/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.pipeline_succeeded_runs_total
+        - selector: pipeline_succeeded_runs_total
           name: succeeded
-        - selector: data_factory.pipeline_failed_runs_total
+        - selector: pipeline_failed_runs_total
           name: failed
-        - selector: data_factory.pipeline_cancelled_runs_total
+        - selector: pipeline_cancelled_runs_total
           name: cancelled
     - id: am_azure_data_factory__pipeline_elapsed_time
       title: Azure Data Factory Pipeline Elapsed Time Runs
@@ -602,7 +602,7 @@ template:
       units: runs/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.pipeline_elapsed_time_runs_total
+        - selector: pipeline_elapsed_time_runs_total
           name: elapsed_time
     - id: am_azure_data_factory__activity_runs
       title: Azure Data Factory Activity Runs
@@ -612,11 +612,11 @@ template:
       units: runs/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.activity_succeeded_runs_total
+        - selector: activity_succeeded_runs_total
           name: succeeded
-        - selector: data_factory.activity_failed_runs_total
+        - selector: activity_failed_runs_total
           name: failed
-        - selector: data_factory.activity_cancelled_runs_total
+        - selector: activity_cancelled_runs_total
           name: cancelled
     - id: am_azure_data_factory__trigger_runs
       title: Azure Data Factory Trigger Runs
@@ -626,11 +626,11 @@ template:
       units: runs/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.trigger_succeeded_runs_total
+        - selector: trigger_succeeded_runs_total
           name: succeeded
-        - selector: data_factory.trigger_failed_runs_total
+        - selector: trigger_failed_runs_total
           name: failed
-        - selector: data_factory.trigger_cancelled_runs_total
+        - selector: trigger_cancelled_runs_total
           name: cancelled
     - id: am_azure_data_factory__ssis_ir_starts
       title: Azure Data Factory SSIS IR Start Operations
@@ -640,11 +640,11 @@ template:
       units: runs/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.ssis_integration_runtime_start_succeeded_total
+        - selector: ssis_integration_runtime_start_succeeded_total
           name: succeeded
-        - selector: data_factory.ssis_integration_runtime_start_failed_total
+        - selector: ssis_integration_runtime_start_failed_total
           name: failed
-        - selector: data_factory.ssis_integration_runtime_start_cancel_total
+        - selector: ssis_integration_runtime_start_cancel_total
           name: cancelled
     - id: am_azure_data_factory__ssis_ir_stops
       title: Azure Data Factory SSIS IR Stop Operations
@@ -654,9 +654,9 @@ template:
       units: runs/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.ssis_integration_runtime_stop_succeeded_total
+        - selector: ssis_integration_runtime_stop_succeeded_total
           name: succeeded
-        - selector: data_factory.ssis_integration_runtime_stop_stuck_total
+        - selector: ssis_integration_runtime_stop_stuck_total
           name: stuck
     - id: am_azure_data_factory__ssis_package_executions
       title: Azure Data Factory SSIS Package Executions
@@ -666,11 +666,11 @@ template:
       units: executions/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.ssis_package_execution_succeeded_total
+        - selector: ssis_package_execution_succeeded_total
           name: succeeded
-        - selector: data_factory.ssis_package_execution_failed_total
+        - selector: ssis_package_execution_failed_total
           name: failed
-        - selector: data_factory.ssis_package_execution_cancel_total
+        - selector: ssis_package_execution_cancel_total
           name: cancelled
     - id: am_azure_data_factory__ir_cpu
       title: Azure Data Factory Integration Runtime CPU
@@ -680,7 +680,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: data_factory.integration_runtime_cpu_percentage_average
+        - selector: integration_runtime_cpu_percentage_average
           name: average
     - id: am_azure_data_factory__ir_memory
       title: Azure Data Factory Integration Runtime Available Memory
@@ -690,7 +690,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: data_factory.integration_runtime_available_memory_average
+        - selector: integration_runtime_available_memory_average
           name: available
     - id: am_azure_data_factory__ir_nodes
       title: Azure Data Factory Integration Runtime Available Nodes
@@ -700,7 +700,7 @@ template:
       units: nodes
       algorithm: absolute
       dimensions:
-        - selector: data_factory.integration_runtime_available_node_number_average
+        - selector: integration_runtime_available_node_number_average
           name: available
     - id: am_azure_data_factory__ir_queue
       title: Azure Data Factory Integration Runtime Queue
@@ -710,7 +710,7 @@ template:
       units: tasks
       algorithm: absolute
       dimensions:
-        - selector: data_factory.integration_runtime_queue_length_average
+        - selector: integration_runtime_queue_length_average
           name: queue_length
     - id: am_azure_data_factory__ir_task_pickup_delay
       title: Azure Data Factory Integration Runtime Task Pickup Delay
@@ -720,7 +720,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: data_factory.integration_runtime_average_task_pickup_delay_average
+        - selector: integration_runtime_average_task_pickup_delay_average
           name: average
     - id: am_azure_data_factory__factory_size
       title: Azure Data Factory Factory Size
@@ -730,9 +730,9 @@ template:
       units: GiB
       algorithm: absolute
       dimensions:
-        - selector: data_factory.factory_size_in_gb_units_maximum
+        - selector: factory_size_in_gb_units_maximum
           name: current
-        - selector: data_factory.max_allowed_factory_size_in_gb_units_maximum
+        - selector: max_allowed_factory_size_in_gb_units_maximum
           name: max_allowed
     - id: am_azure_data_factory__entity_count
       title: Azure Data Factory Entity Count
@@ -742,9 +742,9 @@ template:
       units: entities
       algorithm: absolute
       dimensions:
-        - selector: data_factory.resource_count_maximum
+        - selector: resource_count_maximum
           name: current
-        - selector: data_factory.max_allowed_resource_count_maximum
+        - selector: max_allowed_resource_count_maximum
           name: max_allowed
     - id: am_azure_data_factory__mvnet_ir_copy_capacity
       title: Azure Data Factory MVNet IR Copy Capacity
@@ -754,9 +754,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: data_factory.mv_net_ir_copy_capacity_utilization_maximum
+        - selector: mv_net_ir_copy_capacity_utilization_maximum
           name: utilization
-        - selector: data_factory.mv_net_ir_copy_available_capacity_pct_maximum
+        - selector: mv_net_ir_copy_available_capacity_pct_maximum
           name: available
     - id: am_azure_data_factory__mvnet_ir_copy_queue
       title: Azure Data Factory MVNet IR Copy Queue
@@ -766,7 +766,7 @@ template:
       units: tasks
       algorithm: absolute
       dimensions:
-        - selector: data_factory.mv_net_ir_copy_waiting_queue_length_average
+        - selector: mv_net_ir_copy_waiting_queue_length_average
           name: waiting
     - id: am_azure_data_factory__mvnet_ir_external_capacity
       title: Azure Data Factory MVNet IR External Capacity
@@ -776,9 +776,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: data_factory.mv_net_ir_external_capacity_utilization_maximum
+        - selector: mv_net_ir_external_capacity_utilization_maximum
           name: utilization
-        - selector: data_factory.mv_net_ir_external_available_capacity_pct_maximum
+        - selector: mv_net_ir_external_available_capacity_pct_maximum
           name: available
     - id: am_azure_data_factory__mvnet_ir_external_queue
       title: Azure Data Factory MVNet IR External Queue
@@ -788,7 +788,7 @@ template:
       units: tasks
       algorithm: absolute
       dimensions:
-        - selector: data_factory.mv_net_ir_external_waiting_queue_length_average
+        - selector: mv_net_ir_external_waiting_queue_length_average
           name: waiting
     - id: am_azure_data_factory__mvnet_ir_pipeline_capacity
       title: Azure Data Factory MVNet IR Pipeline Capacity
@@ -798,9 +798,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: data_factory.mv_net_ir_pipeline_capacity_utilization_maximum
+        - selector: mv_net_ir_pipeline_capacity_utilization_maximum
           name: utilization
-        - selector: data_factory.mv_net_ir_pipeline_available_capacity_pct_maximum
+        - selector: mv_net_ir_pipeline_available_capacity_pct_maximum
           name: available
     - id: am_azure_data_factory__mvnet_ir_pipeline_queue
       title: Azure Data Factory MVNet IR Pipeline Queue
@@ -810,7 +810,7 @@ template:
       units: tasks
       algorithm: absolute
       dimensions:
-        - selector: data_factory.mv_net_ir_pipeline_waiting_queue_length_average
+        - selector: mv_net_ir_pipeline_waiting_queue_length_average
           name: waiting
     - id: am_azure_data_factory__airflow_ir_cpu
       title: Azure Data Factory Airflow IR CPU
@@ -820,7 +820,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_cpu_percentage_average
+        - selector: airflow_integration_runtime_cpu_percentage_average
           name: percentage
     - id: am_azure_data_factory__airflow_ir_cpu_usage
       title: Azure Data Factory Airflow IR CPU Usage
@@ -830,7 +830,7 @@ template:
       units: millicores
       algorithm: absolute
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_cpu_usage_average
+        - selector: airflow_integration_runtime_cpu_usage_average
           name: average
     - id: am_azure_data_factory__airflow_ir_memory
       title: Azure Data Factory Airflow IR Memory
@@ -840,7 +840,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_memory_percentage_average
+        - selector: airflow_integration_runtime_memory_percentage_average
           name: percentage
     - id: am_azure_data_factory__airflow_ir_memory_usage
       title: Azure Data Factory Airflow IR Memory Usage
@@ -850,7 +850,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_memory_usage_average
+        - selector: airflow_integration_runtime_memory_usage_average
           name: average
     - id: am_azure_data_factory__airflow_ir_nodes
       title: Azure Data Factory Airflow IR Node Count
@@ -860,7 +860,7 @@ template:
       units: nodes
       algorithm: absolute
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_node_count_average
+        - selector: airflow_integration_runtime_node_count_average
           name: average
     - id: am_azure_data_factory__airflow_ir_dag_collection
       title: Azure Data Factory Airflow IR DAG DB Collection Time
@@ -870,7 +870,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_collect_db_dags_average
+        - selector: airflow_integration_runtime_collect_db_dags_average
           name: average
     - id: am_azure_data_factory__airflow_ir_dag_bag
       title: Azure Data Factory Airflow IR DAG Bag Size
@@ -880,7 +880,7 @@ template:
       units: dags/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_dag_bag_size_total
+        - selector: airflow_integration_runtime_dag_bag_size_total
           name: total
     - id: am_azure_data_factory__airflow_ir_dag_errors
       title: Azure Data Factory Airflow IR DAG Errors
@@ -890,11 +890,11 @@ template:
       units: errors/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_dag_callback_exceptions_total
+        - selector: airflow_integration_runtime_dag_callback_exceptions_total
           name: callback_exceptions
-        - selector: data_factory.airflow_integration_runtime_dag_file_refresh_error_total
+        - selector: airflow_integration_runtime_dag_file_refresh_error_total
           name: file_refresh
-        - selector: data_factory.airflow_integration_runtime_dag_processing_import_errors_total
+        - selector: airflow_integration_runtime_dag_processing_import_errors_total
           name: import
     - id: am_azure_data_factory__airflow_ir_dag_processing_duration
       title: Azure Data Factory Airflow IR DAG Processing Duration
@@ -904,7 +904,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_dag_processing_last_duration_average
+        - selector: airflow_integration_runtime_dag_processing_last_duration_average
           name: last_duration
     - id: am_azure_data_factory__airflow_ir_dag_processing_lag
       title: Azure Data Factory Airflow IR DAG Processing Lag
@@ -914,11 +914,11 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_dag_processing_last_run_seconds_ago_average
+        - selector: airflow_integration_runtime_dag_processing_last_run_seconds_ago_average
           name: last_run_seconds_ago
-        - selector: data_factory.airflow_integration_runtime_dag_processing_processor_timeouts_average
+        - selector: airflow_integration_runtime_dag_processing_processor_timeouts_average
           name: processor_timeouts
-        - selector: data_factory.airflow_integration_runtime_dag_processing_total_parse_time_average
+        - selector: airflow_integration_runtime_dag_processing_total_parse_time_average
           name: total_parse_time
     - id: am_azure_data_factory__airflow_ir_dag_processing_activity
       title: Azure Data Factory Airflow IR DAG Processing Activity
@@ -928,9 +928,9 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_dag_processing_manager_stalls_total
+        - selector: airflow_integration_runtime_dag_processing_manager_stalls_total
           name: manager_stalls
-        - selector: data_factory.airflow_integration_runtime_dag_processing_processes_total
+        - selector: airflow_integration_runtime_dag_processing_processes_total
           name: processes
     - id: am_azure_data_factory__airflow_ir_dag_run_duration
       title: Azure Data Factory Airflow IR DAG Run Duration
@@ -940,9 +940,9 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_dag_run_duration_success_average
+        - selector: airflow_integration_runtime_dag_run_duration_success_average
           name: success
-        - selector: data_factory.airflow_integration_runtime_dag_run_duration_failed_average
+        - selector: airflow_integration_runtime_dag_run_duration_failed_average
           name: failed
     - id: am_azure_data_factory__airflow_ir_dag_run_scheduling
       title: Azure Data Factory Airflow IR DAG Run Scheduling Delays
@@ -952,11 +952,11 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_dag_run_dependency_check_average
+        - selector: airflow_integration_runtime_dag_run_dependency_check_average
           name: dependency_check
-        - selector: data_factory.airflow_integration_runtime_dag_run_first_task_scheduling_delay_average
+        - selector: airflow_integration_runtime_dag_run_first_task_scheduling_delay_average
           name: first_task_delay
-        - selector: data_factory.airflow_integration_runtime_dag_run_schedule_delay_average
+        - selector: airflow_integration_runtime_dag_run_schedule_delay_average
           name: schedule_delay
     - id: am_azure_data_factory__airflow_ir_executor
       title: Azure Data Factory Airflow IR Executor
@@ -966,11 +966,11 @@ template:
       units: slots/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_executor_open_slots_total
+        - selector: airflow_integration_runtime_executor_open_slots_total
           name: open_slots
-        - selector: data_factory.airflow_integration_runtime_executor_queued_tasks_total
+        - selector: airflow_integration_runtime_executor_queued_tasks_total
           name: queued_tasks
-        - selector: data_factory.airflow_integration_runtime_executor_running_tasks_total
+        - selector: airflow_integration_runtime_executor_running_tasks_total
           name: running_tasks
     - id: am_azure_data_factory__airflow_ir_jobs
       title: Azure Data Factory Airflow IR Jobs
@@ -980,11 +980,11 @@ template:
       units: jobs/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_job_start_total
+        - selector: airflow_integration_runtime_job_start_total
           name: started
-        - selector: data_factory.airflow_integration_runtime_job_end_total
+        - selector: airflow_integration_runtime_job_end_total
           name: ended
-        - selector: data_factory.airflow_integration_runtime_job_heartbeat_failure_total
+        - selector: airflow_integration_runtime_job_heartbeat_failure_total
           name: heartbeat_failures
     - id: am_azure_data_factory__airflow_ir_operators
       title: Azure Data Factory Airflow IR Operators
@@ -994,9 +994,9 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_operator_successes_total
+        - selector: airflow_integration_runtime_operator_successes_total
           name: successes
-        - selector: data_factory.airflow_integration_runtime_operator_failures_total
+        - selector: airflow_integration_runtime_operator_failures_total
           name: failures
     - id: am_azure_data_factory__airflow_ir_pool_slots
       title: Azure Data Factory Airflow IR Pool Slots
@@ -1006,11 +1006,11 @@ template:
       units: slots/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_pool_open_slots_total
+        - selector: airflow_integration_runtime_pool_open_slots_total
           name: open
-        - selector: data_factory.airflow_integration_runtime_pool_queued_slots_total
+        - selector: airflow_integration_runtime_pool_queued_slots_total
           name: queued
-        - selector: data_factory.airflow_integration_runtime_pool_running_slots_total
+        - selector: airflow_integration_runtime_pool_running_slots_total
           name: running
     - id: am_azure_data_factory__airflow_ir_pool_starving
       title: Azure Data Factory Airflow IR Pool Starving Tasks
@@ -1020,7 +1020,7 @@ template:
       units: tasks/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_pool_starving_tasks_total
+        - selector: airflow_integration_runtime_pool_starving_tasks_total
           name: starving
     - id: am_azure_data_factory__airflow_ir_scheduler_critical_section
       title: Azure Data Factory Airflow IR Scheduler Critical Section
@@ -1030,7 +1030,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_scheduler_critical_section_duration_average
+        - selector: airflow_integration_runtime_scheduler_critical_section_duration_average
           name: duration
     - id: am_azure_data_factory__airflow_ir_scheduler_activity
       title: Azure Data Factory Airflow IR Scheduler Activity
@@ -1040,11 +1040,11 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_scheduler_critical_section_busy_total
+        - selector: airflow_integration_runtime_scheduler_critical_section_busy_total
           name: critical_section_busy
-        - selector: data_factory.airflow_integration_runtime_scheduler_heartbeat_total
+        - selector: airflow_integration_runtime_scheduler_heartbeat_total
           name: heartbeats
-        - selector: data_factory.airflow_integration_runtime_scheduler_failed_sla_email_attempts_total
+        - selector: airflow_integration_runtime_scheduler_failed_sla_email_attempts_total
           name: failed_sla_emails
     - id: am_azure_data_factory__airflow_ir_scheduler_orphaned_tasks
       title: Azure Data Factory Airflow IR Scheduler Orphaned Tasks
@@ -1054,9 +1054,9 @@ template:
       units: tasks/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_scheduler_orphaned_tasks_adopted_total
+        - selector: airflow_integration_runtime_scheduler_orphaned_tasks_adopted_total
           name: adopted
-        - selector: data_factory.airflow_integration_runtime_scheduler_orphaned_tasks_cleared_total
+        - selector: airflow_integration_runtime_scheduler_orphaned_tasks_cleared_total
           name: cleared
     - id: am_azure_data_factory__airflow_ir_scheduler_tasks
       title: Azure Data Factory Airflow IR Scheduler Tasks
@@ -1066,13 +1066,13 @@ template:
       units: tasks/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_scheduler_tasks_executable_total
+        - selector: airflow_integration_runtime_scheduler_tasks_executable_total
           name: executable
-        - selector: data_factory.airflow_integration_runtime_scheduler_tasks_running_total
+        - selector: airflow_integration_runtime_scheduler_tasks_running_total
           name: running
-        - selector: data_factory.airflow_integration_runtime_scheduler_tasks_starving_total
+        - selector: airflow_integration_runtime_scheduler_tasks_starving_total
           name: starving
-        - selector: data_factory.airflow_integration_runtime_scheduler_tasks_killed_externally_total
+        - selector: airflow_integration_runtime_scheduler_tasks_killed_externally_total
           name: killed_externally
     - id: am_azure_data_factory__airflow_ir_task_instances
       title: Azure Data Factory Airflow IR Task Instances
@@ -1082,17 +1082,17 @@ template:
       units: instances/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_started_task_instances_total
+        - selector: airflow_integration_runtime_started_task_instances_total
           name: started
-        - selector: data_factory.airflow_integration_runtime_task_instance_successes_total
+        - selector: airflow_integration_runtime_task_instance_successes_total
           name: succeeded
-        - selector: data_factory.airflow_integration_runtime_task_instance_failures_total
+        - selector: airflow_integration_runtime_task_instance_failures_total
           name: failed
-        - selector: data_factory.airflow_integration_runtime_task_instance_finished_total
+        - selector: airflow_integration_runtime_task_instance_finished_total
           name: finished
-        - selector: data_factory.airflow_integration_runtime_task_instance_previously_succeeded_total
+        - selector: airflow_integration_runtime_task_instance_previously_succeeded_total
           name: previously_succeeded
-        - selector: data_factory.airflow_integration_runtime_task_instance_created_using_operator_total
+        - selector: airflow_integration_runtime_task_instance_created_using_operator_total
           name: created_via_operator
     - id: am_azure_data_factory__airflow_ir_task_instance_duration
       title: Azure Data Factory Airflow IR Task Instance Duration
@@ -1102,7 +1102,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_task_instance_duration_average
+        - selector: airflow_integration_runtime_task_instance_duration_average
           name: average
     - id: am_azure_data_factory__airflow_ir_task_dag_changes
       title: Azure Data Factory Airflow IR Task DAG Changes
@@ -1112,9 +1112,9 @@ template:
       units: tasks/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_task_removed_from_dag_total
+        - selector: airflow_integration_runtime_task_removed_from_dag_total
           name: removed
-        - selector: data_factory.airflow_integration_runtime_task_restored_to_dag_total
+        - selector: airflow_integration_runtime_task_restored_to_dag_total
           name: restored
     - id: am_azure_data_factory__airflow_ir_triggers
       title: Azure Data Factory Airflow IR Triggers
@@ -1124,11 +1124,11 @@ template:
       units: triggers/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_triggers_succeeded_total
+        - selector: airflow_integration_runtime_triggers_succeeded_total
           name: succeeded
-        - selector: data_factory.airflow_integration_runtime_triggers_failed_total
+        - selector: airflow_integration_runtime_triggers_failed_total
           name: failed
-        - selector: data_factory.airflow_integration_runtime_triggers_running_total
+        - selector: airflow_integration_runtime_triggers_running_total
           name: running
     - id: am_azure_data_factory__airflow_ir_trigger_issues
       title: Azure Data Factory Airflow IR Trigger Issues
@@ -1138,9 +1138,9 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_triggers_blocked_main_thread_total
+        - selector: airflow_integration_runtime_triggers_blocked_main_thread_total
           name: blocked_main_thread
-        - selector: data_factory.airflow_integration_runtime_celery_task_timeout_error_total
+        - selector: airflow_integration_runtime_celery_task_timeout_error_total
           name: celery_timeout_errors
     - id: am_azure_data_factory__airflow_ir_zombies
       title: Azure Data Factory Airflow IR Zombie Tasks Killed
@@ -1150,5 +1150,5 @@ template:
       units: tasks/s
       algorithm: incremental
       dimensions:
-        - selector: data_factory.airflow_integration_runtime_zombies_killed_total
+        - selector: airflow_integration_runtime_zombies_killed_total
           name: killed

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/event_grid.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/event_grid.yaml
@@ -90,9 +90,9 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: event_grid.publish_success_count_total
+        - selector: publish_success_count_total
           name: success
-        - selector: event_grid.publish_fail_count_total
+        - selector: publish_fail_count_total
           name: failed
     - id: am_azure_event_grid__publish_latency
       title: Azure Event Grid Publish Latency
@@ -102,7 +102,7 @@ template:
       units: milliseconds
       algorithm: incremental
       dimensions:
-        - selector: event_grid.publish_success_latency_in_ms_total
+        - selector: publish_success_latency_in_ms_total
           name: latency
     - id: am_azure_event_grid__routing
       title: Azure Event Grid Event Routing
@@ -112,9 +112,9 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: event_grid.matched_event_count_total
+        - selector: matched_event_count_total
           name: matched
-        - selector: event_grid.unmatched_event_count_total
+        - selector: unmatched_event_count_total
           name: unmatched
     - id: am_azure_event_grid__advanced_filter_evaluations
       title: Azure Event Grid Advanced Filter Evaluations
@@ -124,7 +124,7 @@ template:
       units: evaluations/s
       algorithm: incremental
       dimensions:
-        - selector: event_grid.advanced_filter_evaluation_count_total
+        - selector: advanced_filter_evaluation_count_total
           name: evaluations
     - id: am_azure_event_grid__delivery
       title: Azure Event Grid Event Delivery
@@ -134,13 +134,13 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: event_grid.delivery_success_count_total
+        - selector: delivery_success_count_total
           name: delivered
-        - selector: event_grid.delivery_attempt_fail_count_total
+        - selector: delivery_attempt_fail_count_total
           name: failed
-        - selector: event_grid.dropped_event_count_total
+        - selector: dropped_event_count_total
           name: dropped
-        - selector: event_grid.dead_lettered_count_total
+        - selector: dead_lettered_count_total
           name: dead_lettered
     - id: am_azure_event_grid__destination_processing_duration
       title: Azure Event Grid Destination Processing Duration
@@ -150,5 +150,5 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: event_grid.destination_processing_duration_in_ms_average
+        - selector: destination_processing_duration_in_ms_average
           name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/event_hubs.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/event_hubs.yaml
@@ -150,9 +150,9 @@ template:
       units: messages/s
       algorithm: incremental
       dimensions:
-        - selector: event_hubs.incoming_messages_total
+        - selector: incoming_messages_total
           name: in
-        - selector: event_hubs.outgoing_messages_total
+        - selector: outgoing_messages_total
           name: out
     - id: am_azure_event_hubs__data_throughput
       title: Azure Event Hubs Data Throughput
@@ -162,9 +162,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: event_hubs.incoming_bytes_total
+        - selector: incoming_bytes_total
           name: in
-        - selector: event_hubs.outgoing_bytes_total
+        - selector: outgoing_bytes_total
           name: out
     - id: am_azure_event_hubs__requests
       title: Azure Event Hubs Requests
@@ -174,9 +174,9 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: event_hubs.incoming_requests_total
+        - selector: incoming_requests_total
           name: incoming
-        - selector: event_hubs.successful_requests_total
+        - selector: successful_requests_total
           name: successful
     - id: am_azure_event_hubs__errors
       title: Azure Event Hubs Errors
@@ -186,13 +186,13 @@ template:
       units: errors/s
       algorithm: incremental
       dimensions:
-        - selector: event_hubs.server_errors_total
+        - selector: server_errors_total
           name: server
-        - selector: event_hubs.user_errors_total
+        - selector: user_errors_total
           name: user
-        - selector: event_hubs.throttled_requests_total
+        - selector: throttled_requests_total
           name: throttled
-        - selector: event_hubs.quota_exceeded_errors_total
+        - selector: quota_exceeded_errors_total
           name: quota_exceeded
     - id: am_azure_event_hubs__connections
       title: Azure Event Hubs Active Connections
@@ -202,7 +202,7 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: event_hubs.active_connections_average
+        - selector: active_connections_average
           name: active
     - id: am_azure_event_hubs__connection_events
       title: Azure Event Hubs Connection Events
@@ -212,9 +212,9 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: event_hubs.connections_opened_maximum
+        - selector: connections_opened_maximum
           name: opened
-        - selector: event_hubs.connections_closed_maximum
+        - selector: connections_closed_maximum
           name: closed
     - id: am_azure_event_hubs__captured_messages
       title: Azure Event Hubs Captured Messages
@@ -224,7 +224,7 @@ template:
       units: messages/s
       algorithm: incremental
       dimensions:
-        - selector: event_hubs.captured_messages_total
+        - selector: captured_messages_total
           name: total
     - id: am_azure_event_hubs__captured_data
       title: Azure Event Hubs Captured Data
@@ -234,7 +234,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: event_hubs.captured_bytes_total
+        - selector: captured_bytes_total
           name: total
     - id: am_azure_event_hubs__namespace_size
       title: Azure Event Hubs Namespace Size
@@ -244,7 +244,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: event_hubs.size_average
+        - selector: size_average
           name: average
     - id: am_azure_event_hubs__capture_backlog
       title: Azure Event Hubs Capture Backlog
@@ -254,7 +254,7 @@ template:
       units: messages
       algorithm: absolute
       dimensions:
-        - selector: event_hubs.capture_backlog_total
+        - selector: capture_backlog_total
           name: backlog
     - id: am_azure_event_hubs__namespace_resources
       title: Azure Event Hubs Namespace Resources
@@ -264,9 +264,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: event_hubs.namespace_cpu_usage_maximum
+        - selector: namespace_cpu_usage_maximum
           name: cpu
-        - selector: event_hubs.namespace_memory_usage_maximum
+        - selector: namespace_memory_usage_maximum
           name: memory
     - id: am_azure_event_hubs__replication_lag
       title: Azure Event Hubs Replication Lag
@@ -276,7 +276,7 @@ template:
       units: messages
       algorithm: absolute
       dimensions:
-        - selector: event_hubs.replication_lag_count_maximum
+        - selector: replication_lag_count_maximum
           name: messages
     - id: am_azure_event_hubs__replication_lag_duration
       title: Azure Event Hubs Replication Lag Duration
@@ -286,5 +286,5 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: event_hubs.replication_lag_duration_maximum
+        - selector: replication_lag_duration_maximum
           name: duration

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/express_route_circuit.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/express_route_circuit.yaml
@@ -90,7 +90,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: express_route_circuit.arp_availability_average
+        - selector: arp_availability_average
           name: average
     - id: am_azure_express_route_circuit__bgp_availability
       title: Azure ExpressRoute Circuit BGP Availability
@@ -100,7 +100,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: express_route_circuit.bgp_availability_average
+        - selector: bgp_availability_average
           name: average
     - id: am_azure_express_route_circuit__throughput
       title: Azure ExpressRoute Circuit Throughput
@@ -110,9 +110,9 @@ template:
       units: bits/s
       algorithm: absolute
       dimensions:
-        - selector: express_route_circuit.bits_in_per_second_average
+        - selector: bits_in_per_second_average
           name: in
-        - selector: express_route_circuit.bits_out_per_second_average
+        - selector: bits_out_per_second_average
           name: out
     - id: am_azure_express_route_circuit__bandwidth_utilization
       title: Azure ExpressRoute Circuit Bandwidth Utilization
@@ -122,9 +122,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: express_route_circuit.ingress_bandwidth_utilization_maximum
+        - selector: ingress_bandwidth_utilization_maximum
           name: ingress
-        - selector: express_route_circuit.egress_bandwidth_utilization_maximum
+        - selector: egress_bandwidth_utilization_maximum
           name: egress
     - id: am_azure_express_route_circuit__qos_dropped_bits
       title: Azure ExpressRoute Circuit QoS Dropped Bits
@@ -134,9 +134,9 @@ template:
       units: bits/s
       algorithm: absolute
       dimensions:
-        - selector: express_route_circuit.qos_drop_bits_in_per_second_average
+        - selector: qos_drop_bits_in_per_second_average
           name: in
-        - selector: express_route_circuit.qos_drop_bits_out_per_second_average
+        - selector: qos_drop_bits_out_per_second_average
           name: out
     - id: am_azure_express_route_circuit__fastpath_routes
       title: Azure ExpressRoute Circuit FastPath Routes
@@ -146,7 +146,7 @@ template:
       units: routes
       algorithm: absolute
       dimensions:
-        - selector: express_route_circuit.fast_path_routes_count_for_circuit_maximum
+        - selector: fast_path_routes_count_for_circuit_maximum
           name: maximum
     - id: am_azure_express_route_circuit__global_reach_throughput
       title: Azure ExpressRoute Circuit GlobalReach Throughput
@@ -156,7 +156,7 @@ template:
       units: bits/s
       algorithm: absolute
       dimensions:
-        - selector: express_route_circuit.global_reach_bits_in_per_second_average
+        - selector: global_reach_bits_in_per_second_average
           name: in
-        - selector: express_route_circuit.global_reach_bits_out_per_second_average
+        - selector: global_reach_bits_out_per_second_average
           name: out

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/express_route_gateway.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/express_route_gateway.yaml
@@ -106,9 +106,9 @@ template:
       units: bits/s
       algorithm: absolute
       dimensions:
-        - selector: express_route_gateway.er_gateway_connection_bits_in_per_second_average
+        - selector: er_gateway_connection_bits_in_per_second_average
           name: in
-        - selector: express_route_gateway.er_gateway_connection_bits_out_per_second_average
+        - selector: er_gateway_connection_bits_out_per_second_average
           name: out
     - id: am_azure_express_route_gateway__gateway_throughput
       title: Azure ExpressRoute Gateway Throughput
@@ -118,7 +118,7 @@ template:
       units: bits/s
       algorithm: absolute
       dimensions:
-        - selector: express_route_gateway.express_route_gateway_bits_per_second_average
+        - selector: express_route_gateway_bits_per_second_average
           name: average
     - id: am_azure_express_route_gateway__cpu_utilization
       title: Azure ExpressRoute Gateway CPU Utilization
@@ -128,7 +128,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: express_route_gateway.express_route_gateway_cpu_utilization_average
+        - selector: express_route_gateway_cpu_utilization_average
           name: average
     - id: am_azure_express_route_gateway__packets
       title: Azure ExpressRoute Gateway Packets
@@ -138,7 +138,7 @@ template:
       units: packets/s
       algorithm: absolute
       dimensions:
-        - selector: express_route_gateway.express_route_gateway_packets_per_second_average
+        - selector: express_route_gateway_packets_per_second_average
           name: average
     - id: am_azure_express_route_gateway__active_flows
       title: Azure ExpressRoute Gateway Active Flows
@@ -148,7 +148,7 @@ template:
       units: flows
       algorithm: absolute
       dimensions:
-        - selector: express_route_gateway.express_route_gateway_active_flows_average
+        - selector: express_route_gateway_active_flows_average
           name: average
     - id: am_azure_express_route_gateway__routes_advertised
       title: Azure ExpressRoute Gateway Routes Advertised to Peer
@@ -158,7 +158,7 @@ template:
       units: routes
       algorithm: absolute
       dimensions:
-        - selector: express_route_gateway.express_route_gateway_count_of_routes_advertised_to_peer_maximum
+        - selector: express_route_gateway_count_of_routes_advertised_to_peer_maximum
           name: maximum
     - id: am_azure_express_route_gateway__routes_learned
       title: Azure ExpressRoute Gateway Routes Learned from Peer
@@ -168,7 +168,7 @@ template:
       units: routes
       algorithm: absolute
       dimensions:
-        - selector: express_route_gateway.express_route_gateway_count_of_routes_learned_from_peer_maximum
+        - selector: express_route_gateway_count_of_routes_learned_from_peer_maximum
           name: maximum
     - id: am_azure_express_route_gateway__route_changes
       title: Azure ExpressRoute Gateway Route Changes
@@ -178,7 +178,7 @@ template:
       units: changes/s
       algorithm: incremental
       dimensions:
-        - selector: express_route_gateway.express_route_gateway_frequency_of_routes_changed_total
+        - selector: express_route_gateway_frequency_of_routes_changed_total
           name: total
     - id: am_azure_express_route_gateway__max_flows_creation_rate
       title: Azure ExpressRoute Gateway Max Flow Creation Rate
@@ -188,7 +188,7 @@ template:
       units: flows/s
       algorithm: absolute
       dimensions:
-        - selector: express_route_gateway.express_route_gateway_max_flows_creation_rate_maximum
+        - selector: express_route_gateway_max_flows_creation_rate_maximum
           name: maximum
     - id: am_azure_express_route_gateway__vm_count
       title: Azure ExpressRoute Gateway VMs in VNet
@@ -198,5 +198,5 @@ template:
       units: VMs
       algorithm: absolute
       dimensions:
-        - selector: express_route_gateway.express_route_gateway_number_of_vm_in_vnet_maximum
+        - selector: express_route_gateway_number_of_vm_in_vnet_maximum
           name: maximum

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/firewall.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/firewall.yaml
@@ -72,7 +72,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: firewall.firewall_health_average
+        - selector: firewall_health_average
           name: average
     - id: am_azure_firewall__latency
       title: Azure Firewall Latency Probe
@@ -82,7 +82,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: firewall.firewall_latency_png_average
+        - selector: firewall_latency_png_average
           name: average
     - id: am_azure_firewall__throughput
       title: Azure Firewall Throughput
@@ -92,7 +92,7 @@ template:
       units: bits/s
       algorithm: absolute
       dimensions:
-        - selector: firewall.throughput_average
+        - selector: throughput_average
           name: average
     - id: am_azure_firewall__data_processed
       title: Azure Firewall Data Processed
@@ -102,7 +102,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: firewall.data_processed_total
+        - selector: data_processed_total
           name: total
     - id: am_azure_firewall__rule_hits
       title: Azure Firewall Rule Hits
@@ -112,9 +112,9 @@ template:
       units: hits/s
       algorithm: incremental
       dimensions:
-        - selector: firewall.application_rule_hit_total
+        - selector: application_rule_hit_total
           name: application
-        - selector: firewall.network_rule_hit_total
+        - selector: network_rule_hit_total
           name: network
     - id: am_azure_firewall__snat_port_utilization
       title: Azure Firewall SNAT Port Utilization
@@ -124,7 +124,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: firewall.snat_port_utilization_average
+        - selector: snat_port_utilization_average
           name: average
     - id: am_azure_firewall__capacity
       title: Azure Firewall Observed Capacity Units
@@ -134,5 +134,5 @@ template:
       units: units
       algorithm: absolute
       dimensions:
-        - selector: firewall.observed_capacity_average
+        - selector: observed_capacity_average
           name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/front_door.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/front_door.yaml
@@ -144,9 +144,9 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: front_door.total_latency_average
+        - selector: total_latency_average
           name: total
-        - selector: front_door.origin_latency_average
+        - selector: origin_latency_average
           name: origin
     - id: am_azure_front_door__origin_health
       title: Azure Front Door Origin Health
@@ -156,7 +156,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: front_door.origin_health_percentage_average
+        - selector: origin_health_percentage_average
           name: health
     - id: am_azure_front_door__byte_hit_ratio
       title: Azure Front Door Byte Hit Ratio
@@ -166,7 +166,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: front_door.byte_hit_ratio_average
+        - selector: byte_hit_ratio_average
           name: hit_ratio
     - id: am_azure_front_door__error_rate
       title: Azure Front Door Error Rate
@@ -176,9 +176,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: front_door.percentage4xx_average
+        - selector: percentage4xx_average
           name: 4xx
-        - selector: front_door.percentage5xx_average
+        - selector: percentage5xx_average
           name: 5xx
     - id: am_azure_front_door__requests
       title: Azure Front Door Requests
@@ -188,9 +188,9 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: front_door.request_count_total
+        - selector: request_count_total
           name: client
-        - selector: front_door.origin_request_count_total
+        - selector: origin_request_count_total
           name: origin
     - id: am_azure_front_door__data_transfer
       title: Azure Front Door Data Transfer
@@ -200,9 +200,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: front_door.request_size_total
+        - selector: request_size_total
           name: request
-        - selector: front_door.response_size_total
+        - selector: response_size_total
           name: response
     - id: am_azure_front_door__origin_shield_requests
       title: Azure Front Door Origin Shield Requests
@@ -212,11 +212,11 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: front_door.origin_shield_request_count_total
+        - selector: origin_shield_request_count_total
           name: to_shield
-        - selector: front_door.origin_shield_origin_request_count_total
+        - selector: origin_shield_origin_request_count_total
           name: to_origin
-        - selector: front_door.origin_shield_rate_limit_request_count_total
+        - selector: origin_shield_rate_limit_request_count_total
           name: rate_limited
     - id: am_azure_front_door__origin_shield_data_transfer
       title: Azure Front Door Origin Shield Data Transfer
@@ -226,7 +226,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: front_door.origin_shield_request_size_total
+        - selector: origin_shield_request_size_total
           name: request
     - id: am_azure_front_door__waf_requests
       title: Azure Front Door WAF Requests
@@ -236,7 +236,7 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: front_door.web_application_firewall_request_count_total
+        - selector: web_application_firewall_request_count_total
           name: total
     - id: am_azure_front_door__waf_challenges
       title: Azure Front Door WAF Challenges
@@ -246,9 +246,9 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: front_door.web_application_firewall_captcha_request_count_total
+        - selector: web_application_firewall_captcha_request_count_total
           name: captcha
-        - selector: front_door.web_application_firewall_js_request_count_total
+        - selector: web_application_firewall_js_request_count_total
           name: js_challenge
     - id: am_azure_front_door__websocket_connections
       title: Azure Front Door WebSocket Connections
@@ -258,9 +258,9 @@ template:
       units: connections/s
       algorithm: incremental
       dimensions:
-        - selector: front_door.web_socket_connections_total
+        - selector: web_socket_connections_total
           name: requested
-        - selector: front_door.active_web_socket_connections_total
+        - selector: active_web_socket_connections_total
           name: active
     - id: am_azure_front_door__websocket_duration
       title: Azure Front Door WebSocket Connection Duration
@@ -270,5 +270,5 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: front_door.average_web_socket_connection_duration_average
+        - selector: average_web_socket_connection_duration_average
           name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/iot_hub.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/iot_hub.yaml
@@ -426,11 +426,11 @@ template:
       units: messages/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.c2d_commands_egress_complete_success_total
+        - selector: c2d_commands_egress_complete_success_total
           name: completed
-        - selector: iot_hub.c2d_commands_egress_abandon_success_total
+        - selector: c2d_commands_egress_abandon_success_total
           name: abandoned
-        - selector: iot_hub.c2d_commands_egress_reject_success_total
+        - selector: c2d_commands_egress_reject_success_total
           name: rejected
     - id: am_azure_iot_hub__c2d_messages_expired
       title: Azure IoT Hub Cloud-to-Device Messages Expired
@@ -440,7 +440,7 @@ template:
       units: messages/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.c2d_messages_expired_total
+        - selector: c2d_messages_expired_total
           name: expired
     - id: am_azure_iot_hub__c2d_methods
       title: Azure IoT Hub Direct Method Invocations
@@ -450,9 +450,9 @@ template:
       units: invocations/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.c2d_methods_success_total
+        - selector: c2d_methods_success_total
           name: successful
-        - selector: iot_hub.c2d_methods_failure_total
+        - selector: c2d_methods_failure_total
           name: failed
     - id: am_azure_iot_hub__c2d_methods_request_size
       title: Azure IoT Hub Direct Method Request Size
@@ -462,7 +462,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: iot_hub.c2d_methods_request_size_average
+        - selector: c2d_methods_request_size_average
           name: average
     - id: am_azure_iot_hub__c2d_methods_response_size
       title: Azure IoT Hub Direct Method Response Size
@@ -472,7 +472,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: iot_hub.c2d_methods_response_size_average
+        - selector: c2d_methods_response_size_average
           name: average
     - id: am_azure_iot_hub__c2d_twin_reads
       title: Azure IoT Hub Backend Twin Reads
@@ -482,9 +482,9 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.c2d_twin_read_success_total
+        - selector: c2d_twin_read_success_total
           name: successful
-        - selector: iot_hub.c2d_twin_read_failure_total
+        - selector: c2d_twin_read_failure_total
           name: failed
     - id: am_azure_iot_hub__c2d_twin_read_size
       title: Azure IoT Hub Backend Twin Read Size
@@ -494,7 +494,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: iot_hub.c2d_twin_read_size_average
+        - selector: c2d_twin_read_size_average
           name: average
     - id: am_azure_iot_hub__c2d_twin_updates
       title: Azure IoT Hub Backend Twin Updates
@@ -504,9 +504,9 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.c2d_twin_update_success_total
+        - selector: c2d_twin_update_success_total
           name: successful
-        - selector: iot_hub.c2d_twin_update_failure_total
+        - selector: c2d_twin_update_failure_total
           name: failed
     - id: am_azure_iot_hub__c2d_twin_update_size
       title: Azure IoT Hub Backend Twin Update Size
@@ -516,7 +516,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: iot_hub.c2d_twin_update_size_average
+        - selector: c2d_twin_update_size_average
           name: average
     - id: am_azure_iot_hub__d2c_telemetry
       title: Azure IoT Hub Device Telemetry
@@ -526,9 +526,9 @@ template:
       units: messages/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.d2c_telemetry_ingress_all_protocol_total
+        - selector: d2c_telemetry_ingress_all_protocol_total
           name: attempted
-        - selector: iot_hub.d2c_telemetry_ingress_success_total
+        - selector: d2c_telemetry_ingress_success_total
           name: sent
     - id: am_azure_iot_hub__d2c_telemetry_throttle
       title: Azure IoT Hub Telemetry Throttling Errors
@@ -538,7 +538,7 @@ template:
       units: errors/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.d2c_telemetry_ingress_send_throttle_total
+        - selector: d2c_telemetry_ingress_send_throttle_total
           name: throttled
     - id: am_azure_iot_hub__d2c_twin_reads
       title: Azure IoT Hub Device Twin Reads
@@ -548,9 +548,9 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.d2c_twin_read_success_total
+        - selector: d2c_twin_read_success_total
           name: successful
-        - selector: iot_hub.d2c_twin_read_failure_total
+        - selector: d2c_twin_read_failure_total
           name: failed
     - id: am_azure_iot_hub__d2c_twin_read_size
       title: Azure IoT Hub Device Twin Read Size
@@ -560,7 +560,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: iot_hub.d2c_twin_read_size_average
+        - selector: d2c_twin_read_size_average
           name: average
     - id: am_azure_iot_hub__d2c_twin_updates
       title: Azure IoT Hub Device Twin Updates
@@ -570,9 +570,9 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.d2c_twin_update_success_total
+        - selector: d2c_twin_update_success_total
           name: successful
-        - selector: iot_hub.d2c_twin_update_failure_total
+        - selector: d2c_twin_update_failure_total
           name: failed
     - id: am_azure_iot_hub__d2c_twin_update_size
       title: Azure IoT Hub Device Twin Update Size
@@ -582,7 +582,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: iot_hub.d2c_twin_update_size_average
+        - selector: d2c_twin_update_size_average
           name: average
     - id: am_azure_iot_hub__routing_deliveries
       title: Azure IoT Hub Routing Message Deliveries
@@ -592,15 +592,15 @@ template:
       units: messages/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.d2c_telemetry_egress_success_total
+        - selector: d2c_telemetry_egress_success_total
           name: delivered
-        - selector: iot_hub.d2c_telemetry_egress_dropped_total
+        - selector: d2c_telemetry_egress_dropped_total
           name: dropped
-        - selector: iot_hub.d2c_telemetry_egress_orphaned_total
+        - selector: d2c_telemetry_egress_orphaned_total
           name: orphaned
-        - selector: iot_hub.d2c_telemetry_egress_invalid_total
+        - selector: d2c_telemetry_egress_invalid_total
           name: invalid
-        - selector: iot_hub.d2c_telemetry_egress_fallback_total
+        - selector: d2c_telemetry_egress_fallback_total
           name: fallback
     - id: am_azure_iot_hub__routing_delivery_by_endpoint
       title: Azure IoT Hub Routing Deliveries by Endpoint
@@ -610,15 +610,15 @@ template:
       units: messages/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.d2c_endpoints_egress_built_in_events_total
+        - selector: d2c_endpoints_egress_built_in_events_total
           name: builtin_events
-        - selector: iot_hub.d2c_endpoints_egress_event_hubs_total
+        - selector: d2c_endpoints_egress_event_hubs_total
           name: event_hubs
-        - selector: iot_hub.d2c_endpoints_egress_service_bus_queues_total
+        - selector: d2c_endpoints_egress_service_bus_queues_total
           name: service_bus_queues
-        - selector: iot_hub.d2c_endpoints_egress_service_bus_topics_total
+        - selector: d2c_endpoints_egress_service_bus_topics_total
           name: service_bus_topics
-        - selector: iot_hub.d2c_endpoints_egress_storage_total
+        - selector: d2c_endpoints_egress_storage_total
           name: storage
     - id: am_azure_iot_hub__routing_storage_blobs
       title: Azure IoT Hub Routing Blobs Delivered to Storage
@@ -628,7 +628,7 @@ template:
       units: blobs/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.d2c_endpoints_egress_storage_blobs_total
+        - selector: d2c_endpoints_egress_storage_blobs_total
           name: blobs
     - id: am_azure_iot_hub__routing_storage_data
       title: Azure IoT Hub Routing Data Delivered to Storage
@@ -638,7 +638,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.d2c_endpoints_egress_storage_bytes_total
+        - selector: d2c_endpoints_egress_storage_bytes_total
           name: bytes
     - id: am_azure_iot_hub__routing_latency
       title: Azure IoT Hub Routing Latency
@@ -648,15 +648,15 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: iot_hub.d2c_endpoints_latency_built_in_events_average
+        - selector: d2c_endpoints_latency_built_in_events_average
           name: builtin_events
-        - selector: iot_hub.d2c_endpoints_latency_event_hubs_average
+        - selector: d2c_endpoints_latency_event_hubs_average
           name: event_hubs
-        - selector: iot_hub.d2c_endpoints_latency_service_bus_queues_average
+        - selector: d2c_endpoints_latency_service_bus_queues_average
           name: service_bus_queues
-        - selector: iot_hub.d2c_endpoints_latency_service_bus_topics_average
+        - selector: d2c_endpoints_latency_service_bus_topics_average
           name: service_bus_topics
-        - selector: iot_hub.d2c_endpoints_latency_storage_average
+        - selector: d2c_endpoints_latency_storage_average
           name: storage
     - id: am_azure_iot_hub__routing_deliveries_preview
       title: Azure IoT Hub Routing Deliveries (Preview)
@@ -666,7 +666,7 @@ template:
       units: deliveries/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.routing_deliveries_total
+        - selector: routing_deliveries_total
           name: deliveries
     - id: am_azure_iot_hub__routing_delivery_latency_preview
       title: Azure IoT Hub Routing Delivery Latency (Preview)
@@ -676,7 +676,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: iot_hub.routing_delivery_latency_average
+        - selector: routing_delivery_latency_average
           name: average
     - id: am_azure_iot_hub__routing_data_size_preview
       title: Azure IoT Hub Routing Delivery Message Size (Preview)
@@ -686,7 +686,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.routing_data_size_in_bytes_delivered_total
+        - selector: routing_data_size_in_bytes_delivered_total
           name: bytes
     - id: am_azure_iot_hub__connections
       title: Azure IoT Hub Successful Connections
@@ -696,7 +696,7 @@ template:
       units: connections/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.connect_success_total
+        - selector: connect_success_total
           name: successful
     - id: am_azure_iot_hub__connected_devices
       title: Azure IoT Hub Connected Devices
@@ -706,7 +706,7 @@ template:
       units: devices
       algorithm: absolute
       dimensions:
-        - selector: iot_hub.connected_device_count_average
+        - selector: connected_device_count_average
           name: connected
     - id: am_azure_iot_hub__total_devices
       title: Azure IoT Hub Total Devices
@@ -716,7 +716,7 @@ template:
       units: devices
       algorithm: absolute
       dimensions:
-        - selector: iot_hub.total_device_count_average
+        - selector: total_device_count_average
           name: total
     - id: am_azure_iot_hub__daily_message_quota
       title: Azure IoT Hub Daily Message Quota Used
@@ -726,7 +726,7 @@ template:
       units: messages
       algorithm: absolute
       dimensions:
-        - selector: iot_hub.daily_message_quota_used_average
+        - selector: daily_message_quota_used_average
           name: used
     - id: am_azure_iot_hub__data_usage
       title: Azure IoT Hub Device Data Usage
@@ -736,9 +736,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.device_data_usage_total
+        - selector: device_data_usage_total
           name: data_usage
-        - selector: iot_hub.device_data_usage_v2_total
+        - selector: device_data_usage_v2_total
           name: data_usage_v2
     - id: am_azure_iot_hub__configurations
       title: Azure IoT Hub Configuration Operations
@@ -748,7 +748,7 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.configurations_total
+        - selector: configurations_total
           name: operations
     - id: am_azure_iot_hub__event_grid_deliveries
       title: Azure IoT Hub Event Grid Deliveries
@@ -758,7 +758,7 @@ template:
       units: deliveries/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.event_grid_deliveries_total
+        - selector: event_grid_deliveries_total
           name: deliveries
     - id: am_azure_iot_hub__event_grid_latency
       title: Azure IoT Hub Event Grid Latency
@@ -768,7 +768,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: iot_hub.event_grid_latency_average
+        - selector: event_grid_latency_average
           name: average
     - id: am_azure_iot_hub__jobs_status
       title: Azure IoT Hub Job Completions
@@ -778,9 +778,9 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.jobs_completed_total
+        - selector: jobs_completed_total
           name: completed
-        - selector: iot_hub.jobs_failed_total
+        - selector: jobs_failed_total
           name: failed
     - id: am_azure_iot_hub__jobs_cancel
       title: Azure IoT Hub Job Cancellations
@@ -790,9 +790,9 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.jobs_cancel_job_success_total
+        - selector: jobs_cancel_job_success_total
           name: successful
-        - selector: iot_hub.jobs_cancel_job_failure_total
+        - selector: jobs_cancel_job_failure_total
           name: failed
     - id: am_azure_iot_hub__jobs_create_method
       title: Azure IoT Hub Direct Method Job Creations
@@ -802,9 +802,9 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.jobs_create_direct_method_job_success_total
+        - selector: jobs_create_direct_method_job_success_total
           name: successful
-        - selector: iot_hub.jobs_create_direct_method_job_failure_total
+        - selector: jobs_create_direct_method_job_failure_total
           name: failed
     - id: am_azure_iot_hub__jobs_create_twin_update
       title: Azure IoT Hub Twin Update Job Creations
@@ -814,9 +814,9 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.jobs_create_twin_update_job_success_total
+        - selector: jobs_create_twin_update_job_success_total
           name: successful
-        - selector: iot_hub.jobs_create_twin_update_job_failure_total
+        - selector: jobs_create_twin_update_job_failure_total
           name: failed
     - id: am_azure_iot_hub__jobs_list
       title: Azure IoT Hub Job List Calls
@@ -826,9 +826,9 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.jobs_list_jobs_success_total
+        - selector: jobs_list_jobs_success_total
           name: successful
-        - selector: iot_hub.jobs_list_jobs_failure_total
+        - selector: jobs_list_jobs_failure_total
           name: failed
     - id: am_azure_iot_hub__jobs_query
       title: Azure IoT Hub Job Queries
@@ -838,9 +838,9 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.jobs_query_jobs_success_total
+        - selector: jobs_query_jobs_success_total
           name: successful
-        - selector: iot_hub.jobs_query_jobs_failure_total
+        - selector: jobs_query_jobs_failure_total
           name: failed
     - id: am_azure_iot_hub__twin_queries
       title: Azure IoT Hub Twin Queries
@@ -850,9 +850,9 @@ template:
       units: queries/s
       algorithm: incremental
       dimensions:
-        - selector: iot_hub.twin_queries_success_total
+        - selector: twin_queries_success_total
           name: successful
-        - selector: iot_hub.twin_queries_failure_total
+        - selector: twin_queries_failure_total
           name: failed
     - id: am_azure_iot_hub__twin_queries_result_size
       title: Azure IoT Hub Twin Query Result Size
@@ -862,5 +862,5 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: iot_hub.twin_queries_result_size_average
+        - selector: twin_queries_result_size_average
           name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/key_vault.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/key_vault.yaml
@@ -54,7 +54,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: key_vault.availability_average
+        - selector: availability_average
           name: average
     - id: am_azure_key_vault__api_latency
       title: Azure Key Vault API Latency
@@ -64,7 +64,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: key_vault.service_api_latency_average
+        - selector: service_api_latency_average
           name: average
     - id: am_azure_key_vault__saturation
       title: Azure Key Vault Saturation
@@ -74,7 +74,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: key_vault.saturation_shoebox_average
+        - selector: saturation_shoebox_average
           name: average
     - id: am_azure_key_vault__api_activity
       title: Azure Key Vault API Activity
@@ -84,7 +84,7 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: key_vault.service_api_hit_count
+        - selector: service_api_hit_count
           name: hits
-        - selector: key_vault.service_api_result_count
+        - selector: service_api_result_count
           name: results

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/load_balancers.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/load_balancers.yaml
@@ -78,7 +78,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: load_balancers.vip_availability_average
+        - selector: vip_availability_average
           name: average
     - id: am_azure_load_balancers__dip_availability
       title: Azure Load Balancer Health Probe Status
@@ -88,7 +88,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: load_balancers.dip_availability_average
+        - selector: dip_availability_average
           name: average
     - id: am_azure_load_balancers__global_backend_availability
       title: Azure Load Balancer Global Backend Availability
@@ -98,7 +98,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: load_balancers.global_backend_availability_average
+        - selector: global_backend_availability_average
           name: average
     - id: am_azure_load_balancers__byte_throughput
       title: Azure Load Balancer Byte Throughput
@@ -108,7 +108,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: load_balancers.byte_count_total
+        - selector: byte_count_total
           name: total
     - id: am_azure_load_balancers__packet_throughput
       title: Azure Load Balancer Packet Throughput
@@ -118,7 +118,7 @@ template:
       units: packets/s
       algorithm: incremental
       dimensions:
-        - selector: load_balancers.packet_count_total
+        - selector: packet_count_total
           name: total
     - id: am_azure_load_balancers__syn_count
       title: Azure Load Balancer SYN Packets
@@ -128,7 +128,7 @@ template:
       units: packets/s
       algorithm: incremental
       dimensions:
-        - selector: load_balancers.syn_count_total
+        - selector: syn_count_total
           name: total
     - id: am_azure_load_balancers__snat_connections
       title: Azure Load Balancer SNAT Connections
@@ -138,7 +138,7 @@ template:
       units: connections/s
       algorithm: incremental
       dimensions:
-        - selector: load_balancers.snat_connection_count_total
+        - selector: snat_connection_count_total
           name: total
     - id: am_azure_load_balancers__snat_ports
       title: Azure Load Balancer SNAT Port Usage
@@ -148,7 +148,7 @@ template:
       units: ports
       algorithm: absolute
       dimensions:
-        - selector: load_balancers.allocated_snat_ports_average
+        - selector: allocated_snat_ports_average
           name: allocated
-        - selector: load_balancers.used_snat_ports_average
+        - selector: used_snat_ports_average
           name: used

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/log_analytics.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/log_analytics.yaml
@@ -454,7 +454,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.availability_rate_query_average
+        - selector: availability_rate_query_average
           name: availability
     - id: am_azure_log_analytics__ingestion_latency
       title: Azure Log Analytics Ingestion Latency
@@ -464,11 +464,11 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.ingestion_time_average
+        - selector: ingestion_time_average
           name: average
-        - selector: log_analytics.ingestion_time_maximum
+        - selector: ingestion_time_maximum
           name: maximum
-        - selector: log_analytics.ingestion_time_minimum
+        - selector: ingestion_time_minimum
           name: minimum
     - id: am_azure_log_analytics__ingestion_volume
       title: Azure Log Analytics Ingestion Volume
@@ -478,7 +478,7 @@ template:
       units: records/s
       algorithm: incremental
       dimensions:
-        - selector: log_analytics.ingestion_volume_count
+        - selector: ingestion_volume_count
           name: records
     - id: am_azure_log_analytics__queries
       title: Azure Log Analytics Queries
@@ -488,9 +488,9 @@ template:
       units: queries/s
       algorithm: incremental
       dimensions:
-        - selector: log_analytics.query_count_count
+        - selector: query_count_count
           name: total
-        - selector: log_analytics.query_failure_count_count
+        - selector: query_failure_count_count
           name: failed
     - id: am_azure_log_analytics__export_data
       title: Azure Log Analytics Exported Data
@@ -500,7 +500,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: log_analytics.bytes_exported_total
+        - selector: bytes_exported_total
           name: exported
     - id: am_azure_log_analytics__export_records
       title: Azure Log Analytics Exported Records
@@ -510,7 +510,7 @@ template:
       units: records/s
       algorithm: incremental
       dimensions:
-        - selector: log_analytics.records_exported_total
+        - selector: records_exported_total
           name: exported
     - id: am_azure_log_analytics__export_failures
       title: Azure Log Analytics Export Failures
@@ -520,7 +520,7 @@ template:
       units: exports/s
       algorithm: incremental
       dimensions:
-        - selector: log_analytics.export_failed_total
+        - selector: export_failed_total
           name: failed
     - id: am_azure_log_analytics__legacy_cpu_utilization
       title: Azure Log Analytics Legacy CPU Utilization
@@ -530,13 +530,13 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_processor_time_average
+        - selector: average_processor_time_average
           name: processor
-        - selector: log_analytics.average_privileged_time_average
+        - selector: average_privileged_time_average
           name: privileged
-        - selector: log_analytics.average_user_time_average
+        - selector: average_user_time_average
           name: user
-        - selector: log_analytics.average_idle_time_average
+        - selector: average_idle_time_average
           name: idle
     - id: am_azure_log_analytics__legacy_cpu_detailed
       title: Azure Log Analytics Legacy CPU Detailed
@@ -546,13 +546,13 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_dpc_time_average
+        - selector: average_dpc_time_average
           name: dpc
-        - selector: log_analytics.average_interrupt_time_average
+        - selector: average_interrupt_time_average
           name: interrupt
-        - selector: log_analytics.average_io_wait_time_average
+        - selector: average_io_wait_time_average
           name: io_wait
-        - selector: log_analytics.average_nice_time_average
+        - selector: average_nice_time_average
           name: nice
     - id: am_azure_log_analytics__legacy_cpu_pct
       title: Azure Log Analytics Legacy CPU Pct Time
@@ -562,9 +562,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_pct_privileged_time_average
+        - selector: average_pct_privileged_time_average
           name: privileged
-        - selector: log_analytics.average_pct_user_time_average
+        - selector: average_pct_user_time_average
           name: user
     - id: am_azure_log_analytics__legacy_memory_utilization
       title: Azure Log Analytics Legacy Memory Utilization
@@ -574,11 +574,11 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_available_memory_average
+        - selector: average_available_memory_average
           name: available
-        - selector: log_analytics.average_used_memory_average
+        - selector: average_used_memory_average
           name: used
-        - selector: log_analytics.average_committed_bytes_in_use_average
+        - selector: average_committed_bytes_in_use_average
           name: committed
     - id: am_azure_log_analytics__legacy_memory_available
       title: Azure Log Analytics Legacy Available Memory
@@ -588,9 +588,9 @@ template:
       units: megabytes
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_available_m_bytes_average
+        - selector: average_available_m_bytes_average
           name: available_mbytes
-        - selector: log_analytics.average_available_m_bytes_memory_average
+        - selector: average_available_m_bytes_memory_average
           name: available_mbytes_memory
     - id: am_azure_log_analytics__legacy_memory_used_kbytes
       title: Azure Log Analytics Legacy Used Memory (kBytes)
@@ -600,7 +600,7 @@ template:
       units: kilobytes
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_used_memory_k_bytes_average
+        - selector: average_used_memory_k_bytes_average
           name: used
     - id: am_azure_log_analytics__legacy_memory_used_mbytes
       title: Azure Log Analytics Legacy Used Memory (MBytes)
@@ -610,7 +610,7 @@ template:
       units: megabytes
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_used_memory_m_bytes_average
+        - selector: average_used_memory_m_bytes_average
           name: used
     - id: am_azure_log_analytics__legacy_memory_free
       title: Azure Log Analytics Legacy Free Memory
@@ -620,11 +620,11 @@ template:
       units: megabytes
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_free_physical_memory_average
+        - selector: average_free_physical_memory_average
           name: physical
-        - selector: log_analytics.average_free_virtual_memory_average
+        - selector: average_free_virtual_memory_average
           name: virtual
-        - selector: log_analytics.average_virtual_shared_memory_average
+        - selector: average_virtual_shared_memory_average
           name: shared
     - id: am_azure_log_analytics__legacy_swap_utilization
       title: Azure Log Analytics Legacy Swap Utilization
@@ -634,9 +634,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_available_swap_space_average
+        - selector: average_available_swap_space_average
           name: available
-        - selector: log_analytics.average_used_swap_space_average
+        - selector: average_used_swap_space_average
           name: used
     - id: am_azure_log_analytics__legacy_swap_size
       title: Azure Log Analytics Legacy Swap Size
@@ -646,9 +646,9 @@ template:
       units: megabytes
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_available_m_bytes_swap_average
+        - selector: average_available_m_bytes_swap_average
           name: available
-        - selector: log_analytics.average_used_m_bytes_swap_space_average
+        - selector: average_used_m_bytes_swap_space_average
           name: used
     - id: am_azure_log_analytics__legacy_disk_space_utilization
       title: Azure Log Analytics Legacy Disk Space Utilization
@@ -658,9 +658,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_free_space_average
+        - selector: average_free_space_average
           name: free
-        - selector: log_analytics.average_used_space_average
+        - selector: average_used_space_average
           name: used
     - id: am_azure_log_analytics__legacy_disk_inodes
       title: Azure Log Analytics Legacy Disk Inodes
@@ -670,9 +670,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_free_inodes_average
+        - selector: average_free_inodes_average
           name: free
-        - selector: log_analytics.average_used_inodes_average
+        - selector: average_used_inodes_average
           name: used
     - id: am_azure_log_analytics__legacy_disk_free
       title: Azure Log Analytics Legacy Disk Free Space
@@ -682,7 +682,7 @@ template:
       units: megabytes
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_free_megabytes_average
+        - selector: average_free_megabytes_average
           name: free
     - id: am_azure_log_analytics__legacy_disk_io_throughput
       title: Azure Log Analytics Legacy Disk I/O Throughput
@@ -692,13 +692,13 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_disk_read_bytes_sec_average
+        - selector: average_disk_read_bytes_sec_average
           name: read
-        - selector: log_analytics.average_disk_write_bytes_sec_average
+        - selector: average_disk_write_bytes_sec_average
           name: write
-        - selector: log_analytics.average_logical_disk_bytes_sec_average
+        - selector: average_logical_disk_bytes_sec_average
           name: logical
-        - selector: log_analytics.average_physical_disk_bytes_sec_average
+        - selector: average_physical_disk_bytes_sec_average
           name: physical
     - id: am_azure_log_analytics__legacy_disk_io_operations
       title: Azure Log Analytics Legacy Disk I/O Operations
@@ -708,11 +708,11 @@ template:
       units: operations/s
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_disk_reads_sec_average
+        - selector: average_disk_reads_sec_average
           name: reads
-        - selector: log_analytics.average_disk_writes_sec_average
+        - selector: average_disk_writes_sec_average
           name: writes
-        - selector: log_analytics.average_disk_transfers_sec_average
+        - selector: average_disk_transfers_sec_average
           name: transfers
     - id: am_azure_log_analytics__legacy_disk_io_latency
       title: Azure Log Analytics Legacy Disk I/O Latency
@@ -722,11 +722,11 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_avg_disk_sec_read_average
+        - selector: average_avg_disk_sec_read_average
           name: read
-        - selector: log_analytics.average_avg_disk_sec_write_average
+        - selector: average_avg_disk_sec_write_average
           name: write
-        - selector: log_analytics.average_avg_disk_sec_transfer_average
+        - selector: average_avg_disk_sec_transfer_average
           name: transfer
     - id: am_azure_log_analytics__legacy_disk_queue
       title: Azure Log Analytics Legacy Disk Queue Length
@@ -736,7 +736,7 @@ template:
       units: operations
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_current_disk_queue_length_average
+        - selector: average_current_disk_queue_length_average
           name: queue_length
     - id: am_azure_log_analytics__legacy_paging
       title: Azure Log Analytics Legacy Paging Activity
@@ -746,11 +746,11 @@ template:
       units: pages/s
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_page_reads_sec_average
+        - selector: average_page_reads_sec_average
           name: reads
-        - selector: log_analytics.average_page_writes_sec_average
+        - selector: average_page_writes_sec_average
           name: writes
-        - selector: log_analytics.average_pages_sec_average
+        - selector: average_pages_sec_average
           name: total
     - id: am_azure_log_analytics__legacy_paging_files
       title: Azure Log Analytics Legacy Paging Files
@@ -760,9 +760,9 @@ template:
       units: megabytes
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_free_space_in_paging_files_average
+        - selector: average_free_space_in_paging_files_average
           name: free
-        - selector: log_analytics.average_size_stored_in_paging_files_average
+        - selector: average_size_stored_in_paging_files_average
           name: stored
     - id: am_azure_log_analytics__legacy_network_throughput_win
       title: Azure Log Analytics Legacy Network Throughput (Windows)
@@ -772,11 +772,11 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_bytes_received_sec_average
+        - selector: average_bytes_received_sec_average
           name: received
-        - selector: log_analytics.average_bytes_sent_sec_average
+        - selector: average_bytes_sent_sec_average
           name: sent
-        - selector: log_analytics.average_bytes_total_sec_average
+        - selector: average_bytes_total_sec_average
           name: total
     - id: am_azure_log_analytics__legacy_network_traffic
       title: Azure Log Analytics Legacy Network Traffic
@@ -786,11 +786,11 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_total_bytes_average
+        - selector: average_total_bytes_average
           name: total
-        - selector: log_analytics.average_total_bytes_received_average
+        - selector: average_total_bytes_received_average
           name: received
-        - selector: log_analytics.average_total_bytes_transmitted_average
+        - selector: average_total_bytes_transmitted_average
           name: transmitted
     - id: am_azure_log_analytics__legacy_network_packets
       title: Azure Log Analytics Legacy Network Packets
@@ -800,9 +800,9 @@ template:
       units: packets
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_total_packets_received_average
+        - selector: average_total_packets_received_average
           name: received
-        - selector: log_analytics.average_total_packets_transmitted_average
+        - selector: average_total_packets_transmitted_average
           name: transmitted
     - id: am_azure_log_analytics__legacy_network_errors
       title: Azure Log Analytics Legacy Network Errors
@@ -812,11 +812,11 @@ template:
       units: errors
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_total_rx_errors_average
+        - selector: average_total_rx_errors_average
           name: rx
-        - selector: log_analytics.average_total_tx_errors_average
+        - selector: average_total_tx_errors_average
           name: tx
-        - selector: log_analytics.average_total_collisions_average
+        - selector: average_total_collisions_average
           name: collisions
     - id: am_azure_log_analytics__legacy_system
       title: Azure Log Analytics Legacy System
@@ -826,7 +826,7 @@ template:
       units: processes
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_processes_average
+        - selector: average_processes_average
           name: processes
     - id: am_azure_log_analytics__legacy_processor_queue
       title: Azure Log Analytics Legacy Processor Queue
@@ -836,7 +836,7 @@ template:
       units: threads
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_processor_queue_length_average
+        - selector: average_processor_queue_length_average
           name: queue_length
     - id: am_azure_log_analytics__legacy_uptime
       title: Azure Log Analytics Legacy Uptime
@@ -846,7 +846,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_uptime_average
+        - selector: average_uptime_average
           name: uptime
     - id: am_azure_log_analytics__legacy_users
       title: Azure Log Analytics Legacy Users
@@ -856,7 +856,7 @@ template:
       units: users
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.average_users_average
+        - selector: average_users_average
           name: users
     - id: am_azure_log_analytics__legacy_events
       title: Azure Log Analytics Legacy Events
@@ -866,7 +866,7 @@ template:
       units: events/s
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.event_average
+        - selector: event_average
           name: events
     - id: am_azure_log_analytics__legacy_heartbeat
       title: Azure Log Analytics Legacy Heartbeat
@@ -876,7 +876,7 @@ template:
       units: heartbeats/s
       algorithm: incremental
       dimensions:
-        - selector: log_analytics.heartbeat_total
+        - selector: heartbeat_total
           name: heartbeats
     - id: am_azure_log_analytics__legacy_updates
       title: Azure Log Analytics Legacy Updates
@@ -886,5 +886,5 @@ template:
       units: updates
       algorithm: absolute
       dimensions:
-        - selector: log_analytics.update_average
+        - selector: update_average
           name: updates

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/logic_apps.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/logic_apps.yaml
@@ -246,15 +246,15 @@ template:
       units: runs/s
       algorithm: incremental
       dimensions:
-        - selector: logic_apps.runs_started_total
+        - selector: runs_started_total
           name: started
-        - selector: logic_apps.runs_completed_total
+        - selector: runs_completed_total
           name: completed
-        - selector: logic_apps.runs_succeeded_total
+        - selector: runs_succeeded_total
           name: succeeded
-        - selector: logic_apps.runs_failed_total
+        - selector: runs_failed_total
           name: failed
-        - selector: logic_apps.runs_cancelled_total
+        - selector: runs_cancelled_total
           name: cancelled
     - id: am_azure_logic_apps__run_latency
       title: Azure Logic Apps Run Latency
@@ -264,9 +264,9 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: logic_apps.run_latency_average
+        - selector: run_latency_average
           name: all
-        - selector: logic_apps.run_success_latency_average
+        - selector: run_success_latency_average
           name: success
     - id: am_azure_logic_apps__run_failure_rate
       title: Azure Logic Apps Run Failure Rate
@@ -276,7 +276,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: logic_apps.run_failure_percentage_total
+        - selector: run_failure_percentage_total
           name: failure_rate
     - id: am_azure_logic_apps__run_throttling
       title: Azure Logic Apps Run Throttling
@@ -286,9 +286,9 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: logic_apps.run_throttled_events_total
+        - selector: run_throttled_events_total
           name: during_run
-        - selector: logic_apps.run_start_throttled_events_total
+        - selector: run_start_throttled_events_total
           name: at_start
     - id: am_azure_logic_apps__action_lifecycle
       title: Azure Logic Apps Action Lifecycle
@@ -298,15 +298,15 @@ template:
       units: actions/s
       algorithm: incremental
       dimensions:
-        - selector: logic_apps.actions_started_total
+        - selector: actions_started_total
           name: started
-        - selector: logic_apps.actions_completed_total
+        - selector: actions_completed_total
           name: completed
-        - selector: logic_apps.actions_succeeded_total
+        - selector: actions_succeeded_total
           name: succeeded
-        - selector: logic_apps.actions_failed_total
+        - selector: actions_failed_total
           name: failed
-        - selector: logic_apps.actions_skipped_total
+        - selector: actions_skipped_total
           name: skipped
     - id: am_azure_logic_apps__action_latency
       title: Azure Logic Apps Action Latency
@@ -316,9 +316,9 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: logic_apps.action_latency_average
+        - selector: action_latency_average
           name: all
-        - selector: logic_apps.action_success_latency_average
+        - selector: action_success_latency_average
           name: success
     - id: am_azure_logic_apps__action_throttling
       title: Azure Logic Apps Action Throttling
@@ -328,7 +328,7 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: logic_apps.action_throttled_events_total
+        - selector: action_throttled_events_total
           name: total
     - id: am_azure_logic_apps__trigger_lifecycle
       title: Azure Logic Apps Trigger Lifecycle
@@ -338,17 +338,17 @@ template:
       units: triggers/s
       algorithm: incremental
       dimensions:
-        - selector: logic_apps.triggers_started_total
+        - selector: triggers_started_total
           name: started
-        - selector: logic_apps.triggers_completed_total
+        - selector: triggers_completed_total
           name: completed
-        - selector: logic_apps.triggers_succeeded_total
+        - selector: triggers_succeeded_total
           name: succeeded
-        - selector: logic_apps.triggers_fired_total
+        - selector: triggers_fired_total
           name: fired
-        - selector: logic_apps.triggers_failed_total
+        - selector: triggers_failed_total
           name: failed
-        - selector: logic_apps.triggers_skipped_total
+        - selector: triggers_skipped_total
           name: skipped
     - id: am_azure_logic_apps__trigger_latency
       title: Azure Logic Apps Trigger Latency
@@ -358,11 +358,11 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: logic_apps.trigger_latency_average
+        - selector: trigger_latency_average
           name: all
-        - selector: logic_apps.trigger_fire_latency_average
+        - selector: trigger_fire_latency_average
           name: fire
-        - selector: logic_apps.trigger_success_latency_average
+        - selector: trigger_success_latency_average
           name: success
     - id: am_azure_logic_apps__trigger_throttling
       title: Azure Logic Apps Trigger Throttling
@@ -372,7 +372,7 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: logic_apps.trigger_throttled_events_total
+        - selector: trigger_throttled_events_total
           name: total
     - id: am_azure_logic_apps__billable_executions
       title: Azure Logic Apps Billable Executions
@@ -382,11 +382,11 @@ template:
       units: executions/s
       algorithm: incremental
       dimensions:
-        - selector: logic_apps.total_billable_executions_total
+        - selector: total_billable_executions_total
           name: total
-        - selector: logic_apps.billable_action_executions_total
+        - selector: billable_action_executions_total
           name: actions
-        - selector: logic_apps.billable_trigger_executions_total
+        - selector: billable_trigger_executions_total
           name: triggers
     - id: am_azure_logic_apps__billing_by_type
       title: Azure Logic Apps Billing by Type
@@ -396,11 +396,11 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: logic_apps.billing_usage_native_operation_total
+        - selector: billing_usage_native_operation_total
           name: native
-        - selector: logic_apps.billing_usage_standard_connector_total
+        - selector: billing_usage_standard_connector_total
           name: standard_connector
-        - selector: logic_apps.billing_usage_storage_consumption_total
+        - selector: billing_usage_storage_consumption_total
           name: storage
     - id: am_azure_logic_apps__agent
       title: Azure Logic Apps AI Agent Activity
@@ -410,9 +410,9 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: logic_apps.agent_loop_execution_total
+        - selector: agent_loop_execution_total
           name: loop_executions
-        - selector: logic_apps.completion_token_overflow_usage_total
+        - selector: completion_token_overflow_usage_total
           name: completion_overflow
-        - selector: logic_apps.prompt_token_overflow_usage_total
+        - selector: prompt_token_overflow_usage_total
           name: prompt_overflow

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/machine_learning.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/machine_learning.yaml
@@ -414,9 +414,9 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.agents_total
+        - selector: agents_total
           name: agent_events
-        - selector: machine_learning.threads_total
+        - selector: threads_total
           name: thread_events
     - id: am_azure_machine_learning__agent_messages
       title: Azure Machine Learning Agent Messages
@@ -426,7 +426,7 @@ template:
       units: messages/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.messages_total
+        - selector: messages_total
           name: messages
     - id: am_azure_machine_learning__agent_runs
       title: Azure Machine Learning Agent Runs
@@ -436,7 +436,7 @@ template:
       units: runs/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.runs_total
+        - selector: runs_total
           name: runs
     - id: am_azure_machine_learning__agent_tokens
       title: Azure Machine Learning Agent Tokens
@@ -446,7 +446,7 @@ template:
       units: tokens/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.tokens_total
+        - selector: tokens_total
           name: tokens
     - id: am_azure_machine_learning__agent_tool_calls
       title: Azure Machine Learning Agent Tool Calls
@@ -456,7 +456,7 @@ template:
       units: calls/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.tool_calls_total
+        - selector: tool_calls_total
           name: tool_calls
     - id: am_azure_machine_learning__agent_indexed_files
       title: Azure Machine Learning Agent Indexed Files
@@ -466,7 +466,7 @@ template:
       units: files/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.indexed_files_total
+        - selector: indexed_files_total
           name: indexed_files
     - id: am_azure_machine_learning__model_deployments
       title: Azure Machine Learning Model Deployments
@@ -476,11 +476,11 @@ template:
       units: deployments/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.model_deploy_started_total
+        - selector: model_deploy_started_total
           name: started
-        - selector: machine_learning.model_deploy_succeeded_total
+        - selector: model_deploy_succeeded_total
           name: succeeded
-        - selector: machine_learning.model_deploy_failed_total
+        - selector: model_deploy_failed_total
           name: failed
     - id: am_azure_machine_learning__model_registrations
       title: Azure Machine Learning Model Registrations
@@ -490,9 +490,9 @@ template:
       units: registrations/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.model_register_succeeded_total
+        - selector: model_register_succeeded_total
           name: succeeded
-        - selector: machine_learning.model_register_failed_total
+        - selector: model_register_failed_total
           name: failed
     - id: am_azure_machine_learning__cluster_cores
       title: Azure Machine Learning Cluster Cores
@@ -502,15 +502,15 @@ template:
       units: cores
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.active_cores_average
+        - selector: active_cores_average
           name: active
-        - selector: machine_learning.idle_cores_average
+        - selector: idle_cores_average
           name: idle
-        - selector: machine_learning.leaving_cores_average
+        - selector: leaving_cores_average
           name: leaving
-        - selector: machine_learning.preempted_cores_average
+        - selector: preempted_cores_average
           name: preempted
-        - selector: machine_learning.unusable_cores_average
+        - selector: unusable_cores_average
           name: unusable
     - id: am_azure_machine_learning__total_cores
       title: Azure Machine Learning Total Cores
@@ -520,7 +520,7 @@ template:
       units: cores
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.total_cores_average
+        - selector: total_cores_average
           name: total
     - id: am_azure_machine_learning__cluster_nodes
       title: Azure Machine Learning Cluster Nodes
@@ -530,15 +530,15 @@ template:
       units: nodes
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.active_nodes_average
+        - selector: active_nodes_average
           name: active
-        - selector: machine_learning.idle_nodes_average
+        - selector: idle_nodes_average
           name: idle
-        - selector: machine_learning.leaving_nodes_average
+        - selector: leaving_nodes_average
           name: leaving
-        - selector: machine_learning.preempted_nodes_average
+        - selector: preempted_nodes_average
           name: preempted
-        - selector: machine_learning.unusable_nodes_average
+        - selector: unusable_nodes_average
           name: unusable
     - id: am_azure_machine_learning__total_nodes
       title: Azure Machine Learning Total Nodes
@@ -548,7 +548,7 @@ template:
       units: nodes
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.total_nodes_average
+        - selector: total_nodes_average
           name: total
     - id: am_azure_machine_learning__quota_utilization
       title: Azure Machine Learning Quota Utilization
@@ -558,7 +558,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.quota_utilization_percentage_average
+        - selector: quota_utilization_percentage_average
           name: utilization
     - id: am_azure_machine_learning__cpu_utilization
       title: Azure Machine Learning CPU Utilization
@@ -568,9 +568,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.cpu_utilization_average
+        - selector: cpu_utilization_average
           name: cluster_cpu
-        - selector: machine_learning.cpu_utilization_percentage_average
+        - selector: cpu_utilization_percentage_average
           name: node_cpu
     - id: am_azure_machine_learning__cpu_millicores
       title: Azure Machine Learning CPU Millicores
@@ -580,9 +580,9 @@ template:
       units: millicores
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.cpu_utilization_millicores_average
+        - selector: cpu_utilization_millicores_average
           name: used
-        - selector: machine_learning.cpu_capacity_millicores_average
+        - selector: cpu_capacity_millicores_average
           name: capacity
     - id: am_azure_machine_learning__cpu_memory_utilization
       title: Azure Machine Learning CPU Memory Utilization
@@ -592,7 +592,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.cpu_memory_utilization_percentage_average
+        - selector: cpu_memory_utilization_percentage_average
           name: utilization
     - id: am_azure_machine_learning__cpu_memory_megabytes
       title: Azure Machine Learning CPU Memory
@@ -602,9 +602,9 @@ template:
       units: megabytes
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.cpu_memory_utilization_megabytes_average
+        - selector: cpu_memory_utilization_megabytes_average
           name: used
-        - selector: machine_learning.cpu_memory_capacity_megabytes_average
+        - selector: cpu_memory_capacity_megabytes_average
           name: capacity
     - id: am_azure_machine_learning__gpu_utilization
       title: Azure Machine Learning GPU Utilization
@@ -614,9 +614,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.gpu_utilization_average
+        - selector: gpu_utilization_average
           name: cluster_gpu
-        - selector: machine_learning.gpu_utilization_percentage_average
+        - selector: gpu_utilization_percentage_average
           name: node_gpu
     - id: am_azure_machine_learning__gpu_milligpus
       title: Azure Machine Learning GPU MilliGPUs
@@ -626,9 +626,9 @@ template:
       units: milliGPUs
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.gpu_utilization_milli_gpus_average
+        - selector: gpu_utilization_milli_gpus_average
           name: used
-        - selector: machine_learning.gpu_capacity_milli_gpus_average
+        - selector: gpu_capacity_milli_gpus_average
           name: capacity
     - id: am_azure_machine_learning__gpu_memory_utilization
       title: Azure Machine Learning GPU Memory Utilization
@@ -638,9 +638,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.gpu_memory_utilization_average
+        - selector: gpu_memory_utilization_average
           name: cluster_gpu_memory
-        - selector: machine_learning.gpu_memory_utilization_percentage_average
+        - selector: gpu_memory_utilization_percentage_average
           name: node_gpu_memory
     - id: am_azure_machine_learning__gpu_memory_megabytes
       title: Azure Machine Learning GPU Memory
@@ -650,9 +650,9 @@ template:
       units: megabytes
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.gpu_memory_utilization_megabytes_average
+        - selector: gpu_memory_utilization_megabytes_average
           name: used
-        - selector: machine_learning.gpu_memory_capacity_megabytes_average
+        - selector: gpu_memory_capacity_megabytes_average
           name: capacity
     - id: am_azure_machine_learning__gpu_energy
       title: Azure Machine Learning GPU Energy
@@ -662,7 +662,7 @@ template:
       units: joules/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.gpu_energy_joules_total
+        - selector: gpu_energy_joules_total
           name: energy
     - id: am_azure_machine_learning__disk_usage
       title: Azure Machine Learning Disk Usage
@@ -672,9 +672,9 @@ template:
       units: megabytes
       algorithm: absolute
       dimensions:
-        - selector: machine_learning.disk_used_megabytes_average
+        - selector: disk_used_megabytes_average
           name: used
-        - selector: machine_learning.disk_avail_megabytes_average
+        - selector: disk_avail_megabytes_average
           name: available
     - id: am_azure_machine_learning__disk_io
       title: Azure Machine Learning Disk I/O
@@ -684,9 +684,9 @@ template:
       units: megabytes/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.disk_read_megabytes_total
+        - selector: disk_read_megabytes_total
           name: read
-        - selector: machine_learning.disk_write_megabytes_total
+        - selector: disk_write_megabytes_total
           name: write
     - id: am_azure_machine_learning__network_traffic
       title: Azure Machine Learning Network Traffic
@@ -696,9 +696,9 @@ template:
       units: megabytes/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.network_input_megabytes_total
+        - selector: network_input_megabytes_total
           name: in
-        - selector: machine_learning.network_output_megabytes_total
+        - selector: network_output_megabytes_total
           name: out
     - id: am_azure_machine_learning__infiniband_traffic
       title: Azure Machine Learning InfiniBand Traffic
@@ -708,9 +708,9 @@ template:
       units: megabytes/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.ib_receive_megabytes_total
+        - selector: ib_receive_megabytes_total
           name: receive
-        - selector: machine_learning.ib_transmit_megabytes_total
+        - selector: ib_transmit_megabytes_total
           name: transmit
     - id: am_azure_machine_learning__storage_api_calls
       title: Azure Machine Learning Storage API Calls
@@ -720,9 +720,9 @@ template:
       units: calls/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.storage_api_success_count_total
+        - selector: storage_api_success_count_total
           name: success
-        - selector: machine_learning.storage_api_failure_count_total
+        - selector: storage_api_failure_count_total
           name: failure
     - id: am_azure_machine_learning__run_lifecycle
       title: Azure Machine Learning Run Lifecycle
@@ -732,17 +732,17 @@ template:
       units: runs/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.not_started_runs_total
+        - selector: not_started_runs_total
           name: not_started
-        - selector: machine_learning.starting_runs_total
+        - selector: starting_runs_total
           name: starting
-        - selector: machine_learning.preparing_runs_total
+        - selector: preparing_runs_total
           name: preparing
-        - selector: machine_learning.provisioning_runs_total
+        - selector: provisioning_runs_total
           name: provisioning
-        - selector: machine_learning.queued_runs_total
+        - selector: queued_runs_total
           name: queued
-        - selector: machine_learning.started_runs_total
+        - selector: started_runs_total
           name: started
     - id: am_azure_machine_learning__run_completion
       title: Azure Machine Learning Run Completion
@@ -752,17 +752,17 @@ template:
       units: runs/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.completed_runs_total
+        - selector: completed_runs_total
           name: completed
-        - selector: machine_learning.failed_runs_total
+        - selector: failed_runs_total
           name: failed
-        - selector: machine_learning.finalizing_runs_total
+        - selector: finalizing_runs_total
           name: finalizing
-        - selector: machine_learning.cancelled_runs_total
+        - selector: cancelled_runs_total
           name: cancelled
-        - selector: machine_learning.cancel_requested_runs_total
+        - selector: cancel_requested_runs_total
           name: cancel_requested
-        - selector: machine_learning.not_responding_runs_total
+        - selector: not_responding_runs_total
           name: not_responding
     - id: am_azure_machine_learning__run_issues
       title: Azure Machine Learning Run Issues
@@ -772,7 +772,7 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: machine_learning.errors_total
+        - selector: errors_total
           name: errors
-        - selector: machine_learning.warnings_total
+        - selector: warnings_total
           name: warnings

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/mysql_flexible.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/mysql_flexible.yaml
@@ -354,7 +354,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.cpu_percent_average
+        - selector: cpu_percent_average
           name: average
     - id: am_azure_mysql_flexible__memory
       title: Azure MySQL Flexible Server Memory Utilization
@@ -364,7 +364,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.memory_percent_average
+        - selector: memory_percent_average
           name: average
     - id: am_azure_mysql_flexible__io_utilization
       title: Azure MySQL Flexible Server Storage I/O Utilization
@@ -374,7 +374,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.io_consumption_percent_average
+        - selector: io_consumption_percent_average
           name: average
     - id: am_azure_mysql_flexible__cpu_credits
       title: Azure MySQL Flexible Server CPU Credits
@@ -384,9 +384,9 @@ template:
       units: credits
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.cpu_credits_consumed_average
+        - selector: cpu_credits_consumed_average
           name: consumed
-        - selector: mysql_flexible.cpu_credits_remaining_average
+        - selector: cpu_credits_remaining_average
           name: remaining
     - id: am_azure_mysql_flexible__ha_status
       title: Azure MySQL Flexible Server HA Replication Status
@@ -396,9 +396,9 @@ template:
       units: status
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.ha_io_status_maximum
+        - selector: ha_io_status_maximum
           name: io
-        - selector: mysql_flexible.ha_sql_status_maximum
+        - selector: ha_sql_status_maximum
           name: sql
     - id: am_azure_mysql_flexible__replica_status
       title: Azure MySQL Flexible Server Replica Status
@@ -408,9 +408,9 @@ template:
       units: status
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.replica_io_running_maximum
+        - selector: replica_io_running_maximum
           name: io
-        - selector: mysql_flexible.replica_sql_running_maximum
+        - selector: replica_sql_running_maximum
           name: sql
     - id: am_azure_mysql_flexible__uptime
       title: Azure MySQL Flexible Server Uptime
@@ -420,7 +420,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.uptime_maximum
+        - selector: uptime_maximum
           name: uptime
     - id: am_azure_mysql_flexible__replication_lag
       title: Azure MySQL Flexible Server Replication Lag
@@ -430,9 +430,9 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.replication_lag_average
+        - selector: replication_lag_average
           name: replica
-        - selector: mysql_flexible.ha_replication_lag_average
+        - selector: ha_replication_lag_average
           name: ha
     - id: am_azure_mysql_flexible__innodb_row_lock_time
       title: Azure MySQL Flexible Server InnoDB Row Lock Time
@@ -442,7 +442,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.innodb_row_lock_time_average
+        - selector: innodb_row_lock_time_average
           name: average
     - id: am_azure_mysql_flexible__innodb_row_lock_waits
       title: Azure MySQL Flexible Server InnoDB Row Lock Waits
@@ -452,7 +452,7 @@ template:
       units: waits/s
       algorithm: incremental
       dimensions:
-        - selector: mysql_flexible.innodb_row_lock_waits_total
+        - selector: innodb_row_lock_waits_total
           name: total
     - id: am_azure_mysql_flexible__aborted_connections
       title: Azure MySQL Flexible Server Aborted Connections
@@ -462,7 +462,7 @@ template:
       units: connections/s
       algorithm: incremental
       dimensions:
-        - selector: mysql_flexible.aborted_connections_total
+        - selector: aborted_connections_total
           name: total
     - id: am_azure_mysql_flexible__active_connections
       title: Azure MySQL Flexible Server Active Connections
@@ -472,7 +472,7 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.active_connections_average
+        - selector: active_connections_average
           name: average
     - id: am_azure_mysql_flexible__total_connections
       title: Azure MySQL Flexible Server Total Connections
@@ -482,7 +482,7 @@ template:
       units: connections/s
       algorithm: incremental
       dimensions:
-        - selector: mysql_flexible.total_connections_total
+        - selector: total_connections_total
           name: total
     - id: am_azure_mysql_flexible__active_transactions
       title: Azure MySQL Flexible Server Active Transactions
@@ -492,7 +492,7 @@ template:
       units: transactions
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.active_transactions_average
+        - selector: active_transactions_average
           name: average
     - id: am_azure_mysql_flexible__threads_running
       title: Azure MySQL Flexible Server Threads Running
@@ -502,7 +502,7 @@ template:
       units: threads
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.threads_running_maximum
+        - selector: threads_running_maximum
           name: maximum
     - id: am_azure_mysql_flexible__queries
       title: Azure MySQL Flexible Server Queries
@@ -512,9 +512,9 @@ template:
       units: queries/s
       algorithm: incremental
       dimensions:
-        - selector: mysql_flexible.queries_total
+        - selector: queries_total
           name: total
-        - selector: mysql_flexible.slow_queries_total
+        - selector: slow_queries_total
           name: slow
     - id: am_azure_mysql_flexible__dml_statements
       title: Azure MySQL Flexible Server DML Statements
@@ -524,13 +524,13 @@ template:
       units: statements/s
       algorithm: incremental
       dimensions:
-        - selector: mysql_flexible.com_select_total
+        - selector: com_select_total
           name: select
-        - selector: mysql_flexible.com_insert_total
+        - selector: com_insert_total
           name: insert
-        - selector: mysql_flexible.com_update_total
+        - selector: com_update_total
           name: update
-        - selector: mysql_flexible.com_delete_total
+        - selector: com_delete_total
           name: delete
     - id: am_azure_mysql_flexible__ddl_statements
       title: Azure MySQL Flexible Server DDL Statements
@@ -540,15 +540,15 @@ template:
       units: statements/s
       algorithm: incremental
       dimensions:
-        - selector: mysql_flexible.com_create_table_total
+        - selector: com_create_table_total
           name: create_table
-        - selector: mysql_flexible.com_alter_table_total
+        - selector: com_alter_table_total
           name: alter_table
-        - selector: mysql_flexible.com_drop_table_total
+        - selector: com_drop_table_total
           name: drop_table
-        - selector: mysql_flexible.com_create_db_total
+        - selector: com_create_db_total
           name: create_db
-        - selector: mysql_flexible.com_drop_db_total
+        - selector: com_drop_db_total
           name: drop_db
     - id: am_azure_mysql_flexible__lock_deadlocks
       title: Azure MySQL Flexible Server Deadlocks
@@ -558,7 +558,7 @@ template:
       units: deadlocks/s
       algorithm: incremental
       dimensions:
-        - selector: mysql_flexible.lock_deadlocks_total
+        - selector: lock_deadlocks_total
           name: total
     - id: am_azure_mysql_flexible__lock_timeouts
       title: Azure MySQL Flexible Server Lock Timeouts
@@ -568,7 +568,7 @@ template:
       units: timeouts/s
       algorithm: incremental
       dimensions:
-        - selector: mysql_flexible.lock_timeouts_total
+        - selector: lock_timeouts_total
           name: total
     - id: am_azure_mysql_flexible__innodb_buffer_pool_pages
       title: Azure MySQL Flexible Server InnoDB Buffer Pool Pages
@@ -578,13 +578,13 @@ template:
       units: pages
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.innodb_buffer_pool_pages_data_maximum
+        - selector: innodb_buffer_pool_pages_data_maximum
           name: data
-        - selector: mysql_flexible.innodb_buffer_pool_pages_dirty_maximum
+        - selector: innodb_buffer_pool_pages_dirty_maximum
           name: dirty
-        - selector: mysql_flexible.innodb_buffer_pool_pages_free_maximum
+        - selector: innodb_buffer_pool_pages_free_maximum
           name: free
-        - selector: mysql_flexible.innodb_buffer_pool_pages_flushed_average
+        - selector: innodb_buffer_pool_pages_flushed_average
           name: flushed
     - id: am_azure_mysql_flexible__innodb_buffer_pool_io
       title: Azure MySQL Flexible Server InnoDB Buffer Pool I/O
@@ -594,9 +594,9 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: mysql_flexible.innodb_buffer_pool_read_requests_total
+        - selector: innodb_buffer_pool_read_requests_total
           name: read_requests
-        - selector: mysql_flexible.innodb_buffer_pool_reads_total
+        - selector: innodb_buffer_pool_reads_total
           name: disk_reads
     - id: am_azure_mysql_flexible__innodb_data_writes
       title: Azure MySQL Flexible Server InnoDB Data Writes
@@ -606,7 +606,7 @@ template:
       units: writes/s
       algorithm: incremental
       dimensions:
-        - selector: mysql_flexible.innodb_data_writes_total
+        - selector: innodb_data_writes_total
           name: total
     - id: am_azure_mysql_flexible__sort_merge_passes
       title: Azure MySQL Flexible Server Sort Merge Passes
@@ -616,7 +616,7 @@ template:
       units: passes/s
       algorithm: incremental
       dimensions:
-        - selector: mysql_flexible.sort_merge_passes_total
+        - selector: sort_merge_passes_total
           name: total
     - id: am_azure_mysql_flexible__network
       title: Azure MySQL Flexible Server Network Traffic
@@ -626,9 +626,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: mysql_flexible.network_bytes_ingress_total
+        - selector: network_bytes_ingress_total
           name: in
-        - selector: mysql_flexible.network_bytes_egress_total
+        - selector: network_bytes_egress_total
           name: out
     - id: am_azure_mysql_flexible__storage_io
       title: Azure MySQL Flexible Server Storage I/O
@@ -638,7 +638,7 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: mysql_flexible.storage_io_count_total
+        - selector: storage_io_count_total
           name: total
     - id: am_azure_mysql_flexible__storage
       title: Azure MySQL Flexible Server Storage
@@ -648,9 +648,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.storage_used_average
+        - selector: storage_used_average
           name: used
-        - selector: mysql_flexible.storage_limit_maximum
+        - selector: storage_limit_maximum
           name: limit
     - id: am_azure_mysql_flexible__storage_utilization
       title: Azure MySQL Flexible Server Storage Utilization
@@ -660,7 +660,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.storage_percent_average
+        - selector: storage_percent_average
           name: average
     - id: am_azure_mysql_flexible__storage_breakdown
       title: Azure MySQL Flexible Server Storage Breakdown
@@ -670,13 +670,13 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.data_storage_used_average
+        - selector: data_storage_used_average
           name: data
-        - selector: mysql_flexible.ibdata1_storage_used_average
+        - selector: ibdata1_storage_used_average
           name: ibdata1
-        - selector: mysql_flexible.binlog_storage_used_average
+        - selector: binlog_storage_used_average
           name: binlog
-        - selector: mysql_flexible.others_storage_used_average
+        - selector: others_storage_used_average
           name: others
     - id: am_azure_mysql_flexible__backup_storage
       title: Azure MySQL Flexible Server Backup Storage
@@ -686,7 +686,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.backup_storage_used_average
+        - selector: backup_storage_used_average
           name: used
     - id: am_azure_mysql_flexible__serverlog_storage
       title: Azure MySQL Flexible Server Server Log Storage
@@ -696,9 +696,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.serverlog_storage_usage_average
+        - selector: serverlog_storage_usage_average
           name: used
-        - selector: mysql_flexible.serverlog_storage_limit_maximum
+        - selector: serverlog_storage_limit_maximum
           name: limit
     - id: am_azure_mysql_flexible__serverlog_storage_utilization
       title: Azure MySQL Flexible Server Server Log Storage Utilization
@@ -708,7 +708,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.serverlog_storage_percent_average
+        - selector: serverlog_storage_percent_average
           name: average
     - id: am_azure_mysql_flexible__history_list_length
       title: Azure MySQL Flexible Server History List Length
@@ -718,5 +718,5 @@ template:
       units: entries
       algorithm: absolute
       dimensions:
-        - selector: mysql_flexible.trx_rseg_history_len_maximum
+        - selector: trx_rseg_history_len_maximum
           name: maximum

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/nat_gateway.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/nat_gateway.yaml
@@ -60,7 +60,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: nat_gateway.datapath_availability_average
+        - selector: datapath_availability_average
           name: average
     - id: am_azure_nat_gateway__byte_throughput
       title: Azure NAT Gateway Byte Throughput
@@ -70,7 +70,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: nat_gateway.byte_count_total
+        - selector: byte_count_total
           name: total
     - id: am_azure_nat_gateway__packet_throughput
       title: Azure NAT Gateway Packet Throughput
@@ -80,7 +80,7 @@ template:
       units: packets/s
       algorithm: incremental
       dimensions:
-        - selector: nat_gateway.packet_count_total
+        - selector: packet_count_total
           name: total
     - id: am_azure_nat_gateway__dropped_packets
       title: Azure NAT Gateway Dropped Packets
@@ -90,7 +90,7 @@ template:
       units: packets/s
       algorithm: incremental
       dimensions:
-        - selector: nat_gateway.packet_drop_count_total
+        - selector: packet_drop_count_total
           name: total
     - id: am_azure_nat_gateway__snat_connections
       title: Azure NAT Gateway SNAT Connections
@@ -100,7 +100,7 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: nat_gateway.snat_connection_count_total
+        - selector: snat_connection_count_total
           name: total
     - id: am_azure_nat_gateway__total_connections
       title: Azure NAT Gateway Total SNAT Connections
@@ -110,5 +110,5 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: nat_gateway.total_connection_count_total
+        - selector: total_connection_count_total
           name: total

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/postgres_flexible.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/postgres_flexible.yaml
@@ -450,7 +450,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.cpu_percent_average
+        - selector: cpu_percent_average
           name: average
     - id: am_azure_postgres_flexible__memory
       title: Azure PostgreSQL Flexible Server Memory Utilization
@@ -460,7 +460,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.memory_percent_average
+        - selector: memory_percent_average
           name: average
     - id: am_azure_postgres_flexible__availability
       title: Azure PostgreSQL Flexible Server Database Alive
@@ -470,7 +470,7 @@ template:
       units: state
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.is_db_alive_maximum
+        - selector: is_db_alive_maximum
           name: maximum
     - id: am_azure_postgres_flexible__iops
       title: Azure PostgreSQL Flexible Server IOPS
@@ -480,11 +480,11 @@ template:
       units: operations/s
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.iops_average
+        - selector: iops_average
           name: total
-        - selector: postgres_flexible.read_iops_average
+        - selector: read_iops_average
           name: read
-        - selector: postgres_flexible.write_iops_average
+        - selector: write_iops_average
           name: write
     - id: am_azure_postgres_flexible__disk_throughput
       title: Azure PostgreSQL Flexible Server Disk Throughput
@@ -494,9 +494,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.read_throughput_average
+        - selector: read_throughput_average
           name: read
-        - selector: postgres_flexible.write_throughput_average
+        - selector: write_throughput_average
           name: write
     - id: am_azure_postgres_flexible__disk_saturation
       title: Azure PostgreSQL Flexible Server Disk Saturation
@@ -506,9 +506,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.disk_bandwidth_consumed_percentage_average
+        - selector: disk_bandwidth_consumed_percentage_average
           name: bandwidth
-        - selector: postgres_flexible.disk_iops_consumed_percentage_average
+        - selector: disk_iops_consumed_percentage_average
           name: iops
     - id: am_azure_postgres_flexible__disk_queue_depth
       title: Azure PostgreSQL Flexible Server Disk Queue Depth
@@ -518,7 +518,7 @@ template:
       units: operations
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.disk_queue_depth_average
+        - selector: disk_queue_depth_average
           name: average
     - id: am_azure_postgres_flexible__buffer_cache
       title: Azure PostgreSQL Flexible Server Buffer Cache
@@ -528,9 +528,9 @@ template:
       units: blocks/s
       algorithm: incremental
       dimensions:
-        - selector: postgres_flexible.blks_hit_total
+        - selector: blks_hit_total
           name: hits
-        - selector: postgres_flexible.blks_read_total
+        - selector: blks_read_total
           name: reads
     - id: am_azure_postgres_flexible__active_connections
       title: Azure PostgreSQL Flexible Server Active Connections
@@ -540,7 +540,7 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.active_connections_average
+        - selector: active_connections_average
           name: average
     - id: am_azure_postgres_flexible__connection_rate
       title: Azure PostgreSQL Flexible Server Connection Rate
@@ -550,9 +550,9 @@ template:
       units: connections/s
       algorithm: incremental
       dimensions:
-        - selector: postgres_flexible.connections_succeeded_total
+        - selector: connections_succeeded_total
           name: succeeded
-        - selector: postgres_flexible.connections_failed_total
+        - selector: connections_failed_total
           name: failed
     - id: am_azure_postgres_flexible__transactions
       title: Azure PostgreSQL Flexible Server Transactions
@@ -562,9 +562,9 @@ template:
       units: transactions/s
       algorithm: incremental
       dimensions:
-        - selector: postgres_flexible.xact_commit_total
+        - selector: xact_commit_total
           name: committed
-        - selector: postgres_flexible.xact_rollback_total
+        - selector: xact_rollback_total
           name: rolled_back
     - id: am_azure_postgres_flexible__transaction_rate
       title: Azure PostgreSQL Flexible Server Transaction Rate
@@ -574,9 +574,9 @@ template:
       units: transactions/s
       algorithm: incremental
       dimensions:
-        - selector: postgres_flexible.tps_total
+        - selector: tps_total
           name: total
-        - selector: postgres_flexible.xact_total_total
+        - selector: xact_total_total
           name: xact_total
     - id: am_azure_postgres_flexible__deadlocks
       title: Azure PostgreSQL Flexible Server Deadlocks
@@ -586,7 +586,7 @@ template:
       units: deadlocks/s
       algorithm: incremental
       dimensions:
-        - selector: postgres_flexible.deadlocks_total
+        - selector: deadlocks_total
           name: total
     - id: am_azure_postgres_flexible__tuple_reads
       title: Azure PostgreSQL Flexible Server Tuple Reads
@@ -596,9 +596,9 @@ template:
       units: tuples/s
       algorithm: incremental
       dimensions:
-        - selector: postgres_flexible.tup_returned_total
+        - selector: tup_returned_total
           name: returned
-        - selector: postgres_flexible.tup_fetched_total
+        - selector: tup_fetched_total
           name: fetched
     - id: am_azure_postgres_flexible__tuple_writes
       title: Azure PostgreSQL Flexible Server Tuple Writes
@@ -608,11 +608,11 @@ template:
       units: tuples/s
       algorithm: incremental
       dimensions:
-        - selector: postgres_flexible.tup_inserted_total
+        - selector: tup_inserted_total
           name: inserted
-        - selector: postgres_flexible.tup_updated_total
+        - selector: tup_updated_total
           name: updated
-        - selector: postgres_flexible.tup_deleted_total
+        - selector: tup_deleted_total
           name: deleted
     - id: am_azure_postgres_flexible__temp_files
       title: Azure PostgreSQL Flexible Server Temp Files Created
@@ -622,7 +622,7 @@ template:
       units: files/s
       algorithm: incremental
       dimensions:
-        - selector: postgres_flexible.temp_files_total
+        - selector: temp_files_total
           name: total
     - id: am_azure_postgres_flexible__temp_bytes
       title: Azure PostgreSQL Flexible Server Temp Bytes Written
@@ -632,7 +632,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: postgres_flexible.temp_bytes_total
+        - selector: temp_bytes_total
           name: total
     - id: am_azure_postgres_flexible__long_running
       title: Azure PostgreSQL Flexible Server Long Running Operations
@@ -642,9 +642,9 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.longest_query_time_sec_maximum
+        - selector: longest_query_time_sec_maximum
           name: query
-        - selector: postgres_flexible.longest_transaction_time_sec_maximum
+        - selector: longest_transaction_time_sec_maximum
           name: transaction
     - id: am_azure_postgres_flexible__xid_usage
       title: Azure PostgreSQL Flexible Server Transaction ID Usage
@@ -654,9 +654,9 @@ template:
       units: transactions
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.maximum_used_transaction_ids_average
+        - selector: maximum_used_transaction_ids_average
           name: max_used
-        - selector: postgres_flexible.oldest_backend_xmin_maximum
+        - selector: oldest_backend_xmin_maximum
           name: oldest_xmin
     - id: am_azure_postgres_flexible__xmin_age
       title: Azure PostgreSQL Flexible Server Backend XID Age
@@ -666,7 +666,7 @@ template:
       units: transactions
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.oldest_backend_xmin_age_maximum
+        - selector: oldest_backend_xmin_age_maximum
           name: maximum
     - id: am_azure_postgres_flexible__network
       title: Azure PostgreSQL Flexible Server Network Traffic
@@ -676,9 +676,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: postgres_flexible.network_bytes_ingress_total
+        - selector: network_bytes_ingress_total
           name: in
-        - selector: postgres_flexible.network_bytes_egress_total
+        - selector: network_bytes_egress_total
           name: out
     - id: am_azure_postgres_flexible__storage
       title: Azure PostgreSQL Flexible Server Storage
@@ -688,9 +688,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.storage_used_average
+        - selector: storage_used_average
           name: used
-        - selector: postgres_flexible.storage_free_average
+        - selector: storage_free_average
           name: free
     - id: am_azure_postgres_flexible__storage_utilization
       title: Azure PostgreSQL Flexible Server Storage Utilization
@@ -700,7 +700,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.storage_percent_average
+        - selector: storage_percent_average
           name: average
     - id: am_azure_postgres_flexible__wal_storage
       title: Azure PostgreSQL Flexible Server WAL Storage
@@ -710,7 +710,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.txlogs_storage_used_average
+        - selector: txlogs_storage_used_average
           name: used
     - id: am_azure_postgres_flexible__database_size
       title: Azure PostgreSQL Flexible Server Database Size
@@ -720,7 +720,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.database_size_bytes_average
+        - selector: database_size_bytes_average
           name: average
     - id: am_azure_postgres_flexible__backup_storage
       title: Azure PostgreSQL Flexible Server Backup Storage
@@ -730,7 +730,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.backup_storage_used_average
+        - selector: backup_storage_used_average
           name: used
     - id: am_azure_postgres_flexible__replication_lag_time
       title: Azure PostgreSQL Flexible Server Replication Lag
@@ -740,7 +740,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.physical_replication_delay_in_seconds_average
+        - selector: physical_replication_delay_in_seconds_average
           name: average
     - id: am_azure_postgres_flexible__replication_lag_bytes
       title: Azure PostgreSQL Flexible Server Replication Lag Bytes
@@ -750,9 +750,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.physical_replication_delay_in_bytes_maximum
+        - selector: physical_replication_delay_in_bytes_maximum
           name: physical
-        - selector: postgres_flexible.logical_replication_delay_in_bytes_maximum
+        - selector: logical_replication_delay_in_bytes_maximum
           name: logical
     - id: am_azure_postgres_flexible__sessions_by_state
       title: Azure PostgreSQL Flexible Server Sessions by State
@@ -762,7 +762,7 @@ template:
       units: sessions
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.sessions_by_state_maximum
+        - selector: sessions_by_state_maximum
           name: maximum
     - id: am_azure_postgres_flexible__sessions_by_wait_event_type
       title: Azure PostgreSQL Flexible Server Sessions by Wait Event Type
@@ -772,7 +772,7 @@ template:
       units: sessions
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.sessions_by_wait_event_type_maximum
+        - selector: sessions_by_wait_event_type_maximum
           name: maximum
     - id: am_azure_postgres_flexible__autovacuum_operations
       title: Azure PostgreSQL Flexible Server Autovacuum Operations
@@ -782,13 +782,13 @@ template:
       units: operations
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.vacuum_count_user_tables_maximum
+        - selector: vacuum_count_user_tables_maximum
           name: vacuum
-        - selector: postgres_flexible.autovacuum_count_user_tables_maximum
+        - selector: autovacuum_count_user_tables_maximum
           name: autovacuum
-        - selector: postgres_flexible.analyze_count_user_tables_maximum
+        - selector: analyze_count_user_tables_maximum
           name: analyze
-        - selector: postgres_flexible.autoanalyze_count_user_tables_maximum
+        - selector: autoanalyze_count_user_tables_maximum
           name: autoanalyze
     - id: am_azure_postgres_flexible__autovacuum_table_coverage
       title: Azure PostgreSQL Flexible Server Autovacuum Table Coverage
@@ -798,15 +798,15 @@ template:
       units: tables
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.tables_vacuumed_user_tables_maximum
+        - selector: tables_vacuumed_user_tables_maximum
           name: vacuumed
-        - selector: postgres_flexible.tables_autovacuumed_user_tables_maximum
+        - selector: tables_autovacuumed_user_tables_maximum
           name: autovacuumed
-        - selector: postgres_flexible.tables_analyzed_user_tables_maximum
+        - selector: tables_analyzed_user_tables_maximum
           name: analyzed
-        - selector: postgres_flexible.tables_autoanalyzed_user_tables_maximum
+        - selector: tables_autoanalyzed_user_tables_maximum
           name: autoanalyzed
-        - selector: postgres_flexible.tables_counter_user_tables_maximum
+        - selector: tables_counter_user_tables_maximum
           name: total
     - id: am_azure_postgres_flexible__tuple_liveness
       title: Azure PostgreSQL Flexible Server Tuple Liveness
@@ -816,11 +816,11 @@ template:
       units: tuples
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.n_live_tup_user_tables_maximum
+        - selector: n_live_tup_user_tables_maximum
           name: live
-        - selector: postgres_flexible.n_dead_tup_user_tables_maximum
+        - selector: n_dead_tup_user_tables_maximum
           name: dead
-        - selector: postgres_flexible.n_mod_since_analyze_user_tables_maximum
+        - selector: n_mod_since_analyze_user_tables_maximum
           name: modified_since_analyze
     - id: am_azure_postgres_flexible__bloat
       title: Azure PostgreSQL Flexible Server Table Bloat
@@ -830,7 +830,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.bloat_percent_maximum
+        - selector: bloat_percent_maximum
           name: maximum
     - id: am_azure_postgres_flexible__backend_count
       title: Azure PostgreSQL Flexible Server Backend Count
@@ -840,7 +840,7 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.numbackends_maximum
+        - selector: numbackends_maximum
           name: maximum
     - id: am_azure_postgres_flexible__pgbouncer_client_connections
       title: Azure PostgreSQL Flexible Server PgBouncer Client Connections
@@ -850,9 +850,9 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.client_connections_active_maximum
+        - selector: client_connections_active_maximum
           name: active
-        - selector: postgres_flexible.client_connections_waiting_maximum
+        - selector: client_connections_waiting_maximum
           name: waiting
     - id: am_azure_postgres_flexible__pgbouncer_server_connections
       title: Azure PostgreSQL Flexible Server PgBouncer Server Connections
@@ -862,9 +862,9 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.server_connections_active_maximum
+        - selector: server_connections_active_maximum
           name: active
-        - selector: postgres_flexible.server_connections_idle_maximum
+        - selector: server_connections_idle_maximum
           name: idle
     - id: am_azure_postgres_flexible__pgbouncer_pool_count
       title: Azure PostgreSQL Flexible Server PgBouncer Pool Count
@@ -874,7 +874,7 @@ template:
       units: pools
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.num_pools_maximum
+        - selector: num_pools_maximum
           name: pools
     - id: am_azure_postgres_flexible__pgbouncer_pooled_connections
       title: Azure PostgreSQL Flexible Server PgBouncer Pooled Connections
@@ -884,7 +884,7 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.total_pooled_connections_maximum
+        - selector: total_pooled_connections_maximum
           name: pooled_connections
     - id: am_azure_postgres_flexible__cpu_credits
       title: Azure PostgreSQL Flexible Server CPU Credits
@@ -894,9 +894,9 @@ template:
       units: credits
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.cpu_credits_consumed_average
+        - selector: cpu_credits_consumed_average
           name: consumed
-        - selector: postgres_flexible.cpu_credits_remaining_average
+        - selector: cpu_credits_remaining_average
           name: remaining
     - id: am_azure_postgres_flexible__postmaster_cpu
       title: Azure PostgreSQL Flexible Server Postmaster CPU Usage
@@ -906,7 +906,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.postmaster_process_cpu_usage_percent_average
+        - selector: postmaster_process_cpu_usage_percent_average
           name: average
     - id: am_azure_postgres_flexible__max_connections
       title: Azure PostgreSQL Flexible Server Max Connections
@@ -916,7 +916,7 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.max_connections_maximum
+        - selector: max_connections_maximum
           name: maximum
     - id: am_azure_postgres_flexible__tcp_connection_backlog
       title: Azure PostgreSQL Flexible Server TCP Connection Backlog
@@ -926,5 +926,5 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: postgres_flexible.tcp_connection_backlog_maximum
+        - selector: tcp_connection_backlog_maximum
           name: maximum

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/redis_cache.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/redis_cache.yaml
@@ -300,9 +300,9 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: redis_cache.cachehits_total
+        - selector: cachehits_total
           name: hits
-        - selector: redis_cache.cachemisses_total
+        - selector: cachemisses_total
           name: misses
     - id: am_azure_redis_cache__throughput
       title: Azure Cache for Redis Throughput
@@ -312,9 +312,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.cache_read_maximum
+        - selector: cache_read_maximum
           name: read
-        - selector: redis_cache.cache_write_maximum
+        - selector: cache_write_maximum
           name: write
     - id: am_azure_redis_cache__server_load
       title: Azure Cache for Redis Server Load
@@ -324,7 +324,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.server_load_maximum
+        - selector: server_load_maximum
           name: maximum
     - id: am_azure_redis_cache__cpu
       title: Azure Cache for Redis CPU Utilization
@@ -334,7 +334,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.percent_processor_time_maximum
+        - selector: percent_processor_time_maximum
           name: maximum
     - id: am_azure_redis_cache__memory_usage
       title: Azure Cache for Redis Memory Usage
@@ -344,9 +344,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.usedmemory_maximum
+        - selector: usedmemory_maximum
           name: used
-        - selector: redis_cache.usedmemory_rss_maximum
+        - selector: usedmemory_rss_maximum
           name: rss
     - id: am_azure_redis_cache__memory_utilization
       title: Azure Cache for Redis Memory Utilization
@@ -356,7 +356,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.usedmemorypercentage_maximum
+        - selector: usedmemorypercentage_maximum
           name: maximum
     - id: am_azure_redis_cache__clients
       title: Azure Cache for Redis Connected Clients
@@ -366,7 +366,7 @@ template:
       units: clients
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.connectedclients_maximum
+        - selector: connectedclients_maximum
           name: maximum
     - id: am_azure_redis_cache__operations
       title: Azure Cache for Redis Operations
@@ -376,7 +376,7 @@ template:
       units: operations/s
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.operations_per_second_maximum
+        - selector: operations_per_second_maximum
           name: maximum
     - id: am_azure_redis_cache__commands
       title: Azure Cache for Redis Commands Processed
@@ -386,7 +386,7 @@ template:
       units: commands/s
       algorithm: incremental
       dimensions:
-        - selector: redis_cache.totalcommandsprocessed_total
+        - selector: totalcommandsprocessed_total
           name: total
     - id: am_azure_redis_cache__command_types
       title: Azure Cache for Redis Command Types
@@ -396,9 +396,9 @@ template:
       units: commands/s
       algorithm: incremental
       dimensions:
-        - selector: redis_cache.getcommands_total
+        - selector: getcommands_total
           name: get
-        - selector: redis_cache.setcommands_total
+        - selector: setcommands_total
           name: set
     - id: am_azure_redis_cache__latency
       title: Azure Cache for Redis Latency
@@ -408,7 +408,7 @@ template:
       units: microseconds
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.cache_latency_average
+        - selector: cache_latency_average
           name: average
     - id: am_azure_redis_cache__key_events
       title: Azure Cache for Redis Key Events
@@ -418,9 +418,9 @@ template:
       units: keys/s
       algorithm: incremental
       dimensions:
-        - selector: redis_cache.evictedkeys_total
+        - selector: evictedkeys_total
           name: evicted
-        - selector: redis_cache.expiredkeys_total
+        - selector: expiredkeys_total
           name: expired
     - id: am_azure_redis_cache__total_keys
       title: Azure Cache for Redis Total Keys
@@ -430,7 +430,7 @@ template:
       units: keys
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.totalkeys_maximum
+        - selector: totalkeys_maximum
           name: maximum
     - id: am_azure_redis_cache__errors
       title: Azure Cache for Redis Errors
@@ -440,7 +440,7 @@ template:
       units: errors
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.errors_maximum
+        - selector: errors_maximum
           name: maximum
     - id: am_azure_redis_cache__miss_rate
       title: Azure Cache for Redis Miss Rate
@@ -450,7 +450,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.cachemissrate_total
+        - selector: cachemissrate_total
           name: miss_rate
     - id: am_azure_redis_cache__latency_p99
       title: Azure Cache for Redis P99 Latency
@@ -460,7 +460,7 @@ template:
       units: microseconds
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.latency_p99_average
+        - selector: latency_p99_average
           name: p99
     - id: am_azure_redis_cache__connection_rate
       title: Azure Cache for Redis Connection Rate
@@ -470,9 +470,9 @@ template:
       units: connections/s
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.all_connections_created_per_second_maximum
+        - selector: all_connections_created_per_second_maximum
           name: created
-        - selector: redis_cache.all_connections_closed_per_second_maximum
+        - selector: all_connections_closed_per_second_maximum
           name: closed
     - id: am_azure_redis_cache__aad_clients
       title: Azure Cache for Redis Entra Token Clients
@@ -482,7 +482,7 @@ template:
       units: clients
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.connected_clients_using_aad_token_maximum
+        - selector: connected_clients_using_aad_token_maximum
           name: maximum
     - id: am_azure_redis_cache__instance_cache_hits
       title: Azure Cache for Redis Instance Hit Rate
@@ -492,9 +492,9 @@ template:
       units: operations/s
       algorithm: incremental
       dimensions:
-        - selector: redis_cache.allcachehits_total
+        - selector: allcachehits_total
           name: hits
-        - selector: redis_cache.allcachemisses_total
+        - selector: allcachemisses_total
           name: misses
     - id: am_azure_redis_cache__instance_throughput
       title: Azure Cache for Redis Instance Throughput
@@ -504,9 +504,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.allcache_read_maximum
+        - selector: allcache_read_maximum
           name: read
-        - selector: redis_cache.allcache_write_maximum
+        - selector: allcache_write_maximum
           name: write
     - id: am_azure_redis_cache__instance_server_load
       title: Azure Cache for Redis Instance Server Load
@@ -516,9 +516,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.allserver_load_maximum
+        - selector: allserver_load_maximum
           name: server_load
-        - selector: redis_cache.allpercentprocessortime_maximum
+        - selector: allpercentprocessortime_maximum
           name: cpu
     - id: am_azure_redis_cache__instance_memory_usage
       title: Azure Cache for Redis Instance Memory Usage
@@ -528,9 +528,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.allusedmemory_maximum
+        - selector: allusedmemory_maximum
           name: used
-        - selector: redis_cache.allusedmemory_rss_maximum
+        - selector: allusedmemory_rss_maximum
           name: rss
     - id: am_azure_redis_cache__instance_memory_utilization
       title: Azure Cache for Redis Instance Memory Utilization
@@ -540,7 +540,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.allusedmemorypercentage_maximum
+        - selector: allusedmemorypercentage_maximum
           name: maximum
     - id: am_azure_redis_cache__instance_clients
       title: Azure Cache for Redis Instance Connected Clients
@@ -550,7 +550,7 @@ template:
       units: clients
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.allconnectedclients_maximum
+        - selector: allconnectedclients_maximum
           name: maximum
     - id: am_azure_redis_cache__instance_operations
       title: Azure Cache for Redis Instance Operations
@@ -560,7 +560,7 @@ template:
       units: operations/s
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.alloperations_per_second_maximum
+        - selector: alloperations_per_second_maximum
           name: maximum
     - id: am_azure_redis_cache__instance_commands
       title: Azure Cache for Redis Instance Commands Processed
@@ -570,11 +570,11 @@ template:
       units: commands/s
       algorithm: incremental
       dimensions:
-        - selector: redis_cache.alltotalcommandsprocessed_total
+        - selector: alltotalcommandsprocessed_total
           name: total
-        - selector: redis_cache.allgetcommands_total
+        - selector: allgetcommands_total
           name: get
-        - selector: redis_cache.allsetcommands_total
+        - selector: allsetcommands_total
           name: set
     - id: am_azure_redis_cache__instance_total_keys
       title: Azure Cache for Redis Instance Total Keys
@@ -584,7 +584,7 @@ template:
       units: keys
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.alltotalkeys_maximum
+        - selector: alltotalkeys_maximum
           name: maximum
     - id: am_azure_redis_cache__instance_key_events
       title: Azure Cache for Redis Instance Key Events
@@ -594,9 +594,9 @@ template:
       units: keys/s
       algorithm: incremental
       dimensions:
-        - selector: redis_cache.allevictedkeys_total
+        - selector: allevictedkeys_total
           name: evicted
-        - selector: redis_cache.allexpiredkeys_total
+        - selector: allexpiredkeys_total
           name: expired
     - id: am_azure_redis_cache__geo_replication_lag
       title: Azure Cache for Redis Geo-Replication Connectivity Lag
@@ -606,7 +606,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.geo_replication_connectivity_lag_average
+        - selector: geo_replication_connectivity_lag_average
           name: average
     - id: am_azure_redis_cache__geo_replication_sync_offset
       title: Azure Cache for Redis Geo-Replication Data Sync Offset
@@ -616,7 +616,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.geo_replication_data_sync_offset_average
+        - selector: geo_replication_data_sync_offset_average
           name: average
     - id: am_azure_redis_cache__geo_replication_sync_events
       title: Azure Cache for Redis Geo-Replication Sync Events
@@ -626,9 +626,9 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: redis_cache.geo_replication_full_sync_event_started_count
+        - selector: geo_replication_full_sync_event_started_count
           name: started
-        - selector: redis_cache.geo_replication_full_sync_event_finished_count
+        - selector: geo_replication_full_sync_event_finished_count
           name: finished
     - id: am_azure_redis_cache__geo_replication_health
       title: Azure Cache for Redis Geo-Replication Health
@@ -638,5 +638,5 @@ template:
       units: status
       algorithm: absolute
       dimensions:
-        - selector: redis_cache.geo_replication_healthy_average
+        - selector: geo_replication_healthy_average
           name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/service_bus.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/service_bus.yaml
@@ -174,9 +174,9 @@ template:
       units: messages/s
       algorithm: incremental
       dimensions:
-        - selector: service_bus.incoming_messages_total
+        - selector: incoming_messages_total
           name: in
-        - selector: service_bus.outgoing_messages_total
+        - selector: outgoing_messages_total
           name: out
     - id: am_azure_service_bus__message_operations
       title: Azure Service Bus Message Operations
@@ -186,9 +186,9 @@ template:
       units: messages/s
       algorithm: incremental
       dimensions:
-        - selector: service_bus.complete_message_total
+        - selector: complete_message_total
           name: completed
-        - selector: service_bus.abandon_message_total
+        - selector: abandon_message_total
           name: abandoned
     - id: am_azure_service_bus__queue_depth
       title: Azure Service Bus Queue Depth
@@ -198,7 +198,7 @@ template:
       units: messages
       algorithm: absolute
       dimensions:
-        - selector: service_bus.active_messages_average
+        - selector: active_messages_average
           name: active
     - id: am_azure_service_bus__problem_messages
       title: Azure Service Bus Problem Messages
@@ -208,9 +208,9 @@ template:
       units: messages
       algorithm: absolute
       dimensions:
-        - selector: service_bus.deadlettered_messages_average
+        - selector: deadlettered_messages_average
           name: dead_lettered
-        - selector: service_bus.scheduled_messages_average
+        - selector: scheduled_messages_average
           name: scheduled
     - id: am_azure_service_bus__total_messages
       title: Azure Service Bus Total Messages
@@ -220,7 +220,7 @@ template:
       units: messages
       algorithm: absolute
       dimensions:
-        - selector: service_bus.messages_average
+        - selector: messages_average
           name: total
     - id: am_azure_service_bus__requests
       title: Azure Service Bus Requests
@@ -230,9 +230,9 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: service_bus.incoming_requests_total
+        - selector: incoming_requests_total
           name: incoming
-        - selector: service_bus.successful_requests_total
+        - selector: successful_requests_total
           name: successful
     - id: am_azure_service_bus__errors
       title: Azure Service Bus Errors
@@ -242,11 +242,11 @@ template:
       units: errors/s
       algorithm: incremental
       dimensions:
-        - selector: service_bus.server_errors_total
+        - selector: server_errors_total
           name: server
-        - selector: service_bus.user_errors_total
+        - selector: user_errors_total
           name: user
-        - selector: service_bus.throttled_requests_total
+        - selector: throttled_requests_total
           name: throttled
     - id: am_azure_service_bus__connections
       title: Azure Service Bus Active Connections
@@ -256,7 +256,7 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: service_bus.active_connections_total
+        - selector: active_connections_total
           name: active
     - id: am_azure_service_bus__connection_events
       title: Azure Service Bus Connection Events
@@ -266,9 +266,9 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: service_bus.connections_opened_average
+        - selector: connections_opened_average
           name: opened
-        - selector: service_bus.connections_closed_average
+        - selector: connections_closed_average
           name: closed
     - id: am_azure_service_bus__namespace_size
       title: Azure Service Bus Namespace Size
@@ -278,7 +278,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: service_bus.size_average
+        - selector: size_average
           name: average
     - id: am_azure_service_bus__data_throughput
       title: Azure Service Bus Data Throughput
@@ -288,9 +288,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: service_bus.incoming_bytes_total
+        - selector: incoming_bytes_total
           name: in
-        - selector: service_bus.outgoing_bytes_total
+        - selector: outgoing_bytes_total
           name: out
     - id: am_azure_service_bus__namespace_resources
       title: Azure Service Bus Namespace Resources
@@ -300,9 +300,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: service_bus.namespace_cpu_usage_maximum
+        - selector: namespace_cpu_usage_maximum
           name: cpu
-        - selector: service_bus.namespace_memory_usage_maximum
+        - selector: namespace_memory_usage_maximum
           name: memory
     - id: am_azure_service_bus__send_latency
       title: Azure Service Bus Send Latency
@@ -312,7 +312,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: service_bus.server_send_latency_average
+        - selector: server_send_latency_average
           name: average
     - id: am_azure_service_bus__replication_lag
       title: Azure Service Bus Replication Lag
@@ -322,7 +322,7 @@ template:
       units: messages
       algorithm: absolute
       dimensions:
-        - selector: service_bus.replication_lag_count_maximum
+        - selector: replication_lag_count_maximum
           name: messages
     - id: am_azure_service_bus__replication_lag_duration
       title: Azure Service Bus Replication Lag Duration
@@ -332,7 +332,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: service_bus.replication_lag_duration_maximum
+        - selector: replication_lag_duration_maximum
           name: duration
     - id: am_azure_service_bus__checkpoint_operations
       title: Azure Service Bus Pending Checkpoint Operations
@@ -342,5 +342,5 @@ template:
       units: operations
       algorithm: absolute
       dimensions:
-        - selector: service_bus.pending_checkpoint_operation_count_total
+        - selector: pending_checkpoint_operation_count_total
           name: pending

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/sql_database.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/sql_database.yaml
@@ -236,9 +236,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_database.cpu_percent_average
+        - selector: cpu_percent_average
           name: average
-        - selector: sql_database.cpu_percent_maximum
+        - selector: cpu_percent_maximum
           name: maximum
     - id: am_azure_sql_database__instance_cpu
       title: Azure SQL Database Instance CPU Utilization
@@ -248,7 +248,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_database.sql_instance_cpu_percent_average
+        - selector: sql_instance_cpu_percent_average
           name: average
     - id: am_azure_sql_database__instance_memory
       title: Azure SQL Database Instance Memory Utilization
@@ -258,7 +258,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_database.sql_instance_memory_percent_average
+        - selector: sql_instance_memory_percent_average
           name: average
     - id: am_azure_sql_database__dtu_consumption
       title: Azure SQL Database DTU Consumption
@@ -268,7 +268,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_database.dtu_consumption_percent_average
+        - selector: dtu_consumption_percent_average
           name: average
     - id: am_azure_sql_database__io_utilization
       title: Azure SQL Database I/O Utilization
@@ -278,9 +278,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_database.physical_data_read_percent_average
+        - selector: physical_data_read_percent_average
           name: data_read
-        - selector: sql_database.log_write_percent_average
+        - selector: log_write_percent_average
           name: log_write
     - id: am_azure_sql_database__resource_utilization
       title: Azure SQL Database Resource Utilization
@@ -290,9 +290,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_database.workers_percent_average
+        - selector: workers_percent_average
           name: workers
-        - selector: sql_database.sessions_percent_average
+        - selector: sessions_percent_average
           name: sessions
     - id: am_azure_sql_database__availability
       title: Azure SQL Database Availability
@@ -302,7 +302,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_database.availability_average
+        - selector: availability_average
           name: average
     - id: am_azure_sql_database__connections
       title: Azure SQL Database Connection Events
@@ -312,13 +312,13 @@ template:
       units: connections/s
       algorithm: incremental
       dimensions:
-        - selector: sql_database.connection_successful_total
+        - selector: connection_successful_total
           name: successful
-        - selector: sql_database.connection_failed_total
+        - selector: connection_failed_total
           name: failed_system
-        - selector: sql_database.connection_failed_user_error_total
+        - selector: connection_failed_user_error_total
           name: failed_user
-        - selector: sql_database.blocked_by_firewall_total
+        - selector: blocked_by_firewall_total
           name: firewall_blocked
     - id: am_azure_sql_database__deadlocks
       title: Azure SQL Database Deadlocks
@@ -328,7 +328,7 @@ template:
       units: deadlocks/s
       algorithm: incremental
       dimensions:
-        - selector: sql_database.deadlock_total
+        - selector: deadlock_total
           name: total
     - id: am_azure_sql_database__storage
       title: Azure SQL Database Storage
@@ -338,9 +338,9 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: sql_database.storage_average
+        - selector: storage_average
           name: used
-        - selector: sql_database.allocated_data_storage_average
+        - selector: allocated_data_storage_average
           name: allocated
     - id: am_azure_sql_database__storage_utilization
       title: Azure SQL Database Storage Utilization
@@ -350,7 +350,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_database.storage_percent_average
+        - selector: storage_percent_average
           name: average
     - id: am_azure_sql_database__tempdb_size
       title: Azure SQL Database Tempdb Size
@@ -360,9 +360,9 @@ template:
       units: KiB
       algorithm: absolute
       dimensions:
-        - selector: sql_database.tempdb_data_size_average
+        - selector: tempdb_data_size_average
           name: data
-        - selector: sql_database.tempdb_log_size_average
+        - selector: tempdb_log_size_average
           name: log
     - id: am_azure_sql_database__tempdb_log_utilization
       title: Azure SQL Database Tempdb Log Utilization
@@ -372,7 +372,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_database.tempdb_log_used_percent_average
+        - selector: tempdb_log_used_percent_average
           name: average
     - id: am_azure_sql_database__vcore_usage
       title: Azure SQL Database vCore Usage
@@ -382,9 +382,9 @@ template:
       units: vCores
       algorithm: absolute
       dimensions:
-        - selector: sql_database.cpu_used_average
+        - selector: cpu_used_average
           name: used
-        - selector: sql_database.cpu_limit_average
+        - selector: cpu_limit_average
           name: limit
     - id: am_azure_sql_database__dtu_usage
       title: Azure SQL Database DTU Usage
@@ -394,9 +394,9 @@ template:
       units: DTU
       algorithm: absolute
       dimensions:
-        - selector: sql_database.dtu_used_average
+        - selector: dtu_used_average
           name: used
-        - selector: sql_database.dtu_limit_average
+        - selector: dtu_limit_average
           name: limit
     - id: am_azure_sql_database__sessions_count
       title: Azure SQL Database Sessions Count
@@ -406,7 +406,7 @@ template:
       units: sessions
       algorithm: absolute
       dimensions:
-        - selector: sql_database.sessions_count_average
+        - selector: sessions_count_average
           name: average
     - id: am_azure_sql_database__replication_lag
       title: Azure SQL Database Replication Lag
@@ -416,7 +416,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: sql_database.replication_lag_seconds_average
+        - selector: replication_lag_seconds_average
           name: average
     - id: am_azure_sql_database__xtp_storage
       title: Azure SQL Database In-Memory OLTP Storage
@@ -426,7 +426,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_database.xtp_storage_percent_average
+        - selector: xtp_storage_percent_average
           name: average
     - id: am_azure_sql_database__serverless_utilization
       title: Azure SQL Database Serverless Utilization
@@ -436,9 +436,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_database.app_cpu_percent_average
+        - selector: app_cpu_percent_average
           name: cpu
-        - selector: sql_database.app_memory_percent_average
+        - selector: app_memory_percent_average
           name: memory
     - id: am_azure_sql_database__serverless_billing
       title: Azure SQL Database Serverless Billing
@@ -448,9 +448,9 @@ template:
       units: vCore-seconds/s
       algorithm: incremental
       dimensions:
-        - selector: sql_database.app_cpu_billed_total
+        - selector: app_cpu_billed_total
           name: total
-        - selector: sql_database.app_cpu_billed_ha_replicas_total
+        - selector: app_cpu_billed_ha_replicas_total
           name: ha_replicas
     - id: am_azure_sql_database__free_tier_usage
       title: Azure SQL Database Free Tier Usage
@@ -460,9 +460,9 @@ template:
       units: vCore-seconds
       algorithm: absolute
       dimensions:
-        - selector: sql_database.free_amount_consumed_average
+        - selector: free_amount_consumed_average
           name: consumed
-        - selector: sql_database.free_amount_remaining_average
+        - selector: free_amount_remaining_average
           name: remaining
     - id: am_azure_sql_database__ledger_digest
       title: Azure SQL Database Ledger Digest Uploads
@@ -472,7 +472,7 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: sql_database.ledger_digest_upload_success_count
+        - selector: ledger_digest_upload_success_count
           name: success
-        - selector: sql_database.ledger_digest_upload_failed_count
+        - selector: ledger_digest_upload_failed_count
           name: failed

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/sql_elastic_pool.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/sql_elastic_pool.yaml
@@ -176,9 +176,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.cpu_percent_average
+        - selector: cpu_percent_average
           name: average
-        - selector: sql_elastic_pool.cpu_percent_maximum
+        - selector: cpu_percent_maximum
           name: maximum
     - id: am_azure_sql_elastic_pool__instance_cpu
       title: Azure SQL Elastic Pool Instance CPU Utilization
@@ -188,7 +188,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.sql_instance_cpu_percent_average
+        - selector: sql_instance_cpu_percent_average
           name: average
     - id: am_azure_sql_elastic_pool__instance_memory
       title: Azure SQL Elastic Pool Instance Memory Utilization
@@ -198,7 +198,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.sql_instance_memory_percent_average
+        - selector: sql_instance_memory_percent_average
           name: average
     - id: am_azure_sql_elastic_pool__dtu_consumption
       title: Azure SQL Elastic Pool DTU Consumption
@@ -208,7 +208,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.dtu_consumption_percent_average
+        - selector: dtu_consumption_percent_average
           name: average
     - id: am_azure_sql_elastic_pool__io_utilization
       title: Azure SQL Elastic Pool I/O Utilization
@@ -218,9 +218,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.physical_data_read_percent_average
+        - selector: physical_data_read_percent_average
           name: data_read
-        - selector: sql_elastic_pool.log_write_percent_average
+        - selector: log_write_percent_average
           name: log_write
     - id: am_azure_sql_elastic_pool__resource_utilization
       title: Azure SQL Elastic Pool Resource Utilization
@@ -230,9 +230,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.workers_percent_average
+        - selector: workers_percent_average
           name: workers
-        - selector: sql_elastic_pool.sessions_percent_average
+        - selector: sessions_percent_average
           name: sessions
     - id: am_azure_sql_elastic_pool__sessions_count
       title: Azure SQL Elastic Pool Sessions Count
@@ -242,7 +242,7 @@ template:
       units: sessions
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.sessions_count_average
+        - selector: sessions_count_average
           name: average
     - id: am_azure_sql_elastic_pool__storage
       title: Azure SQL Elastic Pool Storage
@@ -252,11 +252,11 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.storage_used_average
+        - selector: storage_used_average
           name: used
-        - selector: sql_elastic_pool.allocated_data_storage_average
+        - selector: allocated_data_storage_average
           name: allocated
-        - selector: sql_elastic_pool.storage_limit_average
+        - selector: storage_limit_average
           name: limit
     - id: am_azure_sql_elastic_pool__storage_utilization
       title: Azure SQL Elastic Pool Storage Utilization
@@ -266,9 +266,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.storage_percent_average
+        - selector: storage_percent_average
           name: used
-        - selector: sql_elastic_pool.allocated_data_storage_percent_average
+        - selector: allocated_data_storage_percent_average
           name: allocated
     - id: am_azure_sql_elastic_pool__xtp_storage
       title: Azure SQL Elastic Pool In-Memory OLTP Storage
@@ -278,7 +278,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.xtp_storage_percent_average
+        - selector: xtp_storage_percent_average
           name: average
     - id: am_azure_sql_elastic_pool__tempdb_size
       title: Azure SQL Elastic Pool Tempdb Size
@@ -288,9 +288,9 @@ template:
       units: KiB
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.tempdb_data_size_average
+        - selector: tempdb_data_size_average
           name: data
-        - selector: sql_elastic_pool.tempdb_log_size_average
+        - selector: tempdb_log_size_average
           name: log
     - id: am_azure_sql_elastic_pool__tempdb_log_utilization
       title: Azure SQL Elastic Pool Tempdb Log Utilization
@@ -300,7 +300,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.tempdb_log_used_percent_average
+        - selector: tempdb_log_used_percent_average
           name: average
     - id: am_azure_sql_elastic_pool__vcore_usage
       title: Azure SQL Elastic Pool vCore Usage
@@ -310,9 +310,9 @@ template:
       units: vCores
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.cpu_used_average
+        - selector: cpu_used_average
           name: used
-        - selector: sql_elastic_pool.cpu_limit_average
+        - selector: cpu_limit_average
           name: limit
     - id: am_azure_sql_elastic_pool__edtu_usage
       title: Azure SQL Elastic Pool eDTU Usage
@@ -322,9 +322,9 @@ template:
       units: eDTU
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.e_dtu_used_average
+        - selector: e_dtu_used_average
           name: used
-        - selector: sql_elastic_pool.e_dtu_limit_average
+        - selector: e_dtu_limit_average
           name: limit
     - id: am_azure_sql_elastic_pool__serverless_utilization
       title: Azure SQL Elastic Pool Serverless Utilization
@@ -334,9 +334,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_elastic_pool.app_cpu_percent_average
+        - selector: app_cpu_percent_average
           name: cpu
-        - selector: sql_elastic_pool.app_memory_percent_average
+        - selector: app_memory_percent_average
           name: memory
     - id: am_azure_sql_elastic_pool__serverless_billing
       title: Azure SQL Elastic Pool Serverless Billing
@@ -346,5 +346,5 @@ template:
       units: vCore-seconds/s
       algorithm: incremental
       dimensions:
-        - selector: sql_elastic_pool.app_cpu_billed_total
+        - selector: app_cpu_billed_total
           name: total

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/sql_managed_instance.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/sql_managed_instance.yaml
@@ -68,9 +68,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: sql_managed_instance.avg_cpu_percent_average
+        - selector: avg_cpu_percent_average
           name: average
-        - selector: sql_managed_instance.avg_cpu_percent_maximum
+        - selector: avg_cpu_percent_maximum
           name: maximum
     - id: am_azure_sql_managed_instance__io_throughput
       title: Azure SQL Managed Instance I/O Throughput
@@ -80,9 +80,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: sql_managed_instance.io_bytes_read_average
+        - selector: io_bytes_read_average
           name: read
-        - selector: sql_managed_instance.io_bytes_written_average
+        - selector: io_bytes_written_average
           name: written
     - id: am_azure_sql_managed_instance__io_requests
       title: Azure SQL Managed Instance I/O Requests
@@ -92,7 +92,7 @@ template:
       units: requests/s
       algorithm: absolute
       dimensions:
-        - selector: sql_managed_instance.io_requests_average
+        - selector: io_requests_average
           name: average
     - id: am_azure_sql_managed_instance__storage
       title: Azure SQL Managed Instance Storage
@@ -102,9 +102,9 @@ template:
       units: MiB
       algorithm: absolute
       dimensions:
-        - selector: sql_managed_instance.reserved_storage_mb_average
+        - selector: reserved_storage_mb_average
           name: reserved
-        - selector: sql_managed_instance.storage_space_used_mb_average
+        - selector: storage_space_used_mb_average
           name: used
     - id: am_azure_sql_managed_instance__virtual_core_count
       title: Azure SQL Managed Instance Virtual Core Count
@@ -114,5 +114,5 @@ template:
       units: cores
       algorithm: absolute
       dimensions:
-        - selector: sql_managed_instance.virtual_core_count_average
+        - selector: virtual_core_count_average
           name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/storage_accounts.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/storage_accounts.yaml
@@ -70,7 +70,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: storage_accounts.availability_average
+        - selector: availability_average
           name: average
     - id: am_azure_storage_accounts__transactions
       title: Azure Storage Account Transactions
@@ -80,7 +80,7 @@ template:
       units: transactions/s
       algorithm: incremental
       dimensions:
-        - selector: storage_accounts.transactions_total
+        - selector: transactions_total
           name: total
     - id: am_azure_storage_accounts__throughput
       title: Azure Storage Account Throughput
@@ -90,9 +90,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: storage_accounts.ingress_total
+        - selector: ingress_total
           name: ingress
-        - selector: storage_accounts.egress_total
+        - selector: egress_total
           name: egress
     - id: am_azure_storage_accounts__e2e_latency
       title: Azure Storage Account End-to-End Latency
@@ -102,9 +102,9 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: storage_accounts.success_e2e_latency_average
+        - selector: success_e2e_latency_average
           name: average
-        - selector: storage_accounts.success_e2e_latency_maximum
+        - selector: success_e2e_latency_maximum
           name: maximum
     - id: am_azure_storage_accounts__server_latency
       title: Azure Storage Account Server Latency
@@ -114,9 +114,9 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: storage_accounts.success_server_latency_average
+        - selector: success_server_latency_average
           name: average
-        - selector: storage_accounts.success_server_latency_maximum
+        - selector: success_server_latency_maximum
           name: maximum
     - id: am_azure_storage_accounts__used_capacity
       title: Azure Storage Account Used Capacity
@@ -126,5 +126,5 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: storage_accounts.used_capacity_average
+        - selector: used_capacity_average
           name: average

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/stream_analytics.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/stream_analytics.yaml
@@ -142,9 +142,9 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: stream_analytics.input_events_total
+        - selector: input_events_total
           name: in
-        - selector: stream_analytics.output_events_total
+        - selector: output_events_total
           name: out
     - id: am_azure_stream_analytics__input_data_throughput
       title: Azure Stream Analytics Input Data Throughput
@@ -154,7 +154,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: stream_analytics.input_event_bytes_total
+        - selector: input_event_bytes_total
           name: received
     - id: am_azure_stream_analytics__input_sources_received
       title: Azure Stream Analytics Input Sources Received
@@ -164,7 +164,7 @@ template:
       units: sources/s
       algorithm: incremental
       dimensions:
-        - selector: stream_analytics.input_events_sources_per_second_total
+        - selector: input_events_sources_per_second_total
           name: received
     - id: am_azure_stream_analytics__event_timing
       title: Azure Stream Analytics Event Timing Issues
@@ -174,11 +174,11 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: stream_analytics.late_input_events_total
+        - selector: late_input_events_total
           name: late
-        - selector: stream_analytics.early_input_events_total
+        - selector: early_input_events_total
           name: early
-        - selector: stream_analytics.dropped_or_adjusted_events_total
+        - selector: dropped_or_adjusted_events_total
           name: out_of_order
     - id: am_azure_stream_analytics__backlogged_events
       title: Azure Stream Analytics Backlogged Events
@@ -188,7 +188,7 @@ template:
       units: events
       algorithm: absolute
       dimensions:
-        - selector: stream_analytics.input_events_sources_backlogged_average
+        - selector: input_events_sources_backlogged_average
           name: backlogged
     - id: am_azure_stream_analytics__watermark_delay
       title: Azure Stream Analytics Watermark Delay
@@ -198,7 +198,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: stream_analytics.output_watermark_delay_seconds_maximum
+        - selector: output_watermark_delay_seconds_maximum
           name: delay
     - id: am_azure_stream_analytics__errors
       title: Azure Stream Analytics Errors
@@ -208,11 +208,11 @@ template:
       units: errors/s
       algorithm: incremental
       dimensions:
-        - selector: stream_analytics.errors_total
+        - selector: errors_total
           name: runtime
-        - selector: stream_analytics.conversion_errors_total
+        - selector: conversion_errors_total
           name: data_conversion
-        - selector: stream_analytics.deserialization_error_total
+        - selector: deserialization_error_total
           name: deserialization
     - id: am_azure_stream_analytics__function_requests
       title: Azure Stream Analytics Function Requests
@@ -222,9 +222,9 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: stream_analytics.aml_callout_requests_total
+        - selector: aml_callout_requests_total
           name: total
-        - selector: stream_analytics.aml_callout_failed_requests_total
+        - selector: aml_callout_failed_requests_total
           name: failed
     - id: am_azure_stream_analytics__function_events
       title: Azure Stream Analytics Function Events
@@ -234,7 +234,7 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: stream_analytics.aml_callout_input_events_total
+        - selector: aml_callout_input_events_total
           name: input
     - id: am_azure_stream_analytics__resource_utilization
       title: Azure Stream Analytics Resource Utilization
@@ -244,7 +244,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: stream_analytics.process_cpu_usage_percentage_average
+        - selector: process_cpu_usage_percentage_average
           name: cpu
-        - selector: stream_analytics.resource_utilization_average
+        - selector: resource_utilization_average
           name: su_memory

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/synapse.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/synapse.yaml
@@ -180,7 +180,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.builtin_sql_pool_data_processed_bytes_total
+        - selector: builtin_sql_pool_data_processed_bytes_total
           name: processed
     - id: am_azure_synapse__builtin_sql_pool_login_attempts
       title: Azure Synapse Built-in SQL Pool Login Attempts
@@ -190,7 +190,7 @@ template:
       units: attempts/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.builtin_sql_pool_login_attempts_total
+        - selector: builtin_sql_pool_login_attempts_total
           name: login_attempts
     - id: am_azure_synapse__builtin_sql_pool_requests
       title: Azure Synapse Built-in SQL Pool Requests Ended
@@ -200,7 +200,7 @@ template:
       units: requests/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.builtin_sql_pool_requests_ended_total
+        - selector: builtin_sql_pool_requests_ended_total
           name: requests
     - id: am_azure_synapse__activity_runs
       title: Azure Synapse Activity Runs
@@ -210,7 +210,7 @@ template:
       units: runs/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.integration_activity_runs_ended_total
+        - selector: integration_activity_runs_ended_total
           name: ended
     - id: am_azure_synapse__pipeline_runs
       title: Azure Synapse Pipeline Runs
@@ -220,7 +220,7 @@ template:
       units: runs/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.integration_pipeline_runs_ended_total
+        - selector: integration_pipeline_runs_ended_total
           name: ended
     - id: am_azure_synapse__trigger_runs
       title: Azure Synapse Trigger Runs
@@ -230,7 +230,7 @@ template:
       units: runs/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.integration_trigger_runs_ended_total
+        - selector: integration_trigger_runs_ended_total
           name: ended
     - id: am_azure_synapse__link_connection_events
       title: Azure Synapse Link Connection Events
@@ -240,7 +240,7 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.integration_link_connection_events_total
+        - selector: integration_link_connection_events_total
           name: events
     - id: am_azure_synapse__link_table_events
       title: Azure Synapse Link Table Events
@@ -250,7 +250,7 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.integration_link_table_events_total
+        - selector: integration_link_table_events_total
           name: events
     - id: am_azure_synapse__link_processed_rows
       title: Azure Synapse Link Processed Changed Rows
@@ -260,7 +260,7 @@ template:
       units: rows/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.integration_link_processed_changed_rows_total
+        - selector: integration_link_processed_changed_rows_total
           name: changed_rows
     - id: am_azure_synapse__link_data_volume
       title: Azure Synapse Link Processed Data Volume
@@ -270,7 +270,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.integration_link_processed_data_volume_total
+        - selector: integration_link_processed_data_volume_total
           name: processed
     - id: am_azure_synapse__link_processing_latency
       title: Azure Synapse Link Processing Latency
@@ -280,7 +280,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: synapse.integration_link_processing_latency_in_seconds_average
+        - selector: integration_link_processing_latency_in_seconds_average
           name: average
     - id: am_azure_synapse__streaming_event_flow
       title: Azure Synapse Streaming Event Flow
@@ -290,9 +290,9 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.sql_streaming_input_events_total
+        - selector: sql_streaming_input_events_total
           name: in
-        - selector: synapse.sql_streaming_output_events_total
+        - selector: sql_streaming_output_events_total
           name: out
     - id: am_azure_synapse__streaming_input_throughput
       title: Azure Synapse Streaming Input Data Throughput
@@ -302,7 +302,7 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.sql_streaming_input_event_bytes_total
+        - selector: sql_streaming_input_event_bytes_total
           name: received
     - id: am_azure_synapse__streaming_input_sources
       title: Azure Synapse Streaming Input Sources Received
@@ -312,7 +312,7 @@ template:
       units: sources/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.sql_streaming_input_events_sources_per_second_total
+        - selector: sql_streaming_input_events_sources_per_second_total
           name: received
     - id: am_azure_synapse__streaming_event_timing
       title: Azure Synapse Streaming Event Timing Issues
@@ -322,13 +322,13 @@ template:
       units: events/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.sql_streaming_late_input_events_total
+        - selector: sql_streaming_late_input_events_total
           name: late
-        - selector: synapse.sql_streaming_early_input_events_total
+        - selector: sql_streaming_early_input_events_total
           name: early
-        - selector: synapse.sql_streaming_out_of_order_events_total
+        - selector: sql_streaming_out_of_order_events_total
           name: out_of_order
-        - selector: synapse.sql_streaming_backlogged_input_event_sources_total
+        - selector: sql_streaming_backlogged_input_event_sources_total
           name: backlogged
     - id: am_azure_synapse__streaming_watermark_delay
       title: Azure Synapse Streaming Watermark Delay
@@ -338,7 +338,7 @@ template:
       units: seconds
       algorithm: absolute
       dimensions:
-        - selector: synapse.sql_streaming_output_watermark_delay_seconds_maximum
+        - selector: sql_streaming_output_watermark_delay_seconds_maximum
           name: delay
     - id: am_azure_synapse__streaming_errors
       title: Azure Synapse Streaming Errors
@@ -348,11 +348,11 @@ template:
       units: errors/s
       algorithm: incremental
       dimensions:
-        - selector: synapse.sql_streaming_runtime_errors_total
+        - selector: sql_streaming_runtime_errors_total
           name: runtime
-        - selector: synapse.sql_streaming_conversion_errors_total
+        - selector: sql_streaming_conversion_errors_total
           name: data_conversion
-        - selector: synapse.sql_streaming_deserialization_error_total
+        - selector: sql_streaming_deserialization_error_total
           name: deserialization
     - id: am_azure_synapse__streaming_resource_utilization
       title: Azure Synapse Streaming Resource Utilization
@@ -362,5 +362,5 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: synapse.sql_streaming_resource_utilization_average
+        - selector: sql_streaming_resource_utilization_average
           name: utilization

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/virtual_machines.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/virtual_machines.yaml
@@ -396,7 +396,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.percentage_cpu_average
+        - selector: percentage_cpu_average
           name: average
     - id: am_azure_virtual_machines__cpu_credits
       title: Azure Virtual Machine CPU Credits
@@ -406,9 +406,9 @@ template:
       units: credits
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.cpu_credits_consumed_average
+        - selector: cpu_credits_consumed_average
           name: consumed
-        - selector: virtual_machines.cpu_credits_remaining_average
+        - selector: cpu_credits_remaining_average
           name: remaining
     - id: am_azure_virtual_machines__memory
       title: Azure Virtual Machine Available Memory
@@ -418,7 +418,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.available_memory_bytes_average
+        - selector: available_memory_bytes_average
           name: available
     - id: am_azure_virtual_machines__memory_percentage
       title: Azure Virtual Machine Available Memory Percentage
@@ -428,7 +428,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.available_memory_percentage_average
+        - selector: available_memory_percentage_average
           name: available
     - id: am_azure_virtual_machines__availability
       title: Azure Virtual Machine Availability
@@ -438,7 +438,7 @@ template:
       units: state
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.vm_availability_metric_average
+        - selector: vm_availability_metric_average
           name: average
     - id: am_azure_virtual_machines__network_traffic
       title: Azure Virtual Machine Network Traffic
@@ -448,9 +448,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: virtual_machines.network_in_total_total
+        - selector: network_in_total_total
           name: in
-        - selector: virtual_machines.network_out_total_total
+        - selector: network_out_total_total
           name: out
     - id: am_azure_virtual_machines__network_flows
       title: Azure Virtual Machine Network Flows
@@ -460,9 +460,9 @@ template:
       units: flows
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.inbound_flows_average
+        - selector: inbound_flows_average
           name: in
-        - selector: virtual_machines.outbound_flows_average
+        - selector: outbound_flows_average
           name: out
     - id: am_azure_virtual_machines__network_flow_creation_rate
       title: Azure Virtual Machine Network Flow Creation Rate
@@ -472,9 +472,9 @@ template:
       units: flows/s
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.inbound_flows_maximum_creation_rate_average
+        - selector: inbound_flows_maximum_creation_rate_average
           name: in
-        - selector: virtual_machines.outbound_flows_maximum_creation_rate_average
+        - selector: outbound_flows_maximum_creation_rate_average
           name: out
     - id: am_azure_virtual_machines__disk_throughput
       title: Azure Virtual Machine Disk Throughput
@@ -484,9 +484,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: virtual_machines.disk_read_bytes_total
+        - selector: disk_read_bytes_total
           name: read
-        - selector: virtual_machines.disk_write_bytes_total
+        - selector: disk_write_bytes_total
           name: write
     - id: am_azure_virtual_machines__disk_iops
       title: Azure Virtual Machine Disk IOPS
@@ -496,9 +496,9 @@ template:
       units: operations/s
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.disk_read_operations_sec_average
+        - selector: disk_read_operations_sec_average
           name: read
-        - selector: virtual_machines.disk_write_operations_sec_average
+        - selector: disk_write_operations_sec_average
           name: write
     - id: am_azure_virtual_machines__os_disk_throughput
       title: Azure Virtual Machine OS Disk Throughput
@@ -508,9 +508,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.os_disk_read_bytes_sec_average
+        - selector: os_disk_read_bytes_sec_average
           name: read
-        - selector: virtual_machines.os_disk_write_bytes_sec_average
+        - selector: os_disk_write_bytes_sec_average
           name: write
     - id: am_azure_virtual_machines__os_disk_iops
       title: Azure Virtual Machine OS Disk IOPS
@@ -520,9 +520,9 @@ template:
       units: operations/s
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.os_disk_read_operations_sec_average
+        - selector: os_disk_read_operations_sec_average
           name: read
-        - selector: virtual_machines.os_disk_write_operations_sec_average
+        - selector: os_disk_write_operations_sec_average
           name: write
     - id: am_azure_virtual_machines__os_disk_latency
       title: Azure Virtual Machine OS Disk Latency
@@ -532,7 +532,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.os_disk_latency_average
+        - selector: os_disk_latency_average
           name: average
     - id: am_azure_virtual_machines__os_disk_queue_depth
       title: Azure Virtual Machine OS Disk Queue Depth
@@ -542,7 +542,7 @@ template:
       units: operations
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.os_disk_queue_depth_average
+        - selector: os_disk_queue_depth_average
           name: average
     - id: am_azure_virtual_machines__os_disk_throttling
       title: Azure Virtual Machine OS Disk Throttling
@@ -552,9 +552,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.os_disk_bandwidth_consumed_percentage_average
+        - selector: os_disk_bandwidth_consumed_percentage_average
           name: bandwidth
-        - selector: virtual_machines.os_disk_iops_consumed_percentage_average
+        - selector: os_disk_iops_consumed_percentage_average
           name: iops
     - id: am_azure_virtual_machines__os_disk_burst_capacity
       title: Azure Virtual Machine OS Disk Burst Capacity
@@ -564,9 +564,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.os_disk_max_burst_bandwidth_average
+        - selector: os_disk_max_burst_bandwidth_average
           name: max_burst
-        - selector: virtual_machines.os_disk_target_bandwidth_average
+        - selector: os_disk_target_bandwidth_average
           name: target
     - id: am_azure_virtual_machines__os_disk_burst_iops_capacity
       title: Azure Virtual Machine OS Disk Burst IOPS Capacity
@@ -576,9 +576,9 @@ template:
       units: iops
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.os_disk_max_burst_iops_average
+        - selector: os_disk_max_burst_iops_average
           name: max_burst
-        - selector: virtual_machines.os_disk_target_iops_average
+        - selector: os_disk_target_iops_average
           name: target
     - id: am_azure_virtual_machines__os_disk_burst_credits
       title: Azure Virtual Machine OS Disk Burst Credits Used
@@ -588,9 +588,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.os_disk_used_burst_bps_credits_percentage_average
+        - selector: os_disk_used_burst_bps_credits_percentage_average
           name: bandwidth
-        - selector: virtual_machines.os_disk_used_burst_io_credits_percentage_average
+        - selector: os_disk_used_burst_io_credits_percentage_average
           name: io
     - id: am_azure_virtual_machines__data_disk_throughput
       title: Azure Virtual Machine Data Disk Throughput
@@ -600,9 +600,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.data_disk_read_bytes_sec_average
+        - selector: data_disk_read_bytes_sec_average
           name: read
-        - selector: virtual_machines.data_disk_write_bytes_sec_average
+        - selector: data_disk_write_bytes_sec_average
           name: write
     - id: am_azure_virtual_machines__data_disk_iops
       title: Azure Virtual Machine Data Disk IOPS
@@ -612,9 +612,9 @@ template:
       units: operations/s
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.data_disk_read_operations_sec_average
+        - selector: data_disk_read_operations_sec_average
           name: read
-        - selector: virtual_machines.data_disk_write_operations_sec_average
+        - selector: data_disk_write_operations_sec_average
           name: write
     - id: am_azure_virtual_machines__data_disk_latency
       title: Azure Virtual Machine Data Disk Latency
@@ -624,7 +624,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.data_disk_latency_average
+        - selector: data_disk_latency_average
           name: average
     - id: am_azure_virtual_machines__data_disk_queue_depth
       title: Azure Virtual Machine Data Disk Queue Depth
@@ -634,7 +634,7 @@ template:
       units: operations
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.data_disk_queue_depth_average
+        - selector: data_disk_queue_depth_average
           name: average
     - id: am_azure_virtual_machines__data_disk_throttling
       title: Azure Virtual Machine Data Disk Throttling
@@ -644,9 +644,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.data_disk_bandwidth_consumed_percentage_average
+        - selector: data_disk_bandwidth_consumed_percentage_average
           name: bandwidth
-        - selector: virtual_machines.data_disk_iops_consumed_percentage_average
+        - selector: data_disk_iops_consumed_percentage_average
           name: iops
     - id: am_azure_virtual_machines__data_disk_burst_capacity
       title: Azure Virtual Machine Data Disk Burst Capacity
@@ -656,9 +656,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.data_disk_max_burst_bandwidth_average
+        - selector: data_disk_max_burst_bandwidth_average
           name: max_burst
-        - selector: virtual_machines.data_disk_target_bandwidth_average
+        - selector: data_disk_target_bandwidth_average
           name: target
     - id: am_azure_virtual_machines__data_disk_burst_iops_capacity
       title: Azure Virtual Machine Data Disk Burst IOPS Capacity
@@ -668,9 +668,9 @@ template:
       units: iops
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.data_disk_max_burst_iops_average
+        - selector: data_disk_max_burst_iops_average
           name: max_burst
-        - selector: virtual_machines.data_disk_target_iops_average
+        - selector: data_disk_target_iops_average
           name: target
     - id: am_azure_virtual_machines__data_disk_burst_credits
       title: Azure Virtual Machine Data Disk Burst Credits Used
@@ -680,9 +680,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.data_disk_used_burst_bps_credits_percentage_average
+        - selector: data_disk_used_burst_bps_credits_percentage_average
           name: bandwidth
-        - selector: virtual_machines.data_disk_used_burst_io_credits_percentage_average
+        - selector: data_disk_used_burst_io_credits_percentage_average
           name: io
     - id: am_azure_virtual_machines__temp_disk_throughput
       title: Azure Virtual Machine Temp Disk Throughput
@@ -692,9 +692,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.temp_disk_read_bytes_sec_average
+        - selector: temp_disk_read_bytes_sec_average
           name: read
-        - selector: virtual_machines.temp_disk_write_bytes_sec_average
+        - selector: temp_disk_write_bytes_sec_average
           name: write
     - id: am_azure_virtual_machines__temp_disk_iops
       title: Azure Virtual Machine Temp Disk IOPS
@@ -704,9 +704,9 @@ template:
       units: operations/s
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.temp_disk_read_operations_sec_average
+        - selector: temp_disk_read_operations_sec_average
           name: read
-        - selector: virtual_machines.temp_disk_write_operations_sec_average
+        - selector: temp_disk_write_operations_sec_average
           name: write
     - id: am_azure_virtual_machines__temp_disk_latency
       title: Azure Virtual Machine Temp Disk Latency
@@ -716,7 +716,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.temp_disk_latency_average
+        - selector: temp_disk_latency_average
           name: average
     - id: am_azure_virtual_machines__temp_disk_queue_depth
       title: Azure Virtual Machine Temp Disk Queue Depth
@@ -726,7 +726,7 @@ template:
       units: operations
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.temp_disk_queue_depth_average
+        - selector: temp_disk_queue_depth_average
           name: average
     - id: am_azure_virtual_machines__premium_data_disk_cache
       title: Azure Virtual Machine Premium Data Disk Cache
@@ -736,9 +736,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.premium_data_disk_cache_read_hit_average
+        - selector: premium_data_disk_cache_read_hit_average
           name: hit
-        - selector: virtual_machines.premium_data_disk_cache_read_miss_average
+        - selector: premium_data_disk_cache_read_miss_average
           name: miss
     - id: am_azure_virtual_machines__premium_os_disk_cache
       title: Azure Virtual Machine Premium OS Disk Cache
@@ -748,9 +748,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.premium_os_disk_cache_read_hit_average
+        - selector: premium_os_disk_cache_read_hit_average
           name: hit
-        - selector: virtual_machines.premium_os_disk_cache_read_miss_average
+        - selector: premium_os_disk_cache_read_miss_average
           name: miss
     - id: am_azure_virtual_machines__vm_cached_throttling
       title: Azure Virtual Machine Cached IO Throttling
@@ -760,9 +760,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.vm_cached_bandwidth_consumed_percentage_average
+        - selector: vm_cached_bandwidth_consumed_percentage_average
           name: bandwidth
-        - selector: virtual_machines.vm_cached_iops_consumed_percentage_average
+        - selector: vm_cached_iops_consumed_percentage_average
           name: iops
     - id: am_azure_virtual_machines__vm_uncached_throttling
       title: Azure Virtual Machine Uncached IO Throttling
@@ -772,9 +772,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.vm_uncached_bandwidth_consumed_percentage_average
+        - selector: vm_uncached_bandwidth_consumed_percentage_average
           name: bandwidth
-        - selector: virtual_machines.vm_uncached_iops_consumed_percentage_average
+        - selector: vm_uncached_iops_consumed_percentage_average
           name: iops
     - id: am_azure_virtual_machines__vm_cached_burst_credits
       title: Azure Virtual Machine Cached Burst Credits Used
@@ -784,9 +784,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.vm_local_used_burst_bps_credits_percentage_average
+        - selector: vm_local_used_burst_bps_credits_percentage_average
           name: bandwidth
-        - selector: virtual_machines.vm_local_used_burst_io_credits_percentage_average
+        - selector: vm_local_used_burst_io_credits_percentage_average
           name: io
     - id: am_azure_virtual_machines__vm_uncached_burst_credits
       title: Azure Virtual Machine Uncached Burst Credits Used
@@ -796,7 +796,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: virtual_machines.vm_remote_used_burst_bps_credits_percentage_average
+        - selector: vm_remote_used_burst_bps_credits_percentage_average
           name: bandwidth
-        - selector: virtual_machines.vm_remote_used_burst_io_credits_percentage_average
+        - selector: vm_remote_used_burst_io_credits_percentage_average
           name: io

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/vmss.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/vmss.yaml
@@ -396,7 +396,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vmss.percentage_cpu_average
+        - selector: percentage_cpu_average
           name: average
     - id: am_azure_vmss__cpu_credits
       title: Azure VMSS CPU Credits
@@ -406,9 +406,9 @@ template:
       units: credits
       algorithm: absolute
       dimensions:
-        - selector: vmss.cpu_credits_consumed_average
+        - selector: cpu_credits_consumed_average
           name: consumed
-        - selector: vmss.cpu_credits_remaining_average
+        - selector: cpu_credits_remaining_average
           name: remaining
     - id: am_azure_vmss__memory
       title: Azure VMSS Available Memory
@@ -418,7 +418,7 @@ template:
       units: bytes
       algorithm: absolute
       dimensions:
-        - selector: vmss.available_memory_bytes_average
+        - selector: available_memory_bytes_average
           name: available
     - id: am_azure_vmss__memory_percentage
       title: Azure VMSS Available Memory Percentage
@@ -428,7 +428,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vmss.available_memory_percentage_average
+        - selector: available_memory_percentage_average
           name: available
     - id: am_azure_vmss__availability
       title: Azure VMSS Availability
@@ -438,7 +438,7 @@ template:
       units: state
       algorithm: absolute
       dimensions:
-        - selector: vmss.vm_availability_metric_average
+        - selector: vm_availability_metric_average
           name: average
     - id: am_azure_vmss__network_traffic
       title: Azure VMSS Network Traffic
@@ -448,9 +448,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: vmss.network_in_total_total
+        - selector: network_in_total_total
           name: in
-        - selector: vmss.network_out_total_total
+        - selector: network_out_total_total
           name: out
     - id: am_azure_vmss__network_flows
       title: Azure VMSS Network Flows
@@ -460,9 +460,9 @@ template:
       units: flows
       algorithm: absolute
       dimensions:
-        - selector: vmss.inbound_flows_average
+        - selector: inbound_flows_average
           name: in
-        - selector: vmss.outbound_flows_average
+        - selector: outbound_flows_average
           name: out
     - id: am_azure_vmss__network_flow_creation_rate
       title: Azure VMSS Network Flow Creation Rate
@@ -472,9 +472,9 @@ template:
       units: flows/s
       algorithm: absolute
       dimensions:
-        - selector: vmss.inbound_flows_maximum_creation_rate_average
+        - selector: inbound_flows_maximum_creation_rate_average
           name: in
-        - selector: vmss.outbound_flows_maximum_creation_rate_average
+        - selector: outbound_flows_maximum_creation_rate_average
           name: out
     - id: am_azure_vmss__disk_throughput
       title: Azure VMSS Disk Throughput
@@ -484,9 +484,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: vmss.disk_read_bytes_total
+        - selector: disk_read_bytes_total
           name: read
-        - selector: vmss.disk_write_bytes_total
+        - selector: disk_write_bytes_total
           name: write
     - id: am_azure_vmss__disk_iops
       title: Azure VMSS Disk IOPS
@@ -496,9 +496,9 @@ template:
       units: operations/s
       algorithm: absolute
       dimensions:
-        - selector: vmss.disk_read_operations_sec_average
+        - selector: disk_read_operations_sec_average
           name: read
-        - selector: vmss.disk_write_operations_sec_average
+        - selector: disk_write_operations_sec_average
           name: write
     - id: am_azure_vmss__os_disk_throughput
       title: Azure VMSS OS Disk Throughput
@@ -508,9 +508,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: vmss.os_disk_read_bytes_sec_average
+        - selector: os_disk_read_bytes_sec_average
           name: read
-        - selector: vmss.os_disk_write_bytes_sec_average
+        - selector: os_disk_write_bytes_sec_average
           name: write
     - id: am_azure_vmss__os_disk_iops
       title: Azure VMSS OS Disk IOPS
@@ -520,9 +520,9 @@ template:
       units: operations/s
       algorithm: absolute
       dimensions:
-        - selector: vmss.os_disk_read_operations_sec_average
+        - selector: os_disk_read_operations_sec_average
           name: read
-        - selector: vmss.os_disk_write_operations_sec_average
+        - selector: os_disk_write_operations_sec_average
           name: write
     - id: am_azure_vmss__os_disk_latency
       title: Azure VMSS OS Disk Latency
@@ -532,7 +532,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: vmss.os_disk_latency_average
+        - selector: os_disk_latency_average
           name: average
     - id: am_azure_vmss__os_disk_queue_depth
       title: Azure VMSS OS Disk Queue Depth
@@ -542,7 +542,7 @@ template:
       units: operations
       algorithm: absolute
       dimensions:
-        - selector: vmss.os_disk_queue_depth_average
+        - selector: os_disk_queue_depth_average
           name: average
     - id: am_azure_vmss__os_disk_throttling
       title: Azure VMSS OS Disk Throttling
@@ -552,9 +552,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vmss.os_disk_bandwidth_consumed_percentage_average
+        - selector: os_disk_bandwidth_consumed_percentage_average
           name: bandwidth
-        - selector: vmss.os_disk_iops_consumed_percentage_average
+        - selector: os_disk_iops_consumed_percentage_average
           name: iops
     - id: am_azure_vmss__os_disk_burst_capacity
       title: Azure VMSS OS Disk Burst Capacity
@@ -564,9 +564,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: vmss.os_disk_max_burst_bandwidth_average
+        - selector: os_disk_max_burst_bandwidth_average
           name: max_burst
-        - selector: vmss.os_disk_target_bandwidth_average
+        - selector: os_disk_target_bandwidth_average
           name: target
     - id: am_azure_vmss__os_disk_burst_iops_capacity
       title: Azure VMSS OS Disk Burst IOPS Capacity
@@ -576,9 +576,9 @@ template:
       units: iops
       algorithm: absolute
       dimensions:
-        - selector: vmss.os_disk_max_burst_iops_average
+        - selector: os_disk_max_burst_iops_average
           name: max_burst
-        - selector: vmss.os_disk_target_iops_average
+        - selector: os_disk_target_iops_average
           name: target
     - id: am_azure_vmss__os_disk_burst_credits
       title: Azure VMSS OS Disk Burst Credits Used
@@ -588,9 +588,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vmss.os_disk_used_burst_bps_credits_percentage_average
+        - selector: os_disk_used_burst_bps_credits_percentage_average
           name: bandwidth
-        - selector: vmss.os_disk_used_burst_io_credits_percentage_average
+        - selector: os_disk_used_burst_io_credits_percentage_average
           name: io
     - id: am_azure_vmss__data_disk_throughput
       title: Azure VMSS Data Disk Throughput
@@ -600,9 +600,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: vmss.data_disk_read_bytes_sec_average
+        - selector: data_disk_read_bytes_sec_average
           name: read
-        - selector: vmss.data_disk_write_bytes_sec_average
+        - selector: data_disk_write_bytes_sec_average
           name: write
     - id: am_azure_vmss__data_disk_iops
       title: Azure VMSS Data Disk IOPS
@@ -612,9 +612,9 @@ template:
       units: operations/s
       algorithm: absolute
       dimensions:
-        - selector: vmss.data_disk_read_operations_sec_average
+        - selector: data_disk_read_operations_sec_average
           name: read
-        - selector: vmss.data_disk_write_operations_sec_average
+        - selector: data_disk_write_operations_sec_average
           name: write
     - id: am_azure_vmss__data_disk_latency
       title: Azure VMSS Data Disk Latency
@@ -624,7 +624,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: vmss.data_disk_latency_average
+        - selector: data_disk_latency_average
           name: average
     - id: am_azure_vmss__data_disk_queue_depth
       title: Azure VMSS Data Disk Queue Depth
@@ -634,7 +634,7 @@ template:
       units: operations
       algorithm: absolute
       dimensions:
-        - selector: vmss.data_disk_queue_depth_average
+        - selector: data_disk_queue_depth_average
           name: average
     - id: am_azure_vmss__data_disk_throttling
       title: Azure VMSS Data Disk Throttling
@@ -644,9 +644,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vmss.data_disk_bandwidth_consumed_percentage_average
+        - selector: data_disk_bandwidth_consumed_percentage_average
           name: bandwidth
-        - selector: vmss.data_disk_iops_consumed_percentage_average
+        - selector: data_disk_iops_consumed_percentage_average
           name: iops
     - id: am_azure_vmss__data_disk_burst_capacity
       title: Azure VMSS Data Disk Burst Capacity
@@ -656,9 +656,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: vmss.data_disk_max_burst_bandwidth_average
+        - selector: data_disk_max_burst_bandwidth_average
           name: max_burst
-        - selector: vmss.data_disk_target_bandwidth_average
+        - selector: data_disk_target_bandwidth_average
           name: target
     - id: am_azure_vmss__data_disk_burst_iops_capacity
       title: Azure VMSS Data Disk Burst IOPS Capacity
@@ -668,9 +668,9 @@ template:
       units: iops
       algorithm: absolute
       dimensions:
-        - selector: vmss.data_disk_max_burst_iops_average
+        - selector: data_disk_max_burst_iops_average
           name: max_burst
-        - selector: vmss.data_disk_target_iops_average
+        - selector: data_disk_target_iops_average
           name: target
     - id: am_azure_vmss__data_disk_burst_credits
       title: Azure VMSS Data Disk Burst Credits Used
@@ -680,9 +680,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vmss.data_disk_used_burst_bps_credits_percentage_average
+        - selector: data_disk_used_burst_bps_credits_percentage_average
           name: bandwidth
-        - selector: vmss.data_disk_used_burst_io_credits_percentage_average
+        - selector: data_disk_used_burst_io_credits_percentage_average
           name: io
     - id: am_azure_vmss__temp_disk_throughput
       title: Azure VMSS Temp Disk Throughput
@@ -692,9 +692,9 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: vmss.temp_disk_read_bytes_sec_average
+        - selector: temp_disk_read_bytes_sec_average
           name: read
-        - selector: vmss.temp_disk_write_bytes_sec_average
+        - selector: temp_disk_write_bytes_sec_average
           name: write
     - id: am_azure_vmss__temp_disk_iops
       title: Azure VMSS Temp Disk IOPS
@@ -704,9 +704,9 @@ template:
       units: operations/s
       algorithm: absolute
       dimensions:
-        - selector: vmss.temp_disk_read_operations_sec_average
+        - selector: temp_disk_read_operations_sec_average
           name: read
-        - selector: vmss.temp_disk_write_operations_sec_average
+        - selector: temp_disk_write_operations_sec_average
           name: write
     - id: am_azure_vmss__temp_disk_latency
       title: Azure VMSS Temp Disk Latency
@@ -716,7 +716,7 @@ template:
       units: milliseconds
       algorithm: absolute
       dimensions:
-        - selector: vmss.temp_disk_latency_average
+        - selector: temp_disk_latency_average
           name: average
     - id: am_azure_vmss__temp_disk_queue_depth
       title: Azure VMSS Temp Disk Queue Depth
@@ -726,7 +726,7 @@ template:
       units: operations
       algorithm: absolute
       dimensions:
-        - selector: vmss.temp_disk_queue_depth_average
+        - selector: temp_disk_queue_depth_average
           name: average
     - id: am_azure_vmss__premium_data_disk_cache
       title: Azure VMSS Premium Data Disk Cache
@@ -736,9 +736,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vmss.premium_data_disk_cache_read_hit_average
+        - selector: premium_data_disk_cache_read_hit_average
           name: hit
-        - selector: vmss.premium_data_disk_cache_read_miss_average
+        - selector: premium_data_disk_cache_read_miss_average
           name: miss
     - id: am_azure_vmss__premium_os_disk_cache
       title: Azure VMSS Premium OS Disk Cache
@@ -748,9 +748,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vmss.premium_os_disk_cache_read_hit_average
+        - selector: premium_os_disk_cache_read_hit_average
           name: hit
-        - selector: vmss.premium_os_disk_cache_read_miss_average
+        - selector: premium_os_disk_cache_read_miss_average
           name: miss
     - id: am_azure_vmss__vm_cached_throttling
       title: Azure VMSS Cached IO Throttling
@@ -760,9 +760,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vmss.vm_cached_bandwidth_consumed_percentage_average
+        - selector: vm_cached_bandwidth_consumed_percentage_average
           name: bandwidth
-        - selector: vmss.vm_cached_iops_consumed_percentage_average
+        - selector: vm_cached_iops_consumed_percentage_average
           name: iops
     - id: am_azure_vmss__vm_uncached_throttling
       title: Azure VMSS Uncached IO Throttling
@@ -772,9 +772,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vmss.vm_uncached_bandwidth_consumed_percentage_average
+        - selector: vm_uncached_bandwidth_consumed_percentage_average
           name: bandwidth
-        - selector: vmss.vm_uncached_iops_consumed_percentage_average
+        - selector: vm_uncached_iops_consumed_percentage_average
           name: iops
     - id: am_azure_vmss__vm_cached_burst_credits
       title: Azure VMSS Cached Burst Credits Used
@@ -784,9 +784,9 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vmss.vm_local_used_burst_bps_credits_percentage_average
+        - selector: vm_local_used_burst_bps_credits_percentage_average
           name: bandwidth
-        - selector: vmss.vm_local_used_burst_io_credits_percentage_average
+        - selector: vm_local_used_burst_io_credits_percentage_average
           name: io
     - id: am_azure_vmss__vm_uncached_burst_credits
       title: Azure VMSS Uncached Burst Credits Used
@@ -796,7 +796,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vmss.vm_remote_used_burst_bps_credits_percentage_average
+        - selector: vm_remote_used_burst_bps_credits_percentage_average
           name: bandwidth
-        - selector: vmss.vm_remote_used_burst_io_credits_percentage_average
+        - selector: vm_remote_used_burst_io_credits_percentage_average
           name: io

--- a/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/vpn_gateway.yaml
+++ b/src/go/plugin/go.d/config/go.d/azure_monitor.profiles/default/vpn_gateway.yaml
@@ -318,7 +318,7 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.average_bandwidth_average
+        - selector: average_bandwidth_average
           name: average
     - id: am_azure_vpn_gateway__p2s_bandwidth
       title: Azure VPN Gateway P2S Bandwidth
@@ -328,7 +328,7 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.p2s_bandwidth_average
+        - selector: p2s_bandwidth_average
           name: average
     - id: am_azure_vpn_gateway__p2s_connections
       title: Azure VPN Gateway P2S Connection Count
@@ -338,7 +338,7 @@ template:
       units: connections
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.p2s_connection_count_total
+        - selector: p2s_connection_count_total
           name: total
     - id: am_azure_vpn_gateway__gateway_flows
       title: Azure VPN Gateway Flows
@@ -348,9 +348,9 @@ template:
       units: flows
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.inbound_flows_count_maximum
+        - selector: inbound_flows_count_maximum
           name: inbound
-        - selector: vpn_gateway.outbound_flows_count_maximum
+        - selector: outbound_flows_count_maximum
           name: outbound
     - id: am_azure_vpn_gateway__tunnel_bandwidth
       title: Azure VPN Gateway Tunnel Bandwidth
@@ -360,7 +360,7 @@ template:
       units: bytes/s
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.tunnel_average_bandwidth_average
+        - selector: tunnel_average_bandwidth_average
           name: average
     - id: am_azure_vpn_gateway__tunnel_bytes
       title: Azure VPN Gateway Tunnel Bytes
@@ -370,9 +370,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: vpn_gateway.tunnel_egress_bytes_total
+        - selector: tunnel_egress_bytes_total
           name: egress
-        - selector: vpn_gateway.tunnel_ingress_bytes_total
+        - selector: tunnel_ingress_bytes_total
           name: ingress
     - id: am_azure_vpn_gateway__tunnel_packets
       title: Azure VPN Gateway Tunnel Packets
@@ -382,9 +382,9 @@ template:
       units: packets/s
       algorithm: incremental
       dimensions:
-        - selector: vpn_gateway.tunnel_egress_packets_total
+        - selector: tunnel_egress_packets_total
           name: egress
-        - selector: vpn_gateway.tunnel_ingress_packets_total
+        - selector: tunnel_ingress_packets_total
           name: ingress
     - id: am_azure_vpn_gateway__tunnel_peak_pps
       title: Azure VPN Gateway Tunnel Peak PPS
@@ -394,7 +394,7 @@ template:
       units: packets/s
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.tunnel_peak_packets_maximum
+        - selector: tunnel_peak_packets_maximum
           name: peak
     - id: am_azure_vpn_gateway__tunnel_total_flows
       title: Azure VPN Gateway Tunnel Total Flows
@@ -404,7 +404,7 @@ template:
       units: flows/s
       algorithm: incremental
       dimensions:
-        - selector: vpn_gateway.tunnel_total_flow_count_total
+        - selector: tunnel_total_flow_count_total
           name: total
     - id: am_azure_vpn_gateway__tunnel_nat_allocations
       title: Azure VPN Gateway Tunnel NAT Allocations
@@ -414,7 +414,7 @@ template:
       units: allocations/s
       algorithm: incremental
       dimensions:
-        - selector: vpn_gateway.tunnel_nat_allocations_total
+        - selector: tunnel_nat_allocations_total
           name: total
     - id: am_azure_vpn_gateway__tunnel_nated_bytes
       title: Azure VPN Gateway Tunnel NATed Bytes
@@ -424,9 +424,9 @@ template:
       units: bytes/s
       algorithm: incremental
       dimensions:
-        - selector: vpn_gateway.tunnel_nated_bytes_total
+        - selector: tunnel_nated_bytes_total
           name: nated
-        - selector: vpn_gateway.tunnel_reverse_nated_bytes_total
+        - selector: tunnel_reverse_nated_bytes_total
           name: reverse_nated
     - id: am_azure_vpn_gateway__tunnel_nated_packets
       title: Azure VPN Gateway Tunnel NATed Packets
@@ -436,9 +436,9 @@ template:
       units: packets/s
       algorithm: incremental
       dimensions:
-        - selector: vpn_gateway.tunnel_nated_packets_total
+        - selector: tunnel_nated_packets_total
           name: nated
-        - selector: vpn_gateway.tunnel_reverse_nated_packets_total
+        - selector: tunnel_reverse_nated_packets_total
           name: reverse_nated
     - id: am_azure_vpn_gateway__tunnel_nat_flows
       title: Azure VPN Gateway Tunnel NAT Flows
@@ -448,7 +448,7 @@ template:
       units: flows/s
       algorithm: incremental
       dimensions:
-        - selector: vpn_gateway.tunnel_nat_flow_count_total
+        - selector: tunnel_nat_flow_count_total
           name: total
     - id: am_azure_vpn_gateway__tunnel_packet_drops
       title: Azure VPN Gateway Tunnel Packet Drops
@@ -458,9 +458,9 @@ template:
       units: packets/s
       algorithm: incremental
       dimensions:
-        - selector: vpn_gateway.tunnel_egress_packet_drop_count_total
+        - selector: tunnel_egress_packet_drop_count_total
           name: egress
-        - selector: vpn_gateway.tunnel_ingress_packet_drop_count_total
+        - selector: tunnel_ingress_packet_drop_count_total
           name: ingress
     - id: am_azure_vpn_gateway__tunnel_ts_mismatch_drops
       title: Azure VPN Gateway Tunnel TS Mismatch Drops
@@ -470,9 +470,9 @@ template:
       units: packets/s
       algorithm: incremental
       dimensions:
-        - selector: vpn_gateway.tunnel_egress_packet_drop_ts_mismatch_total
+        - selector: tunnel_egress_packet_drop_ts_mismatch_total
           name: egress
-        - selector: vpn_gateway.tunnel_ingress_packet_drop_ts_mismatch_total
+        - selector: tunnel_ingress_packet_drop_ts_mismatch_total
           name: ingress
     - id: am_azure_vpn_gateway__tunnel_nat_packet_drops
       title: Azure VPN Gateway Tunnel NAT Packet Drops
@@ -482,7 +482,7 @@ template:
       units: packets/s
       algorithm: incremental
       dimensions:
-        - selector: vpn_gateway.tunnel_nat_packet_drop_total
+        - selector: tunnel_nat_packet_drop_total
           name: total
     - id: am_azure_vpn_gateway__ipsec_sa
       title: Azure VPN Gateway IPsec Security Associations
@@ -492,9 +492,9 @@ template:
       units: associations
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.mmsa_count_total
+        - selector: mmsa_count_total
           name: mmsa
-        - selector: vpn_gateway.qmsa_count_total
+        - selector: qmsa_count_total
           name: qmsa
     - id: am_azure_vpn_gateway__bgp_peer_status
       title: Azure VPN Gateway BGP Peer Status
@@ -504,7 +504,7 @@ template:
       units: status
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.bgp_peer_status_average
+        - selector: bgp_peer_status_average
           name: average
     - id: am_azure_vpn_gateway__bgp_routes
       title: Azure VPN Gateway BGP Routes
@@ -514,9 +514,9 @@ template:
       units: routes/s
       algorithm: incremental
       dimensions:
-        - selector: vpn_gateway.bgp_routes_advertised_total
+        - selector: bgp_routes_advertised_total
           name: advertised
-        - selector: vpn_gateway.bgp_routes_learned_total
+        - selector: bgp_routes_learned_total
           name: learned
     - id: am_azure_vpn_gateway__route_counts
       title: Azure VPN Gateway Route Counts
@@ -526,9 +526,9 @@ template:
       units: routes
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.user_vpn_route_count_total
+        - selector: user_vpn_route_count_total
           name: user_vpn
-        - selector: vpn_gateway.vnet_address_prefix_count_total
+        - selector: vnet_address_prefix_count_total
           name: vnet_prefix
     - id: am_azure_vpn_gateway__er_gateway_bandwidth
       title: Azure VPN Gateway ExpressRoute Bandwidth
@@ -538,7 +538,7 @@ template:
       units: bits/s
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.express_route_gateway_bits_per_second_average
+        - selector: express_route_gateway_bits_per_second_average
           name: average
     - id: am_azure_vpn_gateway__er_gateway_cpu
       title: Azure VPN Gateway ExpressRoute CPU Utilization
@@ -548,7 +548,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.express_route_gateway_cpu_utilization_average
+        - selector: express_route_gateway_cpu_utilization_average
           name: average
     - id: am_azure_vpn_gateway__er_gateway_packets
       title: Azure VPN Gateway ExpressRoute Packets
@@ -558,7 +558,7 @@ template:
       units: packets/s
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.express_route_gateway_packets_per_second_average
+        - selector: express_route_gateway_packets_per_second_average
           name: average
     - id: am_azure_vpn_gateway__er_gateway_active_flows
       title: Azure VPN Gateway ExpressRoute Active Flows
@@ -568,7 +568,7 @@ template:
       units: flows
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.express_route_gateway_active_flows_average
+        - selector: express_route_gateway_active_flows_average
           name: average
     - id: am_azure_vpn_gateway__er_gateway_routes_advertised
       title: Azure VPN Gateway ExpressRoute Routes Advertised to Peer
@@ -578,7 +578,7 @@ template:
       units: routes
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.express_route_gateway_count_of_routes_advertised_to_peer_maximum
+        - selector: express_route_gateway_count_of_routes_advertised_to_peer_maximum
           name: maximum
     - id: am_azure_vpn_gateway__er_gateway_routes_learned
       title: Azure VPN Gateway ExpressRoute Routes Learned from Peer
@@ -588,7 +588,7 @@ template:
       units: routes
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.express_route_gateway_count_of_routes_learned_from_peer_maximum
+        - selector: express_route_gateway_count_of_routes_learned_from_peer_maximum
           name: maximum
     - id: am_azure_vpn_gateway__er_gateway_route_changes
       title: Azure VPN Gateway ExpressRoute Route Changes
@@ -598,7 +598,7 @@ template:
       units: changes/s
       algorithm: incremental
       dimensions:
-        - selector: vpn_gateway.express_route_gateway_frequency_of_routes_changed_total
+        - selector: express_route_gateway_frequency_of_routes_changed_total
           name: total
     - id: am_azure_vpn_gateway__er_gateway_max_flows_rate
       title: Azure VPN Gateway ExpressRoute Max Flow Creation Rate
@@ -608,7 +608,7 @@ template:
       units: flows/s
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.express_route_gateway_max_flows_creation_rate_maximum
+        - selector: express_route_gateway_max_flows_creation_rate_maximum
           name: maximum
     - id: am_azure_vpn_gateway__er_gateway_vm_count
       title: Azure VPN Gateway ExpressRoute VMs in VNet
@@ -618,7 +618,7 @@ template:
       units: VMs
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.express_route_gateway_number_of_vm_in_vnet_maximum
+        - selector: express_route_gateway_number_of_vm_in_vnet_maximum
           name: maximum
     - id: am_azure_vpn_gateway__scalable_er_bandwidth
       title: Azure VPN Gateway Scalable ExpressRoute Bandwidth
@@ -628,7 +628,7 @@ template:
       units: bits/s
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.scalable_express_route_gateway_bits_per_second_average
+        - selector: scalable_express_route_gateway_bits_per_second_average
           name: average
     - id: am_azure_vpn_gateway__scalable_er_cpu
       title: Azure VPN Gateway Scalable ExpressRoute CPU Utilization
@@ -638,7 +638,7 @@ template:
       units: percentage
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.scalable_express_route_gateway_cpu_utilization_average
+        - selector: scalable_express_route_gateway_cpu_utilization_average
           name: average
     - id: am_azure_vpn_gateway__scalable_er_packets
       title: Azure VPN Gateway Scalable ExpressRoute Packets
@@ -648,7 +648,7 @@ template:
       units: packets/s
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.scalable_express_route_gateway_packets_per_second_average
+        - selector: scalable_express_route_gateway_packets_per_second_average
           name: average
     - id: am_azure_vpn_gateway__scalable_er_active_flows
       title: Azure VPN Gateway Scalable ExpressRoute Active Flows
@@ -658,7 +658,7 @@ template:
       units: flows
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.scalable_express_route_gateway_active_flows_average
+        - selector: scalable_express_route_gateway_active_flows_average
           name: average
     - id: am_azure_vpn_gateway__scalable_er_routes_advertised
       title: Azure VPN Gateway Scalable ExpressRoute Routes Advertised
@@ -668,7 +668,7 @@ template:
       units: routes
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.scalable_express_route_gateway_count_of_routes_advertised_to_peer_maximum
+        - selector: scalable_express_route_gateway_count_of_routes_advertised_to_peer_maximum
           name: maximum
     - id: am_azure_vpn_gateway__scalable_er_routes_learned
       title: Azure VPN Gateway Scalable ExpressRoute Routes Learned
@@ -678,7 +678,7 @@ template:
       units: routes
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.scalable_express_route_gateway_count_of_routes_learned_from_peer_maximum
+        - selector: scalable_express_route_gateway_count_of_routes_learned_from_peer_maximum
           name: maximum
     - id: am_azure_vpn_gateway__scalable_er_route_changes
       title: Azure VPN Gateway Scalable ExpressRoute Route Changes
@@ -688,7 +688,7 @@ template:
       units: changes/s
       algorithm: incremental
       dimensions:
-        - selector: vpn_gateway.scalable_express_route_gateway_frequency_of_routes_changed_total
+        - selector: scalable_express_route_gateway_frequency_of_routes_changed_total
           name: total
     - id: am_azure_vpn_gateway__scalable_er_max_flows_rate
       title: Azure VPN Gateway Scalable ExpressRoute Max Flow Creation Rate
@@ -698,7 +698,7 @@ template:
       units: flows/s
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.scalable_express_route_gateway_max_flows_creation_rate_maximum
+        - selector: scalable_express_route_gateway_max_flows_creation_rate_maximum
           name: maximum
     - id: am_azure_vpn_gateway__scalable_er_vm_count
       title: Azure VPN Gateway Scalable ExpressRoute VMs in VNet
@@ -708,7 +708,7 @@ template:
       units: VMs
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.scalable_express_route_gateway_number_of_vm_in_vnet_maximum
+        - selector: scalable_express_route_gateway_number_of_vm_in_vnet_maximum
           name: maximum
     - id: am_azure_vpn_gateway__scalable_er_scale_units
       title: Azure VPN Gateway Scalable ExpressRoute Scale Units
@@ -718,5 +718,5 @@ template:
       units: units
       algorithm: absolute
       dimensions:
-        - selector: vpn_gateway.scalable_express_route_gateway_scale_unit_maximum
+        - selector: scalable_express_route_gateway_scale_unit_maximum
           name: maximum


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortened selector keys in Azure Monitor stock profiles by removing the resource prefix (e.g., application_gateway.bytes_sent_total → bytes_sent_total) for cleaner, consistent configs. Added a test to enforce the shorthand; no functional changes.

- **Refactors**
  - Updated all default Azure Monitor profile YAMLs to use shorthand selectors (drop the service prefix before the dot).
  - Added a unit test to ensure stock profiles don’t use dotted selectors and keep the shorthand.
  - Changes are limited to stock profiles in `go.d/azure_monitor`; runtime behavior and metrics are unchanged.

<sup>Written for commit ac90674a2844481af88db48919d35102c20baf89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

