### PR TITLE
feat(go.d/sd): Add HTTP service discovery 

### DIFF
--- a/docs/fleet-configuration-management.md
+++ b/docs/fleet-configuration-management.md
@@ -193,7 +193,10 @@ The go.d.plugin provides auto-discovery for 150+ applications through multiple m
 - **[Docker container discovery](https://learn.netdata.cloud/docs/collecting-metrics/container-services/docker) (dockersd)** - Discovers applications running in Docker containers
 - **[Kubernetes service discovery](https://learn.netdata.cloud/docs/netdata-agent/installation/kubernetes) (k8ssd)** - Discovers services running in Kubernetes pods
 - **[SNMP device discovery](https://learn.netdata.cloud/docs/collecting-metrics/network-devices/snmp) (snmpsd)** - Discovers and profiles SNMP-enabled network devices
+- **HTTP service discovery (http)** - Fetches JSON or YAML discovery items from an HTTP endpoint and creates collector jobs through service templates
 - **Configuration file scanning** - Detects applications based on their configuration files
+
+HTTP service discovery templates must generate job configs with `name` and `module`. The `module` is the collector name, such as `httpcheck` or `ping`; it can be omitted only in curated rules where the service rule ID is the intended collector module.
 
 **Platform-specific behavior**:
 

--- a/src/go/plugin/agent/discovery/sd/pipeline/funcmap.go
+++ b/src/go/plugin/agent/discovery/sd/pipeline/funcmap.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/bmatcuk/doublestar/v4"
+	"gopkg.in/yaml.v2"
 )
 
 func newFuncMap() template.FuncMap {
@@ -25,6 +26,10 @@ func newFuncMap() template.FuncMap {
 		"promPort": func(port string) string {
 			v, _ := strconv.Atoi(port)
 			return prometheusPortAllocations[v]
+		},
+		"toYaml": func(v any) (string, error) {
+			bs, err := yaml.Marshal(v)
+			return string(bs), err
 		},
 	}
 

--- a/src/go/plugin/agent/discovery/sd/pipeline/services_test.go
+++ b/src/go/plugin/agent/discovery/sd/pipeline/services_test.go
@@ -119,3 +119,102 @@ func TestServiceEngine_compose(t *testing.T) {
 		})
 	}
 }
+
+func TestServiceEngine_composeHTTPItems(t *testing.T) {
+	tests := map[string]struct {
+		configYAML  string
+		target      model.Target
+		wantConfigs []confgroup.Config
+	}{
+		"full job pass-through preserves module": {
+			configYAML: `
+- id: "passthrough"
+  match: '{{ true }}'
+  config_template: |
+    {{ .Item | toYaml }}
+`,
+			target: &itemTarget{Item: map[string]any{
+				"module": "nginx",
+				"name":   "local",
+				"url":    "http://127.0.0.1/stub_status",
+			}},
+			wantConfigs: []confgroup.Config{
+				{"module": "nginx", "name": "local", "url": "http://127.0.0.1/stub_status"},
+			},
+		},
+		"full job pass-through preserves numeric fields": {
+			configYAML: `
+- id: "passthrough"
+  match: '{{ true }}'
+  config_template: |
+    {{ .Item | toYaml }}
+`,
+			target: &itemTarget{Item: map[string]any{
+				"module": "httpcheck",
+				"name":   "api",
+				"url":    "http://127.0.0.1/health",
+				"port":   float64(80),
+			}},
+			wantConfigs: []confgroup.Config{
+				{"module": "httpcheck", "name": "api", "url": "http://127.0.0.1/health", "port": 80},
+			},
+		},
+		"endpoint object fills module from rule id": {
+			configYAML: `
+- id: "httpcheck"
+  match: '{{ hasKey .Item "url" }}'
+  config_template: |
+    name: {{ .Item.name }}
+    url: {{ .Item.url }}
+`,
+			target: &itemTarget{Item: map[string]any{
+				"name": "api",
+				"url":  "http://127.0.0.1/health",
+			}},
+			wantConfigs: []confgroup.Config{
+				{"module": "httpcheck", "name": "api", "url": "http://127.0.0.1/health"},
+			},
+		},
+		"scalar endpoint string uses TUID": {
+			configYAML: `
+- id: "httpcheck"
+  match: '{{ kindIs "string" .Item }}'
+  config_template: |
+    name: {{ .TUID }}
+    url: {{ .Item }}
+`,
+			target: &itemTarget{Item: "http://127.0.0.1/health", tuid: "http_item_1"},
+			wantConfigs: []confgroup.Config{
+				{"module": "httpcheck", "name": "http_item_1", "url": "http://127.0.0.1/health"},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var cfg []ServiceRuleConfig
+			err := yaml.Unmarshal([]byte(test.configYAML), &cfg)
+			require.NoErrorf(t, err, "yaml unmarshalling of services config")
+
+			svr, err := newServiceEngine(cfg)
+			require.NoErrorf(t, err, "service engine creation")
+
+			assert.Equal(t, test.wantConfigs, svr.compose(test.target))
+		})
+	}
+}
+
+type itemTarget struct {
+	model.Base
+	Item any
+	tuid string
+}
+
+func (t itemTarget) TUID() string {
+	if t.tuid != "" {
+		return t.tuid
+	}
+	return "item"
+}
+
+func (t itemTarget) Hash() uint64 { return 1 }

