### PR TITLE
Improve child to parent provided ML trained data

### DIFF
--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -3,6 +3,7 @@
 #include "ml_config.h"
 #include "ml_features.h"
 #include "ml_kmeans.h"
+#include "ml_private.h"
 
 #include <algorithm>
 #include <cmath>
@@ -862,6 +863,59 @@ static void test_kmeans_timestamp_rejection()
     }
 }
 
+static void test_downstream_model_short_circuit_and_requeue()
+{
+    fprintf(stderr, "  test_downstream_model_short_circuit_and_requeue...\n");
+
+    enum ml_worker_result worker_res = ML_WORKER_RESULT_OK;
+    bool should_short_circuit = ml_dimension_train_model_precheck(METRIC_TYPE_VARIABLE,
+                                                                  true,
+                                                                  false,
+                                                                  &worker_res);
+    ML_TEST_ASSERT(should_short_circuit,
+                   "downstream-supplied dimensions should short-circuit local training");
+    ML_TEST_ASSERT(worker_res == ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED,
+                   "downstream-supplied dimensions should short-circuit local training");
+    ML_TEST_ASSERT(!ml_should_requeue_create_new_model(worker_res),
+                   "downstream-supplied result should stop CREATE_NEW_MODEL requeueing");
+
+    worker_res = ML_WORKER_RESULT_OK;
+    should_short_circuit = ml_dimension_train_model_precheck(METRIC_TYPE_VARIABLE,
+                                                             false,
+                                                             false,
+                                                             &worker_res);
+    ML_TEST_ASSERT(!should_short_circuit,
+                   "dimensions without downstream models should continue to training");
+    ML_TEST_ASSERT(ml_should_requeue_create_new_model(ML_WORKER_RESULT_OK),
+                   "ordinary training results should keep CREATE_NEW_MODEL items requeueing");
+}
+
+static void test_reset_generation_cancels_model_publish()
+{
+    fprintf(stderr, "  test_reset_generation_cancels_model_publish...\n");
+
+    bool training_in_progress = true;
+    bool should_publish = ml_should_publish_model_update(true, 8, 7, &training_in_progress);
+    ML_TEST_ASSERT(!should_publish,
+                   "generation mismatch should cancel model publication");
+    ML_TEST_ASSERT(!training_in_progress,
+                   "generation mismatch should clear training_in_progress");
+
+    training_in_progress = true;
+    should_publish = ml_should_publish_model_update(false, 7, 7, &training_in_progress);
+    ML_TEST_ASSERT(!should_publish,
+                   "stopped hosts should cancel model publication");
+    ML_TEST_ASSERT(!training_in_progress,
+                   "stopped-host cancellation should clear training_in_progress");
+
+    training_in_progress = true;
+    should_publish = ml_should_publish_model_update(true, 7, 7, &training_in_progress);
+    ML_TEST_ASSERT(should_publish,
+                   "matching generation on a running host should allow model publication");
+    ML_TEST_ASSERT(training_in_progress,
+                   "successful publication path should leave training_in_progress unchanged");
+}
+
 extern "C" int ml_unittest()
 {
     fprintf(stderr, "\nML unit tests:\n");
@@ -888,6 +942,8 @@ extern "C" int ml_unittest()
     test_parameter_combinations();
     test_kmeans_timestamp_roundtrip();
     test_kmeans_timestamp_rejection();
+    test_downstream_model_short_circuit_and_requeue();
+    test_reset_generation_cancels_model_publish();
 
     fprintf(stderr, "\nML tests: %d run, %d failed\n", tests_run, tests_failed);
 

--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -880,6 +880,18 @@ static void test_downstream_model_short_circuit_and_requeue()
                    "downstream-supplied result should stop CREATE_NEW_MODEL requeueing");
 
     worker_res = ML_WORKER_RESULT_OK;
+    should_short_circuit = ml_dimension_train_model_precheck(METRIC_TYPE_CONSTANT,
+                                                             true,
+                                                             false,
+                                                             &worker_res);
+    ML_TEST_ASSERT(should_short_circuit,
+                   "constant downstream-supplied dimensions should short-circuit local training");
+    ML_TEST_ASSERT(worker_res == ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED,
+                   "constant downstream-supplied dimensions should drain CREATE_NEW_MODEL items");
+    ML_TEST_ASSERT(!ml_should_requeue_create_new_model(worker_res),
+                   "constant downstream-supplied result should stop CREATE_NEW_MODEL requeueing");
+
+    worker_res = ML_WORKER_RESULT_OK;
     should_short_circuit = ml_dimension_train_model_precheck(METRIC_TYPE_VARIABLE,
                                                              false,
                                                              false,

--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -900,6 +900,19 @@ static void test_downstream_model_short_circuit_and_requeue()
                    "dimensions without downstream models should continue to training");
     ML_TEST_ASSERT(ml_should_requeue_create_new_model(ML_WORKER_RESULT_OK),
                    "ordinary training results should keep CREATE_NEW_MODEL items requeueing");
