### PR TITLE
web_client: allow MCP Streamable HTTP headers in CORS preflight

### DIFF
--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -849,6 +849,7 @@ void web_client_build_http_header(struct web_client *w) {
                        "Server: Netdata Embedded HTTP Server %s\r\n"
                        "Access-Control-Allow-Origin: %s\r\n"
                        "Access-Control-Allow-Credentials: true\r\n"
+                       "Access-Control-Expose-Headers: Mcp-Session-Id\r\n"
                        "Date: %s\r\n",
                        w->response.code,
                        code_msg,
@@ -883,7 +884,6 @@ void web_client_build_http_header(struct web_client *w) {
         buffer_strcat(w->response.header_output,
                 "Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS\r\n"
                         "Access-Control-Allow-Headers: accept, x-requested-with, origin, content-type, cookie, pragma, cache-control, x-auth-token, x-netdata-auth, x-transaction-id, authorization, mcp-protocol-version, mcp-session-id, last-event-id\r\n"
-                        "Access-Control-Expose-Headers: Mcp-Session-Id\r\n"
                         "Access-Control-Max-Age: 1209600\r\n" // 86400 * 14
         );
     }

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -862,11 +862,17 @@ void web_client_build_http_header(struct web_client *w) {
 
     // MCP-specific CORS: scoped to MCP transport endpoints only so the
     // broader CORS posture for non-MCP endpoints is not widened
-    // unnecessarily. See PR #22258 review feedback.
+    // unnecessarily.
     //
     // Netdata exposes two MCP transports:
     //   /mcp  — Streamable HTTP (+ SSE via Accept negotiation)
     //   /sse  — legacy SSE-only MCP endpoint
+    //
+    // url_path_decoded is the decoded path only — the query string is
+    // parsed into w->url_query_string_decoded — so the prefix test is
+    // "exactly /mcp or /sse, or /mcp/... / /sse/...". A matching path
+    // segment boundary is required to prevent a hypothetical /mcpfoo
+    // from slipping through.
     const char *url_path = buffer_tostring(w->url_path_decoded);
     size_t url_path_len = buffer_strlen(w->url_path_decoded);
     bool is_mcp_path = false;
@@ -874,8 +880,7 @@ void web_client_build_http_header(struct web_client *w) {
         bool has_mcp_prefix =
             memcmp(url_path, "/mcp", 4) == 0 || memcmp(url_path, "/sse", 4) == 0;
         if(has_mcp_prefix)
-            is_mcp_path =
-                (url_path_len == 4 || url_path[4] == '/' || url_path[4] == '?');
+            is_mcp_path = (url_path_len == 4 || url_path[4] == '/');
     }
 
     if(is_mcp_path && w->mode != HTTP_REQUEST_MODE_OPTIONS)
@@ -903,13 +908,15 @@ void web_client_build_http_header(struct web_client *w) {
 
     if(w->mode == HTTP_REQUEST_MODE_OPTIONS) {
         if(is_mcp_path) {
-            // MCP Streamable HTTP needs DELETE (session teardown) and
-            // extra request headers (mcp-protocol-version, mcp-session-id,
-            // last-event-id for SSE resumption, authorization for bearer
-            // tokens). Scoped to /mcp so non-MCP endpoints retain the
-            // narrower allowlist.
+            // MCP needs extra request headers (mcp-protocol-version,
+            // mcp-session-id, last-event-id for SSE resumption,
+            // authorization for bearer tokens). Methods stay GET/POST —
+            // the current handlers do not implement DELETE session
+            // teardown, so advertising it in the preflight would let
+            // clients past preflight only to get a 405. Add DELETE here
+            // when the handlers learn to honour it.
             buffer_strcat(w->response.header_output,
-                    "Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS\r\n"
+                    "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
                             "Access-Control-Allow-Headers: accept, x-requested-with, origin, content-type, cookie, pragma, cache-control, x-auth-token, x-netdata-auth, x-transaction-id, authorization, mcp-protocol-version, mcp-session-id, last-event-id\r\n"
                             "Access-Control-Max-Age: 1209600\r\n" // 86400 * 14
             );

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -881,8 +881,9 @@ void web_client_build_http_header(struct web_client *w) {
 
     if(w->mode == HTTP_REQUEST_MODE_OPTIONS) {
         buffer_strcat(w->response.header_output,
-                "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
-                        "Access-Control-Allow-Headers: accept, x-requested-with, origin, content-type, cookie, pragma, cache-control, x-auth-token, x-netdata-auth, x-transaction-id\r\n"
+                "Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS\r\n"
+                        "Access-Control-Allow-Headers: accept, x-requested-with, origin, content-type, cookie, pragma, cache-control, x-auth-token, x-netdata-auth, x-transaction-id, authorization, mcp-protocol-version, mcp-session-id, last-event-id\r\n"
+                        "Access-Control-Expose-Headers: Mcp-Session-Id\r\n"
                         "Access-Control-Max-Age: 1209600\r\n" // 86400 * 14
         );
     }

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -849,7 +849,6 @@ void web_client_build_http_header(struct web_client *w) {
                        "Server: Netdata Embedded HTTP Server %s\r\n"
                        "Access-Control-Allow-Origin: %s\r\n"
                        "Access-Control-Allow-Credentials: true\r\n"
-                       "Access-Control-Expose-Headers: Mcp-Session-Id\r\n"
                        "Date: %s\r\n",
                        w->response.code,
                        code_msg,
@@ -860,6 +859,20 @@ void web_client_build_http_header(struct web_client *w) {
 
         http_header_content_type(w->response.header_output, w->response.data->content_type);
     }
+
+    // MCP-specific CORS: scoped to /mcp* paths only so the broader CORS
+    // posture for non-MCP endpoints is not widened unnecessarily. See PR
+    // #22258 review feedback.
+    const char *url_path = buffer_tostring(w->url_path_decoded);
+    size_t url_path_len = buffer_strlen(w->url_path_decoded);
+    bool is_mcp_path =
+        url_path_len >= 4
+        && memcmp(url_path, "/mcp", 4) == 0
+        && (url_path_len == 4 || url_path[4] == '/' || url_path[4] == '?');
+
+    if(is_mcp_path && w->mode != HTTP_REQUEST_MODE_OPTIONS)
+        buffer_strcat(w->response.header_output,
+                      "Access-Control-Expose-Headers: Mcp-Session-Id\r\n");
 
     if(unlikely(web_x_frame_options))
         buffer_sprintf(w->response.header_output, "X-Frame-Options: %s\r\n", web_x_frame_options);
@@ -881,11 +894,25 @@ void web_client_build_http_header(struct web_client *w) {
     }
 
     if(w->mode == HTTP_REQUEST_MODE_OPTIONS) {
-        buffer_strcat(w->response.header_output,
-                "Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS\r\n"
-                        "Access-Control-Allow-Headers: accept, x-requested-with, origin, content-type, cookie, pragma, cache-control, x-auth-token, x-netdata-auth, x-transaction-id, authorization, mcp-protocol-version, mcp-session-id, last-event-id\r\n"
-                        "Access-Control-Max-Age: 1209600\r\n" // 86400 * 14
-        );
+        if(is_mcp_path) {
+            // MCP Streamable HTTP needs DELETE (session teardown) and
+            // extra request headers (mcp-protocol-version, mcp-session-id,
+            // last-event-id for SSE resumption, authorization for bearer
+            // tokens). Scoped to /mcp so non-MCP endpoints retain the
+            // narrower allowlist.
+            buffer_strcat(w->response.header_output,
+                    "Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS\r\n"
+                            "Access-Control-Allow-Headers: accept, x-requested-with, origin, content-type, cookie, pragma, cache-control, x-auth-token, x-netdata-auth, x-transaction-id, authorization, mcp-protocol-version, mcp-session-id, last-event-id\r\n"
+                            "Access-Control-Max-Age: 1209600\r\n" // 86400 * 14
+            );
+        }
+        else {
+            buffer_strcat(w->response.header_output,
+                    "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
+                            "Access-Control-Allow-Headers: accept, x-requested-with, origin, content-type, cookie, pragma, cache-control, x-auth-token, x-netdata-auth, x-transaction-id\r\n"
+                            "Access-Control-Max-Age: 1209600\r\n" // 86400 * 14
+            );
+        }
     }
     else {
         buffer_sprintf(w->response.header_output,

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -860,15 +860,23 @@ void web_client_build_http_header(struct web_client *w) {
         http_header_content_type(w->response.header_output, w->response.data->content_type);
     }
 
-    // MCP-specific CORS: scoped to /mcp* paths only so the broader CORS
-    // posture for non-MCP endpoints is not widened unnecessarily. See PR
-    // #22258 review feedback.
+    // MCP-specific CORS: scoped to MCP transport endpoints only so the
+    // broader CORS posture for non-MCP endpoints is not widened
+    // unnecessarily. See PR #22258 review feedback.
+    //
+    // Netdata exposes two MCP transports:
+    //   /mcp  — Streamable HTTP (+ SSE via Accept negotiation)
+    //   /sse  — legacy SSE-only MCP endpoint
     const char *url_path = buffer_tostring(w->url_path_decoded);
     size_t url_path_len = buffer_strlen(w->url_path_decoded);
-    bool is_mcp_path =
-        url_path_len >= 4
-        && memcmp(url_path, "/mcp", 4) == 0
-        && (url_path_len == 4 || url_path[4] == '/' || url_path[4] == '?');
+    bool is_mcp_path = false;
+    if(url_path_len >= 4) {
+        bool has_mcp_prefix =
+            memcmp(url_path, "/mcp", 4) == 0 || memcmp(url_path, "/sse", 4) == 0;
+        if(has_mcp_prefix)
+            is_mcp_path =
+                (url_path_len == 4 || url_path[4] == '/' || url_path[4] == '?');
+    }
 
     if(is_mcp_path && w->mode != HTTP_REQUEST_MODE_OPTIONS)
         buffer_strcat(w->response.header_output,

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -274,6 +274,13 @@ void web_client_request_done(struct web_client *w) {
     web_client_disable_tracking_required(w);
     web_client_disable_keepalive(w);
 
+    // Clear URL-derived flags between requests. PATH_IS_MCP is re-set
+    // during the next URL decode; clearing it here makes sure a keepalive
+    // connection cannot carry the previous request's classification into
+    // a new request that fails before URL decoding runs (e.g., malformed
+    // request line, unsupported method).
+    web_client_flag_clear(w, WEB_CLIENT_FLAG_PATH_IS_MCP);
+
     w->header_parse_tries = 0;
     w->header_parse_last_size = 0;
 
@@ -889,27 +896,26 @@ void web_client_build_http_header(struct web_client *w) {
     }
 
     if(w->mode == HTTP_REQUEST_MODE_OPTIONS) {
-        if(is_mcp_path) {
-            // MCP needs extra request headers (mcp-protocol-version,
-            // mcp-session-id, last-event-id for SSE resumption,
-            // authorization for bearer tokens). Methods stay GET/POST —
-            // the current handlers do not implement DELETE session
-            // teardown, so advertising it in the preflight would let
-            // clients past preflight only to get a 405. Add DELETE here
-            // when the handlers learn to honour it.
+        // Methods, max-age, and the base header allowlist are identical
+        // for every OPTIONS preflight. MCP preflights append the extra
+        // request headers the SDK uses: mcp-protocol-version,
+        // mcp-session-id, last-event-id (SSE resumption), authorization
+        // (bearer tokens). DELETE is *not* advertised — the MCP handlers
+        // currently return 405 for it, and advertising it would let the
+        // preflight succeed only for the real request to fail. Add DELETE
+        // here when the handlers learn session teardown.
+        buffer_strcat(w->response.header_output,
+                "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
+                        "Access-Control-Allow-Headers: accept, x-requested-with, origin, content-type, cookie, pragma, cache-control, x-auth-token, x-netdata-auth, x-transaction-id");
+
+        if(is_mcp_path)
             buffer_strcat(w->response.header_output,
-                    "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
-                            "Access-Control-Allow-Headers: accept, x-requested-with, origin, content-type, cookie, pragma, cache-control, x-auth-token, x-netdata-auth, x-transaction-id, authorization, mcp-protocol-version, mcp-session-id, last-event-id\r\n"
-                            "Access-Control-Max-Age: 1209600\r\n" // 86400 * 14
-            );
-        }
-        else {
-            buffer_strcat(w->response.header_output,
-                    "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
-                            "Access-Control-Allow-Headers: accept, x-requested-with, origin, content-type, cookie, pragma, cache-control, x-auth-token, x-netdata-auth, x-transaction-id\r\n"
-                            "Access-Control-Max-Age: 1209600\r\n" // 86400 * 14
-            );
-        }
+                          ", authorization, mcp-protocol-version, mcp-session-id, last-event-id");
+
+        buffer_strcat(w->response.header_output,
+                      "\r\n"
+                              "Access-Control-Max-Age: 1209600\r\n" // 86400 * 14
+        );
     }
     else {
         buffer_sprintf(w->response.header_output,
@@ -1888,11 +1894,11 @@ void web_client_decode_path_and_query_string(struct web_client *w, const char *p
         // header builder, including for OPTIONS preflights which bypass
         // the dispatcher. Matching requires a path-segment boundary so a
         // hypothetical /mcpfoo does not leak through.
-        const char *p = buffer_tostring(w->url_path_decoded);
-        size_t plen = buffer_strlen(w->url_path_decoded);
-        if(plen >= 4
-           && (memcmp(p, "/mcp", 4) == 0 || memcmp(p, "/sse", 4) == 0)
-           && (plen == 4 || p[4] == '/'))
+        const char *decoded_path = buffer_tostring(w->url_path_decoded);
+        size_t decoded_path_len = buffer_strlen(w->url_path_decoded);
+        if(decoded_path_len >= 4
+           && (memcmp(decoded_path, "/mcp", 4) == 0 || memcmp(decoded_path, "/sse", 4) == 0)
+           && (decoded_path_len == 4 || decoded_path[4] == '/'))
             web_client_flag_set(w, WEB_CLIENT_FLAG_PATH_IS_MCP);
     }
 }

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -860,28 +860,10 @@ void web_client_build_http_header(struct web_client *w) {
         http_header_content_type(w->response.header_output, w->response.data->content_type);
     }
 
-    // MCP-specific CORS: scoped to MCP transport endpoints only so the
-    // broader CORS posture for non-MCP endpoints is not widened
-    // unnecessarily.
-    //
-    // Netdata exposes two MCP transports:
-    //   /mcp  — Streamable HTTP (+ SSE via Accept negotiation)
-    //   /sse  — legacy SSE-only MCP endpoint
-    //
-    // url_path_decoded is the decoded path only — the query string is
-    // parsed into w->url_query_string_decoded — so the prefix test is
-    // "exactly /mcp or /sse, or /mcp/... / /sse/...". A matching path
-    // segment boundary is required to prevent a hypothetical /mcpfoo
-    // from slipping through.
-    const char *url_path = buffer_tostring(w->url_path_decoded);
-    size_t url_path_len = buffer_strlen(w->url_path_decoded);
-    bool is_mcp_path = false;
-    if(url_path_len >= 4) {
-        bool has_mcp_prefix =
-            memcmp(url_path, "/mcp", 4) == 0 || memcmp(url_path, "/sse", 4) == 0;
-        if(has_mcp_prefix)
-            is_mcp_path = (url_path_len == 4 || url_path[4] == '/');
-    }
+    // MCP-specific CORS: widen the allowlist + advertise exposed
+    // headers only for MCP transport endpoints (/mcp, /sse). The flag
+    // is set once during URL decoding; see WEB_CLIENT_FLAG_PATH_IS_MCP.
+    bool is_mcp_path = web_client_flag_check(w, WEB_CLIENT_FLAG_PATH_IS_MCP);
 
     if(is_mcp_path && w->mode != HTTP_REQUEST_MODE_OPTIONS)
         buffer_strcat(w->response.header_output,
@@ -1865,6 +1847,11 @@ void web_client_decode_path_and_query_string(struct web_client *w, const char *p
         // do not overwrite this if it is already filled
         buffer_strcat(w->url_as_received, path_and_query_string);
 
+    // PATH_IS_MCP is a function of the URL alone; clear and re-derive on
+    // every decode so keepalived connections reusing the same web_client
+    // for a different URL see a fresh value.
+    web_client_flag_clear(w, WEB_CLIENT_FLAG_PATH_IS_MCP);
+
     if(w->mode == HTTP_REQUEST_MODE_STREAM) {
         // in stream mode, there is no path
 
@@ -1893,6 +1880,20 @@ void web_client_decode_path_and_query_string(struct web_client *w, const char *p
             buffer_strcat(w->url_query_string_decoded, "");
             buffer_strcat(w->url_path_decoded, buffer);
         }
+
+        // Classify path: set PATH_IS_MCP when the URL addresses one of
+        // Netdata's MCP transport endpoints (/mcp or /sse, and their
+        // subpaths). Done here — at URL-decoding time — so the flag is
+        // available later both to the URL dispatcher and to the response
+        // header builder, including for OPTIONS preflights which bypass
+        // the dispatcher. Matching requires a path-segment boundary so a
+        // hypothetical /mcpfoo does not leak through.
+        const char *p = buffer_tostring(w->url_path_decoded);
+        size_t plen = buffer_strlen(w->url_path_decoded);
+        if(plen >= 4
+           && (memcmp(p, "/mcp", 4) == 0 || memcmp(p, "/sse", 4) == 0)
+           && (plen == 4 || p[4] == '/'))
+            web_client_flag_set(w, WEB_CLIENT_FLAG_PATH_IS_MCP);
     }
 }
 

--- a/src/web/server/web_client.h
+++ b/src/web/server/web_client.h
@@ -70,9 +70,14 @@ typedef enum __attribute__((packed)) {
     WEB_CLIENT_FLAG_ACCEPT_SSE              = (1 << 26),
     WEB_CLIENT_FLAG_ACCEPT_TEXT             = (1 << 27),
     WEB_CLIENT_FLAG_MCP_PREVIEW_KEY         = (1 << 28), // Authorization header matched MCP preview key
+    WEB_CLIENT_FLAG_PATH_IS_MCP             = (1 << 29), // URL path is /mcp[/...] or /sse[/...] — set during URL decoding so it's also available for OPTIONS preflights (which skip the URL dispatcher)
 } WEB_CLIENT_FLAGS;
 
 #define WEB_CLIENT_FLAG_PATH_WITH_VERSION (WEB_CLIENT_FLAG_PATH_IS_V0|WEB_CLIENT_FLAG_PATH_IS_V1|WEB_CLIENT_FLAG_PATH_IS_V2|WEB_CLIENT_FLAG_PATH_IS_V3)
+// PATH_IS_MCP is intentionally *not* in the reset mask: it is set during
+// URL decoding, not during URL dispatch, so resetting it here (which runs
+// after decoding but before dispatch on POST/GET/etc.) would wipe it
+// before the response builder could read it.
 #define web_client_reset_path_flags(w) (w)->flags &= ~(WEB_CLIENT_FLAG_PATH_WITH_VERSION|WEB_CLIENT_FLAG_PATH_HAS_TRAILING_SLASH|WEB_CLIENT_FLAG_PATH_HAS_FILE_EXTENSION)
 
 #define web_client_flag_check(w, flag) ((w)->flags & (flag))


### PR DESCRIPTION
## Summary

Browser-based MCP clients (anything that uses the Model Context Protocol TypeScript SDK over Streamable HTTP, e.g. MCP Inspector or any web-hosted tool) fail to talk to Netdata's `/mcp` endpoint across an origin, because the CORS preflight response rejects the `Mcp-Protocol-Version` header.

**Symptom the browser shows:**

> Access to fetch at 'https://registry.my-netdata.io/mcp' from origin 'https://…' has been blocked by CORS policy: Request header field `mcp-protocol-version` is not allowed by Access-Control-Allow-Headers in preflight response.

**What actually happens:**

1. `POST /mcp` (initialize) — no `Mcp-Protocol-Version` header yet, preflight passes, handshake succeeds.
2. `POST /mcp` (notifications/initialized) — MCP SDK now includes `Mcp-Protocol-Version` with the negotiated version. Preflight fails. `Failed to fetch`.
3. Session left half-open; the user sees "Connect failed" even though the handshake logically worked.

## Changes

**Scoping.** All CORS widening is scoped to Netdata's two MCP transport endpoints — `/mcp` and `/sse` — via a new `WEB_CLIENT_FLAG_PATH_IS_MCP` flag set once during URL decoding. Non-MCP endpoints see CORS headers byte-identical to pre-PR master.

For MCP endpoints only:

- `Access-Control-Allow-Headers`: adds `authorization`, `mcp-protocol-version`, `mcp-session-id`, `last-event-id`.
  - `authorization` — bearer-token MCP servers.
  - `mcp-protocol-version` — required by the MCP spec on every post-handshake request.
  - `mcp-session-id` — echoed by the client on every request after the server assigns it on `initialize`.
  - `last-event-id` — SSE reconnection to a resumable stream.
- `Access-Control-Expose-Headers: Mcp-Session-Id` on actual (non-OPTIONS) responses, so browser JS can read the session id the server sets on the initialize response.

`Access-Control-Allow-Methods` stays `GET, POST, OPTIONS` for both MCP and non-MCP endpoints. DELETE (MCP session teardown) is not yet implemented by the handlers; advertising it would let preflights pass only for the real request to 405. Follow-up work: implement DELETE in the MCP handlers, then add it here.

WebSocket MCP transport is unaffected — WebSockets don't preflight.

## Test plan

- [ ] Before: open any browser-based MCP client pointed at a Netdata Parent's `/mcp` URL → observe `Failed to fetch` on the second POST with the CORS error in DevTools.
- [ ] After: same client → handshake completes, tools/list returns, subsequent calls work.
- [ ] Same test against `/sse`.
- [ ] Existing dashboard (same-origin) still connects normally.
- [ ] stdio transport and WebSocket transport unaffected.
- [ ] Preflight to a non-MCP endpoint (e.g. `/api/v1/info`) returns the original allow-list (no authorization / mcp-* headers, no Expose-Headers).