### PR TITLE
agents: add coverity-audit, sonarqube-audit, graphql-audit skills

### DIFF
--- a/.agents/skills/coverity-audit/SKILL.md
+++ b/.agents/skills/coverity-audit/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: coverity-audit
+description: Triage Coverity Scan defects (https://scan.coverity.com) for this project — fetch outstanding/dismissed/fixed defects, run multi-model analysis, finalize verdicts (Bug / FalsePositive / Intentional) on the upstream tracker. Use when the user asks to "review Coverity defects", "triage Coverity findings", "fetch Coverity outstanding", or anything mentioning Coverity Scan, CIDs, or the scan.coverity.com web UI.
+---
+
+# Coverity Scan triage skill
+
+This skill drives the Coverity Scan unofficial JSON API to fetch defect lists,
+fetch per-defect details, and apply triage decisions (classification, severity,
+action, comment). The Coverity Scan **public** site has no documented API; the
+scripts here mimic what the browser does.
+
+The skill operates on the project configured in `.env` (see Setup). Scripts
+auto-detect the repo root and write all artifacts under `<repo-root>/.local/`.
+
+## MANDATORY — startup sequence when this skill is invoked
+
+Do these steps in this order. Skipping any step costs the user their session.
+
+### Step 1 — ask the user for a fresh cookie
+
+Coverity Scan auth is cookie-based and tied to a live browser session. Give
+the user the exact recipe (verbatim):
+
+> 1. Open https://scan.coverity.com/projects/<owner>-<repo>?tab=overview
+>    (replace `<owner>-<repo>` with the project slug; e.g. `netdata-netdata`).
+> 2. Click **"View Defects"** at the top right -- a new tab opens to
+>    https://scan4.scan.coverity.com/# (or `scanN.scan.coverity.com` --
+>    Coverity load-balances across hosts; use whichever URL you land on as
+>    `COVERITY_HOST` in `.env`).
+> 3. **Keep that tab open the whole time we work.** Closing it kills the
+>    session immediately.
+> 4. Press **F12** to open DevTools, switch to the **Network** tab.
+> 5. Click any defect in the list -- 3-4 requests appear in the Network tab.
+> 6. Right-click any of those requests, select **Copy > Copy as cURL**.
+> 7. Paste the entire curl command back here.
+
+If the curl the user pastes does NOT contain a `-b 'cookie=...'` line, ask
+again -- they likely picked "Copy as fetch" or "Copy as Node.js fetch"
+instead of "Copy as cURL".
+
+### Step 2 — save the cookie in `.env`
+
+Extract the value of the `-b` argument from the user's curl and write/update
+`<repo-root>/.env` with:
+
+```bash
+COVERITY_COOKIE='<paste-the-entire-cookie-blob-here>'
+COVERITY_PROJECT_ID=<numeric-projectId-from-the-URL>
+COVERITY_VIEW_OUTSTANDING=<viewId-of-the-Outstanding-view>
+COVERITY_HOST=https://scan4.scan.coverity.com
+```
+
+`.env` is gitignored. The cookie blob must include both `COVJSESSIONID-build`
+and `XSRF-TOKEN`. The scripts extract `XSRF-TOKEN` automatically.
+
+### Step 3 — start the keepalive (background)
+
+```
+Bash tool with run_in_background=true,
+command="bash .agents/skills/coverity-audit/scripts/keepalive.sh"
+```
+
+The keepalive **exits non-zero the moment a ping fails** (session expired,
+browser tab closed, cookie went bad). The orchestrator's background-task
+notification fires immediately so you know to ask the user for a fresh cookie
+and restart from Step 1.
+
+**Stop the keepalive at the end of the triage session** by killing its
+background task.
+
+### Step 4 — proceed with the actual triage work
+
+Now and only now is it safe to fetch tables, fetch details, run analyzers,
+finalize defects.
+
+## MANDATORY — keep this skill alive
+
+**If you (the agent) discover a new pattern, gotcha, working flow, correction,
+or any piece of knowledge while running this skill — update this `SKILL.md`
+AND commit it BEFORE proceeding. Knowledge that isn't committed is lost.**
+
+Examples of things to capture:
+- New verdict mapping discovered
+- New API endpoint/parameter that was undocumented
+- New failure mode (Cloudflare quirks, session-expiry signals, rate limits)
+- New scrape pattern for displayImpact, owner, history, etc.
+
+## Setup
+
+### 1. Browser tab — must stay open
+
+Coverity authentication is cookie-based and tied to a live browser session.
+**The Coverity Scan tab must remain open in the user's browser for the
+entire triage run.** Closing the tab kills the cookie, no amount of
+keepalive pings can revive it.
+
+### 2. Capture the cookie
+
+Ask the user (Costa) to:
+
+1. Open https://scan.coverity.com and navigate to the project's defects view.
+2. Open DevTools → Network panel.
+3. Click any request to `*.scan.coverity.com` (e.g. the `table.json` XHR).
+4. Right-click → **Copy → Copy as cURL**.
+5. Paste the entire curl command somewhere the agent can read it (the chat,
+   a temp file). The agent will extract the `-b 'cookie=...'` value.
+
+The agent then writes `<repo-root>/.env` (gitignored) with:
+
+```bash
+# Coverity Scan
+COVERITY_COOKIE='<paste the entire single-quoted cookie string from the curl -b argument>'
+COVERITY_PROJECT_ID=<numeric projectId — find it in the URL or table.json query>
+COVERITY_VIEW_OUTSTANDING=<viewId of the "Outstanding" view, optional but recommended>
+# COVERITY_HOST defaults to https://scan4.scan.coverity.com — override only if Coverity routed you elsewhere
+```
+
+The cookie blob must include both the session id (`COVJSESSIONID-build=...`)
+and the CSRF token (`XSRF-TOKEN=...`). The scripts extract `XSRF-TOKEN` from
+the cookie automatically.
+
+### 3. Start the keepalive (background)
+
+Run `keepalive.sh` as a background task at the start of the triage session:
+
+```
+Bash tool with run_in_background=true,
+command="bash .agents/skills/coverity-audit/scripts/keepalive.sh"
+```
+
+It pings every 5 minutes (`PING_INTERVAL=300`) and exits non-zero the moment
+the session goes bad — that's the signal to ask the user for a fresh cookie.
+
+**Stop** the keepalive at the end of the session.
+
+## Verdict enum
+
+These are the only valid verdicts. The mapping to Coverity attributes lives
+in `scripts/finalize-defect.sh`:
+
+| Verdict                          | Coverity classification | Action          |
+|----------------------------------|-------------------------|-----------------|
+| TRUE_BUG_MEMORY_CORRUPTION       | Bug (24)                | Fix Submitted (3) |
+| TRUE_BUG_CRASH                   | Bug (24)                | Fix Submitted (3) |
+| TRUE_BUG_RESOURCE_LEAK           | Bug (24)                | Fix Submitted (3) |
+| TRUE_BUG_LOGIC                   | Bug (24)                | Fix Submitted (3) |
+| TRUE_BUG_UB                      | Bug (24)                | Fix Submitted (3) |
+| FALSE_POSITIVE_GUARD_EXISTS      | False Positive (22)     | Ignore (5)        |
+| FALSE_POSITIVE_UNREACHABLE       | False Positive (22)     | Ignore (5)        |
+| FALSE_POSITIVE_TRUSTED_INPUT     | False Positive (22)     | Ignore (5)        |
+| FALSE_POSITIVE_TOOL_MODEL        | False Positive (22)     | Ignore (5)        |
+| IMPOSSIBLE_CONDITIONS            | False Positive (22)     | Ignore (5)        |
+| COSMETIC                         | Intentional (23)        | Ignore (5)        |
+| NEEDS_HUMAN                      | (no-op — flag for the user) |
+| CODE_GONE                        | (no-op when refactor removed the path; map to FalsePositive+Ignore in pipeline) |
+
+Severity (Coverity's displayImpact -> attribute 1):
+- High -> 11 (Major), Medium -> 12 (Moderate), Low -> 13 (Minor),
+  unknown -> 10 (Unspecified)
+
+## Phases (queue scopes)
+
+When walking the defect tracker, group work by phase:
+
+1. **Outstanding** — the live queue. Default; verdicts always applied.
+2. **Old / dismissed** — previously closed. Apply a verdict only if it
+   *disagrees* with the existing classification.
+3. **Fixed** — already fixed in code. Verify, usually no-op.
+4. **Unclassified non-outstanding** — corner cases.
+5. **Re-runs** — anything we previously triaged that has resurfaced.
+
+## Workflow
+
+### Step 1 — fetch the table (per phase)
+
+Inspect the Coverity UI, count pages for the view, then:
+
+```
+bash .agents/skills/coverity-audit/scripts/fetch-table.sh \
+    "${COVERITY_VIEW_OUTSTANDING}" 7 .local/audits/coverity/raw/outstanding
+```
+
+Produces `.local/audits/coverity/raw/outstanding-page1.json` ... and a
+combined flat array at `.local/audits/coverity/raw/outstanding-all.json`.
+
+### Step 2 — fetch per-defect details
+
+```
+bash .agents/skills/coverity-audit/scripts/fetch-details.sh \
+    .local/audits/coverity/raw/outstanding-all.json \
+    .local/audits/coverity/details
+```
+
+One file per CID at `.local/audits/coverity/details/cid-<CID>.json`.
+
+### Step 3 — triage one defect
+
+For each CID, the orchestrator drives a multi-model verdict. Suggested layout
+(matches the established pipeline):
+
+```
+.local/audits/coverity/triage/<phase>/cid-<CID>/
+    analyzers/        # per-model output (glm, kimi, qwen, ...)
+    decision.json     # consensus or override decision
+    comment.txt       # ASCII-only comment posted to Coverity
+    fix.commit        # if TRUE_BUG_*: SHA of the fix commit
+```
+
+### Step 4 — finalize on Coverity
+
+Once verdict + comment + (optional) fix commit are in place:
+
+```
+bash .agents/skills/coverity-audit/scripts/finalize-defect.sh \
+    <CID> <VERDICT> <PHASE> .local/audits/coverity/triage/<phase>/cid-<CID>/comment.txt \
+    [<commit-sha>]
+```
+
+This:
+- Skips silently for `NEEDS_HUMAN` and `CODE_GONE`.
+- Reads `displayImpact` from the table-fetch artifacts to derive severity.
+- Appends `Fix commit: <sha>` to the comment when a SHA is given.
+- Posts the JSON to `/sourcebrowser/updatedefecttriage.json`.
+
+## ASCII-only comments — non-negotiable
+
+Coverity Scan sits behind Cloudflare. The WAF rejects bodies containing
+non-ASCII bytes (em-dashes, smart quotes, accented letters) with a 403
+Cloudflare challenge that looks like an expired-session error but isn't.
+
+- Use `--` instead of em-dash (U+2014).
+- Use straight quotes `"` `'` instead of smart quotes.
+- The scripts reject non-ASCII before the network round-trip.
+
+## Failure modes — quick diagnosis
+
+| Symptom                                            | Likely cause                                  |
+|----------------------------------------------------|-----------------------------------------------|
+| HTTP 401 / 403 / 302 → HTML response               | Session expired. Recapture cookie from browser. |
+| HTTP 403 with Cloudflare challenge HTML            | Either non-ASCII in comment, or browser tab closed. |
+| keepalive.sh exits non-zero                        | Same as above. Ask user for a fresh cookie.   |
+| HTTP 200 but `defectStatus` empty                  | XSRF token stale. Recapture cookie.            |
+| `Could not parse session from .env`                | Wrong cookie format. Paste the FULL `-b 'k=v; ...'` string. |
+
+## Recurring tips
+
+- The `lastDefectInstanceId` field, NOT `cid`, is what `defectdetails.json` wants.
+- Pages appear paginated server-side. The `pageSize` is fixed by the view; use
+  `totalCount / pageSize` for `<pages>` in `fetch-table.sh`.
+- Coverity caches results aggressively; if a CID disappears from "Outstanding"
+  immediately after finalize, a fresh fetch can take a few seconds to reflect.
+- Idempotence: `fetch-details.sh` skips files already present, so partial runs
+  are safe to re-invoke.

--- a/.agents/skills/coverity-audit/SKILL.md
+++ b/.agents/skills/coverity-audit/SKILL.md
@@ -360,9 +360,12 @@ After review and (if needed) a fix commit:
 
 ```
 bash .agents/skills/coverity-audit/scripts/finalize-defect.sh \
-    <CID> <VERDICT> <SCOPE> .local/audits/coverity/triage/<scope>/cid-<N>/comment.txt \
+    <CID> <VERDICT> <scope> .local/audits/coverity/triage/<scope>/cid-<N>/comment.txt \
     [<commit-sha>]
 ```
+
+`<scope>` is the same name `prepare-defect.sh` uses (e.g. `outstanding`,
+`dismissed`, `fixed`, `unclassified`).
 
 This:
 - Skips silently for `NEEDS_HUMAN` and `CODE_GONE`.
@@ -370,9 +373,9 @@ This:
 - Appends `Fix commit: <sha>` to the comment when a SHA is given.
 - Posts JSON to `/sourcebrowser/updatedefecttriage.json`.
 
-For phases other than "outstanding" (re-triaging dismissed/fixed/etc.),
-finalize-defect only acts when the new verdict disagrees with the existing
-classification — caller's responsibility to assert that.
+For scopes other than "outstanding" (re-triaging dismissed/fixed/etc.),
+finalize-defect prints a warning -- the caller is asserting that the new
+verdict disagrees with the existing classification. It still applies.
 
 ---
 

--- a/.agents/skills/coverity-audit/SKILL.md
+++ b/.agents/skills/coverity-audit/SKILL.md
@@ -1,60 +1,93 @@
 ---
 name: coverity-audit
-description: Triage Coverity Scan defects (https://scan.coverity.com) for this project — fetch outstanding/dismissed/fixed defects, run multi-model analysis, finalize verdicts (Bug / FalsePositive / Intentional) on the upstream tracker. Use when the user asks to "review Coverity defects", "triage Coverity findings", "fetch Coverity outstanding", or anything mentioning Coverity Scan, CIDs, or the scan.coverity.com web UI.
+description: Triage Coverity Scan defects (https://scan.coverity.com) for this project — fetch defect lists, fetch per-defect details, and apply triage decisions (Bug / FalsePositive / Intentional with severity, action, and a comment). Use when the user asks to "review Coverity defects", "triage Coverity findings", "fetch Coverity outstanding", or anything mentioning Coverity Scan, CIDs, or scan.coverity.com.
 ---
 
 # Coverity Scan triage skill
 
-This skill drives the Coverity Scan unofficial JSON API to fetch defect lists,
-fetch per-defect details, and apply triage decisions (classification, severity,
-action, comment). The Coverity Scan **public** site has no documented API; the
-scripts here mimic what the browser does.
+This skill drives the Coverity Scan unofficial JSON API (the public site has
+no documented API — the scripts mimic what the browser does) for the project
+configured in `.env`. Scripts auto-detect the repo root and write all
+artifacts under `<repo-root>/.local/audits/coverity/`.
 
-The skill operates on the project configured in `.env` (see Setup). Scripts
-auto-detect the repo root and write all artifacts under `<repo-root>/.local/`.
+The skill captures **operational knowledge** (how the API works, where it
+trips up, what the data means). It does NOT prescribe a review pipeline —
+how you actually triage each defect (single model, multi-model, manual) is
+adhoc; agree the approach with the user up front.
+
+## MANDATORY — keep this skill alive
+
+If you (the agent) discover a new pattern, gotcha, working flow, correction,
+or any piece of knowledge while running this skill — update this `SKILL.md`
+AND commit it BEFORE proceeding. Knowledge that isn't committed is lost.
+
+Examples of things to capture:
+- New view IDs encountered (and what each represents)
+- New API endpoint or parameter behavior
+- New failure mode (Cloudflare quirks, session expiry signals, rate limits)
+- New FP guardrail you found via the codebase (idiom that Coverity mismodels)
+- New severity / classification mapping detail learned the hard way
+
+---
 
 ## MANDATORY — startup sequence when this skill is invoked
 
 Do these steps in this order. Skipping any step costs the user their session.
 
-### Step 1 — ask the user for a fresh cookie
+### Step 1 — agree the triage approach with the user
+
+Coverity reviews are usually 1-3 defects. Sometimes hundreds. Ask the user:
+
+- "How many defects are we looking at — one specific CID, or a sweep?"
+- "How do you want to review them — you read each one, you spawn one agent
+  per defect, you want me to use multiple models for cross-checking, …?"
+
+Do NOT default to a heavy multi-stage pipeline; that's only worth setting up
+when there are tens of defects to crunch. For small batches a single agent
+or the user reading the bundle directly is usually faster.
+
+If the user does want a multi-model approach, a sensible (not prescribed)
+shape is: cheap models surface ideas, the strongest coding model produces
+the actual analysis + fix, the strongest reviewing model sanity-checks the
+result. The user picks the actual CLIs/models — this skill does not assume
+any specific tool.
+
+### Step 2 — ask the user for a fresh cookie
 
 Coverity Scan auth is cookie-based and tied to a live browser session. Give
-the user the exact recipe (verbatim):
+the user the exact recipe:
 
 > 1. Open https://scan.coverity.com/projects/<owner>-<repo>?tab=overview
->    (replace `<owner>-<repo>` with the project slug; e.g. `netdata-netdata`).
+>    (replace `<owner>-<repo>` with the project slug, e.g. `netdata-netdata`).
 > 2. Click **"View Defects"** at the top right -- a new tab opens to
 >    https://scan4.scan.coverity.com/# (or `scanN.scan.coverity.com` --
->    Coverity load-balances across hosts; use whichever URL you land on as
->    `COVERITY_HOST` in `.env`).
+>    Coverity load-balances; use whichever URL you land on as `COVERITY_HOST`).
 > 3. **Keep that tab open the whole time we work.** Closing it kills the
 >    session immediately.
-> 4. Press **F12** to open DevTools, switch to the **Network** tab.
+> 4. Press F12 to open DevTools, switch to the Network tab.
 > 5. Click any defect in the list -- 3-4 requests appear in the Network tab.
-> 6. Right-click any of those requests, select **Copy > Copy as cURL**.
-> 7. Paste the entire curl command back here.
+> 6. Right-click any of those requests, select Copy > **Copy as cURL**.
+> 7. Paste the entire curl command back to me.
 
 If the curl the user pastes does NOT contain a `-b 'cookie=...'` line, ask
-again -- they likely picked "Copy as fetch" or "Copy as Node.js fetch"
-instead of "Copy as cURL".
+again -- they probably picked "Copy as fetch" or "Copy as Node.js fetch".
 
-### Step 2 — save the cookie in `.env`
+### Step 3 — save the cookie in `.env`
 
 Extract the value of the `-b` argument from the user's curl and write/update
 `<repo-root>/.env` with:
 
 ```bash
 COVERITY_COOKIE='<paste-the-entire-cookie-blob-here>'
-COVERITY_PROJECT_ID=<numeric-projectId-from-the-URL>
-COVERITY_VIEW_OUTSTANDING=<viewId-of-the-Outstanding-view>
+COVERITY_PROJECT_ID=<numeric projectId from the URL or table.json query>
+COVERITY_VIEW_OUTSTANDING=<viewId of the Outstanding view>
 COVERITY_HOST=https://scan4.scan.coverity.com
 ```
 
 `.env` is gitignored. The cookie blob must include both `COVJSESSIONID-build`
 and `XSRF-TOKEN`. The scripts extract `XSRF-TOKEN` automatically.
 
-### Step 3 — start the keepalive (background)
+### Step 4 — start the keepalive (background)
 
 ```
 Bash tool with run_in_background=true,
@@ -63,118 +96,232 @@ command="bash .agents/skills/coverity-audit/scripts/keepalive.sh"
 
 The keepalive **exits non-zero the moment a ping fails** (session expired,
 browser tab closed, cookie went bad). The orchestrator's background-task
-notification fires immediately so you know to ask the user for a fresh cookie
-and restart from Step 1.
+notification fires immediately so you know to ask for a fresh cookie and
+restart.
 
 **Stop the keepalive at the end of the triage session** by killing its
 background task.
 
-### Step 4 — proceed with the actual triage work
+### Step 5 — proceed with the actual triage work
 
-Now and only now is it safe to fetch tables, fetch details, run analyzers,
-finalize defects.
+Now (and only now) is it safe to fetch tables, fetch details, prepare
+defect bundles, finalize verdicts.
 
-## MANDATORY — keep this skill alive
+---
 
-**If you (the agent) discover a new pattern, gotcha, working flow, correction,
-or any piece of knowledge while running this skill — update this `SKILL.md`
-AND commit it BEFORE proceeding. Knowledge that isn't committed is lost.**
+## CRITICAL — server-side view state
 
-Examples of things to capture:
-- New verdict mapping discovered
-- New API endpoint/parameter that was undocumented
-- New failure mode (Cloudflare quirks, session-expiry signals, rate limits)
-- New scrape pattern for displayImpact, owner, history, etc.
+Coverity's table API has a **stateful, server-side view cursor**. The
+`/views/table.json` POST changes server-state (which page is "current"),
+then the `/reports/table.json` GET reads whatever the current state is.
 
-## Setup
+This has two consequences:
 
-### 1. Browser tab — must stay open
+### 1. Pagination is two-step, not one-shot
 
-Coverity authentication is cookie-based and tied to a live browser session.
-**The Coverity Scan tab must remain open in the user's browser for the
-entire triage run.** Closing the tab kills the cookie, no amount of
-keepalive pings can revive it.
+Per page:
+1. `POST /views/table.json {projectId, viewId, pageNum}` -- moves the cursor
+2. `GET /reports/table.json?projectId=...&viewId=...` -- reads the page
 
-### 2. Capture the cookie
+`fetch-table.sh` handles both steps and the page loop.
 
-Ask the user (Costa) to:
+### 2. **The user MUST NOT touch the Coverity UI while a fetch is running**
 
-1. Open https://scan.coverity.com and navigate to the project's defects view.
-2. Open DevTools → Network panel.
-3. Click any request to `*.scan.coverity.com` (e.g. the `table.json` XHR).
-4. Right-click → **Copy → Copy as cURL**.
-5. Paste the entire curl command somewhere the agent can read it (the chat,
-   a temp file). The agent will extract the `-b 'cookie=...'` value.
+If the user clicks a different view, scrolls to a different page, sorts a
+column, applies a filter — the server-side cursor moves under our scripts'
+feet. The scripts will then fetch garbage (rows from whatever view the user
+just opened, not the view the script asked for).
 
-The agent then writes `<repo-root>/.env` (gitignored) with:
+Tell the user explicitly: "I'm about to fetch the defect list. Don't click
+in the Coverity tab until I say I'm done."
 
-```bash
-# Coverity Scan
-COVERITY_COOKIE='<paste the entire single-quoted cookie string from the curl -b argument>'
-COVERITY_PROJECT_ID=<numeric projectId — find it in the URL or table.json query>
-COVERITY_VIEW_OUTSTANDING=<viewId of the "Outstanding" view, optional but recommended>
-# COVERITY_HOST defaults to https://scan4.scan.coverity.com — override only if Coverity routed you elsewhere
+If the user accidentally interferes, re-run the fetch script — it's
+idempotent on cached pages but not on already-corrupted ones, so delete the
+output JSONs and re-fetch from page 1.
+
+---
+
+## Coverity views (queue scopes)
+
+Coverity organizes defects into named **views**, each with a numeric
+`viewId`. The skill operates per-view.
+
+### How to find a view's ID
+
+In the Coverity UI:
+- Click the project's defects view, then the view selector dropdown.
+- Each view has a URL like `https://scan4.scan.coverity.com/#viewId=NNNNN`.
+- That `NNNNN` is the value to put in `.env` (or pass to `fetch-table.sh`).
+
+### Common view types you'll encounter
+
+The default project ships with these (the IDs are project-specific):
+
+- **Outstanding** — the live queue: defects neither classified nor dismissed.
+  Where day-to-day triage happens. Save its viewId as
+  `COVERITY_VIEW_OUTSTANDING` (also used by the keepalive).
+- **All in project** — every defect, including already-classified ones.
+  Useful for batch rescans or full audits.
+- **Dismissed** — defects classified as False Positive / Intentional and
+  ignored. Useful for re-review when the underlying code changed.
+- **Fixed** — defects Coverity now considers fixed. Verification queue.
+- **Unclassified non-outstanding** — corner cases.
+
+When a user asks you to operate on a non-default view, ask them to give you
+its viewId from the UI. You can have multiple `COVERITY_VIEW_*` env vars.
+
+### Switching views without confusing the cursor
+
+The view-state cursor described above is **per-session**. If you want to
+fetch view A then view B, do them sequentially (not concurrently): each
+`fetch-table.sh` call sends its own POST that resets the cursor. There is
+no need to "go back" -- just call it again with the next viewId.
+
+---
+
+## Coverity attribute reference
+
+Triage values are sent as integer **attribute IDs**, not names:
+
+### Classification (attribute 3)
+
+| ID | Name           |
+|----|----------------|
+| 20 | Unclassified   |
+| 21 | Pending        |
+| 22 | False Positive |
+| 23 | Intentional    |
+| 24 | Bug            |
+
+### Severity (attribute 1)
+
+| ID | Name        |
+|----|-------------|
+| 10 | Unspecified |
+| 11 | Major       |
+| 12 | Moderate    |
+| 13 | Minor       |
+
+### Action (attribute 2)
+
+| ID | Name              |
+|----|-------------------|
+|  1 | Undecided         |
+|  2 | Fix Required      |
+|  3 | Fix Submitted     |
+|  4 | Modeling Required |
+|  5 | Ignore            |
+
+### External reference (attribute 4)
+
+Free-form string. The scripts always send `null`.
+
+### Sensible (verdict → attributes) mappings
+
+These are what `finalize-defect.sh` applies when given a verdict from the
+suggested vocabulary below:
+
+| Outcome           | classification (3) | action (2) |
+|-------------------|--------------------|------------|
+| Real bug, fixed   | 24 Bug             | 3 Fix Submitted |
+| False positive    | 22 False Positive  | 5 Ignore       |
+| Cosmetic / harmless | 23 Intentional   | 5 Ignore       |
+
+### Coverity displayImpact → severity ID
+
+`finalize-defect.sh` maps `defect-summary.json#displayImpact` to severity:
+
+| displayImpact | severity ID | name        |
+|---------------|-------------|-------------|
+| `High`        | 11          | Major       |
+| `Medium`      | 12          | Moderate    |
+| `Low`         | 13          | Minor       |
+| `null` / missing | 10       | Unspecified |
+
+---
+
+## Suggested verdict vocabulary
+
+This is the taxonomy used historically; you can reuse it or replace it. The
+`finalize-defect.sh` script understands these names directly:
+
+### Real bugs (classification = 24 Bug, action = 3 Fix Submitted)
+
+| Verdict                       | When to use                                                          |
+|-------------------------------|----------------------------------------------------------------------|
+| `TRUE_BUG_MEMORY_CORRUPTION`  | OOB read/write, UAF, double-free, type confusion, stack-escape UAF.  |
+| `TRUE_BUG_CRASH`              | Reachable NULL deref / div-by-zero / assert / fatal. No corruption.  |
+| `TRUE_BUG_RESOURCE_LEAK`      | fd / memory / lock / refcount leak that accumulates on a reachable path. |
+| `TRUE_BUG_LOGIC`              | Wrong result, wrong metric, wrong stored/transmitted data. No crash. |
+| `TRUE_BUG_UB`                 | Spec-UB (signed overflow, strict aliasing) compiles today but latent.|
+
+### False positives (classification = 22 FP, action = 5 Ignore)
+
+| Verdict                          | When to use                                                  |
+|----------------------------------|--------------------------------------------------------------|
+| `FALSE_POSITIVE_GUARD_EXISTS`    | The code has a check Coverity failed to track.               |
+| `FALSE_POSITIVE_UNREACHABLE`     | The flagged path cannot be reached under any realistic state.|
+| `FALSE_POSITIVE_TRUSTED_INPUT`   | Tainted source is actually trusted (root-owned local file).  |
+| `FALSE_POSITIVE_TOOL_MODEL`      | Coverity's semantic model is wrong (e.g. doesn't know `mallocz` cannot return NULL). |
+| `IMPOSSIBLE_CONDITIONS`          | Combination of states existing invariants prevent.           |
+
+### Cosmetic (classification = 23 Intentional, action = 5 Ignore)
+
+| Verdict     | When to use                                                  |
+|-------------|--------------------------------------------------------------|
+| `COSMETIC`  | Not a bug: unused value, dead branch, redundant expression.  |
+
+### Bookkeeping (no Coverity update)
+
+| Verdict       | When to use                                                            |
+|---------------|------------------------------------------------------------------------|
+| `CODE_GONE`   | The flagged file/function no longer exists. (`finalize-defect.sh` skips.) |
+| `NEEDS_HUMAN` | Genuinely unsure after reasonable investigation. (`finalize-defect.sh` skips.) |
+
+---
+
+## Per-defect workdir convention
+
+`prepare-defect.sh` creates a per-defect directory under
+`.local/audits/coverity/triage/<scope>/cid-<N>/` with:
+
+- `defect-summary.json` — the row from the table dump
+- `defect-details.json` — the per-defect details (event trace, CWE, checker)
+- `source-context.c` — ~150 lines of source around the main event
+- `TODO.md` — per-defect notes; keep all per-defect artifacts inside
+
+Whatever review approach the user picks, write its outputs here too (e.g.
+analyzer reports, decider reasoning, commit message draft, build-verify
+log). Don't pile per-defect stuff at the repo root.
+
+---
+
+## CID vs defectInstanceId
+
+Two IDs for one defect, both flying around the API:
+
+- **`cid`** is stable across scans. Use it for tracking, comments, your
+  permanent records.
+- **`defectInstanceId`** is per-scan. The `defectdetails.json` endpoint
+  takes a `defectInstanceId`, NOT a `cid`. Each `table.json` row carries the
+  current `lastDefectInstanceId` for its CID.
+
+When all you have is a CID (e.g. you're acting on an old list, or working
+from external triage notes), use:
+
+```
+bash .agents/skills/coverity-audit/scripts/resolve-cid-to-diid.sh <cid>
+# prints the current defectInstanceId, or "GONE" if Coverity no longer reports it
 ```
 
-The cookie blob must include both the session id (`COVJSESSIONID-build=...`)
-and the CSRF token (`XSRF-TOKEN=...`). The scripts extract `XSRF-TOKEN` from
-the cookie automatically.
+Internally it queries `/reports/defects.json?cid=N` and parses
+`defectInstanceId` out of the returned `.url` field.
 
-### 3. Start the keepalive (background)
-
-Run `keepalive.sh` as a background task at the start of the triage session:
-
-```
-Bash tool with run_in_background=true,
-command="bash .agents/skills/coverity-audit/scripts/keepalive.sh"
-```
-
-It pings every 5 minutes (`PING_INTERVAL=300`) and exits non-zero the moment
-the session goes bad — that's the signal to ask the user for a fresh cookie.
-
-**Stop** the keepalive at the end of the session.
-
-## Verdict enum
-
-These are the only valid verdicts. The mapping to Coverity attributes lives
-in `scripts/finalize-defect.sh`:
-
-| Verdict                          | Coverity classification | Action          |
-|----------------------------------|-------------------------|-----------------|
-| TRUE_BUG_MEMORY_CORRUPTION       | Bug (24)                | Fix Submitted (3) |
-| TRUE_BUG_CRASH                   | Bug (24)                | Fix Submitted (3) |
-| TRUE_BUG_RESOURCE_LEAK           | Bug (24)                | Fix Submitted (3) |
-| TRUE_BUG_LOGIC                   | Bug (24)                | Fix Submitted (3) |
-| TRUE_BUG_UB                      | Bug (24)                | Fix Submitted (3) |
-| FALSE_POSITIVE_GUARD_EXISTS      | False Positive (22)     | Ignore (5)        |
-| FALSE_POSITIVE_UNREACHABLE       | False Positive (22)     | Ignore (5)        |
-| FALSE_POSITIVE_TRUSTED_INPUT     | False Positive (22)     | Ignore (5)        |
-| FALSE_POSITIVE_TOOL_MODEL        | False Positive (22)     | Ignore (5)        |
-| IMPOSSIBLE_CONDITIONS            | False Positive (22)     | Ignore (5)        |
-| COSMETIC                         | Intentional (23)        | Ignore (5)        |
-| NEEDS_HUMAN                      | (no-op — flag for the user) |
-| CODE_GONE                        | (no-op when refactor removed the path; map to FalsePositive+Ignore in pipeline) |
-
-Severity (Coverity's displayImpact -> attribute 1):
-- High -> 11 (Major), Medium -> 12 (Moderate), Low -> 13 (Minor),
-  unknown -> 10 (Unspecified)
-
-## Phases (queue scopes)
-
-When walking the defect tracker, group work by phase:
-
-1. **Outstanding** — the live queue. Default; verdicts always applied.
-2. **Old / dismissed** — previously closed. Apply a verdict only if it
-   *disagrees* with the existing classification.
-3. **Fixed** — already fixed in code. Verify, usually no-op.
-4. **Unclassified non-outstanding** — corner cases.
-5. **Re-runs** — anything we previously triaged that has resurfaced.
+---
 
 ## Workflow
 
-### Step 1 — fetch the table (per phase)
-
-Inspect the Coverity UI, count pages for the view, then:
+### Fetch a view's table
 
 ```
 bash .agents/skills/coverity-audit/scripts/fetch-table.sh \
@@ -183,45 +330,51 @@ bash .agents/skills/coverity-audit/scripts/fetch-table.sh \
 
 Produces `.local/audits/coverity/raw/outstanding-page1.json` ... and a
 combined flat array at `.local/audits/coverity/raw/outstanding-all.json`.
+Pass the right page count (visible in the UI) for the view.
 
-### Step 2 — fetch per-defect details
+**Reminder**: the user must not touch the UI during a fetch.
+
+### Fetch per-defect details
 
 ```
 bash .agents/skills/coverity-audit/scripts/fetch-details.sh \
     .local/audits/coverity/raw/outstanding-all.json \
-    .local/audits/coverity/details
+    .local/audits/coverity/details/outstanding
 ```
 
-One file per CID at `.local/audits/coverity/details/cid-<CID>.json`.
+One file per CID at `<details>/cid-<N>.json`. Idempotent.
 
-### Step 3 — triage one defect
-
-For each CID, the orchestrator drives a multi-model verdict. Suggested layout
-(matches the established pipeline):
+### Bundle a defect for review
 
 ```
-.local/audits/coverity/triage/<phase>/cid-<CID>/
-    analyzers/        # per-model output (glm, kimi, qwen, ...)
-    decision.json     # consensus or override decision
-    comment.txt       # ASCII-only comment posted to Coverity
-    fix.commit        # if TRUE_BUG_*: SHA of the fix commit
+bash .agents/skills/coverity-audit/scripts/prepare-defect.sh <CID> outstanding
 ```
 
-### Step 4 — finalize on Coverity
+Creates `.local/audits/coverity/triage/outstanding/cid-<N>/` with the bundle.
+The actual review (single-model, multi-model, human) is **adhoc** — agree
+the approach with the user.
 
-Once verdict + comment + (optional) fix commit are in place:
+### Apply a verdict
+
+After review and (if needed) a fix commit:
 
 ```
 bash .agents/skills/coverity-audit/scripts/finalize-defect.sh \
-    <CID> <VERDICT> <PHASE> .local/audits/coverity/triage/<phase>/cid-<CID>/comment.txt \
+    <CID> <VERDICT> <SCOPE> .local/audits/coverity/triage/<scope>/cid-<N>/comment.txt \
     [<commit-sha>]
 ```
 
 This:
 - Skips silently for `NEEDS_HUMAN` and `CODE_GONE`.
-- Reads `displayImpact` from the table-fetch artifacts to derive severity.
+- Reads `displayImpact` from the table dump to derive severity.
 - Appends `Fix commit: <sha>` to the comment when a SHA is given.
-- Posts the JSON to `/sourcebrowser/updatedefecttriage.json`.
+- Posts JSON to `/sourcebrowser/updatedefecttriage.json`.
+
+For phases other than "outstanding" (re-triaging dismissed/fixed/etc.),
+finalize-defect only acts when the new verdict disagrees with the existing
+classification — caller's responsibility to assert that.
+
+---
 
 ## ASCII-only comments — non-negotiable
 
@@ -233,22 +386,85 @@ Cloudflare challenge that looks like an expired-session error but isn't.
 - Use straight quotes `"` `'` instead of smart quotes.
 - The scripts reject non-ASCII before the network round-trip.
 
+---
+
+## Project-specific FP guardrails (Netdata)
+
+Most of the cost of a Coverity audit is rejecting false positives. Before
+calling something a bug in this codebase, rule out these idioms — Coverity
+mis-models all of them:
+
+1. **`z`-suffix allocators never fail.** `mallocz`, `callocz`, `reallocz`,
+   `strdupz`, `strndupz`, `mallocz_flex` call `fatal()` on OOM. They cannot
+   return NULL. Any "possible NULL deref after `mallocz`" warning is FP.
+2. **`freez(NULL)` is safe.** Same for `string_freez`, etc.
+3. **`DOUBLE_LINKED_LIST_*` macros** (`libnetdata/linked-lists.h`) manage
+   prev/next with their own invariants. Raw pointer manipulation inside
+   them is expected.
+4. **`buffer_*` API** (`libnetdata/buffer/`) auto-grows the underlying
+   `buffer->buffer[]` on write. Direct indexing of `buffer->buffer[N]` from
+   callers is the risk, not the API.
+5. **`STRING` is refcounted and interned** (`libnetdata/string/`).
+   `string_strdupz` increments refcount on an existing intern;
+   `string_dup` acquires a new reference. Mixing them is a refcount bug.
+6. **`ARAL` is a slab allocator** (`libnetdata/aral/`). Objects are reused
+   — UAF looks different here: the same address is re-issued. A pointer
+   that "still works" after `aral_freez` may be a reused object.
+7. **`DICTIONARY`** has `dictionary_acquired_item_get` / `_release` with
+   refcounts. Raw access bypasses the refcount.
+8. **Custom locks** (`spinlock_lock`, `rw_spinlock_*`) — not pthread.
+   Coverity MISSING_LOCK warnings often misunderstand them.
+9. **Platform**: glibc + musl. Watch glibc-only assumptions
+   (e.g. `strerror_r` signature).
+10. **Compilers**: gcc + clang both must compile.
+11. **Process model**: long-running daemon, spawns plugin subprocesses over
+    a line-based stdin/stdout protocol. Plugin stdin is typically trusted;
+    streaming peers are UNTRUSTED remote peers over TCP.
+
+---
+
+## Input trust boundaries (Netdata)
+
+Used to decide whether a tainted-data path is `FALSE_POSITIVE_TRUSTED_INPUT`:
+
+| Source                       | Trust                          | Module                             |
+|------------------------------|--------------------------------|------------------------------------|
+| Local `/proc`, `/sys`        | Trusted (root-owned)           | `collectors/proc.plugin/`, `cgroups.plugin/` |
+| Plugin stdin (our plugins)   | Trusted                        | `plugins.d/`, `collectors/*.plugin/` |
+| Streaming peer (remote agent)| **UNTRUSTED**                  | `streaming/`, `stream-*`            |
+| HTTP request (dashboard API) | Semi-trusted (usually localhost) | `web/api/`, `web/server/`         |
+| MCP request                  | Semi-trusted (localhost)       | `web/mcp/`                          |
+| Cloud (aclk)                 | Trusted (TLS + token to Netdata Cloud) | `aclk/`                    |
+| Config files                 | Trusted (root-owned)           | `daemon/config/`, `health/`         |
+
+---
+
 ## Failure modes — quick diagnosis
 
-| Symptom                                            | Likely cause                                  |
-|----------------------------------------------------|-----------------------------------------------|
-| HTTP 401 / 403 / 302 → HTML response               | Session expired. Recapture cookie from browser. |
-| HTTP 403 with Cloudflare challenge HTML            | Either non-ASCII in comment, or browser tab closed. |
-| keepalive.sh exits non-zero                        | Same as above. Ask user for a fresh cookie.   |
-| HTTP 200 but `defectStatus` empty                  | XSRF token stale. Recapture cookie.            |
-| `Could not parse session from .env`                | Wrong cookie format. Paste the FULL `-b 'k=v; ...'` string. |
+| Symptom                                              | Likely cause                                                |
+|------------------------------------------------------|-------------------------------------------------------------|
+| HTTP 401 / 403 / 302, response is HTML               | Session expired. Recapture cookie from browser.             |
+| HTTP 403 with Cloudflare challenge HTML              | Either non-ASCII in comment, or browser tab closed.         |
+| keepalive.sh exits non-zero                          | Same as above. Ask user for a fresh cookie.                 |
+| HTTP 200 but `defectStatus` empty                    | XSRF token stale. Recapture cookie.                         |
+| `Could not parse session from .env`                  | Wrong cookie format. Paste the FULL `-b 'k=v; ...'` string. |
+| Fetched rows look wrong (different view)             | User clicked in the UI mid-fetch. Delete output JSONs and re-fetch. |
+| `.url` field missing in `/reports/defects.json` reply | Coverity no longer reports this CID -- treat as `CODE_GONE`. |
+| Cookie expires in mid-run despite keepalive          | Browser tab was closed. Reopen the tab and recapture cookie. |
+
+---
 
 ## Recurring tips
 
 - The `lastDefectInstanceId` field, NOT `cid`, is what `defectdetails.json` wants.
-- Pages appear paginated server-side. The `pageSize` is fixed by the view; use
-  `totalCount / pageSize` for `<pages>` in `fetch-table.sh`.
 - Coverity caches results aggressively; if a CID disappears from "Outstanding"
   immediately after finalize, a fresh fetch can take a few seconds to reflect.
 - Idempotence: `fetch-details.sh` skips files already present, so partial runs
   are safe to re-invoke.
+- `prepare-defect.sh` uses Coverity's `displayFile` and the main-event line
+  to extract source context. If Coverity's line numbers are stale (after a
+  refactor), the context may not center on the current code -- use it as a
+  hint, not an authoritative location.
+- Coverity load-balances across `scanN.scan.coverity.com` hosts. Whatever
+  hostname your browser landed on must be the one in `COVERITY_HOST`;
+  cookies are per-host.

