### PR TITLE
ebpf.plugin: fix PID accounting shared-memory pool leak and 100% CPU spin

### DIFF
--- a/src/collectors/collectors-ipc/ebpf-ipc.c
+++ b/src/collectors/collectors-ipc/ebpf-ipc.c
@@ -94,9 +94,13 @@ bool netdata_ebpf_reset_shm_pointer_unsafe(int fd, uint32_t pid, enum ebpf_pids_
 
 netdata_ebpf_pid_stats_t *netdata_ebpf_get_shm_pointer_unsafe(uint32_t pid, enum ebpf_pids_index idx)
 {
-    if (!integration_shm || ebpf_stat_values.current >= ebpf_stat_values.total)
+    if (!integration_shm)
         return NULL;
 
+    // Do NOT short-circuit on a full pool here: an already-tracked PID
+    // must still be reachable so its module bits can be updated or
+    // cleared. ebpf_find_or_create_index_pid() returns the existing slot
+    // regardless of pool saturation and only rejects *new* allocations.
     uint32_t shm_idx = ebpf_find_or_create_index_pid(pid);
     if (shm_idx == UINT32_MAX || shm_idx >= ebpf_stat_values.total)
         return NULL;
@@ -175,9 +179,14 @@ void netdata_integration_cleanup_shm()
         shm_fd_ebpf_integration = -1;
     }
 
-    // Drop the POSIX shm object so a subsequent plugin run starts from a
-    // fresh region instead of inheriting the previous run's bytes.
+    // Drop the POSIX shm object and the named semaphore so a subsequent
+    // plugin run starts from a fresh region and a freshly-initialised
+    // semaphore. Without the sem_unlink, a crashed previous instance can
+    // leave the semaphore at 0 and the next run will spin on
+    // sem_timedwait timeouts (sem_open(O_CREAT) ignores the initial value
+    // when the named semaphore already exists).
     (void)shm_unlink(NETDATA_EBPF_INTEGRATION_NAME);
+    (void)sem_unlink(NETDATA_EBPF_SHM_INTEGRATION_NAME);
 }
 
 int netdata_integration_initialize_shm(size_t pids)
@@ -214,6 +223,10 @@ int netdata_integration_initialize_shm(size_t pids)
     // current size is a no-op.
     memset(integration_shm, 0, length);
 
