### PR TITLE
Optimize health DB lookups

### DIFF
--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -385,7 +385,10 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
     RRDCALC *rc;
     foreach_rrdcalc_in_rrdhost_read(host, rc) {
         // Reclaim the previous alert's query scratch before starting the
-        // next one. Cheap no-op on the first iteration of a fresh arena.
+        // next one. The arena is reused across every alert of every host in
+        // this iteration, so this reset trims trailing pages left by the
+        // previous alert (same host or prior host). No-op only on the very
+        // first alert after the arena was created.
         onewayalloc_reset(owa);
 
         if(unlikely(!service_running(SERVICE_HEALTH) || !rrdhost_should_run_health(host))) {

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -317,7 +317,13 @@ static void do_eval_expression(
 }
 
 // returns the number of runnable alerts
-static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_delay, time_t now, time_t *next_run) {
+//
+// The caller owns `owa` and provides it so a single arena can be reused
+// across all hosts of one iteration (and, in the multi-threaded variant,
+// across all hosts a single worker processes). The arena is reset between
+// alerts inside this function, so peak memory stays bounded by one alert's
+// scratch no matter how many hosts flow through it.
+static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_delay, time_t now, time_t *next_run, ONEWAYALLOC *owa) {
     size_t runnable = 0;
     struct health_alert_status_counts status_counts = { 0 };
     bool snapshot_complete = true;
@@ -369,9 +375,19 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
             return;
     }
 
+    // Reuse the caller-provided arena across every alert's DB lookup. Each
+    // alert's scratch (RRDR + query state) is released via onewayalloc_reset
+    // at the top of the next iteration — trims the page list back to a
+    // single head page. Net effect: one mmap/munmap for the whole health
+    // iteration, regardless of host count or alert count.
+
     // the first loop is to lookup values from the db
     RRDCALC *rc;
     foreach_rrdcalc_in_rrdhost_read(host, rc) {
+        // Reclaim the previous alert's query scratch before starting the
+        // next one. Cheap no-op on the first iteration of a fresh arena.
+        onewayalloc_reset(owa);
+
         if(unlikely(!service_running(SERVICE_HEALTH) || !rrdhost_should_run_health(host))) {
             snapshot_complete = false;
             break;
@@ -464,7 +480,8 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                     break;
             }
 
-            int ret = rrdset2value_api_v1(rc->rrdset, NULL, &rc->value, rrdcalc_dimensions(rc), 1,
+            int ret = rrdset2value_api_v1_with_owa(owa,
+                                          rc->rrdset, NULL, &rc->value, rrdcalc_dimensions(rc), 1,
                                           rc->config.after, rc->config.before, rc->config.time_group, group_options,
                                           0, rc->config.options | RRDR_OPTION_SELECTED_TIER,
                                           &rc->db_after,&rc->db_before,
@@ -781,14 +798,20 @@ static void health_event_loop(void) {
         worker_is_busy(WORKER_HEALTH_JOB_RRD_LOCK);
         uint64_t loop = __atomic_add_fetch(&health_evloop_iteration, 1, __ATOMIC_RELAXED);
 
+        // Single onewayalloc arena reused across every host in this iteration —
+        // one mmap/munmap pair for the whole cycle instead of per host.
+        ONEWAYALLOC *iter_owa = onewayalloc_create(0);
+
         RRDHOST *host;
         dfe_start_reentrant(rrdhost_root_index, host) {
             if(unlikely(!service_running(SERVICE_HEALTH)))
                 break;
 
-            health_event_loop_for_host(host, apply_hibernation_delay, now, &next_run);
+            health_event_loop_for_host(host, apply_hibernation_delay, now, &next_run, iter_owa);
         }
         dfe_done(host);
+
+        onewayalloc_destroy(iter_owa);
 
         if(unlikely(!service_running(SERVICE_HEALTH)))
             break;

--- a/src/libnetdata/onewayalloc/onewayalloc.c
+++ b/src/libnetdata/onewayalloc/onewayalloc.c
@@ -184,6 +184,48 @@ void *onewayalloc_doublesize(ONEWAYALLOC *owa, const void *src, size_t oldsize) 
     return dst;
 }
 
+void onewayalloc_reset(ONEWAYALLOC *owa) {
+#ifdef FSANITIZE_ADDRESS
+    // Under the sanitizer path, onewayalloc_mallocz goes straight to the
+    // system allocator and nothing is tracked in the owa page list — there
+    // is nothing to reset. Individual allocations are released by callers
+    // via onewayalloc_freez() (which calls freez() under the sanitizer).
+    (void)owa;
+    return;
+#endif
+
+    if (!owa) return;
+
+    OWA_PAGE *head = (OWA_PAGE *)owa;
+
+    // Free every page except the head; we keep the head so the caller can
+    // reuse the arena without another mmap.
+    size_t freed_size = 0;
+    OWA_PAGE *page = head->next;
+    while (page) {
+        OWA_PAGE *p = page;
+        page = page->next;
+        freed_size += p->size;
+        if (p->mmap)
+            nd_munmap(p, p->size);
+        else
+            freez(p);
+    }
+
+    if (freed_size)
+        __atomic_sub_fetch(&onewayalloc_total_memory, freed_size, __ATOMIC_RELAXED);
+
+    // Roll the head page's bump cursor back to the position right after the
+    // OWA_PAGE header, and rewire the single-page list so head == last.
+    head->next = NULL;
+    head->last = head;
+    head->offset = natural_alignment(sizeof(OWA_PAGE));
+    head->stats_pages = 1;
+    head->stats_pages_size = head->size;
+    // stats_mallocs_made / stats_mallocs_size are lifetime counters and
+    // intentionally left alone, to keep them useful across resets.
+}
+
 void onewayalloc_destroy(ONEWAYALLOC *owa) {
     if(!owa) return;
 

--- a/src/libnetdata/onewayalloc/onewayalloc.c
+++ b/src/libnetdata/onewayalloc/onewayalloc.c
@@ -185,16 +185,15 @@ void *onewayalloc_doublesize(ONEWAYALLOC *owa, const void *src, size_t oldsize) 
 }
 
 void onewayalloc_reset(ONEWAYALLOC *owa) {
+    if (!owa) return;
+
 #ifdef FSANITIZE_ADDRESS
     // Under the sanitizer path, onewayalloc_mallocz goes straight to the
     // system allocator and nothing is tracked in the owa page list — there
     // is nothing to reset. Individual allocations are released by callers
     // via onewayalloc_freez() (which calls freez() under the sanitizer).
-    (void)owa;
     return;
 #endif
-
-    if (!owa) return;
 
     OWA_PAGE *head = (OWA_PAGE *)owa;
 
@@ -220,10 +219,14 @@ void onewayalloc_reset(ONEWAYALLOC *owa) {
     head->next = NULL;
     head->last = head;
     head->offset = natural_alignment(sizeof(OWA_PAGE));
+
+    // stats_pages / stats_pages_size describe the arena's *current* footprint
+    // (what is mapped right now), so they reflect the single-page post-reset
+    // state. stats_mallocs_made / stats_mallocs_size are lifetime counters
+    // (total allocations ever served by this arena) and are intentionally
+    // preserved across resets, to stay useful for diagnostics.
     head->stats_pages = 1;
     head->stats_pages_size = head->size;
-    // stats_mallocs_made / stats_mallocs_size are lifetime counters and
-    // intentionally left alone, to keep them useful across resets.
 }
 
 void onewayalloc_destroy(ONEWAYALLOC *owa) {

--- a/src/libnetdata/onewayalloc/onewayalloc.h
+++ b/src/libnetdata/onewayalloc/onewayalloc.h
@@ -14,6 +14,13 @@ void onewayalloc_destroy(ONEWAYALLOC *owa);
 // do many short bursts of allocations back-to-back (e.g. evaluating all
 // the alerts of one host) and want to amortise the mmap/munmap cost of
 // create/destroy across the whole burst.
+//
+// Important: reset does NOT zero the retained head page. Subsequent
+// onewayalloc_mallocz() calls may return memory that still holds bytes
+// from the previous burst — this matches the mallocz() contract (the "z"
+// means "fatal on failure", not "zeroed"). Callers that need zeroed
+// memory must use onewayalloc_callocz() just as they would against a
+// freshly-created arena; the reset path does not relax that contract.
 void onewayalloc_reset(ONEWAYALLOC *owa);
 
 void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size);

--- a/src/libnetdata/onewayalloc/onewayalloc.h
+++ b/src/libnetdata/onewayalloc/onewayalloc.h
@@ -8,6 +8,14 @@ typedef void ONEWAYALLOC;
 ONEWAYALLOC *onewayalloc_create(size_t size_hint);
 void onewayalloc_destroy(ONEWAYALLOC *owa);
 
+// Reset the arena to an empty state without destroying it. Frees every
+// page except the head, and rolls the head page's bump pointer back to
+// its initial offset so the arena is reusable. Intended for callers that
+// do many short bursts of allocations back-to-back (e.g. evaluating all
+// the alerts of one host) and want to amortise the mmap/munmap cost of
+// create/destroy across the whole burst.
+void onewayalloc_reset(ONEWAYALLOC *owa);
+
 void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size);
 void *onewayalloc_callocz(ONEWAYALLOC *owa, size_t nmemb, size_t size);
 char *onewayalloc_strdupz(ONEWAYALLOC *owa, const char *s);

--- a/src/web/api/formatters/rrd2json.c
+++ b/src/web/api/formatters/rrd2json.c
@@ -10,8 +10,9 @@ void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb)
     buffer_json_finalize(wb);
 }
 
-int rrdset2value_api_v1(
-        RRDSET *st
+int rrdset2value_api_v1_with_owa(
+        ONEWAYALLOC *owa
+        , RRDSET *st
         , BUFFER *wb
         , NETDATA_DOUBLE *n
         , const char *dimensions
@@ -36,7 +37,6 @@ int rrdset2value_api_v1(
 ) {
     int ret = HTTP_RESP_INTERNAL_SERVER_ERROR;
 
-    ONEWAYALLOC *owa = onewayalloc_create(0);
     RRDR *r = rrd2rrdr_legacy(
             owa,
             st,
@@ -95,6 +95,42 @@ int rrdset2value_api_v1(
 
 cleanup:
     rrdr_free(owa, r);
+    return ret;
+}
+
+int rrdset2value_api_v1(
+        RRDSET *st
+        , BUFFER *wb
+        , NETDATA_DOUBLE *n
+        , const char *dimensions
+        , size_t points
+        , time_t after
+        , time_t before
+        , RRDR_TIME_GROUPING group_method
+        , const char *group_options
+        , time_t resampling_time
+        , uint32_t options
+        , time_t *db_after
+        , time_t *db_before
+        , size_t *db_points_read
+        , size_t *db_points_per_tier
+        , size_t *result_points_generated
+        , int *value_is_null
+        , NETDATA_DOUBLE *anomaly_rate
+        , time_t timeout
+        , size_t tier
+        , QUERY_SOURCE query_source
+        , STORAGE_PRIORITY priority
+) {
+    // Back-compat wrapper for callers that don't need to reuse the arena
+    // across calls (e.g. the badge code path). Creates a throwaway owa.
+    ONEWAYALLOC *owa = onewayalloc_create(0);
+    int ret = rrdset2value_api_v1_with_owa(
+            owa, st, wb, n, dimensions, points, after, before,
+            group_method, group_options, resampling_time, options,
+            db_after, db_before, db_points_read, db_points_per_tier,
+            result_points_generated, value_is_null, anomaly_rate,
+            timeout, tier, query_source, priority);
     onewayalloc_destroy(owa);
     return ret;
 }

--- a/src/web/api/formatters/rrd2json.c
+++ b/src/web/api/formatters/rrd2json.c
@@ -35,6 +35,8 @@ int rrdset2value_api_v1_with_owa(
         , QUERY_SOURCE query_source
         , STORAGE_PRIORITY priority
 ) {
+    internal_fatal(!owa, "rrdset2value_api_v1_with_owa(): owa must be non-NULL");
+
     int ret = HTTP_RESP_INTERNAL_SERVER_ERROR;
 
     RRDR *r = rrd2rrdr_legacy(

--- a/src/web/api/formatters/rrd2json.h
+++ b/src/web/api/formatters/rrd2json.h
@@ -49,6 +49,38 @@ int rrdset2value_api_v1(
         , STORAGE_PRIORITY priority
 );
 
+// Same contract as rrdset2value_api_v1 but uses a caller-provided
+// onewayalloc arena. Lets a caller that issues many back-to-back queries
+// (e.g. evaluating all alerts on one host) amortise the mmap/munmap cost
+// of owa create/destroy across the whole burst. The caller owns the owa's
+// lifetime; between calls they should invoke onewayalloc_reset() to reclaim
+// trailing pages and keep peak memory bounded. `owa` must be non-NULL.
+int rrdset2value_api_v1_with_owa(
+        ONEWAYALLOC *owa
+        , RRDSET *st
+        , BUFFER *wb
+        , NETDATA_DOUBLE *n
+        , const char *dimensions
+        , size_t points
+        , time_t after
+        , time_t before
+        , RRDR_TIME_GROUPING group_method
+        , const char *group_options
+        , time_t resampling_time
+        , uint32_t options
+        , time_t *db_after
+        , time_t *db_before
+        , size_t *db_points_read
+        , size_t *db_points_per_tier
+        , size_t *result_points_generated
+        , int *value_is_null
+        , NETDATA_DOUBLE *anomaly_rate
+        , time_t timeout
+        , size_t tier
+        , QUERY_SOURCE query_source
+        , STORAGE_PRIORITY priority
+);
+
 static inline bool rrdr_dimension_should_be_exposed(RRDR_DIMENSION_FLAGS rrdr_dim_flags, RRDR_OPTIONS options) {
     if(unlikely((options & RRDR_OPTION_RETURN_RAW) && (rrdr_dim_flags & RRDR_DIMENSION_QUERIED)))
         return true;


### PR DESCRIPTION
##### Summary
- Optimize health DB lookups by reusing onewayalloc arena and adding reset functionality

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse a single onewayalloc arena for all health DB lookups and add a reset API to reclaim pages between alerts. This cuts per-iteration mmap/munmap churn and keeps memory bounded to one alert’s scratch.

- **Refactors**
  - Added onewayalloc_reset to free all pages except the head, rewind the bump pointer, and refresh page stats (no-op under ASan). Reset does not zero the retained head; use onewayalloc_callocz() if needed.
  - Introduced rrdset2value_api_v1_with_owa; the original function now wraps it with a short-lived arena for back-compat.
  - Health loop creates one arena per iteration, passes it into health_event_loop_for_host, resets before each alert, and routes DB queries through the new API.

<sup>Written for commit 7e2a82199b02069202ca390d5a6d35100c26cad4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