--- a/.agents/skills/coverity-audit/scripts/_lib.sh
+++ b/.agents/skills/coverity-audit/scripts/_lib.sh
@@ -5,10 +5,16 @@
 set -euo pipefail
 
 # ANSI colors for transparent output (per the project's run() pattern).
+# These are referenced by sourcing scripts; shellcheck cannot see that.
+# shellcheck disable=SC2034
 COV_RED='\033[0;31m'
+# shellcheck disable=SC2034
 COV_GREEN='\033[0;32m'
+# shellcheck disable=SC2034
 COV_YELLOW='\033[1;33m'
+# shellcheck disable=SC2034
 COV_GRAY='\033[0;90m'
+# shellcheck disable=SC2034
 COV_NC='\033[0m'
 
 # Locate the repo root by walking up from the script directory.
@@ -34,8 +40,10 @@ cov_load_env() {
         echo -e "${COV_RED}[ERROR]${COV_NC} Missing ${env}. See SKILL.md for the .env template." >&2
         return 1
     fi
+    set -a
     # shellcheck disable=SC1090
-    set -a; source "${env}"; set +a
+    source "${env}"
+    set +a
 
     : "${COVERITY_COOKIE:?COVERITY_COOKIE is empty in .env — paste a fresh cookie from the browser}"
     : "${COVERITY_PROJECT_ID:?COVERITY_PROJECT_ID is empty in .env}"
@@ -67,10 +75,23 @@ cov_audit_dir() {
 # Reject non-ASCII bytes in a string. Coverity's edge (Cloudflare) rejects
 # em-dashes and smart quotes with a 403 challenge; far better to fail before
 # the network round-trip than to debug a Cloudflare block.
+#
+# `tr -d '\000-\177'` deletes ALL ASCII bytes; anything left is non-ASCII.
+# This is portable across GNU and BSD/macOS (unlike `grep -P`, which is GNU-only).
 cov_require_ascii() {
     local s="$1"
-    if LC_ALL=C grep -qP '[^\x00-\x7F]' <<< "${s}"; then
+    if LC_ALL=C printf '%s' "${s}" | LC_ALL=C tr -d '\000-\177' | grep -q .; then
         echo -e "${COV_RED}[ERROR]${COV_NC} Comment contains non-ASCII characters. Cloudflare blocks them. Replace em-dashes with '--' and curly quotes with straight quotes." >&2
+        return 1
+    fi
+}
+
+# CID validation: Coverity CIDs are positive integers. Reject anything else
+# before interpolating into jq filters, URLs, or paths.
+cov_require_numeric_cid() {
+    local cid="$1"
+    if [[ ! "${cid}" =~ ^[0-9]+$ ]]; then
+        echo -e "${COV_RED}[ERROR]${COV_NC} CID must be a positive integer, got: '${cid}'" >&2
         return 1
     fi
 }

--- a/.agents/skills/coverity-audit/scripts/_lib.sh
+++ b/.agents/skills/coverity-audit/scripts/_lib.sh
@@ -43,7 +43,7 @@ cov_load_env() {
     local root env
     root="$(cov_repo_root)"
     env="${root}/.env"
-    if [[ ! -r "${env}" ]]; then
+    if [[ ! -f "${env}" || ! -r "${env}" ]]; then
         echo -e "${COV_RED}[ERROR]${COV_NC} Missing ${env}. See SKILL.md for the .env template." >&2
         return 1
     fi

--- a/.agents/skills/coverity-audit/scripts/_lib.sh
+++ b/.agents/skills/coverity-audit/scripts/_lib.sh
@@ -53,11 +53,15 @@ cov_load_env() {
 }
 
 # Audit artifacts go under .local/audits/coverity/ at the repo root.
-# .local/ is gitignored — see AGENTS.md for the convention.
+# .local/ is gitignored -- see AGENTS.md for the convention.
+# Creates the directory on first call so callers can redirect output into
+# subpaths without thinking about it.
 cov_audit_dir() {
-    local root
+    local root dir
     root="$(cov_repo_root)"
-    echo "${root}/.local/audits/coverity"
+    dir="${root}/.local/audits/coverity"
+    mkdir -p "${dir}"
+    echo "${dir}"
 }
 
 # Reject non-ASCII bytes in a string. Coverity's edge (Cloudflare) rejects

--- a/.agents/skills/coverity-audit/scripts/_lib.sh
+++ b/.agents/skills/coverity-audit/scripts/_lib.sh
@@ -5,17 +5,24 @@
 set -euo pipefail
 
 # ANSI colors for transparent output (per the project's run() pattern).
-# These are referenced by sourcing scripts; shellcheck cannot see that.
+#
+# IMPORTANT: define with $'...' so the variables contain real ESC bytes,
+# not the literal four-character string "\033". This way both `echo -e
+# "${COV_RED}..."` and `printf '%s' "${COV_RED}..."` render correctly --
+# without forcing every printf format string to be the variable itself
+# (which trips shellcheck SC2059) or %b (which adds inconsistency).
+#
+# Color vars are referenced by sourcing scripts; shellcheck cannot see that.
 # shellcheck disable=SC2034
-COV_RED='\033[0;31m'
+COV_RED=$'\033[0;31m'
 # shellcheck disable=SC2034
-COV_GREEN='\033[0;32m'
+COV_GREEN=$'\033[0;32m'
 # shellcheck disable=SC2034
-COV_YELLOW='\033[1;33m'
+COV_YELLOW=$'\033[1;33m'
 # shellcheck disable=SC2034
-COV_GRAY='\033[0;90m'
+COV_GRAY=$'\033[0;90m'
 # shellcheck disable=SC2034
-COV_NC='\033[0m'
+COV_NC=$'\033[0m'
 
 # Locate the repo root by walking up from the script directory.
 # This way the scripts work no matter where the user runs them from.
@@ -47,6 +54,10 @@ cov_load_env() {
 
     : "${COVERITY_COOKIE:?COVERITY_COOKIE is empty in .env — paste a fresh cookie from the browser}"
     : "${COVERITY_PROJECT_ID:?COVERITY_PROJECT_ID is empty in .env}"
+    if [[ ! "${COVERITY_PROJECT_ID}" =~ ^[1-9][0-9]*$ ]]; then
+        echo -e "${COV_RED}[ERROR]${COV_NC} COVERITY_PROJECT_ID must be a positive integer, got: '${COVERITY_PROJECT_ID}'" >&2
+        return 1
+    fi
     : "${COVERITY_HOST:=https://scan4.scan.coverity.com}"
     : "${COVERITY_USER_AGENT:=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36}"
     export COVERITY_COOKIE COVERITY_PROJECT_ID COVERITY_HOST COVERITY_USER_AGENT
@@ -86,11 +97,11 @@ cov_require_ascii() {
     fi
 }
 
-# CID validation: Coverity CIDs are positive integers. Reject anything else
-# before interpolating into jq filters, URLs, or paths.
+# CID validation: Coverity CIDs are positive integers (>= 1). Reject anything
+# else before interpolating into jq filters, URLs, or paths.
 cov_require_numeric_cid() {
     local cid="$1"
-    if [[ ! "${cid}" =~ ^[0-9]+$ ]]; then
+    if [[ ! "${cid}" =~ ^[1-9][0-9]*$ ]]; then
         echo -e "${COV_RED}[ERROR]${COV_NC} CID must be a positive integer, got: '${cid}'" >&2
         return 1
     fi

--- a/.agents/skills/coverity-audit/scripts/_lib.sh
+++ b/.agents/skills/coverity-audit/scripts/_lib.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Common helpers for coverity-audit scripts.
+# Sourced from the per-action scripts; not executed directly.
+
+set -euo pipefail
+
+# ANSI colors for transparent output (per the project's run() pattern).
+COV_RED='\033[0;31m'
+COV_GREEN='\033[0;32m'
+COV_YELLOW='\033[1;33m'
+COV_GRAY='\033[0;90m'
+COV_NC='\033[0m'
+
+# Locate the repo root by walking up from the script directory.
+# This way the scripts work no matter where the user runs them from.
+cov_repo_root() {
+    git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel
+}
+
+# Source `<repo-root>/.env` if it exists. .env is the user's local-only
+# secrets file (gitignored). It must export at least:
+#   COVERITY_COOKIE        — the full Cookie header value pasted from a curl
+#                            copy-as-cURL captured in DevTools
+#   COVERITY_PROJECT_ID    — Coverity Scan numeric projectId (constant per project)
+#   COVERITY_HOST          — defaults to https://scan4.scan.coverity.com
+# Optional:
+#   COVERITY_VIEW_OUTSTANDING — viewId of the Outstanding view
+#   COVERITY_USER_AGENT      — overridable UA string
+cov_load_env() {
+    local root env
+    root="$(cov_repo_root)"
+    env="${root}/.env"
+    if [[ ! -r "${env}" ]]; then
+        echo -e "${COV_RED}[ERROR]${COV_NC} Missing ${env}. See SKILL.md for the .env template." >&2
+        return 1
+    fi
+    # shellcheck disable=SC1090
+    set -a; source "${env}"; set +a
+
+    : "${COVERITY_COOKIE:?COVERITY_COOKIE is empty in .env — paste a fresh cookie from the browser}"
+    : "${COVERITY_PROJECT_ID:?COVERITY_PROJECT_ID is empty in .env}"
+    : "${COVERITY_HOST:=https://scan4.scan.coverity.com}"
+    : "${COVERITY_USER_AGENT:=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36}"
+    export COVERITY_COOKIE COVERITY_PROJECT_ID COVERITY_HOST COVERITY_USER_AGENT
+
+    # Extract XSRF-TOKEN from the cookie string.
+    COVERITY_XSRF="$(printf '%s' "${COVERITY_COOKIE}" | sed -n 's/.*XSRF-TOKEN=\([^;]*\).*/\1/p')"
+    if [[ -z "${COVERITY_XSRF}" ]]; then
+        echo -e "${COV_RED}[ERROR]${COV_NC} XSRF-TOKEN not found inside COVERITY_COOKIE. Did you paste the full Cookie header?" >&2
+        return 1
+    fi
+    export COVERITY_XSRF
+}
+
+# Audit artifacts go under .local/audits/coverity/ at the repo root.
+# .local/ is gitignored — see AGENTS.md for the convention.
+cov_audit_dir() {
+    local root
+    root="$(cov_repo_root)"
+    echo "${root}/.local/audits/coverity"
+}
+
+# Reject non-ASCII bytes in a string. Coverity's edge (Cloudflare) rejects
+# em-dashes and smart quotes with a 403 challenge; far better to fail before
+# the network round-trip than to debug a Cloudflare block.
+cov_require_ascii() {
+    local s="$1"
+    if LC_ALL=C grep -qP '[^\x00-\x7F]' <<< "${s}"; then
+        echo -e "${COV_RED}[ERROR]${COV_NC} Comment contains non-ASCII characters. Cloudflare blocks them. Replace em-dashes with '--' and curly quotes with straight quotes." >&2
+        return 1
+    fi
+}

--- a/.agents/skills/coverity-audit/scripts/fetch-details.sh
+++ b/.agents/skills/coverity-audit/scripts/fetch-details.sh
@@ -17,6 +17,11 @@ cov_load_env
 INPUT="${1:?usage: $0 <input-defects.json> <output-dir>}"
 OUT_DIR="${2:?usage: $0 <input-defects.json> <output-dir>}"
 
+if [[ ! -f "${INPUT}" || ! -r "${INPUT}" ]]; then
+    echo -e "${COV_RED}[ERROR]${COV_NC} input file not a readable regular file: '${INPUT}'" >&2
+    exit 1
+fi
+
 mkdir -p "${OUT_DIR}"
 
 TOTAL="$(jq 'length' "${INPUT}")"

--- a/.agents/skills/coverity-audit/scripts/fetch-details.sh
+++ b/.agents/skills/coverity-audit/scripts/fetch-details.sh
@@ -11,6 +11,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 cov_load_env
 

--- a/.agents/skills/coverity-audit/scripts/fetch-details.sh
+++ b/.agents/skills/coverity-audit/scripts/fetch-details.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Fetch per-defect details from Coverity Scan for each CID in a table.json dump.
+#
+# Usage:
+#   fetch-details.sh <input-defects.json> <output-dir>
+#
+# Reads cookies/XSRF/UA from .env via _lib.sh.
+# For each row, calls /sourcebrowser/defectdetails.json?defectInstanceId=<lastDefectInstanceId>.
+# Skips rows whose output file already exists (idempotent; safe to re-run).
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+cov_load_env
+
+INPUT="${1:?usage: $0 <input-defects.json> <output-dir>}"
+OUT_DIR="${2:?usage: $0 <input-defects.json> <output-dir>}"
+
+mkdir -p "${OUT_DIR}"
+
+TOTAL="$(jq 'length' "${INPUT}")"
+echo -e "${COV_GRAY}Fetching details for ${TOTAL} defects into ${OUT_DIR}${COV_NC}" >&2
+
+i=0
+fetched=0
+skipped=0
+failed=0
+
+while IFS=$'\t' read -r cid defect_instance_id; do
+    i=$((i + 1))
+    out_file="${OUT_DIR}/cid-${cid}.json"
+    if [[ -s "${out_file}" ]]; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+    sleep 0.3
+
+    http_code="$(curl -sS --max-time 30 \
+        -w '%{http_code}' \
+        -o "${out_file}" \
+        -H "accept: application/json, text/plain, */*" \
+        -H "referer: ${COVERITY_HOST}/" \
+        -H "user-agent: ${COVERITY_USER_AGENT}" \
+        -H "x-xsrf-token: ${COVERITY_XSRF}" \
+        -b "${COVERITY_COOKIE}" \
+        "${COVERITY_HOST}/sourcebrowser/defectdetails.json?projectId=${COVERITY_PROJECT_ID}&defectInstanceId=${defect_instance_id}" || echo "000")"
+
+    if [[ "${http_code}" != "200" ]]; then
+        failed=$((failed + 1))
+        echo -e "${COV_RED}[${i}/${TOTAL}] cid=${cid} diid=${defect_instance_id} HTTP=${http_code}${COV_NC}" >&2
+        if [[ "${http_code}" == "401" || "${http_code}" == "403" ]]; then
+            echo -e "${COV_RED}Session likely expired. Recapture cookie from browser, update .env, retry.${COV_NC}" >&2
+            rm -f "${out_file}"
+            exit 2
+        fi
+        rm -f "${out_file}"
+        continue
+    fi
+
+    fetched=$((fetched + 1))
+    if (( i % 20 == 0 )); then
+        echo -e "${COV_GRAY}[${i}/${TOTAL}] fetched=${fetched} skipped=${skipped} failed=${failed}${COV_NC}" >&2
+    fi
+done < <(jq -r '.[] | "\(.cid)\t\(.lastDefectInstanceId)"' "${INPUT}")
+
+echo -e "${COV_GREEN}Done. fetched=${fetched} skipped=${skipped} failed=${failed} total=${TOTAL}${COV_NC}" >&2

--- a/.agents/skills/coverity-audit/scripts/fetch-details.sh
+++ b/.agents/skills/coverity-audit/scripts/fetch-details.sh
@@ -29,6 +29,19 @@ failed=0
 
 while IFS=$'\t' read -r cid defect_instance_id; do
     i=$((i + 1))
+    # cid comes from the input JSON (Coverity-supplied) and lands in the
+    # output filename. Validate numeric before path construction so a
+    # corrupted/manipulated INPUT cannot write outside OUT_DIR.
+    if [[ ! "${cid}" =~ ^[1-9][0-9]*$ ]]; then
+        failed=$((failed + 1))
+        echo -e "${COV_RED}[${i}/${TOTAL}] non-numeric cid in input: '${cid}' -- skipping${COV_NC}" >&2
+        continue
+    fi
+    if [[ ! "${defect_instance_id}" =~ ^[1-9][0-9]*$ ]]; then
+        failed=$((failed + 1))
+        echo -e "${COV_RED}[${i}/${TOTAL}] cid=${cid} non-numeric defectInstanceId: '${defect_instance_id}' -- skipping${COV_NC}" >&2
+        continue
+    fi
     out_file="${OUT_DIR}/cid-${cid}.json"
     if [[ -s "${out_file}" ]]; then
         skipped=$((skipped + 1))

--- a/.agents/skills/coverity-audit/scripts/fetch-table.sh
+++ b/.agents/skills/coverity-audit/scripts/fetch-table.sh
@@ -69,5 +69,13 @@ for page in $(seq 1 "${PAGES}"); do
 done
 
 combined="${PREFIX}-all.json"
-jq -s '[.[].resultSet.results[]]' "${PREFIX}"-page*.json > "${combined}"
+# Build the explicit page-file list. A glob (`-page*.json`) would pick up
+# stale page files from a previous larger fetch (e.g. running with PAGES=5
+# after a prior run with PAGES=7 would merge 7 pages into "all"). Enumerate
+# only the pages we asked for in this invocation.
+page_files=()
+for page in $(seq 1 "${PAGES}"); do
+    page_files+=("${PREFIX}-page${page}.json")
+done
+jq -s '[.[].resultSet.results[]]' "${page_files[@]}" > "${combined}"
 echo -e "${COV_GREEN}Combined $(jq 'length' "${combined}") defects into ${combined}${COV_NC}" >&2

--- a/.agents/skills/coverity-audit/scripts/fetch-table.sh
+++ b/.agents/skills/coverity-audit/scripts/fetch-table.sh
@@ -62,14 +62,27 @@ for page in $(seq 1 "${PAGES}"); do
     fi
 
     # Step 2: fetch the now-current page.
+    # Capture exit status of curl explicitly so a transport failure (timeout,
+    # connection reset, DNS) doesn't leave a non-empty partial file behind
+    # that the next run would treat as cached.
     get_http=$(curl -sS -o "${out}" -w '%{http_code}' \
         -H "accept: application/json, text/plain, */*" \
         -H "referer: ${COVERITY_HOST}/" \
         -H "user-agent: ${COVERITY_USER_AGENT}" \
         -b "${COVERITY_COOKIE}" \
-        "${COVERITY_HOST}/reports/table.json?projectId=${COVERITY_PROJECT_ID}&viewId=${VIEW_ID}")
+        "${COVERITY_HOST}/reports/table.json?projectId=${COVERITY_PROJECT_ID}&viewId=${VIEW_ID}" \
+        || echo "000")
     if [[ "${get_http}" != "200" ]]; then
         echo -e "${COV_RED}[page ${page}] GET failed HTTP=${get_http}${COV_NC}" >&2
+        rm -f "${out}"
+        exit 3
+    fi
+    # Validate response is JSON with the expected shape -- a Cloudflare
+    # challenge or a 200-with-HTML-body would otherwise be cached as
+    # 'valid' and confuse subsequent runs.
+    if ! jq -e '.resultSet.results | type == "array"' "${out}" >/dev/null 2>&1; then
+        echo -e "${COV_RED}[page ${page}] response not in expected shape; first 200 chars:${COV_NC}" >&2
+        head -c 200 "${out}" >&2; echo >&2
         rm -f "${out}"
         exit 3
     fi

--- a/.agents/skills/coverity-audit/scripts/fetch-table.sh
+++ b/.agents/skills/coverity-audit/scripts/fetch-table.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Fetch all pages of a Coverity Scan view table.
+#
+# Usage:
+#   fetch-table.sh <viewId> <pages> <output-prefix>
+# Example:
+#   fetch-table.sh 41549 7 .local/audits/coverity/raw/outstanding
+#
+# Coverity's UI uses two steps per page:
+#   1) POST /views/table.json    {projectId, viewId, pageNum}    -- updates server view state
+#   2) GET  /reports/table.json?projectId=X&viewId=Y             -- fetches rows for current state
+#
+# The script combines all pages into <prefix>-all.json (a flat array).
+# Pages already on disk are skipped (idempotent).
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+cov_load_env
+
+VIEW_ID="${1:?usage: $0 <viewId> <pages> <output-prefix>}"
+PAGES="${2:?usage: $0 <viewId> <pages> <output-prefix>}"
+PREFIX="${3:?usage: $0 <viewId> <pages> <output-prefix>}"
+
+mkdir -p "$(dirname "${PREFIX}")"
+
+for page in $(seq 1 "${PAGES}"); do
+    out="${PREFIX}-page${page}.json"
+    if [[ -s "${out}" ]]; then
+        echo -e "${COV_GRAY}[page ${page}/${PAGES}] cached ${out}${COV_NC}" >&2
+        continue
+    fi
+
+    # Step 1: set server-side page state.
+    post_body="{\"projectId\":${COVERITY_PROJECT_ID},\"viewId\":${VIEW_ID},\"pageNum\":${page}}"
+    post_http=$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+        -H "accept: application/json, text/plain, */*" \
+        -H "content-type: application/json" \
+        -H "origin: ${COVERITY_HOST}" \
+        -H "referer: ${COVERITY_HOST}/" \
+        -H "user-agent: ${COVERITY_USER_AGENT}" \
+        -H "x-xsrf-token: ${COVERITY_XSRF}" \
+        -b "${COVERITY_COOKIE}" \
+        --data-raw "${post_body}" \
+        "${COVERITY_HOST}/views/table.json")
+    if [[ "${post_http}" != "200" ]]; then
+        echo -e "${COV_RED}[page ${page}] POST failed HTTP=${post_http}${COV_NC}" >&2
+        exit 2
+    fi
+
+    # Step 2: fetch the now-current page.
+    get_http=$(curl -sS -o "${out}" -w '%{http_code}' \
+        -H "accept: application/json, text/plain, */*" \
+        -H "referer: ${COVERITY_HOST}/" \
+        -H "user-agent: ${COVERITY_USER_AGENT}" \
+        -b "${COVERITY_COOKIE}" \
+        "${COVERITY_HOST}/reports/table.json?projectId=${COVERITY_PROJECT_ID}&viewId=${VIEW_ID}")
+    if [[ "${get_http}" != "200" ]]; then
+        echo -e "${COV_RED}[page ${page}] GET failed HTTP=${get_http}${COV_NC}" >&2
+        rm -f "${out}"
+        exit 3
+    fi
+
+    count=$(jq '.resultSet.results | length' "${out}")
+    total=$(jq '.resultSet.totalCount' "${out}")
+    echo -e "${COV_GRAY}[page ${page}/${PAGES}] fetched ${count} rows (total=${total})${COV_NC}" >&2
+    sleep 0.3
+done
+
+combined="${PREFIX}-all.json"
+jq -s '[.[].resultSet.results[]]' "${PREFIX}"-page*.json > "${combined}"
+echo -e "${COV_GREEN}Combined $(jq 'length' "${combined}") defects into ${combined}${COV_NC}" >&2

--- a/.agents/skills/coverity-audit/scripts/fetch-table.sh
+++ b/.agents/skills/coverity-audit/scripts/fetch-table.sh
@@ -23,6 +23,18 @@ VIEW_ID="${1:?usage: $0 <viewId> <pages> <output-prefix>}"
 PAGES="${2:?usage: $0 <viewId> <pages> <output-prefix>}"
 PREFIX="${3:?usage: $0 <viewId> <pages> <output-prefix>}"
 
+# View IDs and page counts are positive integers. Reject anything else
+# before the loop -- otherwise non-numeric PAGES would make `seq` produce
+# no output, and the final jq merge would block waiting on stdin.
+if [[ ! "${VIEW_ID}" =~ ^[1-9][0-9]*$ ]]; then
+    echo -e "${COV_RED}[ERROR]${COV_NC} viewId must be a positive integer, got: '${VIEW_ID}'" >&2
+    exit 1
+fi
+if [[ ! "${PAGES}" =~ ^[1-9][0-9]*$ ]]; then
+    echo -e "${COV_RED}[ERROR]${COV_NC} pages must be a positive integer, got: '${PAGES}'" >&2
+    exit 1
+fi
+
 mkdir -p "$(dirname "${PREFIX}")"
 
 for page in $(seq 1 "${PAGES}"); do

--- a/.agents/skills/coverity-audit/scripts/fetch-table.sh
+++ b/.agents/skills/coverity-audit/scripts/fetch-table.sh
@@ -16,6 +16,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 cov_load_env
 

--- a/.agents/skills/coverity-audit/scripts/finalize-defect.sh
+++ b/.agents/skills/coverity-audit/scripts/finalize-defect.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Apply a verdict to one Coverity defect (high-level wrapper around update-triage.sh).
+#
+# Usage:
+#   finalize-defect.sh <cid> <verdict> <phase> <comment-file> [commit-sha]
+#
+# Verdicts:
+#   TRUE_BUG_MEMORY_CORRUPTION, TRUE_BUG_CRASH, TRUE_BUG_RESOURCE_LEAK,
+#   TRUE_BUG_LOGIC, TRUE_BUG_UB              -> Bug + Fix Submitted
+#   FALSE_POSITIVE_GUARD_EXISTS, FALSE_POSITIVE_UNREACHABLE,
+#   FALSE_POSITIVE_TRUSTED_INPUT,
+#   FALSE_POSITIVE_TOOL_MODEL,
+#   IMPOSSIBLE_CONDITIONS                    -> False Positive + Ignore
+#   COSMETIC                                 -> Intentional + Ignore
+#   NEEDS_HUMAN, CODE_GONE                   -> NO-OP (skipped, exit 0)
+#
+# Phases:
+#   1     outstanding queue (default, applied unconditionally)
+#   2..5  old/dismissed/fixed/unclassified — caller asserts the verdict
+#         disagrees with the existing classification
+#
+# Severity is mapped from Coverity's displayImpact field. The script reads it
+# from .local/audits/coverity/raw/outstanding-all.json (phase 1) or
+# .local/audits/coverity/raw/all-in-project-all.json (fallback).
+# If neither file exists, severity defaults to Unspecified.
+#
+# If a commit SHA is given, the script appends "Fix commit: <sha>" to the
+# comment before posting.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+
+CID="${1:?usage: $0 <cid> <verdict> <phase> <comment-file> [commit-sha]}"
+VERDICT="${2:?usage}"
+PHASE="${3:?usage}"
+COMMENT_FILE="${4:?usage}"
+COMMIT_SHA="${5:-}"
+
+# Verdicts that never touch the UI.
+case "${VERDICT}" in
+    NEEDS_HUMAN|CODE_GONE)
+        echo -e "${COV_YELLOW}Skipping Coverity update for CID ${CID} -- verdict=${VERDICT}.${COV_NC}" >&2
+        exit 0
+        ;;
+esac
+
+# Verdict -> (classification, action).
+case "${VERDICT}" in
+    TRUE_BUG_MEMORY_CORRUPTION|TRUE_BUG_CRASH|TRUE_BUG_RESOURCE_LEAK|TRUE_BUG_LOGIC|TRUE_BUG_UB)
+        CLASS_ID=24; ACT_ID=3 ;;
+    FALSE_POSITIVE_GUARD_EXISTS|FALSE_POSITIVE_UNREACHABLE|FALSE_POSITIVE_TRUSTED_INPUT|FALSE_POSITIVE_TOOL_MODEL|IMPOSSIBLE_CONDITIONS)
+        CLASS_ID=22; ACT_ID=5 ;;
+    COSMETIC)
+        CLASS_ID=23; ACT_ID=5 ;;
+    *)
+        echo -e "${COV_RED}Unknown verdict: ${VERDICT}${COV_NC}" >&2; exit 1 ;;
+esac
+
+# Severity from displayImpact.
+audit="$(cov_audit_dir)"
+impact=""
+for f in "${audit}/raw/outstanding-all.json" "${audit}/raw/all-in-project-all.json"; do
+    if [[ -r "${f}" ]]; then
+        impact="$(jq -r ".[] | select(.cid==${CID}) | .displayImpact" "${f}" 2>/dev/null || true)"
+        [[ -n "${impact}" && "${impact}" != "null" ]] && break
+    fi
+done
+
+case "${impact}" in
+    High)        SEV_ID=11 ;;
+    Medium)      SEV_ID=12 ;;
+    Low)         SEV_ID=13 ;;
+    *)           SEV_ID=10 ;;
+esac
+
+echo -e "${COV_GRAY}CID ${CID}: verdict=${VERDICT} -> class=${CLASS_ID} sev=${SEV_ID} (impact=${impact:-unknown}) act=${ACT_ID}${COV_NC}" >&2
+
+# If a commit SHA is given, append it to the comment before posting.
+if [[ -n "${COMMIT_SHA}" ]]; then
+    tmp_comment="$(mktemp --tmpdir cov-comment-XXXXXX.txt)"
+    trap 'rm -f "${tmp_comment}"' EXIT
+    {
+        cat "${COMMENT_FILE}"
+        printf '\nFix commit: %s\n' "${COMMIT_SHA}"
+    } > "${tmp_comment}"
+    effective="${tmp_comment}"
+else
+    effective="${COMMENT_FILE}"
+fi
+
+if [[ "${PHASE}" != "1" ]]; then
+    echo -e "${COV_YELLOW}Phase ${PHASE}: applying ONLY because caller asserts verdict disagrees with the existing classification.${COV_NC}" >&2
+fi
+
+"$(dirname "$0")/update-triage.sh" "${CID}" "${CLASS_ID}" "${SEV_ID}" "${ACT_ID}" "${effective}"

--- a/.agents/skills/coverity-audit/scripts/finalize-defect.sh
+++ b/.agents/skills/coverity-audit/scripts/finalize-defect.sh
@@ -31,6 +31,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 
 CID="${1:?usage: $0 <cid> <verdict> <scope> <comment-file> [commit-sha]}"

--- a/.agents/skills/coverity-audit/scripts/finalize-defect.sh
+++ b/.agents/skills/coverity-audit/scripts/finalize-defect.sh
@@ -71,7 +71,7 @@ esac
 audit="$(cov_audit_dir)"
 impact=""
 for f in "${audit}/raw/outstanding-all.json" "${audit}/raw/all-in-project-all.json"; do
-    if [[ -r "${f}" ]]; then
+    if [[ -f "${f}" && -r "${f}" ]]; then
         impact="$(jq -r --argjson cid "${CID}" '.[] | select(.cid==$cid) | .displayImpact' "${f}" 2>/dev/null || true)"
         [[ -n "${impact}" && "${impact}" != "null" ]] && break
     fi

--- a/.agents/skills/coverity-audit/scripts/finalize-defect.sh
+++ b/.agents/skills/coverity-audit/scripts/finalize-defect.sh
@@ -42,10 +42,15 @@ COMMIT_SHA="${5:-}"
 cov_require_numeric_cid "${CID}"
 
 # Verdicts that never touch the UI.
+# Anything other than NEEDS_HUMAN / CODE_GONE falls through to the next
+# case statement which decides classification/action; the *) here just
+# documents that explicitly.
 case "${VERDICT}" in
     NEEDS_HUMAN|CODE_GONE)
         echo -e "${COV_YELLOW}Skipping Coverity update for CID ${CID} -- verdict=${VERDICT}.${COV_NC}" >&2
         exit 0
+        ;;
+    *)
         ;;
 esac
 

--- a/.agents/skills/coverity-audit/scripts/finalize-defect.sh
+++ b/.agents/skills/coverity-audit/scripts/finalize-defect.sh
@@ -2,7 +2,7 @@
 # Apply a verdict to one Coverity defect (high-level wrapper around update-triage.sh).
 #
 # Usage:
-#   finalize-defect.sh <cid> <verdict> <phase> <comment-file> [commit-sha]
+#   finalize-defect.sh <cid> <verdict> <scope> <comment-file> [commit-sha]
 #
 # Verdicts:
 #   TRUE_BUG_MEMORY_CORRUPTION, TRUE_BUG_CRASH, TRUE_BUG_RESOURCE_LEAK,
@@ -14,13 +14,14 @@
 #   COSMETIC                                 -> Intentional + Ignore
 #   NEEDS_HUMAN, CODE_GONE                   -> NO-OP (skipped, exit 0)
 #
-# Phases:
-#   1     outstanding queue (default, applied unconditionally)
-#   2..5  old/dismissed/fixed/unclassified — caller asserts the verdict
-#         disagrees with the existing classification
+# Scope:
+#   "outstanding"  default; applied unconditionally
+#   anything else  ("dismissed", "fixed", "unclassified", ...) -- caller
+#                  asserts the new verdict disagrees with the existing
+#                  Coverity classification; the script will warn but proceed.
 #
 # Severity is mapped from Coverity's displayImpact field. The script reads it
-# from .local/audits/coverity/raw/outstanding-all.json (phase 1) or
+# from .local/audits/coverity/raw/outstanding-all.json or
 # .local/audits/coverity/raw/all-in-project-all.json (fallback).
 # If neither file exists, severity defaults to Unspecified.
 #
@@ -32,11 +33,13 @@ set -euo pipefail
 # shellcheck source=./_lib.sh
 source "$(dirname "$0")/_lib.sh"
 
-CID="${1:?usage: $0 <cid> <verdict> <phase> <comment-file> [commit-sha]}"
+CID="${1:?usage: $0 <cid> <verdict> <scope> <comment-file> [commit-sha]}"
 VERDICT="${2:?usage}"
-PHASE="${3:?usage}"
+SCOPE="${3:?usage}"
 COMMENT_FILE="${4:?usage}"
 COMMIT_SHA="${5:-}"