+
+    worker_res = ML_WORKER_RESULT_OK;
+    should_short_circuit = ml_dimension_train_model_precheck(METRIC_TYPE_VARIABLE,
+                                                             false,
+                                                             true,
+                                                             &worker_res);
+    ML_TEST_ASSERT(should_short_circuit,
+                   "training-in-progress dimensions should short-circuit local training");
+    ML_TEST_ASSERT(worker_res == ML_WORKER_RESULT_TRAINING_IN_PROGRESS,
+                   "training-in-progress dimensions should report the distinct result");
+    ML_TEST_ASSERT(ml_should_requeue_create_new_model(worker_res),
+                   "training-in-progress result should keep CREATE_NEW_MODEL items requeueing "
+                   "so the dim stays in the periodic retrain cycle");
 }
 
 static void test_reset_generation_cancels_model_publish()

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -671,6 +671,49 @@ static void ml_dimension_stream_kmeans(ml_worker_t *worker, const ml_dimension_t
     pulse_ml_models_sent();
 }
 
+bool ml_dimension_train_model_precheck(enum ml_metric_type mt,
+                                       bool has_received_downstream_model,
+                                       bool training_in_progress,
+                                       enum ml_worker_result *worker_res)
+{
+    if (mt == METRIC_TYPE_CONSTANT) {
+        *worker_res = ML_WORKER_RESULT_OK;
+        return true;
+    }
+
+    if (has_received_downstream_model) {
+        *worker_res = ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED;
+        return true;
+    }
+
+    if (training_in_progress) {
+        *worker_res = ML_WORKER_RESULT_OK;
+        return true;
+    }
+
+    return false;
+}
+
+bool ml_should_requeue_create_new_model(enum ml_worker_result worker_res)
+{
+    return worker_res != ML_WORKER_RESULT_NULL_ACQUIRED_DIMENSION &&
+           worker_res != ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED;
+}
+
+bool ml_should_publish_model_update(bool host_running,
+                                    uint32_t current_generation,
+                                    uint32_t expected_generation,
+                                    bool *training_in_progress)
+{
+    if (!host_running || current_generation != expected_generation) {
+        if (training_in_progress)
+            *training_in_progress = false;
+        return false;
+    }
+
+    return true;
+}
+
 static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim, uint32_t expected_generation)
 {
     worker_is_busy(WORKER_TRAIN_UPDATE_MODELS);
@@ -678,8 +721,10 @@ static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim,
     spinlock_lock(&dim->slock);
 
     ml_host_t *host = (ml_host_t *) dim->rd->rrdset->rrdhost->ml_host;
-    if (!host || !host->ml_running || dim->reset_generation != expected_generation) {
-        dim->training_in_progress = false;
+    if (!ml_should_publish_model_update(host && host->ml_running,
+                                        dim->reset_generation,
+                                        expected_generation,
+                                        &dim->training_in_progress)) {
         spinlock_unlock(&dim->slock);
         return;
     }
@@ -733,21 +778,13 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
     worker_is_busy(WORKER_TRAIN_QUERY);
 
     spinlock_lock(&dim->slock);
-    if (dim->mt == METRIC_TYPE_CONSTANT) {
+    ml_worker_result precheck;
+    if (ml_dimension_train_model_precheck(dim->mt,
+                                          dim->has_received_downstream_model,
+                                          dim->training_in_progress,
+                                          &precheck)) {
         spinlock_unlock(&dim->slock);
-        return ML_WORKER_RESULT_OK;
-    }
-
-    if (dim->has_received_downstream_model) {
-        spinlock_unlock(&dim->slock);
-        return ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED;
-    }
-
-    // Check if training is already in progress for this dimension
-    // If so, skip this training request to prevent concurrent access to dim->kmeans
-    if (dim->training_in_progress) {
-        spinlock_unlock(&dim->slock);
-        return ML_WORKER_RESULT_OK;
+        return precheck;
     }
 
     // Mark training as in progress and snapshot the generation so that
@@ -1330,8 +1367,7 @@ void ml_train_main(void *arg) {
         switch (item.type) {
             case ML_QUEUE_ITEM_TYPE_CREATE_NEW_MODEL: {
                 worker_res = ml_worker_create_new_model(worker, item.create_new_model);
-                if (worker_res != ML_WORKER_RESULT_NULL_ACQUIRED_DIMENSION &&
-                    worker_res != ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED) {
+                if (ml_should_requeue_create_new_model(worker_res)) {
                     ml_queue_push(worker->queue, item);
                 }
                 break;

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -687,7 +687,7 @@ bool ml_dimension_train_model_precheck(enum ml_metric_type mt,
     }
 
     if (training_in_progress) {
-        *worker_res = ML_WORKER_RESULT_OK;
+        *worker_res = ML_WORKER_RESULT_TRAINING_IN_PROGRESS;
         return true;
     }
 
@@ -696,6 +696,9 @@ bool ml_dimension_train_model_precheck(enum ml_metric_type mt,
 
 bool ml_should_requeue_create_new_model(enum ml_worker_result worker_res)
 {
+    // TRAINING_IN_PROGRESS keeps requeueing so the dim stays in the periodic
+    // retrain cycle; the worker loop is paced by Cfg.train_every, so this is
+    // not a tight CPU spin.
     return worker_res != ML_WORKER_RESULT_NULL_ACQUIRED_DIMENSION &&
            worker_res != ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED;
 }
@@ -1427,6 +1430,9 @@ void ml_train_main(void *arg) {
                     loop_stats.item_result_chart_under_replication = 1;
                     break;
                 case ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED:
+                    loop_stats.item_result_ok = 1;
+                    break;
+                case ML_WORKER_RESULT_TRAINING_IN_PROGRESS:
                     loop_stats.item_result_ok = 1;
                     break;
             }

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -714,7 +714,7 @@ bool ml_should_publish_model_update(bool host_running,
     return true;
 }
 
-static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim, uint32_t expected_generation)
+static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim, uint32_t expected_generation, bool from_downstream)
 {
     worker_is_busy(WORKER_TRAIN_UPDATE_MODELS);
 
@@ -728,6 +728,12 @@ static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim,
         spinlock_unlock(&dim->slock);
         return;
     }
+
+    // Mark the dim as downstream-supplied only after the publish-check passes
+    // and under the same slock as the install. Setting it earlier would risk
+    // suppressing local training if the install was cancelled.
+    if (from_downstream)
+        dim->has_received_downstream_model = true;
 
     if (dim->km_contexts.size() < Cfg.num_models_to_use) {
         dim->km_contexts.emplace_back(dim->kmeans);
@@ -845,7 +851,7 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
     }
 
     // update models
-    ml_dimension_update_models(worker, dim, generation);
+    ml_dimension_update_models(worker, dim, generation, /*from_downstream=*/false);
 
     return worker_result;
 }
@@ -1308,15 +1314,15 @@ static enum ml_worker_result ml_worker_add_existing_model(ml_worker_t *worker, m
         return ML_WORKER_RESULT_OK;
     }
 
-    // The model survived all checks and will be installed — mark this dimension
-    // as supplied by downstream. Only set the flag here so that rejected models
-    // (duplicates, stale, or concurrent-training) do not permanently suppress
-    // local retraining.
-    Dim->has_received_downstream_model = true;
+    // Stage the incoming kmeans into the dim's working buffer; the actual
+    // install into km_contexts and the has_received_downstream_model flag-set
+    // happen inside ml_dimension_update_models() under the same slock as the
+    // publish-check, so a concurrent ml_host_stop() either commits both or
+    // cancels both.
     Dim->kmeans = req.inlined_km;
     uint32_t generation = Dim->reset_generation;
     spinlock_unlock(&Dim->slock);
-    ml_dimension_update_models(worker, Dim, generation);
+    ml_dimension_update_models(worker, Dim, generation, /*from_downstream=*/true);
 
     pulse_ml_models_received();
     return ML_WORKER_RESULT_OK;

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -671,14 +671,14 @@ static void ml_dimension_stream_kmeans(ml_worker_t *worker, const ml_dimension_t
     pulse_ml_models_sent();
 }
 
-static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim)
+static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim, uint32_t expected_generation)
 {
     worker_is_busy(WORKER_TRAIN_UPDATE_MODELS);
 
     spinlock_lock(&dim->slock);
 
     ml_host_t *host = (ml_host_t *) dim->rd->rrdset->rrdhost->ml_host;
-    if (!host || !host->ml_running) {
+    if (!host || !host->ml_running || dim->reset_generation != expected_generation) {
         dim->training_in_progress = false;
         spinlock_unlock(&dim->slock);
         return;
@@ -712,7 +712,7 @@ static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim)
     dim->suppression_anomaly_counter = 0;
     dim->suppression_window_counter = 0;
 
-    // Add the newly generated model to the list of pending models to flush
+    // Add the latest model to the list of pending models to flush.
     ml_model_info_t model_info;
     nd_uuid_t *rd_uuid = uuidmap_uuid_ptr(dim->rd->uuid);
     uuid_copy(model_info.metric_uuid, *rd_uuid);
@@ -738,6 +738,11 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
         return ML_WORKER_RESULT_OK;
     }
 
+    if (dim->has_received_downstream_model) {
+        spinlock_unlock(&dim->slock);
+        return ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED;
+    }
+
     // Check if training is already in progress for this dimension
     // If so, skip this training request to prevent concurrent access to dim->kmeans
     if (dim->training_in_progress) {
@@ -745,8 +750,11 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
         return ML_WORKER_RESULT_OK;
     }
 
-    // Mark training as in progress
+    // Mark training as in progress and snapshot the generation so that
+    // ml_dimension_update_models() can detect a stop/reset that happened
+    // while training was running.
     dim->training_in_progress = true;
+    uint32_t generation = dim->reset_generation;
     spinlock_unlock(&dim->slock);
 
     auto P = ml_dimension_calculated_numbers(worker, dim);
@@ -779,14 +787,14 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
             worker->scratch_training_cns, training_response.total_values,
             worker->training_cns, training_response.total_values
         };
-        
+
         // Calculate dynamic sampling ratio based on expected output size
         // After diff and smooth, we'll have approximately this many vectors
         size_t expected_vectors = training_response.total_values;
         if (Cfg.diff_n > 0) expected_vectors--;
         if (smoothing_window > 1) expected_vectors = expected_vectors - smoothing_window + 1;
         expected_vectors = expected_vectors - Cfg.lag_n;
-        
+
         double sampling_ratio = 1.0;
         if (expected_vectors > Cfg.max_training_vectors) {
             sampling_ratio = (double)Cfg.max_training_vectors / expected_vectors;
@@ -800,7 +808,7 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
     }
 
     // update models
-    ml_dimension_update_models(worker, dim);
+    ml_dimension_update_models(worker, dim, generation);
 
     return worker_result;
 }
@@ -1053,12 +1061,15 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
                 auto &um = host->context_anomaly_rate;
                 auto it = um.find(key);
                 if (it == um.end()) {
-                    um[key] = ml_context_anomaly_rate_t {
+                    STRING *owned_key = string_dup(key);
+                    auto insert_result = um.emplace(owned_key, ml_context_anomaly_rate_t {
                         .rd = NULL,
                         .normal_dimensions = 0,
                         .anomalous_dimensions = 0
-                    };
-                    it = um.find(key);
+                    });
+                    if (!insert_result.second)
+                        string_freez(owned_key);
+                    it = insert_result.first;
                 }
 
                 it->second.anomalous_dimensions += chart_mls.num_anomalous_dimensions;
@@ -1084,15 +1095,6 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
         ml_update_host_and_detection_rate_charts(host, host->host_anomaly_rate * 10000.0, owa);
     } else {
         host->host_anomaly_rate = 0.0;
-
-        auto &um = host->context_anomaly_rate;
-        for (auto &entry: um) {
-            entry.second = ml_context_anomaly_rate_t {
-                .rd = NULL,
-                .normal_dimensions = 0,
-                .anomalous_dimensions = 0
-            };
-        }
     }
 }
 
