### PR TITLE
Fix memory-safety and correctness bugs surfaced by Coverity audit (part 1)

### DIFF
--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -487,6 +487,9 @@ bool claim_agent_from_split_files(void) {
         unlink(filename);
     }
 
+    freez(token);
+    freez(rooms);
+
     return ret;
 }
 

--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -625,7 +625,7 @@ void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, 
 
     bool existing = false;
     bool *found = dictionary_set(dirs, dirname, &existing, sizeof(existing));
-    if (*found) {
+    if (unlikely(!found) || *found) {
         closedir(dir);
         return;
     }

--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -625,8 +625,10 @@ void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, 
 
     bool existing = false;
     bool *found = dictionary_set(dirs, dirname, &existing, sizeof(existing));
-    if (*found)
+    if (*found) {
+        closedir(dir);
         return;
+    }
     *found = true;
 
     // Read each entry in the directory.

--- a/src/daemon/machine-guid.c
+++ b/src/daemon/machine-guid.c
@@ -209,16 +209,12 @@ static ND_MACHINE_GUID machine_guid_get_or_create(void) {
     rfc3339_datetime_ut(h.last_modified_ut_rfc3339, sizeof(h.last_modified_ut_rfc3339), h.last_modified_ut, 2, true);
     nd_machine_guid = h;
 
-    // Ensure the registry directory exists.
-    if (access(pathname, W_OK) != 0) {
-        nd_log(NDLS_DAEMON, NDLP_DEBUG, "MACHINE_GUID: cannot access directory '%s'. Attempting to create it.", pathname);
-
-        errno_clear();
-        if (mkdir(pathname, 0775) != 0 && errno != EEXIST) {
-            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot create directory '%s'", pathname);
-            // Even if directory creation fails, continue with in-memory GUID.
-            return h;
-        }
+    // Avoid a check-then-create race; mkdir() + EEXIST is sufficient.
+    errno_clear();
+    if (mkdir(pathname, 0775) != 0 && errno != EEXIST) {
+        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot create directory '%s'", pathname);
+        // Even if directory creation fails, continue with in-memory GUID.
+        return h;
     }
 
     errno_clear();

--- a/src/daemon/machine-guid.c
+++ b/src/daemon/machine-guid.c
@@ -211,10 +211,20 @@ static ND_MACHINE_GUID machine_guid_get_or_create(void) {
 
     // Avoid a check-then-create race; mkdir() + EEXIST is sufficient.
     errno_clear();
-    if (mkdir(pathname, 0775) != 0 && errno != EEXIST) {
-        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot create directory '%s'", pathname);
-        // Even if directory creation fails, continue with in-memory GUID.
-        return h;
+    if (mkdir(pathname, 0775) != 0) {
+        if (errno != EEXIST) {
+            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot create directory '%s'", pathname);
+            // Even if directory creation fails, continue with in-memory GUID.
+            return h;
+        }
+
+        // EEXIST — verify it is actually a directory.
+        struct stat st;
+        if (stat(pathname, &st) != 0 || !S_ISDIR(st.st_mode)) {
+            nd_log(NDLS_DAEMON, NDLP_ERR,
+                   "MACHINE_GUID: path '%s' exists but is not a directory", pathname);
+            return h;
+        }
     }
 
     errno_clear();

--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -96,7 +96,7 @@ void nd_signal_handler(int signo, siginfo_t *info, void *context __maybe_unused)
                 len = strcatz(b, len, ")", sizeof(b));
             }
             len = strcatz(b, len, " in thread ", sizeof(b));
-            print_uint64(&b[len], gettid_cached());
+            len += print_uint64(&b[len], gettid_cached());
             len = strcatz(b, len, " ", sizeof(b));
             len = strcatz(b, len, nd_thread_tag_async_safe(), sizeof(b));
             len = strcatz(b, len, "!\n", sizeof(b));

--- a/src/database/contexts/api_v2_contexts_alerts.c
+++ b/src/database/contexts/api_v2_contexts_alerts.c
@@ -254,7 +254,7 @@ static void alerts_v2_insert_callback(const DICTIONARY_ITEM *item __maybe_unused
     t->ati = ctl->alerts.ati++;
 
     t->nodes = dictionary_create(DICT_OPTION_SINGLE_THREADED|DICT_OPTION_VALUE_LINK_DONT_CLONE|DICT_OPTION_NAME_LINK_DONT_CLONE);
-    t->configs = dictionary_create(DICT_OPTION_SINGLE_THREADED|DICT_OPTION_VALUE_LINK_DONT_CLONE|DICT_OPTION_NAME_LINK_DONT_CLONE);
+    t->configs = dictionary_create(DICT_OPTION_SINGLE_THREADED|DICT_OPTION_VALUE_LINK_DONT_CLONE);
 
     alerts_v2_add(t, rc);
 }

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1423,9 +1423,11 @@ bool journalfile_migrate_to_v2_callback(Word_t section, unsigned datafile_fileno
     uint32_t trailer_offset = total_file_size;
     total_file_size  += sizeof(struct journal_v2_block_trailer);
 
-    int fd_v2;
+    int fd_v2 = -1;
     uint8_t *data_start = nd_mmap_advanced(path, total_file_size, MAP_SHARED, 0, false, true, &fd_v2);
     if(!data_start) {
+        if(fd_v2 != -1)
+            close(fd_v2);
         nd_log_daemon(NDLP_WARNING, "DBENGINE: Failed to allocate %"PRIu64" bytes of memory for journal file \"%s\". Will retry later", total_file_size, path);
         return false;
     }
@@ -1603,6 +1605,8 @@ bool journalfile_migrate_to_v2_callback(Word_t section, unsigned datafile_fileno
     netdata_log_info("DBENGINE: failed to build index \"%s\", file will be skipped", path);
 
     nd_munmap(data_start, total_file_size);
+    if(fd_v2 != -1)
+        close(fd_v2);
     unlink(path);
     return false;
 }

--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -426,7 +426,9 @@ void health_alarm_log_populate(
     time_t duration = sqlite3_column_int64(res, DURATION);
     alarm_log->duration =  (duration > 0) ? duration : 0;
 
-    alarm_log->non_clear_duration = sqlite3_column_int64(res, NON_CLEAR_DURATION);
+    int64_t non_clear_duration = sqlite3_column_int64(res, NON_CLEAR_DURATION);
+    alarm_log->non_clear_duration = (non_clear_duration <= 0) ? 0 :
+                                    (non_clear_duration > UINT32_MAX) ? UINT32_MAX : (uint32_t)non_clear_duration;
 
     alarm_log->status = rrdcalc_status_to_proto_enum(current_status);
     alarm_log->old_status = rrdcalc_status_to_proto_enum((RRDCALC_STATUS)sqlite3_column_int64(res, OLD_STATUS));

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2602,8 +2602,9 @@ static void start_metadata_hosts(uv_work_t *req)
 
     store_alert_transitions((struct judy_list_t *)worker->pending_alert_list, true, false);
 
-    if (!SHUTDOWN_REQUESTED(config))
-        store_ctx_cleanup_list(config, (struct judy_list_t *)worker->pending_ctx_cleanup_list);
+    // This helper already skips database scheduling once shutdown starts, but it
+    // still has to release the worker-owned Judy list on that path.
+    store_ctx_cleanup_list(config, (struct judy_list_t *)worker->pending_ctx_cleanup_list);
 
     worker_is_busy(UV_EVENT_METADATA_STORE);
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2613,8 +2613,11 @@ static void start_metadata_hosts(uv_work_t *req)
     COMPUTE_DURATION(report_duration, "us", all_started_ut, now_monotonic_usec());
     nd_log_daemon(NDLP_DEBUG, "Checking all hosts completed in %s", report_duration);
 
+    // This helper already skips dimension deletion once shutdown starts, but it
+    // still has to release the worker-owned Judy list on that path.
+    do_pending_uuid_deletion(config, (struct judy_list_t *)worker->pending_uuid_deletion);
+
     if (!SHUTDOWN_REQUESTED(config)) {
-        do_pending_uuid_deletion(config, (struct judy_list_t *)worker->pending_uuid_deletion);
         run_metadata_cleanup(config);
     }
 

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -122,7 +122,8 @@ static STRING *rrdcalc_replace_variables_with_rrdset_labels(const char *line, RR
             freez(temp);
             temp = buf;
         }
-        else if (!strncmp(var, RRDCALC_VAR_LABEL, RRDCALC_VAR_LABEL_LEN)) {
+        else if (!strncmp(var, RRDCALC_VAR_LABEL, RRDCALC_VAR_LABEL_LEN) &&
+                 i > (int)RRDCALC_VAR_LABEL_LEN && var[i - 1] == '}') {
             char label_val[RRDCALC_VAR_MAX + RRDCALC_VAR_LABEL_LEN + 1] = { 0 };
             strcpy(label_val, var+RRDCALC_VAR_LABEL_LEN);
             label_val[i - RRDCALC_VAR_LABEL_LEN - 1] = '\0';

--- a/src/libnetdata/functions_evloop/functions_evloop.c
+++ b/src/libnetdata/functions_evloop/functions_evloop.c
@@ -79,7 +79,7 @@ struct functions_evloop_globals {
 static void rrd_functions_worker_canceller(void *data) {
     struct functions_evloop_globals *wg = data;
     netdata_mutex_lock(&wg->worker_mutex);
-    wg->workers_exit = true;
+    __atomic_store_n(&wg->workers_exit, true, __ATOMIC_RELAXED);
     netdata_cond_signal(&wg->worker_cond_var);
     netdata_mutex_unlock(&wg->worker_mutex);
 }
@@ -93,7 +93,7 @@ static void rrd_functions_worker_globals_worker_main(void *arg) {
     while (true) {
         netdata_mutex_lock(&wg->worker_mutex);
 
-        if(wg->workers_exit || nd_thread_signaled_to_cancel()) {
+        if(__atomic_load_n(&wg->workers_exit, __ATOMIC_RELAXED) || nd_thread_signaled_to_cancel()) {
             netdata_mutex_unlock(&wg->worker_mutex);
             break;
         }
@@ -115,7 +115,7 @@ static void rrd_functions_worker_globals_worker_main(void *arg) {
 
         netdata_mutex_unlock(&wg->worker_mutex);
 
-        if(wg->workers_exit || nd_thread_signaled_to_cancel()) {
+        if(__atomic_load_n(&wg->workers_exit, __ATOMIC_RELAXED) || nd_thread_signaled_to_cancel()) {
             if(acquired)
                 dictionary_acquired_item_release(wg->worker_queue, acquired);
 

--- a/src/libnetdata/worker_utilization/worker_utilization.c
+++ b/src/libnetdata/worker_utilization/worker_utilization.c
@@ -261,7 +261,7 @@ void worker_unregister(void) {
         spinlock_unlock(&workname->spinlock);
 
         if(!workname->base) {
-            JError_t J_Error;
+            JError_t J_Error = { 0 };
 
             JudyAllocThreadPulseReset();
             int ret = JudyHSDel(&workers_globals.worknames_JudyHS, (void *)worker->workname, workname_size, &J_Error);

--- a/src/libnetdata/worker_utilization/worker_utilization.c
+++ b/src/libnetdata/worker_utilization/worker_utilization.c
@@ -261,11 +261,21 @@ void worker_unregister(void) {
         spinlock_unlock(&workname->spinlock);
 
         if(!workname->base) {
+            JError_t J_Error;
+
             JudyAllocThreadPulseReset();
-            JudyHSDel(&workers_globals.worknames_JudyHS, (void *) worker->workname, workname_size, PJE0);
+            int ret = JudyHSDel(&workers_globals.worknames_JudyHS, (void *)worker->workname, workname_size, &J_Error);
             int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
-            freez(workname);
-            workers_globals.memory = (int64_t)workers_globals.memory - (int64_t)sizeof(struct workers_workname) + judy_mem;
+            workers_globals.memory = (int64_t)workers_globals.memory + judy_mem;
+
+            if(likely(ret == 1)) {
+                freez(workname);
+                workers_globals.memory = (int64_t)workers_globals.memory - (int64_t)sizeof(struct workers_workname);
+            }
+            else if(unlikely(ret == JERR))
+                netdata_log_error("WORKER_UTILIZATION: cannot delete worker workname '%s' from JudyHS, JU_ERRNO_* == %u, ID == %d", worker->workname, JU_ERRNO(&J_Error), JU_ERRID(&J_Error));
+            else
+                netdata_log_error("WORKER_UTILIZATION: worker workname '%s' disappeared from JudyHS during unregister", worker->workname);
         }
     }
     workers_globals.memory -= sizeof(struct worker) + strlen(worker->tag) + 1 + strlen(worker->workname) + 1;


### PR DESCRIPTION
##### Summary
- Split / based on  #22234



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes memory-safety, resource leaks, and race conditions found by Coverity across the agent. Improves startup robustness, journal migration, alert serialization, and worker shutdown.

- **Bug Fixes**
  - Free leaked buffers in claim split-file flow; always release metadata cleanup and UUID-deletion Judy lists on shutdown.
  - Close leaked descriptors: close duplicate DIRs in systemd-journal (including on `dictionary_set()` NULL), and close migrated journal fds on mmap/build failures.
  - Remove access()/mkdir() race for machine GUID; on EEXIST verify the path is a directory.
  - Clone alert config keys to avoid a use-after-free; require closing brace in `${label:...}` parsing.
  - Clamp SQLite `non_clear_duration` to uint32 range.
  - Make `workers_exit` checks atomic in functions evloop; fix fatal-signal log to include the thread id.
  - In worker utilization, only free workname after successful `JudyHSDel()`, zero-initialize `JError_t`, and adjust memory accounting; log unexpected delete failures.

<sup>Written for commit 39d8bdef525de7681b49599b4822d68078e71af0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

