### PR TITLE
feat(go.d/snmp): improve Fortinet FortiGate SNMP monitoring

### DIFF
--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-ha.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-ha.yaml
@@ -56,11 +56,11 @@ metrics:
           unit: "{packet}/s"
       - OID: 1.3.6.1.4.1.12356.101.13.2.1.1.8
         name: fgHaStatsByteCount
-        chart_meta:
-          description: Bytes processed by the HA cluster member
-          family: 'System/HA/Node/Traffic/Traffic'
-          unit: "bit/s"
         scale_factor: 8
+        chart_meta:
+          description: Network bandwidth processed by the HA cluster member
+          family: 'System/HA/Node/Traffic/Bandwidth'
+          unit: "bit/s"
       - OID: 1.3.6.1.4.1.12356.101.13.2.1.1.9
         name: fgHaStatsIdsCount
         chart_meta:

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-ha.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-ha.yaml
@@ -1,0 +1,103 @@
+# High Availability cluster monitoring for Fortinet FortiGate devices
+# fgHaInfo scalars: cluster mode, group, priority
+# fgHaStatsTable: per-node CPU, memory, network, sessions, security events, sync status
+
+metrics:
+  ### HA cluster scalars
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.12356.101.13.1.1.0
+      name: fgHaSystemMode
+      chart_meta:
+        description: HA system operating mode
+        family: 'System/HA/Cluster/Mode'
+        unit: "{status}"
+      mapping:
+        1: standalone
+        2: activeActive
+        3: activePassive
+
+  ### HA per-node statistics table
+  - MIB: FORTINET-FORTIGATE-MIB
+    table:
+      OID: 1.3.6.1.4.1.12356.101.13.2.1
+      name: fgHaStatsTable
+    symbols:
+      - OID: 1.3.6.1.4.1.12356.101.13.2.1.1.3
+        name: fgHaStatsCpuUsage
+        chart_meta:
+          description: CPU usage of the HA cluster member
+          family: 'System/HA/Node/CPU/Usage'
+          unit: "%"
+      - OID: 1.3.6.1.4.1.12356.101.13.2.1.1.4
+        name: fgHaStatsMemUsage
+        chart_meta:
+          description: Memory usage of the HA cluster member
+          family: 'System/HA/Node/Memory/Usage'
+          unit: "%"
+      - OID: 1.3.6.1.4.1.12356.101.13.2.1.1.5
+        name: fgHaStatsNetUsage
+        scale_factor: 1000
+        chart_meta:
+          description: Network bandwidth usage of the HA cluster member
+          family: 'System/HA/Node/Network/Bandwidth'
+          unit: "bit/s"
+      - OID: 1.3.6.1.4.1.12356.101.13.2.1.1.6
+        name: fgHaStatsSesCount
+        chart_meta:
+          description: Active session count on the HA cluster member
+          family: 'System/HA/Node/Session/Count'
+          unit: "{session}"
+      - OID: 1.3.6.1.4.1.12356.101.13.2.1.1.7
+        name: fgHaStatsPktCount
+        chart_meta:
+          description: Packets processed by the HA cluster member
+          family: 'System/HA/Node/Traffic/Packets'
+          unit: "{packet}/s"
+      - OID: 1.3.6.1.4.1.12356.101.13.2.1.1.8
+        name: fgHaStatsByteCount
+        chart_meta:
+          description: Bytes processed by the HA cluster member
+          family: 'System/HA/Node/Traffic/Traffic'
+          unit: "bit/s"
+        scale_factor: 8
+      - OID: 1.3.6.1.4.1.12356.101.13.2.1.1.9
+        name: fgHaStatsIdsCount
+        chart_meta:
+          description: IPS events detected by the HA cluster member
+          family: 'System/HA/Node/Security/IPS'
+          unit: "{event}/s"
+      - OID: 1.3.6.1.4.1.12356.101.13.2.1.1.10
+        name: fgHaStatsAvCount
+        chart_meta:
+          description: Antivirus events detected by the HA cluster member
+          family: 'System/HA/Node/Security/Antivirus'
+          unit: "{event}/s"
+      - OID: 1.3.6.1.4.1.12356.101.13.2.1.1.12
+        name: fgHaStatsSyncStatus
+        chart_meta:
+          description: Configuration sync status of the HA cluster member
+          family: 'System/HA/Node/Sync/Status'
+          unit: "{status}"
+        mapping:
+          0: out_of_sync
+          1: in_sync
+    metric_tags:
+      - tag: ha_node_index
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.13.2.1.1.1
+          name: fgHaStatsIndex
+      - tag: _ha_node_serial
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.13.2.1.1.2
+          name: fgHaStatsSerial
+      - tag: _ha_node_hostname
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.13.2.1.1.11
+          name: fgHaStatsHostname
+
+metric_tags:
+  - tag: _ha_group_name
+    symbol:
+      OID: 1.3.6.1.4.1.12356.101.13.1.7.0
+      name: fgHaGroupName

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-hardware.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-hardware.yaml
@@ -1,0 +1,67 @@
+# Hardware sensor monitoring for Fortinet FortiGate devices
+# fgHwSensorTable: temperature, fan speed, voltage, and alarm status per sensor
+
+metrics:
+  # Sensor value — split by type using transform (same pattern as MikroTik/ENTITY-SENSOR-MIB)
+  - MIB: FORTINET-FORTIGATE-MIB
+    table:
+      OID: 1.3.6.1.4.1.12356.101.4.3.2
+      name: fgHwSensorTable
+    symbols:
+      # fgHwSensorEntValue is DisplayString — extract numeric part before transform
+      - OID: 1.3.6.1.4.1.12356.101.4.3.2.1.3
+        name: fgHwSensorEntValue
+        extract_value: '([\d.]+)'
+        chart_meta:
+          description: Hardware sensor reading
+          family: 'Hardware/Sensor'
+          unit: "1"
+        transform: |
+          {{- $name := index .Metric.Tags "rm:sensor_name" | default "" | lower -}}
+          {{- if or (contains "temp" $name) (contains "cpu" $name) (contains "thermal" $name) -}}
+            {{- setName .Metric "fgHwSensorEntValue_temperature" -}}
+            {{- setUnit .Metric "Cel" -}}
+            {{- setFamily .Metric "Hardware/Sensor/Temperature/Value" -}}
+            {{- setDesc .Metric "Temperature sensor reading" -}}
+          {{- else if or (contains "fan" $name) -}}
+            {{- setName .Metric "fgHwSensorEntValue_fan_speed" -}}
+            {{- setUnit .Metric "{revolution}/min" -}}
+            {{- setFamily .Metric "Hardware/Sensor/FanSpeed/Value" -}}
+            {{- setDesc .Metric "Fan rotation speed" -}}
+          {{- else if or (contains "vcc" $name) (contains "volt" $name) (hasSuffix "v" $name) -}}
+            {{- setName .Metric "fgHwSensorEntValue_voltage" -}}
+            {{- setUnit .Metric "V" -}}
+            {{- setFamily .Metric "Hardware/Sensor/Voltage/Value" -}}
+            {{- setDesc .Metric "Voltage sensor reading" -}}
+          {{- else if or (contains "power" $name) (contains "psu" $name) (contains "ps" $name) -}}
+            {{- setName .Metric "fgHwSensorEntValue_power" -}}
+            {{- setUnit .Metric "W" -}}
+            {{- setFamily .Metric "Hardware/Sensor/Power/Value" -}}
+            {{- setDesc .Metric "Power sensor reading" -}}
+          {{- else -}}
+            {{- setName .Metric "fgHwSensorEntValue_other" -}}
+            {{- setFamily .Metric "Hardware/Sensor/Other/Value" -}}
+            {{- setDesc .Metric "Unclassified sensor reading" -}}
+          {{- end -}}
+      - OID: 1.3.6.1.4.1.12356.101.4.3.2.1.4
+        name: fgHwSensorEntAlarmStatus
+        chart_meta:
+          description: Hardware sensor alarm status
+          family: 'Hardware/Sensor/Status'
+          unit: "{status}"
+        mapping:
+          0: ok
+          1: alarm
+    metric_tags:
+      - tag: sensor_index
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.4.3.2.1.1
+          name: fgHwSensorEntIndex
+      - tag: _sensor_name
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.4.3.2.1.2
+          name: fgHwSensorEntName
+      - tag: rm:sensor_name
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.4.3.2.1.2
+          name: fgHwSensorEntName

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-hardware.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-hardware.yaml
@@ -11,7 +11,7 @@ metrics:
       # fgHwSensorEntValue is DisplayString — extract numeric part before transform
       - OID: 1.3.6.1.4.1.12356.101.4.3.2.1.3
         name: fgHwSensorEntValue
-        extract_value: '([\d.]+)'
+        extract_value: '(\d+)'
         chart_meta:
           description: Hardware sensor reading
           family: 'Hardware/Sensor'

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-sdwan.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-sdwan.yaml
@@ -24,14 +24,14 @@ metrics:
           description: Average latency of SD-WAN health-check link within last 30 probes
           family: 'Network/SD-WAN/Link/Latency'
           unit: "ms"
-        extract_value: '([\d.]+)'
+        extract_value: '(\d+)'
       - OID: 1.3.6.1.4.1.12356.101.4.9.2.1.6
         name: fgVWLHealthCheckLinkJitter
         chart_meta:
           description: Average jitter of SD-WAN health-check link within last 30 probes
           family: 'Network/SD-WAN/Link/Jitter'
           unit: "ms"
-        extract_value: '([\d.]+)'
+        extract_value: '(\d+)'
       - OID: 1.3.6.1.4.1.12356.101.4.9.2.1.7
         name: fgVWLHealthCheckLinkPacketSend
         chart_meta:
@@ -50,7 +50,7 @@ metrics:
           description: Packet loss percentage of SD-WAN health-check link within last 30 probes
           family: 'Network/SD-WAN/Link/PacketLoss'
           unit: "%"
-        extract_value: '([\d.]+)'
+        extract_value: '(\d+)'
     metric_tags:
       - tag: sdwan_healthcheck
         symbol:
@@ -86,14 +86,14 @@ metrics:
           description: Average latency of link monitor probe
           family: 'Network/LinkMonitor/Latency'
           unit: "ms"
-        extract_value: '([\d.]+)'
+        extract_value: '(\d+)'
       - OID: 1.3.6.1.4.1.12356.101.4.8.2.1.5
         name: fgLinkMonitorJitter
         chart_meta:
           description: Average jitter of link monitor probe
           family: 'Network/LinkMonitor/Jitter'
           unit: "ms"
-        extract_value: '([\d.]+)'
+        extract_value: '(\d+)'
       - OID: 1.3.6.1.4.1.12356.101.4.8.2.1.6
         name: fgLinkMonitorPacketSend
         chart_meta:
@@ -112,7 +112,7 @@ metrics:
           description: Packet loss percentage of link monitor probe
           family: 'Network/LinkMonitor/PacketLoss'
           unit: "%"