+    // Drop any leftover named semaphore from a previous (possibly crashed)
+    // run so sem_open honours the initial value below instead of reusing
+    // whatever state the previous instance left it in.
+    (void)sem_unlink(NETDATA_EBPF_SHM_INTEGRATION_NAME);
     shm_mutex_ebpf_integration = sem_open(
         NETDATA_EBPF_SHM_INTEGRATION_NAME, O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH, 1);
     if (shm_mutex_ebpf_integration != SEM_FAILED) {

--- a/src/collectors/collectors-ipc/ebpf-ipc.c
+++ b/src/collectors/collectors-ipc/ebpf-ipc.c
@@ -60,20 +60,31 @@ static bool ebpf_find_pid_shm_del_unsafe(uint32_t pid, enum ebpf_pids_index shm_
     return false;
 }
 
-static uint32_t ebpf_find_or_create_index_pid(uint32_t pid)
+// Returns the slot index for pid and sets *created to true when a new slot was
+// allocated. A fresh slot is memset to zero so callers never inherit stale bits
+// or counters from a prior PID that used the same index (prevents the compaction
+// stale-tail and PID-reuse contamination paths).
+static uint32_t ebpf_find_or_create_index_pid(uint32_t pid, bool *created)
 {
     uint32_t idx;
-    if (ebpf_shm_find_index_unsafe(pid, &idx))
+    if (ebpf_shm_find_index_unsafe(pid, &idx)) {
+        *created = false;
         return idx;
+    }
 
-    if (ebpf_stat_values.current >= ebpf_stat_values.total)
+    if (ebpf_stat_values.current >= ebpf_stat_values.total) {
+        *created = false;
         return UINT32_MAX;
+    }
 
     Pvoid_t *Pvalue = JudyLIns(&ebpf_ipc_JudyL, (Word_t)pid, PJE0);
     internal_fatal(!Pvalue || Pvalue == PJERR, "EBPF: pid judy index");
 
     uint32_t new_idx = ebpf_stat_values.current++;
     *Pvalue = IDX_TO_JVALUE(new_idx);
+
+    memset(&integration_shm[new_idx], 0, sizeof(integration_shm[new_idx]));
+    *created = true;
 
     return new_idx;
 }
@@ -91,7 +102,8 @@ netdata_ebpf_pid_stats_t *netdata_ebpf_get_shm_pointer_unsafe(uint32_t pid, enum
     if (!integration_shm || ebpf_stat_values.current >= ebpf_stat_values.total)
         return NULL;
 
-    uint32_t shm_idx = ebpf_find_or_create_index_pid(pid);
+    bool created;
+    uint32_t shm_idx = ebpf_find_or_create_index_pid(pid, &created);
     if (shm_idx == UINT32_MAX || shm_idx >= ebpf_stat_values.total)
         return NULL;
 
@@ -100,6 +112,52 @@ netdata_ebpf_pid_stats_t *netdata_ebpf_get_shm_pointer_unsafe(uint32_t pid, enum
     ptr->threads |= (1UL << (idx << 1));
 
     return ptr;
+}
+
+// Read-only lookup: returns the existing slot for pid or NULL. Does not
+// allocate, does not set any bit. Aggregation paths that iterate PID lists
+// from /proc or cgroup snapshots MUST use this variant, otherwise every live
+// PID acquires module bits for modules that may never observe it in their own
+// BPF map and the bits can never be cleared — the shm pool then fills
+// monotonically.
+netdata_ebpf_pid_stats_t *netdata_ebpf_lookup_shm_pointer_unsafe(uint32_t pid)
+{
+    if (!integration_shm)
+        return NULL;
+
+    uint32_t shm_idx;
+    if (!ebpf_shm_find_index_unsafe(pid, &shm_idx))
+        return NULL;
+
+    if (shm_idx >= ebpf_stat_values.current)
+        return NULL;
+
+    return &integration_shm[shm_idx];
+}
+
+// Module teardown helper: clear this module's bit across every slot that has
+// it set. For slots that become empty the existing del path compacts in place,
+// which swaps the last slot into the freed index — so we do not advance i when
+// the current counter drops.
+void netdata_ebpf_sweep_shm_for_module_unsafe(enum ebpf_pids_index idx)
+{
+    if (!integration_shm)
+        return;
+
+    const uint32_t mask = (1U << (idx << 1));
+    uint32_t i = 0;
+    while (i < ebpf_stat_values.current) {
+        netdata_ebpf_pid_stats_t *ptr = &integration_shm[i];
+        if (!(ptr->threads & mask)) {
+            i++;
+            continue;
+        }
+
+        uint32_t before = ebpf_stat_values.current;
+        (void)ebpf_find_pid_shm_del_unsafe(ptr->pid, idx);
+        if (ebpf_stat_values.current >= before)
+            i++;
+    }
 }
 
 void netdata_integration_cleanup_shm()

--- a/src/collectors/collectors-ipc/ebpf-ipc.c
+++ b/src/collectors/collectors-ipc/ebpf-ipc.c
@@ -60,22 +60,18 @@ static bool ebpf_find_pid_shm_del_unsafe(uint32_t pid, enum ebpf_pids_index shm_
     return false;
 }
 
-// Returns the slot index for pid and sets *created to true when a new slot was
-// allocated. A fresh slot is memset to zero so callers never inherit stale bits
-// or counters from a prior PID that used the same index (prevents the compaction
-// stale-tail and PID-reuse contamination paths).
-static uint32_t ebpf_find_or_create_index_pid(uint32_t pid, bool *created)
+// Returns the slot index for pid, allocating a new slot if needed. A fresh
+// slot is memset to zero so callers never inherit stale bits or counters from
+// a prior PID that used the same index (prevents the compaction stale-tail
+// and PID-reuse contamination paths).
+static uint32_t ebpf_find_or_create_index_pid(uint32_t pid)
 {
     uint32_t idx;
-    if (ebpf_shm_find_index_unsafe(pid, &idx)) {
-        *created = false;
+    if (ebpf_shm_find_index_unsafe(pid, &idx))
         return idx;
-    }
 
-    if (ebpf_stat_values.current >= ebpf_stat_values.total) {
-        *created = false;
+    if (ebpf_stat_values.current >= ebpf_stat_values.total)
         return UINT32_MAX;
-    }
 
     Pvoid_t *Pvalue = JudyLIns(&ebpf_ipc_JudyL, (Word_t)pid, PJE0);
     internal_fatal(!Pvalue || Pvalue == PJERR, "EBPF: pid judy index");
@@ -84,7 +80,6 @@ static uint32_t ebpf_find_or_create_index_pid(uint32_t pid, bool *created)
     *Pvalue = IDX_TO_JVALUE(new_idx);
 
     memset(&integration_shm[new_idx], 0, sizeof(integration_shm[new_idx]));
-    *created = true;
 
     return new_idx;
 }
@@ -102,8 +97,7 @@ netdata_ebpf_pid_stats_t *netdata_ebpf_get_shm_pointer_unsafe(uint32_t pid, enum
     if (!integration_shm || ebpf_stat_values.current >= ebpf_stat_values.total)
         return NULL;
 
-    bool created;
-    uint32_t shm_idx = ebpf_find_or_create_index_pid(pid, &created);
+    uint32_t shm_idx = ebpf_find_or_create_index_pid(pid);
     if (shm_idx == UINT32_MAX || shm_idx >= ebpf_stat_values.total)
         return NULL;
 
@@ -180,6 +174,10 @@ void netdata_integration_cleanup_shm()
         close(shm_fd_ebpf_integration);
         shm_fd_ebpf_integration = -1;
     }
+
+    // Drop the POSIX shm object so a subsequent plugin run starts from a
+    // fresh region instead of inheriting the previous run's bytes.
+    (void)shm_unlink(NETDATA_EBPF_INTEGRATION_NAME);
 }
 
 int netdata_integration_initialize_shm(size_t pids)
@@ -210,6 +208,11 @@ int netdata_integration_initialize_shm(size_t pids)
         integration_shm = NULL;
         goto end_shm;
     }