--- a/src/go/plugin/go.d/config/go.d/sd/http.conf
+++ b/src/go/plugin/go.d/config/go.d/sd/http.conf
@@ -1,0 +1,73 @@
+## ===================================================================
+## WARNING: HTTP DISCOVERY IS DISABLED BY DEFAULT
+## To enable, change "disabled: yes" to "disabled: no" below
+## AND configure the endpoint and service rules for your environment.
+## ===================================================================
+
+disabled: yes
+
+discoverer:
+  http:
+    ## HTTP endpoint that returns either:
+    ##   - a bare array: [ ... ]
+    ##   - an envelope: { "items": [ ... ] }
+    #url: "https://example.com/netdata/go.d/jobs.yaml"
+
+    ## How often to fetch the endpoint (default: 1m).
+    ## Set to 0 for a one-shot fetch. One-shot mode fetches once when this
+    ## SD pipeline starts; it does not refetch on SD reload unless the pipeline
+    ## itself is recreated.
+    #interval: "1m"
+
+    ## Response format: auto, json, or yaml (default: auto).
+    ## Auto uses Content-Type when clear, then tries JSON before YAML.
+    #format: auto
+
+    ## Standard HTTP options from go.d collectors are supported.
+    #headers:
+    #  Accept: application/yaml
+    #username: ""
+    #password: ""
+
+    ## If bearer_token_file points under /var/run/secrets/ and Netdata is not
+    ## running in Kubernetes, missing token files are ignored.
+    #bearer_token_file: ""
+
+    #timeout: "2s"
+    #proxy_url: ""
+    #tls_skip_verify: no
+
+services:
+  ## Full job pass-through. The fetched item must already be a go.d job config.
+  ## Pass-through items must include both name and module. The module is the
+  ## collector name, for example httpcheck, ping, or nginx.
+  ## `toYaml` serializes the decoded item to YAML for config_template parsing.
+  ## `.Item` is remote response data; `.TUID` and `.Hash` are target methods and
+  ## do not interact with same-named keys inside `.Item`.
+  - id: "passthrough"
+    match: '{{ true }}'
+    config_template: |
+      {{ .Item | toYaml }}
+
+  ## Example for an array of endpoint strings:
+  ##   items:
+  ##     - "https://example.com/health"
+  ##
+  ## - id: "httpcheck"
+  ##   # Because id is httpcheck, module may be omitted from this curated rule.
+  ##   match: '{{ kindIs "string" .Item }}'
+  ##   config_template: |
+  ##     name: {{ .TUID }}
+  ##     url: {{ .Item }}
+
+  ## Example for an array of endpoint objects:
+  ##   items:
+  ##     - name: "api"
+  ##       url: "https://api.example.com/health"
+  ##
+  ## - id: "httpcheck"
+  ##   # Because id is httpcheck, module may be omitted from this curated rule.
+  ##   match: '{{ and (kindIs "map" .Item) (hasKey .Item "url") }}'
+  ##   config_template: |
+  ##     name: {{ .Item.name }}
+  ##     url: {{ .Item.url }}

