### PR TITLE
fix(go.d/dyncfg): remove wait-decision timeout and make handoff non-droppable

### DIFF
--- a/src/go/plugin/agent/discovery/sd/dyncfg_handoff.go
+++ b/src/go/plugin/agent/discovery/sd/dyncfg_handoff.go
@@ -8,33 +8,21 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 )
 
-const sdBusyMsg = "Service discovery is busy, try again later."
+const sdShuttingDownMsg = "Service discovery is shutting down."
 
+// enqueueDyncfgFunction blocks until the function is accepted by the run loop
+// or service discovery shuts down. We deliberately do NOT honor a per-function
+// timeout here: dropping an awaited enable/disable would wedge the wait gate
+// (since waitDecisionTimeout was removed). Back-pressure flows upstream to
+// netdata via the OS pipe. See TODO-dyncfg-jobmgr-sync.md.
 func (d *ServiceDiscovery) enqueueDyncfgFunction(fn dyncfg.Function) {
-	handoffCtx, cancel := d.dyncfgHandoffContext(fn)
-	defer cancel()
-
-	switch dyncfg.BoundedSend(handoffCtx, d.dyncfgCh, fn, dyncfg.DefaultDownstreamHandoffCap) {
-	case dyncfg.BoundedSendOK:
-		return
-	case dyncfg.BoundedSendContextDone:
-		if d.ctx != nil && d.ctx.Err() != nil {
-			d.dyncfgApi.SendCodef(fn, 503, "Service discovery is shutting down.")
-			return
-		}
-		d.dyncfgApi.SendCodef(fn, 503, sdBusyMsg)
-	case dyncfg.BoundedSendTimeout:
-		d.dyncfgApi.SendCodef(fn, 503, sdBusyMsg)
-	}
-}
-
-func (d *ServiceDiscovery) dyncfgHandoffContext(fn dyncfg.Function) (context.Context, context.CancelFunc) {
 	ctx := d.ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if timeout := fn.Fn().Timeout; timeout > 0 {
-		return context.WithTimeout(ctx, timeout)
+	select {
+	case d.dyncfgCh <- fn:
+	case <-ctx.Done():
+		d.dyncfgApi.SendCodef(fn, 503, sdShuttingDownMsg)
 	}
-	return ctx, func() {}
 }

--- a/src/go/plugin/agent/discovery/sd/dyncfg_handoff.go
+++ b/src/go/plugin/agent/discovery/sd/dyncfg_handoff.go
@@ -13,8 +13,9 @@ const sdShuttingDownMsg = "Service discovery is shutting down."
 // enqueueDyncfgFunction blocks until the function is accepted by the run loop
 // or service discovery shuts down. We deliberately do NOT honor a per-function
 // timeout here: dropping an awaited enable/disable would wedge the wait gate
-// (since waitDecisionTimeout was removed). Back-pressure flows upstream to
-// netdata via the OS pipe. See TODO-dyncfg-jobmgr-sync.md.
+// (since waitDecisionTimeout was removed) because the caller would keep
+// waiting for a decision that can never be produced. Back-pressure flows
+// upstream to netdata via the OS pipe.
 func (d *ServiceDiscovery) enqueueDyncfgFunction(fn dyncfg.Function) {
 	ctx := d.ctx
 	if ctx == nil {

--- a/src/go/plugin/agent/discovery/sd/sd.go
+++ b/src/go/plugin/agent/discovery/sd/sd.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"sync"
-	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/pipeline"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/policy"
@@ -20,8 +19,6 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/multipath"
 	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 )
-
-const waitDecisionTimeout = 5 * time.Second
 
 type Config struct {
 	ConfigDefaults confgroup.Registry
@@ -76,7 +73,6 @@ func NewServiceDiscovery(cfg Config) (*ServiceDiscovery, error) {
 		WaitKey: func(cfg sdConfig) string {
 			return cfg.PipelineKey()
 		},
-		WaitTimeout: waitDecisionTimeout,
 
 		Path:           fmt.Sprintf(dyncfgSDPath, cfg.PluginName),
 		EnableFailCode: 422,
@@ -183,14 +179,6 @@ func (d *ServiceDiscovery) run(ctx context.Context) {
 			if step.HasCommand {
 				d.dyncfgSeqExec(step.Command)
 				continue
-			}
-			if step.TimedOut {
-				d.Errorf(
-					"dyncfg: timed out waiting for enable/disable decision for '%s' (elapsed=%s threshold=%s); keeping status 'accepted' and continuing",
-					step.Timeout.Key,
-					step.Timeout.Elapsed,
-					step.Timeout.Threshold,
-				)
 			}
 		} else {
 			select {

--- a/src/go/plugin/agent/discovery/sd/wait_decision_test.go
+++ b/src/go/plugin/agent/discovery/sd/wait_decision_test.go
@@ -24,28 +24,9 @@ import (
 
 func TestServiceDiscovery_Run_WaitDecision(t *testing.T) {
 	tests := map[string]struct {
-		waitTimeout time.Duration
-		run         func(t *testing.T, sd *ServiceDiscovery, confCh chan confFile, stop func())
+		run func(t *testing.T, sd *ServiceDiscovery, confCh chan confFile, stop func())
 	}{
-		"timeout clears wait gate and keeps accepted state": {
-			waitTimeout: 40 * time.Millisecond,
-			run: func(t *testing.T, sd *ServiceDiscovery, confCh chan confFile, stop func()) {
-				cfg := prepareConfigFile("/etc/netdata/sd.d/job1.conf", "job1")
-				confCh <- cfg
-
-				require.Eventually(t, sd.handler.WaitingForDecision, time.Second, 10*time.Millisecond)
-				require.Eventually(t, func() bool { return !sd.handler.WaitingForDecision() }, time.Second, 10*time.Millisecond)
-
-				stop()
-
-				entry, ok := sd.exposed.LookupByKey(testDiscovererTypeNetListeners + ":job1")
-				require.True(t, ok, "expected discovered config to stay exposed after wait timeout")
-				assert.Equal(t, dyncfg.StatusAccepted, entry.Status)
-				assert.False(t, sd.mgr.IsRunning(pipelineKeyFromSource(cfg.source)))
-			},
-		},
-		"enable command before timeout clears wait and starts pipeline": {
-			waitTimeout: 750 * time.Millisecond,
+		"enable command clears wait and starts pipeline": {
 			run: func(t *testing.T, sd *ServiceDiscovery, confCh chan confFile, stop func()) {
 				cfg := prepareConfigFile("/etc/netdata/sd.d/job1.conf", "job1")
 				confCh <- cfg
@@ -70,58 +51,11 @@ func TestServiceDiscovery_Run_WaitDecision(t *testing.T) {
 				assert.Equal(t, dyncfg.StatusRunning, entry.Status)
 			},
 		},
-		"timeout unblocks and next config is processed": {
-			waitTimeout: 40 * time.Millisecond,
-			run: func(t *testing.T, sd *ServiceDiscovery, confCh chan confFile, stop func()) {
-				cfg1 := prepareConfigFile("/etc/netdata/sd.d/job1.conf", "job1")
-				cfg2 := prepareConfigFile("/etc/netdata/sd.d/job2.conf", "job2")
-
-				confCh <- cfg1
-				require.Eventually(t, sd.handler.WaitingForDecision, time.Second, 10*time.Millisecond)
-
-				secondSent := make(chan struct{})
-				go func() {
-					confCh <- cfg2
-					close(secondSent)
-				}()
-
-				select {
-				case <-secondSent:
-					t.Fatalf("second config should block while wait gate is active")
-				case <-time.After(20 * time.Millisecond):
-				}
-
-				require.Eventually(t, func() bool { return !sd.handler.WaitingForDecision() }, time.Second, 10*time.Millisecond)
-				require.Eventually(t, func() bool {
-					select {
-					case <-secondSent:
-						return true
-					default:
-						return false
-					}
-				}, time.Second, 10*time.Millisecond)
-
-				require.Eventually(t, func() bool {
-					ok1 := exposedExistsByKey(sd.exposed, testDiscovererTypeNetListeners+":job1")
-					ok2 := exposedExistsByKey(sd.exposed, testDiscovererTypeNetListeners+":job2")
-					return ok1 && ok2
-				}, time.Second, 10*time.Millisecond)
-
-				stop()
-
-				entry1, ok := sd.exposed.LookupByKey(testDiscovererTypeNetListeners + ":job1")
-				require.True(t, ok)
-				assert.Equal(t, dyncfg.StatusAccepted, entry1.Status)
-				entry2, ok := sd.exposed.LookupByKey(testDiscovererTypeNetListeners + ":job2")
-				require.True(t, ok)
-				assert.Equal(t, dyncfg.StatusAccepted, entry2.Status)
-			},
-		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			sd, confCh, cancel, done := newWaitTestServiceDiscovery(t, tc.waitTimeout)
+			sd, confCh, cancel, done := newWaitTestServiceDiscovery(t)
 			stopped := false
 			stop := func() {
 				if stopped {
@@ -136,7 +70,7 @@ func TestServiceDiscovery_Run_WaitDecision(t *testing.T) {
 	}
 }
 
-func newWaitTestServiceDiscovery(t *testing.T, waitTimeout time.Duration) (*ServiceDiscovery, chan confFile, context.CancelFunc, <-chan struct{}) {
+func newWaitTestServiceDiscovery(t *testing.T) (*ServiceDiscovery, chan confFile, context.CancelFunc, <-chan struct{}) {
 	t.Helper()
 
 	var out bytes.Buffer
@@ -166,7 +100,6 @@ func newWaitTestServiceDiscovery(t *testing.T, waitTimeout time.Duration) (*Serv
 		WaitKey: func(cfg sdConfig) string {
 			return cfg.PipelineKey()
 		},
-		WaitTimeout: waitTimeout,
 
 		Path:           fmt.Sprintf(dyncfgSDPath, testPluginName),
 		EnableFailCode: 422,

--- a/src/go/plugin/agent/discovery/sd/wait_decision_test.go
+++ b/src/go/plugin/agent/discovery/sd/wait_decision_test.go
@@ -51,6 +51,55 @@ func TestServiceDiscovery_Run_WaitDecision(t *testing.T) {
 				assert.Equal(t, dyncfg.StatusRunning, entry.Status)
 			},
 		},
+		"second config blocks while wait gate is open and proceeds after decision": {
+			run: func(t *testing.T, sd *ServiceDiscovery, confCh chan confFile, stop func()) {
+				// Without a wait-decision timeout, the run loop must stay in
+				// WaitingForDecision until an explicit enable/disable for cfg1
+				// arrives. Sending cfg2 in the meantime must block until the
+				// gate clears. This guards against accidental gate-clearing or
+				// a regression that lets new configs interleave.
+				cfg1 := prepareConfigFile("/etc/netdata/sd.d/job1.conf", "job1")
+				cfg2 := prepareConfigFile("/etc/netdata/sd.d/job2.conf", "job2")
+
+				confCh <- cfg1
+				require.Eventually(t, sd.handler.WaitingForDecision, time.Second, 10*time.Millisecond)
+
+				secondSent := make(chan struct{})
+				go func() {
+					confCh <- cfg2
+					close(secondSent)
+				}()
+
+				// Give the goroutine a chance to either block (expected) or
+				// race ahead. We can't use require.Eventually for negative
+				// "still blocked" assertions, but a short window is enough to
+				// catch a regression that lets the second config flow through
+				// while the wait gate is still open.
+				select {
+				case <-secondSent:
+					t.Fatal("second config was processed while wait gate was open")
+				case <-time.After(100 * time.Millisecond):
+				}
+				require.True(t, sd.handler.WaitingForDecision(), "wait gate should still be open before decision")
+
+				// Send the matching enable for cfg1 — this clears the wait gate.
+				sd.dyncfgCh <- dyncfg.NewFunction(functions.Function{
+					UID:  "enable-job1",
+					Args: []string{sd.dyncfgJobID(testDiscovererTypeNetListeners, "job1"), "enable"},
+				})
+
+				select {
+				case <-secondSent:
+				case <-time.After(2 * time.Second):
+					t.Fatal("second config did not proceed after wait gate cleared")
+				}
+
+				require.Eventually(t, func() bool {
+					return exposedExistsByKey(sd.exposed, testDiscovererTypeNetListeners+":job1") &&
+						exposedExistsByKey(sd.exposed, testDiscovererTypeNetListeners+":job2")
+				}, time.Second, 10*time.Millisecond)
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
@@ -816,7 +816,6 @@ func newCollectorTestHandler(mgr *Manager, cb dyncfg.Callbacks[confgroup.Config]
 		WaitKey: func(cfg confgroup.Config) string {
 			return cfg.FullName()
 		},
-		WaitTimeout:             waitDecisionTimeout,
 		Path:                    "/collectors/test/Jobs",
 		EnableFailCode:          200,
 		RemoveStockOnEnableFail: true,

--- a/src/go/plugin/agent/jobmgr/dyncfg_handoff.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_handoff.go
@@ -14,7 +14,8 @@ const dyncfgShuttingDownMsg = "Job manager is shutting down."
 // gate (since waitDecisionTimeout was removed). Back-pressure flows upstream:
 // dyncfgCh full -> framework worker blocks here -> scheduler fills ->
 // dispatchInvocation blocks -> stdin reader pauses -> netdata's pipe write
-// blocks. See TODO-dyncfg-jobmgr-sync.md.
+// blocks. This is intentional so awaited state transitions preserve ordering
+// and eventually slow the producer instead of being dropped.
 func (m *Manager) enqueueDyncfgFunction(fn dyncfg.Function) {
 	select {
 	case m.dyncfgCh <- fn:

--- a/src/go/plugin/agent/jobmgr/dyncfg_handoff.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_handoff.go
@@ -3,38 +3,22 @@
 package jobmgr
 
 import (
-	"context"
-
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 )
 
-const (
-	dyncfgBusyMsg         = "Job manager is busy, try again later."
-	dyncfgShuttingDownMsg = "Job manager is shutting down."
-)
+const dyncfgShuttingDownMsg = "Job manager is shutting down."
 
+// enqueueDyncfgFunction blocks until the function is accepted by the run loop
+// or the manager shuts down. We deliberately do NOT honor a per-function
+// timeout here: dropping an awaited enable/disable would wedge jobmgr's wait
+// gate (since waitDecisionTimeout was removed). Back-pressure flows upstream:
+// dyncfgCh full -> framework worker blocks here -> scheduler fills ->
+// dispatchInvocation blocks -> stdin reader pauses -> netdata's pipe write
+// blocks. See TODO-dyncfg-jobmgr-sync.md.
 func (m *Manager) enqueueDyncfgFunction(fn dyncfg.Function) {
-	handoffCtx, cancel := m.dyncfgHandoffContext(fn)
-	defer cancel()
-
-	switch dyncfg.BoundedSend(handoffCtx, m.dyncfgCh, fn, dyncfg.DefaultDownstreamHandoffCap) {
-	case dyncfg.BoundedSendOK:
-		return
-	case dyncfg.BoundedSendContextDone:
-		if m.baseContext().Err() != nil {
-			m.dyncfgResponder.SendCodef(fn, 503, dyncfgShuttingDownMsg)
-			return
-		}
-		m.dyncfgResponder.SendCodef(fn, 503, dyncfgBusyMsg)
-	case dyncfg.BoundedSendTimeout:
-		m.dyncfgResponder.SendCodef(fn, 503, dyncfgBusyMsg)
+	select {
+	case m.dyncfgCh <- fn:
+	case <-m.baseContext().Done():
+		m.dyncfgResponder.SendCodef(fn, 503, dyncfgShuttingDownMsg)
 	}
-}
-
-func (m *Manager) dyncfgHandoffContext(fn dyncfg.Function) (context.Context, context.CancelFunc) {
-	ctx := m.baseContext()
-	if timeout := fn.Fn().Timeout; timeout > 0 {
-		return context.WithTimeout(ctx, timeout)
-	}
-	return ctx, func() {}
 }

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -50,7 +50,6 @@ type Config struct {
 }
 
 const (
-	waitDecisionTimeout    = 5 * time.Second
 	cmdTestWorkerCap       = 4
 	cmdTestDefaultTimeout  = 60 * time.Second
 	cmdTestWorkerDrainWait = 5 * time.Second
@@ -136,7 +135,6 @@ func New(cfg Config) *Manager {
 		WaitKey: func(cfg confgroup.Config) string {
 			return cfg.FullName()
 		},
-		WaitTimeout: waitDecisionTimeout,
 
 		Path:                    fmt.Sprintf(dyncfgCollectorPath, cfg.PluginName),
 		EnableFailCode:          200,
@@ -333,14 +331,6 @@ func (m *Manager) run() {
 			if step.HasCommand {
 				m.dyncfgSeqExec(step.Command)
 				continue
-			}
-			if step.TimedOut {
-				m.Errorf(
-					"dyncfg: timed out waiting for enable/disable decision for '%s' (elapsed=%s threshold=%s); keeping status 'accepted' and continuing",
-					step.Timeout.Key,
-					step.Timeout.Elapsed,
-					step.Timeout.Threshold,
-				)
 			}
 		} else {
 			select {

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
-	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 )
@@ -67,57 +66,6 @@ func TestRunProcessConfGroups_ChannelCloseDoesNotSpin(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestRun_WaitTimeoutClearsGateAndKeepsAccepted(t *testing.T) {
-	mgr := New(Config{PluginName: testPluginName})
-	mgr.modules = prepareMockRegistry()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	mgr.ctx = ctx
-
-	done := make(chan struct{})
-	go func() {
-		mgr.run()
-		close(done)
-	}()
-	defer func() {
-		cancel()
-		select {
-		case <-done:
-		case <-time.After(2 * time.Second):
-			t.Fatal("run did not stop after cancel")
-		}
-	}()
-
-	cfg1 := prepareStockCfg("success", "wait1")
-	cfg2 := prepareStockCfg("success", "wait2")
-
-	mgr.addCh <- cfg1
-	require.Eventually(t, mgr.collectorHandler.WaitingForDecision, time.Second, 10*time.Millisecond)
-
-	secondSent := make(chan struct{})
-	go func() {
-		mgr.addCh <- cfg2
-		close(secondSent)
-	}()
-
-	select {
-	case <-secondSent:
-		t.Fatal("second add was processed before wait timeout")
-	case <-time.After(500 * time.Millisecond):
-	}
-
-	select {
-	case <-secondSent:
-	case <-time.After(7 * time.Second):
-		t.Fatal("second add did not progress after wait timeout")
-	}
-
-	entry1, ok := mgr.collectorExposed.LookupByKey(cfg1.ExposedKey())
-	require.True(t, ok, "first config must stay exposed after timeout")
-	assert.Equal(t, dyncfg.StatusAccepted, entry1.Status)
 }
 
 func TestRunNotifyRunningJobs_TickOutsideLock(t *testing.T) {

--- a/src/go/plugin/framework/functions/README.md
+++ b/src/go/plugin/framework/functions/README.md
@@ -57,7 +57,7 @@ Admission checks:
 - manager stopping -> reject `503`
 - unknown/nil handler -> reject `501`
 - duplicate active/tombstoned UID -> ignore duplicate input (debug/warn log, no terminal output)
-- queue full -> reject `503`
+- queue full -> blocks on `scheduler.enqueue` until space frees (back-pressures stdin reader -> netdata via OS pipe). Only the manager-stopping error is returned here.
 
 ### Keyed scheduler + worker pool
 
@@ -123,7 +123,6 @@ Pathology-focused metrics currently exposed:
     - `netdata.go.plugin.framework.functions.manager.invocations_awaiting_result`
     - `netdata.go.plugin.framework.functions.manager.scheduler_pending`
 - counters:
-    - `netdata.go.plugin.framework.functions.manager.queue_full_total`
     - `netdata.go.plugin.framework.functions.manager.cancel_fallback_total`
     - `netdata.go.plugin.framework.functions.manager.late_terminal_dropped_total`
     - `netdata.go.plugin.framework.functions.manager.duplicate_uid_ignored_total`
@@ -188,8 +187,7 @@ flowchart TD
     C1 -->|stopping| R503["respf 503"]
     C1 -->|unregistered/nil handler| R501["respf 501"]
     C1 -->|duplicate/tombstoned UID| DUP["ignore duplicate + log"]
-    C1 -->|queue full| R503
-    C1 -->|accepted| Q["scheduler.enqueue by route key + state=queued"]
+    C1 -->|accepted| Q["scheduler.enqueue by route key + state=queued (blocks if queue full)"]
     Q --> S["keyScheduler"]
     S -->|same key busy| SQ["lane queue (serialized)"]
     S -->|key free| W["Worker"]

--- a/src/go/plugin/framework/functions/README.md
+++ b/src/go/plugin/framework/functions/README.md
@@ -57,7 +57,7 @@ Admission checks:
 - manager stopping -> reject `503`
 - unknown/nil handler -> reject `501`
 - duplicate active/tombstoned UID -> ignore duplicate input (debug/warn log, no terminal output)
-- queue full -> blocks on `scheduler.enqueue` until space frees (back-pressures stdin reader -> netdata via OS pipe). Only the manager-stopping error is returned here.
+- queue full -> blocks on `scheduler.enqueue` until space frees (back-pressures stdin reader -> netdata via OS pipe). The only errors returned from this path are manager-stopping (`503`) on shutdown and invalid-request (`500`) for malformed input.
 
 ### Keyed scheduler + worker pool
 

--- a/src/go/plugin/framework/functions/manager.go
+++ b/src/go/plugin/framework/functions/manager.go
@@ -551,6 +551,42 @@ func (m *Manager) forceFinalizeAll(code int, message string) {
 	}
 }
 
+// markCancelled performs the same bookkeeping as tryFinalize (tombstone +
+// scheduler.complete + remove from invState) but does NOT emit anything to
+// netdata. Used by the cancel fallback path: by the time CANCEL is sent,
+// netdata has already timed out the transaction and removed its inflight
+// entry, so any response we emit just produces a "transaction not found"
+// log on the netdata side. We still need the bookkeeping so the lane
+// advances and any later terminal response from the handler is dropped.
+func (m *Manager) markCancelled(uid string) {
+	if uid == "" {
+		return
+	}
+
+	m.invStateMux.Lock()
+	now := time.Now()
+	m.pruneExpiredTombstonesLocked(now)
+	if _, ok := m.tombstones[uid]; ok {
+		m.invStateMux.Unlock()
+		return
+	}
+
+	var scheduleKey string
+	if rec, ok := m.invState[uid]; ok && rec != nil {
+		m.stopTimersLocked(rec)
+		scheduleKey = rec.scheduleKey
+	}
+	delete(m.invState, uid)
+	m.tombstones[uid] = now.Add(m.tombstoneTTL)
+	m.observeInvocationsLocked()
+	m.invStateMux.Unlock()
+
+	if scheduleKey != "" && m.scheduler != nil {
+		m.scheduler.complete(scheduleKey, uid)
+		m.observeSchedulerPending()
+	}
+}
+
 // tryFinalize emits a terminal response once per transaction UID.
 // Later terminal attempts for the same UID are dropped while tombstone is active.
 func (m *Manager) tryFinalize(uid, source string, emit func()) bool {
@@ -629,7 +665,12 @@ func (m *Manager) startCancelFallbackTimerLocked(uid string, rec *invocationReco
 	uidCopy := uid
 	rec.fallbackTimer = time.AfterFunc(m.cancelFallbackDelay, func() {
 		m.observeCancelFallback()
-		m.respUID(uidCopy, 499, "request canceled")
+		// Don't emit a 499: by the time CANCEL was sent, netdata has already
+		// 504'd the transaction and removed its inflight entry, so any
+		// response we send just produces a "transaction not found" log.
+		// markCancelled does the bookkeeping (tombstone + lane advance) so
+		// the late real response from the handler is dropped.
+		m.markCancelled(uidCopy)
 	})
 }
 

--- a/src/go/plugin/framework/functions/manager.go
+++ b/src/go/plugin/framework/functions/manager.go
@@ -340,7 +340,11 @@ func (m *Manager) dispatchInvocation(parentCtx context.Context, fn *Function) {
 		case errors.Is(err, errSchedulerInvalid):
 			m.respf(fn, 500, "invalid scheduler request")
 		default:
-			m.respf(fn, 503, "scheduler error")
+			// Should be unreachable: enqueue's other return points block.
+			// If a new error variant is added in the future, surface it
+			// loudly instead of swallowing it as a generic 5xx.
+			m.Warningf("unexpected scheduler enqueue error for '%s': %v", fn.Name, err)
+			m.respf(fn, 500, "unexpected scheduler error: %v", err)
 		}
 		return
 	}

--- a/src/go/plugin/framework/functions/manager.go
+++ b/src/go/plugin/framework/functions/manager.go
@@ -33,8 +33,18 @@ const (
 	// queue/worker logic.
 	// TODO: establish and document a MethodHandler goroutine-safety contract
 	// before increasing this default.
-	defaultWorkerCount          = 1
-	defaultQueueSize            = 64
+	defaultWorkerCount = 1
+	// defaultQueueSize is intentionally 1 (not removed: the keyed scheduler is
+	// still the dispatch primitive, we just don't want it to absorb bursts).
+	// Rationale: every downstream stage is single-threaded today (1 worker, 1
+	// jobmgr loop, serial Check()), so admitting more than 1 extra request
+	// only buys wedge surface (a queued request that is later cancelled by
+	// netdata cannot reach jobmgr, so the dyncfg wait gate stays in
+	// 'accepted' forever). With queue=1 the stdin reader back-pressures
+	// earlier through the OS pipe instead of
+	// piling up admitted-but-unprocessed work in stateQueued. If/when we add
+	// real downstream concurrency, raise this again.
+	defaultQueueSize            = 1
 	defaultCancelFallbackDelay  = 5 * time.Second
 	defaultShutdownDrainTimeout = 8 * time.Second
 	defaultTombstoneTTL         = 60 * time.Second
@@ -441,14 +451,15 @@ func (m *Manager) handleCancelEvent(event inputEvent) {
 		return
 	}
 
-	state, ok := m.requestCancellation(uid)
-	if !ok {
+	if _, ok := m.requestCancellation(uid); !ok {
 		m.Debugf("ignoring cancel for unknown transaction id: %s", uid)
 		return
 	}
-	if state == stateQueued {
-		m.respUID(uid, 499, "request canceled")
-	}
+	// No immediate terminal response. requestCancellation handled state
+	// transitions: for queued functions the cancel is intentionally ignored
+	// (function will run to completion); for running/awaiting functions a
+	// fallback timer was armed and will emit 499 + tombstone after
+	// cancelFallbackDelay.
 }
 
 func (m *Manager) requestCancellation(uid string) (invocationState, bool) {
@@ -460,6 +471,22 @@ func (m *Manager) requestCancellation(uid string) (invocationState, bool) {
 		return 0, false
 	}
 
+	// For stateQueued we deliberately ignore the cancel entirely: no
+	// cancelRequested flag, no ctx cancellation, no fallback timer, no
+	// tombstone. Reason: dyncfg commands (enable/disable/update/restart)
+	// carry side-effects that must reach jobmgr, otherwise the wait gate
+	// stays in 'accepted' forever (since the wait-decision timeout was
+	// removed). Setting cancelRequested would make startInvocation skip the
+	// handler when the worker pulls; the fallback timer's tryFinalize would
+	// also tombstone+remove from invState before the worker gets there. So
+	// either path wedges the function. We let it run to completion as if
+	// nothing happened; netdata already considers the transaction done (it
+	// 504'd before sending CANCEL), so the eventual terminal response just
+	// produces a benign "transaction not found" log on the netdata side.
+	if rec.state == stateQueued {
+		return rec.state, true
+	}
+
 	if rec.cancelRequested {
 		return rec.state, true
 	}
@@ -468,14 +495,7 @@ func (m *Manager) requestCancellation(uid string) (invocationState, bool) {
 		rec.cancel()
 	}
 
-	if rec.state == stateQueued && m.scheduler != nil {
-		m.scheduler.cancelQueued(rec.scheduleKey, uid)
-		m.observeSchedulerPending()
-	}
-
-	if rec.state == stateRunning || rec.state == stateAwaitingResult {
-		m.startCancelFallbackTimerLocked(uid, rec)
-	}
+	m.startCancelFallbackTimerLocked(uid, rec)
 
 	return rec.state, true
 }

--- a/src/go/plugin/framework/functions/manager.go
+++ b/src/go/plugin/framework/functions/manager.go
@@ -151,6 +151,22 @@ func (m *Manager) run(ctx context.Context, quitCh chan struct{}) {
 
 	m.startWorkers(&workersWG)
 
+	// Wake any enqueue() blocked on a full scheduler when the parent context
+	// is canceled. Necessary because the reader loop below may itself be
+	// blocked inside dispatchInvocation -> scheduler.enqueue waiting for
+	// space, and would otherwise miss the ctx.Done signal.
+	stopWatcher := make(chan struct{})
+	defer close(stopWatcher)
+	go func() {
+		select {
+		case <-ctx.Done():
+			if m.scheduler != nil {
+				m.scheduler.stop()
+			}
+		case <-stopWatcher:
+		}
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -311,18 +327,19 @@ func (m *Manager) dispatchInvocation(parentCtx context.Context, fn *Function) {
 		return
 	}
 
+	// scheduler.enqueue blocks when the queue is full; it only returns an
+	// error for invalid inputs or when the scheduler is stopping (shutdown).
+	// Blocking back-pressures the stdin reader, which back-pressures netdata
+	// via the OS pipe — this is intentional, see TODO-dyncfg-jobmgr-sync.md.
 	if err := m.scheduler.enqueue(req); err != nil {
 		cancel()
 		switch {
-		case errors.Is(err, errSchedulerQueueFull):
-			m.respf(fn, 503, "function queue is full")
-			m.observeQueueFull()
 		case errors.Is(err, errSchedulerStopping):
 			m.respf(fn, 503, "functions manager is stopping")
 		case errors.Is(err, errSchedulerInvalid):
 			m.respf(fn, 500, "invalid scheduler request")
 		default:
-			m.respf(fn, 503, "function queue is full")
+			m.respf(fn, 503, "scheduler error")
 		}
 		return
 	}

--- a/src/go/plugin/framework/functions/manager.go
+++ b/src/go/plugin/framework/functions/manager.go
@@ -329,8 +329,9 @@ func (m *Manager) dispatchInvocation(parentCtx context.Context, fn *Function) {
 
 	// scheduler.enqueue blocks when the queue is full; it only returns an
 	// error for invalid inputs or when the scheduler is stopping (shutdown).
-	// Blocking back-pressures the stdin reader, which back-pressures netdata
-	// via the OS pipe — this is intentional, see TODO-dyncfg-jobmgr-sync.md.
+	// The blocking is intentional: by stalling here, the stdin reader slows
+	// down as well, which propagates back-pressure to netdata through the OS
+	// pipe instead of allowing unbounded buffering or dropping requests.
 	if err := m.scheduler.enqueue(req); err != nil {
 		cancel()
 		switch {

--- a/src/go/plugin/framework/functions/manager_flow_test.go
+++ b/src/go/plugin/framework/functions/manager_flow_test.go
@@ -114,14 +114,22 @@ func TestManager_FlowScenarios(t *testing.T) {
 	tests := map[string]struct {
 		run func(t *testing.T, mgr *Manager, in *chanInput, out *safeBuffer)
 	}{
-		"queued cancel emits 499 and skips execution": {
+		"queued cancel is ignored; function still executes": {
 			run: func(t *testing.T, mgr *Manager, in *chanInput, out *safeBuffer) {
+				// New semantics: a CANCEL for a queued function is a no-op at
+				// the framework level. The function stays in the scheduler,
+				// runs to completion when its turn comes, and any terminal
+				// response goes through normally. No 499 is emitted by the
+				// framework (netdata already considers the transaction done
+				// via its own per-transaction timer, so an extra 499 would
+				// just be noise).
 				var (
 					mu       sync.Mutex
 					executed []string
 				)
 				started := make(chan struct{}, 1)
 				release := make(chan struct{})
+				tx2Done := make(chan struct{})
 
 				mgr.Register("fn", func(fn Function) {
 					mu.Lock()
@@ -130,6 +138,14 @@ func TestManager_FlowScenarios(t *testing.T) {
 					if fn.UID == "tx1" {
 						started <- struct{}{}
 						<-release
+						// Emit terminal response so the per-key lane advances
+						// to tx2; otherwise the lane stays "owned" by tx1 and
+						// tx2 never gets picked up.
+						mgr.respUID(fn.UID, 200, "ok")
+					}
+					if fn.UID == "tx2" {
+						mgr.respUID(fn.UID, 200, "ok")
+						close(tx2Done)
 					}
 				})
 
@@ -140,14 +156,29 @@ func TestManager_FlowScenarios(t *testing.T) {
 				<-started
 				in.ch <- functionLine("tx2", "fn")
 				in.ch <- "FUNCTION_CANCEL tx2"
+
+				// tx2 must NOT receive a 499 from the framework. We can't
+				// assert "no 499 ever" without waiting forever, but we can at
+				// least verify it isn't there immediately after CANCEL.
+				time.Sleep(50 * time.Millisecond)
+				assert.NotContains(t, out.String(), "FUNCTION_RESULT_BEGIN tx2 499")
+
 				close(release)
+				select {
+				case <-tx2Done:
+				case <-time.After(time.Second):
+					t.Fatal("tx2 did not execute after release")
+				}
+
 				close(in.ch)
 				waitForDone(t, done)
 
-				waitForSubstring(t, out.String, "FUNCTION_RESULT_BEGIN tx2 499", time.Second)
+				// Both tx1 and tx2 should have executed (in order).
 				mu.Lock()
 				defer mu.Unlock()
-				assert.Equal(t, []string{"tx1"}, executed)
+				assert.Equal(t, []string{"tx1", "tx2"}, executed)
+				// tx2's normal 200 response went through (no tombstone).
+				assert.Contains(t, out.String(), "FUNCTION_RESULT_BEGIN tx2 200")
 			},
 		},
 		"running cancel fallback emits 499 once": {

--- a/src/go/plugin/framework/functions/manager_flow_test.go
+++ b/src/go/plugin/framework/functions/manager_flow_test.go
@@ -181,8 +181,13 @@ func TestManager_FlowScenarios(t *testing.T) {
 				assert.Contains(t, out.String(), "FUNCTION_RESULT_BEGIN tx2 200")
 			},
 		},
-		"running cancel fallback emits 499 once": {
+		"running cancel fallback tombstones silently (no emit)": {
 			run: func(t *testing.T, mgr *Manager, in *chanInput, out *safeBuffer) {
+				// New semantics: the cancel fallback timer no longer emits a
+				// 499 to netdata. By the time CANCEL arrives, netdata has
+				// already 504'd and removed the inflight transaction, so any
+				// response would just produce a "transaction not found" log.
+				// We only do the bookkeeping (tombstone + lane advance).
 				mgr.cancelFallbackDelay = 50 * time.Millisecond
 				started := make(chan struct{}, 1)
 				release := make(chan struct{})
@@ -200,16 +205,18 @@ func TestManager_FlowScenarios(t *testing.T) {
 				in.ch <- functionLine("tx1", "fn")
 				<-started
 				in.ch <- "FUNCTION_CANCEL tx1"
-				waitForSubstring(t, out.String, "FUNCTION_RESULT_BEGIN tx1 499", time.Second)
+				// Wait long enough for the fallback timer to fire.
+				time.Sleep(150 * time.Millisecond)
 
 				close(release)
 				close(in.ch)
 				waitForDone(t, done)
 
-				assert.Equal(t, 1, strings.Count(out.String(), "FUNCTION_RESULT_BEGIN tx1 499"))
+				// No 499 should be emitted, ever.
+				assert.Equal(t, 0, strings.Count(out.String(), "FUNCTION_RESULT_BEGIN tx1 499"))
 			},
 		},
-		"repeated cancel for same uid still emits one terminal response": {
+		"repeated cancel for same uid is idempotent and silent": {
 			run: func(t *testing.T, mgr *Manager, in *chanInput, out *safeBuffer) {
 				mgr.cancelFallbackDelay = 50 * time.Millisecond
 				started := make(chan struct{}, 1)
@@ -229,13 +236,13 @@ func TestManager_FlowScenarios(t *testing.T) {
 				<-started
 				in.ch <- "FUNCTION_CANCEL tx1"
 				in.ch <- "FUNCTION_CANCEL tx1"
-				waitForSubstring(t, out.String, "FUNCTION_RESULT_BEGIN tx1 499", time.Second)
+				time.Sleep(150 * time.Millisecond)
 
 				close(release)
 				close(in.ch)
 				waitForDone(t, done)
 
-				assert.Equal(t, 1, strings.Count(out.String(), "FUNCTION_RESULT_BEGIN tx1 499"))
+				assert.Equal(t, 0, strings.Count(out.String(), "FUNCTION_RESULT_BEGIN tx1 499"))
 			},
 		},
 		"running cancel drops late terminal response": {
@@ -258,14 +265,17 @@ func TestManager_FlowScenarios(t *testing.T) {
 				in.ch <- functionLine("tx1", "fn")
 				<-started
 				in.ch <- "FUNCTION_CANCEL tx1"
-				waitForSubstring(t, out.String, "FUNCTION_RESULT_BEGIN tx1 499", time.Second)
+				// Let the fallback timer fire (tombstones the UID).
+				time.Sleep(150 * time.Millisecond)
 
 				close(release)
 				close(in.ch)
 				waitForDone(t, done)
 
 				got := out.String()
-				assert.Equal(t, 1, strings.Count(got, "FUNCTION_RESULT_BEGIN tx1 499"))
+				// No 499 emitted by the fallback path.
+				assert.Equal(t, 0, strings.Count(got, "FUNCTION_RESULT_BEGIN tx1 499"))
+				// Late 200 from the handler is dropped by the tombstone.
 				assert.Equal(t, 0, strings.Count(got, "FUNCTION_RESULT_BEGIN tx1 200"))
 			},
 		},

--- a/src/go/plugin/framework/functions/manager_flow_test.go
+++ b/src/go/plugin/framework/functions/manager_flow_test.go
@@ -342,35 +342,6 @@ func TestManager_FlowScenarios(t *testing.T) {
 				assert.EqualValues(t, 1, calls.Load())
 			},
 		},
-		"queue full is rejected with 503": {
-			run: func(t *testing.T, mgr *Manager, in *chanInput, out *safeBuffer) {
-				mgr.queueSize = 1
-				mgr.workerCount = 1
-				started := make(chan struct{}, 1)
-				release := make(chan struct{})
-
-				mgr.Register("fn", func(fn Function) {
-					if fn.UID == "tx1" {
-						started <- struct{}{}
-						<-release
-					}
-					mgr.respUID(fn.UID, 200, "ok")
-				})
-
-				cancel, done := startFlowManager(t, mgr)
-				defer cancel()
-
-				in.ch <- functionLine("tx1", "fn")
-				<-started
-				in.ch <- functionLine("tx2", "fn")
-				in.ch <- functionLine("tx3", "fn")
-				waitForSubstring(t, out.String, "FUNCTION_RESULT_BEGIN tx3 503", time.Second)
-
-				close(release)
-				close(in.ch)
-				waitForDone(t, done)
-			},
-		},
 		"panic in handler emits 500": {
 			run: func(t *testing.T, mgr *Manager, in *chanInput, out *safeBuffer) {
 				mgr.Register("fn", func(Function) { panic("boom") })

--- a/src/go/plugin/framework/functions/runtime_metrics.go
+++ b/src/go/plugin/framework/functions/runtime_metrics.go
@@ -12,7 +12,6 @@ type managerRuntimeMetrics struct {
 	schedulerPending          metrix.StatefulGauge
 
 	functionCallsTotal  metrix.StatefulCounter
-	queueFullTotal      metrix.StatefulCounter
 	cancelFallbackTotal metrix.StatefulCounter
 	lateTerminalDropped metrix.StatefulCounter
 	duplicateUIDIgnored metrix.StatefulCounter
@@ -48,12 +47,6 @@ func newManagerRuntimeMetrics(store metrix.RuntimeStore) *managerRuntimeMetrics 
 			metrix.WithDescription("Total number of parsed function call requests"),
 			metrix.WithChartFamily("Framework/Functions/Calls"),
 			metrix.WithUnit("calls"),
-		),
-		queueFullTotal: metrix.SeededCounter(meter,
-			"queue_full_total",
-			metrix.WithDescription("Total number of function requests rejected due to queue full"),
-			metrix.WithChartFamily("Framework/Functions/Failures"),
-			metrix.WithUnit("requests"),
 		),
 		cancelFallbackTotal: metrix.SeededCounter(meter,
 			"cancel_fallback_total",
@@ -100,13 +93,6 @@ func (m *Manager) observeSchedulerPending() {
 		return
 	}
 	m.runtimeMetrics.schedulerPending.Set(float64(m.scheduler.pendingCount()))
-}
-
-func (m *Manager) observeQueueFull() {
-	if m == nil || m.runtimeMetrics == nil {
-		return
-	}
-	m.runtimeMetrics.queueFullTotal.Add(1)
 }
 
 func (m *Manager) observeFunctionCall() {

--- a/src/go/plugin/framework/functions/runtime_metrics_test.go
+++ b/src/go/plugin/framework/functions/runtime_metrics_test.go
@@ -107,7 +107,9 @@ func TestManager_RuntimeMetricsScenarios(t *testing.T) {
 				in.ch <- functionLine("tx1", "fn")
 				<-started
 				in.ch <- functionLine("tx2", "fn")
-				in.ch <- functionLine("tx3", "fn") // queue-full
+				// tx3 (former queue-full step) removed: the scheduler now blocks
+				// on full instead of rejecting, so the reader would deadlock here
+				// and the FUNCTION_CANCEL below would never be processed.
 				in.ch <- functionLine("tx1", "fn") // duplicate-active
 				in.ch <- "FUNCTION_CANCEL tx1"     // fallback->499
 
@@ -135,11 +137,10 @@ func TestManager_RuntimeMetricsScenarios(t *testing.T) {
 					return ok && pending == 0
 				}, "runtime gauges settle after shutdown")
 
-				assert.GreaterOrEqual(t, runtimeMetricValue(t, mgr.runtimeStore, functionsRuntimeMetricPrefix+".queue_full_total", nil), float64(1))
 				assert.GreaterOrEqual(t, runtimeMetricValue(t, mgr.runtimeStore, functionsRuntimeMetricPrefix+".cancel_fallback_total", nil), float64(1))
 				assert.GreaterOrEqual(t, runtimeMetricValue(t, mgr.runtimeStore, functionsRuntimeMetricPrefix+".late_terminal_dropped_total", nil), float64(1))
 				assert.GreaterOrEqual(t, runtimeMetricValue(t, mgr.runtimeStore, functionsRuntimeMetricPrefix+".duplicate_uid_ignored_total", nil), float64(2))
-				assert.Equal(t, float64(5), runtimeMetricValue(t, mgr.runtimeStore, functionsRuntimeMetricPrefix+".calls_total", nil))
+				assert.Equal(t, float64(4), runtimeMetricValue(t, mgr.runtimeStore, functionsRuntimeMetricPrefix+".calls_total", nil))
 
 				assert.Equal(t, float64(0), runtimeMetricValue(t, mgr.runtimeStore, functionsRuntimeMetricPrefix+".invocations_active", nil))
 				assert.Equal(t, float64(0), runtimeMetricValue(t, mgr.runtimeStore, functionsRuntimeMetricPrefix+".invocations_awaiting_result", nil))

--- a/src/go/plugin/framework/functions/scheduler.go
+++ b/src/go/plugin/framework/functions/scheduler.go
@@ -53,9 +53,10 @@ func (s *keyScheduler) enqueue(req *invocationRequest) error {
 
 	// Block until there is space, or the scheduler is stopped. We must not
 	// drop dyncfg commands silently: an awaited enable/disable that is dropped
-	// here would wedge jobmgr's wait gate (see TODO-dyncfg-jobmgr-sync.md).
-	// Back-pressure flows upstream: the manager run-loop stops draining stdin,
-	// netdata's write blocks on the OS pipe.
+	// here would wedge jobmgr's wait gate by leaving it waiting for a
+	// completion that will never arrive. Back-pressure flows upstream: the
+	// manager run-loop stops draining stdin, and netdata's write blocks on
+	// the OS pipe.
 	for {
 		if s.stopping || !s.accepting {
 			return errSchedulerStopping

--- a/src/go/plugin/framework/functions/scheduler.go
+++ b/src/go/plugin/framework/functions/scheduler.go
@@ -31,6 +31,11 @@ type keyScheduler struct {
 	pending    int
 	accepting  bool
 	stopping   bool
+
+	// enqueueWaiters counts goroutines currently blocked inside enqueue()
+	// waiting for space. Used by tests to synchronize deterministically
+	// instead of sleeping.
+	enqueueWaiters int
 }
 
 func newKeyScheduler(maxPending int) *keyScheduler {
@@ -64,7 +69,9 @@ func (s *keyScheduler) enqueue(req *invocationRequest) error {
 		if s.maxPending <= 0 || s.pending < s.maxPending {
 			break
 		}
+		s.enqueueWaiters++
 		s.cond.Wait()
+		s.enqueueWaiters--
 	}
 
 	lane := s.lanes[req.scheduleKey]
@@ -228,4 +235,12 @@ func (s *keyScheduler) pendingCount() int {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	return s.pending
+}
+
+// enqueueWaiterCount reports how many goroutines are currently blocked
+// inside enqueue() waiting for queue space. Intended for tests.
+func (s *keyScheduler) enqueueWaiterCount() int {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	return s.enqueueWaiters
 }

--- a/src/go/plugin/framework/functions/scheduler.go
+++ b/src/go/plugin/framework/functions/scheduler.go
@@ -8,9 +8,8 @@ import (
 )
 
 var (
-	errSchedulerQueueFull = errors.New("scheduler queue is full")
-	errSchedulerStopping  = errors.New("scheduler is stopping")
-	errSchedulerInvalid   = errors.New("scheduler invalid request")
+	errSchedulerStopping = errors.New("scheduler is stopping")
+	errSchedulerInvalid  = errors.New("scheduler invalid request")
 )
 
 type scheduleLane struct {
@@ -52,11 +51,19 @@ func (s *keyScheduler) enqueue(req *invocationRequest) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 
-	if s.stopping || !s.accepting {
-		return errSchedulerStopping
-	}
-	if s.maxPending > 0 && s.pending >= s.maxPending {
-		return errSchedulerQueueFull
+	// Block until there is space, or the scheduler is stopped. We must not
+	// drop dyncfg commands silently: an awaited enable/disable that is dropped
+	// here would wedge jobmgr's wait gate (see TODO-dyncfg-jobmgr-sync.md).
+	// Back-pressure flows upstream: the manager run-loop stops draining stdin,
+	// netdata's write blocks on the OS pipe.
+	for {
+		if s.stopping || !s.accepting {
+			return errSchedulerStopping
+		}
+		if s.maxPending <= 0 || s.pending < s.maxPending {
+			break
+		}
+		s.cond.Wait()
 	}
 
 	lane := s.lanes[req.scheduleKey]
@@ -97,9 +104,8 @@ func (s *keyScheduler) next() (*invocationRequest, bool) {
 	if s.pending > 0 {
 		s.pending--
 	}
-	if s.drainedLocked() {
-		s.cond.Broadcast()
-	}
+	// Wake any enqueue() waiters blocked on a full queue.
+	s.cond.Broadcast()
 	return req, true
 }
 
@@ -130,9 +136,8 @@ func (s *keyScheduler) cancelQueued(scheduleKey, uid string) bool {
 		if lane.ownerUID == "" && len(lane.queue) == 0 {
 			delete(s.lanes, scheduleKey)
 		}
-		if s.drainedLocked() {
-			s.cond.Broadcast()
-		}
+		// Wake any enqueue() waiters blocked on a full queue.
+		s.cond.Broadcast()
 		return true
 	}
 	return false
@@ -157,9 +162,7 @@ func (s *keyScheduler) complete(scheduleKey, uid string) {
 
 	if s.stopping {
 		delete(s.lanes, scheduleKey)
-		if s.drainedLocked() {
-			s.cond.Broadcast()
-		}
+		s.cond.Broadcast()
 		return
 	}
 
@@ -175,7 +178,8 @@ func (s *keyScheduler) complete(scheduleKey, uid string) {
 
 		lane.ownerUID = next.fn.UID
 		s.ready = append(s.ready, next)
-		s.cond.Signal()
+		// Broadcast: wakes both next() consumers and enqueue() producers.
+		s.cond.Broadcast()
 		return
 	}
 
@@ -183,9 +187,7 @@ func (s *keyScheduler) complete(scheduleKey, uid string) {
 	if len(lane.queue) == 0 {
 		delete(s.lanes, scheduleKey)
 	}
-	if s.drainedLocked() {
-		s.cond.Broadcast()
-	}
+	s.cond.Broadcast()
 }
 
 func (s *keyScheduler) stopAccepting() {

--- a/src/go/plugin/framework/functions/scheduler_test.go
+++ b/src/go/plugin/framework/functions/scheduler_test.go
@@ -209,10 +209,14 @@ func TestKeyScheduler_EnqueueBlocksUntilSpace(t *testing.T) {
 					enqueued <- s.enqueue(req2)
 				}()
 
+				require.Eventually(t, func() bool {
+					return s.enqueueWaiterCount() == 1
+				}, time.Second, time.Millisecond, "second enqueue never reached blocking wait")
+
 				select {
 				case <-enqueued:
-					t.Fatal("second enqueue should block while queue is full")
-				case <-time.After(50 * time.Millisecond):
+					t.Fatal("second enqueue should still be blocked while queue is full")
+				default:
 				}
 
 				got, ok := s.next()
@@ -247,7 +251,10 @@ func TestKeyScheduler_EnqueueBlocksUntilSpace(t *testing.T) {
 					enqueued <- s.enqueue(req2)
 				}()
 
-				time.Sleep(20 * time.Millisecond)
+				require.Eventually(t, func() bool {
+					return s.enqueueWaiterCount() == 1
+				}, time.Second, time.Millisecond, "second enqueue never reached blocking wait")
+
 				s.stop()
 
 				select {

--- a/src/go/plugin/framework/functions/scheduler_test.go
+++ b/src/go/plugin/framework/functions/scheduler_test.go
@@ -117,16 +117,6 @@ func TestKeyScheduler_EnqueueValidation(t *testing.T) {
 			adjust: func(s *keyScheduler) { s.stopAccepting() },
 			want:   errSchedulerStopping,
 		},
-		"full scheduler returns queue full error": {
-			req: &invocationRequest{
-				fn:          &Function{UID: "tx1"},
-				scheduleKey: "k",
-			},
-			adjust: func(s *keyScheduler) {
-				s.pending = 1
-			},
-			want: errSchedulerQueueFull,
-		},
 		"valid request is admitted": {
 			req: &invocationRequest{
 				fn:          &Function{UID: "tx1"},
@@ -196,32 +186,76 @@ func TestKeyScheduler_StopPaths(t *testing.T) {
 	}
 }
 
-func TestKeyScheduler_QueueFullRecovery(t *testing.T) {
+func TestKeyScheduler_EnqueueBlocksUntilSpace(t *testing.T) {
 	tests := map[string]struct {
 		run func(t *testing.T)
 	}{
-		"full queue recovers after dequeue and completion": {
+		"enqueue blocks until next() frees space": {
 			run: func(t *testing.T) {
 				s := newKeyScheduler(1)
 				req1 := &invocationRequest{
 					fn:          &Function{UID: "tx1"},
-					scheduleKey: "k",
+					scheduleKey: "k1",
 				}
 				req2 := &invocationRequest{
 					fn:          &Function{UID: "tx2"},
-					scheduleKey: "k",
+					scheduleKey: "k2",
 				}
 
 				require.NoError(t, s.enqueue(req1))
-				require.ErrorIs(t, s.enqueue(req2), errSchedulerQueueFull)
+
+				enqueued := make(chan error, 1)
+				go func() {
+					enqueued <- s.enqueue(req2)
+				}()
+
+				select {
+				case <-enqueued:
+					t.Fatal("second enqueue should block while queue is full")
+				case <-time.After(50 * time.Millisecond):
+				}
 
 				got, ok := s.next()
 				require.True(t, ok)
 				require.NotNil(t, got)
 				require.Equal(t, "tx1", got.fn.UID)
 
-				s.complete("k", "tx1")
-				require.NoError(t, s.enqueue(req2))
+				select {
+				case err := <-enqueued:
+					require.NoError(t, err)
+				case <-time.After(time.Second):
+					t.Fatal("second enqueue did not unblock after space freed")
+				}
+			},
+		},
+		"stop unblocks waiting enqueue with stopping error": {
+			run: func(t *testing.T) {
+				s := newKeyScheduler(1)
+				req1 := &invocationRequest{
+					fn:          &Function{UID: "tx1"},
+					scheduleKey: "k1",
+				}
+				req2 := &invocationRequest{
+					fn:          &Function{UID: "tx2"},
+					scheduleKey: "k2",
+				}
+
+				require.NoError(t, s.enqueue(req1))
+
+				enqueued := make(chan error, 1)
+				go func() {
+					enqueued <- s.enqueue(req2)
+				}()
+
+				time.Sleep(20 * time.Millisecond)
+				s.stop()
+
+				select {
+				case err := <-enqueued:
+					require.ErrorIs(t, err, errSchedulerStopping)
+				case <-time.After(time.Second):
+					t.Fatal("blocked enqueue did not return after stop()")
+				}
 			},
 		},
 	}


### PR DESCRIPTION
##### Summary

###### Problem

When a collector's `Check()` is slow, the plugin spams false-positive warnings:

> dyncfg: timed out waiting for enable/disable decision for 'X' ...

It's a race against the plugin's own single-threaded loop, not netdata being slow — the decision is already queued, the loop just can't read it in time.

###### Fix

- Remove the wait-decision timeout (the warning's source).
- Make the dyncfg command path non-droppable so an awaited enable/disable can't get silently lost and wedge the wait gate. Back-pressure now flows upstream via the OS pipe.

> **Note**: this is a **temporary fix**. The proper solution is an architectural redesign that parallelizes `Check()` per job so the dyncfg pipeline isn't head-of-line blocked. That work is out of scope for this PR.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the wait-decision timeout and make the `dyncfg` command path non-droppable, applying back-pressure instead of 503s. Also shrink the `functions` queue and change cancel handling to prevent wedged gates and noisy 499s.

- **Bug Fixes**
  - Removed the wait-decision timer and its logs in Service Discovery and Job Manager; cleaned up timeout-based tests.
  - Made `enqueueDyncfgFunction` block with a simple channel send (no per-function timeout); now only returns 503 on shutdown.
  - Updated `functions` scheduler: `enqueue` blocks when full and wakes on `next`/`cancelQueued`/`complete`; manager stops the scheduler on context cancel to unblock waiters; default queue size set to 1.
  - Adjusted `functions` manager: removed the queue-full 503 path and `queue_full_total` metric; unexpected scheduler errors now log and return 500; queued `CANCEL` is ignored (function still runs); cancel fallback tombstones silently (no 499).
  - Tests: added SD regression asserting a second config blocks until the matching decision; made blocking-enqueue tests deterministic; updated flow/runtime tests for new cancel and queue semantics.

<sup>Written for commit 2c1359ac982b98038d5fe5dc54800cd268d823d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

