### PR TITLE
Fix pluginsd cleanup race with active collector

### DIFF
--- a/src/database/rrdset-slots.c
+++ b/src/database/rrdset-slots.c
@@ -222,7 +222,7 @@ void rrdset_pluginsd_receive_unslot_and_cleanup(RRDSET *st) {
             // that the collector is actively dereferencing.
             // Legitimate teardown clears collector_tid via
             // rrdhost_pluginsd_receive_chart_slots_free() after the receiver
-            // is fully stopped - cleanup will succeed on the next pass.
+            // is fully stopped, before invoking cleanup.
             nd_log_limit_static_global_var(erl, 1, 0);
             nd_log_limit(&erl, NDLS_DAEMON, NDLP_WARNING,
                          "PLUGINSD: attempted cleanup while collector (tid %d) is still active on chart, skipping",

--- a/src/database/rrdset-slots.c
+++ b/src/database/rrdset-slots.c
@@ -212,12 +212,17 @@ void rrdset_pluginsd_receive_unslot_and_cleanup(RRDSET *st) {
     pid_t collector_tid = __atomic_load_n(&st->pluginsd.collector_tid, __ATOMIC_ACQUIRE);
     pid_t current_tid = gettid_cached();
     if(collector_tid != 0) {
-        if(collector_tid != current_tid &&
-           !rrdset_flag_check(st, RRDSET_FLAG_COLLECTION_FINISHED)) {
-            internal_fatal(true,
-                           "PRD_ARRAY: cleanup called while collector (tid %d) is still active - lifecycle violation",
-                           collector_tid);
-
+        if(collector_tid != current_tid) {
+            // A different thread owns this chart as collector.
+            // We must not release PRD dimension references while that thread may
+            // still be using cached rd pointers from the array.
+            // RRDSET_FLAG_COLLECTION_FINISHED is not a reliable signal here:
+            // it can be set by the cleanup caller (service thread) rather than
+            // by the collector itself, creating a race where we free dimensions
+            // that the collector is actively dereferencing.
+            // Legitimate teardown clears collector_tid via
+            // rrdhost_pluginsd_receive_chart_slots_free() after the receiver
+            // is fully stopped - cleanup will succeed on the next pass.
             nd_log_limit_static_global_var(erl, 1, 0);
             nd_log_limit(&erl, NDLS_DAEMON, NDLP_WARNING,
                          "PLUGINSD: attempted cleanup while collector (tid %d) is still active on chart, skipping",
@@ -226,28 +231,19 @@ void rrdset_pluginsd_receive_unslot_and_cleanup(RRDSET *st) {
             return;
         }
 
-        if(collector_tid == current_tid) {
-            // Cleanup in the collector thread should not normally happen.
-            // Keep this explicit so we don't mask it as a stale tid case.
+        // We ARE the collector thread - safe to proceed with cleanup.
+        // This should not normally happen; keep it explicit so we don't
+        // mask it as a stale tid case.
 #ifdef NETDATA_INTERNAL_CHECKS
-            internal_fatal(true,
-                           "PRD_ARRAY: cleanup called from collector thread (tid %d) - lifecycle violation",
-                           collector_tid);
+        internal_fatal(true,
+                       "PRD_ARRAY: cleanup called from collector thread (tid %d) - lifecycle violation",
+                       collector_tid);
 #endif
 
-            nd_log_limit_static_global_var(erl_collector, 1, 0);
-            nd_log_limit(&erl_collector, NDLS_DAEMON, NDLP_WARNING,
-                         "PLUGINSD: cleanup called from collector thread (tid %d), forcing collector_tid=0",
-                         collector_tid);
-        }
-        else {
-            // Finalization can hit stale collector_tid on charts that were not switched away.
-            // Treat this as cleanup ownership handoff and continue.
-            nd_log_limit_static_global_var(erl_finalize, 1, 0);
-            nd_log_limit(&erl_finalize, NDLS_DAEMON, NDLP_WARNING,
-                         "PLUGINSD: cleanup forcing stale collector_tid=%d to 0 for finalized chart",
-                         collector_tid);
-        }
+        nd_log_limit_static_global_var(erl_collector, 1, 0);
+        nd_log_limit(&erl_collector, NDLS_DAEMON, NDLP_WARNING,
+                     "PLUGINSD: cleanup called from collector thread (tid %d), forcing collector_tid=0",
+                     collector_tid);
 
         __atomic_store_n(&st->pluginsd.collector_tid, 0, __ATOMIC_RELEASE);
     }


### PR DESCRIPTION
##### Summary
- Prevent lifecycle violations by improving thread ownership checks.
- Address race condition when releasing PRD dimension references under active collector threads.
- Refactor stale `collector_tid` handling and clarify comments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where pluginsd cleanup could free PRD dimension refs while a collector thread still used them. Enforces strict ownership: cleanup only proceeds in the collector thread; otherwise it is skipped.

- **Bug Fixes**
  - Skip cleanup when `collector_tid` is set and not the current thread; stop relying on `RRDSET_FLAG_COLLECTION_FINISHED`.
  - If called by the collector thread, assert/log and set `collector_tid=0` before proceeding; clarify that teardown clears it in `rrdhost_pluginsd_receive_chart_slots_free()`.
  - Remove stale `collector_tid` handoff path and tighten teardown comments/logging to prevent lifecycle violations.

<sup>Written for commit 4a2f22a86f472ea73273ac5c22b9541c80506556. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