+
+    // Wipe any bytes left over from a prior plugin run — shm_open with
+    // O_CREAT on an existing object does not truncate, and ftruncate to the
+    // current size is a no-op.
+    memset(integration_shm, 0, length);
 
     shm_mutex_ebpf_integration = sem_open(
         NETDATA_EBPF_SHM_INTEGRATION_NAME, O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH, 1);

--- a/src/collectors/collectors-ipc/ebpf-ipc.h
+++ b/src/collectors/collectors-ipc/ebpf-ipc.h
@@ -339,7 +339,9 @@ typedef struct netdata_ebpf_pid_stats {
 int netdata_integration_initialize_shm(size_t pids);
 void netdata_integration_cleanup_shm();
 netdata_ebpf_pid_stats_t *netdata_ebpf_get_shm_pointer_unsafe(uint32_t pid, enum ebpf_pids_index idx);
+netdata_ebpf_pid_stats_t *netdata_ebpf_lookup_shm_pointer_unsafe(uint32_t pid);
 bool netdata_ebpf_reset_shm_pointer_unsafe(int fd, uint32_t pid, enum ebpf_pids_index idx);
+void netdata_ebpf_sweep_shm_for_module_unsafe(enum ebpf_pids_index idx);
 void netdata_integration_current_ipc_data(ebpf_user_mem_stat_t *values);
 
 extern sem_t *shm_mutex_ebpf_integration;

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -914,7 +914,7 @@ void ebpf_parse_proc_files()
         if (ebpf_plugin_stop())
             break;
 
-        if (kill(pids->pid, 0)) { // No PID found
+        if (kill(pids->pid, 0) == -1 && errno == ESRCH) {
             ebpf_pid_data_t *next = pids->next;
             ebpf_reset_specific_pid_data(pids);
             pids = next;

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -188,65 +188,15 @@ static inline ebpf_pid_data_t *ebpf_get_pid_data(uint32_t pid, uint32_t tgid, ch
     return ptr;
 }
 
-static inline void ebpf_release_pid_data(ebpf_pid_data_t *eps, int fd, uint32_t key, uint32_t idx)
-{
-    if (fd) {
-        bpf_map_delete_elem(fd, &key);
-    }
-    eps->thread_collecting &= ~(1 << idx);
-    if (!eps->thread_collecting && !eps->has_proc_file) {
-        ebpf_del_pid_entry((pid_t)key);
-    }
-}
-
+// The only caller of ebpf_get_pid_data() passes NETDATA_EBPF_PIDS_PROC_FILE,
+// so `thread_collecting` in an ebpf_pid_data_t only ever has that single high
+// bit set. The per-module (idx < PROC_FILE) branch in the old
+// ebpf_reset_specific_pid_data() was therefore unreachable. Collapse the
+// function to its effective behaviour so a future reader is not confused by
+// dead BPF/freez housekeeping that never ran.
 static inline void ebpf_reset_specific_pid_data(ebpf_pid_data_t *ptr)
 {
-    int idx;
-    uint32_t pid = ptr->pid;
-    for (idx = NETDATA_EBPF_PIDS_PROCESS_IDX; idx < NETDATA_EBPF_PIDS_PROC_FILE; idx++) {
-        if (!(ptr->thread_collecting & (1 << idx))) {
-            continue;
-        }
-        // Check if we still have the map loaded
-        int fd = ebpf_get_pid_map_fd(idx);
-        if (fd <= STDERR_FILENO)
-            continue;
-
-        bpf_map_delete_elem(fd, &pid);
-        ebpf_hash_table_pids_count--;
-        void *clean;
-        switch (idx) {
-            case NETDATA_EBPF_PIDS_PROCESS_IDX:
-                clean = ptr->process;
-                break;
-            case NETDATA_EBPF_PIDS_SOCKET_IDX:
-                clean = ptr->socket;
-                break;
-            case NETDATA_EBPF_PIDS_CACHESTAT_IDX:
-                clean = ptr->cachestat;
-                break;
-            case NETDATA_EBPF_PIDS_DCSTAT_IDX:
-                clean = ptr->dc;
-                break;
-            case NETDATA_EBPF_PIDS_SWAP_IDX:
-                clean = ptr->swap;
-                break;
-            case NETDATA_EBPF_PIDS_VFS_IDX:
-                clean = ptr->vfs;
-                break;
-            case NETDATA_EBPF_PIDS_FD_IDX:
-                clean = ptr->fd;
-                break;
-            case NETDATA_EBPF_PIDS_SHM_IDX:
-                clean = ptr->shm;
-                break;
-            default:
-                clean = NULL;
-        }
-        freez(clean);
-    }
-
-    ebpf_del_pid_entry(pid);
+    ebpf_del_pid_entry(ptr->pid);
 }
 
 typedef struct ebpf_pid_stat {

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -602,6 +602,13 @@ static void ebpf_cachestat_exit(void *pptr)
     if (ebpf_read_cachestat.thread)
         nd_thread_signal_cancel(ebpf_read_cachestat.thread);
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_CACHESTAT_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
@@ -834,13 +841,13 @@ static void ebpf_read_cachestat_apps_table(int maps_per_core)
 
         netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_CACHESTAT_IDX);
         if (!local_pid)
-            continue;
+            goto end_cachestat_loop;
         netdata_publish_cachestat_t *publish = &local_pid->cachestat;
 
         if (!publish->ct || publish->ct != cv->ct) {
             cachestat_save_pid_values(publish, cv);
         } else {
-            if (kill((pid_t)key, 0)) { // No PID found
+            if (kill((pid_t)key, 0) == -1 && errno == ESRCH) {
                 if (netdata_ebpf_reset_shm_pointer_unsafe(fd, key, NETDATA_EBPF_PIDS_CACHESTAT_IDX))
                     memset(publish, 0, sizeof(*publish));
             }
@@ -876,9 +883,8 @@ static void ebpf_update_cachestat_cgroup()
             uint32_t pid = pids->pid;
             netdata_publish_cachestat_t *out = &pids->cachestat;
 
-            netdata_ebpf_pid_stats_t *local_pid =
-                netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_CACHESTAT_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_CACHESTAT_IDX << 1))))
                 continue;
 
             netdata_publish_cachestat_t *in = &local_pid->cachestat;
@@ -916,9 +922,8 @@ static void cachestat_sum_pids_internal(netdata_publish_cachestat_t *publish, vo
                 break;
 
             uint32_t pid = r->pid;
-            netdata_ebpf_pid_stats_t *local_pid =
-                netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_CACHESTAT_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_CACHESTAT_IDX << 1))))
                 continue;
             netdata_publish_cachestat_t *w = &local_pid->cachestat;
             sum_single_pid_cachestat(dst, &w->current);

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -498,6 +498,13 @@ static void ebpf_dcstat_exit(void *pptr)
     if (ebpf_read_dcstat.thread)
         nd_thread_signal_cancel(ebpf_read_dcstat.thread);
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_DCSTAT_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
@@ -588,7 +595,7 @@ static void ebpf_read_dc_apps_table(int maps_per_core)
 
         netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_DCSTAT_IDX);
         if (!local_pid)
