### PR TITLE
Patch release 2.10.3

### DIFF
--- a/src/collectors/collectors-ipc/ebpf-ipc.c
+++ b/src/collectors/collectors-ipc/ebpf-ipc.c
@@ -60,6 +60,10 @@ static bool ebpf_find_pid_shm_del_unsafe(uint32_t pid, enum ebpf_pids_index shm_
     return false;
 }
 
+// Returns the slot index for pid, allocating a new slot if needed. A fresh
+// slot is memset to zero so callers never inherit stale bits or counters from
+// a prior PID that used the same index (prevents the compaction stale-tail
+// and PID-reuse contamination paths).
 static uint32_t ebpf_find_or_create_index_pid(uint32_t pid)
 {
     uint32_t idx;
@@ -75,6 +79,8 @@ static uint32_t ebpf_find_or_create_index_pid(uint32_t pid)
     uint32_t new_idx = ebpf_stat_values.current++;
     *Pvalue = IDX_TO_JVALUE(new_idx);
 
+    memset(&integration_shm[new_idx], 0, sizeof(integration_shm[new_idx]));
+
     return new_idx;
 }
 
@@ -88,9 +94,13 @@ bool netdata_ebpf_reset_shm_pointer_unsafe(int fd, uint32_t pid, enum ebpf_pids_
 
 netdata_ebpf_pid_stats_t *netdata_ebpf_get_shm_pointer_unsafe(uint32_t pid, enum ebpf_pids_index idx)
 {
-    if (!integration_shm || ebpf_stat_values.current >= ebpf_stat_values.total)
+    if (!integration_shm)
         return NULL;
 
+    // Do NOT short-circuit on a full pool here: an already-tracked PID
+    // must still be reachable so its module bits can be updated or
+    // cleared. ebpf_find_or_create_index_pid() returns the existing slot
+    // regardless of pool saturation and only rejects *new* allocations.
     uint32_t shm_idx = ebpf_find_or_create_index_pid(pid);
     if (shm_idx == UINT32_MAX || shm_idx >= ebpf_stat_values.total)
         return NULL;
@@ -100,6 +110,52 @@ netdata_ebpf_pid_stats_t *netdata_ebpf_get_shm_pointer_unsafe(uint32_t pid, enum
     ptr->threads |= (1UL << (idx << 1));
 
     return ptr;
+}
+
+// Read-only lookup: returns the existing slot for pid or NULL. Does not
+// allocate, does not set any bit. Aggregation paths that iterate PID lists
+// from /proc or cgroup snapshots MUST use this variant, otherwise every live
+// PID acquires module bits for modules that may never observe it in their own
+// BPF map and the bits can never be cleared — the shm pool then fills
+// monotonically.
+netdata_ebpf_pid_stats_t *netdata_ebpf_lookup_shm_pointer_unsafe(uint32_t pid)
+{
+    if (!integration_shm)
+        return NULL;
+
+    uint32_t shm_idx;
+    if (!ebpf_shm_find_index_unsafe(pid, &shm_idx))
+        return NULL;
+
+    if (shm_idx >= ebpf_stat_values.current)
+        return NULL;
+
+    return &integration_shm[shm_idx];
+}
+
+// Module teardown helper: clear this module's bit across every slot that has
+// it set. For slots that become empty the existing del path compacts in place,
+// which swaps the last slot into the freed index — so we do not advance i when
+// the current counter drops.
+void netdata_ebpf_sweep_shm_for_module_unsafe(enum ebpf_pids_index idx)
+{
+    if (!integration_shm)
+        return;
+
+    const uint32_t mask = (1U << (idx << 1));
+    uint32_t i = 0;
+    while (i < ebpf_stat_values.current) {
+        netdata_ebpf_pid_stats_t *ptr = &integration_shm[i];
+        if (!(ptr->threads & mask)) {
+            i++;
+            continue;
+        }
+
+        uint32_t before = ebpf_stat_values.current;
+        (void)ebpf_find_pid_shm_del_unsafe(ptr->pid, idx);
+        if (ebpf_stat_values.current >= before)
+            i++;
+    }
 }
 
 void netdata_integration_cleanup_shm()
@@ -122,6 +178,15 @@ void netdata_integration_cleanup_shm()
         close(shm_fd_ebpf_integration);
         shm_fd_ebpf_integration = -1;
     }
+
+    // Drop the POSIX shm object and the named semaphore so a subsequent
+    // plugin run starts from a fresh region and a freshly-initialised
+    // semaphore. Without the sem_unlink, a crashed previous instance can
+    // leave the semaphore at 0 and the next run will spin on
+    // sem_timedwait timeouts (sem_open(O_CREAT) ignores the initial value
+    // when the named semaphore already exists).
+    (void)shm_unlink(NETDATA_EBPF_INTEGRATION_NAME);
+    (void)sem_unlink(NETDATA_EBPF_SHM_INTEGRATION_NAME);
 }
 
 int netdata_integration_initialize_shm(size_t pids)
@@ -153,6 +218,15 @@ int netdata_integration_initialize_shm(size_t pids)
         goto end_shm;
     }
 
