### PR TITLE
network-viewer: stabilize topology around self listeners

### DIFF
--- a/src/collectors/network-viewer.plugin/network-viewer.c
+++ b/src/collectors/network-viewer.plugin/network-viewer.c
@@ -1176,6 +1176,7 @@ static void local_sockets_cb_to_topology(LS_STATE *ls, const LOCAL_SOCKET *n, vo
         return;
 
     NV_TOPOLOGY_CONTEXT *ctx = data;
+    bool hidden_listen_socket = (n->direction == SOCKET_DIRECTION_LISTEN && !ctx->options.sockets_listening);
     ctx->sockets_total++;
 
     char local_ip[INET6_ADDRSTRLEN] = "";
@@ -1223,6 +1224,19 @@ static void local_sockets_cb_to_topology(LS_STATE *ls, const LOCAL_SOCKET *n, vo
             local_actor = dictionary_set(ctx->local_ips, local_ip, &tmp, sizeof(tmp));
         }
         local_actor->sockets++;
+    }
+
+    if(hidden_listen_socket) {
+        NV_PROCESS_ACTOR hidden_owner = {
+            .pid = n->pid,
+            .ppid = n->ppid,
+            .uid = n->uid,
+            .net_ns_inode = n->net_ns_inode,
+        };
+        snprintf(hidden_owner.process, sizeof(hidden_owner.process), "%s", process_name);
+        topology_register_endpoint_owner(ctx, n->net_ns_inode, n->local.protocol, local_ip, n->local.port, &hidden_owner, true);
+        ctx->skipped_sockets++;
+        return;
     }
 
     char process_key[NV_TOPOLOGY_KEY_MAX];
@@ -1290,7 +1304,8 @@ static void local_sockets_cb_to_topology(LS_STATE *ls, const LOCAL_SOCKET *n, vo
     }
 
     bool remote_is_self = topology_ip_belongs_to_self(ctx, remote_ip, remote_address_space);
-    bool create_endpoint_actor = (!remote_is_self || n->direction == SOCKET_DIRECTION_LISTEN);
+    bool self_owned_listen_socket = (n->direction == SOCKET_DIRECTION_LISTEN && remote_is_self);
+    bool create_endpoint_actor = !remote_is_self;
     if(create_endpoint_actor) {
         char endpoint_actor_key[NV_TOPOLOGY_KEY_MAX];
         topology_actor_id_for_remote_endpoint(ctx, remote_ip, remote_address_space, endpoint_actor_key, sizeof(endpoint_actor_key));
@@ -1304,14 +1319,23 @@ static void local_sockets_cb_to_topology(LS_STATE *ls, const LOCAL_SOCKET *n, vo
         ra->sockets++;
     }
 
+    if(self_owned_listen_socket) {
+        ctx->skipped_sockets++;
+        return;
+    }
+
     const struct socket_endpoint *server_endpoint = NULL;
     uint16_t endpoint_port = n->remote.port;
     switch(n->direction) {
         case SOCKET_DIRECTION_LISTEN:
+            server_endpoint = &n->local;
+            endpoint_port = n->local.port;
+            break;
+
         case SOCKET_DIRECTION_INBOUND:
         case SOCKET_DIRECTION_LOCAL_INBOUND:
             server_endpoint = &n->local;
-            endpoint_port = n->local.port;
+            endpoint_port = n->remote.port;
             break;
 
         case SOCKET_DIRECTION_OUTBOUND:
@@ -1499,7 +1523,9 @@ static bool topology_prepare_context(NV_TOPOLOGY_CONTEXT *ctx, usec_t now_ut, co
 
     LS_STATE ls = {
         .config = {
-            .listening = ctx->options.sockets_listening,
+            // Always collect listeners so inbound/outbound socket classification
+            // remains stable across topology socket filters.
+            .listening = true,
             .local = ctx->options.sockets_local,
             .inbound = ctx->options.sockets_inbound,
             .outbound = ctx->options.sockets_outbound,


### PR DESCRIPTION
## Summary
- always collect listener sockets internally so topology classification does not depend on whether `sockets:listening` is selected
- keep hidden listeners in the self-IP and endpoint-owner indexes without surfacing them unless the caller explicitly requests listening sockets
- stop emitting self-owned listen addresses as endpoint actors and keep inbound peer ports intact for established sockets

## Problem
- `topology:network-connections` rendered self-owned listen addresses like `127.0.0.1`, `::1`, and `::ffff:127.x.x.x` as if they were remote endpoints
- adding `sockets:listening` could change the direction and peer-port interpretation of established non-listen sockets

## Testing
- rebuilt and installed the local agent with `./install.sh`
- bearer-authenticated live checks against the local agent confirmed:
  - `topology:network-connections sockets:listening` no longer returns self endpoint actors for `ip:127.0.0.1`, `ip:::1`, or `ip:::ffff:127.0.0.1`
  - existing loopback traffic now renders as process-to-process `local` links instead of process-to-endpoint links
  - the original live regression case stays stable across filters for `python3[1019501]`:
    - `processes:by_pid sockets:inbound` and `processes:by_pid sockets:listening,inbound` both return `python3[1019501]:8080 -> 10.20.1.19:54296` and `python3[1019501]:8080 -> 10.20.1.19:39354` as `inbound`
    - `processes:by_pid sockets:outbound` and `processes:by_pid sockets:listening,outbound` both return `python3[1019501]:59648 -> 13.225.35.67:443` as `outbound`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes network topology around self listeners and loopback traffic. Listeners are always collected internally, hidden unless `sockets:listening` is requested, and direction/ports stay consistent across filters.

- **Bug Fixes**
  - Loopback listen addresses (`127.0.0.1`, `::1`, `::ffff:127.x.x.x`) no longer appear as remote endpoint actors.
  - Established sockets keep correct direction and peer ports with or without `sockets:listening`.
  - Hidden listeners are indexed for endpoint-owner mapping but only shown when `sockets:listening` is requested.

<sup>Written for commit 89a70e5b14a66714fede8fb2ba6e335c1ced0332. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

