### PR TITLE
ci(codeql): enable security-extended suite and align ignore paths

### DIFF
--- a/.github/codeql/c-cpp-config.yml
+++ b/.github/codeql/c-cpp-config.yml
@@ -1,4 +1,7 @@
+queries:
+  - uses: security-extended
+
 paths-ignore:
-  - build/*
-  - httpd/h2o
-  - src/collectors/debugfs.plugin/libsensors/vendored
+  - build/**
+  - externaldeps/**
+  - "**/vendored/**"


### PR DESCRIPTION
## Summary

- Enable the **security-extended** query suite for C/C++ CodeQL analysis. The default suite misses taint-based memory-safety queries (`cpp/uncontrolled-arithmetic`, `cpp/overflow-buffer`, `cpp/static-buffer-overflow`, etc.) which are exactly the classes we need covered beyond what Coverity already catches.
- Align `paths-ignore` with the patterns already excluded from Coverity so vendored and external dependencies stop producing alerts we do not own.
- Remove the stale `httpd/h2o` entry; that directory no longer exists.

## Why

Review of CodeQL's track record on netdata/netdata shows near-zero security value from the default suite so far: in ~2.5 years, only ~45 real findings in our own code, all cosmetic categories (printf format mismatches, `int*int` cast to long, TOCTOU). No use-after-free, buffer overflow, integer underflow, or sign-extension bugs were ever caught in our code. Meanwhile, CodeQL was scanning vendored code (sqlite3, libjudy, libsensors, json, absl, protobuf, dlib) and producing alerts for code we don't own.

Enabling `security-extended` turns on the queries that could actually catch the bug classes that matter to us (taint-tracked integer arithmetic, buffer overflows with range analysis). The path alignment ensures the results are attributable to our code, not upstream dependencies.

## Changes

`.github/codeql/c-cpp-config.yml`:

```diff
+queries:
+  - uses: security-extended
+
 paths-ignore:
-  - build/*
-  - httpd/h2o
-  - src/collectors/debugfs.plugin/libsensors/vendored
+  - build/**
+  - externaldeps/**
+  - "**/vendored/**"
```

The `**/vendored/**` glob is a catch-all that matches every vendored subdirectory (`src/libnetdata/libjudy/vendored`, `src/database/sqlite/vendored`, `src/libnetdata/json/vendored`, `src/collectors/debugfs.plugin/libsensors/vendored`) in a single rule, matching Coverity's equivalent `.*/vendored/.*` pattern.

## Cost / risk

- **Zero monetary cost**: CodeQL is free for public repos; security-extended runs on the same engine as the default suite.
- **Slightly longer CI**: security-extended enables more queries, so the C/C++ scan will take longer (rough estimate: 1.5x current runtime).
- **Expected new findings**: `cpp/uncontrolled-arithmetic` and related queries may fire on `/proc`-derived values. If the noise is excessive we can add custom barriers for our `str2ll()` / `str2uint()` wrappers or narrow the query set further.

## Test plan

- [ ] CodeQL workflow runs successfully on this PR
- [ ] New alerts (if any) are reviewed for true positives vs. false positives
- [ ] Confirm vendored paths no longer produce alerts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable CodeQL `security-extended` for C/C++ and align `paths-ignore` to exclude `build/**`, `externaldeps/**`, and `**/vendored/**`, removing the stale `httpd/h2o` path. This adds taint-based memory-safety checks and cuts noise from vendored code, with a small CI runtime increase.

<sup>Written for commit 6d5019deba7eaae478070b682a788ac074c1254d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