+    // Wipe any bytes left over from a prior plugin run — shm_open with
+    // O_CREAT on an existing object does not truncate, and ftruncate to the
+    // current size is a no-op.
+    memset(integration_shm, 0, length);
+
+    // Drop any leftover named semaphore from a previous (possibly crashed)
+    // run so sem_open honours the initial value below instead of reusing
+    // whatever state the previous instance left it in.
+    (void)sem_unlink(NETDATA_EBPF_SHM_INTEGRATION_NAME);
     shm_mutex_ebpf_integration = sem_open(
         NETDATA_EBPF_SHM_INTEGRATION_NAME, O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH, 1);
     if (shm_mutex_ebpf_integration != SEM_FAILED) {

--- a/src/collectors/collectors-ipc/ebpf-ipc.h
+++ b/src/collectors/collectors-ipc/ebpf-ipc.h
@@ -339,7 +339,9 @@ typedef struct netdata_ebpf_pid_stats {
 int netdata_integration_initialize_shm(size_t pids);
 void netdata_integration_cleanup_shm();
 netdata_ebpf_pid_stats_t *netdata_ebpf_get_shm_pointer_unsafe(uint32_t pid, enum ebpf_pids_index idx);
+netdata_ebpf_pid_stats_t *netdata_ebpf_lookup_shm_pointer_unsafe(uint32_t pid);
 bool netdata_ebpf_reset_shm_pointer_unsafe(int fd, uint32_t pid, enum ebpf_pids_index idx);
+void netdata_ebpf_sweep_shm_for_module_unsafe(enum ebpf_pids_index idx);
 void netdata_integration_current_ipc_data(ebpf_user_mem_stat_t *values);
 
 extern sem_t *shm_mutex_ebpf_integration;

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -914,7 +914,7 @@ void ebpf_parse_proc_files()
         if (ebpf_plugin_stop())
             break;
 
-        if (kill(pids->pid, 0)) { // No PID found
+        if (kill(pids->pid, 0) == -1 && errno == ESRCH) {
             ebpf_pid_data_t *next = pids->next;
             ebpf_reset_specific_pid_data(pids);
             pids = next;

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -188,65 +188,15 @@ static inline ebpf_pid_data_t *ebpf_get_pid_data(uint32_t pid, uint32_t tgid, ch
     return ptr;
 }
 
-static inline void ebpf_release_pid_data(ebpf_pid_data_t *eps, int fd, uint32_t key, uint32_t idx)
-{
-    if (fd) {
-        bpf_map_delete_elem(fd, &key);
-    }
-    eps->thread_collecting &= ~(1 << idx);
-    if (!eps->thread_collecting && !eps->has_proc_file) {
-        ebpf_del_pid_entry((pid_t)key);
-    }
-}
-
+// The only caller of ebpf_get_pid_data() passes NETDATA_EBPF_PIDS_PROC_FILE,
+// so `thread_collecting` in an ebpf_pid_data_t only ever has that single high
+// bit set. The per-module (idx < PROC_FILE) branch in the old
+// ebpf_reset_specific_pid_data() was therefore unreachable. Collapse the
+// function to its effective behaviour so a future reader is not confused by
+// dead BPF/freez housekeeping that never ran.
 static inline void ebpf_reset_specific_pid_data(ebpf_pid_data_t *ptr)
 {
-    int idx;
-    uint32_t pid = ptr->pid;
-    for (idx = NETDATA_EBPF_PIDS_PROCESS_IDX; idx < NETDATA_EBPF_PIDS_PROC_FILE; idx++) {
-        if (!(ptr->thread_collecting & (1 << idx))) {
-            continue;
-        }
-        // Check if we still have the map loaded
-        int fd = ebpf_get_pid_map_fd(idx);
-        if (fd <= STDERR_FILENO)
-            continue;
-
-        bpf_map_delete_elem(fd, &pid);
-        ebpf_hash_table_pids_count--;
-        void *clean;
-        switch (idx) {
-            case NETDATA_EBPF_PIDS_PROCESS_IDX:
-                clean = ptr->process;
-                break;
-            case NETDATA_EBPF_PIDS_SOCKET_IDX:
-                clean = ptr->socket;
-                break;
-            case NETDATA_EBPF_PIDS_CACHESTAT_IDX:
-                clean = ptr->cachestat;
-                break;
-            case NETDATA_EBPF_PIDS_DCSTAT_IDX:
-                clean = ptr->dc;
-                break;
-            case NETDATA_EBPF_PIDS_SWAP_IDX:
-                clean = ptr->swap;
-                break;
-            case NETDATA_EBPF_PIDS_VFS_IDX:
-                clean = ptr->vfs;
-                break;
-            case NETDATA_EBPF_PIDS_FD_IDX:
-                clean = ptr->fd;
-                break;
-            case NETDATA_EBPF_PIDS_SHM_IDX:
-                clean = ptr->shm;
-                break;
-            default:
-                clean = NULL;
-        }
-        freez(clean);
-    }
-
-    ebpf_del_pid_entry(pid);
+    ebpf_del_pid_entry(ptr->pid);
 }
 
 typedef struct ebpf_pid_stat {

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -602,6 +602,13 @@ static void ebpf_cachestat_exit(void *pptr)
     if (ebpf_read_cachestat.thread)
         nd_thread_signal_cancel(ebpf_read_cachestat.thread);
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_CACHESTAT_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
@@ -834,13 +841,13 @@ static void ebpf_read_cachestat_apps_table(int maps_per_core)
 
         netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_CACHESTAT_IDX);
         if (!local_pid)
-            continue;
+            goto end_cachestat_loop;
         netdata_publish_cachestat_t *publish = &local_pid->cachestat;
 
         if (!publish->ct || publish->ct != cv->ct) {
             cachestat_save_pid_values(publish, cv);
         } else {
-            if (kill((pid_t)key, 0)) { // No PID found
+            if (kill((pid_t)key, 0) == -1 && errno == ESRCH) {
                 if (netdata_ebpf_reset_shm_pointer_unsafe(fd, key, NETDATA_EBPF_PIDS_CACHESTAT_IDX))
                     memset(publish, 0, sizeof(*publish));
             }
@@ -876,9 +883,8 @@ static void ebpf_update_cachestat_cgroup()
             uint32_t pid = pids->pid;
             netdata_publish_cachestat_t *out = &pids->cachestat;
 
-            netdata_ebpf_pid_stats_t *local_pid =
-                netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_CACHESTAT_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_CACHESTAT_IDX << 1))))
                 continue;
 
             netdata_publish_cachestat_t *in = &local_pid->cachestat;
@@ -916,9 +922,8 @@ static void cachestat_sum_pids_internal(netdata_publish_cachestat_t *publish, vo
                 break;
 
             uint32_t pid = r->pid;
-            netdata_ebpf_pid_stats_t *local_pid =
-                netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_CACHESTAT_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_CACHESTAT_IDX << 1))))
                 continue;
             netdata_publish_cachestat_t *w = &local_pid->cachestat;
             sum_single_pid_cachestat(dst, &w->current);

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -498,6 +498,13 @@ static void ebpf_dcstat_exit(void *pptr)
     if (ebpf_read_dcstat.thread)
         nd_thread_signal_cancel(ebpf_read_dcstat.thread);
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_DCSTAT_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
@@ -588,7 +595,7 @@ static void ebpf_read_dc_apps_table(int maps_per_core)
 
         netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_DCSTAT_IDX);
         if (!local_pid)
