### PR TITLE
Fix memory-safety and correctness bugs surfaced by Coverity audit (part 3)

### DIFF
--- a/src/aclk/aclk_query.c
+++ b/src/aclk/aclk_query.c
@@ -71,7 +71,7 @@ void mark_pending_req_cancel_all()
     spinlock_lock(&pending_req_list_lock);
     struct pending_req_list *curr = pending_req_list_head;
     while (curr) {
-        curr->canceled = 1;
+        __atomic_store_n(&curr->canceled, 1, __ATOMIC_RELAXED);
         curr = curr->next;
     }
     spinlock_unlock(&pending_req_list_lock);
@@ -86,7 +86,7 @@ int mark_pending_req_cancelled(const char *msg_id)
 
     while (curr) {
         if (curr->hash == hash && strcmp(curr->msg_id, msg_id) == 0) {
-            curr->canceled = 1;
+            __atomic_store_n(&curr->canceled, 1, __ATOMIC_RELAXED);
             spinlock_unlock(&pending_req_list_lock);
             return 0;
         }
@@ -100,7 +100,7 @@ int mark_pending_req_cancelled(const char *msg_id)
 static bool aclk_web_client_interrupt_cb(struct web_client *w __maybe_unused, void *data)
 {
     struct pending_req_list *req = (struct pending_req_list *)data;
-    return req->canceled;
+    return __atomic_load_n(&req->canceled, __ATOMIC_RELAXED);
 }
 
 int http_api_v2(mqtt_wss_client client, aclk_query_t *query)

--- a/src/collectors/apps.plugin/apps_plugin.c
+++ b/src/collectors/apps.plugin/apps_plugin.c
@@ -857,6 +857,7 @@ int main(int argc, char **argv) {
 
         if(unlikely(print_tree_and_exit)) {
             print_hierarchy(root_of_pids());
+            netdata_mutex_unlock(&apps_and_stdout_mutex);
             exit(0);
         }
 

--- a/src/collectors/proc.plugin/proc_mdstat.c
+++ b/src/collectors/proc.plugin/proc_mdstat.c
@@ -70,8 +70,8 @@ static inline void make_chart_obsolete(char *name, const char *id_modifier)
     RRDSET *st = NULL;
 
     if (likely(name && id_modifier)) {
-        snprintfz(id, sizeof(id) - 1, "mdstat.%s_%s", name, id_modifier);
-        st = rrdset_find_active_byname_localhost(id);
+        snprintfz(id, sizeof(id) - 1, "%s_%s", name, id_modifier);
+        st = rrdset_find_active_bytype_localhost("mdstat", id);
         if (likely(st))
             rrdset_is_obsolete___safe_from_collector_thread(st);
     }

--- a/src/collectors/proc.plugin/sys_class_power_supply.c
+++ b/src/collectors/proc.plugin/sys_class_power_supply.c
@@ -274,7 +274,8 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
             struct ps_property *pr;
             if (likely(ps))
             {
-                for(pr = ps->property_root; pr && !read_error; pr = pr->next) {
+                for(pr = ps->property_root; pr && !read_error; ) {
+                    struct ps_property *next = pr->next;
                     struct ps_property_dim *pd;
                     for(pd = pr->property_dim_root; pd; pd = pd->next) {
                         if(likely(!pd->always_zero)) {
@@ -286,6 +287,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                                     collector_error("Cannot open file '%s'", pd->filename);
                                     read_error = 1;
                                     power_supply_free(ps);
+                                    ps = NULL;
                                     break;
                                 }
                             }
@@ -295,6 +297,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                                 collector_error("Cannot read file '%s'", pd->filename);
                                 read_error = 1;
                                 power_supply_free(ps);
+                                ps = NULL;
                                 break;
                             }
                             buffer[r] = '\0';
@@ -311,6 +314,11 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                             }
                         }
                     }
+
+                    if(unlikely(read_error))
+                        break;
+
+                    pr = next;
                 }
             }
         }

