### PR TITLE
fix(go.d/azure_monitor): ignore invalid user profile overrides

### DIFF
--- a/src/go/plugin/go.d/collector/azure_monitor/azureprofiles/catalog.go
+++ b/src/go/plugin/go.d/collector/azure_monitor/azureprofiles/catalog.go
@@ -15,6 +15,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/pkg/executable"
 	"github.com/netdata/netdata/go/plugins/pkg/pluginconfig"
 )
@@ -22,6 +23,8 @@ import (
 const (
 	profilesDirName = "azure_monitor.profiles"
 )
+
+var log = logger.New().With("component", "azure_monitor/azureprofiles")
 
 type Catalog struct {
 	byBaseName            map[string]Profile
@@ -81,7 +84,7 @@ func LoadFromDirs(specs []DirSpec) (Catalog, error) {
 
 		err := filepath.WalkDir(spec.Path, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
-				return err
+				return handleProfileLoadError(spec, path, err)
 			}
 			if d.IsDir() {
 				return nil
@@ -98,12 +101,12 @@ func LoadFromDirs(specs []DirSpec) (Catalog, error) {
 
 			baseName := strings.TrimSpace(profileBaseName(path))
 			if !IsValidProfileName(baseName) {
-				return fmt.Errorf("profile %q: basename must match %q", path, reIdentityID.String())
+				return handleProfileLoadError(spec, path, fmt.Errorf("profile %q: basename must match %q", path, reIdentityID.String()))
 			}
 
 			cfg, err := loadProfileFile(path, baseName)
 			if err != nil {
-				return err
+				return handleProfileLoadError(spec, path, err)
 			}
 			if spec.IsStock {
 				catalog.stockProfileBaseNames[baseName] = struct{}{}
@@ -117,11 +120,11 @@ func LoadFromDirs(specs []DirSpec) (Catalog, error) {
 
 			switch {
 			case prev.IsStock == spec.IsStock:
-				scope := "user"
-				if spec.IsStock {
-					scope = "stock"
+				if !spec.IsStock {
+					log.Warningf("ignoring duplicate user profile basename %q in %q; already loaded from %q", baseName, path, prev.Path)
+					return nil
 				}
-				return fmt.Errorf("duplicate %s profile basename %q in %q and %q", scope, baseName, prev.Path, path)
+				return fmt.Errorf("duplicate stock profile basename %q in %q and %q", baseName, prev.Path, path)
 			case prev.IsStock && !spec.IsStock:
 				seen[baseName] = catalogEntry{Config: cfg, Path: path, BaseName: baseName, IsStock: false}
 			case !prev.IsStock && spec.IsStock:
@@ -154,7 +157,6 @@ func loadProfileFile(path, baseName string) (Profile, error) {
 
 	var cfg Profile
 	dec := yaml.NewDecoder(bytes.NewReader(data))
-	dec.KnownFields(true)
 	if err := dec.Decode(&cfg); err != nil {
 		return Profile{}, fmt.Errorf("unmarshal profile %q: %w", path, err)
 	}
@@ -167,6 +169,15 @@ func loadProfileFile(path, baseName string) (Profile, error) {
 	}
 
 	return cfg, nil
+}
+
+func handleProfileLoadError(spec DirSpec, path string, err error) error {
+	if spec.IsStock {
+		return err
+	}
+
+	log.Warningf("ignoring invalid user profile %q: %v", path, err)
+	return nil
 }
 
 func (c Catalog) Resolve(profileNames []string) ([]ResolvedProfile, error) {

--- a/src/go/plugin/go.d/collector/azure_monitor/profile_catalog_test.go
+++ b/src/go/plugin/go.d/collector/azure_monitor/profile_catalog_test.go
@@ -137,6 +137,201 @@ template:
 	assert.Equal(t, "Azure SQL Database (User Override)", got.DisplayName)
 }
 
+func TestLoadProfileCatalogFromDirs_IgnoresInvalidUserOverrideAndFallsBackToStock(t *testing.T) {
+	dir := t.TempDir()
+	userDir := filepath.Join(dir, "user")
+	stockDir := filepath.Join(dir, "stock")
+
+	require.NoError(t, writeProfileFile(filepath.Join(userDir, "sql_database.yaml"), `
+id: sql_database
+name: Azure SQL Database (Old User Override)
+resource_type: Microsoft.Sql/servers/databases
+metrics:
+  - id: cpu_percent
+    azure_name: cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+template:
+  family: Azure SQL Database (Old User Override)
+  context_namespace: sql_database
+  charts:
+    - id: am_test_sql_database_cpu
+      title: Azure SQL Database CPU
+      context: cpu
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      label_promotion: [resource_name, resource_group, region, resource_type, profile]
+      instances:
+        by_labels: [resource_uid]
+      dimensions:
+        - selector: sql_database.cpu_percent_average
+          name: average
+`))
+	require.NoError(t, writeProfileFile(filepath.Join(stockDir, "sql_database.yaml"), `
+display_name: Azure SQL Database (Stock)
+resource_type: Microsoft.Sql/servers/databases
+metrics:
+  - id: cpu_percent
+    azure_name: cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+template:
+  family: Azure SQL Database (Stock)
+  context_namespace: sql_database
+  charts:
+    - id: am_test_sql_database_cpu
+      title: Azure SQL Database CPU
+      context: cpu
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      label_promotion: [resource_name, resource_group, region, resource_type, profile]
+      instances:
+        by_labels: [resource_uid]
+      dimensions:
+        - selector: sql_database.cpu_percent_average
+          name: average
+`))
+
+	catalog, err := azureprofiles.LoadFromDirs([]azureprofiles.DirSpec{
+		{Path: userDir, IsStock: false},
+		{Path: stockDir, IsStock: true},
+	})
+	require.NoError(t, err)
+
+	gotProfiles, err := catalog.ResolveBaseNames([]string{"sql_database"})
+	require.NoError(t, err)
+	require.Len(t, gotProfiles, 1)
+	assert.Equal(t, "Azure SQL Database (Stock)", gotProfiles[0].DisplayName)
+}
+
+func TestLoadProfileCatalogFromDirs_IgnoresUnknownFieldsInUserProfile(t *testing.T) {
+	dir := t.TempDir()
+	userDir := filepath.Join(dir, "user")
+
+	require.NoError(t, writeProfileFile(filepath.Join(userDir, "sql_database.yaml"), `
+id: sql_database
+name: Azure SQL Database (Ignored Legacy Field)
+display_name: Azure SQL Database (User Override)
+resource_type: Microsoft.Sql/servers/databases
+metrics:
+  - id: cpu_percent
+    azure_name: cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+template:
+  family: Azure SQL Database (User Override)
+  context_namespace: sql_database
+  charts:
+    - id: am_test_sql_database_cpu
+      title: Azure SQL Database CPU
+      context: cpu
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      label_promotion: [resource_name, resource_group, region, resource_type, profile]
+      instances:
+        by_labels: [resource_uid]
+      dimensions:
+        - selector: sql_database.cpu_percent_average
+          name: average
+`))
+
+	catalog, err := azureprofiles.LoadFromDirs([]azureprofiles.DirSpec{
+		{Path: userDir, IsStock: false},
+	})
+	require.NoError(t, err)
+
+	gotProfiles, err := catalog.ResolveBaseNames([]string{"sql_database"})
+	require.NoError(t, err)
+	require.Len(t, gotProfiles, 1)
+	assert.Equal(t, "Azure SQL Database (User Override)", gotProfiles[0].DisplayName)
+}
+
+func TestLoadProfileCatalogFromDirs_IgnoresDuplicateUserBasename(t *testing.T) {
+	dir := t.TempDir()
+	userDirA := filepath.Join(dir, "user-a")
+	userDirB := filepath.Join(dir, "user-b")
+
+	require.NoError(t, writeProfileFile(filepath.Join(userDirA, "sql_database.yaml"), `
+display_name: Azure SQL Database (User A)
+resource_type: Microsoft.Sql/servers/databases
+metrics:
+  - id: cpu_percent
+    azure_name: cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+template:
+  family: Azure SQL Database (User A)
+  context_namespace: sql_database
+  charts:
+    - id: am_test_sql_database_user_a_cpu
+      title: Azure SQL Database CPU
+      context: cpu
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      label_promotion: [resource_name, resource_group, region, resource_type, profile]
+      instances:
+        by_labels: [resource_uid]
+      dimensions:
+        - selector: sql_database.cpu_percent_average
+          name: average
+`))
+	require.NoError(t, writeProfileFile(filepath.Join(userDirB, "sql_database.yaml"), `
+display_name: Azure SQL Database (User B)
+resource_type: Microsoft.Sql/servers/databases
+metrics:
+  - id: cpu_percent
+    azure_name: cpu_percent
+    time_grain: PT1M
+    series:
+      - aggregation: average
+        kind: gauge
+template:
+  family: Azure SQL Database (User B)
+  context_namespace: sql_database
+  charts:
+    - id: am_test_sql_database_user_b_cpu
+      title: Azure SQL Database CPU
+      context: cpu
+      family: Utilization
+      type: line
+      units: percentage
+      algorithm: absolute
+      label_promotion: [resource_name, resource_group, region, resource_type, profile]
+      instances:
+        by_labels: [resource_uid]
+      dimensions:
+        - selector: sql_database.cpu_percent_average
+          name: average
+`))
+
+	catalog, err := azureprofiles.LoadFromDirs([]azureprofiles.DirSpec{
+		{Path: userDirA, IsStock: false},
+		{Path: userDirB, IsStock: false},
+	})
+	require.NoError(t, err)
+
+	gotProfiles, err := catalog.ResolveBaseNames([]string{"sql_database"})
+	require.NoError(t, err)
+	require.Len(t, gotProfiles, 1)
+	assert.Equal(t, "Azure SQL Database (User A)", gotProfiles[0].DisplayName)
+}
+
 func TestLoadProfileCatalogFromDirs_RejectsDuplicateProfileBasenames(t *testing.T) {
 	dir := t.TempDir()
 	stockDir := filepath.Join(dir, "stock")


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Azure Monitor profile loading more resilient by skipping invalid user overrides with a warning and falling back to stock profiles. Prevents failures from legacy fields or duplicate user profiles.

- **Bug Fixes**
  - Skip invalid user profiles; stock profile errors remain fatal.
  - Accept unknown YAML fields in user profiles.
  - Ignore duplicate user basenames (use the first); duplicate stock basenames still error.

<sup>Written for commit 716629071fd8df069b92a23e92fe9c429616cfa9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