-            continue;
+            goto end_dc_loop;
         netdata_publish_dcstat_t *publish = &local_pid->directory_cache;
         if (!publish->ct || publish->ct != cv->ct) {
             publish->ct = cv->ct;
@@ -625,8 +632,8 @@ void ebpf_dcstat_sum_pids(netdata_publish_dcstat_t *publish, struct ebpf_pid_on_
             break;
 
         uint32_t pid = root->pid;
-        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_DCSTAT_IDX);
-        if (!local_pid)
+        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+        if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_DCSTAT_IDX << 1))))
             continue;
         netdata_publish_dcstat_t *w = &local_pid->directory_cache;
 
@@ -680,9 +687,8 @@ static void ebpf_update_dc_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             uint32_t pid = pids->pid;
             netdata_dcstat_pid_t *out = &pids->dc;
-            netdata_ebpf_pid_stats_t *local_pid =
-                netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_DCSTAT_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_DCSTAT_IDX << 1))))
                 continue;
             netdata_publish_dcstat_t *in = &local_pid->directory_cache;
 

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -635,6 +635,13 @@ static void ebpf_fd_exit(void *pptr)
         nd_thread_join(ebpf_read_fd.thread);
     }
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_FD_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
@@ -780,7 +787,7 @@ static void ebpf_read_fd_apps_table(int maps_per_core)
 
         netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_FD_IDX);
         if (!local_pid)
-            continue;
+            goto end_fd_loop;
         netdata_publish_fd_stat_t *publish_fd = &local_pid->fd;
 
         if (kill((pid_t)key, 0) == -1 && errno == ESRCH) {
@@ -815,8 +822,8 @@ static void ebpf_fd_sum_pids(netdata_fd_stat_t *fd, struct ebpf_pid_on_target *r
 
     for (; root; root = root->next) {
         uint32_t pid = root->pid;
-        netdata_ebpf_pid_stats_t *pid_stat = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_FD_IDX);
-        if (!pid_stat)
+        netdata_ebpf_pid_stats_t *pid_stat = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+        if (!pid_stat || !(pid_stat->threads & (1U << (NETDATA_EBPF_PIDS_FD_IDX << 1))))
             continue;
         netdata_publish_fd_stat_t *w = &pid_stat->fd;
 
@@ -868,8 +875,8 @@ static void ebpf_update_fd_cgroup(void)
             uint32_t pid = pids->pid;
             netdata_publish_fd_stat_t *out = &pids->fd;
 
-            netdata_ebpf_pid_stats_t *pid_stat = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_FD_IDX);
-            if (!pid_stat)
+            netdata_ebpf_pid_stats_t *pid_stat = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!pid_stat || !(pid_stat->threads & (1U << (NETDATA_EBPF_PIDS_FD_IDX << 1))))
                 continue;
 
             netdata_publish_fd_stat_t *in = &pid_stat->fd;

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -464,9 +464,8 @@ static void ebpf_update_process_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             uint32_t pid = pids->pid;
             ebpf_publish_process_t *out = &pids->ps;
-            netdata_ebpf_pid_stats_t *local_pid =
-                netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_PROCESS_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_PROCESS_IDX << 1))))
                 continue;
 
             ebpf_publish_process_t *in = &local_pid->process;
