### PR TITLE
fix(json): validate json_object before processing in json_walk function

### DIFF
--- a/src/libnetdata/json/json.c
+++ b/src/libnetdata/json/json.c
@@ -443,8 +443,10 @@ size_t json_walk_object(char *js, jsmntok_t *t, size_t nest, size_t start, JSON_
  */
 #ifdef ENABLE_JSONC
 size_t json_walk(json_object *t, void *callback_data, int (*callback_function)(struct json_entry *)) {
-    JSON_ENTRY e;
+    if (!t || json_object_get_type(t) != json_type_object)
+        return 0;
 
+    JSON_ENTRY e = { 0 };
     e.callback_data = callback_data;
     enum json_type type;
     json_object_object_foreach(t, key, val) {


### PR DESCRIPTION
##### Summary
- Prevent crash on an invalid `health.silencers.json` file eg with `[]`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add input validation to `json_walk` (JSON-C path) so it only processes JSON objects. This prevents a crash when `health.silencers.json` is an array (e.g., `[]`) or otherwise invalid.

- **Bug Fixes**
  - Return early if `t` is NULL or not `json_type_object`.
  - Zero-initialize `JSON_ENTRY` to avoid undefined reads.

<sup>Written for commit f4968f97342421a41ab9172d8ed8556feb714bc4. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22309?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