-        extract_value: '([\d.]+)'
+        extract_value: '(\d+)'
     metric_tags:
       - tag: link_monitor
         symbol:

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-sdwan.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-sdwan.yaml
@@ -1,0 +1,124 @@
+# SD-WAN health-check and link monitor for Fortinet FortiGate devices
+# fgVWLHealthCheckLinkTable: per SD-WAN link state, latency, jitter, packet loss
+# fgLinkMonitorTable: per gateway-probe state, latency, jitter, packet loss
+
+metrics:
+  ### SD-WAN health-check table
+  - MIB: FORTINET-FORTIGATE-MIB
+    table:
+      OID: 1.3.6.1.4.1.12356.101.4.9.2
+      name: fgVWLHealthCheckLinkTable
+    symbols:
+      - OID: 1.3.6.1.4.1.12356.101.4.9.2.1.4
+        name: fgVWLHealthCheckLinkState
+        chart_meta:
+          description: SD-WAN health-check link state
+          family: 'Network/SD-WAN/Link/Status'
+          unit: "{status}"
+        mapping:
+          0: alive
+          1: dead
+      - OID: 1.3.6.1.4.1.12356.101.4.9.2.1.5
+        name: fgVWLHealthCheckLinkLatency
+        chart_meta:
+          description: Average latency of SD-WAN health-check link within last 30 probes
+          family: 'Network/SD-WAN/Link/Latency'
+          unit: "ms"
+        extract_value: '([\d.]+)'
+      - OID: 1.3.6.1.4.1.12356.101.4.9.2.1.6
+        name: fgVWLHealthCheckLinkJitter
+        chart_meta:
+          description: Average jitter of SD-WAN health-check link within last 30 probes
+          family: 'Network/SD-WAN/Link/Jitter'
+          unit: "ms"
+        extract_value: '([\d.]+)'
+      - OID: 1.3.6.1.4.1.12356.101.4.9.2.1.7
+        name: fgVWLHealthCheckLinkPacketSend
+        chart_meta:
+          description: Packets sent per second by SD-WAN health-check on this link
+          family: 'Network/SD-WAN/Link/Packets/Sent'
+          unit: "{packet}/s"
+      - OID: 1.3.6.1.4.1.12356.101.4.9.2.1.8
+        name: fgVWLHealthCheckLinkPacketRecv
+        chart_meta:
+          description: Packets received per second by SD-WAN health-check on this link
+          family: 'Network/SD-WAN/Link/Packets/Received'
+          unit: "{packet}/s"
+      - OID: 1.3.6.1.4.1.12356.101.4.9.2.1.9
+        name: fgVWLHealthCheckLinkPacketLoss
+        chart_meta:
+          description: Packet loss percentage of SD-WAN health-check link within last 30 probes
+          family: 'Network/SD-WAN/Link/PacketLoss'
+          unit: "%"
+        extract_value: '([\d.]+)'
+    metric_tags:
+      - tag: sdwan_healthcheck
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.4.9.2.1.2
+          name: fgVWLHealthCheckLinkName
+      - tag: _sdwan_interface
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.4.9.2.1.14
+          name: fgVWLHealthCheckLinkIfName
+      - tag: _sdwan_vdom
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.4.9.2.1.10
+          name: fgVWLHealthCheckLinkVdom
+
+  ### Link monitor table (gateway health probes)
+  - MIB: FORTINET-FORTIGATE-MIB
+    table:
+      OID: 1.3.6.1.4.1.12356.101.4.8.2
+      name: fgLinkMonitorTable
+    symbols:
+      - OID: 1.3.6.1.4.1.12356.101.4.8.2.1.3
+        name: fgLinkMonitorState
+        chart_meta:
+          description: Link monitor gateway probe state
+          family: 'Network/LinkMonitor/Status'
+          unit: "{status}"
+        mapping:
+          0: alive
+          1: dead
+      - OID: 1.3.6.1.4.1.12356.101.4.8.2.1.4
+        name: fgLinkMonitorLatency
+        chart_meta:
+          description: Average latency of link monitor probe
+          family: 'Network/LinkMonitor/Latency'
+          unit: "ms"
+        extract_value: '([\d.]+)'
+      - OID: 1.3.6.1.4.1.12356.101.4.8.2.1.5
+        name: fgLinkMonitorJitter
+        chart_meta:
+          description: Average jitter of link monitor probe
+          family: 'Network/LinkMonitor/Jitter'
+          unit: "ms"
+        extract_value: '([\d.]+)'
+      - OID: 1.3.6.1.4.1.12356.101.4.8.2.1.6
+        name: fgLinkMonitorPacketSend
+        chart_meta:
+          description: Packets sent by link monitor probe
+          family: 'Network/LinkMonitor/Packets/Sent'
+          unit: "{packet}/s"
+      - OID: 1.3.6.1.4.1.12356.101.4.8.2.1.7
+        name: fgLinkMonitorPacketRecv
+        chart_meta:
+          description: Packets received by link monitor probe
+          family: 'Network/LinkMonitor/Packets/Received'
+          unit: "{packet}/s"
+      - OID: 1.3.6.1.4.1.12356.101.4.8.2.1.8
+        name: fgLinkMonitorPacketLoss
+        chart_meta:
+          description: Packet loss percentage of link monitor probe
+          family: 'Network/LinkMonitor/PacketLoss'
+          unit: "%"
+        extract_value: '([\d.]+)'
+    metric_tags:
+      - tag: link_monitor
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.4.8.2.1.2
+          name: fgLinkMonitorName
+      - tag: _link_monitor_vdom
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.4.8.2.1.9
+          name: fgLinkMonitorVdom

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-security.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-security.yaml
@@ -1,67 +1,24 @@
 # Security telemetry for Fortinet FortiGate devices
 # IPS intrusion stats, antivirus stats, webfilter stats — all per VDOM
+# Metrics are collected as hidden inputs; virtual_metrics combine related
+# dimensions into meaningful multi-dimension charts.
 
 metrics:
-  ### IPS intrusion statistics (per VDOM)
+  ### IPS intrusion statistics (per VDOM) — hidden inputs for virtual_metrics
   - MIB: FORTINET-FORTIGATE-MIB
     table:
       OID: 1.3.6.1.4.1.12356.101.9.2.1
       name: fgIpsStatsTable
     symbols:
-      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.1
-        name: fgIpsIntrusionsDetected
-        chart_meta:
-          description: Total intrusions detected since start-up
-          family: 'Security/IPS/Events/Detected'
-          unit: "{event}/s"
-      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.2
-        name: fgIpsIntrusionsBlocked
-        chart_meta:
-          description: Total intrusions blocked since start-up
-          family: 'Security/IPS/Events/Blocked'
-          unit: "{event}/s"
-      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.3
-        name: fgIpsCritSevDetections
-        chart_meta:
-          description: Critical severity intrusion detections since start-up
-          family: 'Security/IPS/Severity/Critical'
-          unit: "{event}/s"
-      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.4
-        name: fgIpsHighSevDetections
-        chart_meta:
-          description: High severity intrusion detections since start-up
-          family: 'Security/IPS/Severity/High'
-          unit: "{event}/s"
-      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.5
-        name: fgIpsMedSevDetections
-        chart_meta:
-          description: Medium severity intrusion detections since start-up
-          family: 'Security/IPS/Severity/Medium'
-          unit: "{event}/s"
-      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.6
-        name: fgIpsLowSevDetections
-        chart_meta:
-          description: Low severity intrusion detections since start-up
-          family: 'Security/IPS/Severity/Low'
-          unit: "{event}/s"
-      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.7
-        name: fgIpsInfoSevDetections
-        chart_meta:
-          description: Informational severity intrusion detections since start-up
-          family: 'Security/IPS/Severity/Info'
-          unit: "{event}/s"
-      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.8
-        name: fgIpsSignatureDetections
-        chart_meta:
-          description: Signature-based intrusion detections since start-up
-          family: 'Security/IPS/Method/Signature'
-          unit: "{event}/s"
-      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.9
-        name: fgIpsAnomalyDetections
-        chart_meta:
-          description: Anomaly-based intrusion detections since start-up
-          family: 'Security/IPS/Method/Anomaly'
-          unit: "{event}/s"
+      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.1, name: _fgIpsIntrusionsDetected }
+      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.2, name: _fgIpsIntrusionsBlocked }
+      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.3, name: _fgIpsCritSevDetections }
+      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.4, name: _fgIpsHighSevDetections }
+      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.5, name: _fgIpsMedSevDetections }
+      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.6, name: _fgIpsLowSevDetections }
+      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.7, name: _fgIpsInfoSevDetections }
+      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.8, name: _fgIpsSignatureDetections }
+      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.9, name: _fgIpsAnomalyDetections }
     metric_tags:
       - tag: vdom_index
         index: 1
@@ -71,84 +28,24 @@ metrics:
           OID: 1.3.6.1.4.1.12356.101.3.2.1.1.2
           name: fgVdEntName
 
-  ### Antivirus statistics (per VDOM)
+  ### Antivirus statistics (per VDOM) — hidden inputs for virtual_metrics
   - MIB: FORTINET-FORTIGATE-MIB
     table:
       OID: 1.3.6.1.4.1.12356.101.8.2.1
       name: fgAvStatsTable
     symbols:
-      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.1
-        name: fgAvVirusDetected
-        chart_meta:
-          description: Total virus transmissions detected since start-up
-          family: 'Security/Antivirus/Total/Detected'
-          unit: "{virus}/s"
-      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.2
-        name: fgAvVirusBlocked
-        chart_meta:
-          description: Total virus transmissions blocked since start-up
-          family: 'Security/Antivirus/Total/Blocked'
-          unit: "{virus}/s"
-      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.3
-        name: fgAvHTTPVirusDetected
-        chart_meta:
-          description: HTTP virus transmissions detected since start-up
-          family: 'Security/Antivirus/HTTP/Detected'
-          unit: "{virus}/s"
-      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.4
-        name: fgAvHTTPVirusBlocked
-        chart_meta:
-          description: HTTP virus transmissions blocked since start-up
-          family: 'Security/Antivirus/HTTP/Blocked'
-          unit: "{virus}/s"
-      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.5
-        name: fgAvSMTPVirusDetected
-        chart_meta:
-          description: SMTP virus transmissions detected since start-up
-          family: 'Security/Antivirus/SMTP/Detected'
-          unit: "{virus}/s"
-      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.6
-        name: fgAvSMTPVirusBlocked
-        chart_meta:
-          description: SMTP virus transmissions blocked since start-up
-          family: 'Security/Antivirus/SMTP/Blocked'
-          unit: "{virus}/s"
-      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.7
-        name: fgAvPOP3VirusDetected
-        chart_meta:
-          description: POP3 virus transmissions detected since start-up
-          family: 'Security/Antivirus/POP3/Detected'
-          unit: "{virus}/s"
-      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.8
-        name: fgAvPOP3VirusBlocked
-        chart_meta:
-          description: POP3 virus transmissions blocked since start-up
-          family: 'Security/Antivirus/POP3/Blocked'
-          unit: "{virus}/s"
-      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.9
-        name: fgAvIMAPVirusDetected
-        chart_meta:
-          description: IMAP virus transmissions detected since start-up
-          family: 'Security/Antivirus/IMAP/Detected'
-          unit: "{virus}/s"
-      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.10
-        name: fgAvIMAPVirusBlocked
-        chart_meta:
-          description: IMAP virus transmissions blocked since start-up
-          family: 'Security/Antivirus/IMAP/Blocked'
-          unit: "{virus}/s"
-      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.11
-        name: fgAvFTPVirusDetected
-        chart_meta:
-          description: FTP virus transmissions detected since start-up
-          family: 'Security/Antivirus/FTP/Detected'
-          unit: "{virus}/s"
-      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.12
-        name: fgAvFTPVirusBlocked
-        chart_meta:
-          description: FTP virus transmissions blocked since start-up
-          family: 'Security/Antivirus/FTP/Blocked'
-          unit: "{virus}/s"
+      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.1, name: _fgAvVirusDetected }
+      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.2, name: _fgAvVirusBlocked }
+      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.3, name: _fgAvHTTPVirusDetected }
+      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.4, name: _fgAvHTTPVirusBlocked }
+      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.5, name: _fgAvSMTPVirusDetected }
+      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.6, name: _fgAvSMTPVirusBlocked }
+      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.7, name: _fgAvPOP3VirusDetected }
+      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.8, name: _fgAvPOP3VirusBlocked }
+      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.9, name: _fgAvIMAPVirusDetected }
+      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.10, name: _fgAvIMAPVirusBlocked }
+      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.11, name: _fgAvFTPVirusDetected }
+      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.12, name: _fgAvFTPVirusBlocked }
     metric_tags:
       - tag: vdom_index
         index: 1
