### PR TITLE
Fix memory-safety and correctness bugs surfaced by Coverity audit (part 4)

### DIFF
--- a/src/collectors/log2journal/log2journal-logfmt.c
+++ b/src/collectors/log2journal/log2journal-logfmt.c
@@ -53,7 +53,7 @@ static inline bool logftm_parse_value(LOGFMT_STATE *lfs) {
 
     char quote = '\0';
     const char *s = logfmt_current_pos(lfs);
-    if(*s == '\"' || *s == '\'') {
+    if(*s == '"' || *s == '\'') {
         quote = *s;
         logfmt_consume_char(lfs);
     }
@@ -70,27 +70,31 @@ static inline bool logftm_parse_value(LOGFMT_STATE *lfs) {
         if (*s == '\\') {
             s++;
 
-            switch (*s) {
-                case 'n':
-                    copy_newline(lfs, &d, &remaining);
-                    s++;
-                    continue;
+            if(!*s)
+                c = '\\';
+            else {
+                switch (*s) {
+                    case 'n':
+                        copy_newline(lfs, &d, &remaining);
+                        s++;
+                        continue;
 
-                case 't':
-                    copy_tab(lfs, &d, &remaining);
-                    s++;
-                    continue;
+                    case 't':
+                        copy_tab(lfs, &d, &remaining);
+                        s++;
+                        continue;
 
-                case 'f':
-                case 'b':
-                case 'r':
-                    c = ' ';
-                    s++;
-                    break;
+                    case 'f':
+                    case 'b':
+                    case 'r':
+                        c = ' ';
+                        s++;
+                        break;
 
-                default:
-                    c = *s++;
-                    break;
+                    default:
+                        c = *s++;
+                        break;
+                }
             }
         }
         else
@@ -140,10 +144,16 @@ static inline bool logfmt_parse_key(LOGFMT_STATE *lfs) {
     while(*s && *s != '=') {
         char c;
 
-        if (*s == '\\')
+        if (*s == '\\') {
             s++;
 
-        c = journal_key_characters_map[(unsigned char)*s++];
+            if(!*s)
+                c = journal_key_characters_map[(unsigned char)'\\'];
+            else
+                c = journal_key_characters_map[(unsigned char)*s++];
+        }
+        else
+            c = journal_key_characters_map[(unsigned char)*s++];
 
         if(c == '_' && last_c == '_')
             continue;

--- a/src/collectors/log2journal/log2journal-pcre2.c
+++ b/src/collectors/log2journal/log2journal-pcre2.c
@@ -24,7 +24,7 @@ static inline void copy_and_convert_key(PCRE2_STATE *pcre2, const char *key) {
     size_t remaining = sizeof(pcre2->key) - pcre2->key_start;
 
     while(remaining >= 2 && *key) {
-        *d = journal_key_characters_map[(unsigned) (*key)];
+        *d = journal_key_characters_map[(unsigned char)*key];
         remaining--;
         key++;
         d++;

--- a/src/collectors/log2journal/tests.d/logfmt-trailing-backslash.input
+++ b/src/collectors/log2journal/tests.d/logfmt-trailing-backslash.input
@@ -1,0 +1,1 @@
+key=value\

--- a/src/collectors/log2journal/tests.d/logfmt-trailing-backslash.output
+++ b/src/collectors/log2journal/tests.d/logfmt-trailing-backslash.output
@@ -1,0 +1,2 @@
+KEY=value\
+

--- a/src/collectors/log2journal/tests.d/logfmt-trailing-backslash.yaml
+++ b/src/collectors/log2journal/tests.d/logfmt-trailing-backslash.yaml
@@ -1,0 +1,1 @@
+pattern: logfmt

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -1098,6 +1098,14 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
         goto cleanup;
     }
 
+    if((size_t)path_length >= sizeof(path)) {
+        errno = ENAMETOOLONG;
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: socket path for '%s' in runtime directory '%s' was truncated (needed %d bytes, buffer is %zu)",
+               server->name, runtime_directory, path_length, sizeof(path));
+        goto cleanup;
+    }
+
     if((size_t)path_length > max_path_length) {
         errno = ENAMETOOLONG;
         nd_log(NDLS_COLLECTORS, NDLP_ERR,

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -28,21 +28,44 @@ static volatile bool spawn_server_exit = false;
 static volatile bool spawn_server_sigchld = false;
 static SPAWN_REQUEST *spawn_server_requests = NULL;
 
+static size_t spawn_server_max_unix_socket_path_length(void) {
+    struct sockaddr_un server_addr = { 0 };
+    return sizeof(server_addr.sun_path) - 1;
+}
+
+static bool spawn_server_set_unix_socket_path(struct sockaddr_un *server_addr, const char *path, bool log, const char *action) {
+    const size_t max_path_length = sizeof(server_addr->sun_path) - 1;
+
+    if(strlen(path) > max_path_length) {
+        errno = ENAMETOOLONG;
+        if(log)
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "%s '%s': exceeds the %zu-byte AF_UNIX limit",
+                   action, path, max_path_length);
+        return false;
+    }
+
+    strncpyz(server_addr->sun_path, path, max_path_length);
+    return true;
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 
 static int connect_to_spawn_server(const char *path, bool log) {
     int sock = -1;
+    struct sockaddr_un server_addr = {
+        .sun_family = AF_UNIX,
+    };
+
+    if(!spawn_server_set_unix_socket_path(&server_addr, path, log,
+                                          "SPAWN PARENT: Cannot connect() to spawn server on path"))
+        return -1;
 
     if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
         if(log)
             nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN PARENT: cannot create socket() to connect to spawn server.");
         return -1;
     }
-
-    struct sockaddr_un server_addr = {
-        .sun_family = AF_UNIX,
-    };
-    strcpy(server_addr.sun_path, path);
 
     if (connect(sock, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1) {
         if(log)
@@ -956,15 +979,19 @@ static bool spawn_server_create_listening_socket(SPAWN_SERVER *server) {
         return false;
     }
 
+    struct sockaddr_un server_addr = {
+        .sun_family = AF_UNIX,
+    };
+
+    if(!spawn_server_set_unix_socket_path(&server_addr, server->path, true,
+                                          "SPAWN SERVER: Cannot listen on path"))
+        return false;
+
     if ((server->sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to create socket()");
         return false;
     }
 
-    struct sockaddr_un server_addr = {
-        .sun_family = AF_UNIX,
-    };
-    strcpy(server_addr.sun_path, server->path);
     unlink(server->path);
     errno = 0;
 
@@ -1053,13 +1080,30 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
         runtime_directory = "/tmp";
 
     char path[1024];
+    int path_length;
+    const size_t max_path_length = spawn_server_max_unix_socket_path_length();
     if(name && *name) {
         server->name = strdupz(name);
-        snprintf(path, sizeof(path), "%s/netdata-spawn-%s.sock", runtime_directory, name);
+        path_length = snprintf(path, sizeof(path), "%s/netdata-spawn-%s.sock", runtime_directory, name);
     }
     else {
         server->name = strdupz("unnamed");
-        snprintf(path, sizeof(path), "%s/netdata-spawn-%d-%zu.sock", runtime_directory, getpid(), server->id);
+        path_length = snprintf(path, sizeof(path), "%s/netdata-spawn-%d-%zu.sock", runtime_directory, getpid(), server->id);
+    }
+
+    if(path_length < 0) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: failed to generate socket path for '%s'",
+               server->name);
+        goto cleanup;
+    }
+
+    if((size_t)path_length > max_path_length) {
+        errno = ENAMETOOLONG;
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: socket path for '%s' in runtime directory '%s' exceeds the %zu-byte AF_UNIX limit",
+               server->name, runtime_directory, max_path_length);
+        goto cleanup;
     }
 
     server->path = strdupz(path);

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -1101,7 +1101,7 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
     if((size_t)path_length >= sizeof(path)) {
         errno = ENAMETOOLONG;
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
-               "SPAWN SERVER: socket path for '%s' in runtime directory '%s' was truncated (needed %d bytes, buffer is %zu)",
+               "SPAWN SERVER: socket path for '%s' in runtime directory '%s' was truncated (needed %d chars plus NUL, buffer is %zu bytes)",
                server->name, runtime_directory, path_length, sizeof(path));
         goto cleanup;
     }


### PR DESCRIPTION
##### Summary
- Split / based on  #22234


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes memory-safety and correctness issues flagged by Coverity in log2journal and the nofork spawn server, preventing out-of-bounds reads and rejecting invalid AF_UNIX socket paths. Adds a test for trailing backslashes in logfmt and improves error logs.

- **Bug Fixes**
  - log2journal (logfmt): treat a trailing backslash in keys/values as a literal so parsing stays in-bounds; minor quote check cleanup.
  - log2journal (PCRE2): index `journal_key_characters_map` with `(unsigned char)` to avoid large indexes on non-ASCII bytes.
  - spawn server (nofork): validate AF_UNIX socket path length before use; use bounded copies when setting `sun_path`; detect and fail on `snprintf` truncation; fix an error log message.
  - Tests: add `logfmt-trailing-backslash` case to lock behavior.

<sup>Written for commit 023dc8fcbb644122f2b4b307b7b2f6bf1976a3b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

