### PR TITLE
Improve UUID handling in SQLite functions and error reporting

### DIFF
--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -243,8 +243,10 @@ static inline char *sqlite3_uuid_unparse_strdupz(sqlite3_stmt *res, int iCol) {
 
     if(sqlite3_column_type(res, iCol) == SQLITE_NULL)
         uuid_str[0] = '\0';
-    else
-        uuid_unparse_lower(*((nd_uuid_t *) sqlite3_column_blob(res, iCol)), uuid_str);
+    else if (!sqlite3_column_uuid_unparse_lower(res, iCol, uuid_str)) {
+        error_report("ACLK ALERT: Got invalid UUID blob at column %d. Returning empty string.", iCol);
+        uuid_str[0] = '\0';
+    }
 
     return strdupz(uuid_str);
 }

--- a/src/database/sqlite/sqlite_context.c
+++ b/src/database/sqlite/sqlite_context.c
@@ -98,11 +98,14 @@ void ctx_get_chart_list(nd_uuid_t *host_uuid, void (*dict_cb)(SQL_CHART_DATA *, 
     int param = 0;
     SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, host_uuid, sizeof(*host_uuid), SQLITE_STATIC));
 
+    char host_guid[UUID_STR_LEN];
+    uuid_unparse_lower(*host_uuid, host_guid);
+
     param = 0;
     SQL_CHART_DATA chart_data = { 0 };
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
         if (unlikely(!sqlite3_column_uuid_copy(res, 0, chart_data.chart_id))) {
-            error_report("CTX: Got invalid chart id. Ignoring it.");
+            error_report("CTX [%s]: Got invalid chart id in column 0. Ignoring it.", host_guid);
             continue;
         }
 
@@ -136,12 +139,15 @@ void ctx_get_dimension_list(nd_uuid_t *host_uuid, void (*dict_cb)(SQL_DIMENSION_
     int param = 0;
     SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, host_uuid, sizeof(*host_uuid), SQLITE_STATIC));
 
+    char host_guid[UUID_STR_LEN];
+    uuid_unparse_lower(*host_uuid, host_guid);
+
     SQL_DIMENSION_DATA dimension_data;
 
     param = 0;
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
         if (unlikely(!sqlite3_column_uuid_copy(res, 0, dimension_data.dim_id))) {
-            error_report("CTX: Got invalid dimension id. Ignoring it.");
+            error_report("CTX [%s]: Got invalid dimension id in column 0. Ignoring it.", host_guid);
             continue;
         }
 