--- a/src/collectors/statsd.plugin/statsd.c
+++ b/src/collectors/statsd.plugin/statsd.c
@@ -540,13 +540,15 @@ static inline void statsd_process_histogram_or_timer(STATSD_METRIC *m, const cha
         return;
     }
 
-    if(unlikely(m->reset)) {
-        m->histogram.ext->used = 0;
-        statsd_reset_metric(m);
-    }
-
     if(unlikely(value_is_zinit(value))) {
         // magic loading of metric, without affecting anything
+
+        netdata_mutex_lock(&m->histogram.ext->mutex);
+        if(unlikely(m->reset)) {
+            m->histogram.ext->used = 0;
+            statsd_reset_metric(m);
+        }
+        netdata_mutex_unlock(&m->histogram.ext->mutex);
     }
     else {
         NETDATA_DOUBLE v = statsd_parse_float(value, 1.0);
@@ -555,18 +557,23 @@ static inline void statsd_process_histogram_or_timer(STATSD_METRIC *m, const cha
         if(unlikely(isgreater(sampling_rate, 1.0))) sampling_rate = 1.0;
 
         long long samples = llrintndd(1.0 / sampling_rate);
-        while(samples-- > 0) {
+        netdata_mutex_lock(&m->histogram.ext->mutex);
 
+        if(unlikely(m->reset)) {
+            m->histogram.ext->used = 0;
+            statsd_reset_metric(m);
+        }
+
+        while(samples-- > 0) {
             if(unlikely(m->histogram.ext->used == m->histogram.ext->size)) {
-                netdata_mutex_lock(&m->histogram.ext->mutex);
                 m->histogram.ext->size += statsd.histogram_increase_step;
                 m->histogram.ext->values = reallocz(m->histogram.ext->values, sizeof(NETDATA_DOUBLE) * m->histogram.ext->size);
-                netdata_mutex_unlock(&m->histogram.ext->mutex);
             }
 
             m->histogram.ext->values[m->histogram.ext->used++] = v;
         }
 
+        netdata_mutex_unlock(&m->histogram.ext->mutex);
         metric_update_counters_and_obsoletion(m);
     }
 }
@@ -1972,29 +1979,32 @@ static inline void statsd_flush_timer_or_histogram(STATSD_METRIC *m, const char 
     netdata_log_debug(D_STATSD, "flushing %s metric '%s'", dim, m->name);
 
     int updated = 0;
-    if(unlikely(!m->reset && m->count && m->histogram.ext->used > 0)) {
+    if(unlikely(!m->reset && m->count)) {
         netdata_mutex_lock(&m->histogram.ext->mutex);
 
-        size_t len = m->histogram.ext->used;
-        NETDATA_DOUBLE *series = m->histogram.ext->values;
-        sort_series(series, len);
+        if(likely(m->histogram.ext->used > 0)) {
+            size_t len = m->histogram.ext->used;
+            NETDATA_DOUBLE *series = m->histogram.ext->values;
+            sort_series(series, len);
 
-        m->histogram.ext->last_min = (collected_number)roundndd(series[0] * statsd.decimal_detail);
-        m->histogram.ext->last_max = (collected_number)roundndd(series[len - 1] * statsd.decimal_detail);
-        m->last = (collected_number)roundndd(average(series, len) * statsd.decimal_detail);
-        m->histogram.ext->last_stddev = (collected_number)roundndd(standard_deviation(series, len) * statsd.decimal_detail);
-        m->histogram.ext->last_sum = (collected_number)roundndd(sum(series, len) * statsd.decimal_detail);
-        m->histogram.ext->last_median = (collected_number)roundndd(median_on_sorted_series(series, len) * statsd.decimal_detail);
-        m->histogram.ext->last_percentile = (collected_number)roundndd(percentile_on_sorted_series(series, len,  statsd.histogram_percentile / 100) * statsd.decimal_detail);
+            m->histogram.ext->last_min = (collected_number)roundndd(series[0] * statsd.decimal_detail);
+            m->histogram.ext->last_max = (collected_number)roundndd(series[len - 1] * statsd.decimal_detail);
+            m->last = (collected_number)roundndd(average(series, len) * statsd.decimal_detail);
+            m->histogram.ext->last_stddev = (collected_number)roundndd(standard_deviation(series, len) * statsd.decimal_detail);
+            m->histogram.ext->last_sum = (collected_number)roundndd(sum(series, len) * statsd.decimal_detail);
+            m->histogram.ext->last_median = (collected_number)roundndd(median_on_sorted_series(series, len) * statsd.decimal_detail);
+            m->histogram.ext->last_percentile = (collected_number)roundndd(percentile_on_sorted_series(series, len,  statsd.histogram_percentile / 100) * statsd.decimal_detail);
+
+            m->histogram.ext->zeroed = 0;
+            m->reset = 1;
+            updated = 1;
+        }
 
         netdata_mutex_unlock(&m->histogram.ext->mutex);
 
-        netdata_log_debug(D_STATSD, "STATSD %s metric %s: min " COLLECTED_NUMBER_FORMAT ", max " COLLECTED_NUMBER_FORMAT ", last " COLLECTED_NUMBER_FORMAT ", pcent " COLLECTED_NUMBER_FORMAT ", median " COLLECTED_NUMBER_FORMAT ", stddev " COLLECTED_NUMBER_FORMAT ", sum " COLLECTED_NUMBER_FORMAT,
-              dim, m->name, m->histogram.ext->last_min, m->histogram.ext->last_max, m->last, m->histogram.ext->last_percentile, m->histogram.ext->last_median, m->histogram.ext->last_stddev, m->histogram.ext->last_sum);
-
-        m->histogram.ext->zeroed = 0;
-        m->reset = 1;
-        updated = 1;
+        if(updated)
+            netdata_log_debug(D_STATSD, "STATSD %s metric %s: min " COLLECTED_NUMBER_FORMAT ", max " COLLECTED_NUMBER_FORMAT ", last " COLLECTED_NUMBER_FORMAT ", pcent " COLLECTED_NUMBER_FORMAT ", median " COLLECTED_NUMBER_FORMAT ", stddev " COLLECTED_NUMBER_FORMAT ", sum " COLLECTED_NUMBER_FORMAT,
+                  dim, m->name, m->histogram.ext->last_min, m->histogram.ext->last_max, m->last, m->histogram.ext->last_percentile, m->histogram.ext->last_median, m->histogram.ext->last_stddev, m->histogram.ext->last_sum);
     }
     else if(unlikely(!m->histogram.ext->zeroed)) {
         // reset the metrics

--- a/src/collectors/xenstat.plugin/xenstat_plugin.c
+++ b/src/collectors/xenstat.plugin/xenstat_plugin.c
@@ -389,6 +389,7 @@ static int xenstat_collect(xenstat_handle *xhandle, libxl_ctx *ctx, libxl_dominf
         unsigned int id = xenstat_domain_id(domain);
         if(unlikely(libxl_domain_info(ctx, info, id))) {
             netdata_log_error("XENSTAT: cannot get domain info.");
+            continue;
         }
         else {
             snprintfz(uuid, LIBXL_UUID_FMTLEN, LIBXL_UUID_FMT "\n", LIBXL_UUID_BYTES(info->uuid));

--- a/src/database/rrdhost-status.c
+++ b/src/database/rrdhost-status.c
@@ -149,8 +149,19 @@ static inline RRDHOST_INGEST_STATUS rrdhost_status_ingest(RRDHOST *host, RRDHOST
     uint32_t collected_metrics = UINT32_MAX;
     uint32_t replicating_instances = UINT32_MAX;
 
-    time_t since = MAX(host->stream.rcv.status.last_connected, host->stream.rcv.status.last_disconnected);
-    STREAM_HANDSHAKE reason = host->stream.rcv.status.reason;
+    time_t last_connected;
+    time_t last_disconnected;
+    uint32_t connections;
+    STREAM_HANDSHAKE reason;
+
+    rrdhost_receiver_lock(host);
+    last_connected = host->stream.rcv.status.last_connected;
+    last_disconnected = host->stream.rcv.status.last_disconnected;
+    connections = host->stream.rcv.status.connections;
+    reason = host->stream.rcv.status.reason;
+    rrdhost_receiver_unlock(host);
+
+    time_t since = MAX(last_connected, last_disconnected);
 
     if (online) {
         if (db_status == RRDHOST_DB_STATUS_INITIALIZING)
@@ -169,7 +180,7 @@ static inline RRDHOST_INGEST_STATUS rrdhost_status_ingest(RRDHOST *host, RRDHOST
             status = RRDHOST_INGEST_STATUS_ONLINE;
     }
     else {
-        if(!host->stream.rcv.status.connections)
+        if(!connections)
             status = RRDHOST_INGEST_STATUS_ARCHIVED;
         else
             status = RRDHOST_INGEST_STATUS_OFFLINE;
@@ -215,7 +226,7 @@ static inline RRDHOST_INGEST_STATUS rrdhost_status_ingest(RRDHOST *host, RRDHOST
         else
             s->ingest.type = RRDHOST_INGEST_TYPE_ARCHIVED;
 
-        s->ingest.id = host->stream.rcv.status.connections;
+        s->ingest.id = connections;
     }
 
     return status;
@@ -395,4 +406,3 @@ RRDHOST_INGEST_STATUS rrdhost_get_ingest_status(RRDHOST *host, time_t now) {
     RRDHOST_DB_STATUS db_status = rrdhost_status_db(host, now, NULL, flags, online);
     return rrdhost_status_ingest(host, NULL, flags, db_status, online);
 }
-

--- a/src/libnetdata/datetime/rfc3339.c
+++ b/src/libnetdata/datetime/rfc3339.c
@@ -34,18 +34,24 @@ static inline size_t print_2digit(char *buffer, size_t size, int value) {
 }
 
 static inline size_t print_fraction(char *buffer, size_t size, usec_t fraction, size_t digits) {
-    if (!buffer || size < digits) return 0;
+    if (!buffer) return 0;
 
     // Validate and cap the number of digits
     digits = digits < 1 ? 1 : (digits > 9 ? 9 : digits);
+    if (size < digits) return 0;
 
-    // Calculate divisor to get correct precision
-    usec_t divisor = 1;
-    for (size_t i = 0; i < 6 - digits; i++)
-        divisor *= 10;
+    // Scale microseconds to the requested precision
+    if (digits < 6) {
+        usec_t divisor = 1;
+        for (size_t i = digits; i < 6; i++)
+            divisor *= 10;
 
-    // Calculate the fraction to print
-    fraction = fraction / divisor;
+        fraction /= divisor;
+    }
+    else if (digits > 6) {
+        for (size_t i = 6; i < digits; i++)
+            fraction *= 10;
+    }
 
     // Ensure fraction won't exceed the requested number of digits
     usec_t max_value = 1;

--- a/src/libnetdata/json/json-c-parser-unittest.c
+++ b/src/libnetdata/json/json-c-parser-unittest.c
@@ -1453,6 +1453,34 @@ static int test_parse_txt2rfc3339(void) {
 }
 
 // ----------------------------------------------------------------------------
+// RFC3339 formatter regression coverage
+// ----------------------------------------------------------------------------
+static int test_format_rfc3339(void) {
+    int failed = 0;
+    char buffer[RFC3339_MAX_LENGTH];
+    usec_t parsed;
+    size_t len;
+
+    len = rfc3339_datetime_ut(buffer, sizeof(buffer), 123456, 3, true);
+    T(len == strlen("1970-01-01T00:00:00.123Z") && strcmp(buffer, "1970-01-01T00:00:00.123Z") == 0,
+      "format_rfc3339: 3 digits truncate microseconds");
+
+    len = rfc3339_datetime_ut(buffer, sizeof(buffer), 123456, 7, true);
+    T(len == strlen("1970-01-01T00:00:00.1234560Z") && strcmp(buffer, "1970-01-01T00:00:00.1234560Z") == 0,
+      "format_rfc3339: 7 digits keep microseconds and pad trailing zero");
+    parsed = rfc3339_parse_ut(buffer, NULL);
+    T(parsed == 123456, "format_rfc3339: 7-digit output parses back to the same microseconds");
+
+    len = rfc3339_datetime_ut(buffer, sizeof(buffer), 1, 9, true);
+    T(len == strlen("1970-01-01T00:00:00.000001000Z") && strcmp(buffer, "1970-01-01T00:00:00.000001000Z") == 0,
+      "format_rfc3339: 9 digits preserve leading zeros and pad nanoseconds");
+    parsed = rfc3339_parse_ut(buffer, NULL);
+    T(parsed == 1, "format_rfc3339: 9-digit output parses back to the same microseconds");
+
+    return failed;
+}
+
+// ----------------------------------------------------------------------------
 // TXT2PATTERN — branches:
 //   key found: string "*"→NULL, string other→string_strdupz,
 //              other+OPT→skip, other+REQ→error, other+STRICT→error
@@ -2039,6 +2067,7 @@ int json_c_parser_unittest(void) {
         { "TXT2BUFFER",         test_parse_txt2buffer },
         { "TXT2UUID",           test_parse_txt2uuid },
         { "TXT2RFC3339",        test_parse_txt2rfc3339 },
+        { "FORMAT_RFC3339",     test_format_rfc3339 },
         { "TXT2PATTERN",        test_parse_txt2pattern },
         { "TXT2ENUM",           test_parse_txt2enum },
         { "ARRAY_OF_TXT2BITMAP", test_parse_array_of_txt2bitmap },

--- a/src/libnetdata/os/get_system_cpus.c
+++ b/src/libnetdata/os/get_system_cpus.c
@@ -100,9 +100,13 @@ size_t os_read_cpuset_cpus(const char *filename, size_t system_cpus) {
     static char *buf = NULL;
     static size_t buf_size = 0;
 
-    if(!buf) {
-        buf_size = 100U + 6 * system_cpus + 1; // taken from kernel/cgroup/cpuset.c
-        buf = mallocz(buf_size);
+    if(unlikely(!system_cpus))
+        system_cpus = os_get_system_cpus_uncached();
+
+    size_t required_buf_size = 100U + 6 * system_cpus + 1; // taken from kernel/cgroup/cpuset.c
+    if(unlikely(buf_size < required_buf_size)) {
+        buf_size = required_buf_size;
+        buf = reallocz(buf, buf_size);
     }
 
     int ret = read_txt_file(filename, buf, buf_size);


### PR DESCRIPTION
##### Summary
- Split / based on  #22234

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes memory-safety and correctness issues found by Coverity across collectors, core, and libs. Improves thread-safety for cancellation and StatsD histograms, fixes chart lookup and domain handling, and adds RFC3339 formatting tests.

- **Bug Fixes**
  - Thread-safety: atomic cancel flag in ACLK; lock StatsD histogram buffer for reset/growth/append/flush; snapshot receiver status under lock.
  - Correctness: fix mdstat obsolete chart lookup by matching type/id; avoid UAF in power-supply property loop; skip Xen domains when `libxl_domain_info()` fails.
  - Robustness: grow cpuset CPU parser buffer and handle `system_cpus==0`; unlock `apps_and_stdout_mutex` before exit on print-tree path.
  - Time formatting: fix RFC3339 fractional scaling for 1–9 digits and add regression tests.

<sup>Written for commit 74208a3c3acd87c939ff19c633135d9b7ca6d368. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

