### PR TITLE
Fix memory-safety and correctness bugs surfaced by Coverity audit (part 7)

### DIFF
--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -398,6 +398,10 @@ static void test_kmeans_inlined_empty_source_is_zero_initialized()
     }
     assigned = empty_km;
 
+    ML_TEST_ASSERT(assigned.after == empty_km.after, "assigned empty model should preserve 'after'");
+    ML_TEST_ASSERT(assigned.before == empty_km.before, "assigned empty model should preserve 'before'");
+    ML_TEST_ASSERT_DOUBLE_EQ(assigned.min_dist, empty_km.min_dist, 0.0, "assigned empty model should preserve min_dist");
+    ML_TEST_ASSERT_DOUBLE_EQ(assigned.max_dist, empty_km.max_dist, 0.0, "assigned empty model should preserve max_dist");
     for (size_t center = 0; center < assigned.cluster_centers.size(); center++) {
         ML_TEST_ASSERT(assigned.cluster_centers[center].size() == 6, "empty-source centers must keep fixed-size geometry");
         for (long i = 0; i < assigned.cluster_centers[center].size(); i++) {
@@ -409,10 +413,11 @@ static void test_kmeans_inlined_empty_source_is_zero_initialized()
 }
 
 // Test: at the smallest legal input (src_n == diff_n + smooth_n + lag_n),
-// ml_features_preprocess yields exactly one feature vector. ml_dimension_train_model
-// short-circuits in this case because dlib cannot seed 2 cluster centers from a
-// single sample. This guards the boundary so a later refactor cannot silently
-// re-enable training on insufficient input.
+// ml_features_preprocess yields exactly one feature vector. This guards the
+// preprocess boundary that triggers the <2-vectors early-return in
+// ml_dimension_train_model. Scope is intentionally limited to preprocess output:
+// ml_dimension_train_model itself depends on a live ml_dimension_t (worker, rd,
+// rrdset, host, sqlite) and is not unit-testable without significant plumbing.
 static void test_features_preprocess_below_min_for_kmeans()
 {
     fprintf(stderr, "  test_features_preprocess_below_min_for_kmeans...\n");

--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -408,6 +408,36 @@ static void test_kmeans_inlined_empty_source_is_zero_initialized()
     }
 }
 
+// Test: at the smallest legal input (src_n == diff_n + smooth_n + lag_n),
+// ml_features_preprocess yields exactly one feature vector. ml_dimension_train_model
+// short-circuits in this case because dlib cannot seed 2 cluster centers from a
+// single sample. This guards the boundary so a later refactor cannot silently
+// re-enable training on insufficient input.
+static void test_features_preprocess_below_min_for_kmeans()
+{
+    fprintf(stderr, "  test_features_preprocess_below_min_for_kmeans...\n");
+
+    const size_t diff_n = 1;
+    const size_t smooth_n = 1;
+    const size_t lag_n = 1;
+    const size_t src_n = diff_n + smooth_n + lag_n; // 3, the minimum allowed by ml_validate_features_input
+
+    calculated_number_t src[16] = {1.0, 2.0, 3.0};
+    calculated_number_t dst[16] = {0};
+
+    std::vector<DSample> pf;
+    ml_features_t features = {
+        diff_n, smooth_n, lag_n,
+        dst, src_n, src, src_n
+    };
+
+    ml_features_preprocess(&features, pf, 1.0);
+
+    // n_vectors = src_n - diff_n - smooth_n + 1 - lag_n = 3 - 1 - 1 + 1 - 1 = 1
+    ML_TEST_ASSERT(pf.size() == 1, "boundary input should yield exactly 1 feature vector");
+    ML_TEST_ASSERT(pf.size() < 2, "<2 vectors must trigger the kmeans-skip early-return in ml_dimension_train_model");
+}
+
 // Test: circular buffer linearization produces the same result as std::rotate
 static void test_circular_buffer_equivalence()
 {
@@ -1004,6 +1034,7 @@ extern "C" int ml_unittest()
     test_kmeans_scoring();
     test_full_pipeline();
     test_kmeans_inlined_empty_source_is_zero_initialized();
+    test_features_preprocess_below_min_for_kmeans();
     test_circular_buffer_equivalence();
     test_same_value_uses_newest_sample();
     test_preprocess_predict_equivalence();

--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -365,6 +365,49 @@ static void test_kmeans_scoring()
     ML_TEST_ASSERT_DOUBLE_EQ(score_eq, 0.0, 1e-9, "equal min/max should return 0");
 }
 