+
+cov_require_numeric_cid "${CID}"
 
 # Verdicts that never touch the UI.
 case "${VERDICT}" in
@@ -58,12 +61,13 @@ case "${VERDICT}" in
         echo -e "${COV_RED}Unknown verdict: ${VERDICT}${COV_NC}" >&2; exit 1 ;;
 esac
 
-# Severity from displayImpact.
+# Severity from displayImpact. CID is validated numeric above, so embedding
+# it in the jq filter is safe (cov_require_numeric_cid rejects anything else).
 audit="$(cov_audit_dir)"
 impact=""
 for f in "${audit}/raw/outstanding-all.json" "${audit}/raw/all-in-project-all.json"; do
     if [[ -r "${f}" ]]; then
-        impact="$(jq -r ".[] | select(.cid==${CID}) | .displayImpact" "${f}" 2>/dev/null || true)"
+        impact="$(jq -r --argjson cid "${CID}" '.[] | select(.cid==$cid) | .displayImpact' "${f}" 2>/dev/null || true)"
         [[ -n "${impact}" && "${impact}" != "null" ]] && break
     fi
 done
@@ -79,7 +83,7 @@ echo -e "${COV_GRAY}CID ${CID}: verdict=${VERDICT} -> class=${CLASS_ID} sev=${SE
 
 # If a commit SHA is given, append it to the comment before posting.
 if [[ -n "${COMMIT_SHA}" ]]; then
