### PR TITLE
feat(topology): add role field to presentation actor types

### DIFF
--- a/src/collectors/network-viewer.plugin/network-viewer.c
+++ b/src/collectors/network-viewer.plugin/network-viewer.c
@@ -1715,6 +1715,7 @@ static void topology_write_presentation(BUFFER *wb) {
                 buffer_json_member_add_string(wb, "label", "This host");
                 buffer_json_member_add_string(wb, "color_slot", "self");
                 buffer_json_member_add_boolean(wb, "border", true);
+                buffer_json_member_add_string(wb, "role", "actor");
                 buffer_json_member_add_boolean(wb, "size_by_links", true);
 
                 buffer_json_member_add_array(wb, "summary_fields");
@@ -1791,6 +1792,7 @@ static void topology_write_presentation(BUFFER *wb) {
                 buffer_json_member_add_string(wb, "label", "Process");
                 buffer_json_member_add_string(wb, "color_slot", "primary");
                 buffer_json_member_add_boolean(wb, "border", true);
+                buffer_json_member_add_string(wb, "role", "actor");
                 buffer_json_member_add_boolean(wb, "size_by_links", true);
                 buffer_json_member_add_boolean(wb, "show_port_bullets", true);
 
@@ -1925,6 +1927,7 @@ static void topology_write_presentation(BUFFER *wb) {
                 buffer_json_member_add_string(wb, "label", "Endpoint");
                 buffer_json_member_add_string(wb, "color_slot", "derived");
                 buffer_json_member_add_boolean(wb, "border", true);
+                buffer_json_member_add_string(wb, "role", "endpoint");
 
                 buffer_json_member_add_array(wb, "summary_fields");
                 {

--- a/src/web/api/functions/function-streaming.c
+++ b/src/web/api/functions/function-streaming.c
@@ -566,6 +566,7 @@ int function_streaming_topology(BUFFER *wb, const char *function, BUFFER *payloa
                 buffer_json_member_add_string(wb, "color_slot", "primary");
                 buffer_json_member_add_double(wb, "opacity", 1.0);
                 buffer_json_member_add_boolean(wb, "border", true);
+                buffer_json_member_add_string(wb, "role", "actor");
                 buffer_json_member_add_boolean(wb, "size_by_links", true);
                 buffer_json_member_add_boolean(wb, "show_port_bullets", true);
                 streaming_topology_parent_presentation(wb);
@@ -578,6 +579,7 @@ int function_streaming_topology(BUFFER *wb, const char *function, BUFFER *payloa
                 buffer_json_member_add_string(wb, "color_slot", "primary");
                 buffer_json_member_add_double(wb, "opacity", 1.0);
                 buffer_json_member_add_boolean(wb, "border", false);
+                buffer_json_member_add_string(wb, "role", "actor");
                 buffer_json_member_add_boolean(wb, "size_by_links", false);
                 buffer_json_member_add_boolean(wb, "show_port_bullets", false);
                 streaming_topology_child_presentation(wb);
@@ -590,6 +592,7 @@ int function_streaming_topology(BUFFER *wb, const char *function, BUFFER *payloa
                 buffer_json_member_add_string(wb, "color_slot", "warning");
                 buffer_json_member_add_double(wb, "opacity", 1.0);
                 buffer_json_member_add_boolean(wb, "border", false);
+                buffer_json_member_add_string(wb, "role", "actor");
                 buffer_json_member_add_boolean(wb, "size_by_links", false);
                 buffer_json_member_add_boolean(wb, "show_port_bullets", false);
                 streaming_topology_vnode_presentation(wb);
@@ -602,6 +605,7 @@ int function_streaming_topology(BUFFER *wb, const char *function, BUFFER *payloa
                 buffer_json_member_add_string(wb, "color_slot", "dim");
                 buffer_json_member_add_double(wb, "opacity", 0.5);
                 buffer_json_member_add_boolean(wb, "border", false);
+                buffer_json_member_add_string(wb, "role", "actor");
                 buffer_json_member_add_boolean(wb, "size_by_links", false);
                 buffer_json_member_add_boolean(wb, "show_port_bullets", false);
                 streaming_topology_stale_presentation(wb);


### PR DESCRIPTION
## Summary

Add a `role` field to every entry of `presentation.actor_types` emitted by topology functions. Values:

- `"actor"` — first-class; always rendered at full fidelity.
- `"endpoint"` — summarizable; the UI may hide or group these when the graph is dense.

If the field is absent, the frontend treats it as `"actor"` (backward-compatible for older agents).

### Why

The UI topology performance work needs to know which actor types it can summarize at scale (e.g. hide all endpoints and resize actors by connection count when a host has tens of thousands of sockets).

The set of actor types differs per topology source:

- `network-viewer` plugin — `self`, `process`, `endpoint`
- SNMP topology — `device`/`router`/`switch`/... , `endpoint`
- `function-streaming` — `parent`, `child`, `vnode`, `stale`

String-matching on `actor_type` in the frontend would couple it to each backend. An explicit `role` keeps the frontend generic across sources.

### Changes

- `src/collectors/network-viewer.plugin/network-viewer.c` — `self` and `process` emit `"role": "actor"`; `endpoint` emits `"role": "endpoint"`.
- `src/web/api/functions/function-streaming.c` — all four types (`parent`, `child`, `vnode`, `stale`) emit `"role": "actor"`.

### Companion change

The SNMP topology PR (#22109) sets the `role` on its actor types and adds `role` to `topology_presentation_actor_type` in `src/plugins.d/FUNCTION_UI_SCHEMA.json` in a separate commit.

## Test plan

- [ ] Call the network-viewer function and verify `presentation.actor_types.{self,process,endpoint}.role` is present with the expected values.
- [ ] Call the topology:streaming function on a parent and verify `presentation.actor_types.{parent,child,vnode,stale}.role == "actor"`.
- [ ] Frontend with the matching change consuming the new field degrades gracefully on older agents (missing field → treated as `"actor"`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `role` field to each `presentation.actor_types` entry in topology output so the UI can treat first-class actors vs summarizable endpoints. Older agents remain compatible (missing `role` is treated as `"actor"`).

- **New Features**
  - Adds `role` to `presentation.actor_types` with values `"actor"` or `"endpoint"`; absent → `"actor"`.
  - `network-viewer` plugin: `self` and `process` → `"actor"`, `endpoint` → `"endpoint"`.
  - `function-streaming`: `parent`, `child`, `vnode`, `stale` → `"actor"`.

<sup>Written for commit 20d15c8d800add78e2e3e025674a9b4048a6bbc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

