### PR TITLE
Properly sync our CI with the versions of Alpine we officially support.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -69,12 +69,12 @@ include:
     test:
       ebpf-core: true
   - <<: *alpine
-    version: "3.21"
+    version: "3.23"
     support_type: Core
     notes: ''
     eol_check: true
   - <<: *alpine
-    version: "3.20"
+    version: "3.22"
     support_type: Core
     notes: ''
     eol_check: true


### PR DESCRIPTION
##### Summary

We currently test against Edge and the two most recent minor versions, but the build matrix generation hadn’t been updated in quite some time, so we were actually testing against older versions.

##### Test Plan

CI passes on this PR.

##### Additional Information

Closes: #21853

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI to match our supported Alpine versions by bumping the matrix from 3.21/3.20 to 3.23/3.22 (plus Edge). Aligns tests with the policy of Edge + two latest minors and closes #21853.

<sup>Written for commit 21e7ca60a90e742eb6e4d1cfad828ccf9d085e16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

