### PR TITLE
fix(go.d/powerstore): remove extra_details field

### DIFF
--- a/src/go/plugin/go.d/collector/powerstore/client/types.go
+++ b/src/go/plugin/go.d/collector/powerstore/client/types.go
@@ -37,7 +37,6 @@ type Hardware struct {
 	LifecycleState string `json:"lifecycle_state"`
 	StatusLED      string `json:"status_led,omitempty"`
 	ApplianceID    string `json:"appliance_id,omitempty"`
-	ExtraDetails   string `json:"extra_details,omitempty"`
 	PartNumber     string `json:"part_number,omitempty"`
 	SerialNumber   string `json:"serial_number,omitempty"`
 	Slot           int    `json:"slot,omitempty"`


### PR DESCRIPTION
##### Summary

Fixes

> Job check failed: error decoding /hardware response: json: cannot unmarshal object into Go struct field Hardware.extra_details of type string

This field is not used.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `extra_details` field from the `Hardware` struct in `go.d/powerstore` to fix JSON decoding errors on /hardware responses. This prevents job check failures when the API returns an object for `extra_details`.

<sup>Written for commit eb7caaaa072d21d5aab8c9f5eb6b7b37be312c87. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22291?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