@@ -970,6 +969,13 @@ static void ebpf_process_exit(void *pptr)
     netdata_mutex_lock(&lock);
     collect_pids &= ~(1 << EBPF_MODULE_PROCESS_IDX);
     netdata_mutex_unlock(&lock);
+
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_PROCESS_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
 
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
@@ -1508,8 +1514,8 @@ void ebpf_process_sum_values_for_pids(ebpf_process_stat_t *process, struct ebpf_
             break;
 
         uint32_t pid = root->pid;
-        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_PROCESS_IDX);
-        if (!local_pid)
+        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+        if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_PROCESS_IDX << 1))))
             continue;
 
         ebpf_publish_process_t *in = &local_pid->process;
@@ -1556,7 +1562,7 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core)
             netdata_ebpf_pid_stats_t *local_pid =
                 netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_PROCESS_IDX);
             if (!local_pid)
-                continue;
+                goto end_process_loop;
 
             ebpf_publish_process_t *w = &local_pid->process;
 
@@ -1568,7 +1574,7 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core)
                 w->release_call = process_stat_vector[0].release_call;
                 w->task_err = process_stat_vector[0].task_err;
             } else {
-                if (kill((pid_t)key, 0)) { // No PID found
+                if (kill((pid_t)key, 0) == -1 && errno == ESRCH) {
                     if (netdata_ebpf_reset_shm_pointer_unsafe(tbl_pid_stats_fd, key, NETDATA_EBPF_PIDS_PROCESS_IDX))
                         memset(w, 0, sizeof(*w));
                 }

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -481,6 +481,13 @@ static void ebpf_shm_exit(void *pptr)
         nd_thread_join(ebpf_read_shm.thread);
     }
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_SHM_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
@@ -559,8 +566,8 @@ static void ebpf_update_shm_cgroup(void)
         for (pids = ect->pids; pids; pids = pids->next) {
             uint32_t pid = pids->pid;
             netdata_publish_shm_t *out = &pids->shm;
-            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_SHM_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_SHM_IDX << 1))))
                 continue;
 
             netdata_publish_shm_t *in = &local_pid->shm;
@@ -599,13 +606,13 @@ static void ebpf_read_shm_apps_table(int maps_per_core)
 
         netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_SHM_IDX);
         if (!local_pid)
-            continue;
+            goto end_shm_loop;
         netdata_publish_shm_t *publish = &local_pid->shm;
 
         if (!publish->ct || publish->ct != cv->ct) {
             memcpy(publish, &cv[0], sizeof(netdata_publish_shm_t));
         } else {
-            if (kill((pid_t)key, 0)) { // No PID found
+            if (kill((pid_t)key, 0) == -1 && errno == ESRCH) {
                 if (netdata_ebpf_reset_shm_pointer_unsafe(fd, key, NETDATA_EBPF_PIDS_SHM_IDX))
                     memset(publish, 0, sizeof(*publish));
             }
@@ -672,8 +679,8 @@ static void ebpf_shm_sum_pids(netdata_publish_shm_t *shm, struct ebpf_pid_on_tar
     memset(shm, 0, sizeof(netdata_publish_shm_t));
     for (; root; root = root->next) {
         uint32_t pid = root->pid;
-        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_SHM_IDX);
-        if (!local_pid)
+        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+        if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_SHM_IDX << 1))))
             continue;
 
         netdata_publish_shm_t *w = &local_pid->shm;

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -930,6 +930,13 @@ static void ebpf_socket_exit(void *pptr)
         nd_thread_join(ebpf_read_socket.thread);
     }
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_SOCKET_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
@@ -1890,17 +1897,23 @@ static void ebpf_update_array_vectors(ebpf_module_t *em)
     end_socket_loop:; // the empty statement is here to allow code to be compiled by old compilers
         netdata_ebpf_pid_stats_t *local_pid =
             netdata_ebpf_get_shm_pointer_unsafe(key.pid, NETDATA_EBPF_PIDS_SOCKET_IDX);
-        if (!local_pid)
-            continue;
-        ebpf_socket_publish_apps_t *curr = &local_pid->socket;
+        if (local_pid) {
+            ebpf_socket_publish_apps_t *curr = &local_pid->socket;
 
-        if (!deleted)
-            ebpf_socket_fill_publish_apps(curr, values);
-        else {
-            netdata_ebpf_reset_shm_pointer_unsafe(fd, key.pid, NETDATA_EBPF_PIDS_SOCKET_IDX);
-            memset(curr, 0, sizeof(*curr));
-            bpf_map_delete_elem(fd, &key);
+            if (!deleted)
+                ebpf_socket_fill_publish_apps(curr, values);
+            else {
+                netdata_ebpf_reset_shm_pointer_unsafe(fd, key.pid, NETDATA_EBPF_PIDS_SOCKET_IDX);
+                memset(curr, 0, sizeof(*curr));
+            }
         }
+        // The socket map is keyed by a tuple (not by pid), so the generic
+        // reset_shm_pointer_unsafe() deliberately skips bpf_map_delete_elem()
+        // for SOCKET_IDX. Delete the stale socket here regardless of whether
+        // we had a shm slot, otherwise a full shm pool would strand dead
+        // socket entries in the kernel map and we'd re-iterate them forever.
+        if (deleted)
+            bpf_map_delete_elem(fd, &key);
         memset(values, 0, length);
         memcpy(&key, &next_key, sizeof(key));
     }