@@ -158,54 +55,19 @@ metrics:
           OID: 1.3.6.1.4.1.12356.101.3.2.1.1.2
           name: fgVdEntName
 
-  ### Webfilter statistics (per VDOM)
+  ### Webfilter statistics (per VDOM) — hidden inputs for virtual_metrics
   - MIB: FORTINET-FORTIGATE-MIB
     table:
       OID: 1.3.6.1.4.1.12356.101.10.1.2.1
       name: fgWebfilterStatsTable
     symbols:
-      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.1
-        name: fgWfHTTPBlocked
-        chart_meta:
-          description: HTTP sessions blocked by web filter since start-up
-          family: 'Security/Webfilter/HTTP/SessionBlocked'
-          unit: "{session}/s"
-      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.2
-        name: fgWfHTTPSBlocked
-        chart_meta:
-          description: HTTPS sessions blocked by web filter since start-up
-          family: 'Security/Webfilter/HTTPS/SessionBlocked'
-          unit: "{session}/s"
-      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.3
-        name: fgWfHTTPURLBlocked
-        chart_meta:
-          description: HTTP URLs blocked by web filter since start-up
-          family: 'Security/Webfilter/HTTP/URLBlocked'
-          unit: "{url}/s"
-      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.4
-        name: fgWfHTTPSURLBlocked
-        chart_meta:
-          description: HTTPS URLs blocked by web filter since start-up
-          family: 'Security/Webfilter/HTTPS/URLBlocked'
-          unit: "{url}/s"
-      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.5
-        name: fgWfActiveXBlocked
-        chart_meta:
-          description: ActiveX downloads blocked by web filter since start-up
-          family: 'Security/Webfilter/Content/ActiveXBlocked'
-          unit: "{block}/s"
-      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.6
-        name: fgWfCookieBlocked
-        chart_meta:
-          description: HTTP cookies blocked by web filter since start-up
-          family: 'Security/Webfilter/Content/CookieBlocked'
-          unit: "{block}/s"
-      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.7
-        name: fgWfAppletBlocked
-        chart_meta:
-          description: Applets blocked by web filter since start-up
-          family: 'Security/Webfilter/Content/AppletBlocked'
-          unit: "{block}/s"
+      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.1, name: _fgWfHTTPBlocked }
+      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.2, name: _fgWfHTTPSBlocked }
+      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.3, name: _fgWfHTTPURLBlocked }
+      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.4, name: _fgWfHTTPSURLBlocked }
+      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.5, name: _fgWfActiveXBlocked }
+      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.6, name: _fgWfCookieBlocked }
+      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.7, name: _fgWfAppletBlocked }
     metric_tags:
       - tag: vdom_index
         index: 1
@@ -214,3 +76,121 @@ metrics:
         symbol:
           OID: 1.3.6.1.4.1.12356.101.3.2.1.1.2
           name: fgVdEntName
+
+virtual_metrics:
+  ### IPS — combined charts per VDOM
+  - name: fgIpsIntrusions
+    per_row: true
+    group_by: ["vdom_index"]
+    sources:
+      - { metric: _fgIpsIntrusionsDetected, table: fgIpsStatsTable, as: detected }
+      - { metric: _fgIpsIntrusionsBlocked, table: fgIpsStatsTable, as: blocked }
+    chart_meta:
+      description: IPS intrusions detected and blocked
+      family: 'Security/IPS/Events'
+      unit: "{event}/s"
+
+  - name: fgIpsSeverity
+    per_row: true
+    group_by: ["vdom_index"]
+    sources:
+      - { metric: _fgIpsCritSevDetections, table: fgIpsStatsTable, as: critical }
+      - { metric: _fgIpsHighSevDetections, table: fgIpsStatsTable, as: high }
+      - { metric: _fgIpsMedSevDetections, table: fgIpsStatsTable, as: medium }
+      - { metric: _fgIpsLowSevDetections, table: fgIpsStatsTable, as: low }
+      - { metric: _fgIpsInfoSevDetections, table: fgIpsStatsTable, as: info }
+    chart_meta:
+      description: IPS intrusion detections by severity
+      family: 'Security/IPS/Severity'
+      unit: "{event}/s"
+      type: stacked
+
+  - name: fgIpsMethod
+    per_row: true
+    group_by: ["vdom_index"]
+    sources:
+      - { metric: _fgIpsSignatureDetections, table: fgIpsStatsTable, as: signature }
+      - { metric: _fgIpsAnomalyDetections, table: fgIpsStatsTable, as: anomaly }
+    chart_meta:
+      description: IPS intrusion detections by method
+      family: 'Security/IPS/Method'
+      unit: "{event}/s"
+      type: stacked
+
+  ### Antivirus — detected vs blocked total, and by-protocol breakdowns
+  - name: fgAvVirusEvents
+    per_row: true
+    group_by: ["vdom_index"]
+    sources:
+      - { metric: _fgAvVirusDetected, table: fgAvStatsTable, as: detected }
+      - { metric: _fgAvVirusBlocked, table: fgAvStatsTable, as: blocked }
+    chart_meta:
+      description: Antivirus virus events detected and blocked
+      family: 'Security/Antivirus/Events'
+      unit: "{virus}/s"
+
+  - name: fgAvVirusDetectedByProtocol
+    per_row: true
+    group_by: ["vdom_index"]
+    sources:
+      - { metric: _fgAvHTTPVirusDetected, table: fgAvStatsTable, as: http }
+      - { metric: _fgAvSMTPVirusDetected, table: fgAvStatsTable, as: smtp }
+      - { metric: _fgAvPOP3VirusDetected, table: fgAvStatsTable, as: pop3 }
+      - { metric: _fgAvIMAPVirusDetected, table: fgAvStatsTable, as: imap }
+      - { metric: _fgAvFTPVirusDetected, table: fgAvStatsTable, as: ftp }
+    chart_meta:
+      description: Antivirus virus detections by protocol
+      family: 'Security/Antivirus/Detected/Protocol'
+      unit: "{virus}/s"
+      type: stacked
+
+  - name: fgAvVirusBlockedByProtocol
+    per_row: true
+    group_by: ["vdom_index"]
+    sources:
+      - { metric: _fgAvHTTPVirusBlocked, table: fgAvStatsTable, as: http }
+      - { metric: _fgAvSMTPVirusBlocked, table: fgAvStatsTable, as: smtp }
+      - { metric: _fgAvPOP3VirusBlocked, table: fgAvStatsTable, as: pop3 }
+      - { metric: _fgAvIMAPVirusBlocked, table: fgAvStatsTable, as: imap }
+      - { metric: _fgAvFTPVirusBlocked, table: fgAvStatsTable, as: ftp }
+    chart_meta:
+      description: Antivirus virus blocks by protocol
+      family: 'Security/Antivirus/Blocked/Protocol'
+      unit: "{virus}/s"
+      type: stacked
+
+  ### Webfilter — grouped by related dimensions
+  - name: fgWfSessionBlocked
+    per_row: true
+    group_by: ["vdom_index"]
+    sources:
+      - { metric: _fgWfHTTPBlocked, table: fgWebfilterStatsTable, as: http }
+      - { metric: _fgWfHTTPSBlocked, table: fgWebfilterStatsTable, as: https }
+    chart_meta:
+      description: Web filter sessions blocked by protocol
+      family: 'Security/Webfilter/Session/Blocked'
+      unit: "{session}/s"
+
+  - name: fgWfURLBlocked
+    per_row: true
+    group_by: ["vdom_index"]
+    sources:
+      - { metric: _fgWfHTTPURLBlocked, table: fgWebfilterStatsTable, as: http }
+      - { metric: _fgWfHTTPSURLBlocked, table: fgWebfilterStatsTable, as: https }
+    chart_meta:
+      description: Web filter URLs blocked by protocol
+      family: 'Security/Webfilter/URL/Blocked'
+      unit: "{url}/s"
+
+  - name: fgWfContentBlocked
+    per_row: true
+    group_by: ["vdom_index"]
+    sources:
+      - { metric: _fgWfActiveXBlocked, table: fgWebfilterStatsTable, as: activex }
+      - { metric: _fgWfCookieBlocked, table: fgWebfilterStatsTable, as: cookie }
+      - { metric: _fgWfAppletBlocked, table: fgWebfilterStatsTable, as: applet }
+    chart_meta:
+      description: Web filter content blocks by type
+      family: 'Security/Webfilter/Content/Blocked'
+      unit: "{block}/s"
+      type: stacked

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-security.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-security.yaml
@@ -1,0 +1,216 @@
+# Security telemetry for Fortinet FortiGate devices
+# IPS intrusion stats, antivirus stats, webfilter stats — all per VDOM
+
+metrics:
+  ### IPS intrusion statistics (per VDOM)
+  - MIB: FORTINET-FORTIGATE-MIB
+    table:
+      OID: 1.3.6.1.4.1.12356.101.9.2.1
+      name: fgIpsStatsTable
+    symbols:
+      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.1
+        name: fgIpsIntrusionsDetected
+        chart_meta:
+          description: Total intrusions detected since start-up
+          family: 'Security/IPS/Events/Detected'
+          unit: "{event}/s"
+      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.2
+        name: fgIpsIntrusionsBlocked
+        chart_meta:
+          description: Total intrusions blocked since start-up
+          family: 'Security/IPS/Events/Blocked'
+          unit: "{event}/s"
+      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.3
+        name: fgIpsCritSevDetections
+        chart_meta:
+          description: Critical severity intrusion detections since start-up
+          family: 'Security/IPS/Severity/Critical'
+          unit: "{event}/s"
+      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.4
+        name: fgIpsHighSevDetections
+        chart_meta:
+          description: High severity intrusion detections since start-up
+          family: 'Security/IPS/Severity/High'
+          unit: "{event}/s"
+      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.5
+        name: fgIpsMedSevDetections
+        chart_meta:
+          description: Medium severity intrusion detections since start-up
+          family: 'Security/IPS/Severity/Medium'
+          unit: "{event}/s"
+      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.6
+        name: fgIpsLowSevDetections
+        chart_meta:
+          description: Low severity intrusion detections since start-up
+          family: 'Security/IPS/Severity/Low'
+          unit: "{event}/s"
+      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.7
+        name: fgIpsInfoSevDetections
+        chart_meta:
+          description: Informational severity intrusion detections since start-up
+          family: 'Security/IPS/Severity/Info'
+          unit: "{event}/s"
+      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.8
+        name: fgIpsSignatureDetections
+        chart_meta:
+          description: Signature-based intrusion detections since start-up
+          family: 'Security/IPS/Method/Signature'
+          unit: "{event}/s"
+      - OID: 1.3.6.1.4.1.12356.101.9.2.1.1.9
+        name: fgIpsAnomalyDetections
+        chart_meta:
+          description: Anomaly-based intrusion detections since start-up
+          family: 'Security/IPS/Method/Anomaly'
+          unit: "{event}/s"
+    metric_tags:
+      - tag: vdom_index
+        index: 1
+      - tag: _vdom_name
+        table: fgVdTable
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.3.2.1.1.2
+          name: fgVdEntName
+
+  ### Antivirus statistics (per VDOM)
+  - MIB: FORTINET-FORTIGATE-MIB
+    table:
+      OID: 1.3.6.1.4.1.12356.101.8.2.1
+      name: fgAvStatsTable
+    symbols:
+      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.1
+        name: fgAvVirusDetected
+        chart_meta:
+          description: Total virus transmissions detected since start-up
+          family: 'Security/Antivirus/Total/Detected'
+          unit: "{virus}/s"
+      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.2
+        name: fgAvVirusBlocked
+        chart_meta:
+          description: Total virus transmissions blocked since start-up
+          family: 'Security/Antivirus/Total/Blocked'
+          unit: "{virus}/s"
+      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.3
+        name: fgAvHTTPVirusDetected
+        chart_meta:
+          description: HTTP virus transmissions detected since start-up
+          family: 'Security/Antivirus/HTTP/Detected'
+          unit: "{virus}/s"
+      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.4
+        name: fgAvHTTPVirusBlocked
+        chart_meta:
+          description: HTTP virus transmissions blocked since start-up
+          family: 'Security/Antivirus/HTTP/Blocked'
+          unit: "{virus}/s"
+      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.5
+        name: fgAvSMTPVirusDetected
+        chart_meta:
+          description: SMTP virus transmissions detected since start-up
+          family: 'Security/Antivirus/SMTP/Detected'
+          unit: "{virus}/s"
+      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.6
+        name: fgAvSMTPVirusBlocked
+        chart_meta:
+          description: SMTP virus transmissions blocked since start-up
+          family: 'Security/Antivirus/SMTP/Blocked'
+          unit: "{virus}/s"
+      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.7
+        name: fgAvPOP3VirusDetected
+        chart_meta:
+          description: POP3 virus transmissions detected since start-up
+          family: 'Security/Antivirus/POP3/Detected'
+          unit: "{virus}/s"
+      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.8
+        name: fgAvPOP3VirusBlocked
+        chart_meta:
+          description: POP3 virus transmissions blocked since start-up
+          family: 'Security/Antivirus/POP3/Blocked'
+          unit: "{virus}/s"
+      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.9
+        name: fgAvIMAPVirusDetected
+        chart_meta:
+          description: IMAP virus transmissions detected since start-up
+          family: 'Security/Antivirus/IMAP/Detected'
+          unit: "{virus}/s"
+      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.10
+        name: fgAvIMAPVirusBlocked
+        chart_meta:
+          description: IMAP virus transmissions blocked since start-up
+          family: 'Security/Antivirus/IMAP/Blocked'
+          unit: "{virus}/s"
+      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.11
+        name: fgAvFTPVirusDetected
+        chart_meta:
+          description: FTP virus transmissions detected since start-up
+          family: 'Security/Antivirus/FTP/Detected'
+          unit: "{virus}/s"
+      - OID: 1.3.6.1.4.1.12356.101.8.2.1.1.12
+        name: fgAvFTPVirusBlocked
+        chart_meta:
+          description: FTP virus transmissions blocked since start-up
+          family: 'Security/Antivirus/FTP/Blocked'
+          unit: "{virus}/s"
+    metric_tags:
+      - tag: vdom_index
+        index: 1
+      - tag: _vdom_name
+        table: fgVdTable
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.3.2.1.1.2
+          name: fgVdEntName
+
+  ### Webfilter statistics (per VDOM)
+  - MIB: FORTINET-FORTIGATE-MIB
+    table:
+      OID: 1.3.6.1.4.1.12356.101.10.1.2.1
+      name: fgWebfilterStatsTable
+    symbols:
+      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.1
+        name: fgWfHTTPBlocked
+        chart_meta:
+          description: HTTP sessions blocked by web filter since start-up
+          family: 'Security/Webfilter/HTTP/SessionBlocked'
+          unit: "{session}/s"
+      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.2
+        name: fgWfHTTPSBlocked
+        chart_meta:
+          description: HTTPS sessions blocked by web filter since start-up
+          family: 'Security/Webfilter/HTTPS/SessionBlocked'
+          unit: "{session}/s"
+      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.3
+        name: fgWfHTTPURLBlocked
+        chart_meta:
+          description: HTTP URLs blocked by web filter since start-up
+          family: 'Security/Webfilter/HTTP/URLBlocked'
+          unit: "{url}/s"
+      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.4
+        name: fgWfHTTPSURLBlocked
+        chart_meta:
+          description: HTTPS URLs blocked by web filter since start-up
+          family: 'Security/Webfilter/HTTPS/URLBlocked'
+          unit: "{url}/s"
+      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.5
+        name: fgWfActiveXBlocked
+        chart_meta:
+          description: ActiveX downloads blocked by web filter since start-up
+          family: 'Security/Webfilter/Content/ActiveXBlocked'
+          unit: "{block}/s"
+      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.6
+        name: fgWfCookieBlocked
+        chart_meta:
+          description: HTTP cookies blocked by web filter since start-up
+          family: 'Security/Webfilter/Content/CookieBlocked'
+          unit: "{block}/s"
+      - OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.7
+        name: fgWfAppletBlocked
+        chart_meta:
+          description: Applets blocked by web filter since start-up
+          family: 'Security/Webfilter/Content/AppletBlocked'
+          unit: "{block}/s"
+    metric_tags:
+      - tag: vdom_index
+        index: 1
+      - tag: _vdom_name
+        table: fgVdTable
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.3.2.1.1.2
+          name: fgVdEntName

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-security.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-security.yaml
@@ -10,15 +10,15 @@ metrics:
       OID: 1.3.6.1.4.1.12356.101.9.2.1
       name: fgIpsStatsTable
     symbols:
