### PR TITLE
Fix memory-safety and correctness bugs surfaced by Coverity audit

### DIFF
--- a/src/aclk/aclk_query.c
+++ b/src/aclk/aclk_query.c
@@ -71,7 +71,7 @@ void mark_pending_req_cancel_all()
     spinlock_lock(&pending_req_list_lock);
     struct pending_req_list *curr = pending_req_list_head;
     while (curr) {
-        curr->canceled = 1;
+        __atomic_store_n(&curr->canceled, 1, __ATOMIC_RELAXED);
         curr = curr->next;
     }
     spinlock_unlock(&pending_req_list_lock);
@@ -86,7 +86,7 @@ int mark_pending_req_cancelled(const char *msg_id)
 
     while (curr) {
         if (curr->hash == hash && strcmp(curr->msg_id, msg_id) == 0) {
-            curr->canceled = 1;
+            __atomic_store_n(&curr->canceled, 1, __ATOMIC_RELAXED);
             spinlock_unlock(&pending_req_list_lock);
             return 0;
         }
@@ -100,7 +100,7 @@ int mark_pending_req_cancelled(const char *msg_id)
 static bool aclk_web_client_interrupt_cb(struct web_client *w __maybe_unused, void *data)
 {
     struct pending_req_list *req = (struct pending_req_list *)data;
-    return req->canceled;
+    return __atomic_load_n(&req->canceled, __ATOMIC_RELAXED);
 }
 
 int http_api_v2(mqtt_wss_client client, aclk_query_t *query)

--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -270,7 +270,17 @@ static bool send_curl_request(const char *machine_guid, const char *hostname, co
     };
 
     // configure the request
-    headers = curl_slist_append(headers, "Content-Type: application/json");
+    struct curl_slist *headers_with_content_type = curl_slist_append(headers, "Content-Type: application/json");
+    if(unlikely(!headers_with_content_type)) {
+        claim_agent_failure_reason_set("Cannot append Content-Type header to the claim request");
+        curl_easy_cleanup(curl);
+        if(headers)
+            curl_slist_free_all(headers);
+        *can_retry = false;
+        return false;
+    }
+    headers = headers_with_content_type;
+
     CURL_SETOPT_OR_RETURN(CURLOPT_URL, target_url);
     CURL_SETOPT_OR_RETURN(CURLOPT_CUSTOMREQUEST, "PUT");
     CURL_SETOPT_OR_RETURN(CURLOPT_POSTFIELDS, buffer_tostring(wb));

--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -84,6 +84,11 @@ static bool check_and_generate_certificates() {
 
 static size_t response_write_callback(void *ptr, size_t size, size_t nmemb, void *stream) {
     struct claim_response_buffer *response = stream;
+
+    if (unlikely(nmemb && size > SIZE_MAX / nmemb)) {
+        response->too_large = true;
+        return 0;
+    }
     size_t real_size = size * nmemb;
 
     if (unlikely(real_size > CLAIM_RESPONSE_SIZE_LIMIT - buffer_strlen(response->wb))) {

--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -159,6 +159,7 @@ static bool send_curl_request(const char *machine_guid, const char *hostname, co
     CURLcode res;
     char target_url[2048];
     char public_key[2048] = "";
+    size_t public_key_bytes_read = 0;
     FILE *fp;
     struct curl_slist *headers = NULL;
 
@@ -175,12 +176,13 @@ static bool send_curl_request(const char *machine_guid, const char *hostname, co
     // Read the public key
     CLEAN_CHAR_P *public_key_file = filename_from_path_entry_strdupz(netdata_configured_cloud_dir, "public.pem");
     fp = fopen(public_key_file, "r");
-    if (!fp || fread(public_key, 1, sizeof(public_key), fp) == 0) {
+    if (!fp || (public_key_bytes_read = fread(public_key, 1, sizeof(public_key) - 1, fp)) == 0) {
         claim_agent_failure_reason_set("cannot read public key file '%s'", public_key_file);
         if (fp) fclose(fp);
         *can_retry = false;
         return false;
     }
+    public_key[public_key_bytes_read] = '\0';
     fclose(fp);
 
     // check if we have trusted.pem

--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -487,6 +487,9 @@ bool claim_agent_from_split_files(void) {
         unlink(filename);
     }
 
+    freez(token);
+    freez(rooms);
+
     return ret;
 }
 

--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -9,6 +9,13 @@
 #include <openssl/pem.h>
 #include <openssl/err.h>
 
+#define CLAIM_RESPONSE_SIZE_LIMIT (10 * 1024 * 1024)
+
+struct claim_response_buffer {
+    BUFFER *wb;
+    bool too_large;
+};
+
 static bool check_and_generate_certificates() {
     FILE *fp;
     EVP_PKEY *pkey = NULL;
@@ -76,10 +83,15 @@ static bool check_and_generate_certificates() {
 }
 
 static size_t response_write_callback(void *ptr, size_t size, size_t nmemb, void *stream) {
-    BUFFER *wb = stream;
+    struct claim_response_buffer *response = stream;
     size_t real_size = size * nmemb;
 
-    buffer_memcat(wb, ptr, real_size);
+    if (unlikely(real_size > CLAIM_RESPONSE_SIZE_LIMIT - buffer_strlen(response->wb))) {
+        response->too_large = true;
+        return 0;
+    }
+
+    buffer_memcat(response->wb, ptr, real_size);
 
     return real_size;
 }
@@ -233,6 +245,10 @@ static bool send_curl_request(const char *machine_guid, const char *hostname, co
 
     // we will receive the response in this
     CLEAN_BUFFER *response = buffer_create(0, NULL);
+    struct claim_response_buffer response_buffer = {
+        .wb = response,
+        .too_large = false,
+    };
 
     // configure the request
     headers = curl_slist_append(headers, "Content-Type: application/json");
@@ -241,7 +257,8 @@ static bool send_curl_request(const char *machine_guid, const char *hostname, co
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, buffer_tostring(wb));
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, response_write_callback);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, response);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_buffer);
+    curl_easy_setopt(curl, CURLOPT_MAXFILESIZE_LARGE, (curl_off_t)CLAIM_RESPONSE_SIZE_LIMIT);
 
     if(trusted_key_file)
         curl_easy_setopt(curl, CURLOPT_CAINFO, trusted_key_file);
@@ -278,19 +295,33 @@ static bool send_curl_request(const char *machine_guid, const char *hostname, co
     // execute the request
     res = curl_easy_perform(curl);
     if (res != CURLE_OK) {
-        claim_agent_failure_reason_set("Request failed with error: %s\n"
-                                       "proxy: '%s',\n"
-                                       "insecure: %s,\n"
-                                       "public key file: '%s',\n"
-                                       "trusted key file: '%s'",
-                                       curl_easy_strerror(res),
-                                       proxy,
-                                       insecure ? "true" : "false",
-                                       public_key_file ? public_key_file : "none",
-                                       trusted_key_file ? trusted_key_file : "none");
+        bool response_too_large = (res == CURLE_FILESIZE_EXCEEDED || response_buffer.too_large);
+
+        if (response_too_large)
+            claim_agent_failure_reason_set("Request failed: response body exceeded %zu bytes\n"
+                                           "proxy: '%s',\n"
+                                           "insecure: %s,\n"
+                                           "public key file: '%s',\n"
+                                           "trusted key file: '%s'",
+                                           (size_t)CLAIM_RESPONSE_SIZE_LIMIT,
+                                           proxy,
+                                           insecure ? "true" : "false",
+                                           public_key_file ? public_key_file : "none",
+                                           trusted_key_file ? trusted_key_file : "none");
+        else
+            claim_agent_failure_reason_set("Request failed with error: %s\n"
+                                           "proxy: '%s',\n"
+                                           "insecure: %s,\n"
+                                           "public key file: '%s',\n"
+                                           "trusted key file: '%s'",
+                                           curl_easy_strerror(res),
+                                           proxy,
+                                           insecure ? "true" : "false",
+                                           public_key_file ? public_key_file : "none",
+                                           trusted_key_file ? trusted_key_file : "none");
         curl_easy_cleanup(curl);
         curl_slist_free_all(headers);
-        *can_retry = true;
+        *can_retry = !response_too_large;
         return false;
     }
 

--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -166,6 +166,18 @@ static int debug_callback(CURL *handle, curl_infotype type, char *data, size_t s
     return 0;
 }
 
+static bool cleanup_curl_request_failure(CURL *curl, struct curl_slist *headers, bool *can_retry, CURLcode res,
+                                         const char *option) {
+    claim_agent_failure_reason_set("Cannot configure request (%s failed: %s)", option, curl_easy_strerror(res));
+
+    curl_easy_cleanup(curl);
+    if(headers)
+        curl_slist_free_all(headers);
+
+    *can_retry = false;
+    return false;
+}
+
 static bool send_curl_request(const char *machine_guid, const char *hostname, const char *token, const char *rooms, const char *url, const char *proxy, bool insecure, bool *can_retry) {
     CURL *curl;
     CURLcode res;
@@ -240,8 +252,15 @@ static bool send_curl_request(const char *machine_guid, const char *hostname, co
         return false;
     }
 
+#define CURL_SETOPT_OR_RETURN(option, value)                                                       \
+    do {                                                                                           \
+        res = curl_easy_setopt(curl, option, value);                                               \
+        if(unlikely(res != CURLE_OK))                                                              \
+            return cleanup_curl_request_failure(curl, headers, can_retry, res, #option);          \
+    } while(0)
+
     // curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-    curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, debug_callback);
+    CURL_SETOPT_OR_RETURN(CURLOPT_DEBUGFUNCTION, debug_callback);
 
     // we will receive the response in this
     CLEAN_BUFFER *response = buffer_create(0, NULL);
@@ -252,28 +271,28 @@ static bool send_curl_request(const char *machine_guid, const char *hostname, co
 
     // configure the request
     headers = curl_slist_append(headers, "Content-Type: application/json");
-    curl_easy_setopt(curl, CURLOPT_URL, target_url);
-    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, buffer_tostring(wb));
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, response_write_callback);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_buffer);
-    curl_easy_setopt(curl, CURLOPT_MAXFILESIZE_LARGE, (curl_off_t)CLAIM_RESPONSE_SIZE_LIMIT);
+    CURL_SETOPT_OR_RETURN(CURLOPT_URL, target_url);
+    CURL_SETOPT_OR_RETURN(CURLOPT_CUSTOMREQUEST, "PUT");
+    CURL_SETOPT_OR_RETURN(CURLOPT_POSTFIELDS, buffer_tostring(wb));
+    CURL_SETOPT_OR_RETURN(CURLOPT_HTTPHEADER, headers);
+    CURL_SETOPT_OR_RETURN(CURLOPT_WRITEFUNCTION, response_write_callback);
+    CURL_SETOPT_OR_RETURN(CURLOPT_WRITEDATA, &response_buffer);
+    CURL_SETOPT_OR_RETURN(CURLOPT_MAXFILESIZE_LARGE, (curl_off_t)CLAIM_RESPONSE_SIZE_LIMIT);
 
     if(trusted_key_file)
-        curl_easy_setopt(curl, CURLOPT_CAINFO, trusted_key_file);
+        CURL_SETOPT_OR_RETURN(CURLOPT_CAINFO, trusted_key_file);
 
     // Proxy configuration
     if (proxy) {
         if (!*proxy || strcmp(proxy, "none") == 0) {
             // disable proxy configuration in libcurl
-            curl_easy_setopt(curl, CURLOPT_PROXY, "");
+            CURL_SETOPT_OR_RETURN(CURLOPT_PROXY, "");
             proxy = "none";
         }
 
         else if (strcmp(proxy, "env") != 0) {
             // set the custom proxy for libcurl
-            curl_easy_setopt(curl, CURLOPT_PROXY, proxy);
+            CURL_SETOPT_OR_RETURN(CURLOPT_PROXY, proxy);
         }
 
         else {
@@ -284,13 +303,15 @@ static bool send_curl_request(const char *machine_guid, const char *hostname, co
 
     // Insecure option
     if (insecure) {
-        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+        CURL_SETOPT_OR_RETURN(CURLOPT_SSL_VERIFYPEER, 0L);
+        CURL_SETOPT_OR_RETURN(CURLOPT_SSL_VERIFYHOST, 0L);
     }
 
     // Set timeout options
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10L);
-    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5L);
+    CURL_SETOPT_OR_RETURN(CURLOPT_TIMEOUT, 10L);
+    CURL_SETOPT_OR_RETURN(CURLOPT_CONNECTTIMEOUT, 5L);
+
+#undef CURL_SETOPT_OR_RETURN
 
     // execute the request
     res = curl_easy_perform(curl);

--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -321,16 +321,20 @@ static bool send_curl_request(const char *machine_guid, const char *hostname, co
                 if (json_object_object_get_ex(parsed_json, "errorMsgKey", &error_key_obj))
                     error_key = json_object_get_string(error_key_obj);
 
-                if (strcmp(error_key, "ErrInvalidNodeID") == 0)
-                    claim_agent_failure_reason_set("Failed: the node id is invalid");
-                else if (strcmp(error_key, "ErrInvalidNodeName") == 0)
-                    claim_agent_failure_reason_set("Failed: the node name is invalid");
-                else if (strcmp(error_key, "ErrInvalidRoomID") == 0)
-                    claim_agent_failure_reason_set("Failed: one or more room ids are invalid");
-                else if (strcmp(error_key, "ErrInvalidPublicKey") == 0)
-                    claim_agent_failure_reason_set("Failed: the public key is invalid");
+                if(error_key) {
+                    if (strcmp(error_key, "ErrInvalidNodeID") == 0)
+                        claim_agent_failure_reason_set("Failed: the node id is invalid");
+                    else if (strcmp(error_key, "ErrInvalidNodeName") == 0)
+                        claim_agent_failure_reason_set("Failed: the node name is invalid");
+                    else if (strcmp(error_key, "ErrInvalidRoomID") == 0)
+                        claim_agent_failure_reason_set("Failed: one or more room ids are invalid");
+                    else if (strcmp(error_key, "ErrInvalidPublicKey") == 0)
+                        claim_agent_failure_reason_set("Failed: the public key is invalid");
+                    else
+                        claim_agent_failure_reason_set("Failed with description '%s'", error_key);
+                }
                 else
-                    claim_agent_failure_reason_set("Failed with description '%s'", error_key);
+                    claim_agent_failure_reason_set("Failed with a response code %ld", http_status_code);
 
                 json_object_put(parsed_json);
             }

--- a/src/claim/claim_id.c
+++ b/src/claim/claim_id.c
@@ -51,7 +51,7 @@ bool claim_id_set_str(const char *claim_id_str) {
 }
 
 ND_UUID claim_id_get_uuid(void) {
-    static ND_UUID uuid;
+    ND_UUID uuid;
     spinlock_lock(&claim.spinlock);
     uuid = claim.claim_uuid;
     spinlock_unlock(&claim.spinlock);

--- a/src/collectors/apps.plugin/apps_plugin.c
+++ b/src/collectors/apps.plugin/apps_plugin.c
@@ -857,6 +857,7 @@ int main(int argc, char **argv) {
 
         if(unlikely(print_tree_and_exit)) {
             print_hierarchy(root_of_pids());
+            netdata_mutex_unlock(&apps_and_stdout_mutex);
             exit(0);
         }
 

--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -1002,7 +1002,7 @@ static inline void ebpf_check_before2go()
         int active_count = 0;
         netdata_mutex_lock(&ebpf_exit_cleanup);
         for (j = 0; ebpf_modules[j].info.thread_name != NULL; j++) {
-            if (ebpf_modules[j].enabled < NETDATA_THREAD_EBPF_STOPPING)
+            if (ebpf_module_enabled_get(&ebpf_modules[j]) < NETDATA_THREAD_EBPF_STOPPING)
                 active_count++;
         }
         netdata_mutex_unlock(&ebpf_exit_cleanup);
@@ -1130,7 +1130,9 @@ void ebpf_stop_threads(int sig)
 
     int i;
     for (i = 0; ebpf_modules[i].info.thread_name != NULL; i++) {
-        if (ebpf_modules[i].enabled < NETDATA_THREAD_EBPF_STOPPING && ebpf_modules[i].thread &&
+        enum ebpf_threads_status enabled = ebpf_module_enabled_get(&ebpf_modules[i]);
+
+        if (enabled < NETDATA_THREAD_EBPF_STOPPING && ebpf_modules[i].thread &&
             ebpf_modules[i].thread->thread) {
             nd_thread_signal_cancel(ebpf_modules[i].thread->thread);
 #ifdef NETDATA_DEV_MODE
@@ -1141,12 +1143,14 @@ void ebpf_stop_threads(int sig)
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 
     for (i = 0; ebpf_modules[i].info.thread_name != NULL; i++) {
-        if (ebpf_modules[i].enabled < NETDATA_THREAD_EBPF_STOPPED && ebpf_threads[i].thread) {
+        enum ebpf_threads_status enabled = ebpf_module_enabled_get(&ebpf_modules[i]);
+
+        if (enabled < NETDATA_THREAD_EBPF_STOPPED && ebpf_threads[i].thread) {
             netdata_log_info(
                 "EBPF SHUTDOWN: about to join module[%d]='%s' (state=%u).",
                 i,
                 ebpf_modules[i].info.thread_name,
-                ebpf_modules[i].enabled);
+                enabled);
             usec_t join_started_ut = now_monotonic_usec();
             nd_thread_join(ebpf_threads[i].thread);
             usec_t join_duration_ut = now_monotonic_usec() - join_started_ut;
@@ -1576,7 +1580,7 @@ static inline void ebpf_send_hash_table_pid_data(char *chart, uint32_t idx)
         if (wem->functions.apps_routine)
             write_chart_dimension(
                 (char *)wem->info.thread_name,
-                (wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ? wem->hash_table_stats[idx] : 0);
+                (ebpf_module_enabled_get(wem) < NETDATA_THREAD_EBPF_STOPPING) ? wem->hash_table_stats[idx] : 0);
     }
     ebpf_write_end_chart();
 }
@@ -1594,7 +1598,8 @@ static inline void ebpf_send_global_hash_table_data()
     for (i = 0; i < EBPF_MODULE_FUNCTION_IDX; i++) {
         ebpf_module_t *wem = &ebpf_modules[i];
         write_chart_dimension(
-            (char *)wem->info.thread_name, (wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ? NETDATA_CONTROLLER_END : 0);
+            (char *)wem->info.thread_name,
+            (ebpf_module_enabled_get(wem) < NETDATA_THREAD_EBPF_STOPPING) ? NETDATA_CONTROLLER_END : 0);
     }
     ebpf_write_end_chart();
 }
@@ -1616,7 +1621,8 @@ void ebpf_send_statistic_data()
         if (wem->functions.fnct_routine)
             continue;
 
-        write_chart_dimension((char *)wem->info.thread_name, (wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ? 1 : 0);
+        write_chart_dimension(
+            (char *)wem->info.thread_name, (ebpf_module_enabled_get(wem) < NETDATA_THREAD_EBPF_STOPPING) ? 1 : 0);
     }
     ebpf_write_end_chart();
 
@@ -1635,7 +1641,7 @@ void ebpf_send_statistic_data()
 
         write_chart_dimension(
             (char *)wem->info.thread_name,
-            (wem->lifetime && wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ?
+            (wem->lifetime && ebpf_module_enabled_get(wem) < NETDATA_THREAD_EBPF_STOPPING) ?
                 (long long)(wem->lifetime - wem->running_time) :
                 0);
     }
@@ -1682,13 +1688,14 @@ void ebpf_send_statistic_data()
             continue;
 
         ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, wem->functions.fcnt_thread_chart_name, "");
-        write_chart_dimension((char *)wem->info.thread_name, (wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ? 1 : 0);
+        write_chart_dimension(
+            (char *)wem->info.thread_name, (ebpf_module_enabled_get(wem) < NETDATA_THREAD_EBPF_STOPPING) ? 1 : 0);
         ebpf_write_end_chart();
 
         ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, wem->functions.fcnt_thread_lifetime_name, "");
         write_chart_dimension(
             (char *)wem->info.thread_name,
-            (wem->lifetime && wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ?
+            (wem->lifetime && ebpf_module_enabled_get(wem) < NETDATA_THREAD_EBPF_STOPPING) ?
                 (long long)(wem->lifetime - wem->running_time) :
                 0);
         ebpf_write_end_chart();
@@ -2372,8 +2379,8 @@ int main(int argc, char **argv)
         ebpf_module_t *em = &ebpf_modules[i];
         em->thread = st;
         em->thread_id = i;
-        if (em->enabled != NETDATA_THREAD_EBPF_NOT_RUNNING) {
-            em->enabled = NETDATA_THREAD_EBPF_RUNNING;
+        if (ebpf_module_enabled_get(em) != NETDATA_THREAD_EBPF_NOT_RUNNING) {
+            ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_RUNNING);
             em->lifetime = EBPF_NON_FUNCTION_LIFE_TIME;
 
             if (em->functions.apps_routine && (em->apps_charts || em->cgroup_charts)) {

--- a/src/collectors/ebpf.plugin/ebpf.h
+++ b/src/collectors/ebpf.plugin/ebpf.h
@@ -335,12 +335,26 @@ static inline bool ebpf_plugin_stop(void)
            nd_thread_signaled_to_cancel();
 }
 
+// `enabled` is sampled from stats/shutdown paths without a single shared mutex.
+// Keep those state transitions defined without changing the plugin's lock layout.
+static inline enum ebpf_threads_status ebpf_module_enabled_get(ebpf_module_t *em)
+{
+    return __atomic_load_n(&em->enabled, __ATOMIC_RELAXED);
+}
+
+static inline void ebpf_module_enabled_set(ebpf_module_t *em, enum ebpf_threads_status enabled)
+{
+    __atomic_store_n(&em->enabled, enabled, __ATOMIC_RELAXED);
+}
+
 static inline bool ebpf_module_thread_has_valid_state(ebpf_module_t *em)
 {
-    if (likely(em->enabled == NETDATA_THREAD_EBPF_RUNNING || em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING))
+    enum ebpf_threads_status enabled = ebpf_module_enabled_get(em);
+
+    if (likely(enabled == NETDATA_THREAD_EBPF_RUNNING || enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING))
         return true;
 
-    collector_error("Cannot start thread %s with invalid state %u.", em->info.thread_name, (unsigned int)em->enabled);
+    collector_error("Cannot start thread %s with invalid state %u.", em->info.thread_name, (unsigned int)enabled);
     return false;
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -590,7 +590,7 @@ static void ebpf_cachestat_exit(void *pptr)
 
     if (!cachestat_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
@@ -602,7 +602,7 @@ static void ebpf_cachestat_exit(void *pptr)
     if (ebpf_read_cachestat.thread)
         nd_thread_signal_cancel(ebpf_read_cachestat.thread);
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_cachestat_cgroup_charts(em);
@@ -623,7 +623,7 @@ static void ebpf_cachestat_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 
     freez(cachestat_vector);

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -498,7 +498,7 @@ static void ebpf_dcstat_exit(void *pptr)
     if (ebpf_read_dcstat.thread)
         nd_thread_signal_cancel(ebpf_read_dcstat.thread);
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_dc_cgroup_charts(em);
@@ -519,7 +519,7 @@ static void ebpf_dcstat_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_disk.c
+++ b/src/collectors/ebpf.plugin/ebpf_disk.c
@@ -478,12 +478,12 @@ static void ebpf_disk_exit(void *pptr)
 
     if (!disk_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         ebpf_obsolete_disk_global(em);
         netdata_mutex_unlock(&lock);
@@ -510,7 +510,7 @@ static void ebpf_disk_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -621,7 +621,7 @@ static void ebpf_fd_exit(void *pptr)
 
     if (!fd_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
@@ -635,7 +635,7 @@ static void ebpf_fd_exit(void *pptr)
         nd_thread_join(ebpf_read_fd.thread);
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_fd_cgroup_charts(em);
@@ -661,7 +661,7 @@ static void ebpf_fd_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/src/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -905,12 +905,12 @@ static void ebpf_filesystem_exit(void *pptr)
     }
     if (!dimensions && !filesystem_hash_values && !has_resources) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         ebpf_obsolete_filesystem_global(em);
 
@@ -930,7 +930,7 @@ static void ebpf_filesystem_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_functions.c
+++ b/src/collectors/ebpf.plugin/ebpf_functions.c
@@ -25,7 +25,7 @@ static int ebpf_function_start_thread(ebpf_module_t *em, int period)
         period = EBPF_DEFAULT_LIFETIME;
 
     st->thread = NULL;
-    em->enabled = NETDATA_THREAD_EBPF_FUNCTION_RUNNING;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_FUNCTION_RUNNING);
     em->lifetime = period;
 
 #ifdef NETDATA_INTERNAL_CHECKS
@@ -427,7 +427,7 @@ static void ebpf_function_socket_manipulation(
     }
     rw_spinlock_write_unlock(&ebpf_judy_pid.index.rw_spinlock);
 
-    if (em->enabled > NETDATA_THREAD_EBPF_FUNCTION_RUNNING) {
+    if (ebpf_module_enabled_get(em) > NETDATA_THREAD_EBPF_FUNCTION_RUNNING) {
         // Cleanup when we already had a thread running
         rw_spinlock_write_lock(&ebpf_judy_pid.index.rw_spinlock);
         ebpf_socket_clean_judy_array_unsafe();
@@ -443,8 +443,9 @@ static void ebpf_function_socket_manipulation(
     } else {
         netdata_mutex_lock(&ebpf_exit_cleanup);
         if (period < 0)
-            em->lifetime = (em->enabled != NETDATA_THREAD_EBPF_FUNCTION_RUNNING) ? EBPF_NON_FUNCTION_LIFE_TIME :
-                                                                                   EBPF_DEFAULT_LIFETIME;
+            em->lifetime = (ebpf_module_enabled_get(em) != NETDATA_THREAD_EBPF_FUNCTION_RUNNING) ?
+                               EBPF_NON_FUNCTION_LIFE_TIME :
+                               EBPF_DEFAULT_LIFETIME;
     }
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 

--- a/src/collectors/ebpf.plugin/ebpf_functions.c
+++ b/src/collectors/ebpf.plugin/ebpf_functions.c
@@ -8,6 +8,30 @@
  *  EBPF FUNCTION COMMON
  *****************************************************************/
 
+typedef struct ebpf_function_thread_start {
+    ebpf_module_t *em;
+    void (*start_routine)(void *);
+    bool ready;
+    bool run;
+} ebpf_function_thread_start_t;
+
+static void ebpf_function_thread_start(void *ptr)
+{
+    ebpf_function_thread_start_t *ctx = ptr;
+
+    // Keep the new thread parked until its owner publishes the module state.
+    while (!__atomic_load_n(&ctx->ready, __ATOMIC_ACQUIRE))
+        tinysleep();
+
+    bool run = __atomic_load_n(&ctx->run, __ATOMIC_ACQUIRE);
+    ebpf_module_t *em = ctx->em;
+    void (*start_routine)(void *) = ctx->start_routine;
+    freez(ctx);
+
+    if (run)
+        start_routine(em);
+}
+
 /**
  * Function Start thread
  *
@@ -24,16 +48,40 @@ static int ebpf_function_start_thread(ebpf_module_t *em, int period)
     if (period <= 0)
         period = EBPF_DEFAULT_LIFETIME;
 
-    st->thread = NULL;
-    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_FUNCTION_RUNNING);
-    em->lifetime = period;
-
 #ifdef NETDATA_INTERNAL_CHECKS
     netdata_log_info("Starting thread %s with lifetime = %d", em->info.thread_name, period);
 #endif
 
-    st->thread = nd_thread_create(st->name, NETDATA_THREAD_OPTION_DEFAULT, st->start_routine, em);
-    return st->thread ? 0 : 1;
+    ebpf_function_thread_start_t *ctx = callocz(1, sizeof(*ctx));
+    ctx->em = em;
+    ctx->start_routine = st->start_routine;
+
+    ND_THREAD *thread = nd_thread_create(st->name, NETDATA_THREAD_OPTION_DEFAULT, ebpf_function_thread_start, ctx);
+    if (!thread) {
+        freez(ctx);
+        return 1;
+    }
+
+    bool run = true;
+    netdata_mutex_lock(&ebpf_exit_cleanup);
+    if (ebpf_plugin_stop())
+        run = false;
+    else {
+        st->thread = thread;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_FUNCTION_RUNNING);
+        em->lifetime = period;
+    }
+    __atomic_store_n(&ctx->run, run, __ATOMIC_RELEASE);
+    __atomic_store_n(&ctx->ready, true, __ATOMIC_RELEASE);
+    netdata_mutex_unlock(&ebpf_exit_cleanup);
+
+    if (!run) {
+        nd_thread_signal_cancel(thread);
+        nd_thread_join(thread);
+        return 1;
+    }
+
+    return 0;
 }
 
 /*****************************************************************
@@ -434,10 +482,8 @@ static void ebpf_function_socket_manipulation(
         rw_spinlock_write_unlock(&ebpf_judy_pid.index.rw_spinlock);
 
         collect_pids |= 1 << EBPF_MODULE_SOCKET_IDX;
-        netdata_mutex_lock(&ebpf_exit_cleanup);
         if (ebpf_function_start_thread(em, period)) {
             ebpf_function_error(transaction, HTTP_RESP_INTERNAL_SERVER_ERROR, "Cannot start thread.");
-            netdata_mutex_unlock(&ebpf_exit_cleanup);
             return;
         }
     } else {
@@ -446,8 +492,8 @@ static void ebpf_function_socket_manipulation(
             em->lifetime = (ebpf_module_enabled_get(em) != NETDATA_THREAD_EBPF_FUNCTION_RUNNING) ?
                                EBPF_NON_FUNCTION_LIFE_TIME :
                                EBPF_DEFAULT_LIFETIME;
+        netdata_mutex_unlock(&ebpf_exit_cleanup);
     }
-    netdata_mutex_unlock(&ebpf_exit_cleanup);
 
     BUFFER *wb = buffer_create(4096, NULL);
     buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_NEWLINE_ON_ARRAY_ITEMS);

--- a/src/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/src/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -224,7 +224,7 @@ static void hardirq_cleanup(void *pptr)
     if (!em)
         return;
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
         if (hardirq_safe_clean)
@@ -236,7 +236,7 @@ static void hardirq_cleanup(void *pptr)
 
     if (!hardirq_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
@@ -275,7 +275,7 @@ static void hardirq_cleanup(void *pptr)
     }
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/src/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -161,12 +161,12 @@ static void mdflush_exit(void *pptr)
 
     if (!mdflush_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
         ebpf_obsolete_mdflush_global(em);
@@ -179,7 +179,7 @@ static void mdflush_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_mount.c
+++ b/src/collectors/ebpf.plugin/ebpf_mount.c
@@ -279,7 +279,7 @@ static void ebpf_mount_exit(void *pptr)
     if (!em)
         return;
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
         ebpf_obsolete_mount_global(em);
@@ -292,7 +292,7 @@ static void ebpf_mount_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/src/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -126,7 +126,7 @@ static void oomkill_cleanup(void *pptr)
     collect_pids &= ~(1 << EBPF_MODULE_OOMKILL_IDX);
     netdata_mutex_unlock(&lock);
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
         if (em->cgroup_charts) {
@@ -143,7 +143,7 @@ static void oomkill_cleanup(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -565,14 +565,14 @@ void ebpf_oomkill_thread(void *ptr)
         // When we are not running integration with apps, we won't fill necessary variables for this thread to run, so
         // we need to disable it.
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        if (em->enabled)
+        if (ebpf_module_enabled_get(em))
             netdata_log_info("%s apps integration is completely disabled.", NETDATA_DEFAULT_OOM_DISABLED_MSG);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
 
         goto endoomkill;
     } else if (running_on_kernel < NETDATA_EBPF_KERNEL_4_14) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        if (em->enabled)
+        if (ebpf_module_enabled_get(em))
             netdata_log_info("%s kernel does not have necessary tracepoints.", NETDATA_DEFAULT_OOM_DISABLED_MSG);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
 

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -962,7 +962,7 @@ static void ebpf_process_exit(void *pptr)
 
     if (!process_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
@@ -971,7 +971,7 @@ static void ebpf_process_exit(void *pptr)
     collect_pids &= ~(1 << EBPF_MODULE_PROCESS_IDX);
     netdata_mutex_unlock(&lock);
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_process_cgroup_charts(em);
@@ -998,7 +998,7 @@ static void ebpf_process_exit(void *pptr)
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
     process_pid_fd = -1;
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -1795,7 +1795,8 @@ void ebpf_process_thread(void *ptr)
     CLEANUP_FUNCTION_REGISTER(ebpf_process_exit) cleanup_ptr = em;
 
     if (!ebpf_module_thread_has_valid_state(em)) {
-        em->enabled = em->global_charts = em->apps_charts = em->cgroup_charts = NETDATA_THREAD_EBPF_STOPPING;
+        em->global_charts = em->apps_charts = em->cgroup_charts = NETDATA_THREAD_EBPF_STOPPING;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPING);
         netdata_mutex_lock(&ebpf_exit_cleanup);
         ebpf_update_disabled_plugin_stats(em);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
@@ -1806,7 +1807,8 @@ void ebpf_process_thread(void *ptr)
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
     if (ebpf_process_enable_tracepoints()) {
-        em->enabled = em->global_charts = em->apps_charts = em->cgroup_charts = NETDATA_THREAD_EBPF_STOPPING;
+        em->global_charts = em->apps_charts = em->cgroup_charts = NETDATA_THREAD_EBPF_STOPPING;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPING);
     }
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 
@@ -1816,7 +1818,8 @@ void ebpf_process_thread(void *ptr)
 
     set_local_pointers();
     if (ebpf_process_load_bpf(em)) {
-        em->enabled = em->global_charts = em->apps_charts = em->cgroup_charts = NETDATA_THREAD_EBPF_STOPPING;
+        em->global_charts = em->apps_charts = em->cgroup_charts = NETDATA_THREAD_EBPF_STOPPING;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPING);
     }
 
     int algorithms[NETDATA_KEY_PUBLISH_PROCESS_END] = {

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -481,7 +481,7 @@ static void ebpf_shm_exit(void *pptr)
         nd_thread_join(ebpf_read_shm.thread);
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_shm_cgroup_charts(em);
@@ -502,7 +502,7 @@ static void ebpf_shm_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -525,7 +525,7 @@ static inline int ebpf_socket_load_and_attach(struct socket_bpf *obj, ebpf_modul
 static void ebpf_socket_free(ebpf_module_t *em)
 {
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     ebpf_update_stats(&plugin_statistics, em);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 
@@ -930,7 +930,7 @@ static void ebpf_socket_exit(void *pptr)
         nd_thread_join(ebpf_read_socket.thread);
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
         if (em->cgroup_charts) {

--- a/src/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/src/collectors/ebpf.plugin/ebpf_softirq.c
@@ -75,12 +75,12 @@ static void softirq_cleanup(void *pptr)
 
     if (!softirq_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
         ebpf_obsolete_softirq_global(em);
@@ -99,7 +99,7 @@ static void softirq_cleanup(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -452,7 +452,7 @@ static void ebpf_swap_exit(void *pptr)
         nd_thread_join(ebpf_read_swap.thread);
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_swap_cgroup_charts(em);
@@ -471,7 +471,7 @@ static void ebpf_swap_exit(void *pptr)
 
     if (!swap_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
@@ -485,7 +485,7 @@ static void ebpf_swap_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_sync.c
+++ b/src/collectors/ebpf.plugin/ebpf_sync.c
@@ -288,7 +288,7 @@ static void ebpf_sync_exit(void *pptr)
     if (!em)
         return;
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         ebpf_obsolete_sync_global(em);
         netdata_mutex_unlock(&lock);
@@ -298,7 +298,7 @@ static void ebpf_sync_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/src/collectors/ebpf.plugin/ebpf_vfs.c
@@ -909,7 +909,7 @@ static void ebpf_vfs_exit(void *pptr)
     if (ebpf_read_vfs.thread)
         nd_thread_signal_cancel(ebpf_read_vfs.thread);
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_vfs_cgroup_charts(em);
@@ -930,7 +930,7 @@ static void ebpf_vfs_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/libbpf_api/ebpf.c
+++ b/src/collectors/ebpf.plugin/libbpf_api/ebpf.c
@@ -532,7 +532,7 @@ void ebpf_update_stats(ebpf_plugin_stats_t *report, ebpf_module_t *em)
     int value;
 
     // It is not necessary to report more information.
-    if (em->enabled > NETDATA_THREAD_EBPF_FUNCTION_RUNNING)
+    if (ebpf_module_enabled_get(em) > NETDATA_THREAD_EBPF_FUNCTION_RUNNING)
         value = -1;
     else
         value = 1;

--- a/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
+++ b/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
@@ -409,7 +409,7 @@ void ebpf_set_thread_mode(netdata_run_mode_t lmode)
 
 void ebpf_enable_specific_chart(ebpf_module_t *em, int disable_cgroup)
 {
-    em->enabled = NETDATA_THREAD_EBPF_RUNNING;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_RUNNING);
 
     if (!disable_cgroup) {
         em->cgroup_charts = CONFIG_BOOLEAN_YES;
@@ -527,7 +527,7 @@ void read_collector_values(int *disable_cgroups, int update_every, netdata_ebpf_
 
     network_viewer_opt.enabled = enabled;
     if (enabled) {
-        if (!ebpf_modules[EBPF_MODULE_SOCKET_IDX].enabled)
+        if (!ebpf_module_enabled_get(&ebpf_modules[EBPF_MODULE_SOCKET_IDX]))
             ebpf_enable_chart(EBPF_MODULE_SOCKET_IDX, *disable_cgroups);
 
         parse_network_viewer_section(&collector_config);
@@ -1225,7 +1225,7 @@ void ebpf_parse_ips_unsafe(const char *ptr)
  */
 void ebpf_create_apps_for_module(ebpf_module_t *em, ebpf_target_t *root)
 {
-    if (em->enabled < NETDATA_THREAD_EBPF_STOPPING && em->apps_charts && em->functions.apps_routine)
+    if (ebpf_module_enabled_get(em) < NETDATA_THREAD_EBPF_STOPPING && em->apps_charts && em->functions.apps_routine)
         em->functions.apps_routine(em, root);
 }
 
@@ -1609,7 +1609,7 @@ void disable_all_global_charts()
 {
     int i;
     for (i = 0; ebpf_modules[i].info.thread_name; i++) {
-        ebpf_modules[i].enabled = NETDATA_THREAD_EBPF_NOT_RUNNING;
+        ebpf_module_enabled_set(&ebpf_modules[i], NETDATA_THREAD_EBPF_NOT_RUNNING);
         ebpf_modules[i].global_charts = 0;
     }
 }

--- a/src/collectors/log2journal/log2journal-logfmt.c
+++ b/src/collectors/log2journal/log2journal-logfmt.c
@@ -53,7 +53,7 @@ static inline bool logftm_parse_value(LOGFMT_STATE *lfs) {
 
     char quote = '\0';
     const char *s = logfmt_current_pos(lfs);
-    if(*s == '\"' || *s == '\'') {
+    if(*s == '"' || *s == '\'') {
         quote = *s;
         logfmt_consume_char(lfs);
     }
@@ -70,27 +70,31 @@ static inline bool logftm_parse_value(LOGFMT_STATE *lfs) {
         if (*s == '\\') {
             s++;
 
-            switch (*s) {
-                case 'n':
-                    copy_newline(lfs, &d, &remaining);
-                    s++;
-                    continue;
+            if(!*s)
+                c = '\\';
+            else {
+                switch (*s) {
+                    case 'n':
+                        copy_newline(lfs, &d, &remaining);
+                        s++;
+                        continue;
 
-                case 't':
-                    copy_tab(lfs, &d, &remaining);
-                    s++;
-                    continue;
+                    case 't':
+                        copy_tab(lfs, &d, &remaining);
+                        s++;
+                        continue;
 
-                case 'f':
-                case 'b':
-                case 'r':
-                    c = ' ';
-                    s++;
-                    break;
+                    case 'f':
+                    case 'b':
+                    case 'r':
+                        c = ' ';
+                        s++;
+                        break;
 
-                default:
-                    c = *s++;
-                    break;
+                    default:
+                        c = *s++;
+                        break;
+                }
             }
         }
         else
@@ -140,10 +144,16 @@ static inline bool logfmt_parse_key(LOGFMT_STATE *lfs) {
     while(*s && *s != '=') {
         char c;
 
-        if (*s == '\\')
+        if (*s == '\\') {
             s++;
 
-        c = journal_key_characters_map[(unsigned char)*s++];
+            if(!*s)
+                c = journal_key_characters_map[(unsigned char)'\\'];
+            else
+                c = journal_key_characters_map[(unsigned char)*s++];
+        }
+        else
+            c = journal_key_characters_map[(unsigned char)*s++];
 
         if(c == '_' && last_c == '_')
             continue;

--- a/src/collectors/log2journal/log2journal-pcre2.c
+++ b/src/collectors/log2journal/log2journal-pcre2.c
@@ -24,7 +24,7 @@ static inline void copy_and_convert_key(PCRE2_STATE *pcre2, const char *key) {
     size_t remaining = sizeof(pcre2->key) - pcre2->key_start;
 
     while(remaining >= 2 && *key) {
-        *d = journal_key_characters_map[(unsigned) (*key)];
+        *d = journal_key_characters_map[(unsigned char)*key];
         remaining--;
         key++;
         d++;

--- a/src/collectors/log2journal/tests.d/logfmt-trailing-backslash.input
+++ b/src/collectors/log2journal/tests.d/logfmt-trailing-backslash.input
@@ -1,0 +1,1 @@
+key=value\

--- a/src/collectors/log2journal/tests.d/logfmt-trailing-backslash.output
+++ b/src/collectors/log2journal/tests.d/logfmt-trailing-backslash.output
@@ -1,0 +1,2 @@
+KEY=value\
+

--- a/src/collectors/log2journal/tests.d/logfmt-trailing-backslash.yaml
+++ b/src/collectors/log2journal/tests.d/logfmt-trailing-backslash.yaml
@@ -1,0 +1,1 @@
+pattern: logfmt

--- a/src/collectors/proc.plugin/proc_mdstat.c
+++ b/src/collectors/proc.plugin/proc_mdstat.c
@@ -70,8 +70,8 @@ static inline void make_chart_obsolete(char *name, const char *id_modifier)
     RRDSET *st = NULL;
 
     if (likely(name && id_modifier)) {
-        snprintfz(id, sizeof(id) - 1, "mdstat.%s_%s", name, id_modifier);
-        st = rrdset_find_active_byname_localhost(id);
+        snprintfz(id, sizeof(id) - 1, "%s_%s", name, id_modifier);
+        st = rrdset_find_active_bytype_localhost("mdstat", id);
         if (likely(st))
             rrdset_is_obsolete___safe_from_collector_thread(st);
     }

--- a/src/collectors/proc.plugin/sys_class_power_supply.c
+++ b/src/collectors/proc.plugin/sys_class_power_supply.c
@@ -274,7 +274,8 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
             struct ps_property *pr;
             if (likely(ps))
             {
-                for(pr = ps->property_root; pr && !read_error; pr = pr->next) {
+                for(pr = ps->property_root; pr && !read_error; ) {
+                    struct ps_property *next = pr->next;
                     struct ps_property_dim *pd;
                     for(pd = pr->property_dim_root; pd; pd = pd->next) {
                         if(likely(!pd->always_zero)) {
@@ -286,6 +287,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                                     collector_error("Cannot open file '%s'", pd->filename);
                                     read_error = 1;
                                     power_supply_free(ps);
+                                    ps = NULL;
                                     break;
                                 }
                             }
@@ -295,6 +297,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                                 collector_error("Cannot read file '%s'", pd->filename);
                                 read_error = 1;
                                 power_supply_free(ps);
+                                ps = NULL;
                                 break;
                             }
                             buffer[r] = '\0';
@@ -311,6 +314,11 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                             }
                         }
                     }
+
+                    if(unlikely(read_error))
+                        break;
+
+                    pr = next;
                 }
             }
         }

--- a/src/collectors/statsd.plugin/statsd.c
+++ b/src/collectors/statsd.plugin/statsd.c
@@ -540,13 +540,15 @@ static inline void statsd_process_histogram_or_timer(STATSD_METRIC *m, const cha
         return;
     }
 
-    if(unlikely(m->reset)) {
-        m->histogram.ext->used = 0;
-        statsd_reset_metric(m);
-    }
-
     if(unlikely(value_is_zinit(value))) {
         // magic loading of metric, without affecting anything
+
+        netdata_mutex_lock(&m->histogram.ext->mutex);
+        if(unlikely(m->reset)) {
+            m->histogram.ext->used = 0;
+            statsd_reset_metric(m);
+        }
+        netdata_mutex_unlock(&m->histogram.ext->mutex);
     }
     else {
         NETDATA_DOUBLE v = statsd_parse_float(value, 1.0);
@@ -555,18 +557,23 @@ static inline void statsd_process_histogram_or_timer(STATSD_METRIC *m, const cha
         if(unlikely(isgreater(sampling_rate, 1.0))) sampling_rate = 1.0;
 
         long long samples = llrintndd(1.0 / sampling_rate);
-        while(samples-- > 0) {
+        netdata_mutex_lock(&m->histogram.ext->mutex);
 
+        if(unlikely(m->reset)) {
+            m->histogram.ext->used = 0;
+            statsd_reset_metric(m);
+        }
+
+        while(samples-- > 0) {
             if(unlikely(m->histogram.ext->used == m->histogram.ext->size)) {
-                netdata_mutex_lock(&m->histogram.ext->mutex);
                 m->histogram.ext->size += statsd.histogram_increase_step;
                 m->histogram.ext->values = reallocz(m->histogram.ext->values, sizeof(NETDATA_DOUBLE) * m->histogram.ext->size);
-                netdata_mutex_unlock(&m->histogram.ext->mutex);
             }
 
             m->histogram.ext->values[m->histogram.ext->used++] = v;
         }
 
+        netdata_mutex_unlock(&m->histogram.ext->mutex);
         metric_update_counters_and_obsoletion(m);
     }
 }
@@ -1972,29 +1979,32 @@ static inline void statsd_flush_timer_or_histogram(STATSD_METRIC *m, const char 
     netdata_log_debug(D_STATSD, "flushing %s metric '%s'", dim, m->name);
 
     int updated = 0;
-    if(unlikely(!m->reset && m->count && m->histogram.ext->used > 0)) {
+    if(unlikely(!m->reset && m->count)) {
         netdata_mutex_lock(&m->histogram.ext->mutex);
 
-        size_t len = m->histogram.ext->used;
-        NETDATA_DOUBLE *series = m->histogram.ext->values;
-        sort_series(series, len);
+        if(likely(m->histogram.ext->used > 0)) {
+            size_t len = m->histogram.ext->used;
+            NETDATA_DOUBLE *series = m->histogram.ext->values;
+            sort_series(series, len);
 
-        m->histogram.ext->last_min = (collected_number)roundndd(series[0] * statsd.decimal_detail);
-        m->histogram.ext->last_max = (collected_number)roundndd(series[len - 1] * statsd.decimal_detail);
-        m->last = (collected_number)roundndd(average(series, len) * statsd.decimal_detail);
-        m->histogram.ext->last_stddev = (collected_number)roundndd(standard_deviation(series, len) * statsd.decimal_detail);
-        m->histogram.ext->last_sum = (collected_number)roundndd(sum(series, len) * statsd.decimal_detail);
-        m->histogram.ext->last_median = (collected_number)roundndd(median_on_sorted_series(series, len) * statsd.decimal_detail);
-        m->histogram.ext->last_percentile = (collected_number)roundndd(percentile_on_sorted_series(series, len,  statsd.histogram_percentile / 100) * statsd.decimal_detail);
+            m->histogram.ext->last_min = (collected_number)roundndd(series[0] * statsd.decimal_detail);
+            m->histogram.ext->last_max = (collected_number)roundndd(series[len - 1] * statsd.decimal_detail);
+            m->last = (collected_number)roundndd(average(series, len) * statsd.decimal_detail);
+            m->histogram.ext->last_stddev = (collected_number)roundndd(standard_deviation(series, len) * statsd.decimal_detail);
+            m->histogram.ext->last_sum = (collected_number)roundndd(sum(series, len) * statsd.decimal_detail);
+            m->histogram.ext->last_median = (collected_number)roundndd(median_on_sorted_series(series, len) * statsd.decimal_detail);
+            m->histogram.ext->last_percentile = (collected_number)roundndd(percentile_on_sorted_series(series, len,  statsd.histogram_percentile / 100) * statsd.decimal_detail);
+
+            m->histogram.ext->zeroed = 0;
+            m->reset = 1;
+            updated = 1;
+        }
 
         netdata_mutex_unlock(&m->histogram.ext->mutex);
 
-        netdata_log_debug(D_STATSD, "STATSD %s metric %s: min " COLLECTED_NUMBER_FORMAT ", max " COLLECTED_NUMBER_FORMAT ", last " COLLECTED_NUMBER_FORMAT ", pcent " COLLECTED_NUMBER_FORMAT ", median " COLLECTED_NUMBER_FORMAT ", stddev " COLLECTED_NUMBER_FORMAT ", sum " COLLECTED_NUMBER_FORMAT,
-              dim, m->name, m->histogram.ext->last_min, m->histogram.ext->last_max, m->last, m->histogram.ext->last_percentile, m->histogram.ext->last_median, m->histogram.ext->last_stddev, m->histogram.ext->last_sum);
-
-        m->histogram.ext->zeroed = 0;
-        m->reset = 1;
-        updated = 1;
+        if(updated)
+            netdata_log_debug(D_STATSD, "STATSD %s metric %s: min " COLLECTED_NUMBER_FORMAT ", max " COLLECTED_NUMBER_FORMAT ", last " COLLECTED_NUMBER_FORMAT ", pcent " COLLECTED_NUMBER_FORMAT ", median " COLLECTED_NUMBER_FORMAT ", stddev " COLLECTED_NUMBER_FORMAT ", sum " COLLECTED_NUMBER_FORMAT,
+                  dim, m->name, m->histogram.ext->last_min, m->histogram.ext->last_max, m->last, m->histogram.ext->last_percentile, m->histogram.ext->last_median, m->histogram.ext->last_stddev, m->histogram.ext->last_sum);
     }
     else if(unlikely(!m->histogram.ext->zeroed)) {
         // reset the metrics

--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -625,7 +625,7 @@ void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, 
 
     bool existing = false;
     bool *found = dictionary_set(dirs, dirname, &existing, sizeof(existing));
-    if (*found) {
+    if (unlikely(!found) || *found) {
         closedir(dir);
         return;
     }

--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -625,8 +625,10 @@ void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, 
 
     bool existing = false;
     bool *found = dictionary_set(dirs, dirname, &existing, sizeof(existing));
-    if (*found)
+    if (*found) {
+        closedir(dir);
         return;
+    }
     *found = true;
 
     // Read each entry in the directory.

--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -625,7 +625,12 @@ void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, 
 
     bool existing = false;
     bool *found = dictionary_set(dirs, dirname, &existing, sizeof(existing));
-    if (unlikely(!found) || *found) {
+    if (unlikely(!found)) {
+        netdata_log_error("Cannot track visited directory '%s' (dictionary_set failed); stopping recursion", dirname);
+        closedir(dir);
+        return;
+    }
+    if (*found) {
         closedir(dir);
         return;
     }

--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -639,7 +639,7 @@ void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, 
         ssize_t len = snprintfz(full_path, sizeof(full_path), "%s/%s", dirname, entry->d_name);
 
         if (entry->d_type == DT_DIR) {
-            nd_journal_directory_scan_recursively(files, dirs, full_path, depth++);
+            nd_journal_directory_scan_recursively(files, dirs, full_path, depth + 1);
         } else if (entry->d_type == DT_REG && is_journal_file(full_path, len, NULL)) {
             if (files)
                 dictionary_set(files, full_path, NULL, 0);
@@ -654,7 +654,7 @@ void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, 
                 // The symbolic link points to a directory
                 char resolved_path[FILENAME_MAX + 1];
                 if (realpath(full_path, resolved_path) != NULL) {
-                    nd_journal_directory_scan_recursively(files, dirs, resolved_path, depth++);
+                    nd_journal_directory_scan_recursively(files, dirs, resolved_path, depth + 1);
                 }
             } else if (S_ISREG(info.st_mode) && is_journal_file(full_path, len, NULL)) {
                 if (files)

--- a/src/collectors/xenstat.plugin/xenstat_plugin.c
+++ b/src/collectors/xenstat.plugin/xenstat_plugin.c
@@ -389,6 +389,7 @@ static int xenstat_collect(xenstat_handle *xhandle, libxl_ctx *ctx, libxl_dominf
         unsigned int id = xenstat_domain_id(domain);
         if(unlikely(libxl_domain_info(ctx, info, id))) {
             netdata_log_error("XENSTAT: cannot get domain info.");
+            continue;
         }
         else {
             snprintfz(uuid, LIBXL_UUID_FMTLEN, LIBXL_UUID_FMT "\n", LIBXL_UUID_BYTES(info->uuid));

--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -389,9 +389,7 @@ static int remove_ephemeral_host(BUFFER *wb, RRDHOST *host, bool report_error, b
         host->node_id = UUID_ZERO;
         buffer_sprintf(wb, "Node '%s' (machine guid: %s) has been unregistered",
                        rrdhost_hostname(host), host->machine_guid);
-        rrd_wrlock();
-        rrdhost_free___while_having_rrd_wrlock(host);
-        rrd_wrunlock();
+        rrdhost_free___without_having_rrd_wrlock(host);
         return 1;
     }
 

--- a/src/daemon/machine-guid.c
+++ b/src/daemon/machine-guid.c
@@ -209,16 +209,12 @@ static ND_MACHINE_GUID machine_guid_get_or_create(void) {
     rfc3339_datetime_ut(h.last_modified_ut_rfc3339, sizeof(h.last_modified_ut_rfc3339), h.last_modified_ut, 2, true);
     nd_machine_guid = h;
 
-    // Ensure the registry directory exists.
-    if (access(pathname, W_OK) != 0) {
-        nd_log(NDLS_DAEMON, NDLP_DEBUG, "MACHINE_GUID: cannot access directory '%s'. Attempting to create it.", pathname);
-
-        errno_clear();
-        if (mkdir(pathname, 0775) != 0 && errno != EEXIST) {
-            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot create directory '%s'", pathname);
-            // Even if directory creation fails, continue with in-memory GUID.
-            return h;
-        }
+    // Avoid a check-then-create race; mkdir() + EEXIST is sufficient.
+    errno_clear();
+    if (mkdir(pathname, 0775) != 0 && errno != EEXIST) {
+        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot create directory '%s'", pathname);
+        // Even if directory creation fails, continue with in-memory GUID.
+        return h;
     }
 
     errno_clear();

--- a/src/daemon/machine-guid.c
+++ b/src/daemon/machine-guid.c
@@ -211,10 +211,20 @@ static ND_MACHINE_GUID machine_guid_get_or_create(void) {
 
     // Avoid a check-then-create race; mkdir() + EEXIST is sufficient.
     errno_clear();
-    if (mkdir(pathname, 0775) != 0 && errno != EEXIST) {
-        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot create directory '%s'", pathname);
-        // Even if directory creation fails, continue with in-memory GUID.
-        return h;
+    if (mkdir(pathname, 0775) != 0) {
+        if (errno != EEXIST) {
+            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot create directory '%s'", pathname);
+            // Even if directory creation fails, continue with in-memory GUID.
+            return h;
+        }
+
+        // EEXIST — verify it is actually a directory.
+        struct stat st;
+        if (stat(pathname, &st) != 0 || !S_ISDIR(st.st_mode)) {
+            nd_log(NDLS_DAEMON, NDLP_ERR,
+                   "MACHINE_GUID: path '%s' exists but is not a directory", pathname);
+            return h;
+        }
     }
 
     errno_clear();

--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -96,7 +96,7 @@ void nd_signal_handler(int signo, siginfo_t *info, void *context __maybe_unused)
                 len = strcatz(b, len, ")", sizeof(b));
             }
             len = strcatz(b, len, " in thread ", sizeof(b));
-            print_uint64(&b[len], gettid_cached());
+            len += print_uint64(&b[len], gettid_cached());
             len = strcatz(b, len, " ", sizeof(b));
             len = strcatz(b, len, nd_thread_tag_async_safe(), sizeof(b));
             len = strcatz(b, len, "!\n", sizeof(b));

--- a/src/database/contexts/api_v2_contexts_alerts.c
+++ b/src/database/contexts/api_v2_contexts_alerts.c
@@ -254,7 +254,7 @@ static void alerts_v2_insert_callback(const DICTIONARY_ITEM *item __maybe_unused
     t->ati = ctl->alerts.ati++;
 
     t->nodes = dictionary_create(DICT_OPTION_SINGLE_THREADED|DICT_OPTION_VALUE_LINK_DONT_CLONE|DICT_OPTION_NAME_LINK_DONT_CLONE);
-    t->configs = dictionary_create(DICT_OPTION_SINGLE_THREADED|DICT_OPTION_VALUE_LINK_DONT_CLONE|DICT_OPTION_NAME_LINK_DONT_CLONE);
+    t->configs = dictionary_create(DICT_OPTION_SINGLE_THREADED|DICT_OPTION_VALUE_LINK_DONT_CLONE);
 
     alerts_v2_add(t, rc);
 }

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1423,9 +1423,11 @@ bool journalfile_migrate_to_v2_callback(Word_t section, unsigned datafile_fileno
     uint32_t trailer_offset = total_file_size;
     total_file_size  += sizeof(struct journal_v2_block_trailer);
 
-    int fd_v2;
+    int fd_v2 = -1;
     uint8_t *data_start = nd_mmap_advanced(path, total_file_size, MAP_SHARED, 0, false, true, &fd_v2);
     if(!data_start) {
+        if(fd_v2 != -1)
+            close(fd_v2);
         nd_log_daemon(NDLP_WARNING, "DBENGINE: Failed to allocate %"PRIu64" bytes of memory for journal file \"%s\". Will retry later", total_file_size, path);
         return false;
     }
@@ -1603,6 +1605,8 @@ bool journalfile_migrate_to_v2_callback(Word_t section, unsigned datafile_fileno
     netdata_log_info("DBENGINE: failed to build index \"%s\", file will be skipped", path);
 
     nd_munmap(data_start, total_file_size);
+    if(fd_v2 != -1)
+        close(fd_v2);
     unlink(path);
     return false;
 }

--- a/src/database/rrdhost-status.c
+++ b/src/database/rrdhost-status.c
@@ -149,8 +149,19 @@ static inline RRDHOST_INGEST_STATUS rrdhost_status_ingest(RRDHOST *host, RRDHOST
     uint32_t collected_metrics = UINT32_MAX;
     uint32_t replicating_instances = UINT32_MAX;
 
-    time_t since = MAX(host->stream.rcv.status.last_connected, host->stream.rcv.status.last_disconnected);
-    STREAM_HANDSHAKE reason = host->stream.rcv.status.reason;
+    time_t last_connected;
+    time_t last_disconnected;
+    uint32_t connections;
+    STREAM_HANDSHAKE reason;
+
+    rrdhost_receiver_lock(host);
+    last_connected = host->stream.rcv.status.last_connected;
+    last_disconnected = host->stream.rcv.status.last_disconnected;
+    connections = host->stream.rcv.status.connections;
+    reason = host->stream.rcv.status.reason;
+    rrdhost_receiver_unlock(host);
+
+    time_t since = MAX(last_connected, last_disconnected);
 
     if (online) {
         if (db_status == RRDHOST_DB_STATUS_INITIALIZING)
@@ -169,7 +180,7 @@ static inline RRDHOST_INGEST_STATUS rrdhost_status_ingest(RRDHOST *host, RRDHOST
             status = RRDHOST_INGEST_STATUS_ONLINE;
     }
     else {
-        if(!host->stream.rcv.status.connections)
+        if(!connections)
             status = RRDHOST_INGEST_STATUS_ARCHIVED;
         else
             status = RRDHOST_INGEST_STATUS_OFFLINE;
@@ -215,7 +226,7 @@ static inline RRDHOST_INGEST_STATUS rrdhost_status_ingest(RRDHOST *host, RRDHOST
         else
             s->ingest.type = RRDHOST_INGEST_TYPE_ARCHIVED;
 
-        s->ingest.id = host->stream.rcv.status.connections;
+        s->ingest.id = connections;
     }
 
     return status;
@@ -395,4 +406,3 @@ RRDHOST_INGEST_STATUS rrdhost_get_ingest_status(RRDHOST *host, time_t now) {
     RRDHOST_DB_STATUS db_status = rrdhost_status_db(host, now, NULL, flags, online);
     return rrdhost_status_ingest(host, NULL, flags, db_status, online);
 }
-

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -800,23 +800,15 @@ void rrdhost_cleanup_data_collection_and_health(RRDHOST *host) {
            rrdhost_hostname(host));
 }
 
-void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host) {
-    if(!host) return;
-
-    nd_log(NDLS_DAEMON, NDLP_DEBUG,
-           "RRD: 'host:%s' freeing memory...",
-           rrdhost_hostname(host));
-
-    // ------------------------------------------------------------------------
-    // first remove it from the indexes, so that it will not be discoverable
-
+static void rrdhost_unlink___while_having_rrd_wrlock(RRDHOST *host) {
+    // Remove it from the indexes first, so blocking teardown cannot rediscover it.
     rrdhost_index_del_by_guid(host);
 
     if (host->prev)
         DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(localhost, host, prev, next);
+}
 
-    // ------------------------------------------------------------------------
-
+static void rrdhost_free_unlinked(RRDHOST *host) {
     rrdhost_cleanup_data_collection_and_health(host);
 
     // ------------------------------------------------------------------------
@@ -845,6 +837,23 @@ void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host) {
     string_freez(host->stream.snd.api_key);
     string_freez(host->stream.snd.destination);
     freez(host);
+}
+
+void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host) {
+    if(!host) return;
+
+    rrdhost_unlink___while_having_rrd_wrlock(host);
+    rrdhost_free_unlinked(host);
+}
+
+void rrdhost_free___without_having_rrd_wrlock(RRDHOST *host) {
+    if(!host) return;
+
+    rrd_wrlock();
+    rrdhost_unlink___while_having_rrd_wrlock(host);
+    rrd_wrunlock();
+
+    rrdhost_free_unlinked(host);
 }
 
 void rrdhost_free_all(void) {

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -456,6 +456,7 @@ RRDHOST *rrdhost_find_or_create(
 void rrdhost_free_all(void);
 
 void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host);
+void rrdhost_free___without_having_rrd_wrlock(RRDHOST *host);
 void rrdhost_cleanup_data_collection_and_health(RRDHOST *host);
 
 bool rrdhost_should_be_cleaned_up(RRDHOST *host, RRDHOST *protected_host, time_t now_s);

--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -424,7 +424,9 @@ void health_alarm_log_populate(
     time_t duration = sqlite3_column_int64(res, DURATION);
     alarm_log->duration =  (duration > 0) ? duration : 0;
 
-    alarm_log->non_clear_duration = sqlite3_column_int64(res, NON_CLEAR_DURATION);
+    int64_t non_clear_duration = sqlite3_column_int64(res, NON_CLEAR_DURATION);
+    alarm_log->non_clear_duration = (non_clear_duration <= 0) ? 0 :
+                                    (non_clear_duration > UINT32_MAX) ? UINT32_MAX : (uint32_t)non_clear_duration;
 
     alarm_log->status = rrdcalc_status_to_proto_enum(current_status);
     alarm_log->old_status = rrdcalc_status_to_proto_enum((RRDCALC_STATUS)sqlite3_column_int64(res, OLD_STATUS));

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2606,8 +2606,11 @@ static void start_metadata_hosts(uv_work_t *req)
     COMPUTE_DURATION(report_duration, "us", all_started_ut, now_monotonic_usec());
     nd_log_daemon(NDLP_DEBUG, "Checking all hosts completed in %s", report_duration);
 
+    // This helper already skips dimension deletion once shutdown starts, but it
+    // still has to release the worker-owned Judy list on that path.
+    do_pending_uuid_deletion(config, (struct judy_list_t *)worker->pending_uuid_deletion);
+
     if (!SHUTDOWN_REQUESTED(config)) {
-        do_pending_uuid_deletion(config, (struct judy_list_t *)worker->pending_uuid_deletion);
         run_metadata_cleanup(config);
     }
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2595,8 +2595,9 @@ static void start_metadata_hosts(uv_work_t *req)
 
     store_alert_transitions((struct judy_list_t *)worker->pending_alert_list, true, false);
 
-    if (!SHUTDOWN_REQUESTED(config))
-        store_ctx_cleanup_list(config, (struct judy_list_t *)worker->pending_ctx_cleanup_list);
+    // This helper already skips database scheduling once shutdown starts, but it
+    // still has to release the worker-owned Judy list on that path.
+    store_ctx_cleanup_list(config, (struct judy_list_t *)worker->pending_ctx_cleanup_list);
 
     worker_is_busy(UV_EVENT_METADATA_STORE);
 

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -122,7 +122,8 @@ static STRING *rrdcalc_replace_variables_with_rrdset_labels(const char *line, RR
             freez(temp);
             temp = buf;
         }
-        else if (!strncmp(var, RRDCALC_VAR_LABEL, RRDCALC_VAR_LABEL_LEN)) {
+        else if (!strncmp(var, RRDCALC_VAR_LABEL, RRDCALC_VAR_LABEL_LEN) &&
+                 i > (int)RRDCALC_VAR_LABEL_LEN && var[i - 1] == '}') {
             char label_val[RRDCALC_VAR_MAX + RRDCALC_VAR_LABEL_LEN + 1] = { 0 };
             strcpy(label_val, var+RRDCALC_VAR_LABEL_LEN);
             label_val[i - RRDCALC_VAR_LABEL_LEN - 1] = '\0';

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -441,18 +441,20 @@ void rrdcalc_unlink_and_delete(RRDHOST *host, RRDCALC *rc, bool having_ll_wrlock
 // RRDCALC cleanup API functions
 
 void rrdcalc_unlink_and_delete_all_rrdset_alerts(RRDSET *st) {
-    RRDCALC *rc, *last = NULL;
-    rw_spinlock_write_lock(&st->alerts.spinlock);
-    while((rc = st->alerts.base)) {
-        if(last == rc) {
-            netdata_log_error("RRDCALC: malformed list of alerts linked to chart - cannot cleanup - giving up.");
-            break;
-        }
-        last = rc;
+    RRDHOST *host = st->rrdhost;
+    RRDCALC *rc;
 
-        rrdcalc_unlink_and_delete(st->rrdhost, rc, true);
+    // Keep the removal snapshot under the alert dictionary write traversal lock,
+    // so it cannot race with concurrent health-thread updates of rc->value.
+    foreach_rrdcalc_in_rrdhost_write(host, rc) {
+        if(rc->rrdset != st)
+            continue;
+
+        rw_spinlock_write_lock(&st->alerts.spinlock);
+        rrdcalc_unlink_and_delete(host, rc, true);
+        rw_spinlock_write_unlock(&st->alerts.spinlock);
     }
-    rw_spinlock_write_unlock(&st->alerts.spinlock);
+    foreach_rrdcalc_in_rrdhost_done(rc);
 }
 
 void rrdcalc_delete_all(RRDHOST *host) {

--- a/src/libnetdata/datetime/rfc3339.c
+++ b/src/libnetdata/datetime/rfc3339.c
@@ -34,18 +34,24 @@ static inline size_t print_2digit(char *buffer, size_t size, int value) {
 }
 
 static inline size_t print_fraction(char *buffer, size_t size, usec_t fraction, size_t digits) {
-    if (!buffer || size < digits) return 0;
+    if (!buffer) return 0;
 
     // Validate and cap the number of digits
     digits = digits < 1 ? 1 : (digits > 9 ? 9 : digits);
+    if (size < digits) return 0;
 
-    // Calculate divisor to get correct precision
-    usec_t divisor = 1;
-    for (size_t i = 0; i < 6 - digits; i++)
-        divisor *= 10;
+    // Scale microseconds to the requested precision
+    if (digits < 6) {
+        usec_t divisor = 1;
+        for (size_t i = digits; i < 6; i++)
+            divisor *= 10;
 
-    // Calculate the fraction to print
-    fraction = fraction / divisor;
+        fraction /= divisor;
+    }
+    else if (digits > 6) {
+        for (size_t i = 6; i < digits; i++)
+            fraction *= 10;
+    }
 
     // Ensure fraction won't exceed the requested number of digits
     usec_t max_value = 1;

--- a/src/libnetdata/dictionary/dictionary-item.h
+++ b/src/libnetdata/dictionary/dictionary-item.h
@@ -482,6 +482,7 @@ static inline DICTIONARY_ITEM *dict_item_add_or_reset_value_and_acquire(DICTIONA
 
             if(item_check_and_acquire_advanced(dict, item, true) != RC_ITEM_OK) {
                 spins++;
+                item = NULL;
                 continue;
             }
 

--- a/src/libnetdata/dictionary/dictionary-unittest.c
+++ b/src/libnetdata/dictionary/dictionary-unittest.c
@@ -1026,6 +1026,7 @@ size_t dictionary_unittest_views(void) {
     }
     else if(item_flag_check(view_item2, ITEM_FLAG_DELETED) || view_item2->shared != master_item2->shared) {
         fprintf(stderr, "View replacement returned stale/deleted item\n");
+        dictionary_acquired_item_release(view, view_item2);
         errors++;
     }
     else

--- a/src/libnetdata/dictionary/dictionary-unittest.c
+++ b/src/libnetdata/dictionary/dictionary-unittest.c
@@ -935,6 +935,9 @@ size_t dictionary_unittest_views(void) {
     struct dictionary_stats stats = {};
     DICTIONARY *master = dictionary_create_advanced(DICT_OPTION_NONE, &stats, 0);
     DICTIONARY *view = dictionary_create_view(master);
+    DICTIONARY_ITEM *master_item2 = NULL;
+    DICTIONARY_ITEM *view_item2 = NULL;
+    DICTIONARY_ITEM *lookup = NULL;
 
     fprintf(stderr, "\n\nChecking dictionary views...\n");
 
@@ -1003,6 +1006,41 @@ size_t dictionary_unittest_views(void) {
     dictionary_acquired_item_release(view, item1_on_view);
     errors += unittest_check_dictionary("master", master, 0, 0, 1, 0, 1);
     errors += unittest_check_dictionary("view", view, 0, 0, 1, 0, 1);
+
+    fprintf(stderr, "\nPASS 3: Replacing a stale view item after master deletion:\n");
+    item1_on_master = dictionary_set_and_acquire_item(master, "KEY 1", "VALUE1", strlen("VALUE1") + 1);
+    item1_on_view = dictionary_view_set_and_acquire_item(view, "KEY 1 ON VIEW", item1_on_master);
+    dictionary_acquired_item_release(view, item1_on_view);
+    dictionary_del(master, "KEY 1");
+
+    // Suppress the preflight garbage collection once so view_set() exercises
+    // the stale-entry cleanup path inside dict_item_add_or_reset_value_and_acquire().
+    __atomic_store_n(&view->last_gc_run_us, now_realtime_usec(), __ATOMIC_RELAXED);
+
+    master_item2 = dictionary_set_and_acquire_item(master, "KEY 1", "VALUE2", strlen("VALUE2") + 1);
+    view_item2 = dictionary_view_set_and_acquire_item(view, "KEY 1 ON VIEW", master_item2);
+
+    if(!view_item2) {
+        fprintf(stderr, "View replacement returned NULL\n");
+        errors++;
+    }
+    else if(item_flag_check(view_item2, ITEM_FLAG_DELETED) || view_item2->shared != master_item2->shared) {
+        fprintf(stderr, "View replacement returned stale/deleted item\n");
+        errors++;
+    }
+    else
+        dictionary_acquired_item_release(view, view_item2);
+
+    lookup = (DICTIONARY_ITEM *)dictionary_get_and_acquire_item(view, "KEY 1 ON VIEW");
+    if(!lookup || item_flag_check(lookup, ITEM_FLAG_DELETED) || lookup->shared != master_item2->shared) {
+        fprintf(stderr, "View lookup did not resolve to the replacement item\n");
+        errors++;
+    }
+    if(lookup)
+        dictionary_acquired_item_release(view, lookup);
+
+    dictionary_acquired_item_release(master, master_item2);
+    dictionary_acquired_item_release(master, item1_on_master);
 
     dictionary_destroy(master);
     dictionary_destroy(view);

--- a/src/libnetdata/functions_evloop/functions_evloop.c
+++ b/src/libnetdata/functions_evloop/functions_evloop.c
@@ -79,7 +79,7 @@ struct functions_evloop_globals {
 static void rrd_functions_worker_canceller(void *data) {
     struct functions_evloop_globals *wg = data;
     netdata_mutex_lock(&wg->worker_mutex);
-    wg->workers_exit = true;
+    __atomic_store_n(&wg->workers_exit, true, __ATOMIC_RELAXED);
     netdata_cond_signal(&wg->worker_cond_var);
     netdata_mutex_unlock(&wg->worker_mutex);
 }
@@ -93,7 +93,7 @@ static void rrd_functions_worker_globals_worker_main(void *arg) {
     while (true) {
         netdata_mutex_lock(&wg->worker_mutex);
 
-        if(wg->workers_exit || nd_thread_signaled_to_cancel()) {
+        if(__atomic_load_n(&wg->workers_exit, __ATOMIC_RELAXED) || nd_thread_signaled_to_cancel()) {
             netdata_mutex_unlock(&wg->worker_mutex);
             break;
         }
@@ -115,7 +115,7 @@ static void rrd_functions_worker_globals_worker_main(void *arg) {
 
         netdata_mutex_unlock(&wg->worker_mutex);
 
-        if(wg->workers_exit || nd_thread_signaled_to_cancel()) {
+        if(__atomic_load_n(&wg->workers_exit, __ATOMIC_RELAXED) || nd_thread_signaled_to_cancel()) {
             if(acquired)
                 dictionary_acquired_item_release(wg->worker_queue, acquired);
 

--- a/src/libnetdata/functions_evloop/functions_evloop.c
+++ b/src/libnetdata/functions_evloop/functions_evloop.c
@@ -89,29 +89,30 @@ static void rrd_functions_worker_globals_worker_main(void *arg) {
 
     nd_thread_register_canceller(rrd_functions_worker_canceller, wg);
 
-    bool last_acquired = true;
     while (true) {
-        netdata_mutex_lock(&wg->worker_mutex);
-
-        if(__atomic_load_n(&wg->workers_exit, __ATOMIC_RELAXED) || nd_thread_signaled_to_cancel()) {
-            netdata_mutex_unlock(&wg->worker_mutex);
-            break;
-        }
-
-        if(dictionary_entries(wg->worker_queue) == 0 || !last_acquired)
-            netdata_cond_wait(&wg->worker_cond_var, &wg->worker_mutex);
-
         const DICTIONARY_ITEM *acquired = NULL;
         struct functions_evloop_worker_job *j;
-        dfe_start_write(wg->worker_queue, j) {
-            if(j->running || j->cancelled)
-                continue;
 
-            acquired = dictionary_acquired_item_dup(wg->worker_queue, j_dfe.item);
-            j->running = true;
-            break;
+        netdata_mutex_lock(&wg->worker_mutex);
+
+        // Keep the scan and the wait under worker_mutex so a new-job signal
+        // cannot land after we decide to sleep but before the thread blocks.
+        while(!__atomic_load_n(&wg->workers_exit, __ATOMIC_RELAXED) && !nd_thread_signaled_to_cancel()) {
+            dfe_start_write(wg->worker_queue, j) {
+                if(j->running || j->cancelled)
+                    continue;
+
+                acquired = dictionary_acquired_item_dup(wg->worker_queue, j_dfe.item);
+                j->running = true;
+                break;
+            }
+            dfe_done(j);
+
+            if(acquired)
+                break;
+
+            netdata_cond_wait(&wg->worker_cond_var, &wg->worker_mutex);
         }
-        dfe_done(j);
 
         netdata_mutex_unlock(&wg->worker_mutex);
 
@@ -129,15 +130,12 @@ static void rrd_functions_worker_globals_worker_main(void *arg) {
             };
             ND_LOG_STACK_PUSH(lgs);
 
-            last_acquired = true;
             j = dictionary_acquired_item_value(acquired);
             j->cb(j->transaction, j->cmd, &j->stop_monotonic_ut, &j->cancelled, j->payload, j->access, j->source, j->cb_data);
             dictionary_del(wg->worker_queue, j->transaction);
             dictionary_acquired_item_release(wg->worker_queue, acquired);
             dictionary_garbage_collect(wg->worker_queue);
         }
-        else
-            last_acquired = false;
     }
 }
 

--- a/src/libnetdata/json/json-c-parser-unittest.c
+++ b/src/libnetdata/json/json-c-parser-unittest.c
@@ -1448,6 +1448,34 @@ static int test_parse_txt2rfc3339(void) {
 }
 
 // ----------------------------------------------------------------------------
+// RFC3339 formatter regression coverage
+// ----------------------------------------------------------------------------
+static int test_format_rfc3339(void) {
+    int failed = 0;
+    char buffer[RFC3339_MAX_LENGTH];
+    usec_t parsed;
+    size_t len;
+
+    len = rfc3339_datetime_ut(buffer, sizeof(buffer), 123456, 3, true);
+    T(len == strlen("1970-01-01T00:00:00.123Z") && strcmp(buffer, "1970-01-01T00:00:00.123Z") == 0,
+      "format_rfc3339: 3 digits truncate microseconds");
+
+    len = rfc3339_datetime_ut(buffer, sizeof(buffer), 123456, 7, true);
+    T(len == strlen("1970-01-01T00:00:00.1234560Z") && strcmp(buffer, "1970-01-01T00:00:00.1234560Z") == 0,
+      "format_rfc3339: 7 digits keep microseconds and pad trailing zero");
+    parsed = rfc3339_parse_ut(buffer, NULL);
+    T(parsed == 123456, "format_rfc3339: 7-digit output parses back to the same microseconds");
+
+    len = rfc3339_datetime_ut(buffer, sizeof(buffer), 1, 9, true);
+    T(len == strlen("1970-01-01T00:00:00.000001000Z") && strcmp(buffer, "1970-01-01T00:00:00.000001000Z") == 0,
+      "format_rfc3339: 9 digits preserve leading zeros and pad nanoseconds");
+    parsed = rfc3339_parse_ut(buffer, NULL);
+    T(parsed == 1, "format_rfc3339: 9-digit output parses back to the same microseconds");
+
+    return failed;
+}
+
+// ----------------------------------------------------------------------------
 // TXT2PATTERN — branches:
 //   key found: string "*"→NULL, string other→string_strdupz,
 //              other+OPT→skip, other+REQ→error, other+STRICT→error
@@ -1936,6 +1964,7 @@ int json_c_parser_unittest(void) {
         { "TXT2BUFFER",         test_parse_txt2buffer },
         { "TXT2UUID",           test_parse_txt2uuid },
         { "TXT2RFC3339",        test_parse_txt2rfc3339 },
+        { "FORMAT_RFC3339",     test_format_rfc3339 },
         { "TXT2PATTERN",        test_parse_txt2pattern },
         { "TXT2ENUM",           test_parse_txt2enum },
         { "ARRAY_OF_TXT2BITMAP", test_parse_array_of_txt2bitmap },

--- a/src/libnetdata/os/get_system_cpus.c
+++ b/src/libnetdata/os/get_system_cpus.c
@@ -100,9 +100,13 @@ size_t os_read_cpuset_cpus(const char *filename, size_t system_cpus) {
     static char *buf = NULL;
     static size_t buf_size = 0;
 
-    if(!buf) {
-        buf_size = 100U + 6 * system_cpus + 1; // taken from kernel/cgroup/cpuset.c
-        buf = mallocz(buf_size);
+    if(unlikely(!system_cpus))
+        system_cpus = os_get_system_cpus_uncached();
+
+    size_t required_buf_size = 100U + 6 * system_cpus + 1; // taken from kernel/cgroup/cpuset.c
+    if(unlikely(buf_size < required_buf_size)) {
+        buf_size = required_buf_size;
+        buf = reallocz(buf, buf_size);
     }
 
     int ret = read_txt_file(filename, buf, buf_size);

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -1098,6 +1098,14 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
         goto cleanup;
     }
 
+    if((size_t)path_length >= sizeof(path)) {
+        errno = ENAMETOOLONG;
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: socket path for '%s' in runtime directory '%s' was truncated (needed %d bytes, buffer is %zu)",
+               server->name, runtime_directory, path_length, sizeof(path));
+        goto cleanup;
+    }
+
     if((size_t)path_length > max_path_length) {
         errno = ENAMETOOLONG;
         nd_log(NDLS_COLLECTORS, NDLP_ERR,

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -28,21 +28,44 @@ static volatile bool spawn_server_exit = false;
 static volatile bool spawn_server_sigchld = false;
 static SPAWN_REQUEST *spawn_server_requests = NULL;
 
+static size_t spawn_server_max_unix_socket_path_length(void) {
+    struct sockaddr_un server_addr = { 0 };
+    return sizeof(server_addr.sun_path) - 1;
+}
+
+static bool spawn_server_set_unix_socket_path(struct sockaddr_un *server_addr, const char *path, bool log, const char *action) {
+    const size_t max_path_length = sizeof(server_addr->sun_path) - 1;
+
+    if(strlen(path) > max_path_length) {
+        errno = ENAMETOOLONG;
+        if(log)
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "%s '%s': exceeds the %zu-byte AF_UNIX limit",
+                   action, path, max_path_length);
+        return false;
+    }
+
+    strncpyz(server_addr->sun_path, path, max_path_length);
+    return true;
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 
 static int connect_to_spawn_server(const char *path, bool log) {
     int sock = -1;
+    struct sockaddr_un server_addr = {
+        .sun_family = AF_UNIX,
+    };
+
+    if(!spawn_server_set_unix_socket_path(&server_addr, path, log,
+                                          "SPAWN PARENT: Cannot connect() to spawn server on path"))
+        return -1;
 
     if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
         if(log)
             nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN PARENT: cannot create socket() to connect to spawn server.");
         return -1;
     }
-
-    struct sockaddr_un server_addr = {
-        .sun_family = AF_UNIX,
-    };
-    strcpy(server_addr.sun_path, path);
 
     if (connect(sock, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1) {
         if(log)
@@ -956,15 +979,19 @@ static bool spawn_server_create_listening_socket(SPAWN_SERVER *server) {
         return false;
     }
 
+    struct sockaddr_un server_addr = {
+        .sun_family = AF_UNIX,
+    };
+
+    if(!spawn_server_set_unix_socket_path(&server_addr, server->path, true,
+                                          "SPAWN SERVER: Cannot listen on path"))
+        return false;
+
     if ((server->sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to create socket()");
         return false;
     }
 
-    struct sockaddr_un server_addr = {
-        .sun_family = AF_UNIX,
-    };
-    strcpy(server_addr.sun_path, server->path);
     unlink(server->path);
     errno = 0;
 
@@ -1053,13 +1080,30 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
         runtime_directory = "/tmp";
 
     char path[1024];
+    int path_length;
+    const size_t max_path_length = spawn_server_max_unix_socket_path_length();
     if(name && *name) {
         server->name = strdupz(name);
-        snprintf(path, sizeof(path), "%s/netdata-spawn-%s.sock", runtime_directory, name);
+        path_length = snprintf(path, sizeof(path), "%s/netdata-spawn-%s.sock", runtime_directory, name);
     }
     else {
         server->name = strdupz("unnamed");
-        snprintf(path, sizeof(path), "%s/netdata-spawn-%d-%zu.sock", runtime_directory, getpid(), server->id);
+        path_length = snprintf(path, sizeof(path), "%s/netdata-spawn-%d-%zu.sock", runtime_directory, getpid(), server->id);
+    }
+
+    if(path_length < 0) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: failed to generate socket path for '%s'",
+               server->name);
+        goto cleanup;
+    }
+
+    if((size_t)path_length > max_path_length) {
+        errno = ENAMETOOLONG;
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: socket path for '%s' in runtime directory '%s' exceeds the %zu-byte AF_UNIX limit",
+               server->name, runtime_directory, max_path_length);
+        goto cleanup;
     }
 
     server->path = strdupz(path);

--- a/src/libnetdata/worker_utilization/worker_utilization.c
+++ b/src/libnetdata/worker_utilization/worker_utilization.c
@@ -261,7 +261,7 @@ void worker_unregister(void) {
         spinlock_unlock(&workname->spinlock);
 
         if(!workname->base) {
-            JError_t J_Error;
+            JError_t J_Error = { 0 };
 
             JudyAllocThreadPulseReset();
             int ret = JudyHSDel(&workers_globals.worknames_JudyHS, (void *)worker->workname, workname_size, &J_Error);

--- a/src/libnetdata/worker_utilization/worker_utilization.c
+++ b/src/libnetdata/worker_utilization/worker_utilization.c
@@ -261,11 +261,21 @@ void worker_unregister(void) {
         spinlock_unlock(&workname->spinlock);
 
         if(!workname->base) {
+            JError_t J_Error;
+
             JudyAllocThreadPulseReset();
-            JudyHSDel(&workers_globals.worknames_JudyHS, (void *) worker->workname, workname_size, PJE0);
+            int ret = JudyHSDel(&workers_globals.worknames_JudyHS, (void *)worker->workname, workname_size, &J_Error);
             int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
-            freez(workname);
-            workers_globals.memory = (int64_t)workers_globals.memory - (int64_t)sizeof(struct workers_workname) + judy_mem;
+            workers_globals.memory = (int64_t)workers_globals.memory + judy_mem;
+
+            if(likely(ret == 1)) {
+                freez(workname);
+                workers_globals.memory = (int64_t)workers_globals.memory - (int64_t)sizeof(struct workers_workname);
+            }
+            else if(unlikely(ret == JERR))
+                netdata_log_error("WORKER_UTILIZATION: cannot delete worker workname '%s' from JudyHS, JU_ERRNO_* == %u, ID == %d", worker->workname, JU_ERRNO(&J_Error), JU_ERRID(&J_Error));
+            else
+                netdata_log_error("WORKER_UTILIZATION: worker workname '%s' disappeared from JudyHS during unregister", worker->workname);
         }
     }
     workers_globals.memory -= sizeof(struct worker) + strlen(worker->tag) + 1 + strlen(worker->workname) + 1;

--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -364,6 +364,49 @@ static void test_kmeans_scoring()
     ML_TEST_ASSERT_DOUBLE_EQ(score_eq, 0.0, 1e-9, "equal min/max should return 0");
 }
 
+// Test: converting an empty ml_kmeans_t must produce deterministic zeroed centers.
+static void test_kmeans_inlined_empty_source_is_zero_initialized()
+{
+    fprintf(stderr, "  test_kmeans_inlined_empty_source_is_zero_initialized...\n");
+
+    ml_kmeans_t empty_km;
+    empty_km.cluster_centers.clear();
+    empty_km.min_dist = 1.5;
+    empty_km.max_dist = 9.5;
+    empty_km.after = 11;
+    empty_km.before = 22;
+
+    ml_kmeans_inlined_t constructed(empty_km);
+    ML_TEST_ASSERT(constructed.after == empty_km.after, "constructed empty model should preserve 'after'");
+    ML_TEST_ASSERT(constructed.before == empty_km.before, "constructed empty model should preserve 'before'");
+    ML_TEST_ASSERT_DOUBLE_EQ(constructed.min_dist, empty_km.min_dist, 0.0, "constructed empty model should preserve min_dist");
+    ML_TEST_ASSERT_DOUBLE_EQ(constructed.max_dist, empty_km.max_dist, 0.0, "constructed empty model should preserve max_dist");
+    for (size_t center = 0; center < constructed.cluster_centers.size(); center++) {
+        ML_TEST_ASSERT(constructed.cluster_centers[center].size() == 6, "constructed empty-source centers must keep fixed-size geometry");
+        for (long i = 0; i < constructed.cluster_centers[center].size(); i++) {
+            char msg[160];
+            snprintf(msg, sizeof(msg), "constructed empty-source center[%zu](%ld) should be zero", center, i);
+            ML_TEST_ASSERT_DOUBLE_EQ(constructed.cluster_centers[center](i), 0.0, 0.0, msg);
+        }
+    }
+
+    ml_kmeans_inlined_t assigned;
+    for (int i = 0; i < 6; i++) {
+        assigned.cluster_centers[0](i) = 10.0 + i;
+        assigned.cluster_centers[1](i) = 20.0 + i;
+    }
+    assigned = empty_km;
+
+    for (size_t center = 0; center < assigned.cluster_centers.size(); center++) {
+        ML_TEST_ASSERT(assigned.cluster_centers[center].size() == 6, "empty-source centers must keep fixed-size geometry");
+        for (long i = 0; i < assigned.cluster_centers[center].size(); i++) {
+            char msg[160];
+            snprintf(msg, sizeof(msg), "empty-source center[%zu](%ld) should be zero", center, i);
+            ML_TEST_ASSERT_DOUBLE_EQ(assigned.cluster_centers[center](i), 0.0, 0.0, msg);
+        }
+    }
+}
+
 // Test: circular buffer linearization produces the same result as std::rotate
 static void test_circular_buffer_equivalence()
 {
@@ -881,6 +924,7 @@ extern "C" int ml_unittest()
     test_features_zero_smooth_matches_one();
     test_kmeans_scoring();
     test_full_pipeline();
+    test_kmeans_inlined_empty_source_is_zero_initialized();
     test_circular_buffer_equivalence();
     test_same_value_uses_newest_sample();
     test_preprocess_predict_equivalence();

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -795,6 +795,21 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
         // Apply sampling during lag feature extraction
         ml_features_preprocess(&features, worker->training_samples, sampling_ratio);
 
+        // Preprocessing can still leave fewer than 2 vectors after smoothing, lag extraction,
+        // or sampling, and k-means cannot build 2 cluster centers from that input.
+        if (worker->training_samples.size() < 2) {
+            spinlock_lock(&dim->slock);
+
+            dim->mt = METRIC_TYPE_CONSTANT;
+            dim->suppression_anomaly_counter = 0;
+            dim->suppression_window_counter = 0;
+            dim->training_in_progress = false;
+
+            spinlock_unlock(&dim->slock);
+
+            return ML_WORKER_RESULT_NOT_ENOUGH_COLLECTED_VALUES;
+        }
+
         ml_kmeans_init(&dim->kmeans);
         ml_kmeans_train(&dim->kmeans, worker->training_samples, Cfg.max_kmeans_iters, training_response.query_after_t, training_response.query_before_t);
     }

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1011,11 +1011,10 @@ ml_host_detect_once(ml_host_t *host)
     worker_is_busy(WORKER_JOB_DETECTION_COLLECT_STATS);
 
     ml_machine_learning_stats_t mls_copy = {};
+    ml_machine_learning_stats_t host_mls = {};
+    calculated_number_t host_anomaly_rate = 0.0;
 
     if (host->ml_running) {
-        netdata_mutex_lock(&host->mutex);
-        host->mls = {};
-
         /*
          * prediction/detection stats
         */
@@ -1032,20 +1031,20 @@ ml_host_detect_once(ml_host_t *host)
 
             ml_machine_learning_stats_t chart_mls = chart->mls;
 
-            host->mls.num_machine_learning_status_enabled += chart_mls.num_machine_learning_status_enabled;
-            host->mls.num_machine_learning_status_disabled_sp += chart_mls.num_machine_learning_status_disabled_sp;
+            host_mls.num_machine_learning_status_enabled += chart_mls.num_machine_learning_status_enabled;
+            host_mls.num_machine_learning_status_disabled_sp += chart_mls.num_machine_learning_status_disabled_sp;
 
-            host->mls.num_metric_type_constant += chart_mls.num_metric_type_constant;
-            host->mls.num_metric_type_variable += chart_mls.num_metric_type_variable;
+            host_mls.num_metric_type_constant += chart_mls.num_metric_type_constant;
+            host_mls.num_metric_type_variable += chart_mls.num_metric_type_variable;
 
-            host->mls.num_training_status_untrained += chart_mls.num_training_status_untrained;
-            host->mls.num_training_status_pending_without_model += chart_mls.num_training_status_pending_without_model;
-            host->mls.num_training_status_trained += chart_mls.num_training_status_trained;
-            host->mls.num_training_status_pending_with_model += chart_mls.num_training_status_pending_with_model;
-            host->mls.num_training_status_silenced += chart_mls.num_training_status_silenced;
+            host_mls.num_training_status_untrained += chart_mls.num_training_status_untrained;
+            host_mls.num_training_status_pending_without_model += chart_mls.num_training_status_pending_without_model;
+            host_mls.num_training_status_trained += chart_mls.num_training_status_trained;
+            host_mls.num_training_status_pending_with_model += chart_mls.num_training_status_pending_with_model;
+            host_mls.num_training_status_silenced += chart_mls.num_training_status_silenced;
 
-            host->mls.num_anomalous_dimensions += chart_mls.num_anomalous_dimensions;
-            host->mls.num_normal_dimensions += chart_mls.num_normal_dimensions;
+            host_mls.num_anomalous_dimensions += chart_mls.num_anomalous_dimensions;
+            host_mls.num_normal_dimensions += chart_mls.num_normal_dimensions;
 
             if (spinlock_trylock(&host->context_anomaly_rate_spinlock))
             {
@@ -1068,20 +1067,30 @@ ml_host_detect_once(ml_host_t *host)
         }
         rrdset_foreach_done(rsp);
 
-        host->host_anomaly_rate = 0.0;
-        size_t NumActiveDimensions = host->mls.num_anomalous_dimensions + host->mls.num_normal_dimensions;
-        if (NumActiveDimensions)
-              host->host_anomaly_rate = static_cast<double>(host->mls.num_anomalous_dimensions) / NumActiveDimensions;
+        size_t num_active_dimensions = host_mls.num_anomalous_dimensions + host_mls.num_normal_dimensions;
+        if (num_active_dimensions)
+            host_anomaly_rate = static_cast<double>(host_mls.num_anomalous_dimensions) / num_active_dimensions;
 
-        mls_copy = host->mls;
+        bool publish_stats = false;
 
+        // Publish the final host snapshot after chart traversal so chart
+        // deletion cannot block other host->mutex users for the full walk.
+        netdata_mutex_lock(&host->mutex);
+        if (host->ml_running) {
+            host->mls = host_mls;
+            host->host_anomaly_rate = host_anomaly_rate;
+            mls_copy = host->mls;
+            publish_stats = true;
+        }
         netdata_mutex_unlock(&host->mutex);
 
-        worker_is_busy(WORKER_JOB_DETECTION_DIM_CHART);
-        ml_update_dimensions_chart(host, mls_copy);
+        if (publish_stats) {
+            worker_is_busy(WORKER_JOB_DETECTION_DIM_CHART);
+            ml_update_dimensions_chart(host, mls_copy);
 
-        worker_is_busy(WORKER_JOB_DETECTION_HOST_CHART);
-        ml_update_host_and_detection_rate_charts(host, host->host_anomaly_rate * 10000.0);
+            worker_is_busy(WORKER_JOB_DETECTION_HOST_CHART);
+            ml_update_host_and_detection_rate_charts(host, host_anomaly_rate * 10000.0);
+        }
     } else {
         host->host_anomaly_rate = 0.0;
 

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1010,11 +1010,11 @@ ml_host_detect_once(ml_host_t *host)
 {
     worker_is_busy(WORKER_JOB_DETECTION_COLLECT_STATS);
 
-    host->mls = {};
     ml_machine_learning_stats_t mls_copy = {};
 
     if (host->ml_running) {
         netdata_mutex_lock(&host->mutex);
+        host->mls = {};
 
         /*
          * prediction/detection stats

--- a/src/ml/ml_kmeans.h
+++ b/src/ml/ml_kmeans.h
@@ -33,21 +33,16 @@ struct ml_kmeans_inlined_t {
     time_t after;
     time_t before;
 
-    ml_kmeans_inlined_t() : min_dist(0), max_dist(0), after(0), before(0)
+    ml_kmeans_inlined_t() : cluster_centers{}, min_dist(0), max_dist(0), after(0), before(0)
     {
     }
 
-    explicit ml_kmeans_inlined_t(const ml_kmeans_t &km)
+    explicit ml_kmeans_inlined_t(const ml_kmeans_t &km) : cluster_centers{}, min_dist(km.min_dist), max_dist(km.max_dist), after(km.after), before(km.before)
     {
         if (km.cluster_centers.size() == 2) {
             cluster_centers[0] = km.cluster_centers[0];
             cluster_centers[1] = km.cluster_centers[1];
         }
-
-        min_dist = km.min_dist;
-        max_dist = km.max_dist;
-        after = km.after;
-        before = km.before;
     }
 
     ml_kmeans_inlined_t &operator=(const ml_kmeans_t &km)
@@ -55,6 +50,9 @@ struct ml_kmeans_inlined_t {
         if (km.cluster_centers.size() == 2) {
             cluster_centers[0] = km.cluster_centers[0];
             cluster_centers[1] = km.cluster_centers[1];
+        }
+        else {
+            cluster_centers = std::array<DSample, 2>{};
         }
         min_dist = km.min_dist;
         max_dist = km.max_dist;

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -87,6 +87,10 @@ void ml_host_stop(RRDHOST *rh) {
     // reset host stats
     host->mls = ml_machine_learning_stats_t();
 
+    // Chart deletion can hold the dictionary writer across lengthy cleanup.
+    // Do not carry host->mutex into the traversal below.
+    netdata_mutex_unlock(&host->mutex);
+
     // reset charts/dims
     void *rsp = NULL;
     rrdset_foreach_read(rsp, host->rh) {
@@ -123,8 +127,6 @@ void ml_host_stop(RRDHOST *rh) {
         rrddim_foreach_done(rdp);
     }
     rrdset_foreach_done(rsp);
-
-    netdata_mutex_unlock(&host->mutex);
 }
 
 void ml_host_get_info(RRDHOST *rh, BUFFER *wb)


### PR DESCRIPTION
## Summary

17 commits fixing memory-safety and correctness bugs surfaced by a multi-model triage of 104 outstanding Coverity CIDs on the Netdata codebase. Each commit is tied to a single Coverity defect class and represents a minimum root-cause change. Two commits are orphan findings (not Coverity-flagged) that the review surfaced.

### Memory corruption / OOB

- `c1340023a4` **spawn_server: reject oversized unix socket paths** — stack buffer overflow via `strcpy(server_addr.sun_path, path)` when `NETDATA_RUN_DIR` is oversized. CIDs 439982, 439997.
- `8dde0c5434` **libnetdata: grow cpuset cpu parser buffer** — static buffer pinned at 101 bytes on startup (caller passes `system_cpus=0`), causing silent truncation and OOB read on long `cpuset.cpus`. CID 425864.
- `74c3baa3fb` **log2journal: handle trailing logfmt escapes safely** — 1-byte OOB read when a logfmt line ends in a lone backslash. CID 410217.
- `fcddb9ffc1` **log2journal: fix utf named-group key indexing** — sign-extended index into 256-byte table on signed-char platforms with UTF-8 named groups. CID 410102.
- `40d87845d0` **health: fix malformed \${label:...} parsing** — `size_t` underflow → OOB write on unterminated `\${label:` in health config. CID 439996.

### Use-after-release / logic

- `c78aea03e8` **dictionary: retry view inserts after stale entry cleanup** — retry loop failed to reset `item = NULL` on rejected acquire, leaving dangling pointers reachable. Added regression test. CID 414657.
- `8da4e70c19` **worker_utilization: handle JudyHSDel failure** — `worker_unregister()` freed the workname even when `JudyHSDel` returned JERR, leaving a dangling pointer still indexed in the JudyHS table. CID 468190.
- `848f07e271` **daemon: remove machine guid access precheck** — TOCTOU in `machine_guid_get_or_create()` running pre-privilege-drop. CID 457948.

### Reachable crashes

- `c8a53fddef` **claim: guard missing 422 errorMsgKey** — null-deref on `strcmp(error_key, ...)` when the Cloud server's 422 body omits `errorMsgKey`. CID 501624.
- `de07ba77b9` **claim: terminate public key read buffer** — missing NUL terminator on full-buffer `public.pem` read; subsequent JSON consumer reads past the stack buffer. CID 501623.
- `79678f6b1d` **claim: handle curl option setup failures** — silent `curl_easy_setopt` failures on admin-controlled proxy config. CID 501625.
- `a32c726277` **xenstat: skip domains without libxl domain info** — uninit uuid read when `libxl_domain_info()` fails. CID 413854.

### Resource leaks

- `1f2d93c69c` **claim: free split-file claim buffers** — token/rooms leak on the success path of `claim_agent_from_split_files()`. CIDs 442342, 442346.
- `b5c505c444` **systemd-journal: fix duplicate scan dir handle leak** — `DIR*` leak when `nd_journal_directory_scan_recursively()` early-returns on a repeated directory. CID 459644.

### Other

- `bafc5ab147` **datetime: fix rfc3339 fractional scaling** — integer overflow in `print_fraction()` when callers request 7–9 digits; added regression tests. CID 457729.
- `63b3c5d7bc` **sqlite: clamp alert non_clear_duration for aclk** — `int64` → `uint32` narrowing on SQLite column read. CID 440042.

### Orphan findings (not Coverity-flagged, surfaced during review)

- `5c5696c309` **systemd-journal: pass depth+1 to recursive directory scan** — `depth++` post-increment passed old depth to the recursive call, silently truncating deep journal hierarchies.
- `0333f913a7` **claim: cap claim response body size** — unbounded HTTP response buffer → OOM DoS from a malicious Cloud endpoint. 10 MiB cap via `CURLOPT_MAXFILESIZE_LARGE` + write-callback guard.

## Test plan

- [x] `cmake --build build --parallel \$(nproc)` clean on every commit
- [x] Each commit individually reviewed by three open-weight analyzers (glm-5.1, kimi-k2.5, qwen) plus codex plus opus
- [x] Coverity triage updated to *Bug / Fix Submitted* for each fixed CID
- [ ] CI integration tests (to run on PR)

## Follow-up (for team discussion — not in this PR)

Ten additional findings were surfaced by the review pipeline but deliberately left out to keep each commit tied to one CID. A separate `REVIEW-FINDINGS.md` covers:

- statsd tag-parser dropping leading whitespace
- cgroup v2 `memory.max` \"max\" sentinel missed due to trailing newline
- cpuset parser hardening (latent)
- Dictionary master-dict spin risk (pre-existing)
- Unbounded claim API parameter lengths (authenticated-only)
- Naming / cosmetic and dead-code cleanups

## Audit methodology

Each CID was independently analysed by three open-weight models (glm-5.1, kimi-k2.5, qwen), then decided/fixed by codex, then reviewed by claude-opus. When analysts disagreed, codex broke the tie with independent reasoning; opus then verified the fix against the original CID plus Netdata idioms. Build was verified clean (exit 0) after every fix before Coverity triage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes memory-safety, race, and correctness bugs found by Coverity across core modules and adds guardrails to ML model training. Prevents OOB/UAF/leaks, missed wakeups, and improves diagnostics in `claim`, `log2journal`, `systemd-journal`, `ebpf`, `statsd`, `sqlite`, `rrdhost`, and more.

- **Bug Fixes**
  - Memory safety/resources: close v2 journal FDs on migration failures in `dbengine`; free metadata cleanup list and pending UUID deletions on shutdown in `sqlite`; avoid UAF in `sys_class_power_supply` property loop; clone `alerts_v2` config dictionary keys to avoid stack-escape UAF.
  - Concurrency/races: make `ebpf` module state reads/writes atomic and start function threads outside the cleanup lock; atomically load/store ACLK pending-request cancel flag; snapshot `rrdhost` receiver status under its lock; protect `statsd` histogram/timer sample buffer (reset/grow/append/flush) with its mutex; fix missed worker wakeups and use atomic `workers_exit` in `functions_evloop`; unlock `apps.plugin` mutex before early exit; narrow ML host mutex scope during detection and move stats reset under the mutex.
  - Claim robustness: NUL-terminate `public.pem` reads; handle missing `errorMsgKey`; check `curl_easy_setopt` and `curl_slist_append` failures; cap response size to 10 MiB and guard `size * nmemb` overflow in the write-callback (plus `CURLOPT_MAXFILESIZE_LARGE`); improve failure messages.
  - Logic/UAF: fix `dictionary` view insert retry after stale cleanup; only free `worker_utilization` workname on successful `JudyHSDel` and zero-init `JError_t` for logging; remove `machine-guid` TOCTOU with `mkdir(..., EEXIST)` and verify the path is a directory; free removed stale nodes outside the global RRD lock.
  - Crash avoidance: in `xenstat`, skip domains when `libxl_domain_info()` fails.
  - Leaks and traversal: free `claim_agent_from_split_files()` buffers on success; in `systemd-journal`, close duplicate `DIR*`, also close on `dictionary_set()` NULL, log visited-directory tracking failures, and recurse with `depth + 1`.
  - Correctness/diagnostics: fix proc `mdstat` obsolete-chart lookup so long md names are obsoleted correctly; fix RFC3339 fractional scaling for 1–9 digits and add round-trip tests; clamp SQLite `non_clear_duration` to `uint32_t`; fix deadly-signal log to include the correct thread id; reject undersized ML k-means training output and zero-initialize inlined centers to avoid publishing empty/indeterminate models.
  - Memory safety: reject oversize AF_UNIX paths and detect `snprintf` truncation in `spawn_server`; fix logfmt trailing backslash parsing and UTF named-group key indexing in `log2journal`; guard malformed `${label:...}` in `health`; grow `cpuset` buffer in `os_read_cpuset_cpus`.
  - Tests: add regression cases for logfmt trailing backslash, RFC3339 formatter (format and parse) round-trips, dictionary view stale-entry replacement, and ML k-means empty-source handling.

<sup>Written for commit e01be4c3875fea82af33791aa4631dbf2e9ef29f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

