### PR TITLE
Patch Release 2.10.1

### DIFF
--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -112,7 +112,7 @@ func New(cfg Config) *Manager {
 		started:    make(chan struct{}),
 		addCh:      make(chan confgroup.Config),
 		rmCh:       make(chan confgroup.Config),
-		dyncfgCh:   make(chan dyncfg.Function),
+		dyncfgCh:   make(chan dyncfg.Function, 32),
 		cmdTestSem: make(chan struct{}, cmdTestWorkerCap),
 
 		dyncfgResponder: api,

--- a/src/go/plugin/framework/dyncfg/handoff.go
+++ b/src/go/plugin/framework/dyncfg/handoff.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const DefaultDownstreamHandoffCap = time.Second
+const DefaultDownstreamHandoffCap = 10 * time.Second
 
 type BoundedSendResult uint8
 

--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -239,6 +239,11 @@ func (c *Collector) initAndConnectSNMPClient() (gosnmp.Handler, error) {
 		return snmpClient, nil
 	}
 
+	if c.Config.Options.MaxRepetitions == 0 {
+		c.disableBulkWalk = true
+		return snmpClient, nil
+	}
+
 	if c.adjMaxRepetitions != 0 {
 		snmpClient.SetMaxRepetitions(c.adjMaxRepetitions)
 	} else {

--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -30,15 +30,23 @@ func (c *Collector) collect() (map[string]int64, error) {
 		return nil, err
 	}
 
-	mx, err := c.collectMetrics()
-	if err != nil {
+	if c.PingOnly {
+		return c.collectPingOnly()
+	}
+	return c.collectDeviceMetrics()
+}
+
+func (c *Collector) collectPingOnly() (map[string]int64, error) {
+	mx := make(map[string]int64)
+
+	if err := c.collectPing(mx); err != nil {
 		return nil, err
 	}
 
 	return mx, nil
 }
 
-func (c *Collector) collectMetrics() (map[string]int64, error) {
+func (c *Collector) collectDeviceMetrics() (map[string]int64, error) {
 	var (
 		snmpMx map[string]int64
 		pingMx map[string]int64
@@ -112,7 +120,7 @@ func (c *Collector) ensureInitialized() error {
 		})
 	}
 
-	if c.ddSnmpColl == nil && !c.Ping.Enabled {
+	if c.ddSnmpColl == nil && !c.PingOnly && !c.Ping.Enabled {
 		return errors.New("no profiles found and ping disabled")
 	}
 
@@ -130,7 +138,7 @@ func (c *Collector) ensureInitialized() error {
 
 	c.sysInfo = si
 
-	if c.Ping.Enabled {
+	if c.PingOnly || c.Ping.Enabled {
 		c.addPingCharts()
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -135,7 +135,7 @@ func (c *Collector) Init(context.Context) error {
 		return fmt.Errorf("failed to initialize SNMP client: %v", err)
 	}
 
-	if c.Ping.Enabled {
+	if c.PingOnly || c.Ping.Enabled {
 		pr, err := c.initProber()
 		if err != nil {
 			return fmt.Errorf("failed to initialize ping prober: %v", err)
@@ -157,6 +157,12 @@ func (c *Collector) Check(context.Context) error {
 
 	if _, err := snmputils.GetSysInfo(c.snmpClient); err != nil {
 		return err
+	}
+
+	if c.PingOnly && c.prober != nil {
+		if _, err := c.prober.Ping(c.Hostname); err != nil && isPingUnrecoverableError(err) {
+			return fmt.Errorf("ping check failed: %v", err)
+		}
 	}
 
 	return nil

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -7,8 +7,14 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
+	probing "github.com/prometheus-community/pro-bing"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/ping"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
@@ -185,6 +191,58 @@ func TestCollector_Check(t *testing.T) {
 				return c
 			},
 		},
+
+		"success: ping_only with successful ping": {
+			wantErr: false,
+			prepare: func(m *snmpmock.MockHandler) *Collector {
+				setMockClientInitExpect(m)
+				setMockClientSysInfoExpect(m)
+
+				c := New()
+				c.Config = prepareV2Config()
+				c.PingOnly = true
+				c.CreateVnode = false
+				c.newSnmpClient = func() gosnmp.Handler { return m }
+				c.newProber = func(cfg ping.ProberConfig, log *logger.Logger) ping.Prober { return &mockProber{} }
+				return c
+			},
+		},
+
+		"success: ping_only with recoverable ping error": {
+			wantErr: false,
+			prepare: func(m *snmpmock.MockHandler) *Collector {
+				setMockClientInitExpect(m)
+				setMockClientSysInfoExpect(m)
+
+				c := New()
+				c.Config = prepareV2Config()
+				c.PingOnly = true
+				c.CreateVnode = false
+				c.newSnmpClient = func() gosnmp.Handler { return m }
+				c.newProber = func(cfg ping.ProberConfig, log *logger.Logger) ping.Prober {
+					return &mockProber{pingErr: errors.New("host unreachable")}
+				}
+				return c
+			},
+		},
+
+		"failure: ping_only with unrecoverable ping error": {
+			wantErr: true,
+			prepare: func(m *snmpmock.MockHandler) *Collector {
+				setMockClientInitExpect(m)
+				setMockClientSysInfoExpect(m)
+
+				c := New()
+				c.Config = prepareV2Config()
+				c.PingOnly = true
+				c.CreateVnode = false
+				c.newSnmpClient = func() gosnmp.Handler { return m }
+				c.newProber = func(cfg ping.ProberConfig, log *logger.Logger) ping.Prober {
+					return &mockProber{pingErr: syscall.EPERM}
+				}
+				return c
+			},
+		},
 	}
 
 	for name, tc := range tests {
@@ -326,6 +384,30 @@ func TestCollector_Collect(t *testing.T) {
 			},
 		},
 	}
+	tests["collects ping only metrics"] = struct {
+		prepare func(m *snmpmock.MockHandler) *Collector
+		want    map[string]int64
+	}{
+		prepare: func(m *snmpmock.MockHandler) *Collector {
+			setMockClientInitExpect(m)
+			setMockClientSysInfoExpect(m)
+
+			collr := New()
+			collr.Config = prepareV2Config()
+			collr.PingOnly = true
+			collr.CreateVnode = false
+			collr.newSnmpClient = func() gosnmp.Handler { return m }
+			collr.newProber = func(cfg ping.ProberConfig, log *logger.Logger) ping.Prober { return &mockProber{} }
+
+			return collr
+		},
+		want: map[string]int64{
+			"ping_rtt_min":    (10 * time.Millisecond).Microseconds(),
+			"ping_rtt_max":    (20 * time.Millisecond).Microseconds(),
+			"ping_rtt_avg":    (15 * time.Millisecond).Microseconds(),
+			"ping_rtt_stddev": (5 * time.Millisecond).Microseconds(),
+		},
+	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -343,6 +425,30 @@ func TestCollector_Collect(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+type mockProber struct {
+	pingErr error
+}
+
+func (m *mockProber) Ping(host string) (*probing.Statistics, error) {
+	if m.pingErr != nil {
+		return nil, m.pingErr
+	}
+
+	stats := probing.Statistics{
+		PacketsRecv:           5,
+		PacketsSent:           5,
+		PacketsRecvDuplicates: 0,
+		PacketLoss:            0,
+		Addr:                  host,
+		MinRtt:                time.Millisecond * 10,
+		MaxRtt:                time.Millisecond * 20,
+		AvgRtt:                time.Millisecond * 15,
+		StdDevRtt:             time.Millisecond * 5,
+	}
+
+	return &stats, nil
 }
 
 type mockDdSnmpCollector struct {

--- a/src/go/plugin/go.d/collector/snmp/config.go
+++ b/src/go/plugin/go.d/collector/snmp/config.go
@@ -41,7 +41,7 @@ type (
 	}
 	OptionsConfig struct {
 		Port           int    `yaml:"port,omitempty" json:"port"`
-		Retries        int    `yaml:"retries,omitempty" json:"retries"`
+		Retries        int    `yaml:"retries" json:"retries"`
 		Timeout        int    `yaml:"timeout,omitempty" json:"timeout"`
 		Version        string `yaml:"version,omitempty" json:"version"`
 		MaxOIDs        int    `yaml:"max_request_size,omitempty" json:"max_request_size"`

--- a/src/go/plugin/go.d/collector/snmp/config.go
+++ b/src/go/plugin/go.d/collector/snmp/config.go
@@ -22,7 +22,8 @@ type (
 
 		ManualProfiles []string `yaml:"manual_profiles,omitempty" json:"manual_profiles"`
 
-		Ping PingConfig `yaml:"ping,omitempty" json:"ping"`
+		PingOnly bool       `yaml:"ping_only,omitempty" json:"ping_only"`
+		Ping     PingConfig `yaml:"ping,omitempty" json:"ping"`
 	}
 
 	PingConfig struct {

--- a/src/go/plugin/go.d/collector/snmp/config_schema.json
+++ b/src/go/plugin/go.d/collector/snmp/config_schema.json
@@ -202,6 +202,12 @@
         },
         "uniqueItems": true
       },
+      "ping_only": {
+        "title": "Ping only",
+        "description": "Collect only ICMP round-trip time and skip SNMP profile metrics. Implies ping is enabled regardless of the ping.enabled setting.",
+        "type": "boolean",
+        "default": false
+      },
       "ping": {
         "title": "Ping",
         "type": [
@@ -312,6 +318,9 @@
         "ui:widget": "password"
       }
     },
+    "ping_only": {
+      "ui:help": "A minimal SNMP sysInfo query still runs at startup for device identification, profile matching, and metadata."
+    },
     "ping": {
       "interface": {
         "ui:widget": "hidden"
@@ -335,6 +344,7 @@
         {
           "title": "Ping",
           "fields": [
+            "ping_only",
             "ping"
           ]
         },

--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -385,7 +385,7 @@ modules:
 
             - name: ping_only
               group: Ping
-              description: Collect only ICMP round-trip metrics and skip periodic SNMP polling. A minimal SNMP sysInfo probe still runs at setup for naming/labels/metadata.
+              description: Collect only ICMP round-trip metrics and skip periodic SNMP polling. Implies ping is enabled regardless of the `ping.enabled` setting. A minimal SNMP sysInfo probe still runs at setup for naming/labels/metadata.
               default_value: false
               required: false
             - name: ping.enabled

--- a/src/go/plugin/go.d/collector/snmp/testdata/config.json
+++ b/src/go/plugin/go.d/collector/snmp/testdata/config.json
@@ -31,6 +31,7 @@
   "manual_profiles": [
     "ok"
   ],
+  "ping_only": true,
   "ping": {
     "enabled": true,
     "network": "ip",

--- a/src/go/plugin/go.d/collector/snmp/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/snmp/testdata/config.yaml
@@ -30,6 +30,7 @@ options:
   max_request_size: 123
   max_repetitions: 123
 
+ping_only: yes
 ping:
   enabled: yes
   network: ip


### PR DESCRIPTION
##### Summary
- fix(go.d): reduce transient 503 errors on dyncfg enable/disable (#22183)
- feat(go.d/snmp): add `ping_only` option (#22180)
- fix(go.d/snmp): fix retries serialization and bulk walk disable (#22179)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces transient 503 errors when toggling dynamic config and adds `ping_only` to `go.d/snmp` to collect only ICMP RTT without SNMP polling.

- **Bug Fixes**
  - Buffer `dyncfgCh` (32) and raise downstream handoff to 10s to avoid drops/timeouts.
  - `go.d/snmp`: fix `retries` serialization and disable bulk walk when `max_repetitions` is 0.

<sup>Written for commit bc9fa3c14196dfe87fa01f91fc9e157002a43036. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



