### PR TITLE
Fix memory-safety and correctness bugs surfaced by Coverity audit (part 5)

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -1001,7 +1001,7 @@ static inline void ebpf_check_before2go()
         int active_count = 0;
         netdata_mutex_lock(&ebpf_exit_cleanup);
         for (j = 0; ebpf_modules[j].info.thread_name != NULL; j++) {
-            if (ebpf_modules[j].enabled < NETDATA_THREAD_EBPF_STOPPING)
+            if (ebpf_module_enabled_get(&ebpf_modules[j]) < NETDATA_THREAD_EBPF_STOPPING)
                 active_count++;
         }
         netdata_mutex_unlock(&ebpf_exit_cleanup);
@@ -1124,7 +1124,9 @@ void ebpf_stop_threads(int sig)
 
     int i;
     for (i = 0; ebpf_modules[i].info.thread_name != NULL; i++) {
-        if (ebpf_modules[i].enabled < NETDATA_THREAD_EBPF_STOPPING && ebpf_modules[i].thread &&
+        enum ebpf_threads_status enabled = ebpf_module_enabled_get(&ebpf_modules[i]);
+
+        if (enabled < NETDATA_THREAD_EBPF_STOPPING && ebpf_modules[i].thread &&
             ebpf_modules[i].thread->thread) {
             nd_thread_signal_cancel(ebpf_modules[i].thread->thread);
 #ifdef NETDATA_DEV_MODE
@@ -1135,12 +1137,14 @@ void ebpf_stop_threads(int sig)
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 
     for (i = 0; ebpf_modules[i].info.thread_name != NULL; i++) {
-        if (ebpf_modules[i].enabled < NETDATA_THREAD_EBPF_STOPPED && ebpf_threads[i].thread) {
+        enum ebpf_threads_status enabled = ebpf_module_enabled_get(&ebpf_modules[i]);
+
+        if (enabled < NETDATA_THREAD_EBPF_STOPPED && ebpf_threads[i].thread) {
             netdata_log_info(
                 "EBPF SHUTDOWN: about to join module[%d]='%s' (state=%u).",
                 i,
                 ebpf_modules[i].info.thread_name,
-                ebpf_modules[i].enabled);
+                enabled);
             usec_t join_started_ut = now_monotonic_usec();
             nd_thread_join(ebpf_threads[i].thread);
             usec_t join_duration_ut = now_monotonic_usec() - join_started_ut;
@@ -1576,7 +1580,7 @@ static inline void ebpf_send_hash_table_pid_data(char *chart, uint32_t idx)
         if (wem->functions.apps_routine)
             write_chart_dimension(
                 (char *)wem->info.thread_name,
-                (wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ? wem->hash_table_stats[idx] : 0);
+                (ebpf_module_enabled_get(wem) < NETDATA_THREAD_EBPF_STOPPING) ? wem->hash_table_stats[idx] : 0);
     }
     ebpf_write_end_chart();
 }
@@ -1594,7 +1598,8 @@ static inline void ebpf_send_global_hash_table_data()
     for (i = 0; i < EBPF_MODULE_FUNCTION_IDX; i++) {
         ebpf_module_t *wem = &ebpf_modules[i];
         write_chart_dimension(
-            (char *)wem->info.thread_name, (wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ? NETDATA_CONTROLLER_END : 0);
+            (char *)wem->info.thread_name,
+            (ebpf_module_enabled_get(wem) < NETDATA_THREAD_EBPF_STOPPING) ? NETDATA_CONTROLLER_END : 0);
     }
     ebpf_write_end_chart();
 }
@@ -1616,7 +1621,8 @@ void ebpf_send_statistic_data()
         if (wem->functions.fnct_routine)
             continue;
 
-        write_chart_dimension((char *)wem->info.thread_name, (wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ? 1 : 0);
+        write_chart_dimension(
+            (char *)wem->info.thread_name, (ebpf_module_enabled_get(wem) < NETDATA_THREAD_EBPF_STOPPING) ? 1 : 0);
     }
     ebpf_write_end_chart();
 
@@ -1635,7 +1641,7 @@ void ebpf_send_statistic_data()
 
         write_chart_dimension(
             (char *)wem->info.thread_name,
-            (wem->lifetime && wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ?
+            (wem->lifetime && ebpf_module_enabled_get(wem) < NETDATA_THREAD_EBPF_STOPPING) ?
                 (long long)(wem->lifetime - wem->running_time) :
                 0);
     }
@@ -1682,13 +1688,14 @@ void ebpf_send_statistic_data()
             continue;
 
         ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, wem->functions.fcnt_thread_chart_name, "");
-        write_chart_dimension((char *)wem->info.thread_name, (wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ? 1 : 0);
+        write_chart_dimension(
+            (char *)wem->info.thread_name, (ebpf_module_enabled_get(wem) < NETDATA_THREAD_EBPF_STOPPING) ? 1 : 0);
         ebpf_write_end_chart();
 
         ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, wem->functions.fcnt_thread_lifetime_name, "");
         write_chart_dimension(
             (char *)wem->info.thread_name,
-            (wem->lifetime && wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ?
+            (wem->lifetime && ebpf_module_enabled_get(wem) < NETDATA_THREAD_EBPF_STOPPING) ?
                 (long long)(wem->lifetime - wem->running_time) :
                 0);
         ebpf_write_end_chart();
@@ -2372,8 +2379,8 @@ int main(int argc, char **argv)
         ebpf_module_t *em = &ebpf_modules[i];
         em->thread = st;
         em->thread_id = i;
-        if (em->enabled != NETDATA_THREAD_EBPF_NOT_RUNNING) {
-            em->enabled = NETDATA_THREAD_EBPF_RUNNING;
+        if (ebpf_module_enabled_get(em) != NETDATA_THREAD_EBPF_NOT_RUNNING) {
+            ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_RUNNING);
             em->lifetime = EBPF_NON_FUNCTION_LIFE_TIME;
 
             if (em->functions.apps_routine && (em->apps_charts || em->cgroup_charts)) {

--- a/src/collectors/ebpf.plugin/ebpf.h
+++ b/src/collectors/ebpf.plugin/ebpf.h
@@ -367,12 +367,26 @@ static inline bool ebpf_plugin_stop(void)
            nd_thread_signaled_to_cancel();
 }
 
+// `enabled` is sampled from stats/shutdown paths without a single shared mutex.
+// Keep those state transitions defined without changing the plugin's lock layout.
+static inline enum ebpf_threads_status ebpf_module_enabled_get(ebpf_module_t *em)
+{
+    return __atomic_load_n(&em->enabled, __ATOMIC_RELAXED);
+}
+
+static inline void ebpf_module_enabled_set(ebpf_module_t *em, enum ebpf_threads_status enabled)
+{
+    __atomic_store_n(&em->enabled, enabled, __ATOMIC_RELAXED);
+}
+
 static inline bool ebpf_module_thread_has_valid_state(ebpf_module_t *em)
 {
-    if (likely(em->enabled == NETDATA_THREAD_EBPF_RUNNING || em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING))
+    enum ebpf_threads_status enabled = ebpf_module_enabled_get(em);
+
+    if (likely(enabled == NETDATA_THREAD_EBPF_RUNNING || enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING))
         return true;
 
-    collector_error("Cannot start thread %s with invalid state %u.", em->info.thread_name, (unsigned int)em->enabled);
+    collector_error("Cannot start thread %s with invalid state %u.", em->info.thread_name, (unsigned int)enabled);
     return false;
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -590,7 +590,7 @@ static void ebpf_cachestat_exit(void *pptr)
 
     if (!cachestat_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
@@ -609,7 +609,7 @@ static void ebpf_cachestat_exit(void *pptr)
         sem_post(shm_mutex_ebpf_integration);
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_cachestat_cgroup_charts(em);
@@ -630,7 +630,7 @@ static void ebpf_cachestat_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 
     freez(cachestat_vector);

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -505,7 +505,7 @@ static void ebpf_dcstat_exit(void *pptr)
         sem_post(shm_mutex_ebpf_integration);
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_dc_cgroup_charts(em);
@@ -526,7 +526,7 @@ static void ebpf_dcstat_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_disk.c
+++ b/src/collectors/ebpf.plugin/ebpf_disk.c
@@ -478,12 +478,12 @@ static void ebpf_disk_exit(void *pptr)
 
     if (!disk_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         ebpf_obsolete_disk_global(em);
         netdata_mutex_unlock(&lock);
@@ -510,7 +510,7 @@ static void ebpf_disk_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -621,7 +621,7 @@ static void ebpf_fd_exit(void *pptr)
 
     if (!fd_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
@@ -642,7 +642,7 @@ static void ebpf_fd_exit(void *pptr)
         sem_post(shm_mutex_ebpf_integration);
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_fd_cgroup_charts(em);
@@ -668,7 +668,7 @@ static void ebpf_fd_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/src/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -905,12 +905,12 @@ static void ebpf_filesystem_exit(void *pptr)
     }
     if (!dimensions && !filesystem_hash_values && !has_resources) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         ebpf_obsolete_filesystem_global(em);
 
@@ -930,7 +930,7 @@ static void ebpf_filesystem_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_functions.c
+++ b/src/collectors/ebpf.plugin/ebpf_functions.c
@@ -25,7 +25,7 @@ static int ebpf_function_start_thread(ebpf_module_t *em, int period)
         period = EBPF_DEFAULT_LIFETIME;
 
     st->thread = NULL;
-    em->enabled = NETDATA_THREAD_EBPF_FUNCTION_RUNNING;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_FUNCTION_RUNNING);
     em->lifetime = period;
 
 #ifdef NETDATA_INTERNAL_CHECKS
@@ -427,7 +427,7 @@ static void ebpf_function_socket_manipulation(
     }
     rw_spinlock_write_unlock(&ebpf_judy_pid.index.rw_spinlock);
 
-    if (em->enabled > NETDATA_THREAD_EBPF_FUNCTION_RUNNING) {
+    if (ebpf_module_enabled_get(em) > NETDATA_THREAD_EBPF_FUNCTION_RUNNING) {
         // Cleanup when we already had a thread running
         rw_spinlock_write_lock(&ebpf_judy_pid.index.rw_spinlock);
         ebpf_socket_clean_judy_array_unsafe();
@@ -443,8 +443,9 @@ static void ebpf_function_socket_manipulation(
     } else {
         netdata_mutex_lock(&ebpf_exit_cleanup);
         if (period < 0)
-            em->lifetime = (em->enabled != NETDATA_THREAD_EBPF_FUNCTION_RUNNING) ? EBPF_NON_FUNCTION_LIFE_TIME :
-                                                                                   EBPF_DEFAULT_LIFETIME;
+            em->lifetime = (ebpf_module_enabled_get(em) != NETDATA_THREAD_EBPF_FUNCTION_RUNNING) ?
+                               EBPF_NON_FUNCTION_LIFE_TIME :
+                               EBPF_DEFAULT_LIFETIME;
     }
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 

--- a/src/collectors/ebpf.plugin/ebpf_functions.c
+++ b/src/collectors/ebpf.plugin/ebpf_functions.c
@@ -8,6 +8,30 @@
  *  EBPF FUNCTION COMMON
  *****************************************************************/
 
+typedef struct ebpf_function_thread_start {
+    ebpf_module_t *em;
+    void (*start_routine)(void *);
+    bool ready;
+    bool run;
+} ebpf_function_thread_start_t;
+
+static void ebpf_function_thread_start(void *ptr)
+{
+    ebpf_function_thread_start_t *ctx = ptr;
+
+    // Keep the new thread parked until its owner publishes the module state.
+    while (!__atomic_load_n(&ctx->ready, __ATOMIC_ACQUIRE))
+        tinysleep();
+
+    bool run = __atomic_load_n(&ctx->run, __ATOMIC_ACQUIRE);
+    ebpf_module_t *em = ctx->em;
+    void (*start_routine)(void *) = ctx->start_routine;
+    freez(ctx);
+
+    if (run)
+        start_routine(em);
+}
+
 /**
  * Function Start thread
  *
@@ -24,16 +48,40 @@ static int ebpf_function_start_thread(ebpf_module_t *em, int period)
     if (period <= 0)
         period = EBPF_DEFAULT_LIFETIME;
 
-    st->thread = NULL;
-    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_FUNCTION_RUNNING);
-    em->lifetime = period;
-
 #ifdef NETDATA_INTERNAL_CHECKS
     netdata_log_info("Starting thread %s with lifetime = %d", em->info.thread_name, period);
 #endif
 
-    st->thread = nd_thread_create(st->name, NETDATA_THREAD_OPTION_DEFAULT, st->start_routine, em);
-    return st->thread ? 0 : 1;
+    ebpf_function_thread_start_t *ctx = callocz(1, sizeof(*ctx));
+    ctx->em = em;
+    ctx->start_routine = st->start_routine;
+
+    ND_THREAD *thread = nd_thread_create(st->name, NETDATA_THREAD_OPTION_DEFAULT, ebpf_function_thread_start, ctx);
+    if (!thread) {
+        freez(ctx);
+        return 1;
+    }
+
+    bool run = true;
+    netdata_mutex_lock(&ebpf_exit_cleanup);
+    if (ebpf_plugin_stop())
+        run = false;
+    else {
+        st->thread = thread;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_FUNCTION_RUNNING);
+        em->lifetime = period;
+    }
+    __atomic_store_n(&ctx->run, run, __ATOMIC_RELEASE);
+    __atomic_store_n(&ctx->ready, true, __ATOMIC_RELEASE);
+    netdata_mutex_unlock(&ebpf_exit_cleanup);
+
+    if (!run) {
+        nd_thread_signal_cancel(thread);
+        nd_thread_join(thread);
+        return 1;
+    }
+
+    return 0;
 }
 
 /*****************************************************************
@@ -434,10 +482,8 @@ static void ebpf_function_socket_manipulation(
         rw_spinlock_write_unlock(&ebpf_judy_pid.index.rw_spinlock);
 
         collect_pids |= 1 << EBPF_MODULE_SOCKET_IDX;
-        netdata_mutex_lock(&ebpf_exit_cleanup);
         if (ebpf_function_start_thread(em, period)) {
             ebpf_function_error(transaction, HTTP_RESP_INTERNAL_SERVER_ERROR, "Cannot start thread.");
-            netdata_mutex_unlock(&ebpf_exit_cleanup);
             return;
         }
     } else {
@@ -446,8 +492,8 @@ static void ebpf_function_socket_manipulation(
             em->lifetime = (ebpf_module_enabled_get(em) != NETDATA_THREAD_EBPF_FUNCTION_RUNNING) ?
                                EBPF_NON_FUNCTION_LIFE_TIME :
                                EBPF_DEFAULT_LIFETIME;
+        netdata_mutex_unlock(&ebpf_exit_cleanup);
     }
-    netdata_mutex_unlock(&ebpf_exit_cleanup);
 
     BUFFER *wb = buffer_create(4096, NULL);
     buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_NEWLINE_ON_ARRAY_ITEMS);

--- a/src/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/src/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -224,7 +224,7 @@ static void hardirq_cleanup(void *pptr)
     if (!em)
         return;
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
         if (hardirq_safe_clean)
@@ -236,7 +236,7 @@ static void hardirq_cleanup(void *pptr)
 
     if (!hardirq_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
@@ -275,7 +275,7 @@ static void hardirq_cleanup(void *pptr)
     }
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/src/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -161,12 +161,12 @@ static void mdflush_exit(void *pptr)
 
     if (!mdflush_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
         ebpf_obsolete_mdflush_global(em);
@@ -179,7 +179,7 @@ static void mdflush_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_mount.c
+++ b/src/collectors/ebpf.plugin/ebpf_mount.c
@@ -279,7 +279,7 @@ static void ebpf_mount_exit(void *pptr)
     if (!em)
         return;
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
         ebpf_obsolete_mount_global(em);
@@ -292,7 +292,7 @@ static void ebpf_mount_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/src/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -126,7 +126,7 @@ static void oomkill_cleanup(void *pptr)
     collect_pids &= ~(1 << EBPF_MODULE_OOMKILL_IDX);
     netdata_mutex_unlock(&lock);
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
         if (em->cgroup_charts) {
@@ -143,7 +143,7 @@ static void oomkill_cleanup(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -565,14 +565,14 @@ void ebpf_oomkill_thread(void *ptr)
         // When we are not running integration with apps, we won't fill necessary variables for this thread to run, so
         // we need to disable it.
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        if (em->enabled)
+        if (ebpf_module_enabled_get(em))
             netdata_log_info("%s apps integration is completely disabled.", NETDATA_DEFAULT_OOM_DISABLED_MSG);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
 
         goto endoomkill;
     } else if (running_on_kernel < NETDATA_EBPF_KERNEL_4_14) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        if (em->enabled)
+        if (ebpf_module_enabled_get(em))
             netdata_log_info("%s kernel does not have necessary tracepoints.", NETDATA_DEFAULT_OOM_DISABLED_MSG);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
 

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -961,7 +961,7 @@ static void ebpf_process_exit(void *pptr)
 
     if (!process_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
@@ -977,7 +977,7 @@ static void ebpf_process_exit(void *pptr)
         sem_post(shm_mutex_ebpf_integration);
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_process_cgroup_charts(em);
@@ -1004,7 +1004,7 @@ static void ebpf_process_exit(void *pptr)
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
     process_pid_fd = -1;
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -1801,7 +1801,8 @@ void ebpf_process_thread(void *ptr)
     CLEANUP_FUNCTION_REGISTER(ebpf_process_exit) cleanup_ptr = em;
 
     if (!ebpf_module_thread_has_valid_state(em)) {
-        em->enabled = em->global_charts = em->apps_charts = em->cgroup_charts = NETDATA_THREAD_EBPF_STOPPING;
+        em->global_charts = em->apps_charts = em->cgroup_charts = NETDATA_THREAD_EBPF_STOPPING;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPING);
         netdata_mutex_lock(&ebpf_exit_cleanup);
         ebpf_update_disabled_plugin_stats(em);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
@@ -1812,7 +1813,8 @@ void ebpf_process_thread(void *ptr)
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
     if (ebpf_process_enable_tracepoints()) {
-        em->enabled = em->global_charts = em->apps_charts = em->cgroup_charts = NETDATA_THREAD_EBPF_STOPPING;
+        em->global_charts = em->apps_charts = em->cgroup_charts = NETDATA_THREAD_EBPF_STOPPING;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPING);
     }
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 
@@ -1822,7 +1824,8 @@ void ebpf_process_thread(void *ptr)
 
     set_local_pointers();
     if (ebpf_process_load_bpf(em)) {
-        em->enabled = em->global_charts = em->apps_charts = em->cgroup_charts = NETDATA_THREAD_EBPF_STOPPING;
+        em->global_charts = em->apps_charts = em->cgroup_charts = NETDATA_THREAD_EBPF_STOPPING;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPING);
     }
 
     int algorithms[NETDATA_KEY_PUBLISH_PROCESS_END] = {

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -488,7 +488,7 @@ static void ebpf_shm_exit(void *pptr)
         sem_post(shm_mutex_ebpf_integration);
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_shm_cgroup_charts(em);
@@ -509,7 +509,7 @@ static void ebpf_shm_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -525,7 +525,7 @@ static inline int ebpf_socket_load_and_attach(struct socket_bpf *obj, ebpf_modul
 static void ebpf_socket_free(ebpf_module_t *em)
 {
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     ebpf_update_stats(&plugin_statistics, em);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 
@@ -937,7 +937,7 @@ static void ebpf_socket_exit(void *pptr)
         sem_post(shm_mutex_ebpf_integration);
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
         if (em->cgroup_charts) {

--- a/src/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/src/collectors/ebpf.plugin/ebpf_softirq.c
@@ -75,12 +75,12 @@ static void softirq_cleanup(void *pptr)
 
     if (!softirq_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
 
         ebpf_obsolete_softirq_global(em);
@@ -99,7 +99,7 @@ static void softirq_cleanup(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -459,7 +459,7 @@ static void ebpf_swap_exit(void *pptr)
         sem_post(shm_mutex_ebpf_integration);
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_swap_cgroup_charts(em);
@@ -478,7 +478,7 @@ static void ebpf_swap_exit(void *pptr)
 
     if (!swap_safe_clean) {
         netdata_mutex_lock(&ebpf_exit_cleanup);
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
         netdata_mutex_unlock(&ebpf_exit_cleanup);
         return;
     }
@@ -492,7 +492,7 @@ static void ebpf_swap_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_sync.c
+++ b/src/collectors/ebpf.plugin/ebpf_sync.c
@@ -288,7 +288,7 @@ static void ebpf_sync_exit(void *pptr)
     if (!em)
         return;
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         ebpf_obsolete_sync_global(em);
         netdata_mutex_unlock(&lock);
@@ -298,7 +298,7 @@ static void ebpf_sync_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/src/collectors/ebpf.plugin/ebpf_vfs.c
@@ -916,7 +916,7 @@ static void ebpf_vfs_exit(void *pptr)
         sem_post(shm_mutex_ebpf_integration);
     }
 
-    if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
+    if (ebpf_module_enabled_get(em) == NETDATA_THREAD_EBPF_FUNCTION_RUNNING && !ebpf_plugin_stop()) {
         netdata_mutex_lock(&lock);
         if (em->cgroup_charts) {
             ebpf_obsolete_vfs_cgroup_charts(em);
@@ -937,7 +937,7 @@ static void ebpf_vfs_exit(void *pptr)
         em->functions.bpf_unload(em);
 
     netdata_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPED);
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/src/collectors/ebpf.plugin/libbpf_api/ebpf.c
+++ b/src/collectors/ebpf.plugin/libbpf_api/ebpf.c
@@ -532,7 +532,7 @@ void ebpf_update_stats(ebpf_plugin_stats_t *report, ebpf_module_t *em)
     int value;
 
     // It is not necessary to report more information.
-    if (em->enabled > NETDATA_THREAD_EBPF_FUNCTION_RUNNING)
+    if (ebpf_module_enabled_get(em) > NETDATA_THREAD_EBPF_FUNCTION_RUNNING)
         value = -1;
     else
         value = 1;

--- a/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
+++ b/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
@@ -409,7 +409,7 @@ void ebpf_set_thread_mode(netdata_run_mode_t lmode)
 
 void ebpf_enable_specific_chart(ebpf_module_t *em, int disable_cgroup)
 {
-    em->enabled = NETDATA_THREAD_EBPF_RUNNING;
+    ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_RUNNING);
 
     if (!disable_cgroup) {
         em->cgroup_charts = CONFIG_BOOLEAN_YES;
@@ -527,7 +527,7 @@ void read_collector_values(int *disable_cgroups, int update_every, netdata_ebpf_
 
     network_viewer_opt.enabled = enabled;
     if (enabled) {
-        if (!ebpf_modules[EBPF_MODULE_SOCKET_IDX].enabled)
+        if (!ebpf_module_enabled_get(&ebpf_modules[EBPF_MODULE_SOCKET_IDX]))
             ebpf_enable_chart(EBPF_MODULE_SOCKET_IDX, *disable_cgroups);
 
         parse_network_viewer_section(&collector_config);
@@ -1225,7 +1225,7 @@ void ebpf_parse_ips_unsafe(const char *ptr)
  */
 void ebpf_create_apps_for_module(ebpf_module_t *em, ebpf_target_t *root)
 {
-    if (em->enabled < NETDATA_THREAD_EBPF_STOPPING && em->apps_charts && em->functions.apps_routine)
+    if (ebpf_module_enabled_get(em) < NETDATA_THREAD_EBPF_STOPPING && em->apps_charts && em->functions.apps_routine)
         em->functions.apps_routine(em, root);
 }
 
@@ -1609,7 +1609,7 @@ void disable_all_global_charts()
 {
     int i;
     for (i = 0; ebpf_modules[i].info.thread_name; i++) {
-        ebpf_modules[i].enabled = NETDATA_THREAD_EBPF_NOT_RUNNING;
+        ebpf_module_enabled_set(&ebpf_modules[i], NETDATA_THREAD_EBPF_NOT_RUNNING);
         ebpf_modules[i].global_charts = 0;
     }
 }

--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -625,7 +625,12 @@ void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, 
 
     bool existing = false;
     bool *found = dictionary_set(dirs, dirname, &existing, sizeof(existing));
-    if (unlikely(!found) || *found) {
+    if (unlikely(!found)) {
+        netdata_log_error("Cannot track visited directory '%s' (dictionary_set failed); stopping recursion", dirname);
+        closedir(dir);
+        return;
+    }
+    if (*found) {
         closedir(dir);
         return;
     }

--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -639,7 +639,7 @@ void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, 
         ssize_t len = snprintfz(full_path, sizeof(full_path), "%s/%s", dirname, entry->d_name);
 
         if (entry->d_type == DT_DIR) {
-            nd_journal_directory_scan_recursively(files, dirs, full_path, depth++);
+            nd_journal_directory_scan_recursively(files, dirs, full_path, depth + 1);
         } else if (entry->d_type == DT_REG && is_journal_file(full_path, len, NULL)) {
             if (files)
                 dictionary_set(files, full_path, NULL, 0);
@@ -654,7 +654,7 @@ void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, 
                 // The symbolic link points to a directory
                 char resolved_path[FILENAME_MAX + 1];
                 if (realpath(full_path, resolved_path) != NULL) {
-                    nd_journal_directory_scan_recursively(files, dirs, resolved_path, depth++);
+                    nd_journal_directory_scan_recursively(files, dirs, resolved_path, depth + 1);
                 }
             } else if (S_ISREG(info.st_mode) && is_journal_file(full_path, len, NULL)) {
                 if (files)

--- a/src/libnetdata/dictionary/dictionary-item.h
+++ b/src/libnetdata/dictionary/dictionary-item.h
@@ -482,6 +482,7 @@ static inline DICTIONARY_ITEM *dict_item_add_or_reset_value_and_acquire(DICTIONA
 
             if(item_check_and_acquire_advanced(dict, item, true) != RC_ITEM_OK) {
                 spins++;
+                item = NULL;
                 continue;
             }
 

--- a/src/libnetdata/dictionary/dictionary-unittest.c
+++ b/src/libnetdata/dictionary/dictionary-unittest.c
@@ -1026,6 +1026,7 @@ size_t dictionary_unittest_views(void) {
     }
     else if(item_flag_check(view_item2, ITEM_FLAG_DELETED) || view_item2->shared != master_item2->shared) {
         fprintf(stderr, "View replacement returned stale/deleted item\n");
+        dictionary_acquired_item_release(view, view_item2);
         errors++;
     }
     else

--- a/src/libnetdata/dictionary/dictionary-unittest.c
+++ b/src/libnetdata/dictionary/dictionary-unittest.c
@@ -935,6 +935,9 @@ size_t dictionary_unittest_views(void) {
     struct dictionary_stats stats = {};
     DICTIONARY *master = dictionary_create_advanced(DICT_OPTION_NONE, &stats, 0);
     DICTIONARY *view = dictionary_create_view(master);
+    DICTIONARY_ITEM *master_item2 = NULL;
+    DICTIONARY_ITEM *view_item2 = NULL;
+    DICTIONARY_ITEM *lookup = NULL;
 
     fprintf(stderr, "\n\nChecking dictionary views...\n");
 
@@ -1003,6 +1006,41 @@ size_t dictionary_unittest_views(void) {
     dictionary_acquired_item_release(view, item1_on_view);
     errors += unittest_check_dictionary("master", master, 0, 0, 1, 0, 1);
     errors += unittest_check_dictionary("view", view, 0, 0, 1, 0, 1);
+
+    fprintf(stderr, "\nPASS 3: Replacing a stale view item after master deletion:\n");
+    item1_on_master = dictionary_set_and_acquire_item(master, "KEY 1", "VALUE1", strlen("VALUE1") + 1);
+    item1_on_view = dictionary_view_set_and_acquire_item(view, "KEY 1 ON VIEW", item1_on_master);
+    dictionary_acquired_item_release(view, item1_on_view);
+    dictionary_del(master, "KEY 1");
+
+    // Suppress the preflight garbage collection once so view_set() exercises
+    // the stale-entry cleanup path inside dict_item_add_or_reset_value_and_acquire().
+    __atomic_store_n(&view->last_gc_run_us, now_realtime_usec(), __ATOMIC_RELAXED);
+
+    master_item2 = dictionary_set_and_acquire_item(master, "KEY 1", "VALUE2", strlen("VALUE2") + 1);
+    view_item2 = dictionary_view_set_and_acquire_item(view, "KEY 1 ON VIEW", master_item2);
+
+    if(!view_item2) {
+        fprintf(stderr, "View replacement returned NULL\n");
+        errors++;
+    }
+    else if(item_flag_check(view_item2, ITEM_FLAG_DELETED) || view_item2->shared != master_item2->shared) {
+        fprintf(stderr, "View replacement returned stale/deleted item\n");
+        errors++;
+    }
+    else
+        dictionary_acquired_item_release(view, view_item2);
+
+    lookup = (DICTIONARY_ITEM *)dictionary_get_and_acquire_item(view, "KEY 1 ON VIEW");
+    if(!lookup || item_flag_check(lookup, ITEM_FLAG_DELETED) || lookup->shared != master_item2->shared) {
+        fprintf(stderr, "View lookup did not resolve to the replacement item\n");
+        errors++;
+    }
+    if(lookup)
+        dictionary_acquired_item_release(view, lookup);
+
+    dictionary_acquired_item_release(master, master_item2);
+    dictionary_acquired_item_release(master, item1_on_master);
 
     dictionary_destroy(master);
     dictionary_destroy(view);


### PR DESCRIPTION
##### Summary
- Split / based on  #22234


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes race conditions and correctness issues found by Coverity: makes eBPF module state updates thread-safe, prevents thread-start races during shutdown, fixes journal directory scan depth, and resolves a dictionary stale-view insert bug with tests. Improves shutdown reliability, avoids truncated journal discovery, and removes intermittent crashes.

- Bug Fixes
  - eBPF: replaced direct `em->enabled` reads/writes with atomic helpers and updated all checks/assignments across modules; sets STOPPED via helper during cleanup; statistics and shutdown paths now read a consistent state.
  - eBPF: starts function threads outside the `ebpf_exit_cleanup` mutex using a parked thread that only runs after state is published, avoiding deadlocks and races during restarts and shutdown.
  - systemd-journal: passes `depth + 1` when recursing (not `depth++`) to prevent inflated depths and truncated scans; logs failures to track visited directories and stops recursion safely.
  - dictionary: clears a rejected item pointer to retry after stale view-entry cleanup; adds a regression test for stale view replacement and fixes a missing release in the test.

<sup>Written for commit 95c0002280a090fce3ce0446b4fe7980df18b38b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

