### PR TITLE
Fix memory-safety and correctness bugs surfaced by Coverity audit (part 8)

### DIFF
--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -389,9 +389,7 @@ static int remove_ephemeral_host(BUFFER *wb, RRDHOST *host, bool report_error, b
         host->node_id = UUID_ZERO;
         buffer_sprintf(wb, "Node '%s' (machine guid: %s) has been unregistered",
                        rrdhost_hostname(host), host->machine_guid);
-        rrd_wrlock();
-        rrdhost_free___while_having_rrd_wrlock(host);
-        rrd_wrunlock();
+        rrdhost_free___without_having_rrd_wrlock(host);
         return 1;
     }
 

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -800,23 +800,15 @@ void rrdhost_cleanup_data_collection_and_health(RRDHOST *host) {
            rrdhost_hostname(host));
 }
 
-void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host) {
-    if(!host) return;
-
-    nd_log(NDLS_DAEMON, NDLP_DEBUG,
-           "RRD: 'host:%s' freeing memory...",
-           rrdhost_hostname(host));
-
-    // ------------------------------------------------------------------------
-    // first remove it from the indexes, so that it will not be discoverable
-
+static void rrdhost_unlink___while_having_rrd_wrlock(RRDHOST *host) {
+    // Remove it from the indexes first, so blocking teardown cannot rediscover it.
     rrdhost_index_del_by_guid(host);
 
     if (host->prev)
         DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(localhost, host, prev, next);
+}
 
-    // ------------------------------------------------------------------------
-
+static void rrdhost_free_unlinked(RRDHOST *host) {
     rrdhost_cleanup_data_collection_and_health(host);
 
     // ------------------------------------------------------------------------
@@ -845,6 +837,23 @@ void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host) {
     string_freez(host->stream.snd.api_key);
     string_freez(host->stream.snd.destination);
     freez(host);
+}
+
+void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host) {
+    if(!host) return;
+
+    rrdhost_unlink___while_having_rrd_wrlock(host);
+    rrdhost_free_unlinked(host);
+}
+
+void rrdhost_free___without_having_rrd_wrlock(RRDHOST *host) {
+    if(!host) return;
+
+    rrd_wrlock();
+    rrdhost_unlink___while_having_rrd_wrlock(host);
+    rrd_wrunlock();
+
+    rrdhost_free_unlinked(host);
 }
 
 void rrdhost_free_all(void) {

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -456,6 +456,7 @@ RRDHOST *rrdhost_find_or_create(
 void rrdhost_free_all(void);
 
 void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host);
+void rrdhost_free___without_having_rrd_wrlock(RRDHOST *host);
 void rrdhost_cleanup_data_collection_and_health(RRDHOST *host);
 
 bool rrdhost_should_be_cleaned_up(RRDHOST *host, RRDHOST *protected_host, time_t now_s);


### PR DESCRIPTION
## Summary

Single follow-up commit not yet covered by parts 1-7 (#22266, #22267, #22268, #22270, #22279, #22280, #22281).

@stelfrag — could you pick this one up and review when you get a chance? Thanks for splitting the original PR into reviewable parts.

## CID 442107 (SLEEP) — `daemon: free removed stale nodes outside rrd lock`

`remove_ephemeral_host()` in `src/daemon/commands.c` held the global RRD write lock while calling `rrdhost_free___while_having_rrd_wrlock()`, which performs blocking teardown work (logging, stream-shutdown waits, data collection cleanup, health cleanup). Every other RRD writer was stalled meanwhile.

The fix splits host removal into:

- `rrdhost_unlink___while_having_rrd_wrlock()` — fast index removal, runs under the lock
- `rrdhost_free_unlinked()` — slow teardown (`cleanup_data_collection_and_health`, free), runs after the lock is released

A new wrapper `rrdhost_free___without_having_rrd_wrlock()` encapsulates the lock-then-unlink-then-unlock-then-free pattern for callers like `remove_ephemeral_host()`.

Files changed:
- `src/daemon/commands.c`
- `src/database/rrdhost.c`
- `src/database/rrdhost.h`

3 files changed, +23 -15.

## Test plan

- [ ] CI build passes
- [ ] Coverity scan no longer reports CID 442107

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Coverity CID 442107 by moving slow host teardown outside the global RRD write lock to prevent stalls. Host unlinking now happens under the lock, with teardown after unlock for better responsiveness.

- **Bug Fixes**
  - Unlink under lock with `rrdhost_unlink___while_having_rrd_wrlock()`, then teardown via `rrdhost_free_unlinked()` after releasing the lock.
  - Added `rrdhost_free___without_having_rrd_wrlock()` and updated `remove_ephemeral_host()` to use it.
  - Keeps cleanup order intact while minimizing lock hold time.

<sup>Written for commit 509be03b5d6d0b63cb7f64fdd376d8a3cc011db6. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22293?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

