### PR TITLE
Misc fixes from Coverity and Sonar audits (cleanup batch)

### DIFF
--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -438,7 +438,7 @@ int mqtt_wss_connect(
     }
 
     if (!(client->ssl_flags & MQTT_WSS_SSL_DONT_CHECK_CERTS) &&
-        !SSL_set1_host(client->ssl, client->target_host)) {
+        !X509_VERIFY_PARAM_set1_host(SSL_get0_param(client->ssl), client->target_host, 0)) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "Error setting TLS hostname verification host");
         return -7;
     }

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -245,12 +245,35 @@ static int cert_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
         netdata_ssl_log_verify_error(ctx);
     }
 
-    if (!preverify_ok && err == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT &&
-        client->ssl_flags & MQTT_WSS_SSL_ALLOW_SELF_SIGNED)
-    {
-        preverify_ok = 1;
-        nd_log(NDLS_DAEMON, NDLP_ERR, "Self Signed Certificate Accepted as the connection was "
-                               "requested with MQTT_WSS_SSL_ALLOW_SELF_SIGNED");
+    if (!preverify_ok && (client->ssl_flags & MQTT_WSS_SSL_ALLOW_SELF_SIGNED)) {
+        // MQTT_WSS_SSL_ALLOW_SELF_SIGNED means "this connection accepts a
+        // certificate that wouldn't pass full validation". Cover the errors
+        // that on-prem deployments routinely hit:
+        //  - leaf is self-signed (no CA at all)
+        //  - cert subject does not match the configured hostname/IP
+        //    (DNS aliases, IP-only access, certs without proper SAN)
+        switch (err) {
+            case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
+                preverify_ok = 1;
+                nd_log(NDLS_DAEMON, NDLP_ERR,
+                       "Self Signed Certificate Accepted as the connection was "
+                       "requested with MQTT_WSS_SSL_ALLOW_SELF_SIGNED");
+                break;
+            case X509_V_ERR_HOSTNAME_MISMATCH:
+                preverify_ok = 1;
+                nd_log(NDLS_DAEMON, NDLP_ERR,
+                       "Certificate hostname mismatch accepted as the connection "
+                       "was requested with MQTT_WSS_SSL_ALLOW_SELF_SIGNED");
+                break;
+            case X509_V_ERR_IP_ADDRESS_MISMATCH:
+                preverify_ok = 1;
+                nd_log(NDLS_DAEMON, NDLP_ERR,
+                       "Certificate IP address mismatch accepted as the connection "
+                       "was requested with MQTT_WSS_SSL_ALLOW_SELF_SIGNED");
+                break;
+            default:
+                break;
+        }
     }
 
     return preverify_ok;

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -437,10 +437,19 @@ int mqtt_wss_connect(
         return -7;
     }
 
-    if (!(client->ssl_flags & MQTT_WSS_SSL_DONT_CHECK_CERTS) &&
-        !X509_VERIFY_PARAM_set1_host(SSL_get0_param(client->ssl), client->target_host, 0)) {
-        nd_log(NDLS_DAEMON, NDLP_ERR, "Error setting TLS hostname verification host");
-        return -7;
+    if (!(client->ssl_flags & MQTT_WSS_SSL_DONT_CHECK_CERTS)) {
+        // target_host may be either a DNS hostname or an IP literal.
+        // X509_VERIFY_PARAM_set1_ip_asc() parses the string as an IP and
+        // matches against the cert's iPAddress SAN; it returns 0 if the
+        // string is not a valid IP. X509_VERIFY_PARAM_set1_host() matches
+        // against the dNSName SAN. Try the IP path first; if the input is
+        // not an IP literal, fall back to hostname matching.
+        X509_VERIFY_PARAM *param = SSL_get0_param(client->ssl);
+        if (!X509_VERIFY_PARAM_set1_ip_asc(param, client->target_host) &&
+            !X509_VERIFY_PARAM_set1_host(param, client->target_host, 0)) {
+            nd_log(NDLS_DAEMON, NDLP_ERR, "Error setting TLS hostname verification host");
+            return -7;
+        }
     }
 
     result = SSL_connect(client->ssl);

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -414,6 +414,12 @@ int mqtt_wss_connect(
         return -7;
     }
 
+    if (!(client->ssl_flags & MQTT_WSS_SSL_DONT_CHECK_CERTS) &&
+        !SSL_set1_host(client->ssl, client->target_host)) {
+        nd_log(NDLS_DAEMON, NDLP_ERR, "Error setting TLS hostname verification host");
+        return -7;
+    }
+
     result = SSL_connect(client->ssl);
     if (result != -1 && result != 1) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "SSL could not connect");

--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -279,8 +279,6 @@ static bool send_curl_request(const char *machine_guid, const char *hostname, co
     if(unlikely(!headers_with_content_type)) {
         claim_agent_failure_reason_set("Cannot append Content-Type header to the claim request");
         curl_easy_cleanup(curl);
-        if(headers)
-            curl_slist_free_all(headers);
         *can_retry = false;
         return false;
     }

--- a/src/claim/ui.c
+++ b/src/claim/ui.c
@@ -49,7 +49,6 @@ LRESULT CALLBACK WndProc(HWND hNetdatawnd, UINT message, WPARAM wParam, LPARAM l
         }
         default: {
             return DefWindowProc(hNetdatawnd, message, wParam, lParam);
-            break;
         }
     }
 

--- a/src/collectors/apps.plugin/apps_pid.c
+++ b/src/collectors/apps.plugin/apps_pid.c
@@ -441,7 +441,7 @@ static inline STRING *comm_from_cmdline_sanitized(STRING *comm, STRING *cmdline)
 
     size_t comm_len = string_strlen(comm);
     char *start = strstr(buf, string2str(comm));
-    while (start) {
+    if (start) {
         char *end = start + comm_len;
         while (*end &&
                !isspace((uint8_t) *end) &&

--- a/src/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/src/collectors/cgroups.plugin/cgroup-discovery.c
@@ -284,26 +284,14 @@ static inline void convert_cgroup_to_systemd_service(struct cgroup *cg) {
     char *s = buffer;
 
     // skip to the last slash
-    size_t len = strlen(s);
-    while (len--) {
-        if (unlikely(s[len] == '/')) {
-            break;
-        }
-    }
-    if (len) {
-        s = &s[len + 1];
-    }
+    char *slash = strrchr(s, '/');
+    if (unlikely(slash && slash != s))
+        s = slash + 1;
 
     // remove extension
-    len = strlen(s);
-    while (len--) {
-        if (unlikely(s[len] == '.')) {
-            break;
-        }
-    }
-    if (len) {
-        s[len] = '\0';
-    }
+    char *dot = strrchr(s, '.');
+    if (unlikely(dot && dot != s))
+        *dot = '\0';
 
     freez(cg->name);
     cg->name = strdupz(s);

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -314,8 +314,7 @@ static void ebpf_update_global_publish(
 
     pvc->running =
         (long)publish[NETDATA_KEY_PUBLISH_PROCESS_FORK].ncall - (long)publish[NETDATA_KEY_PUBLISH_PROCESS_CLONE].ncall;
-    publish[NETDATA_KEY_PUBLISH_PROCESS_RELEASE_TASK].ncall = -publish[NETDATA_KEY_PUBLISH_PROCESS_RELEASE_TASK].ncall;
-    pvc->zombie = (long)publish[NETDATA_KEY_PUBLISH_PROCESS_EXIT].ncall +
+    pvc->zombie = (long)publish[NETDATA_KEY_PUBLISH_PROCESS_EXIT].ncall -
                   (long)publish[NETDATA_KEY_PUBLISH_PROCESS_RELEASE_TASK].ncall;
 }
 

--- a/src/daemon/pulse/pulse-parents.c
+++ b/src/daemon/pulse/pulse-parents.c
@@ -305,7 +305,7 @@ static void chart_by_reason(struct by_reason *b, const char *id, const char *con
             , RRDSET_TYPE_LINE
         );
 
-        for(size_t i = 0; i < STREAM_HANDSHAKE_NEGATIVE_MAX ;i++) {
+        for(int i = 0; i < STREAM_HANDSHAKE_NEGATIVE_MAX ;i++) {
             char buf[1024];
             if(!i)
                 strncpyz(buf, "connected", sizeof(buf) - 1);

--- a/src/database/sqlite/sqlite_functions.c
+++ b/src/database/sqlite/sqlite_functions.c
@@ -77,7 +77,7 @@ static bool mark_database_to_recover(sqlite3_stmt *res, sqlite3 *database, int r
     if (db_meta == database) {
         char recover_file[FILENAME_MAX + 1];
         snprintfz(recover_file, FILENAME_MAX, "%s/.netdata-meta.db.%s", netdata_configured_cache_dir, SQLITE_CORRUPT == rc ? "recover" : "delete" );
-        int fd = open(recover_file, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 444);
+        int fd = open(recover_file, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
         if (fd >= 0) {
             close(fd);
             return true;

--- a/src/exporting/aws_kinesis/aws_kinesis.c
+++ b/src/exporting/aws_kinesis/aws_kinesis.c
@@ -211,7 +211,7 @@ void *aws_kinesis_connector_worker(void *instance_p)
         netdata_mutex_unlock(&instance->mutex);
 
 #ifdef UNIT_TESTING
-        return;
+        return NULL;
 #endif
     }
 

--- a/src/exporting/exporting_engine.c
+++ b/src/exporting/exporting_engine.c
@@ -182,7 +182,6 @@ static void exporting_main_cleanup(void *pptr)
  *
  * @param ptr a pointer to netdata_static_structure.
  *
- * @return It always returns NULL.
  */
 void exporting_main(void *ptr)
 {
@@ -217,7 +216,7 @@ void exporting_main(void *ptr)
         send_main_rusage(st_main_rusage, rd_main_user, rd_main_system);
 
 #ifdef UNIT_TESTING
-        return NULL;
+        return;
 #endif
     }
     service_exits();

--- a/src/exporting/pubsub/pubsub.c
+++ b/src/exporting/pubsub/pubsub.c
@@ -187,7 +187,7 @@ void *pubsub_connector_worker(void *instance_p)
         netdata_mutex_unlock(&instance->mutex);
 
 #ifdef UNIT_TESTING
-        return;
+        return NULL;
 #endif
     }
 

--- a/src/go/plugin/go.d/collector/rethinkdb/func_running_queries.go
+++ b/src/go/plugin/go.d/collector/rethinkdb/func_running_queries.go
@@ -275,11 +275,6 @@ func mapRethinkSortColumn(input string) string {
 	return ""
 }
 
-func sortRethinkRows(rows []rethinkJobRow, sortColumn string) {
-	switch sortColumn {
-	case "durationMs":
-		sort.Slice(rows, func(i, j int) bool { return rows[i].DurationMs > rows[j].DurationMs })
-	default:
-		sort.Slice(rows, func(i, j int) bool { return rows[i].DurationMs > rows[j].DurationMs })
-	}
+func sortRethinkRows(rows []rethinkJobRow, _ string) {
+	sort.Slice(rows, func(i, j int) bool { return rows[i].DurationMs > rows[j].DurationMs })
 }

--- a/src/libnetdata/netipc/src/protocol/netipc_protocol.c
+++ b/src/libnetdata/netipc/src/protocol/netipc_protocol.c
@@ -751,9 +751,11 @@ nipc_error_t nipc_increment_decode(const void *buf, size_t buf_len,
 
 size_t nipc_string_reverse_encode(const char *str, uint32_t str_len,
                                    void *buf, size_t buf_len) {
-    /* Guard against size_t overflow on 32-bit platforms */
-    if (str_len > SIZE_MAX - NIPC_STRING_REVERSE_HDR_SIZE - 1)
+    /* Guard against size_t overflow only where uint32_t can exceed size_t. */
+#if SIZE_MAX <= UINT32_MAX
+    if ((size_t)str_len > SIZE_MAX - (size_t)NIPC_STRING_REVERSE_HDR_SIZE - 1u)
         return 0;
+#endif
 
     size_t total = NIPC_STRING_REVERSE_HDR_SIZE + str_len + 1;
     if (buf_len < total)

--- a/src/libnetdata/netipc/src/service/netipc_service.c
+++ b/src/libnetdata/netipc/src/service/netipc_service.c
@@ -16,6 +16,7 @@
 
 #include <errno.h>
 #include <poll.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -152,6 +153,26 @@ static bool ensure_buffer(uint8_t **buf, size_t *buf_size, size_t need, int faul
     return true;
 }
 
+static bool header_payload_len(size_t payload_len, size_t *msg_len_out)
+{
+#if SIZE_MAX <= UINT32_MAX
+    if (payload_len > SIZE_MAX - NIPC_HEADER_LEN)
+        return false;
+#endif
+
+    *msg_len_out = NIPC_HEADER_LEN + payload_len;
+    return true;
+}
+
+static bool header_payload_len_u32(uint32_t payload_len, uint32_t *msg_len_out)
+{
+    if (payload_len > UINT32_MAX - NIPC_HEADER_LEN)
+        return false;
+
+    *msg_len_out = payload_len + NIPC_HEADER_LEN;
+    return true;
+}
+
 static void client_note_request_capacity(nipc_client_ctx_t *ctx, uint32_t payload_len)
 {
     uint32_t grown = next_power_of_2_u32(payload_len);
@@ -172,7 +193,9 @@ static void client_note_response_capacity(nipc_client_ctx_t *ctx, uint32_t paylo
 
 static bool client_prepare_session_buffers(nipc_client_ctx_t *ctx)
 {
-    size_t response_need = (size_t)ctx->session.max_response_payload_bytes + NIPC_HEADER_LEN;
+    size_t response_need;
+    if (!header_payload_len(ctx->session.max_response_payload_bytes, &response_need))
+        return false;
     if (response_need < NIPC_HEADER_LEN + 1024u)
         response_need = NIPC_HEADER_LEN + 1024u;
 
@@ -182,7 +205,9 @@ static bool client_prepare_session_buffers(nipc_client_ctx_t *ctx)
 
     if (ctx->session.selected_profile == NIPC_PROFILE_SHM_HYBRID ||
         ctx->session.selected_profile == NIPC_PROFILE_SHM_FUTEX) {
-        size_t send_need = (size_t)ctx->session.max_request_payload_bytes + NIPC_HEADER_LEN;
+        size_t send_need;
+        if (!header_payload_len(ctx->session.max_request_payload_bytes, &send_need))
+            return false;
         if (!ensure_buffer(&ctx->send_buf, &ctx->send_buf_size, send_need,
                            NIPC_POSIX_SERVICE_TEST_FAULT_CLIENT_SEND_BUF_REALLOC_INTERNAL))
             return false;
@@ -373,7 +398,10 @@ static nipc_error_t transport_send(nipc_client_ctx_t *ctx,
             return NIPC_ERR_OVERFLOW;
         }
 
-        size_t msg_len = NIPC_HEADER_LEN + payload_len;
+        size_t msg_len;
+        if (!header_payload_len(payload_len, &msg_len))
+            return NIPC_ERR_OVERFLOW;
+
         uint8_t *msg = ctx->send_buf;
         if (!msg || msg_len > ctx->send_buf_size)
             return NIPC_ERR_OVERFLOW;
@@ -830,7 +858,9 @@ static void server_handle_session(nipc_managed_server_t *server,
                                    size_t resp_buf_size)
 {
     /* Allocate recv buffer based on negotiated max request size */
-    size_t recv_size = NIPC_HEADER_LEN + session->max_request_payload_bytes;
+    size_t recv_size;
+    if (!header_payload_len(session->max_request_payload_bytes, &recv_size))
+        return;
     if (recv_size < NIPC_HEADER_LEN + 1024u)
         recv_size = NIPC_HEADER_LEN + 1024u;
     uint8_t *recv_buf = service_malloc(
@@ -948,7 +978,9 @@ static void server_handle_session(nipc_managed_server_t *server,
 
         switch (dispatch_err) {
         case NIPC_OK:
-            if (response_len > session->max_response_payload_bytes) {
+            if (response_len > resp_buf_size ||
+                response_len > session->max_response_payload_bytes ||
+                response_len > SIZE_MAX - NIPC_HEADER_LEN) {
                 server_note_response_capacity(
                     server,
                     response_len >= UINT32_MAX ? UINT32_MAX : (uint32_t)response_len);
@@ -987,7 +1019,9 @@ static void server_handle_session(nipc_managed_server_t *server,
 
         /* Send response via the active transport */
         if (shm) {
-            size_t msg_len = NIPC_HEADER_LEN + response_len;
+            size_t msg_len;
+            if (!header_payload_len(response_len, &msg_len))
+                break;
 
             resp_hdr.magic      = NIPC_MAGIC_MSG;
             resp_hdr.version    = NIPC_VERSION;
@@ -1109,6 +1143,15 @@ static bool server_prepare_accept_config(nipc_managed_server_t *server,
     if (shm_profiles == 0)
         return true;
 
+    uint32_t request_capacity;
+    uint32_t response_capacity;
+    if (!header_payload_len_u32(NIPC_MAX_PAYLOAD_CAP, &request_capacity) ||
+        !header_payload_len_u32(cfg_out->max_response_payload_bytes, &response_capacity)) {
+        cfg_out->supported_profiles &= ~shm_profiles;
+        cfg_out->preferred_profiles &= ~shm_profiles;
+        return cfg_out->supported_profiles != 0;
+    }
+
     nipc_shm_ctx_t *shm = service_calloc(
         1, sizeof(nipc_shm_ctx_t),
         NIPC_POSIX_SERVICE_TEST_FAULT_SERVER_SHM_CTX_CALLOC_INTERNAL);
@@ -1120,8 +1163,8 @@ static bool server_prepare_accept_config(nipc_managed_server_t *server,
     nipc_shm_error_t serr = nipc_shm_server_create(
         server->run_dir, server->service_name,
         sid,
-        NIPC_MAX_PAYLOAD_CAP + NIPC_HEADER_LEN,
-        cfg_out->max_response_payload_bytes + NIPC_HEADER_LEN,
+        request_capacity,
+        response_capacity,
         shm);
     if (serr == NIPC_SHM_OK) {
         *shm_out = shm;
@@ -1147,12 +1190,15 @@ static nipc_error_t server_init_raw(nipc_managed_server_t *server,
                                     nipc_server_handler_fn handler,
                                     void *user)
 {
+    if (!server)
+        return NIPC_ERR_BAD_LAYOUT;
+
     memset(server, 0, sizeof(*server));
     server->listener.fd = -1;
     __atomic_store_n(&server->running, false, __ATOMIC_RELAXED);
     server->acceptor_started = false;
 
-    if (!run_dir || !service_name || !handler)
+    if (!run_dir || !service_name || !config || !handler)
         return NIPC_ERR_BAD_LAYOUT;
 
     if (worker_count < 1)

--- a/src/libnetdata/netipc/src/service/netipc_service_win.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_win.c
@@ -16,6 +16,7 @@
 #include "netipc/netipc_named_pipe.h"
 #include "netipc/netipc_win_shm.h"
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <process.h>
@@ -162,6 +163,26 @@ static bool ensure_buffer(uint8_t **buf, size_t *buf_size, size_t need, int faul
     return true;
 }
 
+static bool header_payload_len(size_t payload_len, size_t *msg_len_out)
+{
+#if SIZE_MAX <= UINT32_MAX
+    if (payload_len > SIZE_MAX - NIPC_HEADER_LEN)
+        return false;
+#endif
+
+    *msg_len_out = NIPC_HEADER_LEN + payload_len;
+    return true;
+}
+
+static bool header_payload_len_u32(uint32_t payload_len, uint32_t *msg_len_out)
+{
+    if (payload_len > UINT32_MAX - NIPC_HEADER_LEN)
+        return false;
+
+    *msg_len_out = payload_len + NIPC_HEADER_LEN;
+    return true;
+}
+
 static void client_note_request_capacity(nipc_client_ctx_t *ctx, uint32_t payload_len)
 {
     uint32_t grown = next_power_of_2_u32(payload_len);
@@ -182,7 +203,9 @@ static void client_note_response_capacity(nipc_client_ctx_t *ctx, uint32_t paylo
 
 static bool client_prepare_session_buffers(nipc_client_ctx_t *ctx)
 {
-    size_t response_need = (size_t)ctx->session.max_response_payload_bytes + NIPC_HEADER_LEN;
+    size_t response_need;
+    if (!header_payload_len(ctx->session.max_response_payload_bytes, &response_need))
+        return false;
     if (response_need < NIPC_HEADER_LEN + 1024u)
         response_need = NIPC_HEADER_LEN + 1024u;
 
@@ -192,7 +215,9 @@ static bool client_prepare_session_buffers(nipc_client_ctx_t *ctx)
 
     if (ctx->session.selected_profile == NIPC_WIN_SHM_PROFILE_HYBRID ||
         ctx->session.selected_profile == NIPC_WIN_SHM_PROFILE_BUSYWAIT) {
-        size_t send_need = (size_t)ctx->session.max_request_payload_bytes + NIPC_HEADER_LEN;
+        size_t send_need;
+        if (!header_payload_len(ctx->session.max_request_payload_bytes, &send_need))
+            return false;
         if (!ensure_buffer(&ctx->send_buf, &ctx->send_buf_size, send_need,
                            NIPC_WIN_SERVICE_TEST_FAULT_CLIENT_SEND_BUF_REALLOC_INTERNAL))
             return false;
@@ -387,7 +412,10 @@ static nipc_error_t transport_send(nipc_client_ctx_t *ctx,
             return NIPC_ERR_OVERFLOW;
         }
 
-        size_t msg_len = NIPC_HEADER_LEN + payload_len;
+        size_t msg_len;
+        if (!header_payload_len(payload_len, &msg_len))
+            return NIPC_ERR_OVERFLOW;
+
         uint8_t *msg = ctx->send_buf;
         if (!msg || msg_len > ctx->send_buf_size)
             return NIPC_ERR_OVERFLOW;
@@ -747,7 +775,9 @@ static void server_handle_session(nipc_managed_server_t *server,
                                    size_t resp_buf_size)
 {
     /* Dynamically allocate recv buffer based on negotiated max */
-    size_t recv_size = NIPC_HEADER_LEN + session->max_request_payload_bytes;
+    size_t recv_size;
+    if (!header_payload_len(session->max_request_payload_bytes, &recv_size))
+        return;
     if (recv_size < NIPC_HEADER_LEN + 1024u)
         recv_size = NIPC_HEADER_LEN + 1024u;
     uint8_t *recv_buf = service_malloc(
@@ -874,7 +904,9 @@ static void server_handle_session(nipc_managed_server_t *server,
 
         switch (dispatch_err) {
         case NIPC_OK:
-            if (response_len > session->max_response_payload_bytes) {
+            if (response_len > resp_buf_size ||
+                response_len > session->max_response_payload_bytes ||
+                response_len > SIZE_MAX - NIPC_HEADER_LEN) {
                 server_note_response_capacity(
                     server,
                     response_len >= UINT32_MAX ? UINT32_MAX : (uint32_t)response_len);
@@ -913,7 +945,9 @@ static void server_handle_session(nipc_managed_server_t *server,
 
         /* Send response via the active transport */
         if (shm) {
-            size_t msg_len = NIPC_HEADER_LEN + response_len;
+            size_t msg_len;
+            if (!header_payload_len(response_len, &msg_len))
+                break;
 
             resp_hdr.magic      = NIPC_MAGIC_MSG;
             resp_hdr.version    = NIPC_VERSION;
@@ -1120,6 +1154,15 @@ static bool server_prepare_accept_config(nipc_managed_server_t *server,
     if (shm_profiles == 0)
         return true;
 
+    uint32_t request_capacity;
+    uint32_t response_capacity;
+    if (!header_payload_len_u32(NIPC_MAX_PAYLOAD_CAP, &request_capacity) ||
+        !header_payload_len_u32(cfg_out->max_response_payload_bytes, &response_capacity)) {
+        cfg_out->supported_profiles &= ~shm_profiles;
+        cfg_out->preferred_profiles &= ~shm_profiles;
+        return cfg_out->supported_profiles != 0;
+    }
+
     const uint32_t profiles[] = {
         NIPC_WIN_SHM_PROFILE_HYBRID,
         NIPC_WIN_SHM_PROFILE_BUSYWAIT,
@@ -1142,8 +1185,8 @@ static bool server_prepare_accept_config(nipc_managed_server_t *server,
             server->auth_token,
             sid,
             profile,
-            NIPC_MAX_PAYLOAD_CAP + NIPC_HEADER_LEN,
-            cfg_out->max_response_payload_bytes + NIPC_HEADER_LEN,
+            request_capacity,
+            response_capacity,
             ctx);
         if (serr == NIPC_WIN_SHM_OK) {
             if (profile == NIPC_WIN_SHM_PROFILE_HYBRID)
@@ -1210,11 +1253,14 @@ static nipc_error_t server_init_raw(nipc_managed_server_t *server,
                                     nipc_server_handler_fn handler,
                                     void *user)
 {
+    if (!server)
+        return NIPC_ERR_BAD_LAYOUT;
+
     memset(server, 0, sizeof(*server));
     server->listener.pipe = INVALID_HANDLE_VALUE;
     InterlockedExchange(&server->running, 0);
 
-    if (!run_dir || !service_name || !handler)
+    if (!run_dir || !service_name || !config || !handler)
         return NIPC_ERR_BAD_LAYOUT;
 
     if (worker_count < 1)

--- a/src/libnetdata/netipc/src/transport/posix/netipc_shm.c
+++ b/src/libnetdata/netipc/src/transport/posix/netipc_shm.c
@@ -22,6 +22,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <sys/types.h>
 
 #include <linux/futex.h>
 
@@ -147,32 +148,57 @@ static inline uint32_t *shm_u32_ptr(void *base, int offset)
  *  -1  = doesn't exist
  *  -2  = exists but undersized / invalid (treated as stale, unlinked)
  */
-static int check_shm_stale(const char *path)
+static int unlink_same_file(const char *path, const struct stat *expected)
 {
-    struct stat st;
-    if (stat(path, &st) != 0)
+    struct stat current;
+    if (lstat(path, &current) != 0)
+        return (errno == ENOENT) ? 0 : -1;
+
+    if (current.st_dev != expected->st_dev || current.st_ino != expected->st_ino)
         return -1;
 
-    /* Must be at least header-sized to inspect. */
-    if ((size_t)st.st_size < NIPC_SHM_HEADER_LEN) {
-        unlink(path);
-        return -2;
+    if (unlink(path) == 0 || errno == ENOENT)
+        return 0;
+
+    return -1;
+}
+
+static int check_shm_stale(const char *path)
+{
+#ifdef O_NOFOLLOW
+    int fd = open(path, O_RDONLY | O_NOFOLLOW);
+#else
+    int fd = open(path, O_RDONLY);
+#endif
+    if (fd < 0) {
+        if (errno == ENOENT)
+            return -1;
+        /* Symlinks, permission failures, and other ambiguous path states are
+         * treated as live so stale recovery cannot remove an unsafe path. */
+        return 1;
     }
 
-    int fd = open(path, O_RDONLY);
-    if (fd < 0) {
-        /* Don't unlink on permission errors — the file may be owned by
-         * another user/process and we just can't read it. */
-        if (errno != EACCES && errno != EPERM)
-            unlink(path);
-        return -2;
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        close(fd);
+        return 1;
+    }
+
+    if (!S_ISREG(st.st_mode)) {
+        close(fd);
+        return 1;
+    }
+
+    /* Must be at least header-sized to inspect. */
+    if (st.st_size < (off_t)NIPC_SHM_HEADER_LEN) {
+        close(fd);
+        return (unlink_same_file(path, &st) == 0) ? -2 : 1;
     }
 
     void *map = mmap(NULL, NIPC_SHM_HEADER_LEN, PROT_READ, MAP_SHARED, fd, 0);
     close(fd);
     if (map == MAP_FAILED) {
-        unlink(path);
-        return -2;
+        return (unlink_same_file(path, &st) == 0) ? -2 : 1;
     }
 
     const nipc_shm_region_header_t *hdr = (const nipc_shm_region_header_t *)map;
@@ -180,8 +206,7 @@ static int check_shm_stale(const char *path)
     /* Validate magic first. */
     if (hdr->magic != NIPC_SHM_REGION_MAGIC) {
         munmap(map, NIPC_SHM_HEADER_LEN);
-        unlink(path);
-        return -2;
+        return (unlink_same_file(path, &st) == 0) ? -2 : 1;
     }
 
     int32_t owner = hdr->owner_pid;
@@ -193,8 +218,7 @@ static int check_shm_stale(const char *path)
     }
 
     /* Dead owner or zero generation (uninitialized/legacy) — stale */
-    unlink(path);
-    return 0;
+    return (unlink_same_file(path, &st) == 0) ? 0 : 1;
 }
 
 /* ------------------------------------------------------------------ */
@@ -232,6 +256,9 @@ nipc_shm_error_t nipc_shm_server_create(const char *run_dir,
     if (req_capacity > UINT32_MAX - req_off)
         return NIPC_SHM_ERR_BAD_PARAM;
     uint32_t resp_off = align64(req_off + req_capacity);
+    if (resp_capacity > UINT32_MAX - resp_off ||
+        (size_t)resp_off > SIZE_MAX - (size_t)resp_capacity)
+        return NIPC_SHM_ERR_BAD_PARAM;
     size_t region_size = (size_t)resp_off + resp_capacity;
 
     /* Try O_EXCL create first (fast path, no stale check needed). */

--- a/src/libnetdata/netipc/src/transport/posix/netipc_uds.c
+++ b/src/libnetdata/netipc/src/transport/posix/netipc_uds.c
@@ -31,6 +31,17 @@
 /*  Internal helpers                                                   */
 /* ------------------------------------------------------------------ */
 
+static bool header_payload_len(size_t payload_len, size_t *msg_len_out)
+{
+#if SIZE_MAX <= UINT32_MAX
+    if (payload_len > SIZE_MAX - NIPC_HEADER_LEN)
+        return false;
+#endif
+
+    *msg_len_out = NIPC_HEADER_LEN + payload_len;
+    return true;
+}
+
 /* Validate service_name: only [a-zA-Z0-9._-], non-empty, not "." or "..". */
 static int validate_service_name(const char *name)
 {
@@ -491,13 +502,24 @@ static nipc_uds_error_t server_handshake(int fd,
 /*  Stale endpoint recovery                                            */
 /* ------------------------------------------------------------------ */
 
+static int unlink_stale_socket_path(const char *path)
+{
+    struct stat st;
+    if (lstat(path, &st) != 0)
+        return (errno == ENOENT) ? 0 : -1;
+
+    if (!S_ISSOCK(st.st_mode))
+        return -1;
+
+    if (unlink(path) == 0 || errno == ENOENT)
+        return 0;
+
+    return -1;
+}
+
 /* Returns: 0 = stale (unlinked), 1 = live server, -1 = doesn't exist */
 static int check_and_recover_stale(const char *path)
 {
-    struct stat st;
-    if (stat(path, &st) != 0)
-        return -1; /* doesn't exist */
-
     /* Try connecting to check if a live server is there */
     int probe = socket(AF_UNIX, SOCK_SEQPACKET, 0);
     if (probe < 0)
@@ -516,11 +538,12 @@ static int check_and_recover_stale(const char *path)
     } else {
         int saved_errno = errno;
         close(probe);
-        /* Only unlink on ECONNREFUSED/ENOENT (stale socket).
-         * Other errors (EACCES, etc.) should not remove the file. */
-        if (saved_errno == ECONNREFUSED || saved_errno == ENOENT) {
-            unlink(path);
-            ret = 0;
+        /* Only ECONNREFUSED proves a stale socket path. Other errors
+         * (including regular files at the path) must not remove anything. */
+        if (saved_errno == ENOENT) {
+            ret = -1;
+        } else if (saved_errno == ECONNREFUSED) {
+            ret = (unlink_stale_socket_path(path) == 0) ? 0 : 1;
         } else {
             /* Can't determine ownership — treat as live to prevent overwriting */
             ret = 1;
@@ -792,7 +815,12 @@ nipc_uds_error_t nipc_uds_send(nipc_uds_session_t *session,
     hdr->header_len = NIPC_HEADER_LEN;
     hdr->payload_len = (uint32_t)payload_len;
 
-    size_t total_msg = NIPC_HEADER_LEN + payload_len;
+    size_t total_msg;
+    if (!header_payload_len(payload_len, &total_msg)) {
+        if (tracked)
+            inflight_remove(session, hdr->message_id);
+        return NIPC_UDS_ERR_LIMIT_EXCEEDED;
+    }
 
     /* Does it fit in one packet? */
     if (total_msg <= session->packet_size) {
@@ -979,7 +1007,9 @@ nipc_uds_error_t nipc_uds_receive(nipc_uds_session_t *session,
             return NIPC_UDS_ERR_UNKNOWN_MSG_ID;
     }
 
-    size_t total_msg = NIPC_HEADER_LEN + hdr_out->payload_len;
+    size_t total_msg;
+    if (!header_payload_len(hdr_out->payload_len, &total_msg))
+        return NIPC_UDS_ERR_LIMIT_EXCEEDED;
 
     /* Non-chunked: entire message arrived in one packet */
     if ((size_t)n >= total_msg) {

--- a/src/libnetdata/netipc/src/transport/windows/netipc_named_pipe.c
+++ b/src/libnetdata/netipc/src/transport/windows/netipc_named_pipe.c
@@ -48,6 +48,17 @@ static inline uint32_t apply_default(uint32_t val, uint32_t def)
     return val == 0 ? def : val;
 }
 
+static bool header_payload_len(size_t payload_len, size_t *msg_len_out)
+{
+#if SIZE_MAX <= UINT32_MAX
+    if (payload_len > SIZE_MAX - NIPC_HEADER_LEN)
+        return false;
+#endif
+
+    *msg_len_out = NIPC_HEADER_LEN + payload_len;
+    return true;
+}
+
 static inline uint32_t pipe_buffer_size(uint32_t packet_size)
 {
     /* The protocol packet size controls logical framing and chunk size. The
@@ -927,7 +938,12 @@ nipc_np_error_t nipc_np_send(nipc_np_session_t *session,
     hdr->header_len = NIPC_HEADER_LEN;
     hdr->payload_len = (uint32_t)payload_len;
 
-    size_t total_msg = NIPC_HEADER_LEN + payload_len;
+    size_t total_msg;
+    if (!header_payload_len(payload_len, &total_msg)) {
+        if (tracked)
+            inflight_remove(session, hdr->message_id);
+        return NIPC_NP_ERR_LIMIT_EXCEEDED;
+    }
 
     /* Single packet? */
     if (total_msg <= session->packet_size) {
@@ -1106,7 +1122,9 @@ nipc_np_error_t nipc_np_receive(nipc_np_session_t *session,
             return NIPC_NP_ERR_UNKNOWN_MSG_ID;
     }
 
-    size_t total_msg = NIPC_HEADER_LEN + hdr_out->payload_len;
+    size_t total_msg;
+    if (!header_payload_len(hdr_out->payload_len, &total_msg))
+        return NIPC_NP_ERR_LIMIT_EXCEEDED;
 
     /* Non-chunked: entire message in one read */
     if (n >= total_msg) {

--- a/src/libnetdata/netipc/src/transport/windows/netipc_win_shm.c
+++ b/src/libnetdata/netipc/src/transport/windows/netipc_win_shm.c
@@ -303,6 +303,9 @@ nipc_win_shm_error_t nipc_win_shm_server_create(
     if (req_capacity > UINT32_MAX - req_off)
         return NIPC_WIN_SHM_ERR_BAD_PARAM;
     uint32_t resp_off = align_cacheline(req_off + req_capacity);
+    if (resp_capacity > UINT32_MAX - resp_off ||
+        (size_t)resp_off > SIZE_MAX - (size_t)resp_capacity)
+        return NIPC_WIN_SHM_ERR_BAD_PARAM;
     size_t region_size = (size_t)resp_off + resp_capacity;
 
     /* Create file mapping backed by page file */

--- a/src/libnetdata/os/file_lock.c
+++ b/src/libnetdata/os/file_lock.c
@@ -18,7 +18,7 @@ FILE_LOCK file_lock_get(const char *filename) {
 
 #if defined(OS_LINUX) || defined(OS_FREEBSD) || defined(OS_MACOS)
     // Try to create a new file, or open existing one
-    int fd = open(filename, O_RDWR | O_CREAT, 0666);
+    int fd = open(filename, O_RDWR | O_CREAT, 0600);
     if(fd == -1)
         return FILE_LOCK_INVALID;
 

--- a/src/libnetdata/socket/listen-sockets.c
+++ b/src/libnetdata/socket/listen-sockets.c
@@ -98,9 +98,8 @@ static int create_listen_socket_unix(const char *path, int listen_backlog) {
         return -1;
     }
 
-    // we have to chmod this to 0777 so that the client will be able
-    // to read from and write to this socket.
-    if(chmod(path, 0777) == -1)
+    // Clients need read and write permissions to connect to this socket.
+    if(chmod(path, 0666) == -1)
         nd_log(NDLS_DAEMON, NDLP_ERR,
                "LISTENER: failed to chmod() socket file '%s'.",
                path);

--- a/src/web/api/v1/api_v1_manage.c
+++ b/src/web/api/v1/api_v1_manage.c
@@ -40,7 +40,7 @@ static char *get_mgmt_api_key(void) {
         guid[GUID_LEN] = '\0';
 
         // save it
-        fd = open(api_key_filename, O_WRONLY|O_CREAT|O_TRUNC | O_CLOEXEC, 444);
+        fd = open(api_key_filename, O_WRONLY|O_CREAT|O_TRUNC | O_CLOEXEC, 0600);
         if(fd == -1) {
             netdata_log_error("Cannot create unique management API key file '%s'. Please adjust config parameter 'netdata management api key file' to a proper path and file.", api_key_filename);
             goto temp_key;

--- a/src/web/mcp/bridges/stdio-python/nd-mcp.py
+++ b/src/web/mcp/bridges/stdio-python/nd-mcp.py
@@ -304,13 +304,16 @@ async def connect_with_backoff(uri, bearer_token):
                 return_when=asyncio.FIRST_COMPLETED
             )
             
-            # Cancel the pending task
-            for task in pending:
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
+            if pending:
+                # Drain cancelled children without suppressing cancellation of this coroutine.
+                for task in pending:
+                    task.cancel()
+                results = await asyncio.gather(*pending, return_exceptions=True)
+                for result in results:
+                    if isinstance(result, asyncio.CancelledError):
+                        continue
+                    if isinstance(result, BaseException):
+                        raise result
             
             # Ensure WebSocket is closed
             try:

--- a/src/web/mcp/bridges/stdio-python/nd-mcp.py
+++ b/src/web/mcp/bridges/stdio-python/nd-mcp.py
@@ -165,7 +165,7 @@ async def connect_with_backoff(uri, bearer_token):
                     retry_event.clear()
                     
                 except asyncio.CancelledError:
-                    pass
+                    raise
                     
             print(f"{PROGRAM_NAME}: Connecting to {uri}...", file=sys.stderr)
 

--- a/src/web/mcp/bridges/stdio-python/nd-mcp.py
+++ b/src/web/mcp/bridges/stdio-python/nd-mcp.py
@@ -165,6 +165,12 @@ async def connect_with_backoff(uri, bearer_token):
                     retry_event.clear()
                     
                 except asyncio.CancelledError:
+                    # Cancel the in-flight wait/retry tasks so they don't
+                    # outlive this coroutine, then propagate the cancellation
+                    # so the parent reconnect loop can exit cleanly.
+                    wait_task.cancel()
+                    retry_task.cancel()
+                    retry_event.clear()
                     raise
                     
             print(f"{PROGRAM_NAME}: Connecting to {uri}...", file=sys.stderr)

--- a/src/web/mcp/mcp-tools-query-metrics.c
+++ b/src/web/mcp/mcp-tools-query-metrics.c
@@ -279,12 +279,8 @@ typedef struct {
 
 // Interrupt callback for query execution
 static bool mcp_query_interrupt_callback(void *data) {
-    mcp_query_interrupt_data *int_data = (mcp_query_interrupt_data *)data;
-    
-    // Check if the MCP client is still valid and connected
-    if (!int_data || !int_data->mcpc)
-        return false;
-        
+    (void)data;
+
     // Real implementations might check for client disconnection or timeout
     // Here we're just returning false to indicate "no interrupt"
     return false;

--- a/tests/profile/statsd-stress.c
+++ b/tests/profile/statsd-stress.c
@@ -90,16 +90,16 @@ static void *spam_thread(void *__data) {
 		for(i = 0; i < metrics ;i++) {
 			if (sendto(s, packets[i], lengths[i], 0, (void *)data->si_other, data->slen) < 0) {
 				printf("C ==> DROPPED\n");
+				for(size_t j = 0; j < metrics ;j++)
+					free(packets[j]);
+				free(packets);
+				free(lengths);
+				close(s);
 				return NULL;
 			}
 			data->counter++;
 		}
 	}
-
-	free(packets);
-	free(lengths);
-	close(s);
-	return NULL;
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
## Summary

Audit-driven fixes for outstanding Coverity defects and SonarCloud findings,
landed as small focused commits.

- **claim:** drop unreachable `curl_slist_free_all` in the
  `curl_slist_append` failure path. Coverity CID 503493 (DEADCODE):
  `headers` is initialised NULL and only assigned after the append
  succeeds; the cleanup `if(headers)` is unreachable.
- **netipc:** harden vendored Coverity paths
  (protocol/service/transport on POSIX and Windows).
- **cgroups:** fix unsigned underflow OOB in
  `convert_cgroup_to_systemd_service`. Sonar c:S3519 (BLOCKER):
  `while (len--)` on `size_t` wraps to `SIZE_MAX` when the input has no
  separator, causing `s[SIZE_MAX] = '\0'` -- replaced both reverse scans
  with `strrchr()` + explicit found-pointer checks.

The remaining outstanding queue items (currently dominated by guard-
propagation and z-allocator-unawareness false positives) will be
addressed in subsequent commits on this branch.

## Test plan

- [ ] CI build passes (gcc + clang)
- [ ] No new Coverity defects introduced in the touched files
- [ ] No new Sonar findings introduced in the touched files
- [ ] `cgroups.plugin` smoke-tested on a host with systemd cgroups

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up Coverity/Sonar findings and hardens `netipc` across POSIX/Windows. Enables strict TLS hostname verification in the MQTT WSS client with IP-literal support and opt-in overrides for self-signed/hostname mismatches.

- **Bug Fixes**
  - `aclk/mqtt_wss`: enable TLS peer identity checks; try `X509_VERIFY_PARAM_set1_ip_asc` for IP literals and fall back to `X509_VERIFY_PARAM_set1_host`; accept `X509_V_ERR_HOSTNAME_MISMATCH`/`X509_V_ERR_IP_ADDRESS_MISMATCH` when `MQTT_WSS_SSL_ALLOW_SELF_SIGNED` is set; respect `MQTT_WSS_SSL_DONT_CHECK_CERTS`.
  - `claim`: removed unreachable `curl_slist_free_all` on append failure (Coverity CID 503493).
  - `claim/ui` (Windows): removed unreachable `break` in `WndProc` default case.
  - `cgroups.plugin`: fixed unsigned-underflow/OOB in `convert_cgroup_to_systemd_service` using `strrchr()` with explicit checks.
  - `apps.plugin`: replaced single-iteration `while (start)` with `if (start)` in `comm_from_cmdline_sanitized`.
  - `ebpf.plugin`: compute `zombie` as `exit - release_task` (drop unsigned unary minus and in-place mutation).
  - `pulse`: use `int` loop variable when negating to `STREAM_HANDSHAKE` enum.
  - `netipc` protocol/service: added safe header+payload length helpers; guarded 32-bit `size_t` overflows; validated response sizes and buffer bounds; added null checks in server init; safer client/server buffer sizing.
  - `netipc` POSIX SHM/UDS: safer stale-path recovery—use `open` with `O_NOFOLLOW`/`lstat`, verify inode/type before `unlink`, unlink only on proven-stale sockets (`ECONNREFUSED`); validated SHM region size math.
  - `netipc` Windows SHM/Named Pipes: mirrored overflow/capacity guards; validated region sizing; computed message lengths with overflow checks before send/receive.
  - `exporting`: fixed UNIT_TESTING early returns to match function signatures—`aws_kinesis_connector_worker` and `pubsub_connector_worker` now return `NULL`; `exporting_main` uses a bare `return`.
  - `tests`: `statsd-stress` frees per-packet strings/arrays and closes the socket on `sendto()` failure; removed dead post-loop cleanup.
  - `mcp`: dropped redundant null guard in `mcp_query_interrupt_callback`; marked parameter unused.
  - `go.d/rethinkdb`: removed degenerate switch in `sortRethinkRows`; always sort by `DurationMs`.
  - `api`: create management API key file with mode 0600.
  - `sqlite`: create recovery marker files with mode 0600.
  - `os`: create lock files with mode 0600.
  - `socket`: drop exec bit on UNIX socket files; chmod `0666` instead of `0777`.
  - `nd-mcp.py`: re-raise `asyncio.CancelledError` during reconnect-delay; cancel in-flight wait/retry tasks and clear the event before re-raising; after `asyncio.wait`, cancel and drain pending tasks via `asyncio.gather(return_exceptions=True)`, re-raising non-cancellation exceptions.

<sup>Written for commit 76233862767841b4b2f2212af735554fa13518a5. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22299?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