+// Test: converting an empty ml_kmeans_t must produce deterministic zeroed centers.
+static void test_kmeans_inlined_empty_source_is_zero_initialized()
+{
+    fprintf(stderr, "  test_kmeans_inlined_empty_source_is_zero_initialized...\n");
+
+    ml_kmeans_t empty_km;
+    empty_km.cluster_centers.clear();
+    empty_km.min_dist = 1.5;
+    empty_km.max_dist = 9.5;
+    empty_km.after = 11;
+    empty_km.before = 22;
+
+    ml_kmeans_inlined_t constructed(empty_km);
+    ML_TEST_ASSERT(constructed.after == empty_km.after, "constructed empty model should preserve 'after'");
+    ML_TEST_ASSERT(constructed.before == empty_km.before, "constructed empty model should preserve 'before'");
+    ML_TEST_ASSERT_DOUBLE_EQ(constructed.min_dist, empty_km.min_dist, 0.0, "constructed empty model should preserve min_dist");
+    ML_TEST_ASSERT_DOUBLE_EQ(constructed.max_dist, empty_km.max_dist, 0.0, "constructed empty model should preserve max_dist");
+    for (size_t center = 0; center < constructed.cluster_centers.size(); center++) {
+        ML_TEST_ASSERT(constructed.cluster_centers[center].size() == 6, "constructed empty-source centers must keep fixed-size geometry");
+        for (long i = 0; i < constructed.cluster_centers[center].size(); i++) {
+            char msg[160];
+            snprintf(msg, sizeof(msg), "constructed empty-source center[%zu](%ld) should be zero", center, i);
+            ML_TEST_ASSERT_DOUBLE_EQ(constructed.cluster_centers[center](i), 0.0, 0.0, msg);
+        }
+    }
+
+    ml_kmeans_inlined_t assigned;
+    for (int i = 0; i < 6; i++) {
+        assigned.cluster_centers[0](i) = 10.0 + i;
+        assigned.cluster_centers[1](i) = 20.0 + i;
+    }
+    assigned = empty_km;
+
+    for (size_t center = 0; center < assigned.cluster_centers.size(); center++) {
+        ML_TEST_ASSERT(assigned.cluster_centers[center].size() == 6, "empty-source centers must keep fixed-size geometry");
+        for (long i = 0; i < assigned.cluster_centers[center].size(); i++) {
+            char msg[160];
+            snprintf(msg, sizeof(msg), "empty-source center[%zu](%ld) should be zero", center, i);
+            ML_TEST_ASSERT_DOUBLE_EQ(assigned.cluster_centers[center](i), 0.0, 0.0, msg);
+        }
+    }
+}
+
 // Test: circular buffer linearization produces the same result as std::rotate
 static void test_circular_buffer_equivalence()
 {
@@ -960,6 +1003,7 @@ extern "C" int ml_unittest()
     test_features_zero_smooth_matches_one();
     test_kmeans_scoring();
     test_full_pipeline();
+    test_kmeans_inlined_empty_source_is_zero_initialized();
     test_circular_buffer_equivalence();
     test_same_value_uses_newest_sample();
     test_preprocess_predict_equivalence();

--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -446,45 +446,24 @@ static void test_features_preprocess_below_min_for_kmeans()
 
 // Test: ml_dimension_finalize_constant_state is the shared post-cycle state
 // transition used by both the successful-training path and the undersampled
-// early-return. mt is always set to CONSTANT and suppression counters are
-// reset; ts is promoted to TRAINED only when km_contexts already holds a
-// model, so a model-less dimension is not falsely counted as trained.
+// early-return. It sets mt = CONSTANT, ts = TRAINED, and resets suppression
+// counters. Matches the existing master behavior in ml_dimension_update_models.
 static void test_dimension_finalize_constant_state()
 {
     fprintf(stderr, "  test_dimension_finalize_constant_state...\n");
 
-    // Case 1: a prior model exists -> ts is promoted to TRAINED.
-    {
-        ml_dimension_t dim = {};
-        dim.mt = METRIC_TYPE_VARIABLE;
-        dim.ts = TRAINING_STATUS_UNTRAINED;
-        dim.suppression_anomaly_counter = 7;
-        dim.suppression_window_counter = 13;
-        dim.km_contexts.emplace_back();
+    ml_dimension_t dim = {};
+    dim.mt = METRIC_TYPE_VARIABLE;
+    dim.ts = TRAINING_STATUS_UNTRAINED;
+    dim.suppression_anomaly_counter = 7;
+    dim.suppression_window_counter = 13;
 
-        ml_dimension_finalize_constant_state(&dim);
+    ml_dimension_finalize_constant_state(&dim);
 
-        ML_TEST_ASSERT(dim.mt == METRIC_TYPE_CONSTANT, "mt must become CONSTANT");
-        ML_TEST_ASSERT(dim.ts == TRAINING_STATUS_TRAINED, "ts must promote to TRAINED with prior model");
-        ML_TEST_ASSERT(dim.suppression_anomaly_counter == 0, "anomaly counter must reset");
-        ML_TEST_ASSERT(dim.suppression_window_counter == 0, "window counter must reset");
-    }
-
-    // Case 2: no prior models -> ts stays where it was (do not lie in stats).
-    {
-        ml_dimension_t dim = {};
-        dim.mt = METRIC_TYPE_VARIABLE;
-        dim.ts = TRAINING_STATUS_UNTRAINED;
-        dim.suppression_anomaly_counter = 7;
-        dim.suppression_window_counter = 13;
-
-        ml_dimension_finalize_constant_state(&dim);
-
-        ML_TEST_ASSERT(dim.mt == METRIC_TYPE_CONSTANT, "mt must become CONSTANT");
-        ML_TEST_ASSERT(dim.ts == TRAINING_STATUS_UNTRAINED, "ts must stay UNTRAINED with no model");
-        ML_TEST_ASSERT(dim.suppression_anomaly_counter == 0, "anomaly counter must reset");
-        ML_TEST_ASSERT(dim.suppression_window_counter == 0, "window counter must reset");
-    }
+    ML_TEST_ASSERT(dim.mt == METRIC_TYPE_CONSTANT, "mt must become CONSTANT");
+    ML_TEST_ASSERT(dim.ts == TRAINING_STATUS_TRAINED, "ts must become TRAINED");
+    ML_TEST_ASSERT(dim.suppression_anomaly_counter == 0, "anomaly counter must reset");
+    ML_TEST_ASSERT(dim.suppression_window_counter == 0, "window counter must reset");
 }
 
 // Test: circular buffer linearization produces the same result as std::rotate

--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -453,12 +453,16 @@ static void test_dimension_finalize_constant_state()
     fprintf(stderr, "  test_dimension_finalize_constant_state...\n");
 
     ml_dimension_t dim = {};
+    spinlock_init(&dim.slock);
     dim.mt = METRIC_TYPE_VARIABLE;
     dim.ts = TRAINING_STATUS_UNTRAINED;
     dim.suppression_anomaly_counter = 7;
     dim.suppression_window_counter = 13;
 
+    // Match the helper's documented contract (caller holds dim->slock).
+    spinlock_lock(&dim.slock);
     ml_dimension_finalize_constant_state(&dim);
+    spinlock_unlock(&dim.slock);
 
     ML_TEST_ASSERT(dim.mt == METRIC_TYPE_CONSTANT, "mt must become CONSTANT");
     ML_TEST_ASSERT(dim.ts == TRAINING_STATUS_TRAINED, "ts must become TRAINED");

--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "ml_config.h"
+#include "ml_dimension.h"
 #include "ml_features.h"
 #include "ml_kmeans.h"
 #include "ml_private.h"
@@ -441,6 +442,49 @@ static void test_features_preprocess_below_min_for_kmeans()
     // n_vectors = src_n - diff_n - smooth_n + 1 - lag_n = 3 - 1 - 1 + 1 - 1 = 1
     ML_TEST_ASSERT(pf.size() == 1, "boundary input should yield exactly 1 feature vector");
     ML_TEST_ASSERT(pf.size() < 2, "<2 vectors must trigger the kmeans-skip early-return in ml_dimension_train_model");
+}
+
+// Test: ml_dimension_finalize_constant_state is the shared post-cycle state
+// transition used by both the successful-training path and the undersampled
+// early-return. mt is always set to CONSTANT and suppression counters are
+// reset; ts is promoted to TRAINED only when km_contexts already holds a
+// model, so a model-less dimension is not falsely counted as trained.
+static void test_dimension_finalize_constant_state()
+{
+    fprintf(stderr, "  test_dimension_finalize_constant_state...\n");
+
+    // Case 1: a prior model exists -> ts is promoted to TRAINED.
+    {
+        ml_dimension_t dim = {};
+        dim.mt = METRIC_TYPE_VARIABLE;
+        dim.ts = TRAINING_STATUS_UNTRAINED;
+        dim.suppression_anomaly_counter = 7;
+        dim.suppression_window_counter = 13;
+        dim.km_contexts.emplace_back();
+
+        ml_dimension_finalize_constant_state(&dim);
+
+        ML_TEST_ASSERT(dim.mt == METRIC_TYPE_CONSTANT, "mt must become CONSTANT");
+        ML_TEST_ASSERT(dim.ts == TRAINING_STATUS_TRAINED, "ts must promote to TRAINED with prior model");
+        ML_TEST_ASSERT(dim.suppression_anomaly_counter == 0, "anomaly counter must reset");
+        ML_TEST_ASSERT(dim.suppression_window_counter == 0, "window counter must reset");
+    }
+
+    // Case 2: no prior models -> ts stays where it was (do not lie in stats).
+    {
+        ml_dimension_t dim = {};
+        dim.mt = METRIC_TYPE_VARIABLE;
+        dim.ts = TRAINING_STATUS_UNTRAINED;
+        dim.suppression_anomaly_counter = 7;
+        dim.suppression_window_counter = 13;
+
+        ml_dimension_finalize_constant_state(&dim);
+
+        ML_TEST_ASSERT(dim.mt == METRIC_TYPE_CONSTANT, "mt must become CONSTANT");
+        ML_TEST_ASSERT(dim.ts == TRAINING_STATUS_UNTRAINED, "ts must stay UNTRAINED with no model");
+        ML_TEST_ASSERT(dim.suppression_anomaly_counter == 0, "anomaly counter must reset");
+        ML_TEST_ASSERT(dim.suppression_window_counter == 0, "window counter must reset");
+    }
 }
 
 // Test: circular buffer linearization produces the same result as std::rotate