-      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.1, name: _fgIpsIntrusionsDetected }
-      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.2, name: _fgIpsIntrusionsBlocked }
-      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.3, name: _fgIpsCritSevDetections }
-      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.4, name: _fgIpsHighSevDetections }
-      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.5, name: _fgIpsMedSevDetections }
-      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.6, name: _fgIpsLowSevDetections }
-      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.7, name: _fgIpsInfoSevDetections }
-      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.8, name: _fgIpsSignatureDetections }
-      - { OID: 1.3.6.1.4.1.12356.101.9.2.1.1.9, name: _fgIpsAnomalyDetections }
+      - {OID: 1.3.6.1.4.1.12356.101.9.2.1.1.1, name: _fgIpsIntrusionsDetected}
+      - {OID: 1.3.6.1.4.1.12356.101.9.2.1.1.2, name: _fgIpsIntrusionsBlocked}
+      - {OID: 1.3.6.1.4.1.12356.101.9.2.1.1.3, name: _fgIpsCritSevDetections}
+      - {OID: 1.3.6.1.4.1.12356.101.9.2.1.1.4, name: _fgIpsHighSevDetections}
+      - {OID: 1.3.6.1.4.1.12356.101.9.2.1.1.5, name: _fgIpsMedSevDetections}
+      - {OID: 1.3.6.1.4.1.12356.101.9.2.1.1.6, name: _fgIpsLowSevDetections}
+      - {OID: 1.3.6.1.4.1.12356.101.9.2.1.1.7, name: _fgIpsInfoSevDetections}
+      - {OID: 1.3.6.1.4.1.12356.101.9.2.1.1.8, name: _fgIpsSignatureDetections}
+      - {OID: 1.3.6.1.4.1.12356.101.9.2.1.1.9, name: _fgIpsAnomalyDetections}
     metric_tags:
       - tag: vdom_index
         index: 1
@@ -34,18 +34,18 @@ metrics:
       OID: 1.3.6.1.4.1.12356.101.8.2.1
       name: fgAvStatsTable
     symbols:
-      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.1, name: _fgAvVirusDetected }
-      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.2, name: _fgAvVirusBlocked }
-      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.3, name: _fgAvHTTPVirusDetected }
-      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.4, name: _fgAvHTTPVirusBlocked }
-      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.5, name: _fgAvSMTPVirusDetected }
-      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.6, name: _fgAvSMTPVirusBlocked }
-      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.7, name: _fgAvPOP3VirusDetected }
-      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.8, name: _fgAvPOP3VirusBlocked }
-      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.9, name: _fgAvIMAPVirusDetected }
-      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.10, name: _fgAvIMAPVirusBlocked }
-      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.11, name: _fgAvFTPVirusDetected }
-      - { OID: 1.3.6.1.4.1.12356.101.8.2.1.1.12, name: _fgAvFTPVirusBlocked }
+      - {OID: 1.3.6.1.4.1.12356.101.8.2.1.1.1, name: _fgAvVirusDetected}
+      - {OID: 1.3.6.1.4.1.12356.101.8.2.1.1.2, name: _fgAvVirusBlocked}
+      - {OID: 1.3.6.1.4.1.12356.101.8.2.1.1.3, name: _fgAvHTTPVirusDetected}
+      - {OID: 1.3.6.1.4.1.12356.101.8.2.1.1.4, name: _fgAvHTTPVirusBlocked}
+      - {OID: 1.3.6.1.4.1.12356.101.8.2.1.1.5, name: _fgAvSMTPVirusDetected}
+      - {OID: 1.3.6.1.4.1.12356.101.8.2.1.1.6, name: _fgAvSMTPVirusBlocked}
+      - {OID: 1.3.6.1.4.1.12356.101.8.2.1.1.7, name: _fgAvPOP3VirusDetected}
+      - {OID: 1.3.6.1.4.1.12356.101.8.2.1.1.8, name: _fgAvPOP3VirusBlocked}
+      - {OID: 1.3.6.1.4.1.12356.101.8.2.1.1.9, name: _fgAvIMAPVirusDetected}
+      - {OID: 1.3.6.1.4.1.12356.101.8.2.1.1.10, name: _fgAvIMAPVirusBlocked}
+      - {OID: 1.3.6.1.4.1.12356.101.8.2.1.1.11, name: _fgAvFTPVirusDetected}
+      - {OID: 1.3.6.1.4.1.12356.101.8.2.1.1.12, name: _fgAvFTPVirusBlocked}
     metric_tags:
       - tag: vdom_index
         index: 1
@@ -61,13 +61,13 @@ metrics:
       OID: 1.3.6.1.4.1.12356.101.10.1.2.1
       name: fgWebfilterStatsTable
     symbols:
-      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.1, name: _fgWfHTTPBlocked }
-      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.2, name: _fgWfHTTPSBlocked }
-      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.3, name: _fgWfHTTPURLBlocked }
-      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.4, name: _fgWfHTTPSURLBlocked }
-      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.5, name: _fgWfActiveXBlocked }
-      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.6, name: _fgWfCookieBlocked }
-      - { OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.7, name: _fgWfAppletBlocked }
+      - {OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.1, name: _fgWfHTTPBlocked}
+      - {OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.2, name: _fgWfHTTPSBlocked}
+      - {OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.3, name: _fgWfHTTPURLBlocked}
+      - {OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.4, name: _fgWfHTTPSURLBlocked}
+      - {OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.5, name: _fgWfActiveXBlocked}
+      - {OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.6, name: _fgWfCookieBlocked}
+      - {OID: 1.3.6.1.4.1.12356.101.10.1.2.1.1.7, name: _fgWfAppletBlocked}
     metric_tags:
       - tag: vdom_index
         index: 1
@@ -83,8 +83,8 @@ virtual_metrics:
     per_row: true
     group_by: ["vdom_index"]
     sources:
-      - { metric: _fgIpsIntrusionsDetected, table: fgIpsStatsTable, as: detected }
-      - { metric: _fgIpsIntrusionsBlocked, table: fgIpsStatsTable, as: blocked }
+      - {metric: _fgIpsIntrusionsDetected, table: fgIpsStatsTable, as: detected}
+      - {metric: _fgIpsIntrusionsBlocked, table: fgIpsStatsTable, as: blocked}
     chart_meta:
       description: IPS intrusions detected and blocked
       family: 'Security/IPS/Events'
@@ -94,11 +94,11 @@ virtual_metrics:
     per_row: true
     group_by: ["vdom_index"]
     sources:
-      - { metric: _fgIpsCritSevDetections, table: fgIpsStatsTable, as: critical }
-      - { metric: _fgIpsHighSevDetections, table: fgIpsStatsTable, as: high }
-      - { metric: _fgIpsMedSevDetections, table: fgIpsStatsTable, as: medium }
-      - { metric: _fgIpsLowSevDetections, table: fgIpsStatsTable, as: low }
-      - { metric: _fgIpsInfoSevDetections, table: fgIpsStatsTable, as: info }
+      - {metric: _fgIpsCritSevDetections, table: fgIpsStatsTable, as: critical}
+      - {metric: _fgIpsHighSevDetections, table: fgIpsStatsTable, as: high}
+      - {metric: _fgIpsMedSevDetections, table: fgIpsStatsTable, as: medium}
+      - {metric: _fgIpsLowSevDetections, table: fgIpsStatsTable, as: low}
+      - {metric: _fgIpsInfoSevDetections, table: fgIpsStatsTable, as: info}
     chart_meta:
       description: IPS intrusion detections by severity
       family: 'Security/IPS/Severity'
@@ -109,8 +109,8 @@ virtual_metrics:
     per_row: true
     group_by: ["vdom_index"]
     sources:
-      - { metric: _fgIpsSignatureDetections, table: fgIpsStatsTable, as: signature }
-      - { metric: _fgIpsAnomalyDetections, table: fgIpsStatsTable, as: anomaly }
+      - {metric: _fgIpsSignatureDetections, table: fgIpsStatsTable, as: signature}
+      - {metric: _fgIpsAnomalyDetections, table: fgIpsStatsTable, as: anomaly}
     chart_meta:
       description: IPS intrusion detections by method
       family: 'Security/IPS/Method'
@@ -122,8 +122,8 @@ virtual_metrics:
     per_row: true
     group_by: ["vdom_index"]
     sources:
-      - { metric: _fgAvVirusDetected, table: fgAvStatsTable, as: detected }
-      - { metric: _fgAvVirusBlocked, table: fgAvStatsTable, as: blocked }
+      - {metric: _fgAvVirusDetected, table: fgAvStatsTable, as: detected}
+      - {metric: _fgAvVirusBlocked, table: fgAvStatsTable, as: blocked}
     chart_meta:
       description: Antivirus virus events detected and blocked
       family: 'Security/Antivirus/Events'
@@ -133,11 +133,11 @@ virtual_metrics:
     per_row: true
     group_by: ["vdom_index"]
     sources:
-      - { metric: _fgAvHTTPVirusDetected, table: fgAvStatsTable, as: http }
-      - { metric: _fgAvSMTPVirusDetected, table: fgAvStatsTable, as: smtp }
-      - { metric: _fgAvPOP3VirusDetected, table: fgAvStatsTable, as: pop3 }
-      - { metric: _fgAvIMAPVirusDetected, table: fgAvStatsTable, as: imap }
-      - { metric: _fgAvFTPVirusDetected, table: fgAvStatsTable, as: ftp }
+      - {metric: _fgAvHTTPVirusDetected, table: fgAvStatsTable, as: http}
+      - {metric: _fgAvSMTPVirusDetected, table: fgAvStatsTable, as: smtp}
+      - {metric: _fgAvPOP3VirusDetected, table: fgAvStatsTable, as: pop3}
+      - {metric: _fgAvIMAPVirusDetected, table: fgAvStatsTable, as: imap}
+      - {metric: _fgAvFTPVirusDetected, table: fgAvStatsTable, as: ftp}
     chart_meta:
       description: Antivirus virus detections by protocol
       family: 'Security/Antivirus/Detected/Protocol'
@@ -148,11 +148,11 @@ virtual_metrics:
     per_row: true
     group_by: ["vdom_index"]
     sources:
-      - { metric: _fgAvHTTPVirusBlocked, table: fgAvStatsTable, as: http }
-      - { metric: _fgAvSMTPVirusBlocked, table: fgAvStatsTable, as: smtp }
-      - { metric: _fgAvPOP3VirusBlocked, table: fgAvStatsTable, as: pop3 }
-      - { metric: _fgAvIMAPVirusBlocked, table: fgAvStatsTable, as: imap }
-      - { metric: _fgAvFTPVirusBlocked, table: fgAvStatsTable, as: ftp }
+      - {metric: _fgAvHTTPVirusBlocked, table: fgAvStatsTable, as: http}
+      - {metric: _fgAvSMTPVirusBlocked, table: fgAvStatsTable, as: smtp}
+      - {metric: _fgAvPOP3VirusBlocked, table: fgAvStatsTable, as: pop3}
+      - {metric: _fgAvIMAPVirusBlocked, table: fgAvStatsTable, as: imap}
+      - {metric: _fgAvFTPVirusBlocked, table: fgAvStatsTable, as: ftp}
     chart_meta:
       description: Antivirus virus blocks by protocol
       family: 'Security/Antivirus/Blocked/Protocol'
@@ -164,8 +164,8 @@ virtual_metrics:
     per_row: true
     group_by: ["vdom_index"]
     sources:
-      - { metric: _fgWfHTTPBlocked, table: fgWebfilterStatsTable, as: http }
-      - { metric: _fgWfHTTPSBlocked, table: fgWebfilterStatsTable, as: https }
+      - {metric: _fgWfHTTPBlocked, table: fgWebfilterStatsTable, as: http}
+      - {metric: _fgWfHTTPSBlocked, table: fgWebfilterStatsTable, as: https}
     chart_meta:
       description: Web filter sessions blocked by protocol
       family: 'Security/Webfilter/Session/Blocked'
@@ -175,8 +175,8 @@ virtual_metrics:
     per_row: true
     group_by: ["vdom_index"]
     sources:
-      - { metric: _fgWfHTTPURLBlocked, table: fgWebfilterStatsTable, as: http }
-      - { metric: _fgWfHTTPSURLBlocked, table: fgWebfilterStatsTable, as: https }
+      - {metric: _fgWfHTTPURLBlocked, table: fgWebfilterStatsTable, as: http}
+      - {metric: _fgWfHTTPSURLBlocked, table: fgWebfilterStatsTable, as: https}
     chart_meta:
       description: Web filter URLs blocked by protocol
       family: 'Security/Webfilter/URL/Blocked'
@@ -186,9 +186,9 @@ virtual_metrics:
     per_row: true
     group_by: ["vdom_index"]
     sources:
-      - { metric: _fgWfActiveXBlocked, table: fgWebfilterStatsTable, as: activex }
-      - { metric: _fgWfCookieBlocked, table: fgWebfilterStatsTable, as: cookie }
-      - { metric: _fgWfAppletBlocked, table: fgWebfilterStatsTable, as: applet }
+      - {metric: _fgWfActiveXBlocked, table: fgWebfilterStatsTable, as: activex}
+      - {metric: _fgWfCookieBlocked, table: fgWebfilterStatsTable, as: cookie}
+      - {metric: _fgWfAppletBlocked, table: fgWebfilterStatsTable, as: applet}
     chart_meta:
       description: Web filter content blocks by type
       family: 'Security/Webfilter/Content/Blocked'

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-wireless.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_fortinet-fortigate-wireless.yaml
@@ -1,0 +1,128 @@
+# Wireless controller and access point monitoring for Fortinet FortiGate devices
+# fgWcInfo scalars: controller summary (AP count, station count, capacity)
+# fgWcWtpSessionTable: per-AP connection state, uptime, CPU, memory, stations, traffic
+
+metrics:
+  ### Wireless controller summary scalars
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.12356.101.14.2.4.0
+      name: fgWcInfoWtpManaged
+      chart_meta:
+        description: Number of wireless access points managed by this controller
+        family: 'Network/Wireless/Controller/AccessPoints/Managed'
+        unit: "{ap}"
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.12356.101.14.2.3.0
+      name: fgWcInfoWtpCapacity
+      chart_meta:
+        description: Maximum number of wireless access points this controller can manage
+        family: 'Network/Wireless/Controller/AccessPoints/Capacity'
+        unit: "{ap}"
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.12356.101.14.2.5.0
+      name: fgWcInfoWtpSessions
+      chart_meta:
+        description: Number of wireless access points currently connecting to this controller
+        family: 'Network/Wireless/Controller/AccessPoints/Connecting'
+        unit: "{ap}"
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.12356.101.14.2.7.0
+      name: fgWcInfoStationCount
+      chart_meta:
+        description: Number of wireless client stations currently connected
+        family: 'Network/Wireless/Controller/Stations/Active'
+        unit: "{station}"
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.12356.101.14.2.6.0
+      name: fgWcInfoStationCapacity
+      chart_meta:
+        description: Maximum number of wireless client stations supported
+        family: 'Network/Wireless/Controller/Stations/Capacity'
+        unit: "{station}"
+
+  ### Per-AP session table
+  - MIB: FORTINET-FORTIGATE-MIB
+    table:
+      OID: 1.3.6.1.4.1.12356.101.14.4.4
+      name: fgWcWtpSessionTable
+    symbols:
+      - OID: 1.3.6.1.4.1.12356.101.14.4.4.1.7
+        name: fgWcWtpSessionConnectionState
+        chart_meta:
+          description: Wireless access point connection state to controller
+          family: 'Network/Wireless/AccessPoint/Status/Connection'
+          unit: "{status}"
+        mapping:
+          0: other
+          1: offLine
+          2: onLine
+          3: downloadingImage
+          4: connectedImage
+          5: other2
+      - OID: 1.3.6.1.4.1.12356.101.14.4.4.1.8
+        name: fgWcWtpSessionWtpUpTime
+        scale_factor: 0.01
+        chart_meta:
+          description: Time since the wireless access point last booted
+          family: 'Network/Wireless/AccessPoint/Uptime'
+          unit: "s"
+      - OID: 1.3.6.1.4.1.12356.101.14.4.4.1.17
+        name: fgWcWtpSessionWtpStationCount
+        chart_meta:
+          description: Number of client stations currently connected to this access point
+          family: 'Network/Wireless/AccessPoint/Clients/Active'
+          unit: "{station}"
+      - OID: 1.3.6.1.4.1.12356.101.14.4.4.1.18
+        name: fgWcWtpSessionWtpByteRxCount
+        scale_factor: 8
+        chart_meta:
+          description: Traffic received by this wireless access point
+          family: 'Network/Wireless/AccessPoint/Traffic/In'
+          unit: "bit/s"
+      - OID: 1.3.6.1.4.1.12356.101.14.4.4.1.19
+        name: fgWcWtpSessionWtpByteTxCount
+        scale_factor: 8
+        chart_meta:
+          description: Traffic transmitted by this wireless access point
+          family: 'Network/Wireless/AccessPoint/Traffic/Out'
+          unit: "bit/s"
+      - OID: 1.3.6.1.4.1.12356.101.14.4.4.1.20
+        name: fgWcWtpSessionWtpCpuUsage
+        chart_meta:
+          description: Current CPU usage of the wireless access point
+          family: 'Network/Wireless/AccessPoint/CPU/Usage'
+          unit: "%"
+      - OID: 1.3.6.1.4.1.12356.101.14.4.4.1.21
+        name: fgWcWtpSessionWtpMemoryUsage
+        chart_meta:
+          description: Current memory usage of the wireless access point
+          family: 'Network/Wireless/AccessPoint/Memory/Usage'
+          unit: "%"
+      - OID: 1.3.6.1.4.1.12356.101.14.4.4.1.22
+        name: fgWcWtpSessionWtpMemoryCapacity
+        scale_factor: 1024
+        chart_meta:
+          description: Total physical memory installed on the wireless access point
+          family: 'Network/Wireless/AccessPoint/Memory/Total'
+          unit: "By"
+    metric_tags:
+      - tag: wtp_id
+        index: 1
+      - tag: _wtp_model
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.14.4.4.1.12
+          name: fgWcWtpSessionWtpModelNumber
+      - tag: _wtp_profile
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.14.4.4.1.11
+          name: fgWcWtpSessionWtpProfileName
+      - tag: _wtp_ip
+        symbol:
+          OID: 1.3.6.1.4.1.12356.101.14.4.4.1.3
+          name: fgWcWtpSessionWtpIpAddress
+          format: ip_address

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/fortinet-fortigate.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/fortinet-fortigate.yaml
@@ -135,20 +135,9 @@ metrics:
           description: Processor CPU usage averaged over last minute
           family: 'System/Processor/Usage/Total'
           unit: "%"
