### PR TITLE
go.d/snmp: add reusable profile engine helpers

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/charts.go
+++ b/src/go/plugin/go.d/collector/snmp/charts.go
@@ -211,6 +211,10 @@ func (c *Collector) addProfileScalarMetricChart(m ddsnmp.Metric) {
 	tags := c.chartBaseLabels()
 
 	maps.Copy(tags, m.Profile.Tags)
+	for k, v := range m.Tags {
+		newKey := strings.TrimPrefix(k, "_")
+		tags[newKey] = v
+	}
 	for k, v := range tags {
 		chart.Labels = append(chart.Labels, collectorapi.Label{Key: k, Value: v})
 	}

--- a/src/go/plugin/go.d/collector/snmp/charts.go
+++ b/src/go/plugin/go.d/collector/snmp/charts.go
@@ -211,10 +211,7 @@ func (c *Collector) addProfileScalarMetricChart(m ddsnmp.Metric) {
 	tags := c.chartBaseLabels()
 
 	maps.Copy(tags, m.Profile.Tags)
-	for k, v := range m.Tags {
-		newKey := strings.TrimPrefix(k, "_")
-		tags[newKey] = v
-	}
+	addMetricTagLabels(tags, m.Tags)
 	for k, v := range tags {
 		chart.Labels = append(chart.Labels, collectorapi.Label{Key: k, Value: v})
 	}
@@ -271,10 +268,7 @@ func (c *Collector) addProfileTableMetricChart(m ddsnmp.Metric) {
 	tags := c.chartBaseLabels()
 
 	maps.Copy(tags, m.Profile.Tags)
-	for k, v := range m.Tags {
-		newKey := strings.TrimPrefix(k, "_")
-		tags[newKey] = v
-	}
+	addMetricTagLabels(tags, m.Tags)
 
 	for k, v := range tags {
 		chart.Labels = append(chart.Labels, collectorapi.Label{Key: k, Value: v})
@@ -330,6 +324,27 @@ func (c *Collector) chartBaseLabels() map[string]string {
 	}
 
 	return labels
+}
+
+func addMetricTagLabels(labels, tags map[string]string) {
+	for k, v := range tags {
+		if strings.HasPrefix(k, "_") {
+			continue
+		}
+		labels[k] = v
+	}
+	for k, v := range tags {
+		if !strings.HasPrefix(k, "_") {
+			continue
+		}
+		key := strings.TrimPrefix(k, "_")
+		if key == "" {
+			continue
+		}
+		if _, ok := labels[key]; !ok {
+			labels[key] = v
+		}
+	}
 }
 
 func dimAlgoFromDdSnmpType(m ddsnmp.Metric) collectorapi.DimAlgo {

--- a/src/go/plugin/go.d/collector/snmp/charts.go
+++ b/src/go/plugin/go.d/collector/snmp/charts.go
@@ -331,7 +331,7 @@ func addMetricTagLabels(labels, tags map[string]string) {
 		if strings.HasPrefix(k, "_") {
 			continue
 		}
-		labels[k] = v
+		addMetricTagLabel(labels, k, v)
 	}
 	for k, v := range tags {
 		if !strings.HasPrefix(k, "_") {
@@ -341,9 +341,13 @@ func addMetricTagLabels(labels, tags map[string]string) {
 		if key == "" {
 			continue
 		}
-		if existing, ok := labels[key]; !ok || existing == "" {
-			labels[key] = v
-		}
+		addMetricTagLabel(labels, key, v)
+	}
+}
+
+func addMetricTagLabel(labels map[string]string, key, value string) {
+	if existing, ok := labels[key]; !ok || existing == "" {
+		labels[key] = value
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp/charts.go
+++ b/src/go/plugin/go.d/collector/snmp/charts.go
@@ -341,7 +341,7 @@ func addMetricTagLabels(labels, tags map[string]string) {
 		if key == "" {
 			continue
 		}
-		if _, ok := labels[key]; !ok {
+		if existing, ok := labels[key]; !ok || existing == "" {
 			labels[key] = v
 		}
 	}

--- a/src/go/plugin/go.d/collector/snmp/charts_test.go
+++ b/src/go/plugin/go.d/collector/snmp/charts_test.go
@@ -50,12 +50,15 @@ func TestCollector_AddProfileScalarMetricChart_LabelsIncludeMetricTags(t *testin
 func TestAddMetricTagLabels_PrefersUnprefixedTags(t *testing.T) {
 	labels := map[string]string{
 		"empty_profile_label": "",
+		"profile_tag":         "profile-value",
 		"vendor":              "device-vendor",
 	}
 
 	addMetricTagLabels(labels, map[string]string{
 		"component":            "vpn",
 		"empty_metric_label":   "",
+		"profile_tag":          "metric-profile-value",
+		"vendor":               "",
 		"_component":           "private-vpn",
 		"_empty_metric_label":  "metric-fallback",
 		"_empty_profile_label": "profile-fallback",
@@ -69,6 +72,7 @@ func TestAddMetricTagLabels_PrefersUnprefixedTags(t *testing.T) {
 		"empty_metric_label":  "metric-fallback",
 		"empty_profile_label": "profile-fallback",
 		"license_state_raw":   "active",
+		"profile_tag":         "profile-value",
 		"vendor":              "device-vendor",
 	}, labels)
 }

--- a/src/go/plugin/go.d/collector/snmp/charts_test.go
+++ b/src/go/plugin/go.d/collector/snmp/charts_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
+)
+
+func TestCollector_AddProfileScalarMetricChart_LabelsIncludeMetricTags(t *testing.T) {
+	collr := New()
+	collr.Hostname = "192.0.2.1"
+	collr.sysInfo = &snmputils.SysInfo{
+		Name:   "test-device",
+		Vendor: "test-vendor",
+	}
+
+	collr.addProfileScalarMetricChart(ddsnmp.Metric{
+		Name:  "license.status",
+		Value: 1,
+		Tags: map[string]string{
+			"component":          "vpn",
+			"_license_state_raw": "active",
+		},
+		Profile: &ddsnmp.ProfileMetrics{
+			Tags: map[string]string{"profile_tag": "profile_value"},
+		},
+	})
+
+	chart := collr.Charts().Get("snmp_device_prof_license_status")
+	require.NotNil(t, chart)
+
+	assert.Equal(t, map[string]string{
+		"address":           "192.0.2.1",
+		"component":         "vpn",
+		"license_state_raw": "active",
+		"profile_tag":       "profile_value",
+		"sysName":           "test-device",
+		"vendor":            "test-vendor",
+	}, chartLabels(chart))
+}
+
+func chartLabels(chart *collectorapi.Chart) map[string]string {
+	labels := make(map[string]string, len(chart.Labels))
+	for _, label := range chart.Labels {
+		labels[label.Key] = label.Value
+	}
+	return labels
+}

--- a/src/go/plugin/go.d/collector/snmp/charts_test.go
+++ b/src/go/plugin/go.d/collector/snmp/charts_test.go
@@ -26,6 +26,7 @@ func TestCollector_AddProfileScalarMetricChart_LabelsIncludeMetricTags(t *testin
 		Value: 1,
 		Tags: map[string]string{
 			"component":          "vpn",
+			"_component":         "private-vpn",
 			"_license_state_raw": "active",
 		},
 		Profile: &ddsnmp.ProfileMetrics{
@@ -44,6 +45,24 @@ func TestCollector_AddProfileScalarMetricChart_LabelsIncludeMetricTags(t *testin
 		"sysName":           "test-device",
 		"vendor":            "test-vendor",
 	}, chartLabels(chart))
+}
+
+func TestAddMetricTagLabels_PrefersUnprefixedTags(t *testing.T) {
+	labels := map[string]string{"vendor": "device-vendor"}
+
+	addMetricTagLabels(labels, map[string]string{
+		"component":          "vpn",
+		"_component":         "private-vpn",
+		"_license_state_raw": "active",
+		"_vendor":            "private-vendor",
+		"_":                  "ignored",
+	})
+
+	assert.Equal(t, map[string]string{
+		"component":         "vpn",
+		"license_state_raw": "active",
+		"vendor":            "device-vendor",
+	}, labels)
 }
 
 func chartLabels(chart *collectorapi.Chart) map[string]string {

--- a/src/go/plugin/go.d/collector/snmp/charts_test.go
+++ b/src/go/plugin/go.d/collector/snmp/charts_test.go
@@ -48,20 +48,28 @@ func TestCollector_AddProfileScalarMetricChart_LabelsIncludeMetricTags(t *testin
 }
 
 func TestAddMetricTagLabels_PrefersUnprefixedTags(t *testing.T) {
-	labels := map[string]string{"vendor": "device-vendor"}
+	labels := map[string]string{
+		"empty_profile_label": "",
+		"vendor":              "device-vendor",
+	}
 
 	addMetricTagLabels(labels, map[string]string{
-		"component":          "vpn",
-		"_component":         "private-vpn",
-		"_license_state_raw": "active",
-		"_vendor":            "private-vendor",
-		"_":                  "ignored",
+		"component":            "vpn",
+		"empty_metric_label":   "",
+		"_component":           "private-vpn",
+		"_empty_metric_label":  "metric-fallback",
+		"_empty_profile_label": "profile-fallback",
+		"_license_state_raw":   "active",
+		"_vendor":              "private-vendor",
+		"_":                    "ignored",
 	})
 
 	assert.Equal(t, map[string]string{
-		"component":         "vpn",
-		"license_state_raw": "active",
-		"vendor":            "device-vendor",
+		"component":           "vpn",
+		"empty_metric_label":  "metric-fallback",
+		"empty_profile_label": "profile-fallback",
+		"license_state_raw":   "active",
+		"vendor":              "device-vendor",
 	}, labels)
 }
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation.go
@@ -222,6 +222,22 @@ func validateEnrichMetrics(metrics []MetricsConfig) error {
 		}
 		if metricConfig.IsScalar() {
 			errs = append(errs, validateEnrichSymbol(&metricConfig.Symbol, ScalarSymbol))
+			for i := range metricConfig.MetricTags {
+				metricTag := &metricConfig.MetricTags[i]
+				errs = append(errs, validateEnrichMetricTag(metricTag))
+				if metricTag.Table != "" {
+					errs = append(errs, fmt.Errorf("scalar metric_tags do not support `table` lookups (tag=%q, table=%q)", metricTag.Tag, metricTag.Table))
+				}
+				if metricTag.Index != 0 {
+					errs = append(errs, fmt.Errorf("scalar metric_tags do not support `index` lookups (tag=%q, index=%d)", metricTag.Tag, metricTag.Index))
+				}
+				if len(metricTag.IndexTransform) > 0 {
+					errs = append(errs, fmt.Errorf("scalar metric_tags do not support `index_transform` (tag=%q)", metricTag.Tag))
+				}
+				if metricTag.Symbol.OID == "" {
+					errs = append(errs, fmt.Errorf("scalar metric_tags require `symbol.OID` (tag=%q)", metricTag.Tag))
+				}
+			}
 		}
 		if metricConfig.IsColumn() {
 			for j := range metricConfig.Symbols {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation.go
@@ -222,8 +222,8 @@ func validateEnrichMetrics(metrics []MetricsConfig) error {
 		}
 		if metricConfig.IsScalar() {
 			errs = append(errs, validateEnrichSymbol(&metricConfig.Symbol, ScalarSymbol))
-			for i := range metricConfig.MetricTags {
-				metricTag := &metricConfig.MetricTags[i]
+			for j := range metricConfig.MetricTags {
+				metricTag := &metricConfig.MetricTags[j]
 				errs = append(errs, validateEnrichMetricTag(metricTag))
 				if metricTag.Table != "" {
 					errs = append(errs, fmt.Errorf("scalar metric_tags do not support `table` lookups (tag=%q, table=%q)", metricTag.Tag, metricTag.Table))

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation_test.go
@@ -459,6 +459,107 @@ func Test_validateEnrichMetrics(t *testing.T) {
 				},
 			},
 		},
+		"scalar metric_tags with scalar OID symbol are supported": {
+			wantError: false,
+			metrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						OID:  "1.2.3",
+						Name: "myMetric",
+					},
+					MetricTags: MetricTagConfigList{
+						{
+							OID: "1.2.4",
+							Symbol: SymbolConfigCompat{
+								Name: "stateSource",
+							},
+							Tag: "state",
+						},
+					},
+				},
+			},
+			wantMetrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						OID:  "1.2.3",
+						Name: "myMetric",
+					},
+					MetricTags: MetricTagConfigList{
+						{
+							Tag: "state",
+							Symbol: SymbolConfigCompat{
+								OID:  "1.2.4",
+								Name: "stateSource",
+							},
+						},
+					},
+				},
+			},
+		},
+		"scalar metric_tags do not support index lookups": {
+			wantError: true,
+			metrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						OID:  "1.2.3",
+						Name: "myMetric",
+					},
+					MetricTags: MetricTagConfigList{
+						{
+							Tag:   "idx",
+							Index: 1,
+						},
+					},
+				},
+			},
+		},
+		"scalar metric_tags do not support table lookups": {
+			wantError: true,
+			metrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						OID:  "1.2.3",
+						Name: "myMetric",
+					},
+					MetricTags: MetricTagConfigList{
+						{
+							Tag:   "peer",
+							Table: "ifTable",
+							Symbol: SymbolConfigCompat{
+								OID:  "1.2.4",
+								Name: "ifDescr",
+							},
+						},
+					},
+				},
+			},
+		},
+		"scalar metric_tags do not support index transforms": {
+			wantError: true,
+			metrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						OID:  "1.2.3",
+						Name: "myMetric",
+					},
+					MetricTags: MetricTagConfigList{
+						{
+							Tag: "peer",
+							Symbol: SymbolConfigCompat{
+								OID:  "1.2.4",
+								Name: "peerState",
+							},
+							IndexTransform: []MetricIndexTransform{
+								{
+									Start: 1,
+									End:   1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
@@ -105,7 +105,6 @@ func (c *Collector) Collect() ([]*ddsnmp.ProfileMetrics, error) {
 		}
 
 		c.updateProfileMetrics(pm)
-		pm.HiddenMetrics = collectHiddenMetrics(pm.Metrics)
 
 		metrics = append(metrics, pm)
 
@@ -120,6 +119,7 @@ func (c *Collector) Collect() ([]*ddsnmp.ProfileMetrics, error) {
 			pm.Stats.Timing.VirtualMetrics = time.Since(now)
 		}
 
+		pm.HiddenMetrics = collectHiddenMetrics(pm.Metrics)
 		pm.Metrics = slices.DeleteFunc(pm.Metrics, func(m ddsnmp.Metric) bool { return strings.HasPrefix(m.Name, "_") })
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
@@ -134,7 +134,7 @@ func (c *Collector) Collect() ([]*ddsnmp.ProfileMetrics, error) {
 }
 
 func collectHiddenMetrics(metrics []ddsnmp.Metric) []ddsnmp.Metric {
-	hidden := make([]ddsnmp.Metric, 0, len(metrics))
+	var hidden []ddsnmp.Metric
 	for _, metric := range metrics {
 		if strings.HasPrefix(metric.Name, "_") {
 			hidden = append(hidden, metric)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
@@ -105,6 +105,7 @@ func (c *Collector) Collect() ([]*ddsnmp.ProfileMetrics, error) {
 		}
 
 		c.updateProfileMetrics(pm)
+		pm.HiddenMetrics = collectHiddenMetrics(pm.Metrics)
 
 		metrics = append(metrics, pm)
 
@@ -114,11 +115,12 @@ func (c *Collector) Collect() ([]*ddsnmp.ProfileMetrics, error) {
 				vmetrics[i].Profile = pm
 			}
 
-			pm.Metrics = slices.DeleteFunc(pm.Metrics, func(m ddsnmp.Metric) bool { return strings.HasPrefix(m.Name, "_") })
 			pm.Metrics = append(pm.Metrics, vmetrics...)
 			pm.Stats.Metrics.Virtual += int64(len(vmetrics))
 			pm.Stats.Timing.VirtualMetrics = time.Since(now)
 		}
+
+		pm.Metrics = slices.DeleteFunc(pm.Metrics, func(m ddsnmp.Metric) bool { return strings.HasPrefix(m.Name, "_") })
 	}
 
 	if len(metrics) == 0 && len(errs) > 0 {
@@ -129,6 +131,16 @@ func (c *Collector) Collect() ([]*ddsnmp.ProfileMetrics, error) {
 	}
 
 	return metrics, nil
+}
+
+func collectHiddenMetrics(metrics []ddsnmp.Metric) []ddsnmp.Metric {
+	hidden := make([]ddsnmp.Metric, 0, len(metrics))
+	for _, metric := range metrics {
+		if strings.HasPrefix(metric.Name, "_") {
+			hidden = append(hidden, metric)
+		}
+	}
+	return hidden
 }
 
 func (c *Collector) SetSNMPClient(snmpClient gosnmp.Handler) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_device_meta.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_device_meta.go
@@ -176,6 +176,9 @@ func (dc *deviceMetadataCollector) processSymbolValue(cfg ddprofiledefinition.Sy
 
 	val, err := convPduToStringf(pdu, cfg.Format)
 	if err != nil {
+		if errors.Is(err, errNoTextDateValue) {
+			return "", nil
+		}
 		return "", err
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar.go
@@ -20,6 +20,7 @@ type scalarCollector struct {
 	missingOIDs map[string]bool
 	log         *logger.Logger
 	valProc     *valueProcessor
+	tagProc     *globalTagProcessor
 }
 
 func newScalarCollector(snmpClient gosnmp.Handler, missingOIDs map[string]bool, log *logger.Logger) *scalarCollector {
@@ -28,6 +29,7 @@ func newScalarCollector(snmpClient gosnmp.Handler, missingOIDs map[string]bool, 
 		missingOIDs: missingOIDs,
 		log:         log,
 		valProc:     newValueProcessor(),
+		tagProc:     newGlobalTagProcessor(),
 	}
 }
 
@@ -70,6 +72,20 @@ func (sc *scalarCollector) identifyScalarOIDs(configs []ddprofiledefinition.Metr
 		}
 
 		oids = append(oids, cfg.Symbol.OID)
+
+		for _, tagCfg := range cfg.MetricTags {
+			if tagCfg.Symbol.OID == "" {
+				continue
+			}
+
+			tagOID := trimOID(tagCfg.Symbol.OID)
+			if sc.missingOIDs[tagOID] {
+				missingOIDs = append(missingOIDs, tagCfg.Symbol.OID)
+				continue
+			}
+
+			oids = append(oids, tagCfg.Symbol.OID)
+		}
 	}
 
 	// Sort and deduplicate
@@ -148,6 +164,16 @@ func (sc *scalarCollector) processScalarMetric(cfg ddprofiledefinition.MetricsCo
 	}
 
 	staticTags := parseStaticTags(cfg.StaticTags)
+	tags := make(map[string]string)
+	ta := tagAdder{tags: tags}
+	for _, tagCfg := range cfg.MetricTags {
+		if tagCfg.Symbol.OID == "" {
+			continue
+		}
+		if err := sc.tagProc.processTag(tagCfg, pdus, ta); err != nil {
+			sc.log.Debugf("Error processing scalar tag '%s' for metric '%s': %v", tagCfg.Tag, cfg.Symbol.Name, err)
+		}
+	}
 
-	return buildScalarMetric(cfg.Symbol, pdu, value, staticTags)
+	return buildScalarMetric(cfg.Symbol, pdu, value, tags, staticTags)
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar.go
@@ -160,6 +160,9 @@ func (sc *scalarCollector) processScalarMetric(cfg ddprofiledefinition.MetricsCo
 
 	value, err := sc.valProc.processValue(cfg.Symbol, pdu)
 	if err != nil {
+		if errors.Is(err, errNoTextDateValue) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("error processing value for OID %s (%s): %w", cfg.Symbol.Name, cfg.Symbol.OID, err)
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar.go
@@ -167,14 +167,17 @@ func (sc *scalarCollector) processScalarMetric(cfg ddprofiledefinition.MetricsCo
 	}
 
 	staticTags := parseStaticTags(cfg.StaticTags)
-	tags := make(map[string]string)
-	ta := tagAdder{tags: tags}
-	for _, tagCfg := range cfg.MetricTags {
-		if tagCfg.Symbol.OID == "" {
-			continue
-		}
-		if err := sc.tagProc.processTag(tagCfg, pdus, ta); err != nil {
-			sc.log.Debugf("Error processing scalar tag '%s' for metric '%s': %v", tagCfg.Tag, cfg.Symbol.Name, err)
+	var tags map[string]string
+	if len(cfg.MetricTags) > 0 {
+		tags = make(map[string]string)
+		ta := tagAdder{tags: tags}
+		for _, tagCfg := range cfg.MetricTags {
+			if tagCfg.Symbol.OID == "" {
+				continue
+			}
+			if err := sc.tagProc.processTag(tagCfg, pdus, ta); err != nil {
+				sc.log.Debugf("Error processing scalar tag '%s' for metric '%s': %v", tagCfg.Tag, cfg.Symbol.Name, err)
+			}
 		}
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar_test.go
@@ -103,6 +103,68 @@ func TestScalarCollector_Collect(t *testing.T) {
 			},
 			expectedError: false,
 		},
+		"scalar metric with dynamic metric tags": {
+			profile: &ddsnmp.Profile{
+				SourceFile: "test-profile.yaml",
+				Definition: &ddprofiledefinition.ProfileDefinition{
+					Metrics: []ddprofiledefinition.MetricsConfig{
+						{
+							Symbol: ddprofiledefinition.SymbolConfig{
+								OID:  "1.3.6.1.4.1.2604.5.1.5.1.1.0",
+								Name: "_license_row",
+								Mapping: map[string]string{
+									"1": "1",
+									"4": "2",
+								},
+							},
+							StaticTags: []ddprofiledefinition.StaticMetricTagConfig{
+								{Tag: "_license_id", Value: "base_firewall"},
+							},
+							MetricTags: []ddprofiledefinition.MetricTagConfig{
+								{
+									Tag: "license_state",
+									Symbol: ddprofiledefinition.SymbolConfigCompat{
+										OID: "1.3.6.1.4.1.2604.5.1.5.1.1.0",
+									},
+									Mapping: map[string]string{
+										"1": "trial",
+										"4": "expired",
+									},
+								},
+								{
+									Tag: "license_expiry",
+									Symbol: ddprofiledefinition.SymbolConfigCompat{
+										OID: "1.3.6.1.4.1.2604.5.1.5.1.2.0",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMock: func(m *snmpmock.MockHandler) {
+				expectSNMPGet(m, []string{"1.3.6.1.4.1.2604.5.1.5.1.1.0", "1.3.6.1.4.1.2604.5.1.5.1.2.0"}, []gosnmp.SnmpPDU{
+					createIntegerPDU("1.3.6.1.4.1.2604.5.1.5.1.1.0", 4),
+					createStringPDU("1.3.6.1.4.1.2604.5.1.5.1.2.0", "11 Nov 2031"),
+				})
+			},
+			expectedResult: []ddsnmp.Metric{
+				{
+					Name:       "_license_row",
+					Value:      2,
+					MetricType: "gauge",
+					Tags: map[string]string{
+						"_license_id":    "base_firewall",
+						"license_state":  "expired",
+						"license_expiry": "11 Nov 2031",
+					},
+					StaticTags: map[string]string{
+						"_license_id": "base_firewall",
+					},
+				},
+			},
+			expectedError: false,
+		},
 		"OID not found - returns empty metrics": {
 			profile: createTestProfile("test-profile.yaml", []ddprofiledefinition.MetricsConfig{
 				createScalarMetric("1.3.6.1.2.1.1.3.0", "sysUpTime"),
@@ -732,4 +794,32 @@ func TestScalarCollector_Collect(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestScalarCollector_IdentifyScalarOIDs_SkipsTagOIDsWhenPrimaryOIDIsKnownMissing(t *testing.T) {
+	sc := &scalarCollector{
+		missingOIDs: map[string]bool{
+			"1.3.6.1.4.1.2604.5.1.5.1.1.0": true,
+		},
+	}
+
+	oids, missing := sc.identifyScalarOIDs([]ddprofiledefinition.MetricsConfig{
+		{
+			Symbol: ddprofiledefinition.SymbolConfig{
+				OID:  "1.3.6.1.4.1.2604.5.1.5.1.1.0",
+				Name: "_license_row",
+			},
+			MetricTags: []ddprofiledefinition.MetricTagConfig{
+				{
+					Tag: "license_state",
+					Symbol: ddprofiledefinition.SymbolConfigCompat{
+						OID: "1.3.6.1.4.1.2604.5.1.5.1.2.0",
+					},
+				},
+			},
+		},
+	})
+
+	assert.Empty(t, oids)
+	assert.Equal(t, []string{"1.3.6.1.4.1.2604.5.1.5.1.1.0"}, missing)
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar_test.go
@@ -165,6 +165,53 @@ func TestScalarCollector_Collect(t *testing.T) {
 			},
 			expectedError: false,
 		},
+		"text_date sentinel skips scalar metric without processing error": {
+			profile: &ddsnmp.Profile{
+				SourceFile: "test-profile.yaml",
+				Definition: &ddprofiledefinition.ProfileDefinition{
+					Metrics: []ddprofiledefinition.MetricsConfig{
+						{
+							Symbol: ddprofiledefinition.SymbolConfig{
+								OID:    "1.3.6.1.4.1.999.1.1.0",
+								Name:   "license.expiry",
+								Format: "text_date",
+							},
+						},
+					},
+				},
+			},
+			setupMock: func(m *snmpmock.MockHandler) {
+				expectSNMPGet(m, []string{"1.3.6.1.4.1.999.1.1.0"}, []gosnmp.SnmpPDU{
+					createStringPDU("1.3.6.1.4.1.999.1.1.0", "never"),
+				})
+			},
+			expectedResult: []ddsnmp.Metric{},
+			expectedError:  false,
+		},
+		"invalid text_date still fails when no scalar metrics are usable": {
+			profile: &ddsnmp.Profile{
+				SourceFile: "test-profile.yaml",
+				Definition: &ddprofiledefinition.ProfileDefinition{
+					Metrics: []ddprofiledefinition.MetricsConfig{
+						{
+							Symbol: ddprofiledefinition.SymbolConfig{
+								OID:    "1.3.6.1.4.1.999.1.1.0",
+								Name:   "license.expiry",
+								Format: "text_date",
+							},
+						},
+					},
+				},
+			},
+			setupMock: func(m *snmpmock.MockHandler) {
+				expectSNMPGet(m, []string{"1.3.6.1.4.1.999.1.1.0"}, []gosnmp.SnmpPDU{
+					createStringPDU("1.3.6.1.4.1.999.1.1.0", "not-a-date"),
+				})
+			},
+			expectedResult: nil,
+			expectedError:  true,
+			errorContains:  `text_date: cannot parse "not-a-date"`,
+		},
 		"OID not found - returns empty metrics": {
 			profile: createTestProfile("test-profile.yaml", []ddprofiledefinition.MetricsConfig{
 				createScalarMetric("1.3.6.1.2.1.1.3.0", "sysUpTime"),

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
@@ -541,6 +541,9 @@ func (tc *tableCollector) buildMetricsFromCache(ctx *cacheProcessingContext, sta
 			for _, sym := range syms {
 				value, err := tc.valProc.processValue(sym, pdu)
 				if err != nil {
+					if errors.Is(err, errNoTextDateValue) {
+						continue
+					}
 					stats.Errors.Processing.Table++
 					tc.log.Debugf("Error processing value for %s: %v", sym.Name, err)
 					continue

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
@@ -51,6 +51,7 @@ func (tc *tableCollector) collect(prof *ddsnmp.Profile, stats *ddsnmp.Collection
 }
 
 // tableWalkResult holds the walked data for a single table
+// tableWalkResult holds the walked data for a single table
 type tableWalkResult struct {
 	// tableOID is the base OID of the table (e.g., "1.3.6.1.2.1.2.2" for ifTable)
 	// Used to identify which table this result belongs to
@@ -491,22 +492,23 @@ func (tc *tableCollector) collectWithCache(ctx *cacheProcessingContext, stats *d
 		}
 	}
 
-	ctx.pdus = make(map[string]gosnmp.SnmpPDU)
-	if len(oidsToGet) > 0 {
-		// GET current values
-		pdus, err := tc.snmpGet(oidsToGet, stats)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get cached OIDs: %w", err)
-		}
-
-		// Validate response
-		if len(pdus) < len(oidsToGet)/2 {
-			return nil, fmt.Errorf("table structure may have changed, got %d/%d PDUs", len(pdus), len(oidsToGet))
-		}
-
-		ctx.pdus = pdus
+	if len(oidsToGet) == 0 {
+		return nil, nil
 	}
 
+	// GET current values
+	pdus, err := tc.snmpGet(oidsToGet, stats)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cached OIDs: %w", err)
+	}
+
+	// Validate response
+	if len(pdus) < len(oidsToGet)/2 {
+		return nil, fmt.Errorf("table structure may have changed, got %d/%d PDUs", len(pdus), len(oidsToGet))
+	}
+
+	// Add PDUs to context and build metrics
+	ctx.pdus = pdus
 	return tc.buildMetricsFromCache(ctx, stats)
 }
 
@@ -521,21 +523,6 @@ func (tc *tableCollector) buildMetricsFromCache(ctx *cacheProcessingContext, sta
 		rowTags := make(map[string]string)
 		if tags, ok := ctx.cachedTags[index]; ok {
 			maps.Copy(rowTags, tags)
-		}
-
-		for _, sym := range ctx.config.Symbols {
-			if !sym.ConstantValueOne {
-				continue
-			}
-
-			metric, err := buildTableMetric(sym, gosnmp.SnmpPDU{Type: gosnmp.Gauge32, Value: uint(1)}, 1, rowTags, staticTags, ctx.tableName)
-			if err != nil {
-				stats.Errors.Processing.Table++
-				errs = append(errs, err)
-				continue
-			}
-
-			metrics = append(metrics, *metric)
 		}
 
 		// Process each metric column
@@ -653,9 +640,6 @@ func parseStaticTags(staticTags []ddprofiledefinition.StaticMetricTagConfig) map
 func buildColumnOIDs(cfg ddprofiledefinition.MetricsConfig) map[string][]ddprofiledefinition.SymbolConfig {
 	columnOIDs := make(map[string][]ddprofiledefinition.SymbolConfig)
 	for _, sym := range cfg.Symbols {
-		if sym.OID == "" || sym.ConstantValueOne {
-			continue
-		}
 		columnOID := trimOID(sym.OID)
 		columnOIDs[columnOID] = append(columnOIDs[columnOID], sym)
 	}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
@@ -653,7 +653,7 @@ func parseStaticTags(staticTags []ddprofiledefinition.StaticMetricTagConfig) map
 func buildColumnOIDs(cfg ddprofiledefinition.MetricsConfig) map[string][]ddprofiledefinition.SymbolConfig {
 	columnOIDs := make(map[string][]ddprofiledefinition.SymbolConfig)
 	for _, sym := range cfg.Symbols {
-		if sym.OID == "" {
+		if sym.OID == "" || sym.ConstantValueOne {
 			continue
 		}
 		columnOID := trimOID(sym.OID)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
@@ -51,7 +51,6 @@ func (tc *tableCollector) collect(prof *ddsnmp.Profile, stats *ddsnmp.Collection
 }
 
 // tableWalkResult holds the walked data for a single table
-// tableWalkResult holds the walked data for a single table
 type tableWalkResult struct {
 	// tableOID is the base OID of the table (e.g., "1.3.6.1.2.1.2.2" for ifTable)
 	// Used to identify which table this result belongs to
@@ -492,23 +491,22 @@ func (tc *tableCollector) collectWithCache(ctx *cacheProcessingContext, stats *d
 		}
 	}
 
-	if len(oidsToGet) == 0 {
-		return nil, nil
+	ctx.pdus = make(map[string]gosnmp.SnmpPDU)
+	if len(oidsToGet) > 0 {
+		// GET current values
+		pdus, err := tc.snmpGet(oidsToGet, stats)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get cached OIDs: %w", err)
+		}
+
+		// Validate response
+		if len(pdus) < len(oidsToGet)/2 {
+			return nil, fmt.Errorf("table structure may have changed, got %d/%d PDUs", len(pdus), len(oidsToGet))
+		}
+
+		ctx.pdus = pdus
 	}
 
-	// GET current values
-	pdus, err := tc.snmpGet(oidsToGet, stats)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get cached OIDs: %w", err)
-	}
-
-	// Validate response
-	if len(pdus) < len(oidsToGet)/2 {
-		return nil, fmt.Errorf("table structure may have changed, got %d/%d PDUs", len(pdus), len(oidsToGet))
-	}
-
-	// Add PDUs to context and build metrics
-	ctx.pdus = pdus
 	return tc.buildMetricsFromCache(ctx, stats)
 }
 
@@ -523,6 +521,21 @@ func (tc *tableCollector) buildMetricsFromCache(ctx *cacheProcessingContext, sta
 		rowTags := make(map[string]string)
 		if tags, ok := ctx.cachedTags[index]; ok {
 			maps.Copy(rowTags, tags)
+		}
+
+		for _, sym := range ctx.config.Symbols {
+			if !sym.ConstantValueOne {
+				continue
+			}
+
+			metric, err := buildTableMetric(sym, gosnmp.SnmpPDU{Type: gosnmp.Gauge32, Value: uint(1)}, 1, rowTags, staticTags, ctx.tableName)
+			if err != nil {
+				stats.Errors.Processing.Table++
+				errs = append(errs, err)
+				continue
+			}
+
+			metrics = append(metrics, *metric)
 		}
 
 		// Process each metric column
@@ -640,6 +653,9 @@ func parseStaticTags(staticTags []ddprofiledefinition.StaticMetricTagConfig) map
 func buildColumnOIDs(cfg ddprofiledefinition.MetricsConfig) map[string][]ddprofiledefinition.SymbolConfig {
 	columnOIDs := make(map[string][]ddprofiledefinition.SymbolConfig)
 	for _, sym := range cfg.Symbols {
+		if sym.OID == "" {
+			continue
+		}
 		columnOID := trimOID(sym.OID)
 		columnOIDs[columnOID] = append(columnOIDs[columnOID], sym)
 	}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_test.go
@@ -4102,6 +4102,28 @@ func TestTableCollector_Collect(t *testing.T) {
 	}
 }
 
+func TestBuildColumnOIDs_SkipsConstantValueOneSymbols(t *testing.T) {
+	cfg := ddprofiledefinition.MetricsConfig{
+		Symbols: []ddprofiledefinition.SymbolConfig{
+			{
+				OID:  "1.2.3.1",
+				Name: "real_metric",
+			},
+			{
+				OID:              "1.2.3.2",
+				Name:             "_row_anchor",
+				ConstantValueOne: true,
+			},
+		},
+	}
+
+	got := buildColumnOIDs(cfg)
+
+	require.Len(t, got, 1)
+	require.Contains(t, got, "1.2.3.1")
+	assert.NotContains(t, got, "1.2.3.2")
+}
+
 func TestCollector_Collect_TableCaching(t *testing.T) {
 	tests := map[string]struct {
 		profiles       []*ddsnmp.Profile

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_test.go
@@ -4102,28 +4102,6 @@ func TestTableCollector_Collect(t *testing.T) {
 	}
 }
 
-func TestBuildColumnOIDs_SkipsConstantValueOneSymbols(t *testing.T) {
-	cfg := ddprofiledefinition.MetricsConfig{
-		Symbols: []ddprofiledefinition.SymbolConfig{
-			{
-				OID:  "1.2.3.1",
-				Name: "real_metric",
-			},
-			{
-				OID:              "1.2.3.2",
-				Name:             "_row_anchor",
-				ConstantValueOne: true,
-			},
-		},
-	}
-
-	got := buildColumnOIDs(cfg)
-
-	require.Len(t, got, 1)
-	require.Contains(t, got, "1.2.3.1")
-	assert.NotContains(t, got, "1.2.3.2")
-}
-
 func TestCollector_Collect_TableCaching(t *testing.T) {
 	tests := map[string]struct {
 		profiles       []*ddsnmp.Profile

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_test.go
@@ -189,6 +189,15 @@ func TestCollector_Collect_PreservesHiddenMetrics(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name: "_privateMetric_total",
+					Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
+						{
+							Metric: "_privateMetric",
+							Table:  "privateTable",
+						},
+					},
+				},
 			},
 		},
 	}
@@ -208,8 +217,9 @@ func TestCollector_Collect_PreservesHiddenMetrics(t *testing.T) {
 	require.Len(t, results, 1)
 
 	pm := results[0]
-	require.Len(t, pm.HiddenMetrics, 1)
+	require.Len(t, pm.HiddenMetrics, 2)
 	assert.Equal(t, "_privateMetric", pm.HiddenMetrics[0].Name)
+	assert.Equal(t, "_privateMetric_total", pm.HiddenMetrics[1].Name)
 	require.Len(t, pm.Metrics, 1)
 	assert.Equal(t, "privateMetric_total", pm.Metrics[0].Name)
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_test.go
@@ -150,6 +150,70 @@ func TestCollector_Collect_StatsSnapshot(t *testing.T) {
 	assert.Equal(t, expected, pm.Stats)
 }
 
+func TestCollector_Collect_PreservesHiddenMetrics(t *testing.T) {
+	ctrl, mockHandler := setupMockHandler(t)
+	defer ctrl.Finish()
+
+	expectSNMPWalk(mockHandler,
+		gosnmp.Version2c,
+		"1.3.6.1.4.1.99999.1",
+		[]gosnmp.SnmpPDU{
+			createCounter32PDU("1.3.6.1.4.1.99999.1.1.1", 100),
+		},
+	)
+
+	profile := &ddsnmp.Profile{
+		SourceFile: "hidden-metrics-profile.yaml",
+		Definition: &ddprofiledefinition.ProfileDefinition{
+			Metrics: []ddprofiledefinition.MetricsConfig{
+				{
+					Table: ddprofiledefinition.SymbolConfig{
+						OID:  "1.3.6.1.4.1.99999.1",
+						Name: "privateTable",
+					},
+					Symbols: []ddprofiledefinition.SymbolConfig{
+						{
+							OID:  "1.3.6.1.4.1.99999.1.1",
+							Name: "_privateMetric",
+						},
+					},
+				},
+			},
+			VirtualMetrics: []ddprofiledefinition.VirtualMetricConfig{
+				{
+					Name: "privateMetric_total",
+					Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
+						{
+							Metric: "_privateMetric",
+							Table:  "privateTable",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	handleCrossTableTagsWithoutMetrics(profile)
+	require.NoError(t, ddsnmp.CompileTransforms(profile))
+
+	collector := New(Config{
+		SnmpClient:  mockHandler,
+		Profiles:    []*ddsnmp.Profile{profile},
+		Log:         logger.New(),
+		SysObjectID: "",
+	})
+
+	results, err := collector.Collect()
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	pm := results[0]
+	require.Len(t, pm.HiddenMetrics, 1)
+	assert.Equal(t, "_privateMetric", pm.HiddenMetrics[0].Name)
+	require.Len(t, pm.Metrics, 1)
+	assert.Equal(t, "privateMetric_total", pm.Metrics[0].Name)
+}
+
 func TestLongestCommonPrefix(t *testing.T) {
 	assert.Equal(t, "1.3.6.1.2.1.31.1.1.1", longestCommonPrefix([]string{
 		"1.3.6.1.2.1.31.1.1.1.1",

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/common_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/common_test.go
@@ -5,6 +5,7 @@ package ddsnmpcollector
 import (
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/gosnmp/gosnmp"
@@ -108,6 +109,19 @@ func createGauge32PDU(name string, value uint) gosnmp.SnmpPDU {
 
 func createTimeTicksPDU(name string, value uint32) gosnmp.SnmpPDU {
 	return createPDU(name, gosnmp.TimeTicks, value)
+}
+
+func createDateAndTimePDU(name string, value time.Time) gosnmp.SnmpPDU {
+	return createPDU(name, gosnmp.OctetString, []byte{
+		byte(value.Year() >> 8),
+		byte(value.Year()),
+		byte(value.Month()),
+		byte(value.Day()),
+		byte(value.Hour()),
+		byte(value.Minute()),
+		byte(value.Second()),
+		0,
+	})
 }
 
 func createNoSuchObjectPDU(name string) gosnmp.SnmpPDU {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/metric_builder.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/metric_builder.go
@@ -71,8 +71,9 @@ func (mb *metricBuilder) build() ddsnmp.Metric {
 	return mb.metric
 }
 
-func buildScalarMetric(cfg ddprofiledefinition.SymbolConfig, pdu gosnmp.SnmpPDU, value int64, staticTags map[string]string) (*ddsnmp.Metric, error) {
+func buildScalarMetric(cfg ddprofiledefinition.SymbolConfig, pdu gosnmp.SnmpPDU, value int64, tags, staticTags map[string]string) (*ddsnmp.Metric, error) {
 	metric := newMetricBuilder(cfg.Name, value).
+		withTags(tags).
 		withStaticTags(staticTags).
 		fromSymbol(cfg, pdu).
 		build()

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
@@ -170,24 +170,7 @@ func (p *tableRowProcessor) processRowMetrics(row *tableRowData, ctx *tableRowPr
 	for _, syms := range ctx.columnOIDs {
 		symbolCount += len(syms)
 	}
-	for _, sym := range ctx.config.Symbols {
-		if sym.ConstantValueOne {
-			symbolCount++
-		}
-	}
 	metrics := make([]ddsnmp.Metric, 0, symbolCount)
-
-	for _, sym := range ctx.config.Symbols {
-		if !sym.ConstantValueOne {
-			continue
-		}
-		metric, err := p.createMetric(sym, gosnmp.SnmpPDU{Type: gosnmp.Gauge32, Value: uint(1)}, row)
-		if err != nil {
-			p.log.Debugf("Error creating metric %s: %v", sym.Name, err)
-			continue
-		}
-		metrics = append(metrics, *metric)
-	}
 
 	for columnOID, syms := range ctx.columnOIDs {
 		pdu, ok := row.pdus[columnOID]
@@ -210,10 +193,6 @@ func (p *tableRowProcessor) processRowMetrics(row *tableRowData, ctx *tableRowPr
 }
 
 func (p *tableRowProcessor) createMetric(sym ddprofiledefinition.SymbolConfig, pdu gosnmp.SnmpPDU, row *tableRowData) (*ddsnmp.Metric, error) {
-	if sym.ConstantValueOne {
-		return buildTableMetric(sym, gosnmp.SnmpPDU{Type: gosnmp.Gauge32, Value: uint(1)}, 1, row.tags, row.staticTags, row.tableName)
-	}
-
 	value, err := p.valProc.processValue(sym, pdu)
 	if err != nil {
 		return nil, fmt.Errorf("error processing value: %w", err)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
@@ -1,6 +1,7 @@
 package ddsnmpcollector
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -184,6 +185,9 @@ func (p *tableRowProcessor) processRowMetrics(row *tableRowData, ctx *tableRowPr
 				p.log.Debugf("Error creating metric %s: %v", sym.Name, err)
 				continue
 			}
+			if metric == nil {
+				continue
+			}
 
 			metrics = append(metrics, *metric)
 		}
@@ -195,6 +199,9 @@ func (p *tableRowProcessor) processRowMetrics(row *tableRowData, ctx *tableRowPr
 func (p *tableRowProcessor) createMetric(sym ddprofiledefinition.SymbolConfig, pdu gosnmp.SnmpPDU, row *tableRowData) (*ddsnmp.Metric, error) {
 	value, err := p.valProc.processValue(sym, pdu)
 	if err != nil {
+		if errors.Is(err, errNoTextDateValue) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("error processing value: %w", err)
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
@@ -170,7 +170,24 @@ func (p *tableRowProcessor) processRowMetrics(row *tableRowData, ctx *tableRowPr
 	for _, syms := range ctx.columnOIDs {
 		symbolCount += len(syms)
 	}
+	for _, sym := range ctx.config.Symbols {
+		if sym.ConstantValueOne {
+			symbolCount++
+		}
+	}
 	metrics := make([]ddsnmp.Metric, 0, symbolCount)
+
+	for _, sym := range ctx.config.Symbols {
+		if !sym.ConstantValueOne {
+			continue
+		}
+		metric, err := p.createMetric(sym, gosnmp.SnmpPDU{Type: gosnmp.Gauge32, Value: uint(1)}, row)
+		if err != nil {
+			p.log.Debugf("Error creating metric %s: %v", sym.Name, err)
+			continue
+		}
+		metrics = append(metrics, *metric)
+	}
 
 	for columnOID, syms := range ctx.columnOIDs {
 		pdu, ok := row.pdus[columnOID]
@@ -193,6 +210,10 @@ func (p *tableRowProcessor) processRowMetrics(row *tableRowData, ctx *tableRowPr
 }
 
 func (p *tableRowProcessor) createMetric(sym ddprofiledefinition.SymbolConfig, pdu gosnmp.SnmpPDU, row *tableRowData) (*ddsnmp.Metric, error) {
+	if sym.ConstantValueOne {
+		return buildTableMetric(sym, gosnmp.SnmpPDU{Type: gosnmp.Gauge32, Value: uint(1)}, 1, row.tags, row.staticTags, row.tableName)
+	}
+
 	value, err := p.valProc.processValue(sym, pdu)
 	if err != nil {
 		return nil, fmt.Errorf("error processing value: %w", err)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package ddsnmpcollector
 
 import (

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+func TestTableRowProcessor_ProcessRowMetrics_SkipsTextDateNoValue(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	row := &tableRowData{
+		pdus: map[string]gosnmp.SnmpPDU{
+			"1.3.6.1.4.1.999.1.1.1": createStringPDU("1.3.6.1.4.1.999.1.1.1.1", "never"),
+		},
+		tags:       map[string]string{},
+		staticTags: map[string]string{},
+		tableName:  "licenseTable",
+	}
+	ctx := &tableRowProcessingContext{
+		columnOIDs: map[string][]ddprofiledefinition.SymbolConfig{
+			"1.3.6.1.4.1.999.1.1.1": {
+				{
+					OID:    "1.3.6.1.4.1.999.1.1.1",
+					Name:   "license.expiry",
+					Format: "text_date",
+				},
+			},
+		},
+	}
+
+	metrics, err := p.processRowMetrics(row, ctx)
+
+	require.NoError(t, err)
+	assert.Empty(t, metrics)
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/tag_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/tag_processor.go
@@ -3,6 +3,8 @@
 package ddsnmpcollector
 
 import (
+	"errors"
+
 	"github.com/gosnmp/gosnmp"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
@@ -56,6 +58,9 @@ func (p *tableTagProcessor) processTag(cfg ddprofiledefinition.MetricTagConfig, 
 
 	val, err := convPduToStringf(pdu, cfg.Symbol.Format)
 	if err != nil {
+		if errors.Is(err, errNoTextDateValue) {
+			return nil
+		}
 		return err
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/tag_processor_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/tag_processor_test.go
@@ -33,6 +33,22 @@ func TestTableTagProcessor_ProcessTag_Uint32Format(t *testing.T) {
 	assert.Equal(t, "4200000000", ta.tags["remote_as"])
 }
 
+func TestTableTagProcessor_ProcessTag_TextDateNoValueSkipsTag(t *testing.T) {
+	processor := newTableTagProcessor()
+	ta := tagAdder{tags: map[string]string{}}
+
+	err := processor.processTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "license_expiry",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			OID:    "1.3.6.1.4.1.999.1.2",
+			Format: "text_date",
+		},
+	}, createStringPDU("1.3.6.1.4.1.999.1.2.0", "n/a"), ta)
+
+	require.NoError(t, err)
+	assert.Empty(t, ta.tags)
+}
+
 func TestMetricTagDisplayName(t *testing.T) {
 	tests := map[string]struct {
 		cfg  ddprofiledefinition.MetricTagConfig

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
@@ -4,6 +4,7 @@ package ddsnmpcollector
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -16,6 +17,8 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
 )
+
+var errNoTextDateValue = errors.New("text_date: no timestamp value")
 
 func getMetricTypeFromPDUType(pdu gosnmp.SnmpPDU) ddprofiledefinition.ProfileMetricType {
 	switch pdu.Type {
@@ -87,6 +90,9 @@ func convPduToStringf(pdu gosnmp.SnmpPDU, format string) (string, error) {
 		}
 		ts, ok := ddsnmp.ParseTextDate(raw)
 		if !ok {
+			if ddsnmp.IsTextDateNoValue(raw) {
+				return "", errNoTextDateValue
+			}
 			return "", fmt.Errorf("text_date: cannot parse %q", raw)
 		}
 		return strconv.FormatInt(ts, 10), nil

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/gosnmp/gosnmp"
@@ -71,6 +72,24 @@ func convPduToStringf(pdu gosnmp.SnmpPDU, format string) (string, error) {
 			return "", fmt.Errorf("cannot convert %T to hex", pdu.Value)
 		}
 		return hex.EncodeToString(bs), nil
+	case "snmp_dateandtime":
+		ts, err := convPduToDateAndTimeUnix(pdu)
+		if err != nil {
+			return "", err
+		}
+		return strconv.FormatInt(ts, 10), nil
+	case "text_date":
+		// Decode textual dates into unix timestamps directly from the
+		// fresh PDU value on every poll.
+		raw, err := convPduToString(pdu)
+		if err != nil {
+			return "", err
+		}
+		ts, ok := ddsnmp.ParseTextDate(raw)
+		if !ok {
+			return "", fmt.Errorf("text_date: cannot parse %q", raw)
+		}
+		return strconv.FormatInt(ts, 10), nil
 	default:
 		// For unknown formats, use the default string conversion
 		return convPduToString(pdu)
@@ -92,6 +111,62 @@ func convNumericPduToInt64f(pdu gosnmp.SnmpPDU, format string) (int64, error) {
 	}
 
 	return value, nil
+}
+
+func convPduToDateAndTimeUnix(pdu gosnmp.SnmpPDU) (int64, error) {
+	var bs []byte
+
+	switch v := pdu.Value.(type) {
+	case []byte:
+		bs = v
+	case string:
+		bs = []byte(v)
+	default:
+		return 0, fmt.Errorf("cannot convert %T to SNMP DateAndTime", pdu.Value)
+	}
+
+	if len(bs) != 8 && len(bs) != 11 {
+		return 0, fmt.Errorf("invalid SNMP DateAndTime length %d", len(bs))
+	}
+
+	year := int(bs[0])<<8 | int(bs[1])
+	month := time.Month(bs[2])
+	day := int(bs[3])
+	hour := int(bs[4])
+	minute := int(bs[5])
+	second := int(bs[6])
+	deci := int(bs[7])
+
+	loc := time.UTC
+	if len(bs) == 11 {
+		sign := bs[8]
+		tzHours := int(bs[9])
+		tzMinutes := int(bs[10])
+		if sign != '+' && sign != '-' {
+			return 0, fmt.Errorf("invalid SNMP DateAndTime UTC direction %q", sign)
+		}
+		if tzHours > 13 {
+			return 0, fmt.Errorf("invalid SNMP DateAndTime UTC hours offset %d", tzHours)
+		}
+		if tzMinutes > 59 {
+			return 0, fmt.Errorf("invalid SNMP DateAndTime UTC minutes offset %d", tzMinutes)
+		}
+		offset := tzHours*3600 + tzMinutes*60
+		if sign == '-' {
+			offset = -offset
+		}
+		loc = time.FixedZone("snmp", offset)
+	}
+
+	if second == 60 {
+		return 0, fmt.Errorf("unsupported SNMP DateAndTime leap second")
+	}
+
+	tm := time.Date(year, month, day, hour, minute, second, deci*100_000_000, loc)
+	if tm.Year() != year || tm.Month() != month || tm.Day() != day || tm.Hour() != hour || tm.Minute() != minute || tm.Second() != second || tm.Nanosecond()/100_000_000 != deci {
+		return 0, fmt.Errorf("invalid SNMP DateAndTime value")
+	}
+	return tm.Unix(), nil
 }
 
 func convPduToString(pdu gosnmp.SnmpPDU) (string, error) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
@@ -143,6 +143,10 @@ func convPduToDateAndTimeUnix(pdu gosnmp.SnmpPDU) (int64, error) {
 	second := int(bs[6])
 	deci := int(bs[7])
 
+	// The 8-octet SNMPv2-TC DateAndTime form omits timezone fields when
+	// only local time is known. The collector does not know the device's
+	// timezone, so it uses UTC as a deterministic fallback; 11-octet values
+	// use their embedded UTC offset below.
 	loc := time.UTC
 	if len(bs) == 11 {
 		sign := bs[8]

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils_test.go
@@ -45,6 +45,26 @@ func TestConvPduToStringf_SNMPDateAndTime(t *testing.T) {
 	}
 }
 
+func TestConvPduToStringf_TextDate(t *testing.T) {
+	got, err := convPduToStringf(createStringPDU("1.2.3", "2026-12-31"), "text_date")
+	require.NoError(t, err)
+	assert.EqualValues(t, time.Date(2026, time.December, 31, 0, 0, 0, 0, time.UTC).Unix(), mustParseInt64(t, got))
+}
+
+func TestConvPduToStringf_TextDateNoValue(t *testing.T) {
+	for _, raw := range []string{"", "0", "never", "n/a", "4294967295"} {
+		got, err := convPduToStringf(createStringPDU("1.2.3", raw), "text_date")
+		require.ErrorIs(t, err, errNoTextDateValue, "raw=%q", raw)
+		assert.Empty(t, got, "raw=%q", raw)
+	}
+}
+
+func TestConvPduToStringf_TextDateInvalid(t *testing.T) {
+	_, err := convPduToStringf(createStringPDU("1.2.3", "not-a-date"), "text_date")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `text_date: cannot parse "not-a-date"`)
+}
+
 func TestConvPduToDateAndTimeUnix_Invalid(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvPduToStringf_SNMPDateAndTime(t *testing.T) {
+	tests := []struct {
+		name string
+		pdu  gosnmp.SnmpPDU
+		want int64
+	}{
+		{
+			name: "without timezone",
+			pdu: gosnmp.SnmpPDU{
+				Type:  gosnmp.OctetString,
+				Value: []byte{0x07, 0xE8, 0x04, 0x03, 0x0A, 0x0B, 0x0C, 0x00},
+			},
+			want: time.Date(2024, time.April, 3, 10, 11, 12, 0, time.UTC).Unix(),
+		},
+		{
+			name: "with timezone",
+			pdu: gosnmp.SnmpPDU{
+				Type:  gosnmp.OctetString,
+				Value: []byte{0x07, 0xE8, 0x04, 0x03, 0x0A, 0x0B, 0x0C, 0x00, '+', 0x02, 0x00},
+			},
+			want: time.Date(2024, time.April, 3, 8, 11, 12, 0, time.UTC).Unix(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := convPduToStringf(tt.pdu, "snmp_dateandtime")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, mustParseInt64(t, got))
+		})
+	}
+}
+
+func TestConvPduToDateAndTimeUnix_Invalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		value []byte
+	}{
+		{
+			name:  "invalid month",
+			value: []byte{0x07, 0xE8, 0x0D, 0x03, 0x0A, 0x0B, 0x0C, 0x00},
+		},
+		{
+			name:  "invalid day",
+			value: []byte{0x07, 0xE8, 0x04, 0x00, 0x0A, 0x0B, 0x0C, 0x00},
+		},
+		{
+			name:  "invalid hour",
+			value: []byte{0x07, 0xE8, 0x04, 0x03, 0x18, 0x0B, 0x0C, 0x00},
+		},
+		{
+			name:  "invalid minute",
+			value: []byte{0x07, 0xE8, 0x04, 0x03, 0x0A, 0x3C, 0x0C, 0x00},
+		},
+		{
+			name:  "invalid second",
+			value: []byte{0x07, 0xE8, 0x04, 0x03, 0x0A, 0x0B, 0x3D, 0x00},
+		},
+		{
+			name:  "leap second unsupported",
+			value: []byte{0x07, 0xE8, 0x04, 0x03, 0x0A, 0x0B, 0x3C, 0x00},
+		},
+		{
+			name:  "invalid decisecond",
+			value: []byte{0x07, 0xE8, 0x04, 0x03, 0x0A, 0x0B, 0x0C, 0x0A},
+		},
+		{
+			name:  "invalid timezone direction",
+			value: []byte{0x07, 0xE8, 0x04, 0x03, 0x0A, 0x0B, 0x0C, 0x00, 'x', 0x02, 0x00},
+		},
+		{
+			name:  "invalid timezone hours",
+			value: []byte{0x07, 0xE8, 0x04, 0x03, 0x0A, 0x0B, 0x0C, 0x00, '+', 0x0E, 0x00},
+		},
+		{
+			name:  "invalid timezone minutes",
+			value: []byte{0x07, 0xE8, 0x04, 0x03, 0x0A, 0x0B, 0x0C, 0x00, '+', 0x02, 0x3C},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := convPduToDateAndTimeUnix(gosnmp.SnmpPDU{
+				Type:  gosnmp.OctetString,
+				Value: tt.value,
+			})
+			require.Error(t, err)
+		})
+	}
+}
+
+func mustParseInt64(t *testing.T, s string) int64 {
+	t.Helper()
+
+	v, err := strconv.ParseInt(s, 10, 64)
+	require.NoError(t, err)
+	return v
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/value_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/value_processor.go
@@ -25,10 +25,22 @@ func newValueProcessor() *valueProcessor {
 }
 
 func (p *valueProcessor) processValue(sym ddprofiledefinition.SymbolConfig, pdu gosnmp.SnmpPDU) (int64, error) {
+	if isStringValueFormat(sym.Format) {
+		return p.stringProcessor.processValue(sym, pdu)
+	}
 	if isPduNumericType(pdu) {
 		return p.numericProcessor.processValue(sym, pdu)
 	}
 	return p.stringProcessor.processValue(sym, pdu)
+}
+
+func isStringValueFormat(format string) bool {
+	switch format {
+	case "hex", "ip_address", "mac_address", "snmp_dateandtime", "text_date":
+		return true
+	default:
+		return false
+	}
 }
 
 // numericValueProcessor handles numeric PDU types

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/value_processor_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/value_processor_test.go
@@ -114,3 +114,27 @@ func TestNumericValueProcessor_ProcessValue_Uint32Format(t *testing.T) {
 		})
 	}
 }
+
+func TestValueProcessor_ProcessValue_TextDateFormatOnNumericPDU(t *testing.T) {
+	processor := newValueProcessor()
+	symbol := ddprofiledefinition.SymbolConfig{
+		OID:    "1.3.6.1.4.1.99999.1.1.0",
+		Name:   "licenseExpiry",
+		Format: "text_date",
+	}
+
+	value, err := processor.processValue(symbol, gosnmp.SnmpPDU{
+		Name:  "1.3.6.1.4.1.99999.1.1.0",
+		Type:  gosnmp.Gauge32,
+		Value: uint32(1798675200),
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1798675200, value)
+
+	_, err = processor.processValue(symbol, gosnmp.SnmpPDU{
+		Name:  "1.3.6.1.4.1.99999.1.1.0",
+		Type:  gosnmp.Gauge32,
+		Value: uint32(4294967295),
+	})
+	require.ErrorIs(t, err, errNoTextDateValue)
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/metric.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/metric.go
@@ -11,6 +11,7 @@ type ProfileMetrics struct {
 	DeviceMetadata map[string]MetaTag
 	Tags           map[string]string
 	Metrics        []Metric
+	HiddenMetrics  []Metric
 	Stats          CollectionStats
 }
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
@@ -273,25 +273,19 @@ func (p *Profile) removeConstantMetrics() {
 		return
 	}
 
-	metrics := p.Definition.Metrics[:0]
-	for _, metric := range p.Definition.Metrics {
-		if metric.IsScalar() && metric.Symbol.ConstantValueOne {
-			continue
+	p.Definition.Metrics = slices.DeleteFunc(p.Definition.Metrics, func(m ddprofiledefinition.MetricsConfig) bool {
+		if m.IsScalar() && m.Symbol.ConstantValueOne {
+			return true
 		}
 
-		if metric.IsColumn() {
-			metric.Symbols = slices.DeleteFunc(metric.Symbols, func(s ddprofiledefinition.SymbolConfig) bool {
-				return s.ConstantValueOne && !strings.HasPrefix(s.Name, "_")
+		if m.IsColumn() {
+			m.Symbols = slices.DeleteFunc(m.Symbols, func(s ddprofiledefinition.SymbolConfig) bool {
+				return s.ConstantValueOne
 			})
-			if len(metric.Symbols) == 0 {
-				continue
-			}
 		}
 
-		metrics = append(metrics, metric)
-	}
-
-	p.Definition.Metrics = metrics
+		return m.IsColumn() && len(m.Symbols) == 0
+	})
 }
 
 // sortProfilesBySpecificity sorts profiles by their match specificity.

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile.go
@@ -273,19 +273,25 @@ func (p *Profile) removeConstantMetrics() {
 		return
 	}
 
-	p.Definition.Metrics = slices.DeleteFunc(p.Definition.Metrics, func(m ddprofiledefinition.MetricsConfig) bool {
-		if m.IsScalar() && m.Symbol.ConstantValueOne {
-			return true
+	metrics := p.Definition.Metrics[:0]
+	for _, metric := range p.Definition.Metrics {
+		if metric.IsScalar() && metric.Symbol.ConstantValueOne {
+			continue
 		}
 
-		if m.IsColumn() {
-			m.Symbols = slices.DeleteFunc(m.Symbols, func(s ddprofiledefinition.SymbolConfig) bool {
-				return s.ConstantValueOne
+		if metric.IsColumn() {
+			metric.Symbols = slices.DeleteFunc(metric.Symbols, func(s ddprofiledefinition.SymbolConfig) bool {
+				return s.ConstantValueOne && !strings.HasPrefix(s.Name, "_")
 			})
+			if len(metric.Symbols) == 0 {
+				continue
+			}
 		}
 
-		return m.IsColumn() && len(m.Symbols) == 0
-	})
+		metrics = append(metrics, metric)
+	}
+
+	p.Definition.Metrics = metrics
 }
 
 // sortProfilesBySpecificity sorts profiles by their match specificity.

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
@@ -174,44 +174,6 @@ func Test_FindProfiles(t *testing.T) {
 	}
 }
 
-func TestProfile_removeConstantMetrics_PreservesHiddenTableHelpers(t *testing.T) {
-	prof := &Profile{
-		Definition: &ddprofiledefinition.ProfileDefinition{
-			Metrics: []ddprofiledefinition.MetricsConfig{
-				{
-					Table: ddprofiledefinition.SymbolConfig{
-						OID:  "1.2.5",
-						Name: "helperTable",
-					},
-					Symbols: []ddprofiledefinition.SymbolConfig{
-						{
-							OID:              "1.2.5.1.1",
-							Name:             "visible_table_helper",
-							ConstantValueOne: true,
-						},
-						{
-							OID:              "1.2.5.1.2",
-							Name:             "_hidden_table_helper",
-							ConstantValueOne: true,
-						},
-						{
-							OID:  "1.2.5.1.3",
-							Name: "real_metric",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	prof.removeConstantMetrics()
-
-	require.Len(t, prof.Definition.Metrics, 1)
-	require.Len(t, prof.Definition.Metrics[0].Symbols, 2)
-	assert.Equal(t, "_hidden_table_helper", prof.Definition.Metrics[0].Symbols[0].Name)
-	assert.Equal(t, "real_metric", prof.Definition.Metrics[0].Symbols[1].Name)
-}
-
 func Test_Profile_merge(t *testing.T) {
 	profiles := FindProfiles("1.3.6.1.4.1.9.1.1216", "", nil) // cisco-nexus
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
@@ -174,6 +174,44 @@ func Test_FindProfiles(t *testing.T) {
 	}
 }
 
+func TestProfile_removeConstantMetrics_PreservesHiddenTableHelpers(t *testing.T) {
+	prof := &Profile{
+		Definition: &ddprofiledefinition.ProfileDefinition{
+			Metrics: []ddprofiledefinition.MetricsConfig{
+				{
+					Table: ddprofiledefinition.SymbolConfig{
+						OID:  "1.2.5",
+						Name: "helperTable",
+					},
+					Symbols: []ddprofiledefinition.SymbolConfig{
+						{
+							OID:              "1.2.5.1.1",
+							Name:             "visible_table_helper",
+							ConstantValueOne: true,
+						},
+						{
+							OID:              "1.2.5.1.2",
+							Name:             "_hidden_table_helper",
+							ConstantValueOne: true,
+						},
+						{
+							OID:  "1.2.5.1.3",
+							Name: "real_metric",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	prof.removeConstantMetrics()
+
+	require.Len(t, prof.Definition.Metrics, 1)
+	require.Len(t, prof.Definition.Metrics[0].Symbols, 2)
+	assert.Equal(t, "_hidden_table_helper", prof.Definition.Metrics[0].Symbols[0].Name)
+	assert.Equal(t, "real_metric", prof.Definition.Metrics[0].Symbols[1].Name)
+}
+
 func Test_Profile_merge(t *testing.T) {
 	profiles := FindProfiles("1.3.6.1.4.1.9.1.1216", "", nil) // cisco-nexus
 
@@ -190,6 +228,117 @@ func Test_Profile_merge(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestProfileMerge_ColumnSymbolsWithSameNameFromBaseArePreserved(t *testing.T) {
+	child := &Profile{
+		Definition: &ddprofiledefinition.ProfileDefinition{},
+	}
+	base := &Profile{
+		Definition: &ddprofiledefinition.ProfileDefinition{
+			Metrics: []ddprofiledefinition.MetricsConfig{
+				{
+					Table: ddprofiledefinition.SymbolConfig{OID: "1.2.3", Name: "tableA"},
+					Symbols: []ddprofiledefinition.SymbolConfig{
+						{OID: "1.2.3.1", Name: "_license_row"},
+						{OID: "1.2.3.2", Name: "_license_row"},
+					},
+				},
+				{
+					Table: ddprofiledefinition.SymbolConfig{OID: "1.2.4", Name: "tableB"},
+					Symbols: []ddprofiledefinition.SymbolConfig{
+						{OID: "1.2.4.1", Name: "_license_row"},
+					},
+				},
+			},
+		},
+	}
+
+	child.mergeMetrics(base)
+
+	require.Len(t, child.Definition.Metrics, 2)
+	require.Len(t, child.Definition.Metrics[0].Symbols, 2)
+	assert.Equal(t, "1.2.3.1", child.Definition.Metrics[0].Symbols[0].OID)
+	assert.Equal(t, "1.2.3.2", child.Definition.Metrics[0].Symbols[1].OID)
+	require.Len(t, child.Definition.Metrics[1].Symbols, 1)
+	assert.Equal(t, "1.2.4.1", child.Definition.Metrics[1].Symbols[0].OID)
+}
+
+func TestProfileMerge_DifferentTablesDoNotOverrideColumnsByName(t *testing.T) {
+	child := &Profile{
+		Definition: &ddprofiledefinition.ProfileDefinition{
+			Metrics: []ddprofiledefinition.MetricsConfig{
+				{
+					Table: ddprofiledefinition.SymbolConfig{OID: "9.9.9", Name: "childTable"},
+					Symbols: []ddprofiledefinition.SymbolConfig{
+						{OID: "9.9.9.1", Name: "memory.used"},
+					},
+				},
+			},
+		},
+	}
+	base := &Profile{
+		Definition: &ddprofiledefinition.ProfileDefinition{
+			Metrics: []ddprofiledefinition.MetricsConfig{
+				{
+					Table: ddprofiledefinition.SymbolConfig{OID: "1.2.3", Name: "baseTable"},
+					Symbols: []ddprofiledefinition.SymbolConfig{
+						{OID: "1.2.3.1", Name: "memory.used"},
+						{OID: "1.2.3.2", Name: "memory.free"},
+					},
+				},
+			},
+		},
+	}
+
+	child.mergeMetrics(base)
+
+	require.Len(t, child.Definition.Metrics, 2)
+	assert.Equal(t, "childTable", child.Definition.Metrics[0].Table.Name)
+	require.Len(t, child.Definition.Metrics[0].Symbols, 1)
+	assert.Equal(t, "memory.used", child.Definition.Metrics[0].Symbols[0].Name)
+	assert.Equal(t, "baseTable", child.Definition.Metrics[1].Table.Name)
+	require.Len(t, child.Definition.Metrics[1].Symbols, 2)
+	assert.Equal(t, "memory.used", child.Definition.Metrics[1].Symbols[0].Name)
+	assert.Equal(t, "memory.free", child.Definition.Metrics[1].Symbols[1].Name)
+}
+
+func TestProfileMerge_BaseScalarDuplicateAddedOnce(t *testing.T) {
+	child := &Profile{
+		Definition: &ddprofiledefinition.ProfileDefinition{},
+	}
+	base := &Profile{
+		Definition: &ddprofiledefinition.ProfileDefinition{
+			Metrics: []ddprofiledefinition.MetricsConfig{
+				{
+					Symbol: ddprofiledefinition.SymbolConfig{
+						OID:  "1.2.3.0",
+						Name: "license.expiry",
+					},
+				},
+				{
+					Symbol: ddprofiledefinition.SymbolConfig{
+						OID:  "1.2.3.0",
+						Name: "license.expiry",
+					},
+				},
+				{
+					Symbol: ddprofiledefinition.SymbolConfig{
+						OID:  "1.2.4.0",
+						Name: "license.state",
+					},
+				},
+			},
+		},
+	}
+
+	child.mergeMetrics(base)
+
+	require.Len(t, child.Definition.Metrics, 2)
+	assert.Equal(t, "license.expiry", child.Definition.Metrics[0].Symbol.Name)
+	assert.Equal(t, "1.2.3.0", child.Definition.Metrics[0].Symbol.OID)
+	assert.Equal(t, "license.state", child.Definition.Metrics[1].Symbol.Name)
+	assert.Equal(t, "1.2.4.0", child.Definition.Metrics[1].Symbol.OID)
 }
 
 func TestDeduplicateMetricsAcrossProfiles(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
@@ -420,30 +420,28 @@ var textDateLayouts = []string{
 }
 
 // ParseTextDate accepts integer- and string-encoded SNMP date shapes (epoch
-// seconds, milliseconds, the 0xFFFFFFFF "never" sentinel, and the textual
-// layouts above) and returns the equivalent unix timestamp. It is exported so
-// the value-processor format "text_date" in ddsnmpcollector/utils.go can apply
-// the same parsing rules.
+// seconds, milliseconds, decimal no-value sentinels such as 0 and 4294967295,
+// and the textual layouts above) and returns the equivalent unix timestamp. It
+// is exported so the value-processor format "text_date" in
+// ddsnmpcollector/utils.go can apply the same parsing rules.
 func ParseTextDate(raw string) (int64, bool) {
 	return parseTextDate(raw)
 }
 
+// IsTextDateNoValue reports whether raw is a vendor no-timestamp sentinel
+// accepted by ParseTextDate.
+func IsTextDateNoValue(raw string) bool {
+	return isTextDateNoValue(raw)
+}
+
 func parseTextDate(raw string) (int64, bool) {
 	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return 0, false
-	}
-	switch strings.ToLower(raw) {
-	case "0", "none", "n/a", "na", "perpetual", "permanent", "never", "unlimited":
+	if isTextDateNoValue(raw) {
 		return 0, false
 	}
 
 	if n, err := strconv.ParseInt(raw, 10, 64); err == nil {
 		switch {
-		case n <= 0:
-			return 0, false
-		case n == 4_294_967_295:
-			return 0, false
 		case n > 1_000_000_000_000:
 			return n / 1000, true
 		default:
@@ -460,4 +458,22 @@ func parseTextDate(raw string) (int64, bool) {
 		}
 	}
 	return 0, false
+}
+
+func isTextDateNoValue(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return true
+	}
+
+	switch strings.ToLower(raw) {
+	case "0", "none", "n/a", "na", "perpetual", "permanent", "never", "unlimited":
+		return true
+	}
+
+	if n, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		return n <= 0 || n == 4_294_967_295
+	}
+
+	return false
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
@@ -9,7 +9,9 @@ import (
 	"math"
 	"net"
 	"strconv"
+	"strings"
 	"text/template"
+	"time"
 
 	"github.com/Masterminds/sprig/v3"
 
@@ -321,9 +323,142 @@ func newMetricTransformFuncMap() template.FuncMap {
 
 			return ""
 		},
+		"licenseDateFromTag": func(m *Metric, tagName, kind string) string {
+			/*
+				licenseDateFromTag parses a vendor date string carried in a metric tag,
+				replaces the metric value with its unix epoch, and stamps the licensing
+				value kind. Use it when the SNMP OID returns a textual date (e.g.,
+				Checkpoint's "1Jan2030", Sophos' "2026-03-15", Blue Coat's "Mar 15 2026")
+				and snmp_dateandtime cannot be applied.
+
+				kind must be one of the timestamp value kinds accepted by licenseRow:
+				expiry_timestamp, authorization_timestamp, certificate_timestamp,
+				grace_timestamp.
+
+				If parsing fails the metric is left untouched and no licensing kind is
+				stamped, so collector-level consumers can ignore the row signal.
+			*/
+			if m.Tags == nil {
+				return ""
+			}
+			raw := strings.TrimSpace(m.Tags[tagName])
+			if raw == "" {
+				return ""
+			}
+
+			ts, ok := parseTextDate(raw)
+			if !ok {
+				return ""
+			}
+			m.Value = ts
+			m.Tags["_license_value_kind"] = kind
+			return ""
+		},
+		"licenseRow": func(m *Metric, kind string) string {
+			/*
+				licenseRow marks a metric as a licensing row carrier for a collector-level
+				licensing consumer.
+
+				Profiles describe each licensing signal as a hidden ("_"-prefixed) metric
+				whose value corresponds to the signal itself (expiry epoch, used count,
+				severity, etc). The transform stamps a "value kind" tag so the collector
+				knows how to interpret the integer value.
+
+				Supported kinds:
+				  - "expiry_timestamp"           absolute unix-epoch expiry
+				  - "expiry_remaining"           seconds-from-now until expiry
+				  - "authorization_timestamp"    absolute unix-epoch auth expiry
+				  - "authorization_remaining"    seconds-from-now auth expiry
+				  - "certificate_timestamp"      absolute unix-epoch cert expiry
+				  - "certificate_remaining"      seconds-from-now cert expiry
+				  - "grace_timestamp"            absolute unix-epoch grace/eval end
+				  - "grace_remaining"            seconds-from-now grace/eval end
+				  - "usage"                      used license units (integer)
+				  - "capacity"                   total license capacity (integer)
+				  - "available"                  available license units (integer)
+				  - "usage_percent"              usage pressure in percent (0-100)
+				  - "state_severity"             normalized severity (0 healthy, 1 degraded, 2 broken)
+
+				Multiple signals for the same logical license can be merged by the
+				collector-level licensing consumer.
+			*/
+			if m.Tags == nil {
+				m.Tags = make(map[string]string)
+			}
+			m.Tags["_license_value_kind"] = kind
+			return ""
+		},
 	}
 
 	maps.Copy(fm, extra)
 
 	return fm
+}
+
+// textDateLayouts is the set of vendor-friendly date formats accepted by
+// text_date and licenseDateFromTag. The list is intentionally generous:
+// vendors that publish operational dates through SNMP rarely agree on a single
+// textual format. parseTextDate stops at the first layout that succeeds.
+var textDateLayouts = []string{
+	time.RFC3339,
+	"2006-01-02 15:04:05",
+	"2006-01-02",
+	"02/01/2006",
+	"01/02/2006",
+	"Mon Jan 2 15:04:05 2006",
+	"Mon Jan 2 2006",
+	"Mon 2 January 2006",
+	"2 January 2006",
+	"January 2 2006",
+	"Jan 2 2006",
+	"Jan 2 2006 15:04:05",
+	"2 Jan 2006",
+	"2 Jan 2006 15:04:05",
+	"02 Jan 2006",
+	"02 Jan 2006 15:04:05",
+	"02Jan2006",
+	"2Jan2006",
+}
+
+// ParseTextDate accepts integer- and string-encoded SNMP date shapes (epoch
+// seconds, milliseconds, the 0xFFFFFFFF "never" sentinel, and the textual
+// layouts above) and returns the equivalent unix timestamp. It is exported so
+// the value-processor format "text_date" in ddsnmpcollector/utils.go can apply
+// the same parsing rules.
+func ParseTextDate(raw string) (int64, bool) {
+	return parseTextDate(raw)
+}
+
+func parseTextDate(raw string) (int64, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, false
+	}
+	switch strings.ToLower(raw) {
+	case "0", "none", "n/a", "na", "perpetual", "permanent", "never", "unlimited":
+		return 0, false
+	}
+
+	if n, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		switch {
+		case n <= 0:
+			return 0, false
+		case n == 4_294_967_295:
+			return 0, false
+		case n > 1_000_000_000_000:
+			return n / 1000, true
+		default:
+			return n, true
+		}
+	}
+
+	for _, layout := range textDateLayouts {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t.Unix(), true
+		}
+		if t, err := time.ParseInLocation(layout, raw, time.UTC); err == nil {
+			return t.Unix(), true
+		}
+	}
+	return 0, false
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
@@ -398,13 +398,12 @@ func newMetricTransformFuncMap() template.FuncMap {
 // textDateLayouts is the set of vendor-friendly date formats accepted by
 // text_date and licenseDateFromTag. The list is intentionally generous:
 // vendors that publish operational dates through SNMP rarely agree on a single
-// textual format. parseTextDate stops at the first layout that succeeds.
+// textual format. Numeric slash-only dates are intentionally excluded because
+// dd/mm/yyyy and mm/dd/yyyy are ambiguous for values like 01/02/2024.
 var textDateLayouts = []string{
 	time.RFC3339,
 	"2006-01-02 15:04:05",
 	"2006-01-02",
-	"02/01/2006",
-	"01/02/2006",
 	"Mon Jan 2 15:04:05 2006",
 	"Mon Jan 2 2006",
 	"Mon 2 January 2006",

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
@@ -454,9 +454,6 @@ func parseTextDate(raw string) (int64, bool) {
 		if t, err := time.Parse(layout, raw); err == nil {
 			return t.Unix(), true
 		}
-		if t, err := time.ParseInLocation(layout, raw, time.UTC); err == nil {
-			return t.Unix(), true
-		}
 	}
 	return 0, false
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
@@ -441,8 +441,9 @@ func parseTextDate(raw string) (int64, bool) {
 	}
 
 	if n, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		digits := strings.TrimLeft(raw, "+-")
 		switch {
-		case n > 1_000_000_000_000:
+		case len(digits) >= 12:
 			return n / 1000, true
 		default:
 			return n, true

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/transform.go
@@ -323,70 +323,29 @@ func newMetricTransformFuncMap() template.FuncMap {
 
 			return ""
 		},
-		"licenseDateFromTag": func(m *Metric, tagName, kind string) string {
-			/*
-				licenseDateFromTag parses a vendor date string carried in a metric tag,
-				replaces the metric value with its unix epoch, and stamps the licensing
-				value kind. Use it when the SNMP OID returns a textual date (e.g.,
-				Checkpoint's "1Jan2030", Sophos' "2026-03-15", Blue Coat's "Mar 15 2026")
-				and snmp_dateandtime cannot be applied.
-
-				kind must be one of the timestamp value kinds accepted by licenseRow:
-				expiry_timestamp, authorization_timestamp, certificate_timestamp,
-				grace_timestamp.
-
-				If parsing fails the metric is left untouched and no licensing kind is
-				stamped, so collector-level consumers can ignore the row signal.
-			*/
+		"licenseDateFromTag": func(m *Metric, tagName, kind string) (string, error) {
+			// licenseDateFromTag parses a vendor date string carried in a metric tag,
+			// replaces the metric value with its unix epoch, and stamps the licensing
+			// value kind. It is intentionally limited to timestamp value kinds; other
+			// licensing row kinds can use the generic setTag transform directly.
+			if !isLicenseDateValueKind(kind) {
+				return "", fmt.Errorf("licenseDateFromTag: unsupported value kind %q", kind)
+			}
 			if m.Tags == nil {
-				return ""
+				return "", nil
 			}
 			raw := strings.TrimSpace(m.Tags[tagName])
 			if raw == "" {
-				return ""
+				return "", nil
 			}
 
 			ts, ok := parseTextDate(raw)
 			if !ok {
-				return ""
+				return "", nil
 			}
 			m.Value = ts
 			m.Tags["_license_value_kind"] = kind
-			return ""
-		},
-		"licenseRow": func(m *Metric, kind string) string {
-			/*
-				licenseRow marks a metric as a licensing row carrier for a collector-level
-				licensing consumer.
-
-				Profiles describe each licensing signal as a hidden ("_"-prefixed) metric
-				whose value corresponds to the signal itself (expiry epoch, used count,
-				severity, etc). The transform stamps a "value kind" tag so the collector
-				knows how to interpret the integer value.
-
-				Supported kinds:
-				  - "expiry_timestamp"           absolute unix-epoch expiry
-				  - "expiry_remaining"           seconds-from-now until expiry
-				  - "authorization_timestamp"    absolute unix-epoch auth expiry
-				  - "authorization_remaining"    seconds-from-now auth expiry
-				  - "certificate_timestamp"      absolute unix-epoch cert expiry
-				  - "certificate_remaining"      seconds-from-now cert expiry
-				  - "grace_timestamp"            absolute unix-epoch grace/eval end
-				  - "grace_remaining"            seconds-from-now grace/eval end
-				  - "usage"                      used license units (integer)
-				  - "capacity"                   total license capacity (integer)
-				  - "available"                  available license units (integer)
-				  - "usage_percent"              usage pressure in percent (0-100)
-				  - "state_severity"             normalized severity (0 healthy, 1 degraded, 2 broken)
-
-				Multiple signals for the same logical license can be merged by the
-				collector-level licensing consumer.
-			*/
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
-			}
-			m.Tags["_license_value_kind"] = kind
-			return ""
+			return "", nil
 		},
 	}
 
@@ -432,6 +391,15 @@ func ParseTextDate(raw string) (int64, bool) {
 // accepted by ParseTextDate.
 func IsTextDateNoValue(raw string) bool {
 	return isTextDateNoValue(raw)
+}
+
+func isLicenseDateValueKind(kind string) bool {
+	switch kind {
+	case "expiry_timestamp", "authorization_timestamp", "certificate_timestamp", "grace_timestamp":
+		return true
+	default:
+		return false
+	}
 }
 
 func parseTextDate(raw string) (int64, bool) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/transform_license_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/transform_license_test.go
@@ -69,6 +69,14 @@ func TestLicenseDateFromTagTransform_ParsesCheckpointShortDate(t *testing.T) {
 	assert.NotZero(t, m.Value)
 }
 
+func TestLicenseDateFromTagTransform_RejectsAmbiguousSlashDate(t *testing.T) {
+	m := &Metric{Value: 999, Tags: map[string]string{"x": "01/02/2024"}}
+	runLicenseTransform(t, `{{- licenseDateFromTag .Metric "x" "expiry_timestamp" -}}`, m)
+
+	assert.Empty(t, m.Tags["_license_value_kind"])
+	assert.EqualValues(t, 999, m.Value)
+}
+
 func TestLicenseDateFromTagTransform_RejectsSentinels(t *testing.T) {
 	cases := []string{"0", "never", "perpetual", "n/a", "4294967295", ""}
 	for _, raw := range cases {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/transform_license_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/transform_license_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmp
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runLicenseTransform compiles a transform body and applies it to the given
+// metric. It mirrors the minimal "execute the template against {Metric: m}"
+// contract used by ddsnmpcollector.applyTransform, without crossing package
+// boundaries just for the test.
+func runLicenseTransform(t *testing.T, body string, m *Metric) {
+	t.Helper()
+	tmpl, err := compileTransform(body)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, tmpl.Execute(&buf, struct{ Metric *Metric }{Metric: m}))
+}
+
+func TestLicenseRowTransform_StampsValueKindOnTagsMap(t *testing.T) {
+	m := &Metric{Value: 42, Tags: map[string]string{}}
+	runLicenseTransform(t, `{{- licenseRow .Metric "expiry_timestamp" -}}`, m)
+
+	assert.Equal(t, "expiry_timestamp", m.Tags["_license_value_kind"])
+	assert.EqualValues(t, 42, m.Value)
+}
+
+func TestLicenseRowTransform_AllocatesTagsWhenNil(t *testing.T) {
+	m := &Metric{Value: 1}
+	runLicenseTransform(t, `{{- licenseRow .Metric "state_severity" -}}`, m)
+
+	require.NotNil(t, m.Tags)
+	assert.Equal(t, "state_severity", m.Tags["_license_value_kind"])
+}
+
+func TestLicenseDateFromTagTransform_ParsesISODate(t *testing.T) {
+	m := &Metric{
+		Value: 0,
+		Tags:  map[string]string{"_license_expiry_text": "2026-12-31"},
+	}
+	runLicenseTransform(t, `{{- licenseDateFromTag .Metric "_license_expiry_text" "expiry_timestamp" -}}`, m)
+
+	assert.Equal(t, "expiry_timestamp", m.Tags["_license_value_kind"])
+	// 2026-12-31 00:00:00 UTC
+	assert.EqualValues(t, 1798675200, m.Value)
+}
+
+func TestLicenseDateFromTagTransform_ParsesEpochSeconds(t *testing.T) {
+	m := &Metric{Value: 0, Tags: map[string]string{"x": "1798675200"}}
+	runLicenseTransform(t, `{{- licenseDateFromTag .Metric "x" "expiry_timestamp" -}}`, m)
+	assert.EqualValues(t, 1798675200, m.Value)
+}
+
+func TestLicenseDateFromTagTransform_ParsesEpochMillis(t *testing.T) {
+	m := &Metric{Value: 0, Tags: map[string]string{"x": "1798675200000"}}
+	runLicenseTransform(t, `{{- licenseDateFromTag .Metric "x" "expiry_timestamp" -}}`, m)
+	assert.EqualValues(t, 1798675200, m.Value)
+}
+
+func TestLicenseDateFromTagTransform_ParsesCheckpointShortDate(t *testing.T) {
+	// Checkpoint sends licensingExpirationDate as "2Jan2030", "1Jan2030", etc.
+	m := &Metric{Value: 0, Tags: map[string]string{"x": "1Jan2030"}}
+	runLicenseTransform(t, `{{- licenseDateFromTag .Metric "x" "expiry_timestamp" -}}`, m)
+	assert.NotZero(t, m.Value)
+}
+
+func TestLicenseDateFromTagTransform_RejectsSentinels(t *testing.T) {
+	cases := []string{"0", "never", "perpetual", "n/a", "4294967295", ""}
+	for _, raw := range cases {
+		m := &Metric{Value: 999, Tags: map[string]string{"x": raw}}
+		runLicenseTransform(t, `{{- licenseDateFromTag .Metric "x" "expiry_timestamp" -}}`, m)
+		// Untouched: no value_kind stamp, original value preserved.
+		assert.Empty(t, m.Tags["_license_value_kind"], "raw=%q", raw)
+		assert.EqualValues(t, 999, m.Value, "raw=%q", raw)
+	}
+}
+
+func TestLicenseDateFromTagTransform_NoTagsMapIsNoop(t *testing.T) {
+	m := &Metric{Value: 7}
+	runLicenseTransform(t, `{{- licenseDateFromTag .Metric "x" "expiry_timestamp" -}}`, m)
+	assert.EqualValues(t, 7, m.Value)
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/transform_license_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/transform_license_test.go
@@ -88,6 +88,18 @@ func TestLicenseDateFromTagTransform_RejectsSentinels(t *testing.T) {
 	}
 }
 
+func TestIsTextDateNoValue(t *testing.T) {
+	noValues := []string{"", "0", "-1", "never", "perpetual", "permanent", "n/a", "na", "none", "unlimited", "4294967295"}
+	for _, raw := range noValues {
+		assert.True(t, IsTextDateNoValue(raw), "raw=%q", raw)
+	}
+
+	values := []string{"1", "1798675200", "2026-12-31", "not-a-date"}
+	for _, raw := range values {
+		assert.False(t, IsTextDateNoValue(raw), "raw=%q", raw)
+	}
+}
+
 func TestLicenseDateFromTagTransform_NoTagsMapIsNoop(t *testing.T) {
 	m := &Metric{Value: 7}
 	runLicenseTransform(t, `{{- licenseDateFromTag .Metric "x" "expiry_timestamp" -}}`, m)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/transform_license_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/transform_license_test.go
@@ -62,6 +62,12 @@ func TestLicenseDateFromTagTransform_ParsesEpochMillis(t *testing.T) {
 	assert.EqualValues(t, 1798675200, m.Value)
 }
 
+func TestLicenseDateFromTagTransform_ParsesTwelveDigitEpochMillis(t *testing.T) {
+	m := &Metric{Value: 0, Tags: map[string]string{"x": "946684800000"}}
+	runLicenseTransform(t, `{{- licenseDateFromTag .Metric "x" "expiry_timestamp" -}}`, m)
+	assert.EqualValues(t, 946684800, m.Value)
+}
+
 func TestLicenseDateFromTagTransform_ParsesCheckpointShortDate(t *testing.T) {
 	// Checkpoint sends licensingExpirationDate as "2Jan2030", "1Jan2030", etc.
 	m := &Metric{Value: 0, Tags: map[string]string{"x": "1Jan2030"}}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/transform_license_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/transform_license_test.go
@@ -16,23 +16,29 @@ import (
 // boundaries just for the test.
 func runLicenseTransform(t *testing.T, body string, m *Metric) {
 	t.Helper()
-	tmpl, err := compileTransform(body)
-	require.NoError(t, err)
-	var buf bytes.Buffer
-	require.NoError(t, tmpl.Execute(&buf, struct{ Metric *Metric }{Metric: m}))
+	require.NoError(t, executeLicenseTransform(body, m))
 }
 
-func TestLicenseRowTransform_StampsValueKindOnTagsMap(t *testing.T) {
+func executeLicenseTransform(body string, m *Metric) error {
+	tmpl, err := compileTransform(body)
+	if err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	return tmpl.Execute(&buf, struct{ Metric *Metric }{Metric: m})
+}
+
+func TestSetTagTransform_StampsValueKindOnTagsMap(t *testing.T) {
 	m := &Metric{Value: 42, Tags: map[string]string{}}
-	runLicenseTransform(t, `{{- licenseRow .Metric "expiry_timestamp" -}}`, m)
+	runLicenseTransform(t, `{{- setTag .Metric "_license_value_kind" "expiry_timestamp" -}}`, m)
 
 	assert.Equal(t, "expiry_timestamp", m.Tags["_license_value_kind"])
 	assert.EqualValues(t, 42, m.Value)
 }
 
-func TestLicenseRowTransform_AllocatesTagsWhenNil(t *testing.T) {
+func TestSetTagTransform_AllocatesTagsWhenNil(t *testing.T) {
 	m := &Metric{Value: 1}
-	runLicenseTransform(t, `{{- licenseRow .Metric "state_severity" -}}`, m)
+	runLicenseTransform(t, `{{- setTag .Metric "_license_value_kind" "state_severity" -}}`, m)
 
 	require.NotNil(t, m.Tags)
 	assert.Equal(t, "state_severity", m.Tags["_license_value_kind"])
@@ -91,6 +97,18 @@ func TestLicenseDateFromTagTransform_RejectsSentinels(t *testing.T) {
 		// Untouched: no value_kind stamp, original value preserved.
 		assert.Empty(t, m.Tags["_license_value_kind"], "raw=%q", raw)
 		assert.EqualValues(t, 999, m.Value, "raw=%q", raw)
+	}
+}
+
+func TestLicenseDateFromTagTransform_RejectsUnsupportedKind(t *testing.T) {
+	for _, kind := range []string{"usage", "expiry_remaining", "not_a_kind"} {
+		m := &Metric{Value: 999, Tags: map[string]string{"x": "2026-12-31"}}
+		err := executeLicenseTransform(`{{- licenseDateFromTag .Metric "x" "`+kind+`" -}}`, m)
+
+		require.Error(t, err, "kind=%q", kind)
+		assert.Contains(t, err.Error(), `licenseDateFromTag: unsupported value kind`, "kind=%q", kind)
+		assert.Empty(t, m.Tags["_license_value_kind"], "kind=%q", kind)
+		assert.EqualValues(t, 999, m.Value, "kind=%q", kind)
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -349,7 +349,7 @@ See also
 
 #### Underscore-prefixed metrics
 
-Metric names that start with an underscore (e.g., `_ifHCInOctets`) are **private**: they’re collected but **not** propagated to the SNMP collector output. Use them as internal building blocks (typically as inputs for [virtual_metrics](#7-virtual_metrics)) so the final metric set remains clean. After virtual metrics are computed, the collector drops underscored metrics from the exported set.
+Metric names that start with an underscore (e.g., `_ifHCInOctets`) are **private**: they’re collected but **not** propagated to the SNMP collector output. Use them as internal building blocks (typically as inputs for [virtual_metrics](#7-virtual_metrics)) so the final metric set remains clean. After virtual metrics are computed, the collector drops underscored metrics from the exported set, while preserving them in the internal hidden metric set for collector-level consumers.
 
 ```yaml
 # IF-MIB::ifXTable
@@ -370,6 +370,11 @@ virtual_metrics:
       - { metric: _ifHCInOctets,  table: ifXTable, as: in }
       - { metric: _ifHCOutOctets, table: ifXTable, as: out }
 ```
+
+Hidden table symbols may also use `constant_value_one: true` to emit a row
+presence/helper metric with value `1` without polling a value column. Non-hidden
+constant table symbols are discarded during profile preparation so they do not
+create accidental chart output.
 
 #### Scalar symbol fallbacks
 
@@ -757,14 +762,15 @@ They let you distinguish between instances (for example, which interface, disk, 
 - Attaches tags to each metric as labels.
 - Uses tags to differentiate rows when building charts.
 - Requires at least one tag for every **table metric** (to identify each row).
-- Ignores tags for **scalar metrics**, which represent a single value per device.
+- Supports optional **scalar metric_tags** when a scalar metric needs
+  descriptive dynamic labels from other scalar OIDs.
 
 **Key Concepts**:
 
 | Concept                            | Description                                                                                                                                   |
 |------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | **Table metrics must have tags**   | Each table row must be uniquely identified by at least one tag (for example, interface name or index). Without tags, only one row is emitted. |
-| **Scalar metrics don’t need tags** | Scalars represent one value for the entire device, not per-instance data.                                                                     |
+| **Scalar metrics don’t need tags for identity** | Scalars represent one value for the entire device, so tags are optional context rather than row identifiers.                      |
 | **Static tags**                    | Fixed values that never change (for example, datacenter, environment).                                                                        |
 | **Dynamic tags**                   | Extracted from SNMP data — from table columns, related tables, or row indexes.                                                                |
 | **Global tags**                    | Defined in the profile’s top-level `metric_tags` section and applied to all metrics.                                                          |
@@ -783,6 +789,8 @@ They let you distinguish between instances (for example, which interface, disk, 
 
 - Each **table metric** must define at least one **tag source** (`metric_tags`) to distinguish rows.
 - Tags can come from **the same table**, **another table**, or the **row index** itself.
+- Scalar metrics may define **symbol-based** `metric_tags` to attach
+  descriptive labels from other scalar OIDs.
 - Tag transformations (`mapping`, `extract_value`, `match_pattern`, `match + tags`) can modify or extract parts of raw values.
 - **Static tags** apply globally and are not transformed.
 - **Index transformations** are a special mechanism used only for aligning multi-part indexes between tables.
@@ -1460,6 +1468,7 @@ These transformations are typically used to:
 |---------------------------------|-------------------------------------------------------------------|-------------------------------------|
 | `mapping`                       | Convert numeric or string codes into state dimensions.            | `1 → up`, `2 → down`, `3 → testing` |
 | `extract_value`                 | Extract a numeric substring via regex.                            | `"23.8 °C" → "23"`                  |
+| `format`                        | Decode raw SNMP data into a value shape before other processing.  | DateAndTime bytes → unix timestamp  |
 | `scale_factor`                  | Multiply values by a constant to adjust units.                    | `"1.5" (MBps) × 8 → 12 (Mbps)`      |
 | `match_pattern` + `match_value` | *Not applicable* for metric values (use `extract_value` instead). | —                                   |
 
@@ -1495,6 +1504,16 @@ These transformations are typically used to:
     ```yaml
     format: hex
     extract_value: '^([0-9a-f]{2})'   # First byte of an OCTET STRING
+    ```
+
+- `format: snmp_dateandtime`
+    ```yaml
+    format: snmp_dateandtime   # SNMPv2-TC DateAndTime OCTET STRING -> unix timestamp
+    ```
+
+- `format: text_date`
+    ```yaml
+    format: text_date   # Textual dates such as "2026-12-31" -> unix timestamp
     ```
 
 - `scale_factor`
@@ -1573,6 +1592,34 @@ metrics:
 - If the value doesn’t match, the original string is retained.
 - Ideal for string metrics that embed numbers, units, or labels.
 - If `format: hex` is also set, the extracted value is interpreted as hexadecimal before being stored as a metric.
+
+### Format
+
+Use `format` to decode raw SNMP values before the rest of the value
+processor runs.
+
+Supported formats:
+
+- `hex`: decodes OCTET STRING bytes to lowercase hexadecimal text.
+- `ip_address`: decodes IP address values.
+- `mac_address`: decodes MAC address values.
+- `snmp_dateandtime`: decodes SNMPv2-TC `DateAndTime` OCTET STRING values
+  into unix timestamps.
+- `text_date`: parses common textual date strings and epoch strings into
+  unix timestamps.
+- `uint32`: interprets integer values as unsigned 32-bit values.
+
+```yaml
+metrics:
+  - MIB: EXAMPLE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.99999.1.1.0
+      name: example.expiry_timestamp
+      format: snmp_dateandtime
+```
+
+The decoded value becomes the metric value seen by later processing steps,
+such as `extract_value`, `mapping`, `scale_factor`, or `transform`.
 
 ### Scale Factor
 

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -371,29 +371,6 @@ virtual_metrics:
       - { metric: _ifHCOutOctets, table: ifXTable, as: out }
 ```
 
-Hidden table symbols may also use `constant_value_one: true` to emit a row
-presence/helper metric with value `1` without polling a value column. Non-hidden
-constant table symbols are discarded during profile preparation so they do not
-create accidental chart output.
-
-Use this only for hidden row carriers: cases where the useful information is
-the row and its tags, not a numeric SNMP column. The table is still walked for
-the tag columns, but the constant helper itself is not polled.
-
-```yaml
-metrics:
-  - MIB: EXAMPLE-MIB
-    table: { OID: 1.3.6.1.4.1.99999.1, name: exampleStateTable }
-    symbols:
-      - name: _example_row_present
-        constant_value_one: true
-    metric_tags:
-      - tag: example_row_id
-        symbol: { OID: 1.3.6.1.4.1.99999.1.1.2, name: exampleRowID }
-      - tag: example_row_state
-        symbol: { OID: 1.3.6.1.4.1.99999.1.1.3, name: exampleRowState }
-```
-
 #### Scalar symbol fallbacks
 
 You can express “try this OID, otherwise try that OID” by declaring **multiple scalar metrics with the same** `symbol.name`, each pointing to a different OID. At runtime the collector **GETs** all declared scalar OIDs, marks missing ones, and **emits** the metric from whichever OID returns data. Missing OIDs are skipped cleanly.

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -376,6 +376,24 @@ presence/helper metric with value `1` without polling a value column. Non-hidden
 constant table symbols are discarded during profile preparation so they do not
 create accidental chart output.
 
+Use this only for hidden row carriers: cases where the useful information is
+the row and its tags, not a numeric SNMP column. The table is still walked for
+the tag columns, but the constant helper itself is not polled.
+
+```yaml
+metrics:
+  - MIB: EXAMPLE-MIB
+    table: { OID: 1.3.6.1.4.1.99999.1, name: exampleStateTable }
+    symbols:
+      - name: _example_row_present
+        constant_value_one: true
+    metric_tags:
+      - tag: example_row_id
+        symbol: { OID: 1.3.6.1.4.1.99999.1.1.2, name: exampleRowID }
+      - tag: example_row_state
+        symbol: { OID: 1.3.6.1.4.1.99999.1.1.3, name: exampleRowState }
+```
+
 #### Scalar symbol fallbacks
 
 You can express “try this OID, otherwise try that OID” by declaring **multiple scalar metrics with the same** `symbol.name`, each pointing to a different OID. At runtime the collector **GETs** all declared scalar OIDs, marks missing ones, and **emits** the metric from whichever OID returns data. Missing OIDs are skipped cleanly.

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -1601,7 +1601,8 @@ Supported formats:
 - `snmp_dateandtime`: decodes SNMPv2-TC `DateAndTime` OCTET STRING values
   into unix timestamps.
 - `text_date`: parses common textual date strings and epoch strings into
-  unix timestamps.
+  unix timestamps. Vendor no-value sentinels such as `0`, `4294967295`,
+  `never`, and `n/a` are treated as missing values.
 - `uint32`: interprets integer values as unsigned 32-bit values.
 
 ```yaml

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -757,18 +757,16 @@ They let you distinguish between instances (for example, which interface, disk, 
 - Attaches tags to each metric as labels.
 - Uses tags to differentiate rows when building charts.
 - Requires at least one tag for every **table metric** (to identify each row).
-- Supports optional **scalar metric_tags** when a scalar metric needs
-  descriptive dynamic labels from other scalar OIDs.
 
 **Key Concepts**:
 
-| Concept                            | Description                                                                                                                                   |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| **Table metrics must have tags**   | Each table row must be uniquely identified by at least one tag (for example, interface name or index). Without tags, only one row is emitted. |
-| **Scalar metrics don’t need tags for identity** | Scalars represent one value for the entire device, so tags are optional context rather than row identifiers.                      |
-| **Static tags**                    | Fixed values that never change (for example, datacenter, environment).                                                                        |
-| **Dynamic tags**                   | Extracted from SNMP data — from table columns, related tables, or row indexes.                                                                |
-| **Global tags**                    | Defined in the profile’s top-level `metric_tags` section and applied to all metrics.                                                          |
+| Concept                                         | Description                                                                                                                                   |
+|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| **Table metrics must have tags**                | Each table row must be uniquely identified by at least one tag (for example, interface name or index). Without tags, only one row is emitted. |
+| **Scalar metrics don’t need tags for identity** | Scalars represent one value for the entire device, so tags are not part of their normal public identity contract.                             |
+| **Static tags**                                 | Fixed values that never change (for example, datacenter, environment).                                                                        |
+| **Dynamic tags**                                | Extracted from SNMP data — from table columns, related tables, or row indexes.                                                                |
+| **Global tags**                                 | Defined in the profile’s top-level `metric_tags` section and applied to all metrics.                                                          |
 
 **Tag Types and Available Transformations**:
 
@@ -784,11 +782,15 @@ They let you distinguish between instances (for example, which interface, disk, 
 
 - Each **table metric** must define at least one **tag source** (`metric_tags`) to distinguish rows.
 - Tags can come from **the same table**, **another table**, or the **row index** itself.
-- Scalar metrics may define **symbol-based** `metric_tags` to attach
-  descriptive labels from other scalar OIDs.
+- Scalar metrics do not use tags for identity. Internal bundled profiles may
+  attach sidecar scalar values to hidden carrier metrics, but that is not a
+  stable public authoring contract.
 - Tag transformations (`mapping`, `extract_value`, `match_pattern`, `match + tags`) can modify or extract parts of raw values.
 - **Static tags** apply globally and are not transformed.
 - **Index transformations** are a special mechanism used only for aligning multi-part indexes between tables.
+- Avoid reusing built-in device label names such as `sysName`, `address`,
+  `vendor`, `model`, and `device_type` for row tags. Those keys are reserved
+  for collector-provided device metadata labels.
 
 **How the Collector Matches Values and Tags**:
 
@@ -1465,26 +1467,26 @@ These transformations are typically used to:
 
 **Available Value Transformations**:
 
-| Transformation                  | Purpose                                                           | Example Input → Output              |
-|---------------------------------|-------------------------------------------------------------------|-------------------------------------|
-| `mapping`                       | Convert numeric or string codes into state dimensions.            | `1 → up`, `2 → down`, `3 → testing` |
-| `extract_value`                 | Extract a numeric substring via regex.                            | `"23.8 °C" → "23"`                  |
-| `format`                        | Decode raw SNMP data into a value shape before other processing.  | DateAndTime bytes → unix timestamp  |
-| `scale_factor`                  | Multiply values by a constant to adjust units.                    | `"1.5" (MBps) × 8 → 12 (Mbps)`      |
-| `match_pattern` + `match_value` | Replace string metric values using regex groups or static text before numeric parsing. | `"state=2" → "2"`        |
+| Transformation                  | Purpose                                                                                | Example Input → Output              |
+|---------------------------------|----------------------------------------------------------------------------------------|-------------------------------------|
+| `mapping`                       | Convert numeric or string codes into state dimensions.                                 | `1 → up`, `2 → down`, `3 → testing` |
+| `extract_value`                 | Extract a numeric substring via regex.                                                 | `"23.8 °C" → "23"`                  |
+| `format`                        | Decode raw SNMP data into a value shape before other processing.                       | DateAndTime bytes → unix timestamp  |
+| `scale_factor`                  | Multiply values by a constant to adjust units.                                         | `"1.5" (MBps) × 8 → 12 (Mbps)`      |
+| `match_pattern` + `match_value` | Replace string metric values using regex groups or static text before numeric parsing. | `"state=2" → "2"`                   |
 
 **Combination & Behavior**:
 
-| Rule                      | Description                                                                                                               |
-|---------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| **Where**                 | Metric value transformations are used inside `metrics[*].symbol` or `metrics[*].symbols[]`; `format` also applies when symbols are used for metric tags or device metadata. |
-| **Order of application**  | 1️⃣ `format` (if present) → 2️⃣ `extract_value` (if present) → 3️⃣ `match_pattern` + `match_value` (if present) → 4️⃣ `mapping` → 5️⃣ numeric parsing → 6️⃣ `scale_factor`. |
-| **Scale factor position** | `scale_factor` is always applied **last**, after all other metric value transformations.                                 |
-| **String base parsing**   | String-like values are parsed as base-10 by default. If `format: hex` is set, extracted values are parsed as base-16.   |
-| **Data type handling**    | Transformations preserve numeric type (integer/float) unless the mapping converts it to a multi-value metric.             |
-| **Error handling**        | `extract_value` keeps the original value when it does not match; `match_pattern` fails the metric value when it does not match; no-value `format` sentinels are treated as missing. |
-| **Applicability**         | Metric value transformations affect metric values only; `format` also decodes tag and metadata symbol values.             |
-| **Mapping behavior**      | Always produces a multi-value metric where each mapped entry becomes a dimension; the active one reports `1`, others `0`. |
+| Rule                      | Description                                                                                                                                                                                                                                                                                                                                              |
+|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Where**                 | Metric value transformations are used inside `metrics[*].symbol` or `metrics[*].symbols[]`; `format` also applies when symbols are used for metric tags or device metadata.                                                                                                                                                                              |
+| **Order of application**  | For string-decoded metric values: 1️⃣ `format` (if present) → 2️⃣ `extract_value` (if present) → 3️⃣ `match_pattern` + `match_value` (if present) → 4️⃣ `mapping` → 5️⃣ numeric parsing → 6️⃣ `scale_factor`. Ordinary numeric PDUs skip the string-only `extract_value` and `match_pattern` steps and use numeric parsing → `mapping` → `scale_factor`. |
+| **Scale factor position** | `scale_factor` is always applied **last**, after all other metric value transformations.                                                                                                                                                                                                                                                                 |
+| **String base parsing**   | String-like values are parsed as base-10 by default. If `format: hex` is set, extracted values are parsed as base-16.                                                                                                                                                                                                                                    |
+| **Data type handling**    | Transformations preserve numeric type (integer/float) unless the mapping converts it to a multi-value metric.                                                                                                                                                                                                                                            |
+| **Error handling**        | `extract_value` keeps the original value when it does not match; `match_pattern` fails the metric value when it does not match; no-value `format` sentinels are treated as missing.                                                                                                                                                                      |
+| **Applicability**         | Metric value transformations affect metric values only; `format` also decodes tag and metadata symbol values.                                                                                                                                                                                                                                            |
+| **Mapping behavior**      | Always produces a multi-value metric where each mapped entry becomes a dimension; the active one reports `1`, others `0`.                                                                                                                                                                                                                                |
 
 **Quick Syntax Recap**:
 
@@ -1602,7 +1604,9 @@ textual or numeric representation.
 For metric values, `format` runs before the rest of the value-processing
 pipeline. For metric tags and device metadata, `format` runs before their own
 supported extraction, match, and mapping rules. `scale_factor` remains
-metric-value-only.
+metric-value-only. Ordinary numeric PDUs do not pass through string-only
+processing such as `extract_value` or `match_pattern` unless an explicit
+string-decoding `format` routes them through the string processor first.
 
 If a format yields no value (for example, `text_date` encounters a vendor
 sentinel such as `0`, `4294967295`, `never`, or `n/a`), the result is treated
@@ -1732,40 +1736,40 @@ The collector evaluates alternatives **in order** and uses the **first** set tha
 
 ### Config reference
 
-| Item               | Field          | Type                 | Required | Default | Applies to               | Description                                                                                                                                                                     |
-|--------------------|----------------|----------------------|----------|---------|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Virtual Metric** | `name`         | string               | yes      | —       | all                      | Unique within the profile. Used as metric/chart base name.                                                                                                                      |
-|                    | `sources`      | array\<Source\>      | no*      | —       | totals, per_row, grouped | Direct source set. Ignored if `alternatives` exist (alternatives take precedence).                                                                                              |
-|                    | `alternatives` | array\<Alternative\> | no*      | —       | totals, per_row, grouped | Ordered fallback sets. The first alternative whose sources produce data is used.                                                                                                |
-|                    | `per_row`      | bool                 | no       | false   | per-row/grouped          | When `true`, emits one output per input row; sources become dimensions; row tags attach.                                                                                        |
+| Item               | Field          | Type                 | Required | Default | Applies to               | Description                                                                                                                                                                                                     |
+|--------------------|----------------|----------------------|----------|---------|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Virtual Metric** | `name`         | string               | yes      | —       | all                      | Unique within the profile. Used as metric/chart base name.                                                                                                                                                      |
+|                    | `sources`      | array\<Source\>      | no*      | —       | totals, per_row, grouped | Direct source set. Ignored if `alternatives` exist (alternatives take precedence).                                                                                                                              |
+|                    | `alternatives` | array\<Alternative\> | no*      | —       | totals, per_row, grouped | Ordered fallback sets. The first alternative whose sources produce data is used.                                                                                                                                |
+|                    | `per_row`      | bool                 | no       | false   | per-row/grouped          | When `true`, emits one output per input row; sources become dimensions; row tags attach.                                                                                                                        |
 |                    | `group_by`     | array\<string\>      | no       | —       | per-row/grouped          | Label(s) used as row-key hints (in order). With `per_row:true`, missing/empty hints fall back to a stable key built from all non-underscore tags. With `per_row:false`, this acts like PromQL’s `sum by (...)`. |
-|                    | `emit_tags`    | array\<EmitTag\>     | no       | —       | per-row/grouped          | Renames or selects which source tags are emitted on the resulting virtual metric. Useful when grouping by private tags such as `_neighbor` but exporting standard tags such as `neighbor`. |
-|                    | `chart_meta`   | object               | no       | —       | all                      | Presentation metadata (`description`, `family`, `unit`, `type`).                                                                                                                |
-| **Source**         | `metric`       | string               | yes      | —       | —                        | Name of an existing metric (scalar or table column metric).                                                                                                                     |
-|                    | `table`        | string               | no*      | —       | —                        | Table name for the originating metric. Required for table-derived grouped/per-row virtual metrics. Scalar sources may omit it.                                                   |
-|                    | `as`           | string               | no       | —       | —                        | Optional dimension name within a composite (e.g., `in`, `out`). Single-source virtual metrics do not need it.                                                                   |
-|                    | `dim`          | string               | no       | —       | —                        | Selects one dimension from a MultiValue source metric (for example `start` or `established`) before aggregation. Useful when composing virtual metrics from mapped status charts. |
-| **EmitTag**        | `tag`          | string               | yes      | —       | —                        | Output tag name to emit on the virtual metric.                                                                                                                                   |
-|                    | `from`         | string               | yes      | —       | —                        | Existing source-tag name to copy from the grouped source rows.                                                                                                                   |
-| **Alternative**    | `sources`      | array\<Source\>      | yes      | —       | —                        | All sources in an alternative are evaluated together. If none produce data, the collector tries the next alternative. Per-row/group rules apply within the winning alternative. |
+|                    | `emit_tags`    | array\<EmitTag\>     | no       | —       | per-row/grouped          | Renames or selects which source tags are emitted on the resulting virtual metric. Useful when grouping by private tags such as `_neighbor` but exporting standard tags such as `neighbor`.                      |
+|                    | `chart_meta`   | object               | no       | —       | all                      | Presentation metadata (`description`, `family`, `unit`, `type`).                                                                                                                                                |
+| **Source**         | `metric`       | string               | yes      | —       | —                        | Name of an existing metric (scalar or table column metric).                                                                                                                                                     |
+|                    | `table`        | string               | no*      | —       | —                        | Table name for the originating metric. Required for table-derived grouped/per-row virtual metrics. Scalar sources may omit it.                                                                                  |
+|                    | `as`           | string               | no       | —       | —                        | Optional dimension name within a composite (e.g., `in`, `out`). Single-source virtual metrics do not need it.                                                                                                   |
+|                    | `dim`          | string               | no       | —       | —                        | Selects one dimension from a MultiValue source metric (for example `start` or `established`) before aggregation. Useful when composing virtual metrics from mapped status charts.                               |
+| **EmitTag**        | `tag`          | string               | yes      | —       | —                        | Output tag name to emit on the virtual metric.                                                                                                                                                                  |
+|                    | `from`         | string               | yes      | —       | —                        | Existing source-tag name to copy from the grouped source rows.                                                                                                                                                  |
+| **Alternative**    | `sources`      | array\<Source\>      | yes      | —       | —                        | All sources in an alternative are evaluated together. If none produce data, the collector tries the next alternative. Per-row/group rules apply within the winning alternative.                                 |
 
 > At least one of `sources` or `alternatives` **must be defined**.
 
 #### Rules & Constraints
 
-| Rule                              | Description                                                                                                                                            |
-|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Precedence**                    | If both `sources` and `alternatives` exist, `alternatives` take precedence.                                                                            |
-| **Same-table requirement**        | When `per_row` or `group_by` is used, all sources must originate from the same table. For alternatives, this rule applies within each alternative set. |
-| **per_row: true**                 | One output per input row; multiple sources become chart dimensions (`as`); row tags attach automatically.                                              |
-| **group_by (with per_row:true)**  | Acts as row-key hints (in order). Missing or empty hints fall back to a stable key built from all non-underscore tags.                                  |
-| **group_by (with per_row:false)** | Aggregates rows by the listed labels, similar to PromQL’s `sum by (...)`.                                                                              |
+| Rule                              | Description                                                                                                                                                                                                      |
+|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Precedence**                    | If both `sources` and `alternatives` exist, `alternatives` take precedence.                                                                                                                                      |
+| **Same-table requirement**        | When `per_row` or `group_by` is used, all sources must originate from the same table. For alternatives, this rule applies within each alternative set.                                                           |
+| **per_row: true**                 | One output per input row; multiple sources become chart dimensions (`as`); row tags attach automatically.                                                                                                        |
+| **group_by (with per_row:true)**  | Acts as row-key hints (in order). Missing or empty hints fall back to a stable key built from all non-underscore tags.                                                                                           |
+| **group_by (with per_row:false)** | Aggregates rows by the listed labels, similar to PromQL’s `sum by (...)`.                                                                                                                                        |
 | **emit_tags**                     | If omitted, `per_row:true` emits the winning row tags as-is. Grouped non-`per_row` metrics emit the `group_by` labels by default. When set, only the listed tags are emitted, using the `from` source-tag names. |
-| **Alternative evaluation**        | Alternatives are checked in order. The first whose sources produce data becomes the “winner”; others are ignored.                                      |
-| **Parent metadata**               | The virtual metric emits charts using its own `name` and `chart_meta`, even when data comes from an alternative.                                       |
-| **Dimensions**                    | Each `as` value defines a dimension in the resulting chart (e.g., `in`, `out`, `total`).                                                               |
-| **Selected source dimension**     | When `dim` is set on a source, the collector reads only that MultiValue dimension from the source metric and ignores the rest.                            |
-| **Totals vs per-row**             | Omitting both `per_row` and `group_by` produces a single total chart across all rows (device-wide view).                                               |
+| **Alternative evaluation**        | Alternatives are checked in order. The first whose sources produce data becomes the “winner”; others are ignored.                                                                                                |
+| **Parent metadata**               | The virtual metric emits charts using its own `name` and `chart_meta`, even when data comes from an alternative.                                                                                                 |
+| **Dimensions**                    | Each `as` value defines a dimension in the resulting chart (e.g., `in`, `out`, `total`).                                                                                                                         |
+| **Selected source dimension**     | When `dim` is set on a source, the collector reads only that MultiValue dimension from the source metric and ignores the rest.                                                                                   |
+| **Totals vs per-row**             | Omitting both `per_row` and `group_by` produces a single total chart across all rows (device-wide view).                                                                                                         |
 
 ### Examples
 

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -1599,7 +1599,9 @@ Supported formats:
 - `ip_address`: decodes IP address values.
 - `mac_address`: decodes MAC address values.
 - `snmp_dateandtime`: decodes SNMPv2-TC `DateAndTime` OCTET STRING values
-  into unix timestamps.
+  into unix timestamps. The 11-octet form uses its embedded UTC offset. The
+  8-octet form has no timezone fields, so the collector interprets it as UTC
+  because the device timezone is unavailable.
 - `text_date`: parses common textual date strings and epoch strings into
   unix timestamps. Vendor no-value sentinels such as `0`, `4294967295`,
   `never`, and `n/a` are treated as missing values.

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -1447,9 +1447,15 @@ metric_tags:
 
 ## Value Transformation
 
-Value transformations let you **process or normalize raw SNMP metric values** before they are stored and charted.
+Value transformations let you **decode, process, or normalize raw SNMP symbol values** before they are stored and charted.
 
-They are applied **per symbol (per OID)** during SNMP data collection. They modify only **metric values**, not tags or metadata, and are **not applied to virtual metrics**.
+For metrics, they are applied **per symbol (per OID)** during SNMP data
+collection and are **not applied to virtual metrics**.
+
+`format` is the exception to the "metric values only" rule: it is symbol
+decoding, so it also applies when the same symbol is used for metric tags or
+device metadata. After decoding, metric tags and device metadata follow their
+own supported transformation rules.
 
 These transformations are typically used to:
 
@@ -1465,19 +1471,19 @@ These transformations are typically used to:
 | `extract_value`                 | Extract a numeric substring via regex.                            | `"23.8 °C" → "23"`                  |
 | `format`                        | Decode raw SNMP data into a value shape before other processing.  | DateAndTime bytes → unix timestamp  |
 | `scale_factor`                  | Multiply values by a constant to adjust units.                    | `"1.5" (MBps) × 8 → 12 (Mbps)`      |
-| `match_pattern` + `match_value` | *Not applicable* for metric values (use `extract_value` instead). | —                                   |
+| `match_pattern` + `match_value` | Replace string metric values using regex groups or static text before numeric parsing. | `"state=2" → "2"`        |
 
 **Combination & Behavior**:
 
 | Rule                      | Description                                                                                                               |
 |---------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| **Where**                 | Value transformations are used inside `metrics[*].symbol` or `metrics[*].symbols[]`.                                      |
-| **Order of application**  | 1️⃣ `extract_value` (if present) → 2️⃣ `mapping` → 3️⃣ `scale_factor`.                                                    |
-| **Scale factor position** | `scale_factor` is always applied **last**, after all other transformations.                                               |
+| **Where**                 | Metric value transformations are used inside `metrics[*].symbol` or `metrics[*].symbols[]`; `format` also applies when symbols are used for metric tags or device metadata. |
+| **Order of application**  | 1️⃣ `format` (if present) → 2️⃣ `extract_value` (if present) → 3️⃣ `match_pattern` + `match_value` (if present) → 4️⃣ `mapping` → 5️⃣ numeric parsing → 6️⃣ `scale_factor`. |
+| **Scale factor position** | `scale_factor` is always applied **last**, after all other metric value transformations.                                 |
 | **String base parsing**   | String-like values are parsed as base-10 by default. If `format: hex` is set, extracted values are parsed as base-16.   |
 | **Data type handling**    | Transformations preserve numeric type (integer/float) unless the mapping converts it to a multi-value metric.             |
-| **Error handling**        | If a transformation fails (e.g., regex doesn’t match), the collector keeps the original value.                            |
-| **Applicability**         | Transformations affect metric values only — not metadata or tags.                                                         |
+| **Error handling**        | `extract_value` keeps the original value when it does not match; `match_pattern` fails the metric value when it does not match; no-value `format` sentinels are treated as missing. |
+| **Applicability**         | Metric value transformations affect metric values only; `format` also decodes tag and metadata symbol values.             |
 | **Mapping behavior**      | Always produces a multi-value metric where each mapped entry becomes a dimension; the active one reports `1`, others `0`. |
 
 **Quick Syntax Recap**:
@@ -1590,8 +1596,19 @@ metrics:
 
 ### Format
 
-Use `format` to decode raw SNMP values before the rest of the value
-processor runs.
+Use `format` to decode raw SNMP values as a symbol is converted into its
+textual or numeric representation.
+
+For metric values, `format` runs before the rest of the value-processing
+pipeline. For metric tags and device metadata, `format` runs before their own
+supported extraction, match, and mapping rules. `scale_factor` remains
+metric-value-only.
+
+If a format yields no value (for example, `text_date` encounters a vendor
+sentinel such as `0`, `4294967295`, `never`, or `n/a`), the result is treated
+as missing. For metrics, no metric value is produced from that symbol. For
+metric tags and device metadata, no tag or metadata value is produced from that
+symbol.
 
 Supported formats:
 

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/cyberpower-pdu.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/cyberpower-pdu.yaml
@@ -186,10 +186,6 @@ metrics:
         2: powerSupplyOneFailed
         3: powerSupplyTwoFailed
         4: powerSupplyOneandTwoFailed
-    metric_tags:
-      - symbol:
-          OID:
-          name: ePDUOutletBankIndex
   - MIB: CPS-MIB
     table:
       OID: 1.3.6.1.4.1.3808.1.1.3.5.2


### PR DESCRIPTION
## Summary

Extracts reusable SNMP profile-engine support needed by follow-up profile features:

- allow scalar metrics to collect symbol-based `metric_tags` and expose those tags as scalar chart labels
- preserve underscore-prefixed hidden metrics internally while keeping them out of exported chart metrics
- add `snmp_dateandtime` and `text_date` value formats for profile symbols
- add `licenseDateFromTag` for the specific case where a hidden row needs to parse a tag-carried textual date into the metric value
- remove one malformed empty scalar `metric_tags` entry from `cyberpower-pdu.yaml`, which is now rejected by stricter validation

## Scope

This PR intentionally does not add licensing charts, alerts, profiles, aggregation, or `snmp:licenses`. Those remain in the follow-up licensing monitoring PR. This PR only isolates reusable SNMP profile-engine behavior for review.

`licenseRow` was removed from this PR. Profiles that only need to stamp `_license_value_kind` can use the existing generic `setTag` transform.

## Validation

- `cd src/go && go test -count=1 ./plugin/go.d/collector/snmp/ddsnmp/...`
- `cd src/go && go test -count=1 ./plugin/go.d/collector/snmp -run 'TestCollector_AddProfileScalarMetricChart_LabelsIncludeMetricTags|TestCollector_Collect'`\n- `cd src/go && go test -count=1 ./plugin/go.d/collector/snmp/...`\n- `git diff --check`