### PR TITLE
feat(go.d/snmp): add `ping_only` option

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -30,15 +30,23 @@ func (c *Collector) collect() (map[string]int64, error) {
 		return nil, err
 	}
 
-	mx, err := c.collectMetrics()
-	if err != nil {
+	if c.PingOnly {
+		return c.collectPingOnly()
+	}
+	return c.collectDeviceMetrics()
+}
+
+func (c *Collector) collectPingOnly() (map[string]int64, error) {
+	mx := make(map[string]int64)
+
+	if err := c.collectPing(mx); err != nil {
 		return nil, err
 	}
 
 	return mx, nil
 }
 
-func (c *Collector) collectMetrics() (map[string]int64, error) {
+func (c *Collector) collectDeviceMetrics() (map[string]int64, error) {
 	var (
 		snmpMx map[string]int64
 		pingMx map[string]int64
@@ -112,7 +120,7 @@ func (c *Collector) ensureInitialized() error {
 		})
 	}
 
-	if c.ddSnmpColl == nil && !c.Ping.Enabled {
+	if c.ddSnmpColl == nil && !c.PingOnly && !c.Ping.Enabled {
 		return errors.New("no profiles found and ping disabled")
 	}
 
@@ -130,7 +138,7 @@ func (c *Collector) ensureInitialized() error {
 
 	c.sysInfo = si
 
-	if c.Ping.Enabled {
+	if c.PingOnly || c.Ping.Enabled {
 		c.addPingCharts()
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -159,6 +159,12 @@ func (c *Collector) Check(context.Context) error {
 		return err
 	}
 
+	if c.PingOnly && c.prober != nil {
+		if _, err := c.prober.Ping(c.Hostname); err != nil && isPingUnrecoverableError(err) {
+			return fmt.Errorf("ping check failed: %v", err)
+		}
+	}
+
 	return nil
 }
 

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -135,7 +135,7 @@ func (c *Collector) Init(context.Context) error {
 		return fmt.Errorf("failed to initialize SNMP client: %v", err)
 	}
 
-	if c.Ping.Enabled {
+	if c.PingOnly || c.Ping.Enabled {
 		pr, err := c.initProber()
 		if err != nil {
 			return fmt.Errorf("failed to initialize ping prober: %v", err)

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -8,7 +8,12 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
+	probing "github.com/prometheus-community/pro-bing"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/ping"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
@@ -326,6 +331,30 @@ func TestCollector_Collect(t *testing.T) {
 			},
 		},
 	}
+	tests["collects ping only metrics"] = struct {
+		prepare func(m *snmpmock.MockHandler) *Collector
+		want    map[string]int64
+	}{
+		prepare: func(m *snmpmock.MockHandler) *Collector {
+			setMockClientInitExpect(m)
+			setMockClientSysInfoExpect(m)
+
+			collr := New()
+			collr.Config = prepareV2Config()
+			collr.PingOnly = true
+			collr.CreateVnode = false
+			collr.newSnmpClient = func() gosnmp.Handler { return m }
+			collr.newProber = func(cfg ping.ProberConfig, log *logger.Logger) ping.Prober { return &mockProber{} }
+
+			return collr
+		},
+		want: map[string]int64{
+			"ping_rtt_min":    (10 * time.Millisecond).Microseconds(),
+			"ping_rtt_max":    (20 * time.Millisecond).Microseconds(),
+			"ping_rtt_avg":    (15 * time.Millisecond).Microseconds(),
+			"ping_rtt_stddev": (5 * time.Millisecond).Microseconds(),
+		},
+	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -343,6 +372,30 @@ func TestCollector_Collect(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+type mockProber struct {
+	errOnPing bool
+}
+
+func (m *mockProber) Ping(host string) (*probing.Statistics, error) {
+	if m.errOnPing {
+		return nil, errors.New("mock.Ping() error")
+	}
+
+	stats := probing.Statistics{
+		PacketsRecv:           5,
+		PacketsSent:           5,
+		PacketsRecvDuplicates: 0,
+		PacketLoss:            0,
+		Addr:                  host,
+		MinRtt:                time.Millisecond * 10,
+		MaxRtt:                time.Millisecond * 20,
+		AvgRtt:                time.Millisecond * 15,
+		StdDevRtt:             time.Millisecond * 5,
+	}
+
+	return &stats, nil
 }
 
 type mockDdSnmpCollector struct {

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -187,6 +188,58 @@ func TestCollector_Check(t *testing.T) {
 				c.CreateVnode = false
 				c.Ping.Enabled = false
 				c.newSnmpClient = func() gosnmp.Handler { return m }
+				return c
+			},
+		},
+
+		"success: ping_only with successful ping": {
+			wantErr: false,
+			prepare: func(m *snmpmock.MockHandler) *Collector {
+				setMockClientInitExpect(m)
+				setMockClientSysInfoExpect(m)
+
+				c := New()
+				c.Config = prepareV2Config()
+				c.PingOnly = true
+				c.CreateVnode = false
+				c.newSnmpClient = func() gosnmp.Handler { return m }
+				c.newProber = func(cfg ping.ProberConfig, log *logger.Logger) ping.Prober { return &mockProber{} }
+				return c
+			},
+		},
+
+		"success: ping_only with recoverable ping error": {
+			wantErr: false,
+			prepare: func(m *snmpmock.MockHandler) *Collector {
+				setMockClientInitExpect(m)
+				setMockClientSysInfoExpect(m)
+
+				c := New()
+				c.Config = prepareV2Config()
+				c.PingOnly = true
+				c.CreateVnode = false
+				c.newSnmpClient = func() gosnmp.Handler { return m }
+				c.newProber = func(cfg ping.ProberConfig, log *logger.Logger) ping.Prober {
+					return &mockProber{pingErr: errors.New("host unreachable")}
+				}
+				return c
+			},
+		},
+
+		"failure: ping_only with unrecoverable ping error": {
+			wantErr: true,
+			prepare: func(m *snmpmock.MockHandler) *Collector {
+				setMockClientInitExpect(m)
+				setMockClientSysInfoExpect(m)
+
+				c := New()
+				c.Config = prepareV2Config()
+				c.PingOnly = true
+				c.CreateVnode = false
+				c.newSnmpClient = func() gosnmp.Handler { return m }
+				c.newProber = func(cfg ping.ProberConfig, log *logger.Logger) ping.Prober {
+					return &mockProber{pingErr: syscall.EPERM}
+				}
 				return c
 			},
 		},
@@ -375,12 +428,12 @@ func TestCollector_Collect(t *testing.T) {
 }
 
 type mockProber struct {
-	errOnPing bool
+	pingErr error
 }
 
 func (m *mockProber) Ping(host string) (*probing.Statistics, error) {
-	if m.errOnPing {
-		return nil, errors.New("mock.Ping() error")
+	if m.pingErr != nil {
+		return nil, m.pingErr
 	}
 
 	stats := probing.Statistics{

--- a/src/go/plugin/go.d/collector/snmp/config.go
+++ b/src/go/plugin/go.d/collector/snmp/config.go
@@ -22,7 +22,8 @@ type (
 
 		ManualProfiles []string `yaml:"manual_profiles,omitempty" json:"manual_profiles"`
 
-		Ping PingConfig `yaml:"ping,omitempty" json:"ping"`
+		PingOnly bool       `yaml:"ping_only,omitempty" json:"ping_only"`
+		Ping     PingConfig `yaml:"ping,omitempty" json:"ping"`
 	}
 
 	PingConfig struct {

--- a/src/go/plugin/go.d/collector/snmp/config_schema.json
+++ b/src/go/plugin/go.d/collector/snmp/config_schema.json
@@ -210,7 +210,7 @@
       },
       "ping_only": {
         "title": "Ping only",
-        "description": "Collect only ICMP round-trip time and skip SNMP profile metrics.",
+        "description": "Collect only ICMP round-trip time and skip SNMP profile metrics. Implies ping is enabled regardless of the ping.enabled setting.",
         "type": "boolean",
         "default": false
       },
@@ -328,7 +328,7 @@
       }
     },
     "ping_only": {
-      "ui:help": "A minimal SNMP sysInfo query still runs during vnode setup for identification/metadata."
+      "ui:help": "A minimal SNMP sysInfo query still runs at startup for device identification, profile matching, and metadata."
     },
     "ping": {
       "interface": {

--- a/src/go/plugin/go.d/collector/snmp/config_schema.json
+++ b/src/go/plugin/go.d/collector/snmp/config_schema.json
@@ -208,6 +208,12 @@
         },
         "uniqueItems": true
       },
+      "ping_only": {
+        "title": "Ping only",
+        "description": "Collect only ICMP round-trip time and skip SNMP profile metrics.",
+        "type": "boolean",
+        "default": false
+      },
       "ping": {
         "title": "Ping",
         "type": [
@@ -321,6 +327,9 @@
         "ui:help": "Advanced. Usually left empty. Required when targeting a specific context on multi-context agents or when driving snmpsim virtual devices."
       }
     },
+    "ping_only": {
+      "ui:help": "A minimal SNMP sysInfo query still runs during vnode setup for identification/metadata."
+    },
     "ping": {
       "interface": {
         "ui:widget": "hidden"
@@ -344,6 +353,7 @@
         {
           "title": "Ping",
           "fields": [
+            "ping_only",
             "ping"
           ]
         },

--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -390,7 +390,7 @@ modules:
 
             - name: ping_only
               group: Ping
-              description: Collect only ICMP round-trip metrics and skip periodic SNMP polling. A minimal SNMP sysInfo probe still runs at setup for naming/labels/metadata.
+              description: Collect only ICMP round-trip metrics and skip periodic SNMP polling. Implies ping is enabled regardless of the `ping.enabled` setting. A minimal SNMP sysInfo probe still runs at setup for naming/labels/metadata.
               default_value: false
               required: false
             - name: ping.enabled

--- a/src/go/plugin/go.d/collector/snmp/testdata/config.json
+++ b/src/go/plugin/go.d/collector/snmp/testdata/config.json
@@ -32,6 +32,7 @@
   "manual_profiles": [
     "ok"
   ],
+  "ping_only": true,
   "ping": {
     "enabled": true,
     "network": "ip",

--- a/src/go/plugin/go.d/collector/snmp/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/snmp/testdata/config.yaml
@@ -31,6 +31,7 @@ options:
   max_request_size: 123
   max_repetitions: 123
 
+ping_only: yes
 ping:
   enabled: yes
   network: ip


### PR DESCRIPTION
When enabled, the collector collects only ICMP round-trip time metrics during Collect(). SNMP is still used during initialization to query sysInfo and profile metadata for Virtual Node creation and labeling.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ping_only` to the `go.d/snmp` collector. When enabled, it collects only ICMP RTT and skips SNMP polling; a minimal SNMP sysInfo runs once at startup for device identification, profile matching, and metadata. Also validates reachability during Check and fails on unrecoverable ping errors.

- **New Features**
  - New `ping_only` boolean in config/schema; default is `false`.
  - Skips SNMP profile metrics; `ping_only` implies ping is enabled and initializes the prober.
  - Adds ping charts when `ping_only` is enabled.
  - During `Check()`, if `ping_only` is set, ping is executed and fails only on unrecoverable errors (e.g., EPERM/EACCES); transient errors are allowed.

- **Migration**
  - Set `ping_only: true` to collect only ping RTT metrics.
  - SNMP sysInfo still runs at startup for device identification and labeling.

<sup>Written for commit e2f7a1e2f7abeb6d09d204349b7da11b8490d919. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

