### PR TITLE
feat(go.d/mssql): add transaction log monitoring

### DIFF
--- a/src/go/plugin/go.d/collector/mssql/charts.go
+++ b/src/go/plugin/go.d/collector/mssql/charts.go
@@ -48,6 +48,9 @@ const (
 	prioDatabaseLogFlushes
 	prioDatabaseLogFlushed
 	prioDatabaseLogGrowths
+	prioDatabaseLogFileSize
+	prioDatabaseLogPercentUsed
+	prioDatabaseLogTruncationsShrinks
 	prioDatabaseIOStall
 	prioDatabaseDeadlocks
 	prioDatabaseLockWaits
@@ -541,6 +544,44 @@ var (
 			{ID: "database_%s_log_growths", Name: "growths", Algo: collectorapi.Incremental},
 		},
 	}
+	databaseLogFileSizeChartTmpl = collectorapi.Chart{
+		ID:       "database_%s_log_file_size",
+		Title:    "Transaction log file size",
+		Units:    "bytes",
+		Fam:      "db log",
+		Ctx:      "mssql.database_log_file_size",
+		Type:     collectorapi.Stacked,
+		Priority: prioDatabaseLogFileSize,
+		Dims: collectorapi.Dims{
+			{ID: "database_%s_log_size_used", Name: "used"},
+			{ID: "database_%s_log_size_free", Name: "free"},
+		},
+	}
+	databaseLogPercentUsedChartTmpl = collectorapi.Chart{
+		ID:       "database_%s_log_percent_used",
+		Title:    "Transaction log space utilization",
+		Units:    "percentage",
+		Fam:      "db log",
+		Ctx:      "mssql.database_log_percent_used",
+		Type:     collectorapi.Line,
+		Priority: prioDatabaseLogPercentUsed,
+		Dims: collectorapi.Dims{
+			{ID: "database_%s_log_percent_used", Name: "used", Div: 100},
+		},
+	}
+	databaseLogTruncationsShrinksChartTmpl = collectorapi.Chart{
+		ID:       "database_%s_log_truncations_shrinks",
+		Title:    "Transaction log truncations and shrinks",
+		Units:    "events/s",
+		Fam:      "db log",
+		Ctx:      "mssql.database_log_truncations_shrinks",
+		Type:     collectorapi.Line,
+		Priority: prioDatabaseLogTruncationsShrinks,
+		Dims: collectorapi.Dims{
+			{ID: "database_%s_log_truncations", Name: "truncations", Algo: collectorapi.Incremental},
+			{ID: "database_%s_log_shrinks", Name: "shrinks", Algo: collectorapi.Incremental},
+		},
+	}
 	databaseIOStallChartTmpl = collectorapi.Chart{
 		ID:       "database_%s_io_stall",
 		Title:    "Database I/O stall time",
@@ -770,6 +811,30 @@ func (c *Collector) addDatabaseCharts(dbName string) {
 		databaseBackupRestoreThroughputChartTmpl.Copy(),
 		databaseStateChartTmpl.Copy(),
 		databaseReadOnlyChartTmpl.Copy(),
+	}
+
+	dbID := cleanDatabaseName(dbName)
+
+	for _, chart := range *charts {
+		chart.ID = fmt.Sprintf(chart.ID, dbID)
+		chart.Labels = []collectorapi.Label{
+			{Key: "database", Value: dbName},
+		}
+		for _, dim := range chart.Dims {
+			dim.ID = fmt.Sprintf(dim.ID, dbID)
+		}
+	}
+
+	if err := c.Charts().Add(*charts...); err != nil {
+		c.Warning(err)
+	}
+}
+
+func (c *Collector) addDatabaseLogCharts(dbName string) {
+	charts := &collectorapi.Charts{
+		databaseLogFileSizeChartTmpl.Copy(),
+		databaseLogPercentUsedChartTmpl.Copy(),
+		databaseLogTruncationsShrinksChartTmpl.Copy(),
 	}
 
 	dbID := cleanDatabaseName(dbName)

--- a/src/go/plugin/go.d/collector/mssql/collect.go
+++ b/src/go/plugin/go.d/collector/mssql/collect.go
@@ -16,6 +16,11 @@ import (
 // noLatencySentinel is the value SQL Server returns when no latency data is available
 const noLatencySentinel = 999999
 
+const (
+	maxKBToBytes        = int64(1<<63-1) / 1024
+	maxKBToCentiPercent = int64(1<<63-1) / 10000
+)
+
 func (c *Collector) collect() (map[string]int64, error) {
 	if c.db == nil {
 		db, err := c.openConnection()
@@ -358,6 +363,9 @@ func (c *Collector) collectDatabaseMetrics(mx map[string]int64) error {
 	if err := c.collectLogGrowths(mx); err != nil {
 		return err
 	}
+	if err := c.collectDatabaseLogCounters(mx); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -405,6 +413,110 @@ func (c *Collector) collectDatabaseCounters(mx map[string]int64) error {
 	}
 
 	return rows.Err()
+}
+
+type databaseLogCounters struct {
+	sizeKB          int64
+	usedKB          int64
+	truncations     int64
+	shrinks         int64
+	hasSize         bool
+	hasUsed         bool
+	hasTruncations  bool
+	hasShrinks      bool
+	hasKnownCounter bool
+}
+
+func (c *Collector) collectDatabaseLogCounters(mx map[string]int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout.Duration())
+	defer cancel()
+
+	rows, err := c.db.QueryContext(ctx, queryDatabaseLogCounters)
+	if err != nil {
+		return fmt.Errorf("database log counters query failed: %v", err)
+	}
+	defer rows.Close()
+
+	counters := make(map[string]*databaseLogCounters)
+
+	for rows.Next() {
+		var dbName, counterName string
+		var value int64
+		if err := rows.Scan(&dbName, &counterName, &value); err != nil {
+			continue
+		}
+		if value < 0 {
+			continue
+		}
+
+		dbName = strings.TrimSpace(dbName)
+		counterName = strings.TrimSpace(counterName)
+		if dbName == "" {
+			continue
+		}
+
+		if !c.seenDatabasesWithLog[dbName] {
+			c.seenDatabasesWithLog[dbName] = true
+			c.addDatabaseLogCharts(dbName)
+		}
+
+		if counters[dbName] == nil {
+			counters[dbName] = &databaseLogCounters{}
+		}
+
+		switch counterName {
+		case "Log File(s) Size (KB)":
+			counters[dbName].sizeKB = value
+			counters[dbName].hasSize = true
+			counters[dbName].hasKnownCounter = true
+		case "Log File(s) Used Size (KB)":
+			counters[dbName].usedKB = value
+			counters[dbName].hasUsed = true
+			counters[dbName].hasKnownCounter = true
+		case "Log Truncations":
+			counters[dbName].truncations = value
+			counters[dbName].hasTruncations = true
+			counters[dbName].hasKnownCounter = true
+		case "Log Shrinks":
+			counters[dbName].shrinks = value
+			counters[dbName].hasShrinks = true
+			counters[dbName].hasKnownCounter = true
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for dbName, values := range counters {
+		if values == nil || !values.hasKnownCounter {
+			continue
+		}
+
+		dbID := cleanDatabaseName(dbName)
+
+		if values.hasSize && values.hasUsed && values.sizeKB > 0 &&
+			values.sizeKB <= maxKBToBytes && values.usedKB <= maxKBToBytes {
+			usedBytes := values.usedKB * 1024
+			freeKB := max(values.sizeKB-values.usedKB, 0)
+
+			mx[fmt.Sprintf("database_%s_log_size_used", dbID)] = usedBytes
+			mx[fmt.Sprintf("database_%s_log_size_free", dbID)] = freeKB * 1024
+
+			if values.usedKB <= maxKBToCentiPercent {
+				mx[fmt.Sprintf("database_%s_log_percent_used", dbID)] = values.usedKB * 10000 / values.sizeKB
+			}
+		}
+
+		if values.hasTruncations {
+			mx[fmt.Sprintf("database_%s_log_truncations", dbID)] = values.truncations
+		}
+		if values.hasShrinks {
+			mx[fmt.Sprintf("database_%s_log_shrinks", dbID)] = values.shrinks
+		}
+	}
+
+	return nil
 }
 
 func (c *Collector) collectLockStatsByResourceType(mx map[string]int64) error {

--- a/src/go/plugin/go.d/collector/mssql/collector.go
+++ b/src/go/plugin/go.d/collector/mssql/collector.go
@@ -50,12 +50,13 @@ func New() *Collector {
 
 		charts: instanceCharts.Copy(),
 
-		seenDatabases:      make(map[string]bool),
-		seenWaitTypes:      make(map[string]bool),
-		seenLockTypes:      make(map[string]bool),
-		seenLockStatsTypes: make(map[string]bool),
-		seenJobs:           make(map[string]bool),
-		seenReplications:   make(map[string]bool),
+		seenDatabases:        make(map[string]bool),
+		seenDatabasesWithLog: make(map[string]bool),
+		seenWaitTypes:        make(map[string]bool),
+		seenLockTypes:        make(map[string]bool),
+		seenLockStatsTypes:   make(map[string]bool),
+		seenJobs:             make(map[string]bool),
+		seenReplications:     make(map[string]bool),
 
 		seenAGs:                make(map[string]bool),
 		seenAGReplicas:         make(map[string]bool),
@@ -155,12 +156,13 @@ type Collector struct {
 
 	version string
 
-	seenDatabases      map[string]bool
-	seenWaitTypes      map[string]bool
-	seenLockTypes      map[string]bool
-	seenLockStatsTypes map[string]bool
-	seenJobs           map[string]bool
-	seenReplications   map[string]bool
+	seenDatabases        map[string]bool
+	seenDatabasesWithLog map[string]bool
+	seenWaitTypes        map[string]bool
+	seenLockTypes        map[string]bool
+	seenLockStatsTypes   map[string]bool
+	seenJobs             map[string]bool
+	seenReplications     map[string]bool
 
 	hadrEnabled  bool // true if Always On AG is enabled on this instance
 	hadrChecked  bool // true after the HADR check has been performed

--- a/src/go/plugin/go.d/collector/mssql/integrations/microsoft_sql_server.md
+++ b/src/go/plugin/go.d/collector/mssql/integrations/microsoft_sql_server.md
@@ -425,8 +425,11 @@ jobs:
 
 ## Alerts
 
-There are no alerts configured by default for this integration.
+The following alerts are available:
 
+| Alert name  | On metric | Description |
+|:------------|:----------|:------------|
+| [ mssql_database_log_percent_used ](https://github.com/netdata/netdata/blob/master/src/health/health.d/mssql.conf) | mssql.database_log_percent_used | SQL Server transaction log percent used has been above 90% for the last 15 minutes |
 
 ## Metrics
 
@@ -492,6 +495,9 @@ Metrics:
 | mssql.database_log_flushes | flushes | flushes/s | • | • |
 | mssql.database_log_flushed | flushed | bytes/s | • | • |
 | mssql.database_log_growths | growths | growths | • | • |
+| mssql.database_log_file_size | used, free | bytes | • | • |
+| mssql.database_log_percent_used | used | percentage | • | • |
+| mssql.database_log_truncations_shrinks | truncations, shrinks | events/s | • | • |
 | mssql.database_io_stall | read, write | ms | • | • |
 | mssql.database_data_file_size | size | bytes | • | • |
 | mssql.database_backup_restore_throughput | throughput | bytes/s | • | • |
@@ -1058,6 +1064,4 @@ Ensure SQL Server is configured for mixed mode authentication if using SQL login
 
 The monitoring user needs VIEW SERVER STATE permission.
 Grant it with: `GRANT VIEW SERVER STATE TO netdata_user;`
-
-
 

--- a/src/go/plugin/go.d/collector/mssql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mssql/metadata.yaml
@@ -400,7 +400,11 @@ modules:
             description: |
               The monitoring user needs VIEW SERVER STATE permission.
               Grant it with: `GRANT VIEW SERVER STATE TO netdata_user;`
-    alerts: []
+    alerts:
+      - name: mssql_database_log_percent_used
+        metric: mssql.database_log_percent_used
+        info: SQL Server transaction log percent used has been above 90% for the last 15 minutes
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/mssql.conf
     functions:
       description: |
         This collector exposes real-time functions for interactive troubleshooting in the Live tab.
@@ -1155,6 +1159,26 @@ modules:
               chart_type: line
               dimensions:
                 - name: growths
+            - name: mssql.database_log_file_size
+              description: Transaction Log File Size
+              unit: bytes
+              chart_type: stacked
+              dimensions:
+                - name: used
+                - name: free
+            - name: mssql.database_log_percent_used
+              description: Transaction Log Space Utilization
+              unit: percentage
+              chart_type: line
+              dimensions:
+                - name: used
+            - name: mssql.database_log_truncations_shrinks
+              description: Transaction Log Truncations and Shrinks
+              unit: events/s
+              chart_type: line
+              dimensions:
+                - name: truncations
+                - name: shrinks
             - name: mssql.database_io_stall
               description: I/O Stall Time
               unit: ms

--- a/src/go/plugin/go.d/collector/mssql/mssql_test.go
+++ b/src/go/plugin/go.d/collector/mssql/mssql_test.go
@@ -152,6 +152,68 @@ func TestCollector_Collect(t *testing.T) {
 		notWantMetrics []string
 		checkCollector func(t *testing.T, c *Collector)
 	}{
+		"database log counters: complete unordered rows": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryDatabaseLogCounters).WillReturnRows(
+					sqlmock.NewRows([]string{"database_name", "counter_name", "cntr_value"}).
+						AddRow("AppDB", "Log Shrinks", int64(2)).
+						AddRow("AppDB", "Log File(s) Used Size (KB)", int64(256)).
+						AddRow("AppDB", "Log Truncations", int64(3)).
+						AddRow("AppDB", "Log File(s) Size (KB)", int64(1024)),
+				)
+			},
+			collectFn: func(c *Collector, mx map[string]int64) error { return c.collectDatabaseLogCounters(mx) },
+			wantMetrics: map[string]int64{
+				"database_appdb_log_size_used":    256 * 1024,
+				"database_appdb_log_size_free":    768 * 1024,
+				"database_appdb_log_percent_used": 2500,
+				"database_appdb_log_truncations":  3,
+				"database_appdb_log_shrinks":      2,
+			},
+			checkCollector: func(t *testing.T, c *Collector) {
+				assert.True(t, c.seenDatabasesWithLog["AppDB"])
+			},
+		},
+		"database log counters: missing used skips size and percent": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryDatabaseLogCounters).WillReturnRows(
+					sqlmock.NewRows([]string{"database_name", "counter_name", "cntr_value"}).
+						AddRow("AppDB", "Log File(s) Size (KB)", int64(1024)).
+						AddRow("AppDB", "Log Truncations", int64(3)),
+				)
+			},
+			collectFn: func(c *Collector, mx map[string]int64) error { return c.collectDatabaseLogCounters(mx) },
+			wantMetrics: map[string]int64{
+				"database_appdb_log_truncations": 3,
+			},
+			notWantMetrics: []string{
+				"database_appdb_log_size_used",
+				"database_appdb_log_size_free",
+				"database_appdb_log_percent_used",
+			},
+		},
+		"database log counters: used greater than size clamps free": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryDatabaseLogCounters).WillReturnRows(
+					sqlmock.NewRows([]string{"database_name", "counter_name", "cntr_value"}).
+						AddRow("AppDB", "Log File(s) Size (KB)", int64(100)).
+						AddRow("AppDB", "Log File(s) Used Size (KB)", int64(150)),
+				)
+			},
+			collectFn: func(c *Collector, mx map[string]int64) error { return c.collectDatabaseLogCounters(mx) },
+			wantMetrics: map[string]int64{
+				"database_appdb_log_size_used":    150 * 1024,
+				"database_appdb_log_size_free":    0,
+				"database_appdb_log_percent_used": 15000,
+			},
+		},
+		"database log counters: query error": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryDatabaseLogCounters).WillReturnError(fmt.Errorf("access denied"))
+			},
+			collectFn: func(c *Collector, mx map[string]int64) error { return c.collectDatabaseLogCounters(mx) },
+			wantErr:   true,
+		},
 		"ag health: success": {
 			prepareMock: func(mock sqlmock.Sqlmock) {
 				mock.ExpectQuery(queryAGHealth).WillReturnRows(

--- a/src/go/plugin/go.d/collector/mssql/queries.go
+++ b/src/go/plugin/go.d/collector/mssql/queries.go
@@ -101,6 +101,26 @@ WHERE object_name LIKE '%Databases%'
   );
 `
 
+// queryDatabaseLogCounters gets per-database transaction log size and activity counters
+const queryDatabaseLogCounters = `
+SELECT
+  RTRIM(pc.instance_name) AS database_name,
+  RTRIM(pc.counter_name) AS counter_name,
+  pc.cntr_value
+FROM sys.dm_os_performance_counters AS pc
+INNER JOIN sys.databases AS d
+  ON d.database_id = DB_ID(RTRIM(pc.instance_name))
+WHERE pc.object_name LIKE '%Databases%'
+  AND pc.instance_name NOT IN ('_Total', 'mssqlsystemresource')
+  AND d.database_id > 4
+  AND pc.counter_name IN (
+    'Log File(s) Size (KB)',
+    'Log File(s) Used Size (KB)',
+    'Log Truncations',
+    'Log Shrinks'
+  );
+`
+
 // queryDatabaseLocks gets per-database lock metrics
 const queryDatabaseLocks = `
 SELECT

--- a/src/health/health.d/mssql.conf
+++ b/src/health/health.d/mssql.conf
@@ -1,0 +1,16 @@
+
+# database transaction log utilization
+
+ template: mssql_database_log_percent_used
+       on: mssql.database_log_percent_used
+    class: Utilization
+     type: Database
+component: Microsoft SQL Server
+   lookup: min -15m unaligned of used
+    units: %
+    every: 1m
+     warn: $this > 90
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Server database ${label:database} transaction log utilization
+     info: SQL Server transaction log percent used has been above 90% for the last 15 minutes
+       to: dba


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-database SQL Server transaction log monitoring to the `go.d/mssql` collector. New charts show size, utilization, and truncation/shrink activity, plus an alert for sustained high utilization.

- **New Features**
  - Collects per-database log counters from `sys.dm_os_performance_counters` and auto-creates charts when a DB is first seen.
  - New charts: `mssql.database_log_file_size` (used/free bytes), `mssql.database_log_percent_used` (percentage), `mssql.database_log_truncations_shrinks` (events/s).
  - New alert `mssql_database_log_percent_used`: warns when utilization > 90% for 15m (added in `src/health/health.d/mssql.conf`, linked in docs/metadata).
  - Adds edge-case handling and tests (unordered rows, missing values, used > size, query error).

<sup>Written for commit a70cab5382320bbdd3b1527e96aa3b06018514e7. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22319?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

