### PR TITLE
Remove VLA (variable-length arrays)  (Streaming and Web)

### DIFF
--- a/src/streaming/stream-parents.c
+++ b/src/streaming/stream-parents.c
@@ -602,15 +602,16 @@ bool stream_parent_connect_to_one_unsafe(
         return false;
     }
 
-    STREAM_PARENT *array[size];
+    STREAM_PARENT **array = callocz(size, sizeof(*array));
     usec_t now_ut = now_realtime_usec();
+    bool rc = false;
 
     // fetch stream info for all of them and put them in the array
     size_t count = 0, skipped_but_useful = 0, skipped_not_useful = 0, potential = 0;
     for (STREAM_PARENT *d = host->stream.snd.parents.all; d && count < size ; d = d->next) {
         if (nd_thread_signaled_to_cancel()) {
             sender_sock->error = ND_SOCK_ERR_THREAD_CANCELLED;
-            return false;
+            goto cleanup;
         }
 
         // make sure they all have a random number
@@ -740,7 +741,7 @@ bool stream_parent_connect_to_one_unsafe(
             pulse_host_status(host, PULSE_HOST_STATUS_SND_NO_DST, 0);
         }
 
-        return false;
+        goto cleanup;
     }
 
     // order the parents in the array the way we want to connect
@@ -831,7 +832,7 @@ bool stream_parent_connect_to_one_unsafe(
             sender_sock->error = ND_SOCK_ERR_THREAD_CANCELLED;
             host->stream.snd.status.reason = STREAM_HANDSHAKE_DISCONNECT_SIGNALED_TO_STOP;
             pulse_host_status(host, PULSE_HOST_STATUS_SND_OFFLINE, host->stream.snd.status.reason);
-            return false;
+            goto cleanup;
         }
 
         nd_log(NDLS_DAEMON, NDLP_DEBUG,
@@ -873,7 +874,8 @@ bool stream_parent_connect_to_one_unsafe(
             sender_sock->error = ND_SOCK_ERR_NONE;
             host->stream.snd.status.reason = STREAM_HANDSHAKE_SP_CONNECTED;
             pulse_host_status(host, PULSE_HOST_STATUS_SND_CONNECTING, host->stream.snd.status.reason);
-            return true;
+            rc = true;
+            goto cleanup;
         }
         else {
             stream_parent_nd_sock_error_to_reason(d, sender_sock);
@@ -889,7 +891,10 @@ bool stream_parent_connect_to_one_unsafe(
     }
 
     pulse_host_status(host, PULSE_HOST_STATUS_SND_OFFLINE, 0);
-    return false;
+
+cleanup:
+    freez(array);
+    return rc;
 }
 
 bool stream_parent_connect_to_one(

--- a/src/web/api/functions/function-metrics-cardinality.c
+++ b/src/web/api/functions/function-metrics-cardinality.c
@@ -69,8 +69,7 @@ int function_metrics_cardinality(BUFFER *wb, const char *function __maybe_unused
     // Parse function parameters
     bool by_node = false;
     {
-        char function_copy[strlen(function) + 1];
-        memcpy(function_copy, function, sizeof(function_copy));
+        char *function_copy = strdupz(function);
         char *words[1024];
         size_t num_words = quoted_strings_splitter_whitespace(function_copy, words, 1024);
         for (size_t i = 1; i < num_words; i++) {
@@ -81,9 +80,11 @@ int function_metrics_cardinality(BUFFER *wb, const char *function __maybe_unused
                 by_node = false;
             } else if (strcmp(param, "info") == 0) {
                 buffer_json_finalize(wb);
+                freez(function_copy);
                 return HTTP_RESP_OK;
             }
         }
+        freez(function_copy);
     }
 
     DICTIONARY *contexts_dict = dictionary_create(DICT_OPTION_SINGLE_THREADED|DICT_OPTION_DONT_OVERWRITE_VALUE);

--- a/src/web/api/maps/rrdr_options.c
+++ b/src/web/api/maps/rrdr_options.c
@@ -84,7 +84,12 @@ static RRDR_OPTIONS rrdr_options_parse_one_n(const char *o, size_t len) {
     if(!o || !len) return ret;
 
     for(int i = 0; rrdr_options[i].name ; i++) {
-        if (strlen(rrdr_options[i].name) == len && !strncmp(o, rrdr_options[i].name, len)) {
+        const char *name = rrdr_options[i].name;
+        // Keep the dereference-site null check explicit before calling strlen().
+        if(!name)
+            continue;
+
+        if (strlen(name) == len && !strncmp(o, name, len)) {
             ret |= rrdr_options[i].value;
             break;
         }

--- a/src/web/api/maps/rrdr_options.c
+++ b/src/web/api/maps/rrdr_options.c
@@ -74,17 +74,41 @@ RRDR_OPTIONS rrdr_options_parse_one(const char *o) {
     return ret;
 }
 
-RRDR_OPTIONS rrdr_options_parse(const char *options_str) {
-    char src[strlen(options_str) + 1];
-    strcatz(src, 0, options_str, sizeof(src));
-    char *o = src;
+static inline bool rrdr_options_is_separator(char c) {
+    return c == ',' || c == ' ' || c == '|';
+}
 
+static RRDR_OPTIONS rrdr_options_parse_one_n(const char *o, size_t len) {
     RRDR_OPTIONS ret = 0;
-    char *tok;
 
-    while(o && *o && (tok = strsep_skip_consecutive_separators(&o, ", |"))) {
-        if(!*tok) continue;
-        ret |= rrdr_options_parse_one(tok);
+    if(!o || !len) return ret;
+
+    for(int i = 0; rrdr_options[i].name ; i++) {
+        if (strlen(rrdr_options[i].name) == len && !strncmp(o, rrdr_options[i].name, len)) {
+            ret |= rrdr_options[i].value;
+            break;
+        }
+    }
+
+    return ret;
+}
+
+RRDR_OPTIONS rrdr_options_parse(const char *options_str) {
+    RRDR_OPTIONS ret = 0;
+
+    if(!options_str || !*options_str)
+        return ret;
+
+    const char *s = options_str;
+    while(*s) {
+        while(*s && rrdr_options_is_separator(*s))
+            s++;
+
+        const char *tok = s;
+        while(*s && !rrdr_options_is_separator(*s))
+            s++;
+
+        ret |= rrdr_options_parse_one_n(tok, (size_t)(s - tok));
     }
 
     return ret;

--- a/src/web/api/maps/rrdr_options.c
+++ b/src/web/api/maps/rrdr_options.c
@@ -83,11 +83,10 @@ static RRDR_OPTIONS rrdr_options_parse_one_n(const char *o, size_t len) {
 
     if(!o || !len) return ret;
 
-    for(int i = 0; rrdr_options[i].name ; i++) {
+    for(int i = 0; ; i++) {
         const char *name = rrdr_options[i].name;
-        // Keep the dereference-site null check explicit before calling strlen().
         if(!name)
-            continue;
+            break;
 
         if (strlen(name) == len && !strncmp(o, name, len)) {
             ret |= rrdr_options[i].value;

--- a/src/web/api/maps/rrdr_options.c
+++ b/src/web/api/maps/rrdr_options.c
@@ -78,6 +78,18 @@ static inline bool rrdr_options_is_separator(char c) {
     return c == ',' || c == ' ' || c == '|';
 }
 
+static inline bool rrdr_option_token_matches(const char *token, size_t len, const char *name) {
+    if(!name)
+        return false;
+
+    for(size_t i = 0; i < len; i++) {
+        if(!name[i] || token[i] != name[i])
+            return false;
+    }
+
+    return name[len] == '\0';
+}
+
 static RRDR_OPTIONS rrdr_options_parse_one_n(const char *o, size_t len) {
     RRDR_OPTIONS ret = 0;
 
@@ -88,7 +100,7 @@ static RRDR_OPTIONS rrdr_options_parse_one_n(const char *o, size_t len) {
         if(!name)
             break;
 
-        if (strlen(name) == len && !strncmp(o, name, len)) {
+        if (rrdr_option_token_matches(o, len, name)) {
             ret |= rrdr_options[i].value;
             break;
         }

--- a/src/web/api/queries/backfill.c
+++ b/src/web/api/queries/backfill.c
@@ -46,7 +46,7 @@ bool backfill_request_add(RRDSET *st, backfill_callback_t cb, struct backfill_re
         return rc;
 
     size_t added = 0;
-    struct backfill_dim_work *array[dimensions];
+    struct backfill_dim_work *array[200];
 
     if(backfill_globals.running) {
         struct backfill_request *br = aral_callocz(backfill_globals.ar_br);
@@ -225,7 +225,7 @@ void backfill_thread(void *ptr) {
     size_t threads = netdata_conf_cpus() / 2;
     if(threads < 2) threads = 2;
     if(threads > 16) threads = 16;
-    ND_THREAD *th[threads - 1];
+    ND_THREAD *th[15];
 
     for(size_t t = 0; t < threads - 1 ;t++) {
         char tag[15];
@@ -258,4 +258,3 @@ void backfill_thread(void *ptr) {
 
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
-

--- a/src/web/api/queries/query-group-by.c
+++ b/src/web/api/queries/query-group-by.c
@@ -6,12 +6,11 @@ static inline bool group_by_is_separator(char c) {
     return c == ',' || c == '|' || c == ' ';
 }
 
-static inline bool group_by_token_matches(const char *token, size_t len, const char *name) {
-    // Keep the dereference-site null check explicit before calling strlen().
+static inline bool group_by_token_matches(const char *token, size_t len, const char *name, size_t name_len) {
     if(!name)
         return false;
 
-    return strlen(name) == len && !strncmp(token, name, len);
+    return name_len == len && !strncmp(token, name, len);
 }
 
 RRDR_GROUP_BY group_by_parse(const char *group_by_txt) {
@@ -32,28 +31,28 @@ RRDR_GROUP_BY group_by_parse(const char *group_by_txt) {
         size_t len = (size_t)(s - key);
         if(!len) continue;
 
-        if (group_by_token_matches(key, len, "selected"))
+        if (group_by_token_matches(key, len, "selected", sizeof("selected") - 1))
             group_by |= RRDR_GROUP_BY_SELECTED;
 
-        if (group_by_token_matches(key, len, "dimension"))
+        if (group_by_token_matches(key, len, "dimension", sizeof("dimension") - 1))
             group_by |= RRDR_GROUP_BY_DIMENSION;
 
-        if (group_by_token_matches(key, len, "instance"))
+        if (group_by_token_matches(key, len, "instance", sizeof("instance") - 1))
             group_by |= RRDR_GROUP_BY_INSTANCE;
 
-        if (group_by_token_matches(key, len, "percentage-of-instance"))
+        if (group_by_token_matches(key, len, "percentage-of-instance", sizeof("percentage-of-instance") - 1))
             group_by |= RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE;
 
-        if (group_by_token_matches(key, len, "label"))
+        if (group_by_token_matches(key, len, "label", sizeof("label") - 1))
             group_by |= RRDR_GROUP_BY_LABEL;
 
-        if (group_by_token_matches(key, len, "node"))
+        if (group_by_token_matches(key, len, "node", sizeof("node") - 1))
             group_by |= RRDR_GROUP_BY_NODE;
 
-        if (group_by_token_matches(key, len, "context"))
+        if (group_by_token_matches(key, len, "context", sizeof("context") - 1))
             group_by |= RRDR_GROUP_BY_CONTEXT;
 
-        if (group_by_token_matches(key, len, "units"))
+        if (group_by_token_matches(key, len, "units", sizeof("units") - 1))
             group_by |= RRDR_GROUP_BY_UNITS;
     }
 

--- a/src/web/api/queries/query-group-by.c
+++ b/src/web/api/queries/query-group-by.c
@@ -7,6 +7,10 @@ static inline bool group_by_is_separator(char c) {
 }
 
 static inline bool group_by_token_matches(const char *token, size_t len, const char *name) {
+    // Keep the dereference-site null check explicit before calling strlen().
+    if(!name)
+        return false;
+
     return strlen(name) == len && !strncmp(token, name, len);
 }
 

--- a/src/web/api/queries/query-group-by.c
+++ b/src/web/api/queries/query-group-by.c
@@ -2,39 +2,54 @@
 
 #include "query-internal.h"
 
-RRDR_GROUP_BY group_by_parse(const char *group_by_txt) {
-    char src[strlen(group_by_txt) + 1];
-    strcatz(src, 0, group_by_txt, sizeof(src));
-    char *s = src;
+static inline bool group_by_is_separator(char c) {
+    return c == ',' || c == '|' || c == ' ';
+}
 
+static inline bool group_by_token_matches(const char *token, size_t len, const char *name) {
+    return strlen(name) == len && !strncmp(token, name, len);
+}
+
+RRDR_GROUP_BY group_by_parse(const char *group_by_txt) {
     RRDR_GROUP_BY group_by = RRDR_GROUP_BY_NONE;
 
-    while(s) {
-        char *key = strsep_skip_consecutive_separators(&s, ",| ");
-        if (!key || !*key) continue;
+    if(!group_by_txt || !*group_by_txt)
+        return group_by;
 
-        if (strcmp(key, "selected") == 0)
+    const char *s = group_by_txt;
+    while(*s) {
+        while(*s && group_by_is_separator(*s))
+            s++;
+
+        const char *key = s;
+        while(*s && !group_by_is_separator(*s))
+            s++;
+
+        size_t len = (size_t)(s - key);
+        if(!len) continue;
+
+        if (group_by_token_matches(key, len, "selected"))
             group_by |= RRDR_GROUP_BY_SELECTED;
 
-        if (strcmp(key, "dimension") == 0)
+        if (group_by_token_matches(key, len, "dimension"))
             group_by |= RRDR_GROUP_BY_DIMENSION;
 
-        if (strcmp(key, "instance") == 0)
+        if (group_by_token_matches(key, len, "instance"))
             group_by |= RRDR_GROUP_BY_INSTANCE;
 
-        if (strcmp(key, "percentage-of-instance") == 0)
+        if (group_by_token_matches(key, len, "percentage-of-instance"))
             group_by |= RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE;
 
-        if (strcmp(key, "label") == 0)
+        if (group_by_token_matches(key, len, "label"))
             group_by |= RRDR_GROUP_BY_LABEL;
 
-        if (strcmp(key, "node") == 0)
+        if (group_by_token_matches(key, len, "node"))
             group_by |= RRDR_GROUP_BY_NODE;
 
-        if (strcmp(key, "context") == 0)
+        if (group_by_token_matches(key, len, "context"))
             group_by |= RRDR_GROUP_BY_CONTEXT;
 
-        if (strcmp(key, "units") == 0)
+        if (group_by_token_matches(key, len, "units"))
             group_by |= RRDR_GROUP_BY_UNITS;
     }
 
@@ -224,4 +239,3 @@ void rrd2rrdr_set_timestamps(RRDR *r) {
                    "QUERY: wrong last timestamp in the query, expected %ld, found %ld",
                    before_wanted, r->t[points_wanted - 1]);
 }
-

--- a/src/web/api/queries/query-plan.c
+++ b/src/web/api/queries/query-plan.c
@@ -123,7 +123,7 @@ static size_t rrddim_find_best_tier_for_timeframe(QUERY_TARGET *qt, time_t after
         return 0;
     }
 
-    long weight[nd_profile.storage_tiers];
+    long weight[RRD_STORAGE_TIERS];
 
     for(size_t tier = 0; tier < nd_profile.storage_tiers; tier++) {
 

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -1405,13 +1405,17 @@ static double ks_2samp(
 }
 
 static double kstwo(
+    ONEWAYALLOC *owa,
     NETDATA_DOUBLE baseline[], int baseline_points,
     NETDATA_DOUBLE highlight[], int highlight_points,
     uint32_t base_shifts) {
 
+    if(unlikely(baseline_points <= 1 || highlight_points <= 1))
+        return NAN;
+
     // -1 in size, since the calculate_pairs_diffs() returns one less point
-    DIFFS_NUMBERS baseline_diffs[baseline_points - 1];
-    DIFFS_NUMBERS highlight_diffs[highlight_points - 1];
+    DIFFS_NUMBERS *baseline_diffs = onewayalloc_mallocz(owa, (size_t)(baseline_points - 1) * sizeof(*baseline_diffs));
+    DIFFS_NUMBERS *highlight_diffs = onewayalloc_mallocz(owa, (size_t)(highlight_points - 1) * sizeof(*highlight_diffs));
 
     int base_size = (int)calculate_pairs_diff(baseline_diffs, baseline, baseline_points);
     int high_size = (int)calculate_pairs_diff(highlight_diffs, highlight, highlight_points);
@@ -1549,7 +1553,7 @@ static void rrdset_metric_correlations_ks2(
 
     stats->binary_searches += 2 * (base_points - 1) + 2 * (high_points - 1);
 
-    double prob = kstwo(baseline, (int)base_points, highlight, (int)high_points, shifts);
+    double prob = kstwo(owa, baseline, (int)base_points, highlight, (int)high_points, shifts);
     if(!isnan(prob) && !isinf(prob)) {
 
         // these conditions should never happen, but still let's check
@@ -1805,7 +1809,7 @@ static size_t spread_results_evenly(DICTIONARY *results, WEIGHTS_STATS *stats) {
         stats->max_base_high_ratio = 1.0;
 
     // create an array of the right size and copy all the values in it
-    NETDATA_DOUBLE slots[dimensions];
+    NETDATA_DOUBLE *slots = mallocz(dimensions * sizeof(*slots));
     dimensions = 0;
     dfe_start_read(results, t) {
         if(t->flags & RESULT_IS_PERCENTAGE_OF_TIME)
@@ -1815,7 +1819,10 @@ static size_t spread_results_evenly(DICTIONARY *results, WEIGHTS_STATS *stats) {
     }
     dfe_done(t);
 
-    if(!dimensions) return 0;   // Coverity fix
+    if(!dimensions) {
+        freez(slots);
+        return 0;   // Coverity fix
+    }
 
     // sort the array with the values of all dimensions
     qsort(slots, dimensions, sizeof(NETDATA_DOUBLE), compare_netdata_doubles);
@@ -1844,6 +1851,7 @@ static size_t spread_results_evenly(DICTIONARY *results, WEIGHTS_STATS *stats) {
     }
     dfe_done(t);
 
+    freez(slots);
     return dimensions;
 }
 
@@ -2691,4 +2699,3 @@ int mc_unittest(void) {
 
     return errors;
 }
-

--- a/src/web/api/v1/api_v1_config.c
+++ b/src/web/api/v1/api_v1_config.c
@@ -40,18 +40,20 @@ int api_v1_config(RRDHOST *host, struct web_client *w, char *url __maybe_unused)
 
     size_t len = strlen(action) + (id ? strlen(id) : 0) + strlen(path) + (add_name ? strlen(add_name) : 0) + 100;
 
-    char cmd[len];
+    char *cmd = mallocz(len);
     if(strcmp(action, "tree") == 0)
-        snprintfz(cmd, sizeof(cmd), PLUGINSD_FUNCTION_CONFIG " tree '%s' '%s'", path, id?id:"");
+        snprintfz(cmd, len, PLUGINSD_FUNCTION_CONFIG " tree '%s' '%s'", path, id?id:"");
     else {
         DYNCFG_CMDS c = dyncfg_cmds2id(action);
         if(!id || !*id || !dyncfg_is_valid_id(id)) {
             rrd_call_function_error(w->response.data, "Invalid id", HTTP_RESP_BAD_REQUEST);
+            freez(cmd);
             return HTTP_RESP_BAD_REQUEST;
         }
 
         if(c == DYNCFG_CMD_NONE) {
             rrd_call_function_error(w->response.data, "Invalid action", HTTP_RESP_BAD_REQUEST);
+            freez(cmd);
             return HTTP_RESP_BAD_REQUEST;
         }
 
@@ -69,12 +71,13 @@ int api_v1_config(RRDHOST *host, struct web_client *w, char *url __maybe_unused)
 
             if(!add_name || !*add_name || !dyncfg_is_valid_id(add_name)) {
                 rrd_call_function_error(w->response.data, "Invalid name", HTTP_RESP_BAD_REQUEST);
+                freez(cmd);
                 return HTTP_RESP_BAD_REQUEST;
             }
-            snprintfz(cmd, sizeof(cmd), PLUGINSD_FUNCTION_CONFIG " %s %s %s", id, dyncfg_id2cmd_one(c), add_name);
+            snprintfz(cmd, len, PLUGINSD_FUNCTION_CONFIG " %s %s %s", id, dyncfg_id2cmd_one(c), add_name);
         }
         else
-            snprintfz(cmd, sizeof(cmd), PLUGINSD_FUNCTION_CONFIG " %s %s", id, dyncfg_id2cmd_one(c));
+            snprintfz(cmd, len, PLUGINSD_FUNCTION_CONFIG " %s %s", id, dyncfg_id2cmd_one(c));
     }
 
     CLEAN_BUFFER *source = buffer_create(100, NULL);
@@ -88,5 +91,6 @@ int api_v1_config(RRDHOST *host, struct web_client *w, char *url __maybe_unused)
                                 web_client_interrupt_callback, w,
                                 w->payload, buffer_tostring(source), false);
 
+    freez(cmd);
     return code;
 }

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -1070,15 +1070,10 @@ static inline int web_client_switch_host(RRDHOST *host, struct web_client *w, ch
                 //no delim found
                 return append_slash_to_url_and_redirect(w);
 
-            size_t len = strlen(url) + 2;
-            char buf[len];
-            buf[0] = '/';
-            strcpy(&buf[1], url);
-            buf[len - 1] = '\0';
-
             buffer_flush(w->url_path_decoded);
-            buffer_strcat(w->url_path_decoded, buf);
-            return func(host, w, buf);
+            buffer_strcat(w->url_path_decoded, "/");
+            buffer_strcat(w->url_path_decoded, url);
+            return func(host, w, (char *)buffer_tostring(w->url_path_decoded));
         }
     }
 

--- a/src/web/websocket/websocket-internal.h
+++ b/src/web/websocket/websocket-internal.h
@@ -170,6 +170,8 @@ typedef struct websocket_thread {
 
     struct {
         int pipe[2];                 // Command pipe [0] = read, [1] = write
+        char *buffer;                // Reusable scratch buffer for command payloads
+        size_t buffer_size;
     } cmd;
 
 } WEBSOCKET_THREAD;

--- a/src/web/websocket/websocket-send.c
+++ b/src/web/websocket/websocket-send.c
@@ -376,9 +376,9 @@ int websocket_protocol_send_close(WS_CLIENT *wsc, WEBSOCKET_CLOSE_CODE code, con
         reason_len = 123; // Truncate reason to fit
     }
 
-    // Use stack buffer for close frame payload (max 125 bytes per RFC 6455)
+    // Control frames are capped at 125 bytes, so a fixed stack buffer is sufficient.
     size_t payload_len = 2 + reason_len;
-    char payload[payload_len];
+    char payload[125];
 
     // Set status code in network byte order (big-endian)
     uint16_t code_value = (uint16_t)code;

--- a/src/web/websocket/websocket-thread.c
+++ b/src/web/websocket/websocket-thread.c
@@ -282,12 +282,18 @@ static void websocket_thread_process_commands(WEBSOCKET_THREAD *wth) {
                 }
 
                 uint32_t message_len = header.len - sizeof(opcode);
-                char message[message_len + 1];
+                if(message_len + 1 > wth->cmd.buffer_size) {
+                    wth->cmd.buffer = reallocz(wth->cmd.buffer, message_len + 1);
+                    wth->cmd.buffer_size = message_len + 1;
+                }
+
+                char *message = wth->cmd.buffer;
                 bytes = read_pipe_block(wth->cmd.pipe[PIPE_READ], message, message_len);
                 if(bytes != message_len) {
                     netdata_log_error("WEBSOCKET[%zu]: Failed to read broadcast message from pipe", wth->id);
                     continue;
                 }
+                message[message_len] = '\0';
 
                 // Ensure we have the complete message
                 if(header.len != sizeof(WEBSOCKET_OPCODE) + message_len) {
@@ -567,6 +573,9 @@ void websocket_thread(void *ptr) {
         close(wth->cmd.pipe[PIPE_WRITE]);
         wth->cmd.pipe[PIPE_WRITE] = -1;
     }
+
+    freez(wth->cmd.buffer);
+    wth->cmd.buffer_size = 0;
 
     // Mark thread as not running
     spinlock_lock(&wth->spinlock);

--- a/src/web/websocket/websocket-utils.c
+++ b/src/web/websocket/websocket-utils.c
@@ -77,8 +77,8 @@ void websocket_dump_debug(WS_CLIENT *wsc __maybe_unused, const char *payload __m
     if (payload && payload_length > 0) {
         size_t bytes_to_dump = (payload_length < 32) ? payload_length : 32;
 
-        char hex_dump[bytes_to_dump * 2 + 1];
-        char ascii_dump[bytes_to_dump + 1];
+        char hex_dump[(32 * 2) + 1];
+        char ascii_dump[32 + 1];
 
         // Payload check is redundant as we already have it in the outer if
 


### PR DESCRIPTION
##### Summary
This PR proceed with code changes started in https://github.com/netdata/netdata/pull/22218. This time, it is modified codes in src/claim and src/daemon directories.

##### Test Plan

- Compile this branch on different OS and compilers;
- Verify it is working as expected.

##### Additional Information
This PR was already tested on:

| Operate System| Version|
|----------------------|-----------|
|Slackware Linux | Current|
|Windows | 11 |
|Ubuntu | 22.04|

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes remaining VLAs in Streaming and Web paths, replacing them with heap or fixed-size buffers and safer token parsing. No functional changes intended.

- **Refactors**
  - Streaming: parent selection uses a heap array (`callocz`) with centralized cleanup on all exits.
  - Web/API parsing: RRDR options and group-by switch to non-copying token scans (no temporary string copies).
  - Function metrics cardinality: parse with `strdupz` and free on all exits.
  - Queries/weights: use `RRD_STORAGE_TIERS` for fixed arrays; K–S diffs allocated via `onewayalloc` with guards for small inputs.
  - Backfill: cap per-request work items to 200 and worker threads to 15 using fixed-size arrays.
  - API v1/web client: build command/URL strings on the heap or `buffer_*`; free on validation errors and all exits.
  - WebSocket: reusable thread command buffer with explicit null-termination; close frame payload uses a fixed 125-byte stack buffer; debug dumps capped at 32 bytes.
  - Misc: removed ad-hoc VLAs across send/parse paths.

<sup>Written for commit 5d6808c3a582c37e0ef86cfcdabc92b8d88af641. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->