-            continue;
+            goto end_dc_loop;
         netdata_publish_dcstat_t *publish = &local_pid->directory_cache;
         if (!publish->ct || publish->ct != cv->ct) {
             publish->ct = cv->ct;
@@ -625,8 +632,8 @@ void ebpf_dcstat_sum_pids(netdata_publish_dcstat_t *publish, struct ebpf_pid_on_
             break;
 
         uint32_t pid = root->pid;
-        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_DCSTAT_IDX);
-        if (!local_pid)
+        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+        if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_DCSTAT_IDX << 1))))
             continue;
         netdata_publish_dcstat_t *w = &local_pid->directory_cache;
 
@@ -680,9 +687,8 @@ static void ebpf_update_dc_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             uint32_t pid = pids->pid;
             netdata_dcstat_pid_t *out = &pids->dc;
-            netdata_ebpf_pid_stats_t *local_pid =
-                netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_DCSTAT_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_DCSTAT_IDX << 1))))
                 continue;
             netdata_publish_dcstat_t *in = &local_pid->directory_cache;
 

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -635,6 +635,13 @@ static void ebpf_fd_exit(void *pptr)
         nd_thread_join(ebpf_read_fd.thread);
     }
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_FD_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
@@ -780,7 +787,7 @@ static void ebpf_read_fd_apps_table(int maps_per_core)
 
         netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_FD_IDX);
         if (!local_pid)
