### PR TITLE
fix(go.d/snmp): use snmpEngineTime as primary uptime source

### DIFF
--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_system-base.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_system-base.yaml
@@ -9,6 +9,21 @@ metric_tags:
     tag: device_hostname
 
 metrics:
+  # Prefer SNMP-FRAMEWORK-MIB (snmpEngineTime) as the primary uptime source.
+  # It is reported in seconds and does not suffer from the ~497-day wrap
+  # limitation of TimeTicks (uint32) used by hrSystemUptime/sysUpTime.
+  # This makes it more reliable for long-running devices.
+  # Note: this reflects SNMP engine uptime, which in practice usually
+  # aligns with system uptime.
+  # We keep the same metric name (systemUptime) so the fallback logic works.
+  - MIB: SNMP-FRAMEWORK-MIB
+    symbol:
+      OID: 1.3.6.1.6.3.10.2.1.3.0
+      name: systemUptime
+      chart_meta:
+        description: Time since the system was last rebooted or powered on.
+        family: 'System/Uptime'
+        unit: "s"
   - MIB: HOST-RESOURCES-MIB
     symbol:
       OID: 1.3.6.1.2.1.25.1.1.0


### PR DESCRIPTION
##### Summary

Prefer SNMP-FRAMEWORK-MIB (snmpEngineTime) as the primary uptime source.

It is reported in seconds and does not suffer from the ~497-day wrap limitation of TimeTicks (uint32) used by hrSystemUptime/sysUpTime. This makes it more reliable for long-running devices.

Note: this reflects SNMP engine uptime, which in practice usually aligns with system uptime.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the SNMP uptime source to `SNMP-FRAMEWORK-MIB::snmpEngineTime` to avoid TimeTicks wrap and improve reliability on long-running devices. Keeps the `systemUptime` metric name and preserves fallbacks.

- **Bug Fixes**
  - Prefer OID `1.3.6.1.6.3.10.2.1.3.0` (seconds) over `hrSystemUptime/sysUpTime`.
  - Avoids the ~497-day wrap from TimeTicks.
  - Keeps metric name `systemUptime` so existing charts and fallbacks continue to work.

<sup>Written for commit 92edcc20c7901e2c209bf407217b41b874f51641. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