--- a/src/go/plugin/go.d/discovery/sdext/config_schema_http.json
+++ b/src/go/plugin/go.d/discovery/sdext/config_schema_http.json
@@ -1,0 +1,286 @@
+{
+  "jsonSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "HTTP Service Discovery",
+    "description": "Fetches JSON or YAML service discovery items from an HTTP endpoint.",
+    "type": "object",
+    "properties": {
+      "discoverer": {
+        "title": "Discoverer",
+        "type": "object",
+        "properties": {
+          "http": {
+            "title": "HTTP",
+            "type": "object",
+            "properties": {
+              "url": {
+                "title": "URL",
+                "description": "HTTP endpoint that returns a bare array or an object with an items array.",
+                "type": "string",
+                "format": "uri"
+              },
+              "method": {
+                "title": "Method",
+                "description": "HTTP method used to fetch discovery items.",
+                "type": "string"
+              },
+              "headers": {
+                "title": "Headers",
+                "description": "HTTP request headers.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "body": {
+                "title": "Body",
+                "description": "Optional HTTP request body.",
+                "type": "string"
+              },
+              "username": {
+                "title": "Username",
+                "description": "Basic authentication username.",
+                "type": "string"
+              },
+              "password": {
+                "title": "Password",
+                "description": "Basic authentication password.",
+                "type": "string"
+              },
+              "bearer_token_file": {
+                "title": "Bearer token file",
+                "description": "Path to a file containing a bearer token. The file is read for each request.",
+                "type": "string"
+              },
+              "interval": {
+                "title": "Poll interval",
+                "description": "How often to fetch the endpoint. Set to 0 for a one-shot fetch.",
+                "type": "string",
+                "pattern": "^[0-9]+(\\.[0-9]+)?(ms|s|m|h|d|w|mo|y)?$",
+                "default": "1m"
+              },
+              "timeout": {
+                "title": "Timeout",
+                "description": "HTTP request timeout, in seconds.",
+                "type": "number",
+                "minimum": 0.1,
+                "default": 2
+              },
+              "format": {
+                "title": "Response format",
+                "description": "Response format. Auto uses Content-Type when clear, then tries JSON before YAML.",
+                "type": "string",
+                "enum": [
+                  "auto",
+                  "json",
+                  "yaml"
+                ],
+                "default": "auto"
+              },
+              "not_follow_redirects": {
+                "title": "Do not follow redirects",
+                "type": "boolean"
+              },
+              "proxy_url": {
+                "title": "Proxy URL",
+                "type": "string"
+              },
+              "proxy_username": {
+                "title": "Proxy username",
+                "type": "string"
+              },
+              "proxy_password": {
+                "title": "Proxy password",
+                "type": "string"
+              },
+              "tls_ca": {
+                "title": "TLS CA",
+                "description": "Path to CA certificate used to verify the endpoint.",
+                "type": "string"
+              },
+              "tls_cert": {
+                "title": "TLS certificate",
+                "description": "Path to client TLS certificate.",
+                "type": "string"
+              },
+              "tls_key": {
+                "title": "TLS key",
+                "description": "Path to client TLS key.",
+                "type": "string"
+              },
+              "tls_skip_verify": {
+                "title": "Skip TLS verification",
+                "type": "boolean"
+              },
+              "force_http2": {
+                "title": "Force HTTP/2",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "url"
+            ]
+          }
+        },
+        "required": [
+          "http"
+        ]
+      },
+      "services": {
+        "title": "Service rules",
+        "description": "- Match fetched HTTP discovery items and generate collector configurations.\n- Generated job configs must include `name` and `module`; `module` is the collector name, for example `httpcheck` or `ping`.\n- If a generated config omits `module`, the rule ID is used as `module`; rely on this only for curated rules where the rule ID is the intended collector.\n- `.Item` contains the fetched item. String items expose the string as `.Item`; object items expose fields under `.Item`.",
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "Rule ID",
+              "description": "Unique identifier for this rule. If config_template omits module, this value is used as the module. Use that fallback only when the rule ID is the intended collector name.",
+              "type": "string"
+            },
+            "match": {
+              "title": "Match expression",
+              "description": "Go template expression that must evaluate to 'true' for the rule to match the fetched item.",
+              "type": "string"
+            },
+            "config_template": {
+              "title": "Config template",
+              "description": "Go template that generates the data collection job configuration in YAML format. Generated configs must include name and module unless module is intentionally filled from the rule ID.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "match"
+          ]
+        }
+      }
+    },
+    "required": [
+      "discoverer",
+      "services"
+    ]
+  },
+  "uiSchema": {
+    "uiOptions": {
+      "fullPage": true
+    },
+    "ui:flavour": "tabs",
+    "ui:options": {
+      "tabs": [
+        {
+          "title": "Discovery",
+          "fields": [
+            "discoverer"
+          ]
+        },
+        {
+          "title": "Services",
+          "fields": [
+            "services"
+          ]
+        }
+      ]
+    },
+    "discoverer": {
+      "http": {
+        "ui:flavour": "tabs",
+        "ui:options": {
+          "tabs": [
+            {
+              "title": "Request",
+              "fields": [
+                "url",
+                "format",
+                "not_follow_redirects",
+                "interval",
+                "timeout",
+                "method",
+                "body"
+              ]
+            },
+            {
+              "title": "Auth",
+              "fields": [
+                "username",
+                "password",
+                "bearer_token_file"
+              ]
+            },
+            {
+              "title": "TLS",
+              "fields": [
+                "tls_ca",
+                "tls_cert",
+                "tls_key",
+                "tls_skip_verify"
+              ]
+            },
+            {
+              "title": "Proxy",
+              "fields": [
+                "proxy_url",
+                "proxy_username",
+                "proxy_password",
+                "force_http2"
+              ]
+            },
+            {
+              "title": "Headers",
+              "fields": [
+                "headers"
+              ]
+            }
+          ]
+        },
+        "url": {
+          "ui:placeholder": "https://example.com/netdata/go.d/jobs.yaml"
+        },
+        "method": {
+          "ui:widget": "hidden"
+        },
+        "body": {
+          "ui:widget": "hidden"
+        },
+        "interval": {
+          "ui:placeholder": "1m",
+          "ui:help": "Examples: 30s, 1m, 5m. Use 0 for one-shot fetch."
+        },
+        "format": {
+          "ui:placeholder": "auto",
+          "ui:widget": "radio",
+          "ui:options": {
+            "inline": true
+          }
+        },
+        "password": {
+          "ui:widget": "password"
+        },
+        "proxy_password": {
+          "ui:widget": "password"
+        },
+        "force_http2": {
+          "ui:widget": "hidden"
+        }
+      }
+    },
+    "services": {
+      "ui:listFlavour": "list",
+      "items": {
+        "id": {
+          "ui:placeholder": "httpcheck"
+        },
+        "match": {
+          "ui:widget": "textarea",
+          "ui:placeholder": "{{ true }}",
+          "ui:help": "| Field | Description |\n|-------|-------------|\n| `.Item` | Fetched item. Object fields are under `.Item`, for example `.Item.url`. String items expose the string itself. |\n| `.TUID` | Stable target unique ID. |\n| `.Hash` | Stable content-sensitive target hash. |"
+        },
+        "config_template": {
+          "ui:widget": "textarea",
+          "ui:placeholder": "name: {{ .TUID }}\nmodule: httpcheck\nurl: {{ .Item }}"
+        }
+      }
+    }
+  }
+}

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/config.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/config.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package httpsd
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/confopt"
+	"github.com/netdata/netdata/go/plugins/pkg/web"
+)
+
+const (
+	defaultInterval = time.Minute
+	defaultTimeout  = 2 * time.Second
+
+	responseBodyLimit = 10 * 1024 * 1024
+
+	formatAuto = "auto"
+	formatJSON = "json"
+	formatYAML = "yaml"
+)
+
+type Config struct {
+	Source string `yaml:"-" json:"-"`
+
+	web.HTTPConfig `yaml:",inline" json:""`
+
+	Interval *confopt.LongDuration `yaml:"interval,omitempty" json:"interval,omitempty"`
+	Format   string                `yaml:"format,omitempty" json:"format,omitempty"`
+}
+
+func (c Config) validate() error {
+	if strings.TrimSpace(c.URL) == "" {
+		return errors.New("url is required")
+	}
+
+	u, err := url.Parse(c.URL)
+	if err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return fmt.Errorf("unsupported url scheme %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return errors.New("url host is required")
+	}
+
+	switch c.format() {
+	case formatAuto, formatJSON, formatYAML:
+	default:
+		return fmt.Errorf("unsupported format %q", c.Format)
+	}
+
+	if c.Interval != nil && c.Interval.Duration() < 0 {
+		return errors.New("interval cannot be negative")
+	}
+
+	return nil
+}
+
+func (c Config) interval() time.Duration {
+	if c.Interval == nil {
+		return defaultInterval
+	}
+	return c.Interval.Duration()
+}
+
+func (c Config) clientConfig() web.ClientConfig {
+	cfg := c.ClientConfig
+	if cfg.Timeout.Duration() <= 0 {
+		cfg.Timeout = confopt.Duration(defaultTimeout)
+	}
+	return cfg
+}
+
+func (c Config) format() string {
+	if v := strings.TrimSpace(strings.ToLower(c.Format)); v != "" {
+		return v
+	}
+	return formatAuto
+}

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/discoverer.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/discoverer.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package httpsd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/pkg/web"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/model"
+)
+
+const (
+	shortName = "http"
+	fullName  = "sd:http"
+)
+
+func NewDiscoverer(cfg Config) (*Discoverer, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	client, err := web.NewHTTPClient(cfg.clientConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	d := &Discoverer{
+		Logger: logger.New().With(
+			slog.String("component", "service discovery"),
+			slog.String("discoverer", shortName),
+		),
+		client:   client,
+		request:  cfg.RequestConfig,
+		interval: cfg.interval(),
+		parser:   responseParser{format: cfg.format()},
+		source:   sourceString(cfg),
+	}
+
+	return d, nil
+}
+
+type Discoverer struct {
+	*logger.Logger
+	model.Base
+
+	client  *http.Client
+	request web.RequestConfig
+
+	interval time.Duration
+	parser   responseParser
+	source   string
+}
+
+func (d *Discoverer) String() string {
+	return fullName
+}
+
+func (d *Discoverer) Discover(ctx context.Context, in chan<- []model.TargetGroup) {
+	d.Info("instance is started")
+	d.Debugf("used config: interval: %s, response body limit: %d, source: %s", d.interval, responseBodyLimit, d.source)
+	defer func() { d.Info("instance is stopped") }()
+
+	d.discover(ctx, in)
+
+	if d.interval <= 0 {
+		return
+	}
+
+	tk := time.NewTicker(d.interval)
+	defer tk.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tk.C:
+			d.discover(ctx, in)
+		}
+	}
+}
+
+func (d *Discoverer) discover(ctx context.Context, in chan<- []model.TargetGroup) {
+	tgg, err := d.fetchTargetGroup(ctx)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			d.Warning(err)
+		}
+		return
+	}
+
+	model.SendTargetGroup(ctx, in, tgg)
+}
+
+func (d *Discoverer) fetchTargetGroup(ctx context.Context) (model.TargetGroup, error) {
+	req, err := web.NewHTTPRequest(d.request)
+	if err != nil {
+		return nil, fmt.Errorf("create HTTP request: %w", err)
+	}
+	req = req.WithContext(ctx)
+	safeURL := sanitizedURL(req.URL.String())
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request to %q failed: %w", safeURL, err)
+	}
+	if resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s %q returned HTTP status code: %d", req.Method, safeURL, resp.StatusCode)
+	}
+
+	bs, err := readResponseBody(resp.Body, responseBodyLimit)
+	if err != nil {
+		return nil, fmt.Errorf("read response from %q: %w", safeURL, err)
+	}
+
+	items, err := d.parser.parse(bs, resp.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, fmt.Errorf("parse response from %q: %w", safeURL, err)
+	}
+
+	targets, err := targetsFromItems(d.source, items)
+	if err != nil {
+		return nil, err
+	}
+
+	return &targetGroup{
+		source:  d.source,
+		targets: targets,
+	}, nil
+}
+
+func readResponseBody(r io.Reader, maxBytes int64) ([]byte, error) {
+	lr := io.LimitReader(r, maxBytes+1)
+	bs, err := io.ReadAll(lr)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(bs)) > maxBytes {
+		return nil, fmt.Errorf("response body exceeds limit (%d bytes)", maxBytes)
+	}
+	return bs, nil
+}

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/discoverer_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/discoverer_test.go
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package httpsd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/confopt"
+	"github.com/netdata/netdata/go/plugins/pkg/web"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/model"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDiscoverer(t *testing.T) {
+	tests := map[string]struct {
+		cfg      Config
+		wantErr  bool
+		validate func(*testing.T, *Discoverer)
+	}{
+		"valid defaults": {
+			cfg: Config{
+				HTTPConfig: web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: "http://127.0.0.1"},
+				},
+			},
+			validate: func(t *testing.T, d *Discoverer) {
+				assert.Equal(t, defaultInterval, d.interval)
+				assert.Equal(t, defaultTimeout, d.client.Timeout)
+				assert.Equal(t, formatAuto, d.parser.format)
+			},
+		},
+		"explicit one shot": {
+			cfg: Config{
+				HTTPConfig: web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: "http://127.0.0.1"},
+				},
+				Interval: durationPtr(0),
+			},
+			validate: func(t *testing.T, d *Discoverer) {
+				assert.Zero(t, d.interval)
+			},
+		},
+		"negative interval": {
+			cfg: Config{
+				HTTPConfig: web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: "http://127.0.0.1"},
+				},
+				Interval: durationPtr(-time.Second),
+			},
+			wantErr: true,
+		},
+		"explicit format": {
+			cfg: Config{
+				HTTPConfig: web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: "http://127.0.0.1"},
+				},
+				Format: "yaml",
+			},
+			validate: func(t *testing.T, d *Discoverer) {
+				assert.Equal(t, formatYAML, d.parser.format)
+			},
+		},
+		"negative timeout uses default": {
+			cfg: Config{
+				HTTPConfig: web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: "http://127.0.0.1"},
+					ClientConfig:  web.ClientConfig{Timeout: confopt.Duration(-time.Second)},
+				},
+			},
+			validate: func(t *testing.T, d *Discoverer) {
+				assert.Equal(t, defaultTimeout, d.client.Timeout)
+			},
+		},
+		"missing url": {
+			wantErr: true,
+		},
+		"unsupported scheme": {
+			cfg: Config{
+				HTTPConfig: web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: "ftp://127.0.0.1"},
+				},
+			},
+			wantErr: true,
+		},
+		"unsupported format": {
+			cfg: Config{
+				HTTPConfig: web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: "http://127.0.0.1"},
+				},
+				Format: "toml",
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			d, err := NewDiscoverer(tc.cfg)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, d)
+			if tc.validate != nil {
+				tc.validate(t, d)
+			}
+		})
+	}
+}
+
+func TestDiscoverer_fetchTargetGroup(t *testing.T) {
+	var gotMethod, gotBody, gotHeader, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotHeader = r.Header.Get("X-Test")
+		gotAuth = r.Header.Get("Authorization")
+		bs, _ := ioReadAllString(r)
+		gotBody = bs
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `[{"name":"api","url":"http://127.0.0.1"}]`)
+	}))
+	defer srv.Close()
+
+	d, err := NewDiscoverer(Config{
+		HTTPConfig: web.HTTPConfig{
+			RequestConfig: web.RequestConfig{
+				URL:      srv.URL,
+				Method:   http.MethodPost,
+				Body:     "request-body",
+				Username: "user",
+				Password: "pass",
+				Headers:  map[string]string{"X-Test": "value"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	tgg, err := d.fetchTargetGroup(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "request-body", gotBody)
+	assert.Equal(t, "value", gotHeader)
+	assert.NotEmpty(t, gotAuth)
+	assert.Equal(t, fullName, tgg.Provider())
+	assert.Len(t, tgg.Targets(), 1)
+	assert.Contains(t, tgg.Source(), "discoverer=http,url="+srv.URL+",hash=")
+}
+
+func TestDiscoverer_NotFollowRedirects(t *testing.T) {
+	var finalHit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			http.Redirect(w, r, "/final", http.StatusFound)
+		case "/final":
+			finalHit = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `[]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	d, err := NewDiscoverer(Config{
+		HTTPConfig: web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: srv.URL},
+			ClientConfig:  web.ClientConfig{NotFollowRedirect: true},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = d.fetchTargetGroup(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "redirect")
+	assert.False(t, finalHit)
+}
+
+func TestDiscoverer_BearerTokenFileReread(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	require.NoError(t, os.WriteFile(tokenFile, []byte("token-1"), 0o600))
+
+	var mu sync.Mutex
+	var auths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		auths = append(auths, r.Header.Get("Authorization"))
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `[]`)
+	}))
+	defer srv.Close()
+
+	d, err := NewDiscoverer(Config{
+		HTTPConfig: web.HTTPConfig{
+			RequestConfig: web.RequestConfig{
+				URL:             srv.URL,
+				BearerTokenFile: tokenFile,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = d.fetchTargetGroup(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(tokenFile, []byte("token-2"), 0o600))
+	_, err = d.fetchTargetGroup(context.Background())
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, auths, 2)
+	assert.Equal(t, "Bearer token-1", auths[0])
+	assert.Equal(t, "Bearer token-2", auths[1])
+}
+
+func TestDiscoverer_ResponseBodyLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		chunk := strings.Repeat("x", 1024)
+		for written := int64(0); written <= responseBodyLimit; written += int64(len(chunk)) {
+			if _, err := w.Write([]byte(chunk)); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	d, err := NewDiscoverer(Config{
+		HTTPConfig: web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: srv.URL},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = d.fetchTargetGroup(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "response body exceeds limit")
+}
+
+func TestDiscoverer_ErrorUsesSanitizedURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	rawURL := strings.Replace(srv.URL, "http://", "http://user:pass@", 1) + "/path?token=secret#fragment"
+	d, err := NewDiscoverer(Config{
+		HTTPConfig: web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: rawURL},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = d.fetchTargetGroup(context.Background())
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "/path")
+	assert.NotContains(t, err.Error(), "user")
+	assert.NotContains(t, err.Error(), "pass")
+	assert.NotContains(t, err.Error(), "token")
+	assert.NotContains(t, err.Error(), "secret")
+	assert.NotContains(t, err.Error(), "fragment")
+}
+
+func TestDiscoverer_DiscoverFailureDoesNotEmit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	d, err := NewDiscoverer(Config{
+		HTTPConfig: web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: srv.URL},
+		},
+		Interval: durationPtr(0),
+	})
+	require.NoError(t, err)
+
+	ch := make(chan []model.TargetGroup, 1)
+	d.Discover(context.Background(), ch)
+
+	select {
+	case got := <-ch:
+		t.Fatalf("expected no emission, got %v", got)
+	default:
+	}
+}
+
+func TestDiscoverer_DiscoverEmptySuccessEmitsEmptyTargetGroup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `[]`)
+	}))
+	defer srv.Close()
+
+	d, err := NewDiscoverer(Config{
+		HTTPConfig: web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: srv.URL},
+		},
+		Interval: durationPtr(0),
+	})
+	require.NoError(t, err)
+
+	ch := make(chan []model.TargetGroup, 1)
+	d.Discover(context.Background(), ch)
+
+	select {
+	case got := <-ch:
+		require.Len(t, got, 1)
+		assert.Empty(t, got[0].Targets())
+	case <-time.After(time.Second):
+		t.Fatal("expected empty target group emission")
+	}
+}
+
+func TestDiscoverer_DiscoverPollsInterval(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `[]`)
+	}))
+	defer srv.Close()
+
+	d, err := NewDiscoverer(Config{
+		HTTPConfig: web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: srv.URL},
+		},
+		Interval: durationPtr(10 * time.Millisecond),
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan []model.TargetGroup, 4)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.Discover(ctx, ch)
+	}()
+
+	for range 2 {
+		select {
+		case got := <-ch:
+			require.Len(t, got, 1)
+			assert.Empty(t, got[0].Targets())
+		case <-time.After(time.Second):
+			t.Fatal("expected target group emission")
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("discoverer did not stop after context cancellation")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.GreaterOrEqual(t, calls, 2)
+}
+
+func durationPtr(d time.Duration) *confopt.LongDuration {
+	v := confopt.LongDuration(d)
+	return &v
+}
+
+func ioReadAllString(r *http.Request) (string, error) {
+	bs, err := io.ReadAll(r.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(bs), nil
+}

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/parser.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/parser.go
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package httpsd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/model"
+
+	"gopkg.in/yaml.v2"
+)
+
+type responseParser struct {
+	format string
+}
+
+func (p responseParser) parse(bs []byte, contentType string) ([]any, error) {
+	switch p.format {
+	case formatJSON:
+		return parseItemsJSON(bs)
+	case formatYAML:
+		return parseItemsYAML(bs)
+	case formatAuto:
+		return p.parseAuto(bs, contentType)
+	default:
+		return nil, fmt.Errorf("unsupported format %q", p.format)
+	}
+}
+
+func (p responseParser) parseAuto(bs []byte, contentType string) ([]any, error) {
+	switch detectContentTypeFormat(contentType) {
+	case formatJSON:
+		return parseItemsJSON(bs)
+	case formatYAML:
+		return parseItemsYAML(bs)
+	}
+
+	items, jsonErr := parseItemsJSON(bs)
+	if jsonErr == nil {
+		return items, nil
+	}
+
+	items, yamlErr := parseItemsYAML(bs)
+	if yamlErr == nil {
+		return items, nil
+	}
+
+	return nil, fmt.Errorf("parse response as json: %v; parse response as yaml: %v", jsonErr, yamlErr)
+}
+
+func detectContentTypeFormat(contentType string) string {
+	if i := strings.IndexByte(contentType, ';'); i >= 0 {
+		contentType = contentType[:i]
+	}
+	contentType = strings.TrimSpace(strings.ToLower(contentType))
+
+	switch {
+	case contentType == "application/json",
+		contentType == "text/json",
+		strings.HasSuffix(contentType, "+json"):
+		return formatJSON
+	case contentType == "application/yaml",
+		contentType == "application/x-yaml",
+		contentType == "text/yaml",
+		contentType == "text/x-yaml",
+		strings.HasSuffix(contentType, "+yaml"),
+		strings.HasSuffix(contentType, "+x-yaml"):
+		return formatYAML
+	default:
+		return ""
+	}
+}
+
+func parseItemsJSON(bs []byte) ([]any, error) {
+	dec := json.NewDecoder(bytes.NewReader(bs))
+
+	var data any
+	if err := dec.Decode(&data); err != nil {
+		return nil, err
+	}
+	var extra any
+	if err := dec.Decode(&extra); err == nil {
+		return nil, errors.New("multiple JSON values are not supported")
+	} else if !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+
+	return extractItems(data)
+}
+
+func parseItemsYAML(bs []byte) ([]any, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(bs))
+
+	var data any
+	if err := dec.Decode(&data); err != nil {
+		return nil, err
+	}
+	var extra any
+	if err := dec.Decode(&extra); err == nil {
+		return nil, errors.New("multiple YAML documents are not supported")
+	} else if !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+
+	data, err := normalizeYAMLValue(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return extractItems(data)
+}
+
+func extractItems(data any) ([]any, error) {
+	switch v := data.(type) {
+	case []any:
+		return normalizeItems(v)
+	case map[string]any:
+		items, ok := v["items"]
+		if !ok {
+			return nil, errors.New("unsupported response envelope: missing items field")
+		}
+		arr, ok := items.([]any)
+		if !ok {
+			return nil, fmt.Errorf("unsupported response envelope: items must be an array, got %T", items)
+		}
+		return normalizeItems(arr)
+	default:
+		return nil, fmt.Errorf("unsupported response format: expected array or object with items array, got %T", data)
+	}
+}
+
+func normalizeItems(items []any) ([]any, error) {
+	out := make([]any, 0, len(items))
+	for i, item := range items {
+		norm, err := normalizeItem(item)
+		if err != nil {
+			return nil, fmt.Errorf("item[%d]: %w", i, err)
+		}
+		out = append(out, norm)
+	}
+	return out, nil
+}
+
+func normalizeItem(item any) (any, error) {
+	switch v := item.(type) {
+	case map[string]any:
+		return normalizeMap(v)
+	case string:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("unsupported item type %T", item)
+	}
+}
+
+func normalizeYAMLValue(v any) (any, error) {
+	switch vv := v.(type) {
+	case map[any]any:
+		m := make(map[string]any, len(vv))
+		for k, iv := range vv {
+			ks, ok := k.(string)
+			if !ok {
+				return nil, fmt.Errorf("yaml map key must be string, got %T", k)
+			}
+			norm, err := normalizeYAMLValue(iv)
+			if err != nil {
+				return nil, err
+			}
+			m[ks] = norm
+		}
+		return m, nil
+	case map[string]any:
+		return normalizeMap(vv)
+	case []any:
+		arr := make([]any, 0, len(vv))
+		for _, iv := range vv {
+			norm, err := normalizeYAMLValue(iv)
+			if err != nil {
+				return nil, err
+			}
+			arr = append(arr, norm)
+		}
+		return arr, nil
+	default:
+		return v, nil
+	}
+}
+
+func normalizeMap(src map[string]any) (map[string]any, error) {
+	m := make(map[string]any, len(src))
+	for k, v := range src {
+		norm, err := normalizeYAMLValue(v)
+		if err != nil {
+			return nil, err
+		}
+		m[k] = norm
+	}
+	return m, nil
+}
+
+func targetsFromItems(source string, items []any) ([]model.Target, error) {
+	targets := make([]model.Target, 0, len(items))
+	for i, item := range items {
+		canonical, err := canonicalJSON(item)
+		if err != nil {
+			return nil, fmt.Errorf("item[%d]: canonical encoding: %w", i, err)
+		}
+
+		tgt := &target{
+			label: itemLabel(item, canonical),
+			Item:  item,
+		}
+		hash, err := model.CalcHash(struct {
+			Source string
+			Item   string
+		}{
+			Source: source,
+			Item:   string(canonical),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("item[%d]: target hash: %w", i, err)
+		}
+		tgt.hash = hash
+		targets = append(targets, tgt)
+	}
+	return targets, nil
+}
+
+func itemLabel(item any, canonical []byte) string {
+	if m, ok := item.(map[string]any); ok {
+		if v, ok := m["name"].(string); ok {
+			if name := strings.TrimSpace(v); name != "" {
+				return name
+			}
+		}
+	}
+	return fmt.Sprintf("item-%x", hashBytes(canonical))
+}
+
+func canonicalJSON(v any) ([]byte, error) {
+	return json.Marshal(canonicalValue(v))
+}
+
+func canonicalValue(v any) any {
+	switch vv := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(vv))
+		for k := range vv {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		m := make(map[string]any, len(vv))
+		for _, k := range keys {
+			m[k] = canonicalValue(vv[k])
+		}
+		return m
+	case []any:
+		arr := make([]any, 0, len(vv))
+		for _, iv := range vv {
+			arr = append(arr, canonicalValue(iv))
+		}
+		return arr
+	default:
+		return v
+	}
+}
+
+func hashBytes(bs []byte) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write(bs)
+	return h.Sum64()
+}

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/parser_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/parser_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package httpsd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponseParser_parse(t *testing.T) {
+	tests := map[string]struct {
+		format      string
+		contentType string
+		body        string
+		want        []any
+		wantErr     bool
+		wantErrText string
+	}{
+		"json bare array": {
+			format:      formatJSON,
+			contentType: "application/json",
+			body:        `[{"name":"api","url":"http://127.0.0.1"}, "http://127.0.0.2"]`,
+			want: []any{
+				map[string]any{"name": "api", "url": "http://127.0.0.1"},
+				"http://127.0.0.2",
+			},
+		},
+		"yaml bare array": {
+			format: formatYAML,
+			body: `
+- name: api
+  url: http://127.0.0.1
+- http://127.0.0.2
+`,
+			want: []any{
+				map[string]any{"name": "api", "url": "http://127.0.0.1"},
+				"http://127.0.0.2",
+			},
+		},
+		"json envelope": {
+			format: formatJSON,
+			body:   `{"items":[{"name":"api"}]}`,
+			want:   []any{map[string]any{"name": "api"}},
+		},
+		"yaml envelope": {
+			format: formatYAML,
+			body: `
+items:
+  - name: api
+`,
+			want: []any{map[string]any{"name": "api"}},
+		},
+		"auto content type json": {
+			format:      formatAuto,
+			contentType: "application/vnd.netdata.discovery+json; charset=utf-8",
+			body:        `[{"name":"api"}]`,
+			want:        []any{map[string]any{"name": "api"}},
+		},
+		"auto content type yaml": {
+			format:      formatAuto,
+			contentType: "application/x-yaml",
+			body: `
+- name: api
+`,
+			want: []any{map[string]any{"name": "api"}},
+		},
+		"auto json first without content type": {
+			format: formatAuto,
+			body:   `[{"name":"api"}]`,
+			want:   []any{map[string]any{"name": "api"}},
+		},
+		"unsupported envelope": {
+			format:  formatYAML,
+			body:    `jobs: []`,
+			wantErr: true,
+		},
+		"unsupported item type": {
+			format:  formatJSON,
+			body:    `[1]`,
+			wantErr: true,
+		},
+		"malformed": {
+			format:  formatAuto,
+			body:    `[`,
+			wantErr: true,
+		},
+		"json trailing garbage": {
+			format:      formatJSON,
+			body:        `{"items":[]}garbage`,
+			wantErr:     true,
+			wantErrText: "invalid character",
+		},
+		"json multiple values": {
+			format:      formatJSON,
+			body:        `{"items":[]} {"items":[]}`,
+			wantErr:     true,
+			wantErrText: "multiple JSON values",
+		},
+		"yaml multiple documents": {
+			format: formatYAML,
+			body: `
+items: []
+---
+items: []
+`,
+			wantErr:     true,
+			wantErrText: "multiple YAML documents",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			items, err := responseParser{format: tc.format}.parse([]byte(tc.body), tc.contentType)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				if tc.wantErrText != "" {
+					assert.Contains(t, err.Error(), tc.wantErrText)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, items)
+			}
+		})
+	}
+}
+
+func TestTargetsFromItems_HashStability(t *testing.T) {
+	items1, err := parseItemsJSON([]byte(`[{"name":"api","url":"http://127.0.0.1","headers":{"b":"2","a":"1"}}]`))
+	require.NoError(t, err)
+	items2, err := parseItemsJSON([]byte(`[{"headers":{"a":"1","b":"2"},"url":"http://127.0.0.1","name":"api"}]`))
+	require.NoError(t, err)
+
+	targets1, err := targetsFromItems("source", items1)
+	require.NoError(t, err)
+	targets2, err := targetsFromItems("source", items2)
+	require.NoError(t, err)
+
+	require.Len(t, targets1, 1)
+	require.Len(t, targets2, 1)
+	assert.Equal(t, targets1[0].Hash(), targets2[0].Hash())
+	assert.Equal(t, targets1[0].TUID(), targets2[0].TUID())
+}
+
+func TestTargetsFromItems_ContentChangesHash(t *testing.T) {
+	items1, err := parseItemsJSON([]byte(`[{"name":"api","url":"http://127.0.0.1"}]`))
+	require.NoError(t, err)
+	items2, err := parseItemsJSON([]byte(`[{"name":"api","url":"http://127.0.0.2"}]`))
+	require.NoError(t, err)
+
+	targets1, err := targetsFromItems("source", items1)
+	require.NoError(t, err)
+	targets2, err := targetsFromItems("source", items2)
+	require.NoError(t, err)
+
+	require.Len(t, targets1, 1)
+	require.Len(t, targets2, 1)
+	assert.NotEqual(t, targets1[0].Hash(), targets2[0].Hash())
+}
+
+func TestTargetsFromItems_StringItem(t *testing.T) {
+	targets, err := targetsFromItems("source", []any{"http://127.0.0.1"})
+	require.NoError(t, err)
+
+	require.Len(t, targets, 1)
+	tgt := targets[0].(*target)
+	assert.Equal(t, "http://127.0.0.1", tgt.Item)
+	assert.NotEmpty(t, tgt.TUID())
+	assert.Contains(t, tgt.TUID(), "http_item-")
+}
+
+func TestSourceString_SanitizesURLAndIsStable(t *testing.T) {
+	cfg := Config{}
+	cfg.URL = "https://user:pass@example.com/path?token=secret#fragment"
+	cfg.Headers = map[string]string{"X-Test": "value"}
+
+	src1 := sourceString(cfg)
+	src2 := sourceString(cfg)
+
+	assert.Equal(t, src1, src2)
+	assert.Contains(t, src1, "discoverer=http,url=https://example.com/path,hash=")
+	assert.NotContains(t, src1, "user")
+	assert.NotContains(t, src1, "pass")
+	assert.NotContains(t, src1, "token")
+	assert.NotContains(t, src1, "secret")
+	assert.NotContains(t, src1, "fragment")
+}

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/source.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/source.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package httpsd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+func sourceString(cfg Config) string {
+	src := fmt.Sprintf("discoverer=%s,url=%s,hash=%x", shortName, sanitizedURL(cfg.URL), sourceHash(cfg))
+	if cfg.Source != "" {
+		src += fmt.Sprintf(",%s", cfg.Source)
+	}
+	return src
+}
+
+func sanitizedURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+func sourceHash(cfg Config) uint64 {
+	type identity struct {
+		HTTPConfig any    `json:"http_config"`
+		Format     string `json:"format"`
+	}
+
+	bs, _ := json.Marshal(identity{
+		HTTPConfig: cfg.HTTPConfig,
+		Format:     cfg.format(),
+	})
+	return hashBytes(bs)
+}

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/target.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/target.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package httpsd
+
+import (
+	"fmt"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/model"
+)
+
+type targetGroup struct {
+	source  string
+	targets []model.Target
+}
+
+func (g *targetGroup) Provider() string        { return fullName }
+func (g *targetGroup) Source() string          { return g.source }
+func (g *targetGroup) Targets() []model.Target { return g.targets }
+
+type target struct {
+	model.Base `hash:"ignore"`
+
+	hash  uint64
+	label string
+
+	Item any
+}
+
+func (t *target) TUID() string { return fmt.Sprintf("http_%s_%x", t.label, t.hash) }
+func (t *target) Hash() uint64 { return t.hash }

--- a/src/go/plugin/go.d/discovery/sdext/registry.go
+++ b/src/go/plugin/go.d/discovery/sdext/registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/model"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/discovery/sdext/discoverer/dockersd"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/discovery/sdext/discoverer/httpsd"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/discovery/sdext/discoverer/k8ssd"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/discovery/sdext/discoverer/netlistensd"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/discovery/sdext/discoverer/snmpsd"
@@ -17,6 +18,7 @@ import (
 const (
 	discovererNetListeners = "net_listeners"
 	discovererDocker       = "docker"
+	discovererHTTP         = "http"
 	discovererK8s          = "k8s"
 	discovererSNMP         = "snmp"
 )
@@ -34,6 +36,12 @@ func Registry(includeDocker bool) sd.Registry {
 			schemaK8s,
 			parseJSONConfig[[]k8ssd.Config],
 			newK8sDiscoverers,
+		),
+		sd.NewDescriptor(
+			discovererHTTP,
+			schemaHTTP,
+			parseJSONConfig[httpsd.Config],
+			newHTTPDiscoverers,
 		),
 		sd.NewDescriptor(
 			discovererSNMP,
@@ -73,6 +81,15 @@ func newNetListenersDiscoverers(cfg netlistensd.Config, source string) ([]model.
 func newDockerDiscoverers(cfg dockersd.Config, source string) ([]model.Discoverer, error) {
 	cfg.Source = source
 	d, err := dockersd.NewDiscoverer(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return []model.Discoverer{d}, nil
+}
+
+func newHTTPDiscoverers(cfg httpsd.Config, source string) ([]model.Discoverer, error) {
+	cfg.Source = source
+	d, err := httpsd.NewDiscoverer(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/src/go/plugin/go.d/discovery/sdext/registry_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/registry_test.go
@@ -10,8 +10,10 @@ import (
 
 func TestRegistry_DockerInclusion(t *testing.T) {
 	withDocker := Registry(true)
+	assert.Contains(t, withDocker.Types(), discovererHTTP)
 	assert.Contains(t, withDocker.Types(), discovererDocker)
 
 	withoutDocker := Registry(false)
+	assert.Contains(t, withoutDocker.Types(), discovererHTTP)
 	assert.NotContains(t, withoutDocker.Types(), discovererDocker)
 }

--- a/src/go/plugin/go.d/discovery/sdext/schemas.go
+++ b/src/go/plugin/go.d/discovery/sdext/schemas.go
@@ -13,5 +13,8 @@ var schemaDocker string
 //go:embed "config_schema_k8s.json"
 var schemaK8s string
 
+//go:embed "config_schema_http.json"
+var schemaHTTP string
+
 //go:embed "config_schema_snmp.json"
 var schemaSNMP string


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HTTP-based service discovery to `go.d` that fetches JSON/YAML items from an HTTP endpoint and turns them into collector jobs via simple service rules. Supports polling or one‑shot mode, stable target IDs/hashes, and sanitized URLs in logs and source strings.

- **New Features**
  - New `http` discoverer: accepts a bare array or `{ items: [...] }`; formats `auto|json|yaml` (auto uses Content‑Type, then JSON, then YAML); 10MB response limit; standard `go.d` HTTP options (headers, method/body, basic/bearer auth with token file re-read, proxy/TLS, optional redirect following).
  - Polling interval (default 1m) or one‑shot (`interval: 0`); safe source strings include a config hash and sanitized URL.
  - Stable hashing via canonical JSON; `.Item`, `.TUID`, and `.Hash` available in templates; TUID uses `name` when present.
  - Added `toYaml` to the SD pipeline template func map; registry, JSON schema, docs, and `go.d/sd/http.conf` added.

- **Migration**
  - Enable in `go.d/sd/http.conf` and set `discoverer.http.url` (optionally `format`).
  - Define `services` rules with `match` and `config_template`. Generated configs must include `name` and `module` (collector like `httpcheck` or `ping`). You may omit `module` only in curated rules where the rule `id` is the intended collector. For pass‑through items, use `.Item` or `{{ .Item | toYaml }}`.

<sup>Written for commit 98977d5a7a7862219aa84bc7db040e1fffa31039. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

