### PR TITLE
fix(cmake): IBM MQ FetchContent check breaks incremental rebuilds

### DIFF
--- a/packaging/cmake/Modules/NetdataIBMPlugin.cmake
+++ b/packaging/cmake/Modules/NetdataIBMPlugin.cmake
@@ -27,7 +27,7 @@ macro(add_ibm_plugin_target)
     URL_HASH SHA256=${IBM_MQ_HASH}
   )
 
-  if(DEFINED FETCHCONTENT_SOURCE_DIR_IBM_MQ)
+  if(FETCHCONTENT_SOURCE_DIR_IBM_MQ)
     message(STATUS "Copying IBM MQ client library sources from ${FETCHCONTENT_SOURCE_DIR_IBM_MQ} to ${IBM_MQ_BUILD_DIR}")
     file(REMOVE_RECURSE "${IBM_MQ_BUILD_DIR}")
     execute_process(


### PR DESCRIPTION
## Summary

`add_ibm_plugin_target()` in `packaging/cmake/Modules/NetdataIBMPlugin.cmake` uses `if(DEFINED FETCHCONTENT_SOURCE_DIR_IBM_MQ)` (a name-test) to decide whether to copy from a user-provided source dir or download via FetchContent. This breaks every incremental rebuild after the first successful configure.

## Root cause

`FetchContent_MakeAvailable(ibm_mq)` calls (transitively) the following inside cmake's own `Modules/FetchContent.cmake` (lines 2049-2052):

```cmake
set(FETCHCONTENT_SOURCE_DIR_${contentNameUpper}
    "${FETCHCONTENT_SOURCE_DIR_${contentNameUpper}}"
    CACHE PATH "When not empty, overrides where to find pre-populated content for ${contentName}")
```

This unconditionally creates the cache entry `FETCHCONTENT_SOURCE_DIR_IBM_MQ:PATH=` on the first configure, even if the user did not set it. The initial value is empty and is persisted to `build/CMakeCache.txt`.

cmake itself then uses a value-test (`if(FETCHCONTENT_SOURCE_DIR_${contentNameUpper})` — line 2054), so an empty cache entry is harmless to cmake.

But the netdata module uses `if(DEFINED ...)` — a name-test. After the first configure the variable is defined (cache entry exists) but empty, so the test passes and we invoke:

```
cmake -E copy_directory "" "<build>/ibm-mqclient"
```

which fails with cmake's `-E` usage error and triggers `message(FATAL_ERROR "Failed to prepare IBM MQ client library directory")`.

| Build pass | Cache entry | `if(DEFINED …)` | Result |
|---|---|---|---|
| 1st (clean `build/`) | absent | false → `else` | downloads, succeeds, but cache now holds empty entry |
| 2nd+ (incremental) | empty | **true** → `if` | `cmake -E copy_directory ""` → FATAL_ERROR |

## Fix

Use the same value-test idiom cmake itself uses. An empty cache entry now correctly falls through to the `else` branch.

```diff
- if(DEFINED FETCHCONTENT_SOURCE_DIR_IBM_MQ)
+ if(FETCHCONTENT_SOURCE_DIR_IBM_MQ)
```

Behavior preserved when a user sets a real path (e.g. `packaging/build-package.sh:83` passes `FETCHCONTENT_SOURCE_DIR_IBM_MQ=${SOURCE_DIR}/tmp/ibm_mq` for CI package builds — that path is non-empty so the test still passes and the copy still runs).

## Test plan

- [x] Clean `build/` + configure: `else` branch runs (download path), succeeds
- [x] Reconfigure with existing `build/`: previously failed, now `else` branch runs again, succeeds
- [ ] CI package builds with `FETCHCONTENT_SOURCE_DIR_IBM_MQ` explicitly set to a non-empty path: copy path runs as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix IBM MQ plugin incremental rebuilds by changing the FetchContent condition to a value check. Empty `FETCHCONTENT_SOURCE_DIR_IBM_MQ` cache entries now use the download path; non-empty user paths still copy as before.

<sup>Written for commit c7b29b513cd50a9423600e850b3540bc4a051630. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

