### PR TITLE
refactor(go.d/dyncfg): split job-name validation per domain

### DIFF
--- a/src/go/plugin/agent/discovery/sd/dyncfg.go
+++ b/src/go/plugin/agent/discovery/sd/dyncfg.go
@@ -83,6 +83,10 @@ func (cb *sdCallbacks) ExtractKey(fn dyncfg.Function) (key, name string, ok bool
 	return dt + ":" + name, name, true
 }
 
+func (cb *sdCallbacks) ValidateJobName(name string) error {
+	return dyncfg.JobNameRuleAllowDots(name)
+}
+
 func (cb *sdCallbacks) ParseAndValidate(fn dyncfg.Function, name string) (sdConfig, error) {
 	dt, _, _ := cb.sd.extractDiscovererAndName(fn.ID())
 	if _, err := parseDyncfgPayload(fn.Payload(), dt, name, cb.sd.configDefaults, cb.sd.discovererRegistry(), true); err != nil {
@@ -251,7 +255,7 @@ func (d *ServiceDiscovery) dyncfgCmdTest(fn dyncfg.Function) {
 	if !isJob {
 		name = dyncfgTemplateJobName(fn)
 	}
-	if err := dyncfg.ValidateJobName(name); err != nil {
+	if err := dyncfg.JobNameRuleAllowDots(name); err != nil {
 		d.Warningf("dyncfg: test: unacceptable job name '%s' for '%s': %v", name, dt, err)
 		d.dyncfgApi.SendCodef(fn, 400, "Unacceptable job name '%s': %v.", name, err)
 		return

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
@@ -58,6 +58,10 @@ func (cb *collectorCallbacks) ExtractKey(fn dyncfg.Function) (key, name string, 
 	return key, jn, true
 }
 
+func (cb *collectorCallbacks) ValidateJobName(name string) error {
+	return dyncfg.JobNameRuleStrict(name)
+}
+
 func (cb *collectorCallbacks) ParseAndValidate(fn dyncfg.Function, name string) (confgroup.Config, error) {
 	mn, ok := cb.mgr.extractModuleName(fn.ID())
 	if !ok {

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_cmds.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_cmds.go
@@ -114,7 +114,7 @@ func (m *Manager) dyncfgCmdTest(fn dyncfg.Function) {
 
 	m.Infof("dyncfg: %s: %s/%s job by user '%s'", cmd, mn, jn, fn.User())
 
-	if err := dyncfg.ValidateJobName(jn); err != nil {
+	if err := dyncfg.JobNameRuleStrict(jn); err != nil {
 		m.Warningf("dyncfg: %s: module %s: unacceptable job name '%s': %v", cmd, mn, jn, err)
 		m.dyncfgResponder.SendCodef(fn, 400, "Unacceptable job name '%s': %v.", jn, err)
 		return

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
@@ -874,6 +874,10 @@ func (cb *collectorSeqTestCallbacks) ExtractKey(fn dyncfg.Function) (key, name s
 	return cb.mgr.collectorCallbacks.ExtractKey(fn)
 }
 
+func (cb *collectorSeqTestCallbacks) ValidateJobName(name string) error {
+	return dyncfg.JobNameRuleStrict(name)
+}
+
 func (cb *collectorSeqTestCallbacks) ParseAndValidate(fn dyncfg.Function, _ string) (confgroup.Config, error) {
 	cfg, ok := cb.parsed[fn.Command()]
 	if !ok {

--- a/src/go/plugin/agent/jobmgr/secretsctl/callbacks.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/callbacks.go
@@ -132,6 +132,10 @@ func (cb *secretStoreCallbacks) ExtractKey(fn dyncfg.Function) (key, name string
 	return key, name, true
 }
 
+func (cb *secretStoreCallbacks) ValidateJobName(name string) error {
+	return dyncfg.JobNameRuleAllowDots(name)
+}
+
 func (cb *secretStoreCallbacks) ParseAndValidate(fn dyncfg.Function, name string) (secretstore.Config, error) {
 	var kind secretstore.StoreKind
 	if fn.Command() == dyncfg.CommandAdd {

--- a/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
@@ -60,7 +60,7 @@ func (c *Controller) dyncfgCmdAdd(fn dyncfg.Function) {
 		c.api.SendCodef(fn, 400, "%v", err)
 		return
 	}
-	if err := dyncfg.ValidateJobName(name); err != nil {
+	if err := dyncfg.JobNameRuleAllowDots(name); err != nil {
 		c.api.SendCodef(fn, 400, "invalid job name '%s': %v.", name, err)
 		return
 	}

--- a/src/go/plugin/agent/jobmgr/secretstore_deps.go
+++ b/src/go/plugin/agent/jobmgr/secretstore_deps.go
@@ -289,7 +289,7 @@ func extractSecretStoreKeysFromString(value string, seen map[string]struct{}) {
 		if !kind.IsValid() {
 			continue
 		}
-		if err := dyncfg.ValidateJobName(name); err != nil {
+		if err := dyncfg.JobNameRuleAllowDots(name); err != nil {
 			continue
 		}
 		seen[secretstore.StoreKey(kind, name)] = struct{}{}

--- a/src/go/plugin/agent/jobmgr/vnodectl/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/vnodectl/dyncfg.go
@@ -111,7 +111,7 @@ func (c *Controller) dyncfgCmdAdd(fn dyncfg.Function) {
 		c.api.SendCodef(fn, 400, "Missing vnode name.")
 		return
 	}
-	if err := dyncfg.ValidateJobName(name); err != nil {
+	if err := dyncfg.JobNameRuleAllowDots(name); err != nil {
 		c.Warningf("dyncfg: %s: unacceptable vnode name '%s': %v", dyncfg.CommandAdd, name, err)
 		c.api.SendCodef(fn, 400, "Unacceptable vnode name '%s': %v.", name, err)
 		return

--- a/src/go/plugin/agent/secrets/secretstore/helpers.go
+++ b/src/go/plugin/agent/secrets/secretstore/helpers.go
@@ -5,5 +5,5 @@ package secretstore
 import "github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 
 func validateStoreName(name string) error {
-	return dyncfg.ValidateJobName(name)
+	return dyncfg.JobNameRuleAllowDots(name)
 }

--- a/src/go/plugin/framework/dyncfg/handler.go
+++ b/src/go/plugin/framework/dyncfg/handler.go
@@ -21,6 +21,10 @@ type Callbacks[C Config] interface {
 	// Includes all validation (including heavy checks like module instantiation).
 	ParseAndValidate(fn Function, name string) (C, error)
 
+	// ValidateJobName enforces the domain's job-name policy. Called before
+	// ParseAndValidate so cheap name-format rejections happen without parsing payload.
+	ValidateJobName(name string) error
+
 	// Start creates a work unit and starts it. Owns the full start lifecycle
 	// including pre-start cleanup and post-fail retry scheduling.
 	// Return CodedError to override EnableFailCode.
@@ -437,7 +441,7 @@ func (h *Handler[C]) CmdAdd(fn Function) {
 		return
 	}
 
-	if err := ValidateJobName(name); err != nil {
+	if err := h.cb.ValidateJobName(name); err != nil {
 		h.api.SendCodef(fn, 400, "invalid job name '%s': %v.", name, err)
 		return
 	}

--- a/src/go/plugin/framework/dyncfg/handler_test.go
+++ b/src/go/plugin/framework/dyncfg/handler_test.go
@@ -1198,14 +1198,14 @@ func TestJobNameRuleStrict(t *testing.T) {
 		input   string
 		wantErr bool
 	}{
-		"valid":               {input: "my_job"},
-		"valid with numbers":  {input: "job123"},
-		"valid with dashes":   {input: "my-job"},
-		"space":               {input: "my job", wantErr: true},
-		"tab":                 {input: "my\tjob", wantErr: true},
-		"dot":                 {input: "my.job", wantErr: true},
-		"colon":               {input: "my:job", wantErr: true},
-		"empty":               {input: ""},
+		"valid":              {input: "my_job"},
+		"valid with numbers": {input: "job123"},
+		"valid with dashes":  {input: "my-job"},
+		"space":              {input: "my job", wantErr: true},
+		"tab":                {input: "my\tjob", wantErr: true},
+		"dot":                {input: "my.job", wantErr: true},
+		"colon":              {input: "my:job", wantErr: true},
+		"empty":              {input: ""},
 	}
 
 	for name, tt := range tests {

--- a/src/go/plugin/framework/dyncfg/handler_test.go
+++ b/src/go/plugin/framework/dyncfg/handler_test.go
@@ -73,6 +73,10 @@ func (m *mockCallbacks) ParseAndValidate(fn Function, name string) (testConfig, 
 	return testConfig{uid: "dyncfg:" + name, key: name, sourceType: "dyncfg", source: "test"}, nil
 }
 
+func (m *mockCallbacks) ValidateJobName(name string) error {
+	return JobNameRuleStrict(name)
+}
+
 func (m *mockCallbacks) Start(cfg testConfig) error {
 	m.startCalls = append(m.startCalls, cfg)
 	if m.startFn != nil {
@@ -1187,31 +1191,58 @@ func TestNotifyJobCreate_SupportedCommands(t *testing.T) {
 	}
 }
 
-// --- ValidateJobName Tests ---
+// --- Job-name rule tests ---
 
-func TestValidateJobName(t *testing.T) {
-	tests := []struct {
-		name    string
+func TestJobNameRuleStrict(t *testing.T) {
+	tests := map[string]struct {
 		input   string
 		wantErr bool
 	}{
-		{"valid", "my_job", false},
-		{"valid with numbers", "job123", false},
-		{"valid with dashes", "my-job", false},
-		{"space", "my job", true},
-		{"tab", "my\tjob", true},
-		{"dot", "my.job", true},
-		{"colon", "my:job", true},
-		{"empty", "", false},
+		"valid":               {input: "my_job"},
+		"valid with numbers":  {input: "job123"},
+		"valid with dashes":   {input: "my-job"},
+		"space":               {input: "my job", wantErr: true},
+		"tab":                 {input: "my\tjob", wantErr: true},
+		"dot":                 {input: "my.job", wantErr: true},
+		"colon":               {input: "my:job", wantErr: true},
+		"empty":               {input: ""},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateJobName(tt.input)
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := JobNameRuleStrict(tt.input)
 			if tt.wantErr {
-				assert.Error(t, err, fmt.Sprintf("ValidateJobName(%q) should fail", tt.input))
+				assert.Error(t, err, fmt.Sprintf("JobNameRuleStrict(%q) should fail", tt.input))
 			} else {
-				assert.NoError(t, err, fmt.Sprintf("ValidateJobName(%q) should pass", tt.input))
+				assert.NoError(t, err, fmt.Sprintf("JobNameRuleStrict(%q) should pass", tt.input))
+			}
+		})
+	}
+}
+
+func TestJobNameRuleAllowDots(t *testing.T) {
+	tests := map[string]struct {
+		input   string
+		wantErr bool
+	}{
+		"valid":              {input: "my_job"},
+		"valid with numbers": {input: "job123"},
+		"valid with dashes":  {input: "my-job"},
+		"dotted name":        {input: "my.job"},
+		"fqdn":               {input: "host.example.com"},
+		"space":              {input: "my job", wantErr: true},
+		"tab":                {input: "my\tjob", wantErr: true},
+		"colon":              {input: "my:job", wantErr: true},
+		"empty":              {input: ""},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := JobNameRuleAllowDots(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err, fmt.Sprintf("JobNameRuleAllowDots(%q) should fail", tt.input))
+			} else {
+				assert.NoError(t, err, fmt.Sprintf("JobNameRuleAllowDots(%q) should pass", tt.input))
 			}
 		})
 	}

--- a/src/go/plugin/framework/dyncfg/validate.go
+++ b/src/go/plugin/framework/dyncfg/validate.go
@@ -8,14 +8,34 @@ import (
 	"unicode"
 )
 
-// ValidateJobName checks that a job name contains no spaces, dots, or colons.
-func ValidateJobName(jobName string) error {
-	for _, r := range jobName {
+// JobNameRuleStrict rejects spaces, dots, and colons.
+// Use for collector job names, which must not conflict with dyncfg template/job
+// ID separators (':') or module hierarchy ('.').
+func JobNameRuleStrict(name string) error {
+	if err := rejectSpacesAndColons(name); err != nil {
+		return err
+	}
+	for _, r := range name {
+		if r == '.' {
+			return fmt.Errorf("contains '%c'", r)
+		}
+	}
+	return nil
+}
+
+// JobNameRuleAllowDots rejects spaces and colons but allows dots.
+// Use for service discovery, vnode, and secretstore names where dotted identifiers
+// are legitimate (e.g. hostnames, FQDNs).
+func JobNameRuleAllowDots(name string) error {
+	return rejectSpacesAndColons(name)
+}
+
+func rejectSpacesAndColons(name string) error {
+	for _, r := range name {
 		if unicode.IsSpace(r) {
 			return errors.New("contains spaces")
 		}
-		switch r {
-		case '.', ':':
+		if r == ':' {
 			return fmt.Errorf("contains '%c'", r)
 		}
 	}


### PR DESCRIPTION
Job-name validation policy is now a Callbacks[C] method so each domain declares its rule explicitly. Two reusable helpers live in the framework:

  - JobNameRuleStrict     (collector — no spaces, dots, colons)
  - JobNameRuleAllowDots  (SD, vnode, secretstore — allows dots in names)

Removes the package-level dyncfg.ValidateJobName default that was imposing collector rules on all callers, and lets SD/vnode/secretstore accept dotted identifiers (e.g. FQDNs).

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split job-name validation by domain in `dyncfg`. Collectors keep strict names; service discovery, vnode, and secretstore now accept dotted names (e.g., FQDNs).

- **Refactors**
  - Move job-name checks to `Callbacks[C].ValidateJobName`; `Handler.CmdAdd` calls it before parsing.
  - Add helpers: `JobNameRuleStrict` (collectors) and `JobNameRuleAllowDots` (SD, vnode, secretstore).
  - Remove global `dyncfg.ValidateJobName`; update all call sites and tests.

- **Migration**
  - If you implement `dyncfg.Callbacks`, add `ValidateJobName(name string) error` and use the appropriate helper.

<sup>Written for commit f6e287417b7c5f763abebcbf3d7a83d2f48a82c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