@@ -1040,6 +1084,7 @@ extern "C" int ml_unittest()
     test_full_pipeline();
     test_kmeans_inlined_empty_source_is_zero_initialized();
     test_features_preprocess_below_min_for_kmeans();
+    test_dimension_finalize_constant_state();
     test_circular_buffer_equivalence();
     test_same_value_uses_newest_sample();
     test_preprocess_predict_equivalence();

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1076,11 +1076,11 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
 {
     worker_is_busy(WORKER_JOB_DETECTION_COLLECT_STATS);
 
-    host->mls = {};
     ml_machine_learning_stats_t mls_copy = {};
 
     if (host->ml_running) {
         netdata_mutex_lock(&host->mutex);
+        host->mls = {};
 
         /*
          * prediction/detection stats

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1098,6 +1098,11 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
     calculated_number_t host_anomaly_rate = 0.0;
 
     if (host->ml_running) {
+        // Snapshot the stop generation before the unlocked walk. If it changes
+        // by the time we publish, a stop ran while we were reading chart->mls
+        // and the accumulated snapshot must be discarded.
+        uint64_t stop_gen_before = host->ml_stop_generation.load(std::memory_order_acquire);
+
         /*
          * prediction/detection stats
         */
@@ -1159,15 +1164,18 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
 
         // Publish the final host snapshot after chart traversal so chart
         // deletion cannot block other host->mutex users for the full walk.
-        // If ml_running flipped to false during the walk, ml_host_stop may
-        // have raced our unlocked chart->mls reads — zero the snapshot
-        // and the per-context counts so we don't surface partially-
-        // clobbered stats. The chart updates below run unconditionally:
-        // ml_update_dimensions_chart reads host->ml_running directly (so
-        // the ml_running chart records the stop), and the chart-update
-        // path resets and republishes the rest.
+        // Discard the snapshot if either (a) ml_running is now false, or
+        // (b) the stop generation changed since the walk started — the
+        // latter catches a stop+start that completed during the walk and
+        // would otherwise pass the boolean check. In either case our
+        // unlocked chart->mls reads may have raced ml_host_stop, so zero
+        // the snapshot and the per-context counts. The chart updates below
+        // run unconditionally: ml_update_dimensions_chart reads
+        // host->ml_running directly (so the ml_running chart records the
+        // stop), and the chart-update path resets and republishes the rest.
         netdata_mutex_lock(&host->mutex);
-        if (!host->ml_running) {
+        uint64_t stop_gen_after = host->ml_stop_generation.load(std::memory_order_acquire);
+        if (!host->ml_running || stop_gen_before != stop_gen_after) {
             host_mls = {};
             host_anomaly_rate = 0.0;
 

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -730,8 +730,7 @@ static bool ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim,
 void ml_dimension_finalize_constant_state(ml_dimension_t *dim)
 {
     dim->mt = METRIC_TYPE_CONSTANT;
-    if (!dim->km_contexts.empty())
-        dim->ts = TRAINING_STATUS_TRAINED;
+    dim->ts = TRAINING_STATUS_TRAINED;
     dim->suppression_anomaly_counter = 0;
     dim->suppression_window_counter = 0;
 }

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1178,9 +1178,9 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
             host_anomaly_rate = 0.0;
 
             spinlock_lock(&host->context_anomaly_rate_spinlock);
-            for (auto &[key, entry] : host->context_anomaly_rate) {
-                entry.anomalous_dimensions = 0;
-                entry.normal_dimensions = 0;
+            for (auto &p : host->context_anomaly_rate) {
+                p.second.anomalous_dimensions = 0;
+                p.second.normal_dimensions = 0;
             }
             spinlock_unlock(&host->context_anomaly_rate_spinlock);
         }

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1158,16 +1158,23 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
         // Publish the final host snapshot after chart traversal so chart
         // deletion cannot block other host->mutex users for the full walk.
         // If ml_running flipped to false during the walk, ml_host_stop may
-        // have raced our unlocked chart->mls reads; zero the snapshot so
-        // we don't surface partially-clobbered host stats. The chart
-        // updates below run unconditionally: ml_update_dimensions_chart
-        // reads host->ml_running directly (so the ml_running chart records
-        // the stop) and ml_update_host_and_detection_rate_charts resets
-        // the context_anomaly_rate counts.
+        // have raced our unlocked chart->mls reads — zero the snapshot
+        // and the per-context counts so we don't surface partially-
+        // clobbered stats. The chart updates below run unconditionally:
+        // ml_update_dimensions_chart reads host->ml_running directly (so
+        // the ml_running chart records the stop), and the chart-update
+        // path resets and republishes the rest.
         netdata_mutex_lock(&host->mutex);
         if (!host->ml_running) {
             host_mls = {};
             host_anomaly_rate = 0.0;
+
+            spinlock_lock(&host->context_anomaly_rate_spinlock);
+            for (auto &entry : host->context_anomaly_rate) {
+                entry.second.anomalous_dimensions = 0;
+                entry.second.normal_dimensions = 0;
+            }
+            spinlock_unlock(&host->context_anomaly_rate_spinlock);
         }
         host->mls = host_mls;
         host->host_anomaly_rate = host_anomaly_rate;

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -726,7 +726,6 @@ bool ml_should_publish_model_update(bool host_running,
     return true;
 }
 
-static bool ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim, uint32_t expected_generation, bool from_downstream)
 void ml_dimension_finalize_constant_state(ml_dimension_t *dim)
 {
     dim->mt = METRIC_TYPE_CONSTANT;
@@ -735,7 +734,7 @@ void ml_dimension_finalize_constant_state(ml_dimension_t *dim)
     dim->suppression_window_counter = 0;
 }
 
-static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim)
+static bool ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim, uint32_t expected_generation, bool from_downstream)
 {
     worker_is_busy(WORKER_TRAIN_UPDATE_MODELS);
 

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1077,11 +1077,10 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
     worker_is_busy(WORKER_JOB_DETECTION_COLLECT_STATS);
 
     ml_machine_learning_stats_t mls_copy = {};
+    ml_machine_learning_stats_t host_mls = {};
+    calculated_number_t host_anomaly_rate = 0.0;
 
     if (host->ml_running) {
-        netdata_mutex_lock(&host->mutex);
-        host->mls = {};
-
         /*
          * prediction/detection stats
         */
@@ -1098,20 +1097,20 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
 
             ml_machine_learning_stats_t chart_mls = chart->mls;
 
-            host->mls.num_machine_learning_status_enabled += chart_mls.num_machine_learning_status_enabled;
-            host->mls.num_machine_learning_status_disabled_sp += chart_mls.num_machine_learning_status_disabled_sp;
+            host_mls.num_machine_learning_status_enabled += chart_mls.num_machine_learning_status_enabled;
+            host_mls.num_machine_learning_status_disabled_sp += chart_mls.num_machine_learning_status_disabled_sp;
 
-            host->mls.num_metric_type_constant += chart_mls.num_metric_type_constant;
-            host->mls.num_metric_type_variable += chart_mls.num_metric_type_variable;
+            host_mls.num_metric_type_constant += chart_mls.num_metric_type_constant;
+            host_mls.num_metric_type_variable += chart_mls.num_metric_type_variable;
 
-            host->mls.num_training_status_untrained += chart_mls.num_training_status_untrained;
-            host->mls.num_training_status_pending_without_model += chart_mls.num_training_status_pending_without_model;
-            host->mls.num_training_status_trained += chart_mls.num_training_status_trained;
-            host->mls.num_training_status_pending_with_model += chart_mls.num_training_status_pending_with_model;
-            host->mls.num_training_status_silenced += chart_mls.num_training_status_silenced;
+            host_mls.num_training_status_untrained += chart_mls.num_training_status_untrained;
+            host_mls.num_training_status_pending_without_model += chart_mls.num_training_status_pending_without_model;
+            host_mls.num_training_status_trained += chart_mls.num_training_status_trained;
+            host_mls.num_training_status_pending_with_model += chart_mls.num_training_status_pending_with_model;
+            host_mls.num_training_status_silenced += chart_mls.num_training_status_silenced;
 
-            host->mls.num_anomalous_dimensions += chart_mls.num_anomalous_dimensions;
-            host->mls.num_normal_dimensions += chart_mls.num_normal_dimensions;
+            host_mls.num_anomalous_dimensions += chart_mls.num_anomalous_dimensions;
+            host_mls.num_normal_dimensions += chart_mls.num_normal_dimensions;
 
             if (spinlock_trylock(&host->context_anomaly_rate_spinlock))
             {
@@ -1137,20 +1136,30 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
         }
         rrdset_foreach_done(rsp);
 
-        host->host_anomaly_rate = 0.0;
-        size_t NumActiveDimensions = host->mls.num_anomalous_dimensions + host->mls.num_normal_dimensions;
-        if (NumActiveDimensions)
-              host->host_anomaly_rate = static_cast<double>(host->mls.num_anomalous_dimensions) / NumActiveDimensions;
+        size_t num_active_dimensions = host_mls.num_anomalous_dimensions + host_mls.num_normal_dimensions;
+        if (num_active_dimensions)
+            host_anomaly_rate = static_cast<double>(host_mls.num_anomalous_dimensions) / num_active_dimensions;
 
-        mls_copy = host->mls;
+        bool publish_stats = false;
 
+        // Publish the final host snapshot after chart traversal so chart
+        // deletion cannot block other host->mutex users for the full walk.
+        netdata_mutex_lock(&host->mutex);
+        if (host->ml_running) {
+            host->mls = host_mls;
+            host->host_anomaly_rate = host_anomaly_rate;
+            mls_copy = host->mls;
+            publish_stats = true;
+        }
         netdata_mutex_unlock(&host->mutex);
 
-        worker_is_busy(WORKER_JOB_DETECTION_DIM_CHART);
-        ml_update_dimensions_chart(host, mls_copy);
+        if (publish_stats) {
+            worker_is_busy(WORKER_JOB_DETECTION_DIM_CHART);
+            ml_update_dimensions_chart(host, mls_copy);
 
-        worker_is_busy(WORKER_JOB_DETECTION_HOST_CHART);
-        ml_update_host_and_detection_rate_charts(host, host->host_anomaly_rate * 10000.0, owa);
+            worker_is_busy(WORKER_JOB_DETECTION_HOST_CHART);
+            ml_update_host_and_detection_rate_charts(host, host_anomaly_rate * 10000.0, owa);
+        }
     } else {
         host->host_anomaly_rate = 0.0;
     }

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -861,12 +861,16 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
         // Apply sampling during lag feature extraction
         ml_features_preprocess(&features, worker->training_samples, sampling_ratio);
 
-        // Preprocessing can still leave fewer than 2 vectors after smoothing, lag extraction,
-        // or sampling, and k-means cannot build 2 cluster centers from that input.
+        // Preprocessing can still leave fewer than 2 vectors after smoothing, lag
+        // extraction, or sampling, and k-means cannot build 2 cluster centers from
+        // that input. Match the post-training state ml_dimension_update_models would
+        // have set (mt, ts, suppression counters) so prediction is what re-arms
+        // training, the same self-correcting loop already used after every cycle.
         if (worker->training_samples.size() < 2) {
             spinlock_lock(&dim->slock);
 
             dim->mt = METRIC_TYPE_CONSTANT;
+            dim->ts = TRAINING_STATUS_TRAINED;
             dim->suppression_anomaly_counter = 0;
             dim->suppression_window_counter = 0;
             dim->training_in_progress = false;

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1155,26 +1155,30 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
         if (num_active_dimensions)
             host_anomaly_rate = static_cast<double>(host_mls.num_anomalous_dimensions) / num_active_dimensions;
 
-        bool publish_stats = false;
-
         // Publish the final host snapshot after chart traversal so chart
         // deletion cannot block other host->mutex users for the full walk.
+        // If ml_running flipped to false during the walk, ml_host_stop may
+        // have raced our unlocked chart->mls reads; zero the snapshot so
+        // we don't surface partially-clobbered host stats. The chart
+        // updates below run unconditionally: ml_update_dimensions_chart
+        // reads host->ml_running directly (so the ml_running chart records
+        // the stop) and ml_update_host_and_detection_rate_charts resets
+        // the context_anomaly_rate counts.
         netdata_mutex_lock(&host->mutex);
-        if (host->ml_running) {
-            host->mls = host_mls;
-            host->host_anomaly_rate = host_anomaly_rate;
-            mls_copy = host->mls;
-            publish_stats = true;
+        if (!host->ml_running) {
+            host_mls = {};
+            host_anomaly_rate = 0.0;
         }
+        host->mls = host_mls;
+        host->host_anomaly_rate = host_anomaly_rate;
+        mls_copy = host_mls;
         netdata_mutex_unlock(&host->mutex);
 
-        if (publish_stats) {
-            worker_is_busy(WORKER_JOB_DETECTION_DIM_CHART);
-            ml_update_dimensions_chart(host, mls_copy);
+        worker_is_busy(WORKER_JOB_DETECTION_DIM_CHART);
+        ml_update_dimensions_chart(host, mls_copy);
 
-            worker_is_busy(WORKER_JOB_DETECTION_HOST_CHART);
-            ml_update_host_and_detection_rate_charts(host, host_anomaly_rate * 10000.0, owa);
-        }
+        worker_is_busy(WORKER_JOB_DETECTION_HOST_CHART);
+        ml_update_host_and_detection_rate_charts(host, host_anomaly_rate * 10000.0, owa);
     } else {
         host->host_anomaly_rate = 0.0;
     }

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -861,6 +861,21 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
         // Apply sampling during lag feature extraction
         ml_features_preprocess(&features, worker->training_samples, sampling_ratio);
 
+        // Preprocessing can still leave fewer than 2 vectors after smoothing, lag extraction,
+        // or sampling, and k-means cannot build 2 cluster centers from that input.
+        if (worker->training_samples.size() < 2) {
+            spinlock_lock(&dim->slock);
+
+            dim->mt = METRIC_TYPE_CONSTANT;
+            dim->suppression_anomaly_counter = 0;
+            dim->suppression_window_counter = 0;
+            dim->training_in_progress = false;
+
+            spinlock_unlock(&dim->slock);
+
+            return ML_WORKER_RESULT_NOT_ENOUGH_COLLECTED_VALUES;
+        }
+
         ml_kmeans_init(&dim->kmeans);
         ml_kmeans_train(&dim->kmeans, worker->training_samples, Cfg.max_kmeans_iters, training_response.query_after_t, training_response.query_before_t);
     }

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -727,6 +727,16 @@ bool ml_should_publish_model_update(bool host_running,
 }
 
 static bool ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim, uint32_t expected_generation, bool from_downstream)
+void ml_dimension_finalize_constant_state(ml_dimension_t *dim)
+{
+    dim->mt = METRIC_TYPE_CONSTANT;
+    if (!dim->km_contexts.empty())
+        dim->ts = TRAINING_STATUS_TRAINED;
+    dim->suppression_anomaly_counter = 0;
+    dim->suppression_window_counter = 0;
+}
+
+static void ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim)
 {
     worker_is_busy(WORKER_TRAIN_UPDATE_MODELS);
 
@@ -769,11 +779,7 @@ static bool ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim,
         }
     }
 