-            continue;
+            goto end_fd_loop;
         netdata_publish_fd_stat_t *publish_fd = &local_pid->fd;
 
         if (kill((pid_t)key, 0) == -1 && errno == ESRCH) {
@@ -815,8 +822,8 @@ static void ebpf_fd_sum_pids(netdata_fd_stat_t *fd, struct ebpf_pid_on_target *r
 
     for (; root; root = root->next) {
         uint32_t pid = root->pid;
-        netdata_ebpf_pid_stats_t *pid_stat = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_FD_IDX);
-        if (!pid_stat)
+        netdata_ebpf_pid_stats_t *pid_stat = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+        if (!pid_stat || !(pid_stat->threads & (1U << (NETDATA_EBPF_PIDS_FD_IDX << 1))))
             continue;
         netdata_publish_fd_stat_t *w = &pid_stat->fd;
 
@@ -868,8 +875,8 @@ static void ebpf_update_fd_cgroup(void)
             uint32_t pid = pids->pid;
             netdata_publish_fd_stat_t *out = &pids->fd;
 
-            netdata_ebpf_pid_stats_t *pid_stat = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_FD_IDX);
-            if (!pid_stat)
+            netdata_ebpf_pid_stats_t *pid_stat = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!pid_stat || !(pid_stat->threads & (1U << (NETDATA_EBPF_PIDS_FD_IDX << 1))))
                 continue;
 
             netdata_publish_fd_stat_t *in = &pid_stat->fd;

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -464,9 +464,8 @@ static void ebpf_update_process_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             uint32_t pid = pids->pid;
             ebpf_publish_process_t *out = &pids->ps;
-            netdata_ebpf_pid_stats_t *local_pid =
-                netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_PROCESS_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_PROCESS_IDX << 1))))
                 continue;
 
             ebpf_publish_process_t *in = &local_pid->process;
@@ -970,6 +969,13 @@ static void ebpf_process_exit(void *pptr)
     netdata_mutex_lock(&lock);
     collect_pids &= ~(1 << EBPF_MODULE_PROCESS_IDX);
     netdata_mutex_unlock(&lock);
+
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_PROCESS_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
 
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
@@ -1508,8 +1514,8 @@ void ebpf_process_sum_values_for_pids(ebpf_process_stat_t *process, struct ebpf_
             break;
 
         uint32_t pid = root->pid;
-        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_PROCESS_IDX);
-        if (!local_pid)
+        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+        if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_PROCESS_IDX << 1))))
             continue;
 
         ebpf_publish_process_t *in = &local_pid->process;
@@ -1556,7 +1562,7 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core)
             netdata_ebpf_pid_stats_t *local_pid =
                 netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_PROCESS_IDX);
             if (!local_pid)
-                continue;
+                goto end_process_loop;
 
             ebpf_publish_process_t *w = &local_pid->process;
 
@@ -1568,7 +1574,7 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core)
                 w->release_call = process_stat_vector[0].release_call;
                 w->task_err = process_stat_vector[0].task_err;
             } else {
-                if (kill((pid_t)key, 0)) { // No PID found
+                if (kill((pid_t)key, 0) == -1 && errno == ESRCH) {
                     if (netdata_ebpf_reset_shm_pointer_unsafe(tbl_pid_stats_fd, key, NETDATA_EBPF_PIDS_PROCESS_IDX))
                         memset(w, 0, sizeof(*w));
                 }

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -481,6 +481,13 @@ static void ebpf_shm_exit(void *pptr)
         nd_thread_join(ebpf_read_shm.thread);
     }
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_SHM_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
@@ -559,8 +566,8 @@ static void ebpf_update_shm_cgroup(void)
         for (pids = ect->pids; pids; pids = pids->next) {
             uint32_t pid = pids->pid;
             netdata_publish_shm_t *out = &pids->shm;
-            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_SHM_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_SHM_IDX << 1))))
                 continue;
 
             netdata_publish_shm_t *in = &local_pid->shm;
@@ -599,13 +606,13 @@ static void ebpf_read_shm_apps_table(int maps_per_core)
 
         netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_SHM_IDX);
         if (!local_pid)
-            continue;
+            goto end_shm_loop;
         netdata_publish_shm_t *publish = &local_pid->shm;
 
         if (!publish->ct || publish->ct != cv->ct) {
             memcpy(publish, &cv[0], sizeof(netdata_publish_shm_t));
         } else {
-            if (kill((pid_t)key, 0)) { // No PID found
+            if (kill((pid_t)key, 0) == -1 && errno == ESRCH) {
                 if (netdata_ebpf_reset_shm_pointer_unsafe(fd, key, NETDATA_EBPF_PIDS_SHM_IDX))
                     memset(publish, 0, sizeof(*publish));
             }
@@ -672,8 +679,8 @@ static void ebpf_shm_sum_pids(netdata_publish_shm_t *shm, struct ebpf_pid_on_tar
     memset(shm, 0, sizeof(netdata_publish_shm_t));
     for (; root; root = root->next) {
         uint32_t pid = root->pid;
-        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_SHM_IDX);
-        if (!local_pid)
+        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+        if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_SHM_IDX << 1))))
             continue;
 
         netdata_publish_shm_t *w = &local_pid->shm;

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -1905,9 +1905,15 @@ static void ebpf_update_array_vectors(ebpf_module_t *em)
             else {
                 netdata_ebpf_reset_shm_pointer_unsafe(fd, key.pid, NETDATA_EBPF_PIDS_SOCKET_IDX);
                 memset(curr, 0, sizeof(*curr));
-                bpf_map_delete_elem(fd, &key);
             }
         }
