### PR TITLE
chore(go): go fix

### DIFF
--- a/src/go/pkg/netipc/protocol/codec_edge_test.go
+++ b/src/go/pkg/netipc/protocol/codec_edge_test.go
@@ -831,7 +831,7 @@ func TestBatchBuilderFinishNoCompaction(t *testing.T) {
 	}
 
 	// Verify access
-	for i := uint32(0); i < count; i++ {
+	for i := range count {
 		_, err := BatchItemGet(buf[:total], count, i)
 		if err != nil {
 			t.Fatalf("item %d: %v", i, err)

--- a/src/go/pkg/netipc/protocol/frame.go
+++ b/src/go/pkg/netipc/protocol/frame.go
@@ -272,7 +272,7 @@ func BatchDirDecode(buf []byte, itemCount uint32, packedAreaLen uint32) ([]Batch
 	}
 
 	out := make([]BatchEntry, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		base := i * 8
 		off := ne.Uint32(buf[base : base+4])
 		length := ne.Uint32(buf[base+4 : base+8])
@@ -296,7 +296,7 @@ func BatchDirValidate(buf []byte, itemCount uint32, packedAreaLen uint32) error 
 	if len(buf) < dirSize {
 		return ErrTruncated
 	}
-	for i := 0; i < count; i++ {
+	for i := range count {
 		base := i * 8
 		off := ne.Uint32(buf[base : base+4])
 		length := ne.Uint32(buf[base+4 : base+8])

--- a/src/go/pkg/netipc/protocol/frame_test.go
+++ b/src/go/pkg/netipc/protocol/frame_test.go
@@ -1430,7 +1430,7 @@ func TestCgroupsResponseLargeSnapshot(t *testing.T) {
 	buf := make([]byte, 1024*1024)
 	b := NewCgroupsBuilder(buf, n, 1, 12345)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		name := []byte("cgroup-" + string(rune('A'+i%26)))
 		path := []byte("/sys/fs/cgroup/system.slice/cgroup-" + string(rune('A'+i%26)))
 		if err := b.Add(uint32(i), uint32(i%4), uint32(i%2), name, path); err != nil {
@@ -1448,7 +1448,7 @@ func TestCgroupsResponseLargeSnapshot(t *testing.T) {
 		t.Fatalf("ItemCount = %d, want %d", view.ItemCount, n)
 	}
 
-	for i := uint32(0); i < n; i++ {
+	for i := range uint32(n) {
 		item, err := view.Item(i)
 		if err != nil {
 			t.Fatalf("item %d: %v", i, err)

--- a/src/go/pkg/netipc/transport/posix/shm_linux.go
+++ b/src/go/pkg/netipc/transport/posix/shm_linux.go
@@ -341,10 +341,7 @@ func ShmClientAttach(runDir, serviceName string, sessionID uint64) (*ShmContext,
 	// Validate region size
 	reqEnd := int(reqOff) + int(reqCap)
 	respEnd := int(respOff) + int(respCap)
-	needed := reqEnd
-	if respEnd > needed {
-		needed = respEnd
-	}
+	needed := max(respEnd, reqEnd)
 	if fileSize < needed {
 		syscall.Munmap(data)
 		f.Close()
@@ -496,10 +493,7 @@ func (c *ShmContext) ShmReceive(buf []byte, timeoutMs uint32) (int, error) {
 	}
 
 	// Limit copy to the smaller of caller buffer and SHM area capacity
-	maxCopy := len(buf)
-	if int(areaCap) < maxCopy {
-		maxCopy = int(areaCap)
-	}
+	maxCopy := min(int(areaCap), len(buf))
 
 	// Phase 1: spin. Copy immediately on observing the advance.
 	observed := false

--- a/src/go/pkg/netipc/transport/posix/shm_linux_test.go
+++ b/src/go/pkg/netipc/transport/posix/shm_linux_test.go
@@ -96,9 +96,7 @@ func TestShmDirectRoundtrip(t *testing.T) {
 	var wg sync.WaitGroup
 	var serverErr error
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, err := ShmServerCreate(testShmRunDir, svc, 1, 4096, 4096)
 		if err != nil {
 			serverErr = fmt.Errorf("server create: %w", err)
@@ -130,7 +128,7 @@ func TestShmDirectRoundtrip(t *testing.T) {
 		if err := ctx.ShmSend(resp); err != nil {
 			serverErr = fmt.Errorf("server send: %w", err)
 		}
-	}()
+	})
 
 	client := waitShmClientAttach(t, testShmRunDir, svc, 1)
 	defer client.ShmClose()
@@ -181,9 +179,7 @@ func TestShmMultipleRoundtrips(t *testing.T) {
 	var wg sync.WaitGroup
 	var serverErr error
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, err := ShmServerCreate(testShmRunDir, svc, 2, 4096, 4096)
 		if err != nil {
 			serverErr = fmt.Errorf("server create: %w", err)
@@ -192,7 +188,7 @@ func TestShmMultipleRoundtrips(t *testing.T) {
 		defer ctx.ShmDestroy()
 
 		buf := make([]byte, 65536)
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			mlen, err := ctx.ShmReceive(buf, 5000)
 			if err != nil {
 				serverErr = fmt.Errorf("server receive %d: %w", i, err)
@@ -211,13 +207,13 @@ func TestShmMultipleRoundtrips(t *testing.T) {
 				return
 			}
 		}
-	}()
+	})
 
 	client := waitShmClientAttach(t, testShmRunDir, svc, 2)
 	defer client.ShmClose()
 
 	respBuf := make([]byte, 65536)
-	for i := uint64(0); i < 10; i++ {
+	for i := range uint64(10) {
 		payload := []byte{byte(i)}
 		msg := buildShmMessage(protocol.KindRequest, 1, i+1, payload)
 		if err := client.ShmSend(msg); err != nil {
@@ -322,9 +318,7 @@ func TestShmLargeMessage(t *testing.T) {
 	var wg sync.WaitGroup
 	var serverErr error
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, err := ShmServerCreate(testShmRunDir, svc, 4, 65536, 65536)
 		if err != nil {
 			serverErr = fmt.Errorf("server create: %w", err)
@@ -350,7 +344,7 @@ func TestShmLargeMessage(t *testing.T) {
 		if err := ctx.ShmSend(resp); err != nil {
 			serverErr = fmt.Errorf("server send: %w", err)
 		}
-	}()
+	})
 
 	client := waitShmClientAttach(t, testShmRunDir, svc, 4)
 	defer client.ShmClose()
@@ -515,12 +509,12 @@ func TestShmMultiClient(t *testing.T) {
 	slots := make([]serverSlot, numClients)
 
 	// Create server regions and start goroutines that receive + echo
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		sessionID := uint64(i + 1)
 		ctx, err := ShmServerCreate(testShmRunDir, svc, sessionID, 4096, 4096)
 		if err != nil {
 			// Clean up already-created regions
-			for j := 0; j < i; j++ {
+			for j := range i {
 				slots[j].ctx.ShmDestroy()
 			}
 			t.Fatalf("server create session %d: %v", sessionID, err)
@@ -528,9 +522,7 @@ func TestShmMultiClient(t *testing.T) {
 		slots[i].ctx = ctx
 
 		idx := i
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			buf := make([]byte, 65536)
 			mlen, err := slots[idx].ctx.ShmReceive(buf, 5000)
 			if err != nil {
@@ -553,13 +545,13 @@ func TestShmMultiClient(t *testing.T) {
 			if err := slots[idx].ctx.ShmSend(resp); err != nil {
 				slots[idx].err = fmt.Errorf("send: %w", err)
 			}
-		}()
+		})
 	}
 
 	// Attach clients and send unique messages
 	clients := make([]*ShmContext, numClients)
 	payloads := make([][]byte, numClients)
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		sessionID := uint64(i + 1)
 		c := waitShmClientAttach(t, testShmRunDir, svc, sessionID)
 		defer c.ShmClose()
@@ -574,7 +566,7 @@ func TestShmMultiClient(t *testing.T) {
 	}
 
 	// Each client receives its own response
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		respBuf := make([]byte, 65536)
 		rlen, err := clients[i].ShmReceive(respBuf, 5000)
 		if err != nil {
@@ -603,7 +595,7 @@ func TestShmMultiClient(t *testing.T) {
 	wg.Wait()
 
 	// Check for server errors and verify no cross-contamination
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		if slots[i].err != nil {
 			t.Errorf("server %d error: %v", i, slots[i].err)
 			continue
@@ -620,7 +612,7 @@ func TestShmMultiClient(t *testing.T) {
 	}
 
 	// Cleanup all server regions
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		slots[i].ctx.ShmDestroy()
 	}
 }

--- a/src/go/pkg/netipc/transport/posix/uds.go
+++ b/src/go/pkg/netipc/transport/posix/uds.go
@@ -266,10 +266,7 @@ func (s *Session) sendInner(hdr *protocol.Header, payload []byte) error {
 		return wrapErr(ErrBadParam, "packet_size too small")
 	}
 
-	firstChunkPayload := len(payload)
-	if firstChunkPayload > chunkPayloadBudget {
-		firstChunkPayload = chunkPayloadBudget
-	}
+	firstChunkPayload := min(len(payload), chunkPayloadBudget)
 
 	remainingAfterFirst := len(payload) - firstChunkPayload
 	continuationChunks := uint32(0)
@@ -289,10 +286,7 @@ func (s *Session) sendInner(hdr *protocol.Header, payload []byte) error {
 	offset := firstChunkPayload
 	for ci := uint32(1); ci < chunkCount; ci++ {
 		remaining := len(payload) - offset
-		thisChunk := remaining
-		if thisChunk > chunkPayloadBudget {
-			thisChunk = chunkPayloadBudget
-		}
+		thisChunk := min(remaining, chunkPayloadBudget)
 
 		chk := protocol.ChunkHeader{
 			Magic:           protocol.MagicChunk,

--- a/src/go/pkg/netipc/transport/posix/uds_test.go
+++ b/src/go/pkg/netipc/transport/posix/uds_test.go
@@ -202,7 +202,7 @@ func TestMultiClient(t *testing.T) {
 	clients := make([]*Session, numClients)
 	servers := make([]*Session, numClients)
 
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		acceptCh := acceptAsync(listener)
 
 		cCfg := defaultClientConfig()
@@ -220,15 +220,15 @@ func TestMultiClient(t *testing.T) {
 	}
 
 	defer func() {
-		for i := 0; i < numClients; i++ {
+		for i := range numClients {
 			clients[i].Close()
 			servers[i].Close()
 		}
 	}()
 
 	// Each client sends a unique message
-	for i := 0; i < numClients; i++ {
-		payload := []byte(fmt.Sprintf("client_%d", i))
+	for i := range numClients {
+		payload := fmt.Appendf(nil, "client_%d", i)
 		hdr := protocol.Header{
 			Kind:      protocol.KindRequest,
 			Code:      protocol.MethodIncrement,
@@ -242,13 +242,13 @@ func TestMultiClient(t *testing.T) {
 
 	// Each server receives and echoes
 	buf := make([]byte, 4096)
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		rHdr, rPayload, err := servers[i].Receive(buf)
 		if err != nil {
 			t.Fatalf("server[%d] Receive: %v", i, err)
 		}
 
-		expected := []byte(fmt.Sprintf("client_%d", i))
+		expected := fmt.Appendf(nil, "client_%d", i)
 		if !bytes.Equal(rPayload, expected) {
 			t.Errorf("server[%d] payload = %q, want %q", i, rPayload, expected)
 		}
@@ -265,7 +265,7 @@ func TestMultiClient(t *testing.T) {
 	}
 
 	// Each client receives its echo
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		rHdr, rPayload, err := clients[i].Receive(buf)
 		if err != nil {
 			t.Fatalf("client[%d] Receive: %v", i, err)
@@ -273,7 +273,7 @@ func TestMultiClient(t *testing.T) {
 		if rHdr.MessageID != uint64(100+i) {
 			t.Errorf("client[%d] message_id = %d, want %d", i, rHdr.MessageID, 100+i)
 		}
-		expected := []byte(fmt.Sprintf("client_%d", i))
+		expected := fmt.Appendf(nil, "client_%d", i)
 		if !bytes.Equal(rPayload, expected) {
 			t.Errorf("client[%d] response payload = %q, want %q", i, rPayload, expected)
 		}
@@ -318,7 +318,7 @@ func TestPipelining(t *testing.T) {
 			ItemCount: 1,
 			MessageID: mid,
 		}
-		payload := []byte(fmt.Sprintf("req_%d", mid))
+		payload := fmt.Appendf(nil, "req_%d", mid)
 		if err := client.Send(&hdr, payload); err != nil {
 			t.Fatalf("client Send(%d): %v", mid, err)
 		}
@@ -332,7 +332,7 @@ func TestPipelining(t *testing.T) {
 	}
 	reqs := make([]reqInfo, 0, 3)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		rHdr, rPayload, err := server.Receive(buf)
 		if err != nil {
 			t.Fatalf("server Receive[%d]: %v", i, err)
@@ -356,7 +356,7 @@ func TestPipelining(t *testing.T) {
 
 	// Client receives 3 responses (should arrive in reverse order)
 	received := make(map[uint64][]byte)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		rHdr, rPayload, err := client.Receive(buf)
 		if err != nil {
 			t.Fatalf("client Receive[%d]: %v", i, err)
@@ -374,7 +374,7 @@ func TestPipelining(t *testing.T) {
 			t.Errorf("missing response for message_id %d", mid)
 			continue
 		}
-		expected := []byte(fmt.Sprintf("resp_req_%d", mid))
+		expected := fmt.Appendf(nil, "resp_req_%d", mid)
 		if !bytes.Equal(payload, expected) {
 			t.Errorf("message_id %d: payload = %q, want %q", mid, payload, expected)
 		}
@@ -938,11 +938,9 @@ func TestConcurrentSendReceive(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Server goroutine: receive and echo
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		buf := make([]byte, 65600)
-		for i := 0; i < numMessages; i++ {
+		for i := range numMessages {
 			rHdr, rPayload, err := server.Receive(buf)
 			if err != nil {
 				t.Errorf("server Receive[%d]: %v", i, err)
@@ -959,11 +957,11 @@ func TestConcurrentSendReceive(t *testing.T) {
 				return
 			}
 		}
-	}()
+	})
 
 	// Client: send all, then receive all
-	for i := 0; i < numMessages; i++ {
-		payload := []byte(fmt.Sprintf("message_%d", i))
+	for i := range numMessages {
+		payload := fmt.Appendf(nil, "message_%d", i)
 		hdr := protocol.Header{
 			Kind:      protocol.KindRequest,
 			Code:      protocol.MethodIncrement,
@@ -977,7 +975,7 @@ func TestConcurrentSendReceive(t *testing.T) {
 
 	received := make(map[uint64]bool)
 	buf := make([]byte, 65600)
-	for i := 0; i < numMessages; i++ {
+	for i := range numMessages {
 		rHdr, _, err := client.Receive(buf)
 		if err != nil {
 			t.Fatalf("client Receive[%d]: %v", i, err)
@@ -987,7 +985,7 @@ func TestConcurrentSendReceive(t *testing.T) {
 
 	wg.Wait()
 
-	for i := 0; i < numMessages; i++ {
+	for i := range numMessages {
 		if !received[uint64(i)] {
 			t.Errorf("missing response for message_id %d", i)
 		}
@@ -1199,7 +1197,7 @@ func TestMultipleChunkedMessages(t *testing.T) {
 	defer server.Close()
 
 	// Send 3 chunked messages sequentially
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		size := 500 + i*200
 		payload := make([]byte, size)
 		for j := range payload {
@@ -1367,11 +1365,9 @@ func TestPipeline10(t *testing.T) {
 
 	// Server goroutine: receive and echo
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		buf := make([]byte, 4096)
-		for i := 0; i < count; i++ {
+		for i := range count {
 			rHdr, rPayload, err := server.Receive(buf)
 			if err != nil {
 				t.Errorf("server Receive[%d]: %v", i, err)
@@ -1388,7 +1384,7 @@ func TestPipeline10(t *testing.T) {
 				return
 			}
 		}
-	}()
+	})
 
 	// Client sends 10 requests before reading any
 	for i := uint64(1); i <= count; i++ {
@@ -1465,11 +1461,9 @@ func TestPipeline100(t *testing.T) {
 
 	// Server goroutine
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		buf := make([]byte, 4096)
-		for i := 0; i < count; i++ {
+		for i := range count {
 			rHdr, rPayload, err := server.Receive(buf)
 			if err != nil {
 				t.Errorf("server Receive[%d]: %v", i, err)
@@ -1486,7 +1480,7 @@ func TestPipeline100(t *testing.T) {
 				return
 			}
 		}
-	}()
+	})
 
 	// Client sends 100 requests
 	for i := uint64(1); i <= count; i++ {
@@ -1560,11 +1554,9 @@ func TestPipelineMixedSizes(t *testing.T) {
 
 	// Server goroutine
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		buf := make([]byte, 8192)
-		for i := 0; i < count; i++ {
+		for i := range count {
 			rHdr, rPayload, err := server.Receive(buf)
 			if err != nil {
 				t.Errorf("server Receive[%d]: %v", i, err)
@@ -1581,7 +1573,7 @@ func TestPipelineMixedSizes(t *testing.T) {
 				return
 			}
 		}
-	}()
+	})
 
 	// Client sends all messages
 	for i, sz := range sizes {
@@ -1668,11 +1660,9 @@ func TestPipelineChunked(t *testing.T) {
 
 	// Server goroutine
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		buf := make([]byte, forcedPacketSize)
-		for i := 0; i < count; i++ {
+		for i := range count {
 			rHdr, rPayload, err := server.Receive(buf)
 			if err != nil {
 				t.Errorf("server Receive[%d]: %v", i, err)
@@ -1689,7 +1679,7 @@ func TestPipelineChunked(t *testing.T) {
 				return
 			}
 		}
-	}()
+	})
 
 	// Client sends all chunked messages
 	for i, sz := range sizes {

--- a/src/go/plugin/agent/discovery/sd/pipeline/accumulator_test.go
+++ b/src/go/plugin/agent/discovery/sd/pipeline/accumulator_test.go
@@ -30,8 +30,7 @@ func TestAccumulator_Run_FlushesPendingGroupsWhenDiscoverersExit(t *testing.T) {
 		}),
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	updates := make(chan []model.TargetGroup)
 	done := make(chan struct{})


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied go fix and Go 1.22+ idioms across IPC protocol, POSIX transports, and tests. No behavior changes; small readability and micro-performance wins in hot paths and tests.

- **Refactors**
  - Replaced index loops with integer `range` (e.g., `for i := range n`) across protocol and transport code.
  - Used built-in `min`/`max` for bounds checks in `shm_linux.go` and `uds.go`.
  - Switched to `fmt.Appendf` to build `[]byte` payloads without extra allocations in `uds_test.go`.
  - Used `t.Context()` in tests instead of `context.WithCancel`.
  - Simplified test goroutine setup with `wg.Go(...)` to reduce boilerplate.

<sup>Written for commit 2c3b6e7b9f5e0c70e1b5a937fe62eba693e13ed2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