@@ -1926,9 +1939,8 @@ void ebpf_socket_resume_apps_data()
         memset(&w->socket, 0, sizeof(ebpf_socket_publish_apps_t));
         for (; move; move = move->next) {
             uint32_t pid = move->pid;
-            netdata_ebpf_pid_stats_t *local_pid =
-                netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_SOCKET_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_SOCKET_IDX << 1))))
                 continue;
 
             ebpf_socket_publish_apps_t *ws = &local_pid->socket;
@@ -1965,9 +1977,8 @@ static void ebpf_update_socket_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             uint32_t pid = pids->pid;
             ebpf_socket_publish_apps_t *publish = &ect->publish_socket;
-            netdata_ebpf_pid_stats_t *local_pid =
-                netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_SOCKET_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_SOCKET_IDX << 1))))
                 continue;
 
             ebpf_socket_publish_apps_t *in = &local_pid->socket;

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -452,6 +452,13 @@ static void ebpf_swap_exit(void *pptr)
         nd_thread_join(ebpf_read_swap.thread);
     }
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_SWAP_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
@@ -537,8 +544,8 @@ static void ebpf_update_swap_cgroup(void)
         for (pids = ect->pids; pids; pids = pids->next) {
             uint32_t pid = pids->pid;
             netdata_publish_swap_t *out = &pids->swap;
-            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_SWAP_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_SWAP_IDX << 1))))
                 continue;
             netdata_publish_swap_t *in = &local_pid->swap;
 
@@ -563,8 +570,8 @@ static void ebpf_swap_sum_pids(netdata_publish_swap_t *swap, struct ebpf_pid_on_
 
     for (; root; root = root->next) {
         uint32_t pid = root->pid;
-        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_SWAP_IDX);
-        if (!local_pid)
+        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+        if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_SWAP_IDX << 1))))
             continue;
         netdata_publish_swap_t *w = &local_pid->swap;
 
@@ -624,13 +631,13 @@ static void ebpf_read_swap_apps_table(int maps_per_core)
 
         netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_SWAP_IDX);
         if (!local_pid)
-            continue;
+            goto end_swap_loop;
         netdata_publish_swap_t *publish = &local_pid->swap;
 
         if (!publish->ct || publish->ct != cv->ct) {
             memcpy(publish, cv, sizeof(netdata_publish_swap_t));
         } else {
-            if (kill((pid_t)key, 0)) { // No PID found
+            if (kill((pid_t)key, 0) == -1 && errno == ESRCH) {
                 if (netdata_ebpf_reset_shm_pointer_unsafe(fd, key, NETDATA_EBPF_PIDS_SWAP_IDX))
                     memset(publish, 0, sizeof(*publish));
             }

--- a/src/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/src/collectors/ebpf.plugin/ebpf_vfs.c
@@ -909,6 +909,13 @@ static void ebpf_vfs_exit(void *pptr)
     if (ebpf_read_vfs.thread)
         nd_thread_signal_cancel(ebpf_read_vfs.thread);
 
+    // Drop this module's bits from the shared PID pool so its slots don't
+    // stay pinned if the plugin keeps running after the module stops.
+    if (integration_shm && ebpf_shm_sem_wait_or_stop(shm_mutex_ebpf_integration)) {
+        netdata_ebpf_sweep_shm_for_module_unsafe(NETDATA_EBPF_PIDS_VFS_IDX);
+        sem_post(shm_mutex_ebpf_integration);
+    }
+
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
@@ -1135,8 +1142,8 @@ static void ebpf_vfs_sum_pids(netdata_publish_vfs_t *vfs, struct ebpf_pid_on_tar
 
     for (; root; root = root->next) {
         uint32_t pid = root->pid;
-        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_VFS_IDX);
-        if (!local_pid)
+        netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+        if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_VFS_IDX << 1))))
             continue;
 
         netdata_publish_vfs_t *w = &local_pid->vfs;
@@ -1303,13 +1310,13 @@ static void ebpf_vfs_read_apps(int maps_per_core)
 
         netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(key, NETDATA_EBPF_PIDS_VFS_IDX);
         if (!local_pid)