+        // The socket map is keyed by a tuple (not by pid), so the generic
+        // reset_shm_pointer_unsafe() deliberately skips bpf_map_delete_elem()
+        // for SOCKET_IDX. Delete the stale socket here regardless of whether
+        // we had a shm slot, otherwise a full shm pool would strand dead
+        // socket entries in the kernel map and we'd re-iterate them forever.
+        if (deleted)
+            bpf_map_delete_elem(fd, &key);
         memset(values, 0, length);
         memcpy(&key, &next_key, sizeof(key));
     }

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -930,6 +930,13 @@ static void ebpf_socket_exit(void *pptr)
         nd_thread_join(ebpf_read_socket.thread);
     }
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_SOCKET_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
@@ -1890,16 +1897,16 @@ static void ebpf_update_array_vectors(ebpf_module_t *em)
     end_socket_loop:; // the empty statement is here to allow code to be compiled by old compilers
         netdata_ebpf_pid_stats_t *local_pid =
             netdata_ebpf_get_shm_pointer_unsafe(key.pid, NETDATA_EBPF_PIDS_SOCKET_IDX);
-        if (!local_pid)
-            continue;
-        ebpf_socket_publish_apps_t *curr = &local_pid->socket;
+        if (local_pid) {
+            ebpf_socket_publish_apps_t *curr = &local_pid->socket;
 
-        if (!deleted)
-            ebpf_socket_fill_publish_apps(curr, values);
-        else {
-            netdata_ebpf_reset_shm_pointer_unsafe(fd, key.pid, NETDATA_EBPF_PIDS_SOCKET_IDX);
-            memset(curr, 0, sizeof(*curr));
-            bpf_map_delete_elem(fd, &key);
+            if (!deleted)
+                ebpf_socket_fill_publish_apps(curr, values);
+            else {
+                netdata_ebpf_reset_shm_pointer_unsafe(fd, key.pid, NETDATA_EBPF_PIDS_SOCKET_IDX);
+                memset(curr, 0, sizeof(*curr));
+                bpf_map_delete_elem(fd, &key);
+            }
         }
         memset(values, 0, length);
         memcpy(&key, &next_key, sizeof(key));
@@ -1926,9 +1933,8 @@ void ebpf_socket_resume_apps_data()
         memset(&w->socket, 0, sizeof(ebpf_socket_publish_apps_t));
         for (; move; move = move->next) {
             uint32_t pid = move->pid;
-            netdata_ebpf_pid_stats_t *local_pid =
-                netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_SOCKET_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_SOCKET_IDX << 1))))
                 continue;
 
             ebpf_socket_publish_apps_t *ws = &local_pid->socket;
@@ -1965,9 +1971,8 @@ static void ebpf_update_socket_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             uint32_t pid = pids->pid;
             ebpf_socket_publish_apps_t *publish = &ect->publish_socket;
-            netdata_ebpf_pid_stats_t *local_pid =
-                netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_SOCKET_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_SOCKET_IDX << 1))))
                 continue;
 
             ebpf_socket_publish_apps_t *in = &local_pid->socket;

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -452,6 +452,13 @@ static void ebpf_swap_exit(void *pptr)
         nd_thread_join(ebpf_read_swap.thread);
     }
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_SWAP_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
@@ -537,8 +544,8 @@ static void ebpf_update_swap_cgroup(void)
         for (pids = ect->pids; pids; pids = pids->next) {
             uint32_t pid = pids->pid;
             netdata_publish_swap_t *out = &pids->swap;
-            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_SWAP_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_SWAP_IDX << 1))))
                 continue;
             netdata_publish_swap_t *in = &local_pid->swap;
 
@@ -563,8 +570,8 @@ static void ebpf_swap_sum_pids(netdata_publish_swap_t *swap, struct ebpf_pid_on_
 
     for (; root; root = root->next) {
         uint32_t pid = root->pid;
-        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_SWAP_IDX);
-        if (!local_pid)
+        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+        if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_SWAP_IDX << 1))))
             continue;
         netdata_publish_swap_t *w = &local_pid->swap;
 
@@ -624,13 +631,13 @@ static void ebpf_read_swap_apps_table(int maps_per_core)
 
         netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_SWAP_IDX);
         if (!local_pid)
