### PR TITLE
docs: remove stale log viewer guide links

### DIFF
--- a/src/crates/netdata-log-viewer/README.md
+++ b/src/crates/netdata-log-viewer/README.md
@@ -99,9 +99,10 @@ open http://localhost:16686
 
 ## Development
 
-See [QUICKSTART.md](./QUICKSTART.md) for the fast development loop.
+Use this README for the current development loop and tracing workflow.
 
-See [DEVELOPMENT.md](./DEVELOPMENT.md) for comprehensive documentation.
+For plugin-specific configuration details, see
+[`otel-signal-viewer-plugin/README.md`](./otel-signal-viewer-plugin/README.md).
 
 ### Development Workflow
 
@@ -128,8 +129,7 @@ netdata-log-viewer/
 ├── types/                   # Shared request/response types
 ├── watcher-plugin/          # DEPRECATED - no longer needed
 ├── lv/                      # DEPRECATED - no longer needed
-├── DEVELOPMENT.md           # Detailed development guide
-├── QUICKSTART.md            # Fast reference guide
+├── otel-signal-viewer-plugin/README.md  # Plugin-specific configuration guide
 └── README.md                # This file
 ```
 


### PR DESCRIPTION
## Summary
- remove README references to missing `QUICKSTART.md` and `DEVELOPMENT.md` guides in `src/crates/netdata-log-viewer`
- point readers to the current plugin-specific guide that actually exists in-tree
- keep the project structure section aligned with the files shipped in the repo

## Validation
- `rg -n "QUICKSTART.md|DEVELOPMENT.md" src/crates/netdata-log-viewer/README.md`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale links to `QUICKSTART.md` and `DEVELOPMENT.md` in `src/crates/netdata-log-viewer/README.md`, directing readers to `otel-signal-viewer-plugin/README.md` and clarifying that this README covers the dev loop and tracing workflow. Updated the project structure list to match the files that exist.

<sup>Written for commit 2c354ae2e856dbff8702487103c7d01a6c7c4f80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

