### PR TITLE
Fix ebpf shutdown and cgroup ipc integration

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/src/collectors/cgroups.plugin/cgroup-discovery.c
@@ -1194,6 +1194,9 @@ void cgroup_discovery_worker(void *ptr)
         discovery_find_all_cgroups();
     }
 
+    // Stop the netipc server first so its worker threads cannot iterate cgroup_root while we free it.
+    cgroup_netipc_cleanup();
+
     // free all cgroups
     netdata_mutex_lock(&cgroup_root_mutex);
     while(cgroup_root) {
@@ -1204,7 +1207,6 @@ void cgroup_discovery_worker(void *ptr)
     netdata_mutex_unlock(&cgroup_root_mutex);
 
     collector_info("discovery thread stopped");
-    cgroup_netipc_cleanup();
     worker_unregister();
     service_exits();
     __atomic_store_n(&discovery_thread.exited, 1, __ATOMIC_RELEASE);

--- a/src/collectors/cgroups.plugin/cgroup-netipc.c
+++ b/src/collectors/cgroups.plugin/cgroup-netipc.c
@@ -90,12 +90,8 @@ static bool cgroups_snapshot_handler(void *user __maybe_unused,
         }
     }
 
-    netdata_mutex_unlock(&cgroup_root_mutex);
-
     bool log_zero_generation = false;
     bool log_truncated_generation = false;
-
-    netdata_mutex_lock(&cgroup_root_mutex);
 
     if (count == 0 && last_logged_zero_generation != snapshot_generation) {
         last_logged_zero_generation = snapshot_generation;

--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -1158,6 +1158,12 @@ void ebpf_stop_threads(int sig)
 #endif
     netdata_mutex_unlock(&mutex_cgroup_shm);
 
+    // Join the cgroup integration thread before ebpf_exit() tears down the netipc cache it reads.
+    if (cgroup_integration_thread.thread) {
+        nd_thread_join(cgroup_integration_thread.thread);
+        cgroup_integration_thread.thread = NULL;
+    }
+
     usec_t before_checks_ut = now_monotonic_usec();
     if (!ebpf_pre_exit_check_done) {
         ebpf_check_before2go();

--- a/src/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/src/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -347,11 +347,8 @@ static void ebpf_parse_cgroup_netipc_data(void)
     uint64_t generation = ebpf_cgroup_cache.generation;
     uint32_t enabled_count = 0;
 
-    // Publish the latest cgroup state before collectors read the lock-free flags.
     int systemd_enabled = (int)ebpf_cgroup_cache.systemd_enabled;
     int integration_active = (count > 0) ? 1 : 0;
-    ebpf_cgroup_systemd_enabled_set(systemd_enabled);
-    ebpf_cgroup_integration_active_set(integration_active);
 
     for (uint32_t i = 0; i < count; i++) {
         const nipc_cgroups_cache_item_t *item = &ebpf_cgroup_cache.items[i];
@@ -371,6 +368,10 @@ static void ebpf_parse_cgroup_netipc_data(void)
         netdata_mutex_lock(&mutex_cgroup_shm);
         preserved_targets = ebpf_count_cgroup_targets_unsafe();
         preserved_pids = ebpf_count_cgroup_pids_unsafe();
+        // Publish flags while holding the mutex so collectors never observe a flag
+        // change before the pid/target lists match it.
+        ebpf_cgroup_systemd_enabled_set(systemd_enabled);
+        ebpf_cgroup_integration_active_set(integration_active);
         netdata_mutex_unlock(&mutex_cgroup_shm);
 
         if (last_count != 0 ||
@@ -416,6 +417,10 @@ static void ebpf_parse_cgroup_netipc_data(void)
     int chart_refresh_needed = previous_count != count;
     ebpf_send_cgroup_chart_set(chart_refresh_needed);
     previous_count = count;
+    // Publish integration flags only after the target/pid lists have been rebuilt,
+    // so collectors never observe integration_active=1 with stale pid state.
+    ebpf_cgroup_systemd_enabled_set(systemd_enabled);
+    ebpf_cgroup_integration_active_set(integration_active);
     netdata_mutex_unlock(&mutex_cgroup_shm);
 
     if (last_count != count ||
@@ -423,8 +428,7 @@ static void ebpf_parse_cgroup_netipc_data(void)
         previous_imported_targets != imported_targets ||
         previous_total_pids != total_pids ||
         previous_integration_active != integration_active ||
-        previous_systemd_enabled != systemd_enabled ||
-        enabled_count == 0 || imported_targets == 0 || total_pids == 0) {
+        previous_systemd_enabled != systemd_enabled) {
         collector_info(
             "EBPF CGROUP: netipc snapshot generation=%llu items=%u enabled=%u imported_targets=%zu total_pids=%zu "
             "send_cgroup_chart=%d integration_active=%d systemd_enabled=%d refresh_failures=%d",


### PR DESCRIPTION

##### Summary
- Ensure proper cleanup and synchronization in cgroup and ebpf integration


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shutdown races between eBPF and cgroup IPC to prevent use-after-free and inconsistent metrics. Orders teardown and synchronizes flag updates so collectors never read stale cgroup state.

- **Bug Fixes**
  - Stop the netipc server before freeing cgroup lists in cgroup discovery.
  - Remove redundant lock/unlock in the cgroup snapshot handler to avoid gaps in `cgroup_root` protection.
  - Join the eBPF cgroup integration thread before `ebpf_exit()` to avoid reading a torn-down netipc cache.
  - Publish `systemd_enabled` and `integration_active` while holding the cgroup mutex and only after PID/target lists are rebuilt.
  - Reduce log noise by emitting the cgroup snapshot log only on state changes.

<sup>Written for commit 0bac15e132fe8efd050773b875e0300ce461622a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

