### PR TITLE
Introduce RCU-based locking for dictionaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1189,6 +1189,8 @@ set(LIBNETDATA_FILES
         src/libnetdata/locks/spinlock.h
         src/libnetdata/locks/rw-spinlock.c
         src/libnetdata/locks/rw-spinlock.h
+        src/libnetdata/locks/rcu.c
+        src/libnetdata/locks/rcu.h
         src/libnetdata/atomics/atomic_flags.h
         src/libnetdata/atomics/atomics.h
         src/libnetdata/locks/waitq.c
@@ -1203,6 +1205,8 @@ set(LIBNETDATA_FILES
         src/libnetdata/locks/benchmark.h
         src/libnetdata/locks/benchmark-rw.c
         src/libnetdata/locks/benchmark-rw.h
+        src/libnetdata/locks/benchmark-rcu.c
+        src/libnetdata/locks/benchmark-rcu.h
         src/libnetdata/memory/nd-mallocz.c
         src/libnetdata/memory/nd-mallocz.h
         src/libnetdata/memory/nd-mmap.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1276,6 +1276,8 @@ set(LIBNETDATA_FILES
         src/libnetdata/locks/rw-spinlock.c
         src/libnetdata/locks/rw-spinlock.h
         src/libnetdata/locks/rw-spinlock-unittest.c
+        src/libnetdata/locks/rcu.c
+        src/libnetdata/locks/rcu.h
         src/libnetdata/atomics/atomic_flags.h
         src/libnetdata/atomics/atomics.h
         src/libnetdata/atomics/single_writer.h
@@ -1291,6 +1293,8 @@ set(LIBNETDATA_FILES
         src/libnetdata/locks/benchmark.h
         src/libnetdata/locks/benchmark-rw.c
         src/libnetdata/locks/benchmark-rw.h
+        src/libnetdata/locks/benchmark-rcu.c
+        src/libnetdata/locks/benchmark-rcu.h
         src/libnetdata/memory/nd-mallocz.c
         src/libnetdata/memory/nd-mallocz.h
         src/libnetdata/memory/nd-mmap.c

--- a/src/libnetdata/dictionary/dictionary-callbacks.h
+++ b/src/libnetdata/dictionary/dictionary-callbacks.h
@@ -19,7 +19,7 @@ static inline void dictionary_execute_insert_callback(DICTIONARY *dict, DICTIONA
                    "DICTIONARY: Running insert callback on item '%s' of dictionary",
                    item_get_name(item));
 
-    dict->hooks->insert_callback(item, item->shared->value, constructor_data?constructor_data:dict->hooks->insert_callback_data);
+    dict->hooks->insert_callback(item, dict_item_value_get(item), constructor_data?constructor_data:dict->hooks->insert_callback_data);
     DICTIONARY_STATS_CALLBACK_INSERTS_PLUS1(dict);
 }
 
@@ -35,7 +35,7 @@ static inline bool dictionary_execute_conflict_callback(DICTIONARY *dict, DICTIO
                    item_get_name(item));
 
     bool ret = dict->hooks->conflict_callback(
-        item, item->shared->value, new_value,
+        item, dict_item_value_get(item), new_value,
         constructor_data ? constructor_data : dict->hooks->conflict_callback_data);
 
     DICTIONARY_STATS_CALLBACK_CONFLICTS_PLUS1(dict);
@@ -54,7 +54,7 @@ static inline void dictionary_execute_react_callback(DICTIONARY *dict, DICTIONAR
                    "DICTIONARY: Running react callback on item '%s' of dictionary",
                    item_get_name(item));
 
-    dict->hooks->react_callback(item, item->shared->value,
+    dict->hooks->react_callback(item, dict_item_value_get(item),
                                 constructor_data?constructor_data:dict->hooks->react_callback_data);
 
     DICTIONARY_STATS_CALLBACK_REACTS_PLUS1(dict);
@@ -72,7 +72,7 @@ static inline void dictionary_execute_delete_callback(DICTIONARY *dict, DICTIONA
                    "DICTIONARY: Running delete callback on item '%s' of dictionary",
                    item_get_name(item));
 
-    dict->hooks->delete_callback(item, item->shared->value, dict->hooks->delelte_callback_data);
+    dict->hooks->delete_callback(item, dict_item_value_get(item), dict->hooks->delelte_callback_data);
 
     DICTIONARY_STATS_CALLBACK_DELETES_PLUS1(dict);
 }

--- a/src/libnetdata/dictionary/dictionary-internals.h
+++ b/src/libnetdata/dictionary/dictionary-internals.h
@@ -155,6 +155,11 @@ struct dictionary {
         uint32_t writer_depth;          // nesting of write locks
     } items;
 
+    struct {
+        DICTIONARY_ITEM *head;          // items removed from linked list, pending rcu_synchronize + free
+        SPINLOCK spinlock;              // protects the pending list (accessed outside write lock)
+    } rcu_pending_free;
+
     struct dictionary_hooks *hooks;     // pointer to external function callbacks to be called at certain points
     struct dictionary_stats *stats;     // statistics data, when DICT_OPTION_STATS is set
 
@@ -199,6 +204,102 @@ static bool dict_item_set_deleted(DICTIONARY *dict, DICTIONARY_ITEM *item);
 static int item_check_and_acquire_advanced(DICTIONARY *dict, DICTIONARY_ITEM *item, bool having_index_lock);
 #define item_is_not_referenced_and_can_be_removed(dict, item) (item_is_not_referenced_and_can_be_removed_advanced(dict, item) == RC_ITEM_OK)
 static inline int item_is_not_referenced_and_can_be_removed_advanced(DICTIONARY *dict, DICTIONARY_ITEM *item);
+
+// Queue an item for deferred freeing after the next rcu_synchronize().
+// The item must already be removed from the linked list (RCU-safe removal).
+// Uses item->prev (cleared by RCU-safe removal) as the singly-linked list pointer.
+static inline void dict_rcu_pending_free_queue(DICTIONARY *dict, DICTIONARY_ITEM *item) {
+    spinlock_lock(&dict->rcu_pending_free.spinlock);
+    item->prev = dict->rcu_pending_free.head;
+    dict->rcu_pending_free.head = item;
+    spinlock_unlock(&dict->rcu_pending_free.spinlock);
+}
+
+static inline DICTIONARY_ITEM *dict_rcu_pending_free_detach(DICTIONARY *dict) {
+    spinlock_lock(&dict->rcu_pending_free.spinlock);
+    DICTIONARY_ITEM *list = dict->rcu_pending_free.head;
+    dict->rcu_pending_free.head = NULL;
+    spinlock_unlock(&dict->rcu_pending_free.spinlock);
+
+    return list;
+}
+
+static inline size_t dict_rcu_pending_free_free_list(DICTIONARY *dict, DICTIONARY_ITEM *list) {
+    size_t bytes = 0;
+
+    while(list) {
+        DICTIONARY_ITEM *freeme = list;
+        list = freeme->prev;
+        freeme->prev = NULL;
+        freeme->next = NULL;
+        bytes += dict_item_free_with_hooks(dict, freeme);
+    }
+
+    return bytes;
+}
+
+// Drain the deferred-free list: call rcu_synchronize() once, then free all items.
+// Returns the number of items freed.
+// If the calling thread is currently inside an RCU read-side CS (nesting > 0),
+// skip the drain — calling rcu_synchronize() would block on other threads'
+// read-side CSs, causing livelock during bulk deletions (e.g. startup with
+// 800+ nodes). The items stay queued and will be drained at the next
+// quiescent call point (dictionary_destroy, or a GC triggered outside a CS).
+static inline size_t dict_rcu_pending_free_drain(DICTIONARY *dict) {
+    if(is_dictionary_single_threaded(dict))
+        return 0;
+
+    // Don't drain while inside an RCU read-side CS — rcu_synchronize()
+    // would block on other threads' CSs, causing livelock during bulk
+    // deletions (e.g. 800+ nodes loading contexts at startup).
+    if(rcu_thread_in_read_cs())
+        return 0;
+
+    // Atomically detach the entire list under the spinlock.
+    DICTIONARY_ITEM *list = dict_rcu_pending_free_detach(dict);
+
+    if(!list)
+        return 0;
+
+    // Single grace period for all items in the batch
+    if(!rcu_synchronize()) {
+        // Timeout — readers still active. DO NOT free the items.
+        // Re-queue them so they can be retried later.
+        // This leaks memory if the stall is permanent, but prevents
+        // use-after-free which is worse.
+        spinlock_lock(&dict->rcu_pending_free.spinlock);
+        // Find the tail of our detached list and link it to current head
+        DICTIONARY_ITEM *tail = list;
+        while(tail->prev)
+            tail = tail->prev;
+        tail->prev = dict->rcu_pending_free.head;
+        dict->rcu_pending_free.head = list;
+        spinlock_unlock(&dict->rcu_pending_free.spinlock);
+        return 0;
+    }
+
+    // Free all items — grace period confirmed complete
+    size_t count = 0;
+    for(DICTIONARY_ITEM *curr = list; curr; curr = curr->prev)
+        count++;
+
+    dict_rcu_pending_free_free_list(dict, list);
+    return count;
+}
+
+// RCU-safe item availability check for traversals.
+// Does NOT acquire a reference — only checks if the item is visible.
+// Safe to call only inside an RCU read-side critical section.
+static inline bool item_is_available_for_rcu_traversal(DICTIONARY_ITEM *item) {
+    if(item_flag_check(item, ITEM_FLAG_DELETED))
+        return false;
+    if(item_flag_check(item, ITEM_FLAG_BEING_CREATED))
+        return false;
+    // also skip items that are currently being deleted (refcount set to REFCOUNT_DELETED)
+    if(__atomic_load_n(&item->refcount, __ATOMIC_ACQUIRE) < 0)
+        return false;
+    return true;
+}
 
 // ----------------------------------------------------------------------------
 // validate each pointer is indexed once - internal checks only

--- a/src/libnetdata/dictionary/dictionary-internals.h
+++ b/src/libnetdata/dictionary/dictionary-internals.h
@@ -132,6 +132,12 @@ struct dictionary_hooks {
     void *delelte_callback_data;
 };
 
+typedef struct dictionary_rcu_retired_value {
+    struct dictionary_rcu_retired_value *next;
+    void *value;
+    size_t bytes;
+} DICTIONARY_RCU_RETIRED_VALUE;
+
 struct dictionary {
 #ifdef FSANITIZE_ADDRESS
     STACKTRACE_ARRAY stacktraces;   // stack traces from all acquisition points
@@ -157,6 +163,7 @@ struct dictionary {
 
     struct {
         DICTIONARY_ITEM *head;          // items removed from linked list, pending rcu_synchronize + free
+        DICTIONARY_RCU_RETIRED_VALUE *values; // replaced values pending rcu_synchronize + free
         SPINLOCK spinlock;              // protects the pending list (accessed outside write lock)
     } rcu_pending_free;
 
@@ -191,6 +198,9 @@ void garbage_collect_pending_deletes(DICTIONARY *dict);
 static inline void item_linked_list_remove(DICTIONARY *dict, DICTIONARY_ITEM *item);
 static size_t dict_item_free_with_hooks(DICTIONARY *dict, DICTIONARY_ITEM *item);
 static inline const char *item_get_name(const DICTIONARY_ITEM *item);
+static inline void dict_item_value_freez(DICTIONARY *dict, void *ptr);
+static inline void *dict_item_value_get(const DICTIONARY_ITEM *item);
+static inline void dict_item_value_set(DICTIONARY_ITEM *item, void *value);
 static inline int hashtable_delete_unsafe(DICTIONARY *dict, const char *name, size_t name_len, DICTIONARY_ITEM *item);
 static void item_release(DICTIONARY *dict, DICTIONARY_ITEM *item);
 static bool dict_item_set_deleted(DICTIONARY *dict, DICTIONARY_ITEM *item);
@@ -215,10 +225,28 @@ static inline void dict_rcu_pending_free_queue(DICTIONARY *dict, DICTIONARY_ITEM
     spinlock_unlock(&dict->rcu_pending_free.spinlock);
 }
 
-static inline DICTIONARY_ITEM *dict_rcu_pending_free_detach(DICTIONARY *dict) {
+static inline void dict_rcu_pending_value_queue(DICTIONARY *dict, void *value, size_t bytes) {
+    if(!value)
+        return;
+
+    DICTIONARY_RCU_RETIRED_VALUE *retired = mallocz(sizeof(*retired));
+    retired->value = value;
+    retired->bytes = bytes;
+
+    spinlock_lock(&dict->rcu_pending_free.spinlock);
+    retired->next = dict->rcu_pending_free.values;
+    dict->rcu_pending_free.values = retired;
+    spinlock_unlock(&dict->rcu_pending_free.spinlock);
+}
+
+static inline DICTIONARY_ITEM *dict_rcu_pending_free_detach(DICTIONARY *dict, DICTIONARY_RCU_RETIRED_VALUE **values) {
     spinlock_lock(&dict->rcu_pending_free.spinlock);
     DICTIONARY_ITEM *list = dict->rcu_pending_free.head;
     dict->rcu_pending_free.head = NULL;
+    if(values) {
+        *values = dict->rcu_pending_free.values;
+        dict->rcu_pending_free.values = NULL;
+    }
     spinlock_unlock(&dict->rcu_pending_free.spinlock);
 
     return list;
@@ -233,6 +261,20 @@ static inline size_t dict_rcu_pending_free_free_list(DICTIONARY *dict, DICTIONAR
         freeme->prev = NULL;
         freeme->next = NULL;
         bytes += dict_item_free_with_hooks(dict, freeme);
+    }
+
+    return bytes;
+}
+
+static inline size_t dict_rcu_pending_value_free_list(DICTIONARY *dict, DICTIONARY_RCU_RETIRED_VALUE *list) {
+    size_t bytes = 0;
+
+    while(list) {
+        DICTIONARY_RCU_RETIRED_VALUE *freeme = list;
+        list = freeme->next;
+        dict_item_value_freez(dict, freeme->value);
+        bytes += freeme->bytes + sizeof(*freeme);
+        freez(freeme);
     }
 
     return bytes;
@@ -256,9 +298,10 @@ static inline size_t dict_rcu_pending_free_drain(DICTIONARY *dict) {
         return 0;
 
     // Atomically detach the entire list under the spinlock.
-    DICTIONARY_ITEM *list = dict_rcu_pending_free_detach(dict);
+    DICTIONARY_RCU_RETIRED_VALUE *values = NULL;
+    DICTIONARY_ITEM *list = dict_rcu_pending_free_detach(dict, &values);
 
-    if(!list)
+    if(!list && !values)
         return 0;
 
     // Single grace period for all items in the batch
@@ -269,11 +312,20 @@ static inline size_t dict_rcu_pending_free_drain(DICTIONARY *dict) {
         // use-after-free which is worse.
         spinlock_lock(&dict->rcu_pending_free.spinlock);
         // Find the tail of our detached list and link it to current head
-        DICTIONARY_ITEM *tail = list;
-        while(tail->prev)
-            tail = tail->prev;
-        tail->prev = dict->rcu_pending_free.head;
-        dict->rcu_pending_free.head = list;
+        if(list) {
+            DICTIONARY_ITEM *tail = list;
+            while(tail->prev)
+                tail = tail->prev;
+            tail->prev = dict->rcu_pending_free.head;
+            dict->rcu_pending_free.head = list;
+        }
+        if(values) {
+            DICTIONARY_RCU_RETIRED_VALUE *tail = values;
+            while(tail->next)
+                tail = tail->next;
+            tail->next = dict->rcu_pending_free.values;
+            dict->rcu_pending_free.values = values;
+        }
         spinlock_unlock(&dict->rcu_pending_free.spinlock);
         return 0;
     }
@@ -284,6 +336,7 @@ static inline size_t dict_rcu_pending_free_drain(DICTIONARY *dict) {
         count++;
 
     dict_rcu_pending_free_free_list(dict, list);
+    dict_rcu_pending_value_free_list(dict, values);
     return count;
 }
 

--- a/src/libnetdata/dictionary/dictionary-internals.h
+++ b/src/libnetdata/dictionary/dictionary-internals.h
@@ -247,6 +247,11 @@ struct dictionary {
         uint32_t writer_depth;          // nesting of write locks
     } items;
 
+    struct {
+        DICTIONARY_ITEM *head;          // items removed from linked list, pending rcu_synchronize + free
+        SPINLOCK spinlock;              // protects the pending list (accessed outside write lock)
+    } rcu_pending_free;
+
     struct dictionary_hooks *hooks;     // pointer to external function callbacks to be called at certain points
     struct dictionary_stats *stats;     // statistics data, when DICT_OPTION_STATS is set
 
@@ -292,6 +297,102 @@ static bool dict_item_set_deleted(DICTIONARY *dict, DICTIONARY_ITEM *item);
 static int item_check_and_acquire_advanced(DICTIONARY *dict, DICTIONARY_ITEM *item, bool having_index_lock);
 #define item_is_not_referenced_and_can_be_removed(dict, item) (item_is_not_referenced_and_can_be_removed_advanced(dict, item) == RC_ITEM_OK)
 static inline int item_is_not_referenced_and_can_be_removed_advanced(DICTIONARY *dict, DICTIONARY_ITEM *item);
+
+// Queue an item for deferred freeing after the next rcu_synchronize().
+// The item must already be removed from the linked list (RCU-safe removal).
+// Uses item->prev (cleared by RCU-safe removal) as the singly-linked list pointer.
+static inline void dict_rcu_pending_free_queue(DICTIONARY *dict, DICTIONARY_ITEM *item) {
+    spinlock_lock(&dict->rcu_pending_free.spinlock);
+    item->prev = dict->rcu_pending_free.head;
+    dict->rcu_pending_free.head = item;
+    spinlock_unlock(&dict->rcu_pending_free.spinlock);
+}
+
+static inline DICTIONARY_ITEM *dict_rcu_pending_free_detach(DICTIONARY *dict) {
+    spinlock_lock(&dict->rcu_pending_free.spinlock);
+    DICTIONARY_ITEM *list = dict->rcu_pending_free.head;
+    dict->rcu_pending_free.head = NULL;
+    spinlock_unlock(&dict->rcu_pending_free.spinlock);
+
+    return list;
+}
+
+static inline size_t dict_rcu_pending_free_free_list(DICTIONARY *dict, DICTIONARY_ITEM *list) {
+    size_t bytes = 0;
+
+    while(list) {
+        DICTIONARY_ITEM *freeme = list;
+        list = freeme->prev;
+        freeme->prev = NULL;
+        freeme->next = NULL;
+        bytes += dict_item_free_with_hooks(dict, freeme);
+    }
+
+    return bytes;
+}
+
+// Drain the deferred-free list: call rcu_synchronize() once, then free all items.
+// Returns the number of items freed.
+// If the calling thread is currently inside an RCU read-side CS (nesting > 0),
+// skip the drain — calling rcu_synchronize() would block on other threads'
+// read-side CSs, causing livelock during bulk deletions (e.g. startup with
+// 800+ nodes). The items stay queued and will be drained at the next
+// quiescent call point (dictionary_destroy, or a GC triggered outside a CS).
+static inline size_t dict_rcu_pending_free_drain(DICTIONARY *dict) {
+    if(is_dictionary_single_threaded(dict))
+        return 0;
+
+    // Don't drain while inside an RCU read-side CS — rcu_synchronize()
+    // would block on other threads' CSs, causing livelock during bulk
+    // deletions (e.g. 800+ nodes loading contexts at startup).
+    if(rcu_thread_in_read_cs())
+        return 0;
+
+    // Atomically detach the entire list under the spinlock.
+    DICTIONARY_ITEM *list = dict_rcu_pending_free_detach(dict);
+
+    if(!list)
+        return 0;
+
+    // Single grace period for all items in the batch
+    if(!rcu_synchronize()) {
+        // Timeout — readers still active. DO NOT free the items.
+        // Re-queue them so they can be retried later.
+        // This leaks memory if the stall is permanent, but prevents
+        // use-after-free which is worse.
+        spinlock_lock(&dict->rcu_pending_free.spinlock);
+        // Find the tail of our detached list and link it to current head
+        DICTIONARY_ITEM *tail = list;
+        while(tail->prev)
+            tail = tail->prev;
+        tail->prev = dict->rcu_pending_free.head;
+        dict->rcu_pending_free.head = list;
+        spinlock_unlock(&dict->rcu_pending_free.spinlock);
+        return 0;
+    }
+
+    // Free all items — grace period confirmed complete
+    size_t count = 0;
+    for(DICTIONARY_ITEM *curr = list; curr; curr = curr->prev)
+        count++;
+
+    dict_rcu_pending_free_free_list(dict, list);
+    return count;
+}
+
+// RCU-safe item availability check for traversals.
+// Does NOT acquire a reference — only checks if the item is visible.
+// Safe to call only inside an RCU read-side critical section.
+static inline bool item_is_available_for_rcu_traversal(DICTIONARY_ITEM *item) {
+    if(item_flag_check(item, ITEM_FLAG_DELETED))
+        return false;
+    if(item_flag_check(item, ITEM_FLAG_BEING_CREATED))
+        return false;
+    // also skip items that are currently being deleted (refcount set to REFCOUNT_DELETED)
+    if(__atomic_load_n(&item->refcount, __ATOMIC_ACQUIRE) < 0)
+        return false;
+    return true;
+}
 
 // ----------------------------------------------------------------------------
 // validate each pointer is indexed once - internal checks only

--- a/src/libnetdata/dictionary/dictionary-internals.h
+++ b/src/libnetdata/dictionary/dictionary-internals.h
@@ -223,6 +223,12 @@ struct dictionary_hooks {
     void *delelte_callback_data;
 };
 
+typedef struct dictionary_rcu_retired_value {
+    struct dictionary_rcu_retired_value *next;
+    void *value;
+    size_t bytes;
+} DICTIONARY_RCU_RETIRED_VALUE;
+
 struct dictionary {
 #ifdef FSANITIZE_ADDRESS
     STACKTRACE_ARRAY stacktraces;   // stack traces from all acquisition points
@@ -249,6 +255,7 @@ struct dictionary {
 
     struct {
         DICTIONARY_ITEM *head;          // items removed from linked list, pending rcu_synchronize + free
+        DICTIONARY_RCU_RETIRED_VALUE *values; // replaced values pending rcu_synchronize + free
         SPINLOCK spinlock;              // protects the pending list (accessed outside write lock)
     } rcu_pending_free;
 
@@ -284,6 +291,9 @@ void garbage_collect_pending_deletes(DICTIONARY *dict);
 static inline void item_linked_list_remove(DICTIONARY *dict, DICTIONARY_ITEM *item);
 static size_t dict_item_free_with_hooks(DICTIONARY *dict, DICTIONARY_ITEM *item);
 static inline const char *item_get_name(const DICTIONARY_ITEM *item);
+static inline void dict_item_value_freez(DICTIONARY *dict, void *ptr);
+static inline void *dict_item_value_get(const DICTIONARY_ITEM *item);
+static inline void dict_item_value_set(DICTIONARY_ITEM *item, void *value);
 static inline int hashtable_delete_unsafe(DICTIONARY *dict, const char *name, size_t name_len, DICTIONARY_ITEM *item);
 static void item_release(DICTIONARY *dict, DICTIONARY_ITEM *item);
 static bool dict_item_set_deleted(DICTIONARY *dict, DICTIONARY_ITEM *item);
@@ -308,10 +318,28 @@ static inline void dict_rcu_pending_free_queue(DICTIONARY *dict, DICTIONARY_ITEM
     spinlock_unlock(&dict->rcu_pending_free.spinlock);
 }
 
-static inline DICTIONARY_ITEM *dict_rcu_pending_free_detach(DICTIONARY *dict) {
+static inline void dict_rcu_pending_value_queue(DICTIONARY *dict, void *value, size_t bytes) {
+    if(!value)
+        return;
+
+    DICTIONARY_RCU_RETIRED_VALUE *retired = mallocz(sizeof(*retired));
+    retired->value = value;
+    retired->bytes = bytes;
+
+    spinlock_lock(&dict->rcu_pending_free.spinlock);
+    retired->next = dict->rcu_pending_free.values;
+    dict->rcu_pending_free.values = retired;
+    spinlock_unlock(&dict->rcu_pending_free.spinlock);
+}
+
+static inline DICTIONARY_ITEM *dict_rcu_pending_free_detach(DICTIONARY *dict, DICTIONARY_RCU_RETIRED_VALUE **values) {
     spinlock_lock(&dict->rcu_pending_free.spinlock);
     DICTIONARY_ITEM *list = dict->rcu_pending_free.head;
     dict->rcu_pending_free.head = NULL;
+    if(values) {
+        *values = dict->rcu_pending_free.values;
+        dict->rcu_pending_free.values = NULL;
+    }
     spinlock_unlock(&dict->rcu_pending_free.spinlock);
 
     return list;
@@ -326,6 +354,20 @@ static inline size_t dict_rcu_pending_free_free_list(DICTIONARY *dict, DICTIONAR
         freeme->prev = NULL;
         freeme->next = NULL;
         bytes += dict_item_free_with_hooks(dict, freeme);
+    }
+
+    return bytes;
+}
+
+static inline size_t dict_rcu_pending_value_free_list(DICTIONARY *dict, DICTIONARY_RCU_RETIRED_VALUE *list) {
+    size_t bytes = 0;
+
+    while(list) {
+        DICTIONARY_RCU_RETIRED_VALUE *freeme = list;
+        list = freeme->next;
+        dict_item_value_freez(dict, freeme->value);
+        bytes += freeme->bytes + sizeof(*freeme);
+        freez(freeme);
     }
 
     return bytes;
@@ -349,9 +391,10 @@ static inline size_t dict_rcu_pending_free_drain(DICTIONARY *dict) {
         return 0;
 
     // Atomically detach the entire list under the spinlock.
-    DICTIONARY_ITEM *list = dict_rcu_pending_free_detach(dict);
+    DICTIONARY_RCU_RETIRED_VALUE *values = NULL;
+    DICTIONARY_ITEM *list = dict_rcu_pending_free_detach(dict, &values);
 
-    if(!list)
+    if(!list && !values)
         return 0;
 
     // Single grace period for all items in the batch
@@ -362,11 +405,20 @@ static inline size_t dict_rcu_pending_free_drain(DICTIONARY *dict) {
         // use-after-free which is worse.
         spinlock_lock(&dict->rcu_pending_free.spinlock);
         // Find the tail of our detached list and link it to current head
-        DICTIONARY_ITEM *tail = list;
-        while(tail->prev)
-            tail = tail->prev;
-        tail->prev = dict->rcu_pending_free.head;
-        dict->rcu_pending_free.head = list;
+        if(list) {
+            DICTIONARY_ITEM *tail = list;
+            while(tail->prev)
+                tail = tail->prev;
+            tail->prev = dict->rcu_pending_free.head;
+            dict->rcu_pending_free.head = list;
+        }
+        if(values) {
+            DICTIONARY_RCU_RETIRED_VALUE *tail = values;
+            while(tail->next)
+                tail = tail->next;
+            tail->next = dict->rcu_pending_free.values;
+            dict->rcu_pending_free.values = values;
+        }
         spinlock_unlock(&dict->rcu_pending_free.spinlock);
         return 0;
     }
@@ -377,6 +429,7 @@ static inline size_t dict_rcu_pending_free_drain(DICTIONARY *dict) {
         count++;
 
     dict_rcu_pending_free_free_list(dict, list);
+    dict_rcu_pending_value_free_list(dict, values);
     return count;
 }
 

--- a/src/libnetdata/dictionary/dictionary-item.h
+++ b/src/libnetdata/dictionary/dictionary-item.h
@@ -107,6 +107,31 @@ static inline void dict_item_value_freez(DICTIONARY *dict, void *ptr) {
         freez(ptr);
 }
 
+static inline void *dict_item_value_get(const DICTIONARY_ITEM *item) {
+    return __atomic_load_n(&item->shared->value, __ATOMIC_ACQUIRE);
+}
+
+static inline void dict_item_value_set(DICTIONARY_ITEM *item, void *value) {
+    __atomic_store_n(&item->shared->value, value, __ATOMIC_RELEASE);
+}
+
+static inline size_t dict_item_value_bytes(DICTIONARY *dict, size_t value_len) {
+    if(dict->value_aral)
+        return aral_requested_element_size(dict->value_aral);
+
+    return value_len;
+}
+
+static inline void dict_item_retire_replaced_value(DICTIONARY *dict, void *value, size_t value_len) {
+    if(!value)
+        return;
+
+    if(unlikely(is_dictionary_single_threaded(dict)))
+        dict_item_value_freez(dict, value);
+    else
+        dict_rcu_pending_value_queue(dict, value, dict_item_value_bytes(dict, value_len));
+}
+
 static inline void *dict_item_value_create(DICTIONARY *dict, void *value, size_t value_len) {
     void *ptr = NULL;
 
@@ -158,9 +183,9 @@ static inline DICTIONARY_ITEM *dict_item_create_with_hooks(DICTIONARY *dict, con
         // we are on the master dictionary
 
         if(unlikely(dict->options & DICT_OPTION_VALUE_LINK_DONT_CLONE))
-            item->shared->value = value;
+            dict_item_value_set(item, value);
         else
-            item->shared->value = dict_item_value_create(dict, value, value_len);
+            dict_item_value_set(item, dict_item_value_create(dict, value, value_len));
 
         item->shared->value_len = value_len;
         value_size += value_len;
@@ -191,24 +216,25 @@ static inline void dict_item_reset_value_with_hooks(DICTIONARY *dict, DICTIONARY
 
     if(likely(dict->options & DICT_OPTION_VALUE_LINK_DONT_CLONE)) {
         netdata_log_debug(D_DICTIONARY, "Dictionary: linking value to '%s'", item_get_name(item));
-        item->shared->value = value;
+        dict_item_value_set(item, value);
         item->shared->value_len = value_len;
     }
     else {
         netdata_log_debug(D_DICTIONARY, "Dictionary: cloning value to '%s'", item_get_name(item));
 
-        void *old_value = item->shared->value;
+        void *old_value = dict_item_value_get(item);
+        size_t old_value_len = item->shared->value_len;
         void *new_value = NULL;
         if(value_len) {
             new_value = dict_item_value_mallocz(dict, value_len);
             if(value) memcpy(new_value, value, value_len);
             else memset(new_value, 0, value_len);
         }
-        item->shared->value = new_value;
+        dict_item_value_set(item, new_value);
         item->shared->value_len = value_len;
 
-        netdata_log_debug(D_DICTIONARY, "Dictionary: freeing old value of '%s'", item_get_name(item));
-        dict_item_value_freez(dict, old_value);
+        netdata_log_debug(D_DICTIONARY, "Dictionary: retiring old value of '%s' after RCU grace period", item_get_name(item));
+        dict_item_retire_replaced_value(dict, old_value, old_value_len);
     }
 
     dictionary_execute_insert_callback(dict, item, constructor_data);
@@ -229,8 +255,8 @@ static inline size_t dict_item_free_with_hooks(DICTIONARY *dict, DICTIONARY_ITEM
 
         if(unlikely(!(dict->options & DICT_OPTION_VALUE_LINK_DONT_CLONE))) {
             netdata_log_debug(D_DICTIONARY, "Dictionary freeing value of '%s'", item_get_name(item));
-            dict_item_value_freez(dict, item->shared->value);
-            item->shared->value = NULL;
+            dict_item_value_freez(dict, dict_item_value_get(item));
+            dict_item_value_set(item, NULL);
         }
         value_size += item->shared->value_len;
 
@@ -559,6 +585,9 @@ static inline DICTIONARY_ITEM *dict_item_add_or_reset_value_and_acquire(DICTIONA
 
     if(unlikely(spins > 0))
         DICTIONARY_STATS_INSERT_SPINS_PLUS(dict, spins);
+
+    if(!is_dictionary_single_threaded(dict))
+        dict_rcu_pending_free_drain(dict);
 
     if(is_master_dictionary(dict) && added_or_updated)
         dictionary_execute_react_callback(dict, item, constructor_data);

--- a/src/libnetdata/dictionary/dictionary-item.h
+++ b/src/libnetdata/dictionary/dictionary-item.h
@@ -216,8 +216,8 @@ static inline void dict_item_reset_value_with_hooks(DICTIONARY *dict, DICTIONARY
 
     if(likely(dict->options & DICT_OPTION_VALUE_LINK_DONT_CLONE)) {
         netdata_log_debug(D_DICTIONARY, "Dictionary: linking value to '%s'", item_get_name(item));
-        dict_item_value_set(item, value);
         item->shared->value_len = value_len;
+        dict_item_value_set(item, value);
     }
     else {
         netdata_log_debug(D_DICTIONARY, "Dictionary: cloning value to '%s'", item_get_name(item));
@@ -230,8 +230,8 @@ static inline void dict_item_reset_value_with_hooks(DICTIONARY *dict, DICTIONARY
             if(value) memcpy(new_value, value, value_len);
             else memset(new_value, 0, value_len);
         }
-        dict_item_value_set(item, new_value);
         item->shared->value_len = value_len;
+        dict_item_value_set(item, new_value);
 
         netdata_log_debug(D_DICTIONARY, "Dictionary: retiring old value of '%s' after RCU grace period", item_get_name(item));
         dict_item_retire_replaced_value(dict, old_value, old_value_len);

--- a/src/libnetdata/dictionary/dictionary-item.h
+++ b/src/libnetdata/dictionary/dictionary-item.h
@@ -259,10 +259,20 @@ static inline size_t dict_item_free_with_hooks(DICTIONARY *dict, DICTIONARY_ITEM
 static inline void item_linked_list_add(DICTIONARY *dict, DICTIONARY_ITEM *item) {
     ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE);
 
-    if(dict->options & DICT_OPTION_ADD_IN_FRONT)
-        DOUBLE_LINKED_LIST_PREPEND_ITEM_UNSAFE(dict->items.list, item, prev, next);
-    else
-        DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(dict->items.list, item, prev, next);
+    if(is_dictionary_single_threaded(dict)) {
+        if(dict->options & DICT_OPTION_ADD_IN_FRONT)
+            DOUBLE_LINKED_LIST_PREPEND_ITEM_UNSAFE(dict->items.list, item, prev, next);
+        else
+            DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(dict->items.list, item, prev, next);
+    }
+    else {
+        // RCU-safe insertion: uses atomic release stores on the publication
+        // pointers (head, prev->next) that RCU readers load with acquire.
+        if(dict->options & DICT_OPTION_ADD_IN_FRONT)
+            DOUBLE_LINKED_LIST_PREPEND_ITEM_RCU_SAFE(dict->items.list, item, prev, next);
+        else
+            DOUBLE_LINKED_LIST_APPEND_ITEM_RCU_SAFE(dict->items.list, item, prev, next);
+    }
 
 #ifdef NETDATA_INTERNAL_CHECKS
     item->ll_adder_pid = gettid_cached();
@@ -279,7 +289,14 @@ static inline void item_linked_list_add(DICTIONARY *dict, DICTIONARY_ITEM *item)
 static inline void item_linked_list_remove(DICTIONARY *dict, DICTIONARY_ITEM *item) {
     ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE);
 
-    DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(dict->items.list, item, prev, next);
+    if(is_dictionary_single_threaded(dict)) {
+        DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(dict->items.list, item, prev, next);
+    }
+    else {
+        // RCU-safe removal: preserve item->next so concurrent RCU readers
+        // at this item can still follow the chain forward.
+        DOUBLE_LINKED_LIST_REMOVE_ITEM_RCU_SAFE(dict->items.list, item, prev, next);
+    }
 
 #ifdef NETDATA_INTERNAL_CHECKS
     item->ll_remover_pid = gettid_cached();
@@ -287,6 +304,20 @@ static inline void item_linked_list_remove(DICTIONARY *dict, DICTIONARY_ITEM *it
 
     garbage_collect_pending_deletes(dict);
     ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
+}
+
+static inline void dict_item_retire(DICTIONARY *dict, DICTIONARY_ITEM *item) {
+    if(is_dictionary_single_threaded(dict))
+        dict_item_free_with_hooks(dict, item);
+    else
+        dict_rcu_pending_free_queue(dict, item);
+}
+
+static inline void dict_item_retire_and_try_drain(DICTIONARY *dict, DICTIONARY_ITEM *item) {
+    dict_item_retire(dict, item);
+
+    if(!is_dictionary_single_threaded(dict))
+        dict_rcu_pending_free_drain(dict);
 }
 
 // ----------------------------------------------------------------------------
@@ -324,10 +355,10 @@ static inline void dict_item_free_or_mark_deleted(DICTIONARY *dict, DICTIONARY_I
     int rc = item_is_not_referenced_and_can_be_removed_advanced(dict, item);
     switch(rc) {
         case RC_ITEM_OK:
-            // the item is ours, refcount set to -100
+            // the item is ours, refcount set to REFCOUNT_DELETED
             dict_item_shared_set_deleted(dict, item);
             item_linked_list_remove(dict, item);
-            dict_item_free_with_hooks(dict, item);
+            dict_item_retire_and_try_drain(dict, item);
             break;
 
         case RC_ITEM_IS_REFERENCED:
@@ -365,7 +396,7 @@ static inline void dict_item_release_and_check_if_it_is_deleted_and_can_be_remov
             DICTIONARY_PENDING_DELETES_MINUS1(dict);
 
             item_linked_list_remove(dict, item);
-            dict_item_free_with_hooks(dict, item);
+            dict_item_retire_and_try_drain(dict, item);
         }
     }
     else {

--- a/src/libnetdata/dictionary/dictionary-item.h
+++ b/src/libnetdata/dictionary/dictionary-item.h
@@ -107,6 +107,31 @@ static inline void dict_item_value_freez(DICTIONARY *dict, void *ptr) {
         freez(ptr);
 }
 
+static inline void *dict_item_value_get(const DICTIONARY_ITEM *item) {
+    return __atomic_load_n(&item->shared->value, __ATOMIC_ACQUIRE);
+}
+
+static inline void dict_item_value_set(DICTIONARY_ITEM *item, void *value) {
+    __atomic_store_n(&item->shared->value, value, __ATOMIC_RELEASE);
+}
+
+static inline size_t dict_item_value_bytes(DICTIONARY *dict, size_t value_len) {
+    if(dict->value_aral)
+        return aral_requested_element_size(dict->value_aral);
+
+    return value_len;
+}
+
+static inline void dict_item_retire_replaced_value(DICTIONARY *dict, void *value, size_t value_len) {
+    if(!value)
+        return;
+
+    if(unlikely(is_dictionary_single_threaded(dict)))
+        dict_item_value_freez(dict, value);
+    else
+        dict_rcu_pending_value_queue(dict, value, dict_item_value_bytes(dict, value_len));
+}
+
 static inline void *dict_item_value_create(DICTIONARY *dict, void *value, size_t value_len) {
     void *ptr = NULL;
 
@@ -158,9 +183,9 @@ static inline DICTIONARY_ITEM *dict_item_create_with_hooks(DICTIONARY *dict, con
         // we are on the master dictionary
 
         if(unlikely(dict->options & DICT_OPTION_VALUE_LINK_DONT_CLONE))
-            item->shared->value = value;
+            dict_item_value_set(item, value);
         else
-            item->shared->value = dict_item_value_create(dict, value, value_len);
+            dict_item_value_set(item, dict_item_value_create(dict, value, value_len));
 
         item->shared->value_len = value_len;
         value_size += value_len;
@@ -191,24 +216,25 @@ static inline void dict_item_reset_value_with_hooks(DICTIONARY *dict, DICTIONARY
 
     if(likely(dict->options & DICT_OPTION_VALUE_LINK_DONT_CLONE)) {
         netdata_log_debug(D_DICTIONARY, "Dictionary: linking value to '%s'", item_get_name(item));
-        item->shared->value = value;
+        dict_item_value_set(item, value);
         item->shared->value_len = value_len;
     }
     else {
         netdata_log_debug(D_DICTIONARY, "Dictionary: cloning value to '%s'", item_get_name(item));
 
-        void *old_value = item->shared->value;
+        void *old_value = dict_item_value_get(item);
+        size_t old_value_len = item->shared->value_len;
         void *new_value = NULL;
         if(value_len) {
             new_value = dict_item_value_mallocz(dict, value_len);
             if(value) memcpy(new_value, value, value_len);
             else memset(new_value, 0, value_len);
         }
-        item->shared->value = new_value;
+        dict_item_value_set(item, new_value);
         item->shared->value_len = value_len;
 
-        netdata_log_debug(D_DICTIONARY, "Dictionary: freeing old value of '%s'", item_get_name(item));
-        dict_item_value_freez(dict, old_value);
+        netdata_log_debug(D_DICTIONARY, "Dictionary: retiring old value of '%s' after RCU grace period", item_get_name(item));
+        dict_item_retire_replaced_value(dict, old_value, old_value_len);
     }
 
     dictionary_execute_insert_callback(dict, item, constructor_data);
@@ -229,8 +255,8 @@ static inline size_t dict_item_free_with_hooks(DICTIONARY *dict, DICTIONARY_ITEM
 
         if(unlikely(!(dict->options & DICT_OPTION_VALUE_LINK_DONT_CLONE))) {
             netdata_log_debug(D_DICTIONARY, "Dictionary freeing value of '%s'", item_get_name(item));
-            dict_item_value_freez(dict, item->shared->value);
-            item->shared->value = NULL;
+            dict_item_value_freez(dict, dict_item_value_get(item));
+            dict_item_value_set(item, NULL);
         }
         value_size += item->shared->value_len;
 
@@ -571,6 +597,9 @@ static inline DICTIONARY_ITEM *dict_item_add_or_reset_value_and_acquire(DICTIONA
 
     if(unlikely(spins > 0))
         DICTIONARY_STATS_INSERT_SPINS_PLUS(dict, spins);
+
+    if(!is_dictionary_single_threaded(dict))
+        dict_rcu_pending_free_drain(dict);
 
     if(is_master_dictionary(dict) && added_or_updated)
         dictionary_execute_react_callback(dict, item, constructor_data);

--- a/src/libnetdata/dictionary/dictionary-item.h
+++ b/src/libnetdata/dictionary/dictionary-item.h
@@ -259,10 +259,20 @@ static inline size_t dict_item_free_with_hooks(DICTIONARY *dict, DICTIONARY_ITEM
 static inline void item_linked_list_add(DICTIONARY *dict, DICTIONARY_ITEM *item) {
     ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE);
 
-    if(dict->options & DICT_OPTION_ADD_IN_FRONT)
-        DOUBLE_LINKED_LIST_PREPEND_ITEM_UNSAFE(dict->items.list, item, prev, next);
-    else
-        DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(dict->items.list, item, prev, next);
+    if(is_dictionary_single_threaded(dict)) {
+        if(dict->options & DICT_OPTION_ADD_IN_FRONT)
+            DOUBLE_LINKED_LIST_PREPEND_ITEM_UNSAFE(dict->items.list, item, prev, next);
+        else
+            DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(dict->items.list, item, prev, next);
+    }
+    else {
+        // RCU-safe insertion: uses atomic release stores on the publication
+        // pointers (head, prev->next) that RCU readers load with acquire.
+        if(dict->options & DICT_OPTION_ADD_IN_FRONT)
+            DOUBLE_LINKED_LIST_PREPEND_ITEM_RCU_SAFE(dict->items.list, item, prev, next);
+        else
+            DOUBLE_LINKED_LIST_APPEND_ITEM_RCU_SAFE(dict->items.list, item, prev, next);
+    }
 
 #ifdef NETDATA_INTERNAL_CHECKS
     item->ll_adder_pid = gettid_cached();
@@ -279,7 +289,14 @@ static inline void item_linked_list_add(DICTIONARY *dict, DICTIONARY_ITEM *item)
 static inline void item_linked_list_remove(DICTIONARY *dict, DICTIONARY_ITEM *item) {
     ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE);
 
-    DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(dict->items.list, item, prev, next);
+    if(is_dictionary_single_threaded(dict)) {
+        DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(dict->items.list, item, prev, next);
+    }
+    else {
+        // RCU-safe removal: preserve item->next so concurrent RCU readers
+        // at this item can still follow the chain forward.
+        DOUBLE_LINKED_LIST_REMOVE_ITEM_RCU_SAFE(dict->items.list, item, prev, next);
+    }
 
 #ifdef NETDATA_INTERNAL_CHECKS
     item->ll_remover_pid = gettid_cached();
@@ -287,6 +304,20 @@ static inline void item_linked_list_remove(DICTIONARY *dict, DICTIONARY_ITEM *it
 
     garbage_collect_pending_deletes(dict);
     ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
+}
+
+static inline void dict_item_retire(DICTIONARY *dict, DICTIONARY_ITEM *item) {
+    if(is_dictionary_single_threaded(dict))
+        dict_item_free_with_hooks(dict, item);
+    else
+        dict_rcu_pending_free_queue(dict, item);
+}
+
+static inline void dict_item_retire_and_try_drain(DICTIONARY *dict, DICTIONARY_ITEM *item) {
+    dict_item_retire(dict, item);
+
+    if(!is_dictionary_single_threaded(dict))
+        dict_rcu_pending_free_drain(dict);
 }
 
 // ----------------------------------------------------------------------------
@@ -336,10 +367,10 @@ static inline void dict_item_free_or_mark_deleted(DICTIONARY *dict, DICTIONARY_I
     int rc = item_is_not_referenced_and_can_be_removed_advanced(dict, item);
     switch(rc) {
         case RC_ITEM_OK:
-            // the item is ours, refcount set to -100
+            // the item is ours, refcount set to REFCOUNT_DELETED
             dict_item_shared_set_deleted(dict, item);
             item_linked_list_remove(dict, item);
-            dict_item_free_with_hooks(dict, item);
+            dict_item_retire_and_try_drain(dict, item);
             break;
 
         case RC_ITEM_IS_REFERENCED:
@@ -377,7 +408,7 @@ static inline void dict_item_release_and_check_if_it_is_deleted_and_can_be_remov
             item_pending_deletion_clear(dict, item);
 
             item_linked_list_remove(dict, item);
-            dict_item_free_with_hooks(dict, item);
+            dict_item_retire_and_try_drain(dict, item);
         }
     }
     else {

--- a/src/libnetdata/dictionary/dictionary-locks.h
+++ b/src/libnetdata/dictionary/dictionary-locks.h
@@ -12,6 +12,7 @@ static inline size_t dictionary_locks_init(DICTIONARY *dict) {
     if(likely(!is_dictionary_single_threaded(dict))) {
         rw_spinlock_init(&dict->index.rw_spinlock);
         rw_spinlock_init(&dict->items.rw_spinlock);
+        spinlock_init(&dict->rcu_pending_free.spinlock);
     }
 
     return 0;
@@ -47,8 +48,14 @@ static inline void ll_recursive_lock(DICTIONARY *dict, char rw) {
         return;
     }
 
-    if(rw == DICTIONARY_LOCK_READ || rw == DICTIONARY_LOCK_REENTRANT || rw == 'R') {
-        // read lock
+    if(rw == DICTIONARY_LOCK_READ) {
+        // Use RCU for pure read traversals — zero shared-write overhead.
+        // The calling thread must be RCU-registered (rcu_read_lock auto-registers).
+        rcu_read_lock();
+    }
+    else if(rw == DICTIONARY_LOCK_REENTRANT || rw == 'R') {
+        // REENTRANT mode breaks/reacquires between iterations,
+        // so it cannot use RCU (which requires a continuous read-side CS).
         rw_spinlock_read_lock(&dict->items.rw_spinlock);
     }
     else {
@@ -67,9 +74,10 @@ static inline void ll_recursive_unlock(DICTIONARY *dict, char rw) {
         return;
     }
 
-    if(rw == DICTIONARY_LOCK_READ || rw == DICTIONARY_LOCK_REENTRANT || rw == 'R') {
-        // read unlock
-
+    if(rw == DICTIONARY_LOCK_READ) {
+        rcu_read_unlock();
+    }
+    else if(rw == DICTIONARY_LOCK_REENTRANT || rw == 'R') {
         rw_spinlock_read_unlock(&dict->items.rw_spinlock);
     }
     else {
@@ -79,6 +87,11 @@ static inline void ll_recursive_unlock(DICTIONARY *dict, char rw) {
 
         rw_spinlock_write_unlock(&dict->items.rw_spinlock);
     }
+}
+
+// Returns true if the given lock mode uses RCU (no per-item refcount needed).
+static inline bool ll_lock_is_rcu_mode(DICTIONARY *dict, char rw) {
+    return rw == DICTIONARY_LOCK_READ && !is_dictionary_single_threaded(dict);
 }
 
 static inline void dictionary_index_lock_rdlock(DICTIONARY *dict) {

--- a/src/libnetdata/dictionary/dictionary-locks.h
+++ b/src/libnetdata/dictionary/dictionary-locks.h
@@ -13,6 +13,7 @@ static inline size_t dictionary_locks_init(DICTIONARY *dict) {
         rw_spinlock_init(&dict->index.rw_spinlock);
         rw_spinlock_init(&dict->items.rw_spinlock);
         spinlock_init(&dict->items.pending_deletion_spinlock);
+        spinlock_init(&dict->rcu_pending_free.spinlock);
     }
 
     return 0;
@@ -48,8 +49,14 @@ static inline void ll_recursive_lock(DICTIONARY *dict, char rw) {
         return;
     }
 
-    if(rw == DICTIONARY_LOCK_READ || rw == DICTIONARY_LOCK_REENTRANT || rw == 'R') {
-        // read lock
+    if(rw == DICTIONARY_LOCK_READ) {
+        // Use RCU for pure read traversals — zero shared-write overhead.
+        // The calling thread must be RCU-registered (rcu_read_lock auto-registers).
+        rcu_read_lock();
+    }
+    else if(rw == DICTIONARY_LOCK_REENTRANT || rw == 'R') {
+        // REENTRANT mode breaks/reacquires between iterations,
+        // so it cannot use RCU (which requires a continuous read-side CS).
         rw_spinlock_read_lock(&dict->items.rw_spinlock);
     }
     else {
@@ -68,9 +75,10 @@ static inline void ll_recursive_unlock(DICTIONARY *dict, char rw) {
         return;
     }
 
-    if(rw == DICTIONARY_LOCK_READ || rw == DICTIONARY_LOCK_REENTRANT || rw == 'R') {
-        // read unlock
-
+    if(rw == DICTIONARY_LOCK_READ) {
+        rcu_read_unlock();
+    }
+    else if(rw == DICTIONARY_LOCK_REENTRANT || rw == 'R') {
         rw_spinlock_read_unlock(&dict->items.rw_spinlock);
     }
     else {
@@ -80,6 +88,11 @@ static inline void ll_recursive_unlock(DICTIONARY *dict, char rw) {
 
         rw_spinlock_write_unlock(&dict->items.rw_spinlock);
     }
+}
+
+// Returns true if the given lock mode uses RCU (no per-item refcount needed).
+static inline bool ll_lock_is_rcu_mode(DICTIONARY *dict, char rw) {
+    return rw == DICTIONARY_LOCK_READ && !is_dictionary_single_threaded(dict);
 }
 
 static inline void dictionary_index_lock_rdlock(DICTIONARY *dict) {

--- a/src/libnetdata/dictionary/dictionary-traversal.c
+++ b/src/libnetdata/dictionary/dictionary-traversal.c
@@ -2,6 +2,26 @@
 
 #include "dictionary-internals.h"
 
+// ----------------------------------------------------------------------------
+// RCU-safe pointer helpers for dictionary traversal.
+// Under RCU mode, readers load list/next pointers concurrently with writers
+// (who hold the write lock but NOT the RCU read-side CS). We must use atomic
+// acquire loads so the C11 memory model is satisfied. On x86 these compile
+// to plain loads (TSO guarantees), so there is no runtime cost.
+
+static inline DICTIONARY_ITEM *dict_item_list_head(DICTIONARY *dict, bool rcu_mode) {
+    if(rcu_mode)
+        return __atomic_load_n(&dict->items.list, __ATOMIC_ACQUIRE);
+    else
+        return dict->items.list;
+}
+
+static inline DICTIONARY_ITEM *dict_item_next(DICTIONARY_ITEM *item, bool rcu_mode) {
+    if(rcu_mode)
+        return __atomic_load_n(&item->next, __ATOMIC_ACQUIRE);
+    else
+        return item->next;
+}
 
 // ----------------------------------------------------------------------------
 // traversal with loop
@@ -21,6 +41,11 @@ void *dictionary_foreach_start_rw(DICTFE *dfe) {
         return NULL;
     }
 
+    // Determine if we should use RCU mode for this traversal.
+    // RCU mode: no per-item refcount acquisition during traversal.
+    // Only for pure READ mode on multi-threaded dictionaries.
+    dfe->rcu_mode = ll_lock_is_rcu_mode(dfe->dict, dfe->rw);
+
     dfe->counter = 0;
     dfe->locked = true;
     ll_recursive_lock(dfe->dict, dfe->rw);
@@ -39,11 +64,18 @@ void *dictionary_foreach_start_rw(DICTFE *dfe) {
     }
 
     // get the first item from the list
-    DICTIONARY_ITEM *item = dfe->dict->items.list;
+    DICTIONARY_ITEM *item = dict_item_list_head(dfe->dict, dfe->rcu_mode);
 
-    // skip all the deleted items
-    while(item && !item_check_and_acquire(dfe->dict, item))
-        item = item->next;
+    if(dfe->rcu_mode) {
+        // RCU mode: skip deleted items without acquiring refcount
+        while(item && !item_is_available_for_rcu_traversal(item))
+            item = dict_item_next(item, true);
+    }
+    else {
+        // Legacy mode: skip deleted items with CAS refcount acquisition
+        while(item && !item_check_and_acquire(dfe->dict, item))
+            item = item->next;
+    }
 
     if(likely(item)) {
         dfe->item = item;
@@ -91,15 +123,23 @@ ALWAYS_INLINE void *dictionary_foreach_next(DICTFE *dfe) {
     DICTIONARY_ITEM *item = dfe->item;
 
     // get the next item from the list
-    DICTIONARY_ITEM *item_next = (item) ? item->next : NULL;
+    DICTIONARY_ITEM *item_next = (item) ? dict_item_next(item, dfe->rcu_mode) : NULL;
 
-    // skip all the deleted items until one that can be acquired is found
-    while(item_next && !item_check_and_acquire(dfe->dict, item_next))
-        item_next = item_next->next;
+    if(dfe->rcu_mode) {
+        // RCU mode: skip deleted items without acquiring refcount
+        while(item_next && !item_is_available_for_rcu_traversal(item_next))
+            item_next = dict_item_next(item_next, true);
 
-    if(likely(item)) {
-        dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dfe->dict, item, dfe->rw);
-        // item_release(dfe->dict, item);
+        // No need to release the previous item — we never acquired it
+    }
+    else {
+        // Legacy mode: skip deleted items with CAS refcount acquisition
+        while(item_next && !item_check_and_acquire(dfe->dict, item_next))
+            item_next = item_next->next;
+
+        if(likely(item)) {
+            dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dfe->dict, item, dfe->rw);
+        }
     }
 
     item = item_next;
@@ -138,8 +178,10 @@ void dictionary_foreach_done(DICTFE *dfe) {
 
     // release it, so that it can possibly be deleted
     if(likely(item)) {
-        dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dfe->dict, item, dfe->rw);
-        // item_release(dfe->dict, item);
+        if(!dfe->rcu_mode) {
+            dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dfe->dict, item, dfe->rw);
+        }
+        // In RCU mode: no release needed — we never acquired a refcount
     }
 
     if(likely(dfe->rw != DICTIONARY_LOCK_REENTRANT) && dfe->locked) {
@@ -167,6 +209,8 @@ int dictionary_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough_callba
         return 0;
     }
 
+    bool rcu_mode = ll_lock_is_rcu_mode(dict, rw);
+
     ll_recursive_lock(dict, rw);
 
     if(unlikely(is_dictionary_destroyed(dict))) {
@@ -179,13 +223,22 @@ int dictionary_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough_callba
     // written in such a way, that the callback can delete the active element
 
     int ret = 0;
-    DICTIONARY_ITEM *item = dict->items.list, *item_next;
+    DICTIONARY_ITEM *item = dict_item_list_head(dict, rcu_mode), *item_next;
     while(item) {
 
-        // skip the deleted items
-        if(unlikely(!item_check_and_acquire(dict, item))) {
-            item = item->next;
-            continue;
+        if(rcu_mode) {
+            // RCU mode: skip deleted/unavailable items without refcount
+            if(unlikely(!item_is_available_for_rcu_traversal(item))) {
+                item = dict_item_next(item, true);
+                continue;
+            }
+        }
+        else {
+            // Legacy mode: skip deleted items with CAS refcount acquisition
+            if(unlikely(!item_check_and_acquire(dict, item))) {
+                item = item->next;
+                continue;
+            }
         }
 
         if(unlikely(rw == DICTIONARY_LOCK_REENTRANT))
@@ -198,10 +251,11 @@ int dictionary_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough_callba
 
         // since we have a reference counter, this item cannot be deleted
         // until we release the reference counter, so the pointers are there
-        item_next = item->next;
+        item_next = dict_item_next(item, rcu_mode);
 
-        dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, rw);
-        // item_release(dict, item);
+        if(!rcu_mode) {
+            dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, rw);
+        }
 
         if(unlikely(r < 0)) {
             ret = r;
@@ -235,15 +289,20 @@ int dictionary_sorted_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough
         return 0;
     }
 
-    ll_recursive_lock(dict, rw);
+    // Sorted walkthrough releases the lock before calling callbacks,
+    // so items must be kept alive via refcounts. Force non-RCU lock mode
+    // ('R') to ensure the rw_spinlock is used instead of RCU — RCU would
+    // only protect items during the CS, but we need them after unlock.
+    char lock_mode = (rw == DICTIONARY_LOCK_READ) ? 'R' : rw;
+
+    ll_recursive_lock(dict, lock_mode);
 
     if(unlikely(is_dictionary_destroyed(dict))) {
-        ll_recursive_unlock(dict, rw);
+        ll_recursive_unlock(dict, lock_mode);
         return 0;
     }
 
     DICTIONARY_STATS_WALKTHROUGHS_PLUS1(dict);
-
     size_t entries = __atomic_load_n(&dict->entries, __ATOMIC_RELAXED);
     DICTIONARY_ITEM **array = mallocz(sizeof(DICTIONARY_ITEM *) * entries);
 
@@ -253,7 +312,7 @@ int dictionary_sorted_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough
         if(likely(item_check_and_acquire(dict, item)))
             array[i++] = item;
     }
-    ll_recursive_unlock(dict, rw);
+    ll_recursive_unlock(dict, lock_mode);
 
     if(unlikely(i != entries))
         entries = i;
@@ -271,7 +330,7 @@ int dictionary_sorted_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough
         if(callit)
             r = walkthrough_callback(item, item->shared->value, data);
 
-        dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, rw);
+        dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, lock_mode);
         // item_release(dict, item);
 
         if(r < 0) {
@@ -290,4 +349,3 @@ int dictionary_sorted_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough
 
     return ret;
 }
-

--- a/src/libnetdata/dictionary/dictionary-traversal.c
+++ b/src/libnetdata/dictionary/dictionary-traversal.c
@@ -23,6 +23,13 @@ static inline DICTIONARY_ITEM *dict_item_next(DICTIONARY_ITEM *item, bool rcu_mo
         return item->next;
 }
 
+static inline void *dict_item_value(DICTIONARY_ITEM *item, bool rcu_mode) {
+    if(rcu_mode)
+        return dict_item_value_get(item);
+    else
+        return dict_item_value_get(item);
+}
+
 // ----------------------------------------------------------------------------
 // traversal with loop
 
@@ -80,7 +87,7 @@ void *dictionary_foreach_start_rw(DICTFE *dfe) {
     if(likely(item)) {
         dfe->item = item;
         dfe->name = (char *)item_get_name(item);
-        dfe->value = item->shared->value;
+        dfe->value = dict_item_value(item, dfe->rcu_mode);
     }
     else {
         dfe->item = NULL;
@@ -146,7 +153,7 @@ ALWAYS_INLINE void *dictionary_foreach_next(DICTFE *dfe) {
     if(likely(item)) {
         dfe->item = item;
         dfe->name = (char *)item_get_name(item);
-        dfe->value = item->shared->value;
+        dfe->value = dict_item_value(item, dfe->rcu_mode);
         dfe->counter++;
     }
     else {
@@ -244,13 +251,15 @@ int dictionary_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough_callba
         if(unlikely(rw == DICTIONARY_LOCK_REENTRANT))
             ll_recursive_unlock(dict, rw);
 
-        int r = walkthrough_callback(item, item->shared->value, data);
+        int r = walkthrough_callback(item, dict_item_value(item, rcu_mode), data);
 
         if(unlikely(rw == DICTIONARY_LOCK_REENTRANT))
             ll_recursive_lock(dict, rw);
 
-        // since we have a reference counter, this item cannot be deleted
-        // until we release the reference counter, so the pointers are there
+        // In RCU mode, callback-delete-current-item is safe because removal
+        // preserves item->next and deferred freeing cannot drain while this
+        // thread is still inside the read-side critical section.
+        // In legacy mode, the acquired item refcount keeps the node alive.
         item_next = dict_item_next(item, rcu_mode);
 
         if(!rcu_mode) {
@@ -328,7 +337,7 @@ int dictionary_sorted_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough
         item = array[i];
 
         if(callit)
-            r = walkthrough_callback(item, item->shared->value, data);
+            r = walkthrough_callback(item, dict_item_value_get(item), data);
 
         dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, lock_mode);
         // item_release(dict, item);

--- a/src/libnetdata/dictionary/dictionary-traversal.c
+++ b/src/libnetdata/dictionary/dictionary-traversal.c
@@ -2,6 +2,26 @@
 
 #include "dictionary-internals.h"
 
+// ----------------------------------------------------------------------------
+// RCU-safe pointer helpers for dictionary traversal.
+// Under RCU mode, readers load list/next pointers concurrently with writers
+// (who hold the write lock but NOT the RCU read-side CS). We must use atomic
+// acquire loads so the C11 memory model is satisfied. On x86 these compile
+// to plain loads (TSO guarantees), so there is no runtime cost.
+
+static inline DICTIONARY_ITEM *dict_item_list_head(DICTIONARY *dict, bool rcu_mode) {
+    if(rcu_mode)
+        return __atomic_load_n(&dict->items.list, __ATOMIC_ACQUIRE);
+    else
+        return dict->items.list;
+}
+
+static inline DICTIONARY_ITEM *dict_item_next(DICTIONARY_ITEM *item, bool rcu_mode) {
+    if(rcu_mode)
+        return __atomic_load_n(&item->next, __ATOMIC_ACQUIRE);
+    else
+        return item->next;
+}
 
 // ----------------------------------------------------------------------------
 // traversal with loop
@@ -27,6 +47,11 @@ void *dictionary_foreach_start_rw(DICTFE *dfe) {
         return NULL;
     }
 
+    // Determine if we should use RCU mode for this traversal.
+    // RCU mode: no per-item refcount acquisition during traversal.
+    // Only for pure READ mode on multi-threaded dictionaries.
+    dfe->rcu_mode = ll_lock_is_rcu_mode(dfe->dict, dfe->rw);
+
     dfe->counter = 0;
     dfe->locked = true;
     ll_recursive_lock(dfe->dict, dfe->rw);
@@ -46,11 +71,18 @@ void *dictionary_foreach_start_rw(DICTFE *dfe) {
     }
 
     // get the first item from the list
-    DICTIONARY_ITEM *item = dfe->dict->items.list;
+    DICTIONARY_ITEM *item = dict_item_list_head(dfe->dict, dfe->rcu_mode);
 
-    // skip all the deleted items
-    while(item && !item_check_and_acquire(dfe->dict, item))
-        item = item->next;
+    if(dfe->rcu_mode) {
+        // RCU mode: skip deleted items without acquiring refcount
+        while(item && !item_is_available_for_rcu_traversal(item))
+            item = dict_item_next(item, true);
+    }
+    else {
+        // Legacy mode: skip deleted items with CAS refcount acquisition
+        while(item && !item_check_and_acquire(dfe->dict, item))
+            item = item->next;
+    }
 
     if(likely(item)) {
         dfe->item = item;
@@ -98,15 +130,23 @@ ALWAYS_INLINE void *dictionary_foreach_next(DICTFE *dfe) {
     DICTIONARY_ITEM *item = dfe->item;
 
     // get the next item from the list
-    DICTIONARY_ITEM *item_next = (item) ? item->next : NULL;
+    DICTIONARY_ITEM *item_next = (item) ? dict_item_next(item, dfe->rcu_mode) : NULL;
 
-    // skip all the deleted items until one that can be acquired is found
-    while(item_next && !item_check_and_acquire(dfe->dict, item_next))
-        item_next = item_next->next;
+    if(dfe->rcu_mode) {
+        // RCU mode: skip deleted items without acquiring refcount
+        while(item_next && !item_is_available_for_rcu_traversal(item_next))
+            item_next = dict_item_next(item_next, true);
 
-    if(likely(item)) {
-        dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dfe->dict, item, dfe->rw);
-        // item_release(dfe->dict, item);
+        // No need to release the previous item — we never acquired it
+    }
+    else {
+        // Legacy mode: skip deleted items with CAS refcount acquisition
+        while(item_next && !item_check_and_acquire(dfe->dict, item_next))
+            item_next = item_next->next;
+
+        if(likely(item)) {
+            dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dfe->dict, item, dfe->rw);
+        }
     }
 
     item = item_next;
@@ -150,8 +190,10 @@ void dictionary_foreach_done(DICTFE *dfe) {
 
     // release it, so that it can possibly be deleted
     if(likely(item)) {
-        dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, dfe->rw);
-        // item_release(dict, item);
+        if(!dfe->rcu_mode) {
+            dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, dfe->rw);
+        }
+        // In RCU mode: no release needed — we never acquired a refcount
     }
 
     if(likely(dfe->rw != DICTIONARY_LOCK_REENTRANT) && dfe->locked) {
@@ -182,6 +224,8 @@ static int dictionary_walkthrough_rw_internal(DICTIONARY *dict, char rw, dict_wa
         return 0;
     }
 
+    bool rcu_mode = ll_lock_is_rcu_mode(dict, rw);
+
     ll_recursive_lock(dict, rw);
 
     if(unlikely(is_dictionary_destroyed(dict))) {
@@ -194,9 +238,19 @@ static int dictionary_walkthrough_rw_internal(DICTIONARY *dict, char rw, dict_wa
     // written in such a way, that the callback can delete the active element
 
     int ret = 0;
-    DICTIONARY_ITEM *item = dict->items.list;
-    while(item && !item_check_and_acquire(dict, item))
-        item = item->next;
+
+    // find the first item we can traverse
+    DICTIONARY_ITEM *item = dict_item_list_head(dict, rcu_mode);
+    if(rcu_mode) {
+        // RCU mode: skip deleted/unavailable items without refcount
+        while(item && unlikely(!item_is_available_for_rcu_traversal(item)))
+            item = dict_item_next(item, true);
+    }
+    else {
+        // Legacy mode: skip deleted items with CAS refcount acquisition
+        while(item && unlikely(!item_check_and_acquire(dict, item)))
+            item = item->next;
+    }
 
     while(item) {
         if(unlikely(rw == DICTIONARY_LOCK_REENTRANT))
@@ -208,19 +262,28 @@ static int dictionary_walkthrough_rw_internal(DICTIONARY *dict, char rw, dict_wa
             ll_recursive_lock(dict, rw);
 
         if(unlikely(r < 0)) {
-            dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, rw);
+            if(!rcu_mode)
+                dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, rw);
             ret = r;
             break;
         }
 
         ret += r;
 
-        DICTIONARY_ITEM *item_next = item->next;
-        while(item_next && !item_check_and_acquire(dict, item_next))
-            item_next = item_next->next;
+        // this item cannot be deleted while we hold a reference counter (legacy mode),
+        // or while we are inside the RCU read side (rcu mode), so the pointers are there.
+        // find the next item we can traverse, before releasing the current one.
+        DICTIONARY_ITEM *item_next = dict_item_next(item, rcu_mode);
+        if(rcu_mode) {
+            while(item_next && unlikely(!item_is_available_for_rcu_traversal(item_next)))
+                item_next = dict_item_next(item_next, true);
+        }
+        else {
+            while(item_next && unlikely(!item_check_and_acquire(dict, item_next)))
+                item_next = item_next->next;
 
-        dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, rw);
-        // item_release(dict, item);
+            dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, rw);
+        }
 
         item = item_next;
     }
@@ -247,15 +310,20 @@ static int dictionary_sorted_walkthrough_rw_internal(DICTIONARY *dict, char rw, 
         return 0;
     }
 
-    ll_recursive_lock(dict, rw);
+    // Sorted walkthrough releases the lock before calling callbacks,
+    // so items must be kept alive via refcounts. Force non-RCU lock mode
+    // ('R') to ensure the rw_spinlock is used instead of RCU — RCU would
+    // only protect items during the CS, but we need them after unlock.
+    char lock_mode = (rw == DICTIONARY_LOCK_READ) ? 'R' : rw;
+
+    ll_recursive_lock(dict, lock_mode);
 
     if(unlikely(is_dictionary_destroyed(dict))) {
-        ll_recursive_unlock(dict, rw);
+        ll_recursive_unlock(dict, lock_mode);
         return 0;
     }
 
     DICTIONARY_STATS_WALKTHROUGHS_PLUS1(dict);
-
     size_t entries = __atomic_load_n(&dict->entries, __ATOMIC_RELAXED);
     DICTIONARY_ITEM **array = mallocz(sizeof(DICTIONARY_ITEM *) * entries);
 
@@ -265,7 +333,7 @@ static int dictionary_sorted_walkthrough_rw_internal(DICTIONARY *dict, char rw, 
         if(likely(item_check_and_acquire(dict, item)))
             array[i++] = item;
     }
-    ll_recursive_unlock(dict, rw);
+    ll_recursive_unlock(dict, lock_mode);
 
     if(unlikely(i != entries))
         entries = i;
@@ -283,7 +351,7 @@ static int dictionary_sorted_walkthrough_rw_internal(DICTIONARY *dict, char rw, 
         if(callit)
             r = walkthrough_callback(item, item->shared->value, data);
 
-        dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, rw);
+        dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, lock_mode);
         // item_release(dict, item);
 
         if(r < 0) {

--- a/src/libnetdata/dictionary/dictionary-traversal.c
+++ b/src/libnetdata/dictionary/dictionary-traversal.c
@@ -23,6 +23,13 @@ static inline DICTIONARY_ITEM *dict_item_next(DICTIONARY_ITEM *item, bool rcu_mo
         return item->next;
 }
 
+static inline void *dict_item_value(DICTIONARY_ITEM *item, bool rcu_mode) {
+    if(rcu_mode)
+        return dict_item_value_get(item);
+    else
+        return dict_item_value_get(item);
+}
+
 // ----------------------------------------------------------------------------
 // traversal with loop
 
@@ -87,7 +94,7 @@ void *dictionary_foreach_start_rw(DICTFE *dfe) {
     if(likely(item)) {
         dfe->item = item;
         dfe->name = (char *)item_get_name(item);
-        dfe->value = item->shared->value;
+        dfe->value = dict_item_value(item, dfe->rcu_mode);
     }
     else {
         dfe->item = NULL;
@@ -153,7 +160,7 @@ ALWAYS_INLINE void *dictionary_foreach_next(DICTFE *dfe) {
     if(likely(item)) {
         dfe->item = item;
         dfe->name = (char *)item_get_name(item);
-        dfe->value = item->shared->value;
+        dfe->value = dict_item_value(item, dfe->rcu_mode);
         dfe->counter++;
     }
     else {
@@ -256,7 +263,7 @@ static int dictionary_walkthrough_rw_internal(DICTIONARY *dict, char rw, dict_wa
         if(unlikely(rw == DICTIONARY_LOCK_REENTRANT))
             ll_recursive_unlock(dict, rw);
 
-        int r = walkthrough_callback(item, item->shared->value, data);
+        int r = walkthrough_callback(item, dict_item_value(item, rcu_mode), data);
 
         if(unlikely(rw == DICTIONARY_LOCK_REENTRANT))
             ll_recursive_lock(dict, rw);
@@ -270,9 +277,11 @@ static int dictionary_walkthrough_rw_internal(DICTIONARY *dict, char rw, dict_wa
 
         ret += r;
 
-        // this item cannot be deleted while we hold a reference counter (legacy mode),
-        // or while we are inside the RCU read side (rcu mode), so the pointers are there.
-        // find the next item we can traverse, before releasing the current one.
+        // In RCU mode, callback-delete-current-item is safe because removal
+        // preserves item->next and deferred freeing cannot drain while this
+        // thread is still inside the read-side critical section.
+        // In legacy mode, the acquired item refcount keeps the node alive.
+        // Either way, find the next item we can traverse, before releasing this one.
         DICTIONARY_ITEM *item_next = dict_item_next(item, rcu_mode);
         if(rcu_mode) {
             while(item_next && unlikely(!item_is_available_for_rcu_traversal(item_next)))
@@ -349,7 +358,7 @@ static int dictionary_sorted_walkthrough_rw_internal(DICTIONARY *dict, char rw, 
         item = array[i];
 
         if(callit)
-            r = walkthrough_callback(item, item->shared->value, data);
+            r = walkthrough_callback(item, dict_item_value_get(item), data);
 
         dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, lock_mode);
         // item_release(dict, item);

--- a/src/libnetdata/dictionary/dictionary-unittest.c
+++ b/src/libnetdata/dictionary/dictionary-unittest.c
@@ -1266,6 +1266,145 @@ static int dictionary_destroy_race_unittest(void) {
     return 0;
 }
 
+static int dictionary_destroy_deferred_rcu_unittest(void) {
+    int errors = 0;
+
+    fprintf(stderr, "\nTesting deferred dictionary destruction while inside an RCU read-side CS...\n");
+
+    cleanup_destroyed_dictionaries(false);
+    size_t delayed_before = dictionary_destroy_delayed_count();
+
+    DICTIONARY *guard = dictionary_create(DICT_OPTION_NONE);
+    DICTIONARY *victim = dictionary_create(DICT_OPTION_NONE);
+    dictionary_set(guard, "guard", "G", 2);
+    dictionary_set(victim, "victim", "V", 2);
+
+    void *v;
+    dfe_start_read(guard, v) {
+        size_t freed = dictionary_destroy(victim);
+        if(freed != 0) {
+            fprintf(stderr, "Deferred destroy test: expected victim destroy to queue, got %zu bytes freed\n", freed);
+            errors++;
+        }
+
+        size_t delayed_during = dictionary_destroy_delayed_count();
+        if(delayed_during != delayed_before + 1) {
+            fprintf(stderr, "Deferred destroy test: expected queued count %zu while in RCU CS, got %zu\n",
+                    delayed_before + 1, delayed_during);
+            errors++;
+        }
+
+        size_t remaining = cleanup_destroyed_dictionaries(false);
+        if(remaining != delayed_before + 1) {
+            fprintf(stderr, "Deferred destroy test: expected cleanup to keep victim queued inside RCU CS (remaining=%zu)\n",
+                    remaining);
+            errors++;
+        }
+    }
+    dfe_done(v);
+
+    size_t remaining_after = cleanup_destroyed_dictionaries(false);
+    if(remaining_after != delayed_before) {
+        fprintf(stderr, "Deferred destroy test: expected queued count %zu after leaving RCU CS, got %zu\n",
+                delayed_before, remaining_after);
+        errors++;
+    }
+
+    size_t delayed_after = dictionary_destroy_delayed_count();
+    if(delayed_after != delayed_before) {
+        fprintf(stderr, "Deferred destroy test: expected delayed destroy count %zu after cleanup, got %zu\n",
+                delayed_before, delayed_after);
+        errors++;
+    }
+
+    dictionary_destroy(guard);
+    cleanup_destroyed_dictionaries(false);
+
+    return errors;
+}
+
+static int dictionary_destroy_deferred_rcu_gc_progress_unittest(void) {
+    int errors = 0;
+
+    fprintf(stderr, "\nTesting delayed dictionary destroy progress via dictionary_garbage_collect()...\n");
+
+    cleanup_destroyed_dictionaries(false);
+    size_t delayed_before = dictionary_destroy_delayed_count();
+
+    DICTIONARY *guard = dictionary_create(DICT_OPTION_NONE);
+    DICTIONARY *victim = dictionary_create(DICT_OPTION_NONE);
+    dictionary_set(guard, "guard", "G", 2);
+    dictionary_set(victim, "victim", "V", 2);
+
+    void *v;
+    dfe_start_read(guard, v) {
+        size_t freed = dictionary_destroy(victim);
+        if(freed != 0) {
+            fprintf(stderr, "Deferred destroy GC test: expected victim destroy to queue, got %zu bytes freed\n", freed);
+            errors++;
+        }
+    }
+    dfe_done(v);
+
+    dictionary_garbage_collect(guard);
+
+    size_t delayed_after = dictionary_destroy_delayed_count();
+    if(delayed_after != delayed_before) {
+        fprintf(stderr, "Deferred destroy GC test: expected delayed destroy count %zu after garbage collection, got %zu\n",
+                delayed_before, delayed_after);
+        errors++;
+    }
+
+    dictionary_destroy(guard);
+    cleanup_destroyed_dictionaries(false);
+
+    return errors;
+}
+
+static int dictionary_rcu_value_replace_unittest(void) {
+    int errors = 0;
+
+    fprintf(stderr, "\nTesting RCU traversal value stability across overwrite...\n");
+
+    DICTIONARY *dict = dictionary_create_advanced(DICT_OPTION_FIXED_SIZE, NULL, 64);
+
+    char initial[64];
+    memset(initial, 'A', sizeof(initial));
+    initial[sizeof(initial) - 1] = '\0';
+    dictionary_set(dict, "stable", initial, sizeof(initial));
+
+    void *v;
+    dfe_start_read(dict, v) {
+        char *snapshot = v;
+
+        for(int i = 0; i < 128; i++) {
+            char replacement[64];
+            char tmp_key[32];
+
+            memset(replacement, 'B' + (i % 20), sizeof(replacement));
+            replacement[sizeof(replacement) - 1] = '\0';
+
+            dictionary_set(dict, "stable", replacement, sizeof(replacement));
+
+            snprintfz(tmp_key, sizeof(tmp_key), "tmp-%d", i);
+            dictionary_set(dict, tmp_key, replacement, sizeof(replacement));
+            dictionary_del(dict, tmp_key);
+        }
+
+        if(memcmp(snapshot, initial, sizeof(initial)) != 0) {
+            fprintf(stderr, "RCU overwrite test: traversal value changed while still inside read-side critical section\n");
+            errors++;
+        }
+    }
+    dfe_done(v);
+
+    dictionary_garbage_collect(dict);
+    dictionary_destroy(dict);
+    cleanup_destroyed_dictionaries(false);
+
+    return errors;
+}
+
 #else
 
 static int dictionary_destroy_race_unittest(void) {
@@ -2059,6 +2198,9 @@ int dictionary_unittest(size_t entries) {
         fprintf(stderr, "Destroy on traversal test OK\n");
 
     errors += dictionary_destroy_race_unittest();
+    errors += dictionary_destroy_deferred_rcu_unittest();
+    errors += dictionary_destroy_deferred_rcu_gc_progress_unittest();
+    errors += dictionary_rcu_value_replace_unittest();
 
     cleanup_destroyed_dictionaries(false);
 

--- a/src/libnetdata/dictionary/dictionary-unittest.c
+++ b/src/libnetdata/dictionary/dictionary-unittest.c
@@ -1745,6 +1745,154 @@ int dictionary_unittest_benchmark(void) {
     return 0;
 }
 
+// ============================================================================
+// Read-traversal benchmark: measures dfe_start_read throughput under contention
+// ============================================================================
+
+struct read_bench_thread {
+    int id;
+    volatile int *join;
+    DICTIONARY *dict;
+    uint64_t traversals;
+    uint64_t items_seen;
+    bool is_writer;
+    ND_THREAD *thread;
+};
+
+static void read_bench_reader_thread(void *arg) {
+    struct read_bench_thread *ctx = arg;
+
+    while(!__atomic_load_n(ctx->join, __ATOMIC_RELAXED)) {
+        void *v;
+        dfe_start_read(ctx->dict, v) {
+            (void)v;
+            ctx->items_seen++;
+        }
+        dfe_done(v);
+        ctx->traversals++;
+    }
+}
+
+static void read_bench_writer_thread(void *arg) {
+    struct read_bench_thread *ctx = arg;
+    uint64_t counter = 0;
+    char buf[64];
+
+    while(!__atomic_load_n(ctx->join, __ATOMIC_RELAXED)) {
+        snprintfz(buf, sizeof(buf), "writer-key-%"PRIu64, counter);
+        dictionary_set(ctx->dict, buf, NULL, 0);
+        dictionary_del(ctx->dict, buf);
+        counter++;
+        ctx->traversals = counter;
+    }
+}
+
+static void dictionary_unittest_read_traversal_benchmark(void) {
+    int thread_configs[] = {1, 2, 4, 8};
+    int num_configs = (int)(sizeof(thread_configs) / sizeof(thread_configs[0]));
+    time_t seconds_to_run = 3;
+    size_t dict_entries = 1000;
+
+    fprintf(stderr, "\n=== Dictionary Read-Traversal Benchmark (%zu items, %lld sec per config) ===\n",
+            dict_entries, (long long)seconds_to_run);
+
+    DICTIONARY *dict = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+    char name[64];
+    for(size_t i = 0; i < dict_entries; i++) {
+        snprintfz(name, sizeof(name), "bench-item-%zu", i);
+        dictionary_set(dict, name, NULL, 0);
+    }
+
+    fprintf(stderr, "\n%-10s %10s %16s %16s\n",
+            "Readers", "Writers", "Traversals/sec", "Items/sec");
+    fprintf(stderr, "------------------------------------------------------------\n");
+
+    for(int c = 0; c < num_configs; c++) {
+        int nreaders = thread_configs[c];
+        volatile int join = 0;
+
+        struct read_bench_thread readers[nreaders];
+        memset(readers, 0, sizeof(readers));
+
+        for(int i = 0; i < nreaders; i++) {
+            readers[i] = (struct read_bench_thread){
+                .id = i, .join = &join, .dict = dict,
+                .traversals = 0, .items_seen = 0, .is_writer = false,
+            };
+            char tname[32];
+            snprintfz(tname, sizeof(tname), "rdbench%d", i);
+            readers[i].thread = nd_thread_create(tname, NETDATA_THREAD_OPTION_DONT_LOG,
+                                                  read_bench_reader_thread, &readers[i]);
+        }
+
+        sleep_usec(seconds_to_run * USEC_PER_SEC);
+        __atomic_store_n(&join, 1, __ATOMIC_RELAXED);
+
+        uint64_t total_traversals = 0, total_items = 0;
+        for(int i = 0; i < nreaders; i++) {
+            nd_thread_join(readers[i].thread);
+            total_traversals += readers[i].traversals;
+            total_items += readers[i].items_seen;
+        }
+
+        fprintf(stderr, "%-10d %10d %16.0f %16.0f\n",
+                nreaders, 0,
+                (double)total_traversals / seconds_to_run,
+                (double)total_items / seconds_to_run);
+    }
+
+    fprintf(stderr, "------------------------------------------------------------\n");
+
+    for(int c = 0; c < num_configs; c++) {
+        int nreaders = thread_configs[c];
+        int total = nreaders + 1;
+        volatile int join = 0;
+
+        struct read_bench_thread threads[total];
+        memset(threads, 0, sizeof(threads));
+
+        for(int i = 0; i < nreaders; i++) {
+            threads[i] = (struct read_bench_thread){
+                .id = i, .join = &join, .dict = dict,
+                .traversals = 0, .items_seen = 0, .is_writer = false,
+            };
+            char tname[32];
+            snprintfz(tname, sizeof(tname), "rdbench%d", i);
+            threads[i].thread = nd_thread_create(tname, NETDATA_THREAD_OPTION_DONT_LOG,
+                                                  read_bench_reader_thread, &threads[i]);
+        }
+        threads[nreaders] = (struct read_bench_thread){
+            .id = nreaders, .join = &join, .dict = dict,
+            .traversals = 0, .items_seen = 0, .is_writer = true,
+        };
+        threads[nreaders].thread = nd_thread_create("wrbench", NETDATA_THREAD_OPTION_DONT_LOG,
+                                                     read_bench_writer_thread, &threads[nreaders]);
+
+        sleep_usec(seconds_to_run * USEC_PER_SEC);
+        __atomic_store_n(&join, 1, __ATOMIC_RELAXED);
+
+        uint64_t total_traversals = 0, total_items = 0, write_ops = 0;
+        for(int i = 0; i < total; i++) {
+            nd_thread_join(threads[i].thread);
+            if(threads[i].is_writer)
+                write_ops = threads[i].traversals;
+            else {
+                total_traversals += threads[i].traversals;
+                total_items += threads[i].items_seen;
+            }
+        }
+
+        fprintf(stderr, "%-10d %10d %16.0f %16.0f  (writes: %.0f/sec)\n",
+                nreaders, 1,
+                (double)total_traversals / seconds_to_run,
+                (double)total_items / seconds_to_run,
+                (double)write_ops / seconds_to_run);
+    }
+
+    fprintf(stderr, "\n");
+    dictionary_destroy(dict);
+}
+
 int dictionary_unittest(size_t entries) {
     if(entries < 10) entries = 10;
 
@@ -1829,15 +1977,17 @@ int dictionary_unittest(size_t entries) {
         errors += unittest_check_dictionary("", dict, 1, 1, 0, 1, 0);
         errors += unittest_check_item("ACQUIRED", dict, item, "test", "ITEM1", 1, ITEM_FLAG_NONE, true, true, true);
 
-        fprintf(stderr, "\nChecking that reference counters are increased:\n");
+        fprintf(stderr, "\nChecking refcounts during RCU read traversal (no per-item acquire):\n");
         void *t;
         dfe_start_read(dict, t) {
             errors += unittest_check_dictionary("", dict, 1, 1, 0, 1, 0);
-            errors += unittest_check_item("ACQUIRED TRAVERSAL", dict, item, "test", "ITEM1", 2, ITEM_FLAG_NONE, true, true, true);
+            // RCU traversal does not acquire a per-item refcount, so the
+            // refcount stays at 1 (from the dictionary_get_and_acquire_item above).
+            errors += unittest_check_item("ACQUIRED TRAVERSAL", dict, item, "test", "ITEM1", 1, ITEM_FLAG_NONE, true, true, true);
         }
         dfe_done(t);
 
-        fprintf(stderr, "\nChecking that reference counters are decreased:\n");
+        fprintf(stderr, "\nChecking that reference counters are unchanged after RCU traversal:\n");
         errors += unittest_check_dictionary("", dict, 1, 1, 0, 1, 0);
         errors += unittest_check_item("ACQUIRED TRAVERSAL 2", dict, item, "test", "ITEM1", 1, ITEM_FLAG_NONE, true, true, true);
 
@@ -1895,6 +2045,11 @@ int dictionary_unittest(size_t entries) {
     errors += dictionary_unittest_views();
     errors += dictionary_unittest_threads();
     errors += dictionary_unittest_view_threads();
+
+    // The read-traversal benchmark is available via dictionary_unittest_read_traversal_benchmark()
+    // but not run by default — it adds ~24 seconds of timed workloads.
+    // Uncomment the following line or call it from a dedicated benchmark harness:
+    // dictionary_unittest_read_traversal_benchmark();
 
     if(!dictionary_traverse_or_destroy_unittest()) {
         fprintf(stderr, "Destroy on traversal test failed\n");

--- a/src/libnetdata/dictionary/dictionary-unittest.c
+++ b/src/libnetdata/dictionary/dictionary-unittest.c
@@ -1983,6 +1983,154 @@ int dictionary_unittest_benchmark(void) {
     return 0;
 }
 
+// ============================================================================
+// Read-traversal benchmark: measures dfe_start_read throughput under contention
+// ============================================================================
+
+struct read_bench_thread {
+    int id;
+    volatile int *join;
+    DICTIONARY *dict;
+    uint64_t traversals;
+    uint64_t items_seen;
+    bool is_writer;
+    ND_THREAD *thread;
+};
+
+static void read_bench_reader_thread(void *arg) {
+    struct read_bench_thread *ctx = arg;
+
+    while(!__atomic_load_n(ctx->join, __ATOMIC_RELAXED)) {
+        void *v;
+        dfe_start_read(ctx->dict, v) {
+            (void)v;
+            ctx->items_seen++;
+        }
+        dfe_done(v);
+        ctx->traversals++;
+    }
+}
+
+static void read_bench_writer_thread(void *arg) {
+    struct read_bench_thread *ctx = arg;
+    uint64_t counter = 0;
+    char buf[64];
+
+    while(!__atomic_load_n(ctx->join, __ATOMIC_RELAXED)) {
+        snprintfz(buf, sizeof(buf), "writer-key-%"PRIu64, counter);
+        dictionary_set(ctx->dict, buf, NULL, 0);
+        dictionary_del(ctx->dict, buf);
+        counter++;
+        ctx->traversals = counter;
+    }
+}
+
+static void dictionary_unittest_read_traversal_benchmark(void) {
+    int thread_configs[] = {1, 2, 4, 8};
+    int num_configs = (int)(sizeof(thread_configs) / sizeof(thread_configs[0]));
+    time_t seconds_to_run = 3;
+    size_t dict_entries = 1000;
+
+    fprintf(stderr, "\n=== Dictionary Read-Traversal Benchmark (%zu items, %lld sec per config) ===\n",
+            dict_entries, (long long)seconds_to_run);
+
+    DICTIONARY *dict = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+    char name[64];
+    for(size_t i = 0; i < dict_entries; i++) {
+        snprintfz(name, sizeof(name), "bench-item-%zu", i);
+        dictionary_set(dict, name, NULL, 0);
+    }
+
+    fprintf(stderr, "\n%-10s %10s %16s %16s\n",
+            "Readers", "Writers", "Traversals/sec", "Items/sec");
+    fprintf(stderr, "------------------------------------------------------------\n");
+
+    for(int c = 0; c < num_configs; c++) {
+        int nreaders = thread_configs[c];
+        volatile int join = 0;
+
+        struct read_bench_thread readers[nreaders];
+        memset(readers, 0, sizeof(readers));
+
+        for(int i = 0; i < nreaders; i++) {
+            readers[i] = (struct read_bench_thread){
+                .id = i, .join = &join, .dict = dict,
+                .traversals = 0, .items_seen = 0, .is_writer = false,
+            };
+            char tname[32];
+            snprintfz(tname, sizeof(tname), "rdbench%d", i);
+            readers[i].thread = nd_thread_create(tname, NETDATA_THREAD_OPTION_DONT_LOG,
+                                                  read_bench_reader_thread, &readers[i]);
+        }
+
+        sleep_usec(seconds_to_run * USEC_PER_SEC);
+        __atomic_store_n(&join, 1, __ATOMIC_RELAXED);
+
+        uint64_t total_traversals = 0, total_items = 0;
+        for(int i = 0; i < nreaders; i++) {
+            nd_thread_join(readers[i].thread);
+            total_traversals += readers[i].traversals;
+            total_items += readers[i].items_seen;
+        }
+
+        fprintf(stderr, "%-10d %10d %16.0f %16.0f\n",
+                nreaders, 0,
+                (double)total_traversals / seconds_to_run,
+                (double)total_items / seconds_to_run);
+    }
+
+    fprintf(stderr, "------------------------------------------------------------\n");
+
+    for(int c = 0; c < num_configs; c++) {
+        int nreaders = thread_configs[c];
+        int total = nreaders + 1;
+        volatile int join = 0;
+
+        struct read_bench_thread threads[total];
+        memset(threads, 0, sizeof(threads));
+
+        for(int i = 0; i < nreaders; i++) {
+            threads[i] = (struct read_bench_thread){
+                .id = i, .join = &join, .dict = dict,
+                .traversals = 0, .items_seen = 0, .is_writer = false,
+            };
+            char tname[32];
+            snprintfz(tname, sizeof(tname), "rdbench%d", i);
+            threads[i].thread = nd_thread_create(tname, NETDATA_THREAD_OPTION_DONT_LOG,
+                                                  read_bench_reader_thread, &threads[i]);
+        }
+        threads[nreaders] = (struct read_bench_thread){
+            .id = nreaders, .join = &join, .dict = dict,
+            .traversals = 0, .items_seen = 0, .is_writer = true,
+        };
+        threads[nreaders].thread = nd_thread_create("wrbench", NETDATA_THREAD_OPTION_DONT_LOG,
+                                                     read_bench_writer_thread, &threads[nreaders]);
+
+        sleep_usec(seconds_to_run * USEC_PER_SEC);
+        __atomic_store_n(&join, 1, __ATOMIC_RELAXED);
+
+        uint64_t total_traversals = 0, total_items = 0, write_ops = 0;
+        for(int i = 0; i < total; i++) {
+            nd_thread_join(threads[i].thread);
+            if(threads[i].is_writer)
+                write_ops = threads[i].traversals;
+            else {
+                total_traversals += threads[i].traversals;
+                total_items += threads[i].items_seen;
+            }
+        }
+
+        fprintf(stderr, "%-10d %10d %16.0f %16.0f  (writes: %.0f/sec)\n",
+                nreaders, 1,
+                (double)total_traversals / seconds_to_run,
+                (double)total_items / seconds_to_run,
+                (double)write_ops / seconds_to_run);
+    }
+
+    fprintf(stderr, "\n");
+    dictionary_destroy(dict);
+}
+
 int dictionary_unittest(size_t entries) {
     if(entries < 10) entries = 10;
 
@@ -2069,15 +2217,17 @@ int dictionary_unittest(size_t entries) {
         errors += unittest_check_dictionary("", dict, 1, 1, 0, 1, 0);
         errors += unittest_check_item("ACQUIRED", dict, item, "test", "ITEM1", 1, ITEM_FLAG_NONE, true, true, true);
 
-        fprintf(stderr, "\nChecking that reference counters are increased:\n");
+        fprintf(stderr, "\nChecking refcounts during RCU read traversal (no per-item acquire):\n");
         void *t;
         dfe_start_read(dict, t) {
             errors += unittest_check_dictionary("", dict, 1, 1, 0, 1, 0);
-            errors += unittest_check_item("ACQUIRED TRAVERSAL", dict, item, "test", "ITEM1", 2, ITEM_FLAG_NONE, true, true, true);
+            // RCU traversal does not acquire a per-item refcount, so the
+            // refcount stays at 1 (from the dictionary_get_and_acquire_item above).
+            errors += unittest_check_item("ACQUIRED TRAVERSAL", dict, item, "test", "ITEM1", 1, ITEM_FLAG_NONE, true, true, true);
         }
         dfe_done(t);
 
-        fprintf(stderr, "\nChecking that reference counters are decreased:\n");
+        fprintf(stderr, "\nChecking that reference counters are unchanged after RCU traversal:\n");
         errors += unittest_check_dictionary("", dict, 1, 1, 0, 1, 0);
         errors += unittest_check_item("ACQUIRED TRAVERSAL 2", dict, item, "test", "ITEM1", 1, ITEM_FLAG_NONE, true, true, true);
 
@@ -2138,6 +2288,11 @@ int dictionary_unittest(size_t entries) {
     errors += dictionary_unittest_views();
     errors += dictionary_unittest_threads();
     errors += dictionary_unittest_view_threads();
+
+    // The read-traversal benchmark is available via dictionary_unittest_read_traversal_benchmark()
+    // but not run by default — it adds ~24 seconds of timed workloads.
+    // Uncomment the following line or call it from a dedicated benchmark harness:
+    // dictionary_unittest_read_traversal_benchmark();
 
     if(!dictionary_traverse_or_destroy_unittest()) {
         fprintf(stderr, "Destroy on traversal test failed\n");

--- a/src/libnetdata/dictionary/dictionary-unittest.c
+++ b/src/libnetdata/dictionary/dictionary-unittest.c
@@ -1504,6 +1504,145 @@ static int dictionary_destroy_race_unittest(void) {
     return 0;
 }
 
+static int dictionary_destroy_deferred_rcu_unittest(void) {
+    int errors = 0;
+
+    fprintf(stderr, "\nTesting deferred dictionary destruction while inside an RCU read-side CS...\n");
+
+    cleanup_destroyed_dictionaries(false);
+    size_t delayed_before = dictionary_destroy_delayed_count();
+
+    DICTIONARY *guard = dictionary_create(DICT_OPTION_NONE);
+    DICTIONARY *victim = dictionary_create(DICT_OPTION_NONE);
+    dictionary_set(guard, "guard", "G", 2);
+    dictionary_set(victim, "victim", "V", 2);
+
+    void *v;
+    dfe_start_read(guard, v) {
+        size_t freed = dictionary_destroy(victim);
+        if(freed != 0) {
+            fprintf(stderr, "Deferred destroy test: expected victim destroy to queue, got %zu bytes freed\n", freed);
+            errors++;
+        }
+
+        size_t delayed_during = dictionary_destroy_delayed_count();
+        if(delayed_during != delayed_before + 1) {
+            fprintf(stderr, "Deferred destroy test: expected queued count %zu while in RCU CS, got %zu\n",
+                    delayed_before + 1, delayed_during);
+            errors++;
+        }
+
+        size_t remaining = cleanup_destroyed_dictionaries(false);
+        if(remaining != delayed_before + 1) {
+            fprintf(stderr, "Deferred destroy test: expected cleanup to keep victim queued inside RCU CS (remaining=%zu)\n",
+                    remaining);
+            errors++;
+        }
+    }
+    dfe_done(v);
+
+    size_t remaining_after = cleanup_destroyed_dictionaries(false);
+    if(remaining_after != delayed_before) {
+        fprintf(stderr, "Deferred destroy test: expected queued count %zu after leaving RCU CS, got %zu\n",
+                delayed_before, remaining_after);
+        errors++;
+    }
+
+    size_t delayed_after = dictionary_destroy_delayed_count();
+    if(delayed_after != delayed_before) {
+        fprintf(stderr, "Deferred destroy test: expected delayed destroy count %zu after cleanup, got %zu\n",
+                delayed_before, delayed_after);
+        errors++;
+    }
+
+    dictionary_destroy(guard);
+    cleanup_destroyed_dictionaries(false);
+
+    return errors;
+}
+
+static int dictionary_destroy_deferred_rcu_gc_progress_unittest(void) {
+    int errors = 0;
+
+    fprintf(stderr, "\nTesting delayed dictionary destroy progress via dictionary_garbage_collect()...\n");
+
+    cleanup_destroyed_dictionaries(false);
+    size_t delayed_before = dictionary_destroy_delayed_count();
+
+    DICTIONARY *guard = dictionary_create(DICT_OPTION_NONE);
+    DICTIONARY *victim = dictionary_create(DICT_OPTION_NONE);
+    dictionary_set(guard, "guard", "G", 2);
+    dictionary_set(victim, "victim", "V", 2);
+
+    void *v;
+    dfe_start_read(guard, v) {
+        size_t freed = dictionary_destroy(victim);
+        if(freed != 0) {
+            fprintf(stderr, "Deferred destroy GC test: expected victim destroy to queue, got %zu bytes freed\n", freed);
+            errors++;
+        }
+    }
+    dfe_done(v);
+
+    dictionary_garbage_collect(guard);
+
+    size_t delayed_after = dictionary_destroy_delayed_count();
+    if(delayed_after != delayed_before) {
+        fprintf(stderr, "Deferred destroy GC test: expected delayed destroy count %zu after garbage collection, got %zu\n",
+                delayed_before, delayed_after);
+        errors++;
+    }
+
+    dictionary_destroy(guard);
+    cleanup_destroyed_dictionaries(false);
+
+    return errors;
+}
+
+static int dictionary_rcu_value_replace_unittest(void) {
+    int errors = 0;
+
+    fprintf(stderr, "\nTesting RCU traversal value stability across overwrite...\n");
+
+    DICTIONARY *dict = dictionary_create_advanced(DICT_OPTION_FIXED_SIZE, NULL, 64);
+
+    char initial[64];
+    memset(initial, 'A', sizeof(initial));
+    initial[sizeof(initial) - 1] = '\0';
+    dictionary_set(dict, "stable", initial, sizeof(initial));
+
+    void *v;
+    dfe_start_read(dict, v) {
+        char *snapshot = v;
+
+        for(int i = 0; i < 128; i++) {
+            char replacement[64];
+            char tmp_key[32];
+
+            memset(replacement, 'B' + (i % 20), sizeof(replacement));
+            replacement[sizeof(replacement) - 1] = '\0';
+
+            dictionary_set(dict, "stable", replacement, sizeof(replacement));
+
+            snprintfz(tmp_key, sizeof(tmp_key), "tmp-%d", i);
+            dictionary_set(dict, tmp_key, replacement, sizeof(replacement));
+            dictionary_del(dict, tmp_key);
+        }
+
+        if(memcmp(snapshot, initial, sizeof(initial)) != 0) {
+            fprintf(stderr, "RCU overwrite test: traversal value changed while still inside read-side critical section\n");
+            errors++;
+        }
+    }
+    dfe_done(v);
+
+    dictionary_garbage_collect(dict);
+    dictionary_destroy(dict);
+    cleanup_destroyed_dictionaries(false);
+
+    return errors;
+}
+
 #else
 
 static int dictionary_destroy_race_unittest(void) {
@@ -2302,6 +2441,9 @@ int dictionary_unittest(size_t entries) {
         fprintf(stderr, "Destroy on traversal test OK\n");
 
     errors += dictionary_destroy_race_unittest();
+    errors += dictionary_destroy_deferred_rcu_unittest();
+    errors += dictionary_destroy_deferred_rcu_gc_progress_unittest();
+    errors += dictionary_rcu_value_replace_unittest();
 
     cleanup_destroyed_dictionaries(false);
 

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -237,6 +237,7 @@ void garbage_collect_pending_deletes(DICTIONARY *dict) {
 
 void dictionary_garbage_collect(DICTIONARY *dict) {
     if(!dict) return;
+    cleanup_destroyed_dictionaries(false);
     garbage_collect_pending_deletes(dict);
 }
 
@@ -314,7 +315,9 @@ static bool dictionary_free_all_resources(DICTIONARY *dict, size_t *mem, bool fo
         counted_items++;
     }
 
-    item_size += dict_rcu_pending_free_free_list(dict, dict_rcu_pending_free_detach(dict));
+    DICTIONARY_RCU_RETIRED_VALUE *retired_values = NULL;
+    item_size += dict_rcu_pending_free_free_list(dict, dict_rcu_pending_free_detach(dict, &retired_values));
+    item_size += dict_rcu_pending_value_free_list(dict, retired_values);
 
     dict_size += dictionary_locks_destroy(dict);
     dict_size += reference_counter_free(dict);
@@ -412,8 +415,8 @@ size_t cleanup_destroyed_dictionaries(bool shutdown __maybe_unused)
     for(dict = dictionaries_waiting_to_be_destroyed; dict ; dict = next) {
         next = dict->next;
 
-        DICTIONARY_STATS_DICT_DESTROY_QUEUED_MINUS1(dict);
         if(dictionary_free_all_resources(dict, NULL, false)) {
+            DICTIONARY_STATS_DICT_DESTROY_QUEUED_MINUS1(dict);
             if(last) last->next = next;
             else dictionaries_waiting_to_be_destroyed = next;
         }
@@ -440,8 +443,6 @@ size_t cleanup_destroyed_dictionaries(bool shutdown __maybe_unused)
                 }
             }
 #endif
-
-            DICTIONARY_STATS_DICT_DESTROY_QUEUED_PLUS1(dict);
             last = dict;
             remaining++;
         }
@@ -771,7 +772,7 @@ void *dictionary_set_advanced(DICTIONARY *dict, const char *name, ssize_t name_l
     DICTIONARY_ITEM *item = dictionary_set_and_acquire_item_advanced(dict, name, name_len, value, value_len, constructor_data);
 
     if(likely(item)) {
-        void *v = item->shared->value;
+        void *v = dict_item_value_get(item);
         item_release(dict, item);
         return v;
     }
@@ -802,7 +803,7 @@ void *dictionary_view_set_advanced(DICTIONARY *dict, const char *name, ssize_t n
     DICTIONARY_ITEM *item = dictionary_view_set_and_acquire_item_advanced(dict, name, name_len, master_item);
 
     if(likely(item)) {
-        void *v = item->shared->value;
+        void *v = dict_item_value_get(item);
         item_release(dict, item);
         return v;
     }
@@ -827,7 +828,7 @@ void *dictionary_get_advanced(DICTIONARY *dict, const char *name, ssize_t name_l
     DICTIONARY_ITEM *item = dictionary_get_and_acquire_item_advanced(dict, name, name_len);
 
     if(likely(item)) {
-        void *v = item->shared->value;
+        void *v = dict_item_value_get(item);
         item_release(dict, item);
         return v;
     }
@@ -875,7 +876,7 @@ const char *dictionary_acquired_item_name(DICT_ITEM_CONST DICTIONARY_ITEM *item)
 ALWAYS_INLINE
 void *dictionary_acquired_item_value(DICT_ITEM_CONST DICTIONARY_ITEM *item) {
     if(likely(item))
-        return item->shared->value;
+        return dict_item_value_get(item);
 
     return NULL;
 }

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -178,6 +178,8 @@ void garbage_collect_pending_deletes(DICTIONARY *dict) {
 
     DICTIONARY_STATS_GARBAGE_COLLECTIONS_PLUS1(dict);
 
+    bool needs_rcu = !is_dictionary_single_threaded(dict);
+
     size_t deleted = 0, pending = 0, examined = 0;
     DICTIONARY_ITEM *item = dict->items.list, *item_next;
     while(item) {
@@ -191,8 +193,16 @@ void garbage_collect_pending_deletes(DICTIONARY *dict) {
             // we didn't get a reference
 
             if(item_is_not_referenced_and_can_be_removed(dict, item)) {
-                DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(dict->items.list, item, prev, next);
-                dict_item_free_with_hooks(dict, item);
+                if(needs_rcu) {
+                    // RCU-safe removal preserves item->next for concurrent readers.
+                    // The actual free is deferred until after a grace period.
+                    DOUBLE_LINKED_LIST_REMOVE_ITEM_RCU_SAFE(dict->items.list, item, prev, next);
+                    dict_rcu_pending_free_queue(dict, item);
+                }
+                else {
+                    DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(dict->items.list, item, prev, next);
+                    dict_item_free_with_hooks(dict, item);
+                }
                 deleted++;
 
                 pending = DICTIONARY_PENDING_DELETES_MINUS1(dict);
@@ -213,6 +223,9 @@ void garbage_collect_pending_deletes(DICTIONARY *dict) {
         dictionary_index_wrlock_unlock(dict);
 
     ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
+
+    if(needs_rcu)
+        dict_rcu_pending_free_drain(dict);
 
     (void)deleted;
     (void)examined;
@@ -255,6 +268,14 @@ static bool dictionary_free_all_resources(DICTIONARY *dict, size_t *mem, bool fo
     if(!force && dictionary_referenced_items(dict))
         return false;
 
+    if(!is_dictionary_single_threaded(dict)) {
+        // Readers no longer acquire item references in RCU traversal mode,
+        // so whole-dictionary teardown must wait for a grace period before
+        // freeing items, values, hooks, or the dictionary object itself.
+        if(rcu_thread_in_read_cs() || !rcu_synchronize())
+            return false;
+    }
+
     size_t dict_size = 0, counted_items = 0, item_size = 0, index_size = 0;
     (void)counted_items;
 
@@ -264,13 +285,21 @@ static bool dictionary_free_all_resources(DICTIONARY *dict, size_t *mem, bool fo
     long int pending_deletion_items = dict->pending_deletion_items;
 #endif
 
-    // destroy the index
+    // Detach the item list under the write lock.
+    ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE);
+    DICTIONARY_ITEM *item = dict->items.list;
+    dict->items.list = NULL;
+    ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
+
+    // We already waited for a grace period above, so no pre-destroy RCU reader
+    // can still observe this dictionary, its items, or the payloads hanging off
+    // those items.
+
+    // Destroy the index.
     dictionary_index_lock_wrlock(dict);
     index_size += hashtable_destroy_unsafe(dict);
     dictionary_index_wrlock_unlock(dict);
 
-    ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE);
-    DICTIONARY_ITEM *item = dict->items.list;
     while (item) {
         // cache item->next
         // because we are going to free item
@@ -284,8 +313,8 @@ static bool dictionary_free_all_resources(DICTIONARY *dict, size_t *mem, bool fo
 
         counted_items++;
     }
-    dict->items.list = NULL;
-    ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
+
+    item_size += dict_rcu_pending_free_free_list(dict, dict_rcu_pending_free_detach(dict));
 
     dict_size += dictionary_locks_destroy(dict);
     dict_size += reference_counter_free(dict);
@@ -712,7 +741,10 @@ size_t dictionary_destroy(DICTIONARY *dict) {
     ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
 
     size_t freed;
-    dictionary_free_all_resources(dict, &freed, true);
+    if(!dictionary_free_all_resources(dict, &freed, true)) {
+        dictionary_queue_for_destruction(dict);
+        return 0;
+    }
 
     return freed;
 }

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -315,9 +315,11 @@ static bool dictionary_free_all_resources(DICTIONARY *dict, size_t *mem, bool fo
         counted_items++;
     }
 
-    DICTIONARY_RCU_RETIRED_VALUE *retired_values = NULL;
-    item_size += dict_rcu_pending_free_free_list(dict, dict_rcu_pending_free_detach(dict, &retired_values));
-    item_size += dict_rcu_pending_value_free_list(dict, retired_values);
+    if(!is_dictionary_single_threaded(dict)) {
+        DICTIONARY_RCU_RETIRED_VALUE *retired_values = NULL;
+        item_size += dict_rcu_pending_free_free_list(dict, dict_rcu_pending_free_detach(dict, &retired_values));
+        item_size += dict_rcu_pending_value_free_list(dict, retired_values);
+    }
 
     dict_size += dictionary_locks_destroy(dict);
     dict_size += reference_counter_free(dict);

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -415,12 +415,13 @@ size_t cleanup_destroyed_dictionaries(bool shutdown __maybe_unused)
     for(dict = dictionaries_waiting_to_be_destroyed; dict ; dict = next) {
         next = dict->next;
 
+        DICTIONARY_STATS_DICT_DESTROY_QUEUED_MINUS1(dict);
         if(dictionary_free_all_resources(dict, NULL, false)) {
-            DICTIONARY_STATS_DICT_DESTROY_QUEUED_MINUS1(dict);
             if(last) last->next = next;
             else dictionaries_waiting_to_be_destroyed = next;
         }
         else {
+            DICTIONARY_STATS_DICT_DESTROY_QUEUED_PLUS1(dict);
 #ifdef FSANITIZE_ADDRESS
             size_t ref_items = dictionary_referenced_items(dict);
 

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -509,12 +509,13 @@ size_t cleanup_destroyed_dictionaries(bool shutdown __maybe_unused)
     for(dict = dictionaries_waiting_to_be_destroyed; dict ; dict = next) {
         next = dict->next;
 
+        DICTIONARY_STATS_DICT_DESTROY_QUEUED_MINUS1(dict);
         if(dictionary_free_all_resources(dict, NULL, false)) {
-            DICTIONARY_STATS_DICT_DESTROY_QUEUED_MINUS1(dict);
             if(last) last->next = next;
             else dictionaries_waiting_to_be_destroyed = next;
         }
         else {
+            DICTIONARY_STATS_DICT_DESTROY_QUEUED_PLUS1(dict);
 #ifdef FSANITIZE_ADDRESS
             size_t ref_items = dictionary_referenced_items(dict);
 

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -244,6 +244,7 @@ void dictionary_garbage_collect(DICTIONARY *dict) {
     if(!dict) return;
 
     dictionary_api_enter(dict);
+    cleanup_destroyed_dictionaries(false);
     garbage_collect_pending_deletes(dict);
     dictionary_api_exit(dict);
 }
@@ -408,7 +409,9 @@ static bool dictionary_free_all_resources(DICTIONARY *dict, size_t *mem, bool fo
         counted_items++;
     }
 
-    item_size += dict_rcu_pending_free_free_list(dict, dict_rcu_pending_free_detach(dict));
+    DICTIONARY_RCU_RETIRED_VALUE *retired_values = NULL;
+    item_size += dict_rcu_pending_free_free_list(dict, dict_rcu_pending_free_detach(dict, &retired_values));
+    item_size += dict_rcu_pending_value_free_list(dict, retired_values);
 
     dict_size += dictionary_locks_destroy(dict);
     dict_size += reference_counter_free(dict);
@@ -506,8 +509,8 @@ size_t cleanup_destroyed_dictionaries(bool shutdown __maybe_unused)
     for(dict = dictionaries_waiting_to_be_destroyed; dict ; dict = next) {
         next = dict->next;
 
-        DICTIONARY_STATS_DICT_DESTROY_QUEUED_MINUS1(dict);
         if(dictionary_free_all_resources(dict, NULL, false)) {
+            DICTIONARY_STATS_DICT_DESTROY_QUEUED_MINUS1(dict);
             if(last) last->next = next;
             else dictionaries_waiting_to_be_destroyed = next;
         }
@@ -534,8 +537,6 @@ size_t cleanup_destroyed_dictionaries(bool shutdown __maybe_unused)
                 }
             }
 #endif
-
-            DICTIONARY_STATS_DICT_DESTROY_QUEUED_PLUS1(dict);
             last = dict;
             remaining++;
         }
@@ -939,7 +940,7 @@ void *dictionary_set_advanced(DICTIONARY *dict, const char *name, ssize_t name_l
     DICTIONARY_ITEM *item = dictionary_set_and_acquire_item_advanced(dict, name, name_len, value, value_len, constructor_data);
 
     if(likely(item)) {
-        void *v = item->shared->value;
+        void *v = dict_item_value_get(item);
         dictionary_acquired_item_release(dict, item);
         return v;
     }
@@ -991,7 +992,7 @@ void *dictionary_view_set_advanced(DICTIONARY *dict, const char *name, ssize_t n
     DICTIONARY_ITEM *item = dictionary_view_set_and_acquire_item_advanced(dict, name, name_len, master_item);
 
     if(likely(item)) {
-        void *v = item->shared->value;
+        void *v = dict_item_value_get(item);
         dictionary_acquired_item_release(dict, item);
         return v;
     }
@@ -1026,7 +1027,7 @@ void *dictionary_get_advanced(DICTIONARY *dict, const char *name, ssize_t name_l
     DICTIONARY_ITEM *item = dictionary_get_and_acquire_item_advanced(dict, name, name_len);
 
     if(likely(item)) {
-        void *v = item->shared->value;
+        void *v = dict_item_value_get(item);
         dictionary_acquired_item_release(dict, item);
         return v;
     }
@@ -1097,7 +1098,7 @@ const char *dictionary_acquired_item_name(DICT_ITEM_CONST DICTIONARY_ITEM *item)
 ALWAYS_INLINE
 void *dictionary_acquired_item_value(DICT_ITEM_CONST DICTIONARY_ITEM *item) {
     if(likely(item))
-        return item->shared->value;
+        return dict_item_value_get(item);
 
     return NULL;
 }

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -409,9 +409,11 @@ static bool dictionary_free_all_resources(DICTIONARY *dict, size_t *mem, bool fo
         counted_items++;
     }
 
-    DICTIONARY_RCU_RETIRED_VALUE *retired_values = NULL;
-    item_size += dict_rcu_pending_free_free_list(dict, dict_rcu_pending_free_detach(dict, &retired_values));
-    item_size += dict_rcu_pending_value_free_list(dict, retired_values);
+    if(!is_dictionary_single_threaded(dict)) {
+        DICTIONARY_RCU_RETIRED_VALUE *retired_values = NULL;
+        item_size += dict_rcu_pending_free_free_list(dict, dict_rcu_pending_free_detach(dict, &retired_values));
+        item_size += dict_rcu_pending_value_free_list(dict, retired_values);
+    }
 
     dict_size += dictionary_locks_destroy(dict);
     dict_size += reference_counter_free(dict);

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -182,6 +182,8 @@ void garbage_collect_pending_deletes(DICTIONARY *dict) {
 
     DICTIONARY_STATS_GARBAGE_COLLECTIONS_PLUS1(dict);
 
+    bool needs_rcu = !is_dictionary_single_threaded(dict);
+
     size_t deleted = 0, pending = 0, examined = 0;
     DICTIONARY_ITEM *item = dict->items.list, *item_next;
     while(item) {
@@ -195,9 +197,18 @@ void garbage_collect_pending_deletes(DICTIONARY *dict) {
             // we didn't get a reference
 
             if(item_is_not_referenced_and_can_be_removed(dict, item)) {
-                DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(dict->items.list, item, prev, next);
-                pending = item_pending_deletion_clear(dict, item);
-                dict_item_free_with_hooks(dict, item);
+                if(needs_rcu) {
+                    // RCU-safe removal preserves item->next for concurrent readers.
+                    // The actual free is deferred until after a grace period.
+                    DOUBLE_LINKED_LIST_REMOVE_ITEM_RCU_SAFE(dict->items.list, item, prev, next);
+                    pending = item_pending_deletion_clear(dict, item);
+                    dict_rcu_pending_free_queue(dict, item);
+                }
+                else {
+                    DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(dict->items.list, item, prev, next);
+                    pending = item_pending_deletion_clear(dict, item);
+                    dict_item_free_with_hooks(dict, item);
+                }
                 deleted++;
 
                 if (!pending)
@@ -217,6 +228,9 @@ void garbage_collect_pending_deletes(DICTIONARY *dict) {
         dictionary_index_wrlock_unlock(dict);
 
     ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
+
+    if(needs_rcu)
+        dict_rcu_pending_free_drain(dict);
 
     (void)deleted;
     (void)examined;
@@ -348,6 +362,14 @@ static bool dictionary_free_all_resources(DICTIONARY *dict, size_t *mem, bool fo
     if(!force && (dictionary_referenced_items(dict) || dictionary_inflight(dict)))
         return false;
 
+    if(!is_dictionary_single_threaded(dict)) {
+        // Readers no longer acquire item references in RCU traversal mode,
+        // so whole-dictionary teardown must wait for a grace period before
+        // freeing items, values, hooks, or the dictionary object itself.
+        if(rcu_thread_in_read_cs() || !rcu_synchronize())
+            return false;
+    }
+
     size_t dict_size = 0, counted_items = 0, item_size = 0, index_size = 0;
     (void)counted_items;
 
@@ -357,13 +379,21 @@ static bool dictionary_free_all_resources(DICTIONARY *dict, size_t *mem, bool fo
     long int pending_deletion_items = dict->pending_deletion_items;
 #endif
 
-    // destroy the index
+    // Detach the item list under the write lock.
+    ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE);
+    DICTIONARY_ITEM *item = dict->items.list;
+    dict->items.list = NULL;
+    ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
+
+    // We already waited for a grace period above, so no pre-destroy RCU reader
+    // can still observe this dictionary, its items, or the payloads hanging off
+    // those items.
+
+    // Destroy the index.
     dictionary_index_lock_wrlock(dict);
     index_size += hashtable_destroy_unsafe(dict);
     dictionary_index_wrlock_unlock(dict);
 
-    ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE);
-    DICTIONARY_ITEM *item = dict->items.list;
     while (item) {
         // cache item->next
         // because we are going to free item
@@ -377,8 +407,8 @@ static bool dictionary_free_all_resources(DICTIONARY *dict, size_t *mem, bool fo
 
         counted_items++;
     }
-    dict->items.list = NULL;
-    ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
+
+    item_size += dict_rcu_pending_free_free_list(dict, dict_rcu_pending_free_detach(dict));
 
     dict_size += dictionary_locks_destroy(dict);
     dict_size += reference_counter_free(dict);
@@ -848,7 +878,10 @@ size_t dictionary_destroy(DICTIONARY *dict) {
     ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
 
     size_t freed;
-    dictionary_free_all_resources(dict, &freed, true);
+    if(!dictionary_free_all_resources(dict, &freed, true)) {
+        dictionary_queue_for_destruction(dict);
+        return 0;
+    }
 
     return freed;
 }

--- a/src/libnetdata/dictionary/dictionary.h
+++ b/src/libnetdata/dictionary/dictionary.h
@@ -283,6 +283,7 @@ typedef DICTFE_CONST struct dictionary_foreach {
 
     char rw;                    // the lock mode 'r' or 'w'
     bool locked;                // true when the dictionary is locked
+    bool rcu_mode;              // true when using RCU for read-side (no per-item refcount)
 } DICTFE;
 
 #define dfe_start_read(dict, value) dfe_start_rw(dict, value, DICTIONARY_LOCK_READ)
@@ -300,6 +301,7 @@ typedef DICTFE_CONST struct dictionary_foreach {
                 .counter = 0,                                                                       \
                 .rw = (mode),                                                                       \
                 .locked = false,                                                                    \
+                .rcu_mode = false,                                                                  \
             };                                                                                      \
             (void)(ptr); /* needed to avoid warning when looping without using this */              \
             for((ptr) = dictionary_foreach_start_rw(&ptr ## _dfe);                                  \

--- a/src/libnetdata/dictionary/dictionary.h
+++ b/src/libnetdata/dictionary/dictionary.h
@@ -342,6 +342,7 @@ typedef DICTFE_CONST struct dictionary_foreach {
 
     char rw;                    // the lock mode 'r' or 'w'
     bool locked;                // true when the dictionary is locked
+    bool rcu_mode;              // true when using RCU for read-side (no per-item refcount)
 } DICTFE;
 
 #define dfe_start_read(dict, value) dfe_start_rw(dict, value, DICTIONARY_LOCK_READ)
@@ -359,6 +360,7 @@ typedef DICTFE_CONST struct dictionary_foreach {
                 .counter = 0,                                                                       \
                 .rw = (mode),                                                                       \
                 .locked = false,                                                                    \
+                .rcu_mode = false,                                                                  \
             };                                                                                      \
             (void)(ptr); /* needed to avoid warning when looping without using this */              \
             for((ptr) = dictionary_foreach_start_rw(&ptr ## _dfe);                                  \

--- a/src/libnetdata/libnetdata.h
+++ b/src/libnetdata/libnetdata.h
@@ -78,6 +78,7 @@ extern const char *netdata_configured_host_prefix;
 #include "locks/locks.h"
 #include "locks/spinlock.h"
 #include "locks/rw-spinlock.h"
+#include "locks/rcu.h"
 #include "completion/completion.h"
 #include "libnetdata/locks/waitq.h"
 #include "clocks/clocks.h"

--- a/src/libnetdata/libnetdata.h
+++ b/src/libnetdata/libnetdata.h
@@ -83,6 +83,7 @@ struct web_buffer *run_command_and_get_output_to_buffer(const char *command, int
 #include "locks/locks.h"
 #include "locks/spinlock.h"
 #include "locks/rw-spinlock.h"
+#include "locks/rcu.h"
 #include "completion/completion.h"
 #include "libnetdata/locks/waitq.h"
 #include "clocks/clocks.h"

--- a/src/libnetdata/linked_lists/linked_lists.h
+++ b/src/libnetdata/linked_lists/linked_lists.h
@@ -67,6 +67,76 @@
         (item)->prev = NULL;                                                                   \
     } while (0)
 
+// RCU-safe prepend: publishes the new item to concurrent RCU readers via
+// atomic release stores on the pointers they follow (head and prev->next).
+// All other pointer setup uses plain stores (not visible to readers).
+#define DOUBLE_LINKED_LIST_PREPEND_ITEM_RCU_SAFE(head, item, prev, next)                       \
+    do {                                                                                       \
+        (item)->next = (head);                                                                 \
+                                                                                               \
+        if(likely(head)) {                                                                     \
+            (item)->prev = (head)->prev;                                                       \
+            (head)->prev = (item);                                                             \
+        }                                                                                      \
+        else                                                                                   \
+            (item)->prev = (item);                                                             \
+                                                                                               \
+        /* Publish: readers load head with acquire, so store with release */                   \
+        __atomic_store_n(&(head), (item), __ATOMIC_RELEASE);                                   \
+    } while (0)
+
+// RCU-safe append: publishes the new item to concurrent RCU readers via
+// atomic release stores on the pointers they follow (prev->next or head).
+#define DOUBLE_LINKED_LIST_APPEND_ITEM_RCU_SAFE(head, item, prev, next)                        \
+    do {                                                                                       \
+        (item)->next = NULL;                                                                   \
+                                                                                               \
+        if(likely(head)) {                                                                     \
+            (item)->prev = (head)->prev;                                                       \
+            /* Publish via tail->next: readers follow next with acquire */                     \
+            __atomic_store_n(&(head)->prev->next, (item), __ATOMIC_RELEASE);                   \
+            (head)->prev = (item);                                                             \
+        }                                                                                      \
+        else {                                                                                 \
+            (item)->prev = (item);                                                             \
+            __atomic_store_n(&(head), (item), __ATOMIC_RELEASE);                               \
+        }                                                                                      \
+    } while (0)
+
+// RCU-safe variant: unlinks the item but does NOT clear item->next.
+// This allows concurrent RCU readers at this item to continue forward
+// traversal. The item must NOT be freed until after rcu_synchronize().
+// Uses atomic release stores on pointers that RCU readers follow
+// (head and prev->next) to ensure correct ordering under C11.
+#define DOUBLE_LINKED_LIST_REMOVE_ITEM_RCU_SAFE(head, item, prev, next)                        \
+    do {                                                                                       \
+        fatal_assert((head) != NULL);                                                          \
+        fatal_assert((item)->prev != NULL);                                                    \
+                                                                                               \
+        if((item)->prev == (item))                                                             \
+            /* it is the only item in the list */                                              \
+            __atomic_store_n(&(head), NULL, __ATOMIC_RELEASE);                                 \
+                                                                                               \
+        else if((item) == (head)) {                                                            \
+            /* it is the first item */                                                         \
+            fatal_assert((item)->next != NULL);                                                \
+            (item)->next->prev = (item)->prev;                                                 \
+            __atomic_store_n(&(head), (item)->next, __ATOMIC_RELEASE);                         \
+        }                                                                                      \
+        else {                                                                                 \
+            /* it is any other item */                                                         \
+            __atomic_store_n(&(item)->prev->next, (item)->next, __ATOMIC_RELEASE);             \
+                                                                                               \
+            if ((item)->next)                                                                  \
+                (item)->next->prev = (item)->prev;                                             \
+            else                                                                               \
+                (head)->prev = (item)->prev;                                                   \
+        }                                                                                      \
+                                                                                               \
+        /* item->next intentionally NOT cleared: RCU readers may follow it */                  \
+        (item)->prev = NULL;                                                                   \
+    } while (0)
+
 #define DOUBLE_LINKED_LIST_INSERT_ITEM_BEFORE_UNSAFE(head, existing, item, prev, next)         \
     do {                                                                                       \
         if (existing) {                                                                        \

--- a/src/libnetdata/locks/benchmark-rcu.c
+++ b/src/libnetdata/locks/benchmark-rcu.c
@@ -35,11 +35,6 @@ typedef struct {
     // Shared data that readers read and writers update
     uint64_t shared_value;
 
-    // Validation: detect reader/writer overlap violations
-    volatile int readers;
-    volatile int writers;
-    volatile uint64_t violations;
-
     // Per-thread stats
     struct {
         uint64_t operations;
@@ -76,31 +71,13 @@ typedef struct {
     ND_THREAD *thread;
 } bench_thread_ctx_t;
 
-static inline void bench_check_safety(bench_control_t *ctl, bench_thread_type_t type) {
-    if(type == BENCH_THREAD_READER) {
-        __atomic_add_fetch(&ctl->readers, 1, __ATOMIC_RELAXED);
-        if(__atomic_load_n(&ctl->writers, __ATOMIC_RELAXED) > 0)
-            __atomic_add_fetch(&ctl->violations, 1, __ATOMIC_RELAXED);
-    }
-    else {
-        int w = __atomic_add_fetch(&ctl->writers, 1, __ATOMIC_RELAXED);
-        if(w > 1)
-            __atomic_add_fetch(&ctl->violations, 1, __ATOMIC_RELAXED);
-        if(__atomic_load_n(&ctl->readers, __ATOMIC_RELAXED) > 0)
-            __atomic_add_fetch(&ctl->violations, 1, __ATOMIC_RELAXED);
-    }
-}
-
-static inline void bench_release_safety(bench_control_t *ctl, bench_thread_type_t type) {
-    if(type == BENCH_THREAD_READER)
-        __atomic_sub_fetch(&ctl->readers, 1, __ATOMIC_RELAXED);
-    else
-        __atomic_sub_fetch(&ctl->writers, 1, __ATOMIC_RELAXED);
+static inline uint64_t bench_run_flag_load(uint64_t *flag) {
+    return __atomic_load_n(flag, __ATOMIC_ACQUIRE);
 }
 
 static void bench_wait_for_start(netdata_cond_t *cond, netdata_mutex_t *mutex, uint64_t *flag) {
     netdata_mutex_lock(mutex);
-    while(*flag == 0)
+    while(bench_run_flag_load(flag) == 0)
         netdata_cond_wait(cond, mutex);
     netdata_mutex_unlock(mutex);
 }
@@ -118,7 +95,7 @@ static void rcu_benchmark_thread(void *arg) {
                              &ctl->thread_controls[ctx->thread_id].cond_mutex,
                              &ctl->thread_controls[ctx->thread_id].run_flag);
 
-        if(ctl->thread_controls[ctx->thread_id].run_flag == STOP_SIGNAL)
+        if(bench_run_flag_load(&ctl->thread_controls[ctx->thread_id].run_flag) == STOP_SIGNAL)
             break;
 
         usec_t start = now_monotonic_high_precision_usec();
@@ -128,7 +105,7 @@ static void rcu_benchmark_thread(void *arg) {
             RW_SPINLOCK *lock = ctx->rw_spinlock;
 
             if(ctx->type == BENCH_THREAD_READER) {
-                while(ctl->thread_controls[ctx->thread_id].run_flag) {
+                while(bench_run_flag_load(&ctl->thread_controls[ctx->thread_id].run_flag)) {
                     rw_spinlock_read_lock(lock);
                     // Read shared data
                     uint64_t v __maybe_unused = ctl->shared_value;
@@ -138,7 +115,7 @@ static void rcu_benchmark_thread(void *arg) {
                 }
             }
             else {
-                while(ctl->thread_controls[ctx->thread_id].run_flag) {
+                while(bench_run_flag_load(&ctl->thread_controls[ctx->thread_id].run_flag)) {
                     rw_spinlock_write_lock(lock);
                     ctl->shared_value++;
                     rw_spinlock_write_unlock(lock);
@@ -148,7 +125,7 @@ static void rcu_benchmark_thread(void *arg) {
         }
         else { // BENCH_RCU
             if(ctx->type == BENCH_THREAD_READER) {
-                while(ctl->thread_controls[ctx->thread_id].run_flag) {
+                while(bench_run_flag_load(&ctl->thread_controls[ctx->thread_id].run_flag)) {
                     rcu_read_lock();
                     // Read shared data
                     uint64_t v __maybe_unused = __atomic_load_n(&ctl->shared_value, __ATOMIC_ACQUIRE);
@@ -158,7 +135,7 @@ static void rcu_benchmark_thread(void *arg) {
                 }
             }
             else {
-                while(ctl->thread_controls[ctx->thread_id].run_flag) {
+                while(bench_run_flag_load(&ctl->thread_controls[ctx->thread_id].run_flag)) {
                     // Writers still need mutual exclusion among themselves
                     spinlock_lock(ctx->writer_spinlock);
                     __atomic_add_fetch(&ctl->shared_value, 1, __ATOMIC_RELEASE);
@@ -213,12 +190,6 @@ static void bench_print_thread_stats(const char *test_name, int readers, int wri
     fprintf(stderr, "%4s %8s %12s %12.0f\n",
             "", "WRITER", "TOTAL", writer_ops_per_sec);
 
-    if(__atomic_load_n(&ctl->violations, __ATOMIC_RELAXED) > 0) {
-        fprintf(stderr, "\nFATAL: %"PRIu64" access violations detected!\n",
-                ctl->violations);
-        _exit(1);
-    }
-
     summary->reader_ops_per_sec[lock_type][config_idx] = reader_ops_per_sec;
     summary->writer_ops_per_sec[lock_type][config_idx] = writer_ops_per_sec;
     summary->readers[config_idx] = readers;
@@ -236,14 +207,11 @@ static void bench_run_test(const char *name, int readers, int writers,
     // Reset
     memset(ctl->stats, 0, sizeof(ctl->stats));
     ctl->shared_value = 0;
-    ctl->readers = 0;
-    ctl->writers = 0;
-    ctl->violations = 0;
 
     // Signal threads to start
     for(int i = 0; i < total; i++) {
         netdata_mutex_lock(&ctl->thread_controls[i].cond_mutex);
-        ctl->thread_controls[i].run_flag = 1;
+        __atomic_store_n(&ctl->thread_controls[i].run_flag, 1, __ATOMIC_RELEASE);
         netdata_cond_signal(&ctl->thread_controls[i].cond);
         netdata_mutex_unlock(&ctl->thread_controls[i].cond_mutex);
     }
@@ -321,7 +289,7 @@ int rcu_stress_test(void) {
         for(int i = 0; i < MAX_THREADS; i++) {
             netdata_cond_init(&ctl[lock].thread_controls[i].cond);
             netdata_mutex_init(&ctl[lock].thread_controls[i].cond_mutex);
-            ctl[lock].thread_controls[i].run_flag = 0;
+            __atomic_store_n(&ctl[lock].thread_controls[i].run_flag, 0, __ATOMIC_RELEASE);
 
             contexts[lock][i] = (bench_thread_ctx_t){
                 .thread_id = i,
@@ -379,7 +347,7 @@ int rcu_stress_test(void) {
     for(int lock = 0; lock < NUM_LOCK_TYPES; lock++) {
         for(int i = 0; i < MAX_THREADS; i++) {
             netdata_mutex_lock(&ctl[lock].thread_controls[i].cond_mutex);
-            ctl[lock].thread_controls[i].run_flag = STOP_SIGNAL;
+            __atomic_store_n(&ctl[lock].thread_controls[i].run_flag, STOP_SIGNAL, __ATOMIC_RELEASE);
             netdata_cond_signal(&ctl[lock].thread_controls[i].cond);
             netdata_mutex_unlock(&ctl[lock].thread_controls[i].cond_mutex);
         }

--- a/src/libnetdata/locks/benchmark-rcu.c
+++ b/src/libnetdata/locks/benchmark-rcu.c
@@ -254,8 +254,21 @@ static void bench_print_summary(const bench_summary_t *summary) {
     fprintf(stderr, "\n");
 }
 
+static void bench_stop_threads(bench_control_t *ctl, bench_thread_ctx_t *contexts, int created_threads) {
+    for(int i = 0; i < created_threads; i++) {
+        netdata_mutex_lock(&ctl->thread_controls[i].cond_mutex);
+        __atomic_store_n(&ctl->thread_controls[i].run_flag, STOP_SIGNAL, __ATOMIC_RELEASE);
+        netdata_cond_signal(&ctl->thread_controls[i].cond);
+        netdata_mutex_unlock(&ctl->thread_controls[i].cond_mutex);
+    }
+
+    for(int i = 0; i < created_threads; i++)
+        nd_thread_join(contexts[i].thread);
+}
+
 int rcu_stress_test(void) {
     bench_summary_t summary = {0};
+    int ret = 0;
 
     RW_SPINLOCK rw_spinlock = RW_SPINLOCK_INITIALIZER;
     SPINLOCK rcu_writer_spinlock = SPINLOCK_INITIALIZER;
@@ -284,6 +297,7 @@ int rcu_stress_test(void) {
 
     bench_thread_ctx_t contexts[NUM_LOCK_TYPES][MAX_THREADS];
     memset(contexts, 0, sizeof(contexts));
+    int created_threads[NUM_LOCK_TYPES] = {0};
 
     for(int lock = 0; lock < NUM_LOCK_TYPES; lock++) {
         for(int i = 0; i < MAX_THREADS; i++) {
@@ -309,9 +323,19 @@ int rcu_stress_test(void) {
             char name[32];
             snprintf(name, sizeof(name), "%s_%d",
                      lock == BENCH_RW_SPINLOCK ? "rwsp" : "rcu", i);
-            contexts[lock][i].thread =
+            ND_THREAD *thread =
                 nd_thread_create(name, NETDATA_THREAD_OPTION_DONT_LOG,
                                  rcu_benchmark_thread, &contexts[lock][i]);
+            if(unlikely(!thread)) {
+                nd_log(NDLS_DAEMON, NDLP_ERR,
+                       "RCU benchmark: failed to create %s thread %d",
+                       lock == BENCH_RW_SPINLOCK ? "rw_spinlock" : "rcu", i);
+                ret = 1;
+                goto cleanup;
+            }
+
+            contexts[lock][i].thread = thread;
+            created_threads[lock]++;
         }
     }
 
@@ -345,21 +369,18 @@ int rcu_stress_test(void) {
     // Stop all threads
     fprintf(stderr, "\nStopping threads...\n");
     for(int lock = 0; lock < NUM_LOCK_TYPES; lock++) {
-        for(int i = 0; i < MAX_THREADS; i++) {
-            netdata_mutex_lock(&ctl[lock].thread_controls[i].cond_mutex);
-            __atomic_store_n(&ctl[lock].thread_controls[i].run_flag, STOP_SIGNAL, __ATOMIC_RELEASE);
-            netdata_cond_signal(&ctl[lock].thread_controls[i].cond);
-            netdata_mutex_unlock(&ctl[lock].thread_controls[i].cond_mutex);
-        }
-    }
-
-    fprintf(stderr, "\nWaiting for threads to exit...\n");
-    for(int lock = 0; lock < NUM_LOCK_TYPES; lock++) {
-        for(int i = 0; i < MAX_THREADS; i++)
-            nd_thread_join(contexts[lock][i].thread);
+        bench_stop_threads(&ctl[lock], contexts[lock], created_threads[lock]);
+        created_threads[lock] = 0;
     }
 
     // Cleanup
+cleanup:
+    if(created_threads[0] || created_threads[1]) {
+        fprintf(stderr, "\nWaiting for threads to exit...\n");
+        for(int lock = 0; lock < NUM_LOCK_TYPES; lock++)
+            bench_stop_threads(&ctl[lock], contexts[lock], created_threads[lock]);
+    }
+
     for(int lock = 0; lock < NUM_LOCK_TYPES; lock++) {
         for(int i = 0; i < MAX_THREADS; i++) {
             netdata_cond_destroy(&ctl[lock].thread_controls[i].cond);
@@ -368,5 +389,5 @@ int rcu_stress_test(void) {
     }
 
     rcu_destroy();
-    return 0;
+    return ret;
 }

--- a/src/libnetdata/locks/benchmark-rcu.c
+++ b/src/libnetdata/locks/benchmark-rcu.c
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "benchmark-rcu.h"
+
+// ============================================================================
+// RCU vs RW_SPINLOCK benchmark
+//
+// Compares read-side throughput between epoch-based RCU and RW_SPINLOCK
+// under various reader/writer ratios.
+//
+// What each thread does:
+//   Reader: acquires read lock, reads a shared counter, releases read lock.
+//   Writer: acquires write lock, increments the counter, releases write lock.
+//
+// The counter value is irrelevant — we're measuring lock throughput.
+// ============================================================================
+
+#define MAX_THREADS 64
+#define TEST_DURATION_SEC 1
+#define STOP_SIGNAL UINT64_MAX
+#define MAX_CONFIGS 12
+#define NUM_LOCK_TYPES 2
+
+typedef enum {
+    BENCH_THREAD_READER,
+    BENCH_THREAD_WRITER
+} bench_thread_type_t;
+
+typedef enum {
+    BENCH_RW_SPINLOCK,
+    BENCH_RCU
+} bench_lock_type_t;
+
+typedef struct {
+    // Shared data that readers read and writers update
+    uint64_t shared_value;
+
+    // Validation: detect reader/writer overlap violations
+    volatile int readers;
+    volatile int writers;
+    volatile uint64_t violations;
+
+    // Per-thread stats
+    struct {
+        uint64_t operations;
+        usec_t test_time;
+        volatile int ready;
+    } stats[MAX_THREADS];
+
+    // Per-thread control
+    struct {
+        netdata_cond_t cond;
+        netdata_mutex_t cond_mutex;
+        uint64_t run_flag;
+    } thread_controls[MAX_THREADS];
+} bench_control_t;
+
+typedef struct {
+    double reader_ops_per_sec[NUM_LOCK_TYPES][MAX_CONFIGS];
+    double writer_ops_per_sec[NUM_LOCK_TYPES][MAX_CONFIGS];
+    int readers[MAX_CONFIGS];
+    int writers[MAX_CONFIGS];
+    int config_count;
+} bench_summary_t;
+
+typedef struct {
+    int thread_id;
+    bench_thread_type_t type;
+    bench_lock_type_t lock_type;
+    bench_control_t *control;
+
+    // For RW_SPINLOCK mode
+    RW_SPINLOCK *rw_spinlock;
+    SPINLOCK *writer_spinlock; // serializes writers for RCU mode
+
+    ND_THREAD *thread;
+} bench_thread_ctx_t;
+
+static inline void bench_check_safety(bench_control_t *ctl, bench_thread_type_t type) {
+    if(type == BENCH_THREAD_READER) {
+        __atomic_add_fetch(&ctl->readers, 1, __ATOMIC_RELAXED);
+        if(__atomic_load_n(&ctl->writers, __ATOMIC_RELAXED) > 0)
+            __atomic_add_fetch(&ctl->violations, 1, __ATOMIC_RELAXED);
+    }
+    else {
+        int w = __atomic_add_fetch(&ctl->writers, 1, __ATOMIC_RELAXED);
+        if(w > 1)
+            __atomic_add_fetch(&ctl->violations, 1, __ATOMIC_RELAXED);
+        if(__atomic_load_n(&ctl->readers, __ATOMIC_RELAXED) > 0)
+            __atomic_add_fetch(&ctl->violations, 1, __ATOMIC_RELAXED);
+    }
+}
+
+static inline void bench_release_safety(bench_control_t *ctl, bench_thread_type_t type) {
+    if(type == BENCH_THREAD_READER)
+        __atomic_sub_fetch(&ctl->readers, 1, __ATOMIC_RELAXED);
+    else
+        __atomic_sub_fetch(&ctl->writers, 1, __ATOMIC_RELAXED);
+}
+
+static void bench_wait_for_start(netdata_cond_t *cond, netdata_mutex_t *mutex, uint64_t *flag) {
+    netdata_mutex_lock(mutex);
+    while(*flag == 0)
+        netdata_cond_wait(cond, mutex);
+    netdata_mutex_unlock(mutex);
+}
+
+static void rcu_benchmark_thread(void *arg) {
+    bench_thread_ctx_t *ctx = (bench_thread_ctx_t *)arg;
+    bench_control_t *ctl = ctx->control;
+
+    // Register with RCU subsystem if this is an RCU test
+    if(ctx->lock_type == BENCH_RCU)
+        rcu_register_thread();
+
+    while(1) {
+        bench_wait_for_start(&ctl->thread_controls[ctx->thread_id].cond,
+                             &ctl->thread_controls[ctx->thread_id].cond_mutex,
+                             &ctl->thread_controls[ctx->thread_id].run_flag);
+
+        if(ctl->thread_controls[ctx->thread_id].run_flag == STOP_SIGNAL)
+            break;
+
+        usec_t start = now_monotonic_high_precision_usec();
+        uint64_t operations = 0;
+
+        if(ctx->lock_type == BENCH_RW_SPINLOCK) {
+            RW_SPINLOCK *lock = ctx->rw_spinlock;
+
+            if(ctx->type == BENCH_THREAD_READER) {
+                while(ctl->thread_controls[ctx->thread_id].run_flag) {
+                    rw_spinlock_read_lock(lock);
+                    // Read shared data
+                    uint64_t v __maybe_unused = ctl->shared_value;
+                    (void)v;
+                    rw_spinlock_read_unlock(lock);
+                    operations++;
+                }
+            }
+            else {
+                while(ctl->thread_controls[ctx->thread_id].run_flag) {
+                    rw_spinlock_write_lock(lock);
+                    ctl->shared_value++;
+                    rw_spinlock_write_unlock(lock);
+                    operations++;
+                }
+            }
+        }
+        else { // BENCH_RCU
+            if(ctx->type == BENCH_THREAD_READER) {
+                while(ctl->thread_controls[ctx->thread_id].run_flag) {
+                    rcu_read_lock();
+                    // Read shared data
+                    uint64_t v __maybe_unused = __atomic_load_n(&ctl->shared_value, __ATOMIC_ACQUIRE);
+                    (void)v;
+                    rcu_read_unlock();
+                    operations++;
+                }
+            }
+            else {
+                while(ctl->thread_controls[ctx->thread_id].run_flag) {
+                    // Writers still need mutual exclusion among themselves
+                    spinlock_lock(ctx->writer_spinlock);
+                    __atomic_add_fetch(&ctl->shared_value, 1, __ATOMIC_RELEASE);
+                    spinlock_unlock(ctx->writer_spinlock);
+                    // RCU synchronize not needed in tight benchmark loop —
+                    // in real code you'd call it after replacing a pointer
+                    // before freeing old data.
+                    operations++;
+                }
+            }
+        }
+
+        usec_t test_time = now_monotonic_high_precision_usec() - start;
+        __atomic_store_n(&ctl->stats[ctx->thread_id].test_time, test_time, __ATOMIC_RELEASE);
+        __atomic_store_n(&ctl->stats[ctx->thread_id].operations, operations, __ATOMIC_RELEASE);
+        __atomic_store_n(&ctl->stats[ctx->thread_id].ready, 1, __ATOMIC_RELEASE);
+    }
+
+    if(ctx->lock_type == BENCH_RCU)
+        rcu_unregister_thread();
+}
+
+static void bench_print_thread_stats(const char *test_name, int readers, int writers,
+                                     bench_thread_ctx_t *contexts, bench_control_t *ctl,
+                                     bench_summary_t *summary, int config_idx, int lock_type) {
+    fprintf(stderr, "\n%-20s (readers: %d, writers: %d)\n", test_name, readers, writers);
+    fprintf(stderr, "%4s %8s %12s %12s %12s\n",
+            "THR", "TYPE", "OPS", "OPS/SEC", "TIME (ms)");
+
+    double reader_ops_per_sec = 0;
+    double writer_ops_per_sec = 0;
+    int total = readers + writers;
+
+    for(int i = 0; i < total; i++) {
+        uint64_t ops = __atomic_load_n(&ctl->stats[i].operations, __ATOMIC_RELAXED);
+        usec_t time = __atomic_load_n(&ctl->stats[i].test_time, __ATOMIC_RELAXED);
+        double ops_sec = (double)ops * USEC_PER_SEC / time;
+
+        fprintf(stderr, "%4d %8s %12"PRIu64" %12.0f %12.2f\n",
+                i,
+                contexts[i].type == BENCH_THREAD_READER ? "READER" : "WRITER",
+                ops, ops_sec, (double)time / 1000.0);
+
+        if(contexts[i].type == BENCH_THREAD_READER)
+            reader_ops_per_sec += ops_sec;
+        else
+            writer_ops_per_sec += ops_sec;
+    }
+
+    fprintf(stderr, "%4s %8s %12s %12.0f\n",
+            "", "READER", "TOTAL", reader_ops_per_sec);
+    fprintf(stderr, "%4s %8s %12s %12.0f\n",
+            "", "WRITER", "TOTAL", writer_ops_per_sec);
+
+    if(__atomic_load_n(&ctl->violations, __ATOMIC_RELAXED) > 0) {
+        fprintf(stderr, "\nFATAL: %"PRIu64" access violations detected!\n",
+                ctl->violations);
+        _exit(1);
+    }
+
+    summary->reader_ops_per_sec[lock_type][config_idx] = reader_ops_per_sec;
+    summary->writer_ops_per_sec[lock_type][config_idx] = writer_ops_per_sec;
+    summary->readers[config_idx] = readers;
+    summary->writers[config_idx] = writers;
+}
+
+static void bench_run_test(const char *name, int readers, int writers,
+                           bench_thread_ctx_t *contexts, bench_control_t *ctl,
+                           bench_summary_t *summary, int config_idx, int lock_type) {
+    int total = readers + writers;
+
+    fprintf(stderr, "\nRunning test: %s with %d readers, %d writers...\n",
+            name, readers, writers);
+
+    // Reset
+    memset(ctl->stats, 0, sizeof(ctl->stats));
+    ctl->shared_value = 0;
+    ctl->readers = 0;
+    ctl->writers = 0;
+    ctl->violations = 0;
+
+    // Signal threads to start
+    for(int i = 0; i < total; i++) {
+        netdata_mutex_lock(&ctl->thread_controls[i].cond_mutex);
+        ctl->thread_controls[i].run_flag = 1;
+        netdata_cond_signal(&ctl->thread_controls[i].cond);
+        netdata_mutex_unlock(&ctl->thread_controls[i].cond_mutex);
+    }
+
+    sleep_usec(TEST_DURATION_SEC * USEC_PER_SEC);
+
+    // Stop
+    for(int i = 0; i < total; i++)
+        __atomic_store_n(&ctl->thread_controls[i].run_flag, 0, __ATOMIC_RELEASE);
+
+    // Wait for results
+    for(int i = 0; i < total; i++)
+        while(!__atomic_load_n(&ctl->stats[i].ready, __ATOMIC_ACQUIRE))
+            sleep_usec(10);
+
+    bench_print_thread_stats(name, readers, writers, contexts, ctl,
+                             summary, config_idx, lock_type);
+}
+
+static void bench_print_summary(const bench_summary_t *summary) {
+    const char *lock_names[] = {"rw_spinlock", "rcu"};
+
+    fprintf(stderr, "\n=== RCU vs RW_SPINLOCK: Reader Throughput (Million ops/sec) ===\n\n");
+    fprintf(stderr, "%-14s %-8s %-8s %-14s %-14s\n",
+            "Lock", "Readers", "Writers", "Reader Mops/s", "Writer Mops/s");
+    fprintf(stderr, "--------------------------------------------------------------\n");
+
+    for(int config = 0; config < summary->config_count; config++) {
+        for(int lock = 0; lock < NUM_LOCK_TYPES; lock++) {
+            fprintf(stderr, "%-14s %-8d %-8d %-14.2f %-14.2f\n",
+                    lock_names[lock],
+                    summary->readers[config],
+                    summary->writers[config],
+                    summary->reader_ops_per_sec[lock][config] / 1000000.0,
+                    summary->writer_ops_per_sec[lock][config] / 1000000.0);
+        }
+        if(config < summary->config_count - 1)
+            fprintf(stderr, "--------------------------------------------------------------\n");
+    }
+    fprintf(stderr, "\n");
+}
+
+int rcu_stress_test(void) {
+    bench_summary_t summary = {0};
+
+    RW_SPINLOCK rw_spinlock = RW_SPINLOCK_INITIALIZER;
+    SPINLOCK rcu_writer_spinlock = SPINLOCK_INITIALIZER;
+
+    rcu_init();
+
+    // Test configurations: {readers, writers}
+    int configs[][2] = {
+        {1, 0},
+        {2, 0},
+        {4, 0},
+        {4, 1},
+        {8, 1},
+        {8, 2},
+        {16, 1},
+        {16, 2},
+        {32, 1},
+    };
+
+    int num_configs = (int)(sizeof(configs) / sizeof(configs[0]));
+    summary.config_count = num_configs;
+
+    // One control structure per lock type
+    bench_control_t ctl[NUM_LOCK_TYPES];
+    memset(ctl, 0, sizeof(ctl));
+
+    bench_thread_ctx_t contexts[NUM_LOCK_TYPES][MAX_THREADS];
+    memset(contexts, 0, sizeof(contexts));
+
+    for(int lock = 0; lock < NUM_LOCK_TYPES; lock++) {
+        for(int i = 0; i < MAX_THREADS; i++) {
+            netdata_cond_init(&ctl[lock].thread_controls[i].cond);
+            netdata_mutex_init(&ctl[lock].thread_controls[i].cond_mutex);
+            ctl[lock].thread_controls[i].run_flag = 0;
+
+            contexts[lock][i] = (bench_thread_ctx_t){
+                .thread_id = i,
+                .type = BENCH_THREAD_READER, // will be overridden per config
+                .lock_type = lock,
+                .control = &ctl[lock],
+                .rw_spinlock = &rw_spinlock,
+                .writer_spinlock = &rcu_writer_spinlock,
+            };
+        }
+    }
+
+    // Create all threads
+    fprintf(stderr, "\nStarting RCU benchmark...\n");
+    for(int lock = 0; lock < NUM_LOCK_TYPES; lock++) {
+        for(int i = 0; i < MAX_THREADS; i++) {
+            char name[32];
+            snprintf(name, sizeof(name), "%s_%d",
+                     lock == BENCH_RW_SPINLOCK ? "rwsp" : "rcu", i);
+            contexts[lock][i].thread =
+                nd_thread_create(name, NETDATA_THREAD_OPTION_DONT_LOG,
+                                 rcu_benchmark_thread, &contexts[lock][i]);
+        }
+    }
+
+    sleep_usec(100000); // warm up
+
+    for(int c = 0; c < num_configs; c++) {
+        int readers = configs[c][0];
+        int writers = configs[c][1];
+        int total = readers + writers;
+
+        for(int lock = 0; lock < NUM_LOCK_TYPES; lock++) {
+            // Assign thread roles
+            int idx = 0;
+            for(int r = 0; r < readers; r++)
+                contexts[lock][idx++].type = BENCH_THREAD_READER;
+            for(int w = 0; w < writers; w++)
+                contexts[lock][idx++].type = BENCH_THREAD_WRITER;
+
+            char test_name[64];
+            snprintf(test_name, sizeof(test_name), "%s %dR/%dW",
+                     lock == BENCH_RW_SPINLOCK ? "rw_spinlock" : "rcu",
+                     readers, writers);
+
+            bench_run_test(test_name, readers, writers,
+                           contexts[lock], &ctl[lock], &summary, c, lock);
+        }
+    }
+
+    bench_print_summary(&summary);
+
+    // Stop all threads
+    fprintf(stderr, "\nStopping threads...\n");
+    for(int lock = 0; lock < NUM_LOCK_TYPES; lock++) {
+        for(int i = 0; i < MAX_THREADS; i++) {
+            netdata_mutex_lock(&ctl[lock].thread_controls[i].cond_mutex);
+            ctl[lock].thread_controls[i].run_flag = STOP_SIGNAL;
+            netdata_cond_signal(&ctl[lock].thread_controls[i].cond);
+            netdata_mutex_unlock(&ctl[lock].thread_controls[i].cond_mutex);
+        }
+    }
+
+    fprintf(stderr, "\nWaiting for threads to exit...\n");
+    for(int lock = 0; lock < NUM_LOCK_TYPES; lock++) {
+        for(int i = 0; i < MAX_THREADS; i++)
+            nd_thread_join(contexts[lock][i].thread);
+    }
+
+    // Cleanup
+    for(int lock = 0; lock < NUM_LOCK_TYPES; lock++) {
+        for(int i = 0; i < MAX_THREADS; i++) {
+            netdata_cond_destroy(&ctl[lock].thread_controls[i].cond);
+            netdata_mutex_destroy(&ctl[lock].thread_controls[i].cond_mutex);
+        }
+    }
+
+    rcu_destroy();
+    return 0;
+}

--- a/src/libnetdata/locks/benchmark-rcu.h
+++ b/src/libnetdata/locks/benchmark-rcu.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_BENCHMARK_RCU_H
+#define NETDATA_BENCHMARK_RCU_H
+
+#include "../libnetdata.h"
+
+int rcu_stress_test(void);
+
+#endif //NETDATA_BENCHMARK_RCU_H

--- a/src/libnetdata/locks/rcu.c
+++ b/src/libnetdata/locks/rcu.c
@@ -237,7 +237,7 @@ bool rcu_synchronize(void) {
     RCU_THREAD *self = rcu_tls;
 
     if(unlikely(self && self->nesting > 0)) {
-        fatal_assert(self->nesting == 0);
+        fatal_assert(self->nesting > 0);
         nd_log(NDLS_DAEMON, NDLP_ERR,
                "RCU: rcu_synchronize() called while inside a read-side critical section "
                "(nesting=%u)", self->nesting);

--- a/src/libnetdata/locks/rcu.c
+++ b/src/libnetdata/locks/rcu.c
@@ -235,6 +235,15 @@ ALWAYS_INLINE void rcu_read_unlock_with_trace(const char *func __maybe_unused) {
 
 bool rcu_synchronize(void) {
     RCU_THREAD *self = rcu_tls;
+
+    if(unlikely(self && self->nesting > 0)) {
+        fatal_assert(self->nesting == 0);
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "RCU: rcu_synchronize() called while inside a read-side critical section "
+               "(nesting=%u)", self->nesting);
+        return false;
+    }
+
     spinlock_lock(&rcu_synchronize_spinlock);
 
     // Bump the global epoch. After this, any new rcu_read_lock() will

--- a/src/libnetdata/locks/rcu.c
+++ b/src/libnetdata/locks/rcu.c
@@ -12,14 +12,15 @@
 // Per-thread epoch:
 //   - 0 means "not in a read-side critical section"
 //   - Non-zero means "in a read-side CS, entered at this epoch"
-//   - Written ONLY by the owning thread (no atomics needed for the write).
-//   - Read by writers via atomic load during rcu_synchronize().
+//   - Written only by the owning thread, using atomic release stores to
+//     publish entry/exit from the read-side critical section.
+//   - Read by writers via atomic acquire loads during rcu_synchronize().
 //
 // This design has the following cache-line properties:
 //   - rcu_global_epoch lives on its own line; readers only LOAD it (shared
 //     state, no bouncing).
-//   - Each RCU_THREAD.epoch lives on the owning thread's own cache line;
-//     the owner STOREs, the synchronizer LOADs (no bouncing between readers).
+//   - Each RCU_THREAD.epoch is per-thread state; readers do not contend on a
+//     shared counter, though allocator placement may still allow false sharing.
 //   - The only shared-write operation is the global epoch increment in
 //     rcu_synchronize(), which is the slow path.
 // ============================================================================
@@ -30,16 +31,12 @@
 // Starts at 1 so that a per-thread epoch of 0 unambiguously means "idle".
 static uint64_t rcu_global_epoch __attribute__((aligned(64))) = 1;
 
-// Global count of threads currently in a read-side critical section.
-// Used by rcu_synchronize() for fast-path: if 0 (or only self), return immediately.
-// This IS a shared-write atomic (incremented/decremented on every rcu_read_lock/unlock),
-// but it's only read by writers in rcu_synchronize() — readers don't read it.
-// The cost is one atomic add/sub per outermost rcu_read_lock/unlock, which is
-// acceptable since the fast-path avoids the much more expensive thread-list scan.
-static int32_t rcu_active_readers __attribute__((aligned(64))) = 0;
-
-// Serializes rcu_synchronize() calls and protects the thread registry.
+// Protects the thread registry.
 static SPINLOCK rcu_registry_spinlock = SPINLOCK_INITIALIZER;
+
+// Serializes rcu_synchronize() calls while allowing register/unregister to
+// proceed between snapshot polls.
+static SPINLOCK rcu_synchronize_spinlock = SPINLOCK_INITIALIZER;
 
 // Linked list of all registered threads.
 static RCU_THREAD *rcu_threads_head = NULL;
@@ -53,7 +50,6 @@ static __thread RCU_THREAD *rcu_tls = NULL;
 
 void rcu_init(void) {
     __atomic_store_n(&rcu_global_epoch, 1, __ATOMIC_RELEASE);
-    __atomic_store_n(&rcu_active_readers, 0, __ATOMIC_RELEASE);
     rcu_threads_head = NULL;
 }
 
@@ -72,12 +68,63 @@ void rcu_destroy(void) {
 // Thread registration
 // ============================================================================
 
+static void rcu_thread_release(RCU_THREAD *t) {
+    if(!t)
+        return;
+
+    if(__atomic_sub_fetch(&t->refs, 1, __ATOMIC_ACQ_REL) == 0)
+        freez(t);
+}
+
+static RCU_THREAD **rcu_snapshot_threads(RCU_THREAD *self, size_t *threads_count) {
+    *threads_count = 0;
+
+    spinlock_lock(&rcu_registry_spinlock);
+
+    size_t count = 0;
+    for(RCU_THREAD *t = rcu_threads_head; t; t = t->next) {
+        if(t != self)
+            count++;
+    }
+
+    if(!count) {
+        spinlock_unlock(&rcu_registry_spinlock);
+        return NULL;
+    }
+
+    RCU_THREAD **threads = callocz(count, sizeof(*threads));
+    size_t idx = 0;
+    for(RCU_THREAD *t = rcu_threads_head; t; t = t->next) {
+        if(t == self)
+            continue;
+
+        __atomic_add_fetch(&t->refs, 1, __ATOMIC_ACQ_REL);
+        threads[idx++] = t;
+    }
+
+    spinlock_unlock(&rcu_registry_spinlock);
+
+    *threads_count = idx;
+    return threads;
+}
+
+static void rcu_release_snapshot(RCU_THREAD **threads, size_t threads_count) {
+    if(!threads)
+        return;
+
+    for(size_t i = 0; i < threads_count; i++)
+        rcu_thread_release(threads[i]);
+
+    freez(threads);
+}
+
 void rcu_register_thread(void) {
     if(rcu_tls)
         return; // already registered
 
     RCU_THREAD *t = callocz(1, sizeof(RCU_THREAD));
     // epoch = 0 (idle), nesting = 0
+    __atomic_store_n(&t->refs, 1, __ATOMIC_RELAXED);
 
     spinlock_lock(&rcu_registry_spinlock);
 
@@ -104,7 +151,6 @@ void rcu_unregister_thread(void) {
                t->nesting);
         // Force-clear so rcu_synchronize() won't hang.
         __atomic_store_n(&t->epoch, 0, __ATOMIC_RELEASE);
-        __atomic_sub_fetch(&rcu_active_readers, 1, __ATOMIC_RELEASE);
         t->nesting = 0;
     }
 
@@ -121,7 +167,7 @@ void rcu_unregister_thread(void) {
     spinlock_unlock(&rcu_registry_spinlock);
 
     rcu_tls = NULL;
-    freez(t);
+    rcu_thread_release(t);
 }
 
 bool rcu_thread_is_registered(void) {
@@ -154,8 +200,9 @@ ALWAYS_INLINE void rcu_read_lock_with_trace(const char *func __maybe_unused) {
         // Store our epoch so writers can see we're active.
         __atomic_store_n(&t->epoch, e, __ATOMIC_RELEASE);
 
-        // Increment global active reader count for rcu_synchronize() fast-path.
-        __atomic_add_fetch(&rcu_active_readers, 1, __ATOMIC_RELEASE);
+        // Prevent protected reads in the caller's critical section from
+        // moving before the published epoch.
+        __atomic_thread_fence(__ATOMIC_ACQUIRE);
     }
 }
 
@@ -177,9 +224,6 @@ ALWAYS_INLINE void rcu_read_unlock_with_trace(const char *func __maybe_unused) {
     if(--t->nesting == 0) {
         // Outermost unlock: clear our epoch so writers know we're done.
         __atomic_store_n(&t->epoch, 0, __ATOMIC_RELEASE);
-
-        // Decrement global active reader count.
-        __atomic_sub_fetch(&rcu_active_readers, 1, __ATOMIC_RELEASE);
     }
 }
 
@@ -190,33 +234,30 @@ ALWAYS_INLINE void rcu_read_unlock_with_trace(const char *func __maybe_unused) {
 #define RCU_SYNCHRONIZE_TIMEOUT_SEC 60
 
 bool rcu_synchronize(void) {
-    // Fast path: if no thread (other than ourselves) is in an RCU read-side
-    // CS, there's nothing to wait for. Check the global active reader count.
     RCU_THREAD *self = rcu_tls;
-    int32_t self_contribution = (self && self->nesting > 0) ? 1 : 0;
-    int32_t active = __atomic_load_n(&rcu_active_readers, __ATOMIC_ACQUIRE);
-    if(active <= self_contribution)
-        return true; // no other readers active — grace period trivially complete
+    spinlock_lock(&rcu_synchronize_spinlock);
 
     // Bump the global epoch. After this, any new rcu_read_lock() will
     // snapshot the new epoch, so we only need to wait for threads that
     // hold the old epoch.
     uint64_t old_epoch = __atomic_fetch_add(&rcu_global_epoch, 1, __ATOMIC_ACQ_REL);
 
+    size_t threads_count = 0;
+    RCU_THREAD **threads = rcu_snapshot_threads(self, &threads_count);
+    if(!threads_count) {
+        spinlock_unlock(&rcu_synchronize_spinlock);
+        return true;
+    }
+
     usec_t usec = 1;
     usec_t started = now_monotonic_usec();
-
-    spinlock_lock(&rcu_registry_spinlock);
 
     bool all_clear;
     do {
         all_clear = true;
 
-        for(RCU_THREAD *t = rcu_threads_head; t; t = t->next) {
-            if(t == self)
-                continue; // skip the calling thread
-
-            uint64_t thread_epoch = __atomic_load_n(&t->epoch, __ATOMIC_ACQUIRE);
+        for(size_t i = 0; i < threads_count; i++) {
+            uint64_t thread_epoch = __atomic_load_n(&threads[i]->epoch, __ATOMIC_ACQUIRE);
             if(thread_epoch != 0 && thread_epoch <= old_epoch) {
                 all_clear = false;
                 break;
@@ -231,21 +272,17 @@ bool rcu_synchronize(void) {
                        "RCU: rcu_synchronize() timed out after %d seconds waiting for readers "
                        "(epoch %"PRIu64"). Returning false — caller will defer or retry.",
                        RCU_SYNCHRONIZE_TIMEOUT_SEC, old_epoch);
-                spinlock_unlock(&rcu_registry_spinlock);
+                rcu_release_snapshot(threads, threads_count);
+                spinlock_unlock(&rcu_synchronize_spinlock);
                 return false; // caller MUST NOT free memory
             }
 
-            // Release the spinlock while we sleep to allow threads to
-            // unregister (e.g. if they're exiting).
-            spinlock_unlock(&rcu_registry_spinlock);
-
             microsleep(usec);
             usec = usec >= RCU_MAX_USEC ? RCU_MAX_USEC : usec * 2;
-
-            spinlock_lock(&rcu_registry_spinlock);
         }
     } while(!all_clear);
 
-    spinlock_unlock(&rcu_registry_spinlock);
+    rcu_release_snapshot(threads, threads_count);
+    spinlock_unlock(&rcu_synchronize_spinlock);
     return true;
 }

--- a/src/libnetdata/locks/rcu.c
+++ b/src/libnetdata/locks/rcu.c
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "libnetdata/libnetdata.h"
+
+// ============================================================================
+// Epoch-based RCU implementation
+//
+// Global epoch: monotonically increasing uint64_t.
+//   - Readers snapshot it into their per-thread state on rcu_read_lock().
+//   - Writers bump it, then wait for all readers that hold an old epoch.
+//
+// Per-thread epoch:
+//   - 0 means "not in a read-side critical section"
+//   - Non-zero means "in a read-side CS, entered at this epoch"
+//   - Written ONLY by the owning thread (no atomics needed for the write).
+//   - Read by writers via atomic load during rcu_synchronize().
+//
+// This design has the following cache-line properties:
+//   - rcu_global_epoch lives on its own line; readers only LOAD it (shared
+//     state, no bouncing).
+//   - Each RCU_THREAD.epoch lives on the owning thread's own cache line;
+//     the owner STOREs, the synchronizer LOADs (no bouncing between readers).
+//   - The only shared-write operation is the global epoch increment in
+//     rcu_synchronize(), which is the slow path.
+// ============================================================================
+
+#define RCU_MAX_USEC 512
+
+// Global epoch — readers snapshot, writers bump.
+// Starts at 1 so that a per-thread epoch of 0 unambiguously means "idle".
+static uint64_t rcu_global_epoch __attribute__((aligned(64))) = 1;
+
+// Global count of threads currently in a read-side critical section.
+// Used by rcu_synchronize() for fast-path: if 0 (or only self), return immediately.
+// This IS a shared-write atomic (incremented/decremented on every rcu_read_lock/unlock),
+// but it's only read by writers in rcu_synchronize() — readers don't read it.
+// The cost is one atomic add/sub per outermost rcu_read_lock/unlock, which is
+// acceptable since the fast-path avoids the much more expensive thread-list scan.
+static int32_t rcu_active_readers __attribute__((aligned(64))) = 0;
+
+// Serializes rcu_synchronize() calls and protects the thread registry.
+static SPINLOCK rcu_registry_spinlock = SPINLOCK_INITIALIZER;
+
+// Linked list of all registered threads.
+static RCU_THREAD *rcu_threads_head = NULL;
+
+// Thread-local pointer to this thread's RCU state.
+static __thread RCU_THREAD *rcu_tls = NULL;
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+void rcu_init(void) {
+    __atomic_store_n(&rcu_global_epoch, 1, __ATOMIC_RELEASE);
+    __atomic_store_n(&rcu_active_readers, 0, __ATOMIC_RELEASE);
+    rcu_threads_head = NULL;
+}
+
+static __attribute__((constructor)) void rcu_constructor_init(void) {
+    rcu_init();
+}
+
+void rcu_destroy(void) {
+    // All threads must have unregistered before this is called.
+    // If any remain, it's a bug — but we don't fatal() here to allow
+    // clean shutdown even if some threads leaked.
+    rcu_threads_head = NULL;
+}
+
+// ============================================================================
+// Thread registration
+// ============================================================================
+
+void rcu_register_thread(void) {
+    if(rcu_tls)
+        return; // already registered
+
+    RCU_THREAD *t = callocz(1, sizeof(RCU_THREAD));
+    // epoch = 0 (idle), nesting = 0
+
+    spinlock_lock(&rcu_registry_spinlock);
+
+    t->next = rcu_threads_head;
+    t->prev = NULL;
+    if(rcu_threads_head)
+        rcu_threads_head->prev = t;
+    rcu_threads_head = t;
+
+    spinlock_unlock(&rcu_registry_spinlock);
+
+    rcu_tls = t;
+}
+
+void rcu_unregister_thread(void) {
+    RCU_THREAD *t = rcu_tls;
+    if(!t)
+        return;
+
+    // Ensure we're not inside a read-side critical section.
+    if(t->nesting > 0) {
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "RCU: unregistering thread while inside read-side critical section (nesting=%u)",
+               t->nesting);
+        // Force-clear so rcu_synchronize() won't hang.
+        __atomic_store_n(&t->epoch, 0, __ATOMIC_RELEASE);
+        __atomic_sub_fetch(&rcu_active_readers, 1, __ATOMIC_RELEASE);
+        t->nesting = 0;
+    }
+
+    spinlock_lock(&rcu_registry_spinlock);
+
+    if(t->prev)
+        t->prev->next = t->next;
+    else
+        rcu_threads_head = t->next;
+
+    if(t->next)
+        t->next->prev = t->prev;
+
+    spinlock_unlock(&rcu_registry_spinlock);
+
+    rcu_tls = NULL;
+    freez(t);
+}
+
+bool rcu_thread_is_registered(void) {
+    return rcu_tls != NULL;
+}
+
+bool rcu_thread_in_read_cs(void) {
+    RCU_THREAD *t = rcu_tls;
+    return t && t->nesting > 0;
+}
+
+// ============================================================================
+// Read-side critical section
+// ============================================================================
+
+ALWAYS_INLINE void rcu_read_lock_with_trace(const char *func __maybe_unused) {
+    RCU_THREAD *t = rcu_tls;
+
+    // Gracefully handle unregistered threads: auto-register.
+    // This is a slow path — only the first call per thread pays this cost.
+    if(unlikely(!t)) {
+        rcu_register_thread();
+        t = rcu_tls;
+    }
+
+    if(t->nesting++ == 0) {
+        // Outermost lock: snapshot the global epoch.
+        uint64_t e = __atomic_load_n(&rcu_global_epoch, __ATOMIC_ACQUIRE);
+
+        // Store our epoch so writers can see we're active.
+        __atomic_store_n(&t->epoch, e, __ATOMIC_RELEASE);
+
+        // Increment global active reader count for rcu_synchronize() fast-path.
+        __atomic_add_fetch(&rcu_active_readers, 1, __ATOMIC_RELEASE);
+    }
+}
+
+ALWAYS_INLINE void rcu_read_unlock_with_trace(const char *func __maybe_unused) {
+    RCU_THREAD *t = rcu_tls;
+
+    if(unlikely(!t)) {
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "RCU: rcu_read_unlock() called on unregistered thread in %s", func);
+        return;
+    }
+
+    if(unlikely(t->nesting == 0)) {
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "RCU: rcu_read_unlock() called without matching rcu_read_lock() in %s", func);
+        return;
+    }
+
+    if(--t->nesting == 0) {
+        // Outermost unlock: clear our epoch so writers know we're done.
+        __atomic_store_n(&t->epoch, 0, __ATOMIC_RELEASE);
+
+        // Decrement global active reader count.
+        __atomic_sub_fetch(&rcu_active_readers, 1, __ATOMIC_RELEASE);
+    }
+}
+
+// ============================================================================
+// Writer-side: synchronize (wait for grace period)
+// ============================================================================
+
+#define RCU_SYNCHRONIZE_TIMEOUT_SEC 60
+
+bool rcu_synchronize(void) {
+    // Fast path: if no thread (other than ourselves) is in an RCU read-side
+    // CS, there's nothing to wait for. Check the global active reader count.
+    RCU_THREAD *self = rcu_tls;
+    int32_t self_contribution = (self && self->nesting > 0) ? 1 : 0;
+    int32_t active = __atomic_load_n(&rcu_active_readers, __ATOMIC_ACQUIRE);
+    if(active <= self_contribution)
+        return true; // no other readers active — grace period trivially complete
+
+    // Bump the global epoch. After this, any new rcu_read_lock() will
+    // snapshot the new epoch, so we only need to wait for threads that
+    // hold the old epoch.
+    uint64_t old_epoch = __atomic_fetch_add(&rcu_global_epoch, 1, __ATOMIC_ACQ_REL);
+
+    usec_t usec = 1;
+    usec_t started = now_monotonic_usec();
+
+    spinlock_lock(&rcu_registry_spinlock);
+
+    bool all_clear;
+    do {
+        all_clear = true;
+
+        for(RCU_THREAD *t = rcu_threads_head; t; t = t->next) {
+            if(t == self)
+                continue; // skip the calling thread
+
+            uint64_t thread_epoch = __atomic_load_n(&t->epoch, __ATOMIC_ACQUIRE);
+            if(thread_epoch != 0 && thread_epoch <= old_epoch) {
+                all_clear = false;
+                break;
+            }
+        }
+
+        if(!all_clear) {
+            // Check for timeout — a stalled reader should not block writers forever
+            usec_t elapsed = now_monotonic_usec() - started;
+            if(elapsed >= RCU_SYNCHRONIZE_TIMEOUT_SEC * USEC_PER_SEC) {
+                nd_log(NDLS_DAEMON, NDLP_DEBUG,
+                       "RCU: rcu_synchronize() timed out after %d seconds waiting for readers "
+                       "(epoch %"PRIu64"). Returning false — caller will defer or retry.",
+                       RCU_SYNCHRONIZE_TIMEOUT_SEC, old_epoch);
+                spinlock_unlock(&rcu_registry_spinlock);
+                return false; // caller MUST NOT free memory
+            }
+
+            // Release the spinlock while we sleep to allow threads to
+            // unregister (e.g. if they're exiting).
+            spinlock_unlock(&rcu_registry_spinlock);
+
+            microsleep(usec);
+            usec = usec >= RCU_MAX_USEC ? RCU_MAX_USEC : usec * 2;
+
+            spinlock_lock(&rcu_registry_spinlock);
+        }
+    } while(!all_clear);
+
+    spinlock_unlock(&rcu_registry_spinlock);
+    return true;
+}

--- a/src/libnetdata/locks/rcu.h
+++ b/src/libnetdata/locks/rcu.h
@@ -19,8 +19,7 @@
 //
 // Read-side cost:  1 atomic load (global epoch, shared-read)
 //                + 1 store to per-thread epoch
-//                + 1 shared atomic add/sub on the outermost lock/unlock pair
-//                  for the active-reader fast path in rcu_synchronize()
+//                + 1 acquire fence on the outermost lock() pair
 //
 // Write-side cost: 1 atomic increment (global epoch)
 //                + scan all registered threads (may spin-wait on slow readers)
@@ -39,6 +38,7 @@ typedef struct rcu_thread {
     // --- written by owning thread, read by writers ---
     uint64_t epoch;                     // snapshot of global epoch while in read-side CS; 0 = idle
     uint32_t nesting;                   // nesting depth (private, never read by others)
+    int32_t refs;                       // registry + synchronizer snapshots
 
     // --- registry linkage (protected by rcu_registry_spinlock) ---
     struct rcu_thread *prev;
@@ -57,8 +57,8 @@ void rcu_destroy(void);
 
 // Per-thread lifecycle — every thread that will enter rcu_read_lock() must
 // first call rcu_register_thread(), and must call rcu_unregister_thread()
-// before it exits. Failing to unregister will make rcu_synchronize() wait
-// forever for that thread.
+// before it exits. Failing to unregister will keep stale registry entries
+// around, which can delay or prevent grace periods from completing.
 void rcu_register_thread(void);
 void rcu_unregister_thread(void);
 
@@ -75,8 +75,8 @@ bool rcu_thread_in_read_cs(void);
 // that no writer will complete rcu_synchronize() — i.e. old data will not
 // be freed while the reader holds the lock.
 //
-// These are meant to be very fast, with only one shared atomic add/sub on
-// the outermost lock/unlock pair.
+// These are meant to be very fast, with only a global-epoch load and a
+// per-thread epoch publication on the outermost lock/unlock pair.
 void rcu_read_lock_with_trace(const char *func);
 void rcu_read_unlock_with_trace(const char *func);
 

--- a/src/libnetdata/locks/rcu.h
+++ b/src/libnetdata/locks/rcu.h
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_RCU_H
+#define NETDATA_RCU_H
+
+#include "libnetdata/common.h"
+#include "spinlock.h"
+
+// ============================================================================
+// Epoch-based Read-Copy-Update (RCU)
+//
+// Provides extremely fast read-side critical sections
+// at the cost of slower write-side synchronization.
+//
+// Use this when:
+//   - Reads vastly outnumber writes
+//   - Multiple reader threads contend on the same data
+//   - Current RW_SPINLOCK reader cache-line bouncing is a bottleneck
+//
+// Read-side cost:  1 atomic load (global epoch, shared-read)
+//                + 1 store to per-thread epoch
+//                + 1 shared atomic add/sub on the outermost lock/unlock pair
+//                  for the active-reader fast path in rcu_synchronize()
+//
+// Write-side cost: 1 atomic increment (global epoch)
+//                + scan all registered threads (may spin-wait on slow readers)
+//
+// Nesting: read-side critical sections may nest; only the outermost pair
+//          has any cost.
+//
+// ============================================================================
+
+// Per-thread RCU state.
+// Allocated per thread; callers should not assume cache-line alignment.
+// The epoch field is written ONLY by the owning thread (via atomic release
+// stores) and read by writers during rcu_synchronize() (via atomic acquire
+// loads). The nesting field is private to the owning thread.
+typedef struct rcu_thread {
+    // --- written by owning thread, read by writers ---
+    uint64_t epoch;                     // snapshot of global epoch while in read-side CS; 0 = idle
+    uint32_t nesting;                   // nesting depth (private, never read by others)
+
+    // --- registry linkage (protected by rcu_registry_spinlock) ---
+    struct rcu_thread *prev;
+    struct rcu_thread *next;
+} RCU_THREAD;
+
+// ============================================================================
+// API
+// ============================================================================
+
+// Initialize the RCU subsystem. This is also invoked by a constructor.
+void rcu_init(void);
+
+// Destroy the RCU subsystem — call once at shutdown.
+void rcu_destroy(void);
+
+// Per-thread lifecycle — every thread that will enter rcu_read_lock() must
+// first call rcu_register_thread(), and must call rcu_unregister_thread()
+// before it exits. Failing to unregister will make rcu_synchronize() wait
+// forever for that thread.
+void rcu_register_thread(void);
+void rcu_unregister_thread(void);
+
+// Returns true if the calling thread is registered with RCU.
+bool rcu_thread_is_registered(void);
+
+// Returns true if the calling thread is inside an RCU read-side critical section.
+// Writers should check this before calling rcu_synchronize() to avoid livelock
+// when deleting items from dictionary B while traversing dictionary A.
+bool rcu_thread_in_read_cs(void);
+
+// Read-side critical section.
+// Between rcu_read_lock() and rcu_read_unlock(), the thread is guaranteed
+// that no writer will complete rcu_synchronize() — i.e. old data will not
+// be freed while the reader holds the lock.
+//
+// These are meant to be very fast, with only one shared atomic add/sub on
+// the outermost lock/unlock pair.
+void rcu_read_lock_with_trace(const char *func);
+void rcu_read_unlock_with_trace(const char *func);
+
+#define rcu_read_lock() rcu_read_lock_with_trace(__FUNCTION__)
+#define rcu_read_unlock() rcu_read_unlock_with_trace(__FUNCTION__)
+
+// Writer-side: wait until all threads that were in a read-side critical
+// section at the time of this call have left it.
+//
+// Returns true if the grace period completed successfully — the caller
+// can safely free old data. Returns false if the wait timed out — the
+// caller MUST NOT free the data (readers may still hold pointers).
+//
+// Multiple concurrent rcu_synchronize() calls are serialized internally.
+bool rcu_synchronize(void);
+
+// ----------------------------------------------------------------------------
+// Pointer publication helpers
+//
+// rcu_dereference(p)       — load a pointer that may be updated by writers
+// rcu_assign_pointer(p, v) — publish a new pointer so readers see it
+// ----------------------------------------------------------------------------
+
+#define rcu_dereference(p) \
+    __atomic_load_n(&(p), __ATOMIC_ACQUIRE)
+
+#define rcu_assign_pointer(p, v) \
+    __atomic_store_n(&(p), (v), __ATOMIC_RELEASE)
+
+// ----------------------------------------------------------------------------
+// Pointer-swap RCU pattern for non-DICTIONARY structures
+//
+// Use this when a data structure is rarely modified but frequently read.
+// The writer creates a new version, atomically publishes it, waits for
+// readers to finish with the old version, then frees the old version.
+//
+// Example usage:
+//
+//   // Reader (called frequently):
+//   rcu_read_lock();
+//   struct config *cfg = rcu_dereference(global_config);
+//   use(cfg->field);
+//   rcu_read_unlock();
+//
+//   // Writer (called rarely):
+//   struct config *new_cfg = mallocz(sizeof(*new_cfg));
+//   *new_cfg = *global_config;   // copy
+//   new_cfg->field = new_value;  // modify
+//   struct config *old = global_config;
+//   rcu_assign_pointer(global_config, new_cfg);
+//   rcu_synchronize();           // wait for readers of old
+//   freez(old);                  // safe to free now
+//
+// For singly-linked list element removal:
+//
+//   // Writer removes 'item' from list:
+//   rcu_assign_pointer(prev->next, item->next);  // unlink
+//   rcu_synchronize();                            // wait for readers
+//   freez(item);                                  // safe
+//
+// ----------------------------------------------------------------------------
+
+#endif // NETDATA_RCU_H

--- a/src/libnetdata/locks/rcu.h
+++ b/src/libnetdata/locks/rcu.h
@@ -83,8 +83,12 @@ void rcu_read_unlock_with_trace(const char *func);
 #define rcu_read_lock() rcu_read_lock_with_trace(__FUNCTION__)
 #define rcu_read_unlock() rcu_read_unlock_with_trace(__FUNCTION__)
 
-// Writer-side: wait until all threads that were in a read-side critical
+// Writer-side: wait until all other threads that were in a read-side critical
 // section at the time of this call have left it.
+//
+// This must not be called while the calling thread is itself inside an RCU
+// read-side critical section. Callers should check rcu_thread_in_read_cs()
+// first and defer freeing if they are still traversing protected data.
 //
 // Returns true if the grace period completed successfully — the caller
 // can safely free old data. Returns false if the wait timed out — the

--- a/src/libnetdata/threads/threads.c
+++ b/src/libnetdata/threads/threads.c
@@ -330,6 +330,7 @@ static void nd_thread_exit(ND_THREAD *nti) {
     thread_cache_destroy();
     service_exits();
     worker_unregister();
+    rcu_unregister_thread();
 
     nd_thread_status_set(nti, NETDATA_THREAD_STATUS_FINISHED);
 

--- a/src/libnetdata/threads/threads.c
+++ b/src/libnetdata/threads/threads.c
@@ -400,6 +400,7 @@ static void nd_thread_exit(ND_THREAD *nti) {
     nd_thread_run_cleanup_callbacks();
     thread_cache_destroy();
     worker_unregister();
+    rcu_unregister_thread();
 
     spinlock_lock(&threads_globals.running.spinlock);
     if(nti->list == ND_THREAD_LIST_RUNNING) {


### PR DESCRIPTION
##### Summary
- Added epoch-based RCU implementation and associated API.
- Implemented RCU vs. RW_SPINLOCK performance benchmark with multithreaded configurations.
- Integrated RCU mode into dictionary traversal logic for optimized read-side performance.
- Updated dictionary safety guarantees with RCU read-lock handling during multi-threaded operations.
- Enhanced logging and statistics output to inspect benchmark and RCU performance metrics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces per‑thread, epoch‑based RCU and switches pure read dictionary traversals to it to cut reader contention and keep traversal values stable while writers update. Adds deferred frees for removed items and replaced values, stronger destroy/GC, RCU‑safe list ops, and an RCU vs `rw_spinlock` benchmark plus a read‑traversal micro‑benchmark.

- **New Features**
  - RCU API: `rcu_read_lock/unlock` (auto‑register on first use), `rcu_synchronize` serialized with a 60s timeout and refused inside a read‑side CS; per‑thread `rcu_register_thread/rcu_unregister_thread` (also auto‑unregister on thread exit); pointer helpers `rcu_dereference/rcu_assign_pointer`.
  - Dictionary: `DICTIONARY_LOCK_READ` traversals use RCU with acquire loads for head/next/value; skip hidden/deleted items and those being created; no per‑item refcounts in RCU traversals. RCU‑safe list prepend/append/remove publish via release stores and preserve `next` for readers; reentrant and sorted traversals stay on RW locks (sorted forces `'R'`). Replaced values are retired and freed after a grace period.
  - Reclamation/GC: queue removed items and replaced values; batch drain after a grace period; never drain while in a read‑side CS; on timeout re‑queue and retry later. `dictionary_destroy` detaches the list, waits for a grace period, and queues for delayed destroy if it can’t complete immediately; `dictionary_garbage_collect` advances delayed destroys and drains RCU queues; single‑threaded mode bypasses RCU and frees immediately.
  - Benchmarks/tests: multithreaded RCU vs `rw_spinlock` benchmark and a read‑traversal micro‑benchmark; unit tests for deferred destroy inside a read CS, GC progress, value stability across overwrites, and RCU traversal refcount behavior; benchmark harness has centralized thread cleanup and stronger run‑flag synchronization.

- **Migration**
  - No changes for dictionary users; read traversals are faster and stable under concurrent writes.
  - If you use RCU directly: threads auto‑register on first `rcu_read_lock()` and auto‑unregister on thread exit; don’t call `rcu_synchronize()` inside a read‑side CS; only free retired memory after `rcu_synchronize()` returns true (otherwise defer and retry).

<sup>Written for commit 5dd3050ddbe3c47c9c06a05f00226e7478811748. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22214?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

