### PR TITLE
Remove Fedora 42 from CI and package builds

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -239,13 +239,6 @@ include:
       repo_distro: fedora/43
     test:
       ebpf-core: true
-  - <<: *fedora
-    version: "42"
-    packages:
-      <<: *fedora_packages
-      repo_distro: fedora/42
-    test:
-      ebpf-core: true
 
   - &opensuse
     distro: opensuse
@@ -434,6 +427,13 @@ legacy: # Info for platforms we used to support and still need to handle package
     packages:
       <<: *fedora_packages
       repo_distro: fedora/41
+    test:
+      ebpf-core: true
+  - <<: *fedora
+    version: "42"
+    packages:
+      <<: *fedora_packages
+      repo_distro: fedora/42
     test:
       ebpf-core: true
   - <<: *opensuse

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -77,7 +77,6 @@ Our [static builds](#static-builds) are expected to work on these platforms if a
 | Debian                   | 11.x           | x86\_64, i386, ARMv7, AArch64 |                                                                                                                |
 | Fedora                   | 44             | x86\_64, AArch64              |                                                                                                                |
 | Fedora                   | 43             | x86\_64, AArch64              |                                                                                                                |
-| Fedora                   | 42             | x86\_64, AArch64              |                                                                                                                |
 | openSUSE                 | Tumbleweed     | x86\_64, AArch64              |                                                                                                                |
 | openSUSE                 | Leap 16.0      | x86\_64, AArch64              |                                                                                                                |
 | openSUSE                 | Leap 15.6      | x86\_64, AArch64              |                                                                                                                |
@@ -178,8 +177,8 @@ This is a list of platforms that we have supported in the recent past but no lon
 | Platform | Version   | Notes                |
 |----------|-----------|----------------------|
 | Debian   | 10.x      | EOL as of 2024-07-01 |
+| Fedora   | 42        | EOL as of 2026-05-13 |
 | Fedora   | 41        | EOL as of 2025-12-15 |
-| Fedora   | 40        | EOL as of 2024-11-12 |
 | openSUSE | Leap 15.5 | EOL as of 2024-12-31 |
 | Ubuntu   | 25.04     | EOL as of 2026-01-17 |
 | Ubuntu   | 20.04     | EOL as of 2025-05-31 |


### PR DESCRIPTION
##### Summary

It’s EOL upstream as of 2026-05-13.

##### Test Plan

n/a

##### Additional Information

Closes: #22195 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Fedora 42 from CI and package builds, moving it to the legacy list due to upstream EOL on 2026-05-13. Updated platform support docs to reflect the change.

<sup>Written for commit e070054373c4d86c5082f9c90ec3fa2f93ec4509. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