-    dim->mt = METRIC_TYPE_CONSTANT;
-    dim->ts = TRAINING_STATUS_TRAINED;
-
-    dim->suppression_anomaly_counter = 0;
-    dim->suppression_window_counter = 0;
+    ml_dimension_finalize_constant_state(dim);
 
     // Add the latest model to the list of pending models to flush.
     ml_model_info_t model_info;
@@ -861,25 +867,14 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
         // Apply sampling during lag feature extraction
         ml_features_preprocess(&features, worker->training_samples, sampling_ratio);
 
-        // Preprocessing can still leave fewer than 2 vectors after smoothing, lag
-        // extraction, or sampling, and k-means cannot build 2 cluster centers from
-        // that input. Match the post-training state ml_dimension_update_models would
-        // have set (mt, ts, suppression counters) so prediction re-arms training via
-        // the same self-correcting loop used after every cycle. ts is only promoted
-        // to TRAINED when prior models exist, mirroring the loadtime path above so
-        // stats don't count a model-less dimension as trained.
+        // Preprocessing can leave fewer than 2 vectors after diff/smooth/lag/sampling.
+        // k-means cannot build 2 cluster centers from that input, so reuse the
+        // post-cycle state machine and bail out before kmeans_train.
         if (worker->training_samples.size() < 2) {
             spinlock_lock(&dim->slock);
-
-            dim->mt = METRIC_TYPE_CONSTANT;
-            if (!dim->km_contexts.empty())
-                dim->ts = TRAINING_STATUS_TRAINED;
-            dim->suppression_anomaly_counter = 0;
-            dim->suppression_window_counter = 0;
+            ml_dimension_finalize_constant_state(dim);
             dim->training_in_progress = false;
-
             spinlock_unlock(&dim->slock);
-
             return ML_WORKER_RESULT_NOT_ENOUGH_COLLECTED_VALUES;
         }
 

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1100,7 +1100,7 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
         // Snapshot the stop generation before the unlocked walk. If it changes
         // by the time we publish, a stop ran while we were reading chart->mls
         // and the accumulated snapshot must be discarded.
