### PR TITLE
perf(ml): reuse onewayalloc arena across hosts in detection loop

### DIFF
--- a/src/ml/ad_charts.cc
+++ b/src/ml/ad_charts.cc
@@ -250,7 +250,7 @@ void ml_update_dimensions_chart(ml_host_t *host, const ml_machine_learning_stats
     }
 }
 
-void ml_update_host_and_detection_rate_charts(ml_host_t *host, collected_number AnomalyRate, ONEWAYALLOC *owa) {
+void ml_update_host_and_detection_rate_charts(ml_host_t *host, collected_number anomaly_rate, ONEWAYALLOC *owa) {
     /*
      * Host anomaly rate
     */
@@ -283,7 +283,7 @@ void ml_update_host_and_detection_rate_charts(ml_host_t *host, collected_number 
                 rrddim_add(host->anomaly_rate_rs, "anomaly_rate", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
         }
 
-        rrddim_set_by_pointer(host->anomaly_rate_rs, host->anomaly_rate_rd, AnomalyRate);
+        rrddim_set_by_pointer(host->anomaly_rate_rs, host->anomaly_rate_rd, anomaly_rate);
 
         rrdset_done(host->anomaly_rate_rs);
     }

--- a/src/ml/ad_charts.cc
+++ b/src/ml/ad_charts.cc
@@ -250,7 +250,7 @@ void ml_update_dimensions_chart(ml_host_t *host, const ml_machine_learning_stats
     }
 }
 
-void ml_update_host_and_detection_rate_charts(ml_host_t *host, collected_number AnomalyRate) {
+void ml_update_host_and_detection_rate_charts(ml_host_t *host, collected_number AnomalyRate, ONEWAYALLOC *owa) {
     /*
      * Host anomaly rate
     */
@@ -378,14 +378,17 @@ void ml_update_host_and_detection_rate_charts(ml_host_t *host, collected_number 
          * Compute the values of the dimensions based on the host rate chart
         */
         if (host->ml_running) {
-            ONEWAYALLOC *OWA = onewayalloc_create(0);
+            // Reclaim the previous host's query scratch before starting the
+            // next one. Cheap no-op on the first iteration of a fresh arena.
+            onewayalloc_reset(owa);
+
             time_t Now = now_realtime_sec();
             time_t Before = Now - host->rh->rrd_update_every;
             time_t After = Before - Cfg.anomaly_detection_query_duration;
             RRDR_OPTIONS Options = static_cast<RRDR_OPTIONS>(0x00000000);
 
             RRDR *R = rrd2rrdr_legacy(
-                    OWA,
+                    owa,
                     host->anomaly_rate_rs,
                     1 /* points wanted */,
                     After,
@@ -415,10 +418,8 @@ void ml_update_host_and_detection_rate_charts(ml_host_t *host, collected_number 
                     rrdset_done(host->detector_events_rs);
                 }
 
-                rrdr_free(OWA, R);
+                rrdr_free(owa, R);
             }
-
-            onewayalloc_destroy(OWA);
         } else {
             rrddim_set_by_pointer(host->detector_events_rs,
                                   host->detector_events_above_threshold_rd, 0);

--- a/src/ml/ad_charts.h
+++ b/src/ml/ad_charts.h
@@ -7,7 +7,7 @@
 
 void ml_update_dimensions_chart(ml_host_t *host, const ml_machine_learning_stats_t &mls);
 
-void ml_update_host_and_detection_rate_charts(ml_host_t *host, collected_number anomaly_rate);
+void ml_update_host_and_detection_rate_charts(ml_host_t *host, collected_number anomaly_rate, ONEWAYALLOC *owa);
 
 void ml_update_training_statistics_chart(ml_worker_t *worker, const ml_queue_stats_t &ts);
 

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1109,9 +1109,9 @@ void ml_detect_main(void *arg)
     heartbeat_t hb;
     heartbeat_init(&hb, USEC_PER_SEC);
 
-    // Single onewayalloc arena reused across every host in this iteration —
-    // one mmap/munmap pair for the whole detect thread lifetime instead of
-    // one per host per second. The arena is reset between hosts inside
+    // Single onewayalloc arena reused across every host and loop iteration
+    // for the whole detect thread lifetime — one mmap/munmap pair instead
+    // of one per host per second. The arena is reset between hosts inside
     // ml_update_host_and_detection_rate_charts, so peak memory stays bounded
     // by a single host's anomaly-rate query scratch.
     ONEWAYALLOC *detect_owa = onewayalloc_create(0);

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1006,7 +1006,7 @@ ml_chart_update_dimension(ml_chart_t *chart, ml_dimension_t *dim, bool is_anomal
 #define WORKER_JOB_DETECTION_STATS 3
 
 static void
-ml_host_detect_once(ml_host_t *host)
+ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
 {
     worker_is_busy(WORKER_JOB_DETECTION_COLLECT_STATS);
 
@@ -1081,7 +1081,7 @@ ml_host_detect_once(ml_host_t *host)
         ml_update_dimensions_chart(host, mls_copy);
 
         worker_is_busy(WORKER_JOB_DETECTION_HOST_CHART);
-        ml_update_host_and_detection_rate_charts(host, host->host_anomaly_rate * 10000.0);
+        ml_update_host_and_detection_rate_charts(host, host->host_anomaly_rate * 10000.0, owa);
     } else {
         host->host_anomaly_rate = 0.0;
 
@@ -1109,6 +1109,13 @@ void ml_detect_main(void *arg)
     heartbeat_t hb;
     heartbeat_init(&hb, USEC_PER_SEC);
 
+    // Single onewayalloc arena reused across every host in this iteration —
+    // one mmap/munmap pair for the whole detect thread lifetime instead of
+    // one per host per second. The arena is reset between hosts inside
+    // ml_update_host_and_detection_rate_charts, so peak memory stays bounded
+    // by a single host's anomaly-rate query scratch.
+    ONEWAYALLOC *detect_owa = onewayalloc_create(0);
+
     while (!Cfg.detection_stop && service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
         heartbeat_next(&hb);
@@ -1122,7 +1129,7 @@ void ml_detect_main(void *arg)
             if (!service_running(SERVICE_COLLECTORS))
                 break;
 
-            ml_host_detect_once((ml_host_t *) rh->ml_host);
+            ml_host_detect_once((ml_host_t *) rh->ml_host, detect_owa);
         }
         rrd_rdunlock();
 
@@ -1139,6 +1146,9 @@ void ml_detect_main(void *arg)
             }
         }
     }
+
+    onewayalloc_destroy(detect_owa);
+
     Cfg.training_stop = true;
     finalize_self_prepared_sql_statements();
 }


### PR DESCRIPTION
##### Summary
- Replace the per-host onewayalloc_create/destroy pair in `ml_update_host_and_detection_rate_charts` with a single arena owned by ml_detect_main and reset between hosts — one mmap/munmap pair   per detect-thread lifetime instead of one per host per second.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse a single `ONEWAYALLOC` arena across hosts in the detection loop to eliminate per-host allocations and cut mmap/munmap churn. Improves detection throughput and bounds peak memory to one host’s anomaly-rate query scratch.

- **Refactors**
  - Allocate one `ONEWAYALLOC` in `ml_detect_main`; reuse across hosts and iterations; reset between hosts; destroy on exit.
  - Pass the arena to `ml_host_detect_once` and `ml_update_host_and_detection_rate_charts`; remove per-host create/destroy and use `rrdr_free(owa, R)`.
  - Rename parameter `AnomalyRate` to `anomaly_rate` for consistency.

<sup>Written for commit 3fdd37a4c24f38a81ee6180549af8228ea922173. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

