### PR TITLE
go.d/snmp: extend profile engine contract

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metadata_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metadata_test.go
@@ -53,6 +53,12 @@ func makeMetadata() MetadataConfig {
 						ExtractValue:         ".*",
 						ExtractValueCompiled: regexp.MustCompile(".*"),
 					},
+					LookupSymbol: SymbolConfigCompat{
+						OID:                  "9.8.7",
+						Name:                 "lookupSymbol",
+						ExtractValue:         ".*",
+						ExtractValueCompiled: regexp.MustCompile(".*"),
+					},
 					IndexTransform: []MetricIndexTransform{
 						{
 							Start: 1,

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metrics.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metrics.go
@@ -176,6 +176,11 @@ type MetricTagConfig struct {
 	// pattern is deprecated
 	Symbol SymbolConfigCompat `yaml:"symbol,omitempty" json:"symbol"`
 
+	// LookupSymbol optionally resolves cross-table tags by matching a value from the
+	// current row index against a column in the referenced table, then reading Symbol
+	// from the matched row in that table.
+	LookupSymbol SymbolConfigCompat `yaml:"lookup_symbol,omitempty" json:"lookup_symbol,omitempty"`
+
 	IndexTransform []MetricIndexTransform `yaml:"index_transform,omitempty" json:"index_transform,omitempty"`
 
 	MappingRef string            `yaml:"mapping_ref,omitempty" json:"mapping_ref,omitempty"`
@@ -196,6 +201,7 @@ func (m MetricTagConfig) Clone() MetricTagConfig {
 	// deep copy symbols and structures
 	m2.Column = m.Column.Clone()
 	m2.Symbol = m.Symbol.Clone()
+	m2.LookupSymbol = m.LookupSymbol.Clone()
 	m2.IndexTransform = slices.Clone(m.IndexTransform)
 	m2.Mapping = maps.Clone(m.Mapping)
 	m2.Tags = maps.Clone(m.Tags)
@@ -219,8 +225,9 @@ type MetricTagConfigList []MetricTagConfig
 
 // MetricIndexTransform holds configs for metric index transform
 type MetricIndexTransform struct {
-	Start uint `yaml:"start" json:"start"`
-	End   uint `yaml:"end" json:"end"`
+	Start     uint `yaml:"start" json:"start"`
+	End       uint `yaml:"end" json:"end"`
+	DropRight uint `yaml:"drop_right,omitempty" json:"drop_right,omitempty"`
 }
 
 // MetricsConfigOption holds config for metrics options

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metrics_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/metrics_test.go
@@ -63,6 +63,11 @@ func TestCloneMetricTagConfig(t *testing.T) {
 		},
 		OID:    "2.4",
 		Symbol: SymbolConfigCompat{},
+		LookupSymbol: SymbolConfigCompat{
+			OID:                  "2.4.6.8",
+			ExtractValue:         ".*",
+			ExtractValueCompiled: regexp.MustCompile(".*"),
+		},
 		IndexTransform: []MetricIndexTransform{
 			{
 				Start: 0,
@@ -83,7 +88,7 @@ func TestCloneMetricTagConfig(t *testing.T) {
 	c2 := c.Clone()
 	assert.Equal(t, c, c2)
 	c2.Tags["bar"] = "$2"
-	c2.IndexTransform = append(c2.IndexTransform, MetricIndexTransform{1, 3})
+	c2.IndexTransform = append(c2.IndexTransform, MetricIndexTransform{Start: 1, End: 3})
 	c2.Mapping["3"] = "foo"
 	c2.Tag = "bar"
 	assert.NotEqual(t, c, c2)
@@ -98,6 +103,11 @@ func TestCloneMetricTagConfig(t *testing.T) {
 		},
 		OID:    "2.4",
 		Symbol: SymbolConfigCompat{},
+		LookupSymbol: SymbolConfigCompat{
+			OID:                  "2.4.6.8",
+			ExtractValue:         ".*",
+			ExtractValueCompiled: regexp.MustCompile(".*"),
+		},
 		IndexTransform: []MetricIndexTransform{
 			{
 				Start: 0,
@@ -161,7 +171,7 @@ func TestCloneMetricsConfig(t *testing.T) {
 	conf2 := conf.Clone()
 	assert.Equal(t, conf, conf2)
 	conf2.StaticTags[0] = StaticMetricTagConfig{Tag: "bar", Value: "baz"}
-	conf2.MetricTags[0].IndexTransform = []MetricIndexTransform{{5, 7}}
+	conf2.MetricTags[0].IndexTransform = []MetricIndexTransform{{Start: 5, End: 7}}
 	conf2.Options.Placement = 2
 	conf2.Options.MetricSuffix = ".bar"
 	assert.Equal(t, unchanged, conf)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation.go
@@ -367,6 +367,9 @@ func validateEnrichMetricTag(metricTag *MetricTagConfig) error {
 		errs = append(errs, fmt.Errorf("`tag` or `symbol.name` must be provided if `mapping` (`%s`) is defined", metricTag.Mapping))
 	}
 	for _, transform := range metricTag.IndexTransform {
+		if transform.DropRight != 0 && transform.End != 0 {
+			errs = append(errs, fmt.Errorf("transform rule cannot define both end and drop_right. Invalid rule: %#v", transform))
+		}
 		if transform.DropRight == 0 && transform.Start > transform.End {
 			errs = append(errs, fmt.Errorf("transform rule end should be greater than start. Invalid rule: %#v", transform))
 		}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strings"
 )
 
 var validMetadataResources = map[string]map[string]bool{
@@ -59,6 +60,7 @@ func ValidateEnrichProfile(p *ProfileDefinition) error {
 		validateEnrichSysobjectIDMetadata(p.SysobjectIDMetadata),
 		validateEnrichMetrics(p.Metrics),
 		validateEnrichMetricTags(p.MetricTags),
+		validateEnrichVirtualMetrics(p.Metrics, p.VirtualMetrics),
 	}
 
 	return errors.Join(errs...)
@@ -315,10 +317,40 @@ func validateEnrichMetricTag(metricTag *MetricTagConfig) error {
 		metricTag.Symbol.OID = metricTag.OID
 		metricTag.OID = ""
 	}
-	if metricTag.Symbol.OID != "" || metricTag.Symbol.Name != "" {
+	if isRawIndexMetricTag(*metricTag) {
+		symbol := SymbolConfig(metricTag.Symbol)
+		if symbol.Name == "" && metricTag.Tag == "" {
+			errs = append(errs, errors.New("raw index metric tag requires `tag` or `symbol.name`"))
+		}
+		if symbol.ExtractValue != "" {
+			pattern, err := regexp.Compile(symbol.ExtractValue)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("cannot compile `extract_value` (%s): %s", symbol.ExtractValue, err.Error()))
+			} else {
+				symbol.ExtractValueCompiled = pattern
+			}
+		}
+		if symbol.MatchPattern != "" {
+			pattern, err := regexp.Compile(symbol.MatchPattern)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("cannot compile `match_pattern` (%s): %s", symbol.MatchPattern, err.Error()))
+			} else {
+				symbol.MatchPatternCompiled = pattern
+			}
+		}
+		metricTag.Symbol = SymbolConfigCompat(symbol)
+	} else if metricTag.Symbol.OID != "" || metricTag.Symbol.Name != "" {
 		symbol := SymbolConfig(metricTag.Symbol)
 		errs = append(errs, validateEnrichSymbol(&symbol, MetricTagSymbol))
 		metricTag.Symbol = SymbolConfigCompat(symbol)
+	}
+	if metricTag.LookupSymbol.OID != "" || metricTag.LookupSymbol.Name != "" {
+		symbol := SymbolConfig(metricTag.LookupSymbol)
+		errs = append(errs, validateEnrichSymbol(&symbol, MetricTagSymbol))
+		metricTag.LookupSymbol = SymbolConfigCompat(symbol)
+		if metricTag.Table == "" {
+			errs = append(errs, errors.New("`lookup_symbol` requires `table`"))
+		}
 	}
 	if metricTag.Match != "" {
 		pattern, err := regexp.Compile(metricTag.Match)
@@ -331,14 +363,163 @@ func validateEnrichMetricTag(metricTag *MetricTagConfig) error {
 			errs = append(errs, fmt.Errorf("`tags` mapping must be provided if `match` (`%s`) is defined", metricTag.Match))
 		}
 	}
-	if len(metricTag.Mapping) > 0 && metricTag.Tag == "" {
-		errs = append(errs, fmt.Errorf("``tag` must be provided if `mapping` (`%s`) is defined", metricTag.Mapping))
+	if len(metricTag.Mapping) > 0 && metricTag.Tag == "" && metricTag.Symbol.Name == "" {
+		errs = append(errs, fmt.Errorf("`tag` or `symbol.name` must be provided if `mapping` (`%s`) is defined", metricTag.Mapping))
 	}
 	for _, transform := range metricTag.IndexTransform {
-		if transform.Start > transform.End {
+		if transform.DropRight == 0 && transform.Start > transform.End {
 			errs = append(errs, fmt.Errorf("transform rule end should be greater than start. Invalid rule: %#v", transform))
 		}
 	}
 
 	return errors.Join(errs...)
+}
+
+func isRawIndexMetricTag(metricTag MetricTagConfig) bool {
+	if metricTag.Table != "" || metricTag.Symbol.OID != "" {
+		return false
+	}
+
+	if metricTag.Index != 0 {
+		return metricTag.Symbol.Format != "" ||
+			metricTag.Symbol.ExtractValue != "" ||
+			metricTag.Symbol.MatchPattern != "" ||
+			len(metricTag.Mapping) > 0
+	}
+
+	return len(metricTag.IndexTransform) > 0 ||
+		metricTag.Symbol.Format != "" ||
+		metricTag.Symbol.ExtractValue != "" ||
+		metricTag.Symbol.MatchPattern != "" ||
+		len(metricTag.Mapping) > 0
+}
+
+func validateEnrichVirtualMetrics(metrics []MetricsConfig, vmetrics []VirtualMetricConfig) error {
+	var errs []error
+
+	metricSources := collectVirtualMetricSourceSpecs(metrics)
+
+	seenNames := make(map[string]int)
+
+	for i := range vmetrics {
+		vm := &vmetrics[i]
+
+		if vm.Name == "" {
+			errs = append(errs, fmt.Errorf("virtual_metrics[%d]: missing name", i))
+		} else {
+			if firstIdx, ok := seenNames[vm.Name]; ok {
+				errs = append(errs, fmt.Errorf("virtual_metrics[%d]: duplicate name %q (first occurrence at index %d)", i, vm.Name, firstIdx))
+			} else {
+				seenNames[vm.Name] = i
+			}
+			if _, ok := metricSources[vm.Name]; ok {
+				errs = append(errs, fmt.Errorf("virtual_metrics[%d]: name %q conflicts with an existing metric", i, vm.Name))
+			}
+		}
+
+		for j, label := range vm.GroupBy {
+			if label == "" {
+				errs = append(errs, fmt.Errorf("virtual_metrics[%d].group_by[%d]: label cannot be empty", i, j))
+			}
+		}
+
+		for j, emitTag := range vm.EmitTags {
+			if emitTag.Tag == "" {
+				errs = append(errs, fmt.Errorf("virtual_metrics[%d].emit_tags[%d]: missing tag", i, j))
+			}
+			if emitTag.From == "" {
+				errs = append(errs, fmt.Errorf("virtual_metrics[%d].emit_tags[%d]: missing from", i, j))
+			}
+		}
+
+		grouped := vm.PerRow || len(vm.GroupBy) > 0
+
+		switch {
+		case len(vm.Sources) == 0 && len(vm.Alternatives) == 0:
+			errs = append(errs, fmt.Errorf("virtual_metrics[%d]: must define sources or alternatives", i))
+		case len(vm.Alternatives) == 0:
+			errs = append(errs, validateVirtualMetricSources(fmt.Sprintf("virtual_metrics[%d].sources", i), vm.Sources, metricSources, grouped))
+		default:
+			for j, alt := range vm.Alternatives {
+				if len(alt.Sources) == 0 {
+					errs = append(errs, fmt.Errorf("virtual_metrics[%d].alternatives[%d]: must define sources", i, j))
+					continue
+				}
+				errs = append(errs, validateVirtualMetricSources(fmt.Sprintf("virtual_metrics[%d].alternatives[%d].sources", i, j), alt.Sources, metricSources, grouped))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateVirtualMetricSources(path string, sources []VirtualMetricSourceConfig, metricSources map[string]map[string]virtualMetricSourceSpec, grouped bool) error {
+	var errs []error
+
+	var groupTable string
+	for i, src := range sources {
+		if src.Metric == "" {
+			errs = append(errs, fmt.Errorf("%s[%d]: missing metric", path, i))
+		}
+		if grouped && src.Table == "" {
+			errs = append(errs, fmt.Errorf("%s[%d]: missing table", path, i))
+		}
+
+		if src.Metric != "" {
+			tables, ok := metricSources[src.Metric]
+			switch {
+			case !ok:
+				errs = append(errs, fmt.Errorf("%s[%d]: unknown metric source %q", path, i, src.Metric))
+			case src.Table == "":
+				if _, ok := tables[""]; !ok {
+					errs = append(errs, fmt.Errorf("%s[%d]: missing table for non-scalar source %q", path, i, src.Metric))
+				}
+			default:
+				if _, ok := tables[src.Table]; !ok {
+					errs = append(errs, fmt.Errorf("%s[%d]: unknown metric/table source %q/%q", path, i, src.Metric, src.Table))
+				}
+			}
+		}
+
+		if src.Dim != "" && src.Metric != "" {
+			tables, ok := metricSources[src.Metric]
+			if !ok {
+				continue
+			}
+
+			spec, ok := tables[src.Table]
+			if !ok && src.Table == "" {
+				spec, ok = tables[""]
+			}
+			if !ok {
+				continue
+			}
+
+			switch spec.dimSupport.mode {
+			case virtualMetricDimUnsupported:
+				errs = append(errs, fmt.Errorf("%s[%d]: dim %q requires a MultiValue source metric (%s)", path, i, src.Dim, formatVirtualMetricSourceRef(src)))
+			case virtualMetricDimKnown:
+				if !spec.dimSupport.dims[src.Dim] {
+					errs = append(errs, fmt.Errorf("%s[%d]: dim %q is not available on %s (available: %s)", path, i, src.Dim, formatVirtualMetricSourceRef(src), strings.Join(virtualMetricSourceAvailableDims(spec), ", ")))
+				}
+			}
+		}
+
+		if grouped && src.Table != "" {
+			if groupTable == "" {
+				groupTable = src.Table
+			} else if src.Table != groupTable {
+				errs = append(errs, fmt.Errorf("%s[%d]: grouped virtual metrics require all sources to use the same table (saw %q and %q)", path, i, groupTable, src.Table))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func formatVirtualMetricSourceRef(src VirtualMetricSourceConfig) string {
+	if src.Table == "" {
+		return fmt.Sprintf("metric %q", src.Metric)
+	}
+	return fmt.Sprintf("metric/table %q/%q", src.Metric, src.Table)
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation.go
@@ -364,7 +364,7 @@ func validateEnrichMetricTag(metricTag *MetricTagConfig) error {
 		}
 	}
 	if len(metricTag.Mapping) > 0 && metricTag.Tag == "" && metricTag.Symbol.Name == "" {
-		errs = append(errs, fmt.Errorf("`tag` or `symbol.name` must be provided if `mapping` (`%s`) is defined", metricTag.Mapping))
+		errs = append(errs, fmt.Errorf("`tag` or `symbol.name` must be provided if `mapping` (`%v`) is defined", metricTag.Mapping))
 	}
 	for _, transform := range metricTag.IndexTransform {
 		if transform.DropRight != 0 && transform.End != 0 {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation_test.go
@@ -434,8 +434,8 @@ func Test_validateEnrichMetrics(t *testing.T) {
 				},
 			},
 		},
-		"mapping used without tag": {
-			wantError: true,
+		"mapping used with symbol.name and no explicit tag": {
+			wantError: false,
 			metrics: []MetricsConfig{
 				{
 					Symbols: []SymbolConfig{
@@ -469,6 +469,295 @@ func Test_validateEnrichMetrics(t *testing.T) {
 			}
 			if tc.wantMetrics != nil {
 				assert.Equal(t, tc.wantMetrics, tc.metrics)
+			}
+		})
+	}
+}
+
+func Test_validateEnrichVirtualMetrics(t *testing.T) {
+	baseMetrics := []MetricsConfig{
+		{
+			Table: SymbolConfig{
+				OID:  "1.3.6.1.2.1.31.1.1",
+				Name: "ifXTable",
+			},
+			Symbols: []SymbolConfig{
+				{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
+				{OID: "1.3.6.1.2.1.31.1.1.1.10", Name: "ifHCOutOctets"},
+			},
+			MetricTags: MetricTagConfigList{
+				{Tag: "interface", Index: 1},
+			},
+		},
+		{
+			Table: SymbolConfig{
+				OID:  "1.3.6.1.2.1.2.2",
+				Name: "ifTable",
+			},
+			Symbols: []SymbolConfig{
+				{OID: "1.3.6.1.2.1.2.2.1.14", Name: "ifInErrors"},
+			},
+			MetricTags: MetricTagConfigList{
+				{Tag: "interface", Index: 1},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		metrics         []MetricsConfig
+		virtualMetrics  []VirtualMetricConfig
+		wantErrContains []string
+	}{
+		"valid grouped virtual metric": {
+			metrics: baseMetrics,
+			virtualMetrics: []VirtualMetricConfig{
+				{
+					Name:    "ifTraffic",
+					PerRow:  true,
+					GroupBy: []string{"interface"},
+					Sources: []VirtualMetricSourceConfig{
+						{Metric: "ifHCInOctets", Table: "ifXTable", As: "in"},
+						{Metric: "ifHCOutOctets", Table: "ifXTable", As: "out"},
+					},
+					EmitTags: []VirtualMetricEmitTagConfig{
+						{Tag: "interface", From: "interface"},
+					},
+				},
+			},
+		},
+		"valid scalar total without table": {
+			metrics: append(baseMetrics, MetricsConfig{
+				Symbol: SymbolConfig{
+					OID:  "1.3.6.1.4.1.2021.11.50.0",
+					Name: "_ucd.ssCpuRawUser",
+				},
+			}),
+			virtualMetrics: []VirtualMetricConfig{
+				{
+					Name: "ucd.cpuUsage",
+					Sources: []VirtualMetricSourceConfig{
+						{Metric: "_ucd.ssCpuRawUser", As: "user"},
+					},
+				},
+			},
+		},
+		"valid mapped source dim": {
+			metrics: append(baseMetrics, MetricsConfig{
+				Table: SymbolConfig{
+					OID:  "1.3.6.1.2.1.15.3",
+					Name: "bgpPeerTable",
+				},
+				Symbols: []SymbolConfig{
+					{
+						OID:  "1.3.6.1.2.1.15.3.1.2",
+						Name: "bgpPeerAdminStatus",
+						Mapping: map[string]string{
+							"1": "stop",
+							"2": "start",
+						},
+					},
+				},
+				MetricTags: MetricTagConfigList{
+					{Tag: "neighbor", Index: 1},
+				},
+			}),
+			virtualMetrics: []VirtualMetricConfig{
+				{
+					Name:   "bgpPeerAvailability",
+					PerRow: true,
+					Sources: []VirtualMetricSourceConfig{
+						{Metric: "bgpPeerAdminStatus", Table: "bgpPeerTable", As: "admin_enabled", Dim: "start"},
+					},
+				},
+			},
+		},
+		"invalid mapped source dim": {
+			metrics: append(baseMetrics, MetricsConfig{
+				Table: SymbolConfig{
+					OID:  "1.3.6.1.2.1.15.3",
+					Name: "bgpPeerTable",
+				},
+				Symbols: []SymbolConfig{
+					{
+						OID:  "1.3.6.1.2.1.15.3.1.2",
+						Name: "bgpPeerAdminStatus",
+						Mapping: map[string]string{
+							"1": "stop",
+							"2": "start",
+						},
+					},
+				},
+				MetricTags: MetricTagConfigList{
+					{Tag: "neighbor", Index: 1},
+				},
+			}),
+			virtualMetrics: []VirtualMetricConfig{
+				{
+					Name:   "bgpPeerAvailability",
+					PerRow: true,
+					Sources: []VirtualMetricSourceConfig{
+						{Metric: "bgpPeerAdminStatus", Table: "bgpPeerTable", As: "admin_enabled", Dim: "running"},
+					},
+				},
+			},
+			wantErrContains: []string{
+				`virtual_metrics[0].sources[0]: dim "running" is not available on metric/table "bgpPeerAdminStatus"/"bgpPeerTable" (available: start, stop)`,
+			},
+		},
+		"dim requires multivalue source": {
+			metrics: baseMetrics,
+			virtualMetrics: []VirtualMetricConfig{
+				{
+					Name:   "ifTraffic",
+					PerRow: true,
+					Sources: []VirtualMetricSourceConfig{
+						{Metric: "ifHCInOctets", Table: "ifXTable", As: "in", Dim: "up"},
+					},
+				},
+			},
+			wantErrContains: []string{
+				`virtual_metrics[0].sources[0]: dim "up" requires a MultiValue source metric (metric/table "ifHCInOctets"/"ifXTable")`,
+			},
+		},
+		"valid transform multivalue source dim": {
+			metrics: append(baseMetrics, MetricsConfig{
+				Table: SymbolConfig{
+					OID:  "1.3.6.1.4.1.14988.1.1.3.100",
+					Name: "mtxrHlTable",
+				},
+				Symbols: []SymbolConfig{
+					{
+						OID:  "1.3.6.1.4.1.14988.1.1.3.100.1.3",
+						Name: "mtxrHlSensorState",
+						Transform: `
+{{- setMultivalue .Metric (i64map 0 "down" 1 "up") -}}
+`,
+					},
+				},
+				MetricTags: MetricTagConfigList{
+					{Tag: "sensor", Index: 1},
+				},
+			}),
+			virtualMetrics: []VirtualMetricConfig{
+				{
+					Name:   "sensorAvailability",
+					PerRow: true,
+					Sources: []VirtualMetricSourceConfig{
+						{Metric: "mtxrHlSensorState", Table: "mtxrHlTable", As: "up", Dim: "up"},
+					},
+				},
+			},
+		},
+		"invalid transform multivalue source dim": {
+			metrics: append(baseMetrics, MetricsConfig{
+				Table: SymbolConfig{
+					OID:  "1.3.6.1.4.1.14988.1.1.3.100",
+					Name: "mtxrHlTable",
+				},
+				Symbols: []SymbolConfig{
+					{
+						OID:  "1.3.6.1.4.1.14988.1.1.3.100.1.3",
+						Name: "mtxrHlSensorState",
+						Transform: `
+{{- setMultivalue .Metric (i64map 0 "down" 1 "up") -}}
+`,
+					},
+				},
+				MetricTags: MetricTagConfigList{
+					{Tag: "sensor", Index: 1},
+				},
+			}),
+			virtualMetrics: []VirtualMetricConfig{
+				{
+					Name:   "sensorAvailability",
+					PerRow: true,
+					Sources: []VirtualMetricSourceConfig{
+						{Metric: "mtxrHlSensorState", Table: "mtxrHlTable", As: "up", Dim: "idle"},
+					},
+				},
+			},
+			wantErrContains: []string{
+				`virtual_metrics[0].sources[0]: dim "idle" is not available on metric/table "mtxrHlSensorState"/"mtxrHlTable" (available: down, up)`,
+			},
+		},
+		"missing name and sources": {
+			metrics: baseMetrics,
+			virtualMetrics: []VirtualMetricConfig{
+				{},
+			},
+			wantErrContains: []string{
+				"virtual_metrics[0]: missing name",
+				"virtual_metrics[0]: must define sources or alternatives",
+			},
+		},
+		"duplicate name conflicting with metric": {
+			metrics: baseMetrics,
+			virtualMetrics: []VirtualMetricConfig{
+				{Name: "ifTraffic", Sources: []VirtualMetricSourceConfig{{Metric: "ifHCInOctets", Table: "ifXTable"}}},
+				{Name: "ifTraffic", Sources: []VirtualMetricSourceConfig{{Metric: "ifHCOutOctets", Table: "ifXTable"}}},
+				{Name: "ifInErrors", Sources: []VirtualMetricSourceConfig{{Metric: "ifHCOutOctets", Table: "ifXTable"}}},
+			},
+			wantErrContains: []string{
+				`virtual_metrics[1]: duplicate name "ifTraffic"`,
+				`virtual_metrics[2]: name "ifInErrors" conflicts with an existing metric`,
+			},
+		},
+		"invalid grouped sources and emit tags": {
+			metrics: baseMetrics,
+			virtualMetrics: []VirtualMetricConfig{
+				{
+					Name:    "brokenGrouped",
+					PerRow:  true,
+					GroupBy: []string{"", "interface"},
+					Sources: []VirtualMetricSourceConfig{
+						{Metric: "ifHCInOctets", Table: "ifXTable", As: "in"},
+						{Metric: "ifInErrors", Table: "ifTable", As: "out"},
+						{Metric: "", Table: "", As: "missing"},
+					},
+					EmitTags: []VirtualMetricEmitTagConfig{
+						{Tag: "", From: "interface"},
+						{Tag: "interface", From: ""},
+					},
+				},
+			},
+			wantErrContains: []string{
+				"virtual_metrics[0].group_by[0]: label cannot be empty",
+				"virtual_metrics[0].emit_tags[0]: missing tag",
+				"virtual_metrics[0].emit_tags[1]: missing from",
+				`virtual_metrics[0].sources[1]: grouped virtual metrics require all sources to use the same table`,
+				"virtual_metrics[0].sources[2]: missing metric",
+				"virtual_metrics[0].sources[2]: missing table",
+			},
+		},
+		"invalid alternatives": {
+			metrics: baseMetrics,
+			virtualMetrics: []VirtualMetricConfig{
+				{
+					Name: "ifTraffic",
+					Alternatives: []VirtualMetricAlternativeSourcesConfig{
+						{},
+						{Sources: []VirtualMetricSourceConfig{{Metric: "missingMetric", Table: "ifXTable"}}},
+					},
+				},
+			},
+			wantErrContains: []string{
+				"virtual_metrics[0].alternatives[0]: must define sources",
+				`virtual_metrics[0].alternatives[1].sources[0]: unknown metric source "missingMetric"`,
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateEnrichVirtualMetrics(tt.metrics, tt.virtualMetrics)
+			if len(tt.wantErrContains) == 0 {
+				assert.NoError(t, err)
+				return
+			}
+
+			assert.Error(t, err)
+			for _, msg := range tt.wantErrContains {
+				assert.ErrorContains(t, err, msg)
 			}
 		})
 	}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation_test.go
@@ -825,6 +825,35 @@ func Test_validateEnrichMetricTags(t *testing.T) {
 				},
 			},
 		},
+		"raw index transform with drop_right": {
+			wantError: false,
+			metrics: []MetricTagConfig{
+				{
+					Tag: "remote_addr",
+					IndexTransform: []MetricIndexTransform{
+						{
+							Start:     2,
+							DropRight: 2,
+						},
+					},
+				},
+			},
+		},
+		"raw index transform cannot combine end and drop_right": {
+			wantError: true,
+			metrics: []MetricTagConfig{
+				{
+					Tag: "remote_addr",
+					IndexTransform: []MetricIndexTransform{
+						{
+							Start:     2,
+							End:       6,
+							DropRight: 2,
+						},
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation_test.go
@@ -474,6 +474,21 @@ func Test_validateEnrichMetrics(t *testing.T) {
 	}
 }
 
+func Test_validateEnrichMetricTag_MappingErrorUsesReadableFormat(t *testing.T) {
+	tag := MetricTagConfig{
+		Mapping: map[string]string{
+			"1": "up",
+		},
+	}
+
+	err := validateEnrichMetricTag(&tag)
+
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "map[1:up]")
+		assert.NotContains(t, err.Error(), "%!s")
+	}
+}
+
 func Test_validateEnrichVirtualMetrics(t *testing.T) {
 	baseMetrics := []MetricsConfig{
 		{

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/virtual_metric_dim_validation.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/virtual_metric_dim_validation.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddprofiledefinition
+
+import (
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+type virtualMetricDimSupportMode uint8
+
+const (
+	virtualMetricDimUnsupported virtualMetricDimSupportMode = iota
+	virtualMetricDimKnown
+	virtualMetricDimDynamic
+)
+
+type virtualMetricDimSupport struct {
+	mode virtualMetricDimSupportMode
+	dims map[string]bool
+}
+
+type virtualMetricSourceSpec struct {
+	dimSupport virtualMetricDimSupport
+}
+
+var (
+	virtualMetricI64MapPattern       = regexp.MustCompile(`i64map\b([^)]*)\)`)
+	virtualMetricQuotedStringPattern = regexp.MustCompile(`"(?:[^"\\]|\\.)*"`)
+)
+
+func collectVirtualMetricSourceSpecs(metrics []MetricsConfig) map[string]map[string]virtualMetricSourceSpec {
+	specs := make(map[string]map[string]virtualMetricSourceSpec)
+
+	for _, metric := range metrics {
+		switch {
+		case metric.IsScalar():
+			addVirtualMetricSourceSpec(specs, metric.Symbol.Name, "", buildVirtualMetricSourceSpec(metric.Symbol))
+		case metric.IsColumn():
+			for _, sym := range metric.Symbols {
+				addVirtualMetricSourceSpec(specs, sym.Name, metric.Table.Name, buildVirtualMetricSourceSpec(sym))
+			}
+		}
+	}
+
+	return specs
+}
+
+func addVirtualMetricSourceSpec(specs map[string]map[string]virtualMetricSourceSpec, metricName, tableName string, spec virtualMetricSourceSpec) {
+	tables, ok := specs[metricName]
+	if !ok {
+		tables = make(map[string]virtualMetricSourceSpec)
+		specs[metricName] = tables
+	}
+	tables[tableName] = spec
+}
+
+func buildVirtualMetricSourceSpec(sym SymbolConfig) virtualMetricSourceSpec {
+	return virtualMetricSourceSpec{
+		dimSupport: mergeVirtualMetricDimSupport(
+			buildMappingVirtualMetricDimSupport(sym.Mapping),
+			buildTransformVirtualMetricDimSupport(sym.Transform),
+		),
+	}
+}
+
+func buildMappingVirtualMetricDimSupport(mapping map[string]string) virtualMetricDimSupport {
+	if len(mapping) == 0 {
+		return virtualMetricDimSupport{mode: virtualMetricDimUnsupported}
+	}
+
+	keysNumeric := true
+	valuesNumeric := true
+	for key, value := range mapping {
+		if !isIntegerString(key) {
+			keysNumeric = false
+		}
+		if !isIntegerString(value) {
+			valuesNumeric = false
+		}
+	}
+
+	switch {
+	case keysNumeric && valuesNumeric:
+		return virtualMetricDimSupport{mode: virtualMetricDimUnsupported}
+	case keysNumeric:
+		dims := make(map[string]bool)
+		for _, value := range mapping {
+			dims[value] = true
+		}
+		return virtualMetricDimSupport{mode: virtualMetricDimKnown, dims: dims}
+	default:
+		dims := make(map[string]bool)
+		for key, value := range mapping {
+			if isIntegerString(value) {
+				dims[key] = true
+			}
+		}
+		if len(dims) == 0 {
+			return virtualMetricDimSupport{mode: virtualMetricDimUnsupported}
+		}
+		return virtualMetricDimSupport{mode: virtualMetricDimKnown, dims: dims}
+	}
+}
+
+func buildTransformVirtualMetricDimSupport(transform string) virtualMetricDimSupport {
+	if transform == "" {
+		return virtualMetricDimSupport{mode: virtualMetricDimUnsupported}
+	}
+
+	if strings.Contains(transform, "transformEntitySensorValue") {
+		return virtualMetricDimSupport{mode: virtualMetricDimDynamic}
+	}
+
+	if !strings.Contains(transform, "setMultivalue") {
+		return virtualMetricDimSupport{mode: virtualMetricDimUnsupported}
+	}
+
+	dims := extractTransformMultiValueDims(transform)
+	if len(dims) == 0 {
+		return virtualMetricDimSupport{mode: virtualMetricDimDynamic}
+	}
+
+	return virtualMetricDimSupport{mode: virtualMetricDimKnown, dims: dims}
+}
+
+func mergeVirtualMetricDimSupport(mappingSupport, transformSupport virtualMetricDimSupport) virtualMetricDimSupport {
+	if transformSupport.mode == virtualMetricDimDynamic {
+		return transformSupport
+	}
+
+	if transformSupport.mode == virtualMetricDimKnown {
+		if mappingSupport.mode == virtualMetricDimKnown {
+			dims := make(map[string]bool, len(mappingSupport.dims)+len(transformSupport.dims))
+			for dim := range mappingSupport.dims {
+				dims[dim] = true
+			}
+			for dim := range transformSupport.dims {
+				dims[dim] = true
+			}
+			return virtualMetricDimSupport{mode: virtualMetricDimKnown, dims: dims}
+		}
+		return transformSupport
+	}
+
+	return mappingSupport
+}
+
+func extractTransformMultiValueDims(transform string) map[string]bool {
+	dims := make(map[string]bool)
+
+	for _, match := range virtualMetricI64MapPattern.FindAllStringSubmatch(transform, -1) {
+		if len(match) < 2 {
+			continue
+		}
+
+		for _, token := range virtualMetricQuotedStringPattern.FindAllString(match[1], -1) {
+			dim, err := strconv.Unquote(token)
+			if err != nil || dim == "" {
+				continue
+			}
+			dims[dim] = true
+		}
+	}
+
+	return dims
+}
+
+func virtualMetricSourceAvailableDims(spec virtualMetricSourceSpec) []string {
+	dims := make([]string, 0, len(spec.dimSupport.dims))
+	for dim := range spec.dimSupport.dims {
+		dims = append(dims, dim)
+	}
+	slices.Sort(dims)
+	return dims
+}
+
+func isIntegerString(value string) bool {
+	_, err := strconv.ParseInt(value, 10, 64)
+	return err == nil
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/virtual_metrics.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/virtual_metrics.go
@@ -8,6 +8,7 @@ type VirtualMetricConfig struct {
 	Name         string                                  `yaml:"name"`
 	PerRow       bool                                    `yaml:"per_row"`
 	GroupBy      []string                                `yaml:"group_by"`
+	EmitTags     []VirtualMetricEmitTagConfig            `yaml:"emit_tags"`
 	Sources      []VirtualMetricSourceConfig             `yaml:"sources"`
 	Alternatives []VirtualMetricAlternativeSourcesConfig `yaml:"alternatives"`
 	ChartMeta    ChartMeta                               `yaml:"chart_meta"`
@@ -25,6 +26,7 @@ func (vm VirtualMetricConfig) Clone() VirtualMetricConfig {
 		Name:         vm.Name,
 		PerRow:       vm.PerRow,
 		GroupBy:      slices.Clone(vm.GroupBy),
+		EmitTags:     slices.Clone(vm.EmitTags),
 		Sources:      slices.Clone(vm.Sources),
 		Alternatives: alts,
 		ChartMeta:    vm.ChartMeta,
@@ -32,10 +34,15 @@ func (vm VirtualMetricConfig) Clone() VirtualMetricConfig {
 }
 
 type (
+	VirtualMetricEmitTagConfig struct {
+		Tag  string `yaml:"tag"`
+		From string `yaml:"from"`
+	}
 	VirtualMetricSourceConfig struct {
 		Metric string `yaml:"metric"`
-		Table  string `yaml:"table"` // Required for now
-		As     string `yaml:"as"`    // dimension name for composite charts
+		Table  string `yaml:"table"`
+		As     string `yaml:"as"`  // dimension name for composite charts
+		Dim    string `yaml:"dim"` // optional MultiValue dimension selector for source metrics
 	}
 	VirtualMetricAlternativeSourcesConfig struct {
 		Sources []VirtualMetricSourceConfig `yaml:"sources"`

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
@@ -224,7 +224,8 @@ var metricMetaReplacer = strings.NewReplacer(
 // are still walked during collection. Without this, if a table like ifXTable is used
 // only for cross-table tags (e.g., getting interface names) but has no metrics defined,
 // it won't be walked and the tags will be missing. This creates synthetic metric entries
-// for such tables using the longest common OID prefix of the referenced columns.
+// for such tables using the longest common OID prefix of the referenced columns, including
+// lookup columns used by value-based joins.
 func handleCrossTableTagsWithoutMetrics(prof *ddsnmp.Profile) {
 	if prof.Definition == nil {
 		return
@@ -243,11 +244,15 @@ func handleCrossTableTagsWithoutMetrics(prof *ddsnmp.Profile) {
 			continue
 		}
 		for _, tag := range m.MetricTags {
-			oid := tag.Symbol.OID
-			if tag.Table == "" || seenTableNames[tag.Table] || oid == "" {
+			if tag.Table == "" || seenTableNames[tag.Table] {
 				continue
 			}
-			tagCrossTableOnlyOIDs[tag.Table] = append(tagCrossTableOnlyOIDs[tag.Table], oid)
+			if tag.Symbol.OID != "" {
+				tagCrossTableOnlyOIDs[tag.Table] = append(tagCrossTableOnlyOIDs[tag.Table], tag.Symbol.OID)
+			}
+			if tag.LookupSymbol.OID != "" {
+				tagCrossTableOnlyOIDs[tag.Table] = append(tagCrossTableOnlyOIDs[tag.Table], tag.LookupSymbol.OID)
+			}
 		}
 	}
 
@@ -269,14 +274,32 @@ func longestCommonPrefix(oids []string) string {
 	if len(oids) == 0 {
 		return ""
 	}
-	prefix := oids[0]
+
+	prefixParts := splitOIDParts(oids[0])
 	for i := 1; i < len(oids); i++ {
-		for !strings.HasPrefix(oids[i], prefix) {
-			prefix = prefix[0 : len(prefix)-1]
-			if len(prefix) == 0 {
-				return ""
-			}
+		parts := splitOIDParts(oids[i])
+		n := len(prefixParts)
+		if len(parts) < n {
+			n = len(parts)
+		}
+
+		j := 0
+		for j < n && prefixParts[j] == parts[j] {
+			j++
+		}
+		prefixParts = prefixParts[:j]
+		if len(prefixParts) == 0 {
+			return ""
 		}
 	}
-	return strings.TrimSuffix(prefix, ".")
+
+	return strings.Join(prefixParts, ".")
+}
+
+func splitOIDParts(oid string) []string {
+	parts := strings.Split(strings.Trim(oid, "."), ".")
+	if len(parts) == 1 && parts[0] == "" {
+		return nil
+	}
+	return parts
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_global_tags.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_global_tags.go
@@ -81,8 +81,8 @@ func (gc *globalTagsCollector) processDynamicTags(metricTags []ddprofiledefiniti
 		ta := tagAdder{tags: globalTags}
 
 		if err := gc.tagProc.processTag(tagCfg, pdus, ta); err != nil {
-			errs = append(errs, fmt.Errorf("failed to process tag value for '%s/%s': %w",
-				tagCfg.Tag, tagCfg.Symbol.Name, err))
+			errs = append(errs, fmt.Errorf("failed to process tag value for %q: %w",
+				metricTagDisplayName(tagCfg), err))
 			continue
 		}
 	}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar_test.go
@@ -291,6 +291,10 @@ func TestScalarCollector_Collect(t *testing.T) {
 				{
 					Name:  "sysUpTime",
 					Value: 123456,
+					Tags: map[string]string{
+						"source": "system",
+						"type":   "uptime",
+					},
 					StaticTags: map[string]string{
 						"source": "system",
 						"type":   "uptime",

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
@@ -90,10 +90,11 @@ type (
 
 		// === Computed during processing (set by various methods) ===
 
-		// columnOIDs maps column OIDs to their symbol configurations
-		// Built from config.Symbols, used to identify which columns contain metrics
-		// Key: column OID (e.g., "1.3.6.1.2.1.2.2.1.10"), Value: symbol config
-		columnOIDs map[string]ddprofiledefinition.SymbolConfig
+		// columnOIDs maps column OIDs to all symbol configurations that read from them.
+		// A single column can back multiple metrics when profiles use different
+		// extract_value rules on the same raw OID, such as separate code/subcode fields.
+		// Key: column OID (e.g., "1.3.6.1.2.1.2.2.1.10"), Value: symbol configs
+		columnOIDs map[string][]ddprofiledefinition.SymbolConfig
 
 		// staticTags contains tags that apply to all metrics from this table
 		// Parsed from config.StaticTags (e.g., "source:network")
@@ -148,8 +149,8 @@ type cacheProcessingContext struct {
 
 	// columnOIDs identifies which columns contain metrics (not tags)
 	// Built from config.Symbols, used to filter which OIDs to GET
-	// Key: column OID, Value: symbol configuration
-	columnOIDs map[string]ddprofiledefinition.SymbolConfig
+	// Key: column OID, Value: symbol configurations
+	columnOIDs map[string][]ddprofiledefinition.SymbolConfig
 
 	// pdus contains current metric values fetched via SNMP GET
 	// Only contains metric columns (not tag columns, which are cached)
@@ -438,8 +439,9 @@ func (tc *tableCollector) processRows(ctx *tableProcessingContext, stats *ddsnmp
 	var errs []error
 
 	crossTableCtx := &crossTableContext{
-		walkedData:     ctx.walkedData,
-		tableNameToOID: ctx.tableNameToOID,
+		walkedData:       ctx.walkedData,
+		tableNameToOID:   ctx.tableNameToOID,
+		lookupIndexCache: make(map[crossTableLookupKey]string),
 	}
 
 	for index, rowPDUs := range ctx.rows {
@@ -525,7 +527,7 @@ func (tc *tableCollector) buildMetricsFromCache(ctx *cacheProcessingContext, sta
 
 		// Process each metric column
 		for columnOID, fullOID := range columns {
-			sym, isMetric := ctx.columnOIDs[columnOID]
+			syms, isMetric := ctx.columnOIDs[columnOID]
 			if !isMetric {
 				continue
 			}
@@ -536,21 +538,23 @@ func (tc *tableCollector) buildMetricsFromCache(ctx *cacheProcessingContext, sta
 				continue
 			}
 
-			value, err := tc.valProc.processValue(sym, pdu)
-			if err != nil {
-				stats.Errors.Processing.Table++
-				tc.log.Debugf("Error processing value for %s: %v", sym.Name, err)
-				continue
-			}
+			for _, sym := range syms {
+				value, err := tc.valProc.processValue(sym, pdu)
+				if err != nil {
+					stats.Errors.Processing.Table++
+					tc.log.Debugf("Error processing value for %s: %v", sym.Name, err)
+					continue
+				}
 
-			metric, err := buildTableMetric(sym, pdu, value, rowTags, staticTags, ctx.tableName)
-			if err != nil {
-				stats.Errors.Processing.Table++
-				errs = append(errs, err)
-				continue
-			}
+				metric, err := buildTableMetric(sym, pdu, value, rowTags, staticTags, ctx.tableName)
+				if err != nil {
+					stats.Errors.Processing.Table++
+					errs = append(errs, err)
+					continue
+				}
 
-			metrics = append(metrics, *metric)
+				metrics = append(metrics, *metric)
+			}
 		}
 	}
 
@@ -633,10 +637,11 @@ func parseStaticTags(staticTags []ddprofiledefinition.StaticMetricTagConfig) map
 	return tags
 }
 
-func buildColumnOIDs(cfg ddprofiledefinition.MetricsConfig) map[string]ddprofiledefinition.SymbolConfig {
-	columnOIDs := make(map[string]ddprofiledefinition.SymbolConfig)
+func buildColumnOIDs(cfg ddprofiledefinition.MetricsConfig) map[string][]ddprofiledefinition.SymbolConfig {
+	columnOIDs := make(map[string][]ddprofiledefinition.SymbolConfig)
 	for _, sym := range cfg.Symbols {
-		columnOIDs[trimOID(sym.OID)] = sym
+		columnOID := trimOID(sym.OID)
+		columnOIDs[columnOID] = append(columnOIDs[columnOID], sym)
 	}
 	return columnOIDs
 }
@@ -669,7 +674,7 @@ func buildOrderedTags(cfg ddprofiledefinition.MetricsConfig) []orderedTagConfig 
 	for _, tagCfg := range cfg.MetricTags {
 		var tt tagType
 		switch {
-		case tagCfg.Index != 0:
+		case isIndexTagConfig(tagCfg):
 			tt = tagTypeIndex
 		case tagCfg.Table != "" && tagCfg.Table != cfg.Table.Name:
 			tt = tagTypeCrossTable
@@ -684,4 +689,24 @@ func buildOrderedTags(cfg ddprofiledefinition.MetricsConfig) []orderedTagConfig 
 	}
 
 	return ordered
+}
+
+func isIndexTagConfig(tagCfg ddprofiledefinition.MetricTagConfig) bool {
+	if tagCfg.Index != 0 {
+		return true
+	}
+
+	if tagCfg.Table != "" {
+		return false
+	}
+
+	if tagCfg.Symbol.OID != "" {
+		return false
+	}
+
+	return len(tagCfg.IndexTransform) > 0 ||
+		tagCfg.Symbol.Format != "" ||
+		tagCfg.Symbol.ExtractValue != "" ||
+		tagCfg.Symbol.MatchPattern != "" ||
+		len(tagCfg.Mapping) > 0
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_test.go
@@ -807,11 +807,15 @@ func TestTableCollector_Collect(t *testing.T) {
 				{
 					Name:  "ifInOctets",
 					Value: 1000,
+					Tags: map[string]string{
+						"interface": "eth0",
+						"source":    "interface",
+						"table":     "if",
+					},
 					StaticTags: map[string]string{
 						"source": "interface",
 						"table":  "if",
 					},
-					Tags:       map[string]string{"interface": "eth0"},
 					MetricType: "rate",
 					IsTable:    true,
 					Table:      "ifTable",
@@ -1043,7 +1047,7 @@ func TestTableCollector_Collect(t *testing.T) {
 					Name:       "ifInOctets",
 					Value:      1000,
 					StaticTags: map[string]string{"source": "network"},
-					Tags:       map[string]string{"interface": "eth0", "if_type": "ethernet"},
+					Tags:       map[string]string{"interface": "eth0", "if_type": "ethernet", "source": "network"},
 					MetricType: "rate",
 					IsTable:    true,
 
@@ -2018,6 +2022,159 @@ func TestTableCollector_Collect(t *testing.T) {
 			},
 			expectedError: false,
 		},
+		"huawei route table cross-table tags from augmented tables": {
+			profile: &ddsnmp.Profile{
+				SourceFile: "test-profile.yaml",
+				Definition: &ddprofiledefinition.ProfileDefinition{
+					Metrics: []ddprofiledefinition.MetricsConfig{
+						{
+							Table: ddprofiledefinition.SymbolConfig{
+								OID:  "1.3.6.1.4.1.2011.5.25.177.1.1.3",
+								Name: "hwBgpPeerRouteTable",
+							},
+							Symbols: []ddprofiledefinition.SymbolConfig{
+								{
+									OID:        "1.3.6.1.4.1.2011.5.25.177.1.1.3.1.1",
+									Name:       "huawei.hwBgpPeerPrefixRcvCounter",
+									MetricType: ddprofiledefinition.ProfileMetricTypeMonotonicCount,
+									ChartMeta: ddprofiledefinition.ChartMeta{
+										Description: "The number of prefixes received from the remote BGP peer",
+										Family:      "Network/Routing/BGP/Peer/Prefix/Received/Total",
+										Unit:        "{prefix}",
+									},
+								},
+							},
+							MetricTags: []ddprofiledefinition.MetricTagConfig{
+								{
+									Tag:   "huawei_hw_bgp_peer_vrf_name",
+									Table: "hwBgpPeerAddrFamilyTable",
+									Symbol: ddprofiledefinition.SymbolConfigCompat{
+										OID:  "1.3.6.1.4.1.2011.5.25.177.1.1.1.1.6",
+										Name: "huawei.hwBgpPeerVrfName",
+									},
+								},
+								{
+									Tag:   "huawei_hw_bgp_peer_remote_addr",
+									Table: "hwBgpPeerTable",
+									Symbol: ddprofiledefinition.SymbolConfigCompat{
+										OID:    "1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4",
+										Name:   "huawei.hwBgpPeerRemoteAddr",
+										Format: "ip_address",
+									},
+								},
+								{
+									Tag:   "_routing_instance",
+									Table: "hwBgpPeerAddrFamilyTable",
+									Symbol: ddprofiledefinition.SymbolConfigCompat{
+										OID:  "1.3.6.1.4.1.2011.5.25.177.1.1.1.1.6",
+										Name: "huawei.hwBgpPeerVrfName",
+									},
+								},
+								{
+									Tag:   "_neighbor",
+									Table: "hwBgpPeerTable",
+									Symbol: ddprofiledefinition.SymbolConfigCompat{
+										OID:    "1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4",
+										Name:   "huawei.hwBgpPeerRemoteAddr",
+										Format: "ip_address",
+									},
+								},
+								{
+									Tag:   "_remote_as",
+									Table: "hwBgpPeerTable",
+									Symbol: ddprofiledefinition.SymbolConfigCompat{
+										OID:  "1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2",
+										Name: "huawei.hwBgpPeerRemoteAs",
+									},
+								},
+								{
+									Tag:   "_peer_description",
+									Table: "hwBgpPeerTable",
+									Symbol: ddprofiledefinition.SymbolConfigCompat{
+										OID:  "1.3.6.1.4.1.2011.5.25.177.1.1.2.1.12",
+										Name: "huawei.hwBgpPeerDescription",
+									},
+								},
+								{
+									Tag:   "_address_family",
+									Index: 2,
+									Mapping: map[string]string{
+										"1":   "ipv4",
+										"2":   "ipv6",
+										"25":  "vpls",
+										"196": "l2vpn",
+									},
+								},
+								{
+									Tag:   "_subsequent_address_family",
+									Index: 3,
+									Mapping: map[string]string{
+										"1":   "unicast",
+										"2":   "multicast",
+										"4":   "mpls",
+										"5":   "mcast-vpn",
+										"65":  "vpls",
+										"66":  "mdt",
+										"74":  "sd-wan",
+										"128": "vpn",
+										"132": "route-target",
+									},
+								},
+								{
+									Tag:   "_neighbor_address_type",
+									Index: 4,
+									Mapping: map[string]string{
+										"0":  "unknown",
+										"1":  "ipv4",
+										"2":  "ipv6",
+										"3":  "ipv4z",
+										"4":  "ipv6z",
+										"16": "dns",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMock: func(m *snmpmock.MockHandler) {
+				expectSNMPWalk(m, gosnmp.Version2c, "1.3.6.1.4.1.2011.5.25.177.1.1.3", []gosnmp.SnmpPDU{
+					createCounter32PDU("1.3.6.1.4.1.2011.5.25.177.1.1.3.1.1.100.1.1.1.192.0.2.1", 123),
+				})
+				expectSNMPWalk(m, gosnmp.Version2c, "1.3.6.1.4.1.2011.5.25.177.1.1.1.1.6", []gosnmp.SnmpPDU{
+					createStringPDU("1.3.6.1.4.1.2011.5.25.177.1.1.1.1.6.100.1.1.1.192.0.2.1", "blue"),
+				})
+				expectSNMPWalk(m, gosnmp.Version2c, "1.3.6.1.4.1.2011.5.25.177.1.1.2.1", []gosnmp.SnmpPDU{
+					createGauge32PDU("1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2.100.1.1.1.192.0.2.1", 65001),
+					createPDU("1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.100.1.1.1.192.0.2.1", gosnmp.OctetString, []byte{192, 0, 2, 1}),
+					createStringPDU("1.3.6.1.4.1.2011.5.25.177.1.1.2.1.12.100.1.1.1.192.0.2.1", "Transit-1"),
+				})
+			},
+			expectedResult: []ddsnmp.Metric{
+				{
+					Name:        "huawei.hwBgpPeerPrefixRcvCounter",
+					Description: "The number of prefixes received from the remote BGP peer",
+					Family:      "Network/Routing/BGP/Peer/Prefix/Received/Total",
+					Unit:        "{prefix}",
+					Value:       123,
+					Tags: map[string]string{
+						"huawei_hw_bgp_peer_vrf_name":    "blue",
+						"huawei_hw_bgp_peer_remote_addr": "192.0.2.1",
+						"_routing_instance":              "blue",
+						"_neighbor":                      "192.0.2.1",
+						"_remote_as":                     "65001",
+						"_peer_description":              "Transit-1",
+						"_address_family":                "ipv4",
+						"_subsequent_address_family":     "unicast",
+						"_neighbor_address_type":         "ipv4",
+					},
+					MetricType: ddprofiledefinition.ProfileMetricTypeMonotonicCount,
+					IsTable:    true,
+					Table:      "hwBgpPeerRouteTable",
+				},
+			},
+			expectedError: false,
+		},
 		"cross-table tag with extract_value": {
 			profile: &ddsnmp.Profile{
 				SourceFile: "test-profile.yaml",
@@ -2328,6 +2485,104 @@ func TestTableCollector_Collect(t *testing.T) {
 					IsTable:    true,
 
 					Table: "customTable",
+				},
+			},
+			expectedError: false,
+		},
+		"cross-table tag with lookup_symbol value match": {
+			profile: &ddsnmp.Profile{
+				SourceFile: "test-profile.yaml",
+				Definition: &ddprofiledefinition.ProfileDefinition{
+					Metrics: []ddprofiledefinition.MetricsConfig{
+						{
+							Table: ddprofiledefinition.SymbolConfig{
+								OID:  "1.3.6.1.4.1.2636.5.1.1.2.6.2",
+								Name: "jnxBgpM2PrefixCountersTable",
+							},
+							Symbols: []ddprofiledefinition.SymbolConfig{
+								{
+									OID:  "1.3.6.1.4.1.2636.5.1.1.2.6.2.1.8",
+									Name: "bgpPeerPrefixesAccepted",
+								},
+							},
+							MetricTags: []ddprofiledefinition.MetricTagConfig{
+								{
+									Tag:   "neighbor",
+									Table: "jnxBgpM2PeerTable",
+									Symbol: ddprofiledefinition.SymbolConfigCompat{
+										OID:    "1.3.6.1.4.1.2636.5.1.1.2.1.1.1.11",
+										Name:   "_jnxBgpM2PeerRemoteAddr",
+										Format: "ip_address",
+									},
+									LookupSymbol: ddprofiledefinition.SymbolConfigCompat{
+										OID:  "1.3.6.1.4.1.2636.5.1.1.2.1.1.1.14",
+										Name: "_jnxBgpM2PeerIndex",
+									},
+									IndexTransform: []ddprofiledefinition.MetricIndexTransform{
+										{Start: 0, End: 0},
+									},
+								},
+								{
+									Tag:   "remote_as",
+									Table: "jnxBgpM2PeerTable",
+									Symbol: ddprofiledefinition.SymbolConfigCompat{
+										OID:  "1.3.6.1.4.1.2636.5.1.1.2.1.1.1.13",
+										Name: "_jnxBgpM2PeerRemoteAs",
+									},
+									LookupSymbol: ddprofiledefinition.SymbolConfigCompat{
+										OID:  "1.3.6.1.4.1.2636.5.1.1.2.1.1.1.14",
+										Name: "_jnxBgpM2PeerIndex",
+									},
+									IndexTransform: []ddprofiledefinition.MetricIndexTransform{
+										{Start: 0, End: 0},
+									},
+								},
+								{
+									Tag:   "address_family",
+									Index: 2,
+									Mapping: map[string]string{
+										"1":  "ipv4",
+										"2":  "ipv6",
+										"25": "l2vpn",
+									},
+								},
+								{
+									Tag:   "subsequent_address_family",
+									Index: 3,
+									Mapping: map[string]string{
+										"1":   "unicast",
+										"70":  "evpn",
+										"128": "vpn",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMock: func(m *snmpmock.MockHandler) {
+				expectSNMPWalk(m, gosnmp.Version2c, "1.3.6.1.4.1.2636.5.1.1.2.6.2", []gosnmp.SnmpPDU{
+					createGauge32PDU("1.3.6.1.4.1.2636.5.1.1.2.6.2.1.8.100.1.1", 42),
+				})
+				expectSNMPWalk(m, gosnmp.Version2c, "1.3.6.1.4.1.2636.5.1.1.2.1.1.1", []gosnmp.SnmpPDU{
+					createPDU("1.3.6.1.4.1.2636.5.1.1.2.1.1.1.11.7.1.4.10.0.0.1.1.4.192.0.2.1", gosnmp.OctetString, []byte{192, 0, 2, 1}),
+					createGauge32PDU("1.3.6.1.4.1.2636.5.1.1.2.1.1.1.13.7.1.4.10.0.0.1.1.4.192.0.2.1", 65001),
+					createGauge32PDU("1.3.6.1.4.1.2636.5.1.1.2.1.1.1.14.7.1.4.10.0.0.1.1.4.192.0.2.1", 100),
+				})
+			},
+			expectedResult: []ddsnmp.Metric{
+				{
+					Name:  "bgpPeerPrefixesAccepted",
+					Value: 42,
+					Tags: map[string]string{
+						"neighbor":                  "192.0.2.1",
+						"remote_as":                 "65001",
+						"address_family":            "ipv4",
+						"subsequent_address_family": "unicast",
+					},
+					MetricType: "gauge",
+					IsTable:    true,
+					Table:      "jnxBgpM2PrefixCountersTable",
 				},
 			},
 			expectedError: false,

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_test.go
@@ -149,3 +149,15 @@ func TestCollector_Collect_StatsSnapshot(t *testing.T) {
 
 	assert.Equal(t, expected, pm.Stats)
 }
+
+func TestLongestCommonPrefix(t *testing.T) {
+	assert.Equal(t, "1.3.6.1.2.1.31.1.1.1", longestCommonPrefix([]string{
+		"1.3.6.1.2.1.31.1.1.1.1",
+		"1.3.6.1.2.1.31.1.1.1.18",
+	}))
+
+	assert.Equal(t, "1.3.6.1.4.1.2636.5.1.1.2.1.1.1", longestCommonPrefix([]string{
+		"1.3.6.1.4.1.2636.5.1.1.2.1.1.1.11",
+		"1.3.6.1.4.1.2636.5.1.1.2.1.1.1.14",
+	}))
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics.go
@@ -4,7 +4,6 @@ package ddsnmpcollector
 
 import (
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/netdata/netdata/go/plugins/logger"
@@ -38,17 +37,22 @@ func (p *vmetricsCollector) accumulate(lookup map[vmetricsSourceKey][]vmetricsSi
 			continue
 		}
 
-		v, mv := vmCollapseMetricValue(m)
-
 		type gke struct {
 			key string
 			ok  bool
 		}
 		var gkCache map[*vmetricsAggregator]gke
+		var tags map[string]string
+		var tagsReady bool
 
 		for _, sink := range sinks {
 			agg := sink.agg
 			if agg == nil {
+				continue
+			}
+
+			v, mv, ok := vmResolveSourceValue(m, sink)
+			if !ok {
 				continue
 			}
 
@@ -64,16 +68,20 @@ func (p *vmetricsCollector) accumulate(lookup map[vmetricsSourceKey][]vmetricsSi
 			if gkCache == nil {
 				gkCache = make(map[*vmetricsAggregator]gke, 2)
 			}
+			if !tagsReady {
+				tags = vmMetricTags(m)
+				tagsReady = true
+			}
 			entry, found := gkCache[agg]
 			if !found {
-				k, ok := vmBuildGroupKey(m.Tags, agg)
+				k, ok := vmBuildGroupKey(tags, agg)
 				entry = gke{key: k, ok: ok}
 				gkCache[agg] = entry
 			}
 			if !entry.ok {
 				continue
 			}
-			agg.accumulateGroupedWithKey(sink, entry.key, v, m.Tags)
+			agg.accumulateGroupedWithKey(sink, entry.key, v, tags)
 		}
 	}
 }
@@ -170,8 +178,9 @@ type (
 
 	// sink binding; dimIdx == -1 for non-composite
 	vmetricsSink struct {
-		agg    *vmetricsAggregator
-		dimIdx int16
+		agg       *vmetricsAggregator
+		dimIdx    int16
+		sourceDim string
 	}
 
 	// per-group accumulator (emitted as one table row)
@@ -308,82 +317,21 @@ func (p *vmetricsCollector) getDefinedMetricNames(profMetrics []ddprofiledefinit
 	return names
 }
 
-// vmBuildGroupKey returns a stable group key.
-func vmBuildGroupKey(tags map[string]string, agg *vmetricsAggregator) (string, bool) {
-	if !agg.grouped || len(tags) == 0 {
-		return "", false
-	}
-
-	const (
-		groupKeySep = '\x1F' // ASCII Unit Separator between values/pairs
-		kvSep       = '='    // used in per-row fallback "k=v"
-	)
-
-	agg.keyBuf.Reset()
-
-	if agg.perRow {
-		if len(agg.groupBy) > 0 {
-			for i, l := range agg.groupBy {
-				v := tags[l]
-				if v == "" {
-					return "", false
-				}
-				if i > 0 {
-					agg.keyBuf.WriteByte(groupKeySep)
-				}
-				agg.keyBuf.WriteString(v)
-			}
-			return agg.keyBuf.String(), true
-		}
-
-		// per-row without group_by: stable key from all non-underscore tags
-		keys := make([]string, 0, len(tags))
-		for k := range tags {
-			if !strings.HasPrefix(k, "_") {
-				keys = append(keys, k)
-			}
-		}
-		if len(keys) == 0 {
-			return "", false
-		}
-
-		sort.Strings(keys)
-		for i, k := range keys {
-			if i > 0 {
-				agg.keyBuf.WriteByte(groupKeySep)
-			}
-			agg.keyBuf.WriteString(k)
-			agg.keyBuf.WriteByte(kvSep)
-			agg.keyBuf.WriteString(tags[k])
-		}
-		return agg.keyBuf.String(), true
-	}
-
-	// non per-row: respect group_by exactly; underscore labels are NOT special
-	switch len(agg.groupBy) {
-	case 0:
-		return "", false
-	case 1:
-		l := agg.groupBy[0]
-		v := tags[l]
-		return v, v != ""
-	default:
-		for i, l := range agg.groupBy {
-			v := tags[l]
-			if v == "" {
-				return "", false
-			}
-			if i > 0 {
-				agg.keyBuf.WriteByte(groupKeySep)
-			}
-			agg.keyBuf.WriteString(v)
-		}
-		return agg.keyBuf.String(), true
-	}
-}
-
 // vmBuildEmitTags captures labels to emit for a group (called once per new group)
 func vmBuildEmitTags(tags map[string]string, agg *vmetricsAggregator) map[string]string {
+	if len(agg.config.EmitTags) > 0 {
+		out := make(map[string]string, len(agg.config.EmitTags))
+		for _, spec := range agg.config.EmitTags {
+			if spec.Tag == "" || spec.From == "" {
+				continue
+			}
+			if v := tags[spec.From]; v != "" {
+				out[spec.Tag] = v
+			}
+		}
+		return out
+	}
+
 	if agg.perRow {
 		// per-row: reuse pointer; we never mutate it here
 		return tags
@@ -397,7 +345,29 @@ func vmBuildEmitTags(tags map[string]string, agg *vmetricsAggregator) map[string
 	return out
 }
 
-// vmCollapseMetricValue a metric to an int64 quickly; return mv if present for merge path
+func vmMetricTags(m ddsnmp.Metric) map[string]string {
+	if len(m.StaticTags) == 0 {
+		return m.Tags
+	}
+	if len(m.Tags) == 0 {
+		return m.StaticTags
+	}
+	for k, v := range m.StaticTags {
+		if m.Tags[k] != v {
+			out := make(map[string]string, len(m.Tags)+len(m.StaticTags))
+			for key, value := range m.StaticTags {
+				out[key] = value
+			}
+			for key, value := range m.Tags {
+				out[key] = value
+			}
+			return out
+		}
+	}
+	return m.Tags
+}
+
+// vmCollapseMetricValue collapses a metric to an int64 quickly; return mv if present for merge path.
 func vmCollapseMetricValue(m ddsnmp.Metric) (v int64, mv map[string]int64) {
 	if len(m.MultiValue) == 0 {
 		return m.Value, nil
@@ -407,6 +377,24 @@ func vmCollapseMetricValue(m ddsnmp.Metric) (v int64, mv map[string]int64) {
 		sum += x
 	}
 	return sum, m.MultiValue
+}
+
+func vmResolveSourceValue(m ddsnmp.Metric, sink vmetricsSink) (v int64, mv map[string]int64, ok bool) {
+	if sink.sourceDim == "" {
+		v, mv = vmCollapseMetricValue(m)
+		return v, mv, true
+	}
+
+	if len(m.MultiValue) == 0 {
+		return 0, nil, false
+	}
+
+	v, ok = m.MultiValue[sink.sourceDim]
+	if !ok {
+		return 0, nil, false
+	}
+
+	return v, nil, true
 }
 
 type aggregatorsBuilder struct {
@@ -569,6 +557,10 @@ func (b *aggregatorsBuilder) bindSinks(
 				dimIdx = int16(idx)
 			}
 		}
-		b.sourceToSinks[key] = append(b.sourceToSinks[key], vmetricsSink{agg: agg, dimIdx: dimIdx})
+		b.sourceToSinks[key] = append(b.sourceToSinks[key], vmetricsSink{
+			agg:       agg,
+			dimIdx:    dimIdx,
+			sourceDim: src.Dim,
+		})
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics_groupkey.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics_groupkey.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// vmBuildGroupKey returns a stable group key.
+func vmBuildGroupKey(tags map[string]string, agg *vmetricsAggregator) (string, bool) {
+	if !agg.grouped || len(tags) == 0 {
+		return "", false
+	}
+
+	agg.keyBuf.Reset()
+
+	if agg.perRow {
+		if len(agg.groupBy) > 0 {
+			missingHint := false
+			for _, label := range agg.groupBy {
+				value := tags[label]
+				if value == "" {
+					missingHint = true
+					break
+				}
+				vmWriteGroupKeyPart(&agg.keyBuf, value)
+			}
+			if !missingHint {
+				return agg.keyBuf.String(), true
+			}
+			agg.keyBuf.Reset()
+		}
+
+		// per-row without group_by: stable key from all non-underscore tags
+		keys := make([]string, 0, len(tags))
+		for key := range tags {
+			if !strings.HasPrefix(key, "_") {
+				keys = append(keys, key)
+			}
+		}
+		if len(keys) == 0 {
+			return "", false
+		}
+
+		sort.Strings(keys)
+		for _, key := range keys {
+			vmWriteGroupKeyPart(&agg.keyBuf, key)
+			vmWriteGroupKeyPart(&agg.keyBuf, tags[key])
+		}
+		return agg.keyBuf.String(), true
+	}
+
+	// non per-row: respect group_by exactly; underscore labels are NOT special
+	switch len(agg.groupBy) {
+	case 0:
+		return "", false
+	case 1:
+		label := agg.groupBy[0]
+		value := tags[label]
+		return value, value != ""
+	default:
+		for _, label := range agg.groupBy {
+			value := tags[label]
+			if value == "" {
+				return "", false
+			}
+			vmWriteGroupKeyPart(&agg.keyBuf, value)
+		}
+		return agg.keyBuf.String(), true
+	}
+}
+
+func vmWriteGroupKeyPart(buf *strings.Builder, value string) {
+	buf.WriteString(strconv.Itoa(len(value)))
+	buf.WriteByte(':')
+	buf.WriteString(value)
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics_groupkey.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics_groupkey.go
@@ -33,7 +33,7 @@ func vmBuildGroupKey(tags map[string]string, agg *vmetricsAggregator) (string, b
 			agg.keyBuf.Reset()
 		}
 
-		// per-row without group_by: stable key from all non-underscore tags
+		// per-row without group_by: stable length-prefixed key from all non-underscore tags
 		keys := make([]string, 0, len(tags))
 		for key := range tags {
 			if !strings.HasPrefix(key, "_") {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_vmetrics_test.go
@@ -4,6 +4,7 @@ package ddsnmpcollector
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -746,6 +747,40 @@ func TestVirtualMetricsCollector_Collect(t *testing.T) {
 			},
 		},
 
+		"composite with selected multivalue dimensions": {
+			profileDef: &ddprofiledefinition.ProfileDefinition{
+				VirtualMetrics: []ddprofiledefinition.VirtualMetricConfig{
+					{
+						Name: "bgpPeerAvailability",
+						Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
+							{Metric: "bgpPeerAdminStatus", Table: "bgpPeerTable", As: "admin_enabled", Dim: "start"},
+							{Metric: "bgpPeerState", Table: "bgpPeerTable", As: "established", Dim: "established"},
+						},
+					},
+				},
+			},
+			collectedMetrics: []ddsnmp.Metric{
+				{
+					Name:       "bgpPeerAdminStatus",
+					IsTable:    true,
+					Table:      "bgpPeerTable",
+					MultiValue: map[string]int64{"stop": 0, "start": 1},
+				},
+				{
+					Name:       "bgpPeerState",
+					IsTable:    true,
+					Table:      "bgpPeerTable",
+					MultiValue: map[string]int64{"idle": 0, "connect": 0, "active": 0, "opensent": 0, "openconfirm": 0, "established": 1},
+				},
+			},
+			expected: []ddsnmp.Metric{
+				{
+					Name:       "bgpPeerAvailability",
+					MultiValue: map[string]int64{"admin_enabled": 1, "established": 1},
+				},
+			},
+		},
+
 		"composite with scalar sources (CPU)": {
 			profileDef: &ddprofiledefinition.ProfileDefinition{
 				VirtualMetrics: []ddprofiledefinition.VirtualMetricConfig{
@@ -783,7 +818,7 @@ func TestVirtualMetricsCollector_Collect(t *testing.T) {
 				VirtualMetrics: []ddprofiledefinition.VirtualMetricConfig{
 					{
 						Name:    "ifTrafficPerInterface",
-						GroupBy: []string{"interface", "ifType"},
+						GroupBy: ddprofiledefinition.StringArray{"interface", "ifType"},
 						Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
 							{Metric: "ifHCInOctets", Table: "ifXTable", As: "in"},
 							{Metric: "ifHCOutOctets", Table: "ifXTable", As: "out"},
@@ -818,7 +853,7 @@ func TestVirtualMetricsCollector_Collect(t *testing.T) {
 				VirtualMetrics: []ddprofiledefinition.VirtualMetricConfig{
 					{
 						Name:    "ifErrorsPerInterface",
-						GroupBy: []string{"interface"},
+						GroupBy: ddprofiledefinition.StringArray{"interface"},
 						Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
 							{Metric: "ifInErrors", Table: "ifTable"},
 						},
@@ -906,7 +941,7 @@ func TestVirtualMetricsCollector_Collect(t *testing.T) {
 				VirtualMetrics: []ddprofiledefinition.VirtualMetricConfig{
 					{
 						Name:    "invalidGroupedVM",
-						GroupBy: []string{"interface"},
+						GroupBy: ddprofiledefinition.StringArray{"interface"},
 						Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
 							{Metric: "ifInOctets", Table: "ifTable", As: "in"},
 							{Metric: "ifHCInOctets", Table: "ifXTable", As: "in2"},
@@ -1026,7 +1061,7 @@ func TestVirtualMetricsCollector_Collect(t *testing.T) {
 					{
 						Name:    "ifTrafficPerRowHint",
 						PerRow:  true,
-						GroupBy: []string{"interface"}, // used as row-key hint
+						GroupBy: ddprofiledefinition.StringArray{"interface"}, // used as row-key hint
 						Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
 							{Metric: "ifHCInOctets", Table: "ifXTable", As: "in"},
 							{Metric: "ifHCOutOctets", Table: "ifXTable", As: "out"},
@@ -1058,6 +1093,364 @@ func TestVirtualMetricsCollector_Collect(t *testing.T) {
 					Table:      "ifXTable",
 					Tags:       map[string]string{"interface": "ethB", "ifType": "ethernetCsmacd", "ifIndex": "12"},
 					MultiValue: map[string]int64{"in": 1, "out": 2},
+				},
+			},
+		},
+
+		"per_row with missing key hint falls back to stable visible tags": {
+			profileDef: &ddprofiledefinition.ProfileDefinition{
+				VirtualMetrics: []ddprofiledefinition.VirtualMetricConfig{
+					{
+						Name:    "ifTrafficPerRowHintFallback",
+						PerRow:  true,
+						GroupBy: ddprofiledefinition.StringArray{"interface"},
+						Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
+							{Metric: "ifHCInOctets", Table: "ifXTable", As: "in"},
+							{Metric: "ifHCOutOctets", Table: "ifXTable", As: "out"},
+						},
+					},
+				},
+			},
+			collectedMetrics: []ddsnmp.Metric{
+				{Name: "ifHCInOctets", Value: 5, IsTable: true, Table: "ifXTable",
+					Tags: map[string]string{"ifType": "ethernetCsmacd", "ifIndex": "11"}},
+				{Name: "ifHCOutOctets", Value: 7, IsTable: true, Table: "ifXTable",
+					Tags: map[string]string{"ifType": "ethernetCsmacd", "ifIndex": "11"}},
+			},
+			expected: []ddsnmp.Metric{
+				{
+					Name:       "ifTrafficPerRowHintFallback",
+					IsTable:    true,
+					Table:      "ifXTable",
+					Tags:       map[string]string{"ifType": "ethernetCsmacd", "ifIndex": "11"},
+					MultiValue: map[string]int64{"in": 5, "out": 7},
+				},
+			},
+		},
+
+		"per_row composite with selected multivalue dimensions": {
+			profileDef: &ddprofiledefinition.ProfileDefinition{
+				VirtualMetrics: []ddprofiledefinition.VirtualMetricConfig{
+					{
+						Name:    "bgpPeerAvailability",
+						PerRow:  true,
+						GroupBy: ddprofiledefinition.StringArray{"neighbor"},
+						Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
+							{Metric: "bgpPeerAdminStatus", Table: "bgpPeerTable", As: "admin_enabled", Dim: "start"},
+							{Metric: "bgpPeerState", Table: "bgpPeerTable", As: "established", Dim: "established"},
+						},
+						ChartMeta: ddprofiledefinition.ChartMeta{
+							Description: "Per-peer availability",
+							Family:      "Network/Routing/BGP/Peer/Availability",
+							Unit:        "{status}",
+						},
+					},
+				},
+			},
+			collectedMetrics: []ddsnmp.Metric{
+				{
+					Name:       "bgpPeerAdminStatus",
+					IsTable:    true,
+					Table:      "bgpPeerTable",
+					Tags:       map[string]string{"neighbor": "192.0.2.1", "remote_as": "64512"},
+					MultiValue: map[string]int64{"stop": 0, "start": 1},
+				},
+				{
+					Name:       "bgpPeerState",
+					IsTable:    true,
+					Table:      "bgpPeerTable",
+					Tags:       map[string]string{"neighbor": "192.0.2.1", "remote_as": "64512"},
+					MultiValue: map[string]int64{"idle": 1, "connect": 0, "active": 0, "opensent": 0, "openconfirm": 0, "established": 0},
+				},
+				{
+					Name:       "bgpPeerAdminStatus",
+					IsTable:    true,
+					Table:      "bgpPeerTable",
+					Tags:       map[string]string{"neighbor": "2001:db8::1", "remote_as": "64513"},
+					MultiValue: map[string]int64{"stop": 1, "start": 0},
+				},
+				{
+					Name:       "bgpPeerState",
+					IsTable:    true,
+					Table:      "bgpPeerTable",
+					Tags:       map[string]string{"neighbor": "2001:db8::1", "remote_as": "64513"},
+					MultiValue: map[string]int64{"idle": 1, "connect": 0, "active": 0, "opensent": 0, "openconfirm": 0, "established": 0},
+				},
+			},
+			expected: []ddsnmp.Metric{
+				{
+					Name:        "bgpPeerAvailability",
+					IsTable:     true,
+					Table:       "bgpPeerTable",
+					Tags:        map[string]string{"neighbor": "192.0.2.1", "remote_as": "64512"},
+					MultiValue:  map[string]int64{"admin_enabled": 1, "established": 0},
+					Description: "Per-peer availability",
+					Family:      "Network/Routing/BGP/Peer/Availability",
+					Unit:        "{status}",
+				},
+				{
+					Name:        "bgpPeerAvailability",
+					IsTable:     true,
+					Table:       "bgpPeerTable",
+					Tags:        map[string]string{"neighbor": "2001:db8::1", "remote_as": "64513"},
+					MultiValue:  map[string]int64{"admin_enabled": 0, "established": 0},
+					Description: "Per-peer availability",
+					Family:      "Network/Routing/BGP/Peer/Availability",
+					Unit:        "{status}",
+				},
+			},
+		},
+
+		"per_row composite can group by hidden tags and emit normalized tags": {
+			profileDef: &ddprofiledefinition.ProfileDefinition{
+				VirtualMetrics: []ddprofiledefinition.VirtualMetricConfig{
+					{
+						Name:    "bgpPeerAvailability",
+						PerRow:  true,
+						GroupBy: ddprofiledefinition.StringArray{"_routing_instance", "_neighbor", "_address_family", "_subsequent_address_family"},
+						EmitTags: []ddprofiledefinition.VirtualMetricEmitTagConfig{
+							{Tag: "routing_instance", From: "_routing_instance"},
+							{Tag: "neighbor", From: "_neighbor"},
+							{Tag: "address_family", From: "_address_family"},
+							{Tag: "subsequent_address_family", From: "_subsequent_address_family"},
+							{Tag: "remote_as", From: "_remote_as"},
+						},
+						Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
+							{Metric: "bgpPeerAdminStatus", Table: "hwBgpPeerTable", As: "admin_enabled", Dim: "start"},
+							{Metric: "bgpPeerState", Table: "hwBgpPeerTable", As: "established", Dim: "established"},
+						},
+						ChartMeta: ddprofiledefinition.ChartMeta{
+							Description: "Per-peer availability",
+							Family:      "Network/Routing/BGP/Peer/Availability",
+							Unit:        "{status}",
+						},
+					},
+				},
+			},
+			collectedMetrics: []ddsnmp.Metric{
+				{
+					Name:    "bgpPeerAdminStatus",
+					IsTable: true,
+					Table:   "hwBgpPeerTable",
+					Tags: map[string]string{
+						"huawei_hw_bgp_peer_vrf_name":    "blue",
+						"huawei_hw_bgp_peer_remote_addr": "192.0.2.1",
+						"_routing_instance":              "blue",
+						"_neighbor":                      "192.0.2.1",
+						"_remote_as":                     "64512",
+						"_address_family":                "ipv4",
+						"_subsequent_address_family":     "unicast",
+					},
+					MultiValue: map[string]int64{"stop": 0, "start": 1},
+				},
+				{
+					Name:    "bgpPeerState",
+					IsTable: true,
+					Table:   "hwBgpPeerTable",
+					Tags: map[string]string{
+						"huawei_hw_bgp_peer_vrf_name":    "blue",
+						"huawei_hw_bgp_peer_remote_addr": "192.0.2.1",
+						"_routing_instance":              "blue",
+						"_neighbor":                      "192.0.2.1",
+						"_remote_as":                     "64512",
+						"_address_family":                "ipv4",
+						"_subsequent_address_family":     "unicast",
+					},
+					MultiValue: map[string]int64{"idle": 0, "established": 1},
+				},
+				{
+					Name:    "bgpPeerAdminStatus",
+					IsTable: true,
+					Table:   "hwBgpPeerTable",
+					Tags: map[string]string{
+						"huawei_hw_bgp_peer_vrf_name":    "blue",
+						"huawei_hw_bgp_peer_remote_addr": "192.0.2.1",
+						"_routing_instance":              "blue",
+						"_neighbor":                      "192.0.2.1",
+						"_remote_as":                     "64512",
+						"_address_family":                "ipv6",
+						"_subsequent_address_family":     "unicast",
+					},
+					MultiValue: map[string]int64{"stop": 0, "start": 1},
+				},
+				{
+					Name:    "bgpPeerState",
+					IsTable: true,
+					Table:   "hwBgpPeerTable",
+					Tags: map[string]string{
+						"huawei_hw_bgp_peer_vrf_name":    "blue",
+						"huawei_hw_bgp_peer_remote_addr": "192.0.2.1",
+						"_routing_instance":              "blue",
+						"_neighbor":                      "192.0.2.1",
+						"_remote_as":                     "64512",
+						"_address_family":                "ipv6",
+						"_subsequent_address_family":     "unicast",
+					},
+					MultiValue: map[string]int64{"idle": 1, "established": 0},
+				},
+			},
+			expected: []ddsnmp.Metric{
+				{
+					Name:    "bgpPeerAvailability",
+					IsTable: true,
+					Table:   "hwBgpPeerTable",
+					Tags: map[string]string{
+						"routing_instance":          "blue",
+						"neighbor":                  "192.0.2.1",
+						"address_family":            "ipv4",
+						"subsequent_address_family": "unicast",
+						"remote_as":                 "64512",
+					},
+					MultiValue:  map[string]int64{"admin_enabled": 1, "established": 1},
+					Description: "Per-peer availability",
+					Family:      "Network/Routing/BGP/Peer/Availability",
+					Unit:        "{status}",
+				},
+				{
+					Name:    "bgpPeerAvailability",
+					IsTable: true,
+					Table:   "hwBgpPeerTable",
+					Tags: map[string]string{
+						"routing_instance":          "blue",
+						"neighbor":                  "192.0.2.1",
+						"address_family":            "ipv6",
+						"subsequent_address_family": "unicast",
+						"remote_as":                 "64512",
+					},
+					MultiValue:  map[string]int64{"admin_enabled": 1, "established": 0},
+					Description: "Per-peer availability",
+					Family:      "Network/Routing/BGP/Peer/Availability",
+					Unit:        "{status}",
+				},
+			},
+		},
+
+		"per_row composite can group by metric static tags": {
+			profileDef: &ddprofiledefinition.ProfileDefinition{
+				VirtualMetrics: []ddprofiledefinition.VirtualMetricConfig{
+					{
+						Name:    "bgpPeerUpdates",
+						PerRow:  true,
+						GroupBy: ddprofiledefinition.StringArray{"routing_instance", "neighbor", "address_family", "subsequent_address_family"},
+						EmitTags: []ddprofiledefinition.VirtualMetricEmitTagConfig{
+							{Tag: "routing_instance", From: "routing_instance"},
+							{Tag: "neighbor", From: "neighbor"},
+							{Tag: "address_family", From: "address_family"},
+							{Tag: "subsequent_address_family", From: "subsequent_address_family"},
+							{Tag: "remote_as", From: "remote_as"},
+						},
+						Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
+							{Metric: "bgpPeerInUpdates", Table: "tBgpPeerNgOperTable", As: "received"},
+							{Metric: "bgpPeerOutUpdates", Table: "tBgpPeerNgOperTable", As: "sent"},
+						},
+						ChartMeta: ddprofiledefinition.ChartMeta{
+							Description: "Per-peer update traffic",
+							Family:      "Network/Routing/BGP/Peer/Message/Update",
+							Unit:        "{message}",
+						},
+					},
+				},
+			},
+			collectedMetrics: []ddsnmp.Metric{
+				{
+					Name:       "bgpPeerInUpdates",
+					Value:      11,
+					IsTable:    true,
+					Table:      "tBgpPeerNgOperTable",
+					MetricType: ddprofiledefinition.ProfileMetricTypeRate,
+					Tags: map[string]string{
+						"routing_instance": "Base",
+						"neighbor":         "192.0.2.1",
+						"remote_as":        "64512",
+					},
+					StaticTags: map[string]string{
+						"address_family":            "ipv4",
+						"subsequent_address_family": "unicast",
+					},
+				},
+				{
+					Name:       "bgpPeerOutUpdates",
+					Value:      12,
+					IsTable:    true,
+					Table:      "tBgpPeerNgOperTable",
+					MetricType: ddprofiledefinition.ProfileMetricTypeRate,
+					Tags: map[string]string{
+						"routing_instance": "Base",
+						"neighbor":         "192.0.2.1",
+						"remote_as":        "64512",
+					},
+					StaticTags: map[string]string{
+						"address_family":            "ipv4",
+						"subsequent_address_family": "unicast",
+					},
+				},
+				{
+					Name:       "bgpPeerInUpdates",
+					Value:      21,
+					IsTable:    true,
+					Table:      "tBgpPeerNgOperTable",
+					MetricType: ddprofiledefinition.ProfileMetricTypeRate,
+					Tags: map[string]string{
+						"routing_instance": "Base",
+						"neighbor":         "192.0.2.1",
+						"remote_as":        "64512",
+					},
+					StaticTags: map[string]string{
+						"address_family":            "ipv6",
+						"subsequent_address_family": "unicast",
+					},
+				},
+				{
+					Name:       "bgpPeerOutUpdates",
+					Value:      22,
+					IsTable:    true,
+					Table:      "tBgpPeerNgOperTable",
+					MetricType: ddprofiledefinition.ProfileMetricTypeRate,
+					Tags: map[string]string{
+						"routing_instance": "Base",
+						"neighbor":         "192.0.2.1",
+						"remote_as":        "64512",
+					},
+					StaticTags: map[string]string{
+						"address_family":            "ipv6",
+						"subsequent_address_family": "unicast",
+					},
+				},
+			},
+			expected: []ddsnmp.Metric{
+				{
+					Name:    "bgpPeerUpdates",
+					IsTable: true,
+					Table:   "tBgpPeerNgOperTable",
+					Tags: map[string]string{
+						"routing_instance":          "Base",
+						"neighbor":                  "192.0.2.1",
+						"address_family":            "ipv4",
+						"subsequent_address_family": "unicast",
+						"remote_as":                 "64512",
+					},
+					MultiValue:  map[string]int64{"received": 11, "sent": 12},
+					Description: "Per-peer update traffic",
+					Family:      "Network/Routing/BGP/Peer/Message/Update",
+					Unit:        "{message}",
+					MetricType:  ddprofiledefinition.ProfileMetricTypeRate,
+				},
+				{
+					Name:    "bgpPeerUpdates",
+					IsTable: true,
+					Table:   "tBgpPeerNgOperTable",
+					Tags: map[string]string{
+						"routing_instance":          "Base",
+						"neighbor":                  "192.0.2.1",
+						"address_family":            "ipv6",
+						"subsequent_address_family": "unicast",
+						"remote_as":                 "64512",
+					},
+					MultiValue:  map[string]int64{"received": 21, "sent": 22},
+					Description: "Per-peer update traffic",
+					Family:      "Network/Routing/BGP/Peer/Message/Update",
+					Unit:        "{message}",
+					MetricType:  ddprofiledefinition.ProfileMetricTypeRate,
 				},
 			},
 		},
@@ -1400,7 +1793,7 @@ func TestVirtualMetricsCollector_Collect(t *testing.T) {
 					{
 						Name:    "ifTraffic",
 						PerRow:  true,
-						GroupBy: []string{"interface"},
+						GroupBy: ddprofiledefinition.StringArray{"interface"},
 						Alternatives: []ddprofiledefinition.VirtualMetricAlternativeSourcesConfig{
 							{Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
 								{Metric: "ifHCInOctets", Table: "ifXTable", As: "in"},
@@ -1462,7 +1855,7 @@ func TestVirtualMetricsCollector_Collect(t *testing.T) {
 					{
 						Name:    "ifTraffic",
 						PerRow:  true,
-						GroupBy: []string{"interface"},
+						GroupBy: ddprofiledefinition.StringArray{"interface"},
 						Alternatives: []ddprofiledefinition.VirtualMetricAlternativeSourcesConfig{
 							{Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
 								{Metric: "ifHCInOctets", Table: "ifXTable", As: "in"},
@@ -1526,7 +1919,15 @@ func TestVirtualMetricsCollector_Collect(t *testing.T) {
 }
 
 func Test_vmBuildGroupKey(t *testing.T) {
-	const sep = '\x1F'
+	encodeParts := func(parts ...string) string {
+		var b strings.Builder
+		for _, part := range parts {
+			b.WriteString(strconv.Itoa(len(part)))
+			b.WriteByte(':')
+			b.WriteString(part)
+		}
+		return b.String()
+	}
 
 	tests := map[string]struct {
 		agg     vmetricsAggregator
@@ -1545,7 +1946,7 @@ func Test_vmBuildGroupKey(t *testing.T) {
 			agg:     vmetricsAggregator{grouped: true, perRow: true},
 			tags:    map[string]string{"iface": "eth0", "_if_type": "loopback", "zone": "a"},
 			wantOK:  true,
-			wantKey: "iface=eth0" + string(sep) + "zone=a",
+			wantKey: encodeParts("iface", "eth0", "zone", "a"),
 		},
 
 		"per_row + no groupBy: all tags underscore -> no key": {
@@ -1559,14 +1960,14 @@ func Test_vmBuildGroupKey(t *testing.T) {
 			agg:     vmetricsAggregator{grouped: true, perRow: true, groupBy: []string{"_if_type", "iface"}},
 			tags:    map[string]string{"iface": "eth0", "_if_type": "ethernetCsmacd"},
 			wantOK:  true,
-			wantKey: "ethernetCsmacd" + string(sep) + "eth0",
+			wantKey: encodeParts("ethernetCsmacd", "eth0"),
 		},
 
-		"per_row + groupBy: missing required tag -> no key": {
+		"per_row + groupBy: missing hint falls back to stable visible-tag key": {
 			agg:     vmetricsAggregator{grouped: true, perRow: true, groupBy: []string{"iface", "zone"}},
 			tags:    map[string]string{"iface": "eth0"},
-			wantOK:  false,
-			wantKey: "",
+			wantOK:  true,
+			wantKey: encodeParts("iface", "eth0"),
 		},
 
 		"non per_row + groupBy(1): returns that label value": {
@@ -1580,7 +1981,7 @@ func Test_vmBuildGroupKey(t *testing.T) {
 			agg:     vmetricsAggregator{grouped: true, perRow: false, groupBy: []string{"_if_type", "zone"}},
 			tags:    map[string]string{"_if_type": "ethernetCsmacd", "zone": "edge"},
 			wantOK:  true,
-			wantKey: "ethernetCsmacd" + string(sep) + "edge",
+			wantKey: encodeParts("ethernetCsmacd", "edge"),
 		},
 
 		"non per_row + groupBy: missing one value -> no key": {
@@ -1598,6 +1999,27 @@ func Test_vmBuildGroupKey(t *testing.T) {
 			assert.Equal(t, tc.wantKey, key, "key mismatch")
 		})
 	}
+
+	t.Run("per_row fallback encodes key-value pairs without raw-delimiter collisions", func(t *testing.T) {
+		keyA, okA := vmBuildGroupKey(map[string]string{"a=b": "c"}, &vmetricsAggregator{grouped: true, perRow: true})
+		keyB, okB := vmBuildGroupKey(map[string]string{"a": "b=c"}, &vmetricsAggregator{grouped: true, perRow: true})
+
+		assert.True(t, okA)
+		assert.True(t, okB)
+		assert.NotEqual(t, keyA, keyB)
+	})
+
+	t.Run("multi-label group_by encodes values without separator collisions", func(t *testing.T) {
+		sep := string(rune(0x1F))
+		agg := vmetricsAggregator{grouped: true, groupBy: []string{"iface", "zone"}}
+
+		keyA, okA := vmBuildGroupKey(map[string]string{"iface": "a" + sep + "b", "zone": "c"}, &agg)
+		keyB, okB := vmBuildGroupKey(map[string]string{"iface": "a", "zone": "b" + sep + "c"}, &vmetricsAggregator{grouped: true, groupBy: []string{"iface", "zone"}})
+
+		assert.True(t, okA)
+		assert.True(t, okB)
+		assert.NotEqual(t, keyA, keyB)
+	})
 }
 
 var (

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/cross_table_lookup.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/cross_table_lookup.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+
+	"github.com/gosnmp/gosnmp"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+func (r *crossTableResolver) requiresLookupByValue(tagCfg ddprofiledefinition.MetricTagConfig) bool {
+	return tagCfg.LookupSymbol.OID != "" || tagCfg.LookupSymbol.Name != ""
+}
+
+func (r *crossTableResolver) resolveLookupIndexByValue(
+	tagCfg ddprofiledefinition.MetricTagConfig,
+	lookupValue string,
+	refTableOID string,
+	refTablePDUs map[string]gosnmp.SnmpPDU,
+	ctx *crossTableContext,
+) (string, error) {
+	normalizedLookupValue, ok := r.normalizeLookupValue(ddprofiledefinition.SymbolConfig(tagCfg.LookupSymbol), lookupValue)
+	if !ok {
+		return "", fmt.Errorf("value '%s' could not be normalized for lookup column %s", lookupValue, tagCfg.LookupSymbol.OID)
+	}
+
+	cacheKey := crossTableLookupKey{
+		refTableOID:     refTableOID,
+		lookupColumnOID: trimOID(tagCfg.LookupSymbol.OID),
+		targetColumnOID: trimOID(tagCfg.Symbol.OID),
+		lookupValue:     normalizedLookupValue,
+	}
+	if rowIndex, ok := ctx.lookupIndexCache[cacheKey]; ok {
+		if rowIndex == "" {
+			return "", fmt.Errorf("value '%s' not found in lookup column %s", normalizedLookupValue, tagCfg.LookupSymbol.OID)
+		}
+		return rowIndex, nil
+	}
+
+	rowIndex, err := r.findRowIndexByLookupValue(tagCfg, normalizedLookupValue, refTablePDUs)
+	if err != nil {
+		ctx.lookupIndexCache[cacheKey] = ""
+		return "", err
+	}
+
+	ctx.lookupIndexCache[cacheKey] = rowIndex
+	return rowIndex, nil
+}
+
+func (r *crossTableResolver) findRowIndexByLookupValue(
+	tagCfg ddprofiledefinition.MetricTagConfig,
+	lookupValue string,
+	refTablePDUs map[string]gosnmp.SnmpPDU,
+) (string, error) {
+	lookupSym := tagCfg.LookupSymbol
+	lookupColumnOID := trimOID(lookupSym.OID)
+	prefix := lookupColumnOID + "."
+	matchedIndexes := make([]string, 0, 1)
+
+	for fullOID, pdu := range refTablePDUs {
+		if !strings.HasPrefix(fullOID, prefix) {
+			continue
+		}
+
+		val, ok := r.processLookupSymbolValue(ddprofiledefinition.SymbolConfig(lookupSym), pdu)
+		if !ok || val != lookupValue {
+			continue
+		}
+
+		matchedIndexes = append(matchedIndexes, strings.TrimPrefix(fullOID, prefix))
+	}
+
+	switch len(matchedIndexes) {
+	case 0:
+		return "", fmt.Errorf("value '%s' not found in lookup column %s", lookupValue, lookupSym.OID)
+	case 1:
+		return matchedIndexes[0], nil
+	}
+
+	rowIndex, ok := r.resolveAmbiguousLookupRows(tagCfg, matchedIndexes, refTablePDUs)
+	if ok {
+		return rowIndex, nil
+	}
+
+	return "", fmt.Errorf(
+		"lookup value '%s' matched multiple rows in %s with different values for %s",
+		lookupValue,
+		lookupSym.OID,
+		tagCfg.Symbol.OID,
+	)
+}
+
+func (r *crossTableResolver) processLookupSymbolValue(sym ddprofiledefinition.SymbolConfig, pdu gosnmp.SnmpPDU) (string, bool) {
+	val, err := convPduToStringf(pdu, sym.Format)
+	if err != nil {
+		return "", false
+	}
+
+	return r.normalizeLookupText(sym, val, false)
+}
+
+func (r *crossTableResolver) normalizeLookupValue(sym ddprofiledefinition.SymbolConfig, raw string) (string, bool) {
+	return r.normalizeLookupText(sym, raw, true)
+}
+
+func (r *crossTableResolver) normalizeLookupText(sym ddprofiledefinition.SymbolConfig, val string, applyFormat bool) (string, bool) {
+	if sym.ExtractValueCompiled != nil {
+		sm := sym.ExtractValueCompiled.FindStringSubmatch(val)
+		if len(sm) > 1 {
+			val = sm[1]
+		}
+	}
+
+	if sym.MatchPatternCompiled != nil {
+		sm := sym.MatchPatternCompiled.FindStringSubmatch(val)
+		if len(sm) == 0 {
+			return "", false
+		}
+		val = replaceSubmatches(sym.MatchValue, sm)
+	}
+
+	if applyFormat && sym.Format != "" {
+		formatted, err := formatIndexTagValue(val, sym.Format)
+		if err != nil {
+			return "", false
+		}
+		val = formatted
+	}
+
+	if sym.Format == "ip_address" {
+		if addr, err := netip.ParseAddr(val); err == nil {
+			val = addr.Unmap().String()
+		}
+	}
+
+	if mapped, ok := sym.Mapping[val]; ok {
+		val = mapped
+	}
+
+	return val, true
+}
+
+func (r *crossTableResolver) resolveAmbiguousLookupRows(
+	tagCfg ddprofiledefinition.MetricTagConfig,
+	rowIndexes []string,
+	refTablePDUs map[string]gosnmp.SnmpPDU,
+) (string, bool) {
+	wantValue := ""
+
+	for _, rowIndex := range rowIndexes {
+		value, ok := r.resolveLookupTargetTagValue(tagCfg, rowIndex, refTablePDUs)
+		if !ok {
+			return "", false
+		}
+		if wantValue == "" {
+			wantValue = value
+			continue
+		}
+		if wantValue != value {
+			return "", false
+		}
+	}
+
+	return rowIndexes[0], wantValue != ""
+}
+
+func (r *crossTableResolver) resolveLookupTargetTagValue(
+	tagCfg ddprofiledefinition.MetricTagConfig,
+	rowIndex string,
+	refTablePDUs map[string]gosnmp.SnmpPDU,
+) (string, bool) {
+	pdu, err := r.lookupValue(tagCfg, rowIndex, refTablePDUs)
+	if err != nil {
+		return "", false
+	}
+
+	tags := make(map[string]string, 1)
+	if err := r.tagProcessor.processTag(tagCfg, pdu, tagAdder{tags: tags}); err != nil {
+		return "", false
+	}
+
+	tagName := ternary(tagCfg.Tag != "", tagCfg.Tag, tagCfg.Symbol.Name)
+	value := tags[tagName]
+	return value, value != ""
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/cross_table_lookup.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/cross_table_lookup.go
@@ -43,7 +43,6 @@ func (r *crossTableResolver) resolveLookupIndexByValue(
 
 	rowIndex, err := r.findRowIndexByLookupValue(tagCfg, normalizedLookupValue, refTablePDUs)
 	if err != nil {
-		ctx.lookupIndexCache[cacheKey] = ""
 		return "", err
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/cross_table_lookup_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/cross_table_lookup_test.go
@@ -122,6 +122,50 @@ func TestCrossTableResolver_ResolveLookupIndexByValue_RejectsDuplicateRowsWhenTa
 	assert.Contains(t, err.Error(), tagCfg.Symbol.OID)
 }
 
+func TestCrossTableResolver_ResolveLookupIndexByValue_DoesNotCacheLookupErrorsAsNotFound(t *testing.T) {
+	resolver := newCrossTableResolver(logger.New())
+	tagCfg := lookupTestTagConfig(
+		"remote_as",
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2",
+		"neighbor",
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4",
+	)
+
+	refTablePDUs := map[string]gosnmp.SnmpPDU{
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.1.1.1.4.10.45.2.2": createStringPDU(
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.1.1.1.4.10.45.2.2",
+			"10.45.2.2",
+		),
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.1.128.1.4.10.45.2.2": createStringPDU(
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.1.128.1.4.10.45.2.2",
+			"10.45.2.2",
+		),
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2.0.1.1.1.4.10.45.2.2": createGauge32PDU(
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2.0.1.1.1.4.10.45.2.2",
+			26479,
+		),
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2.0.1.128.1.4.10.45.2.2": createGauge32PDU(
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2.0.1.128.1.4.10.45.2.2",
+			64512,
+		),
+	}
+	ctx := &crossTableContext{lookupIndexCache: map[crossTableLookupKey]string{}}
+
+	for i := 0; i < 2; i++ {
+		_, err := resolver.resolveLookupIndexByValue(
+			tagCfg,
+			"0.0.4.10.45.2.2",
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2",
+			refTablePDUs,
+			ctx,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "matched multiple rows")
+		assert.Contains(t, err.Error(), tagCfg.Symbol.OID)
+	}
+	assert.Empty(t, ctx.lookupIndexCache)
+}
+
 func lookupTestTagConfig(tagName, symbolOID, lookupName, lookupOID string) ddprofiledefinition.MetricTagConfig {
 	return ddprofiledefinition.MetricTagConfig{
 		Tag: tagName,

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/cross_table_lookup_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/cross_table_lookup_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+func TestCrossTableResolver_ResolveLookupIndexByValue_NormalizesIPv6CurrentRowIndex(t *testing.T) {
+	resolver := newCrossTableResolver(logger.New())
+	tagCfg := lookupTestTagConfig(
+		"neighbor",
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4",
+		"neighbor",
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4",
+	)
+
+	refTablePDUs := map[string]gosnmp.SnmpPDU{
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.2.1.2.16.32.1.18.248.0.0.0.0.0.0.0.0.2.35.2.83": createStringPDU(
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.2.1.2.16.32.1.18.248.0.0.0.0.0.0.0.0.2.35.2.83",
+			"2001:12F8::223:253",
+		),
+	}
+
+	rowIndex, err := resolver.resolveLookupIndexByValue(
+		tagCfg,
+		"0.0.16.32.1.18.248.0.0.0.0.0.0.0.0.2.35.2.83",
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2",
+		refTablePDUs,
+		&crossTableContext{lookupIndexCache: map[crossTableLookupKey]string{}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "0.2.1.2.16.32.1.18.248.0.0.0.0.0.0.0.0.2.35.2.83", rowIndex)
+}
+
+func TestCrossTableResolver_ResolveLookupIndexByValue_AllowsDuplicateRowsWhenTargetValueMatches(t *testing.T) {
+	resolver := newCrossTableResolver(logger.New())
+	tagCfg := lookupTestTagConfig(
+		"remote_as",
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2",
+		"neighbor",
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4",
+	)
+
+	refTablePDUs := map[string]gosnmp.SnmpPDU{
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.1.1.1.4.10.45.2.2": createStringPDU(
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.1.1.1.4.10.45.2.2",
+			"10.45.2.2",
+		),
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.1.128.1.4.10.45.2.2": createStringPDU(
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.1.128.1.4.10.45.2.2",
+			"10.45.2.2",
+		),
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2.0.1.1.1.4.10.45.2.2": createGauge32PDU(
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2.0.1.1.1.4.10.45.2.2",
+			26479,
+		),
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2.0.1.128.1.4.10.45.2.2": createGauge32PDU(
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2.0.1.128.1.4.10.45.2.2",
+			26479,
+		),
+	}
+
+	rowIndex, err := resolver.resolveLookupIndexByValue(
+		tagCfg,
+		"0.0.4.10.45.2.2",
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2",
+		refTablePDUs,
+		&crossTableContext{lookupIndexCache: map[crossTableLookupKey]string{}},
+	)
+	require.NoError(t, err)
+	assert.Contains(t, []string{
+		"0.1.1.1.4.10.45.2.2",
+		"0.1.128.1.4.10.45.2.2",
+	}, rowIndex)
+}
+
+func TestCrossTableResolver_ResolveLookupIndexByValue_RejectsDuplicateRowsWhenTargetValueDiffers(t *testing.T) {
+	resolver := newCrossTableResolver(logger.New())
+	tagCfg := lookupTestTagConfig(
+		"remote_as",
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2",
+		"neighbor",
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4",
+	)
+
+	refTablePDUs := map[string]gosnmp.SnmpPDU{
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.1.1.1.4.10.45.2.2": createStringPDU(
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.1.1.1.4.10.45.2.2",
+			"10.45.2.2",
+		),
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.1.128.1.4.10.45.2.2": createStringPDU(
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.4.0.1.128.1.4.10.45.2.2",
+			"10.45.2.2",
+		),
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2.0.1.1.1.4.10.45.2.2": createGauge32PDU(
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2.0.1.1.1.4.10.45.2.2",
+			26479,
+		),
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2.0.1.128.1.4.10.45.2.2": createGauge32PDU(
+			"1.3.6.1.4.1.2011.5.25.177.1.1.2.1.2.0.1.128.1.4.10.45.2.2",
+			64512,
+		),
+	}
+
+	_, err := resolver.resolveLookupIndexByValue(
+		tagCfg,
+		"0.0.4.10.45.2.2",
+		"1.3.6.1.4.1.2011.5.25.177.1.1.2",
+		refTablePDUs,
+		&crossTableContext{lookupIndexCache: map[crossTableLookupKey]string{}},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "matched multiple rows")
+	assert.Contains(t, err.Error(), tagCfg.Symbol.OID)
+}
+
+func lookupTestTagConfig(tagName, symbolOID, lookupName, lookupOID string) ddprofiledefinition.MetricTagConfig {
+	return ddprofiledefinition.MetricTagConfig{
+		Tag: tagName,
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			OID:  symbolOID,
+			Name: tagName,
+		},
+		LookupSymbol: ddprofiledefinition.SymbolConfigCompat{
+			OID:                  lookupOID,
+			Name:                 lookupName,
+			Format:               "ip_address",
+			ExtractValue:         `^(?:[^.]+\.){2}(?:4|16)\.(.*)$`,
+			ExtractValueCompiled: mustCompileRegex(`^(?:[^.]+\.){2}(?:4|16)\.(.*)$`),
+		},
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/index_tag_value.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/index_tag_value.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+func processRawIndexTagValue(cfg ddprofiledefinition.MetricTagConfig, raw string) (string, error) {
+	val := raw
+
+	if cfg.Symbol.ExtractValueCompiled != nil {
+		sm := cfg.Symbol.ExtractValueCompiled.FindStringSubmatch(val)
+		if len(sm) < 2 {
+			return "", fmt.Errorf("extract_value did not match transformed index '%s'", raw)
+		}
+		val = sm[1]
+	}
+
+	if cfg.Symbol.MatchPatternCompiled != nil {
+		sm := cfg.Symbol.MatchPatternCompiled.FindStringSubmatch(val)
+		if len(sm) == 0 {
+			return "", fmt.Errorf("match_pattern '%s' did not match transformed index '%s'", cfg.Symbol.MatchPattern, val)
+		}
+		val = replaceSubmatches(cfg.Symbol.MatchValue, sm)
+	}
+
+	if cfg.Symbol.Format != "" {
+		formatted, err := formatIndexTagValue(val, cfg.Symbol.Format)
+		if err != nil {
+			return "", err
+		}
+		val = formatted
+	}
+
+	if mapped, ok := cfg.Mapping[val]; ok {
+		val = mapped
+	}
+
+	return val, nil
+}
+
+func formatIndexTagValue(raw string, format string) (string, error) {
+	switch format {
+	case "", "string":
+		return raw, nil
+	case "ip_address":
+		return formatIndexIPAddress(raw)
+	default:
+		return raw, nil
+	}
+}
+
+func formatIndexIPAddress(raw string) (string, error) {
+	if strings.Contains(raw, ":") {
+		if s, ok := canonicalIPAddressText(raw); ok {
+			return s, nil
+		}
+		return "", fmt.Errorf("cannot convert transformed index '%s' to IP address", raw)
+	}
+
+	parts := strings.Split(raw, ".")
+	switch len(parts) {
+	case 4, 8, 16, 20:
+	default:
+		return "", fmt.Errorf("cannot convert transformed index '%s' to IP address", raw)
+	}
+
+	bytes := make([]byte, 0, len(parts))
+	for _, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 || n > 255 {
+			return "", fmt.Errorf("cannot convert transformed index '%s' to IP address", raw)
+		}
+		bytes = append(bytes, byte(n))
+	}
+
+	if s, ok := ipAddressFromRawBytes(bytes); ok {
+		return s, nil
+	}
+
+	return "", fmt.Errorf("cannot convert transformed index '%s' to IP address", raw)
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/index_tag_value_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/index_tag_value_test.go
@@ -53,6 +53,24 @@ func TestTableRowProcessor_ProcessIndexTag_RegexMappedFamily(t *testing.T) {
 	assert.Equal(t, "vpn", tagValue)
 }
 
+func TestTableRowProcessor_ProcessIndexTag_PositionUsesSymbolNameFallback(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	tagName, tagValue, err := p.processIndexTag(ddprofiledefinition.MetricTagConfig{
+		Index: 2,
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			Name: "neighbor",
+		},
+		Mapping: map[string]string{
+			"42": "mapped",
+		},
+	}, "7.42.9")
+
+	require.NoError(t, err)
+	assert.Equal(t, "neighbor", tagName)
+	assert.Equal(t, "mapped", tagValue)
+}
+
 func TestTableRowProcessor_ProcessIndexTag_IPv4zAddress(t *testing.T) {
 	p := newTableRowProcessor(logger.New())
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/index_tag_value_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/index_tag_value_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+func TestTableRowProcessor_ProcessIndexTag_DropRightIPAddress(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	tagName, tagValue, err := p.processIndexTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "neighbor",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			Name:   "cbgpPeer2RemoteAddrIndex",
+			Format: "ip_address",
+		},
+		IndexTransform: []ddprofiledefinition.MetricIndexTransform{
+			{
+				Start:     2,
+				DropRight: 2,
+			},
+		},
+	}, "1.4.192.0.2.1.1.128")
+
+	require.NoError(t, err)
+	assert.Equal(t, "neighbor", tagName)
+	assert.Equal(t, "192.0.2.1", tagValue)
+}
+
+func TestTableRowProcessor_ProcessIndexTag_RegexMappedFamily(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	tagName, tagValue, err := p.processIndexTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "subsequent_address_family",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			Name:                 "cbgpPeer2AddrFamilySafiIndex",
+			ExtractValueCompiled: mustCompileRegex(`^(?:\d+\.)+\d+\.(\d+)$`),
+		},
+		Mapping: map[string]string{
+			"128": "vpn",
+		},
+	}, "1.4.192.0.2.1.1.128")
+
+	require.NoError(t, err)
+	assert.Equal(t, "subsequent_address_family", tagName)
+	assert.Equal(t, "vpn", tagValue)
+}
+
+func TestTableRowProcessor_ProcessIndexTag_IPv4zAddress(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	tagName, tagValue, err := p.processIndexTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "neighbor",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			Name:   "bgpPeerRemoteAddrIndex",
+			Format: "ip_address",
+		},
+	}, "192.0.2.1.0.0.0.7")
+
+	require.NoError(t, err)
+	assert.Equal(t, "neighbor", tagName)
+	assert.Equal(t, "192.0.2.1%0.0.0.7", tagValue)
+}
+
+func TestTableRowProcessor_ProcessIndexTag_IPv6zAddress(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	tagName, tagValue, err := p.processIndexTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "neighbor",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			Name:   "bgpPeerRemoteAddrIndex",
+			Format: "ip_address",
+		},
+	}, "254.128.1.2.0.0.0.0.194.213.130.253.254.123.34.167.0.0.14.132")
+
+	require.NoError(t, err)
+	assert.Equal(t, "neighbor", tagName)
+	assert.Equal(t, "fe80:102::c2d5:82fd:fe7b:22a7%0.0.14.132", tagValue)
+}
+
+func TestTableRowProcessor_ProcessIndexTag_TextIPv6AddressIsCanonicalized(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	tagName, tagValue, err := p.processIndexTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "neighbor",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			Name:   "bgpPeerRemoteAddrIndex",
+			Format: "ip_address",
+		},
+	}, "2001:0550:0002:002f:0000:0000:0033:0001")
+
+	require.NoError(t, err)
+	assert.Equal(t, "neighbor", tagName)
+	assert.Equal(t, "2001:550:2:2f::33:1", tagValue)
+}
+
+func TestTableRowProcessor_ProcessIndexTag_RawIPv6AddressIsCanonicalized(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	tagName, tagValue, err := p.processIndexTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "neighbor",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			Name:   "bgpPeerRemoteAddrIndex",
+			Format: "ip_address",
+		},
+	}, "32.1.5.80.0.2.0.47.0.0.0.0.0.51.0.1")
+
+	require.NoError(t, err)
+	assert.Equal(t, "neighbor", tagName)
+	assert.Equal(t, "2001:550:2:2f::33:1", tagValue)
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/ip_address_format.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/ip_address_format.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+func convPduToIPAddress(pdu gosnmp.SnmpPDU) (string, error) {
+	if pdu.Type == gosnmp.IPAddress {
+		return convPduToString(pdu)
+	}
+
+	switch v := pdu.Value.(type) {
+	case []byte:
+		if s, ok := ipAddressFromOctetBytes(v); ok {
+			return s, nil
+		}
+	case string:
+		if s, ok := ipAddressFromText(v); ok {
+			return s, nil
+		}
+	}
+
+	return "", fmt.Errorf("cannot convert %T to IP address", pdu.Value)
+}
+
+func ipAddressFromOctetBytes(bs []byte) (string, bool) {
+	if s, ok := ipAddressFromRawBytes(bs); ok {
+		return s, true
+	}
+
+	if !utf8.Valid(bs) {
+		return "", false
+	}
+
+	return ipAddressFromText(string(bs))
+}
+
+func ipAddressFromText(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", false
+	}
+
+	if s, ok := canonicalIPAddressText(raw); ok {
+		return s, true
+	}
+
+	decoded, ok := parseDecimalOctets(raw)
+	if !ok {
+		return "", false
+	}
+
+	if s, ok := ipAddressFromRawBytes(decoded); ok {
+		return s, true
+	}
+
+	if !utf8.Valid(decoded) {
+		return "", false
+	}
+
+	text := strings.TrimSpace(string(decoded))
+	if s, ok := canonicalIPAddressText(text); ok {
+		return s, true
+	}
+
+	return "", false
+}
+
+func canonicalIPAddressText(raw string) (string, bool) {
+	addr, err := netip.ParseAddr(raw)
+	if err != nil {
+		return "", false
+	}
+	return addr.Unmap().String(), true
+}
+
+func ipAddressFromRawBytes(bs []byte) (string, bool) {
+	switch len(bs) {
+	case 4:
+		return renderIPv4Bytes(bs), true
+	case 8:
+		return renderIPv4Bytes(bs[:4]) + "%" + renderZoneIndex(bs[4:8]), true
+	case 16:
+		return canonicalIPAddressBytes(bs)
+	case 20:
+		if s, ok := canonicalIPAddressBytes(bs[:16]); ok {
+			return s + "%" + renderZoneIndex(bs[16:20]), true
+		}
+		return "", false
+	default:
+		return "", false
+	}
+}
+
+func renderIPv4Bytes(bs []byte) string {
+	return fmt.Sprintf("%d.%d.%d.%d", bs[0], bs[1], bs[2], bs[3])
+}
+
+func canonicalIPAddressBytes(bs []byte) (string, bool) {
+	addr, ok := netip.AddrFromSlice(bs)
+	if !ok {
+		return "", false
+	}
+	return addr.Unmap().String(), true
+}
+
+func renderZoneIndex(bs []byte) string {
+	parts := make([]string, 0, len(bs))
+	for _, b := range bs {
+		parts = append(parts, strconv.Itoa(int(b)))
+	}
+	return strings.Join(parts, ".")
+}
+
+func parseDecimalOctets(raw string) ([]byte, bool) {
+	parts := strings.Split(raw, ".")
+	if len(parts) < 2 {
+		return nil, false
+	}
+
+	out := make([]byte, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			return nil, false
+		}
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 || n > 255 {
+			return nil, false
+		}
+		out = append(out, byte(n))
+	}
+
+	return out, true
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/ip_address_format_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/ip_address_format_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvPduToIPAddress(t *testing.T) {
+	t.Run("raw ipv4 octets", func(t *testing.T) {
+		s, err := convPduToIPAddress(createPDU("1.2.3", gosnmp.OctetString, []byte{169, 254, 247, 2}))
+		require.NoError(t, err)
+		assert.Equal(t, "169.254.247.2", s)
+	})
+
+	t.Run("textual octet string ipv4", func(t *testing.T) {
+		s, err := convPduToIPAddress(createPDU("1.2.3", gosnmp.OctetString, []byte("169.254.247.2")))
+		require.NoError(t, err)
+		assert.Equal(t, "169.254.247.2", s)
+	})
+
+	t.Run("decimal encoded octets that decode to textual ip", func(t *testing.T) {
+		s, err := convPduToIPAddress(createPDU("1.2.3", gosnmp.OctetString, []byte("49.57.50.46.49.54.56.46.50.53.53.46.49.48")))
+		require.NoError(t, err)
+		assert.Equal(t, "192.168.255.10", s)
+	})
+
+	t.Run("textual ipv6 octet string", func(t *testing.T) {
+		input := "2001:0550:0002:002f:0000:0000:0033:0001"
+		s, err := convPduToIPAddress(createPDU("1.2.3", gosnmp.OctetString, []byte("2001:0550:0002:002f:0000:0000:0033:0001")))
+		require.NoError(t, err)
+		assert.Equal(t, netip.MustParseAddr(input).String(), s)
+	})
+
+	t.Run("textual ipv6-mapped ipv4 octet string is unmapped", func(t *testing.T) {
+		s, err := convPduToIPAddress(createPDU("1.2.3", gosnmp.OctetString, []byte("::ffff:192.0.2.10")))
+		require.NoError(t, err)
+		assert.Equal(t, "192.0.2.10", s)
+	})
+
+	t.Run("raw ipv4z octets", func(t *testing.T) {
+		s, err := convPduToIPAddress(createPDU("1.2.3", gosnmp.OctetString, []byte{192, 0, 2, 1, 0, 0, 0, 7}))
+		require.NoError(t, err)
+		assert.Equal(t, "192.0.2.1%0.0.0.7", s)
+	})
+
+	t.Run("raw ipv6 octets are canonicalized like text", func(t *testing.T) {
+		s, err := convPduToIPAddress(createPDU("1.2.3", gosnmp.OctetString, []byte{
+			32, 1, 5, 80, 0, 2, 0, 47, 0, 0, 0, 0, 0, 51, 0, 1,
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "2001:550:2:2f::33:1", s)
+	})
+
+	t.Run("raw ipv6z octets", func(t *testing.T) {
+		s, err := convPduToIPAddress(createPDU("1.2.3", gosnmp.OctetString, []byte{
+			254, 128, 1, 2, 0, 0, 0, 0, 194, 213, 130, 253, 254, 123, 34, 167,
+			0, 0, 14, 132,
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "fe80:102::c2d5:82fd:fe7b:22a7%0.0.14.132", s)
+	})
+
+	t.Run("invalid octet string", func(t *testing.T) {
+		_, err := convPduToIPAddress(createPDU("1.2.3", gosnmp.OctetString, []byte("not-an-ip")))
+		require.Error(t, err)
+	})
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/metric_builder.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/metric_builder.go
@@ -38,6 +38,15 @@ func (mb *metricBuilder) withTags(tags map[string]string) *metricBuilder {
 func (mb *metricBuilder) withStaticTags(tags map[string]string) *metricBuilder {
 	if len(tags) > 0 {
 		mb.metric.StaticTags = maps.Clone(tags)
+		if mb.metric.Tags == nil {
+			mb.metric.Tags = maps.Clone(tags)
+		} else {
+			for k, v := range tags {
+				if current, ok := mb.metric.Tags[k]; !ok || current == "" {
+					mb.metric.Tags[k] = v
+				}
+			}
+		}
 	}
 	return mb
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/metric_builder_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/metric_builder_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricBuilder_WithStaticTagsFillsMissingAndEmptyValues(t *testing.T) {
+	metric := newMetricBuilder("testMetric", 1).
+		withTags(map[string]string{
+			"region":   "",
+			"neighbor": "192.0.2.10",
+		}).
+		withStaticTags(map[string]string{
+			"region": "eu-west",
+			"site":   "athens",
+		}).
+		build()
+
+	assert.Equal(t, map[string]string{
+		"region":   "eu-west",
+		"neighbor": "192.0.2.10",
+		"site":     "athens",
+	}, metric.Tags)
+	assert.Equal(t, map[string]string{
+		"region": "eu-west",
+		"site":   "athens",
+	}, metric.StaticTags)
+}
+
+func TestMetricBuilder_WithStaticTagsKeepsExistingNonEmptyValues(t *testing.T) {
+	metric := newMetricBuilder("testMetric", 1).
+		withTags(map[string]string{
+			"region": "edge",
+		}).
+		withStaticTags(map[string]string{
+			"region": "core",
+		}).
+		build()
+
+	assert.Equal(t, map[string]string{"region": "edge"}, metric.Tags)
+	assert.Equal(t, map[string]string{"region": "core"}, metric.StaticTags)
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
@@ -30,7 +30,7 @@ type (
 	// tableRowProcessingContext contains context needed for processing a row
 	tableRowProcessingContext struct {
 		config        ddprofiledefinition.MetricsConfig
-		columnOIDs    map[string]ddprofiledefinition.SymbolConfig
+		columnOIDs    map[string][]ddprofiledefinition.SymbolConfig
 		crossTableCtx *crossTableContext
 		orderedTags   []orderedTagConfig
 	}
@@ -91,9 +91,13 @@ func (p *tableRowProcessor) processSingleCrossTableTag(row *tableRowData, tagCfg
 }
 
 func (p *tableRowProcessor) processSingleIndexTag(row *tableRowData, tagCfg ddprofiledefinition.MetricTagConfig) {
-	tagName, indexValue, ok := p.processIndexTag(tagCfg, row.index)
-	if !ok {
-		p.log.Debugf("Cannot extract position %d from index %s", tagCfg.Index, row.index)
+	tagName, indexValue, err := p.processIndexTag(tagCfg, row.index)
+	if err != nil {
+		if tagCfg.Index != 0 {
+			p.log.Debugf("Cannot extract position %d from index %s: %v", tagCfg.Index, row.index, err)
+		} else {
+			p.log.Debugf("Cannot process transformed index tag %s from index %s: %v", tagCfg.Tag, row.index, err)
+		}
 		return
 	}
 
@@ -101,19 +105,34 @@ func (p *tableRowProcessor) processSingleIndexTag(row *tableRowData, tagCfg ddpr
 	ta.addTag(tagName, indexValue)
 }
 
-func (p *tableRowProcessor) processIndexTag(cfg ddprofiledefinition.MetricTagConfig, index string) (string, string, bool) {
-	indexValue, ok := p.extractIndexPosition(index, cfg.Index)
-	if !ok {
-		return "", "", false
-	}
-
+func (p *tableRowProcessor) processIndexTag(cfg ddprofiledefinition.MetricTagConfig, index string) (string, string, error) {
 	tagName := ternary(cfg.Tag != "", cfg.Tag, fmt.Sprintf("index%d", cfg.Index))
-
-	if v, ok := cfg.Mapping[indexValue]; ok {
-		indexValue = v
+	if cfg.Index == 0 && cfg.Tag == "" {
+		tagName = cfg.Symbol.Name
 	}
 
-	return tagName, indexValue, true
+	rawValue := index
+	if cfg.Index != 0 {
+		indexValue, ok := p.extractIndexPosition(index, cfg.Index)
+		if !ok {
+			return "", "", fmt.Errorf("position %d not found", cfg.Index)
+		}
+		rawValue = indexValue
+	}
+
+	if cfg.Index == 0 && len(cfg.IndexTransform) > 0 {
+		rawValue = p.crossTableResolver.applyIndexTransform(index, cfg.IndexTransform)
+		if rawValue == "" {
+			return "", "", fmt.Errorf("index transformation failed")
+		}
+	}
+
+	value, err := processRawIndexTagValue(cfg, rawValue)
+	if err != nil {
+		return "", "", err
+	}
+
+	return tagName, value, nil
 }
 
 // extractPosition extracts a specific position from an index
@@ -141,21 +160,27 @@ func (p *tableRowProcessor) extractIndexPosition(index string, position uint) (s
 }
 
 func (p *tableRowProcessor) processRowMetrics(row *tableRowData, ctx *tableRowProcessingContext) ([]ddsnmp.Metric, error) {
-	metrics := make([]ddsnmp.Metric, 0, len(ctx.columnOIDs))
+	symbolCount := 0
+	for _, syms := range ctx.columnOIDs {
+		symbolCount += len(syms)
+	}
+	metrics := make([]ddsnmp.Metric, 0, symbolCount)
 
-	for columnOID, sym := range ctx.columnOIDs {
+	for columnOID, syms := range ctx.columnOIDs {
 		pdu, ok := row.pdus[columnOID]
 		if !ok {
 			continue
 		}
 
-		metric, err := p.createMetric(sym, pdu, row)
-		if err != nil {
-			p.log.Debugf("Error creating metric %s: %v", sym.Name, err)
-			continue
-		}
+		for _, sym := range syms {
+			metric, err := p.createMetric(sym, pdu, row)
+			if err != nil {
+				p.log.Debugf("Error creating metric %s: %v", sym.Name, err)
+				continue
+			}
 
-		metrics = append(metrics, *metric)
+			metrics = append(metrics, *metric)
+		}
 	}
 
 	return metrics, nil
@@ -171,6 +196,12 @@ func (p *tableRowProcessor) createMetric(sym ddprofiledefinition.SymbolConfig, p
 }
 
 type (
+	crossTableLookupKey struct {
+		refTableOID     string
+		lookupColumnOID string
+		targetColumnOID string
+		lookupValue     string
+	}
 	// crossTableResolver handles resolving tags from other tables
 	crossTableResolver struct {
 		log          *logger.Logger
@@ -178,9 +209,10 @@ type (
 	}
 	// crossTableContext contains all data needed for cross-table resolution
 	crossTableContext struct {
-		walkedData     map[string]map[string]gosnmp.SnmpPDU // tableOID -> PDUs
-		tableNameToOID map[string]string                    // tableName -> tableOID
-		rowTags        map[string]string
+		walkedData       map[string]map[string]gosnmp.SnmpPDU // tableOID -> PDUs
+		tableNameToOID   map[string]string                    // tableName -> tableOID
+		lookupIndexCache map[crossTableLookupKey]string       // cache key -> resolved row index
+		rowTags          map[string]string
 	}
 )
 
@@ -206,6 +238,13 @@ func (r *crossTableResolver) resolveCrossTableTag(tagCfg ddprofiledefinition.Met
 	lookupIndex, err := r.transformIndex(index, tagCfg.IndexTransform)
 	if err != nil {
 		return err
+	}
+
+	if r.requiresLookupByValue(tagCfg) {
+		lookupIndex, err = r.resolveLookupIndexByValue(tagCfg, lookupIndex, refTableOID, refTablePDUs, ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	pdu, err := r.lookupValue(tagCfg, lookupIndex, refTablePDUs)
@@ -277,6 +316,12 @@ func (r *crossTableResolver) applyIndexTransform(index string, transforms []ddpr
 
 	for _, transform := range transforms {
 		start, end := transform.Start, transform.End
+		if transform.DropRight > 0 {
+			if int(transform.DropRight) >= len(parts) {
+				return ""
+			}
+			end = uint(len(parts) - int(transform.DropRight) - 1)
+		}
 
 		if int(start) >= len(parts) || end < start || int(end) >= len(parts) {
 			return ""

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
@@ -93,11 +93,7 @@ func (p *tableRowProcessor) processSingleCrossTableTag(row *tableRowData, tagCfg
 func (p *tableRowProcessor) processSingleIndexTag(row *tableRowData, tagCfg ddprofiledefinition.MetricTagConfig) {
 	tagName, indexValue, err := p.processIndexTag(tagCfg, row.index)
 	if err != nil {
-		if tagCfg.Index != 0 {
-			p.log.Debugf("Cannot extract position %d from index %s: %v", tagCfg.Index, row.index, err)
-		} else {
-			p.log.Debugf("Cannot process transformed index tag %s from index %s: %v", metricTagDisplayName(tagCfg), row.index, err)
-		}
+		p.log.Debugf("Cannot process index tag %s from index %s: %v", metricTagDisplayName(tagCfg), row.index, err)
 		return
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
@@ -80,13 +80,13 @@ func (p *tableRowProcessor) processSingleSameTableTag(row *tableRowData, tagCfg 
 
 	ta := tagAdder{tags: row.tags}
 	if err := p.tagProc.processTag(tagCfg, pdu, ta); err != nil {
-		p.log.Debugf("Error processing tag %s: %v", tagCfg.Tag, err)
+		p.log.Debugf("Error processing tag %s: %v", metricTagDisplayName(tagCfg), err)
 	}
 }
 
 func (p *tableRowProcessor) processSingleCrossTableTag(row *tableRowData, tagCfg ddprofiledefinition.MetricTagConfig, ctx *tableRowProcessingContext) {
 	if err := p.crossTableResolver.resolveCrossTableTag(tagCfg, row.index, ctx.crossTableCtx); err != nil {
-		p.log.Debugf("Error resolving cross-table tag %s: %v", tagCfg.Tag, err)
+		p.log.Debugf("Error resolving cross-table tag %s: %v", metricTagDisplayName(tagCfg), err)
 	}
 }
 
@@ -96,7 +96,7 @@ func (p *tableRowProcessor) processSingleIndexTag(row *tableRowData, tagCfg ddpr
 		if tagCfg.Index != 0 {
 			p.log.Debugf("Cannot extract position %d from index %s: %v", tagCfg.Index, row.index, err)
 		} else {
-			p.log.Debugf("Cannot process transformed index tag %s from index %s: %v", tagCfg.Tag, row.index, err)
+			p.log.Debugf("Cannot process transformed index tag %s from index %s: %v", metricTagDisplayName(tagCfg), row.index, err)
 		}
 		return
 	}
@@ -133,6 +133,19 @@ func (p *tableRowProcessor) processIndexTag(cfg ddprofiledefinition.MetricTagCon
 	}
 
 	return tagName, value, nil
+}
+
+func metricTagDisplayName(cfg ddprofiledefinition.MetricTagConfig) string {
+	switch {
+	case cfg.Tag != "":
+		return cfg.Tag
+	case cfg.Symbol.Name != "":
+		return cfg.Symbol.Name
+	case cfg.Index != 0:
+		return fmt.Sprintf("index%d", cfg.Index)
+	default:
+		return "index"
+	}
 }
 
 // extractPosition extracts a specific position from an index

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
@@ -106,10 +106,7 @@ func (p *tableRowProcessor) processSingleIndexTag(row *tableRowData, tagCfg ddpr
 }
 
 func (p *tableRowProcessor) processIndexTag(cfg ddprofiledefinition.MetricTagConfig, index string) (string, string, error) {
-	tagName := ternary(cfg.Tag != "", cfg.Tag, fmt.Sprintf("index%d", cfg.Index))
-	if cfg.Index == 0 && cfg.Tag == "" {
-		tagName = cfg.Symbol.Name
-	}
+	tagName := metricTagDisplayName(cfg)
 
 	rawValue := index
 	if cfg.Index != 0 {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/tag_processor_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/tag_processor_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+func TestTableTagProcessor_ProcessTag_Uint32Format(t *testing.T) {
+	processor := newTableTagProcessor()
+	ta := tagAdder{tags: map[string]string{}}
+
+	err := processor.processTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "remote_as",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			OID:    "1.3.6.1.2.1.15.3.1.9",
+			Name:   "bgpPeerRemoteAs",
+			Format: "uint32",
+		},
+	}, gosnmp.SnmpPDU{
+		Name:  "1.3.6.1.2.1.15.3.1.9.169.254.1.1",
+		Type:  gosnmp.Integer,
+		Value: -94967296,
+	}, ta)
+
+	require.NoError(t, err)
+	assert.Equal(t, "4200000000", ta.tags["remote_as"])
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/tag_processor_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/tag_processor_test.go
@@ -32,3 +32,44 @@ func TestTableTagProcessor_ProcessTag_Uint32Format(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "4200000000", ta.tags["remote_as"])
 }
+
+func TestMetricTagDisplayName(t *testing.T) {
+	tests := map[string]struct {
+		cfg  ddprofiledefinition.MetricTagConfig
+		want string
+	}{
+		"explicit tag": {
+			cfg: ddprofiledefinition.MetricTagConfig{
+				Tag: "neighbor",
+				Symbol: ddprofiledefinition.SymbolConfigCompat{
+					Name: "peer_addr",
+				},
+			},
+			want: "neighbor",
+		},
+		"symbol name fallback": {
+			cfg: ddprofiledefinition.MetricTagConfig{
+				Symbol: ddprofiledefinition.SymbolConfigCompat{
+					Name: "peer_addr",
+				},
+			},
+			want: "peer_addr",
+		},
+		"index fallback": {
+			cfg: ddprofiledefinition.MetricTagConfig{
+				Index: 2,
+			},
+			want: "index2",
+		},
+		"raw index fallback": {
+			cfg:  ddprofiledefinition.MetricTagConfig{},
+			want: "index",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, metricTagDisplayName(tc.cfg))
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
@@ -57,30 +57,13 @@ func convPduToStringf(pdu gosnmp.SnmpPDU, format string) (string, error) {
 	case "mac_address":
 		return convPhysAddressToString(pdu)
 	case "ip_address":
-		if pdu.Type == gosnmp.IPAddress {
-			// Use the default handler for IP addresses
-			return convPduToString(pdu)
+		return convPduToIPAddress(pdu)
+	case "uint32":
+		value, err := convNumericPduToInt64f(pdu, format)
+		if err != nil {
+			return "", err
 		}
-
-		// Try to handle as bytes that represent an IP
-		bs, ok := pdu.Value.([]byte)
-		if !ok {
-			return "", fmt.Errorf("cannot convert %T to IP address", pdu.Value)
-		}
-
-		if len(bs) == 4 {
-			// IPv4
-			return fmt.Sprintf("%d.%d.%d.%d", bs[0], bs[1], bs[2], bs[3]), nil
-		} else if len(bs) == 16 {
-			// IPv6
-			parts := make([]string, 0, 8)
-			for i := 0; i < 16; i += 2 {
-				parts = append(parts, fmt.Sprintf("%02x%02x", bs[i], bs[i+1]))
-			}
-			return strings.Join(parts, ":"), nil
-		}
-
-		return "", fmt.Errorf("cannot convert %v to IP address (incorrect length)", pdu.Value)
+		return strconv.FormatInt(value, 10), nil
 	case "hex":
 		// Convert any value to hex string
 		bs, ok := pdu.Value.([]byte)
@@ -92,6 +75,23 @@ func convPduToStringf(pdu gosnmp.SnmpPDU, format string) (string, error) {
 		// For unknown formats, use the default string conversion
 		return convPduToString(pdu)
 	}
+}
+
+func convNumericPduToInt64f(pdu gosnmp.SnmpPDU, format string) (int64, error) {
+	if !isPduNumericType(pdu) {
+		return 0, fmt.Errorf("cannot convert %T to numeric value", pdu.Value)
+	}
+
+	value := gosnmp.ToBigInt(pdu.Value).Int64()
+
+	switch format {
+	case "uint32":
+		if value < 0 {
+			return int64(uint32(value)), nil
+		}
+	}
+
+	return value, nil
 }
 
 func convPduToString(pdu gosnmp.SnmpPDU) (string, error) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/value_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/value_processor.go
@@ -70,7 +70,10 @@ func (p *numericValueProcessor) processOpaqueDouble(sym ddprofiledefinition.Symb
 }
 
 func (p *numericValueProcessor) processInteger(sym ddprofiledefinition.SymbolConfig, pdu gosnmp.SnmpPDU) (int64, error) {
-	value := gosnmp.ToBigInt(pdu.Value).Int64()
+	value, err := convNumericPduToInt64f(pdu, sym.Format)
+	if err != nil {
+		return 0, err
+	}
 
 	if len(sym.Mapping) > 0 {
 		s := strconv.FormatInt(value, 10)
@@ -114,13 +117,30 @@ func (p *stringValueProcessor) processValue(sym ddprofiledefinition.SymbolConfig
 		s = v
 	}
 
-	value, err := strconv.ParseInt(s, 10, 64)
+	value, err := parseStringMetricValue(sym, s)
 	if err != nil {
-		return 0, fmt.Errorf("cannot convert '%s' to int64: %w", s, err)
+		return 0, err
 	}
 
 	if sym.ScaleFactor != 0 {
 		value = int64(float64(value) * sym.ScaleFactor)
+	}
+
+	return value, nil
+}
+
+func parseStringMetricValue(sym ddprofiledefinition.SymbolConfig, s string) (int64, error) {
+	base := 10
+	if sym.Format == "hex" {
+		base = 16
+	}
+
+	value, err := strconv.ParseInt(s, base, 64)
+	if err != nil {
+		if base == 16 {
+			return 0, fmt.Errorf("cannot convert '%s' to int64 from hex: %w", s, err)
+		}
+		return 0, fmt.Errorf("cannot convert '%s' to int64: %w", s, err)
 	}
 
 	return value, nil

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/value_processor_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/value_processor_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+func TestStringValueProcessor_ProcessValue_HexFormat(t *testing.T) {
+	processor := newValueProcessor()
+	pdu := gosnmp.SnmpPDU{
+		Name:  "1.3.6.1.2.1.15.3.1.14.192.0.2.1",
+		Type:  gosnmp.OctetString,
+		Value: []byte{0x04, 0x03},
+	}
+	zeroPDU := gosnmp.SnmpPDU{
+		Name:  "1.3.6.1.2.1.15.3.1.14.192.0.2.2",
+		Type:  gosnmp.OctetString,
+		Value: []byte{0x00, 0x00},
+	}
+
+	tests := map[string]struct {
+		symbol   ddprofiledefinition.SymbolConfig
+		pdu      gosnmp.SnmpPDU
+		expected int64
+	}{
+		"code": {
+			symbol: ddprofiledefinition.SymbolConfig{
+				OID:                  "1.3.6.1.2.1.15.3.1.14",
+				Name:                 "bgpPeerLastErrorCode",
+				Format:               "hex",
+				ExtractValueCompiled: mustCompileRegex(`^([0-9a-f]{2})`),
+			},
+			pdu:      pdu,
+			expected: 4,
+		},
+		"subcode": {
+			symbol: ddprofiledefinition.SymbolConfig{
+				OID:                  "1.3.6.1.2.1.15.3.1.14",
+				Name:                 "bgpPeerLastErrorSubcode",
+				Format:               "hex",
+				ExtractValueCompiled: mustCompileRegex(`^[0-9a-f]{2}([0-9a-f]{2})`),
+			},
+			pdu:      pdu,
+			expected: 3,
+		},
+		"zero code": {
+			symbol: ddprofiledefinition.SymbolConfig{
+				OID:                  "1.3.6.1.2.1.15.3.1.14",
+				Name:                 "bgpPeerLastErrorCode",
+				Format:               "hex",
+				ExtractValueCompiled: mustCompileRegex(`^(00)`),
+			},
+			pdu:      zeroPDU,
+			expected: 0,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			value, err := processor.processValue(tc.symbol, tc.pdu)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, value)
+		})
+	}
+}
+
+func TestNumericValueProcessor_ProcessValue_Uint32Format(t *testing.T) {
+	processor := newValueProcessor()
+
+	tests := map[string]struct {
+		symbol   ddprofiledefinition.SymbolConfig
+		pdu      gosnmp.SnmpPDU
+		expected int64
+	}{
+		"reinterpret signed int32 as uint32": {
+			symbol: ddprofiledefinition.SymbolConfig{
+				OID:    "1.3.6.1.2.1.15.3.1.9",
+				Name:   "bgpPeerRemoteAs",
+				Format: "uint32",
+			},
+			pdu: gosnmp.SnmpPDU{
+				Name:  "1.3.6.1.2.1.15.3.1.9.169.254.1.1",
+				Type:  gosnmp.Integer,
+				Value: -94967296,
+			},
+			expected: 4200000000,
+		},
+		"preserve positive value": {
+			symbol: ddprofiledefinition.SymbolConfig{
+				OID:    "1.3.6.1.2.1.15.3.1.9",
+				Name:   "bgpPeerRemoteAs",
+				Format: "uint32",
+			},
+			pdu: gosnmp.SnmpPDU{
+				Name:  "1.3.6.1.2.1.15.3.1.9.192.0.2.1",
+				Type:  gosnmp.Integer,
+				Value: 64512,
+			},
+			expected: 64512,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			value, err := processor.processValue(tc.symbol, tc.pdu)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, value)
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/load.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/load.go
@@ -142,6 +142,7 @@ func loadProfileWithExtendsMap(filename string, extendsPaths multipath.MultiPath
 	}
 
 	prof.extensionHierarchy = make([]*extensionInfo, 0, len(prof.Definition.Extends))
+	mergedBases := make([]*Profile, 0, len(prof.Definition.Extends))
 
 	for _, name := range prof.Definition.Extends {
 		if slices.Contains(stack, name) {
@@ -164,8 +165,13 @@ func loadProfileWithExtendsMap(filename string, extendsPaths multipath.MultiPath
 			extensions: mergedBase.extensionHierarchy,
 		}
 		prof.extensionHierarchy = append(prof.extensionHierarchy, extInfo)
+		mergedBases = append(mergedBases, mergedBase)
+	}
 
-		prof.merge(mergedBase)
+	// Merge in reverse so later extends override earlier ones while the
+	// current profile still keeps the highest precedence.
+	for i := len(mergedBases) - 1; i >= 0; i-- {
+		prof.merge(mergedBases[i])
 	}
 
 	return &prof, nil

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
@@ -165,6 +165,8 @@ func (p *Profile) mergeMetrics(base *Profile) {
 		}
 	}
 
+	baseColumns := make(map[columnMetricKey]bool)
+
 	for _, bm := range base.Definition.Metrics {
 		switch {
 		case bm.IsScalar():
@@ -180,7 +182,7 @@ func (p *Profile) mergeMetrics(base *Profile) {
 				if seenColumns[key] {
 					continue
 				}
-				seenColumns[key] = true
+				baseColumns[key] = true
 				symbols = append(symbols, sym)
 			}
 			bm.Symbols = symbols
@@ -188,6 +190,10 @@ func (p *Profile) mergeMetrics(base *Profile) {
 				p.Definition.Metrics = append(p.Definition.Metrics, bm)
 			}
 		}
+	}
+
+	for key := range baseColumns {
+		seenColumns[key] = true
 	}
 
 	seenVmetrics := make(map[string]bool)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
@@ -20,7 +20,6 @@ type scalarMetricKey struct {
 type columnMetricKey struct {
 	tableOID   string
 	tableName  string
-	symbolOID  string
 	symbolName string
 }
 
@@ -205,7 +204,6 @@ func columnMetricSymbolKey(table ddprofiledefinition.SymbolConfig, sym ddprofile
 	return columnMetricKey{
 		tableOID:   table.OID,
 		tableName:  table.Name,
-		symbolOID:  sym.OID,
 		symbolName: sym.Name,
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
@@ -12,6 +12,18 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
 )
 
+type scalarMetricKey struct {
+	name string
+	oid  string
+}
+
+type columnMetricKey struct {
+	tableOID   string
+	tableName  string
+	symbolOID  string
+	symbolName string
+}
+
 // FindProfiles returns profiles matching the given sysObjectID.
 // Profiles are sorted by match specificity: most specific first.
 func FindProfiles(sysObjID, sysDescr string, manualProfiles []string) []*Profile {
@@ -137,19 +149,20 @@ func (p *Profile) merge(base *Profile) {
 	p.mergeMetrics(base)
 	// Append other fields as before (these likely don't need deduplication)
 	p.Definition.MetricTags = append(p.Definition.MetricTags, base.Definition.MetricTags...)
-	p.Definition.StaticTags = append(p.Definition.StaticTags, base.Definition.StaticTags...)
+	p.Definition.StaticTags = append(slices.Clone(base.Definition.StaticTags), p.Definition.StaticTags...)
 }
 
 func (p *Profile) mergeMetrics(base *Profile) {
-	seen := make(map[string]bool)
+	seenScalars := make(map[scalarMetricKey]bool)
+	seenColumns := make(map[columnMetricKey]bool)
 
 	for _, m := range p.Definition.Metrics {
 		switch {
 		case m.IsScalar():
-			seen[m.Symbol.Name+"|"+m.Symbol.OID] = true
+			seenScalars[scalarMetricKey{name: m.Symbol.Name, oid: m.Symbol.OID}] = true
 		case m.IsColumn():
 			for _, sym := range m.Symbols {
-				seen[sym.Name] = true
+				seenColumns[columnMetricSymbolKey(m.Table, sym)] = true
 			}
 		}
 	}
@@ -157,15 +170,16 @@ func (p *Profile) mergeMetrics(base *Profile) {
 	for _, bm := range base.Definition.Metrics {
 		switch {
 		case bm.IsScalar():
-			key := bm.Symbol.Name + "|" + bm.Symbol.OID
-			if !seen[key] {
+			key := scalarMetricKey{name: bm.Symbol.Name, oid: bm.Symbol.OID}
+			if !seenScalars[key] {
 				p.Definition.Metrics = append(p.Definition.Metrics, bm)
-				seen[key] = true
+				seenScalars[key] = true
 			}
 		case bm.IsColumn():
 			bm.Symbols = slices.DeleteFunc(bm.Symbols, func(sym ddprofiledefinition.SymbolConfig) bool {
-				v := seen[sym.Name]
-				seen[sym.Name] = true
+				key := columnMetricSymbolKey(bm.Table, sym)
+				v := seenColumns[key]
+				seenColumns[key] = true
 				return v
 			})
 			if len(bm.Symbols) > 0 {
@@ -184,6 +198,15 @@ func (p *Profile) mergeMetrics(base *Profile) {
 			p.Definition.VirtualMetrics = append(p.Definition.VirtualMetrics, bm)
 			seenVmetrics[bm.Name] = true
 		}
+	}
+}
+
+func columnMetricSymbolKey(table ddprofiledefinition.SymbolConfig, sym ddprofiledefinition.SymbolConfig) columnMetricKey {
+	return columnMetricKey{
+		tableOID:   table.OID,
+		tableName:  table.Name,
+		symbolOID:  sym.OID,
+		symbolName: sym.Name,
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
@@ -153,19 +153,19 @@ func (p *Profile) merge(base *Profile) {
 func (p *Profile) mergeMetrics(base *Profile) {
 	seenScalars := make(map[scalarMetricKey]bool)
 	seenColumns := make(map[columnMetricKey]bool)
+	seenTableOIDs := make(map[string]string)
 
 	for _, m := range p.Definition.Metrics {
 		switch {
 		case m.IsScalar():
 			seenScalars[scalarMetricKey{name: m.Symbol.Name, oid: m.Symbol.OID}] = true
 		case m.IsColumn():
+			seenTableOIDs[columnMetricTableIdentity(m.Table)] = m.Table.OID
 			for _, sym := range m.Symbols {
 				seenColumns[columnMetricSymbolKey(m.Table, sym)] = true
 			}
 		}
 	}
-
-	baseColumns := make(map[columnMetricKey]bool)
 
 	for _, bm := range base.Definition.Metrics {
 		switch {
@@ -176,24 +176,25 @@ func (p *Profile) mergeMetrics(base *Profile) {
 				seenScalars[key] = true
 			}
 		case bm.IsColumn():
+			tableID := columnMetricTableIdentity(bm.Table)
+			if tableOID, ok := seenTableOIDs[tableID]; ok && tableOID != bm.Table.OID {
+				continue
+			}
+
 			symbols := make([]ddprofiledefinition.SymbolConfig, 0, len(bm.Symbols))
 			for _, sym := range bm.Symbols {
 				key := columnMetricSymbolKey(bm.Table, sym)
 				if seenColumns[key] {
 					continue
 				}
-				baseColumns[key] = true
 				symbols = append(symbols, sym)
 			}
 			bm.Symbols = symbols
 			if len(bm.Symbols) > 0 {
 				p.Definition.Metrics = append(p.Definition.Metrics, bm)
+				seenTableOIDs[tableID] = bm.Table.OID
 			}
 		}
-	}
-
-	for key := range baseColumns {
-		seenColumns[key] = true
 	}
 
 	seenVmetrics := make(map[string]bool)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
@@ -18,8 +18,7 @@ type scalarMetricKey struct {
 }
 
 type columnMetricKey struct {
-	tableOID   string
-	tableName  string
+	table      string
 	symbolName string
 }
 
@@ -175,12 +174,16 @@ func (p *Profile) mergeMetrics(base *Profile) {
 				seenScalars[key] = true
 			}
 		case bm.IsColumn():
-			bm.Symbols = slices.DeleteFunc(bm.Symbols, func(sym ddprofiledefinition.SymbolConfig) bool {
+			symbols := make([]ddprofiledefinition.SymbolConfig, 0, len(bm.Symbols))
+			for _, sym := range bm.Symbols {
 				key := columnMetricSymbolKey(bm.Table, sym)
-				v := seenColumns[key]
+				if seenColumns[key] {
+					continue
+				}
 				seenColumns[key] = true
-				return v
-			})
+				symbols = append(symbols, sym)
+			}
+			bm.Symbols = symbols
 			if len(bm.Symbols) > 0 {
 				p.Definition.Metrics = append(p.Definition.Metrics, bm)
 			}
@@ -202,10 +205,16 @@ func (p *Profile) mergeMetrics(base *Profile) {
 
 func columnMetricSymbolKey(table ddprofiledefinition.SymbolConfig, sym ddprofiledefinition.SymbolConfig) columnMetricKey {
 	return columnMetricKey{
-		tableOID:   table.OID,
-		tableName:  table.Name,
+		table:      columnMetricTableIdentity(table),
 		symbolName: sym.Name,
 	}
+}
+
+func columnMetricTableIdentity(table ddprofiledefinition.SymbolConfig) string {
+	if table.Name != "" {
+		return table.Name
+	}
+	return table.OID
 }
 
 func (p *Profile) mergeMetadata(base *Profile) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_merge_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_merge_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmp
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/pkg/multipath"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+func TestProfile_MultipleExtends_TableSymbolLaterOverrideEarlierByNameWithinTable(t *testing.T) {
+	tmp := t.TempDir()
+
+	writeTableBase(t, filepath.Join(tmp, "_base1.yaml"), "1.3.6.1.2.1.2.2", "ifTable", "1.3.6.1.2.1.2.2.1.10", "ifInOctets", "base1")
+	writeTableBase(t, filepath.Join(tmp, "_base2.yaml"), "1.3.6.1.2.1.2.2", "ifTable", "1.3.6.1.2.1.2.2.1.16", "ifInOctets", "base2")
+	writeYAML(t, filepath.Join(tmp, "device.yaml"), ddprofiledefinition.ProfileDefinition{
+		Extends: []string{"_base1.yaml", "_base2.yaml"},
+	})
+
+	prof, err := loadProfile(filepath.Join(tmp, "device.yaml"), multipath.New(tmp))
+	require.NoError(t, err)
+	require.Len(t, prof.Definition.Metrics, 1)
+	require.Len(t, prof.Definition.Metrics[0].Symbols, 1)
+
+	sym := prof.Definition.Metrics[0].Symbols[0]
+	assert.Equal(t, "ifInOctets", sym.Name)
+	assert.Equal(t, "1.3.6.1.2.1.2.2.1.16", sym.OID)
+	assert.Equal(t, "base2", sym.ChartMeta.Description)
+}
+
+func TestProfile_MultipleExtends_TableSymbolsPreserveSameOIDDifferentNames(t *testing.T) {
+	tmp := t.TempDir()
+
+	writeTableBase(t, filepath.Join(tmp, "_base1.yaml"), "1.3.6.1.4.1.999.1", "eventTable", "1.3.6.1.4.1.999.1.1.5", "eventCode", "base1")
+	writeTableBase(t, filepath.Join(tmp, "_base2.yaml"), "1.3.6.1.4.1.999.1", "eventTable", "1.3.6.1.4.1.999.1.1.5", "eventSubCode", "base2")
+	writeYAML(t, filepath.Join(tmp, "device.yaml"), ddprofiledefinition.ProfileDefinition{
+		Extends: []string{"_base1.yaml", "_base2.yaml"},
+	})
+
+	prof, err := loadProfile(filepath.Join(tmp, "device.yaml"), multipath.New(tmp))
+	require.NoError(t, err)
+	require.Len(t, prof.Definition.Metrics, 2)
+
+	got := make(map[string]string)
+	for _, metric := range prof.Definition.Metrics {
+		require.Len(t, metric.Symbols, 1)
+		got[metric.Symbols[0].Name] = metric.Symbols[0].OID
+	}
+
+	assert.Equal(t, map[string]string{
+		"eventCode":    "1.3.6.1.4.1.999.1.1.5",
+		"eventSubCode": "1.3.6.1.4.1.999.1.1.5",
+	}, got)
+}
+
+func writeTableBase(t *testing.T, path, tableOID, tableName, symbolOID, symbolName, description string) {
+	t.Helper()
+
+	writeYAML(t, path, ddprofiledefinition.ProfileDefinition{
+		Metrics: []ddprofiledefinition.MetricsConfig{
+			{
+				Table: ddprofiledefinition.SymbolConfig{
+					OID:  tableOID,
+					Name: tableName,
+				},
+				Symbols: []ddprofiledefinition.SymbolConfig{
+					{
+						OID:  symbolOID,
+						Name: symbolName,
+						ChartMeta: ddprofiledefinition.ChartMeta{
+							Description: description,
+						},
+					},
+				},
+				MetricTags: []ddprofiledefinition.MetricTagConfig{
+					{
+						Tag: "row",
+						IndexTransform: []ddprofiledefinition.MetricIndexTransform{
+							{Start: 0, End: 0},
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_merge_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_merge_test.go
@@ -117,6 +117,31 @@ func TestProfile_MergeMetrics_DoesNotMutateBaseColumnSymbols(t *testing.T) {
 	assert.Equal(t, "ifOutOctets", target.Definition.Metrics[1].Symbols[0].Name)
 }
 
+func TestProfile_MergeMetrics_PreservesRepeatedBaseColumnSymbols(t *testing.T) {
+	target := &Profile{Definition: &ddprofiledefinition.ProfileDefinition{}}
+	base := &Profile{Definition: &ddprofiledefinition.ProfileDefinition{
+		Metrics: []ddprofiledefinition.MetricsConfig{
+			{
+				Table: ddprofiledefinition.SymbolConfig{
+					OID:  "1.3.6.1.4.1.999.1",
+					Name: "eventTable",
+				},
+				Symbols: []ddprofiledefinition.SymbolConfig{
+					{OID: "1.3.6.1.4.1.999.1.1.5", Name: "eventCode"},
+					{OID: "1.3.6.1.4.1.999.1.1.6", Name: "eventCode"},
+				},
+			},
+		},
+	}}
+
+	target.mergeMetrics(base)
+
+	require.Len(t, target.Definition.Metrics, 1)
+	require.Len(t, target.Definition.Metrics[0].Symbols, 2)
+	assert.Equal(t, "1.3.6.1.4.1.999.1.1.5", target.Definition.Metrics[0].Symbols[0].OID)
+	assert.Equal(t, "1.3.6.1.4.1.999.1.1.6", target.Definition.Metrics[0].Symbols[1].OID)
+}
+
 func writeTableBase(t *testing.T, path, tableOID, tableName, symbolOID, symbolName, description string) {
 	t.Helper()
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_merge_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_merge_test.go
@@ -33,6 +33,26 @@ func TestProfile_MultipleExtends_TableSymbolLaterOverrideEarlierByNameWithinTabl
 	assert.Equal(t, "base2", sym.ChartMeta.Description)
 }
 
+func TestProfile_MultipleExtends_TableSymbolLaterOverrideEarlierByTableNameWhenOIDDiffers(t *testing.T) {
+	tmp := t.TempDir()
+
+	writeTableBase(t, filepath.Join(tmp, "_base1.yaml"), "1.3.6.1.2.1.2.2", "ifTable", "1.3.6.1.2.1.2.2.1.10", "ifInOctets", "base1")
+	writeTableBase(t, filepath.Join(tmp, "_base2.yaml"), "1.3.6.1.4.1.999.2", "ifTable", "1.3.6.1.4.1.999.2.1.10", "ifInOctets", "base2")
+	writeYAML(t, filepath.Join(tmp, "device.yaml"), ddprofiledefinition.ProfileDefinition{
+		Extends: []string{"_base1.yaml", "_base2.yaml"},
+	})
+
+	prof, err := loadProfile(filepath.Join(tmp, "device.yaml"), multipath.New(tmp))
+	require.NoError(t, err)
+	require.Len(t, prof.Definition.Metrics, 1)
+	require.Len(t, prof.Definition.Metrics[0].Symbols, 1)
+
+	assert.Equal(t, "1.3.6.1.4.1.999.2", prof.Definition.Metrics[0].Table.OID)
+	assert.Equal(t, "ifTable", prof.Definition.Metrics[0].Table.Name)
+	assert.Equal(t, "1.3.6.1.4.1.999.2.1.10", prof.Definition.Metrics[0].Symbols[0].OID)
+	assert.Equal(t, "base2", prof.Definition.Metrics[0].Symbols[0].ChartMeta.Description)
+}
+
 func TestProfile_MultipleExtends_TableSymbolsPreserveSameOIDDifferentNames(t *testing.T) {
 	tmp := t.TempDir()
 
@@ -58,24 +78,22 @@ func TestProfile_MultipleExtends_TableSymbolsPreserveSameOIDDifferentNames(t *te
 	}, got)
 }
 
-func writeTableBase(t *testing.T, path, tableOID, tableName, symbolOID, symbolName, description string) {
-	t.Helper()
-
-	writeYAML(t, path, ddprofiledefinition.ProfileDefinition{
+func TestProfile_MergeMetrics_DoesNotMutateBaseColumnSymbols(t *testing.T) {
+	target := &Profile{Definition: &ddprofiledefinition.ProfileDefinition{
+		Metrics: []ddprofiledefinition.MetricsConfig{
+			tableMetricConfig("1.3.6.1.2.1.2.2", "ifTable", "1.3.6.1.2.1.2.2.1.10", "ifInOctets", "target"),
+		},
+	}}
+	base := &Profile{Definition: &ddprofiledefinition.ProfileDefinition{
 		Metrics: []ddprofiledefinition.MetricsConfig{
 			{
 				Table: ddprofiledefinition.SymbolConfig{
-					OID:  tableOID,
-					Name: tableName,
+					OID:  "1.3.6.1.2.1.2.2",
+					Name: "ifTable",
 				},
 				Symbols: []ddprofiledefinition.SymbolConfig{
-					{
-						OID:  symbolOID,
-						Name: symbolName,
-						ChartMeta: ddprofiledefinition.ChartMeta{
-							Description: description,
-						},
-					},
+					{OID: "1.3.6.1.2.1.2.2.1.10", Name: "ifInOctets"},
+					{OID: "1.3.6.1.2.1.2.2.1.16", Name: "ifOutOctets"},
 				},
 				MetricTags: []ddprofiledefinition.MetricTagConfig{
 					{
@@ -87,5 +105,50 @@ func writeTableBase(t *testing.T, path, tableOID, tableName, symbolOID, symbolNa
 				},
 			},
 		},
+	}}
+
+	target.mergeMetrics(base)
+
+	require.Len(t, base.Definition.Metrics[0].Symbols, 2)
+	assert.Equal(t, "ifInOctets", base.Definition.Metrics[0].Symbols[0].Name)
+	assert.Equal(t, "ifOutOctets", base.Definition.Metrics[0].Symbols[1].Name)
+	require.Len(t, target.Definition.Metrics, 2)
+	require.Len(t, target.Definition.Metrics[1].Symbols, 1)
+	assert.Equal(t, "ifOutOctets", target.Definition.Metrics[1].Symbols[0].Name)
+}
+
+func writeTableBase(t *testing.T, path, tableOID, tableName, symbolOID, symbolName, description string) {
+	t.Helper()
+
+	writeYAML(t, path, ddprofiledefinition.ProfileDefinition{
+		Metrics: []ddprofiledefinition.MetricsConfig{
+			tableMetricConfig(tableOID, tableName, symbolOID, symbolName, description),
+		},
 	})
+}
+
+func tableMetricConfig(tableOID, tableName, symbolOID, symbolName, description string) ddprofiledefinition.MetricsConfig {
+	return ddprofiledefinition.MetricsConfig{
+		Table: ddprofiledefinition.SymbolConfig{
+			OID:  tableOID,
+			Name: tableName,
+		},
+		Symbols: []ddprofiledefinition.SymbolConfig{
+			{
+				OID:  symbolOID,
+				Name: symbolName,
+				ChartMeta: ddprofiledefinition.ChartMeta{
+					Description: description,
+				},
+			},
+		},
+		MetricTags: []ddprofiledefinition.MetricTagConfig{
+			{
+				Tag: "row",
+				IndexTransform: []ddprofiledefinition.MetricIndexTransform{
+					{Start: 0, End: 0},
+				},
+			},
+		},
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_merge_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_merge_test.go
@@ -53,6 +53,42 @@ func TestProfile_MultipleExtends_TableSymbolLaterOverrideEarlierByTableNameWhenO
 	assert.Equal(t, "base2", prof.Definition.Metrics[0].Symbols[0].ChartMeta.Description)
 }
 
+func TestProfile_MultipleExtends_TableOIDOverrideDropsEarlierTableSymbols(t *testing.T) {
+	tmp := t.TempDir()
+
+	writeYAML(t, filepath.Join(tmp, "_base1.yaml"), ddprofiledefinition.ProfileDefinition{
+		Metrics: []ddprofiledefinition.MetricsConfig{
+			{
+				Table: ddprofiledefinition.SymbolConfig{
+					OID:  "1.3.6.1.2.1.2.2",
+					Name: "ifTable",
+				},
+				Symbols: []ddprofiledefinition.SymbolConfig{
+					{OID: "1.3.6.1.2.1.2.2.1.10", Name: "ifInOctets"},
+					{OID: "1.3.6.1.2.1.2.2.1.16", Name: "ifOutOctets"},
+				},
+				MetricTags: []ddprofiledefinition.MetricTagConfig{
+					{Tag: "row", IndexTransform: []ddprofiledefinition.MetricIndexTransform{{Start: 0, End: 0}}},
+				},
+			},
+		},
+	})
+	writeTableBase(t, filepath.Join(tmp, "_base2.yaml"), "1.3.6.1.4.1.999.2", "ifTable", "1.3.6.1.4.1.999.2.1.10", "ifInOctets", "base2")
+	writeYAML(t, filepath.Join(tmp, "device.yaml"), ddprofiledefinition.ProfileDefinition{
+		Extends: []string{"_base1.yaml", "_base2.yaml"},
+	})
+
+	prof, err := loadProfile(filepath.Join(tmp, "device.yaml"), multipath.New(tmp))
+	require.NoError(t, err)
+	require.Len(t, prof.Definition.Metrics, 1)
+	require.Len(t, prof.Definition.Metrics[0].Symbols, 1)
+
+	assert.Equal(t, "1.3.6.1.4.1.999.2", prof.Definition.Metrics[0].Table.OID)
+	assert.Equal(t, "ifTable", prof.Definition.Metrics[0].Table.Name)
+	assert.Equal(t, "ifInOctets", prof.Definition.Metrics[0].Symbols[0].Name)
+	assert.Equal(t, "1.3.6.1.4.1.999.2.1.10", prof.Definition.Metrics[0].Symbols[0].OID)
+}
+
 func TestProfile_MultipleExtends_TableSymbolsPreserveSameOIDDifferentNames(t *testing.T) {
 	tmp := t.TempDir()
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
@@ -1430,7 +1430,7 @@ func TestProfile_MultipleExtends_LaterOverrideEarlier(t *testing.T) {
 	assert.Equal(t, "base2", mergedStaticTags["source"])
 }
 
-func TestProfile_MultipleExtends_PreservesSameNameFallbackOIDs(t *testing.T) {
+func TestProfile_MultipleExtends_PreservesScalarSameNameFallbackOIDs(t *testing.T) {
 	tmp := t.TempDir()
 
 	writeYAML(t, filepath.Join(tmp, "_base1.yaml"), ddprofiledefinition.ProfileDefinition{

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
@@ -1334,8 +1334,8 @@ func TestProfile_MultipleExtends(t *testing.T) {
 
 	// Main profile extending both
 	main := filepath.Join(tmp, "device.yaml")
-	writeYAML(t, main, map[string]any{
-		"extends": []string{"_base1.yaml", "_base2.yaml"},
+	writeYAML(t, main, ddprofiledefinition.ProfileDefinition{
+		Extends: []string{"_base1.yaml", "_base2.yaml"},
 	})
 
 	paths := multipath.New(tmp)
@@ -1354,6 +1354,80 @@ func TestProfile_MultipleExtends(t *testing.T) {
 	// Check all files
 	allFiles := prof.getAllExtendedFiles()
 	assert.Len(t, allFiles, 2)
+}
+
+func TestProfile_MultipleExtends_LaterOverrideEarlier(t *testing.T) {
+	tmp := t.TempDir()
+
+	writeBase := func(path, suffix string) {
+		writeYAML(t, path, ddprofiledefinition.ProfileDefinition{
+			Metadata: ddprofiledefinition.MetadataConfig{
+				"device": {
+					Fields: map[string]ddprofiledefinition.MetadataField{
+						"model": {Value: suffix},
+					},
+				},
+			},
+			StaticTags: []ddprofiledefinition.StaticMetricTagConfig{
+				{Tag: "source", Value: suffix},
+			},
+			Metrics: []ddprofiledefinition.MetricsConfig{
+				{
+					Symbol: ddprofiledefinition.SymbolConfig{
+						OID:  "1.3.6.1.2.1.1.5.0",
+						Name: "sysName",
+						ChartMeta: ddprofiledefinition.ChartMeta{
+							Description: suffix,
+						},
+					},
+				},
+			},
+			VirtualMetrics: []ddprofiledefinition.VirtualMetricConfig{
+				{
+					Name: "ifTraffic",
+					Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
+						{Metric: "sysName", Table: ""},
+					},
+					ChartMeta: ddprofiledefinition.ChartMeta{
+						Description: suffix,
+					},
+				},
+			},
+		})
+	}
+
+	base1 := filepath.Join(tmp, "_base1.yaml")
+	base2 := filepath.Join(tmp, "_base2.yaml")
+	writeBase(base1, "base1")
+	writeBase(base2, "base2")
+
+	main := filepath.Join(tmp, "device.yaml")
+	writeYAML(t, main, map[string]any{
+		"extends": []string{"_base1.yaml", "_base2.yaml"},
+	})
+
+	prof, err := loadProfile(main, multipath.New(tmp))
+	require.NoError(t, err)
+
+	require.Len(t, prof.Definition.Metrics, 1)
+	assert.Equal(t, "base2", prof.Definition.Metrics[0].Symbol.ChartMeta.Description)
+
+	require.Len(t, prof.Definition.VirtualMetrics, 1)
+	assert.Equal(t, "base2", prof.Definition.VirtualMetrics[0].ChartMeta.Description)
+
+	assert.Equal(t, "base2", prof.Definition.Metadata["device"].Fields["model"].Value)
+
+	require.Len(t, prof.Definition.StaticTags, 2)
+	assert.Equal(t, "base1", prof.Definition.StaticTags[0].Value)
+	assert.Equal(t, "base2", prof.Definition.StaticTags[1].Value)
+
+	mergedStaticTags := make(map[string]string, len(prof.Definition.StaticTags))
+	for _, tag := range prof.Definition.StaticTags {
+		if tag.Tag != "" && tag.Value != "" {
+			mergedStaticTags[tag.Tag] = tag.Value
+		}
+	}
+	assert.Equal(t, "base2", mergedStaticTags["source"])
 }
 
 func TestProfile_ComplexHierarchy(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
@@ -1430,6 +1430,42 @@ func TestProfile_MultipleExtends_LaterOverrideEarlier(t *testing.T) {
 	assert.Equal(t, "base2", mergedStaticTags["source"])
 }
 
+func TestProfile_MultipleExtends_PreservesSameNameFallbackOIDs(t *testing.T) {
+	tmp := t.TempDir()
+
+	writeYAML(t, filepath.Join(tmp, "_base1.yaml"), ddprofiledefinition.ProfileDefinition{
+		Metrics: []ddprofiledefinition.MetricsConfig{
+			{
+				Symbol: ddprofiledefinition.SymbolConfig{
+					OID:  "1.3.6.1.2.1.25.1.1.0",
+					Name: "systemUptime",
+				},
+			},
+		},
+	})
+	writeYAML(t, filepath.Join(tmp, "_base2.yaml"), ddprofiledefinition.ProfileDefinition{
+		Metrics: []ddprofiledefinition.MetricsConfig{
+			{
+				Symbol: ddprofiledefinition.SymbolConfig{
+					OID:  "1.3.6.1.2.1.1.3.0",
+					Name: "systemUptime",
+				},
+			},
+		},
+	})
+	writeYAML(t, filepath.Join(tmp, "device.yaml"), map[string]any{
+		"extends": []string{"_base1.yaml", "_base2.yaml"},
+	})
+
+	prof, err := loadProfile(filepath.Join(tmp, "device.yaml"), multipath.New(tmp))
+	require.NoError(t, err)
+	require.Len(t, prof.Definition.Metrics, 2)
+	assert.Equal(t, "systemUptime", prof.Definition.Metrics[0].Symbol.Name)
+	assert.Equal(t, "1.3.6.1.2.1.1.3.0", prof.Definition.Metrics[0].Symbol.OID)
+	assert.Equal(t, "systemUptime", prof.Definition.Metrics[1].Symbol.Name)
+	assert.Equal(t, "1.3.6.1.2.1.25.1.1.0", prof.Definition.Metrics[1].Symbol.OID)
+}
+
 func TestProfile_ComplexHierarchy(t *testing.T) {
 	tmp := t.TempDir()
 

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -218,7 +218,10 @@ The final profile is the **merged result** of all inherited profiles plus the co
 2. **Metrics are merged** — all metrics from all referenced profiles are included.
 3. **Later overrides earlier** — if the same field is defined multiple times, the last one wins.
 
-Metric override identity includes the OID/table identity, not only the metric name. This is intentional: multiple entries with the same `symbol.name` but different OIDs are preserved as fallback definitions.
+Metric override identity depends on metric type:
+
+- **Scalar metrics** use `symbol.name + symbol.OID`. This preserves same-name scalar fallback definitions that try alternative OIDs.
+- **Table metrics** use `table + symbol.name`. If two inherited profiles define the same table metric name, the later profile wins even when the symbol OID differs. Different metric names can still read from the same column OID when separate transformations are needed.
 
 **Common base profiles**
 
@@ -368,9 +371,9 @@ virtual_metrics:
       - { metric: _ifHCOutOctets, table: ifXTable, as: out }
 ```
 
-#### Multiple symbol fallbacks
+#### Scalar symbol fallbacks
 
-You can express “try this OID, otherwise try that OID” by declaring **multiple metrics with the same** `symbol.name`, each pointing to a different OID. At runtime the collector **GETs** all declared scalar OIDs, marks missing ones, and **emits** the metric from whichever OID returns data. Missing OIDs are skipped cleanly.
+You can express “try this OID, otherwise try that OID” by declaring **multiple scalar metrics with the same** `symbol.name`, each pointing to a different OID. At runtime the collector **GETs** all declared scalar OIDs, marks missing ones, and **emits** the metric from whichever OID returns data. Missing OIDs are skipped cleanly.
 
 ```yaml
 metrics:
@@ -1145,8 +1148,9 @@ metrics:
 
 - `lookup_symbol` is used only for **cross-table tags**
 - it works together with `index_transform`, not instead of it
-- the transformed index value must match **exactly one** row in the target table
-- if no row matches, or if multiple rows match, the tag lookup fails for that row
+- if no row matches, the tag lookup fails for that row
+- if one row matches, the collector reads the requested tag from that row
+- if multiple rows match, the lookup succeeds only when all matched rows resolve to the same final tag value; conflicting values fail the lookup
 
 ### Index-Based
 

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -221,7 +221,7 @@ The final profile is the **merged result** of all inherited profiles plus the co
 Metric override identity depends on metric type:
 
 - **Scalar metrics** use `symbol.name + symbol.OID`. This preserves same-name scalar fallback definitions that try alternative OIDs.
-- **Table metrics** use logical table identity (`table.name` when set, otherwise `table.OID`) + `symbol.name`. If two inherited profiles define the same table metric name, the later profile wins even when the table or symbol OID differs. Different metric names can still read from the same column OID when separate transformations are needed.
+- **Table metrics** use logical table identity (`table.name` when set, otherwise `table.OID`) + `symbol.name`. If two inherited profiles define the same table metric name, the later profile wins even when the table or symbol OID differs. If the same logical table name is inherited with a different table OID, the later table definition replaces the earlier table definition; symbols from the earlier table OID are not merged into the later table. Different metric names can still read from the same column OID when separate transformations are needed.
 
 **Common base profiles**
 

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -221,7 +221,7 @@ The final profile is the **merged result** of all inherited profiles plus the co
 Metric override identity depends on metric type:
 
 - **Scalar metrics** use `symbol.name + symbol.OID`. This preserves same-name scalar fallback definitions that try alternative OIDs.
-- **Table metrics** use `table + symbol.name`. If two inherited profiles define the same table metric name, the later profile wins even when the symbol OID differs. Different metric names can still read from the same column OID when separate transformations are needed.
+- **Table metrics** use logical table identity (`table.name` when set, otherwise `table.OID`) + `symbol.name`. If two inherited profiles define the same table metric name, the later profile wins even when the table or symbol OID differs. Different metric names can still read from the same column OID when separate transformations are needed.
 
 **Common base profiles**
 

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -947,6 +947,7 @@ Cross-table tags let you **use data from another SNMP table** as a tag source.
 - Reads tag values from the specified `table:` instead of the current one.
 - Matches rows between tables by their **index**.
 - When index structures differ, an optional `index_transform` can modify the current table’s index to align it with the target.
+- When the target table is keyed differently, an optional `lookup_symbol` can match a transformed index value against a column in the target table and then read tags from the matched row.
 
 #### Same Index
 
@@ -1064,7 +1065,86 @@ metrics:
 - `start` and `end` positions are **zero-based** (0 = first index element).
 - Each range defines which parts of the index to keep.
 - You can list multiple ranges to combine non-contiguous parts.
+- `drop_right` can be used instead of `end` when you need to keep a variable-length prefix of the index and trim a fixed number of trailing elements.
 - The goal is to make the current table’s index **match** the target table’s index so tags align correctly.
+
+Example with `drop_right`:
+
+```yaml
+metric_tags:
+  - tag: peer_index
+    table: peerTable
+    symbol:
+      OID: 1.2.3.4.5
+      name: peerRemoteAs
+    index_transform:
+      - start: 0
+        drop_right: 2
+```
+
+If the current row index is `1.192.0.2.1.1.128`, the transform keeps `1.192.0.2.1` and drops the trailing AFI / SAFI pair.
+
+#### With Value Lookup (`lookup_symbol`)
+
+Some vendor MIBs split related data across tables that do **not** share the same row index.
+
+For example:
+
+- a prefix-counter table may be indexed by `peerIndex.afi.safi`
+- the peer table may be indexed by `routingInstance.localAddr.remoteAddr`
+- but the peer table still contains a `peerIndex` column
+
+In that case, `index_transform` alone is not enough:
+
+- it can extract the current row's `peerIndex`
+- but it cannot guess which peer-table row owns that `peerIndex`
+
+Use `lookup_symbol` to tell the collector:
+
+1. Extract a lookup value from the current row index
+2. Find the row in the target table whose `lookup_symbol` column matches that value
+3. Read the requested `symbol` from that matched row
+
+```yaml
+metrics:
+  - MIB: BGP4-V2-MIB-JUNIPER
+    table:
+      OID: 1.3.6.1.4.1.2636.5.1.1.2.6.2
+      name: jnxBgpM2PrefixCountersTable
+    symbols:
+      - OID: 1.3.6.1.4.1.2636.5.1.1.2.6.2.1.8
+        name: bgpPeerPrefixesAccepted
+    metric_tags:
+      - tag: neighbor
+        table: jnxBgpM2PeerTable
+        symbol:
+          OID: 1.3.6.1.4.1.2636.5.1.1.2.1.1.1.11
+          name: jnxBgpM2PeerRemoteAddr
+        lookup_symbol:
+          OID: 1.3.6.1.4.1.2636.5.1.1.2.1.1.1.14
+          name: jnxBgpM2PeerIndex
+        index_transform:
+          - start: 0
+            end: 0
+```
+
+**What this does**:
+
+- Collects accepted-prefix counters from the Juniper prefix table
+- Takes the first index element from the current row (`peerIndex`)
+- Scans `jnxBgpM2PeerTable.jnxBgpM2PeerIndex` for a matching value
+- Reads `jnxBgpM2PeerRemoteAddr` from the matched peer-table row
+- Produces metrics like:
+    ```text
+    bgpPeerPrefixesAccepted{neighbor="192.0.2.1"} = 1234
+    ```
+
+**Important behavior**:
+
+- `lookup_symbol` is used only for **cross-table tags**
+- it works together with `index_transform`, not instead of it
+- the transformed index value must match **exactly one** row in the target table
+- if no row matches, or if multiple rows match, the tag lookup fails for that row
 
 ### Index-Based
 
@@ -1078,6 +1158,7 @@ This is useful when a table encodes identifiers (like method, code, or port numb
 - For each `index:` rule, assigns a tag using the specified position in the index.
 - Converts numeric index components to strings automatically.
 - Attaches all resulting tags to the metric collected from that row.
+- Can also derive tags from the full row index using `index_transform` plus `symbol.format`, `symbol.extract_value`, `symbol.match_pattern`, or `mapping`, even when there is no column OID for that tag.
 
 ```yaml
 metrics:
@@ -1118,6 +1199,25 @@ metrics:
     ```text
     sipCommonStatusCodeIns{applIndex="1", sipCommonStatusCodeMethod="6", sipCommonStatusCodeValue="200"} = 42
     ```
+
+Derived tag example from a transformed index:
+
+```yaml
+metric_tags:
+  - tag: neighbor
+    symbol:
+      name: peerRemoteAddrIndex
+      format: ip_address
+    index_transform:
+      - start: 1
+        drop_right: 2
+```
+
+If the current row index is `1.192.0.2.1.1.128`, the collector:
+
+- keeps the peer-address part only: `192.0.2.1`
+- formats it as an IP address
+- emits `neighbor="192.0.2.1"`
 
 ## Tag Transformation
 
@@ -1364,6 +1464,7 @@ These transformations are typically used to:
 | **Where**                 | Value transformations are used inside `metrics[*].symbol` or `metrics[*].symbols[]`.                                      |
 | **Order of application**  | 1️⃣ `extract_value` (if present) → 2️⃣ `mapping` → 3️⃣ `scale_factor`.                                                    |
 | **Scale factor position** | `scale_factor` is always applied **last**, after all other transformations.                                               |
+| **String base parsing**   | String-like values are parsed as base-10 by default. If `format: hex` is set, extracted values are parsed as base-16.   |
 | **Data type handling**    | Transformations preserve numeric type (integer/float) unless the mapping converts it to a multi-value metric.             |
 | **Error handling**        | If a transformation fails (e.g., regex doesn’t match), the collector keeps the original value.                            |
 | **Applicability**         | Transformations affect metric values only — not metadata or tags.                                                         |
@@ -1382,6 +1483,12 @@ These transformations are typically used to:
 - `extract_value`
     ```yaml
     extract_value: '(\d+)'   # First capture group is used
+    ```
+
+- `format: hex`
+    ```yaml
+    format: hex
+    extract_value: '^([0-9a-f]{2})'   # First byte of an OCTET STRING
     ```
 
 - `scale_factor`
@@ -1459,6 +1566,7 @@ metrics:
 - Extracts only the numeric part `"23"` and uses it as the metric value.
 - If the value doesn’t match, the original string is retained.
 - Ideal for string metrics that embed numbers, units, or labels.
+- If `format: hex` is also set, the extracted value is interpreted as hexadecimal before being stored as a metric.
 
 ### Scale Factor
 
@@ -1538,7 +1646,9 @@ virtual_metrics:
           - { metric: <fallbackMetricB>, table: <tableName>, as: <dimensionName> }
 
     per_row: <true|false>
-    group_by: <label | [labels]>
+    group_by: [<labels>]
+    emit_tags:
+      - { tag: <outputTag>, from: <sourceTag> }
     chart_meta:
       description: ...
       family: ...
@@ -1560,11 +1670,15 @@ The collector evaluates alternatives **in order** and uses the **first** set tha
 |                    | `sources`      | array\<Source\>      | no*      | —       | totals, per_row, grouped | Direct source set. Ignored if `alternatives` exist (alternatives take precedence).                                                                                              |
 |                    | `alternatives` | array\<Alternative\> | no*      | —       | totals, per_row, grouped | Ordered fallback sets. The first alternative whose sources produce data is used.                                                                                                |
 |                    | `per_row`      | bool                 | no       | false   | per-row/grouped          | When `true`, emits one output per input row; sources become dimensions; row tags attach.                                                                                        |
-|                    | `group_by`     | string / array       | no       | —       | per-row/grouped          | Label(s) used as row-key hints (in order). Missing/empty hints fall back to a full-tag stable key. With `per_row:false`, this acts like PromQL’s `sum by (...)`.                |
+|                    | `group_by`     | array\<string\>      | no       | —       | per-row/grouped          | Label(s) used as row-key hints (in order). With `per_row:true`, missing/empty hints fall back to a stable key built from all non-underscore tags. With `per_row:false`, this acts like PromQL’s `sum by (...)`. |
+|                    | `emit_tags`    | array\<EmitTag\>     | no       | —       | per-row/grouped          | Renames or selects which source tags are emitted on the resulting virtual metric. Useful when grouping by private tags such as `_neighbor` but exporting standard tags such as `neighbor`. |
 |                    | `chart_meta`   | object               | no       | —       | all                      | Presentation metadata (`description`, `family`, `unit`, `type`).                                                                                                                |
 | **Source**         | `metric`       | string               | yes      | —       | —                        | Name of an existing metric (scalar or table column metric).                                                                                                                     |
-|                    | `table`        | string               | yes      | —       | —                        | Table name for the originating metric. Must match the metric’s table when used in per-row/grouped.                                                                              |
-|                    | `as`           | string               | yes      | —       | —                        | Dimension name within the composite (e.g., `in`, `out`).                                                                                                                        |
+|                    | `table`        | string               | no*      | —       | —                        | Table name for the originating metric. Required for table-derived grouped/per-row virtual metrics. Scalar sources may omit it.                                                   |
+|                    | `as`           | string               | no       | —       | —                        | Optional dimension name within a composite (e.g., `in`, `out`). Single-source virtual metrics do not need it.                                                                   |
+|                    | `dim`          | string               | no       | —       | —                        | Selects one dimension from a MultiValue source metric (for example `start` or `established`) before aggregation. Useful when composing virtual metrics from mapped status charts. |
+| **EmitTag**        | `tag`          | string               | yes      | —       | —                        | Output tag name to emit on the virtual metric.                                                                                                                                   |
+|                    | `from`         | string               | yes      | —       | —                        | Existing source-tag name to copy from the grouped source rows.                                                                                                                   |
 | **Alternative**    | `sources`      | array\<Source\>      | yes      | —       | —                        | All sources in an alternative are evaluated together. If none produce data, the collector tries the next alternative. Per-row/group rules apply within the winning alternative. |
 
 > At least one of `sources` or `alternatives` **must be defined**.
@@ -1576,11 +1690,13 @@ The collector evaluates alternatives **in order** and uses the **first** set tha
 | **Precedence**                    | If both `sources` and `alternatives` exist, `alternatives` take precedence.                                                                            |
 | **Same-table requirement**        | When `per_row` or `group_by` is used, all sources must originate from the same table. For alternatives, this rule applies within each alternative set. |
 | **per_row: true**                 | One output per input row; multiple sources become chart dimensions (`as`); row tags attach automatically.                                              |
-| **group_by (with per_row:true)**  | Acts as row-key hints (in order). Missing or empty hints fall back to a full-tag composite key.                                                        |
+| **group_by (with per_row:true)**  | Acts as row-key hints (in order). Missing or empty hints fall back to a stable key built from all non-underscore tags.                                  |
 | **group_by (with per_row:false)** | Aggregates rows by the listed labels, similar to PromQL’s `sum by (...)`.                                                                              |
+| **emit_tags**                     | If omitted, `per_row:true` emits the winning row tags as-is. Grouped non-`per_row` metrics emit the `group_by` labels by default. When set, only the listed tags are emitted, using the `from` source-tag names. |
 | **Alternative evaluation**        | Alternatives are checked in order. The first whose sources produce data becomes the “winner”; others are ignored.                                      |
 | **Parent metadata**               | The virtual metric emits charts using its own `name` and `chart_meta`, even when data comes from an alternative.                                       |
 | **Dimensions**                    | Each `as` value defines a dimension in the resulting chart (e.g., `in`, `out`, `total`).                                                               |
+| **Selected source dimension**     | When `dim` is set on a source, the collector reads only that MultiValue dimension from the source metric and ignores the rest.                            |
 | **Totals vs per-row**             | Omitting both `per_row` and `group_by` produces a single total chart across all rows (device-wide view).                                               |
 
 ### Examples
@@ -1606,7 +1722,7 @@ virtual_metrics:
 - Creates **one output per input row** in `ifXTable`.
 - Each chart represents one interface with two dimensions: `in` and `out`.
 - `group_by: ["interface"]` provides key hints to keep per-interface charts stable.
-- If a hint is missing or empty, a full-tag composite key is used instead.
+- If a hint is missing or empty, a stable key built from all non-underscore tags is used instead.
 - **Constraint**: `per_row` or `group_by` requires all sources to come from the same table.
 
 #### Total aggregation (sum across all interfaces)
@@ -1644,6 +1760,54 @@ virtual_metrics:
       family: 'Network/InterfaceType/Traffic'
       unit: "bit/s"
 ```
+
+#### Per-row availability from mapped status charts
+
+```yaml
+virtual_metrics:
+  - name: bgpPeerAvailability
+    per_row: true
+    sources:
+      - { metric: bgpPeerAdminStatus, table: bgpPeerTable, as: admin_enabled, dim: start }
+      - { metric: bgpPeerState, table: bgpPeerTable, as: established, dim: established }
+    chart_meta:
+      description: BGP peer administrative and established availability
+      family: 'Network/Routing/BGP/Peer/Availability'
+      unit: "{status}"
+```
+
+**What this does**:
+
+- Reuses mapped one-hot status charts instead of adding duplicate raw-code metrics.
+- Reads only the `start` dimension from `bgpPeerAdminStatus`.
+- Reads only the `established` dimension from `bgpPeerState`.
+- Emits one per-peer chart row with stable dimensions `admin_enabled` and `established`.
+
+#### Per-row grouping by private tags, but emitting normalized tags
+
+```yaml
+virtual_metrics:
+  - name: bgpPeerAvailability
+    per_row: true
+    group_by: ["_neighbor", "_address_family", "_subsequent_address_family"]
+    emit_tags:
+      - { tag: neighbor, from: _neighbor }
+      - { tag: address_family, from: _address_family }
+      - { tag: subsequent_address_family, from: _subsequent_address_family }
+    sources:
+      - { metric: hwBgpPeerAdminStatus, table: hwBgpPeerRouteTable, as: admin_enabled, dim: start }
+      - { metric: hwBgpPeerState, table: hwBgpPeerRouteTable, as: established, dim: established }
+    chart_meta:
+      description: BGP peer availability
+      family: 'Network/Routing/BGP/Peer/Availability'
+      unit: "{status}"
+```
+
+**What this does**:
+
+- Groups rows using private helper tags that are not meant to appear in the final chart labels.
+- Emits standard operator-facing tags on the virtual metric (`neighbor`, `address_family`, `subsequent_address_family`).
+- Avoids collapsing multiple AFI/SAFI rows for the same peer into one output row.
 
 **What this does**:
 

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -218,6 +218,8 @@ The final profile is the **merged result** of all inherited profiles plus the co
 2. **Metrics are merged** — all metrics from all referenced profiles are included.
 3. **Later overrides earlier** — if the same field is defined multiple times, the last one wins.
 
+Metric override identity includes the OID/table identity, not only the metric name. This is intentional: multiple entries with the same `symbol.name` but different OIDs are preserved as fallback definitions.
+
 **Common base profiles**
 
 | Profile             | Provides                                  | Typical Use        |


### PR DESCRIPTION
This PR splits the generic SNMP profile-engine changes out of #22170 so they can be reviewed independently from BGP monitoring.

## Scope

This PR changes only the generic SNMP profile engine, its contract documentation, and focused tests/examples.

It does not include:

- BGP production profiles
- BGP public chart normalization
- BGP fixtures
- BGP health alerts
- function `snmp:bgp-peers`
- BGP integration metadata or user-facing docs

## What changes in the SNMP profile engine

1. Multiple metric definitions may read from the same table column OID when they apply different extraction rules.

2. Table tags can be built from richer index handling, including `drop_right`, raw index formatting, canonical IP formatting, and value-based cross-table lookup with `lookup_symbol`.

3. Virtual metrics now have a stricter and more complete contract:

   - profile-load validation for sources, alternatives, grouping, emitted tags, and dimension selectors
   - `group_by` support for grouped and per-row virtual metrics
   - stable fallback grouping keys for per-row virtual metrics
   - support for selecting dimensions from mapped or transform-derived multi-value metrics

4. Profile `extends` precedence now matches the documented contract: later bases override earlier bases, while the current profile still has final precedence.

5. `profile-format.md` now documents the above behavior with examples and constraints.

## Why this is split

#22170 needs these generic profile-engine features for BGP, but reviewers should be able to validate the generic contract without also reviewing all BGP profiles, alerts, fixtures, and operator-facing behavior in the same PR.

After this PR is merged, #22170 can be rebased so its remaining diff is BGP-specific.

## Testing

```bash
go test -count=1 ./plugin/go.d/collector/snmp/...
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the SNMP profile engine with value-based cross-table tags, richer index handling, stricter virtual metrics, safer `extends` merging (later bases override earlier; tables are replaced on OID override), improved value parsing, and clearer tag diagnostics. Updates docs and tests to match the new contract.

- New Features
  - Multiple metrics can read from the same column OID with different extraction rules.
  - Cross-table tags: add `lookup_symbol` for value-based joins; walk referenced tables (including lookup columns) even when only used for tags.
  - Index tags: support `drop_right` with bounds validation, raw index extraction via `extract_value`/`match_pattern`, and `format: ip_address` with canonical IPv4/IPv6 parsing.
  - Virtual metrics: strict validation for sources/alternatives/grouping/dimension selectors, `group_by` for grouped/per-row metrics, stable per-row fallback keys, dimension selection from multi-value sources, and `emit_tags`.
  - Value formats: robust IP parsing; add `uint32` and `hex` for numeric and string-backed metrics.
  - `extends` merge: later bases override earlier, base profiles are not mutated, and symbol definitions are preserved. Merge identity: scalars use `name+OID`; tables use `table+symbol.name`. If the same table name is inherited with a different table OID, the later table replaces the earlier one; earlier-table symbols are not merged. Base `static_tags` are merged and backfill missing/empty metric tag values.
  - Tag diagnostics: clearer errors with readable tag names and mapping values; allow mappings when `symbol.name` is set without an explicit `tag`; align index-tag fallback names to use `tag` or `symbol.name`; clarify errors for raw index tags and require `tag` or `symbol.name` when using raw index extraction.

- Migration
  - If profiles relied on old `extends` merge order, verify overrides now match the documented behavior.
  - Table metric merge identity changed: same-name table metrics from later bases override earlier ones even when OIDs differ; if the same table name is inherited with a different table OID, the later table replaces the earlier table entirely. Adjust names or extends order if you relied on cross-OID fallbacks.
  - Scalar fallbacks by `name+OID` are preserved.
  - Static tags now backfill missing/empty metric tag values; review charts/alerts if they assumed those tags were absent.
  - Invalid `drop_right` values now fail validation; update any profiles relying on out-of-bounds behavior.

<sup>Written for commit bfef3ddd6f66a797973e2432328b49c9f52790e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