@@ -1219,9 +1221,6 @@ static enum ml_worker_result ml_worker_create_new_model(ml_worker_t *worker, ml_
 }
 
 static enum ml_worker_result ml_worker_add_existing_model(ml_worker_t *worker, ml_request_add_existing_model_t req) {
-    UNUSED(worker);
-    UNUSED(req);
-
     AcquiredDimension AcqDim(req.DLI);
 
     if (!AcqDim.acquired()) {
@@ -1234,19 +1233,54 @@ static enum ml_worker_result ml_worker_add_existing_model(ml_worker_t *worker, m
         return ML_WORKER_RESULT_OK;
     }
 
-    // Check if training is in progress and skip if so to avoid race condition
+    ml_host_t *host = (ml_host_t *) Dim->rd->rrdset->rrdhost->ml_host;
+    if (!host || !host->ml_running) {
+        pulse_ml_models_ignored();
+        return ML_WORKER_RESULT_OK;
+    }
+
     spinlock_lock(&Dim->slock);
+
+    // Loop detection: skip if we already have this exact model.
+    // The (after, before) pair uniquely identifies a model per dimension and is
+    // preserved across hops, so a model that loops back is detected as a duplicate.
+    for (const auto &km : Dim->km_contexts) {
+        if (km.after == req.inlined_km.after && km.before == req.inlined_km.before) {
+            spinlock_unlock(&Dim->slock);
+            pulse_ml_models_ignored();
+            return ML_WORKER_RESULT_OK;
+        }
+    }
+
+    // Reject models that are not newer than the newest accepted model. This
+    // prevents an older model from being re-accepted after it has been evicted
+    // from km_contexts and later loops back from downstream.
+    if (!Dim->km_contexts.empty()) {
+        const auto &latest_km = Dim->km_contexts.back();
+        if (req.inlined_km.before <= latest_km.before) {
+            spinlock_unlock(&Dim->slock);
+            pulse_ml_models_ignored();
+            return ML_WORKER_RESULT_OK;
+        }
+    }
+
+    // Skip if training is in progress to avoid race condition.
     if (Dim->training_in_progress) {
         spinlock_unlock(&Dim->slock);
         pulse_ml_models_ignored();
         return ML_WORKER_RESULT_OK;
     }
-    spinlock_unlock(&Dim->slock);
 
-    // Safe without Dim->slock: per-host work is serialized through a single worker queue,
-    // and stop/reset no longer writes Dim->kmeans from non-worker threads.
+    // The model survived all checks and will be installed — mark this dimension
+    // as supplied by downstream. Only set the flag here so that rejected models
+    // (duplicates, stale, or concurrent-training) do not permanently suppress
+    // local retraining.
+    Dim->has_received_downstream_model = true;
     Dim->kmeans = req.inlined_km;
-    ml_dimension_update_models(worker, Dim);
+    uint32_t generation = Dim->reset_generation;
+    spinlock_unlock(&Dim->slock);
+    ml_dimension_update_models(worker, Dim, generation);
+
     pulse_ml_models_received();
     return ML_WORKER_RESULT_OK;
 }
@@ -1296,7 +1330,8 @@ void ml_train_main(void *arg) {
         switch (item.type) {
             case ML_QUEUE_ITEM_TYPE_CREATE_NEW_MODEL: {
                 worker_res = ml_worker_create_new_model(worker, item.create_new_model);
-                if (worker_res != ML_WORKER_RESULT_NULL_ACQUIRED_DIMENSION) {
+                if (worker_res != ML_WORKER_RESULT_NULL_ACQUIRED_DIMENSION &&
+                    worker_res != ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED) {
                     ml_queue_push(worker->queue, item);
                 }
                 break;
@@ -1345,6 +1380,9 @@ void ml_train_main(void *arg) {
                     break;
                 case ML_WORKER_RESULT_CHART_UNDER_REPLICATION:
                     loop_stats.item_result_chart_under_replication = 1;
+                    break;
+                case ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED:
+                    loop_stats.item_result_ok = 1;
                     break;
             }
 

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -676,13 +676,13 @@ bool ml_dimension_train_model_precheck(enum ml_metric_type mt,
                                        bool training_in_progress,
                                        enum ml_worker_result *worker_res)
 {
-    if (mt == METRIC_TYPE_CONSTANT) {
-        *worker_res = ML_WORKER_RESULT_OK;
+    if (has_received_downstream_model) {
+        *worker_res = ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED;
         return true;
     }
 
-    if (has_received_downstream_model) {
-        *worker_res = ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED;
+    if (mt == METRIC_TYPE_CONSTANT) {
+        *worker_res = ML_WORKER_RESULT_OK;
         return true;
     }
 
@@ -714,7 +714,7 @@ bool ml_should_publish_model_update(bool host_running,
     return true;
 }
 
-static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim, uint32_t expected_generation, bool from_downstream)
+static bool ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim, uint32_t expected_generation, bool from_downstream)
 {
     worker_is_busy(WORKER_TRAIN_UPDATE_MODELS);
 
@@ -726,7 +726,7 @@ static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim,
                                         expected_generation,
                                         &dim->training_in_progress)) {
         spinlock_unlock(&dim->slock);
-        return;
+        return false;
     }
 
     // Mark the dim as downstream-supplied only after the publish-check passes
@@ -776,6 +776,7 @@ static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim,
     dim->training_in_progress = false;
 
     spinlock_unlock(&dim->slock);
+    return true;
 }
 
 static enum ml_worker_result
@@ -789,6 +790,8 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
                                           dim->has_received_downstream_model,
                                           dim->training_in_progress,
                                           &precheck)) {
+        if (precheck == ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED)
+            dim->create_new_model_queued = false;
         spinlock_unlock(&dim->slock);
         return precheck;
     }
@@ -851,7 +854,7 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
     }
 
     // update models
-    ml_dimension_update_models(worker, dim, generation, /*from_downstream=*/false);
+    (void) ml_dimension_update_models(worker, dim, generation, /*from_downstream=*/false);
 
     return worker_result;
 }
