### PR TITLE
fix(dbengine): validate extent disk size and fix uncompressed page bounds

### DIFF
--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -702,7 +702,7 @@ static void journalfile_restore_extent_metadata(struct rrdengine_instance *ctx, 
     count = jf_metric_data->number_of_pages;
     descr_size = sizeof(*jf_metric_data->descr) * count;
     payload_length = sizeof(*jf_metric_data) + descr_size;
-    if (payload_length > max_size) {
+    if (payload_length > max_size || !rrdeng_valid_extent_disk_size(jf_metric_data->extent_size)) {
         netdata_log_error("DBENGINE: corrupted transaction payload.");
         return;
     }

--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -1080,10 +1080,11 @@ void pgc_open_add_hot_page(
     unsigned extent_size)
 {
     if (unlikely(!rrdeng_valid_extent_disk_size(extent_size))) {
-        nd_log(NDLS_DAEMON, NDLP_ERR,
-               "DBENGINE: skipped adding open-cache page for datafile %u of tier %u, "
-               "extent at offset %" PRIu64 " has invalid size %u",
-               datafile->fileno, datafile->tier, extent_offset, extent_size);
+        nd_log_limit_static_thread_var(erl, 10, 0);
+        nd_log_limit(&erl, NDLS_DAEMON, NDLP_ERR,
+                     "DBENGINE: skipped adding open-cache page for datafile %u of tier %u, "
+                     "extent at offset %" PRIu64 " has invalid size %u",
+                     datafile->fileno, datafile->tier, extent_offset, extent_size);
         return;
     }
 

--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -1079,6 +1079,13 @@ void pgc_open_add_hot_page(
     uint64_t extent_offset,
     unsigned extent_size)
 {
+    if (unlikely(!rrdeng_valid_extent_disk_size(extent_size))) {
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "DBENGINE: skipped adding open-cache page for datafile %u of tier %u, "
+               "extent at offset %" PRIu64 " has invalid size %u",
+               datafile->fileno, datafile->tier, extent_offset, extent_size);
+        return;
+    }
 
     if(!datafile_acquire(datafile, DATAFILE_ACQUIRE_OPEN_CACHE)) { // for open cache item
         nd_log_limit_static_thread_var(erl, 10, 0);

--- a/src/database/engine/pdc.c
+++ b/src/database/engine/pdc.c
@@ -1047,7 +1047,7 @@ static bool epdl_populate_pages_from_extent_data(
     uLong crc;
 
     bool can_use_data = true;
-    if(data_length < sizeof(*header) + sizeof(header->descr[0]) + sizeof(*trailer)) {
+    if(!rrdeng_valid_extent_disk_size(data_length)) {
         can_use_data = false;
 
         // added to satisfy the requirements of older compilers (prevent warnings)
@@ -1079,7 +1079,7 @@ static bool epdl_populate_pages_from_extent_data(
     }
 
     crc = crc32(0L, Z_NULL, 0);
-    crc = crc32(crc, data, epdl->extent_size - sizeof(*trailer));
+    crc = crc32(crc, data, data_length - sizeof(*trailer));
     if (unlikely(crc32cmp(trailer->checksum, crc))) {
         ctx_io_error(ctx);
         have_read_error = true;
@@ -1178,10 +1178,22 @@ static bool epdl_populate_pages_from_extent_data(
         }
         else {
             if (RRDENG_COMPRESSION_NONE == header->compression_algorithm) {
-                pgd = pgd_create_from_disk_data(header->descr[i].type,
-                                                      data + payload_offset + page_offset,
-                                                vd.page_length);
-                stats_load_uncompressed++;
+                if (unlikely(page_offset + vd.page_length > payload_length)) {
+                    char log[200 + 1];
+                    snprintfz(log, sizeof(log) - 1, "page %u (out of %u) offset %u + page length %zu, "
+                                        "exceeds the payload size %" PRIu64,
+                                        i, count, page_offset, vd.page_length, payload_length);
+                    epdl_extent_loading_error_log(ctx, epdl, &header->descr[i], log, NDLP_ERR);
+
+                    pgd = PGD_EMPTY;
+                    stats_load_invalid_page++;
+                }
+                else {
+                    pgd = pgd_create_from_disk_data(header->descr[i].type,
+                                                    data + payload_offset + page_offset,
+                                                    vd.page_length);
+                    stats_load_uncompressed++;
+                }
             }
             else {
                 if (unlikely(page_offset + vd.page_length > uncompressed_payload_length)) {
@@ -1275,6 +1287,14 @@ static bool epdl_populate_pages_from_extent_data(
 
 static inline void *datafile_extent_read(struct rrdengine_instance *ctx, uv_file file, uint32_t block, unsigned size_bytes)
 {
+    if (unlikely(!rrdeng_valid_extent_disk_size(size_bytes))) {
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "DBENGINE: refusing to read extent at offset %" PRIu64 " with invalid size %u",
+               BLOCK_TO_OFFSET(block), size_bytes);
+        ctx_io_error(ctx);
+        return NULL;
+    }
+
     void *buffer = NULL;
     uv_fs_t request;
 
@@ -1283,7 +1303,7 @@ static inline void *datafile_extent_read(struct rrdengine_instance *ctx, uv_file
 
     uv_buf_t iov = uv_buf_init(buffer, real_io_size);
     int ret = uv_fs_read(NULL, &request, file, &iov, 1, (int64_t) BLOCK_TO_OFFSET(block), NULL);
-    if (unlikely(-1 == ret)) {
+    if (unlikely(ret != (int)real_io_size)) {
         ctx_io_error(ctx);
         posix_memalign_freez(buffer);
         buffer = NULL;

--- a/src/database/engine/pdc.c
+++ b/src/database/engine/pdc.c
@@ -1288,9 +1288,10 @@ static bool epdl_populate_pages_from_extent_data(
 static inline void *datafile_extent_read(struct rrdengine_instance *ctx, uv_file file, uint32_t block, unsigned size_bytes)
 {
     if (unlikely(!rrdeng_valid_extent_disk_size(size_bytes))) {
-        nd_log(NDLS_DAEMON, NDLP_ERR,
-               "DBENGINE: refusing to read extent at offset %" PRIu64 " with invalid size %u",
-               BLOCK_TO_OFFSET(block), size_bytes);
+        nd_log_limit_static_global_var(erl, 1, 0);
+        nd_log_limit(&erl, NDLS_DAEMON, NDLP_ERR,
+                     "DBENGINE: refusing to read extent at offset %" PRIu64 " with invalid size %u",
+                     BLOCK_TO_OFFSET(block), size_bytes);
         ctx_io_error(ctx);
         return NULL;
     }

--- a/src/database/engine/pdc.c
+++ b/src/database/engine/pdc.c
@@ -1178,7 +1178,8 @@ static bool epdl_populate_pages_from_extent_data(
         }
         else {
             if (RRDENG_COMPRESSION_NONE == header->compression_algorithm) {
-                if (unlikely(page_offset + vd.page_length > payload_length)) {
+                if (unlikely(vd.page_length > payload_length ||
+                             page_offset > payload_length - vd.page_length)) {
                     char log[200 + 1];
                     snprintfz(log, sizeof(log) - 1, "page %u (out of %u) offset %u + page length %zu, "
                                         "exceeds the payload size %" PRIu64,
@@ -1196,7 +1197,8 @@ static bool epdl_populate_pages_from_extent_data(
                 }
             }
             else {
-                if (unlikely(page_offset + vd.page_length > uncompressed_payload_length)) {
+                if (unlikely(vd.page_length > uncompressed_payload_length ||
+                             page_offset > uncompressed_payload_length - vd.page_length)) {
                     char log[200 + 1];
                     snprintfz(log, sizeof(log) - 1, "page %u (out of %u) offset %u + page length %zu, "
                                         "exceeds the uncompressed buffer size %u",
@@ -1304,7 +1306,7 @@ static inline void *datafile_extent_read(struct rrdengine_instance *ctx, uv_file
 
     uv_buf_t iov = uv_buf_init(buffer, real_io_size);
     int ret = uv_fs_read(NULL, &request, file, &iov, 1, (int64_t) BLOCK_TO_OFFSET(block), NULL);
-    if (unlikely(ret != (int)real_io_size)) {
+    if (unlikely(ret < 0 || (unsigned)ret != real_io_size)) {
         ctx_io_error(ctx);
         posix_memalign_freez(buffer);
         buffer = NULL;

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -692,6 +692,10 @@ extent_flush_to_open(struct rrdengine_instance *ctx, struct extent_io_descriptor
     datafile = xt_io_descr->datafile;
 
     bool still_running = ctx_is_available_for_queries(ctx);
+    if (likely(still_running && !have_error))
+        internal_fatal(!rrdeng_valid_extent_disk_size(xt_io_descr->bytes),
+                       "DBENGINE: flushed extent has invalid size %u",
+                       xt_io_descr->bytes);
 
     usec_t max_end_time_ut = 0;
     for (i = 0 ; i < xt_io_descr->descr_count ; ++i) {
@@ -700,7 +704,7 @@ extent_flush_to_open(struct rrdengine_instance *ctx, struct extent_io_descriptor
         if (descr->end_time_ut > max_end_time_ut)
             max_end_time_ut = descr->end_time_ut;
 
-        if (likely(still_running && !have_error))
+        if (likely(still_running && !have_error)) {
             pgc_open_add_hot_page(
                 (Word_t)ctx,
                 descr->metric_id,
@@ -710,6 +714,7 @@ extent_flush_to_open(struct rrdengine_instance *ctx, struct extent_io_descriptor
                 datafile,
                 xt_io_descr->pos,
                 xt_io_descr->bytes);
+        }
 
         page_descriptor_release(descr);
     }

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -58,6 +58,23 @@ struct rrdeng_cmd;
 
 #define MAX_EXTENT_UNCOMPRESSED_SIZE (MAX_PAGES_PER_EXTENT * (RRDENG_BLOCK_SIZE + RRDENG_GORILLA_32BIT_BUFFER_SIZE))
 
+static inline size_t rrdeng_min_extent_disk_size(void) {
+    return sizeof(struct rrdeng_df_extent_header) +
+           sizeof(struct rrdeng_extent_page_descr) +
+           sizeof(struct rrdeng_df_extent_trailer);
+}
+
+static inline size_t rrdeng_max_extent_disk_size(void) {
+    return sizeof(struct rrdeng_df_extent_header) +
+           sizeof(struct rrdeng_extent_page_descr) * MAX_PAGES_PER_EXTENT +
+           MAX_EXTENT_UNCOMPRESSED_SIZE +
+           sizeof(struct rrdeng_df_extent_trailer);
+}
+
+static inline bool rrdeng_valid_extent_disk_size(size_t size) {
+    return size >= rrdeng_min_extent_disk_size() && size <= rrdeng_max_extent_disk_size();
+}
+
 
 #define RRDENG_FILE_NUMBER_SCAN_TMPL "%1u-%10u"
 #define RRDENG_FILE_NUMBER_PRINT_TMPL "%1.1u-%10.10u"


### PR DESCRIPTION
##### Summary
- Add rrdeng_valid_extent_disk_size() and check at journal restore, open-cache add, and disk read. 
- Fix missing bounds check in the uncompressed page path that could read past payload_length on corrupt extent metadata. 
- Treat short reads from uv_fs_read as errors.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates extent disk sizes across restore/open/read/flush paths and strengthens page boundary checks to prevent overreads on corrupt metadata. Short or partial `uv_fs_read` results are treated as errors, with clearer logs for invalid extents.

- **Bug Fixes**
  - Added `rrdeng_valid_extent_disk_size()` with min/max helpers; enforced at journal restore, open-cache add, extent flush, and disk reads; improved logging when skipping invalid extents.
  - Hardened page offset/length validation for both uncompressed and decompressed paths; skip and count invalid pages instead of reading out of bounds.
  - CRC now calculated over `data_length - trailer`; reject mismatched checksums.
  - Treat negative or short `uv_fs_read` returns as errors; free buffers and mark I/O error.

<sup>Written for commit 138338f03d6d9e96b7a08c3e174f456b225edb5e. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22324?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