-        uint64_t stop_gen_before = host->ml_stop_generation.load(std::memory_order_acquire);
+        uint64_t stop_gen_before = host->ml_stop_generation.load();
 
         /*
          * prediction/detection stats
@@ -1173,15 +1173,15 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
         // host->ml_running directly (so the ml_running chart records the
         // stop), and the chart-update path resets and republishes the rest.
         netdata_mutex_lock(&host->mutex);
-        uint64_t stop_gen_after = host->ml_stop_generation.load(std::memory_order_acquire);
+        uint64_t stop_gen_after = host->ml_stop_generation.load();
         if (!host->ml_running || stop_gen_before != stop_gen_after) {
             host_mls = {};
             host_anomaly_rate = 0.0;
 
             spinlock_lock(&host->context_anomaly_rate_spinlock);
-            for (auto &entry : host->context_anomaly_rate) {
-                entry.second.anomalous_dimensions = 0;
-                entry.second.normal_dimensions = 0;
+            for (auto &[key, entry] : host->context_anomaly_rate) {
+                entry.anomalous_dimensions = 0;
+                entry.normal_dimensions = 0;
             }
             spinlock_unlock(&host->context_anomaly_rate_spinlock);
         }

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -864,13 +864,16 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
         // Preprocessing can still leave fewer than 2 vectors after smoothing, lag
         // extraction, or sampling, and k-means cannot build 2 cluster centers from
         // that input. Match the post-training state ml_dimension_update_models would
-        // have set (mt, ts, suppression counters) so prediction is what re-arms
-        // training, the same self-correcting loop already used after every cycle.
+        // have set (mt, ts, suppression counters) so prediction re-arms training via
+        // the same self-correcting loop used after every cycle. ts is only promoted
+        // to TRAINED when prior models exist, mirroring the loadtime path above so
+        // stats don't count a model-less dimension as trained.
         if (worker->training_samples.size() < 2) {
             spinlock_lock(&dim->slock);
 
             dim->mt = METRIC_TYPE_CONSTANT;
-            dim->ts = TRAINING_STATUS_TRAINED;
+            if (!dim->km_contexts.empty())
+                dim->ts = TRAINING_STATUS_TRAINED;
             dim->suppression_anomaly_counter = 0;
             dim->suppression_window_counter = 0;
             dim->training_in_progress = false;

--- a/src/ml/ml_config.cc
+++ b/src/ml/ml_config.cc
@@ -173,6 +173,9 @@ void ml_config_load(ml_config_t *cfg) {
     diff_n = clamp(diff_n, 0u, 1u);
     max_samples_to_smooth = clamp<size_t>(max_samples_to_smooth, 0, 5);
     lag_n = clamp(lag_n, 1u, 5u);
+    // k-means needs at least 2 vectors; sampling caps the output at this value,
+    // so values < 2 would force the undersampled early-return every cycle.
+    max_training_vectors = clamp<size_t>(max_training_vectors, 2, 86400);
 
     max_kmeans_iters = clamp(max_kmeans_iters, 500u, 1000u);
 

--- a/src/ml/ml_config.cc
+++ b/src/ml/ml_config.cc
@@ -173,8 +173,11 @@ void ml_config_load(ml_config_t *cfg) {
     diff_n = clamp(diff_n, 0u, 1u);
     max_samples_to_smooth = clamp<size_t>(max_samples_to_smooth, 0, 5);
     lag_n = clamp(lag_n, 1u, 5u);
-    // k-means needs at least 2 vectors; sampling caps the output at this value,
-    // so values < 2 would force the undersampled early-return every cycle.
+    // max_training_vectors drives the lag-extraction sampling ratio (not a
+    // hard cap on output). A floor of 2 keeps the sampler from being starved
+    // by a misconfigured value. The runtime guard in ml_dimension_train_model
+    // is still required because sampling is probabilistic and can drop the
+    // emitted vector count below 2.
     max_training_vectors = clamp<size_t>(max_training_vectors, 2, 86400);
 
     max_kmeans_iters = clamp(max_kmeans_iters, 500u, 1000u);

--- a/src/ml/ml_config.cc
+++ b/src/ml/ml_config.cc
@@ -175,9 +175,10 @@ void ml_config_load(ml_config_t *cfg) {
     lag_n = clamp(lag_n, 1u, 5u);
     // max_training_vectors drives the lag-extraction sampling ratio (not a
     // hard cap on output). A floor of 2 keeps the sampler from being starved
-    // by a misconfigured value. The runtime guard in ml_dimension_train_model
-    // is still required because sampling is probabilistic and can drop the
-    // emitted vector count below 2.
+    // by a misconfigured value; the ceiling of 86400 (24 hours of 1-second
+    // samples) is well past anything training_window can supply. The runtime
+    // guard in ml_dimension_train_model is still required because sampling is
+    // probabilistic and can drop the emitted vector count below 2.
     max_training_vectors = clamp<size_t>(max_training_vectors, 2, 86400);
 
     max_kmeans_iters = clamp(max_kmeans_iters, 500u, 1000u);

--- a/src/ml/ml_dimension.h
+++ b/src/ml/ml_dimension.h
@@ -35,6 +35,11 @@ ml_dimension_predict(ml_dimension_t *dim, calculated_number_t value, bool exists
 
 bool ml_dimension_deserialize_kmeans(const char *json_str);
 
+// Set dim's post-training state (mt/ts/suppression counters). Caller must hold
+// dim->slock. Used by both the successful-training path and the undersampled
+// early-return so the post-cycle state machine stays in sync.
+void ml_dimension_finalize_constant_state(ml_dimension_t *dim);
+
 class DimensionLookupInfo {
 public:
     DimensionLookupInfo()

--- a/src/ml/ml_host.h
+++ b/src/ml/ml_host.h
@@ -54,6 +54,14 @@ typedef struct {
 
     netdata_mutex_t mutex;
 
+    // Serializes ml_host_start() against ml_host_stop(). Stop holds it across
+    // its full chart/dim reset walk and the final stop-generation bump (it
+    // cannot carry host->mutex into that walk), so a racing start cannot
+    // re-enable ml_running while stop is mid-reset. Without it, a detect walk
+    // could observe ml_running==true with an unchanged stop generation and
+    // publish a snapshot torn by stop's in-flight chart->mls resets.
+    netdata_mutex_t start_stop_mutex;
+
     ml_queue_t *queue;
 
     /*

--- a/src/ml/ml_host.h
+++ b/src/ml/ml_host.h
@@ -40,10 +40,12 @@ typedef struct {
 
     std::atomic<bool> ml_running;
 
-    // Incremented on every ml_host_stop. ml_host_detect_once samples this before
-    // and after its unlocked chart walk; a change means a stop ran during the
-    // walk, so the accumulated snapshot must be discarded even if a subsequent
-    // ml_host_start has flipped ml_running back to true.
+    // Incremented at the END of every ml_host_stop, after all chart/dim resets
+    // have committed. ml_host_detect_once samples this before and after its
+    // unlocked chart walk; a change means a stop completed during the walk
+    // (so detect raced with stop's chart->mls writes) or a stop+start cycle
+    // happened around the walk. In either case the accumulated snapshot must
+    // be discarded even if ml_running is back to true at the re-check.
     std::atomic<uint64_t> ml_stop_generation;
 
     ml_machine_learning_stats_t mls;

--- a/src/ml/ml_host.h
+++ b/src/ml/ml_host.h
@@ -40,6 +40,12 @@ typedef struct {
 
     std::atomic<bool> ml_running;
 
+    // Incremented on every ml_host_stop. ml_host_detect_once samples this before
+    // and after its unlocked chart walk; a change means a stop ran during the
+    // walk, so the accumulated snapshot must be discarded even if a subsequent
+    // ml_host_start has flipped ml_running back to true.
+    std::atomic<uint64_t> ml_stop_generation;
+
     ml_machine_learning_stats_t mls;
 
     calculated_number_t host_anomaly_rate;

--- a/src/ml/ml_kmeans.h
+++ b/src/ml/ml_kmeans.h
@@ -33,21 +33,16 @@ struct ml_kmeans_inlined_t {
     time_t after;
     time_t before;
 
-    ml_kmeans_inlined_t() : min_dist(0), max_dist(0), after(0), before(0)
+    ml_kmeans_inlined_t() : cluster_centers{}, min_dist(0), max_dist(0), after(0), before(0)
     {
     }
 
-    explicit ml_kmeans_inlined_t(const ml_kmeans_t &km)
+    explicit ml_kmeans_inlined_t(const ml_kmeans_t &km) : cluster_centers{}, min_dist(km.min_dist), max_dist(km.max_dist), after(km.after), before(km.before)
     {
         if (km.cluster_centers.size() == 2) {
             cluster_centers[0] = km.cluster_centers[0];
             cluster_centers[1] = km.cluster_centers[1];
         }
-
-        min_dist = km.min_dist;
-        max_dist = km.max_dist;
-        after = km.after;
-        before = km.before;
     }
 
     ml_kmeans_inlined_t &operator=(const ml_kmeans_t &km)
@@ -55,6 +50,9 @@ struct ml_kmeans_inlined_t {
         if (km.cluster_centers.size() == 2) {
             cluster_centers[0] = km.cluster_centers[0];
             cluster_centers[1] = km.cluster_centers[1];
+        }
+        else {
+            cluster_centers = std::array<DSample, 2>{};
         }
         min_dist = km.min_dist;
         max_dist = km.max_dist;

--- a/src/ml/ml_kmeans.h
+++ b/src/ml/ml_kmeans.h
@@ -33,15 +33,21 @@ struct ml_kmeans_inlined_t {
     time_t after;
     time_t before;
 
-    ml_kmeans_inlined_t() : cluster_centers{}, min_dist(0), max_dist(0), after(0), before(0)
+    ml_kmeans_inlined_t() : min_dist(0), max_dist(0), after(0), before(0)
     {
+        cluster_centers[0] = 0;
+        cluster_centers[1] = 0;
     }
 
-    explicit ml_kmeans_inlined_t(const ml_kmeans_t &km) : cluster_centers{}, min_dist(km.min_dist), max_dist(km.max_dist), after(km.after), before(km.before)
+    explicit ml_kmeans_inlined_t(const ml_kmeans_t &km) : min_dist(km.min_dist), max_dist(km.max_dist), after(km.after), before(km.before)
     {
         if (km.cluster_centers.size() == 2) {
             cluster_centers[0] = km.cluster_centers[0];
             cluster_centers[1] = km.cluster_centers[1];
+        }
+        else {
+            cluster_centers[0] = 0;
+            cluster_centers[1] = 0;
         }
     }
 
@@ -52,7 +58,8 @@ struct ml_kmeans_inlined_t {
             cluster_centers[1] = km.cluster_centers[1];
         }
         else {
-            cluster_centers = std::array<DSample, 2>{};
+            cluster_centers[0] = 0;
+            cluster_centers[1] = 0;
         }
         min_dist = km.min_dist;
         max_dist = km.max_dist;

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -165,11 +165,11 @@ void ml_host_stop(RRDHOST *rh) {
         return;
 
     // Prevent new ML activity from publishing while we reset host/dimension
-    // state. Bump the stop generation so a concurrent ml_host_detect_once can
-    // see a stop happened even if a subsequent ml_host_start flips ml_running
-    // back to true before detect's re-check.
+    // state. The ml_running flag gates collectors and the detect loop; the
+    // stop generation is bumped at the end of the function so a concurrent
+    // ml_host_detect_once that observes the new generation is guaranteed to
+    // also see all of our chart->mls / dim resets via seq_cst ordering.
     host->ml_running = false;
-    host->ml_stop_generation.fetch_add(1, std::memory_order_release);
 
     netdata_mutex_lock(&host->mutex);
 
@@ -226,6 +226,13 @@ void ml_host_stop(RRDHOST *rh) {
         rrddim_foreach_done(rdp);
     }
     rrdset_foreach_done(rsp);
+
+    // Publish the stop only after every chart->mls / dim reset is committed.
+    // ml_host_detect_once treats a generation change as "discard the snapshot",
+    // so bumping here guarantees that if detect saw stale chart->mls it will
+    // either also observe the new generation or have already published before
+    // any of our resets started.
+    host->ml_stop_generation.fetch_add(1);
 }
 
 void ml_host_get_info(RRDHOST *rh, BUFFER *wb)

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -104,6 +104,7 @@ void ml_host_new(RRDHOST *rh)
     // fields, producing SIGSEGV faults inside ml_dimension_is_anomalous and
     // similar readers.
     __atomic_store_n(&rh->ml_host, (rrd_ml_host_t *)host, __ATOMIC_RELEASE);
+    host->ml_stop_generation = 0;
 }
 
 void ml_host_delete(RRDHOST *rh)
@@ -163,8 +164,12 @@ void ml_host_stop(RRDHOST *rh) {
     if (!host || !host->ml_running)
         return;
 
-    // Prevent new ML activity from publishing while we reset host/dimension state.
+    // Prevent new ML activity from publishing while we reset host/dimension
+    // state. Bump the stop generation so a concurrent ml_host_detect_once can
+    // see a stop happened even if a subsequent ml_host_start flips ml_running
+    // back to true before detect's re-check.
     host->ml_running = false;
+    host->ml_stop_generation.fetch_add(1, std::memory_order_release);
 
     netdata_mutex_lock(&host->mutex);
 

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -95,6 +95,7 @@ void ml_host_new(RRDHOST *rh)
     spinlock_init(&host->context_anomaly_rate_spinlock);
 
     host->ml_running = false;
+    host->ml_stop_generation = 0;
 
     // Publish with release semantics so readers that load rh->ml_host with
     // acquire semantics observe the host's `rh`, `ml_running`, `mutex`,
@@ -104,7 +105,6 @@ void ml_host_new(RRDHOST *rh)
     // fields, producing SIGSEGV faults inside ml_dimension_is_anomalous and
     // similar readers.
     __atomic_store_n(&rh->ml_host, (rrd_ml_host_t *)host, __ATOMIC_RELEASE);
-    host->ml_stop_generation = 0;
 }
 
 void ml_host_delete(RRDHOST *rh)

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -177,6 +177,10 @@ void ml_host_stop(RRDHOST *rh) {
     host->mls = ml_machine_learning_stats_t();
     ml_host_clear_context_anomaly_rate(host);
 
+    // Chart deletion can hold the dictionary writer across lengthy cleanup.
+    // Do not carry host->mutex into the traversal below.
+    netdata_mutex_unlock(&host->mutex);
+
     // reset charts/dims
     void *rsp = NULL;
     rrdset_foreach_read(rsp, host->rh) {
@@ -217,8 +221,6 @@ void ml_host_stop(RRDHOST *rh) {
         rrddim_foreach_done(rdp);
     }
     rrdset_foreach_done(rsp);
-
-    netdata_mutex_unlock(&host->mutex);
 }
 
 void ml_host_get_info(RRDHOST *rh, BUFFER *wb)

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -92,6 +92,7 @@ void ml_host_new(RRDHOST *rh)
     host->queue = Cfg.workers[times_called++ % Cfg.num_worker_threads].queue;
 
     netdata_mutex_init(&host->mutex);
+    netdata_mutex_init(&host->start_stop_mutex);
     spinlock_init(&host->context_anomaly_rate_spinlock);
 
     host->ml_running = false;
@@ -121,6 +122,7 @@ void ml_host_delete(RRDHOST *rh)
 
     ml_host_clear_context_anomaly_rate(host);
     netdata_mutex_destroy(&host->mutex);
+    netdata_mutex_destroy(&host->start_stop_mutex);
 
     delete host;
 }
@@ -130,16 +132,19 @@ void ml_host_start(RRDHOST *rh) {
     if (!host)
         return;
 
-    // Set ml_running and run the sweep under host->mutex so concurrent
-    // ml_host_start() calls are serialized and the visibility window of the
-    // flag flip is bounded by the same critical section that performs the
-    // sweep.
-    netdata_mutex_lock(&host->mutex);
+    // Serialize against ml_host_stop(): we must not re-enable ml_running
+    // while a stop is still resetting chart/dim state (see ml_host_stop),
+    // and concurrent ml_host_start() calls must not run the sweep twice.
+    netdata_mutex_lock(&host->start_stop_mutex);
 
     if (host->ml_running) {
-        netdata_mutex_unlock(&host->mutex);
+        netdata_mutex_unlock(&host->start_stop_mutex);
         return;
     }
+
+    // Run the sweep under host->mutex so the visibility window of the flag
+    // flip is bounded by the same critical section that performs the sweep.
+    netdata_mutex_lock(&host->mutex);
 
     host->ml_running = true;
 
@@ -157,12 +162,25 @@ void ml_host_start(RRDHOST *rh) {
     rrdset_foreach_done(rsp);
 
     netdata_mutex_unlock(&host->mutex);
+    netdata_mutex_unlock(&host->start_stop_mutex);
 }
 
 void ml_host_stop(RRDHOST *rh) {
     ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
-    if (!host || !host->ml_running)
+    if (!host)
         return;
+
+    // Serialize with ml_host_start() for the WHOLE stop sequence, including
+    // the unlocked chart/dim reset walk and the final generation bump. If a
+    // racing start could flip ml_running back to true mid-reset, a concurrent
+    // ml_host_detect_once would observe ml_running==true with an unchanged
+    // stop generation and publish a snapshot torn by our in-flight resets.
+    netdata_mutex_lock(&host->start_stop_mutex);
+
+    if (!host->ml_running) {
+        netdata_mutex_unlock(&host->start_stop_mutex);
+        return;
+    }
 
     // Prevent new ML activity from publishing while we reset host/dimension
     // state. The ml_running flag gates collectors and the detect loop; the
@@ -172,11 +190,6 @@ void ml_host_stop(RRDHOST *rh) {
     host->ml_running = false;
 
     netdata_mutex_lock(&host->mutex);
-
-    // Re-assert under the mutex so stop deterministically wins over a racing
-    // ml_host_start() that may have flipped the flag back to true after our
-    // early write but before we acquired the mutex.
-    host->ml_running = false;
 
     // reset host stats
     host->mls = ml_machine_learning_stats_t();
@@ -233,6 +246,8 @@ void ml_host_stop(RRDHOST *rh) {
     // either also observe the new generation or have already published before
     // any of our resets started.
     host->ml_stop_generation.fetch_add(1);
+
+    netdata_mutex_unlock(&host->start_stop_mutex);
 }
 
 void ml_host_get_info(RRDHOST *rh, BUFFER *wb)


### PR DESCRIPTION
##### Summary
- Split / based on  #22234


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ML locking and training edge cases to keep host stats coherent, avoid long mutex holds, serialize start/stop, and make k-means deterministic and safe with undersized inputs.

- **Bug Fixes**
  - Detection/host stats: aggregate locally, snapshot/compare ml_stop_generation around the unlocked chart walk, and publish host->mls and host_anomaly_rate under host->mutex; on ml_running=false or generation change, discard the snapshot, zero per-context anomaly counters, and republish. Addresses CIDs 410121, 393056.
  - Start/stop synchronization: add host->start_stop_mutex to serialize ml_host_start() and ml_host_stop(); stop holds it across the full reset and the final generation bump, start holds it during its sweep; prevents re-enabling mid-reset and torn snapshots.
  - Stop path: reset host stats under host->mutex, release it before chart/dim traversals, and bump ml_stop_generation only after all resets commit; initialize it to 0 in ml_host_new(). Addresses CID 393057.
  - ML training correctness: early-return before k-means when preprocessing yields fewer than 2 vectors; under dim->slock call ml_dimension_finalize_constant_state() (mt=CONSTANT, ts=TRAINED, reset suppression), and clear training_in_progress.
  - K-means model safety: zero-initialize ml_kmeans_inlined_t centers by default and when converting/assigning from an empty model; preserve min/max and window bounds. Addresses CID 451560.
  - Config guard: clamp max_training_vectors to [2, 86400].
  - Tests: add unit tests for empty-model conversion, the 1-vector preprocess boundary, and finalize-constant-state.
  - Minor: simplify context_anomaly_rate iteration (no behavior change).

<sup>Written for commit 65817c6515c780500cd40a7ce65f75eca775f093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