@@ -1322,9 +1325,9 @@ static enum ml_worker_result ml_worker_add_existing_model(ml_worker_t *worker, m
     Dim->kmeans = req.inlined_km;
     uint32_t generation = Dim->reset_generation;
     spinlock_unlock(&Dim->slock);
-    ml_dimension_update_models(worker, Dim, generation, /*from_downstream=*/true);
+    if (ml_dimension_update_models(worker, Dim, generation, /*from_downstream=*/true))
+        pulse_ml_models_received();
 
-    pulse_ml_models_received();
     return ML_WORKER_RESULT_OK;
 }
 

--- a/src/ml/ml_dimension.h
+++ b/src/ml/ml_dimension.h
@@ -17,7 +17,9 @@ struct ml_dimension_t {
     SPINLOCK slock;
     uint32_t suppression_window_counter;
     uint32_t suppression_anomaly_counter;
+    uint32_t reset_generation;
     bool training_in_progress;
+    bool has_received_downstream_model;
     size_t cns_head;
 
     std::vector<calculated_number_t> cns;

--- a/src/ml/ml_dimension.h
+++ b/src/ml/ml_dimension.h
@@ -20,6 +20,7 @@ struct ml_dimension_t {
     uint32_t reset_generation;
     bool training_in_progress;
     bool has_received_downstream_model;
+    bool create_new_model_queued;
     size_t cns_head;
 
     std::vector<calculated_number_t> cns;

--- a/src/ml/ml_enums.cc
+++ b/src/ml/ml_enums.cc
@@ -57,6 +57,8 @@ ml_worker_result_to_string(enum ml_worker_result tr)
             return "null-acquired-dim";
         case ML_WORKER_RESULT_CHART_UNDER_REPLICATION:
             return "chart-under-replication";
+        case ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED:
+            return "downstream-model-supplied";
         default:
             return "unknown";
     }

--- a/src/ml/ml_enums.cc
+++ b/src/ml/ml_enums.cc
@@ -59,6 +59,8 @@ ml_worker_result_to_string(enum ml_worker_result tr)
             return "chart-under-replication";
         case ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED:
             return "downstream-model-supplied";
+        case ML_WORKER_RESULT_TRAINING_IN_PROGRESS:
+            return "training-in-progress";
         default:
             return "unknown";
     }

