### PR TITLE
Remove VLA (variable-length arrays)  (dbengine and health)

### DIFF
--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -798,8 +798,7 @@ static SIMPLE_PATTERN_RESULT simple_pattern_match_name_and_value_callback(const 
     t->searches++;
     if(simple_pattern_matches(t->pattern, name)) return -1;
 
-    size_t len = RRDLABELS_MAX_NAME_LENGTH + RRDLABELS_MAX_VALUE_LENGTH + 2; // +1 for =, +1 for \0
-    char tmp[len], *dst = &tmp[0];
+    char tmp[RRDLABELS_MAX_NAME_LENGTH + RRDLABELS_MAX_VALUE_LENGTH + 2], *dst = &tmp[0];
     const char *v = value;
 
     // copy the name
@@ -904,8 +903,8 @@ static int label_to_buffer_callback(const RRDLABEL *lb, void *value __maybe_unus
     size_t n_size = (t->name_sanitizer ) ? ( RRDLABELS_MAX_NAME_LENGTH  * 2 ) : 1;
     size_t v_size = (t->value_sanitizer) ? ( RRDLABELS_MAX_VALUE_LENGTH * 2 ) : 1;
 
-    char n[n_size];
-    char v[v_size];
+    char n[RRDLABELS_MAX_NAME_LENGTH * 2];
+    char v[RRDLABELS_MAX_VALUE_LENGTH * 2];
 
     const char *name = string2str(lb->index.key);
 

--- a/src/health/health_config.c
+++ b/src/health/health_config.c
@@ -523,7 +523,7 @@ static void lookup_data_source_from_rrdr_options(RRD_ALERT_PROTOTYPE *ap) {
                                                                                                     \
     if(value) {                                                                                     \
         typeof(ax->member) _old = ax->member;                                                       \
-        char _buf[strlen(value) + string_strlen(_old) + (_label ? strlen(_label) : 0) + 3];         \
+        char _buf[HEALTH_CONF_MAX_LINE];                                                            \
         snprintfz(_buf, sizeof(_buf), "%s%s%s%s%s",                                                 \
                       _label ? _label : "",                                                         \
                       _label ? "=" : "",                                                            \

--- a/src/health/health_config.c
+++ b/src/health/health_config.c
@@ -523,8 +523,12 @@ static void lookup_data_source_from_rrdr_options(RRD_ALERT_PROTOTYPE *ap) {
                                                                                                     \
     if(value) {                                                                                     \
         typeof(ax->member) _old = ax->member;                                                       \
-        char _buf[HEALTH_CONF_MAX_LINE];                                                            \
-        snprintfz(_buf, sizeof(_buf), "%s%s%s%s%s",                                                 \
+        size_t _label_len = _label ? strlen(_label) : 0;                                            \
+        size_t _value_len = strlen(value);                                                          \
+        size_t _old_len = _old ? string_strlen(_old) : 0;                                           \
+        size_t _buf_len = _label_len + (_label ? 1 : 0) + _value_len + (_old ? 1 : 0) + _old_len + 1; \
+        char *_buf = mallocz(_buf_len);                                                             \
+        snprintfz(_buf, _buf_len, "%s%s%s%s%s",                                                     \
                       _label ? _label : "",                                                         \
                       _label ? "=" : "",                                                            \
                       value,                                                                        \
@@ -532,6 +536,7 @@ static void lookup_data_source_from_rrdr_options(RRD_ALERT_PROTOTYPE *ap) {
                       _old ? string2str(_old) : "");                                                \
         string_freez(_old);                                                                         \
         ax->member = string_strdupz(_buf);                                                          \
+        freez(_buf);                                                                                \
     }                                                                                               \
 } while(0)
 

--- a/src/health/health_dyncfg.c
+++ b/src/health/health_dyncfg.c
@@ -6,6 +6,19 @@
 
 static void health_dyncfg_register_prototype(RRD_ALERT_PROTOTYPE *ap);
 
+static char *health_dyncfg_alert_prototype_id_strdupz(const char *alert_name) {
+    size_t prefix_len = strlen(DYNCFG_HEALTH_ALERT_PROTOTYPE_PREFIX);
+    size_t alert_name_len = strlen(alert_name);
+    size_t id_len = prefix_len + 1 + alert_name_len;
+    char *id = mallocz(id_len + 1);
+
+    int written = snprintfz(id, id_len + 1, DYNCFG_HEALTH_ALERT_PROTOTYPE_PREFIX ":%s", alert_name);
+    internal_fatal((size_t)written != id_len,
+                   "HEALTH DYNCFG: failed to build dyncfg id for alert '%s'", alert_name);
+
+    return id;
+}
+
 // ---------------------------------------------------------------------------------------------------------------------
 // parse the json object of an alert definition
 
@@ -632,9 +645,7 @@ static int dyncfg_health_prototype_job_action(BUFFER *result, DYNCFG_CMDS cmd, B
         return dyncfg_default_response(result, HTTP_RESP_NOT_FOUND, "no alert prototype is available by the name given");
 
     RRD_ALERT_PROTOTYPE *ap = dictionary_acquired_item_value(item);
-
-    char alert_name_dyncfg[HEALTH_CONF_MAX_LINE];
-    snprintfz(alert_name_dyncfg, sizeof(alert_name_dyncfg), DYNCFG_HEALTH_ALERT_PROTOTYPE_PREFIX ":%s", alert_name);
+    CLEAN_CHAR_P *alert_name_dyncfg = health_dyncfg_alert_prototype_id_strdupz(alert_name);
 
     int code = HTTP_RESP_INTERNAL_SERVER_ERROR;
 
@@ -744,9 +755,7 @@ static int dyncfg_health_prototype_job_action(BUFFER *result, DYNCFG_CMDS cmd, B
 int dyncfg_health_cb(const char *transaction __maybe_unused, const char *id, DYNCFG_CMDS cmd, const char *add_name,
                      BUFFER *payload, usec_t *stop_monotonic_ut __maybe_unused, bool *cancelled __maybe_unused,
                      BUFFER *result, HTTP_ACCESS access __maybe_unused, const char *source, void *data __maybe_unused) {
-
-    char buf[HEALTH_CONF_MAX_LINE];
-    strncpyz(buf, id, sizeof(buf) - 1);
+    CLEAN_CHAR_P *buf = strdupz(id);
 
     char *words[100] = { NULL };
     size_t num_words = quoted_strings_splitter_dyncfg_id(buf, words, 100);
@@ -780,14 +789,13 @@ int dyncfg_health_cb(const char *transaction __maybe_unused, const char *id, DYN
 }
 
 void health_dyncfg_unregister_all_prototypes(void) {
-    char key[HEALTH_CONF_MAX_LINE];
     RRD_ALERT_PROTOTYPE *ap;
 
     // remove dyncfg
     // it is ok if they are not added before
 
     dfe_start_read(health_globals.prototypes.dict, ap) {
-        snprintfz(key, sizeof(key), DYNCFG_HEALTH_ALERT_PROTOTYPE_PREFIX ":%s", string2str(ap->config.name));
+        CLEAN_CHAR_P *key = health_dyncfg_alert_prototype_id_strdupz(string2str(ap->config.name));
         dyncfg_del(localhost, key);
     }
     dfe_done(ap);
@@ -795,13 +803,12 @@ void health_dyncfg_unregister_all_prototypes(void) {
 }
 
 static void health_dyncfg_register_prototype(RRD_ALERT_PROTOTYPE *ap) {
-    char key[HEALTH_CONF_MAX_LINE];
+    CLEAN_CHAR_P *key = health_dyncfg_alert_prototype_id_strdupz(string2str(ap->config.name));
 
 //    bool trace = false;
 //    if(string_strcmp(ap->config.name, "ram_available") == 0)
 //        trace = true;
 
-    snprintfz(key, sizeof(key), DYNCFG_HEALTH_ALERT_PROTOTYPE_PREFIX ":%s", string2str(ap->config.name));
     dyncfg_add(localhost, key, "/health/alerts/prototypes",
                ap->_internal.enabled ? DYNCFG_STATUS_ACCEPTED : DYNCFG_STATUS_DISABLED, DYNCFG_TYPE_JOB,
                ap->config.source_type, string2str(ap->config.source),

--- a/src/health/health_dyncfg.c
+++ b/src/health/health_dyncfg.c
@@ -633,7 +633,7 @@ static int dyncfg_health_prototype_job_action(BUFFER *result, DYNCFG_CMDS cmd, B
 
     RRD_ALERT_PROTOTYPE *ap = dictionary_acquired_item_value(item);
 
-    char alert_name_dyncfg[strlen(DYNCFG_HEALTH_ALERT_PROTOTYPE_PREFIX) + strlen(alert_name) + 10];
+    char alert_name_dyncfg[HEALTH_CONF_MAX_LINE];
     snprintfz(alert_name_dyncfg, sizeof(alert_name_dyncfg), DYNCFG_HEALTH_ALERT_PROTOTYPE_PREFIX ":%s", alert_name);
 
     int code = HTTP_RESP_INTERNAL_SERVER_ERROR;
@@ -745,8 +745,8 @@ int dyncfg_health_cb(const char *transaction __maybe_unused, const char *id, DYN
                      BUFFER *payload, usec_t *stop_monotonic_ut __maybe_unused, bool *cancelled __maybe_unused,
                      BUFFER *result, HTTP_ACCESS access __maybe_unused, const char *source, void *data __maybe_unused) {
 
-    char buf[strlen(id) + 1];
-    memcpy(buf, id, sizeof(buf));
+    char buf[HEALTH_CONF_MAX_LINE];
+    strncpyz(buf, id, sizeof(buf) - 1);
 
     char *words[100] = { NULL };
     size_t num_words = quoted_strings_splitter_dyncfg_id(buf, words, 100);

--- a/src/health/health_prototypes.c
+++ b/src/health/health_prototypes.c
@@ -295,15 +295,18 @@ void health_init_prototypes(void) {
 
 static inline struct pattern_array *health_config_add_key_to_values(struct pattern_array *pa, const char *input_key, char *value)
 {
-    char key[HEALTH_CONF_MAX_LINE + 1];
-    char data[HEALTH_CONF_MAX_LINE + 1];
+    size_t value_len = strlen(value);
+    size_t input_key_len = input_key ? strlen(input_key) : 0;
+    size_t key_len = value_len > input_key_len ? value_len : input_key_len;
+    char *key = mallocz(key_len + 1);
+    char *data = mallocz(value_len + 1);
+    char *pair = mallocz((value_len * 2) + 4);
 
     char *s = value;
     size_t i = 0;
 
-    char pair[HEALTH_CONF_MAX_LINE + 1];
     if (input_key)
-        strncpyz(key, input_key, HEALTH_CONF_MAX_LINE);
+        strncpyz(key, input_key, key_len);
     else
         key[0] = '\0';
 
@@ -311,14 +314,14 @@ static inline struct pattern_array *health_config_add_key_to_values(struct patte
         if (*s == '=') {
             //hold the key
             data[i]='\0';
-            strncpyz(key, data, HEALTH_CONF_MAX_LINE);
+            strncpyz(key, data, key_len);
             i=0;
         } else if (*s == ' ') {
             data[i]='\0';
             if (data[0]=='!')
-                snprintfz(pair, HEALTH_CONF_MAX_LINE, "!%s=%s ", key, data + 1);
+                snprintfz(pair, (value_len * 2) + 4, "!%s=%s ", key, data + 1);
             else
-                snprintfz(pair, HEALTH_CONF_MAX_LINE, "%s=%s ", key, data);
+                snprintfz(pair, (value_len * 2) + 4, "%s=%s ", key, data);
 
             pa = pattern_array_add_key_simple_pattern(pa, key, simple_pattern_create(pair, NULL, SIMPLE_PATTERN_EXACT, true));
             i=0;
@@ -330,12 +333,16 @@ static inline struct pattern_array *health_config_add_key_to_values(struct patte
     data[i]='\0';
     if (data[0]) {
         if (data[0]=='!')
-            snprintfz(pair, HEALTH_CONF_MAX_LINE, "!%s=%s ", key, data + 1);
+            snprintfz(pair, (value_len * 2) + 4, "!%s=%s ", key, data + 1);
         else
-            snprintfz(pair, HEALTH_CONF_MAX_LINE, "%s=%s ", key, data);
+            snprintfz(pair, (value_len * 2) + 4, "%s=%s ", key, data);
 
         pa = pattern_array_add_key_simple_pattern(pa, key, simple_pattern_create(pair, NULL, SIMPLE_PATTERN_EXACT, true));
     }
+
+    freez(key);
+    freez(data);
+    freez(pair);
 
     return pa;
 }

--- a/src/health/health_prototypes.c
+++ b/src/health/health_prototypes.c
@@ -298,9 +298,10 @@ static inline struct pattern_array *health_config_add_key_to_values(struct patte
     size_t value_len = strlen(value);
     size_t input_key_len = input_key ? strlen(input_key) : 0;
     size_t key_len = value_len > input_key_len ? value_len : input_key_len;
+    size_t pair_len = key_len + value_len + 4;
     char *key = mallocz(key_len + 1);
     char *data = mallocz(value_len + 1);
-    char *pair = mallocz((value_len * 2) + 4);
+    char *pair = mallocz(pair_len);
 
     char *s = value;
     size_t i = 0;
@@ -319,9 +320,9 @@ static inline struct pattern_array *health_config_add_key_to_values(struct patte
         } else if (*s == ' ') {
             data[i]='\0';
             if (data[0]=='!')
-                snprintfz(pair, (value_len * 2) + 4, "!%s=%s ", key, data + 1);
+                snprintfz(pair, pair_len, "!%s=%s ", key, data + 1);
             else
-                snprintfz(pair, (value_len * 2) + 4, "%s=%s ", key, data);
+                snprintfz(pair, pair_len, "%s=%s ", key, data);
 
             pa = pattern_array_add_key_simple_pattern(pa, key, simple_pattern_create(pair, NULL, SIMPLE_PATTERN_EXACT, true));
             i=0;
@@ -333,9 +334,9 @@ static inline struct pattern_array *health_config_add_key_to_values(struct patte
     data[i]='\0';
     if (data[0]) {
         if (data[0]=='!')
-            snprintfz(pair, (value_len * 2) + 4, "!%s=%s ", key, data + 1);
+            snprintfz(pair, pair_len, "!%s=%s ", key, data + 1);
         else
-            snprintfz(pair, (value_len * 2) + 4, "%s=%s ", key, data);
+            snprintfz(pair, pair_len, "%s=%s ", key, data);
 
         pa = pattern_array_add_key_simple_pattern(pa, key, simple_pattern_create(pair, NULL, SIMPLE_PATTERN_EXACT, true));
     }

--- a/src/health/health_variable.c
+++ b/src/health/health_variable.c
@@ -380,7 +380,7 @@ bool alert_variable_lookup_internal(STRING *variable, void *data, NETDATA_DOUBLE
 
     // find the components of the variable
     {
-        char id[string_strlen(vbd.dim) + 1];
+        char id[RRD_ID_LENGTH_MAX + 1];
         memcpy(id, string2str(vbd.dim), string_strlen(vbd.dim));
         id[string_strlen(vbd.dim)] = '\0';
 

--- a/src/health/health_variable.c
+++ b/src/health/health_variable.c
@@ -380,9 +380,7 @@ bool alert_variable_lookup_internal(STRING *variable, void *data, NETDATA_DOUBLE
 
     // find the components of the variable
     {
-        char id[RRD_ID_LENGTH_MAX + 1];
-        memcpy(id, string2str(vbd.dim), string_strlen(vbd.dim));
-        id[string_strlen(vbd.dim)] = '\0';
+        char *id = strdupz(string2str(vbd.dim));
 
         char *dot = strrchr(id, '.');
         while(dot) {
@@ -397,6 +395,8 @@ bool alert_variable_lookup_internal(STRING *variable, void *data, NETDATA_DOUBLE
             *dot = '.';
             dot = dot2;
         }
+
+        freez(id);
     }
 
 find_best_scored:


### PR DESCRIPTION
##### Summary
This PR proceed with code changes started in https://github.com/netdata/netdata/pull/22114. This time, it is modified codes in src/claim and src/daemon directories.

##### Test Plan

- Compile this branch on different OS and compilers;
- Verify it is working as expected.

##### Additional Information
This PR was already tested on:

| Operate System| Version|
|----------------------|-----------|
|Slackware Linux |Current|
|Debian | 13 |
|FreeBSD | 15|


<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove variable-length arrays from database labels and health code to improve portability and stack safety. Use fixed-size buffers where bounds are known and heap buffers where sizes depend on input; no behavior changes expected.

- **Refactors**
  - src/database/rrdlabels.c: Replace VLA tmp buffer and sanitizer buffers with fixed-size arrays based on `RRDLABELS_MAX_*`.
  - src/health/health_config.c: Allocate concat buffer on the heap using computed lengths; free after use.
  - src/health/health_dyncfg.c: Add helper to build dyncfg IDs (`health_dyncfg_alert_prototype_id_strdupz`); use `strdupz`/`CLEAN_CHAR_P`; remove `HEALTH_CONF_MAX_LINE` stack buffers.
  - src/health/health_prototypes.c: Heap-allocate `key`, `data`, and `pair` sized to inputs; free them.
  - src/health/health_variable.c: Use `strdupz`/`freez` for the dimension ID instead of a VLA.

<sup>Written for commit 84910118bdd38e69c7a822ee2608c09b77b3be60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



