### PR TITLE
fix(go.d/snmp): fix retries serialization and bulk walk disable

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -231,6 +231,11 @@ func (c *Collector) initAndConnectSNMPClient() (gosnmp.Handler, error) {
 		return snmpClient, nil
 	}
 
+	if c.Config.Options.MaxRepetitions == 0 {
+		c.disableBulkWalk = true
+		return snmpClient, nil
+	}
+
 	if c.adjMaxRepetitions != 0 {
 		snmpClient.SetMaxRepetitions(c.adjMaxRepetitions)
 	} else {

--- a/src/go/plugin/go.d/collector/snmp/config.go
+++ b/src/go/plugin/go.d/collector/snmp/config.go
@@ -41,7 +41,7 @@ type (
 	}
 	OptionsConfig struct {
 		Port           int    `yaml:"port,omitempty" json:"port"`
-		Retries        int    `yaml:"retries,omitempty" json:"retries"`
+		Retries        int    `yaml:"retries" json:"retries"`
 		Timeout        int    `yaml:"timeout,omitempty" json:"timeout"`
 		Version        string `yaml:"version,omitempty" json:"version"`
 		MaxOIDs        int    `yaml:"max_request_size,omitempty" json:"max_request_size"`


### PR DESCRIPTION
- Remove omitempty from OptionsConfig.Retries so zero value is serialized
- Skip bulk walk detection when MaxRepetitions is 0, treating it as disabled bulk walk

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `go.d/snmp` config handling: serializes retries when set to 0 and disables bulk walk when `MaxRepetitions` is 0. This respects explicit user settings and avoids unintended bulk-walk detection.

- **Bug Fixes**
  - Removed `omitempty` from `OptionsConfig.Retries` so 0 is serialized.
  - If `MaxRepetitions` is 0, mark bulk walk as disabled and skip detection.

<sup>Written for commit dbac9d1e8d3f8c44776b4d098f83e54903668012. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

