### PR TITLE
fix(go.d): reduce transient 503 errors on dyncfg enable/disable

### DIFF
--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -112,7 +112,7 @@ func New(cfg Config) *Manager {
 		started:    make(chan struct{}),
 		addCh:      make(chan confgroup.Config),
 		rmCh:       make(chan confgroup.Config),
-		dyncfgCh:   make(chan dyncfg.Function),
+		dyncfgCh:   make(chan dyncfg.Function, 32),
 		cmdTestSem: make(chan struct{}, cmdTestWorkerCap),
 
 		dyncfgResponder: api,

--- a/src/go/plugin/framework/dyncfg/handoff.go
+++ b/src/go/plugin/framework/dyncfg/handoff.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const DefaultDownstreamHandoffCap = time.Second
+const DefaultDownstreamHandoffCap = 10 * time.Second
 
 type BoundedSendResult uint8
 


### PR DESCRIPTION
Buffer the dyncfg function channel (0 → 32) so commands can queue while the manager's sequential run-loop is busy with slow operations (e.g. SNMP auto-detection). Increase the handoff timeout from 1s to 10s as a fallback when the buffer is full.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce transient 503 errors when enabling/disabling `dyncfg` by buffering the command channel and extending the handoff timeout. Requests now queue while the `jobmgr` run loop is busy, avoiding premature failures.

- **Bug Fixes**
  - Buffered `dyncfg` function channel to 32 in `jobmgr` so commands queue during slow ops (e.g. SNMP auto-detect).
  - Increased `DefaultDownstreamHandoffCap` from 1s to 10s to prevent timeouts when the buffer is full.

<sup>Written for commit c32737e172f47cf6f718f74d902aeef0312a5c53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

