### PR TITLE
chore: add test fixtures to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,9 @@ build-*/
 # ignore rules for go plugin code
 src/go/plugin/go.d/bin/
 src/go/plugin/go.d/vendor
+# Test fixtures from https://github.com/netdata/testdata
+# Used by tests with: go test -tags=topology_fixtures ./...
+src/go/testdata
 
 # ignore files used with msi installer
 packaging/windows/*.msi


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `src/go/testdata` to `.gitignore` to keep local topology test fixtures out of the repo. These fixtures come from https://github.com/netdata/testdata and are used by `go test -tags=topology_fixtures ./...`.

<sup>Written for commit 228a1aa8c4b99501b400c4e11a128c9e330972b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