-    tmp_comment="$(mktemp --tmpdir cov-comment-XXXXXX.txt)"
+    tmp_comment="$(mktemp "${TMPDIR:-/tmp}/cov-comment-XXXXXX.txt")"
     trap 'rm -f "${tmp_comment}"' EXIT
     {
         cat "${COMMENT_FILE}"
@@ -90,8 +94,8 @@ else
     effective="${COMMENT_FILE}"
 fi
 
-if [[ "${PHASE}" != "1" ]]; then
-    echo -e "${COV_YELLOW}Phase ${PHASE}: applying ONLY because caller asserts verdict disagrees with the existing classification.${COV_NC}" >&2
+if [[ "${SCOPE}" != "outstanding" ]]; then
+    echo -e "${COV_YELLOW}Scope=${SCOPE}: applying ONLY because caller asserts verdict disagrees with the existing classification.${COV_NC}" >&2
 fi
 
 "$(dirname "$0")/update-triage.sh" "${CID}" "${CLASS_ID}" "${SEV_ID}" "${ACT_ID}" "${effective}"

--- a/.agents/skills/coverity-audit/scripts/keepalive.sh
+++ b/.agents/skills/coverity-audit/scripts/keepalive.sh
@@ -39,7 +39,7 @@ fi
 PING_URL="${COVERITY_HOST}/reports/table.json?projectId=${COVERITY_PROJECT_ID}&viewId=${COVERITY_VIEW_OUTSTANDING}"
 
 ping_once() {
-    local body http rc
+    local body rc
     # Capture both body and HTTP code in one go.
     body="$(curl -sS --max-time 30 \
         -H "accept: application/json, text/plain, */*" \

--- a/.agents/skills/coverity-audit/scripts/keepalive.sh
+++ b/.agents/skills/coverity-audit/scripts/keepalive.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Keep the Coverity Scan session warm during a triage run.
+#
+# DESIGN — the script EXITS NON-ZERO the moment a ping fails. That fires the
+# orchestrator's background-task completion notification, so the agent learns
+# *immediately* that the cookie went bad and can ask the user to recapture it.
+# DO NOT silently retry — silent retries hide the failure and waste a triage
+# session's worth of work.
+#
+# The Coverity session cookie expires after a few minutes of inactivity AND
+# requires the user's browser tab on https://scan.coverity.com to be open.
+# Closing the browser tab kills the session immediately; pings stop working.
+#
+# Usage (from an orchestrator agent):
+#   Bash tool with run_in_background=true,
+#   command="bash .agents/skills/coverity-audit/scripts/keepalive.sh"
+#
+# Stop the background task at the end of the triage session.
+#
+# Environment overrides:
+#   PING_INTERVAL   seconds between pings (default 300 = 5 min)
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+cov_load_env
+
+PING_INTERVAL="${PING_INTERVAL:-300}"
+
+# Pick a cheap, authenticated endpoint. /reports/table.json with the configured
+# Outstanding view is ideal — it returns proper JSON when authenticated and
+# HTML (Cloudflare challenge or login redirect) when not.
+if [[ -z "${COVERITY_VIEW_OUTSTANDING:-}" ]]; then
+    echo -e "${COV_RED}[ERROR]${COV_NC} COVERITY_VIEW_OUTSTANDING is not set in .env -- keepalive needs a viewId to ping. See SKILL.md." >&2
+    exit 1
+fi
+
+PING_URL="${COVERITY_HOST}/reports/table.json?projectId=${COVERITY_PROJECT_ID}&viewId=${COVERITY_VIEW_OUTSTANDING}"
+
+ping_once() {
+    local body http rc
+    # Capture both body and HTTP code in one go.
+    body="$(curl -sS --max-time 30 \
+        -H "accept: application/json, text/plain, */*" \
+        -H "user-agent: ${COVERITY_USER_AGENT}" \
+        -H "referer: ${COVERITY_HOST}/" \
+        -b "${COVERITY_COOKIE}" \
+        "${PING_URL}" 2>/dev/null)" || {
+            rc=$?
+            echo "[$(date -Iseconds)] FAIL curl rc=${rc}" >&2
+            return 1
+        }
+
+    if [[ -z "${body}" ]]; then
+        echo "[$(date -Iseconds)] FAIL empty response -- session likely expired" >&2
+        return 1
+    fi
+
+    # Validate the JSON shape -- a Cloudflare challenge or login redirect
+    # returns HTML; we want the structured response.
+    if ! printf '%s' "${body}" | jq -e '.resultSet.results' >/dev/null 2>&1; then
+        echo "[$(date -Iseconds)] FAIL response shape invalid (first 80 chars: '${body:0:80}') -- session likely expired or browser tab closed" >&2
+        return 1
+    fi
+
+    echo "[$(date -Iseconds)] OK" >&2
+    return 0
+}
+
+# First ping immediately -- if we're already dead, fail fast.
+ping_once || exit 1
+echo "[$(date -Iseconds)] keepalive running (interval=${PING_INTERVAL}s)" >&2
+
+while true; do
+    sleep "${PING_INTERVAL}"
+    ping_once || exit 1
+done

--- a/.agents/skills/coverity-audit/scripts/keepalive.sh
+++ b/.agents/skills/coverity-audit/scripts/keepalive.sh
@@ -23,6 +23,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 cov_load_env
 

--- a/.agents/skills/coverity-audit/scripts/keepalive.sh
+++ b/.agents/skills/coverity-audit/scripts/keepalive.sh
@@ -35,6 +35,10 @@ if [[ -z "${COVERITY_VIEW_OUTSTANDING:-}" ]]; then
     echo -e "${COV_RED}[ERROR]${COV_NC} COVERITY_VIEW_OUTSTANDING is not set in .env -- keepalive needs a viewId to ping. See SKILL.md." >&2
     exit 1
 fi
+if [[ ! "${COVERITY_VIEW_OUTSTANDING}" =~ ^[1-9][0-9]*$ ]]; then
+    echo -e "${COV_RED}[ERROR]${COV_NC} COVERITY_VIEW_OUTSTANDING must be a positive integer (got: '${COVERITY_VIEW_OUTSTANDING}')" >&2
+    exit 1
+fi
 
 PING_URL="${COVERITY_HOST}/reports/table.json?projectId=${COVERITY_PROJECT_ID}&viewId=${COVERITY_VIEW_OUTSTANDING}"
 

--- a/.agents/skills/coverity-audit/scripts/prepare-defect.sh
+++ b/.agents/skills/coverity-audit/scripts/prepare-defect.sh
@@ -52,15 +52,17 @@ OUT_DIR="${AUDIT}/triage/${SCOPE}/cid-${CID}"
 ROW_FILE="${AUDIT}/raw/${SCOPE}-all.json"
 DETAILS_SRC="${AUDIT}/details/${SCOPE}/cid-${CID}.json"
 
-if [[ ! -r "${DETAILS_SRC}" && -r "${AUDIT}/details/cid-${CID}.json" ]]; then
+if [[ ( ! -f "${DETAILS_SRC}" || ! -r "${DETAILS_SRC}" ) \
+   && -f "${AUDIT}/details/cid-${CID}.json" \
+   && -r "${AUDIT}/details/cid-${CID}.json" ]]; then
     DETAILS_SRC="${AUDIT}/details/cid-${CID}.json"
 fi
 
-if [[ ! -r "${ROW_FILE}" ]]; then
+if [[ ! -f "${ROW_FILE}" || ! -r "${ROW_FILE}" ]]; then
     echo -e "${COV_RED}Missing ${ROW_FILE}. Run fetch-table.sh first.${COV_NC}" >&2
     exit 1
 fi
-if [[ ! -r "${DETAILS_SRC}" ]]; then
+if [[ ! -f "${DETAILS_SRC}" || ! -r "${DETAILS_SRC}" ]]; then
     echo -e "${COV_RED}Missing ${DETAILS_SRC}. Run fetch-details.sh first.${COV_NC}" >&2
     exit 1
 fi
@@ -95,11 +97,18 @@ main_line="$(jq -r '
 
 ctx_file="${OUT_DIR}/source-context.c"
 if [[ ! -s "${ctx_file}" || "${FORCE}" == "1" ]]; then
-    # An empty/missing displayFile would resolve `${ROOT}/${repo_file}` to
-    # `${ROOT}/`, which IS a readable directory -- the `-r` test below
-    # would pass and `awk ... ${ROOT}/` would crash. Require a non-empty
-    # repo-relative file path AND that the path is a regular file.
-    if [[ -n "${repo_file}" && -f "${ROOT}/${repo_file}" && -r "${ROOT}/${repo_file}" ]]; then
+    # Validation:
+    # 1. Non-empty: an empty displayFile would resolve `${ROOT}/${repo_file}`
+    #    to `${ROOT}/`, which IS a readable directory.
+    # 2. No `..`: prevent path traversal escaping the repo. Coverity's
+    #    displayFile is its source-tree path; legitimate values never
+    #    contain `..`. Reject anything that does.
+    # 3. Regular file + readable.
+    repo_file_ok=1
+    [[ -z "${repo_file}" ]] && repo_file_ok=0
+    [[ "${repo_file}" == *..* ]] && repo_file_ok=0
+    [[ -f "${ROOT}/${repo_file}" && -r "${ROOT}/${repo_file}" ]] || repo_file_ok=0
+    if (( repo_file_ok )); then
         start=$((main_line - 100))
         (( start < 1 )) && start=1
         end=$((main_line + 50))

--- a/.agents/skills/coverity-audit/scripts/prepare-defect.sh
+++ b/.agents/skills/coverity-audit/scripts/prepare-defect.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Bundle one Coverity defect into a per-CID working directory.
+#
+# Usage:
+#   prepare-defect.sh [--force] <cid> [<scope>]
+#
+# <scope> defaults to "outstanding" -- it's only used as a subdirectory name
+# for organizing artifacts, not a Coverity API parameter.
+#
+# Inputs (must already exist; produced by fetch-table.sh + fetch-details.sh):
+#   .local/audits/coverity/raw/<scope>-all.json
+#   .local/audits/coverity/details/<scope>/cid-<N>.json    (or details/cid-<N>.json)
+#
+# Outputs (under <audit-dir>/triage/<scope>/cid-<N>/):
+#   defect-summary.json   -- the row from the table dump
+#   defect-details.json   -- the per-defect details
+#   source-context.c      -- ~150 lines around the main event in the flagged file
+#   TODO.md               -- per-defect scratch (so review work doesn't pile at repo root)
+#
+# Idempotent. Re-running keeps existing files; pass --force to regenerate.
+#
+# This script does NOT prescribe a review pipeline. After preparing the bundle,
+# how you triage it (single model, multiple models, manual review, etc.) is
+# adhoc and should be agreed with the user.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+
+FORCE=0
+if [[ "${1:-}" == "--force" ]]; then
+    FORCE=1; shift
+fi
+
+CID="${1:?usage: $0 [--force] <cid> [<scope>]}"
+SCOPE="${2:-outstanding}"
+
+ROOT="$(cov_repo_root)"
+AUDIT="$(cov_audit_dir)"
+
+OUT_DIR="${AUDIT}/triage/${SCOPE}/cid-${CID}"
+ROW_FILE="${AUDIT}/raw/${SCOPE}-all.json"
+DETAILS_SRC="${AUDIT}/details/${SCOPE}/cid-${CID}.json"
+
+if [[ ! -r "${DETAILS_SRC}" && -r "${AUDIT}/details/cid-${CID}.json" ]]; then
+    DETAILS_SRC="${AUDIT}/details/cid-${CID}.json"
+fi
+
+if [[ ! -r "${ROW_FILE}" ]]; then
+    echo -e "${COV_RED}Missing ${ROW_FILE}. Run fetch-table.sh first.${COV_NC}" >&2
+    exit 1
+fi
+if [[ ! -r "${DETAILS_SRC}" ]]; then
+    echo -e "${COV_RED}Missing ${DETAILS_SRC}. Run fetch-details.sh first.${COV_NC}" >&2
+    exit 1
+fi
+
+mkdir -p "${OUT_DIR}"
+
+# defect-summary.json
+summary="${OUT_DIR}/defect-summary.json"
+if [[ ! -s "${summary}" || "${FORCE}" == "1" ]]; then
+    jq ".[] | select(.cid==${CID})" "${ROW_FILE}" > "${summary}"
+    if [[ ! -s "${summary}" ]]; then
+        echo -e "${COV_RED}CID ${CID} not found in ${ROW_FILE}. Wrong scope, or table is stale?${COV_NC}" >&2
+        rm -f "${summary}"
+        exit 2
+    fi
+fi
+
+# defect-details.json
+details="${OUT_DIR}/defect-details.json"
+if [[ ! -s "${details}" || "${FORCE}" == "1" ]]; then
+    cp "${DETAILS_SRC}" "${details}"
+fi
+
+# source-context.c
+display_file="$(jq -r '.displayFile // ""' "${summary}")"
+repo_file="${display_file#/}"  # strip leading slash; paths are repo-relative
+main_line="$(jq -r '
+    (.occurrences[0].eventSets[0].eventTree | map(select(.main==true))[0]
+     // .occurrences[0].eventSets[0].eventTree[-1])
+    | .lineNumber // 1
+' "${details}")"
+
+ctx_file="${OUT_DIR}/source-context.c"
+if [[ ! -s "${ctx_file}" || "${FORCE}" == "1" ]]; then
+    if [[ -r "${ROOT}/${repo_file}" ]]; then
+        start=$((main_line - 100))
+        (( start < 1 )) && start=1
+        end=$((main_line + 50))
+        {
+            printf '// Extracted from %s (lines %d..%d; main event at line %d).\n' \
+                "${repo_file}" "${start}" "${end}" "${main_line}"
+            printf '// Line numbers are the original file line numbers.\n\n'
+            awk -v s="${start}" -v e="${end}" 'NR>=s && NR<=e {printf "%5d  %s\n", NR, $0}' \
+                "${ROOT}/${repo_file}"
+        } > "${ctx_file}"
+    else
+        echo -e "${COV_YELLOW}Source ${repo_file} not in tree -- CODE_GONE candidate.${COV_NC}" >&2
+        printf '// Source file %s not present in the current tree.\n// Candidate CODE_GONE.\n' \
+            "${repo_file}" > "${ctx_file}"
+    fi
+fi
+
+# TODO.md (so review work doesn't create a TODO at repo root)
+per_todo="${OUT_DIR}/TODO.md"
+if [[ ! -s "${per_todo}" || "${FORCE}" == "1" ]]; then
+    short_type="$(jq -r '.displayType // "unknown"' "${summary}")"
+    impact="$(jq -r '.displayImpact // "unspecified"' "${summary}")"
+    cat > "${per_todo}" <<EOF
+# CID ${CID} -- ${short_type} (${impact} impact)
+
+File:  ${repo_file}
+Line:  ${main_line}
+
+Bundle:
+- defect-summary.json
+- defect-details.json
+- source-context.c
+
+(Use this file for per-defect notes, plan, decisions. Keep all per-defect
+artifacts inside this directory.)
+EOF
+fi
+
+echo -e "${COV_GREEN}Prepared ${OUT_DIR}${COV_NC}" >&2
+ls -1 "${OUT_DIR}"

--- a/.agents/skills/coverity-audit/scripts/prepare-defect.sh
+++ b/.agents/skills/coverity-audit/scripts/prepare-defect.sh
@@ -36,6 +36,8 @@ fi
 CID="${1:?usage: $0 [--force] <cid> [<scope>]}"
 SCOPE="${2:-outstanding}"
 
+cov_require_numeric_cid "${CID}"
+
 ROOT="$(cov_repo_root)"
 AUDIT="$(cov_audit_dir)"
 
@@ -58,10 +60,10 @@ fi
 
 mkdir -p "${OUT_DIR}"
 
-# defect-summary.json
+# defect-summary.json -- CID is validated numeric above, --argjson is safe.
 summary="${OUT_DIR}/defect-summary.json"
 if [[ ! -s "${summary}" || "${FORCE}" == "1" ]]; then
-    jq ".[] | select(.cid==${CID})" "${ROW_FILE}" > "${summary}"
+    jq --argjson cid "${CID}" '.[] | select(.cid==$cid)' "${ROW_FILE}" > "${summary}"
     if [[ ! -s "${summary}" ]]; then
         echo -e "${COV_RED}CID ${CID} not found in ${ROW_FILE}. Wrong scope, or table is stale?${COV_NC}" >&2
         rm -f "${summary}"

--- a/.agents/skills/coverity-audit/scripts/prepare-defect.sh
+++ b/.agents/skills/coverity-audit/scripts/prepare-defect.sh
@@ -38,6 +38,13 @@ SCOPE="${2:-outstanding}"
 
 cov_require_numeric_cid "${CID}"
 
+# Scope is used as a path component (.../triage/<scope>/cid-N/...). Reject
+# anything that could path-escape; allow only simple lowercase identifiers.
+if [[ ! "${SCOPE}" =~ ^[a-z][a-z0-9_-]*$ ]]; then
+    echo -e "${COV_RED}[ERROR]${COV_NC} scope must match ^[a-z][a-z0-9_-]*\$ (got: '${SCOPE}')" >&2
+    exit 1
+fi
+
 ROOT="$(cov_repo_root)"
 AUDIT="$(cov_audit_dir)"
 

--- a/.agents/skills/coverity-audit/scripts/prepare-defect.sh
+++ b/.agents/skills/coverity-audit/scripts/prepare-defect.sh
@@ -88,7 +88,11 @@ main_line="$(jq -r '
 
 ctx_file="${OUT_DIR}/source-context.c"
 if [[ ! -s "${ctx_file}" || "${FORCE}" == "1" ]]; then
-    if [[ -r "${ROOT}/${repo_file}" ]]; then
+    # An empty/missing displayFile would resolve `${ROOT}/${repo_file}` to
+    # `${ROOT}/`, which IS a readable directory -- the `-r` test below
+    # would pass and `awk ... ${ROOT}/` would crash. Require a non-empty
+    # repo-relative file path AND that the path is a regular file.
+    if [[ -n "${repo_file}" && -f "${ROOT}/${repo_file}" && -r "${ROOT}/${repo_file}" ]]; then
         start=$((main_line - 100))
         (( start < 1 )) && start=1
         end=$((main_line + 50))

--- a/.agents/skills/coverity-audit/scripts/prepare-defect.sh
+++ b/.agents/skills/coverity-audit/scripts/prepare-defect.sh
@@ -26,6 +26,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 
 FORCE=0

--- a/.agents/skills/coverity-audit/scripts/resolve-cid-to-diid.sh
+++ b/.agents/skills/coverity-audit/scripts/resolve-cid-to-diid.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Resolve a CID to its current defectInstanceId via /reports/defects.json.
+#
+# Why: many Coverity endpoints (defectdetails.json, the source-browser deep
+# links) take a defectInstanceId, NOT a CID. The CID is stable across runs;
+# the defectInstanceId is per-scan. When you only have a CID (e.g. you're
+# acting on a stale list, or processing per-cid output from a diff tool),
+# you need to look up the current defectInstanceId.
+#
+# Usage:
+#   resolve-cid-to-diid.sh <cid>
+#
+# Prints the defectInstanceId on stdout if resolved, or "GONE" if Coverity has
+# no current defect instance for this CID (the underlying code was removed or
+# the scan no longer reports it).
+#
+# This call is INDEPENDENT of view state -- it queries the defect by CID
+# directly, so it does not interact with the server-side view pagination.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+cov_load_env
+
+CID="${1:?usage: $0 <cid>}"
+
+url="$(curl -sS --max-time 30 \
+    -H "accept: application/json, text/plain, */*" \
+    -H "referer: ${COVERITY_HOST}/" \
+    -H "user-agent: ${COVERITY_USER_AGENT}" \
+    -b "${COVERITY_COOKIE}" \
+    "${COVERITY_HOST}/reports/defects.json?projectId=${COVERITY_PROJECT_ID}&cid=${CID}" \
+    | jq -r '.url // ""')"
+
+if [[ -z "${url}" ]]; then
+    echo "GONE"
+    exit 0
+fi
+
+# The .url field looks like:
+#   /reports.htm#v70389/p15826/defectInstanceId=14451237&fileInstanceId=...&mergedDefectId=...
+diid="$(printf '%s' "${url}" | sed -n 's/.*defectInstanceId=\([0-9]*\).*/\1/p')"
+if [[ -z "${diid}" ]]; then
+    echo "GONE"
+    exit 0
+fi
+
+echo "${diid}"

--- a/.agents/skills/coverity-audit/scripts/resolve-cid-to-diid.sh
+++ b/.agents/skills/coverity-audit/scripts/resolve-cid-to-diid.sh
@@ -24,6 +24,7 @@ source "$(dirname "$0")/_lib.sh"
 cov_load_env
 
 CID="${1:?usage: $0 <cid>}"
+cov_require_numeric_cid "${CID}"
 
 url="$(curl -sS --max-time 30 \
     -H "accept: application/json, text/plain, */*" \

--- a/.agents/skills/coverity-audit/scripts/resolve-cid-to-diid.sh
+++ b/.agents/skills/coverity-audit/scripts/resolve-cid-to-diid.sh
@@ -20,6 +20,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 cov_load_env
 

--- a/.agents/skills/coverity-audit/scripts/update-triage.sh
+++ b/.agents/skills/coverity-audit/scripts/update-triage.sh
@@ -33,7 +33,7 @@ for v in CLASS_ID SEV_ID ACT_ID; do
     fi
 done
 
-if [[ ! -r "${COMMENT_FILE}" ]]; then
+if [[ ! -f "${COMMENT_FILE}" || ! -r "${COMMENT_FILE}" ]]; then
     echo -e "${COV_RED}Comment file not readable: ${COMMENT_FILE}${COV_NC}" >&2
     exit 1
 fi

--- a/.agents/skills/coverity-audit/scripts/update-triage.sh
+++ b/.agents/skills/coverity-audit/scripts/update-triage.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Update Coverity Scan triage for one CID (low-level — usually called by finalize-defect.sh).
+#
+# Usage:
+#   update-triage.sh <cid> <classification> <severity> <action> <comment-file>
+#
+# Coverity attribute IDs (not names):
+#   classification (attr 3): 20=Unclassified  21=Pending  22=FalsePositive  23=Intentional  24=Bug
+#   severity       (attr 1): 10=Unspecified   11=Major    12=Moderate       13=Minor
+#   action         (attr 2): 1=Undecided      2=FixRequired  3=FixSubmitted  4=ModelingRequired  5=Ignore
+#   external ref   (attr 4): always sent null here
+#
+# Comment is read from <comment-file>. MUST be ASCII (Cloudflare blocks em-dashes
+# and smart quotes with a 403 Cloudflare challenge — see SKILL.md).
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+cov_load_env
+
+CID="${1:?usage: $0 <cid> <classification> <severity> <action> <comment-file>}"
+CLASS_ID="${2:?usage}"
+SEV_ID="${3:?usage}"
+ACT_ID="${4:?usage}"
+COMMENT_FILE="${5:?usage}"
+
+if [[ ! -r "${COMMENT_FILE}" ]]; then
+    echo -e "${COV_RED}Comment file not readable: ${COMMENT_FILE}${COV_NC}" >&2
+    exit 1
+fi
+
+# ASCII-only check on the comment body.
+if LC_ALL=C grep -qP '[^\x00-\x7F]' "${COMMENT_FILE}"; then
+    echo -e "${COV_RED}[ERROR]${COV_NC} ${COMMENT_FILE} contains non-ASCII bytes. Cloudflare will block. Replace em-dashes (--) and smart quotes." >&2
+    exit 1
+fi
+
+payload="$(jq -n \
+    --arg cid "${CID}" \
+    --arg class "${CLASS_ID}" \
+    --arg sev "${SEV_ID}" \
+    --arg act "${ACT_ID}" \
+    --arg project "${COVERITY_PROJECT_ID}" \
+    --rawfile comment "${COMMENT_FILE}" \
+    '{
+        triageValues: [
+            {attributeId: 3, attributeValue: $class},
+            {attributeId: 1, attributeValue: $sev},
+            {attributeId: 2, attributeValue: $act},
+            {attributeId: 4, attributeValue: null}
+        ],
+        comment: $comment,
+        mergedDefectIds: [$cid | tonumber],
+        ownerId: -1,
+        projectId: ($project | tonumber),
+        triageStoreIds: [],
+        type: "apply"
+    }')"
+
+echo -e "${COV_GRAY}Posting triage update for CID ${CID} (class=${CLASS_ID} sev=${SEV_ID} act=${ACT_ID})...${COV_NC}" >&2
+
+response_file="$(mktemp --tmpdir cov-triage-XXXXXX.json)"
+trap 'rm -f "${response_file}"' EXIT
+
+http=$(curl -sS -X POST -o "${response_file}" -w '%{http_code}' \
+    -H "accept: application/json, text/plain, */*" \
+    -H "content-type: application/json" \
+    -H "origin: ${COVERITY_HOST}" \
+    -H "referer: ${COVERITY_HOST}/" \
+    -H "user-agent: ${COVERITY_USER_AGENT}" \
+    -H "x-xsrf-token: ${COVERITY_XSRF}" \
+    -b "${COVERITY_COOKIE}" \
+    --data-raw "${payload}" \
+    "${COVERITY_HOST}/sourcebrowser/updatedefecttriage.json")
+
+if [[ "${http}" != "200" ]]; then
+    echo -e "${COV_RED}HTTP ${http} -- update failed${COV_NC}" >&2
+    head -c 500 "${response_file}" >&2; echo >&2
+    if [[ "${http}" == "401" || "${http}" == "403" || "${http}" == "302" ]]; then
+        echo -e "${COV_RED}Session likely expired. Recapture cookie from browser and update .env.${COV_NC}" >&2
+    fi
+    exit 2
+fi
+
+echo -e "${COV_GREEN}OK -- triage updated for CID ${CID}.${COV_NC}" >&2
+jq -c '{defectStatus, lastTriaged, updatedValuesByCid}' "${response_file}" 2>/dev/null || head -c 300 "${response_file}"
+echo

--- a/.agents/skills/coverity-audit/scripts/update-triage.sh
+++ b/.agents/skills/coverity-audit/scripts/update-triage.sh
@@ -27,7 +27,7 @@ COMMENT_FILE="${5:?usage}"
 
 cov_require_numeric_cid "${CID}"
 for v in CLASS_ID SEV_ID ACT_ID; do
-    if [[ ! "${!v}" =~ ^[0-9]+$ ]]; then
+    if [[ ! "${!v}" =~ ^[1-9][0-9]*$ ]]; then
         echo -e "${COV_RED}[ERROR]${COV_NC} ${v} must be a positive integer, got: '${!v}'" >&2
         exit 1
     fi
@@ -45,12 +45,14 @@ if LC_ALL=C tr -d '\000-\177' < "${COMMENT_FILE}" | grep -q .; then
     exit 1
 fi
 
+# cid + project are numeric (validated above); attribute values must be
+# strings per the API.
 payload="$(jq -n \
-    --arg cid "${CID}" \
+    --argjson cid "${CID}" \
     --arg class "${CLASS_ID}" \
     --arg sev "${SEV_ID}" \
     --arg act "${ACT_ID}" \
-    --arg project "${COVERITY_PROJECT_ID}" \
+    --argjson project "${COVERITY_PROJECT_ID}" \
     --rawfile comment "${COMMENT_FILE}" \
     '{
         triageValues: [
@@ -60,9 +62,9 @@ payload="$(jq -n \
             {attributeId: 4, attributeValue: null}
         ],
         comment: $comment,
-        mergedDefectIds: [$cid | tonumber],
+        mergedDefectIds: [$cid],
         ownerId: -1,
-        projectId: ($project | tonumber),
+        projectId: $project,
         triageStoreIds: [],
         type: "apply"
     }')"

--- a/.agents/skills/coverity-audit/scripts/update-triage.sh
+++ b/.agents/skills/coverity-audit/scripts/update-triage.sh
@@ -25,13 +25,22 @@ SEV_ID="${3:?usage}"
 ACT_ID="${4:?usage}"
 COMMENT_FILE="${5:?usage}"
 
+cov_require_numeric_cid "${CID}"
+for v in CLASS_ID SEV_ID ACT_ID; do
+    if [[ ! "${!v}" =~ ^[0-9]+$ ]]; then
+        echo -e "${COV_RED}[ERROR]${COV_NC} ${v} must be a positive integer, got: '${!v}'" >&2
+        exit 1
+    fi
+done
+
 if [[ ! -r "${COMMENT_FILE}" ]]; then
     echo -e "${COV_RED}Comment file not readable: ${COMMENT_FILE}${COV_NC}" >&2
     exit 1
 fi
 
-# ASCII-only check on the comment body.
-if LC_ALL=C grep -qP '[^\x00-\x7F]' "${COMMENT_FILE}"; then
+# ASCII-only check on the comment body. `tr -d '\000-\177'` is portable across
+# GNU and BSD/macOS (`grep -P` is GNU-only).
+if LC_ALL=C tr -d '\000-\177' < "${COMMENT_FILE}" | grep -q .; then
     echo -e "${COV_RED}[ERROR]${COV_NC} ${COMMENT_FILE} contains non-ASCII bytes. Cloudflare will block. Replace em-dashes (--) and smart quotes." >&2
     exit 1
 fi
@@ -60,7 +69,7 @@ payload="$(jq -n \
 
 echo -e "${COV_GRAY}Posting triage update for CID ${CID} (class=${CLASS_ID} sev=${SEV_ID} act=${ACT_ID})...${COV_NC}" >&2
 
-response_file="$(mktemp --tmpdir cov-triage-XXXXXX.json)"
+response_file="$(mktemp "${TMPDIR:-/tmp}/cov-triage-XXXXXX.json")"
 trap 'rm -f "${response_file}"' EXIT
 
 http=$(curl -sS -X POST -o "${response_file}" -w '%{http_code}' \

--- a/.agents/skills/coverity-audit/scripts/update-triage.sh
+++ b/.agents/skills/coverity-audit/scripts/update-triage.sh
@@ -16,6 +16,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 cov_load_env
 

--- a/.agents/skills/graphql-audit/SKILL.md
+++ b/.agents/skills/graphql-audit/SKILL.md
@@ -79,9 +79,9 @@ Default output is a count-by-rule summary for **open** alerts:
 
 Filters:
 ```
-codeql-list.sh --state=open --severity=high
-codeql-list.sh --tool=CodeQL --severity=critical
-codeql-list.sh --raw          # full JSON for programmatic use
+bash .agents/skills/graphql-audit/scripts/codeql-list.sh --state=open --severity=high
+bash .agents/skills/graphql-audit/scripts/codeql-list.sh --tool=CodeQL --severity=critical
+bash .agents/skills/graphql-audit/scripts/codeql-list.sh --raw          # full JSON
 ```
 
 ### Step 2 — inspect a single alert
@@ -109,10 +109,11 @@ on a particular header), GitHub does NOT have a REST bulk endpoint. The
 working pattern is:
 
 ```bash
-codeql-list.sh --raw \
+bash .agents/skills/graphql-audit/scripts/codeql-list.sh --raw \
   | jq -r '.[] | select(.rule.id=="cpp/uninitialized-local") | .number' \
   | while read n; do
-        codeql-dismiss.sh "$n" "false positive" "FP: rule firing on a stub model not real code"
+        bash .agents/skills/graphql-audit/scripts/codeql-dismiss.sh \
+            "$n" "false positive" "FP: rule firing on a stub model not real code"
     done
 ```
 

--- a/.agents/skills/graphql-audit/SKILL.md
+++ b/.agents/skills/graphql-audit/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: graphql-audit
+description: Triage GitHub Code Scanning alerts (CodeQL with security-extended suite) for this repository — list open alerts, dismiss as false positive / won't fix / used in tests, query via GitHub REST + GraphQL. Use when the user asks to "review GitHub security alerts", "check CodeQL findings", "triage code scanning", or anything mentioning Code Scanning, CodeQL, security-extended, or github.com/$repo/security/code-scanning.
+---
+
+# GitHub Code Scanning triage skill
+
+This skill drives the GitHub Code Scanning API (REST + GraphQL via `gh`) for
+the repository's CodeQL alerts. The repo's CI runs the **security-extended**
+CodeQL suite, which surfaces a wider set of findings than the default suite.
+
+The skill operates on whatever repo this checkout points at — it derives the
+`owner/repo` from the `upstream` (or `origin`) git remote. Auth uses the
+`gh` CLI's stored credentials; no token is needed in `.env`.
+
+## MANDATORY — keep this skill alive
+
+**If you (the agent) discover a new pattern, gotcha, working flow, correction,
+or any piece of knowledge while running this skill — update this `SKILL.md`
+AND commit it BEFORE proceeding. Knowledge that isn't committed is lost.**
+
+Examples of things to capture:
+- A CodeQL rule with a known FP pattern + the canonical comment to use
+- A query (GraphQL or REST) that returns useful aggregate views not available in the UI
+- An alert format change or new field that started appearing
+- A way to bulk-dismiss without hitting REST rate limits
+
+## Setup
+
+### Prerequisite — `gh` CLI authenticated
+
+```
+gh auth status
+```
+
+Must show authentication for github.com. If not, run `gh auth login`.
+
+The `gh` user needs **write** scope on the repository to dismiss alerts;
+read scope is enough for listing.
+
+### .env entries
+
+None required for this skill. `gh` handles auth.
+
+(Optional `GITHUB_TOKEN` could go in `.env` if you ever need to bypass `gh`
+and call REST/GraphQL directly via curl, e.g. from a script that runs
+without an authenticated `gh` session.)
+
+## Triage decision matrix
+
+GitHub Code Scanning alerts have three lifecycle states: `open`, `dismissed`,
+`fixed` (auto-detected when the underlying code changes). Manual triage uses
+`dismissed` with one of three reasons:
+
+| Decision         | API value         | When to use                                                        |
+|------------------|-------------------|---------------------------------------------------------------------|
+| False Positive   | `false positive`  | CodeQL is wrong (path is unreachable, type is wider, guard exists) |
+| Won't Fix        | `won't fix`       | Real but acceptable risk; not addressing in this codebase           |
+| Used in Tests    | `used in tests`   | Alert is in test fixtures / vendored test code, not production      |
+
+A dismissed alert can be **reopened** later (manually in the UI or via
+`PATCH /alerts/<n>` with `state=open`); the dismissal history is preserved.
+
+## Workflow
+
+### Step 1 — see what's open
+
+```
+bash .agents/skills/graphql-audit/scripts/codeql-list.sh
+```
+
+Default output is a count-by-rule summary for **open** alerts:
+
+```
+  42  cpp/integer-overflow|warning
+  17  cpp/uninitialized-local|error
+  ...
+```
+
+Filters:
+```
+codeql-list.sh --state=open --severity=high
+codeql-list.sh --tool=CodeQL --severity=critical
+codeql-list.sh --raw          # full JSON for programmatic use
+```
+
+### Step 2 — inspect a single alert
+
+```
+gh api /repos/<owner>/<repo>/code-scanning/alerts/<n>
+```
+
+Or visit `https://github.com/<owner>/<repo>/security/code-scanning/<n>` in
+the browser for the full data-flow view.
+
+### Step 3 — dismiss
+
+```
+bash .agents/skills/graphql-audit/scripts/codeql-dismiss.sh \
+    <alert_number> "false positive" "<short ASCII comment>"
+```
+
+Comments are stored verbatim; keep them short, factual, and ASCII.
+
+### Step 4 — bulk dismissal
+
+For a known-FP rule pattern (e.g., `cpp/uninitialized-local` always firing
+on a particular header), GitHub does NOT have a REST bulk endpoint. The
+working pattern is:
+
+```bash
+codeql-list.sh --raw \
+  | jq -r '.[] | select(.rule.id=="cpp/uninitialized-local") | .number' \
+  | while read n; do
+        codeql-dismiss.sh "$n" "false positive" "FP: rule firing on a stub model not real code"
+    done
+```
+
+Throttle if you have many — the REST API tolerates ~10 req/s for a single
+user.
+
+## What this skill does NOT do
+
+- **CodeQL query authoring**: this skill triages results, not the queries
+  that produce them. To suppress a class of FPs at the source, edit
+  `.github/codeql/` config or the queries themselves.
+- **Workflow management**: enabling/disabling CodeQL runs is in
+  `.github/workflows/codeql.yml` — not here.
+- **Other Advanced Security features** (secret scanning alerts, dependabot)
+  use sibling APIs (`/secret-scanning/alerts`, `/dependabot/alerts`). They
+  could be added to this skill if needed.
+
+## REST vs GraphQL
+
+CodeQL alerts are exposed via REST (`/repos/{owner}/{repo}/code-scanning/...`).
+GraphQL (`gh api graphql`) is useful for cross-repo queries or reaching
+combined data (e.g., alert + commit history in one call):
+
+```
+gh api graphql -f query='
+  query($owner:String!,$name:String!) {
+    repository(owner:$owner, name:$name) {
+      vulnerabilityAlerts(first: 100, states:OPEN) {
+        nodes { securityAdvisory { ghsaId, severity } }
+      }
+    }
+  }' -F owner=netdata -F name=netdata
+```
+
+The above is for **Dependabot** advisories, not CodeQL — CodeQL alerts
+remain REST-only at the time of writing.
+
+## Failure modes — quick diagnosis
+
+| Symptom                                  | Likely cause                                            |
+|------------------------------------------|---------------------------------------------------------|
+| `HTTP 403 Resource not accessible by integration` | gh token lacks `security_events` scope          |
+| `HTTP 404` on the alerts endpoint        | Code Scanning not enabled for the repo, or wrong slug   |
+| `gh: not found`                          | gh CLI not installed                                    |
+| Empty output, no error                   | No alerts in that state — try `--state=dismissed` to confirm gh is reaching the API |
+| Pagination cuts off at 100               | Use `--paginate` (already in `codeql-list.sh`)         |

--- a/.agents/skills/graphql-audit/scripts/_lib.sh
+++ b/.agents/skills/graphql-audit/scripts/_lib.sh
@@ -32,13 +32,30 @@ gh_repo_slug() {
     # Uses bash parameter expansion so repo names containing dots
     # (e.g. "my.repo", "kubernetes-sigs/cluster-api-provider-aws.git") parse
     # correctly. The previous regex `[^/.]+` truncated names with dots.
+    # Returns empty for non-github.com remotes (this skill is GitHub-only).
     local root url
     root="$(gh_repo_root)"
     url="$(git -C "${root}" config --get remote.upstream.url 2>/dev/null \
          || git -C "${root}" config --get remote.origin.url)"
+    if [[ "${url}" != *github.com* ]]; then
+        echo ""
+        return
+    fi
     url="${url%.git}"               # strip trailing .git, if any
     url="${url#*github.com[:/]}"    # strip everything up to and including github.com:/
     echo "${url}"
+}
+
+# Resolve and validate the repo slug. Returns "owner/repo" on stdout or
+# exits non-zero if no slug could be derived.
+gh_require_slug() {
+    local slug
+    slug="$(gh_repo_slug)"
+    if [[ -z "${slug}" || "${slug}" != */* ]]; then
+        echo -e "${GH_RED}[ERROR]${GH_NC} could not derive owner/repo from git remotes (got: '${slug}'). Fix the upstream/origin remote URL." >&2
+        return 1
+    fi
+    printf '%s' "${slug}"
 }
 
 gh_audit_dir() {

--- a/.agents/skills/graphql-audit/scripts/_lib.sh
+++ b/.agents/skills/graphql-audit/scripts/_lib.sh
@@ -4,10 +4,16 @@
 
 set -euo pipefail
 
+# Color vars are used by sourcing scripts; shellcheck cannot see that.
+# shellcheck disable=SC2034
 GH_RED='\033[0;31m'
+# shellcheck disable=SC2034
 GH_GREEN='\033[0;32m'
+# shellcheck disable=SC2034
 GH_YELLOW='\033[1;33m'
+# shellcheck disable=SC2034
 GH_GRAY='\033[0;90m'
+# shellcheck disable=SC2034
 GH_NC='\033[0m'
 
 gh_repo_root() {
@@ -17,12 +23,16 @@ gh_repo_root() {
 
 gh_repo_slug() {
     # Owner/repo of the upstream remote (or origin if no upstream).
+    # Uses bash parameter expansion so repo names containing dots
+    # (e.g. "my.repo", "kubernetes-sigs/cluster-api-provider-aws.git") parse
+    # correctly. The previous regex `[^/.]+` truncated names with dots.
     local root url
     root="$(gh_repo_root)"
     url="$(git -C "${root}" config --get remote.upstream.url 2>/dev/null \
          || git -C "${root}" config --get remote.origin.url)"
-    # Normalise SSH and HTTPS forms to "owner/repo".
-    sed -E 's|^.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$|\1|' <<< "${url}"
+    url="${url%.git}"               # strip trailing .git, if any
+    url="${url#*github.com[:/]}"    # strip everything up to and including github.com:/
+    echo "${url}"
 }
 
 gh_audit_dir() {

--- a/.agents/skills/graphql-audit/scripts/_lib.sh
+++ b/.agents/skills/graphql-audit/scripts/_lib.sh
@@ -26,9 +26,11 @@ gh_repo_slug() {
 }
 
 gh_audit_dir() {
-    local root
+    local root dir
     root="$(gh_repo_root)"
-    echo "${root}/.local/audits/graphql"
+    dir="${root}/.local/audits/graphql"
+    mkdir -p "${dir}"
+    echo "${dir}"
 }
 
 # Run gh against the GitHub API. Authentication comes from `gh auth status`.

--- a/.agents/skills/graphql-audit/scripts/_lib.sh
+++ b/.agents/skills/graphql-audit/scripts/_lib.sh
@@ -37,7 +37,13 @@ gh_repo_slug() {
     root="$(gh_repo_root)"
     url="$(git -C "${root}" config --get remote.upstream.url 2>/dev/null \
          || git -C "${root}" config --get remote.origin.url)"
-    if [[ "${url}" != *github.com* ]]; then
+    # Strict github.com host match. `*github.com*` substring would
+    # accept `notgithub.com` or `github.com.attacker.example.com`.
+    # Three accepted forms cover SCP-style ssh, URL-style ssh, anonymous
+    # https, and credentialed https (`x-access-token:TOK@github.com/...`).
+    if [[ "${url}" != *@github.com:* \
+       && "${url}" != *://github.com/* \
+       && "${url}" != *@github.com/* ]]; then
         echo ""
         return
     fi

--- a/.agents/skills/graphql-audit/scripts/_lib.sh
+++ b/.agents/skills/graphql-audit/scripts/_lib.sh
@@ -4,17 +4,23 @@
 
 set -euo pipefail
 
-# Color vars are used by sourcing scripts; shellcheck cannot see that.
+# IMPORTANT: define with $'...' so the variables contain real ESC bytes,
+# not the literal four-character string "\033". This way both `echo -e
+# "${GH_RED}..."` and `printf '%s' "${GH_RED}..."` render correctly --
+# without forcing every printf format string to be the variable itself
+# (which trips shellcheck SC2059) or %b (which adds inconsistency).
+#
+# Color vars are referenced by sourcing scripts; shellcheck cannot see that.
 # shellcheck disable=SC2034
-GH_RED='\033[0;31m'
+GH_RED=$'\033[0;31m'
 # shellcheck disable=SC2034
-GH_GREEN='\033[0;32m'
+GH_GREEN=$'\033[0;32m'
 # shellcheck disable=SC2034
-GH_YELLOW='\033[1;33m'
+GH_YELLOW=$'\033[1;33m'
 # shellcheck disable=SC2034
-GH_GRAY='\033[0;90m'
+GH_GRAY=$'\033[0;90m'
 # shellcheck disable=SC2034
-GH_NC='\033[0m'
+GH_NC=$'\033[0m'
 
 gh_repo_root() {
     # Walk up from this _lib.sh; that's stable regardless of caller layout.

--- a/.agents/skills/graphql-audit/scripts/_lib.sh
+++ b/.agents/skills/graphql-audit/scripts/_lib.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Common helpers for graphql-audit scripts.
+# Sourced from the per-action scripts; not executed directly.
+
+set -euo pipefail
+
+GH_RED='\033[0;31m'
+GH_GREEN='\033[0;32m'
+GH_YELLOW='\033[1;33m'
+GH_GRAY='\033[0;90m'
+GH_NC='\033[0m'
+
+gh_repo_root() {
+    # Walk up from this _lib.sh; that's stable regardless of caller layout.
+    git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel
+}
+
+gh_repo_slug() {
+    # Owner/repo of the upstream remote (or origin if no upstream).
+    local root url
+    root="$(gh_repo_root)"
+    url="$(git -C "${root}" config --get remote.upstream.url 2>/dev/null \
+         || git -C "${root}" config --get remote.origin.url)"
+    # Normalise SSH and HTTPS forms to "owner/repo".
+    sed -E 's|^.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$|\1|' <<< "${url}"
+}
+
+gh_audit_dir() {
+    local root
+    root="$(gh_repo_root)"
+    echo "${root}/.local/audits/graphql"
+}
+
+# Run gh against the GitHub API. Authentication comes from `gh auth status`.
+# No token is required in .env when using the gh CLI directly.
+gh_api() {
+    if ! command -v gh >/dev/null; then
+        echo -e "${GH_RED}[ERROR]${GH_NC} 'gh' CLI is not installed. Install from https://cli.github.com/." >&2
+        return 1
+    fi
+    gh "$@"
+}

--- a/.agents/skills/graphql-audit/scripts/codeql-dismiss.sh
+++ b/.agents/skills/graphql-audit/scripts/codeql-dismiss.sh
@@ -34,7 +34,7 @@ case "${REASON}" in
         ;;
 esac
 
-slug="$(gh_repo_slug)"
+slug="$(gh_require_slug)"
 echo -e "${GH_GRAY}> Dismissing alert #${NUMBER} on ${slug}: ${REASON}${GH_NC}" >&2
 echo -e "${GH_GRAY}  comment: ${COMMENT}${GH_NC}" >&2
 

--- a/.agents/skills/graphql-audit/scripts/codeql-dismiss.sh
+++ b/.agents/skills/graphql-audit/scripts/codeql-dismiss.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Dismiss one GitHub Code Scanning alert.
+#
+# Usage:
+#   codeql-dismiss.sh <alert_number> <reason> "<comment>"
+#
+# Reasons (per GitHub API):
+#   false positive    -- alert is incorrect
+#   won't fix         -- alert is correct but won't be fixed
+#   used in tests     -- alert appears only in test code
+#
+# This script is WRITE-side: it changes the state of an alert. Use codeql-list.sh
+# (read-only) to find alert numbers first.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+
+NUMBER="${1:?usage: $0 <alert_number> <reason> '<comment>'}"
+REASON="${2:?usage}"
+COMMENT="${3:?usage}"
+
+case "${REASON}" in
+    "false positive"|"won't fix"|"used in tests") ;;
+    *)
+        echo -e "${GH_RED}[ERROR]${GH_NC} Reason must be one of: 'false positive', \"won't fix\", 'used in tests'." >&2
+        exit 2
+        ;;
+esac
+
+slug="$(gh_repo_slug)"
+echo -e "${GH_GRAY}> Dismissing alert #${NUMBER} on ${slug}: ${REASON}${GH_NC}" >&2
+echo -e "${GH_GRAY}  comment: ${COMMENT}${GH_NC}" >&2
+
+gh_api api --method PATCH "/repos/${slug}/code-scanning/alerts/${NUMBER}" \
+    -f state=dismissed \
+    -f dismissed_reason="${REASON}" \
+    -f dismissed_comment="${COMMENT}" \
+    --jq '{number, state, dismissed_reason, dismissed_comment, html_url}'

--- a/.agents/skills/graphql-audit/scripts/codeql-dismiss.sh
+++ b/.agents/skills/graphql-audit/scripts/codeql-dismiss.sh
@@ -15,6 +15,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 
 NUMBER="${1:?usage: $0 <alert_number> <reason> '<comment>'}"

--- a/.agents/skills/graphql-audit/scripts/codeql-dismiss.sh
+++ b/.agents/skills/graphql-audit/scripts/codeql-dismiss.sh
@@ -21,6 +21,11 @@ NUMBER="${1:?usage: $0 <alert_number> <reason> '<comment>'}"
 REASON="${2:?usage}"
 COMMENT="${3:?usage}"
 
+if [[ ! "${NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
+    echo -e "${GH_RED}[ERROR]${GH_NC} alert_number must be a positive integer, got: '${NUMBER}'" >&2
+    exit 1
+fi
+
 case "${REASON}" in
     "false positive"|"won't fix"|"used in tests") ;;
     *)

--- a/.agents/skills/graphql-audit/scripts/codeql-list.sh
+++ b/.agents/skills/graphql-audit/scripts/codeql-list.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# List GitHub Code Scanning alerts (CodeQL with security-extended) for the repo.
+#
+# Usage:
+#   codeql-list.sh                        # all OPEN alerts (default)
+#   codeql-list.sh --state=open|fixed|dismissed
+#   codeql-list.sh --severity=critical|high|medium|low|warning|note|error
+#   codeql-list.sh --tool=CodeQL          # filter by tool name
+#   codeql-list.sh --raw                  # emit raw JSON instead of summary
+#
+# Authentication uses the `gh` CLI's stored credentials.
+# This is a READ-ONLY script.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+
+state="open"
+severity=""
+tool=""
+raw=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --state=*) state="${1#*=}"; shift ;;
+        --severity=*) severity="${1#*=}"; shift ;;
+        --tool=*) tool="${1#*=}"; shift ;;
+        --raw) raw=1; shift ;;
+        -h|--help)
+            sed -n '2,12p' "$0"; exit 0 ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+slug="$(gh_repo_slug)"
+if [[ -z "${slug}" ]]; then
+    echo -e "${GH_RED}[ERROR]${GH_NC} Could not determine repo slug from git remotes." >&2
+    exit 1
+fi
+
+# Build the API path.
+path="/repos/${slug}/code-scanning/alerts?state=${state}&per_page=100"
+[[ -n "${severity}" ]] && path="${path}&severity=${severity}"
+[[ -n "${tool}" ]] && path="${path}&tool_name=${tool}"
+
+# gh api auto-paginates with --paginate.
+echo -e "${GH_GRAY}> gh api --paginate ${path}${GH_NC}" >&2
+data="$(gh_api api --paginate "${path}")"
+
+if (( raw )); then
+    printf '%s\n' "${data}"
+    exit 0
+fi
+
+# Compact summary: count by rule.
+printf '%s\n' "${data}" \
+    | jq -r '.[] | "\(.rule.id)|\(.rule.severity)|\(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)"' \
+    | awk -F'|' '{c[$1"|"$2]++} END{for (k in c) print c[k], k}' \
+    | sort -rn \
+    | head -40 \
+    | column -t -s'|'

--- a/.agents/skills/graphql-audit/scripts/codeql-list.sh
+++ b/.agents/skills/graphql-audit/scripts/codeql-list.sh
@@ -14,6 +14,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 
 state="open"

--- a/.agents/skills/graphql-audit/scripts/codeql-list.sh
+++ b/.agents/skills/graphql-audit/scripts/codeql-list.sh
@@ -33,20 +33,19 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-slug="$(gh_repo_slug)"
-if [[ -z "${slug}" ]]; then
-    echo -e "${GH_RED}[ERROR]${GH_NC} Could not determine repo slug from git remotes." >&2
-    exit 1
-fi
+slug="$(gh_require_slug)"
 
 # Build the API path.
 path="/repos/${slug}/code-scanning/alerts?state=${state}&per_page=100"
 [[ -n "${severity}" ]] && path="${path}&severity=${severity}"
 [[ -n "${tool}" ]] && path="${path}&tool_name=${tool}"
 
-# gh api auto-paginates with --paginate.
+# `gh api --paginate` writes the per-page JSON arrays back-to-back
+# (e.g. `[a,b,c][d,e]`), which is NOT a single valid JSON array. Pipe
+# through `jq -s 'add'` to slurp the multiple top-level values into one
+# array. Without this, downstream `jq '.[]'` only sees the first page.
 echo -e "${GH_GRAY}> gh api --paginate ${path}${GH_NC}" >&2
-data="$(gh_api api --paginate "${path}")"
+data="$(gh_api api --paginate "${path}" | jq -s 'add // []')"
 
 if (( raw )); then
     printf '%s\n' "${data}"

--- a/.agents/skills/pr-reviews/SKILL.md
+++ b/.agents/skills/pr-reviews/SKILL.md
@@ -114,13 +114,21 @@ bash .agents/skills/pr-reviews/scripts/list-open-threads.sh <PR_NUMBER> --short 
 The "short" output is a table: `thread-id | path:line | author`. The full
 form prints every comment in each thread.
 
-### 3. For each open thread
+### 3. For each open thread, ONE AT A TIME
+
+**This is per-thread, not batched.** Do not prepare a list of replies and
+fire them in a loop. Do not post all replies first and resolve all later.
+Walk one thread at a time:
+
+For thread N:
 
 1. **Read the comment carefully.** What is the bot/dev claiming?
 2. **Open the file at the line and verify.** Does the claim hold against
    the current code? Is it valid in context?
 3. **Search the whole PR diff (and adjacent code) for the same class of
-   issue.** Rule #10 -- this is mandatory.
+   issue.** Rule #10 -- this is mandatory. (You only do this sweep once,
+   on the first thread of a class -- subsequent threads in the same
+   class share the same fix.)
 4. **Decide**:
    - If valid -> fix it AND every similar instance you found.
    - If invalid -> understand why the bot got confused. Often a small
@@ -129,13 +137,24 @@ form prints every comment in each thread.
    ```
    bash .agents/skills/pr-reviews/scripts/reply-thread.sh <PR> <comment-id> "<reply>"
    ```
-   (Get `<comment-id>` from `review-threads.json` -> `.[].comments.nodes[0].databaseId`.)
-6. **Resolve the thread.**
+   `<comment-id>` is the `databaseId` of the FIRST comment in the thread
+   (from `review-threads.json` -> `.[].comments.nodes[0].databaseId`).
+6. **Resolve the thread immediately after the reply succeeds.**
    ```
    bash .agents/skills/pr-reviews/scripts/resolve-thread.sh <thread-id>
    ```
-   (Get `<thread-id>` from `review-threads.json` -> `.[].id` -- it's the
-   GraphQL node id, not the numeric REST id.)
+   `<thread-id>` is the GraphQL node id (`review-threads.json` -> `.[].id`,
+   starts with `PRRT_`). Resolving immediately after replying takes the
+   thread out of the "needs attention" view; leaving threads open without
+   resolution accumulates noise.
+
+Then move to thread N+1. Reply-and-resolve, reply-and-resolve. Never
+queue them up.
+
+The reason: the order makes intent visible to humans watching the PR --
+they see "agent posted reply, agent resolved" as one motion per thread,
+not "agent dumped 14 replies, then dumped 14 resolves". Bulk operations
+look mechanical and erode trust in the address pass.
 
 ### 4. Before pushing -- check CI for FAILURES (don't wait)
 

--- a/.agents/skills/pr-reviews/SKILL.md
+++ b/.agents/skills/pr-reviews/SKILL.md
@@ -92,6 +92,22 @@ These are non-negotiable. Skipping any of them will cost the user time.
     the rest one at a time. Every round-trip is 30+ minutes of bot
     review latency. **The fix for one issue means a full re-audit of the
     PR for the same class of issue.** Do that before pushing.
+11. **Don't trust linters alone -- smoke-test every fix.** Static
+    analyzers (shellcheck, etc.) verify a property of the code; they
+    don't verify behavior. A "correct per the linter" fix can change
+    runtime behavior in subtle ways (e.g. a printf format-string fix
+    that stops escape-sequence interpretation, breaking colored output
+    that the linter never knew about). After every fix, run the
+    affected script (or the smallest invocation that exercises the
+    change) and verify the output looks right. "Linter green" is not
+    the same as "still works."
+12. **Before every push, spawn a subagent for a holistic PR review.**
+    See Step 4a in the workflow. The orchestrator's context is biased
+    toward the fixes it just made; a clean-context subagent re-reviewing
+    the WHOLE diff is what catches the issues the orchestrator and the
+    AI reviewers missed. Skipping this turns each iteration into a
+    30-minute round-trip to discover issues that could have been found
+    in 2 minutes locally.
 
 ## Author classes -- different handling per class
 
@@ -240,7 +256,61 @@ For Sonar there is no "thread reply" -- you address the issue with
 either a code fix or a `sonar-mark.sh` action. There's nothing to
 resolve in GitHub for Sonar findings.
 
-### 4. Before pushing -- check CI for FAILURES (don't wait)
+### 4a. Before pushing -- MANDATORY holistic PR review via subagent
+
+This is the most important pre-push step. Skipping it is what makes
+review cycles last for hours.
+
+After you have made all the fixes for the current iteration's findings
+but BEFORE running `git push`, spawn a subagent to re-review the WHOLE
+PR diff (not the small change you just made). The orchestrator's
+context is already loaded with the recent fixes; the subagent's clean
+context is what gives an honest second look.
+
+Why this is non-negotiable:
+
+- AI reviewers (cubic-dev-ai, copilot, sonarqube) only surface their
+  top 3-7 findings. The full set of similar issues remains hidden.
+- Each fix can introduce its own new problems (a printf format-string
+  fix that breaks color rendering, a portability fix that drops a
+  feature, an input-validation fix that rejects valid inputs).
+- Without a holistic pre-push review, every iteration takes ~30 min of
+  bot review latency just to discover problems the orchestrator could
+  have spotted in 2 minutes by re-reading the diff.
+
+How to invoke:
+
+Use the orchestrator's Agent / subagent tool (whatever the harness
+provides). Pass the subagent the PR diff (or the list of touched files)
+and ask it to:
+
+- Verify each fix in this iteration solves the original finding without
+  side effects.
+- Sweep the touched files for similar patterns the original findings
+  did not point at, but which the same reasoning would flag.
+- Sweep the touched files for NEW issues the fixes themselves may have
+  introduced (broken behavior, lost features, regressions).
+- Report findings as a flat list -- file:line + class + suggested fix.
+
+Then the orchestrator addresses every finding the subagent returns
+BEFORE push. Loop the subagent if necessary until it returns a clean
+review. Only then proceed to step 4b.
+
+A good subagent prompt template:
+
+> Re-review PR <N> end-to-end. The current diff is on branch <X>; the
+> base is <master|...>. Recent fixes addressed: <list>. For the WHOLE
+> diff (not just the recent fixes), find:
+> 1. Similar patterns to the ones recently fixed that were NOT pointed
+>    at by reviewers but where the same reasoning applies.
+> 2. Issues the recent fixes may have introduced (regressions, broken
+>    behavior, dropped features).
+> 3. Anything in the diff that does not match the project's
+>    conventions (AGENTS.md, sibling files, the rest of the repo).
+> Report a flat list of file:line + class + suggested fix. Be
+> exhaustive; do not stop at 3-7 findings.
+
+### 4b. Before pushing -- check CI for FAILURES (don't wait)
 
 ```
 bash .agents/skills/pr-reviews/scripts/ci-status.sh <PR_NUMBER>

--- a/.agents/skills/pr-reviews/SKILL.md
+++ b/.agents/skills/pr-reviews/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: pr-reviews
+description: Address pull-request comments and reviews iteratively until the PR is clean — fetch all comments with paranoid pagination, classify by author (AI bot vs human), verify each finding, address it, find similar patterns, reply per-thread, resolve threads, check CI before pushing, retrigger AI reviewers (cubic-dev-ai, copilot), and wait for new feedback. Use when the user says "address PR comments", "look at the reviews on PR N", "deal with the bot comments", "iterate on PR N until clean", or anything mentioning PR comments / reviews / cubic / copilot.
+---
+
+# PR review handler skill
+
+This skill iterates a PR through review/comment cycles until there is nothing
+left to address. PRs in this repo get reviews from human developers and from
+multiple AI assistants -- principally `cubic-dev-ai` and `copilot`. Each
+class is handled differently.
+
+## MANDATORY rules
+
+These are non-negotiable. Skipping any of them will cost the user time.
+
+1. **Pagination paranoia.** Do not stop at round numbers. If a fetch returns
+   exactly 100 / 200 / 300 items, the round count is suspicious -- GitHub
+   pagination defaults to 100, and round-multiples almost always mean there
+   is a next page that the previous client missed. Always re-probe with an
+   explicit `page=N+1` request. `fetch-all.sh` does this automatically.
+2. **Accept all comments and address them all.** No exceptions. No "this is
+   minor, skip it." The bar is: Netdata's performance, stability, and
+   long-term maintainability.
+3. **Verify every comment properly.** No shortcuts. Read the code, follow
+   the trace, confirm the claim. AI bots produce false positives -- judge
+   each one on its merits.
+4. **Reply per-thread, one by one.** No bulk replies. No mechanical "fixed"
+   answers. Each thread gets a substantive reply that explains what you
+   did or why the comment doesn't apply.
+5. **Don't dismiss comments because they look minor.** Even style nits
+   compound. The goal is for the project to thrive.
+6. **Help bots when they're confused.** AI reviewers sometimes flag false
+   positives because the surrounding code is ambiguous. Add a short
+   comment in the source that clarifies the intent -- it helps the next
+   reviewer (human or bot).
+7. **Check CI BEFORE every push, but never WAIT for CI between iterations.**
+   Waiting for CI between bot-review cycles destroys throughput -- a CI
+   run can take 30+ minutes, and during that time the AI reviewers are
+   idle. The right cadence is:
+   - Before each push: run `ci-status.sh`. If there are FAILURES, fix
+     them and bundle into the same push. If checks are still running,
+     that's fine -- ignore them and push anyway. The next push triggers
+     fresh CI on the new code, which is what we actually care about.
+   - After each push: re-trigger the bots, then `wait-for-activity.sh`
+     for new comments (NOT for CI).
+   - If `wait-for-activity.sh` times out (30 min, no new comments):
+     re-check `ci-status.sh`. If checks are still running, that's normal,
+     surface to the user. If there are failures, fix and iterate.
+8. **Re-trigger AI reviewers explicitly.** They do NOT react to thread
+   replies or pushed commits the way humans do.
+   - Copilot: re-add as a requested reviewer (`trigger-copilot.sh`).
+   - cubic-dev-ai: post a new top-level comment mentioning it
+     (`trigger-cubic.sh`).
+9. **Don't loop forever on silent bots.** Some assistants stop responding.
+   That's fine. Use `wait-for-activity.sh` with the 30-min timeout and
+   move on if nothing changes.
+10. **When a bot finds a legit issue, search the WHOLE PR for similar
+    issues.** This is the most expensive rule to ignore. AI reviewers
+    surface their top 3-7 findings, not the full set. If you fix only the
+    ones they pointed at, you'll spend dozens of round-trips discovering
+    the rest one at a time. Every round-trip is 30+ minutes of bot
+    review latency. **The fix for one issue means a full re-audit of the
+    PR for the same class of issue.** Do that before pushing.
+
+## Author classes -- different handling per class
+
+- **AI bots** (`cubic-dev-ai[bot]`, `copilot[bot]` and variants): handle
+  autonomously. Verify the finding, fix or push back with reasoning, reply
+  in-thread, resolve thread.
+- **Informational bots** (`sonarqubecloud[bot]`, `github-actions[bot]`,
+  `netdata-bot[bot]`, `coderabbitai[bot]`): read for signal (e.g. quality
+  gate status). They don't usually require a reply.
+- **Humans** (developers, maintainers, community): consult the user.
+  Maintainer comments matter most -- in this project, we are usually
+  contributors, they are the project owners. Do not respond on the user's
+  behalf without their direction. Surface human comments to the user with
+  a recommendation, then act per their instruction.
+
+## Setup
+
+`gh` CLI authenticated for the repo. Nothing else.
+
+The skill reads `upstream` (or `origin`) from git remotes to derive the
+repo slug. Override with `PR_REPO_SLUG=owner/repo` if working cross-repo.
+
+State for each PR is cached under `<repo-root>/.local/audits/pr-reviews/pr-<N>/`:
+
+- `pr.json` -- top-level PR metadata
+- `issue-comments.json` -- top-level PR comments (REST)
+- `review-comments.json` -- inline review comments (REST)
+- `reviews.json` -- review submissions with body (REST)
+- `review-threads.json` -- per-thread, with `isResolved` (GraphQL)
+- `summary.txt` -- human-readable triage summary
+
+## Workflow
+
+### 1. Fetch all comments (paranoid)
+
+```
+bash .agents/skills/pr-reviews/scripts/fetch-all.sh <PR_NUMBER>
+```
+
+Tail-prints a `summary.txt` that shows the per-author count and the list of
+open review threads. Use this as the input to the rest of the cycle.
+
+### 2. List open threads
+
+```
+bash .agents/skills/pr-reviews/scripts/list-open-threads.sh <PR_NUMBER>          # full bodies
+bash .agents/skills/pr-reviews/scripts/list-open-threads.sh <PR_NUMBER> --short  # one line per thread
+```
+
+The "short" output is a table: `thread-id | path:line | author`. The full
+form prints every comment in each thread.
+
+### 3. For each open thread
+
+1. **Read the comment carefully.** What is the bot/dev claiming?
+2. **Open the file at the line and verify.** Does the claim hold against
+   the current code? Is it valid in context?
+3. **Search the whole PR diff (and adjacent code) for the same class of
+   issue.** Rule #10 -- this is mandatory.
+4. **Decide**:
+   - If valid -> fix it AND every similar instance you found.
+   - If invalid -> understand why the bot got confused. Often a small
+     source comment clarifying the intent will help the next reviewer.
+5. **Reply in the thread.**
+   ```
+   bash .agents/skills/pr-reviews/scripts/reply-thread.sh <PR> <comment-id> "<reply>"
+   ```
+   (Get `<comment-id>` from `review-threads.json` -> `.[].comments.nodes[0].databaseId`.)
+6. **Resolve the thread.**
+   ```
+   bash .agents/skills/pr-reviews/scripts/resolve-thread.sh <thread-id>
+   ```
+   (Get `<thread-id>` from `review-threads.json` -> `.[].id` -- it's the
+   GraphQL node id, not the numeric REST id.)
+
+### 4. Before pushing -- check CI for FAILURES (don't wait)
+
+```
+bash .agents/skills/pr-reviews/scripts/ci-status.sh <PR_NUMBER>
+```
+
+Exit codes:
+- `0` -- all green, safe to push
+- `2` -- runs in progress -- IGNORE this; push anyway. Waiting for CI
+  between iterations destroys throughput. The new push triggers fresh CI
+  on the new code, which is what matters.
+- `3` -- runs failing -- fix the failures and bundle them into the push.
+
+CI failures unrelated to this PR (a flaky test on a different module, an
+infra outage) are NOT in scope for this PR -- note them, surface to the
+user, move on. Do not make drive-by fixes here.
+
+### 5. Push, then re-trigger reviewers
+
+After pushing the fix commit(s):
+
+```
+bash .agents/skills/pr-reviews/scripts/trigger-copilot.sh <PR_NUMBER>
+bash .agents/skills/pr-reviews/scripts/trigger-cubic.sh   <PR_NUMBER>
+```
+
+Copilot re-runs when re-requested as a reviewer. cubic re-reviews when
+mentioned in a new top-level PR comment.
+
+### 6. Wait for new activity
+
+```
+bash .agents/skills/pr-reviews/scripts/wait-for-activity.sh <PR_NUMBER>
+```
+
+Default timeout 30 min, poll every 30 s. Returns 0 on new activity, 124 on
+timeout. Both bots typically post a "no new findings" comment when they
+have nothing left, so the loop ends naturally on a clean PR.
+
+### 7. Loop
+
+Go back to step 1. Continue until either:
+- `fetch-all.sh` reports all threads resolved AND both bots have posted a
+  "no new findings" comment after their most recent re-trigger; or
+- `wait-for-activity.sh` times out (30 min). When that happens:
+   - Re-run `ci-status.sh`. If checks are still running, that's normal --
+     surface state to the user and stop.
+   - If there are CI failures, fix them and start a new iteration
+     (commit, ci-check, push, re-trigger, wait).
+
+## Commit message hygiene
+
+Commit messages on the address-the-comments cycle should describe **the
+change**, not the reviewer or the cycle:
+
+- BAD: "address copilot comments"
+- BAD: "fix bot review feedback"
+- GOOD: "scripts: fix dry-run env var name and printf format-string usage"
+
+Never reference an AI tool by name in commit messages, PR bodies, or
+comments. The work matters; the tool that flagged it does not.
+
+## Replying to bots -- tone
+
+Be substantive but brief. The bot's prompt-text is verbose; your reply
+doesn't have to be. Examples:
+
+- For a valid fix: "Fixed in <sha-or-paragraph>: <one-sentence what changed>."
+- For a false positive: "False positive -- <one-sentence why>: <evidence
+  citation>." Add a code comment if it'll help future reviewers.
+- For a partial fix: "Partial -- fixed the immediate case at <line>, but the
+  related <other-line> is intentional because <reason>."
+
+## Replying to humans -- consult the user
+
+Maintainer / dev / community comments go to the user FIRST. Your message
+should:
+1. Quote the relevant part of their comment.
+2. State your read of what they're asking for.
+3. Propose 1-3 options if it's a design call, or one option if obvious.
+4. Wait for the user's decision.
+
+Then act per their direction. Do not respond to humans on the user's
+behalf without explicit direction.
+
+## Bot directory
+
+| Bot                          | Role                                       | Re-trigger                                       |
+|------------------------------|--------------------------------------------|--------------------------------------------------|
+| `cubic-dev-ai[bot]`          | Line-level code review                     | New PR comment mentioning `@cubic-dev-ai`        |
+| `copilot[bot]`               | Line-level code review                     | Re-add as requested reviewer (`gh pr edit`)      |
+| `sonarqubecloud[bot]`        | Quality-gate status                        | Auto, on each scan run -- read its issue comment |
+| `github-actions[bot]`        | CI status / labels                         | Auto, on each workflow run                        |
+| `netdata-bot[bot]`           | Repo automation (labels, etc.)             | Auto                                              |
+
+If a new AI reviewer appears in the project, classify it by adding to
+`PR_AI_BOT_RE` in `_lib.sh` so the skill recognizes it.
+
+## Failure modes -- quick diagnosis
+
+| Symptom                                                | Likely cause                                                         |
+|--------------------------------------------------------|----------------------------------------------------------------------|
+| `fetch-all.sh` returns suspiciously round counts       | Pagination missed pages. Re-run; fetch-all auto-probes when count is a multiple of 100. |
+| `reply-thread.sh` -> 404                               | Wrong comment id (use `databaseId` from `review-threads.json`, not the GraphQL node id). |
+| `resolve-thread.sh` -> "thread not found"              | Used REST id instead of GraphQL node id.                              |
+| `trigger-copilot.sh` succeeds but no new review        | Reviewer was already requested -- script removes-then-adds to force a fresh run. If still nothing, copilot may be quota-limited; wait. |
+| `trigger-cubic.sh` succeeds but no new review          | cubic ignores comments without an explicit `@cubic-dev-ai` mention. The script always prepends it. |
+| `ci-status.sh` exits 2 (running)                       | CI hasn't finished. Don't push yet -- you'd cancel the runs.          |
+| Bot keeps re-flagging the same line after a fix push   | The bot didn't see the new commit because it wasn't re-triggered.    |
+| `wait-for-activity.sh` 124 timeout                     | Bots are silent -- could be done, could be quota-limited. Check `summary.txt`; if all threads resolved, you're done. |
+
+## MANDATORY -- keep this skill alive
+
+If you (the agent) discover a new pattern, gotcha, working flow, correction,
+or any piece of knowledge while running this skill -- update this `SKILL.md`
+AND commit it BEFORE proceeding. Knowledge that isn't committed is lost.
+
+Examples of things to capture:
+- A new AI reviewer bot that appears in the project (add to the directory + `PR_AI_BOT_RE`)
+- A new common false-positive pattern that warrants a clarifying source comment
+- A new GitHub API quirk (rate limits, undocumented response shapes, pagination edge cases)
+- A retrigger mechanism that changed (e.g. copilot's re-request behavior)

--- a/.agents/skills/pr-reviews/SKILL.md
+++ b/.agents/skills/pr-reviews/SKILL.md
@@ -283,7 +283,14 @@ HEAD. This guarantees you and the reviewers are synchronized.
 ```
 bash .agents/skills/pr-reviews/scripts/fetch-all.sh <PR_NUMBER>
 bash .agents/skills/pr-reviews/scripts/fetch-sonar-findings.sh <PR_NUMBER>
+bash .agents/skills/pr-reviews/scripts/ci-status.sh <PR_NUMBER>
 ```
+
+The `ci-status.sh` line is the third source: a CI failure that is
+CAUSED by this PR's changes (added a script that doesn't pass
+shellcheck, broke a YAML parse, etc.) is in scope and must be folded
+in. CI failures unrelated to this PR are noted, surfaced to the user
+at the end, but not fixed here.
 
 If `summary.txt` shows any new open thread or `sonar-issues.json` shows
 any new issue you haven't addressed yet, **do NOT push**. Loop back to

--- a/.agents/skills/pr-reviews/SKILL.md
+++ b/.agents/skills/pr-reviews/SKILL.md
@@ -108,6 +108,12 @@ These are non-negotiable. Skipping any of them will cost the user time.
     AI reviewers missed. Skipping this turns each iteration into a
     30-minute round-trip to discover issues that could have been found
     in 2 minutes locally.
+13. **Before every push, re-fetch all finding sources one last time.**
+    See Step 4-pre. Reviewers post in parallel; if findings arrive
+    while you're addressing the current batch, they belong in THIS
+    push, not the next one. Without this sync barrier, you and the
+    reviewers stay one round out of sync forever -- the next iteration
+    is always "fixing" issues that no longer apply.
 
 ## Author classes -- different handling per class
 
@@ -172,7 +178,7 @@ the script prints what's needed and exits.
 
 ### 1c. Note the CI signal as a third source
 
-Run `ci-status.sh <PR>` once early to capture which checks are failing
+Run `bash .agents/skills/pr-reviews/scripts/ci-status.sh <PR>` once early to capture which checks are failing
 **right now**. You're looking for failures caused by the current PR
 (typo in a YAML file you added, a script that doesn't pass shellcheck,
 a build that breaks because of the diff). DO NOT fix CI yet -- just note
@@ -255,6 +261,38 @@ For each issue in `sonar-issues.json` and each hotspot in
 For Sonar there is no "thread reply" -- you address the issue with
 either a code fix or a `sonar-mark.sh` action. There's nothing to
 resolve in GitHub for Sonar findings.
+
+### 4-pre. Before pushing -- MANDATORY final-fetch sync barrier
+
+Reviewers run in parallel. Multiple bots and humans can be appending
+findings WHILE you're addressing the current batch. If you push the
+moment your queue is empty, the findings that arrived during this
+iteration get attributed to your fresh commit instead of the previous
+one -- and on the next round you end up "fixing" findings that no
+longer apply because you addressed them implicitly with the next push.
+The result: chronic desync, where your commit and the reviewers'
+findings are always one round apart.
+
+The fix: a sync barrier immediately before push. Re-fetch ALL sources
+(comments, Sonar, CI) one more time. If ANY new finding has arrived
+since you last looked, loop back to step 2 -- address those new
+findings in the SAME upcoming push -- then re-fetch again. Only push
+when a fresh fetch comes back with no new findings against the current
+HEAD. This guarantees you and the reviewers are synchronized.
+
+```
+bash .agents/skills/pr-reviews/scripts/fetch-all.sh <PR_NUMBER>
+bash .agents/skills/pr-reviews/scripts/fetch-sonar-findings.sh <PR_NUMBER>
+```
+
+If `summary.txt` shows any new open thread or `sonar-issues.json` shows
+any new issue you haven't addressed yet, **do NOT push**. Loop back to
+step 2 and address them first. Then re-run the fetch. Only push when
+the fetch is clean.
+
+The same loop applies during the iteration: if you re-fetched while
+addressing the previous batch and saw new findings drop in, fold them
+into the same push rather than dispatching a half-done batch.
 
 ### 4a. Before pushing -- MANDATORY holistic PR review via subagent
 

--- a/.agents/skills/pr-reviews/SKILL.md
+++ b/.agents/skills/pr-reviews/SKILL.md
@@ -349,6 +349,13 @@ Default timeout 30 min, poll every 30 s. Returns 0 on new activity, 124 on
 timeout. Both bots typically post a "no new findings" comment when they
 have nothing left, so the loop ends naturally on a clean PR.
 
+What counts as "new activity":
+- New issue comment / review comment / review on the PR.
+- New commit pushed to the PR head.
+- A review thread getting resolved or unresolved (often by a bot saying
+  "addressed; resolving" -- without this signal we'd miss thread state
+  flips and time out spuriously).
+
 ### 7. Loop
 
 Go back to step 1. Continue until ALL of these are true:
@@ -386,8 +393,13 @@ change**, not the reviewer or the cycle:
 - BAD: "fix bot review feedback"
 - GOOD: "scripts: fix dry-run env var name and printf format-string usage"
 
-Never reference an AI tool by name in commit messages, PR bodies, or
-comments. The work matters; the tool that flagged it does not.
+Never reference an AI tool by name in commit messages or PR bodies. The
+work matters; the tool that flagged it does not.
+
+(Comments on the PR are an exception when they're operational mentions
+required by the bot itself: `@cubic-dev-ai please review again` is a
+direct trigger for that bot, and the trigger script enforces it. Outside
+operational triggers, the same rule applies to comments.)
 
 ## Replying to bots -- tone
 
@@ -434,7 +446,7 @@ If a new AI reviewer appears in the project, classify it by adding to
 | `resolve-thread.sh` -> "thread not found"              | Used REST id instead of GraphQL node id.                              |
 | `trigger-copilot.sh` succeeds but no new review        | Reviewer was already requested -- script removes-then-adds to force a fresh run. If still nothing, copilot may be quota-limited; wait. |
 | `trigger-cubic.sh` succeeds but no new review          | cubic ignores comments without an explicit `@cubic-dev-ai` mention. The script always prepends it. |
-| `ci-status.sh` exits 2 (running)                       | CI hasn't finished. Don't push yet -- you'd cancel the runs.          |
+| `ci-status.sh` exits 2 (running)                       | CI hasn't finished. Push anyway -- waiting on CI between iterations destroys throughput. The next push triggers a fresh CI run on the new code, which is what matters. (See Step 4b.) |
 | Bot keeps re-flagging the same line after a fix push   | The bot didn't see the new commit because it wasn't re-triggered.    |
 | `wait-for-activity.sh` 124 timeout                     | Bots are silent -- could be done, could be quota-limited. Check `summary.txt`; if all threads resolved, you're done. |
 

--- a/.agents/skills/pr-reviews/SKILL.md
+++ b/.agents/skills/pr-reviews/SKILL.md
@@ -6,9 +6,39 @@ description: Address pull-request comments and reviews iteratively until the PR 
 # PR review handler skill
 
 This skill iterates a PR through review/comment cycles until there is nothing
-left to address. PRs in this repo get reviews from human developers and from
-multiple AI assistants -- principally `cubic-dev-ai` and `copilot`. Each
-class is handled differently.
+left to address.
+
+## Your role on a PR
+
+When this skill is in use, the agent's job is to **bring the PR into
+merge-ready shape**: solve the original problem the PR was opened for,
+**and** address every legitimate finding the PR has accumulated, from
+every source. Reviewers, linters, and CI all matter. Comments are the
+loudest source but they are not the only source -- you must proactively
+pull findings from every channel that reports on the PR, not wait for
+something to surface as a chat message.
+
+Sources of findings, in priority order:
+
+1. **Human review comments** -- maintainers / devs / community.
+2. **AI bot review comments** -- cubic-dev-ai, copilot, etc.
+3. **SonarCloud PR findings** -- new code-smell / vulnerability /
+   security-hotspot issues introduced by this PR. SonarCloud does NOT
+   post these as inline GitHub review-comments; only a QualityGate
+   summary is posted to GitHub. The actual findings live behind the
+   SonarCloud API and must be pulled explicitly.
+4. **CI failures relevant to this PR** -- shellcheck, codeql, build /
+   test failures caused by the PR's changes.
+5. **Anything else this repo configures** (Codacy, custom workflows, ...).
+
+A finding is "relevant to this PR" if its existence (or its line
+location) is plausibly caused by the PR's diff. CI failures unrelated to
+this PR (a flaky test on an unrelated module, an infra outage) are NOT
+in scope -- note them, surface to the user at the end, do not fix them
+here.
+
+The bar is the project's performance, stability, and long-term
+maintainability. Don't dismiss findings because they look minor.
 
 ## MANDATORY rules
 
@@ -95,7 +125,10 @@ State for each PR is cached under `<repo-root>/.local/audits/pr-reviews/pr-<N>/`
 
 ## Workflow
 
-### 1. Fetch all comments (paranoid)
+The order is: **gather all findings -> address them per-thread / per-finding
+-> check CI for failures the PR caused -> push -> retrigger -> wait -> loop.**
+
+### 1a. Fetch all comments (paranoid)
 
 ```
 bash .agents/skills/pr-reviews/scripts/fetch-all.sh <PR_NUMBER>
@@ -104,7 +137,33 @@ bash .agents/skills/pr-reviews/scripts/fetch-all.sh <PR_NUMBER>
 Tail-prints a `summary.txt` that shows the per-author count and the list of
 open review threads. Use this as the input to the rest of the cycle.
 
-### 2. List open threads
+### 1b. Fetch SonarCloud PR findings
+
+```
+bash .agents/skills/pr-reviews/scripts/fetch-sonar-findings.sh <PR_NUMBER>
+```
+
+SonarCloud findings are NOT delivered as inline GitHub comments -- only a
+QualityGate summary is. The actual issue list lives behind the SonarCloud
+API. This script writes:
+- `.local/audits/pr-reviews/pr-<N>/sonar-issues.json`
+- `.local/audits/pr-reviews/pr-<N>/sonar-hotspots.json`
+- a brief summary to stdout (counts by rule and severity).
+
+Requires the same `.env` config the `sonarqube-audit` skill uses
+(`SONAR_TOKEN`, `SONAR_HOST_URL`, `SONAR_PROJECT`). If `.env` is missing,
+the script prints what's needed and exits.
+
+### 1c. Note the CI signal as a third source
+
+Run `ci-status.sh <PR>` once early to capture which checks are failing
+**right now**. You're looking for failures caused by the current PR
+(typo in a YAML file you added, a script that doesn't pass shellcheck,
+a build that breaks because of the diff). DO NOT fix CI yet -- just note
+the failures as input alongside review comments and Sonar findings. They
+all get addressed in the same iteration so a single push covers them.
+
+### 2. List open threads (and Sonar findings)
 
 ```
 bash .agents/skills/pr-reviews/scripts/list-open-threads.sh <PR_NUMBER>          # full bodies
@@ -156,6 +215,31 @@ they see "agent posted reply, agent resolved" as one motion per thread,
 not "agent dumped 14 replies, then dumped 14 resolves". Bulk operations
 look mechanical and erode trust in the address pass.
 
+### 3b. Address each Sonar finding
+
+For each issue in `sonar-issues.json` and each hotspot in
+`sonar-hotspots.json`:
+
+1. **Read the rule and the message.** What is Sonar claiming?
+2. **Open the file at the line and verify.** Does the claim hold against
+   the current code?
+3. **Search the whole PR diff (and adjacent code) for the same class of
+   issue.** Same rule #10 as for review comments. If Sonar flagged one
+   instance of S131 (case without default), sweep all case statements.
+   If Sonar flagged S2245 (insecure RNG), sweep all `random()` callsites.
+4. **Decide**:
+   - If valid -> fix it AND every similar instance you found in the
+     project where the same reasoning applies (within the diff, plus
+     nearby code in files this PR already touches).
+   - If invalid -> the corresponding `sonarqube-audit` skill provides
+     `sonar-mark.sh fp <KEY> "<reason>"` to mark it False Positive
+     directly in SonarCloud. Comments are ASCII-only (Cloudflare).
+5. **Repeat until `sonar-issues.json` has zero issues that we caused.**
+
+For Sonar there is no "thread reply" -- you address the issue with
+either a code fix or a `sonar-mark.sh` action. There's nothing to
+resolve in GitHub for Sonar findings.
+
 ### 4. Before pushing -- check CI for FAILURES (don't wait)
 
 ```
@@ -197,14 +281,31 @@ have nothing left, so the loop ends naturally on a clean PR.
 
 ### 7. Loop
 
-Go back to step 1. Continue until either:
-- `fetch-all.sh` reports all threads resolved AND both bots have posted a
-  "no new findings" comment after their most recent re-trigger; or
-- `wait-for-activity.sh` times out (30 min). When that happens:
-   - Re-run `ci-status.sh`. If checks are still running, that's normal --
-     surface state to the user and stop.
-   - If there are CI failures, fix them and start a new iteration
-     (commit, ci-check, push, re-trigger, wait).
+Go back to step 1. Continue until ALL of these are true:
+
+- `fetch-all.sh` reports all review threads resolved.
+- `fetch-sonar-findings.sh` reports zero open issues / hotspots that
+  this PR introduced (or the remaining ones are explicitly marked FP /
+  WontFix).
+- The AI bots have posted a "no new findings" or equivalent comment
+  after their most recent re-trigger.
+- `ci-status.sh` reports no failures caused by this PR (failures
+  unrelated to the PR are noted, surfaced to the user, but not fixed).
+
+When `wait-for-activity.sh` times out (30 min):
+- Re-run `ci-status.sh`. If checks are still running, surface to the
+  user and stop -- the PR is in a clean intermediate state.
+- If there are CI failures attributable to the PR, treat them as a new
+  finding and iterate (commit -> ci-check -> push -> retrigger -> wait).
+- If the failures are unrelated, note them in the final report.
+
+### 8. Final report
+
+When the loop ends, summarize for the user:
+- Findings addressed (count by source: review threads, Sonar, CI).
+- Any unrelated CI failures observed but not fixed (with check name + URL).
+- Any human comments that need their attention.
+- Current PR state (mergeable / blocked, decision, head SHA).
 
 ## Commit message hygiene
 

--- a/.agents/skills/pr-reviews/scripts/_lib.sh
+++ b/.agents/skills/pr-reviews/scripts/_lib.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Common helpers for pr-reviews scripts.
+# Sourced from the per-action scripts; not executed directly.
+
+set -euo pipefail
+
+# Color vars are used by sourcing scripts; shellcheck cannot see that.
+# shellcheck disable=SC2034
+PR_RED='\033[0;31m'
+# shellcheck disable=SC2034
+PR_GREEN='\033[0;32m'
+# shellcheck disable=SC2034
+PR_YELLOW='\033[1;33m'
+# shellcheck disable=SC2034
+PR_GRAY='\033[0;90m'
+# shellcheck disable=SC2034
+PR_NC='\033[0m'
+
+pr_repo_root() {
+    git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel
+}
+
+# Owner/repo of the upstream remote (or origin if no upstream).
+# Override with PR_REPO_SLUG=owner/repo for cross-repo work.
+# Uses bash parameter expansion so repo names containing dots parse correctly.
+pr_repo_slug() {
+    if [[ -n "${PR_REPO_SLUG:-}" ]]; then
+        echo "${PR_REPO_SLUG}"
+        return
+    fi
+    local root url
+    root="$(pr_repo_root)"
+    url="$(git -C "${root}" config --get remote.upstream.url 2>/dev/null \
+         || git -C "${root}" config --get remote.origin.url)"
+    url="${url%.git}"               # strip trailing .git
+    url="${url#*github.com[:/]}"    # strip everything up to and including github.com:/
+    echo "${url}"
+}
+
+# Audit/state directory for pr-reviews artifacts.
+pr_audit_dir() {
+    local root dir
+    root="$(pr_repo_root)"
+    dir="${root}/.local/audits/pr-reviews"
+    mkdir -p "${dir}"
+    echo "${dir}"
+}
+
+# Per-PR working directory.
+pr_state_dir() {
+    local pr="${1:?usage: pr_state_dir <pr-number>}"
+    local dir
+    dir="$(pr_audit_dir)/pr-${pr}"
+    mkdir -p "${dir}"
+    echo "${dir}"
+}
+
+# Verify gh is available and authenticated. Bail loudly otherwise.
+pr_require_gh() {
+    if ! command -v gh >/dev/null; then
+        echo -e "${PR_RED}[ERROR]${PR_NC} 'gh' CLI not installed. https://cli.github.com/" >&2
+        return 1
+    fi
+    if ! gh auth status >/dev/null 2>&1; then
+        echo -e "${PR_RED}[ERROR]${PR_NC} 'gh' is not authenticated. Run 'gh auth login'." >&2
+        return 1
+    fi
+}
+
+# Bot logins recognized by the skill. The first regex matches the AI reviewers
+# the skill iterates with autonomously; the second matches CI/quality bots
+# whose comments are informational (sonar quality gate, etc.).
+PR_AI_BOT_RE='^(cubic-dev-ai|copilot|copilot-pull-request-reviewer|github-copilot)\[bot\]$'
+PR_INFO_BOT_RE='^(sonarqubecloud|netdata-bot|github-actions|coderabbitai)\[bot\]$'
+
+# Classify a login -> "ai_bot" | "info_bot" | "human".
+pr_classify_author() {
+    local login="$1"
+    if [[ "${login}" =~ ${PR_AI_BOT_RE} ]]; then
+        echo "ai_bot"
+    elif [[ "${login}" =~ ${PR_INFO_BOT_RE} ]]; then
+        echo "info_bot"
+    else
+        echo "human"
+    fi
+}
+
+# Pretty timestamp in UTC.
+pr_now_utc() {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}

--- a/.agents/skills/pr-reviews/scripts/_lib.sh
+++ b/.agents/skills/pr-reviews/scripts/_lib.sh
@@ -4,17 +4,23 @@
 
 set -euo pipefail
 
-# Color vars are used by sourcing scripts; shellcheck cannot see that.
+# IMPORTANT: define with $'...' so the variables contain real ESC bytes,
+# not the literal four-character string "\033". This way both `echo -e
+# "${PR_RED}..."` and `printf '%s' "${PR_RED}..."` render correctly --
+# without forcing every printf format string to be the variable itself
+# (which trips shellcheck SC2059) or %b (which adds inconsistency).
+#
+# Color vars are referenced by sourcing scripts; shellcheck cannot see that.
 # shellcheck disable=SC2034
-PR_RED='\033[0;31m'
+PR_RED=$'\033[0;31m'
 # shellcheck disable=SC2034
-PR_GREEN='\033[0;32m'
+PR_GREEN=$'\033[0;32m'
 # shellcheck disable=SC2034
-PR_YELLOW='\033[1;33m'
+PR_YELLOW=$'\033[1;33m'
 # shellcheck disable=SC2034
-PR_GRAY='\033[0;90m'
+PR_GRAY=$'\033[0;90m'
 # shellcheck disable=SC2034
-PR_NC='\033[0m'
+PR_NC=$'\033[0m'
 
 pr_repo_root() {
     git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel
@@ -88,4 +94,16 @@ pr_classify_author() {
 # Pretty timestamp in UTC.
 pr_now_utc() {
     date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+# PR numbers are positive integers (GitHub assigns 1+). Reject anything
+# else before interpolating into REST paths or `gh` arguments. Even though
+# URL interpolation isn't a shell-injection vector, malformed input causes
+# confusing API errors that look like permission/auth issues.
+pr_require_numeric() {
+    local n="$1" name="${2:-PR}"
+    if [[ ! "${n}" =~ ^[1-9][0-9]*$ ]]; then
+        echo -e "${PR_RED}[ERROR]${PR_NC} ${name} must be a positive integer, got: '${n}'" >&2
+        return 1
+    fi
 }

--- a/.agents/skills/pr-reviews/scripts/_lib.sh
+++ b/.agents/skills/pr-reviews/scripts/_lib.sh
@@ -47,7 +47,16 @@ pr_repo_slug() {
     root="$(pr_repo_root)"
     url="$(git -C "${root}" config --get remote.upstream.url 2>/dev/null \
          || git -C "${root}" config --get remote.origin.url)"
-    if [[ "${url}" != *github.com* ]]; then
+    # Match github.com only as a host -- a substring match would accept
+    # `notgithub.com`, `github.com.attacker.example.com`, etc.
+    # Accepted forms (covering all common gh / git remote outputs):
+    #   git@github.com:owner/repo[.git]           (SCP-style ssh)
+    #   ssh://git@github.com/owner/repo[.git]     (URL-style ssh)
+    #   https://github.com/owner/repo[.git]       (anonymous https)
+    #   https://x-access-token:TOK@github.com/... (credentialed https, gh auth)
+    if [[ "${url}" != *@github.com:* \
+       && "${url}" != *://github.com/* \
+       && "${url}" != *@github.com/* ]]; then
         echo ""
         return
     fi

--- a/.agents/skills/pr-reviews/scripts/_lib.sh
+++ b/.agents/skills/pr-reviews/scripts/_lib.sh
@@ -29,8 +29,17 @@ pr_repo_root() {
 # Owner/repo of the upstream remote (or origin if no upstream).
 # Override with PR_REPO_SLUG=owner/repo for cross-repo work.
 # Uses bash parameter expansion so repo names containing dots parse correctly.
+# Returns empty if the URL is not a github.com remote (this skill only
+# supports GitHub).
 pr_repo_slug() {
     if [[ -n "${PR_REPO_SLUG:-}" ]]; then
+        # Validate the override too so callers can't smuggle whitespace or
+        # shell metacharacters in via env. Allowed: owner/repo with
+        # alphanumerics, dot, underscore, hyphen.
+        if [[ ! "${PR_REPO_SLUG}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "" >&2
+            return
+        fi
         echo "${PR_REPO_SLUG}"
         return
     fi
@@ -38,6 +47,10 @@ pr_repo_slug() {
     root="$(pr_repo_root)"
     url="$(git -C "${root}" config --get remote.upstream.url 2>/dev/null \
          || git -C "${root}" config --get remote.origin.url)"
+    if [[ "${url}" != *github.com* ]]; then
+        echo ""
+        return
+    fi
     url="${url%.git}"               # strip trailing .git
     url="${url#*github.com[:/]}"    # strip everything up to and including github.com:/
     echo "${url}"
@@ -106,4 +119,17 @@ pr_require_numeric() {
         echo -e "${PR_RED}[ERROR]${PR_NC} ${name} must be a positive integer, got: '${n}'" >&2
         return 1
     fi
+}
+
+# Resolve and validate the repo slug. Returns "owner/repo" on stdout or
+# exits non-zero if no slug could be derived (no remotes configured, or
+# the URL didn't match github.com).
+pr_require_slug() {
+    local slug
+    slug="$(pr_repo_slug)"
+    if [[ -z "${slug}" || "${slug}" != */* ]]; then
+        echo -e "${PR_RED}[ERROR]${PR_NC} could not derive owner/repo from git remotes (got: '${slug}'). This skill only supports github.com remotes; set PR_REPO_SLUG=owner/repo or fix the remote URL." >&2
+        return 1
+    fi
+    printf '%s' "${slug}"
 }

--- a/.agents/skills/pr-reviews/scripts/ci-status.sh
+++ b/.agents/skills/pr-reviews/scripts/ci-status.sh
@@ -13,6 +13,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 pr_require_gh
 

--- a/.agents/skills/pr-reviews/scripts/ci-status.sh
+++ b/.agents/skills/pr-reviews/scripts/ci-status.sh
@@ -17,6 +17,7 @@ source "$(dirname "$0")/_lib.sh"
 pr_require_gh
 
 PR="${1:?usage: $0 <pr-number> [--json]}"
+pr_require_numeric "${PR}"
 JSON=0
 [[ "${2:-}" == "--json" ]] && JSON=1
 

--- a/.agents/skills/pr-reviews/scripts/ci-status.sh
+++ b/.agents/skills/pr-reviews/scripts/ci-status.sh
@@ -5,10 +5,10 @@
 #   ci-status.sh <pr-number>          # human-readable summary
 #   ci-status.sh <pr-number> --json   # raw JSON
 #
-# This is read-only. It is the precondition before any push: if a CI run is
-# in progress or just finished, the existing results are the ones we want to
-# capture before pushing again -- otherwise the next push restarts CI and we
-# lose the prior signal.
+# This is read-only. Use it BEFORE every push to find FAILURES that must
+# be addressed in the same push. Do NOT wait for in-progress checks
+# between iterations -- the next push will trigger a fresh CI run on the
+# new code, which is what matters. See SKILL.md Step 4b for the policy.
 
 set -euo pipefail
 
@@ -21,7 +21,7 @@ pr_require_numeric "${PR}"
 JSON=0
 [[ "${2:-}" == "--json" ]] && JSON=1
 
-SLUG="$(pr_repo_slug)"
+SLUG="$(pr_require_slug)"
 
 # pr view --json statusCheckRollup gives the per-check breakdown.
 data="$(gh pr view "${PR}" --repo "${SLUG}" --json statusCheckRollup,headRefOid,mergeStateStatus)"
@@ -55,7 +55,10 @@ running=$(jq '[.statusCheckRollup[] | select((.status // "")=="IN_PROGRESS" or (
 echo "Total checks: ${total}   Failing: ${fail}   Running: ${running}"
 
 if (( running > 0 )); then
-    echo -e "${PR_YELLOW}WARNING: ${running} check(s) still running. Pushing now will lose those results.${PR_NC}" >&2
+    # Exit 2 is informational, not a "do not push" signal. The next push
+    # will start a fresh CI run on top of the new code -- that's what we
+    # actually want to verify. The skill's policy is to push anyway.
+    echo -e "${PR_GRAY}Note: ${running} check(s) still running; the next push will start a fresh CI run.${PR_NC}" >&2
     exit 2
 fi
 if (( fail > 0 )); then

--- a/.agents/skills/pr-reviews/scripts/ci-status.sh
+++ b/.agents/skills/pr-reviews/scripts/ci-status.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Report current CI status for a PR head commit.
+#
+# Usage:
+#   ci-status.sh <pr-number>          # human-readable summary
+#   ci-status.sh <pr-number> --json   # raw JSON
+#
+# This is read-only. It is the precondition before any push: if a CI run is
+# in progress or just finished, the existing results are the ones we want to
+# capture before pushing again -- otherwise the next push restarts CI and we
+# lose the prior signal.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+pr_require_gh
+
+PR="${1:?usage: $0 <pr-number> [--json]}"
+JSON=0
+[[ "${2:-}" == "--json" ]] && JSON=1
+
+SLUG="$(pr_repo_slug)"
+
+# pr view --json statusCheckRollup gives the per-check breakdown.
+data="$(gh pr view "${PR}" --repo "${SLUG}" --json statusCheckRollup,headRefOid,mergeStateStatus)"
+
+if (( JSON )); then
+    printf '%s\n' "${data}"
+    exit 0
+fi
+
+head_sha="$(jq -r '.headRefOid' <<< "${data}" | head -c 10)"
+merge_state="$(jq -r '.mergeStateStatus' <<< "${data}")"
+
+echo "Head: ${head_sha}   Merge state: ${merge_state}"
+echo
+
+# Group checks by conclusion / status.
+jq -r '
+    .statusCheckRollup
+    | map(. + {key: ((.conclusion // .status) // "PENDING")})
+    | group_by(.key)
+    | map({key: .[0].key, count: length, names: [.[].name // .[].context]})
+    | sort_by(.key)
+    | .[]
+    | "\(.key)\t\(.count)\t\((.names | sort | unique | join(", ")[0:200]))"
+' <<< "${data}" | column -t -s $'\t'
+
+echo
+total=$(jq '.statusCheckRollup | length' <<< "${data}")
+fail=$(jq '[.statusCheckRollup[] | select((.conclusion // "")|test("FAILURE|TIMED_OUT|CANCELLED"))] | length' <<< "${data}")
+running=$(jq '[.statusCheckRollup[] | select((.status // "")=="IN_PROGRESS" or (.status // "")=="QUEUED")] | length' <<< "${data}")
+echo "Total checks: ${total}   Failing: ${fail}   Running: ${running}"
+
+if (( running > 0 )); then
+    echo -e "${PR_YELLOW}WARNING: ${running} check(s) still running. Pushing now will lose those results.${PR_NC}" >&2
+    exit 2
+fi
+if (( fail > 0 )); then
+    echo -e "${PR_RED}WARNING: ${fail} check(s) failing. Address these BEFORE pushing.${PR_NC}" >&2
+    exit 3
+fi
+exit 0

--- a/.agents/skills/pr-reviews/scripts/fetch-all.sh
+++ b/.agents/skills/pr-reviews/scripts/fetch-all.sh
@@ -31,6 +31,7 @@ source "$(dirname "$0")/_lib.sh"
 pr_require_gh
 
 PR="${1:?usage: $0 <pr-number>}"
+pr_require_numeric "${PR}"
 SLUG="$(pr_repo_slug)"
 DIR="$(pr_state_dir "${PR}")"
 

--- a/.agents/skills/pr-reviews/scripts/fetch-all.sh
+++ b/.agents/skills/pr-reviews/scripts/fetch-all.sh
@@ -27,6 +27,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 pr_require_gh
 
@@ -123,6 +124,9 @@ while true; do
     if [[ -n "${cursor}" ]]; then
         cursor_args+=(-F "after=${cursor}")
     fi
+    # The single-quoted GraphQL string contains $owner/$name/$number as
+    # GraphQL placeholders, not shell variables; SC2016 is expected here.
+    # shellcheck disable=SC2016
     gh api graphql -F owner="${owner}" -F name="${name}" -F number="${PR}" "${cursor_args[@]}" -f query='
         query($owner:String!, $name:String!, $number:Int!, $after:String) {
             repository(owner:$owner, name:$name) {

--- a/.agents/skills/pr-reviews/scripts/fetch-all.sh
+++ b/.agents/skills/pr-reviews/scripts/fetch-all.sh
@@ -32,7 +32,7 @@ pr_require_gh
 
 PR="${1:?usage: $0 <pr-number>}"
 pr_require_numeric "${PR}"
-SLUG="$(pr_repo_slug)"
+SLUG="$(pr_require_slug)"
 DIR="$(pr_state_dir "${PR}")"
 
 echo -e "${PR_GRAY}[fetch-all] PR ${SLUG}#${PR} -> ${DIR}${PR_NC}" >&2
@@ -49,9 +49,15 @@ fetch_paranoid() {
     # Ask for max page size and let gh follow rel=next.
     local sep
     if [[ "${path}" == *\?* ]]; then sep='&'; else sep='?'; fi
-    gh api --paginate "${path}${sep}per_page=100" > "${out}"
+    # `gh api --paginate` writes the per-page JSON arrays back-to-back
+    # (e.g. `[a,b,c][d,e]`), which is NOT a single valid JSON array. Pipe
+    # through `jq -s 'add'` to slurp the multiple top-level values and
+    # concatenate them into one array. (`gh api --paginate --jq '.[]'`
+    # would emit JSONL but loses the array shape we need for the rest of
+    # the loop.)
+    gh api --paginate "${path}${sep}per_page=100" | jq -s 'add // []' > "${out}"
 
-    # Did gh return a JSON array?
+    # Did we end up with a JSON array?
     if ! jq -e 'type=="array"' "${out}" >/dev/null 2>&1; then
         echo -e "${PR_RED}[fetch-all] ${kind}: response is not a JSON array. Auth? Rate limit?${PR_NC}" >&2
         head -c 200 "${out}" >&2; echo >&2
@@ -113,11 +119,11 @@ trap 'rm -f "${threads_tmp}"' EXIT
 cursor=""
 echo '[]' > "${DIR}/review-threads.json"
 while true; do
-    local_cursor_arg=()
+    cursor_args=()
     if [[ -n "${cursor}" ]]; then
-        local_cursor_arg+=(-F "after=${cursor}")
+        cursor_args+=(-F "after=${cursor}")
     fi
-    gh api graphql -F owner="${owner}" -F name="${name}" -F number="${PR}" "${local_cursor_arg[@]}" -f query='
+    gh api graphql -F owner="${owner}" -F name="${name}" -F number="${PR}" "${cursor_args[@]}" -f query='
         query($owner:String!, $name:String!, $number:Int!, $after:String) {
             repository(owner:$owner, name:$name) {
                 pullRequest(number:$number) {
@@ -129,7 +135,9 @@ while true; do
                             isOutdated
                             path
                             line
-                            comments(first:50) {
+                            comments(first:100) {
+                                pageInfo { hasNextPage endCursor }
+                                totalCount
                                 nodes {
                                     id
                                     databaseId
@@ -151,6 +159,17 @@ while true; do
     # Append to running file
     jq -s '.[0] + .[1]' "${DIR}/review-threads.json" <(printf '%s' "${page_nodes}") > "${DIR}/review-threads.json.merged"
     mv "${DIR}/review-threads.json.merged" "${DIR}/review-threads.json"
+
+    # Warn if any thread on this page has more than 100 comments -- the
+    # inner connection is fetched first:100 only, so the tail is cut.
+    truncated_threads="$(jq -r '
+        [.data.repository.pullRequest.reviewThreads.nodes[]
+         | select(.comments.pageInfo.hasNextPage)
+         | .id] | join(", ")
+    ' "${threads_tmp}")"
+    if [[ -n "${truncated_threads}" ]]; then
+        echo -e "${PR_YELLOW}[fetch-all] review-threads: nested comments truncated (>100) for: ${truncated_threads}${PR_NC}" >&2
+    fi
 
     has_next="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' "${threads_tmp}")"
     cursor="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' "${threads_tmp}")"
@@ -178,7 +197,7 @@ echo -e "${PR_GRAY}[fetch-all] review-threads: ${n_threads} threads total${PR_NC
         "${decision}" "${mergeable}" "${merge_state}"
     echo
     echo "Reviewers requested:"
-    jq -r '(.reviewRequests // [])[] | "  - " + (.login // .name)' "${DIR}/pr.json"
+    jq -r '(.reviewRequests // [])[] | "  - " + (.login // .name // "?")' "${DIR}/pr.json"
     echo
     echo "Counts:"
     printf '  issue-comments  : %d\n' "$(jq 'length' "${DIR}/issue-comments.json")"

--- a/.agents/skills/pr-reviews/scripts/fetch-all.sh
+++ b/.agents/skills/pr-reviews/scripts/fetch-all.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Fetch ALL comments / reviews / review threads for a PR, with paranoid pagination.
+#
+# Usage:
+#   fetch-all.sh <pr-number>
+#
+# Outputs (under .local/audits/pr-reviews/pr-<N>/):
+#   pr.json                -- gh pr view dump (state, head sha, etc.)
+#   issue-comments.json    -- /repos/{slug}/issues/{n}/comments       (top-level PR comments)
+#   review-comments.json   -- /repos/{slug}/pulls/{n}/comments        (line-level inline comments)
+#   reviews.json           -- /repos/{slug}/pulls/{n}/reviews         (review submissions with body)
+#   review-threads.json    -- GraphQL reviewThreads (per-thread isResolved + comments[])
+#   summary.txt            -- human-readable triage summary
+#
+# Pagination paranoia:
+#   GitHub paginates everything. Default page size is 30, max 100. The skill's
+#   #1 rule is: "do not stop at the pagination boundary -- if you see exactly
+#   100/200/300 items the round number is suspect; fetch one more page even
+#   when the Link header says no more, just to confirm."
+#
+#   This script:
+#     1. Uses --paginate (gh follows Link rel="next" automatically).
+#     2. Re-checks each result count against round-number multiples of 100.
+#        If suspicious, explicitly requests page=N+1 and merges.
+#     3. Logs the final count for each source so the caller can verify.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+pr_require_gh
+
+PR="${1:?usage: $0 <pr-number>}"
+SLUG="$(pr_repo_slug)"
+DIR="$(pr_state_dir "${PR}")"
+
+echo -e "${PR_GRAY}[fetch-all] PR ${SLUG}#${PR} -> ${DIR}${PR_NC}" >&2
+
+# --- pr.json (state, head sha, draft, requested reviewers, ...) ------------
+gh pr view "${PR}" --repo "${SLUG}" --json \
+    number,title,state,isDraft,headRefName,headRefOid,baseRefName,baseRefOid,reviewDecision,reviewRequests,mergeable,mergeStateStatus,statusCheckRollup,labels,createdAt,updatedAt,author \
+    > "${DIR}/pr.json"
+
+# --- Helper: fetch a paginated REST endpoint with paranoia -----------------
+# Args: <api-path> <output-file> <kind-label>
+fetch_paranoid() {
+    local path="$1" out="$2" kind="$3"
+    # Ask for max page size and let gh follow rel=next.
+    local sep
+    if [[ "${path}" == *\?* ]]; then sep='&'; else sep='?'; fi
+    gh api --paginate "${path}${sep}per_page=100" > "${out}"
+
+    # Did gh return a JSON array?
+    if ! jq -e 'type=="array"' "${out}" >/dev/null 2>&1; then
+        echo -e "${PR_RED}[fetch-all] ${kind}: response is not a JSON array. Auth? Rate limit?${PR_NC}" >&2
+        head -c 200 "${out}" >&2; echo >&2
+        return 1
+    fi
+
+    local n
+    n="$(jq 'length' "${out}")"
+    echo -e "${PR_GRAY}[fetch-all] ${kind}: ${n} items${PR_NC}" >&2
+
+    # Paranoia check: round multiples of 100 are suspicious. Explicitly
+    # request page=N+1 to confirm we've reached the end.
+    if (( n > 0 && n % 100 == 0 )); then
+        local next_page=$(( n / 100 + 1 ))
+        echo -e "${PR_YELLOW}[fetch-all] ${kind}: count is exactly ${n} (multiple of 100). Verifying with explicit page=${next_page}...${PR_NC}" >&2
+
+        local probe
+        probe="$(gh api "${path}${sep}per_page=100&page=${next_page}" 2>/dev/null || echo '[]')"
+        local extra
+        extra="$(jq 'length' <<< "${probe}")"
+        if (( extra > 0 )); then
+            echo -e "${PR_YELLOW}[fetch-all] ${kind}: page ${next_page} had ${extra} more items! Merging.${PR_NC}" >&2
+            # Merge and continue probing further pages until empty.
+            jq -s '.[0] + .[1]' "${out}" <(printf '%s' "${probe}") > "${out}.merged"
+            mv "${out}.merged" "${out}"
+            local p=$(( next_page + 1 ))
+            while true; do
+                probe="$(gh api "${path}${sep}per_page=100&page=${p}" 2>/dev/null || echo '[]')"
+                extra="$(jq 'length' <<< "${probe}")"
+                (( extra == 0 )) && break
+                echo -e "${PR_YELLOW}[fetch-all] ${kind}: page ${p} had ${extra} more.${PR_NC}" >&2
+                jq -s '.[0] + .[1]' "${out}" <(printf '%s' "${probe}") > "${out}.merged"
+                mv "${out}.merged" "${out}"
+                p=$(( p + 1 ))
+            done
+            n="$(jq 'length' "${out}")"
+            echo -e "${PR_GREEN}[fetch-all] ${kind}: final count after probing: ${n}${PR_NC}" >&2
+        else
+            echo -e "${PR_GRAY}[fetch-all] ${kind}: page ${next_page} empty -- ${n} confirmed.${PR_NC}" >&2
+        fi
+    fi
+}
+
+# --- Three REST sources ----------------------------------------------------
+fetch_paranoid "/repos/${SLUG}/issues/${PR}/comments" "${DIR}/issue-comments.json"  "issue-comments"
+fetch_paranoid "/repos/${SLUG}/pulls/${PR}/comments"  "${DIR}/review-comments.json" "review-comments"
+fetch_paranoid "/repos/${SLUG}/pulls/${PR}/reviews"   "${DIR}/reviews.json"         "reviews"
+
+# --- GraphQL reviewThreads (resolved state + thread IDs) -------------------
+# REST does not expose review-thread IDs or isResolved -- we need GraphQL for
+# resolve-thread.sh. Pagination uses cursors here, not pages.
+echo -e "${PR_GRAY}[fetch-all] review-threads (GraphQL)${PR_NC}" >&2
+owner="${SLUG%%/*}"
+name="${SLUG##*/}"
+
+threads_tmp="$(mktemp "${TMPDIR:-/tmp}/pr-threads-XXXXXX.json")"
+trap 'rm -f "${threads_tmp}"' EXIT
+
+cursor=""
+echo '[]' > "${DIR}/review-threads.json"
+while true; do
+    local_cursor_arg=()
+    if [[ -n "${cursor}" ]]; then
+        local_cursor_arg+=(-F "after=${cursor}")
+    fi
+    gh api graphql -F owner="${owner}" -F name="${name}" -F number="${PR}" "${local_cursor_arg[@]}" -f query='
+        query($owner:String!, $name:String!, $number:Int!, $after:String) {
+            repository(owner:$owner, name:$name) {
+                pullRequest(number:$number) {
+                    reviewThreads(first:100, after:$after) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes {
+                            id
+                            isResolved
+                            isOutdated
+                            path
+                            line
+                            comments(first:50) {
+                                nodes {
+                                    id
+                                    databaseId
+                                    body
+                                    author { login }
+                                    createdAt
+                                    url
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ' > "${threads_tmp}"
+
+    page_nodes="$(jq '.data.repository.pullRequest.reviewThreads.nodes' "${threads_tmp}")"
+    n_page="$(jq 'length' <<< "${page_nodes}")"
+    # Append to running file
+    jq -s '.[0] + .[1]' "${DIR}/review-threads.json" <(printf '%s' "${page_nodes}") > "${DIR}/review-threads.json.merged"
+    mv "${DIR}/review-threads.json.merged" "${DIR}/review-threads.json"
+
+    has_next="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' "${threads_tmp}")"
+    cursor="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' "${threads_tmp}")"
+    echo -e "${PR_GRAY}[fetch-all] review-threads: +${n_page} (hasNext=${has_next})${PR_NC}" >&2
+    [[ "${has_next}" == "true" ]] || break
+done
+n_threads="$(jq 'length' "${DIR}/review-threads.json")"
+echo -e "${PR_GRAY}[fetch-all] review-threads: ${n_threads} threads total${PR_NC}" >&2
+
+# --- summary.txt -----------------------------------------------------------
+{
+    echo "PR ${SLUG}#${PR} -- snapshot $(pr_now_utc)"
+    state=$(jq -r '.state' "${DIR}/pr.json")
+    is_draft=$(jq -r '.isDraft' "${DIR}/pr.json")
+    head_oid=$(jq -r '.headRefOid' "${DIR}/pr.json")
+    head_ref=$(jq -r '.headRefName' "${DIR}/pr.json")
+    base_oid=$(jq -r '.baseRefOid' "${DIR}/pr.json")
+    base_ref=$(jq -r '.baseRefName' "${DIR}/pr.json")
+    decision=$(jq -r '.reviewDecision // "none"' "${DIR}/pr.json")
+    mergeable=$(jq -r '.mergeable' "${DIR}/pr.json")
+    merge_state=$(jq -r '.mergeStateStatus' "${DIR}/pr.json")
+    [[ "${is_draft}" == "true" ]] && state="${state} (draft)"
+    printf 'State:    %s\nHead:     %s on %s\nBase:     %s on %s\nDecision: %s\nMerge:    %s / %s\n' \
+        "${state}" "${head_oid:0:10}" "${head_ref}" "${base_oid:0:10}" "${base_ref}" \
+        "${decision}" "${mergeable}" "${merge_state}"
+    echo
+    echo "Reviewers requested:"
+    jq -r '(.reviewRequests // [])[] | "  - " + (.login // .name)' "${DIR}/pr.json"
+    echo
+    echo "Counts:"
+    printf '  issue-comments  : %d\n' "$(jq 'length' "${DIR}/issue-comments.json")"
+    printf '  review-comments : %d\n' "$(jq 'length' "${DIR}/review-comments.json")"
+    printf '  reviews         : %d\n' "$(jq 'length' "${DIR}/reviews.json")"
+    n_resolved=$(jq '[.[] | select(.isResolved)] | length' "${DIR}/review-threads.json")
+    n_open=$(jq '[.[] | select(.isResolved | not)] | length' "${DIR}/review-threads.json")
+    printf '  review-threads  : %d (resolved: %d, open: %d)\n' "${n_threads}" "${n_resolved}" "${n_open}"
+    echo
+    echo "Authors involved (count of items per author across all sources):"
+    {
+        jq -r '.[] | .user.login' "${DIR}/issue-comments.json"
+        jq -r '.[] | .user.login' "${DIR}/review-comments.json"
+        jq -r '.[] | .user.login' "${DIR}/reviews.json"
+    } | sort | uniq -c | sort -rn | sed 's/^/  /'
+    echo
+    echo "Open review threads (need attention):"
+    jq -r '.[] | select(.isResolved | not)
+        | "  THREAD " + .id
+        + "  " + .path + ":" + ((.line // "?") | tostring)
+        + "  comments=" + ((.comments.nodes | length) | tostring)
+        + "  by=" + (.comments.nodes[0].author.login // "?")' \
+        "${DIR}/review-threads.json"
+} > "${DIR}/summary.txt"
+
+echo
+cat "${DIR}/summary.txt"

--- a/.agents/skills/pr-reviews/scripts/fetch-sonar-findings.sh
+++ b/.agents/skills/pr-reviews/scripts/fetch-sonar-findings.sh
@@ -25,6 +25,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 
 # shellcheck disable=SC1091

--- a/.agents/skills/pr-reviews/scripts/fetch-sonar-findings.sh
+++ b/.agents/skills/pr-reviews/scripts/fetch-sonar-findings.sh
@@ -23,6 +23,7 @@ set -euo pipefail
 source "$(dirname "$0")/_lib.sh"
 
 PR="${1:?usage: $0 <pr-number>}"
+pr_require_numeric "${PR}"
 
 ROOT="$(pr_repo_root)"
 ENV="${ROOT}/.env"

--- a/.agents/skills/pr-reviews/scripts/fetch-sonar-findings.sh
+++ b/.agents/skills/pr-reviews/scripts/fetch-sonar-findings.sh
@@ -16,74 +16,37 @@
 # Reads SONAR_TOKEN, SONAR_HOST_URL, SONAR_PROJECT from <repo-root>/.env --
 # the same .env entries the sonarqube-audit skill uses. If they're missing,
 # this script prints what's needed and exits 1.
+#
+# Sourcing strategy: this script is part of pr-reviews, but it leans on
+# the sonarqube-audit skill's `_lib.sh` helpers (sq_load_env, sq_paginate)
+# so we get a single paginator + token-masking implementation, rather
+# than duplicating the loop and risking drift.
 
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
 source "$(dirname "$0")/_lib.sh"
 
+# shellcheck disable=SC1091
+source "$(dirname "$0")/../../sonarqube-audit/scripts/_lib.sh"
+
 PR="${1:?usage: $0 <pr-number>}"
 pr_require_numeric "${PR}"
 
-ROOT="$(pr_repo_root)"
-ENV="${ROOT}/.env"
-
-if [[ ! -r "${ENV}" ]]; then
-    echo -e "${PR_RED}[ERROR]${PR_NC} Missing ${ENV}." >&2
-    echo "Add to ${ENV}:" >&2
-    echo "  SONAR_TOKEN='<token from https://sonarcloud.io/account/security>'" >&2
-    echo "  SONAR_HOST_URL=https://sonarcloud.io" >&2
-    echo "  SONAR_PROJECT=<project_key>" >&2
-    exit 1
-fi
-set -a
-# shellcheck disable=SC1090
-source "${ENV}"
-set +a
-: "${SONAR_TOKEN:?SONAR_TOKEN not set in .env -- see sonarqube-audit/SKILL.md}"
-: "${SONAR_HOST_URL:=https://sonarcloud.io}"
-: "${SONAR_PROJECT:?SONAR_PROJECT not set in .env}"
+# sq_load_env reads <repo-root>/.env; same .env the pr-reviews scripts use.
+sq_load_env
 
 DIR="$(pr_state_dir "${PR}")"
 
-# Paginate through Sonar's issue search filtered by pullRequest. ps=500 is
-# the max per page. Stop when paging.total is reached or a page returns 0.
-fetch_paginated() {
-    local kind="$1" path_with_filter="$2" out="$3"
-    local page=1 total=0 fetched=0
-    echo '[]' > "${out}"
-    while :; do
-        local resp
-        resp="$(curl --fail --silent --show-error -u "${SONAR_TOKEN}:" \
-            "${SONAR_HOST_URL}${path_with_filter}&ps=500&p=${page}")"
-        local items
-        items="$(jq ".${kind}" <<< "${resp}")"
-        local in_page
-        in_page="$(jq 'length' <<< "${items}")"
-        total="$(jq -r '.paging.total' <<< "${resp}")"
-        fetched=$(( fetched + in_page ))
-
-        # Append to running file
-        jq -s '.[0] + .[1]' "${out}" <(printf '%s' "${items}") > "${out}.merged"
-        mv "${out}.merged" "${out}"
-
-        echo -e "${PR_GRAY}[fetch-sonar] ${kind}: page ${page} +${in_page} (running ${fetched}/${total})${PR_NC}" >&2
-        (( fetched >= total || in_page == 0 )) && break
-        page=$(( page + 1 ))
-    done
-}
-
 echo -e "${PR_GRAY}[fetch-sonar] PR ${PR} -> ${DIR}${PR_NC}" >&2
 
-# 1) Issues introduced by the PR (resolved=false: still actionable).
-fetch_paginated "issues" \
-    "/api/issues/search?componentKeys=${SONAR_PROJECT}&pullRequest=${PR}&resolved=false" \
-    "${DIR}/sonar-issues.json"
+# Build per-source path. sq_paginate streams one JSON page per line; jq -s
+# slurps them and concatenates the array under each result key.
+sq_paginate "/api/issues/search?componentKeys=${SONAR_PROJECT}&pullRequest=${PR}&resolved=false" \
+    | jq -s '[.[].issues[]]' > "${DIR}/sonar-issues.json"
 
-# 2) Security Hotspots introduced by the PR.
-fetch_paginated "hotspots" \
-    "/api/hotspots/search?projectKey=${SONAR_PROJECT}&pullRequest=${PR}&status=TO_REVIEW" \
-    "${DIR}/sonar-hotspots.json"
+sq_paginate "/api/hotspots/search?projectKey=${SONAR_PROJECT}&pullRequest=${PR}&status=TO_REVIEW" \
+    | jq -s '[.[].hotspots[]]' > "${DIR}/sonar-hotspots.json"
 
 # Summary
 n_issues="$(jq 'length' "${DIR}/sonar-issues.json")"

--- a/.agents/skills/pr-reviews/scripts/fetch-sonar-findings.sh
+++ b/.agents/skills/pr-reviews/scripts/fetch-sonar-findings.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Fetch SonarCloud findings introduced by a specific pull request.
+#
+# Usage:
+#   fetch-sonar-findings.sh <pr-number>
+#
+# SonarCloud does NOT post per-finding inline comments on the GitHub PR --
+# only a QualityGate summary comment is delivered. The actual issue list
+# lives behind /api/issues/search?pullRequest=<N> and /api/hotspots/search.
+# This script pulls both, so the PR-reviews loop can address them.
+#
+# Outputs (under .local/audits/pr-reviews/pr-<N>/):
+#   sonar-issues.json    -- all open issues this PR introduced
+#   sonar-hotspots.json  -- all open security hotspots this PR introduced
+#
+# Reads SONAR_TOKEN, SONAR_HOST_URL, SONAR_PROJECT from <repo-root>/.env --
+# the same .env entries the sonarqube-audit skill uses. If they're missing,
+# this script prints what's needed and exits 1.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+
+PR="${1:?usage: $0 <pr-number>}"
+
+ROOT="$(pr_repo_root)"
+ENV="${ROOT}/.env"
+
+if [[ ! -r "${ENV}" ]]; then
+    echo -e "${PR_RED}[ERROR]${PR_NC} Missing ${ENV}." >&2
+    echo "Add to ${ENV}:" >&2
+    echo "  SONAR_TOKEN='<token from https://sonarcloud.io/account/security>'" >&2
+    echo "  SONAR_HOST_URL=https://sonarcloud.io" >&2
+    echo "  SONAR_PROJECT=<project_key>" >&2
+    exit 1
+fi
+set -a
+# shellcheck disable=SC1090
+source "${ENV}"
+set +a
+: "${SONAR_TOKEN:?SONAR_TOKEN not set in .env -- see sonarqube-audit/SKILL.md}"
+: "${SONAR_HOST_URL:=https://sonarcloud.io}"
+: "${SONAR_PROJECT:?SONAR_PROJECT not set in .env}"
+
+DIR="$(pr_state_dir "${PR}")"
+
+# Paginate through Sonar's issue search filtered by pullRequest. ps=500 is
+# the max per page. Stop when paging.total is reached or a page returns 0.
+fetch_paginated() {
+    local kind="$1" path_with_filter="$2" out="$3"
+    local page=1 total=0 fetched=0
+    echo '[]' > "${out}"
+    while :; do
+        local resp
+        resp="$(curl --fail --silent --show-error -u "${SONAR_TOKEN}:" \
+            "${SONAR_HOST_URL}${path_with_filter}&ps=500&p=${page}")"
+        local items
+        items="$(jq ".${kind}" <<< "${resp}")"
+        local in_page
+        in_page="$(jq 'length' <<< "${items}")"
+        total="$(jq -r '.paging.total' <<< "${resp}")"
+        fetched=$(( fetched + in_page ))
+
+        # Append to running file
+        jq -s '.[0] + .[1]' "${out}" <(printf '%s' "${items}") > "${out}.merged"
+        mv "${out}.merged" "${out}"
+
+        echo -e "${PR_GRAY}[fetch-sonar] ${kind}: page ${page} +${in_page} (running ${fetched}/${total})${PR_NC}" >&2
+        (( fetched >= total || in_page == 0 )) && break
+        page=$(( page + 1 ))
+    done
+}
+
+echo -e "${PR_GRAY}[fetch-sonar] PR ${PR} -> ${DIR}${PR_NC}" >&2
+
+# 1) Issues introduced by the PR (resolved=false: still actionable).
+fetch_paginated "issues" \
+    "/api/issues/search?componentKeys=${SONAR_PROJECT}&pullRequest=${PR}&resolved=false" \
+    "${DIR}/sonar-issues.json"
+
+# 2) Security Hotspots introduced by the PR.
+fetch_paginated "hotspots" \
+    "/api/hotspots/search?projectKey=${SONAR_PROJECT}&pullRequest=${PR}&status=TO_REVIEW" \
+    "${DIR}/sonar-hotspots.json"
+
+# Summary
+n_issues="$(jq 'length' "${DIR}/sonar-issues.json")"
+n_hotspots="$(jq 'length' "${DIR}/sonar-hotspots.json")"
+
+echo
+echo "SonarCloud findings on PR ${PR}:"
+echo "  issues:   ${n_issues}"
+echo "  hotspots: ${n_hotspots}"
+echo
+if (( n_issues > 0 )); then
+    echo "Issues by severity / rule:"
+    jq -r 'group_by(.severity + " " + .rule) | .[] | "  \(.[0].severity)  \(.[0].rule)  x\(length)"' \
+        "${DIR}/sonar-issues.json"
+    echo
+    echo "Issue details:"
+    jq -r '.[] | "  \(.key)  \(.severity)  \(.rule)  \(.component | sub("^[^:]+:"; ""))\(if .line then ":" + (.line | tostring) else "" end)\n    \(.message)"' \
+        "${DIR}/sonar-issues.json"
+fi
+if (( n_hotspots > 0 )); then
+    echo
+    echo "Hotspots:"
+    jq -r '.[] | "  \(.key)  \(.vulnerabilityProbability)  \(.ruleKey)  \(.component | sub("^[^:]+:"; ""))\(if .line then ":" + (.line | tostring) else "" end)\n    \(.message)"' \
+        "${DIR}/sonar-hotspots.json"
+fi

--- a/.agents/skills/pr-reviews/scripts/list-open-threads.sh
+++ b/.agents/skills/pr-reviews/scripts/list-open-threads.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# List open (unresolved) review threads on a PR with the comments inside each.
+# Usage:
+#   list-open-threads.sh <pr-number>            # full bodies
+#   list-open-threads.sh <pr-number> --short    # one-line per thread
+#
+# Reads from the cached fetch-all.sh dump. Run fetch-all.sh first.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+
+PR="${1:?usage: $0 <pr-number> [--short]}"
+SHORT=0
+[[ "${2:-}" == "--short" ]] && SHORT=1
+
+DIR="$(pr_state_dir "${PR}")"
+FILE="${DIR}/review-threads.json"
+if [[ ! -s "${FILE}" ]]; then
+    echo -e "${PR_RED}Missing ${FILE}. Run fetch-all.sh ${PR} first.${PR_NC}" >&2
+    exit 1
+fi
+
+if (( SHORT )); then
+    jq -r '
+        .[]
+        | select(.isResolved | not)
+        | "\(.id) | \(.path):\(.line // "?") | \(.comments.nodes[0].author.login)"
+    ' "${FILE}" | column -t -s '|'
+else
+    jq -r '
+        .[]
+        | select(.isResolved | not)
+        | "================================================================\nTHREAD: \(.id)\nFile:   \(.path):\(.line // "?")\nOutdated: \(.isOutdated)\n----------------------------------------------------------------\n" + (
+            [.comments.nodes[] | "[\(.author.login) at \(.createdAt)]\n\(.body)\n  -> \(.url)\n"] | join("\n")
+        )
+    ' "${FILE}"
+fi

--- a/.agents/skills/pr-reviews/scripts/list-open-threads.sh
+++ b/.agents/skills/pr-reviews/scripts/list-open-threads.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 source "$(dirname "$0")/_lib.sh"
 
 PR="${1:?usage: $0 <pr-number> [--short]}"
+pr_require_numeric "${PR}"
 SHORT=0
 [[ "${2:-}" == "--short" ]] && SHORT=1
 

--- a/.agents/skills/pr-reviews/scripts/list-open-threads.sh
+++ b/.agents/skills/pr-reviews/scripts/list-open-threads.sh
@@ -9,6 +9,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 
 PR="${1:?usage: $0 <pr-number> [--short]}"

--- a/.agents/skills/pr-reviews/scripts/list-open-threads.sh
+++ b/.agents/skills/pr-reviews/scripts/list-open-threads.sh
@@ -18,7 +18,7 @@ SHORT=0
 
 DIR="$(pr_state_dir "${PR}")"
 FILE="${DIR}/review-threads.json"
-if [[ ! -s "${FILE}" ]]; then
+if [[ ! -f "${FILE}" || ! -r "${FILE}" || ! -s "${FILE}" ]]; then
     echo -e "${PR_RED}Missing ${FILE}. Run fetch-all.sh ${PR} first.${PR_NC}" >&2
     exit 1
 fi

--- a/.agents/skills/pr-reviews/scripts/reply-thread.sh
+++ b/.agents/skills/pr-reviews/scripts/reply-thread.sh
@@ -19,6 +19,7 @@ source "$(dirname "$0")/_lib.sh"
 pr_require_gh
 
 PR="${1:?usage: $0 <pr-number> <comment-id> <body>}"
+pr_require_numeric "${PR}"
 COMMENT_ID="${2:?usage}"
 BODY_ARG="${3:?usage}"
 

--- a/.agents/skills/pr-reviews/scripts/reply-thread.sh
+++ b/.agents/skills/pr-reviews/scripts/reply-thread.sh
@@ -29,12 +29,15 @@ else
     BODY="${BODY_ARG}"
 fi
 
-if [[ -z "${BODY// /}" ]]; then
-    echo -e "${PR_RED}[ERROR]${PR_NC} Empty body." >&2
+# Strip ALL whitespace (spaces, tabs, newlines, carriage returns) before
+# the empty-body check; previous version stripped spaces only and would
+# accept a tab-only or newline-only body.
+if [[ -z "${BODY//[[:space:]]/}" ]]; then
+    echo -e "${PR_RED}[ERROR]${PR_NC} Empty body (whitespace-only)." >&2
     exit 2
 fi
 
-SLUG="$(pr_repo_slug)"
+SLUG="$(pr_require_slug)"
 echo -e "${PR_GRAY}[reply-thread] PR ${SLUG}#${PR} reply to comment ${COMMENT_ID}${PR_NC}" >&2
 
 gh api --method POST "/repos/${SLUG}/pulls/${PR}/comments/${COMMENT_ID}/replies" \

--- a/.agents/skills/pr-reviews/scripts/reply-thread.sh
+++ b/.agents/skills/pr-reviews/scripts/reply-thread.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Reply inside an existing review-comment thread.
+#
+# Usage:
+#   reply-thread.sh <pr-number> <comment-id> <body-text>
+#   reply-thread.sh <pr-number> <comment-id> @<file>
+#
+# <comment-id> is the REST databaseId of any comment in the thread (e.g. one
+# of `databaseId` from review-threads.json -> .comments.nodes[]). The new
+# reply is anchored under that thread automatically.
+#
+# To resolve the thread after replying, call resolve-thread.sh with the
+# thread's GraphQL node id.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+pr_require_gh
+
+PR="${1:?usage: $0 <pr-number> <comment-id> <body>}"
+COMMENT_ID="${2:?usage}"
+BODY_ARG="${3:?usage}"
+
+if [[ "${BODY_ARG}" == @* ]]; then
+    BODY="$(cat "${BODY_ARG#@}")"
+else
+    BODY="${BODY_ARG}"
+fi
+
+if [[ -z "${BODY// /}" ]]; then
+    echo -e "${PR_RED}[ERROR]${PR_NC} Empty body." >&2
+    exit 2
+fi
+
+SLUG="$(pr_repo_slug)"
+echo -e "${PR_GRAY}[reply-thread] PR ${SLUG}#${PR} reply to comment ${COMMENT_ID}${PR_NC}" >&2
+
+gh api --method POST "/repos/${SLUG}/pulls/${PR}/comments/${COMMENT_ID}/replies" \
+    -f body="${BODY}" \
+    --jq '"posted reply id=\(.id) url=\(.html_url)"'

--- a/.agents/skills/pr-reviews/scripts/reply-thread.sh
+++ b/.agents/skills/pr-reviews/scripts/reply-thread.sh
@@ -23,8 +23,15 @@ pr_require_numeric "${PR}"
 COMMENT_ID="${2:?usage}"
 BODY_ARG="${3:?usage}"
 
+pr_require_numeric "${COMMENT_ID}" "comment-id"
+
 if [[ "${BODY_ARG}" == @* ]]; then
-    BODY="$(cat "${BODY_ARG#@}")"
+    body_file="${BODY_ARG#@}"
+    if [[ ! -f "${body_file}" || ! -r "${body_file}" || ! -s "${body_file}" ]]; then
+        echo -e "${PR_RED}[ERROR]${PR_NC} body file not a readable, non-empty regular file: '${body_file}'" >&2
+        exit 1
+    fi
+    BODY="$(cat "${body_file}")"
 else
     BODY="${BODY_ARG}"
 fi

--- a/.agents/skills/pr-reviews/scripts/reply-thread.sh
+++ b/.agents/skills/pr-reviews/scripts/reply-thread.sh
@@ -15,6 +15,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 pr_require_gh
 

--- a/.agents/skills/pr-reviews/scripts/resolve-thread.sh
+++ b/.agents/skills/pr-reviews/scripts/resolve-thread.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Resolve a review thread on a PR (marks the conversation as done in the UI).
+#
+# Usage:
+#   resolve-thread.sh <thread-node-id>
+#
+# <thread-node-id> is the GraphQL id from review-threads.json -> .[].id.
+# It looks like "PRRT_kwDO..." -- not the numeric REST id.
+#
+# Resolving a thread does NOT require a reply, but the convention is to reply
+# first then resolve. See SKILL.md.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+pr_require_gh
+
+THREAD_ID="${1:?usage: $0 <thread-node-id>}"
+
+gh api graphql -F threadId="${THREAD_ID}" -f query='
+    mutation($threadId:ID!) {
+        resolveReviewThread(input: {threadId: $threadId}) {
+            thread { id isResolved }
+        }
+    }
+' --jq '.data.resolveReviewThread.thread | "resolved=\(.isResolved) id=\(.id)"'

--- a/.agents/skills/pr-reviews/scripts/resolve-thread.sh
+++ b/.agents/skills/pr-reviews/scripts/resolve-thread.sh
@@ -13,6 +13,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 pr_require_gh
 
@@ -20,13 +21,19 @@ THREAD_ID="${1:?usage: $0 <thread-node-id>}"
 
 # Review-thread node IDs follow the pattern `PRRT_<base64ish>`. Validate
 # the prefix + the body charset so a malformed value can't reach the API.
-# (The mutation works by node ID alone and doesn't need a repo slug, so
-# we don't pr_require_slug here.)
 if [[ ! "${THREAD_ID}" =~ ^PRRT_[A-Za-z0-9_-]+$ ]]; then
     echo -e "${PR_RED}[ERROR]${PR_NC} thread-node-id must look like 'PRRT_...' (got: '${THREAD_ID}')" >&2
     exit 1
 fi
 
+# Fail fast on non-GitHub remotes. The mutation operates by node ID and
+# does not need the slug, but this script is GitHub-only -- making that
+# explicit at entry catches misconfiguration earlier than letting the
+# mutation hit a non-github API.
+pr_require_slug >/dev/null
+
+# The single-quoted GraphQL string has $threadId as a placeholder.
+# shellcheck disable=SC2016
 gh api graphql -F threadId="${THREAD_ID}" -f query='
     mutation($threadId:ID!) {
         resolveReviewThread(input: {threadId: $threadId}) {

--- a/.agents/skills/pr-reviews/scripts/resolve-thread.sh
+++ b/.agents/skills/pr-reviews/scripts/resolve-thread.sh
@@ -18,6 +18,15 @@ pr_require_gh
 
 THREAD_ID="${1:?usage: $0 <thread-node-id>}"
 
+# Review-thread node IDs follow the pattern `PRRT_<base64ish>`. Validate
+# the prefix + the body charset so a malformed value can't reach the API.
+# (The mutation works by node ID alone and doesn't need a repo slug, so
+# we don't pr_require_slug here.)
+if [[ ! "${THREAD_ID}" =~ ^PRRT_[A-Za-z0-9_-]+$ ]]; then
+    echo -e "${PR_RED}[ERROR]${PR_NC} thread-node-id must look like 'PRRT_...' (got: '${THREAD_ID}')" >&2
+    exit 1
+fi
+
 gh api graphql -F threadId="${THREAD_ID}" -f query='
     mutation($threadId:ID!) {
         resolveReviewThread(input: {threadId: $threadId}) {

--- a/.agents/skills/pr-reviews/scripts/trigger-copilot.sh
+++ b/.agents/skills/pr-reviews/scripts/trigger-copilot.sh
@@ -16,14 +16,14 @@ pr_require_gh
 
 PR="${1:?usage: $0 <pr-number>}"
 pr_require_numeric "${PR}"
-SLUG="$(pr_repo_slug)"
+SLUG="$(pr_require_slug)"
 
 echo -e "${PR_GRAY}[trigger-copilot] PR ${SLUG}#${PR}: re-add @copilot as reviewer${PR_NC}" >&2
 
-# `gh pr edit --add-reviewer` is officially supported and accepts @copilot.
-# It returns a non-zero status if the reviewer is already requested -- which
-# is fine; the side-effect we want (a fresh review run) is triggered by the
-# remove+add, so we do that explicitly to be safe.
+# Force a fresh review run by removing then re-adding the reviewer.
+# `--remove-reviewer @copilot` returns non-zero when copilot is NOT
+# currently a requested reviewer (nothing to remove); we ignore that exit
+# so the subsequent `--add-reviewer` always runs and triggers the review.
 gh pr edit "${PR}" --repo "${SLUG}" --remove-reviewer "@copilot" >/dev/null 2>&1 || true
 gh pr edit "${PR}" --repo "${SLUG}" --add-reviewer "@copilot"
 echo -e "${PR_GREEN}[trigger-copilot] @copilot re-requested.${PR_NC}" >&2

--- a/.agents/skills/pr-reviews/scripts/trigger-copilot.sh
+++ b/.agents/skills/pr-reviews/scripts/trigger-copilot.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Re-request the GitHub Copilot reviewer on a PR.
+#
+# Copilot does not react to comments. It re-runs only when re-added as a
+# requested reviewer. Calling this after pushing is the right way to get a
+# follow-up Copilot review.
+#
+# Usage:
+#   trigger-copilot.sh <pr-number>
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+pr_require_gh
+
+PR="${1:?usage: $0 <pr-number>}"
+SLUG="$(pr_repo_slug)"
+
+echo -e "${PR_GRAY}[trigger-copilot] PR ${SLUG}#${PR}: re-add @copilot as reviewer${PR_NC}" >&2
+
+# `gh pr edit --add-reviewer` is officially supported and accepts @copilot.
+# It returns a non-zero status if the reviewer is already requested -- which
+# is fine; the side-effect we want (a fresh review run) is triggered by the
+# remove+add, so we do that explicitly to be safe.
+gh pr edit "${PR}" --repo "${SLUG}" --remove-reviewer "@copilot" >/dev/null 2>&1 || true
+gh pr edit "${PR}" --repo "${SLUG}" --add-reviewer "@copilot"
+echo -e "${PR_GREEN}[trigger-copilot] @copilot re-requested.${PR_NC}" >&2

--- a/.agents/skills/pr-reviews/scripts/trigger-copilot.sh
+++ b/.agents/skills/pr-reviews/scripts/trigger-copilot.sh
@@ -15,6 +15,7 @@ source "$(dirname "$0")/_lib.sh"
 pr_require_gh
 
 PR="${1:?usage: $0 <pr-number>}"
+pr_require_numeric "${PR}"
 SLUG="$(pr_repo_slug)"
 
 echo -e "${PR_GRAY}[trigger-copilot] PR ${SLUG}#${PR}: re-add @copilot as reviewer${PR_NC}" >&2

--- a/.agents/skills/pr-reviews/scripts/trigger-copilot.sh
+++ b/.agents/skills/pr-reviews/scripts/trigger-copilot.sh
@@ -11,6 +11,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 pr_require_gh
 

--- a/.agents/skills/pr-reviews/scripts/trigger-cubic.sh
+++ b/.agents/skills/pr-reviews/scripts/trigger-cubic.sh
@@ -21,7 +21,7 @@ PR="${1:?usage: $0 <pr-number> [<extra-message>]}"
 pr_require_numeric "${PR}"
 EXTRA="${2:-please review again}"
 
-SLUG="$(pr_repo_slug)"
+SLUG="$(pr_require_slug)"
 BODY="@cubic-dev-ai ${EXTRA}"
 
 echo -e "${PR_GRAY}[trigger-cubic] PR ${SLUG}#${PR}: ${BODY}${PR_NC}" >&2

--- a/.agents/skills/pr-reviews/scripts/trigger-cubic.sh
+++ b/.agents/skills/pr-reviews/scripts/trigger-cubic.sh
@@ -14,6 +14,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 pr_require_gh
 

--- a/.agents/skills/pr-reviews/scripts/trigger-cubic.sh
+++ b/.agents/skills/pr-reviews/scripts/trigger-cubic.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Re-trigger cubic-dev-ai to re-review the PR.
+#
+# Cubic does not react to comments inside threads. It re-reviews when a NEW
+# top-level PR comment mentions it. Posting the comment is the trigger.
+#
+# Usage:
+#   trigger-cubic.sh <pr-number> [<extra-message>]
+#
+# Default body is "@cubic-dev-ai please review again". Override by passing a
+# second argument; the @cubic-dev-ai mention is always prepended so the bot
+# is guaranteed to see it.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+pr_require_gh
+
+PR="${1:?usage: $0 <pr-number> [<extra-message>]}"
+EXTRA="${2:-please review again}"
+
+SLUG="$(pr_repo_slug)"
+BODY="@cubic-dev-ai ${EXTRA}"
+
+echo -e "${PR_GRAY}[trigger-cubic] PR ${SLUG}#${PR}: ${BODY}${PR_NC}" >&2
+
+gh api --method POST "/repos/${SLUG}/issues/${PR}/comments" \
+    -f body="${BODY}" \
+    --jq '"posted comment id=\(.id) url=\(.html_url)"'

--- a/.agents/skills/pr-reviews/scripts/trigger-cubic.sh
+++ b/.agents/skills/pr-reviews/scripts/trigger-cubic.sh
@@ -18,6 +18,7 @@ source "$(dirname "$0")/_lib.sh"
 pr_require_gh
 
 PR="${1:?usage: $0 <pr-number> [<extra-message>]}"
+pr_require_numeric "${PR}"
 EXTRA="${2:-please review again}"
 
 SLUG="$(pr_repo_slug)"

--- a/.agents/skills/pr-reviews/scripts/wait-for-activity.sh
+++ b/.agents/skills/pr-reviews/scripts/wait-for-activity.sh
@@ -32,6 +32,7 @@ source "$(dirname "$0")/_lib.sh"
 pr_require_gh
 
 PR="${1:?usage: $0 <pr-number> [<timeout-seconds>] [<poll-interval-seconds>]}"
+pr_require_numeric "${PR}"
 TIMEOUT="${2:-1800}"
 POLL="${3:-30}"
 

--- a/.agents/skills/pr-reviews/scripts/wait-for-activity.sh
+++ b/.agents/skills/pr-reviews/scripts/wait-for-activity.sh
@@ -36,31 +36,65 @@ pr_require_numeric "${PR}"
 TIMEOUT="${2:-1800}"
 POLL="${3:-30}"
 
-SLUG="$(pr_repo_slug)"
+SLUG="$(pr_require_slug)"
 
 snapshot() {
     # Quick snapshot for change detection -- not a full fetch.
+    #
+    # `gh api --paginate ... --jq '.field'` emits one value per page (JSONL),
+    # so we sum them with awk.  `gh api --paginate ... | jq 'length'` would
+    # NOT work here -- the concatenated arrays from paginate are not a
+    # single JSON value.
     gh pr view "${PR}" --repo "${SLUG}" --json headRefOid \
         --jq '"head=\(.headRefOid)"'
-    gh api "/repos/${SLUG}/issues/${PR}/comments?per_page=1" \
-        --jq '"latest_issue=\(.[0].id // 0)_\(.[0].updated_at // \"\")_count_\(. | length)"' \
-        2>/dev/null || true
-    gh api "/repos/${SLUG}/pulls/${PR}/comments?per_page=1" \
-        --jq '"latest_review_comment=\(.[0].id // 0)_\(.[0].updated_at // \"\")"' \
-        2>/dev/null || true
-    gh api "/repos/${SLUG}/pulls/${PR}/reviews?per_page=1" \
-        --jq '"latest_review=\(.[0].id // 0)_\(.[0].submitted_at // \"\")"' \
-        2>/dev/null || true
-    # Counts (exact -- enumerate via paginated count endpoint via Link parsing).
-    # Cheap proxy: a HEAD on the listing endpoints with per_page=1 returns
-    # a Link header whose last page == total. For correctness we just
-    # paginate.
-    gh api --paginate "/repos/${SLUG}/issues/${PR}/comments?per_page=100" --jq 'length' 2>/dev/null \
+    gh api --paginate "/repos/${SLUG}/issues/${PR}/comments?per_page=100" --jq 'if type=="array" then length else 0 end' 2>/dev/null \
         | awk 'BEGIN{t=0} {t+=$1} END{print "n_issue="t}'
-    gh api --paginate "/repos/${SLUG}/pulls/${PR}/comments?per_page=100" --jq 'length' 2>/dev/null \
+    gh api --paginate "/repos/${SLUG}/pulls/${PR}/comments?per_page=100" --jq 'if type=="array" then length else 0 end' 2>/dev/null \
         | awk 'BEGIN{t=0} {t+=$1} END{print "n_review_comment="t}'
-    gh api --paginate "/repos/${SLUG}/pulls/${PR}/reviews?per_page=100" --jq 'length' 2>/dev/null \
+    gh api --paginate "/repos/${SLUG}/pulls/${PR}/reviews?per_page=100" --jq 'if type=="array" then length else 0 end' 2>/dev/null \
         | awk 'BEGIN{t=0} {t+=$1} END{print "n_review="t}'
+    # Track resolve/unresolve transitions via the GraphQL reviewThreads
+    # connection -- counts of resolved/open threads. A thread getting
+    # resolved/unresolved is real PR activity that the REST counts above
+    # would miss.
+    #
+    # IMPORTANT: this line MUST always be present in the snapshot, even on
+    # transient GraphQL failure. If it disappears intermittently, the
+    # snapshot diff would falsely show "new activity" each time it returns.
+    # We collect the GraphQL output into a variable, fall back to a fixed
+    # literal on any failure, and emit one canonical line.
+    local owner name graphql_out
+    owner="${SLUG%%/*}"
+    name="${SLUG##*/}"
+    # Cursor-paginate threads so PRs with >100 threads are tracked correctly.
+    local cursor='' resolved=0 open=0
+    while :; do
+        local cursor_args=()
+        [[ -n "${cursor}" ]] && cursor_args+=(-F "after=${cursor}")
+        graphql_out="$(gh api graphql -F owner="${owner}" -F name="${name}" -F number="${PR}" \
+            "${cursor_args[@]}" -f query='
+            query($owner:String!, $name:String!, $number:Int!, $after:String) {
+                repository(owner:$owner, name:$name) {
+                    pullRequest(number:$number) {
+                        reviewThreads(first:100, after:$after) {
+                            pageInfo { hasNextPage endCursor }
+                            nodes { isResolved }
+                        }
+                    }
+                }
+            }' 2>/dev/null)" || { echo "threads_resolved=ERR_open=ERR"; return 0; }
+        local r o
+        r=$(jq -r '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved)] | length' <<< "${graphql_out}" 2>/dev/null) || r=0
+        o=$(jq -r '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' <<< "${graphql_out}" 2>/dev/null) || o=0
+        resolved=$(( resolved + r ))
+        open=$(( open + o ))
+        local hasnext nextcur
+        hasnext=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' <<< "${graphql_out}" 2>/dev/null)
+        nextcur=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // ""' <<< "${graphql_out}" 2>/dev/null)
+        [[ "${hasnext}" == "true" ]] || break
+        cursor="${nextcur}"
+    done
+    echo "threads_resolved=${resolved}_open=${open}"
 }
 
 echo -e "${PR_GRAY}[wait] PR ${SLUG}#${PR}  timeout=${TIMEOUT}s  poll=${POLL}s${PR_NC}" >&2
@@ -81,7 +115,11 @@ while true; do
     current="$(snapshot)"
     if [[ "${current}" != "${baseline}" ]]; then
         echo -e "${PR_GREEN}[wait] new activity detected after ${elapsed}s:${PR_NC}" >&2
-        diff <(printf '%s' "${baseline}") <(printf '%s' "${current}") | sed 's/^/    /' >&2
+        # diff exits 1 when inputs differ (that's the success case here);
+        # set -euo pipefail would trip on it. Force exit 0 from the
+        # pipeline so the script proper can return 0 cleanly.
+        { diff <(printf '%s' "${baseline}") <(printf '%s' "${current}") || true; } \
+            | sed 's/^/    /' >&2
         exit 0
     fi
     echo -e "${PR_GRAY}[wait] ${elapsed}s elapsed, no change yet...${PR_NC}" >&2

--- a/.agents/skills/pr-reviews/scripts/wait-for-activity.sh
+++ b/.agents/skills/pr-reviews/scripts/wait-for-activity.sh
@@ -28,6 +28,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 pr_require_gh
 
@@ -74,6 +75,8 @@ snapshot() {
     while :; do
         local cursor_args=()
         [[ -n "${cursor}" ]] && cursor_args+=(-F "after=${cursor}")
+        # GraphQL string has $owner/$name/$number/$after as placeholders.
+        # shellcheck disable=SC2016
         graphql_out="$(gh api graphql -F owner="${owner}" -F name="${name}" -F number="${PR}" \
             "${cursor_args[@]}" -f query='
             query($owner:String!, $name:String!, $number:Int!, $after:String) {

--- a/.agents/skills/pr-reviews/scripts/wait-for-activity.sh
+++ b/.agents/skills/pr-reviews/scripts/wait-for-activity.sh
@@ -36,6 +36,9 @@ pr_require_numeric "${PR}"
 TIMEOUT="${2:-1800}"
 POLL="${3:-30}"
 
+pr_require_numeric "${TIMEOUT}" "timeout-seconds"
+pr_require_numeric "${POLL}"    "poll-interval-seconds"
+
 SLUG="$(pr_require_slug)"
 
 snapshot() {

--- a/.agents/skills/pr-reviews/scripts/wait-for-activity.sh
+++ b/.agents/skills/pr-reviews/scripts/wait-for-activity.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Block until new activity appears on a PR (new comment, new review, new
+# commit), or until the timeout fires.
+#
+# Usage:
+#   wait-for-activity.sh <pr-number> [<timeout-seconds>] [<poll-interval-seconds>]
+#
+# Defaults: timeout=1800 (30 min), poll=30s.
+#
+# Establishes a baseline by reading the cached fetch-all.sh dump (or fetching
+# fresh if missing). Then polls every <poll-interval> seconds for changes.
+# Exits 0 when something new is found; exits 124 on timeout.
+#
+# "New" means any of:
+#   - issue-comments count changed
+#   - review-comments count changed
+#   - reviews count changed
+#   - PR head sha changed (new push)
+#   - reviewThreads isResolved transitions
+#
+# Both cubic-dev-ai and copilot post a comment when they have nothing new
+# to add -- so this loop ends naturally on a clean re-review.
+#
+# Note about Costa's rule: "the PR should never be left with unaddressed
+# comments". After this returns, run fetch-all.sh again, classify the new
+# activity, and address it.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+pr_require_gh
+
+PR="${1:?usage: $0 <pr-number> [<timeout-seconds>] [<poll-interval-seconds>]}"
+TIMEOUT="${2:-1800}"
+POLL="${3:-30}"
+
+SLUG="$(pr_repo_slug)"
+
+snapshot() {
+    # Quick snapshot for change detection -- not a full fetch.
+    gh pr view "${PR}" --repo "${SLUG}" --json headRefOid \
+        --jq '"head=\(.headRefOid)"'
+    gh api "/repos/${SLUG}/issues/${PR}/comments?per_page=1" \
+        --jq '"latest_issue=\(.[0].id // 0)_\(.[0].updated_at // \"\")_count_\(. | length)"' \
+        2>/dev/null || true
+    gh api "/repos/${SLUG}/pulls/${PR}/comments?per_page=1" \
+        --jq '"latest_review_comment=\(.[0].id // 0)_\(.[0].updated_at // \"\")"' \
+        2>/dev/null || true
+    gh api "/repos/${SLUG}/pulls/${PR}/reviews?per_page=1" \
+        --jq '"latest_review=\(.[0].id // 0)_\(.[0].submitted_at // \"\")"' \
+        2>/dev/null || true
+    # Counts (exact -- enumerate via paginated count endpoint via Link parsing).
+    # Cheap proxy: a HEAD on the listing endpoints with per_page=1 returns
+    # a Link header whose last page == total. For correctness we just
+    # paginate.
+    gh api --paginate "/repos/${SLUG}/issues/${PR}/comments?per_page=100" --jq 'length' 2>/dev/null \
+        | awk 'BEGIN{t=0} {t+=$1} END{print "n_issue="t}'
+    gh api --paginate "/repos/${SLUG}/pulls/${PR}/comments?per_page=100" --jq 'length' 2>/dev/null \
+        | awk 'BEGIN{t=0} {t+=$1} END{print "n_review_comment="t}'
+    gh api --paginate "/repos/${SLUG}/pulls/${PR}/reviews?per_page=100" --jq 'length' 2>/dev/null \
+        | awk 'BEGIN{t=0} {t+=$1} END{print "n_review="t}'
+}
+
+echo -e "${PR_GRAY}[wait] PR ${SLUG}#${PR}  timeout=${TIMEOUT}s  poll=${POLL}s${PR_NC}" >&2
+
+baseline="$(snapshot)"
+echo -e "${PR_GRAY}[wait] baseline:${PR_NC}" >&2
+echo "${baseline}" | sed 's/^/    /' >&2
+
+start=$(date +%s)
+while true; do
+    sleep "${POLL}"
+    now=$(date +%s)
+    elapsed=$(( now - start ))
+    if (( elapsed >= TIMEOUT )); then
+        echo -e "${PR_YELLOW}[wait] timeout after ${elapsed}s -- no new activity${PR_NC}" >&2
+        exit 124
+    fi
+    current="$(snapshot)"
+    if [[ "${current}" != "${baseline}" ]]; then
+        echo -e "${PR_GREEN}[wait] new activity detected after ${elapsed}s:${PR_NC}" >&2
+        diff <(printf '%s' "${baseline}") <(printf '%s' "${current}") | sed 's/^/    /' >&2
+        exit 0
+    fi
+    echo -e "${PR_GRAY}[wait] ${elapsed}s elapsed, no change yet...${PR_NC}" >&2
+done

--- a/.agents/skills/sonarqube-audit/SKILL.md
+++ b/.agents/skills/sonarqube-audit/SKILL.md
@@ -125,10 +125,13 @@ Family mode prints all matched keys and prompts before acting unless
 ### Step 4 — dry runs
 
 ```
-SONAR_MARK_DRY_RUN=1 bash .agents/skills/sonarqube-audit/scripts/sonar-mark.sh fp KEY "Comment"
+SONAR_DRY_RUN=1 bash .agents/skills/sonarqube-audit/scripts/sonar-mark.sh fp KEY "Comment"
 ```
 
-Prints the curl command (token masked) without executing.
+In dry-run mode, **write** API calls (mark issues, change hotspot status,
+add comments) are printed but not executed. **Read** API calls (issue
+search, hotspot search used to enumerate findings in family mode) still
+run -- otherwise family mode could not show what it would have acted on.
 
 ## What this skill does NOT do
 
@@ -173,5 +176,5 @@ under `.local/audits/sonarqube/`.
   status/project), so the family-mode helper does it in Python.
 - An issue may be transitioned only between certain states; if you get
   "Cannot do transition from STATUS X to Y", it's already past that state.
-- `SONAR_MARK_DRY_RUN=1` is the right knob when iterating on comments
+- `SONAR_DRY_RUN=1` is the right knob when iterating on comments
   before committing to a bulk operation.

--- a/.agents/skills/sonarqube-audit/SKILL.md
+++ b/.agents/skills/sonarqube-audit/SKILL.md
@@ -173,13 +173,15 @@ Keep a record of profile decisions in a project-local doc under
 |----------------------------------------|-------------------------------------------------------------|
 | HTTP 401 / 403 with HTML body          | Token wrong/expired, or Cloudflare blocking non-ASCII       |
 | Token works for issues but not hotspots| Hotspot endpoints have separate auth checks — token must have `Browse` permission |
-| Family-mode hits ps=500 ceiling        | Use repeated --rule queries with paging (`p=1`, `p=2`)      |
+| Family-mode appears to stop at 500     | Outdated -- `sonar-mark.sh` family-mode now paginates transparently via `sq_paginate`. If you still see truncation, check `sq_paginate`'s array-key recognition list. |
 | `falsepositive` transition rejected    | Issue is not in `OPEN` or `CONFIRMED` state — check current status |
 | Hotspot transition rejected            | Hotspot already in `REVIEWED` state — re-check before retry |
 
 ## Recurring tips
 
-- `api/issues/search` is paged at `ps=500` max. For >500 of a kind, paginate.
+- `api/issues/search` is paged at `ps=500` max. The `sq_paginate` helper
+  in `_lib.sh` walks every page until `paging.total`; use it from any
+  new script instead of re-implementing the loop.
 - Hotspot `ruleKey` filtering is client-side (search only filters by
   status/project), so the family-mode helper does it in Python.
 - An issue may be transitioned only between certain states; if you get

--- a/.agents/skills/sonarqube-audit/SKILL.md
+++ b/.agents/skills/sonarqube-audit/SKILL.md
@@ -155,9 +155,17 @@ To make project-wide changes (deactivate a rule or override severity):
 2. Make your edits there
 3. Assign the project to the new profile (`api/qualityprofiles/add_project`)
 
-This is a one-shot operation per language (c, cpp, go, javascript, python,
-shelldre, godre, etc.) — keep a record of decisions in a project-local doc
-under `.local/audits/sonarqube/`.
+This is a one-shot operation per language. SonarCloud language keys are:
+`c`, `cpp`, `go`, `javascript`, `py`, `shell`, `plsql`, `docker`, `css`,
+`ipynb`, `php` (and others depending on the project). Note the rule-id
+namespaces in `api/issues/search` results may differ from the language
+keys -- e.g. shell rules use the `shelldre:` prefix, Go rules can use
+either `go:` or `godre:` depending on which analyzer fired -- so the
+language argument to qualityprofile APIs is the SHORT key (`shell`,
+`go`), not the rule-namespace prefix.
+
+Keep a record of profile decisions in a project-local doc under
+`.local/audits/sonarqube/`.
 
 ## Failure modes — quick diagnosis
 

--- a/.agents/skills/sonarqube-audit/SKILL.md
+++ b/.agents/skills/sonarqube-audit/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: sonarqube-audit
+description: Triage SonarCloud findings (issues, hotspots, code smells, vulnerabilities) for this project — search what's open, mark False Positive / Won't Fix / Confirm / Safe / Acknowledged / Fixed, batch-mark whole rule families. Use when the user asks to "review Sonar findings", "triage SonarCloud", "mark False Positive on Sonar", or anything mentioning sonarqube/sonarcloud, S2259, S5008, code smells, security hotspots, or sonarcloud.io.
+---
+
+# SonarCloud triage skill
+
+This skill drives the SonarCloud Web API
+(<https://docs.sonarsource.com/sonarcloud/api/>) to enumerate findings and apply
+triage decisions: False Positive / Won't Fix / Confirmed for issues; Reviewed
++ Safe/Acknowledged/Fixed for hotspots. Family-mode lets you mark every open
+finding for a rule in one go.
+
+The skill operates on the project configured in `.env` (see Setup). Scripts
+auto-detect the repo root and write all artifacts under `<repo-root>/.local/`.
+
+## MANDATORY — keep this skill alive
+
+**If you (the agent) discover a new pattern, gotcha, working flow, correction,
+or any piece of knowledge while running this skill — update this `SKILL.md`
+AND commit it BEFORE proceeding. Knowledge that isn't committed is lost.**
+
+Examples of things to capture:
+- New rule with a known FP pattern (and the exact comment to use)
+- A bulk-FP family that's safe to apply project-wide
+- A SonarCloud API quirk (rate limits, undocumented response shapes)
+- A new path/issue exclusion that's safer than per-finding marking
+
+## Setup
+
+### .env entries
+
+```bash
+# SonarCloud
+SONAR_TOKEN='<paste your token from https://sonarcloud.io/account/security>'
+SONAR_HOST_URL=https://sonarcloud.io
+SONAR_PROJECT=<project_key, e.g. netdata_netdata>
+SONAR_ORG=<organization_key, e.g. netdata>
+```
+
+The token is used as **HTTP Basic auth username with empty password**:
+`-u "$SONAR_TOKEN:"` (note the trailing colon).
+
+No browser tab is required — token-based auth is stable across sessions.
+
+## Triage decision matrix
+
+### Issues (Bug, Vulnerability, Code Smell)
+
+| Decision     | API transition  | When to use                                                       |
+|--------------|-----------------|--------------------------------------------------------------------|
+| Confirm      | `confirm`       | Sonar is right, we're going to fix it                             |
+| Won't Fix    | `wontfix`       | Real but acceptable — won't fix (e.g., legacy code being deleted) |
+| False Positive | `falsepositive` | Sonar is wrong (guard exists, unreachable, tool model error)    |
+
+### Security Hotspots
+
+Hotspots have a separate state machine. They go from `TO_REVIEW` to
+`REVIEWED` with one of three resolutions:
+
+| Resolution    | When to use                                                   |
+|---------------|---------------------------------------------------------------|
+| `SAFE`        | Hotspot reviewed, code is fine as-is (no risk in context)    |
+| `ACKNOWLEDGED`| Risk understood, no immediate action — leave for future review |
+| `FIXED`       | Hotspot reviewed and the code was changed to remove the risk  |
+
+## ASCII-only comments — non-negotiable
+
+`api.sonarcloud.io` sits behind Cloudflare, which rejects bodies containing
+non-ASCII bytes (em-dashes, smart quotes) with a 403 challenge. The scripts
+fail before the network round-trip if non-ASCII is detected.
+
+- Use `--` instead of em-dash (U+2014).
+- Use straight quotes `"` `'` instead of smart quotes.
+
+## Workflow
+
+### Step 1 — see what's open
+
+```
+bash .agents/skills/sonarqube-audit/scripts/sonar-search.sh summary
+```
+
+Prints per-rule counts of open issues + open hotspots. Use this to spot
+high-volume rules that are candidates for family-mode bulk marking, and
+project-wide quality-profile or exclusion changes.
+
+### Step 2 — search for specific rule's findings
+
+Issues:
+```
+bash .agents/skills/sonarqube-audit/scripts/sonar-search.sh issues --rule cpp:S5827
+```
+
+Hotspots:
+```
+bash .agents/skills/sonarqube-audit/scripts/sonar-search.sh hotspots --status=TO_REVIEW \
+  | jq '.hotspots[] | select(.ruleKey=="c:S5443")'
+```
+
+### Step 3 — triage
+
+#### Single finding
+
+```
+bash .agents/skills/sonarqube-audit/scripts/sonar-mark.sh fp     <ISSUE_KEY> "<COMMENT>"
+bash .agents/skills/sonarqube-audit/scripts/sonar-mark.sh wontfix <ISSUE_KEY> "<COMMENT>"
+bash .agents/skills/sonarqube-audit/scripts/sonar-mark.sh confirm <ISSUE_KEY> "<COMMENT>"
+
+bash .agents/skills/sonarqube-audit/scripts/sonar-mark.sh safe  <HOTSPOT_KEY> "<COMMENT>"
+bash .agents/skills/sonarqube-audit/scripts/sonar-mark.sh ack   <HOTSPOT_KEY> "<COMMENT>"
+bash .agents/skills/sonarqube-audit/scripts/sonar-mark.sh fixed <HOTSPOT_KEY> "<COMMENT>"
+```
+
+#### Family mode (every open finding for a rule)
+
+```
+bash .agents/skills/sonarqube-audit/scripts/sonar-mark.sh family-fp   <RULE_ID> "<COMMENT>"
+bash .agents/skills/sonarqube-audit/scripts/sonar-mark.sh family-safe <RULE_ID> "<COMMENT>"
+```
+
+Family mode prints all matched keys and prompts before acting unless
+`SONAR_MARK_YES=1` is set.
+
+### Step 4 — dry runs
+
+```
+SONAR_MARK_DRY_RUN=1 bash .agents/skills/sonarqube-audit/scripts/sonar-mark.sh fp KEY "Comment"
+```
+
+Prints the curl command (token masked) without executing.
+
+## What this skill does NOT do
+
+- **Disable rules**: use `api/qualityprofiles/deactivate_rule` directly, or do
+  it in the SonarCloud UI under Quality Profiles.
+- **Configure issue exclusions**: use Project Settings -> Analysis Scope ->
+  Issue Exclusions in the UI.
+- **Rule-tuning audit**: when you want a per-rule KEEP/DISABLE/NARROW decision
+  log, document that separately (it's project-wide policy, not per-finding
+  triage).
+
+## Project-wide quality profile / exclusion configuration
+
+Effective profile lookup:
+```
+GET /api/qualityprofiles/search?project=$SONAR_PROJECT&organization=$SONAR_ORG
+```
+
+To make project-wide changes (deactivate a rule or override severity):
+1. Copy the inherited profile (`api/qualityprofiles/copy`)
+2. Make your edits there
+3. Assign the project to the new profile (`api/qualityprofiles/add_project`)
+
+This is a one-shot operation per language (c, cpp, go, javascript, python,
+shelldre, godre, etc.) — keep a record of decisions in a project-local doc
+under `.local/audits/sonarqube/`.
+
+## Failure modes — quick diagnosis
+
+| Symptom                                | Likely cause                                                |
+|----------------------------------------|-------------------------------------------------------------|
+| HTTP 401 / 403 with HTML body          | Token wrong/expired, or Cloudflare blocking non-ASCII       |
+| Token works for issues but not hotspots| Hotspot endpoints have separate auth checks — token must have `Browse` permission |
+| Family-mode hits ps=500 ceiling        | Use repeated --rule queries with paging (`p=1`, `p=2`)      |
+| `falsepositive` transition rejected    | Issue is not in `OPEN` or `CONFIRMED` state — check current status |
+| Hotspot transition rejected            | Hotspot already in `REVIEWED` state — re-check before retry |
+
+## Recurring tips
+
+- `api/issues/search` is paged at `ps=500` max. For >500 of a kind, paginate.
+- Hotspot `ruleKey` filtering is client-side (search only filters by
+  status/project), so the family-mode helper does it in Python.
+- An issue may be transitioned only between certain states; if you get
+  "Cannot do transition from STATUS X to Y", it's already past that state.
+- `SONAR_MARK_DRY_RUN=1` is the right knob when iterating on comments
+  before committing to a bulk operation.

--- a/.agents/skills/sonarqube-audit/SKILL.md
+++ b/.agents/skills/sonarqube-audit/SKILL.md
@@ -8,8 +8,8 @@ description: Triage SonarCloud findings (issues, hotspots, code smells, vulnerab
 This skill drives the SonarCloud Web API
 (<https://docs.sonarsource.com/sonarcloud/api/>) to enumerate findings and apply
 triage decisions: False Positive / Won't Fix / Confirmed for issues; Reviewed
-+ Safe/Acknowledged/Fixed for hotspots. Family-mode lets you mark every open
-finding for a rule in one go.
+with one of Safe / Acknowledged / Fixed for hotspots. Family-mode lets
+you mark every open finding for a rule in one go.
 
 The skill operates on the project configured in `.env` (see Setup). Scripts
 auto-detect the repo root and write all artifacts under `<repo-root>/.local/`.

--- a/.agents/skills/sonarqube-audit/scripts/_lib.sh
+++ b/.agents/skills/sonarqube-audit/scripts/_lib.sh
@@ -30,7 +30,7 @@ sq_load_env() {
     local root env
     root="$(sq_repo_root)"
     env="${root}/.env"
-    if [[ ! -r "${env}" ]]; then
+    if [[ ! -f "${env}" || ! -r "${env}" ]]; then
         echo -e "${SQ_RED}[ERROR]${SQ_NC} Missing ${env}. See SKILL.md for the .env template." >&2
         return 1
     fi

--- a/.agents/skills/sonarqube-audit/scripts/_lib.sh
+++ b/.agents/skills/sonarqube-audit/scripts/_lib.sh
@@ -68,7 +68,10 @@ sq_require_ascii() {
 # run in dry-run so the caller can see what would be acted on.
 sq_run() {
     local arg
-    printf >&2 '%s' "${SQ_GRAY}> ${SQ_YELLOW}"
+    # Use %b so the literal '\033' inside the color vars is interpreted as
+    # the ESC character. Color vars are constants defined above, so this
+    # is safe with respect to SC2059 (no untrusted format-string content).
+    printf >&2 '%b> %b' "${SQ_GRAY}" "${SQ_YELLOW}"
     for arg in "$@"; do
         if [[ "${arg}" == "${SONAR_TOKEN}:" ]]; then
             printf >&2 '%q ' '<TOKEN>:'
@@ -76,7 +79,7 @@ sq_run() {
             printf >&2 '%q ' "${arg}"
         fi
     done
-    printf >&2 '%s\n' "${SQ_NC}"
+    printf >&2 '%b\n' "${SQ_NC}"
     if [[ "${SONAR_DRY_RUN:-0}" == "1" ]]; then
         return 0
     fi

--- a/.agents/skills/sonarqube-audit/scripts/_lib.sh
+++ b/.agents/skills/sonarqube-audit/scripts/_lib.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Common helpers for sonarqube-audit scripts.
+# Sourced from the per-action scripts; not executed directly.
+
+set -euo pipefail
+
+SQ_RED='\033[0;31m'
+SQ_GREEN='\033[0;32m'
+SQ_YELLOW='\033[1;33m'
+SQ_GRAY='\033[0;90m'
+SQ_NC='\033[0m'
+
+sq_repo_root() {
+    git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel
+}
+
+sq_load_env() {
+    local root env
+    root="$(sq_repo_root)"
+    env="${root}/.env"
+    if [[ ! -r "${env}" ]]; then
+        echo -e "${SQ_RED}[ERROR]${SQ_NC} Missing ${env}. See SKILL.md for the .env template." >&2
+        return 1
+    fi
+    # shellcheck disable=SC1090
+    set -a; source "${env}"; set +a
+
+    : "${SONAR_TOKEN:?SONAR_TOKEN is empty in .env}"
+    : "${SONAR_HOST_URL:=https://sonarcloud.io}"
+    : "${SONAR_PROJECT:?SONAR_PROJECT is empty in .env (e.g. netdata_netdata)}"
+    : "${SONAR_ORG:?SONAR_ORG is empty in .env (e.g. netdata)}"
+    export SONAR_TOKEN SONAR_HOST_URL SONAR_PROJECT SONAR_ORG
+}
+
+sq_audit_dir() {
+    local root
+    root="$(sq_repo_root)"
+    echo "${root}/.local/audits/sonarqube"
+}
+
+# Cloudflare in front of api.sonarcloud.io rejects non-ASCII bodies.
+# Fail before the network round-trip rather than debug a 403 challenge.
+sq_require_ascii() {
+    local s="$1"
+    if LC_ALL=C grep -qP '[^\x00-\x7F]' <<< "${s}"; then
+        echo -e "${SQ_RED}[ERROR]${SQ_NC} Comment contains non-ASCII characters. Cloudflare blocks them. Replace em-dashes with '--' and curly quotes with straight quotes." >&2
+        return 1
+    fi
+}
+
+# Print a curl invocation with the token masked (for transparency without leaking).
+sq_run() {
+    local arg
+    printf >&2 "${SQ_GRAY}> ${SQ_YELLOW}"
+    for arg in "$@"; do
+        if [[ "${arg}" == "${SONAR_TOKEN}:" ]]; then
+            printf >&2 '%q ' '<TOKEN>:'
+        else
+            printf >&2 '%q ' "${arg}"
+        fi
+    done
+    printf >&2 "${SQ_NC}\n"
+    if [[ "${SONAR_DRY_RUN:-0}" == "1" ]]; then
+        return 0
+    fi
+    "$@"
+}

--- a/.agents/skills/sonarqube-audit/scripts/_lib.sh
+++ b/.agents/skills/sonarqube-audit/scripts/_lib.sh
@@ -33,9 +33,11 @@ sq_load_env() {
 }
 
 sq_audit_dir() {
-    local root
+    local root dir
     root="$(sq_repo_root)"
-    echo "${root}/.local/audits/sonarqube"
+    dir="${root}/.local/audits/sonarqube"
+    mkdir -p "${dir}"
+    echo "${dir}"
 }
 
 # Cloudflare in front of api.sonarcloud.io rejects non-ASCII bodies.

--- a/.agents/skills/sonarqube-audit/scripts/_lib.sh
+++ b/.agents/skills/sonarqube-audit/scripts/_lib.sh
@@ -4,10 +4,16 @@
 
 set -euo pipefail
 
+# Color vars are used by sourcing scripts; shellcheck cannot see that.
+# shellcheck disable=SC2034
 SQ_RED='\033[0;31m'
+# shellcheck disable=SC2034
 SQ_GREEN='\033[0;32m'
+# shellcheck disable=SC2034
 SQ_YELLOW='\033[1;33m'
+# shellcheck disable=SC2034
 SQ_GRAY='\033[0;90m'
+# shellcheck disable=SC2034
 SQ_NC='\033[0m'
 
 sq_repo_root() {
@@ -22,8 +28,10 @@ sq_load_env() {
         echo -e "${SQ_RED}[ERROR]${SQ_NC} Missing ${env}. See SKILL.md for the .env template." >&2
         return 1
     fi
+    set -a
     # shellcheck disable=SC1090
-    set -a; source "${env}"; set +a
+    source "${env}"
+    set +a
 
     : "${SONAR_TOKEN:?SONAR_TOKEN is empty in .env}"
     : "${SONAR_HOST_URL:=https://sonarcloud.io}"
@@ -42,18 +50,25 @@ sq_audit_dir() {
 
 # Cloudflare in front of api.sonarcloud.io rejects non-ASCII bodies.
 # Fail before the network round-trip rather than debug a 403 challenge.
+#
+# `tr -d '\000-\177'` deletes ALL ASCII bytes; anything left is non-ASCII.
+# This is portable across GNU and BSD/macOS (unlike `grep -P`, which is GNU-only).
 sq_require_ascii() {
     local s="$1"
-    if LC_ALL=C grep -qP '[^\x00-\x7F]' <<< "${s}"; then
+    if LC_ALL=C printf '%s' "${s}" | LC_ALL=C tr -d '\000-\177' | grep -q .; then
         echo -e "${SQ_RED}[ERROR]${SQ_NC} Comment contains non-ASCII characters. Cloudflare blocks them. Replace em-dashes with '--' and curly quotes with straight quotes." >&2
         return 1
     fi
 }
 
 # Print a curl invocation with the token masked (for transparency without leaking).
+# In SONAR_DRY_RUN mode the command is printed but not executed -- this only
+# affects calls routed through sq_run, which is the WRITE path (api_post).
+# Read-only API calls (issue/hotspot search used to enumerate findings) still
+# run in dry-run so the caller can see what would be acted on.
 sq_run() {
     local arg
-    printf >&2 "${SQ_GRAY}> ${SQ_YELLOW}"
+    printf >&2 '%s' "${SQ_GRAY}> ${SQ_YELLOW}"
     for arg in "$@"; do
         if [[ "${arg}" == "${SONAR_TOKEN}:" ]]; then
             printf >&2 '%q ' '<TOKEN>:'
@@ -61,7 +76,7 @@ sq_run() {
             printf >&2 '%q ' "${arg}"
         fi
     done
-    printf >&2 "${SQ_NC}\n"
+    printf >&2 '%s\n' "${SQ_NC}"
     if [[ "${SONAR_DRY_RUN:-0}" == "1" ]]; then
         return 0
     fi

--- a/.agents/skills/sonarqube-audit/scripts/_lib.sh
+++ b/.agents/skills/sonarqube-audit/scripts/_lib.sh
@@ -4,17 +4,23 @@
 
 set -euo pipefail
 
-# Color vars are used by sourcing scripts; shellcheck cannot see that.
+# IMPORTANT: define with $'...' so the variables contain real ESC bytes,
+# not the literal four-character string "\033". This way both `echo -e
+# "${SQ_RED}..."` and `printf '%s' "${SQ_RED}..."` render correctly --
+# without forcing every printf format string to be the variable itself
+# (which trips shellcheck SC2059) or %b (which adds inconsistency).
+#
+# Color vars are referenced by sourcing scripts; shellcheck cannot see that.
 # shellcheck disable=SC2034
-SQ_RED='\033[0;31m'
+SQ_RED=$'\033[0;31m'
 # shellcheck disable=SC2034
-SQ_GREEN='\033[0;32m'
+SQ_GREEN=$'\033[0;32m'
 # shellcheck disable=SC2034
-SQ_YELLOW='\033[1;33m'
+SQ_YELLOW=$'\033[1;33m'
 # shellcheck disable=SC2034
-SQ_GRAY='\033[0;90m'
+SQ_GRAY=$'\033[0;90m'
 # shellcheck disable=SC2034
-SQ_NC='\033[0m'
+SQ_NC=$'\033[0m'
 
 sq_repo_root() {
     git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel
@@ -36,7 +42,10 @@ sq_load_env() {
     : "${SONAR_TOKEN:?SONAR_TOKEN is empty in .env}"
     : "${SONAR_HOST_URL:=https://sonarcloud.io}"
     : "${SONAR_PROJECT:?SONAR_PROJECT is empty in .env (e.g. netdata_netdata)}"
-    : "${SONAR_ORG:?SONAR_ORG is empty in .env (e.g. netdata)}"
+    # SONAR_ORG is optional today -- the existing scripts don't pass it to
+    # the API, but qualityprofile management calls (documented in SKILL.md)
+    # require it. Default empty; consumers should fail loudly if they need it.
+    : "${SONAR_ORG:=}"
     export SONAR_TOKEN SONAR_HOST_URL SONAR_PROJECT SONAR_ORG
 }
 
@@ -68,10 +77,9 @@ sq_require_ascii() {
 # run in dry-run so the caller can see what would be acted on.
 sq_run() {
     local arg
-    # Use %b so the literal '\033' inside the color vars is interpreted as
-    # the ESC character. Color vars are constants defined above, so this
-    # is safe with respect to SC2059 (no untrusted format-string content).
-    printf >&2 '%b> %b' "${SQ_GRAY}" "${SQ_YELLOW}"
+    # Color vars contain real ESC bytes (defined with $'...'), so '%s' is
+    # both safe (no SC2059) and correctly renders the colors.
+    printf >&2 '%s> %s' "${SQ_GRAY}" "${SQ_YELLOW}"
     for arg in "$@"; do
         if [[ "${arg}" == "${SONAR_TOKEN}:" ]]; then
             printf >&2 '%q ' '<TOKEN>:'
@@ -79,9 +87,10 @@ sq_run() {
             printf >&2 '%q ' "${arg}"
         fi
     done
-    printf >&2 '%b\n' "${SQ_NC}"
+    printf >&2 '%s\n' "${SQ_NC}"
     if [[ "${SONAR_DRY_RUN:-0}" == "1" ]]; then
         return 0
     fi
     "$@"
 }
+

--- a/.agents/skills/sonarqube-audit/scripts/_lib.sh
+++ b/.agents/skills/sonarqube-audit/scripts/_lib.sh
@@ -94,3 +94,95 @@ sq_run() {
     "$@"
 }
 
+# URL-encode a string for inclusion in a Sonar API query parameter.
+# Sonar rule IDs (`c:S2245`, `shelldre:S131`, etc.) contain `:` which must
+# become `%3A`; some rule namespaces also contain other reserved chars.
+# Limitation: emits the codepoint, not UTF-8 bytes, for non-ASCII -- safe
+# for Sonar rule IDs (always ASCII) but do NOT use this for arbitrary
+# user-supplied strings without auditing.
+sq_url_encode() {
+    local s="$1" out="" i ch
+    for (( i=0; i<${#s}; i++ )); do
+        ch="${s:$i:1}"
+        case "${ch}" in
+            [a-zA-Z0-9._~-]) out+="${ch}" ;;
+            *) out+="$(printf '%%%02X' "'${ch}")" ;;
+        esac
+    done
+    printf '%s' "${out}"
+}
+
+# Read-only Sonar API call: prints the masked curl line (transparency)
+# but always executes (dry-run only suppresses WRITE calls). Use this for
+# enumeration calls that drive subsequent decisions (issue/hotspot search).
+sq_run_read() {
+    local arg
+    printf >&2 '%s> %s' "${SQ_GRAY}" "${SQ_YELLOW}"
+    for arg in "$@"; do
+        if [[ "${arg}" == "${SONAR_TOKEN}:" ]]; then
+            printf >&2 '%q ' '<TOKEN>:'
+        else
+            printf >&2 '%q ' "${arg}"
+        fi
+    done
+    printf >&2 '%s\n' "${SQ_NC}"
+    "$@"
+}
+
+# Paginate a Sonar API listing endpoint until paging.total is reached.
+# Emits each page's body to stdout (one JSON value per page); the caller
+# composes them with `jq -s 'reduce .[] as $p (...)'` to sum or merge.
+#
+# Args:
+#   $1 = path with all query params EXCEPT ps and p (e.g.
+#        "/api/issues/search?componentKeys=...&resolved=false")
+#
+# Sonar's max page size is 500; we use it. The function uses sq_run_read
+# so the masked curl is logged but execution is not skipped in dry-run
+# (read-only enumeration should still happen so the caller sees what
+# would be acted on).
+sq_paginate() {
+    local path="$1"
+    local sep
+    if [[ "${path}" == *\?* ]]; then sep='&'; else sep='?'; fi
+    local page=1 total=-1 fetched=0
+    while :; do
+        local resp
+        resp="$(sq_run_read curl --fail --silent --show-error -u "${SONAR_TOKEN}:" \
+            "${SONAR_HOST_URL}${path}${sep}ps=500&p=${page}")"
+
+        # Validate the response is a JSON object with a .paging field --
+        # otherwise we can't decide when to stop and would loop forever
+        # (or terminate prematurely on 0). Bail loudly.
+        if ! jq -e 'type=="object" and has("paging")' >/dev/null 2>&1 <<< "${resp}"; then
+            echo -e "${SQ_RED}[sq_paginate]${SQ_NC} response missing .paging on ${path} page ${page}; first 200 chars:" >&2
+            head -c 200 <<< "${resp}" >&2; echo >&2
+            return 1
+        fi
+
+        printf '%s\n' "${resp}"
+        # Sonar wraps results either under .issues / .hotspots / .components
+        # / .rules / .users; .paging is consistent across endpoints. Reject
+        # any response whose array key we don't recognise so the caller is
+        # forced to add support rather than silently get zero rows.
+        local array_key in_page
+        array_key=$(jq -r '
+            (.issues|values|"issues") //
+            (.hotspots|values|"hotspots") //
+            (.components|values|"components") //
+            (.rules|values|"rules") //
+            (.users|values|"users") //
+            empty
+        ' <<< "${resp}")
+        if [[ -z "${array_key}" ]]; then
+            echo -e "${SQ_RED}[sq_paginate]${SQ_NC} unrecognized payload from ${path}; expected one of issues/hotspots/components/rules/users." >&2
+            return 1
+        fi
+        in_page=$(jq -r --arg k "${array_key}" '.[$k] | length' <<< "${resp}")
+        total=$(jq -r '.paging.total' <<< "${resp}")
+        fetched=$(( fetched + in_page ))
+        (( fetched >= total || in_page == 0 )) && break
+        page=$(( page + 1 ))
+    done
+}
+

--- a/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
+++ b/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
@@ -84,26 +84,59 @@ hotspot_change_status() {
     echo -e "${SQ_GREEN}[OK]${SQ_NC} hotspot ${key} -> REVIEWED/${resolution}" >&2
 }
 
+_url_encode() {
+    # Minimal URL-encoder for Sonar rule IDs like "c:S2245" -> "c%3AS2245".
+    # Avoids relying on python3 -c "import urllib..." for one tiny call.
+    local s="$1" out="" i ch
+    for (( i=0; i<${#s}; i++ )); do
+        ch="${s:$i:1}"
+        case "${ch}" in
+            [a-zA-Z0-9._~-]) out+="${ch}" ;;
+            *) out+="$(printf '%%%02X' "'${ch}")" ;;
+        esac
+    done
+    printf '%s' "${out}"
+}
+
 list_open_issues_for_rule() {
-    local rule="$1"
-    curl --fail --silent --show-error \
-        -u "${SONAR_TOKEN}:" \
-        "${SONAR_HOST_URL}/api/issues/search?componentKeys=${SONAR_PROJECT}&rules=${rule}&resolved=false&ps=500" \
-        | python3 -c 'import json, sys; [print(i["key"]) for i in json.load(sys.stdin)["issues"]]'
+    # Paginated. Sonar caps page size at 500; without paging we'd silently
+    # drop everything past the first page on rules with >500 open issues.
+    local rule="$1" rule_enc
+    rule_enc="$(_url_encode "${rule}")"
+    local page=1 total fetched=0
+    while :; do
+        local resp
+        resp="$(curl --fail --silent --show-error -u "${SONAR_TOKEN}:" \
+            "${SONAR_HOST_URL}/api/issues/search?componentKeys=${SONAR_PROJECT}&rules=${rule_enc}&resolved=false&ps=500&p=${page}")"
+        jq -r '.issues[].key' <<< "${resp}"
+        total=$(jq -r '.paging.total' <<< "${resp}")
+        local in_page
+        in_page=$(jq -r '.issues | length' <<< "${resp}")
+        fetched=$(( fetched + in_page ))
+        (( fetched >= total || in_page == 0 )) && break
+        page=$(( page + 1 ))
+    done
 }
 
 list_open_hotspots_for_rule() {
+    # Sonar's hotspot search does not accept a rule filter -- we have to
+    # fetch all TO_REVIEW hotspots and filter client-side. Pass the rule via
+    # jq's --arg so values containing colons / quotes / shell metacharacters
+    # cannot inject into the filter.
     local rule="$1"
-    curl --fail --silent --show-error \
-        -u "${SONAR_TOKEN}:" \
-        "${SONAR_HOST_URL}/api/hotspots/search?projectKey=${SONAR_PROJECT}&status=TO_REVIEW&ps=500" \
-        | python3 -c "
-import json, sys
-rule = '${rule}'
-for h in json.load(sys.stdin).get('hotspots', []):
-    if h['ruleKey'] == rule:
-        print(h['key'])
-"
+    local page=1 total fetched=0
+    while :; do
+        local resp
+        resp="$(curl --fail --silent --show-error -u "${SONAR_TOKEN}:" \
+            "${SONAR_HOST_URL}/api/hotspots/search?projectKey=${SONAR_PROJECT}&status=TO_REVIEW&ps=500&p=${page}")"
+        jq -r --arg rule "${rule}" '.hotspots[] | select(.ruleKey == $rule) | .key' <<< "${resp}"
+        total=$(jq -r '.paging.total' <<< "${resp}")
+        local in_page
+        in_page=$(jq -r '.hotspots | length' <<< "${resp}")
+        fetched=$(( fetched + in_page ))
+        (( fetched >= total || in_page == 0 )) && break
+        page=$(( page + 1 ))
+    done
 }
 
 confirm_family() {

--- a/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
+++ b/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
@@ -112,7 +112,10 @@ confirm_family() {
     echo -en "${SQ_YELLOW}Proceed? [y/N] ${SQ_NC}" >&2
     local ans
     read -r ans
-    [[ "${ans,,}" == "y" || "${ans,,}" == "yes" ]]
+    # Lowercase via tr -- bash 4+ has ${var,,} but macOS ships bash 3.2.
+    local ans_lc
+    ans_lc=$(printf '%s' "${ans}" | tr '[:upper:]' '[:lower:]')
+    [[ "${ans_lc}" == "y" || "${ans_lc}" == "yes" ]]
 }
 
 family_fp() {

--- a/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
+++ b/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
@@ -84,59 +84,23 @@ hotspot_change_status() {
     echo -e "${SQ_GREEN}[OK]${SQ_NC} hotspot ${key} -> REVIEWED/${resolution}" >&2
 }
 
-_url_encode() {
-    # Minimal URL-encoder for Sonar rule IDs like "c:S2245" -> "c%3AS2245".
-    # Avoids relying on python3 -c "import urllib..." for one tiny call.
-    local s="$1" out="" i ch
-    for (( i=0; i<${#s}; i++ )); do
-        ch="${s:$i:1}"
-        case "${ch}" in
-            [a-zA-Z0-9._~-]) out+="${ch}" ;;
-            *) out+="$(printf '%%%02X' "'${ch}")" ;;
-        esac
-    done
-    printf '%s' "${out}"
-}
-
 list_open_issues_for_rule() {
-    # Paginated. Sonar caps page size at 500; without paging we'd silently
-    # drop everything past the first page on rules with >500 open issues.
+    # Sonar caps page size at 500; sq_paginate walks every page until
+    # paging.total. Token is masked in transparency log.
     local rule="$1" rule_enc
-    rule_enc="$(_url_encode "${rule}")"
-    local page=1 total fetched=0
-    while :; do
-        local resp
-        resp="$(curl --fail --silent --show-error -u "${SONAR_TOKEN}:" \
-            "${SONAR_HOST_URL}/api/issues/search?componentKeys=${SONAR_PROJECT}&rules=${rule_enc}&resolved=false&ps=500&p=${page}")"
-        jq -r '.issues[].key' <<< "${resp}"
-        total=$(jq -r '.paging.total' <<< "${resp}")
-        local in_page
-        in_page=$(jq -r '.issues | length' <<< "${resp}")
-        fetched=$(( fetched + in_page ))
-        (( fetched >= total || in_page == 0 )) && break
-        page=$(( page + 1 ))
-    done
+    rule_enc="$(sq_url_encode "${rule}")"
+    sq_paginate "/api/issues/search?componentKeys=${SONAR_PROJECT}&rules=${rule_enc}&resolved=false" \
+        | jq -r '.issues[].key'
 }
 
 list_open_hotspots_for_rule() {
     # Sonar's hotspot search does not accept a rule filter -- we have to
-    # fetch all TO_REVIEW hotspots and filter client-side. Pass the rule via
-    # jq's --arg so values containing colons / quotes / shell metacharacters
-    # cannot inject into the filter.
+    # fetch all TO_REVIEW hotspots and filter client-side. Pass the rule
+    # via jq's --arg so values containing colons / quotes / shell
+    # metacharacters cannot inject into the filter.
     local rule="$1"
-    local page=1 total fetched=0
-    while :; do
-        local resp
-        resp="$(curl --fail --silent --show-error -u "${SONAR_TOKEN}:" \
-            "${SONAR_HOST_URL}/api/hotspots/search?projectKey=${SONAR_PROJECT}&status=TO_REVIEW&ps=500&p=${page}")"
-        jq -r --arg rule "${rule}" '.hotspots[] | select(.ruleKey == $rule) | .key' <<< "${resp}"
-        total=$(jq -r '.paging.total' <<< "${resp}")
-        local in_page
-        in_page=$(jq -r '.hotspots | length' <<< "${resp}")
-        fetched=$(( fetched + in_page ))
-        (( fetched >= total || in_page == 0 )) && break
-        page=$(( page + 1 ))
-    done
+    sq_paginate "/api/hotspots/search?projectKey=${SONAR_PROJECT}&status=TO_REVIEW" \
+        | jq -r --arg rule "${rule}" '.hotspots[] | select(.ruleKey == $rule) | .key'
 }
 
 confirm_family() {

--- a/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
+++ b/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Apply per-finding triage decisions on SonarCloud:
+#   issues   -> falsepositive | wontfix | confirm
+#   hotspots -> REVIEWED + (SAFE | ACKNOWLEDGED | FIXED)
+#
+# AUTHENTICATION:
+#   Reads SONAR_TOKEN, SONAR_HOST_URL, SONAR_PROJECT, SONAR_ORG from <repo-root>/.env.
+#   Token is sent as basic-auth username with empty password.
+#
+# COMMENTS MUST BE ASCII-ONLY:
+#   Cloudflare's WAF in front of api.sonarcloud.io blocks non-ASCII bodies
+#   (em-dashes, smart quotes, accented characters). Stick to "--", '"', etc.
+#
+# USAGE:
+#   sonar-mark.sh fp     <ISSUE_KEY>   <COMMENT>     # Bug/Vuln -> False Positive
+#   sonar-mark.sh wontfix <ISSUE_KEY>  <COMMENT>     # Bug/Vuln -> Won't Fix
+#   sonar-mark.sh confirm <ISSUE_KEY>  [COMMENT]     # Bug/Vuln -> Confirmed (real, will fix)
+#   sonar-mark.sh safe   <HOTSPOT_KEY> <COMMENT>     # Hotspot  -> REVIEWED + SAFE
+#   sonar-mark.sh ack    <HOTSPOT_KEY> <COMMENT>     # Hotspot  -> REVIEWED + ACKNOWLEDGED
+#   sonar-mark.sh fixed  <HOTSPOT_KEY> <COMMENT>     # Hotspot  -> REVIEWED + FIXED
+#
+# FAMILY MODE (acts on every open finding for a rule):
+#   sonar-mark.sh family-fp   <RULE_ID>   <COMMENT>  # e.g. go:S2077
+#   sonar-mark.sh family-safe <RULE_ID>   <COMMENT>  # e.g. c:S5443
+#
+#   Family mode prints the matched keys and prompts before acting unless
+#   SONAR_MARK_YES=1 is set in the environment.
+#
+# DRY RUN:
+#   Set SONAR_DRY_RUN=1 to print the curl commands without executing.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+sq_load_env
+
+api_post() {
+    local path="$1"; shift
+    sq_run curl --fail --silent --show-error \
+        -u "${SONAR_TOKEN}:" \
+        -X POST "${SONAR_HOST_URL}${path}" "$@"
+}
+
+issue_add_comment() {
+    local key="$1" text="$2"
+    sq_require_ascii "${text}"
+    api_post "/api/issues/add_comment" \
+        --data-urlencode "issue=${key}" \
+        --data-urlencode "text=${text}" \
+        -o /dev/null
+}
+
+issue_transition() {
+    local key="$1" transition="$2"
+    api_post "/api/issues/do_transition" \
+        --data-urlencode "issue=${key}" \
+        --data-urlencode "transition=${transition}" \
+        -o /dev/null
+}
+
+mark_issue() {
+    local transition="$1" key="$2" comment="${3:-}"
+    if [[ -n "${comment}" ]]; then
+        issue_add_comment "${key}" "${comment}"
+    fi
+    issue_transition "${key}" "${transition}"
+    echo -e "${SQ_GREEN}[OK]${SQ_NC} issue ${key} -> ${transition}" >&2
+}
+
+hotspot_change_status() {
+    local key="$1" resolution="$2" comment="$3"
+    sq_require_ascii "${comment}"
+    # Add the comment first so it persists even if the transition fails.
+    api_post "/api/hotspots/add_comment" \
+        --data-urlencode "hotspot=${key}" \
+        --data-urlencode "comment=${comment}" \
+        -o /dev/null
+    api_post "/api/hotspots/change_status" \
+        --data-urlencode "hotspot=${key}" \
+        --data-urlencode "status=REVIEWED" \
+        --data-urlencode "resolution=${resolution}" \
+        -o /dev/null
+    echo -e "${SQ_GREEN}[OK]${SQ_NC} hotspot ${key} -> REVIEWED/${resolution}" >&2
+}
+
+list_open_issues_for_rule() {
+    local rule="$1"
+    curl --fail --silent --show-error \
+        -u "${SONAR_TOKEN}:" \
+        "${SONAR_HOST_URL}/api/issues/search?componentKeys=${SONAR_PROJECT}&rules=${rule}&resolved=false&ps=500" \
+        | python3 -c 'import json, sys; [print(i["key"]) for i in json.load(sys.stdin)["issues"]]'
+}
+
+list_open_hotspots_for_rule() {
+    local rule="$1"
+    curl --fail --silent --show-error \
+        -u "${SONAR_TOKEN}:" \
+        "${SONAR_HOST_URL}/api/hotspots/search?projectKey=${SONAR_PROJECT}&status=TO_REVIEW&ps=500" \
+        | python3 -c "
+import json, sys
+rule = '${rule}'
+for h in json.load(sys.stdin).get('hotspots', []):
+    if h['ruleKey'] == rule:
+        print(h['key'])
+"
+}
+
+confirm_family() {
+    local rule="$1" count="$2" action="$3"
+    if [[ "${SONAR_MARK_YES:-0}" == "1" ]]; then
+        return 0
+    fi
+    echo -e "${SQ_YELLOW}About to ${action} ${count} finding(s) for rule ${rule}.${SQ_NC}" >&2
+    echo -en "${SQ_YELLOW}Proceed? [y/N] ${SQ_NC}" >&2
+    local ans
+    read -r ans
+    [[ "${ans,,}" == "y" || "${ans,,}" == "yes" ]]
+}
+
+family_fp() {
+    local rule="$1" comment="$2"
+    sq_require_ascii "${comment}"
+    local keys
+    keys="$(list_open_issues_for_rule "${rule}")"
+    local count
+    count="$(printf '%s\n' "${keys}" | grep -c . || true)"
+    if [[ "${count}" == "0" ]]; then
+        echo -e "${SQ_YELLOW}No open issues for rule ${rule}.${SQ_NC}" >&2
+        return 0
+    fi
+    echo "${keys}" >&2
+    confirm_family "${rule}" "${count}" "mark as False Positive" || { echo "Aborted." >&2; return 1; }
+    while IFS= read -r key; do
+        [[ -z "${key}" ]] && continue
+        mark_issue "falsepositive" "${key}" "${comment}"
+    done <<< "${keys}"
+}
+
+family_safe() {
+    local rule="$1" comment="$2"
+    sq_require_ascii "${comment}"
+    local keys
+    keys="$(list_open_hotspots_for_rule "${rule}")"
+    local count
+    count="$(printf '%s\n' "${keys}" | grep -c . || true)"
+    if [[ "${count}" == "0" ]]; then
+        echo -e "${SQ_YELLOW}No open hotspots for rule ${rule}.${SQ_NC}" >&2
+        return 0
+    fi
+    echo "${keys}" >&2
+    confirm_family "${rule}" "${count}" "mark REVIEWED/SAFE" || { echo "Aborted." >&2; return 1; }
+    while IFS= read -r key; do
+        [[ -z "${key}" ]] && continue
+        hotspot_change_status "${key}" "SAFE" "${comment}"
+    done <<< "${keys}"
+}
+
+usage() {
+    sed -n '4,33p' "$0"
+    exit 2
+}
+
+cmd="${1:-}"; shift || true
+case "${cmd}" in
+    fp)        mark_issue "falsepositive" "${1:?key required}" "${2:?comment required}" ;;
+    wontfix)   mark_issue "wontfix"       "${1:?key required}" "${2:?comment required}" ;;
+    confirm)   mark_issue "confirm"       "${1:?key required}" "${2:-}" ;;
+    safe)      hotspot_change_status      "${1:?key required}" "SAFE"         "${2:?comment required}" ;;
+    ack)       hotspot_change_status      "${1:?key required}" "ACKNOWLEDGED" "${2:?comment required}" ;;
+    fixed)     hotspot_change_status      "${1:?key required}" "FIXED"        "${2:?comment required}" ;;
+    family-fp)   family_fp   "${1:?rule id required (e.g. go:S2077)}" "${2:?comment required}" ;;
+    family-safe) family_safe "${1:?rule id required (e.g. c:S5443)}"  "${2:?comment required}" ;;
+    ""|-h|--help|help) usage ;;
+    *) echo -e "${SQ_RED}[ERROR]${SQ_NC} Unknown subcommand: ${cmd}" >&2; usage ;;
+esac

--- a/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
+++ b/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
@@ -32,6 +32,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 sq_load_env
 

--- a/.agents/skills/sonarqube-audit/scripts/sonar-search.sh
+++ b/.agents/skills/sonarqube-audit/scripts/sonar-search.sh
@@ -17,6 +17,7 @@
 set -euo pipefail
 
 # shellcheck source=./_lib.sh
+# shellcheck disable=SC1091
 source "$(dirname "$0")/_lib.sh"
 sq_load_env
 

--- a/.agents/skills/sonarqube-audit/scripts/sonar-search.sh
+++ b/.agents/skills/sonarqube-audit/scripts/sonar-search.sh
@@ -2,14 +2,17 @@
 # Search SonarCloud findings for the configured project.
 #
 # Usage:
-#   sonar-search.sh issues   [--rule RULE_ID] [--resolved=false|true] [--ps=500]
-#   sonar-search.sh hotspots [--status=TO_REVIEW|REVIEWED] [--ps=500]
+#   sonar-search.sh issues   [--rule RULE_ID] [--resolved=false|true]
+#   sonar-search.sh hotspots [--status=TO_REVIEW|REVIEWED]
 #   sonar-search.sh summary                                            # rule + count for open issues + hotspots
 #
-# Output: raw JSON (issues / hotspots) to stdout.
+# Output: a single merged JSON object on stdout (.issues / .hotspots is the
+# concatenation of all pages). Always paginated to .paging.total -- a `--ps`
+# arg is no longer accepted because it was a footgun (only the first page
+# was ever returned).
 #
-# This is a READ-ONLY script — it does not mutate Sonar state. Safe to run
-# anytime to inspect what's outstanding.
+# This is a READ-ONLY script -- it does not mutate Sonar state. Safe to
+# run anytime to inspect what's outstanding.
 
 set -euo pipefail
 
@@ -19,50 +22,73 @@ sq_load_env
 
 cmd="${1:-summary}"; shift || true
 
+# Whitelist common URL-param values to avoid raw user input ending up in
+# the URL. Sonar would reject malformed params anyway, but the error
+# messages are confusing -- fail-fast locally instead.
+_validate_resolved() {
+    case "$1" in true|false) ;; *)
+        echo -e "${SQ_RED}[ERROR]${SQ_NC} --resolved must be 'true' or 'false', got: '$1'" >&2
+        return 1 ;;
+    esac
+}
+_validate_status() {
+    case "$1" in TO_REVIEW|REVIEWED) ;; *)
+        echo -e "${SQ_RED}[ERROR]${SQ_NC} --status must be 'TO_REVIEW' or 'REVIEWED', got: '$1'" >&2
+        return 1 ;;
+    esac
+}
+
 case "${cmd}" in
     issues)
         rule=""
         resolved="false"
-        ps="500"
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 --rule) rule="$2"; shift 2 ;;
                 --resolved=*) resolved="${1#*=}"; shift ;;
-                --ps=*) ps="${1#*=}"; shift ;;
                 *) echo "Unknown arg: $1" >&2; exit 2 ;;
             esac
         done
-        url="${SONAR_HOST_URL}/api/issues/search?componentKeys=${SONAR_PROJECT}&resolved=${resolved}&ps=${ps}"
-        [[ -n "${rule}" ]] && url="${url}&rules=${rule}"
-        sq_run curl --fail --silent --show-error -u "${SONAR_TOKEN}:" "${url}"
+        _validate_resolved "${resolved}"
+        path="/api/issues/search?componentKeys=${SONAR_PROJECT}&resolved=${resolved}"
+        # URL-encode the rule id so values containing `:` (always),
+        # spaces, or other reserved chars don't inject extra params.
+        [[ -n "${rule}" ]] && path="${path}&rules=$(sq_url_encode "${rule}")"
+        sq_paginate "${path}" \
+            | jq -s '{paging: .[0].paging, issues: [.[].issues[]]}'
         ;;
 
     hotspots)
         status="TO_REVIEW"
-        ps="500"
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 --status=*) status="${1#*=}"; shift ;;
-                --ps=*) ps="${1#*=}"; shift ;;
                 *) echo "Unknown arg: $1" >&2; exit 2 ;;
             esac
         done
-        url="${SONAR_HOST_URL}/api/hotspots/search?projectKey=${SONAR_PROJECT}&status=${status}&ps=${ps}"
-        sq_run curl --fail --silent --show-error -u "${SONAR_TOKEN}:" "${url}"
+        _validate_status "${status}"
+        path="/api/hotspots/search?projectKey=${SONAR_PROJECT}&status=${status}"
+        sq_paginate "${path}" \
+            | jq -s '{paging: .[0].paging, hotspots: [.[].hotspots[]]}'
         ;;
 
     summary)
         echo "=== Open issues by rule ===" >&2
-        curl --fail --silent --show-error -u "${SONAR_TOKEN}:" \
-            "${SONAR_HOST_URL}/api/issues/search?componentKeys=${SONAR_PROJECT}&resolved=false&ps=500&facets=rules" \
+        # Issue facets are computed server-side and returned on every page;
+        # the first page's facet totals reflect ALL matching issues, so a
+        # single fetch is correct here.
+        sq_run_read curl --fail --silent --show-error -u "${SONAR_TOKEN}:" \
+            "${SONAR_HOST_URL}/api/issues/search?componentKeys=${SONAR_PROJECT}&resolved=false&ps=1&facets=rules" \
             | jq -r '.facets[] | select(.property=="rules") | .values[] | "  \(.val) (\(.count))"' \
             | sort -k2 -t'(' -nr | head -30
 
         echo >&2
         echo "=== Open hotspots by rule ===" >&2
-        curl --fail --silent --show-error -u "${SONAR_TOKEN}:" \
-            "${SONAR_HOST_URL}/api/hotspots/search?projectKey=${SONAR_PROJECT}&status=TO_REVIEW&ps=500" \
-            | jq -r '[.hotspots[] | .ruleKey] | group_by(.) | map({rule: .[0], count: length}) | sort_by(-.count) | .[] | "  \(.rule) (\(.count))"' \
+        # Hotspot search has no facets, so we have to walk every page.
+        sq_paginate "/api/hotspots/search?projectKey=${SONAR_PROJECT}&status=TO_REVIEW" \
+            | jq -s '[.[].hotspots[].ruleKey]
+                     | group_by(.) | map({rule: .[0], count: length})
+                     | sort_by(-.count) | .[] | "  \(.rule) (\(.count))"' -r \
             | head -30
         ;;
 

--- a/.agents/skills/sonarqube-audit/scripts/sonar-search.sh
+++ b/.agents/skills/sonarqube-audit/scripts/sonar-search.sh
@@ -26,14 +26,16 @@ cmd="${1:-summary}"; shift || true
 # the URL. Sonar would reject malformed params anyway, but the error
 # messages are confusing -- fail-fast locally instead.
 _validate_resolved() {
-    case "$1" in true|false) ;; *)
-        echo -e "${SQ_RED}[ERROR]${SQ_NC} --resolved must be 'true' or 'false', got: '$1'" >&2
+    local v="$1"
+    case "${v}" in true|false) ;; *)
+        echo -e "${SQ_RED}[ERROR]${SQ_NC} --resolved must be 'true' or 'false', got: '${v}'" >&2
         return 1 ;;
     esac
 }
 _validate_status() {
-    case "$1" in TO_REVIEW|REVIEWED) ;; *)
-        echo -e "${SQ_RED}[ERROR]${SQ_NC} --status must be 'TO_REVIEW' or 'REVIEWED', got: '$1'" >&2
+    local v="$1"
+    case "${v}" in TO_REVIEW|REVIEWED) ;; *)
+        echo -e "${SQ_RED}[ERROR]${SQ_NC} --status must be 'TO_REVIEW' or 'REVIEWED', got: '${v}'" >&2
         return 1 ;;
     esac
 }
@@ -43,10 +45,18 @@ case "${cmd}" in
         rule=""
         resolved="false"
         while [[ $# -gt 0 ]]; do
-            case "$1" in
-                --rule) rule="$2"; shift 2 ;;
-                --resolved=*) resolved="${1#*=}"; shift ;;
-                *) echo "Unknown arg: $1" >&2; exit 2 ;;
+            arg="$1"
+            case "${arg}" in
+                --rule)
+                    if [[ $# -lt 2 ]]; then
+                        echo -e "${SQ_RED}[ERROR]${SQ_NC} --rule requires a value (e.g. --rule c:S2245)" >&2
+                        exit 2
+                    fi
+                    rule="$2"
+                    shift 2
+                    ;;
+                --resolved=*) resolved="${arg#*=}"; shift ;;
+                *) echo "Unknown arg: ${arg}" >&2; exit 2 ;;
             esac
         done
         _validate_resolved "${resolved}"
@@ -61,9 +71,10 @@ case "${cmd}" in
     hotspots)
         status="TO_REVIEW"
         while [[ $# -gt 0 ]]; do
-            case "$1" in
-                --status=*) status="${1#*=}"; shift ;;
-                *) echo "Unknown arg: $1" >&2; exit 2 ;;
+            arg="$1"
+            case "${arg}" in
+                --status=*) status="${arg#*=}"; shift ;;
+                *) echo "Unknown arg: ${arg}" >&2; exit 2 ;;
             esac
         done
         _validate_status "${status}"

--- a/.agents/skills/sonarqube-audit/scripts/sonar-search.sh
+++ b/.agents/skills/sonarqube-audit/scripts/sonar-search.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Search SonarCloud findings for the configured project.
+#
+# Usage:
+#   sonar-search.sh issues   [--rule RULE_ID] [--resolved=false|true] [--ps=500]
+#   sonar-search.sh hotspots [--status=TO_REVIEW|REVIEWED] [--ps=500]
+#   sonar-search.sh summary                                            # rule + count for open issues + hotspots
+#
+# Output: raw JSON (issues / hotspots) to stdout.
+#
+# This is a READ-ONLY script — it does not mutate Sonar state. Safe to run
+# anytime to inspect what's outstanding.
+
+set -euo pipefail
+
+# shellcheck source=./_lib.sh
+source "$(dirname "$0")/_lib.sh"
+sq_load_env
+
+cmd="${1:-summary}"; shift || true
+
+case "${cmd}" in
+    issues)
+        rule=""
+        resolved="false"
+        ps="500"
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --rule) rule="$2"; shift 2 ;;
+                --resolved=*) resolved="${1#*=}"; shift ;;
+                --ps=*) ps="${1#*=}"; shift ;;
+                *) echo "Unknown arg: $1" >&2; exit 2 ;;
+            esac
+        done
+        url="${SONAR_HOST_URL}/api/issues/search?componentKeys=${SONAR_PROJECT}&resolved=${resolved}&ps=${ps}"
+        [[ -n "${rule}" ]] && url="${url}&rules=${rule}"
+        sq_run curl --fail --silent --show-error -u "${SONAR_TOKEN}:" "${url}"
+        ;;
+
+    hotspots)
+        status="TO_REVIEW"
+        ps="500"
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --status=*) status="${1#*=}"; shift ;;
+                --ps=*) ps="${1#*=}"; shift ;;
+                *) echo "Unknown arg: $1" >&2; exit 2 ;;
+            esac
+        done
+        url="${SONAR_HOST_URL}/api/hotspots/search?projectKey=${SONAR_PROJECT}&status=${status}&ps=${ps}"
+        sq_run curl --fail --silent --show-error -u "${SONAR_TOKEN}:" "${url}"
+        ;;
+
+    summary)
+        echo "=== Open issues by rule ===" >&2
+        curl --fail --silent --show-error -u "${SONAR_TOKEN}:" \
+            "${SONAR_HOST_URL}/api/issues/search?componentKeys=${SONAR_PROJECT}&resolved=false&ps=500&facets=rules" \
+            | jq -r '.facets[] | select(.property=="rules") | .values[] | "  \(.val) (\(.count))"' \
+            | sort -k2 -t'(' -nr | head -30
+
+        echo >&2
+        echo "=== Open hotspots by rule ===" >&2
+        curl --fail --silent --show-error -u "${SONAR_TOKEN}:" \
+            "${SONAR_HOST_URL}/api/hotspots/search?projectKey=${SONAR_PROJECT}&status=TO_REVIEW&ps=500" \
+            | jq -r '[.hotspots[] | .ruleKey] | group_by(.) | map({rule: .[0], count: length}) | sort_by(-.count) | .[] | "  \(.rule) (\(.count))"' \
+            | head -30
+        ;;
+
+    "")
+        echo "usage: $0 issues|hotspots|summary [args...]" >&2
+        exit 2
+        ;;
+    *)
+        echo "Unknown command: ${cmd}" >&2
+        exit 2
+        ;;
+esac

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 gcs-credentials.json
 /.env
 
+# Per-user local working directory (audits, scratch, drafts, temp artifacts).
+# AI agents that follow AGENTS.md treat this as the place to write run-time data.
+/.local/
+
 # Cross-tool AI agent private overrides (per-user, not for sharing)
 **/AGENTS.local.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ Currently available skills:
 - `.agents/skills/coverity-audit/` - Coverity Scan defect triage
 - `.agents/skills/sonarqube-audit/` - SonarCloud findings triage
 - `.agents/skills/graphql-audit/` - GitHub Code Scanning (CodeQL) triage
+- `.agents/skills/pr-reviews/` - PR comment / review iteration loop
 
 ## Local-only working directory
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,13 @@ Convention:
 - `/.local/audits/coverity/`  - Coverity raw fetches, per-defect details, triage decisions
 - `/.local/audits/sonarqube/` - Sonar finding queues, FP comment templates
 - `/.local/audits/graphql/`   - GitHub Code Scanning fetches and dismissals
+- `/.local/audits/pr-reviews/`- Per-PR comment / review caches
+
+Naming: each skill `<topic>-audit/` writes to `.local/audits/<topic>/`
+(the `-audit` suffix is dropped from the directory name so the URL-style
+path stays short). Skills without the `-audit` suffix keep their full
+name (e.g. `pr-reviews/` writes to `.local/audits/pr-reviews/`). When
+adding a new skill, follow this convention.
 
 Nothing under `/.local/` is committed. Treat the directory as ephemeral
 between users and machines, not as a shared source of truth.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,9 @@ Currently available skills:
 `/.local/` at the repo root is gitignored and reserved for per-user runtime
 artifacts: audit reports, fetched API data, scratch notes, queue files,
 intermediate triage decisions. Agents writing skill output should default to
-`<repo-root>/.local/audits/<skill-name>/...`.
+`<repo-root>/.local/audits/<topic>/...` -- where `<topic>` is the skill
+name with any trailing `-audit` suffix removed (so `coverity-audit/`
+writes under `coverity/`, `pr-reviews/` writes under `pr-reviews/`).
 
 Convention:
 - `/.local/audits/coverity/`  - Coverity raw fetches, per-defect details, triage decisions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,43 @@ These files MUST be consistent with each other. For example:
 - "Netdata Agent" (capitalized) when referring to the product
 - "`netdata`" (lowercase, code-formatted) when referring to the process
 - See DICTIONARY.md for precise terminology
+
+## AI agent skills
+
+Repo-scoped skills for AI agents live under `.agents/skills/<skill-name>/`.
+Each skill is self-contained: a `SKILL.md` with frontmatter (`name`,
+`description`) plus its own `scripts/` directory. Skills carry the operational
+knowledge for tasks that recur across sessions (Coverity triage, SonarCloud
+triage, GitHub Code Scanning triage, etc.).
+
+When an agent learns something new while running a skill (a new gotcha, a
+working API call, a corrected workflow) it MUST update the skill's
+`SKILL.md` and commit it before proceeding. Knowledge that isn't committed
+is lost.
+
+Currently available skills:
+- `.agents/skills/coverity-audit/` - Coverity Scan defect triage
+- `.agents/skills/sonarqube-audit/` - SonarCloud findings triage
+- `.agents/skills/graphql-audit/` - GitHub Code Scanning (CodeQL) triage
+
+## Local-only working directory
+
+`/.local/` at the repo root is gitignored and reserved for per-user runtime
+artifacts: audit reports, fetched API data, scratch notes, queue files,
+intermediate triage decisions. Agents writing skill output should default to
+`<repo-root>/.local/audits/<skill-name>/...`.
+
+Convention:
+- `/.local/audits/coverity/`  - Coverity raw fetches, per-defect details, triage decisions
+- `/.local/audits/sonarqube/` - Sonar finding queues, FP comment templates
+- `/.local/audits/graphql/`   - GitHub Code Scanning fetches and dismissals
+
+Nothing under `/.local/` is committed. Treat the directory as ephemeral
+between users and machines, not as a shared source of truth.
+
+## Per-user secrets via `.env`
+
+`/.env` at the repo root is gitignored and holds per-user secrets and
+endpoint configuration consumed by skill scripts: API tokens, session
+cookies, project keys. Each skill's `SKILL.md` documents the variables it
+needs. Never commit secrets; never hard-code tokens in scripts.


### PR DESCRIPTION
## Summary

Adds three repo-scoped AI agent skills under `.agents/skills/` for the recurring static-analysis triage workflows:

- `coverity-audit/` — Coverity Scan defect triage
- `sonarqube-audit/` — SonarCloud findings triage
- `graphql-audit/` — GitHub Code Scanning (CodeQL) triage

Each skill is self-contained:
- `SKILL.md` with frontmatter (`name`, `description`) describing when an AI agent should invoke it
- `scripts/` directory with the shell helpers that drive each platform's API

Scripts auto-detect the repo root and read per-user secrets from the gitignored `/.env`. They write runtime artifacts under the gitignored `/.local/audits/` tree.

## AGENTS.md updates

Three new sections document the conventions:

1. **AI agent skills** — where skills live, plus the rule that any new knowledge discovered while running a skill must be committed back into its `SKILL.md`
2. **Local-only working directory** — the gitignored `/.local/` for runtime artifacts (audit reports, fetched API data, queue files)
3. **Per-user secrets via `.env`** — the gitignored `/.env` for tokens, cookies, project keys

## .gitignore updates

`/.local/` is added (already had `/.env`).

## Verified live before pushing

| Skill              | Live test                                                  |
|--------------------|------------------------------------------------------------|
| coverity-audit     | keepalive ping OK; outstanding-view fetch returned 10 defects |
| sonarqube-audit    | summary returned 30 rules with open issues, 7 with hotspots |
| graphql-audit      | listed 193 path-injection + 109 type-confusion + 28 other rules |

## Test plan

- [ ] CI build / lint passes
- [ ] (manual) An AI agent can read `.agents/skills/coverity-audit/SKILL.md`, ask the user for a fresh cookie via the documented recipe, save it to `.env`, start the keepalive, and run `fetch-table.sh`
- [ ] (manual) `bash .agents/skills/sonarqube-audit/scripts/sonar-search.sh summary` lists the per-rule open counts
- [ ] (manual) `bash .agents/skills/graphql-audit/scripts/codeql-list.sh` lists the open CodeQL alerts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four repo-scoped static-analysis and PR-review skills that drive issues to zero. Now includes SonarCloud PR findings, a mandatory pre-push re-review with a sync barrier, stricter validation, portable local audits on Linux and macOS, and `shellcheck` CI cleanup.

- **New Features**
  - `pr-reviews`: fetch all PR comments/reviews/threads with paranoid pagination; list open threads; reply and resolve; check CI before each push; holistic re-review runs before every push; re-trigger reviewers (`@copilot`, `@cubic-dev-ai`); wait for new activity. Loop ends when threads are resolved, PR-introduced Sonar findings are zero, and no PR-attributable CI failures remain. Uses `gh`; writes to `/.local/audits/pr-reviews/`.
  - `coverity-audit`: per-CID bundles and triage helpers (`prepare-defect.sh`, `resolve-cid-to-diid.sh`, `finalize-defect.sh`, `update-triage.sh`, `keepalive.sh`); ASCII-only comments; reads `COVERITY_*` from `.env`; writes to `/.local/audits/coverity/`.
  - `sonarqube-audit`: search and mark issues/hotspots; family-mode bulk actions; shared paginator `sq_paginate`; reads `SONAR_*` from `.env`.
  - `graphql-audit`: list and dismiss CodeQL alerts via `gh`; derives `owner/repo` from git remotes; writes to `/.local/audits/graphql/`.
  - Shared: repo-root auto-detection; idempotent fetches; masked-token logs; ASCII-only enforcement; auto-create audit dirs; `AGENTS.md` documents skills, `/.local/`, and `.env`; `/.local/` added to `.gitignore`.

- **Bug Fixes**
  - Pagination correctness: slurp `gh api --paginate` streams with `jq -s add`; cursor-paginate PR `reviewThreads`; bump nested comment page size and warn on truncation; add `sq_paginate` and reuse in Sonar search/mark and PR Sonar fetch.
  - Hardening: pre-push sync barrier added to `pr-reviews`; stricter GitHub remote parsing (explicit `github.com` schemes) and `PR_REPO_SLUG` validation; require `-f -r -s` for inputs; reject `..` in Coverity paths; validate numeric IDs (PR, viewId, cid, defectInstanceId, timeouts); enforce thread-node-id pattern; treat Cloudflare HTML as invalid JSON.
  - URL and encoding: move `sq_url_encode` to `_lib.sh` and use across Sonar scripts; consistently encode rule IDs.
  - Portability and robustness: replace Bash 4 lowercasing with `tr` for macOS; validate Sonar pages/keys; add `sq_run_read`; ensure wait-for-activity always emits thread stats and ignore diff exit code.
  - Docs: clearer CI messaging (don’t wait between pushes), explicit script paths in examples, cleaned skill docs, and reviewer-mention guidance.
  - CI/lint and safety: suppress `shellcheck` SC1091 across source-loading scripts and SC2016 in GraphQL query literals; `resolve-thread.sh` now fail-fast checks GitHub remotes via `pr_require_slug`; sync-barrier docs include `ci-status.sh` and note unrelated CI failures are only recorded, not fixed.

<sup>Written for commit ded074473d3ffac6d9591b1a359b9a6f08059416. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22296?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

