### PR TITLE
fix(jsonwrap): handle potential null keys

### DIFF
--- a/src/web/api/formatters/jsonwrap-summary-dimensions.c
+++ b/src/web/api/formatters/jsonwrap-summary-dimensions.c
@@ -134,8 +134,10 @@ void query_target_summary_dimensions_v12(BUFFER *wb, QUERY_TARGET *qt, const cha
             k = rrdmetric_acquired_name(rma);
             if(unlikely(!k || !*k))
                 k = rrdmetric_acquired_id(rma);
-            if(unlikely(!k || !*k))
+            if(unlikely(!k || !*k)) {
+                internal_error(true, "QUERY: dimension at index %ld has empty id and name; skipping it", c);
                 continue;
+            }
             id = k;
             name = k;
         }

--- a/src/web/api/formatters/jsonwrap-summary-dimensions.c
+++ b/src/web/api/formatters/jsonwrap-summary-dimensions.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+    // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "jsonwrap.h"
 #include "jsonwrap-internal.h"
@@ -132,6 +132,8 @@ void query_target_summary_dimensions_v12(BUFFER *wb, QUERY_TARGET *qt, const cha
 
         if(v2) {
             k = rrdmetric_acquired_name(rma);
+            if(unlikely(!k || !*k))
+                k = rrdmetric_acquired_id(rma);
             id = k;
             name = k;
         }
@@ -145,6 +147,8 @@ void query_target_summary_dimensions_v12(BUFFER *wb, QUERY_TARGET *qt, const cha
         }
 
         z = dictionary_set(dict, k, NULL, sizeof(*z));
+        if(unlikely(!z))
+            continue;
         if(!z->id) {
             z->id = id;
             z->name = name;

--- a/src/web/api/formatters/jsonwrap-summary-dimensions.c
+++ b/src/web/api/formatters/jsonwrap-summary-dimensions.c
@@ -1,4 +1,4 @@
-    // SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "jsonwrap.h"
 #include "jsonwrap-internal.h"
@@ -134,6 +134,8 @@ void query_target_summary_dimensions_v12(BUFFER *wb, QUERY_TARGET *qt, const cha
             k = rrdmetric_acquired_name(rma);
             if(unlikely(!k || !*k))
                 k = rrdmetric_acquired_id(rma);
+            if(unlikely(!k || !*k))
+                continue;
             id = k;
             name = k;
         }
@@ -147,8 +149,6 @@ void query_target_summary_dimensions_v12(BUFFER *wb, QUERY_TARGET *qt, const cha
         }
 
         z = dictionary_set(dict, k, NULL, sizeof(*z));
-        if(unlikely(!z))
-            continue;
         if(!z->id) {
             z->id = id;
             z->name = name;


### PR DESCRIPTION
##### Summary
- Fallback to id and check for NULL to avoid NULL dereference
   ```
   SIGSEGV / SEGV_MAPERR / 0x0
   Fatal Error: SIGSEGV / SEGV_MAPERR / 0x0
   query_target_summary_dimensions_v12.cold (jsonwrap-summary-dimensions.c:148)
   rrdr_json_wrapper_begin2.cold (jsonwrap-v2.c:414)
   ```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the JSON summary dimensions formatter by falling back to metric ID when the name is missing and skipping entries with no valid key. Adds dev-mode error logging for visibility and prevents SIGSEGV in v2 JSON wrapping.

- **Bug Fixes**
  - Fallback to `rrdmetric_acquired_id(rma)` when `rrdmetric_acquired_name(rma)` is null or empty.
  - Skip the dimension when both name and id are missing in `query_target_summary_dimensions_v12`.
  - Log a dev-mode error when skipping a dimension with no valid key.

<sup>Written for commit 2ae137eaf9842691088721f5a0ab891136057d64. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22326?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

