### PR TITLE
Add SQLite version to build details and startup log message

### DIFF
--- a/src/daemon/buildinfo.c
+++ b/src/daemon/buildinfo.c
@@ -56,6 +56,7 @@ typedef enum __attribute__((packed)) {
     BIB_FEATURE_TIERING,
     BIB_FEATURE_ML,
     BIB_FEATURE_ALLOCATOR,
+    BIB_DB_SQLITE,
     BIB_DB_DBENGINE,
     BIB_DB_ALLOC,
     BIB_DB_RAM,
@@ -550,6 +551,14 @@ static struct {
                 .print = "Memory Allocator",
                 .json = "allocator",
                 .value = NULL,
+        },
+        [BIB_DB_SQLITE] = {
+                .category = BIC_DATABASE,
+                .type = BIT_STRING,
+                .analytics = NULL,
+                .print = "sqlite",
+                .json = "sqlite",
+                .value = "unknown",
         },
         [BIB_DB_DBENGINE] = {
                 .category = BIC_DATABASE,
@@ -1223,6 +1232,7 @@ __attribute__((constructor)) void initialize_build_info(void) {
     build_info_set_value(BIB_FEATURE_ALLOCATOR, "system");
 #endif
 
+    build_info_set_value(BIB_DB_SQLITE, sqlite3_libversion());
 
 #ifdef ENABLE_DBENGINE
     build_info_set_status(BIB_DB_DBENGINE, true);

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1174,8 +1174,9 @@ int netdata_main(int argc, char **argv) {
     add_agent_event(EVENT_AGENT_START_TIME, (int64_t ) (ready_ut - started_ut));
     usec_t median_start_time = get_agent_event_time_median(EVENT_AGENT_START_TIME);
     netdata_log_info(
-        "NETDATA STARTUP: completed in %llu ms (median start up time is %llu ms). "
+        "NETDATA STARTUP: version '%s', sqlite '%s', completed in %llu ms (median start up time is %llu ms). "
         "Enjoy X-Ray Vision for your infrastructure!",
+        NETDATA_VERSION, sqlite3_libversion(),
         (ready_ut - started_ut) / USEC_PER_MS, median_start_time / USEC_PER_MS);
 
     cleanup_agent_event_log();


### PR DESCRIPTION
##### Summary
- Report sqlite library version during startup and in `netdata -W buildinfo`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report the SQLite library version during startup and in build info to help troubleshooting and support. It now appears in `netdata -W buildinfo` as "sqlite" and in the startup log next to the agent version.

<sup>Written for commit ca40d41fe7f65e58339771d95817e515c0f282a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

