### PR TITLE
netflow-plugin: isolate dependency upgrades

### DIFF
--- a/src/crates/Cargo.lock
+++ b/src/crates/Cargo.lock
@@ -210,6 +210,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +413,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,12 +463,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "bytesize-serde"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d1eb2fd2668859e9785b99700c66b7ea9fdeda35d99f95827a4e5493440178"
 dependencies = [
- "bytesize",
+ "bytesize 1.3.3",
  "serde",
 ]
 
@@ -450,6 +492,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -518,6 +566,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cmsketch"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +585,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -777,6 +844,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "etherparse"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b119b9796ff800751a220394b8b3613f26dd30c48f254f6837e64c464872d1c7"
+checksum = "3ac016aaf11dfe643edcd088a166234bfcb72e7f06691abfcf21e9af524037f4"
 dependencies = [
  "arrayvec",
 ]
@@ -1047,6 +1120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1341,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "hashers"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,9 +1387,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hifijson"
-version = "0.2.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7763b98ba8a24f59e698bf9ab197e7676c640d6455d1580b4ce7dc560f0f0d"
+checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
 name = "http"
@@ -1398,7 +1488,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1687,52 +1776,135 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jaq-core"
-version = "1.5.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6fda09ee08c84c81293fdf811d9ebaa87b327557b5391f290c926d728c2ddd4"
+checksum = "dca0f164c8e9c55fc5aefe60b371df735c719b09930dac185878f2f8c7ab6b68"
 dependencies = [
- "aho-corasick",
- "base64 0.22.1",
- "chrono",
- "hifijson",
- "jaq-interpret",
- "libm",
- "log",
- "regex",
- "urlencoding",
+ "dyn-clone",
+ "once_cell",
+ "typed-arena",
 ]
 
 [[package]]
-name = "jaq-interpret"
-version = "1.5.0"
+name = "jaq-json"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe95ec3c24af3fd9f3dd1091593f5e49b003a66c496a8aa39d764d0a06ae17b"
+checksum = "f5c5baabe63d1d72cde60ec7548a098036773e3541dbc65c6a44fb38e9cfb272"
 dependencies = [
- "ahash",
- "dyn-clone",
+ "bstr",
+ "bytes",
+ "foldhash 0.1.5",
  "hifijson",
  "indexmap 2.13.1",
- "jaq-syn",
- "once_cell",
- "serde_json",
+ "jaq-core",
+ "jaq-std",
+ "num-bigint",
+ "num-traits",
+ "ryu",
+ "self_cell",
+ "serde_core",
 ]
 
 [[package]]
 name = "jaq-std"
-version = "1.6.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfbaa55578fd3b70433b594a370741e0c364e4afff92cc0099623fce87311bc1"
+checksum = "2a11bb307027b20b3dc7b212ad687e7e410cbc43933eec5d498672ab2bc60666"
 dependencies = [
- "jaq-syn",
+ "aho-corasick",
+ "base64 0.22.1",
+ "bstr",
+ "jaq-core",
+ "jiff",
+ "libm",
+ "log",
+ "regex-bites",
+ "urlencoding",
 ]
 
 [[package]]
