### PR TITLE
Fix memory-safety and correctness bugs surfaced by Coverity audit (part 6)

### DIFF
--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -442,19 +442,28 @@ void rrdcalc_unlink_and_delete(RRDHOST *host, RRDCALC *rc, bool having_ll_wrlock
 
 void rrdcalc_unlink_and_delete_all_rrdset_alerts(RRDSET *st) {
     RRDHOST *host = st->rrdhost;
-    RRDCALC *rc;
+    RRDCALC *rc, *last = NULL;
 
-    // Keep the removal snapshot under the alert dictionary write traversal lock,
-    // so it cannot race with concurrent health-thread updates of rc->value.
-    foreach_rrdcalc_in_rrdhost_write(host, rc) {
-        if(rc->rrdset != st)
-            continue;
+    // Acquire the host alert dictionary write lock to exclude the health
+    // thread (which mutates rc fields under foreach_rrdcalc_in_rrdhost_read),
+    // then walk only this chart's alert list to keep the work O(chart-alerts).
+    // The lock is recursive, so dictionary_del_advanced() inside the loop
+    // re-enters safely.
+    dictionary_write_lock(host->rrdcalc_root_index);
+    rw_spinlock_write_lock(&st->alerts.spinlock);
 
-        rw_spinlock_write_lock(&st->alerts.spinlock);
+    while((rc = st->alerts.base)) {
+        if(last == rc) {
+            netdata_log_error("RRDCALC: malformed list of alerts linked to chart - cannot cleanup - giving up.");
+            break;
+        }
+        last = rc;
+
         rrdcalc_unlink_and_delete(host, rc, true);
-        rw_spinlock_write_unlock(&st->alerts.spinlock);
     }
-    foreach_rrdcalc_in_rrdhost_done(rc);
+
+    rw_spinlock_write_unlock(&st->alerts.spinlock);
+    dictionary_write_unlock(host->rrdcalc_root_index);
 }
 
 void rrdcalc_delete_all(RRDHOST *host) {

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -441,18 +441,20 @@ void rrdcalc_unlink_and_delete(RRDHOST *host, RRDCALC *rc, bool having_ll_wrlock
 // RRDCALC cleanup API functions
 
 void rrdcalc_unlink_and_delete_all_rrdset_alerts(RRDSET *st) {
-    RRDCALC *rc, *last = NULL;
-    rw_spinlock_write_lock(&st->alerts.spinlock);
-    while((rc = st->alerts.base)) {
-        if(last == rc) {
-            netdata_log_error("RRDCALC: malformed list of alerts linked to chart - cannot cleanup - giving up.");
-            break;
-        }
-        last = rc;
+    RRDHOST *host = st->rrdhost;
+    RRDCALC *rc;
 
-        rrdcalc_unlink_and_delete(st->rrdhost, rc, true);
+    // Keep the removal snapshot under the alert dictionary write traversal lock,
+    // so it cannot race with concurrent health-thread updates of rc->value.
+    foreach_rrdcalc_in_rrdhost_write(host, rc) {
+        if(rc->rrdset != st)
+            continue;
+
+        rw_spinlock_write_lock(&st->alerts.spinlock);
+        rrdcalc_unlink_and_delete(host, rc, true);
+        rw_spinlock_write_unlock(&st->alerts.spinlock);
     }
-    rw_spinlock_write_unlock(&st->alerts.spinlock);
+    foreach_rrdcalc_in_rrdhost_done(rc);
 }
 
 void rrdcalc_delete_all(RRDHOST *host) {

--- a/src/libnetdata/functions_evloop/functions_evloop.c
+++ b/src/libnetdata/functions_evloop/functions_evloop.c
@@ -89,29 +89,30 @@ static void rrd_functions_worker_globals_worker_main(void *arg) {
 
     nd_thread_register_canceller(rrd_functions_worker_canceller, wg);
 
-    bool last_acquired = true;
     while (true) {
-        netdata_mutex_lock(&wg->worker_mutex);
-
-        if(__atomic_load_n(&wg->workers_exit, __ATOMIC_RELAXED) || nd_thread_signaled_to_cancel()) {
-            netdata_mutex_unlock(&wg->worker_mutex);
-            break;
-        }
-
-        if(dictionary_entries(wg->worker_queue) == 0 || !last_acquired)
-            netdata_cond_wait(&wg->worker_cond_var, &wg->worker_mutex);
-
         const DICTIONARY_ITEM *acquired = NULL;
         struct functions_evloop_worker_job *j;
-        dfe_start_write(wg->worker_queue, j) {
-            if(j->running || j->cancelled)
-                continue;
 
-            acquired = dictionary_acquired_item_dup(wg->worker_queue, j_dfe.item);
-            j->running = true;
-            break;
+        netdata_mutex_lock(&wg->worker_mutex);
+
+        // Keep the scan and the wait under worker_mutex so a new-job signal
+        // cannot land after we decide to sleep but before the thread blocks.
+        while(!__atomic_load_n(&wg->workers_exit, __ATOMIC_RELAXED) && !nd_thread_signaled_to_cancel()) {
+            dfe_start_write(wg->worker_queue, j) {
+                if(j->running || j->cancelled)
+                    continue;
+
+                acquired = dictionary_acquired_item_dup(wg->worker_queue, j_dfe.item);
+                j->running = true;
+                break;
+            }
+            dfe_done(j);
+
+            if(acquired)
+                break;
+
+            netdata_cond_wait(&wg->worker_cond_var, &wg->worker_mutex);
         }
-        dfe_done(j);
 
         netdata_mutex_unlock(&wg->worker_mutex);
 
@@ -129,15 +130,12 @@ static void rrd_functions_worker_globals_worker_main(void *arg) {
             };
             ND_LOG_STACK_PUSH(lgs);
 
-            last_acquired = true;
             j = dictionary_acquired_item_value(acquired);
             j->cb(j->transaction, j->cmd, &j->stop_monotonic_ut, &j->cancelled, j->payload, j->access, j->source, j->cb_data);
             dictionary_del(wg->worker_queue, j->transaction);
             dictionary_acquired_item_release(wg->worker_queue, acquired);
             dictionary_garbage_collect(wg->worker_queue);
         }
-        else
-            last_acquired = false;
     }
 }
 

--- a/src/libnetdata/functions_evloop/functions_evloop.c
+++ b/src/libnetdata/functions_evloop/functions_evloop.c
@@ -99,7 +99,7 @@ static void rrd_functions_worker_globals_worker_main(void *arg) {
         // cannot land after we decide to sleep but before the thread blocks.
         while(!__atomic_load_n(&wg->workers_exit, __ATOMIC_RELAXED) && !nd_thread_signaled_to_cancel()) {
             dfe_start_write(wg->worker_queue, j) {
-                if(j->running || j->cancelled)
+                if(j->running || __atomic_load_n(&j->cancelled, __ATOMIC_RELAXED))
                     continue;
 
                 acquired = dictionary_acquired_item_dup(wg->worker_queue, j_dfe.item);


### PR DESCRIPTION
##### Summary
- Split / based on  #22234


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes memory-safety and concurrency bugs found by Coverity by serializing chart alert deletion and preventing lost worker wakeups. Improves correctness during alert cleanup and queued job processing.

- **Bug Fixes**
  - Health (alert cleanup): Serialize deletion of a chart’s alerts by taking the host alert dictionary write lock while walking the chart list, preventing races with the health thread (CID 380968).
  - Functions event loop: Scan the queue and wait under the same `worker_mutex` so new-job signals can’t be missed and no requests are stranded (CID 439969).

<sup>Written for commit 5c2685cde4c3d0603f1800c2b3c6a02d129ed4ba. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22281?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