--- a/src/database/sqlite/sqlite_context.c
+++ b/src/database/sqlite/sqlite_context.c
@@ -101,7 +101,11 @@ void ctx_get_chart_list(nd_uuid_t *host_uuid, void (*dict_cb)(SQL_CHART_DATA *, 
     param = 0;
     SQL_CHART_DATA chart_data = { 0 };
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-        uuid_copy(chart_data.chart_id, *((nd_uuid_t *)sqlite3_column_blob(res, 0)));
+        if (unlikely(!sqlite3_column_uuid_copy(res, 0, chart_data.chart_id))) {
+            error_report("CTX: Got invalid chart id. Ignoring it.");
+            continue;
+        }
+
         chart_data.id = (char *) sqlite3_column_text(res, 1);
         chart_data.name = (char *) sqlite3_column_text(res, 2);
         chart_data.context = (char *) sqlite3_column_text(res, 3);
@@ -136,7 +140,11 @@ void ctx_get_dimension_list(nd_uuid_t *host_uuid, void (*dict_cb)(SQL_DIMENSION_
 
     param = 0;
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-        uuid_copy(dimension_data.dim_id, *((nd_uuid_t *)sqlite3_column_blob(res, 0)));
+        if (unlikely(!sqlite3_column_uuid_copy(res, 0, dimension_data.dim_id))) {
+            error_report("CTX: Got invalid dimension id. Ignoring it.");
+            continue;
+        }
+
         dimension_data.id = (char *) sqlite3_column_text(res, 1);
         dimension_data.name = (char *) sqlite3_column_text(res, 2);
         dimension_data.hidden = sqlite3_column_int(res, 3);
@@ -426,4 +434,3 @@ int ctx_unittest(void)
 
     return 0;
 }
-

--- a/src/database/sqlite/sqlite_functions.h
+++ b/src/database/sqlite/sqlite_functions.h
@@ -121,6 +121,46 @@ uint64_t sqlite_get_db_space(sqlite3 *db);
 int get_free_page_count(sqlite3 *database);
 int get_database_page_count(sqlite3 *database);
 
+// Return a pointer to the UUID blob stored in column iCol when the current row
+// contains a BLOB with exactly sizeof(nd_uuid_t) bytes. The caller must pass a
+// valid statement positioned on a row. Returns NULL for NULL, non-BLOB, or
+// malformed values.
+static inline const nd_uuid_t *sqlite3_column_uuid_ptr(sqlite3_stmt *res, int iCol) {
+    if (sqlite3_column_type(res, iCol) != SQLITE_BLOB)
+        return NULL;
+
+    const void *uuid = sqlite3_column_blob(res, iCol);
+    if (!uuid || sqlite3_column_bytes(res, iCol) != sizeof(nd_uuid_t))
+        return NULL;
+
+    return (const nd_uuid_t *)uuid;
+}
+
+// Copy the UUID stored in column iCol into dst. The caller must pass a valid
+// statement positioned on a row and a writable destination UUID buffer.
+// Returns true on success, false when the column does not contain a valid UUID blob.
+static inline bool sqlite3_column_uuid_copy(sqlite3_stmt *res, int iCol, nd_uuid_t dst) {
+    const nd_uuid_t *uuid = sqlite3_column_uuid_ptr(res, iCol);
+    if (!uuid)
+        return false;
+
+    uuid_copy(dst, *uuid);
+    return true;
+}
+
+// Convert the UUID stored in column iCol to lowercase text in out. The caller
+// must pass a valid statement positioned on a row and a writable buffer large
+// enough for UUID_STR_LEN bytes. Returns true on success, false when the column
+// does not contain a valid UUID blob.
+static inline bool sqlite3_column_uuid_unparse_lower(sqlite3_stmt *res, int iCol, char *out) {
+    const nd_uuid_t *uuid = sqlite3_column_uuid_ptr(res, iCol);
+    if (!uuid)
+        return false;
+
+    uuid_unparse_lower(*uuid, out);
+    return true;
+}
+
 int sqlite_library_init(void);
 void sqlite_library_shutdown(void);
 

--- a/src/database/sqlite/sqlite_functions.h
+++ b/src/database/sqlite/sqlite_functions.h
@@ -123,8 +123,9 @@ int get_database_page_count(sqlite3 *database);
 
 // Return a pointer to the UUID blob stored in column iCol when the current row
 // contains a BLOB with exactly sizeof(nd_uuid_t) bytes. The caller must pass a
-// valid statement positioned on a row. Returns NULL for NULL, non-BLOB, or
-// malformed values.
+// valid statement positioned on a row. The returned pointer refers to
+// SQLite-owned memory and is only valid until the statement is stepped, reset,
+// or finalized. Returns NULL for NULL, non-BLOB, or malformed values.
 static inline const nd_uuid_t *sqlite3_column_uuid_ptr(sqlite3_stmt *res, int iCol) {
     if (sqlite3_column_type(res, iCol) != SQLITE_BLOB)
         return NULL;

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -1385,14 +1385,13 @@ bool sql_find_alert_transition(
 
     param = 0;
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-        ok = true;
         if (unlikely(!sqlite3_column_uuid_unparse_lower(res, 1, machine_guid))) {
             error_report("HEALTH: Got invalid machine guid while looking up alert transition. Ignoring it.");
-            ok = false;
             continue;
         }
 
         cb(machine_guid, (const char *) sqlite3_column_text(res, 2), sqlite3_column_int(res, 0), data);
+        ok = true;
     }
 
 done:

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -1523,18 +1523,21 @@ run_query:;
     nd_uuid_t host_id;
     nd_uuid_t config_hash_id;
     nd_uuid_t transition_id;
+    size_t invalid_host_ids = 0;
+    size_t invalid_config_hash_ids = 0;
+    size_t invalid_transition_ids = 0;
 
     param = 0;
     while (sqlite3_step(res) == SQLITE_ROW) {
         if (unlikely(!sqlite3_column_uuid_copy(res, 0, host_id))) {
-            error_report("HEALTH: Got invalid host id while loading alert transitions. Ignoring entry.");
+            invalid_host_ids++;
             continue;
         }
 
         atd.host_id = &host_id;
         atd.alarm_id = sqlite3_column_int64(res, 1);
         if (unlikely(!sqlite3_column_uuid_copy(res, 2, config_hash_id))) {
-            error_report("HEALTH: Got invalid config hash id while loading alert transitions. Ignoring entry.");
+            invalid_config_hash_ids++;
             continue;
         }
 
@@ -1561,7 +1564,7 @@ run_query:;
         atd.old_value = (NETDATA_DOUBLE) sqlite3_column_double(res, 22);
         atd.last_repeat = sqlite3_column_int64(res, 23);
         if (unlikely(!sqlite3_column_uuid_copy(res, 24, transition_id))) {
-            error_report("HEALTH: Got invalid transition id while loading alert transitions. Ignoring entry.");
+            invalid_transition_ids++;
             continue;
         }
 
@@ -1574,6 +1577,11 @@ run_query:;
         atd.summary = (const char *) sqlite3_column_text(res, 30);
 
         cb(&atd, data);
+    }
+
+    if (unlikely(invalid_host_ids || invalid_config_hash_ids || invalid_transition_ids)) {
+        error_report("HEALTH: Ignored invalid alert transition rows (host_id=%zu, config_hash_id=%zu, transition_id=%zu).",
+                     invalid_host_ids, invalid_config_hash_ids, invalid_transition_ids);
     }
 
 done:
@@ -1660,13 +1668,14 @@ int sql_get_alert_configuration(
 
     struct sql_alert_config_data acd = {0 };
     nd_uuid_t config_hash_id;
+    size_t invalid_config_hash_ids = 0;
 
     added = 0;
     int param;
     while (sqlite3_step(res) == SQLITE_ROW) {
         param = 0;
         if (unlikely(!sqlite3_column_uuid_copy(res, param++, config_hash_id))) {
-            error_report("HEALTH: Got invalid config hash id while loading alert configuration. Ignoring entry.");
+            invalid_config_hash_ids++;
             continue;
         }
 
@@ -1709,6 +1718,11 @@ int sql_get_alert_configuration(
 
         cb(&acd, data);
         added++;
+    }
+
+    if (unlikely(invalid_config_hash_ids)) {
+        error_report("HEALTH: Ignored %zu alert configuration rows with invalid config_hash_id.",
+                     invalid_config_hash_ids);
     }
 
     SQLITE_FINALIZE(res);

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -543,14 +543,20 @@ void sql_check_removed_alerts_state(RRDHOST *host)
 
     param = 0;
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-        uint32_t alarm_id, alarm_event_id, unique_id;
-        RRDCALC_STATUS status;
+        const nd_uuid_t *transition_uuid = sqlite3_column_uuid_ptr(res, 4);
 
-        status = (RRDCALC_STATUS)sqlite3_column_int(res, 0);
-        unique_id = (uint32_t)sqlite3_column_int64(res, 1);
-        alarm_id = (uint32_t)sqlite3_column_int64(res, 2);
-        alarm_event_id = (uint32_t)sqlite3_column_int64(res, 3);
-        uuid_copy(transition_id, *((nd_uuid_t *)sqlite3_column_blob(res, 4)));
+        RRDCALC_STATUS status = (RRDCALC_STATUS)sqlite3_column_int(res, 0);
+        uint32_t unique_id = (uint32_t)sqlite3_column_int64(res, 1);
+        uint32_t alarm_id = (uint32_t)sqlite3_column_int64(res, 2);
+        uint32_t alarm_event_id = (uint32_t)sqlite3_column_int64(res, 3);
+
+        if (unlikely(!transition_uuid)) {
+            error_report("HEALTH [%s]: Got invalid transition id while checking removed alerts. Ignoring it.",
+                         rrdhost_hostname(host));
+            continue;
+        }
+
+        uuid_copy(transition_id, *transition_uuid);
 
         if (unlikely(status != RRDCALC_STATUS_REMOVED)) {
            if (unlikely(!max_unique_id))
@@ -715,13 +721,26 @@ void sql_health_alarm_log_load(RRDHOST *host)
             }
         }
 
+        if (sqlite3_column_type(res, 30) != SQLITE_NULL &&
+            unlikely(!sqlite3_column_uuid_ptr(res, 30))) {
+            error_report("HEALTH [%s]: Got invalid transition id. Ignoring entry.", rrdhost_hostname(host));
+            errored++;
+            continue;
+        }
+
         ae = health_alarm_entry_create();
 
         ae->unique_id = unique_id;
         ae->alarm_id = alarm_id;
 
-        if (sqlite3_column_type(res, 3) != SQLITE_NULL)
-            uuid_copy(ae->config_hash_id, *((nd_uuid_t *) sqlite3_column_blob(res, 3)));
+        if (sqlite3_column_type(res, 3) != SQLITE_NULL) {
+            if (unlikely(!sqlite3_column_uuid_copy(res, 3, ae->config_hash_id))) {
+                error_report("HEALTH [%s]: Got invalid config hash id. Ignoring entry.", rrdhost_hostname(host));
+                errored++;
+                health_alarm_entry_destroy(ae);
+                continue;
+            }
+        }
 
         ae->alarm_event_id = (uint32_t) sqlite3_column_int64(res, 2);
         ae->updated_by_id = (uint32_t) sqlite3_column_int64(res, 4);
@@ -761,8 +780,11 @@ void sql_health_alarm_log_load(RRDHOST *host)
         ae->type = SQLITE3_COLUMN_STRINGDUP_OR_NULL(res, 28);
         ae->chart_context = SQLITE3_COLUMN_STRINGDUP_OR_NULL(res, 29);
 
-        if (sqlite3_column_type(res, 30) != SQLITE_NULL)
-            uuid_copy(ae->transition_id, *((nd_uuid_t *)sqlite3_column_blob(res, 30)));
+        if (sqlite3_column_type(res, 30) != SQLITE_NULL) {
+            bool copied = sqlite3_column_uuid_copy(res, 30, ae->transition_id);
+            internal_fatal(!copied, "HEALTH [%s]: transition id validation invariant violated while loading health log.",
+                           rrdhost_hostname(host));
+        }
 
         if (sqlite3_column_type(res, 31) != SQLITE_NULL)
             ae->global_id = sqlite3_column_int64(res, 31);
@@ -1056,11 +1078,19 @@ void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, time_t after, const ch
          char new_value_string[100 + 1];
 
          char config_hash_id[UUID_STR_LEN];
-         uuid_unparse_lower(*((nd_uuid_t *)sqlite3_column_blob(stmt_query, 3)), config_hash_id);
+         if (unlikely(!sqlite3_column_uuid_unparse_lower(stmt_query, 3, config_hash_id))) {
+             error_report("HEALTH [%s]: Got invalid config hash id while exporting health log. Ignoring entry.",
+                          rrdhost_hostname(host));
+             continue;
+         }
 
          char transition_id[UUID_STR_LEN] = {0};
-         if (sqlite3_column_type(stmt_query, 30) != SQLITE_NULL)
-            uuid_unparse_lower(*((nd_uuid_t *)sqlite3_column_blob(stmt_query, 30)), transition_id);
+         if (sqlite3_column_type(stmt_query, 30) != SQLITE_NULL &&
+             unlikely(!sqlite3_column_uuid_unparse_lower(stmt_query, 30, transition_id))) {
+             error_report("HEALTH [%s]: Got invalid transition id while exporting health log. Ignoring entry.",
+                          rrdhost_hostname(host));
+             continue;
+         }
 
          char *edit_command = sqlite3_column_bytes(stmt_query, 16) > 0 ?
                                   health_edit_command_from_source((char *)sqlite3_column_text(stmt_query, 16)) :
@@ -1356,7 +1386,12 @@ bool sql_find_alert_transition(
     param = 0;
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
         ok = true;
-        uuid_unparse_lower(*(nd_uuid_t *) sqlite3_column_blob(res, 1), machine_guid);
+        if (unlikely(!sqlite3_column_uuid_unparse_lower(res, 1, machine_guid))) {
+            error_report("HEALTH: Got invalid machine guid while looking up alert transition. Ignoring it.");
+            ok = false;
+            continue;
+        }
+
         cb(machine_guid, (const char *) sqlite3_column_text(res, 2), sqlite3_column_int(res, 0), data);
     }
 
@@ -1486,12 +1521,25 @@ void sql_alert_transitions(
 run_query:;
 
     struct sql_alert_transition_data atd = {0 };
+    nd_uuid_t host_id;
+    nd_uuid_t config_hash_id;
+    nd_uuid_t transition_id;
 
     param = 0;
     while (sqlite3_step(res) == SQLITE_ROW) {
-        atd.host_id = (nd_uuid_t *) sqlite3_column_blob(res, 0);
+        if (unlikely(!sqlite3_column_uuid_copy(res, 0, host_id))) {
+            error_report("HEALTH: Got invalid host id while loading alert transitions. Ignoring entry.");
+            continue;
+        }
+
+        atd.host_id = &host_id;
         atd.alarm_id = sqlite3_column_int64(res, 1);
-        atd.config_hash_id = (nd_uuid_t *)sqlite3_column_blob(res, 2);
+        if (unlikely(!sqlite3_column_uuid_copy(res, 2, config_hash_id))) {
+            error_report("HEALTH: Got invalid config hash id while loading alert transitions. Ignoring entry.");
+            continue;
+        }
+
+        atd.config_hash_id = &config_hash_id;
         atd.alert_name = (const char *) sqlite3_column_text(res, 3);
         atd.chart = (const char *) sqlite3_column_text(res, 4);
         atd.chart_name = (const char *) sqlite3_column_text(res, 5);
@@ -1513,7 +1561,12 @@ run_query:;
         atd.new_value = (NETDATA_DOUBLE) sqlite3_column_double(res, 21);
         atd.old_value = (NETDATA_DOUBLE) sqlite3_column_double(res, 22);
         atd.last_repeat = sqlite3_column_int64(res, 23);
-        atd.transition_id = (nd_uuid_t *) sqlite3_column_blob(res, 24);
+        if (unlikely(!sqlite3_column_uuid_copy(res, 24, transition_id))) {
+            error_report("HEALTH: Got invalid transition id while loading alert transitions. Ignoring entry.");
+            continue;
+        }
+
+        atd.transition_id = &transition_id;
         atd.global_id = sqlite3_column_int64(res, 25);
         atd.classification = (const char *) sqlite3_column_text(res, 26);
         atd.type = (const char *) sqlite3_column_text(res, 27);
@@ -1607,12 +1660,18 @@ int sql_get_alert_configuration(
     }
 
     struct sql_alert_config_data acd = {0 };
+    nd_uuid_t config_hash_id;
 
     added = 0;
     int param;
     while (sqlite3_step(res) == SQLITE_ROW) {
         param = 0;
-        acd.config_hash_id = (nd_uuid_t *) sqlite3_column_blob(res, param++);
+        if (unlikely(!sqlite3_column_uuid_copy(res, param++, config_hash_id))) {
+            error_report("HEALTH: Got invalid config hash id while loading alert configuration. Ignoring entry.");
+            continue;
+        }
+
+        acd.config_hash_id = &config_hash_id;
         acd.name = (const char *) sqlite3_column_text(res, param++);
         acd.selectors.on_template = (const char *) sqlite3_column_text(res, param++);
         acd.selectors.on_key = (const char *) sqlite3_column_text(res, param++);

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -499,8 +499,9 @@ void sql_load_node_id(RRDHOST *host)
     param = 0;
     int rc = sqlite3_step_monitored(res);
     if (likely(rc == SQLITE_ROW)) {
-        if (likely(sqlite3_column_bytes(res, 0) == sizeof(nd_uuid_t)))
-            set_host_node_id(host, (nd_uuid_t *)sqlite3_column_blob(res, 0));
+        const nd_uuid_t *node_id = sqlite3_column_uuid_ptr(res, 0);
+        if (likely(node_id))
+            set_host_node_id(host, (nd_uuid_t *)node_id);
         else
             set_host_node_id(host, NULL);
     }
@@ -1298,14 +1299,19 @@ static bool run_cleanup_loop(
     uint32_t l_checked = 0;
     uint32_t l_deleted = 0;
     while (!time_expired && sqlite3_step_monitored(res) == SQLITE_ROW) {
+        nd_uuid_t uuid = {0};
+
         if (unlikely(SHUTDOWN_REQUESTED(config)))
             break;
 
         *row_id = sqlite3_column_int64(res, 1);
-        rc = check_cb((nd_uuid_t *)sqlite3_column_blob(res, 0), check_stmt, check_flag);
+        if (unlikely(!sqlite3_column_uuid_copy(res, 0, uuid)))
+            continue;
+
+        rc = check_cb(&uuid, check_stmt, check_flag);
 
         if (rc == true) {
-            action_cb((nd_uuid_t *)sqlite3_column_blob(res, 0), action_stmt, action_flag);
+            action_cb(&uuid, action_stmt, action_flag);
             l_deleted++;
 //            if (false == sql_metadata_wal_size_acceptable())
 //                (void) sqlite3_wal_checkpoint(db_meta, NULL);
@@ -1747,14 +1753,15 @@ static bool clean_host_chart_dimensions(sqlite3_stmt **res, int64_t chart_row_id
 
     can_continue = true;
     while (can_continue && sqlite3_step_monitored(*res) == SQLITE_ROW) {
-        if (sqlite3_column_bytes(*res, 0) != sizeof(nd_uuid_t))
+        nd_uuid_t dim_uuid;
+
+        if (!sqlite3_column_uuid_copy(*res, 0, dim_uuid))
             continue;
 
-        nd_uuid_t *dim_uuid = (nd_uuid_t *)sqlite3_column_blob(*res, 0);
         int64_t dimension_id = sqlite3_column_int64(*res, 1);
 
-        if (dimension_can_be_deleted(dim_uuid, NULL, false)) {
-            delete_dimension_by_rowid(&dim_del_stmt, dimension_id, dim_uuid);
+        if (dimension_can_be_deleted(&dim_uuid, NULL, false)) {
+            delete_dimension_by_rowid(&dim_del_stmt, dimension_id, &dim_uuid);
             (*deleted)++;
         }
         (*checked)++;
@@ -2145,15 +2152,15 @@ size_t populate_metrics_from_database(void *mrg, void (*populate_cb)(void *mrg, 
 
     usec_t started_ut = now_monotonic_usec();
     while (sqlite3_step(res) == SQLITE_ROW) {
-        nd_uuid_t *uuid = (nd_uuid_t *)sqlite3_column_blob(res, 0);
-        if (!uuid || sqlite3_column_bytes(res, 0) != sizeof(nd_uuid_t))
+        nd_uuid_t uuid;
+        if (!sqlite3_column_uuid_copy(res, 0, uuid))
             continue;
 
         for (size_t tier = 0; tier < nd_profile.storage_tiers ; tier++) {
             if (unlikely(!multidb_ctx[tier]))
                 continue;
 
-            populate_cb(mrg, (Word_t)multidb_ctx[tier], uuid);
+            populate_cb(mrg, (Word_t)multidb_ctx[tier], &uuid);
         }
         count++;
     }

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -499,9 +499,9 @@ void sql_load_node_id(RRDHOST *host)
     param = 0;
     int rc = sqlite3_step_monitored(res);
     if (likely(rc == SQLITE_ROW)) {
-        const nd_uuid_t *node_id = sqlite3_column_uuid_ptr(res, 0);
-        if (likely(node_id))
-            set_host_node_id(host, (nd_uuid_t *)node_id);
+        nd_uuid_t node_id;
+        if (likely(sqlite3_column_uuid_copy(res, 0, node_id)))
+            set_host_node_id(host, &node_id);
         else
             set_host_node_id(host, NULL);
     }


### PR DESCRIPTION
##### Summary
- Add validation for uuids while loading from db 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates and safely reads UUID blobs from SQLite across health, context, ACLK, and metadata. Adds strict checks for alert transition/config UUIDs and chart/dimension IDs, skipping bad rows and logging clear errors (with host GUID where helpful).

- **New Features**
  - Added `sqlite3_column_uuid_ptr`, `sqlite3_column_uuid_copy`, and `sqlite3_column_uuid_unparse_lower` for safe UUID retrieval and formatting.

- **Bug Fixes**
  - Replaced direct BLOB casts with validation in health logs/exports; alert transitions and configuration loads (host_id, config_hash_id, transition_id, machine GUID); context chart/dimension lists (errors include host GUID); and metadata node ID load, cleanup loops, and metric population. Invalid rows are skipped, with totals logged where relevant.
  - `sqlite3_uuid_unparse_strdupz` now returns empty strings for invalid UUIDs and logs the issue to prevent bad data propagation.

<sup>Written for commit 6a8780b911ee7552fddb782539d693661ae7a9cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