-name = "jaq-syn"
-version = "1.6.0"
+name = "jiff"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba44fe4428c71304604261ecbae047ee9cfb60c4f1a6bd222ebbb31726d3948"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
- "serde",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2128,15 +2300,15 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maxminddb"
-version = "0.25.0"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144de2546bf4846c6c84b7f76be035f7ebbc1e7d40cfb05810ba45c129508321"
+checksum = "76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192"
 dependencies = [
  "ipnetwork",
  "log",
  "memchr",
- "memmap2",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2296,25 +2468,22 @@ dependencies = [
  "allocative",
  "anyhow",
  "async-trait",
- "bincode",
  "bitflags 2.11.0",
  "bitvec",
- "bytesize",
- "bytesize-serde",
+ "bytesize 2.3.1",
  "chrono",
  "clap",
  "etherparse",
  "fst",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
  "humantime",
  "humantime-serde",
  "ipnet",
  "ipnet-trie",
  "itoa",
  "jaq-core",
- "jaq-interpret",
+ "jaq-json",
  "jaq-std",
- "jaq-syn",
  "journal-common",
  "journal-core",
  "journal-engine",
@@ -2336,16 +2505,17 @@ dependencies = [
  "prost 0.14.3",
  "protoc-bin-vendored",
  "regex",
- "reqwest",
+ "reqwest 0.13.2",
+ "rmp-serde",
  "roaring",
  "rt",
  "rustc-hash",
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "sflow-parser",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2375,9 +2545,9 @@ dependencies = [
 
 [[package]]
 name = "netgauze-bgp-pkt"
-version = "0.9.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976c96f06769f989f41c99f11c06165cfb6b5d9fe0d6fee18d5369804186a590"
+checksum = "5169c61be703b97ba5a1be4606d6696e5c8647e5a2791f837a24011d26124077"
 dependencies = [
  "byteorder",
  "ipnet",
@@ -2392,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "netgauze-bmp-pkt"
-version = "0.9.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e559ed37796b9d4116a2eb8f6b4bb64ddc143e6e9b30461838248f569badd51b"
+checksum = "0bd1ae6b4400acac3742103f95ffa7688b042f0a36d9adedf255356d20a9adc4"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -2415,9 +2585,9 @@ dependencies = [
 
 [[package]]
 name = "netgauze-iana"
-version = "0.9.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d927104bf8eb4c0c4fa62f6089da2ae76cbb6632fa29c712494bf6b00ceeec05"
+checksum = "c5a6d28f40b1aee8cf1bfb9bb6463803a45f87fed99a9762ef56d26ac8852fe5"
 dependencies = [
  "serde",
  "strum_macros",
@@ -2425,18 +2595,18 @@ dependencies = [
 
 [[package]]
 name = "netgauze-locate"
-version = "0.9.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7b2913ed285eb74b86fde33a6e69525009008f694777b1d892853c17012366"
+checksum = "5ded50ecdaff76ffd41a42708f4b48f2db70f05c3aa0f4f436c3d74beedbe2ee"
 dependencies = [
  "nom",
 ]
 
 [[package]]
 name = "netgauze-parse-utils"
-version = "0.9.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d87bded02d6ee3d949886f38fe3170df3ea60366c96e69617476532ade293c"
+checksum = "9decd50ea6b044862d048f491a6c8ad62cf2b7d9b905f94e9ddf85d45035d58f"
 dependencies = [
  "netgauze-locate",
  "nom",
@@ -2445,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "netgauze-serde-macros"
-version = "0.9.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c71c31f7611ff298060ea8d1e4f0f3e90390a15ea4d8be52b299253cf2731e"
+checksum = "45f18369c9c01970528485c0fb338040ab86e3433857e362cef20ff17ddd52eb"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2555,6 +2725,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,7 +2804,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -2630,7 +2819,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.3",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.14.5",
@@ -2676,7 +2865,7 @@ name = "otel-plugin"
 version = "0.1.3"
 dependencies = [
  "anyhow",
- "bytesize",
+ "bytesize 1.3.3",
  "bytesize-serde",
  "clap",
  "flatten_otel",
@@ -2708,7 +2897,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytesize",
+ "bytesize 1.3.3",
  "bytesize-serde",
  "foyer",
  "journal-core",
@@ -2864,6 +3053,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3132,6 +3336,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3345,6 +3550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-bites"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a15a2fa0bfda9361941c45550896ae87b15cc6c8c939ea350079670332e211"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,6 +3576,38 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -3374,9 +3617,9 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3387,7 +3630,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3402,6 +3644,25 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -3465,6 +3726,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3497,11 +3759,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3613,6 +3903,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3709,6 +4005,19 @@ name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.1",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.13.1",
  "itoa",
@@ -4378,6 +4687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4635,10 +4950,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.6"
+name = "webpki-root-certs"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4735,6 +5050,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4767,6 +5091,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4804,6 +5143,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4816,6 +5161,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4825,6 +5176,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4852,6 +5209,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4861,6 +5224,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4876,6 +5245,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4885,6 +5260,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src/crates/Cargo.lock
+++ b/src/crates/Cargo.lock
@@ -2513,7 +2513,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml_ng",
+ "serde_yaml",
  "sflow-parser",
  "socket2 0.6.3",
  "tempfile",
@@ -4005,19 +4005,6 @@ name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.13.1",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
-name = "serde_yaml_ng"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.13.1",
  "itoa",

--- a/src/crates/Cargo.lock
+++ b/src/crates/Cargo.lock
@@ -458,27 +458,11 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytesize"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
-
-[[package]]
-name = "bytesize"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "bytesize-serde"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d1eb2fd2668859e9785b99700c66b7ea9fdeda35d99f95827a4e5493440178"
-dependencies = [
- "bytesize 1.3.3",
- "serde",
 ]
 
 [[package]]
@@ -2470,7 +2454,7 @@ dependencies = [
  "async-trait",
  "bitflags 2.11.0",
  "bitvec",
- "bytesize 2.3.1",
+ "bytesize",
  "chrono",
  "clap",
  "etherparse",
@@ -2865,8 +2849,7 @@ name = "otel-plugin"
 version = "0.1.3"
 dependencies = [
  "anyhow",
- "bytesize 1.3.3",
- "bytesize-serde",
+ "bytesize",
  "clap",
  "flatten_otel",
  "humantime",
@@ -2897,8 +2880,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytesize 1.3.3",
- "bytesize-serde",
+ "bytesize",
  "foyer",
  "journal-core",
  "journal-function",

--- a/src/crates/Cargo.toml
+++ b/src/crates/Cargo.toml
@@ -144,8 +144,7 @@ pcap-file = "2.0.0"
 
 # OTEL-specific dependencies
 atty = "0.2"
-bytesize = "1.3"
-bytesize-serde = "0.2"
+bytesize = { version = "2.3.1", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 duct = "0.13"
 humantime = "2.2"

--- a/src/crates/Cargo.toml
+++ b/src/crates/Cargo.toml
@@ -66,7 +66,6 @@ roaring = { git = "https://github.com/netdata/roaring-rs.git", branch="allocativ
 hashbrown = "0.17.0"
 serde = { version = "1.0" }
 rustc-hash = "2.1"
-bincode = { version = "1.3" }
 rmp-serde = "1.3.1"
 notify = "8.2"
 

--- a/src/crates/Cargo.toml
+++ b/src/crates/Cargo.toml
@@ -63,10 +63,11 @@ lzma-rust2 = { version = "0.15", default-features = false, features = ["std", "x
 md5 = "0.7"
 
 roaring = { git = "https://github.com/netdata/roaring-rs.git", branch="allocative" }
-hashbrown = "0.15"
+hashbrown = "0.17.0"
 serde = { version = "1.0" }
 rustc-hash = "2.1"
 bincode = { version = "1.3" }
+rmp-serde = "1.3.1"
 notify = "8.2"
 
 walkdir = "2.4"
@@ -123,23 +124,22 @@ itoa = "1.0"
 base64 = "0.22"
 
 # NetFlow-specific dependencies
-jaq-core = "1.2.0"
-jaq-interpret = "1.2.0"
-jaq-std = "1.5.0"
-jaq-syn = "1.6.0"
-maxminddb = "0.25.0"
+jaq-core = "3.0.0"
+jaq-json = "2.0.0"
+jaq-std = "3.0.0"
+maxminddb = "0.27.3"
 netflow_parser = "0.9.0"
-netgauze-bgp-pkt = "0.9.0"
-netgauze-bmp-pkt = "0.9.0"
+netgauze-bgp-pkt = "0.11.0"
+netgauze-bmp-pkt = "0.11.0"
 sflow-parser = "0.6.0"
-reqwest = { version = "0.12.12", default-features = false }
-socket2 = "0.5.8"
+reqwest = { version = "0.13.2", default-features = false }
+socket2 = "0.6.3"
 tonic-prost = "0.14"
 prost = "0.14"
 fst = "0.4.7"
 tonic-prost-build = "0.14"
 protoc-bin-vendored = "3"
-etherparse = "0.19.0"
+etherparse = "0.20.1"
 pcap-file = "2.0.0"
 
 # OTEL-specific dependencies

--- a/src/crates/netdata-log-viewer/otel-signal-viewer-plugin/Cargo.toml
+++ b/src/crates/netdata-log-viewer/otel-signal-viewer-plugin/Cargo.toml
@@ -31,7 +31,6 @@ foyer = { workspace = true }
 # Configuration support
 anyhow = { workspace = true }
 bytesize = { workspace = true }
-bytesize-serde = { workspace = true }
 num_cpus = "1"
 serde_yaml = { workspace = true }
 parking_lot = { workspace = true }

--- a/src/crates/netdata-log-viewer/otel-signal-viewer-plugin/src/plugin_config.rs
+++ b/src/crates/netdata-log-viewer/otel-signal-viewer-plugin/src/plugin_config.rs
@@ -39,11 +39,9 @@ pub struct CacheConfig {
     pub memory_capacity: usize,
 
     /// Disk cache size (total size of disk-backed cache)
-    #[serde(with = "bytesize_serde")]
     pub disk_capacity: ByteSize,
 
     /// Cache block size (size of cache blocks)
-    #[serde(with = "bytesize_serde")]
     pub block_size: ByteSize,
 
     /// Number of background workers for indexing journal files

--- a/src/crates/netdata-otel/otel-plugin/Cargo.toml
+++ b/src/crates/netdata-otel/otel-plugin/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-bytesize-serde = { workspace = true }
 bytesize = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 humantime-serde = { workspace = true }

--- a/src/crates/netdata-otel/otel-plugin/src/plugin_config/logs.rs
+++ b/src/crates/netdata-otel/otel-plugin/src/plugin_config/logs.rs
@@ -63,7 +63,6 @@ pub struct LogsConfig {
         default_value = "100MB",
         value_parser = parse_bytesize
     )]
-    #[serde(with = "bytesize_serde")]
     pub size_of_journal_file: ByteSize,
 
     /// Maximum number of entries in journal files
@@ -87,7 +86,6 @@ pub struct LogsConfig {
         default_value = "1GB",
         value_parser = parse_bytesize
     )]
-    #[serde(with = "bytesize_serde")]
     pub size_of_journal_files: ByteSize,
 
     /// Maximum age for journal entries (accepts human-readable durations like "7 days", "1 week", "168h")

--- a/src/crates/netflow-plugin/Cargo.toml
+++ b/src/crates/netflow-plugin/Cargo.toml
@@ -28,20 +28,20 @@ journal-log-writer = { workspace = true }
 journal-registry = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
-hashbrown = "0.17.0"
+hashbrown = { workspace = true }
 libc = { workspace = true }
 ipnet = { workspace = true }
 ipnet-trie = { workspace = true }
 itoa = { workspace = true }
-jaq-core = "3.0.0"
-jaq-json = { version = "2.0.0", features = ["serde"] }
-jaq-std = "3.0.0"
-maxminddb = "0.27.3"
+jaq-core = { workspace = true }
+jaq-json = { workspace = true, features = ["serde"] }
+jaq-std = { workspace = true }
+maxminddb = { workspace = true }
 memchr = { workspace = true }
 memmap2 = { workspace = true }
 netflow_parser = { workspace = true }
-netgauze-bgp-pkt = "0.11.0"
-netgauze-bmp-pkt = { version = "0.11.0", features = ["codec"] }
+netgauze-bgp-pkt = { workspace = true }
+netgauze-bmp-pkt = { workspace = true, features = ["codec"] }
 notify = { workspace = true }
 roaring = { workspace = true, features = ["allocative"] }
 serde = { workspace = true, features = ["derive"] }
@@ -54,23 +54,23 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 regex = { workspace = true }
 twox-hash = { workspace = true, features = ["xxhash64"] }
-reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls"] }
+reqwest = { workspace = true, features = ["json", "rustls"] }
 schemars = { workspace = true }
-socket2 = "0.6.3"
+socket2 = { workspace = true }
 tonic = { workspace = true, features = ["transport", "tls-native-roots"] }
 tonic-prost = { workspace = true }
 prost = { workspace = true }
 rustc-hash = { workspace = true }
 thiserror = { workspace = true }
 fst = { workspace = true }
-rmp-serde = "1.3.1"
+rmp-serde = { workspace = true }
 
 rt = { workspace = true }
 netdata-plugin-error = { workspace = true }
 netdata-plugin-protocol = { workspace = true }
 
 [dev-dependencies]
-etherparse = "0.20.1"
+etherparse = { workspace = true }
 pcap-file = { workspace = true }
 proptest = { workspace = true }
 protoc-bin-vendored = { workspace = true }

--- a/src/crates/netflow-plugin/Cargo.toml
+++ b/src/crates/netflow-plugin/Cargo.toml
@@ -46,7 +46,7 @@ notify = { workspace = true }
 roaring = { workspace = true, features = ["allocative"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-serde_yaml_ng = "0.10.0"
+serde_yaml = { workspace = true }
 sflow-parser = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/src/crates/netflow-plugin/Cargo.toml
+++ b/src/crates/netflow-plugin/Cargo.toml
@@ -15,11 +15,9 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 allocative = { workspace = true }
 async-trait = { workspace = true }
-bincode = { workspace = true }
 bitflags = { workspace = true }
 bitvec = { workspace = true }
-bytesize = { workspace = true }
-bytesize-serde = { workspace = true }
+bytesize = { version = "2.3.1", features = ["serde"] }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 journal-common = { workspace = true }
@@ -30,26 +28,25 @@ journal-log-writer = { workspace = true }
 journal-registry = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
-hashbrown = { workspace = true }
+hashbrown = "0.17.0"
 libc = { workspace = true }
 ipnet = { workspace = true }
 ipnet-trie = { workspace = true }
 itoa = { workspace = true }
-jaq-core = { workspace = true }
-jaq-interpret = { workspace = true }
-jaq-std = { workspace = true }
-jaq-syn = { workspace = true }
-maxminddb = { workspace = true, features = ["mmap"] }
+jaq-core = "3.0.0"
+jaq-json = { version = "2.0.0", features = ["serde"] }
+jaq-std = "3.0.0"
+maxminddb = "0.27.3"
 memchr = { workspace = true }
 memmap2 = { workspace = true }
 netflow_parser = { workspace = true }
-netgauze-bgp-pkt = { workspace = true }
-netgauze-bmp-pkt = { workspace = true, features = ["codec"] }
+netgauze-bgp-pkt = "0.11.0"
+netgauze-bmp-pkt = { version = "0.11.0", features = ["codec"] }
 notify = { workspace = true }
 roaring = { workspace = true, features = ["allocative"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
+serde_yaml_ng = "0.10.0"
 sflow-parser = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
@@ -57,22 +54,23 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 regex = { workspace = true }
 twox-hash = { workspace = true, features = ["xxhash64"] }
-reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls"] }
 schemars = { workspace = true }
-socket2 = { workspace = true }
+socket2 = "0.6.3"
 tonic = { workspace = true, features = ["transport", "tls-native-roots"] }
 tonic-prost = { workspace = true }
 prost = { workspace = true }
 rustc-hash = { workspace = true }
 thiserror = { workspace = true }
 fst = { workspace = true }
+rmp-serde = "1.3.1"
 
 rt = { workspace = true }
 netdata-plugin-error = { workspace = true }
 netdata-plugin-protocol = { workspace = true }
 
 [dev-dependencies]
-etherparse = { workspace = true }
+etherparse = "0.20.1"
 pcap-file = { workspace = true }
 proptest = { workspace = true }
 protoc-bin-vendored = { workspace = true }

--- a/src/crates/netflow-plugin/Cargo.toml
+++ b/src/crates/netflow-plugin/Cargo.toml
@@ -17,7 +17,7 @@ allocative = { workspace = true }
 async-trait = { workspace = true }
 bitflags = { workspace = true }
 bitvec = { workspace = true }
-bytesize = { version = "2.3.1", features = ["serde"] }
+bytesize = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 journal-common = { workspace = true }

--- a/src/crates/netflow-plugin/src/api/flows/handler.rs
+++ b/src/crates/netflow-plugin/src/api/flows/handler.rs
@@ -174,7 +174,9 @@ impl NetflowFlowsHandler {
     }
 }
 
-fn parse_flows_request(function_call: &FunctionCall) -> std::result::Result<query::FlowsRequest, FunctionResult> {
+fn parse_flows_request(
+    function_call: &FunctionCall,
+) -> std::result::Result<query::FlowsRequest, FunctionResult> {
     let request_value = if function_call.payload.is_some() {
         payload_to_value(function_call)?
     } else if function_call.args.is_empty() {

--- a/src/crates/netflow-plugin/src/decoder.rs
+++ b/src/crates/netflow-plugin/src/decoder.rs
@@ -1,5 +1,4 @@
 use crate::enrichment::FlowEnricher;
-use bincode::Options;
 use netflow_parser::NetflowPacket;
 use netflow_parser::scoped_parser::AutoScopedParser;
 use netflow_parser::static_versions::{v5::V5, v7::V7};
@@ -85,7 +84,7 @@ const SFLOW_INTERFACE_LOCAL: u32 = 0x3fff_ffff;
 const SFLOW_INTERFACE_FORMAT_INDEX: u32 = 0;
 const SFLOW_INTERFACE_FORMAT_DISCARD: u32 = 1;
 const VXLAN_UDP_PORT: u16 = 4789;
-const DECODER_STATE_SCHEMA_VERSION: u32 = 2;
+const DECODER_STATE_SCHEMA_VERSION: u32 = 3;
 const DECODER_STATE_MAGIC: &[u8; 4] = b"NDFS";
 const DECODER_STATE_HEADER_LEN: usize = 4 + 4 + 8 + 8;
 

--- a/src/crates/netflow-plugin/src/decoder/protocol/ipfix/record/state.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/ipfix/record/state.rs
@@ -237,7 +237,10 @@ mod tests {
         state.apply_reverse_time_overrides();
 
         assert_eq!(
-            state.reverse_overrides.get("FLOW_START_USEC").map(String::as_str),
+            state
+                .reverse_overrides
+                .get("FLOW_START_USEC")
+                .map(String::as_str),
             Some("1042000")
         );
     }

--- a/src/crates/netflow-plugin/src/decoder/protocol/ipfix/special/record.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/ipfix/special/record.rs
@@ -32,11 +32,7 @@ pub(crate) fn decode_ipfix_special_record(
                 let Some(value) = decode_akvorado_unsigned(raw_value) else {
                     continue;
                 };
-                let status = if value & 0x03ff == 0 {
-                    "64"
-                } else {
-                    "128"
-                };
+                let status = if value & 0x03ff == 0 { "64" } else { "128" };
                 fields.insert("FORWARDING_STATUS", status.to_string());
             }
             continue;

--- a/src/crates/netflow-plugin/src/decoder/state/persisted.rs
+++ b/src/crates/netflow-plugin/src/decoder/state/persisted.rs
@@ -4,13 +4,6 @@ pub(crate) const MAX_DECODER_STATE_PAYLOAD_LEN: usize = 8 * 1024 * 1024;
 pub(crate) const MAX_DECODER_STATE_FILE_LEN: usize =
     DECODER_STATE_HEADER_LEN + MAX_DECODER_STATE_PAYLOAD_LEN;
 
-pub(crate) fn decoder_state_bincode_options() -> impl Options {
-    bincode::DefaultOptions::new()
-        .with_fixint_encoding()
-        .with_little_endian()
-        .with_limit(MAX_DECODER_STATE_PAYLOAD_LEN as u64)
-}
-
 pub(crate) fn xxhash64(data: &[u8]) -> u64 {
     let mut hasher = XxHash64::default();
     hasher.write(data);
@@ -20,9 +13,15 @@ pub(crate) fn xxhash64(data: &[u8]) -> u64 {
 pub(crate) fn encode_persisted_namespace_file(
     file: &PersistedDecoderNamespaceFile,
 ) -> Result<Vec<u8>, String> {
-    let payload = decoder_state_bincode_options()
-        .serialize(file)
+    let payload = rmp_serde::to_vec_named(file)
         .map_err(|err| format!("failed to encode decoder namespace state: {err}"))?;
+    if payload.len() > MAX_DECODER_STATE_PAYLOAD_LEN {
+        return Err(format!(
+            "decoder namespace payload exceeds limit (max {} bytes, got {})",
+            MAX_DECODER_STATE_PAYLOAD_LEN,
+            payload.len()
+        ));
+    }
     let payload_hash = xxhash64(&payload);
     let payload_len = payload.len() as u64;
 
@@ -60,8 +59,7 @@ pub(crate) fn decode_persisted_namespace_file(
     if payload_len > MAX_DECODER_STATE_PAYLOAD_LEN {
         return Err(format!(
             "decoder namespace payload exceeds limit (max {} bytes, got {})",
-            MAX_DECODER_STATE_PAYLOAD_LEN,
-            payload_len
+            MAX_DECODER_STATE_PAYLOAD_LEN, payload_len
         ));
     }
     let payload = &data[DECODER_STATE_HEADER_LEN..];
@@ -81,7 +79,6 @@ pub(crate) fn decode_persisted_namespace_file(
         ));
     }
 
-    decoder_state_bincode_options()
-        .deserialize(payload)
+    rmp_serde::from_slice(payload)
         .map_err(|err| format!("failed to decode decoder namespace state: {err}"))
 }

--- a/src/crates/netflow-plugin/src/decoder/tests.rs
+++ b/src/crates/netflow-plugin/src/decoder/tests.rs
@@ -3,10 +3,10 @@ use super::{
     DECODER_STATE_SCHEMA_VERSION, DIRECTION_EGRESS, DIRECTION_INGRESS, DecapsulationMode,
     DecodeStats, DecodedFlow, DecoderStateNamespace, ETYPE_IPV4, ETYPE_IPV6, FlowDecoders,
     FlowFields, FlowRecord, MAX_DECODER_STATE_PAYLOAD_LEN, SamplingState, TimestampSource,
-    append_mpls_label, append_unique_flows, apply_icmp_port_fallback,
-    apply_v9_special_mappings, decode_persisted_namespace_file, decode_v9_special_from_raw_payload,
-    default_exporter_name, field_tracks_presence, finalize_canonical_flow_fields,
-    normalize_direction_value, observe_v9_templates_from_raw_payload, to_field_token, xxhash64,
+    append_mpls_label, append_unique_flows, apply_icmp_port_fallback, apply_v9_special_mappings,
+    decode_persisted_namespace_file, decode_v9_special_from_raw_payload, default_exporter_name,
+    field_tracks_presence, finalize_canonical_flow_fields, normalize_direction_value,
+    observe_v9_templates_from_raw_payload, to_field_token, xxhash64,
 };
 use etherparse::{NetSlice, SlicedPacket, TransportSlice};
 use netflow_parser::variable_versions::v9_lookup::V9Field;

--- a/src/crates/netflow-plugin/src/enrichment.rs
+++ b/src/crates/netflow-plugin/src/enrichment.rs
@@ -12,7 +12,7 @@ use crate::routing::DynamicRoutingRuntime;
 use crate::routing::{DynamicRoutingPeerKey, DynamicRoutingUpdate};
 use anyhow::{Context, Result};
 use ipnet::IpNet;
-use maxminddb::{Mmap, Reader};
+use maxminddb::Reader;
 use regex::Regex;
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};

--- a/src/crates/netflow-plugin/src/enrichment/data/geoip/files.rs
+++ b/src/crates/netflow-plugin/src/enrichment/data/geoip/files.rs
@@ -7,7 +7,7 @@ pub(crate) fn load_geoip_readers(
 ) -> Result<Vec<GeoIpDatabaseReader>> {
     let mut readers = Vec::new();
     for path in paths {
-        match Reader::open_mmap(path) {
+        match Reader::open_readfile(path) {
             Ok(reader) => readers.push(reader),
             Err(err) if optional => {
                 tracing::warn!(

--- a/src/crates/netflow-plugin/src/enrichment/data/geoip/resolver.rs
+++ b/src/crates/netflow-plugin/src/enrichment/data/geoip/resolver.rs
@@ -1,13 +1,5 @@
 use super::*;
 
-fn should_ignore_geoip_lookup_error(err: &maxminddb::MaxMindDbError) -> bool {
-    matches!(
-        err,
-        maxminddb::MaxMindDbError::InvalidInput { message }
-            if message == "cannot look up IPv6 address in IPv4-only database"
-    )
-}
-
 fn warn_unexpected_geoip_lookup_error(
     database_kind: &'static str,
     err: &maxminddb::MaxMindDbError,
@@ -37,10 +29,15 @@ fn lookup_geoip_record<T>(
 where
     T: for<'de> serde::Deserialize<'de>,
 {
+    // Skip IPv6 lookups against IPv4-only databases; maxminddb would otherwise
+    // return an InvalidInput error that we would have to detect by message.
+    if address.is_ipv6() && db.metadata.ip_version == 4 {
+        return None;
+    }
+
     match db.lookup(address).and_then(|record| record.decode::<T>()) {
         Ok(Some(record)) => Some(record),
         Ok(None) => None,
-        Err(err) if should_ignore_geoip_lookup_error(&err) => None,
         Err(err) => {
             warn_unexpected_geoip_lookup_error(database_kind, &err);
             None
@@ -176,18 +173,6 @@ mod tests {
         resolver.refresh_if_needed();
 
         assert_eq!(resolver.last_reload_check, old_check);
-    }
-
-    #[test]
-    fn geoip_lookup_error_classifier_only_ignores_ipv6_in_ipv4_database() {
-        assert!(should_ignore_geoip_lookup_error(
-            &maxminddb::MaxMindDbError::invalid_input(
-                "cannot look up IPv6 address in IPv4-only database"
-            )
-        ));
-        assert!(!should_ignore_geoip_lookup_error(
-            &maxminddb::MaxMindDbError::invalid_database("broken")
-        ));
     }
 
     #[test]

--- a/src/crates/netflow-plugin/src/enrichment/data/geoip/resolver.rs
+++ b/src/crates/netflow-plugin/src/enrichment/data/geoip/resolver.rs
@@ -1,12 +1,16 @@
 use super::*;
 
-fn should_ignore_geoip_lookup_error(err: &maxminddb::MaxMindDBError) -> bool {
-    matches!(err, maxminddb::MaxMindDBError::AddressNotFoundError(_))
+fn should_ignore_geoip_lookup_error(err: &maxminddb::MaxMindDbError) -> bool {
+    matches!(
+        err,
+        maxminddb::MaxMindDbError::InvalidInput { message }
+            if message == "cannot look up IPv6 address in IPv4-only database"
+    )
 }
 
 fn warn_unexpected_geoip_lookup_error(
     database_kind: &'static str,
-    err: &maxminddb::MaxMindDBError,
+    err: &maxminddb::MaxMindDbError,
 ) {
     static ASN_LOOKUP_WARNED: std::sync::Once = std::sync::Once::new();
     static GEO_LOOKUP_WARNED: std::sync::Once = std::sync::Once::new();
@@ -33,8 +37,9 @@ fn lookup_geoip_record<T>(
 where
     T: for<'de> serde::Deserialize<'de>,
 {
-    match db.lookup::<T>(address) {
-        Ok(record) => Some(record),
+    match db.lookup(address).and_then(|record| record.decode::<T>()) {
+        Ok(Some(record)) => Some(record),
+        Ok(None) => None,
         Err(err) if should_ignore_geoip_lookup_error(&err) => None,
         Err(err) => {
             warn_unexpected_geoip_lookup_error(database_kind, &err);
@@ -174,12 +179,14 @@ mod tests {
     }
 
     #[test]
-    fn geoip_lookup_error_classifier_only_ignores_address_not_found() {
+    fn geoip_lookup_error_classifier_only_ignores_ipv6_in_ipv4_database() {
         assert!(should_ignore_geoip_lookup_error(
-            &maxminddb::MaxMindDBError::AddressNotFoundError("missing".to_string())
+            &maxminddb::MaxMindDbError::invalid_input(
+                "cannot look up IPv6 address in IPv4-only database"
+            )
         ));
         assert!(!should_ignore_geoip_lookup_error(
-            &maxminddb::MaxMindDBError::InvalidDatabaseError("broken".to_string())
+            &maxminddb::MaxMindDbError::invalid_database("broken")
         ));
     }
 

--- a/src/crates/netflow-plugin/src/enrichment/data/geoip/types.rs
+++ b/src/crates/netflow-plugin/src/enrichment/data/geoip/types.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(crate) type GeoIpDatabaseReader = Reader<Mmap>;
+pub(crate) type GeoIpDatabaseReader = Reader<Vec<u8>>;
 
 #[derive(Debug)]
 pub(crate) struct GeoIpResolver {

--- a/src/crates/netflow-plugin/src/facet_runtime.rs
+++ b/src/crates/netflow-plugin/src/facet_runtime.rs
@@ -40,6 +40,7 @@ const FACET_STATE_MAGIC: &[u8; 4] = b"NFFS";
 const FACET_STATE_SCHEMA_VERSION: u32 = 1;
 const FACET_STATE_HEADER_LEN: usize = 4 + 4 + 8 + 8;
 const MAX_FACET_STATE_PAYLOAD_LEN: usize = 128 * 1024 * 1024;
+const MAX_FACET_STATE_FILE_LEN: usize = FACET_STATE_HEADER_LEN + MAX_FACET_STATE_PAYLOAD_LEN;
 const FACET_AUTOCOMPLETE_LIMIT: usize = 100;
 const BTREE_ENTRY_OVERHEAD_BYTES: usize = size_of::<usize>() * 4;
 
@@ -961,6 +962,27 @@ fn btree_container_overhead_bytes(len: usize) -> usize {
 }
 
 fn load_persisted_state(state_path: &Path) -> Option<PersistedFacetState> {
+    let file_len = match fs::metadata(state_path) {
+        Ok(metadata) => metadata.len(),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(err) => {
+            tracing::warn!(
+                "failed to stat persisted netflow facet state {}: {}",
+                state_path.display(),
+                err
+            );
+            return None;
+        }
+    };
+    if file_len > MAX_FACET_STATE_FILE_LEN as u64 {
+        tracing::warn!(
+            "skipping oversized persisted netflow facet state {} (max {} bytes, got {})",
+            state_path.display(),
+            MAX_FACET_STATE_FILE_LEN,
+            file_len
+        );
+        return None;
+    }
     let data = match fs::read(state_path) {
         Ok(data) => data,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return None,
@@ -1233,6 +1255,29 @@ mod tests {
                     .collect::<BTreeSet<_>>(),
             );
         }
+    }
+
+    #[test]
+    fn load_persisted_state_skips_oversized_file_without_full_read() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let state_path = tmp.path().join(FACET_STATE_FILE_NAME);
+        // Use a sparse file so we exceed the cap without actually writing 128MiB.
+        let oversized = (MAX_FACET_STATE_FILE_LEN as u64).saturating_add(1);
+        let file = std::fs::File::create(&state_path).expect("create state file");
+        file.set_len(oversized).expect("extend state file");
+        drop(file);
+
+        let metadata = std::fs::metadata(&state_path).expect("stat state file");
+        assert!(
+            metadata.len() > MAX_FACET_STATE_FILE_LEN as u64,
+            "test setup must produce an oversized file"
+        );
+
+        let loaded = load_persisted_state(&state_path);
+        assert!(
+            loaded.is_none(),
+            "oversized facet state file must be skipped, not loaded"
+        );
     }
 
     #[test]

--- a/src/crates/netflow-plugin/src/facet_runtime.rs
+++ b/src/crates/netflow-plugin/src/facet_runtime.rs
@@ -12,18 +12,19 @@ use crate::query::{
     accumulate_targeted_facet_values, facet_field_requires_protocol_scan,
     virtual_flow_field_dependencies,
 };
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use journal_core::file::JournalFileMap;
 use journal_registry::FileInfo;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::io::BufReader;
+use std::hash::Hasher;
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use tokio::sync::Notify;
+use twox_hash::XxHash64;
 
 #[allow(unused_imports)]
 pub(crate) use contribution::{
@@ -33,8 +34,12 @@ pub(crate) use contribution::{
 use sidecar::{delete_sidecar_files, search_sidecar, write_sidecar_files};
 use store::{FacetStore, FacetStoreValueRef, PersistedFacetStore};
 
-const FACET_STATE_VERSION: u32 = 4;
+const FACET_STATE_VERSION: u32 = 5;
 const FACET_STATE_FILE_NAME: &str = "facet-state.bin";
+const FACET_STATE_MAGIC: &[u8; 4] = b"NFFS";
+const FACET_STATE_SCHEMA_VERSION: u32 = 1;
+const FACET_STATE_HEADER_LEN: usize = 4 + 4 + 8 + 8;
+const MAX_FACET_STATE_PAYLOAD_LEN: usize = 128 * 1024 * 1024;
 const FACET_AUTOCOMPLETE_LIMIT: usize = 100;
 const BTREE_ENTRY_OVERHEAD_BYTES: usize = size_of::<usize>() * 4;
 
@@ -815,7 +820,8 @@ fn persist_state_locked(state_path: &Path, state: &mut FacetState) -> Result<()>
             .collect(),
         published: state.published.fields.clone(),
     };
-    let payload = bincode::serialize(&persisted).context("failed to serialize facet state")?;
+    let payload =
+        encode_persisted_facet_state(&persisted).context("failed to serialize facet state")?;
     let tmp_path = state_path.with_extension("bin.tmp");
     fs::write(&tmp_path, &payload).with_context(|| {
         format!(
@@ -832,6 +838,33 @@ fn persist_state_locked(state_path: &Path, state: &mut FacetState) -> Result<()>
     })?;
     state.dirty = false;
     Ok(())
+}
+
+fn facet_state_xxhash64(data: &[u8]) -> u64 {
+    let mut hasher = XxHash64::default();
+    hasher.write(data);
+    hasher.finish()
+}
+
+fn encode_persisted_facet_state(persisted: &PersistedFacetState) -> Result<Vec<u8>> {
+    let payload = rmp_serde::to_vec_named(persisted)?;
+    if payload.len() > MAX_FACET_STATE_PAYLOAD_LEN {
+        bail!(
+            "facet state payload exceeds limit (max {} bytes, got {})",
+            MAX_FACET_STATE_PAYLOAD_LEN,
+            payload.len()
+        );
+    }
+
+    let payload_hash = facet_state_xxhash64(&payload);
+    let payload_len = payload.len() as u64;
+    let mut out = Vec::with_capacity(FACET_STATE_HEADER_LEN + payload.len());
+    out.extend_from_slice(FACET_STATE_MAGIC);
+    out.extend_from_slice(&FACET_STATE_SCHEMA_VERSION.to_le_bytes());
+    out.extend_from_slice(&payload_hash.to_le_bytes());
+    out.extend_from_slice(&payload_len.to_le_bytes());
+    out.extend_from_slice(&payload);
+    Ok(out)
 }
 
 fn estimate_store_map_bytes(fields: &BTreeMap<String, FacetStore>) -> usize {
@@ -928,8 +961,8 @@ fn btree_container_overhead_bytes(len: usize) -> usize {
 }
 
 fn load_persisted_state(state_path: &Path) -> Option<PersistedFacetState> {
-    let file = match fs::File::open(state_path) {
-        Ok(file) => file,
+    let data = match fs::read(state_path) {
+        Ok(data) => data,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return None,
         Err(err) => {
             tracing::warn!(
@@ -940,8 +973,7 @@ fn load_persisted_state(state_path: &Path) -> Option<PersistedFacetState> {
             return None;
         }
     };
-    let persisted = match bincode::deserialize_from::<_, PersistedFacetState>(BufReader::new(file))
-    {
+    let persisted = match decode_persisted_facet_state(&data) {
         Ok(persisted) => persisted,
         Err(err) => {
             tracing::warn!(
@@ -962,6 +994,56 @@ fn load_persisted_state(state_path: &Path) -> Option<PersistedFacetState> {
         return None;
     }
     Some(persisted)
+}
+
+fn decode_persisted_facet_state(data: &[u8]) -> Result<PersistedFacetState> {
+    if data.len() < FACET_STATE_HEADER_LEN {
+        bail!("truncated netflow facet state header");
+    }
+    if &data[..4] != FACET_STATE_MAGIC {
+        bail!("invalid netflow facet state magic");
+    }
+
+    let version = u32::from_le_bytes(data[4..8].try_into().unwrap());
+    if version != FACET_STATE_SCHEMA_VERSION {
+        bail!(
+            "unsupported netflow facet state schema version {} (expected {})",
+            version,
+            FACET_STATE_SCHEMA_VERSION
+        );
+    }
+
+    let expected_hash = u64::from_le_bytes(data[8..16].try_into().unwrap());
+    let payload_len = u64::from_le_bytes(data[16..24].try_into().unwrap());
+    let payload_len = usize::try_from(payload_len)
+        .context("netflow facet state payload length overflows usize")?;
+    if payload_len > MAX_FACET_STATE_PAYLOAD_LEN {
+        bail!(
+            "netflow facet state payload exceeds limit (max {} bytes, got {})",
+            MAX_FACET_STATE_PAYLOAD_LEN,
+            payload_len
+        );
+    }
+
+    let payload = &data[FACET_STATE_HEADER_LEN..];
+    if payload.len() != payload_len {
+        bail!(
+            "netflow facet state payload length mismatch (header {}, actual {})",
+            payload_len,
+            payload.len()
+        );
+    }
+
+    let actual_hash = facet_state_xxhash64(payload);
+    if actual_hash != expected_hash {
+        bail!(
+            "netflow facet state payload hash mismatch (expected {}, got {})",
+            expected_hash,
+            actual_hash
+        );
+    }
+
+    rmp_serde::from_slice(payload).context("failed to decode netflow facet state payload")
 }
 
 fn merge_autocomplete_values(left: Vec<String>, right: Vec<String>) -> Vec<String> {

--- a/src/crates/netflow-plugin/src/facet_runtime/contribution.rs
+++ b/src/crates/netflow-plugin/src/facet_runtime/contribution.rs
@@ -560,5 +560,4 @@ mod tests {
             contribution_strings(&encoded)
         );
     }
-
 }

--- a/src/crates/netflow-plugin/src/ingest.rs
+++ b/src/crates/netflow-plugin/src/ingest.rs
@@ -66,9 +66,6 @@ fn tier_timestamp_lookup_query_end(now_usec: u64) -> u32 {
 }
 
 #[cfg(test)]
-#[path = "ingest_test_support.rs"]
-mod test_support;
-#[cfg(test)]
 #[path = "ingest_bench_support.rs"]
 mod bench_support;
 #[cfg(test)]
@@ -80,6 +77,9 @@ mod resource_bench_support;
 #[cfg(test)]
 #[path = "ingest_resource_bench_tests.rs"]
 mod resource_bench_tests;
+#[cfg(test)]
+#[path = "ingest_test_support.rs"]
+mod test_support;
 #[cfg(test)]
 #[path = "ingest_tests.rs"]
 mod tests;

--- a/src/crates/netflow-plugin/src/ingest/encode.rs
+++ b/src/crates/netflow-plugin/src/ingest/encode.rs
@@ -104,7 +104,10 @@ impl JournalEncodeBuffer {
 
     #[cfg(test)]
     pub(crate) fn debug_field_slices(&self) -> Vec<&[u8]> {
-        self.refs.iter().map(|range| &self.data[range.clone()]).collect()
+        self.refs
+            .iter()
+            .map(|range| &self.data[range.clone()])
+            .collect()
     }
 
     fn push_number(&mut self, name: &str, value: u64) {

--- a/src/crates/netflow-plugin/src/ingest/service/tiers.rs
+++ b/src/crates/netflow-plugin/src/ingest/service/tiers.rs
@@ -109,7 +109,11 @@ impl IngestService {
                         .facet_runtime
                         .observe_active_contribution(Path::new(active_file.path()), &contribution)
                     {
-                        tracing::warn!("facet runtime tier {:?} write update failed: {}", tier, err);
+                        tracing::warn!(
+                            "facet runtime tier {:?} write update failed: {}",
+                            tier,
+                            err
+                        );
                     }
                 }
                 self.metrics

--- a/src/crates/netflow-plugin/src/ingest_bench_support.rs
+++ b/src/crates/netflow-plugin/src/ingest_bench_support.rs
@@ -101,7 +101,9 @@ pub(super) fn warm_protocol_templates(service: &mut IngestService, scenario: &Pr
     let base = fixture_dir();
     for file in scenario.template_files {
         for payload in extract_udp_payloads(&base.join(file)) {
-            service.decoders.decode_udp_payload(payload.source, &payload.data);
+            service
+                .decoders
+                .decode_udp_payload(payload.source, &payload.data);
         }
     }
 }

--- a/src/crates/netflow-plugin/src/ingest_bench_tests.rs
+++ b/src/crates/netflow-plugin/src/ingest_bench_tests.rs
@@ -1,9 +1,9 @@
-use super::test_support::{UdpPayload, new_benchmark_ingest_service};
 use super::bench_support::{
     CARDINALITY_SOURCE_SCENARIO, CardinalityMode, PROTOCOL_SCENARIOS, ProtocolScenario,
     build_cardinality_records, collect_decoded_flows, collect_decoded_flows_for_scenario,
     count_flows_per_round, load_scenario_payloads, total_payload_bytes, warm_protocol_templates,
 };
+use super::test_support::{UdpPayload, new_benchmark_ingest_service};
 use crate::decoder::DecodedFlow;
 use crate::plugin_config::DecapsulationMode as ConfigDecapsulationMode;
 use std::time::Instant;
@@ -188,9 +188,11 @@ fn benchmark_protocol_decode_only(
     for _ in 0..rounds {
         for payload in data_payloads {
             let receive_time_usec = super::now_usec();
-            let batch = service
-                .decoders
-                .decode_udp_payload_at(payload.source, &payload.data, receive_time_usec);
+            let batch = service.decoders.decode_udp_payload_at(
+                payload.source,
+                &payload.data,
+                receive_time_usec,
+            );
             flows += batch.flows.len();
         }
     }
@@ -216,10 +218,9 @@ fn benchmark_protocol_post_decode(
 
     for _ in 0..rounds {
         for flow in &decoded {
-            if service.ingest_decoded_record_for_test(
-                CARDINALITY_BENCH_RECEIVE_TIME_USEC,
-                &flow.record,
-            ) {
+            if service
+                .ingest_decoded_record_for_test(CARDINALITY_BENCH_RECEIVE_TIME_USEC, &flow.record)
+            {
                 entries_since_sync += 1;
             }
         }

--- a/src/crates/netflow-plugin/src/ingest_resource_bench_support.rs
+++ b/src/crates/netflow-plugin/src/ingest_resource_bench_support.rs
@@ -116,7 +116,10 @@ pub(super) fn parse_child_report(output: &std::process::Output) -> ResourceEnvel
     let combined = format!("{stdout}\n{stderr}");
     let json = combined
         .lines()
-        .find_map(|line| line.split_once("RESOURCE_BENCH_RESULT:").map(|(_, json)| json))
+        .find_map(|line| {
+            line.split_once("RESOURCE_BENCH_RESULT:")
+                .map(|(_, json)| json)
+        })
         .unwrap_or_else(|| panic!("resource bench child did not emit result\n{combined}"));
     serde_json::from_str(json)
         .unwrap_or_else(|err| panic!("parse resource bench result JSON: {err}\n{combined}"))

--- a/src/crates/netflow-plugin/src/ingest_resource_bench_tests.rs
+++ b/src/crates/netflow-plugin/src/ingest_resource_bench_tests.rs
@@ -177,7 +177,10 @@ fn run_resource_envelope_case(
             },
         )
         .env(RATE_ENV, flows_per_sec.to_string())
-        .env(WARMUP_ENV, env_u64(WARMUP_ENV, DEFAULT_WARMUP_SECS).to_string())
+        .env(
+            WARMUP_ENV,
+            env_u64(WARMUP_ENV, DEFAULT_WARMUP_SECS).to_string(),
+        )
         .env(
             MEASURE_ENV,
             env_u64(MEASURE_ENV, DEFAULT_MEASURE_SECS).to_string(),
@@ -211,12 +214,9 @@ fn run_resource_envelope_child() -> ResourceEnvelopeReport {
     let warmup_secs = env_u64(WARMUP_ENV, DEFAULT_WARMUP_SECS);
     let measurement_secs = env_u64(MEASURE_ENV, DEFAULT_MEASURE_SECS);
     match layer {
-        ResourceLayer::WriterOnly => run_writer_only_resource_envelope(
-            profile,
-            flows_per_sec,
-            warmup_secs,
-            measurement_secs,
-        ),
+        ResourceLayer::WriterOnly => {
+            run_writer_only_resource_envelope(profile, flows_per_sec, warmup_secs, measurement_secs)
+        }
         ResourceLayer::RawOnly | ResourceLayer::Minute1Only | ResourceLayer::AllTiersBatched => {
             run_plugin_resource_envelope(
                 layer,
@@ -270,8 +270,8 @@ fn run_writer_only_resource_envelope(
     log.sync().expect("sync isolated writer benchmark log");
 
     ResourceEnvelopeReport {
-        methodology:
-            "paced mixed-flow raw journal benchmark with a single disk-backed writer".to_string(),
+        methodology: "paced mixed-flow raw journal benchmark with a single disk-backed writer"
+            .to_string(),
         layer: ResourceLayer::WriterOnly.label().to_string(),
         profile: profile.label().to_string(),
         requested_flows_per_sec: flows_per_sec,
@@ -281,9 +281,7 @@ fn run_writer_only_resource_envelope(
             / elapsed.as_secs_f64(),
         logical_entries_per_sec: measurement_result.logical_entries_written as f64
             / elapsed.as_secs_f64(),
-        read_bytes_per_sec: proc_after
-            .read_bytes
-            .saturating_sub(proc_before.read_bytes) as f64
+        read_bytes_per_sec: proc_after.read_bytes.saturating_sub(proc_before.read_bytes) as f64
             / elapsed.as_secs_f64(),
         write_bytes_per_sec: proc_after
             .write_bytes
@@ -340,14 +338,26 @@ fn run_plugin_resource_envelope(
     service.finish_shutdown_for_test(measurement_result.entries_since_sync);
 
     let logical_bytes = match layer {
-        ResourceLayer::RawOnly => counter_delta(&metrics_before, &metrics_after, "raw_journal_logical_bytes"),
-        ResourceLayer::Minute1Only => counter_delta(&metrics_before, &metrics_after, "raw_journal_logical_bytes")
-            .saturating_add(counter_delta(&metrics_before, &metrics_after, "minute_1_logical_bytes")),
-        ResourceLayer::AllTiersBatched => total_logical_bytes_delta(&metrics_before, &metrics_after),
+        ResourceLayer::RawOnly => {
+            counter_delta(&metrics_before, &metrics_after, "raw_journal_logical_bytes")
+        }
+        ResourceLayer::Minute1Only => {
+            counter_delta(&metrics_before, &metrics_after, "raw_journal_logical_bytes")
+                .saturating_add(counter_delta(
+                    &metrics_before,
+                    &metrics_after,
+                    "minute_1_logical_bytes",
+                ))
+        }
+        ResourceLayer::AllTiersBatched => {
+            total_logical_bytes_delta(&metrics_before, &metrics_after)
+        }
         ResourceLayer::WriterOnly => 0,
     };
     let entries_written = match layer {
-        ResourceLayer::RawOnly => counter_delta(&metrics_before, &metrics_after, "journal_entries_written"),
+        ResourceLayer::RawOnly => {
+            counter_delta(&metrics_before, &metrics_after, "journal_entries_written")
+        }
         ResourceLayer::Minute1Only | ResourceLayer::AllTiersBatched => {
             total_entries_written_delta(&metrics_before, &metrics_after)
         }
@@ -355,8 +365,8 @@ fn run_plugin_resource_envelope(
     };
 
     ResourceEnvelopeReport {
-        methodology:
-            "post-decode paced mixed-flow ingest benchmark with disk-backed journals".to_string(),
+        methodology: "post-decode paced mixed-flow ingest benchmark with disk-backed journals"
+            .to_string(),
         layer: layer.label().to_string(),
         profile: profile.label().to_string(),
         requested_flows_per_sec: flows_per_sec,
@@ -364,9 +374,7 @@ fn run_plugin_resource_envelope(
         cpu_percent_of_one_core: cpu_percent_of_one_core(proc_before, proc_after, elapsed),
         logical_write_bytes_per_sec: logical_bytes as f64 / elapsed.as_secs_f64(),
         logical_entries_per_sec: entries_written as f64 / elapsed.as_secs_f64(),
-        read_bytes_per_sec: proc_after
-            .read_bytes
-            .saturating_sub(proc_before.read_bytes) as f64
+        read_bytes_per_sec: proc_after.read_bytes.saturating_sub(proc_before.read_bytes) as f64
             / elapsed.as_secs_f64(),
         write_bytes_per_sec: proc_after
             .write_bytes
@@ -388,8 +396,12 @@ fn run_plugin_resource_envelope(
 
 fn configure_service_for_layer(service: &mut IngestService, layer: ResourceLayer) {
     if matches!(layer, ResourceLayer::Minute1Only) {
-        service.tier_accumulators.remove(&crate::tiering::TierKind::Minute5);
-        service.tier_accumulators.remove(&crate::tiering::TierKind::Hour1);
+        service
+            .tier_accumulators
+            .remove(&crate::tiering::TierKind::Minute5);
+        service
+            .tier_accumulators
+            .remove(&crate::tiering::TierKind::Hour1);
     }
 }
 
@@ -561,8 +573,11 @@ fn total_entries_written_delta(
     before: &std::collections::HashMap<String, u64>,
     after: &std::collections::HashMap<String, u64>,
 ) -> u64 {
-    counter_delta(before, after, "journal_entries_written")
-        .saturating_add(counter_delta(before, after, "tier_entries_written"))
+    counter_delta(before, after, "journal_entries_written").saturating_add(counter_delta(
+        before,
+        after,
+        "tier_entries_written",
+    ))
 }
 
 fn total_logical_bytes_delta(

--- a/src/crates/netflow-plugin/src/ingest_test_support.rs
+++ b/src/crates/netflow-plugin/src/ingest_test_support.rs
@@ -88,7 +88,8 @@ pub(super) fn new_disk_benchmark_raw_log() -> (TempDir, Log) {
     let retention = cfg.journal.retention_for_tier(TierKind::Raw);
     let mut retention_policy = RetentionPolicy::default();
     if let Some(size_of_journal_files) = retention.size_of_journal_files {
-        retention_policy = retention_policy.with_size_of_journal_files(size_of_journal_files.as_u64());
+        retention_policy =
+            retention_policy.with_size_of_journal_files(size_of_journal_files.as_u64());
     }
     if let Some(duration_of_journal_files) = retention.duration_of_journal_files {
         retention_policy =
@@ -153,7 +154,12 @@ fn decode_pcap_flows(path: &Path, service: &mut IngestService) -> Vec<crate::dec
         if let Some((source, payload)) = extract_udp_payload(packet.data.as_ref()) {
             service.prepare_decoder_state_namespace(source, payload);
             let decoded = service.decoders.decode_udp_payload(source, payload);
-            flows.extend(decoded.flows.into_iter().map(|flow| flow.record.to_fields()));
+            flows.extend(
+                decoded
+                    .flows
+                    .into_iter()
+                    .map(|flow| flow.record.to_fields()),
+            );
         }
     }
     flows

--- a/src/crates/netflow-plugin/src/ingest_tests.rs
+++ b/src/crates/netflow-plugin/src/ingest_tests.rs
@@ -1,7 +1,7 @@
-use super::*;
 use super::test_support::{
     decode_fixture_sequence, find_flow, new_test_ingest_service, new_test_ingest_service_in_dir,
 };
+use super::*;
 use crate::plugin_config::DecapsulationMode as ConfigDecapsulationMode;
 
 #[test]

--- a/src/crates/netflow-plugin/src/main.rs
+++ b/src/crates/netflow-plugin/src/main.rs
@@ -5,10 +5,10 @@ mod charts;
 mod decoder;
 mod enrichment;
 mod facet_catalog;
-#[allow(dead_code)]
-mod flow_index;
 mod facet_runtime;
 mod flow;
+#[allow(dead_code)]
+mod flow_index;
 mod ingest;
 mod memory_allocator;
 #[cfg(test)]

--- a/src/crates/netflow-plugin/src/network_sources/mod.rs
+++ b/src/crates/netflow-plugin/src/network_sources/mod.rs
@@ -9,6 +9,7 @@ mod types;
 
 pub(crate) use runtime::{NetworkSourceRecord, NetworkSourcesRuntime};
 pub(crate) use service::run_network_sources_refresher;
+pub(crate) use transform::compile_jaq_filter;
 
 use crate::enrichment::NetworkAttributes;
 use crate::plugin_config::{RemoteNetworkSourceConfig, RemoteNetworkSourceTlsConfig};

--- a/src/crates/netflow-plugin/src/network_sources/mod.rs
+++ b/src/crates/netflow-plugin/src/network_sources/mod.rs
@@ -14,7 +14,6 @@ use crate::enrichment::NetworkAttributes;
 use crate::plugin_config::{RemoteNetworkSourceConfig, RemoteNetworkSourceTlsConfig};
 use anyhow::{Context, Result};
 use ipnet::IpNet;
-use jaq_interpret::{Ctx, Filter, FilterT, ParseCtx, RcIter, Val};
 use reqwest::{Certificate, Client, Identity, Method};
 use serde::Deserialize;
 use serde_json::Value;

--- a/src/crates/netflow-plugin/src/network_sources/transform.rs
+++ b/src/crates/netflow-plugin/src/network_sources/transform.rs
@@ -1,5 +1,8 @@
 use super::types::CompiledTransform;
 use super::*;
+use jaq_core::load::{Arena, File, Loader};
+use jaq_core::{Compiler, Ctx, Vars, data, unwrap_valr};
+use jaq_json::Val as JaqVal;
 
 pub(super) fn compile_transform(expression: &str) -> Result<CompiledTransform> {
     let normalized = if expression.trim().is_empty() {
@@ -8,27 +11,7 @@ pub(super) fn compile_transform(expression: &str) -> Result<CompiledTransform> {
         expression.trim().to_string()
     };
 
-    let tokens = jaq_syn::Lexer::new(&normalized)
-        .lex()
-        .map_err(|errs| anyhow::anyhow!("failed to lex transform '{}': {:?}", normalized, errs))?;
-    let main = jaq_syn::Parser::new(&tokens)
-        .parse(|parser| parser.module(|module| module.term()))
-        .map_err(|errs| anyhow::anyhow!("failed to parse transform '{}': {:?}", normalized, errs))?
-        .conv(&normalized);
-
-    let mut ctx = ParseCtx::new(Vec::new());
-    ctx.insert_natives(jaq_core::core());
-    ctx.insert_defs(jaq_std::std());
-    let filter = ctx.compile(main);
-    if !ctx.errs.is_empty() {
-        let errors = ctx
-            .errs
-            .into_iter()
-            .map(|err| err.0.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        anyhow::bail!("failed to compile transform '{}': {}", normalized, errors);
-    }
+    let filter = compile_jaq_filter(&normalized)?;
 
     Ok(CompiledTransform {
         expression: normalized,
@@ -37,9 +20,10 @@ pub(super) fn compile_transform(expression: &str) -> Result<CompiledTransform> {
 }
 
 pub(super) fn run_transform(payload: Value, transform: &CompiledTransform) -> Result<Vec<Value>> {
-    let input = Val::from(payload);
-    let inputs = RcIter::new(core::iter::empty());
-    let mut output = transform.filter.run((Ctx::new([], &inputs), input));
+    let input: JaqVal =
+        serde_json::from_value(payload).context("failed to convert JSON payload to jaq value")?;
+    let ctx = Ctx::<data::JustLut<JaqVal>>::new(&transform.filter.lut, Vars::new([]));
+    let mut output = transform.filter.id.run((ctx, input)).map(unwrap_valr);
     let mut rows = Vec::new();
     while let Some(next) = output.next() {
         let value = next.map_err(|err| {
@@ -49,10 +33,48 @@ pub(super) fn run_transform(payload: Value, transform: &CompiledTransform) -> Re
                 err
             )
         })?;
-        rows.push(Value::from(value));
+        rows.push(jaq_value_to_json(value).with_context(|| {
+            format!(
+                "failed to convert transform '{}' result to JSON",
+                transform.expression
+            )
+        })?);
     }
     if rows.is_empty() {
         anyhow::bail!("transform '{}' produced empty result", transform.expression);
     }
     Ok(rows)
+}
+
+fn compile_jaq_filter(
+    expression: &str,
+) -> Result<jaq_core::Filter<jaq_core::data::JustLut<JaqVal>>> {
+    let defs = jaq_core::defs()
+        .chain(jaq_std::defs())
+        .chain(jaq_json::defs());
+    let funs = jaq_core::funs()
+        .chain(jaq_std::funs())
+        .chain(jaq_json::funs());
+    let loader = Loader::new(defs);
+    let arena = Arena::default();
+    let modules = loader
+        .load(
+            &arena,
+            File {
+                code: expression,
+                path: (),
+            },
+        )
+        .map_err(|errs| {
+            anyhow::anyhow!("failed to parse transform '{}': {:?}", expression, errs)
+        })?;
+
+    Compiler::default()
+        .with_funs(funs)
+        .compile(modules)
+        .map_err(|errs| anyhow::anyhow!("failed to compile transform '{}': {:?}", expression, errs))
+}
+
+fn jaq_value_to_json(value: JaqVal) -> Result<Value> {
+    serde_json::from_str(&value.to_string()).context("jaq value is not representable as JSON")
 }

--- a/src/crates/netflow-plugin/src/network_sources/transform.rs
+++ b/src/crates/netflow-plugin/src/network_sources/transform.rs
@@ -1,7 +1,7 @@
 use super::types::CompiledTransform;
 use super::*;
 use jaq_core::load::{Arena, File, Loader};
-use jaq_core::{Compiler, Ctx, Vars, data, unwrap_valr};
+use jaq_core::{Compiler, Ctx, Vars, compile, data, load, unwrap_valr};
 use jaq_json::Val as JaqVal;
 
 pub(super) fn compile_transform(expression: &str) -> Result<CompiledTransform> {
@@ -46,7 +46,7 @@ pub(super) fn run_transform(payload: Value, transform: &CompiledTransform) -> Re
     Ok(rows)
 }
 
-fn compile_jaq_filter(
+pub(crate) fn compile_jaq_filter(
     expression: &str,
 ) -> Result<jaq_core::Filter<jaq_core::data::JustLut<JaqVal>>> {
     let defs = jaq_core::defs()
@@ -66,13 +66,88 @@ fn compile_jaq_filter(
             },
         )
         .map_err(|errs| {
-            anyhow::anyhow!("failed to parse transform '{}': {:?}", expression, errs)
+            anyhow::anyhow!(
+                "failed to parse transform '{}': {}",
+                expression,
+                format_load_errors(&errs)
+            )
         })?;
 
-    Compiler::default()
+    Compiler::<_, data::JustLut<JaqVal>>::default()
         .with_funs(funs)
         .compile(modules)
-        .map_err(|errs| anyhow::anyhow!("failed to compile transform '{}': {:?}", expression, errs))
+        .map_err(|errs| {
+            anyhow::anyhow!(
+                "failed to compile transform '{}': {}",
+                expression,
+                format_compile_errors(&errs)
+            )
+        })
+}
+
+fn format_load_errors<P>(errs: &load::Errors<&str, P>) -> String {
+    let mut parts = Vec::new();
+    for (_file, err) in errs {
+        match err {
+            load::Error::Io(items) => {
+                for (_, msg) in items {
+                    parts.push(format!("io error: {msg}"));
+                }
+            }
+            load::Error::Lex(items) => {
+                for (expected, found) in items {
+                    parts.push(format!(
+                        "lex error near \"{}\": expected {:?}",
+                        truncate_for_display(found),
+                        expected
+                    ));
+                }
+            }
+            load::Error::Parse(items) => {
+                for (expected, input) in items {
+                    parts.push(format!(
+                        "parse error near \"{}\": expected {:?}",
+                        truncate_for_display(input),
+                        expected
+                    ));
+                }
+            }
+        }
+    }
+    if parts.is_empty() {
+        "unknown error".to_string()
+    } else {
+        parts.join("; ")
+    }
+}
+
+fn format_compile_errors<P>(errs: &compile::Errors<&str, P>) -> String {
+    let mut parts = Vec::new();
+    for (_file, items) in errs {
+        for (sym, undefined) in items {
+            parts.push(format!(
+                "undefined {} \"{}\"",
+                undefined.as_str(),
+                truncate_for_display(sym)
+            ));
+        }
+    }
+    if parts.is_empty() {
+        "unknown error".to_string()
+    } else {
+        parts.join("; ")
+    }
+}
+
+fn truncate_for_display(s: &str) -> String {
+    const MAX: usize = 60;
+    let trimmed = s.trim();
+    if trimmed.chars().count() <= MAX {
+        trimmed.to_string()
+    } else {
+        let cut: String = trimmed.chars().take(MAX).collect();
+        format!("{cut}...")
+    }
 }
 
 fn jaq_value_to_json(value: JaqVal) -> Result<Value> {

--- a/src/crates/netflow-plugin/src/network_sources/types.rs
+++ b/src/crates/netflow-plugin/src/network_sources/types.rs
@@ -39,8 +39,15 @@ pub(super) struct SourceRecordState {
     pub(super) by_source: Arc<RwLock<BTreeMap<String, Vec<NetworkSourceRecord>>>>,
 }
 
-#[derive(Debug, Clone)]
 pub(super) struct CompiledTransform {
     pub(super) expression: String,
-    pub(super) filter: Filter,
+    pub(super) filter: jaq_core::Filter<jaq_core::data::JustLut<jaq_json::Val>>,
+}
+
+impl std::fmt::Debug for CompiledTransform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompiledTransform")
+            .field("expression", &self.expression)
+            .finish_non_exhaustive()
+    }
 }

--- a/src/crates/netflow-plugin/src/plugin_config/runtime.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/runtime.rs
@@ -111,7 +111,7 @@ impl PluginConfig {
     fn from_yaml_file(path: &Path) -> Result<Self> {
         let content = fs::read_to_string(path)
             .with_context(|| format!("failed to read {}", path.display()))?;
-        let cfg = serde_yaml_ng::from_str::<Self>(&content)
+        let cfg = serde_yaml::from_str::<Self>(&content)
             .with_context(|| format!("failed to parse {}", path.display()))?;
         Ok(cfg)
     }

--- a/src/crates/netflow-plugin/src/plugin_config/runtime.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/runtime.rs
@@ -111,7 +111,7 @@ impl PluginConfig {
     fn from_yaml_file(path: &Path) -> Result<Self> {
         let content = fs::read_to_string(path)
             .with_context(|| format!("failed to read {}", path.display()))?;
-        let cfg = serde_yaml::from_str::<Self>(&content)
+        let cfg = serde_yaml_ng::from_str::<Self>(&content)
             .with_context(|| format!("failed to parse {}", path.display()))?;
         Ok(cfg)
     }

--- a/src/crates/netflow-plugin/src/plugin_config/validation/enrichment.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/validation/enrichment.rs
@@ -1,6 +1,8 @@
 use crate::plugin_config::{NetworkAttributesValue, PluginConfig, RemoteNetworkSourceTlsConfig};
 use anyhow::{Context, Result};
-use jaq_interpret::ParseCtx;
+use jaq_core::load::{Arena, File, Loader};
+use jaq_core::{Compiler, data};
+use jaq_json::Val as JaqVal;
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -154,38 +156,40 @@ fn validate_network_source_transform(source_name: &str, transform: &str) -> Resu
     } else {
         transform.trim()
     };
-    let tokens = jaq_syn::Lexer::new(normalized).lex().map_err(|errs| {
+    compile_jaq_transform(normalized).map_err(|err| {
         anyhow::anyhow!(
-            "enrichment.network_sources.{source_name}.transform lex error: {:?}",
-            errs
+            "enrichment.network_sources.{source_name}.transform compile error: {}",
+            err
         )
     })?;
-    let main = jaq_syn::Parser::new(&tokens)
-        .parse(|parser| parser.module(|module| module.term()))
-        .map_err(|errs| {
-            anyhow::anyhow!(
-                "enrichment.network_sources.{source_name}.transform parse error: {:?}",
-                errs
-            )
-        })?
-        .conv(normalized);
-    let mut ctx = ParseCtx::new(Vec::new());
-    ctx.insert_natives(jaq_core::core());
-    ctx.insert_defs(jaq_std::std());
-    let _compiled = ctx.compile(main);
-    if !ctx.errs.is_empty() {
-        let errors = ctx
-            .errs
-            .into_iter()
-            .map(|err| err.0.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        anyhow::bail!(
-            "enrichment.network_sources.{source_name}.transform compile error: {}",
-            errors
-        );
-    }
     Ok(())
+}
+
+fn compile_jaq_transform(
+    transform: &str,
+) -> Result<jaq_core::Filter<jaq_core::data::JustLut<JaqVal>>> {
+    let defs = jaq_core::defs()
+        .chain(jaq_std::defs())
+        .chain(jaq_json::defs());
+    let funs = jaq_core::funs()
+        .chain(jaq_std::funs())
+        .chain(jaq_json::funs());
+    let loader = Loader::new(defs);
+    let arena = Arena::default();
+    let modules = loader
+        .load(
+            &arena,
+            File {
+                code: transform,
+                path: (),
+            },
+        )
+        .map_err(|errs| anyhow::anyhow!("parse error: {:?}", errs))?;
+
+    Compiler::<_, data::JustLut<JaqVal>>::default()
+        .with_funs(funs)
+        .compile(modules)
+        .map_err(|errs| anyhow::anyhow!("{:?}", errs))
 }
 
 fn validate_network_source_tls(

--- a/src/crates/netflow-plugin/src/plugin_config/validation/enrichment.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/validation/enrichment.rs
@@ -1,8 +1,6 @@
+use crate::network_sources::compile_jaq_filter;
 use crate::plugin_config::{NetworkAttributesValue, PluginConfig, RemoteNetworkSourceTlsConfig};
 use anyhow::{Context, Result};
-use jaq_core::load::{Arena, File, Loader};
-use jaq_core::{Compiler, data};
-use jaq_json::Val as JaqVal;
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -156,40 +154,13 @@ fn validate_network_source_transform(source_name: &str, transform: &str) -> Resu
     } else {
         transform.trim()
     };
-    compile_jaq_transform(normalized).map_err(|err| {
+    compile_jaq_filter(normalized).map_err(|err| {
         anyhow::anyhow!(
             "enrichment.network_sources.{source_name}.transform compile error: {}",
             err
         )
     })?;
     Ok(())
-}
-
-fn compile_jaq_transform(
-    transform: &str,
-) -> Result<jaq_core::Filter<jaq_core::data::JustLut<JaqVal>>> {
-    let defs = jaq_core::defs()
-        .chain(jaq_std::defs())
-        .chain(jaq_json::defs());
-    let funs = jaq_core::funs()
-        .chain(jaq_std::funs())
-        .chain(jaq_json::funs());
-    let loader = Loader::new(defs);
-    let arena = Arena::default();
-    let modules = loader
-        .load(
-            &arena,
-            File {
-                code: transform,
-                path: (),
-            },
-        )
-        .map_err(|errs| anyhow::anyhow!("parse error: {:?}", errs))?;
-
-    Compiler::<_, data::JustLut<JaqVal>>::default()
-        .with_funs(funs)
-        .compile(modules)
-        .map_err(|errs| anyhow::anyhow!("{:?}", errs))
 }
 
 fn validate_network_source_tls(

--- a/src/crates/netflow-plugin/src/plugin_config_tests.rs
+++ b/src/crates/netflow-plugin/src/plugin_config_tests.rs
@@ -207,7 +207,7 @@ fn plugin_enabled_defaults_to_true() {
 
 #[test]
 fn deserialized_empty_enrichment_section_keeps_provider_defaults() {
-    let cfg: EnrichmentConfig = serde_yaml::from_str("{}").expect("parse enrichment config");
+    let cfg: EnrichmentConfig = serde_yaml_ng::from_str("{}").expect("parse enrichment config");
 
     assert_eq!(
         cfg.asn_providers,
@@ -250,7 +250,7 @@ journal:
   query_facet_max_values_per_field: 5000
 "#;
 
-    let cfg: PluginConfig = serde_yaml::from_str(yaml).expect("yaml should parse");
+    let cfg: PluginConfig = serde_yaml_ng::from_str(yaml).expect("yaml should parse");
     assert!(!cfg.enabled);
 }
 
@@ -381,7 +381,7 @@ tiers:
     size_of_journal_files: null
 "#;
 
-    let cfg: JournalConfig = serde_yaml::from_str(yaml).expect("journal config should parse");
+    let cfg: JournalConfig = serde_yaml_ng::from_str(yaml).expect("journal config should parse");
     let raw = cfg.retention_for_tier(TierKind::Raw);
     let minute_1 = cfg.retention_for_tier(TierKind::Minute1);
 

--- a/src/crates/netflow-plugin/src/plugin_config_tests.rs
+++ b/src/crates/netflow-plugin/src/plugin_config_tests.rs
@@ -207,7 +207,7 @@ fn plugin_enabled_defaults_to_true() {
 
 #[test]
 fn deserialized_empty_enrichment_section_keeps_provider_defaults() {
-    let cfg: EnrichmentConfig = serde_yaml_ng::from_str("{}").expect("parse enrichment config");
+    let cfg: EnrichmentConfig = serde_yaml::from_str("{}").expect("parse enrichment config");
 
     assert_eq!(
         cfg.asn_providers,
@@ -250,7 +250,7 @@ journal:
   query_facet_max_values_per_field: 5000
 "#;
 
-    let cfg: PluginConfig = serde_yaml_ng::from_str(yaml).expect("yaml should parse");
+    let cfg: PluginConfig = serde_yaml::from_str(yaml).expect("yaml should parse");
     assert!(!cfg.enabled);
 }
 
@@ -381,7 +381,7 @@ tiers:
     size_of_journal_files: null
 "#;
 
-    let cfg: JournalConfig = serde_yaml_ng::from_str(yaml).expect("journal config should parse");
+    let cfg: JournalConfig = serde_yaml::from_str(yaml).expect("journal config should parse");
     let raw = cfg.retention_for_tier(TierKind::Raw);
     let minute_1 = cfg.retention_for_tier(TierKind::Minute1);
 

--- a/src/crates/netflow-plugin/src/query.rs
+++ b/src/crates/netflow-plugin/src/query.rs
@@ -1,4 +1,8 @@
 use crate::flow::canonical_flow_field_names;
+use crate::flow_index::{
+    FieldKind as IndexFieldKind, FieldSpec as IndexFieldSpec, FieldValue as IndexFieldValue,
+    FlowId as IndexedFlowId, FlowIndex,
+};
 use crate::plugin_config::PluginConfig;
 use crate::presentation;
 use crate::tiering::TierKind;
@@ -13,10 +17,6 @@ use journal_core::{
     Direction as JournalDirection, JournalCursor, JournalFile, JournalReader, Location,
 };
 use journal_registry::{FileInfo, Monitor, Registry, repository::File as RegistryFile};
-use crate::flow_index::{
-    FieldKind as IndexFieldKind, FieldSpec as IndexFieldSpec, FieldValue as IndexFieldValue,
-    FlowId as IndexedFlowId, FlowIndex,
-};
 use notify::Event;
 use regex::Regex;
 use serde::de::Error as _;

--- a/src/crates/netflow-plugin/src/tiering/index/store.rs
+++ b/src/crates/netflow-plugin/src/tiering/index/store.rs
@@ -10,12 +10,12 @@ use super::super::rollup::{
 };
 use crate::facet_runtime::FacetFileContribution;
 use crate::flow::{FlowFields, FlowRecord};
-use crate::ingest::JournalEncodeBuffer;
-use crate::tiering::FlowMetrics;
-use anyhow::{Context, Result, anyhow};
 #[cfg(test)]
 use crate::flow_index::FieldValue as IndexFieldValue;
 use crate::flow_index::{FlowIndex, FlowIndexMemoryBreakdown};
+use crate::ingest::JournalEncodeBuffer;
+use crate::tiering::FlowMetrics;
+use anyhow::{Context, Result, anyhow};
 use std::collections::{BTreeMap, BTreeSet};
 use std::mem::size_of;
 

--- a/src/crates/netflow-plugin/src/tiering/rollup.rs
+++ b/src/crates/netflow-plugin/src/tiering/rollup.rs
@@ -5,14 +5,14 @@ use crate::flow_index::{
 };
 use std::net::{IpAddr, Ipv4Addr};
 
-mod encode;
 mod emit;
+mod encode;
 mod materialize;
 mod schema;
 
+pub(crate) use emit::emit_rollup_row;
 #[allow(unused_imports)]
 pub(crate) use encode::push_rollup_field_ids;
-pub(crate) use emit::emit_rollup_row;
 #[cfg(test)]
 pub(crate) use materialize::dimensions_for_rollup;
 #[allow(unused_imports)]


### PR DESCRIPTION
## Summary

- isolate netflow-plugin dependency upgrades from the rest of the Rust workspace
- migrate netflow-plugin away from unmaintained direct dependencies used in its own code paths
- update netflow-plugin persistence and enrichment code for the new dependency set

## What changed

- replaced direct `bincode` cache persistence in netflow-plugin with `rmp-serde`
- replaced direct `serde_yaml` usage with `serde_yaml_ng`
- moved netflow-plugin to isolated versions for `bytesize`, `hashbrown`, `jaq-core`, `jaq-std`, `jaq-json`, `maxminddb`, `reqwest`, `socket2`, `netgauze-*`, and `etherparse`
- migrated jaq execution and validation code to the current loader/compiler API
- switched GeoIP reader loading from mmap to readfile loading for the updated maxminddb API
- kept the changes scoped to `src/crates/netflow-plugin/**` plus `src/crates/Cargo.lock`

## Why

The netflow plugin needed newer maintained dependencies, but the rest of the workspace was not approved for coordinated upgrades. This change keeps the dependency refresh local to netflow-plugin and avoids touching other crates.

## Compatibility

- old netflow-plugin decoder and facet cache files are intentionally discarded and rebuilt
- journal data is not migrated and is not affected by this change
- no non-netflow crate source code was changed

## Validation

- `cargo check -p netflow-plugin --color never`
- `cargo test -p netflow-plugin --color never`
- `cargo check --workspace --locked --color never`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `netflow-plugin` deps (jaq 3, GeoIP, reqwest), migrates cache/state to `rmp-serde`, and uses the new `jaq` loader/compiler across runtime and config validation. Adds a safer on-disk state format with headers, size limits, checksums, and pre-load size checks; decoder and facet caches will auto-rebuild.

- **Dependencies**
  - Replaced `bincode` with `rmp-serde` for decoder/facet state (adds headers, payload size limits, and xxhash checksums).
  - Kept `serde_yaml` (reverted `serde_yaml_ng`).
  - Upgraded `jaq` stack: `jaq-core` 3.x + `jaq-json` 2.x + `jaq-std` 3.x; transforms compile via `Loader`/`Compiler` and a shared `compile_jaq_filter` with clearer errors.
  - Updated GeoIP to `maxminddb` 0.27.x; switched to `open_readfile`, skip IPv6 lookups on IPv4-only DBs via metadata, improved errors.
  - Moved pins to `[workspace.dependencies]`: `bytesize` 2.x (with `serde`, removed `bytesize-serde`), `hashbrown` 0.17, `reqwest` 0.13 (rustls + platform verifier), `socket2` 0.6, `netgauze-*` 0.11, `etherparse` 0.20. Minor config code updates in OTEL crates to drop `bytesize-serde`.

- **Migration**
  - Decoder state schema v3 and facet state v5; old cache files are discarded and regenerated on first run.
  - Configs remain compatible; `ByteSize` accepts strings or integers.
  - Validate:
    - cargo check -p netflow-plugin --color never
    - cargo test -p netflow-plugin --color never
    - cargo check --workspace --locked --color never

<sup>Written for commit ec3b823c09fe03b2b6dbe1e4a7e029085b05ed71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