-            continue;
+            goto end_swap_loop;
         netdata_publish_swap_t *publish = &local_pid->swap;
 
         if (!publish->ct || publish->ct != cv->ct) {
             memcpy(publish, cv, sizeof(netdata_publish_swap_t));
         } else {
-            if (kill((pid_t)key, 0)) { // No PID found
+            if (kill((pid_t)key, 0) == -1 && errno == ESRCH) {
                 if (netdata_ebpf_reset_shm_pointer_unsafe(fd, key, NETDATA_EBPF_PIDS_SWAP_IDX))
                     memset(publish, 0, sizeof(*publish));
             }

--- a/src/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/src/collectors/ebpf.plugin/ebpf_vfs.c
@@ -909,6 +909,13 @@ static void ebpf_vfs_exit(void *pptr)
     if (ebpf_read_vfs.thread)
         nd_thread_signal_cancel(ebpf_read_vfs.thread);
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_VFS_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
@@ -1135,8 +1142,8 @@ static void ebpf_vfs_sum_pids(netdata_publish_vfs_t *vfs, struct ebpf_pid_on_tar
 
     for (; root; root = root->next) {
         uint32_t pid = root->pid;
-        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_VFS_IDX);
-        if (!local_pid)
+        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+        if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_VFS_IDX << 1))))
             continue;
 
         netdata_publish_vfs_t *w = &local_pid->vfs;
@@ -1303,13 +1310,13 @@ static void ebpf_vfs_read_apps(int maps_per_core)
 
         netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_VFS_IDX);
         if (!local_pid)
-            continue;
+            goto end_vfs_loop;
         netdata_publish_vfs_t *publish = &local_pid->vfs;
 
         if (!publish->ct || publish->ct != vv->ct) {
             vfs_aggregate_set_vfs(publish, vv);
         } else {
-            if (kill((pid_t)key, 0)) { // No PID found
+            if (kill((pid_t)key, 0) == -1 && errno == ESRCH) {
                 if (netdata_ebpf_reset_shm_pointer_unsafe(fd, key, NETDATA_EBPF_PIDS_VFS_IDX))
                     memset(publish, 0, sizeof(*publish));
             }
@@ -1343,8 +1350,8 @@ static void read_update_vfs_cgroup()
             netdata_publish_vfs_t *out = &pids->vfs;
             memset(out, 0, sizeof(netdata_publish_vfs_t));
 
-            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_VFS_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_VFS_IDX << 1))))
                 continue;
             netdata_publish_vfs_t *in = &local_pid->vfs;
 


### PR DESCRIPTION
## Summary

Fixes a slow-burn leak in `ebpf.plugin`'s per-PID shared-memory accounting pool (`/dev/shm/netdata_shm_integration_ebpf`, 32,768 slots). On a workstation with ~1,300 live PIDs and normal process churn, the pool fills completely within ~15 hours (observed: `current = 32,768`, ≈96% stale entries). Once full, each module's apps-read loop enters an infinite loop and pegs one CPU core at 100% indefinitely.

The hang is the visible symptom; the leak is the cause. This PR fixes both, plus several related secondary bugs found during the investigation.

## Evidence (reproduced on a live process)

- `ebpf.plugin` pid 3228547, thread `EBPF_READ_FD` sampled 3× at 1 s intervals via gdb, alternating between `bpf_map_get_next_key` and `bpf_map_lookup_elem` at `ebpf_fd.c:770-774`, never exiting the loop.
- `(gdb) p ebpf_stat_values` → `{total = 32768, current = 32768}`.
- `ps fax | wc -l` → 1,307. Roughly 31,461 slots (96%) were stale.
- `/dev/shm/netdata_shm_integration_ebpf` = 14 MB = 32,768 × `sizeof(netdata_ebpf_pid_stats_t)`.

## Root cause

`netdata_ebpf_get_shm_pointer_unsafe()` is an allocate-AND-set-bit API, but it is called from two incompatible contexts:

1. **BPF-map iteration** (`ebpf_read_*_apps_table`) — paired with `netdata_ebpf_reset_shm_pointer_unsafe()` via `kill(pid, 0) == ESRCH`. Correct producer/consumer.
2. **Apps & cgroup aggregation helpers** (`*_sum_pids`, `*_update_*_cgroup`, `*_resume_apps_data`) — iterate live-PID lists built from `/proc` and cgroup snapshots and call the same allocating accessor. **No reset path.**

Every second, for every live PID seen in `/proc` or a tracked cgroup, every enabled eBPF module unconditionally sets its bit in that PID's shm slot. When the PID later dies:
- The module's BPF-map iteration clears its bit **and deletes the PID from the kernel BPF map** in the same cycle.
- The next cycle's iteration can no longer find that PID in its BPF map, so the bit cannot be cleared again if another aggregation path re-sets it.
- On the same cycle the `*_sum_pids` / `*_update_*_cgroup` helpers immediately re-set the bit for the dying PID (still present in the apps/cgroup list for one more moment).
- Result: bits accumulate, `threads` never reaches 0, `ebpf_find_pid_shm_del_unsafe` never decrements `current`, slots pin forever.