-      # The processor's CPU system space usage, which is an average calculated over the last minute.
-      - OID: 1.3.6.1.4.1.12356.101.4.4.2.1.10
-        name: fgProcessorSysUsage
-        chart_meta:
-          description: Processor CPU system space usage averaged over last minute
-          family: 'System/Processor/Usage/System'
-          unit: "%"
-      # The processor's CPU user space usage, which is an average calculated over the last minute.
-      - OID: 1.3.6.1.4.1.12356.101.4.4.2.1.9
-        name: fgProcessorUserUsage
-        chart_meta:
-          description: Processor CPU user space usage averaged over last minute
-          family: 'System/Processor/Usage/User'
-          unit: "%"
+      # Hidden inputs for combined processor usage breakdown chart
+      - { OID: 1.3.6.1.4.1.12356.101.4.4.2.1.10, name: _fgProcessorSysUsage }
+      - { OID: 1.3.6.1.4.1.12356.101.4.4.2.1.9, name: _fgProcessorUserUsage }
       # The processor's CPU usage (percentage), which is a 5-second average.
       - OID: 1.3.6.1.4.1.12356.101.4.4.2.1.3
         name: fgProcessorUsage5sec
@@ -320,15 +309,11 @@ metrics:
         description: Number of active sessions on the device
         family: 'Security/Session/Active/Count'
         unit: "{session}"
+  # Session rate scalars — hidden inputs for combined trend chart
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
-      # The average session setup rate over the past minute.
       OID: 1.3.6.1.4.1.12356.101.4.1.11.0
-      name: fgSysSesRate1
-      chart_meta:
-        description: Average session setup rate over the past minute
-        family: 'Security/Session/Rate/Average'
-        unit: "{session}/s"
+      name: _fgSysSesRate1
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       # Number of active ipv6 sessions on the device.
@@ -340,62 +325,32 @@ metrics:
         unit: "{session}"
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
-      # The average ipv6 session setup rate over the past minute.
       OID: 1.3.6.1.4.1.12356.101.4.1.16.0
-      name: fgSysSes6Rate1
-      chart_meta:
-        description: Average IPv6 session setup rate over the past minute
-        family: 'Security/Session/IPv6/Rate/Average'
-        unit: "{session}/s"
-  # Session rate trend scalars (10/30/60 minute averages)
+      name: _fgSysSes6Rate1
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.12.0
-      name: fgSysSesRate10
-      chart_meta:
-        description: Average session setup rate over the past 10 minutes
-        family: 'Security/Session/Rate/10min'
-        unit: "{session}/s"
+      name: _fgSysSesRate10
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.13.0
-      name: fgSysSesRate30
-      chart_meta:
-        description: Average session setup rate over the past 30 minutes
-        family: 'Security/Session/Rate/30min'
-        unit: "{session}/s"
+      name: _fgSysSesRate30
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.14.0
-      name: fgSysSesRate60
-      chart_meta:
-        description: Average session setup rate over the past 60 minutes
-        family: 'Security/Session/Rate/60min'
-        unit: "{session}/s"
+      name: _fgSysSesRate60
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.17.0
-      name: fgSysSes6Rate10
-      chart_meta:
-        description: Average IPv6 session setup rate over the past 10 minutes
-        family: 'Security/Session/IPv6/Rate/10min'
-        unit: "{session}/s"
+      name: _fgSysSes6Rate10
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.18.0
-      name: fgSysSes6Rate30
-      chart_meta:
-        description: Average IPv6 session setup rate over the past 30 minutes
-        family: 'Security/Session/IPv6/Rate/30min'
-        unit: "{session}/s"
+      name: _fgSysSes6Rate30
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.19.0
-      name: fgSysSes6Rate60
-      chart_meta:
-        description: Average IPv6 session setup rate over the past 60 minutes
-        family: 'Security/Session/IPv6/Rate/60min'
-        unit: "{session}/s"
+      name: _fgSysSes6Rate60
 
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
@@ -476,3 +431,40 @@ metrics:
       # Firewall policy6 ID. Only enabled policies are present in this table. Policy IDs are only unique within a virtual domain.
       - tag: policy6_index
         index: 2
+
+virtual_metrics:
+  ### Session rate trend — combined 1/10/30/60 min averages per IP version
+  - name: fgSysSesRateTrend
+    sources:
+      - { metric: _fgSysSesRate1, as: 1m }
+      - { metric: _fgSysSesRate10, as: 10m }
+      - { metric: _fgSysSesRate30, as: 30m }
+      - { metric: _fgSysSesRate60, as: 60m }
+    chart_meta:
+      description: Session setup rate trend (IPv4)
+      family: 'Security/Session/Rate/Trend'
+      unit: "{session}/s"
+
+  - name: fgSysSes6RateTrend
+    sources:
+      - { metric: _fgSysSes6Rate1, as: 1m }
+      - { metric: _fgSysSes6Rate10, as: 10m }
+      - { metric: _fgSysSes6Rate30, as: 30m }
+      - { metric: _fgSysSes6Rate60, as: 60m }
+    chart_meta:
+      description: Session setup rate trend (IPv6)
+      family: 'Security/Session/IPv6/Rate/Trend'
+      unit: "{session}/s"
+
+  ### Processor usage breakdown — user + system combined per processor
+  - name: fgProcessorUsageBreakdown
+    per_row: true
+    group_by: ["processor_index"]
+    sources:
+      - { metric: _fgProcessorUserUsage, table: fgProcessorTable, as: user }
+      - { metric: _fgProcessorSysUsage, table: fgProcessorTable, as: system }
+    chart_meta:
+      description: Processor CPU usage breakdown by user and system space
+      family: 'System/Processor/Usage/Breakdown'
+      unit: "%"
+      type: stacked

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/fortinet-fortigate.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/fortinet-fortigate.yaml
@@ -135,9 +135,20 @@ metrics:
           description: Processor CPU usage averaged over last minute
           family: 'System/Processor/Usage/Total'
           unit: "%"
-      # Hidden inputs for combined processor usage breakdown chart
-      - {OID: 1.3.6.1.4.1.12356.101.4.4.2.1.10, name: _fgProcessorSysUsage}
-      - {OID: 1.3.6.1.4.1.12356.101.4.4.2.1.9, name: _fgProcessorUserUsage}
+      # The processor's CPU system space usage, which is an average calculated over the last minute.
+      - OID: 1.3.6.1.4.1.12356.101.4.4.2.1.10
+        name: fgProcessorSysUsage
+        chart_meta:
+          description: Processor CPU system space usage averaged over last minute
+          family: 'System/Processor/Usage/System'
+          unit: "%"
+      # The processor's CPU user space usage, which is an average calculated over the last minute.
+      - OID: 1.3.6.1.4.1.12356.101.4.4.2.1.9
+        name: fgProcessorUserUsage
+        chart_meta:
+          description: Processor CPU user space usage averaged over last minute
+          family: 'System/Processor/Usage/User'
+          unit: "%"
       # The processor's CPU usage (percentage), which is a 5-second average.
       - OID: 1.3.6.1.4.1.12356.101.4.4.2.1.3
         name: fgProcessorUsage5sec
@@ -309,11 +320,15 @@ metrics:
         description: Number of active sessions on the device
         family: 'Security/Session/Active/Count'
         unit: "{session}"
-  # Session rate scalars — hidden inputs for combined trend chart
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
+      # The average session setup rate over the past minute.
       OID: 1.3.6.1.4.1.12356.101.4.1.11.0
-      name: _fgSysSesRate1
+      name: fgSysSesRate1
+      chart_meta:
+        description: Average session setup rate over the past minute
+        family: 'Security/Session/Rate/Average'
+        unit: "{session}/s"
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       # Number of active ipv6 sessions on the device.
@@ -325,32 +340,62 @@ metrics:
         unit: "{session}"
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
+      # The average ipv6 session setup rate over the past minute.
       OID: 1.3.6.1.4.1.12356.101.4.1.16.0
-      name: _fgSysSes6Rate1
+      name: fgSysSes6Rate1
+      chart_meta:
+        description: Average IPv6 session setup rate over the past minute
+        family: 'Security/Session/IPv6/Rate/Average'
+        unit: "{session}/s"
+  # Session rate trend scalars (10/30/60 minute averages)
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.12.0
-      name: _fgSysSesRate10
+      name: fgSysSesRate10
+      chart_meta:
+        description: Average session setup rate over the past 10 minutes
+        family: 'Security/Session/Rate/10min'
+        unit: "{session}/s"
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.13.0
-      name: _fgSysSesRate30
+      name: fgSysSesRate30
+      chart_meta:
+        description: Average session setup rate over the past 30 minutes
+        family: 'Security/Session/Rate/30min'
+        unit: "{session}/s"
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.14.0
-      name: _fgSysSesRate60
+      name: fgSysSesRate60
+      chart_meta:
+        description: Average session setup rate over the past 60 minutes
+        family: 'Security/Session/Rate/60min'
+        unit: "{session}/s"
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.17.0
-      name: _fgSysSes6Rate10
+      name: fgSysSes6Rate10
+      chart_meta:
+        description: Average IPv6 session setup rate over the past 10 minutes
+        family: 'Security/Session/IPv6/Rate/10min'
+        unit: "{session}/s"
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.18.0
-      name: _fgSysSes6Rate30
+      name: fgSysSes6Rate30
+      chart_meta:
+        description: Average IPv6 session setup rate over the past 30 minutes
+        family: 'Security/Session/IPv6/Rate/30min'
+        unit: "{session}/s"
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.19.0
-      name: _fgSysSes6Rate60
+      name: fgSysSes6Rate60
+      chart_meta:
+        description: Average IPv6 session setup rate over the past 60 minutes
+        family: 'Security/Session/IPv6/Rate/60min'
+        unit: "{session}/s"
 
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
@@ -436,10 +481,10 @@ virtual_metrics:
   ### Session rate trend — combined 1/10/30/60 min averages per IP version
   - name: fgSysSesRateTrend
     sources:
-      - {metric: _fgSysSesRate1, as: 1m}
-      - {metric: _fgSysSesRate10, as: 10m}
-      - {metric: _fgSysSesRate30, as: 30m}
-      - {metric: _fgSysSesRate60, as: 60m}
+      - {metric: fgSysSesRate1, as: 1m}
+      - {metric: fgSysSesRate10, as: 10m}
+      - {metric: fgSysSesRate30, as: 30m}
+      - {metric: fgSysSesRate60, as: 60m}
     chart_meta:
       description: Session setup rate trend (IPv4)
       family: 'Security/Session/Rate/Trend'
@@ -447,10 +492,10 @@ virtual_metrics:
 
   - name: fgSysSes6RateTrend
     sources:
-      - {metric: _fgSysSes6Rate1, as: 1m}
-      - {metric: _fgSysSes6Rate10, as: 10m}
-      - {metric: _fgSysSes6Rate30, as: 30m}
-      - {metric: _fgSysSes6Rate60, as: 60m}
+      - {metric: fgSysSes6Rate1, as: 1m}
+      - {metric: fgSysSes6Rate10, as: 10m}
+      - {metric: fgSysSes6Rate30, as: 30m}
+      - {metric: fgSysSes6Rate60, as: 60m}
     chart_meta:
       description: Session setup rate trend (IPv6)
       family: 'Security/Session/IPv6/Rate/Trend'
@@ -461,8 +506,8 @@ virtual_metrics:
     per_row: true
     group_by: ["processor_index"]
     sources:
-      - {metric: _fgProcessorUserUsage, table: fgProcessorTable, as: user}
-      - {metric: _fgProcessorSysUsage, table: fgProcessorTable, as: system}
+      - {metric: fgProcessorUserUsage, table: fgProcessorTable, as: user}
+      - {metric: fgProcessorSysUsage, table: fgProcessorTable, as: system}
     chart_meta:
       description: Processor CPU usage breakdown by user and system space
       family: 'System/Processor/Usage/Breakdown'

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/fortinet-fortigate.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/fortinet-fortigate.yaml
@@ -6,6 +6,11 @@ extends:
   - _system-base.yaml
   - _std-if-mib.yaml
   - _fortinet-fortigate-vpn-tunnel.yaml
+  - _fortinet-fortigate-hardware.yaml
+  - _fortinet-fortigate-ha.yaml
+  - _fortinet-fortigate-sdwan.yaml
+  - _fortinet-fortigate-security.yaml
+  - _fortinet-fortigate-wireless.yaml
 
 # All fortinet devices have sysObjectID starting with `1.3.6.1.4.1.12356.101.1` (fgModel)
 # We only target Fortinet Fortigate devices (1.3.6.1.4.1.12356.101/fnFortiGateMib)
@@ -136,6 +141,20 @@ metrics:
         chart_meta:
           description: Processor CPU system space usage averaged over last minute
           family: 'System/Processor/Usage/System'
+          unit: "%"
+      # The processor's CPU user space usage, which is an average calculated over the last minute.
+      - OID: 1.3.6.1.4.1.12356.101.4.4.2.1.9
+        name: fgProcessorUserUsage
+        chart_meta:
+          description: Processor CPU user space usage averaged over last minute
+          family: 'System/Processor/Usage/User'
+          unit: "%"
+      # The processor's CPU usage (percentage), which is a 5-second average.
+      - OID: 1.3.6.1.4.1.12356.101.4.4.2.1.3
+        name: fgProcessorUsage5sec
+        chart_meta:
+          description: Processor CPU usage 5-second average
+          family: 'System/Processor/Usage/5sec'
           unit: "%"
     metric_tags:
       # A unique identifier within the fgProcessorTable.
@@ -328,6 +347,56 @@ metrics:
         description: Average IPv6 session setup rate over the past minute
         family: 'Security/Session/IPv6/Rate/Average'
         unit: "{session}/s"
+  # Session rate trend scalars (10/30/60 minute averages)
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.12356.101.4.1.12.0
+      name: fgSysSesRate10
+      chart_meta:
+        description: Average session setup rate over the past 10 minutes
+        family: 'Security/Session/Rate/10min'
+        unit: "{session}/s"
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.12356.101.4.1.13.0
+      name: fgSysSesRate30
+      chart_meta:
+        description: Average session setup rate over the past 30 minutes
+        family: 'Security/Session/Rate/30min'
+        unit: "{session}/s"
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.12356.101.4.1.14.0
+      name: fgSysSesRate60
+      chart_meta:
+        description: Average session setup rate over the past 60 minutes
+        family: 'Security/Session/Rate/60min'
+        unit: "{session}/s"
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.12356.101.4.1.17.0
+      name: fgSysSes6Rate10
+      chart_meta:
+        description: Average IPv6 session setup rate over the past 10 minutes
+        family: 'Security/Session/IPv6/Rate/10min'
+        unit: "{session}/s"
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.12356.101.4.1.18.0
+      name: fgSysSes6Rate30
+      chart_meta:
+        description: Average IPv6 session setup rate over the past 30 minutes
+        family: 'Security/Session/IPv6/Rate/30min'
+        unit: "{session}/s"
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.12356.101.4.1.19.0
+      name: fgSysSes6Rate60
+      chart_meta:
+        description: Average IPv6 session setup rate over the past 60 minutes
+        family: 'Security/Session/IPv6/Rate/60min'
+        unit: "{session}/s"
+
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       # HTTP proxy current connections.
@@ -346,6 +415,10 @@ metrics:
         description: Maximum number of connections supported by HTTP proxy
         family: 'Security/Proxy/HTTP/Connection/Maximum'
         unit: "{connection}"
+
+  # NOTE: interface-to-VDOM binding (fgIntfEntVdom from fgIntfTable) is deferred.
+  # Requires engine support for adding tags to inherited table metrics.
+  # Per-VDOM monitoring is available via fgVdTable (session/CPU/memory per VDOM).
 
   ### Firewall
   # Firewall policy statistics table.

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/fortinet-fortigate.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/fortinet-fortigate.yaml
@@ -136,8 +136,8 @@ metrics:
           family: 'System/Processor/Usage/Total'
           unit: "%"
       # Hidden inputs for combined processor usage breakdown chart
-      - { OID: 1.3.6.1.4.1.12356.101.4.4.2.1.10, name: _fgProcessorSysUsage }
-      - { OID: 1.3.6.1.4.1.12356.101.4.4.2.1.9, name: _fgProcessorUserUsage }
+      - {OID: 1.3.6.1.4.1.12356.101.4.4.2.1.10, name: _fgProcessorSysUsage}
+      - {OID: 1.3.6.1.4.1.12356.101.4.4.2.1.9, name: _fgProcessorUserUsage}
       # The processor's CPU usage (percentage), which is a 5-second average.
       - OID: 1.3.6.1.4.1.12356.101.4.4.2.1.3
         name: fgProcessorUsage5sec
@@ -436,10 +436,10 @@ virtual_metrics:
   ### Session rate trend — combined 1/10/30/60 min averages per IP version
   - name: fgSysSesRateTrend
     sources:
-      - { metric: _fgSysSesRate1, as: 1m }
-      - { metric: _fgSysSesRate10, as: 10m }
-      - { metric: _fgSysSesRate30, as: 30m }
-      - { metric: _fgSysSesRate60, as: 60m }
+      - {metric: _fgSysSesRate1, as: 1m}
+      - {metric: _fgSysSesRate10, as: 10m}
+      - {metric: _fgSysSesRate30, as: 30m}
+      - {metric: _fgSysSesRate60, as: 60m}
     chart_meta:
       description: Session setup rate trend (IPv4)
       family: 'Security/Session/Rate/Trend'
@@ -447,10 +447,10 @@ virtual_metrics:
 
   - name: fgSysSes6RateTrend
     sources:
-      - { metric: _fgSysSes6Rate1, as: 1m }
-      - { metric: _fgSysSes6Rate10, as: 10m }
-      - { metric: _fgSysSes6Rate30, as: 30m }
-      - { metric: _fgSysSes6Rate60, as: 60m }
+      - {metric: _fgSysSes6Rate1, as: 1m}
+      - {metric: _fgSysSes6Rate10, as: 10m}
+      - {metric: _fgSysSes6Rate30, as: 30m}
+      - {metric: _fgSysSes6Rate60, as: 60m}
     chart_meta:
       description: Session setup rate trend (IPv6)
       family: 'Security/Session/IPv6/Rate/Trend'
@@ -461,8 +461,8 @@ virtual_metrics:
     per_row: true
     group_by: ["processor_index"]
     sources:
-      - { metric: _fgProcessorUserUsage, table: fgProcessorTable, as: user }
-      - { metric: _fgProcessorSysUsage, table: fgProcessorTable, as: system }
+      - {metric: _fgProcessorUserUsage, table: fgProcessorTable, as: user}
+      - {metric: _fgProcessorSysUsage, table: fgProcessorTable, as: system}
     chart_meta:
       description: Processor CPU usage breakdown by user and system space
       family: 'System/Processor/Usage/Breakdown'

--- a/src/health/health.d/snmp_fortigate.conf
+++ b/src/health/health.d/snmp_fortigate.conf
@@ -1,0 +1,156 @@
+# Health alerts for Fortinet FortiGate SNMP-monitored devices
+
+# Hardware sensor alarm
+ template: fortigate_hw_sensor_alarm
+       on: snmp_device.fgHwSensorEntAlarmStatus
+    class: Errors
+     type: System
+component: Hardware
+   lookup: average -1m unaligned percentage of ok
+    units: %
+    every: 10s
+     warn: $this < 100
+    delay: down 5m multiplier 1.5 max 1h
+  summary: FortiGate sensor ${label:_sensor_name} alarm
+     info: Hardware sensor ${label:_sensor_name} on FortiGate device has triggered an alarm
+       to: sysadmin
+
+# HA node sync status
+ template: fortigate_ha_node_out_of_sync
+       on: snmp_device.fgHaStatsSyncStatus
+    class: Errors
+     type: System
+component: HA
+   lookup: average -1m unaligned percentage of in_sync
+    units: %
+    every: 10s
+     warn: $this < 100
+    delay: down 2m multiplier 1.5 max 1h
+  summary: FortiGate HA node ${label:_ha_node_hostname} sync
+     info: FortiGate HA cluster member ${label:_ha_node_hostname} (${label:_ha_node_serial}) is out of sync
+       to: sysadmin
+
+# HA node CPU usage
+ template: fortigate_ha_node_cpu_high
+       on: snmp_device.fgHaStatsCpuUsage
+    class: Utilization
+     type: System
+component: HA
+   lookup: average -5m unaligned
+    units: %
+    every: 1m
+     warn: $this > 75
+     crit: $this > 90
+    delay: down 5m multiplier 1.5 max 1h
+  summary: FortiGate HA node ${label:_ha_node_hostname} CPU
+     info: CPU utilization on FortiGate HA cluster member ${label:_ha_node_hostname} is high
+       to: sysadmin
+
+# HA node memory usage
+ template: fortigate_ha_node_memory_high
+       on: snmp_device.fgHaStatsMemUsage
+    class: Utilization
+     type: System
+component: HA
+   lookup: average -5m unaligned
+    units: %
+    every: 1m
+     warn: $this > 80
+     crit: $this > 95
+    delay: down 5m multiplier 1.5 max 1h
+  summary: FortiGate HA node ${label:_ha_node_hostname} memory
+     info: Memory utilization on FortiGate HA cluster member ${label:_ha_node_hostname} is high
+       to: sysadmin
+
+# SD-WAN link dead
+ template: fortigate_sdwan_link_dead
+       on: snmp_device.fgVWLHealthCheckLinkState
+    class: Errors
+     type: System
+component: Network
+   lookup: average -1m unaligned percentage of alive
+    units: %
+    every: 10s
+     crit: $this < 100
+    delay: down 1m multiplier 1.5 max 1h
+  summary: FortiGate SD-WAN ${label:sdwan_healthcheck} link down
+     info: SD-WAN health-check ${label:sdwan_healthcheck} on interface ${label:_sdwan_interface} reports link is dead
+       to: sysadmin
+
+# SD-WAN link high latency
+ template: fortigate_sdwan_link_latency_high
+       on: snmp_device.fgVWLHealthCheckLinkLatency
+    class: Latency
+     type: System
+component: Network
+   lookup: average -5m unaligned
+    units: ms
+    every: 1m
+     warn: $this > 300
+     crit: $this > 500
+    delay: down 5m multiplier 1.5 max 1h
+  summary: FortiGate SD-WAN ${label:sdwan_healthcheck} latency
+     info: SD-WAN health-check ${label:sdwan_healthcheck} on interface ${label:_sdwan_interface} has high latency
+       to: sysadmin
+
+# SD-WAN link packet loss
+ template: fortigate_sdwan_link_packet_loss
+       on: snmp_device.fgVWLHealthCheckLinkPacketLoss
+    class: Errors
+     type: System
+component: Network
+   lookup: average -5m unaligned
+    units: %
+    every: 1m
+     warn: $this > 1
+     crit: $this > 5
+    delay: down 5m multiplier 1.5 max 1h
+  summary: FortiGate SD-WAN ${label:sdwan_healthcheck} packet loss
+     info: SD-WAN health-check ${label:sdwan_healthcheck} on interface ${label:_sdwan_interface} has high packet loss
+       to: sysadmin
+
+# IPS critical severity events
+ template: fortigate_ips_critical_events
+       on: snmp_device.fgIpsCritSevDetections
+    class: Errors
+     type: System
+component: Intrusion Prevention
+   lookup: average -5m unaligned
+    units: events/s
+    every: 1m
+     warn: $this > 0
+     crit: $this > 10
+    delay: down 5m multiplier 1.5 max 1h
+  summary: FortiGate IPS critical events (VDOM ${label:_vdom_name})
+     info: Critical severity intrusions detected on FortiGate VDOM ${label:_vdom_name}
+       to: sysadmin
+
+# Link monitor dead
+ template: fortigate_link_monitor_dead
+       on: snmp_device.fgLinkMonitorState
+    class: Errors
+     type: System
+component: Network
+   lookup: average -1m unaligned percentage of alive
+    units: %
+    every: 10s
+     crit: $this < 100
+    delay: down 1m multiplier 1.5 max 1h
+  summary: FortiGate link monitor ${label:link_monitor} down
+     info: Link monitor ${label:link_monitor} reports gateway probe is dead
+       to: sysadmin
+
+# Wireless AP offline
+ template: fortigate_wireless_ap_offline
+       on: snmp_device.fgWcWtpSessionConnectionState
+    class: Errors
+     type: System
+component: Wireless
+   lookup: average -1m unaligned percentage of onLine
+    units: %
+    every: 10s
+     warn: $this < 100
+    delay: down 5m multiplier 1.5 max 1h
+  summary: FortiGate wireless AP ${label:wtp_id} connection
+     info: Wireless access point ${label:wtp_id} (model ${label:_wtp_model}) is not online
+       to: sysadmin