-            continue;
+            goto end_vfs_loop;
         netdata_publish_vfs_t *publish = &local_pid->vfs;
 
         if (!publish->ct || publish->ct != vv->ct) {
             vfs_aggregate_set_vfs(publish, vv);
         } else {
-            if (kill((pid_t)key, 0)) { // No PID found
+            if (kill((pid_t)key, 0) == -1 && errno == ESRCH) {
                 if (netdata_ebpf_reset_shm_pointer_unsafe(fd, key, NETDATA_EBPF_PIDS_VFS_IDX))
                     memset(publish, 0, sizeof(*publish));
             }
@@ -1343,8 +1350,8 @@ static void read_update_vfs_cgroup()
             netdata_publish_vfs_t *out = &pids->vfs;
             memset(out, 0, sizeof(netdata_publish_vfs_t));
 
-            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_get_shm_pointer_unsafe(pid, NETDATA_EBPF_PIDS_VFS_IDX);
-            if (!local_pid)
+            netdata_ebpf_pid_stats_t *local_pid = netdata_ebpf_lookup_shm_pointer_unsafe(pid);
+            if (!local_pid || !(local_pid->threads & (1U << (NETDATA_EBPF_PIDS_VFS_IDX << 1))))
                 continue;
             netdata_publish_vfs_t *in = &local_pid->vfs;
 

--- a/src/go/plugin/agent/discovery/sd/dyncfg.go
+++ b/src/go/plugin/agent/discovery/sd/dyncfg.go
@@ -83,6 +83,10 @@ func (cb *sdCallbacks) ExtractKey(fn dyncfg.Function) (key, name string, ok bool
 	return dt + ":" + name, name, true
 }
 
+func (cb *sdCallbacks) ValidateJobName(name string) error {
+	return dyncfg.JobNameRuleAllowDots(name)
+}
+
 func (cb *sdCallbacks) ParseAndValidate(fn dyncfg.Function, name string) (sdConfig, error) {
 	dt, _, _ := cb.sd.extractDiscovererAndName(fn.ID())
 	if _, err := parseDyncfgPayload(fn.Payload(), dt, name, cb.sd.configDefaults, cb.sd.discovererRegistry(), true); err != nil {
@@ -251,7 +255,7 @@ func (d *ServiceDiscovery) dyncfgCmdTest(fn dyncfg.Function) {
 	if !isJob {
 		name = dyncfgTemplateJobName(fn)
 	}
-	if err := dyncfg.ValidateJobName(name); err != nil {
+	if err := dyncfg.JobNameRuleAllowDots(name); err != nil {
 		d.Warningf("dyncfg: test: unacceptable job name '%s' for '%s': %v", name, dt, err)
 		d.dyncfgApi.SendCodef(fn, 400, "Unacceptable job name '%s': %v.", name, err)
 		return

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
@@ -58,6 +58,10 @@ func (cb *collectorCallbacks) ExtractKey(fn dyncfg.Function) (key, name string, 
 	return key, jn, true
 }
 
+func (cb *collectorCallbacks) ValidateJobName(name string) error {
+	return dyncfg.JobNameRuleStrict(name)
+}
+
 func (cb *collectorCallbacks) ParseAndValidate(fn dyncfg.Function, name string) (confgroup.Config, error) {
 	mn, ok := cb.mgr.extractModuleName(fn.ID())
 	if !ok {

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_cmds.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_cmds.go
@@ -114,7 +114,7 @@ func (m *Manager) dyncfgCmdTest(fn dyncfg.Function) {
 
 	m.Infof("dyncfg: %s: %s/%s job by user '%s'", cmd, mn, jn, fn.User())
 
-	if err := dyncfg.ValidateJobName(jn); err != nil {
+	if err := dyncfg.JobNameRuleStrict(jn); err != nil {
 		m.Warningf("dyncfg: %s: module %s: unacceptable job name '%s': %v", cmd, mn, jn, err)
 		m.dyncfgResponder.SendCodef(fn, 400, "Unacceptable job name '%s': %v.", jn, err)
 		return

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
@@ -874,6 +874,10 @@ func (cb *collectorSeqTestCallbacks) ExtractKey(fn dyncfg.Function) (key, name s
 	return cb.mgr.collectorCallbacks.ExtractKey(fn)
 }
 
+func (cb *collectorSeqTestCallbacks) ValidateJobName(name string) error {
+	return dyncfg.JobNameRuleStrict(name)
+}
+
 func (cb *collectorSeqTestCallbacks) ParseAndValidate(fn dyncfg.Function, _ string) (confgroup.Config, error) {
 	cfg, ok := cb.parsed[fn.Command()]
 	if !ok {

--- a/src/go/plugin/agent/jobmgr/secretsctl/callbacks.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/callbacks.go
@@ -132,6 +132,10 @@ func (cb *secretStoreCallbacks) ExtractKey(fn dyncfg.Function) (key, name string
 	return key, name, true
 }
 
+func (cb *secretStoreCallbacks) ValidateJobName(name string) error {
+	return dyncfg.JobNameRuleAllowDots(name)
+}
+
 func (cb *secretStoreCallbacks) ParseAndValidate(fn dyncfg.Function, name string) (secretstore.Config, error) {
 	var kind secretstore.StoreKind
 	if fn.Command() == dyncfg.CommandAdd {

--- a/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
@@ -60,7 +60,7 @@ func (c *Controller) dyncfgCmdAdd(fn dyncfg.Function) {
 		c.api.SendCodef(fn, 400, "%v", err)
 		return
 	}
-	if err := dyncfg.ValidateJobName(name); err != nil {
+	if err := dyncfg.JobNameRuleAllowDots(name); err != nil {
 		c.api.SendCodef(fn, 400, "invalid job name '%s': %v.", name, err)
 		return
 	}

--- a/src/go/plugin/agent/jobmgr/secretstore_deps.go
+++ b/src/go/plugin/agent/jobmgr/secretstore_deps.go
@@ -289,7 +289,7 @@ func extractSecretStoreKeysFromString(value string, seen map[string]struct{}) {
 		if !kind.IsValid() {
 			continue
 		}
-		if err := dyncfg.ValidateJobName(name); err != nil {
+		if err := dyncfg.JobNameRuleAllowDots(name); err != nil {
 			continue
 		}
 		seen[secretstore.StoreKey(kind, name)] = struct{}{}

--- a/src/go/plugin/agent/jobmgr/vnodectl/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/vnodectl/dyncfg.go
@@ -111,7 +111,7 @@ func (c *Controller) dyncfgCmdAdd(fn dyncfg.Function) {
 		c.api.SendCodef(fn, 400, "Missing vnode name.")
 		return
 	}
-	if err := dyncfg.ValidateJobName(name); err != nil {
+	if err := dyncfg.JobNameRuleAllowDots(name); err != nil {
 		c.Warningf("dyncfg: %s: unacceptable vnode name '%s': %v", dyncfg.CommandAdd, name, err)
 		c.api.SendCodef(fn, 400, "Unacceptable vnode name '%s': %v.", name, err)
 		return

--- a/src/go/plugin/agent/secrets/secretstore/helpers.go
+++ b/src/go/plugin/agent/secrets/secretstore/helpers.go
@@ -5,5 +5,5 @@ package secretstore
 import "github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 
 func validateStoreName(name string) error {
-	return dyncfg.ValidateJobName(name)
+	return dyncfg.JobNameRuleAllowDots(name)
 }

--- a/src/go/plugin/framework/dyncfg/handler.go
+++ b/src/go/plugin/framework/dyncfg/handler.go
@@ -21,6 +21,10 @@ type Callbacks[C Config] interface {
 	// Includes all validation (including heavy checks like module instantiation).
 	ParseAndValidate(fn Function, name string) (C, error)
 
+	// ValidateJobName enforces the domain's job-name policy. Called before
+	// ParseAndValidate so cheap name-format rejections happen without parsing payload.
+	ValidateJobName(name string) error
+
 	// Start creates a work unit and starts it. Owns the full start lifecycle
 	// including pre-start cleanup and post-fail retry scheduling.
 	// Return CodedError to override EnableFailCode.
@@ -437,7 +441,7 @@ func (h *Handler[C]) CmdAdd(fn Function) {
 		return
 	}
 
-	if err := ValidateJobName(name); err != nil {
+	if err := h.cb.ValidateJobName(name); err != nil {
 		h.api.SendCodef(fn, 400, "invalid job name '%s': %v.", name, err)
 		return
 	}

--- a/src/go/plugin/framework/dyncfg/handler_test.go
+++ b/src/go/plugin/framework/dyncfg/handler_test.go
@@ -73,6 +73,10 @@ func (m *mockCallbacks) ParseAndValidate(fn Function, name string) (testConfig, 
 	return testConfig{uid: "dyncfg:" + name, key: name, sourceType: "dyncfg", source: "test"}, nil
 }
 
+func (m *mockCallbacks) ValidateJobName(name string) error {
+	return JobNameRuleStrict(name)
+}
+
 func (m *mockCallbacks) Start(cfg testConfig) error {
 	m.startCalls = append(m.startCalls, cfg)
 	if m.startFn != nil {
@@ -1187,31 +1191,58 @@ func TestNotifyJobCreate_SupportedCommands(t *testing.T) {
 	}
 }
 
-// --- ValidateJobName Tests ---
+// --- Job-name rule tests ---
 
-func TestValidateJobName(t *testing.T) {
-	tests := []struct {
-		name    string
+func TestJobNameRuleStrict(t *testing.T) {
+	tests := map[string]struct {
 		input   string
 		wantErr bool
 	}{
-		{"valid", "my_job", false},
-		{"valid with numbers", "job123", false},
-		{"valid with dashes", "my-job", false},
-		{"space", "my job", true},
-		{"tab", "my\tjob", true},
-		{"dot", "my.job", true},
-		{"colon", "my:job", true},
-		{"empty", "", false},
+		"valid":              {input: "my_job"},
+		"valid with numbers": {input: "job123"},
+		"valid with dashes":  {input: "my-job"},
+		"space":              {input: "my job", wantErr: true},
+		"tab":                {input: "my\tjob", wantErr: true},
+		"dot":                {input: "my.job", wantErr: true},
+		"colon":              {input: "my:job", wantErr: true},
+		"empty":              {input: ""},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateJobName(tt.input)
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := JobNameRuleStrict(tt.input)
 			if tt.wantErr {
-				assert.Error(t, err, fmt.Sprintf("ValidateJobName(%q) should fail", tt.input))
+				assert.Error(t, err, fmt.Sprintf("JobNameRuleStrict(%q) should fail", tt.input))
 			} else {
-				assert.NoError(t, err, fmt.Sprintf("ValidateJobName(%q) should pass", tt.input))
+				assert.NoError(t, err, fmt.Sprintf("JobNameRuleStrict(%q) should pass", tt.input))
+			}
+		})
+	}
+}
+
+func TestJobNameRuleAllowDots(t *testing.T) {
+	tests := map[string]struct {
+		input   string
+		wantErr bool
+	}{
+		"valid":              {input: "my_job"},
+		"valid with numbers": {input: "job123"},
+		"valid with dashes":  {input: "my-job"},
+		"dotted name":        {input: "my.job"},
+		"fqdn":               {input: "host.example.com"},
+		"space":              {input: "my job", wantErr: true},
+		"tab":                {input: "my\tjob", wantErr: true},
+		"colon":              {input: "my:job", wantErr: true},
+		"empty":              {input: ""},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := JobNameRuleAllowDots(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err, fmt.Sprintf("JobNameRuleAllowDots(%q) should fail", tt.input))
+			} else {
+				assert.NoError(t, err, fmt.Sprintf("JobNameRuleAllowDots(%q) should pass", tt.input))
 			}
 		})
 	}

--- a/src/go/plugin/framework/dyncfg/validate.go
+++ b/src/go/plugin/framework/dyncfg/validate.go
@@ -8,14 +8,34 @@ import (
 	"unicode"
 )
 
-// ValidateJobName checks that a job name contains no spaces, dots, or colons.
-func ValidateJobName(jobName string) error {
-	for _, r := range jobName {
+// JobNameRuleStrict rejects spaces, dots, and colons.
+// Use for collector job names, which must not conflict with dyncfg template/job
+// ID separators (':') or module hierarchy ('.').
+func JobNameRuleStrict(name string) error {
+	if err := rejectSpacesAndColons(name); err != nil {
+		return err
+	}
+	for _, r := range name {
+		if r == '.' {
+			return fmt.Errorf("contains '%c'", r)
+		}
+	}
+	return nil
+}
+
+// JobNameRuleAllowDots rejects spaces and colons but allows dots.
+// Use for service discovery, vnode, and secretstore names where dotted identifiers
+// are legitimate (e.g. hostnames, FQDNs).
+func JobNameRuleAllowDots(name string) error {
+	return rejectSpacesAndColons(name)
+}
+
+func rejectSpacesAndColons(name string) error {
+	for _, r := range name {
 		if unicode.IsSpace(r) {
 			return errors.New("contains spaces")
 		}
-		switch r {
-		case '.', ':':
+		if r == ':' {
 			return fmt.Errorf("contains '%c'", r)
 		}
 	}

--- a/src/go/plugin/go.d/collector/powerstore/client/types.go
+++ b/src/go/plugin/go.d/collector/powerstore/client/types.go
@@ -37,7 +37,6 @@ type Hardware struct {
 	LifecycleState string `json:"lifecycle_state"`
 	StatusLED      string `json:"status_led,omitempty"`
 	ApplianceID    string `json:"appliance_id,omitempty"`
-	ExtraDetails   string `json:"extra_details,omitempty"`
 	PartNumber     string `json:"part_number,omitempty"`
 	SerialNumber   string `json:"serial_number,omitempty"`
 	Slot           int    `json:"slot,omitempty"`

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_system-base.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_system-base.yaml
@@ -9,6 +9,21 @@ metric_tags:
     tag: device_hostname
 
 metrics:
+  # Prefer SNMP-FRAMEWORK-MIB (snmpEngineTime) as the primary uptime source.
+  # It is reported in seconds and does not suffer from the ~497-day wrap
+  # limitation of TimeTicks (uint32) used by hrSystemUptime/sysUpTime.
+  # This makes it more reliable for long-running devices.
+  # Note: this reflects SNMP engine uptime, which in practice usually
+  # aligns with system uptime.
+  # We keep the same metric name (systemUptime) so the fallback logic works.
+  - MIB: SNMP-FRAMEWORK-MIB
+    symbol:
+      OID: 1.3.6.1.6.3.10.2.1.3.0
+      name: systemUptime
+      chart_meta:
+        description: Time since the system was last rebooted or powered on.
+        family: 'System/Uptime'
+        unit: "s"
   - MIB: HOST-RESOURCES-MIB
     symbol:
       OID: 1.3.6.1.2.1.25.1.1.0


### PR DESCRIPTION
##### Summary
- fix(go.d/powerstore): remove extra_details field (#22291)
- fix(go.d/snmp): use snmpEngineTime as primary uptime source (#22231)
- ebpf.plugin: fix PID accounting shared-memory pool leak and 100% CPU spin (#22232)
- refactor(go.d/dyncfg): split job-name validation per domain (#22247)




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a PID shared-memory pool leak and 100% CPU spin in `ebpf.plugin`, splits dynamic-config job name validation by domain, switches SNMP uptime to `snmpEngineTime`, and removes an obsolete PowerStore field.

- **Bug Fixes**
  - Separated SHM lookup from allocation; aggregation uses a non-allocating lookup. Zeroed new slots and sweep module bits on exit to release stale entries.
  - Prevented infinite loops when SHM is full by always advancing BPF map iteration; always delete dead socket tuples from the kernel map.
  - Fixed PID liveness checks to only treat ESRCH as dead; cleaned SHM/semaphore lifecycle with `shm_unlink`/`sem_unlink` and wiped the region on init.
  - Made `SNMP-FRAMEWORK-MIB::snmpEngineTime` the primary `systemUptime` in `go.d/snmp`; keeps the same metric name and HR-MIB as fallback.
  - Removed `ExtraDetails` from `go.d/powerstore` Hardware to match the API and avoid decode errors.

- **Migration**
  - If you implement `dyncfg.Callbacks`, add `ValidateJobName(name string) error`.
  - Use `JobNameRuleStrict` for collectors; use `JobNameRuleAllowDots` for service discovery, secret store, and vnode names.

<sup>Written for commit 58b6d16e0bfd10dbb906140c3f3c64ba09def51e. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22249?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->