--- a/src/ml/ml_enums.h
+++ b/src/ml/ml_enums.h
@@ -51,6 +51,9 @@ enum ml_worker_result {
 
     // Chart is under replication
     ML_WORKER_RESULT_CHART_UNDER_REPLICATION,
+
+    // This dimension is now supplied by downstream ML models; stop local requeueing
+    ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED,
 };
 
 const char *ml_worker_result_to_string(enum ml_worker_result tr);

--- a/src/ml/ml_enums.h
+++ b/src/ml/ml_enums.h
@@ -54,6 +54,10 @@ enum ml_worker_result {
 
     // This dimension is now supplied by downstream ML models; stop local requeueing
     ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED,
+
+    // Another worker is already training this dimension; the item is requeued
+    // so the dim stays in the periodic retrain cycle.
+    ML_WORKER_RESULT_TRAINING_IN_PROGRESS,
 };
 
 const char *ml_worker_result_to_string(enum ml_worker_result tr);

--- a/src/ml/ml_private.h
+++ b/src/ml/ml_private.h
@@ -11,6 +11,16 @@
 void ml_train_main(void *arg);
 void ml_detect_main(void *arg);
 
+bool ml_dimension_train_model_precheck(enum ml_metric_type mt,
+                                       bool has_received_downstream_model,
+                                       bool training_in_progress,
+                                       enum ml_worker_result *worker_res);
+bool ml_should_requeue_create_new_model(enum ml_worker_result worker_res);
+bool ml_should_publish_model_update(bool host_running,
+                                    uint32_t current_generation,
+                                    uint32_t expected_generation,
+                                    bool *training_in_progress);
+
 extern sqlite3 *ml_db;
 extern const char *db_models_create_table;
 

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -8,6 +8,35 @@
 
 #define ML_METADATA_VERSION 2
 
