### PR TITLE
fix: the sync_tester in sync_tester.c

### DIFF
--- a/tests/ebpf/sync_tester.c
+++ b/tests/ebpf/sync_tester.c
@@ -63,7 +63,8 @@ void test_msync(char *output, char *text, size_t length)
         return;
     }
 
-    (void) strcpy( (char*) address, text);
+    (void) strncpy( (char*) address, text, pagesize - 1);
+    ((char*) address)[pagesize - 1] = '\0';
 
     if ( msync( address, pagesize, MS_SYNC) < 0 ) {
         perror("msync failed with error:");


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `tests/ebpf/sync_tester.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `tests/ebpf/sync_tester.c:66` |
| **CWE** | CWE-120 |

**Description**: The sync_tester.c file uses strcpy() without bounds checking at line 66. The strcpy() function copies the entire 'text' string to 'address' without validating that the destination buffer has sufficient space. This is a classic buffer overflow vulnerability where an attacker-controlled 'text' parameter longer than the allocated buffer will overwrite adjacent memory.

## Changes
- `tests/ebpf/sync_tester.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix buffer overflow in tests/ebpf/sync_tester.c by replacing strcpy with a bounded strncpy. Copy at most pagesize - 1 bytes and set the last byte to '\0' to prevent memory overruns.

<sup>Written for commit de5e57c065e35b955df84cf2946d2ccc214d11cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