--- a/src/health/health.d/snmp_fortigate.conf
+++ b/src/health/health.d/snmp_fortigate.conf
@@ -116,7 +116,7 @@ component: Network
      type: System
 component: Intrusion Prevention
    lookup: average -5m unaligned of critical
-    units: events/s
+    units: {event}/s
     every: 1m
      warn: $this > 0
      crit: $this > 10

--- a/src/health/health.d/snmp_fortigate.conf
+++ b/src/health/health.d/snmp_fortigate.conf
@@ -111,11 +111,11 @@ component: Network
 
 # IPS critical severity events
  template: fortigate_ips_critical_events
-       on: snmp_device.fgIpsCritSevDetections
+       on: snmp_device.fgIpsSeverity
     class: Errors
      type: System
 component: Intrusion Prevention
-   lookup: average -5m unaligned
+   lookup: average -5m unaligned of critical
     units: events/s
     every: 1m
      warn: $this > 0

--- a/src/health/health.d/snmp_fortigate.conf
+++ b/src/health/health.d/snmp_fortigate.conf
@@ -2,7 +2,7 @@
 
 # Hardware sensor alarm
  template: fortigate_hw_sensor_alarm
-       on: snmp_device.fgHwSensorEntAlarmStatus
+       on: snmp.device_prof_fgHwSensorEntAlarmStatus
     class: Errors
      type: System
 component: Hardware
@@ -11,13 +11,13 @@ component: Hardware
     every: 10s
      warn: $this < 100
     delay: down 5m multiplier 1.5 max 1h
-  summary: FortiGate sensor ${label:_sensor_name} alarm
-     info: Hardware sensor ${label:_sensor_name} on FortiGate device has triggered an alarm
+  summary: FortiGate sensor ${label:sensor_name} alarm
+     info: Hardware sensor ${label:sensor_name} on FortiGate device has triggered an alarm
        to: sysadmin
 
 # HA node sync status
  template: fortigate_ha_node_out_of_sync
-       on: snmp_device.fgHaStatsSyncStatus
+       on: snmp.device_prof_fgHaStatsSyncStatus
     class: Errors
      type: System
 component: HA
@@ -26,13 +26,13 @@ component: HA
     every: 10s
      warn: $this < 100
     delay: down 2m multiplier 1.5 max 1h
-  summary: FortiGate HA node ${label:_ha_node_hostname} sync
-     info: FortiGate HA cluster member ${label:_ha_node_hostname} (${label:_ha_node_serial}) is out of sync
+  summary: FortiGate HA node ${label:ha_node_hostname} sync
+     info: FortiGate HA cluster member ${label:ha_node_hostname} (${label:ha_node_serial}) is out of sync
        to: sysadmin
 
 # HA node CPU usage
  template: fortigate_ha_node_cpu_high
-       on: snmp_device.fgHaStatsCpuUsage
+       on: snmp.device_prof_fgHaStatsCpuUsage
     class: Utilization
      type: System
 component: HA
@@ -42,13 +42,13 @@ component: HA
      warn: $this > 75
      crit: $this > 90
     delay: down 5m multiplier 1.5 max 1h
-  summary: FortiGate HA node ${label:_ha_node_hostname} CPU
-     info: CPU utilization on FortiGate HA cluster member ${label:_ha_node_hostname} is high
+  summary: FortiGate HA node ${label:ha_node_hostname} CPU
+     info: CPU utilization on FortiGate HA cluster member ${label:ha_node_hostname} is high
        to: sysadmin
 
 # HA node memory usage
  template: fortigate_ha_node_memory_high
-       on: snmp_device.fgHaStatsMemUsage
+       on: snmp.device_prof_fgHaStatsMemUsage
     class: Utilization
      type: System
 component: HA
@@ -58,13 +58,13 @@ component: HA
      warn: $this > 80
      crit: $this > 95
     delay: down 5m multiplier 1.5 max 1h
-  summary: FortiGate HA node ${label:_ha_node_hostname} memory
-     info: Memory utilization on FortiGate HA cluster member ${label:_ha_node_hostname} is high
+  summary: FortiGate HA node ${label:ha_node_hostname} memory
+     info: Memory utilization on FortiGate HA cluster member ${label:ha_node_hostname} is high
        to: sysadmin
 
 # SD-WAN link dead
  template: fortigate_sdwan_link_dead
-       on: snmp_device.fgVWLHealthCheckLinkState
+       on: snmp.device_prof_fgVWLHealthCheckLinkState
     class: Errors
      type: System
 component: Network
@@ -74,12 +74,12 @@ component: Network
      crit: $this < 100
     delay: down 1m multiplier 1.5 max 1h
   summary: FortiGate SD-WAN ${label:sdwan_healthcheck} link down
-     info: SD-WAN health-check ${label:sdwan_healthcheck} on interface ${label:_sdwan_interface} reports link is dead
+     info: SD-WAN health-check ${label:sdwan_healthcheck} on interface ${label:sdwan_interface} reports link is dead
        to: sysadmin
 
 # SD-WAN link high latency
  template: fortigate_sdwan_link_latency_high
-       on: snmp_device.fgVWLHealthCheckLinkLatency
+       on: snmp.device_prof_fgVWLHealthCheckLinkLatency
     class: Latency
      type: System
 component: Network
@@ -90,12 +90,12 @@ component: Network
      crit: $this > 500
     delay: down 5m multiplier 1.5 max 1h
   summary: FortiGate SD-WAN ${label:sdwan_healthcheck} latency
-     info: SD-WAN health-check ${label:sdwan_healthcheck} on interface ${label:_sdwan_interface} has high latency
+     info: SD-WAN health-check ${label:sdwan_healthcheck} on interface ${label:sdwan_interface} has high latency
        to: sysadmin
 
 # SD-WAN link packet loss
  template: fortigate_sdwan_link_packet_loss
-       on: snmp_device.fgVWLHealthCheckLinkPacketLoss
+       on: snmp.device_prof_fgVWLHealthCheckLinkPacketLoss
     class: Errors
      type: System
 component: Network
@@ -106,12 +106,12 @@ component: Network
      crit: $this > 5
     delay: down 5m multiplier 1.5 max 1h
   summary: FortiGate SD-WAN ${label:sdwan_healthcheck} packet loss
-     info: SD-WAN health-check ${label:sdwan_healthcheck} on interface ${label:_sdwan_interface} has high packet loss
+     info: SD-WAN health-check ${label:sdwan_healthcheck} on interface ${label:sdwan_interface} has high packet loss
        to: sysadmin
 
 # IPS critical severity events
  template: fortigate_ips_critical_events
-       on: snmp_device.fgIpsSeverity
+       on: snmp.device_prof_fgIpsSeverity
     class: Errors
      type: System
 component: Intrusion Prevention
@@ -121,13 +121,13 @@ component: Intrusion Prevention
      warn: $this > 0
      crit: $this > 10
     delay: down 5m multiplier 1.5 max 1h
-  summary: FortiGate IPS critical events (VDOM ${label:_vdom_name})
-     info: Critical severity intrusions detected on FortiGate VDOM ${label:_vdom_name}
+  summary: FortiGate IPS critical events (VDOM ${label:vdom_name})
+     info: Critical severity intrusions detected on FortiGate VDOM ${label:vdom_name}
        to: sysadmin
 
 # Link monitor dead
  template: fortigate_link_monitor_dead
-       on: snmp_device.fgLinkMonitorState
+       on: snmp.device_prof_fgLinkMonitorState
     class: Errors
      type: System
 component: Network
@@ -142,7 +142,7 @@ component: Network
 
 # Wireless AP offline
  template: fortigate_wireless_ap_offline
-       on: snmp_device.fgWcWtpSessionConnectionState
+       on: snmp.device_prof_fgWcWtpSessionConnectionState
     class: Errors
      type: System
 component: Wireless
@@ -152,5 +152,5 @@ component: Wireless
      warn: $this < 100
     delay: down 5m multiplier 1.5 max 1h
   summary: FortiGate wireless AP ${label:wtp_id} connection
-     info: Wireless access point ${label:wtp_id} (model ${label:_wtp_model}) is not online
+     info: Wireless access point ${label:wtp_id} (model ${label:wtp_model}) is not online
        to: sysadmin


### PR DESCRIPTION
## Summary

Adds comprehensive Fortinet FortiGate SNMP monitoring coverage to bring Netdata to parity with — and in several areas beyond — Zabbix, CheckMK, LibreNMS, and OpenNMS.

- **Hardware sensors**: temperature, fan speed, voltage, power readings + alarm status (transform-based type splitting)
- **HA cluster**: per-node CPU, memory, bandwidth, sessions, IPS/AV events, sync status
- **SD-WAN**: per-link health-check state, latency, jitter, packet loss
- **IPS/AV/Webfilter**: intrusion detection by severity, antivirus by protocol, web filter blocks — all per VDOM
- **Wireless controller**: AP count/capacity, per-AP connection state, CPU, memory, clients, traffic
- **Link monitor**: gateway probe state, latency, jitter, packet loss
- **Session trends**: 10/30/60 min session rate averages (IPv4 + IPv6)
- **CPU breakdown**: processor user-space and 5-second average usage
- **Health alerts**: 10 alert templates for sensor alarm, HA sync, SD-WAN degradation, IPS critical events, link monitor, AP offline

Security, session rate, and processor metrics use `virtual_metrics` to combine related dimensions into multi-dimension charts (e.g., IPS detected+blocked, severity stacked, session rate trend). Original single-value metrics are preserved for backwards compatibility.

All changes are **profile-only YAML** — zero Go code modifications. Uses only documented profile engine features (`extract_value`, `mapping`, `transform`, cross-table tags, `chart_meta`, `virtual_metrics`).

## What's excluded (handled by other PRs)

- **BGP**: PR #22170
- **License monitoring**: PR #22122
- **Interface-to-VDOM tag binding**: deferred — requires engine support for adding tags to inherited table metrics

## Test plan

- [x] `go build ./plugin/go.d/collector/snmp/...` passes
- [x] `go test ./plugin/go.d/collector/snmp/... -count=1` — all pass (4 packages)
- [x] All YAML files pass `yamllint` validation
- [ ] Real FortiGate device validation (no live device available — validated against LibreNMS snmpsim recordings and MIB definitions)