+static void ml_host_clear_context_anomaly_rate(ml_host_t *host)
+{
+    spinlock_lock(&host->context_anomaly_rate_spinlock);
+
+    for (auto &entry : host->context_anomaly_rate)
+        string_freez(entry.first);
+
+    host->context_anomaly_rate.clear();
+
+    spinlock_unlock(&host->context_anomaly_rate_spinlock);
+}
+
+static void ml_dimension_enqueue_create_model(RRDHOST *rh, RRDDIM *rd)
+{
+    ml_host_t *host = (ml_host_t *) rh->ml_host;
+    if (!host)
+        return;
+
+    ml_queue_item_t item;
+    item.type = ML_QUEUE_ITEM_TYPE_CREATE_NEW_MODEL;
+    item.create_new_model.DLI = DimensionLookupInfo(
+        &rh->machine_guid[0],
+        rd->rrdset->id,
+        rd->id
+    );
+
+    ml_queue_push(host->queue, item);
+}
+
 bool ml_capable()
 {
     return true;
@@ -60,6 +89,7 @@ void ml_host_delete(RRDHOST *rh)
     if (!host)
         return;
 
+    ml_host_clear_context_anomaly_rate(host);
     netdata_mutex_destroy(&host->mutex);
 
     delete host;
@@ -68,10 +98,39 @@ void ml_host_delete(RRDHOST *rh)
 
 void ml_host_start(RRDHOST *rh) {
     ml_host_t *host = (ml_host_t *) rh->ml_host;
-    if (!host)
+    if (!host || host->ml_running)
         return;
 
     host->ml_running = true;
+
+    netdata_mutex_lock(&host->mutex);
+
+    void *rsp = NULL;
+    rrdset_foreach_read(rsp, host->rh) {
+        RRDSET *rs = static_cast<RRDSET *>(rsp);
+
+        void *rdp = NULL;
+        rrddim_foreach_read(rdp, rs) {
+            RRDDIM *rd = static_cast<RRDDIM *>(rdp);
+            ml_dimension_t *dim = (ml_dimension_t *) rd->ml_dimension;
+            if (!dim)
+                continue;
+
+            bool should_enqueue = false;
+
+            spinlock_lock(&dim->slock);
+            should_enqueue = (dim->ts == TRAINING_STATUS_UNTRAINED) &&
+                             (!dim->has_received_downstream_model || dim->km_contexts.empty());
+            spinlock_unlock(&dim->slock);
+
+            if (should_enqueue)
+                ml_dimension_enqueue_create_model(rh, rd);
+        }
+        rrddim_foreach_done(rdp);
+    }
+    rrdset_foreach_done(rsp);
+
+    netdata_mutex_unlock(&host->mutex);
 }
 
 void ml_host_stop(RRDHOST *rh) {
@@ -86,6 +145,7 @@ void ml_host_stop(RRDHOST *rh) {
 
     // reset host stats
     host->mls = ml_machine_learning_stats_t();
+    ml_host_clear_context_anomaly_rate(host);
 
     // reset charts/dims
     void *rsp = NULL;
@@ -117,6 +177,8 @@ void ml_host_stop(RRDHOST *rh) {
             dim->cns.clear();
             dim->cns_head = 0;
             dim->km_contexts.clear();
+            dim->has_received_downstream_model = false;
+            dim->reset_generation++;
 
             spinlock_unlock(&dim->slock);
         }
@@ -204,7 +266,7 @@ bool ml_host_running(RRDHOST *rh) {
     if(!host)
         return false;
 
-    return true;
+    return host->ml_running;
 }
 
 void ml_host_get_models(RRDHOST *rh, BUFFER *wb)
@@ -274,6 +336,8 @@ void ml_dimension_new(RRDDIM *rd)
     dim->suppression_anomaly_counter = 0;
     dim->suppression_window_counter = 0;
     dim->training_in_progress = false;
+    dim->has_received_downstream_model = false;
+    dim->reset_generation = 0;
     dim->cns_head = 0;
 
     ml_kmeans_init(&dim->kmeans);
@@ -291,24 +355,7 @@ void ml_dimension_new(RRDDIM *rd)
 
     metaqueue_ml_load_models(rd);
 
-    // add to worker queue
-    {
-        RRDHOST *rh = rd->rrdset->rrdhost;
-        ml_host_t *host = (ml_host_t *) rh->ml_host;
-
-        ml_queue_item_t item;
-        item.type = ML_QUEUE_ITEM_TYPE_CREATE_NEW_MODEL;
-
-        ml_request_create_new_model_t req;
-        req.DLI = DimensionLookupInfo(
-            &rh->machine_guid[0],
-            rd->rrdset->id,
-            rd->id
-        );
-        item.create_new_model = req;
-
-        ml_queue_push(host->queue, item);
-    }
+    ml_dimension_enqueue_create_model(rd->rrdset->rrdhost, rd);
 }
 
 void ml_dimension_delete(RRDDIM *rd)

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -155,6 +155,11 @@ void ml_host_stop(RRDHOST *rh) {
 
     netdata_mutex_lock(&host->mutex);
 
+    // Re-assert under the mutex so stop deterministically wins over a racing
+    // ml_host_start() that may have flipped the flag back to true after our
+    // early write but before we acquired the mutex.
+    host->ml_running = false;
+
     // reset host stats
     host->mls = ml_machine_learning_stats_t();
     ml_host_clear_context_anomaly_rate(host);

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -26,6 +26,21 @@ static void ml_dimension_enqueue_create_model(RRDHOST *rh, RRDDIM *rd)
     if (!host)
         return;
 
+    ml_dimension_t *dim = (ml_dimension_t *) rd->ml_dimension;
+    if (!dim)
+        return;
+
+    spinlock_lock(&dim->slock);
+    bool should_enqueue = !dim->create_new_model_queued &&
+                          dim->ts == TRAINING_STATUS_UNTRAINED &&
+                          (!dim->has_received_downstream_model || dim->km_contexts.empty());
+    if (should_enqueue)
+        dim->create_new_model_queued = true;
+    spinlock_unlock(&dim->slock);
+
+    if (!should_enqueue)
+        return;
+
     ml_queue_item_t item;
     item.type = ML_QUEUE_ITEM_TYPE_CREATE_NEW_MODEL;
     item.create_new_model.DLI = DimensionLookupInfo(
@@ -121,19 +136,7 @@ void ml_host_start(RRDHOST *rh) {
         void *rdp = NULL;
         rrddim_foreach_read(rdp, rs) {
             RRDDIM *rd = static_cast<RRDDIM *>(rdp);
-            ml_dimension_t *dim = (ml_dimension_t *) rd->ml_dimension;
-            if (!dim)
-                continue;
-
-            bool should_enqueue = false;
-
-            spinlock_lock(&dim->slock);
-            should_enqueue = (dim->ts == TRAINING_STATUS_UNTRAINED) &&
-                             (!dim->has_received_downstream_model || dim->km_contexts.empty());
-            spinlock_unlock(&dim->slock);
-
-            if (should_enqueue)
-                ml_dimension_enqueue_create_model(rh, rd);
+            ml_dimension_enqueue_create_model(rh, rd);
         }
         rrddim_foreach_done(rdp);
     }
@@ -346,6 +349,7 @@ void ml_dimension_new(RRDDIM *rd)
     dim->suppression_window_counter = 0;
     dim->training_in_progress = false;
     dim->has_received_downstream_model = false;
+    dim->create_new_model_queued = false;
     dim->reset_generation = 0;
     dim->cns_head = 0;
 

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -190,6 +190,8 @@ void ml_host_stop(RRDHOST *rh) {
             dim->cns_head = 0;
             dim->km_contexts.clear();
             dim->has_received_downstream_model = false;
+            // create_new_model_queued not reset here: stop does not drain the
+            // worker queue, so pending CREATE_NEW_MODEL items remain valid.
             dim->reset_generation++;
 
             spinlock_unlock(&dim->slock);

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -98,12 +98,21 @@ void ml_host_delete(RRDHOST *rh)
 
 void ml_host_start(RRDHOST *rh) {
     ml_host_t *host = (ml_host_t *) rh->ml_host;
-    if (!host || host->ml_running)
+    if (!host)
         return;
 
-    host->ml_running = true;
-
+    // Set ml_running and run the sweep under host->mutex so concurrent
+    // ml_host_start() calls are serialized and the visibility window of the
+    // flag flip is bounded by the same critical section that performs the
+    // sweep.
     netdata_mutex_lock(&host->mutex);
+
+    if (host->ml_running) {
+        netdata_mutex_unlock(&host->mutex);
+        return;
+    }
+
+    host->ml_running = true;
 
     void *rsp = NULL;
     rrdset_foreach_read(rsp, host->rh) {
@@ -355,7 +364,13 @@ void ml_dimension_new(RRDDIM *rd)
 
     metaqueue_ml_load_models(rd);
 
-    ml_dimension_enqueue_create_model(rd->rrdset->rrdhost, rd);
+    // Only enqueue once ml is running for this host. Otherwise, ml_host_start()
+    // will sweep all untrained dimensions and enqueue them when it runs.
+    // This avoids double-enqueueing the same dim from both paths.
+    RRDHOST *rh = rd->rrdset->rrdhost;
+    ml_host_t *host = (ml_host_t *) rh->ml_host;
+    if (host && host->ml_running)
+        ml_dimension_enqueue_create_model(rh, rd);
 }
 
 void ml_dimension_delete(RRDDIM *rd)


### PR DESCRIPTION
- Improve support for downstream-supplied ML models and enhance dimension handling logic
- Introduced `ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED` result type for managing dimensions with downstream-provided models.
- Added logic to skip retraining for dimensions flagged as supplied by downstream models.
- Refactored ML dimension and host operations, adding generation tracking (`reset_generation`) and context management (`ml_host_clear_context_anomaly_rate`).
- Enhanced safety and performance by improving model update checks, avoiding duplicate or stale models, and simplifying initialization/enqueue workflows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for downstream-supplied ML models and harden training/model updates to prevent loops, stale writes, and unnecessary requeueing. Tighten start/stop/enqueue flow to avoid double-enqueue, race windows, and ensure deterministic stop.

- **New Features**
  - Support downstream models per dimension; set the flag only when the model installs (atomic with `km_contexts`) to skip local retraining.
  - Add `ML_WORKER_RESULT_DOWNSTREAM_MODEL_SUPPLIED` and `ML_WORKER_RESULT_TRAINING_IN_PROGRESS`; stop requeueing for downstream-supplied dims and keep requeueing when training is already running.
  - On host start, enqueue only untrained dims that aren’t downstream-supplied or have no models.

- **Refactors**
  - Centralize precheck/requeue/publish via `ml_dimension_train_model_precheck()`, `ml_should_requeue_create_new_model()`, and `ml_should_publish_model_update()`; snapshot generation at train start and cancel publishes on stop or mismatch.
  - Harden model intake: ignore when host isn’t running; reject duplicate/older models by `(after,before)`; skip during active training.
  - Enqueue flow: serialize `ml_host_start()` with `host->mutex`; enqueue only when `ml_running`; add `create_new_model_queued` to prevent duplicate items.
  - Stop is deterministic: reassert `ml_running = false` under `host->mutex` so stop wins over a racing start; clear context via `ml_host_clear_context_anomaly_rate()`.
  - Context and resets: own keys; on stop reset per-dim state (`reset_generation++`, `has_received_downstream_model = false`).
  - Fix `ml_host_running()` to return `ml_running`; add unit tests for short-circuit, requeue, and publish.

<sup>Written for commit 6cecc4b18b9d4a44874a99ac897b5ef004fc626b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