Once the pool is full, `get_shm_pointer_unsafe()` returns NULL. The eight apps-read loops had a bare `continue;` after the NULL check, skipping `key = next_key;`, so `bpf_map_get_next_key()` re-returned the same key forever and the thread spun at 100% CPU.

## Changes

| Fix | What | Why |
|---|---|---|
| **A** | Split alloc from lookup. New `netdata_ebpf_lookup_shm_pointer_unsafe(pid)` returns slot or NULL with **no** allocation and **no** bit-set. Replace `get_shm_pointer_unsafe` with the new function at **16 aggregation call sites** in 8 modules. Keep `get_shm_pointer_unsafe` at the 8 BPF-map iteration sites. Aggregation paths also gate on the module bit being set. | Removes the root cause: aggregation can no longer allocate or dirty slots it cannot clean up. |
| **B** | Replace bare `continue;` with `goto end_*_loop;` in all 8 apps-read loops so `key = next_key;` always runs. | Prevents the 100% CPU infinite loop even in the rare case the pool is legitimately exhausted. |
| **C** | Zero freshly-allocated slots. `ebpf_find_or_create_index_pid()` now `memset`s the slot on the create branch. | Compacted tails and PID reuse cannot leak stale bits or per-module counters into new occupants. |
| **D** | Fix `kill()` error-check pattern. Five modules used `if (kill(pid, 0))`, which treats `EPERM` (cross-UID processes) as "process is dead". Switched to `if (kill(pid, 0) == -1 && errno == ESRCH)`. Also applied to `ebpf_parse_proc_files()`. | Prevents `ebpf.plugin` from erroneously deleting the kernel BPF map entry and zeroing shm data for live processes owned by other users. |
| **E** | Collapse `ebpf_reset_specific_pid_data()` to `ebpf_del_pid_entry(pid)` and remove unused `ebpf_release_pid_data`. | `thread_collecting` only ever has `NETDATA_EBPF_PIDS_PROC_FILE` set, so the `idx < PROC_FILE` switch was unreachable. |
| **F** | New `netdata_ebpf_sweep_shm_for_module_unsafe(idx)` called in every `*_exit` under `shm_mutex_ebpf_integration`. | On module shutdown / runtime disable, the shm bits this module set are cleared, so its slots can be reclaimed instead of staying pinned. |
| **G** | Zero the whole mapped shm region on init + `shm_unlink` and `sem_unlink` on cleanup (and `sem_unlink` before `sem_open` on init). | `shm_open(O_CREAT)` on an existing object neither truncates nor zeros it, and `sem_open(O_CREAT)` ignores the initial value when the named semaphore already exists. Without this, a crashed previous instance could leave the semaphore at 0 and the next run would spin on `sem_timedwait` timeouts, or keep ghost PID data in the unused `[current, total)` range of `/dev/shm`. |
| **H** | In `get_shm_pointer_unsafe()`, drop the redundant `current >= total` early guard. `ebpf_find_or_create_index_pid()` already returns existing slots unconditionally and only rejects new allocations when the pool is full. | The old guard made already-tracked PIDs unreachable the moment the pool filled, blocking module-bit updates/clears. (Copilot review.) |
| **I** | Socket apps iteration: move `bpf_map_delete_elem(fd, &key)` out of the `if (local_pid) { ... }` branch; it is conditioned only on the socket's own `deleted` signal. | With a full shm pool, `local_pid == NULL` caused dead socket tuples to stay in the kernel map forever, growing unbounded. (Copilot review.) |

## Test plan

- [x] `cmake --build build --target ebpf.plugin` on Arch Linux / gcc 15, builds clean. No new warnings in the changed files (only the pre-existing vendored-Judy `-Wstringop-overflow` warnings remain).
- [x] Live-install verification: shm counter on the new binary settles proportional to BPF-observed PIDs (e.g. 261 slots used vs 1,269 live PIDs on the reporter's workstation), instead of growing monotonically toward 32,768.
- [ ] Long-run soak test on a production-like host.
- [ ] Verify no regression in eBPF apps/cgroup charts under `collect pid = real parent` (default) and `collect pid = all` modes.
- [ ] Verify module restart (e.g. toggle `fd` off then on via config) leaves `ebpf_stat_values.current` consistent.

## Notes

- Root-cause analysis independently confirmed by five separate reviewers (codex gpt-5.4, GLM-5.1, Qwen3.5-Plus, MiniMax-M2.7, an opus-class agent) all converging on the alloc-without-reset asymmetry.
- Copilot raised five post-opening review points; all have been addressed: unused `bool *created` out-param removed; early `current >= total` guard removed from `get_shm_pointer_unsafe`; `sem_unlink` added to cleanup and pre-open; socket kernel-map delete moved out of the `local_pid` branch; this notes section now reflects that `shm_unlink`/`sem_unlink` **are** part of this PR (originally deferred, then rolled in as part of fix G).