### PR TITLE
fix(go.d/snmp): reduce default MaxOIDs to 20 and remove 32-bit counter fallback

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -47,7 +47,7 @@ func New() *Collector {
 				Retries:        1,
 				Timeout:        5,
 				Version:        gosnmp.Version2c.String(),
-				MaxOIDs:        60,
+				MaxOIDs:        20,
 				MaxRepetitions: 25,
 			},
 			User: UserConfig{

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -738,7 +738,7 @@ func prepareV1Config() Config {
 			Retries:        1,
 			Timeout:        5,
 			Version:        gosnmp.Version1.String(),
-			MaxOIDs:        60,
+			MaxOIDs:        20,
 			MaxRepetitions: 25,
 		},
 	}

--- a/src/go/plugin/go.d/collector/snmp/config_schema.json
+++ b/src/go/plugin/go.d/collector/snmp/config_schema.json
@@ -117,7 +117,7 @@
             "description": "The maximum number of OIDs allowed in a single GET request.",
             "type": "integer",
             "minimum": 1,
-            "default": 60
+            "default": 20
           }
         },
         "required": [

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-if-mib.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-if-mib.yaml
@@ -20,11 +20,11 @@ metrics:
       name: ifTable
     symbols:
       # 32-bit octets (fallback for traffic)
-      - { OID: 1.3.6.1.2.1.2.2.1.10, name: _ifInOctets, scale_factor: 8 }
-      - { OID: 1.3.6.1.2.1.2.2.1.16, name: _ifOutOctets, scale_factor: 8 }
+      #      - { OID: 1.3.6.1.2.1.2.2.1.10, name: _ifInOctets, scale_factor: 8 }
+      #      - { OID: 1.3.6.1.2.1.2.2.1.16, name: _ifOutOctets, scale_factor: 8 }
       # 32-bit unicast packets (fallback for unicast packet rate)
-      - { OID: 1.3.6.1.2.1.2.2.1.11, name: _ifInUcastPkts }
-      - { OID: 1.3.6.1.2.1.2.2.1.17, name: _ifOutUcastPkts }
+      #      - { OID: 1.3.6.1.2.1.2.2.1.11, name: _ifInUcastPkts }
+      #      - { OID: 1.3.6.1.2.1.2.2.1.17, name: _ifOutUcastPkts }
       # 32-bit only
       - { OID: 1.3.6.1.2.1.2.2.1.14, name: _ifInErrors }
       - { OID: 1.3.6.1.2.1.2.2.1.20, name: _ifOutErrors }
@@ -128,29 +128,21 @@ virtual_metrics:
   # TOTALS (all interfaces)
   # ======================
 
-  # Traffic total (prefer 64-bit HC; fallback to 32-bit)
+  # Traffic total (64-bit HC only)
   - name: ifTotalTraffic
-    alternatives:
-      - sources:
-          - { metric: _ifHCInOctets,  table: ifXTable, as: in }
-          - { metric: _ifHCOutOctets, table: ifXTable, as: out }
-      - sources:
-          - { metric: _ifInOctets,  table: ifTable, as: in }
-          - { metric: _ifOutOctets, table: ifTable, as: out }
+    sources:
+      - { metric: _ifHCInOctets,  table: ifXTable, as: in }
+      - { metric: _ifHCOutOctets, table: ifXTable, as: out }
     chart_meta:
       description: Total traffic across all interfaces
       family: 'Network/Total/Traffic'
       unit: "bit/s"
 
-  # Unicast packets total (prefer 64-bit HC; fallback to 32-bit)
+  # Unicast packets total (64-bit HC only)
   - name: ifTotalPacketsUcast
-    alternatives:
-      - sources:
-          - { metric: _ifHCInUcastPkts,  table: ifXTable, as: in }
-          - { metric: _ifHCOutUcastPkts, table: ifXTable, as: out }
-      - sources:
-          - { metric: _ifInUcastPkts,  table: ifTable, as: in }
-          - { metric: _ifOutUcastPkts, table: ifTable, as: out }
+    sources:
+      - { metric: _ifHCInUcastPkts,  table: ifXTable, as: in }
+      - { metric: _ifHCOutUcastPkts, table: ifXTable, as: out }
     chart_meta:
       description: Total unicast packets across all interfaces
       family: 'Network/Total/Packet/Unicast'
@@ -209,33 +201,25 @@ virtual_metrics:
   # PER INTERFACE (per_row)
   # =========================
 
-  # Traffic per interface
+  # Traffic per interface (64-bit HC only)
   - name: ifTraffic
     per_row: true
     group_by: ["interface"]
-    alternatives:
-      - sources:
-          - { metric: _ifHCInOctets,  table: ifXTable, as: in }
-          - { metric: _ifHCOutOctets, table: ifXTable, as: out }
-      - sources:
-          - { metric: _ifInOctets,  table: ifTable, as: in }
-          - { metric: _ifOutOctets, table: ifTable, as: out }
+    sources:
+      - { metric: _ifHCInOctets,  table: ifXTable, as: in }
+      - { metric: _ifHCOutOctets, table: ifXTable, as: out }
     chart_meta:
       description: Traffic
       family: 'Network/Interface/Traffic/Total'
       unit: "bit/s"
 
-  # Unicast packets per interface
+  # Unicast packets per interface (64-bit HC only)
   - name: ifPacketsUcast
     per_row: true
     group_by: ["interface"]
-    alternatives:
-      - sources:
-          - { metric: _ifHCInUcastPkts,  table: ifXTable, as: in }
-          - { metric: _ifHCOutUcastPkts, table: ifXTable, as: out }
-      - sources:
-          - { metric: _ifInUcastPkts,  table: ifTable, as: in }
-          - { metric: _ifOutUcastPkts, table: ifTable, as: out }
+    sources:
+      - { metric: _ifHCInUcastPkts,  table: ifXTable, as: in }
+      - { metric: _ifHCOutUcastPkts, table: ifXTable, as: out }
     chart_meta:
       description: Unicast packets
       family: 'Network/Interface/Packet/Unicast'


### PR DESCRIPTION
- Lower default MaxOIDs from 60 to 20 for more reliable SNMP polling.
- Remove 32-bit counter alternatives from IF-MIB virtual metrics to prevent counter type switching between collection cycles, which causes overflow due to mixing 32-bit and 64-bit counter values.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced SNMP GET batch size and enforced 64-bit IF-MIB counters to improve polling reliability and prevent counter overflows.

- **Bug Fixes**
  - Lowered default MaxOIDs from 60 to 20 for more reliable SNMP polling.
  - Removed 32-bit counter fallbacks for IF-MIB traffic and unicast packets to avoid type switching and overflow.

- **Migration**
  - Devices without 64-bit `ifXTable` counters will no longer expose traffic/unicast metrics from IF-MIB.
  - You can override MaxOIDs in config if your devices handle larger batches.

<sup>Written for commit 617916bae2a6a860a453e60c78af750aa0a8fffe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

