### PR TITLE
fix SNMP down interface collection

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/collect_snmp.go
+++ b/src/go/plugin/go.d/collector/snmp/collect_snmp.go
@@ -59,10 +59,15 @@ func (c *Collector) collectProfileScalarMetrics(mx map[string]int64, pms []*ddsn
 
 func (c *Collector) collectProfileTableMetrics(mx map[string]int64, pms []*ddsnmp.ProfileMetrics) {
 	seen := make(map[string]bool)
+	ifaceStatuses := c.prepareIfaceMetrics(pms)
 
 	for _, pm := range pms {
 		for _, m := range pm.Metrics {
 			if !m.IsTable || m.Name == "" || len(m.Tags) == 0 {
+				continue
+			}
+
+			if skipDownIfaceMetric(m, ifaceStatuses) {
 				continue
 			}
 
@@ -87,10 +92,6 @@ func (c *Collector) collectProfileTableMetrics(mx map[string]int64, pms []*ddsnm
 					mx[id] = v
 				}
 			}
-
-			if isIfaceMetric(m.Name) {
-				c.updateIfaceCacheEntry(m)
-			}
 		}
 	}
 
@@ -100,6 +101,77 @@ func (c *Collector) collectProfileTableMetrics(mx map[string]int64, pms []*ddsnm
 			c.removeProfileTableMetricChart(key)
 		}
 	}
+}
+
+type ifaceStatus struct {
+	admin    string
+	hasAdmin bool
+	oper     string
+	hasOper  bool
+}
+
+func (s ifaceStatus) hasStatus() bool {
+	return s.hasAdmin || s.hasOper
+}
+
+func (s ifaceStatus) isUp() bool {
+	return s.hasAdmin && s.hasOper && s.admin == "up" && s.oper == "up"
+}
+
+func (c *Collector) prepareIfaceMetrics(pms []*ddsnmp.ProfileMetrics) map[string]ifaceStatus {
+	statuses := make(map[string]ifaceStatus)
+
+	for _, pm := range pms {
+		for _, m := range pm.Metrics {
+			if !m.IsTable || m.Name == "" || len(m.Tags) == 0 {
+				continue
+			}
+
+			if isIfaceMetric(m.Name) {
+				c.updateIfaceCacheEntry(m)
+			}
+
+			updateIfaceStatus(statuses, m)
+		}
+	}
+
+	return statuses
+}
+
+func updateIfaceStatus(statuses map[string]ifaceStatus, m ddsnmp.Metric) {
+	ifaceName := m.Tags[tagInterface]
+	if ifaceName == "" {
+		return
+	}
+
+	status := statuses[ifaceName]
+
+	switch m.Name {
+	case "ifAdminStatus":
+		status.admin = extractStatus(m.MultiValue)
+		status.hasAdmin = true
+	case "ifOperStatus":
+		status.oper = extractStatus(m.MultiValue)
+		status.hasOper = true
+	default:
+		return
+	}
+
+	statuses[ifaceName] = status
+}
+
+func skipDownIfaceMetric(m ddsnmp.Metric, statuses map[string]ifaceStatus) bool {
+	ifaceName := m.Tags[tagInterface]
+	if ifaceName == "" {
+		return false
+	}
+
+	status, ok := statuses[ifaceName]
+	if !ok || !status.hasStatus() {
+		return false
+	}
+
+	return !status.isUp()
 }
 
 func (c *Collector) collectProfileStats(mx map[string]int64, pms []*ddsnmp.ProfileMetrics) {

--- a/src/go/plugin/go.d/collector/snmp/collect_snmp_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collect_snmp_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmp
+
+import (
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectProfileTableMetricsSkipsKnownDownInterfaces(t *testing.T) {
+	collr, mx := collectProfileTableMetricsForTest(
+		ifTrafficMetric("eth0", 100, 200),
+		ifTrafficMetric("eth1", 300, 400),
+		ifAdminStatusMetric("eth0", "up"),
+		ifOperStatusMetric("eth0", "up"),
+		ifAdminStatusMetric("eth1", "up"),
+		ifOperStatusMetric("eth1", "down"),
+	)
+
+	assert.Equal(t, int64(100), mx["snmp_device_prof_ifTraffic_eth0_in"])
+	assert.Equal(t, int64(200), mx["snmp_device_prof_ifTraffic_eth0_out"])
+	assert.NotContains(t, mx, "snmp_device_prof_ifTraffic_eth1_in")
+	assert.NotContains(t, mx, "snmp_device_prof_ifTraffic_eth1_out")
+	assert.NotContains(t, mx, "snmp_device_prof_ifAdminStatus_eth1_up")
+	assert.NotContains(t, mx, "snmp_device_prof_ifOperStatus_eth1_down")
+
+	collr.ifaceCache.mu.RLock()
+	defer collr.ifaceCache.mu.RUnlock()
+
+	entry := collr.ifaceCache.interfaces["eth1"]
+	require.NotNil(t, entry)
+	assert.Equal(t, "up", entry.adminStatus)
+	assert.Equal(t, "down", entry.operStatus)
+}
+
+func TestCollectProfileTableMetricsKeepsUpInterfaces(t *testing.T) {
+	_, mx := collectProfileTableMetricsForTest(
+		ifTrafficMetric("eth0", 100, 200),
+		ifAdminStatusMetric("eth0", "up"),
+		ifOperStatusMetric("eth0", "up"),
+	)
+
+	assert.Equal(t, int64(100), mx["snmp_device_prof_ifTraffic_eth0_in"])
+	assert.Equal(t, int64(200), mx["snmp_device_prof_ifTraffic_eth0_out"])
+	assert.Equal(t, int64(1), mx["snmp_device_prof_ifAdminStatus_eth0_up"])
+	assert.Equal(t, int64(1), mx["snmp_device_prof_ifOperStatus_eth0_up"])
+}
+
+func TestCollectProfileTableMetricsKeepsInterfacesWithNoStatus(t *testing.T) {
+	_, mx := collectProfileTableMetricsForTest(ifTrafficMetric("eth0", 100, 200))
+
+	assert.Equal(t, int64(100), mx["snmp_device_prof_ifTraffic_eth0_in"])
+	assert.Equal(t, int64(200), mx["snmp_device_prof_ifTraffic_eth0_out"])
+}
+
+func TestCollectProfileTableMetricsSkipsInterfacesWithPartialStatus(t *testing.T) {
+	_, mx := collectProfileTableMetricsForTest(
+		ifTrafficMetric("eth0", 100, 200),
+		ifAdminStatusMetric("eth0", "up"),
+	)
+
+	assert.NotContains(t, mx, "snmp_device_prof_ifTraffic_eth0_in")
+	assert.NotContains(t, mx, "snmp_device_prof_ifTraffic_eth0_out")
+}
+
+func TestCollectProfileTableMetricsKeepsNonInterfaceTableMetrics(t *testing.T) {
+	_, mx := collectProfileTableMetricsForTest(ddsnmp.Metric{
+		Name:    "cpuUsage",
+		IsTable: true,
+		Tags:    map[string]string{"slot": "1"},
+		Value:   42,
+	})
+
+	assert.Equal(t, int64(42), mx["snmp_device_prof_cpuUsage_1"])
+}
+
+func TestCollectProfileTableMetricsRemovesChartsForInterfacesThatGoDown(t *testing.T) {
+	collr := newTestSNMPCollector()
+
+	collr.resetIfaceCache()
+	mx := make(map[string]int64)
+	collr.collectProfileTableMetrics(mx, profileMetrics(
+		ifTrafficMetric("eth0", 100, 200),
+		ifAdminStatusMetric("eth0", "up"),
+		ifOperStatusMetric("eth0", "up"),
+	))
+	collr.finalizeIfaceCache()
+
+	const key = "ifTraffic_eth0"
+	require.True(t, collr.seenTableMetrics[key])
+
+	chart := collr.Charts().Get("snmp_device_prof_ifTraffic_eth0")
+	require.NotNil(t, chart)
+	assert.False(t, chart.IsRemoved())
+
+	collr.resetIfaceCache()
+	mx = make(map[string]int64)
+	collr.collectProfileTableMetrics(mx, profileMetrics(
+		ifTrafficMetric("eth0", 300, 400),
+		ifAdminStatusMetric("eth0", "up"),
+		ifOperStatusMetric("eth0", "down"),
+	))
+	collr.finalizeIfaceCache()
+
+	assert.NotContains(t, mx, "snmp_device_prof_ifTraffic_eth0_in")
+	assert.False(t, collr.seenTableMetrics[key])
+
+	chart = collr.Charts().Get("snmp_device_prof_ifTraffic_eth0")
+	require.NotNil(t, chart)
+	assert.True(t, chart.IsRemoved())
+}
+
+func collectProfileTableMetricsForTest(metrics ...ddsnmp.Metric) (*Collector, map[string]int64) {
+	collr := newTestSNMPCollector()
+	mx := make(map[string]int64)
+
+	collr.resetIfaceCache()
+	collr.collectProfileTableMetrics(mx, profileMetrics(metrics...))
+	collr.finalizeIfaceCache()
+
+	return collr, mx
+}
+
+func newTestSNMPCollector() *Collector {
+	collr := New()
+	collr.sysInfo = &snmputils.SysInfo{Name: "mock sysName"}
+	return collr
+}
+
+func profileMetrics(metrics ...ddsnmp.Metric) []*ddsnmp.ProfileMetrics {
+	pm := &ddsnmp.ProfileMetrics{
+		Tags:    map[string]string{},
+		Metrics: metrics,
+	}
+	for i := range pm.Metrics {
+		if pm.Metrics[i].Profile == nil {
+			pm.Metrics[i].Profile = pm
+		}
+	}
+	return []*ddsnmp.ProfileMetrics{pm}
+}
+
+func ifTrafficMetric(iface string, in, out int64) ddsnmp.Metric {
+	return ddsnmp.Metric{
+		Name:    "ifTraffic",
+		IsTable: true,
+		Tags:    map[string]string{tagInterface: iface},
+		MultiValue: map[string]int64{
+			"in":  in,
+			"out": out,
+		},
+	}
+}
+
+func ifAdminStatusMetric(iface, status string) ddsnmp.Metric {
+	return ifaceStatusMetric("ifAdminStatus", iface, status, []string{"up", "down", "testing"})
+}
+
+func ifOperStatusMetric(iface, status string) ddsnmp.Metric {
+	return ifaceStatusMetric("ifOperStatus", iface, status, []string{"up", "down", "testing", "unknown", "dormant", "notPresent", "lowerLayerDown"})
+}
+
+func ifaceStatusMetric(name, iface, status string, values []string) ddsnmp.Metric {
+	mv := make(map[string]int64, len(values))
+	for _, v := range values {
+		if v == status {
+			mv[v] = 1
+		} else {
+			mv[v] = 0
+		}
+	}
+
+	return ddsnmp.Metric{
+		Name:       name,
+		IsTable:    true,
+		Tags:       map[string]string{tagInterface: iface},
+		MultiValue: mv,
+	}
+}


### PR DESCRIPTION
## Summary

This changes the SNMP module profile table emission path so interface-tagged profile metrics are emitted to netdata only when the interface status is known to be fully up: admin `up` and oper `up`.

The module still processes interface status internally, because it needs that status to decide what to emit and because the `snmp:interfaces` function depends on the interface cache.

## Problem

Before this change, `collectProfileTableMetrics()` emitted every tagged table metric into the collection map first, then updated the interface cache afterward for metrics tracked by `snmp:interfaces`. That means IF-MIB status was not part of the decision to create or update profile charts.

For network interfaces that are admin down or oper down, the module still created/updated profile charts such as traffic, packet, error, discard, and status charts. These down-interface time series then appeared in netdata query results and dashboards, where they could show partial-data marks even though the interface was not an active traffic interface.

The existing `snmp:interfaces` function already had a separate post-collection guard: it sets float values to `nil` when admin or oper status is not `up`. That protected the function output only. It did not protect profile chart collection.

## Implementation

The table collection path now has a pre-emission interface pass:

1. Walk the profile table metrics once before chart emission.
2. Update the existing interface cache from known interface metrics.
3. Build an admin/oper status map by interface name.
4. During normal table emission, skip interface-tagged metrics when status is known and not fully up.
5. Do not mark skipped metrics as `seen`, so the existing stale-chart cleanup removes charts for interfaces that transition from up to down.

This keeps the change local to the module emission path. It does not change raw SNMP table walking, because status is only known after the SNMP collection layer returns table metrics.

## Behavior

- Admin `up` and oper `up`: interface profile metrics are emitted.
- Admin or oper present and not `up`: interface profile metrics are skipped.
- Only one of admin/oper status is present: interface is not considered fully up, matching the stricter rule already used by `snmp:interfaces`.
- No admin/oper status for the interface: metrics are kept, because the module cannot prove the interface is down.
- Non-interface table metrics are unaffected.
- The `snmp:interfaces` function still receives cache updates, including down-interface status, so it can continue to list interface identity/status while masking float values for down interfaces.

## Tests

Added focused coverage for:

- Down interface metrics are not emitted to netdata.
- Traffic before status in the returned metric list is still filtered correctly because status is precomputed first.
- Up interface metrics continue to be emitted.
- Interfaces with no status continue to be emitted.
- Interfaces with partial status are skipped.
- Non-interface table metrics are unaffected.
- Existing profile charts are marked removed when an interface transitions down.

Commands run:

```
cd src/go && go test ./plugin/go.d/collector/snmp
cd src/go && go test ./plugin/go.d/collector/snmp/...
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SNMP profile collection for down interfaces by emitting interface-tagged metrics only when both admin and oper status are up. Prevents charts and time series for inactive interfaces and cleans them up when an interface goes down.

- **Bug Fixes**
  - Precompute per-interface admin/oper status and skip interface-tagged metrics unless both are `up`.
  - Keep metrics when status is unknown; non-interface table metrics are unchanged.
  - Skipped metrics aren’t marked as seen, so stale charts are removed when an interface transitions down.
  - Interface cache still updates, so `snmp:interfaces` keeps reporting identity/status while masking floats for down interfaces.

<sup>Written for commit 3989ce9695f7095974339dd11a4339c583201b40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

