### PR TITLE
fix(go.d/adaptecraid): ignore non-Hard-drive entries in PD parse

### DIFF
--- a/src/go/plugin/go.d/collector/adaptecraid/collect_pd.go
+++ b/src/go/plugin/go.d/collector/adaptecraid/collect_pd.go
@@ -104,6 +104,12 @@ func parsePhysDevInfo(bs []byte) (map[string]*physicalDevice, error) {
 		}
 
 		switch {
+		case strings.HasPrefix(line, "Device is"):
+			// Skip non-disk entries such as "Device is an Enclosure Services Device".
+			if line != "Device is a Hard drive" {
+				delete(devices, pd.number)
+				pd = nil
+			}
 		case strings.HasPrefix(line, "State"):
 			pd.state = getColonSepValue(line)
 		case strings.HasPrefix(line, "Reported Location"):

--- a/src/go/plugin/go.d/collector/adaptecraid/collector_test.go
+++ b/src/go/plugin/go.d/collector/adaptecraid/collector_test.go
@@ -18,10 +18,11 @@ var (
 	dataConfigJSON, _ = os.ReadFile("testdata/config.json")
 	dataConfigYAML, _ = os.ReadFile("testdata/config.yaml")
 
-	dataLogicalDevicesOld, _      = os.ReadFile("testdata/getconfig-ld-old.txt")
-	dataPhysicalDevicesOld, _     = os.ReadFile("testdata/getconfig-pd-old.txt")
-	dataLogicalDevicesCurrent, _  = os.ReadFile("testdata/getconfig-ld-current.txt")
-	dataPhysicalDevicesCurrent, _ = os.ReadFile("testdata/getconfig-pd-current.txt")
+	dataLogicalDevicesOld, _            = os.ReadFile("testdata/getconfig-ld-old.txt")
+	dataPhysicalDevicesOld, _           = os.ReadFile("testdata/getconfig-pd-old.txt")
+	dataLogicalDevicesCurrent, _        = os.ReadFile("testdata/getconfig-ld-current.txt")
+	dataPhysicalDevicesCurrent, _       = os.ReadFile("testdata/getconfig-pd-current.txt")
+	dataPhysicalDevicesWithEnclosure, _ = os.ReadFile("testdata/getconfig-pd-with-enclosure.txt")
 )
 
 func Test_testDataIsValid(t *testing.T) {
@@ -29,10 +30,11 @@ func Test_testDataIsValid(t *testing.T) {
 		"dataConfigJSON": dataConfigJSON,
 		"dataConfigYAML": dataConfigYAML,
 
-		"dataLogicalDevicesOld":      dataLogicalDevicesOld,
-		"dataPhysicalDevicesOld":     dataPhysicalDevicesOld,
-		"dataLogicalDevicesCurrent":  dataLogicalDevicesCurrent,
-		"dataPhysicalDevicesCurrent": dataPhysicalDevicesCurrent,
+		"dataLogicalDevicesOld":            dataLogicalDevicesOld,
+		"dataPhysicalDevicesOld":           dataPhysicalDevicesOld,
+		"dataLogicalDevicesCurrent":        dataLogicalDevicesCurrent,
+		"dataPhysicalDevicesCurrent":       dataPhysicalDevicesCurrent,
+		"dataPhysicalDevicesWithEnclosure": dataPhysicalDevicesWithEnclosure,
 	} {
 		require.NotNil(t, data, name)
 	}
@@ -119,6 +121,10 @@ func TestCollector_Check(t *testing.T) {
 			wantFail:    false,
 			prepareMock: prepareMockOkCurrent,
 		},
+		"success case with enclosure data": {
+			wantFail:    false,
+			prepareMock: prepareMockOkWithEnclosure,
+		},
 		"err on exec": {
 			wantFail:    true,
 			prepareMock: prepareMockErr,
@@ -200,6 +206,50 @@ func TestCollector_Collect(t *testing.T) {
 				"pd_5_smart_warnings":        0,
 			},
 		},
+		"success case with enclosure data": {
+			prepareMock: prepareMockOkWithEnclosure,
+			wantCharts:  len(ldChartsTmpl)*1 + (len(pdChartsTmpl)-1)*12,
+			wantMetrics: map[string]int64{
+				"ld_0_health_state_critical":  0,
+				"ld_0_health_state_ok":        1,
+				"pd_0_health_state_critical":  0,
+				"pd_0_health_state_ok":        1,
+				"pd_0_smart_warnings":         0,
+				"pd_1_health_state_critical":  0,
+				"pd_1_health_state_ok":        1,
+				"pd_1_smart_warnings":         0,
+				"pd_10_health_state_critical": 0,
+				"pd_10_health_state_ok":       1,
+				"pd_10_smart_warnings":        0,
+				"pd_11_health_state_critical": 0,
+				"pd_11_health_state_ok":       1,
+				"pd_11_smart_warnings":        0,
+				"pd_2_health_state_critical":  0,
+				"pd_2_health_state_ok":        1,
+				"pd_2_smart_warnings":         0,
+				"pd_3_health_state_critical":  0,
+				"pd_3_health_state_ok":        1,
+				"pd_3_smart_warnings":         0,
+				"pd_4_health_state_critical":  0,
+				"pd_4_health_state_ok":        1,
+				"pd_4_smart_warnings":         0,
+				"pd_5_health_state_critical":  0,
+				"pd_5_health_state_ok":        1,
+				"pd_5_smart_warnings":         0,
+				"pd_6_health_state_critical":  0,
+				"pd_6_health_state_ok":        1,
+				"pd_6_smart_warnings":         0,
+				"pd_7_health_state_critical":  0,
+				"pd_7_health_state_ok":        1,
+				"pd_7_smart_warnings":         0,
+				"pd_8_health_state_critical":  0,
+				"pd_8_health_state_ok":        1,
+				"pd_8_smart_warnings":         0,
+				"pd_9_health_state_critical":  0,
+				"pd_9_health_state_ok":        1,
+				"pd_9_smart_warnings":         0,
+			},
+		},
 		"err on exec": {
 			prepareMock: prepareMockErr,
 		},
@@ -236,6 +286,13 @@ func prepareMockOkCurrent() *mockArcconfExec {
 	return &mockArcconfExec{
 		ldData: dataLogicalDevicesCurrent,
 		pdData: dataPhysicalDevicesCurrent,
+	}
+}
+
+func prepareMockOkWithEnclosure() *mockArcconfExec {
+	return &mockArcconfExec{
+		ldData: dataLogicalDevicesCurrent,
+		pdData: dataPhysicalDevicesWithEnclosure,
 	}
 }
 

--- a/src/go/plugin/go.d/collector/adaptecraid/testdata/getconfig-pd-with-enclosure.txt
+++ b/src/go/plugin/go.d/collector/adaptecraid/testdata/getconfig-pd-with-enclosure.txt
@@ -1,0 +1,446 @@
+Controllers found: 1
+----------------------------------------------------------------------
+Physical Device information
+----------------------------------------------------------------------
+      Device #0
+         Device is a Hard drive
+         State                                : Online
+         Block Size                           : 512 Bytes
+         Supported                            : Yes
+         Transfer Speed                       : SATA 6.0 Gb/s
+         Reported Channel,Device(T:L)         : 0,16(16:0)
+         Reported Location                    : Enclosure 0, Slot 0( Connector Unknown )
+         Reported ESD(T:L)                    : 2,0(0:0)
+         Vendor                               : ATA
+         Model                                : INTEL SSDSC2KB019T
+         Firmware                             : SCV10111
+         Serial number                        : XXXXXXXXXXXXXXXXXX
+         Reserved Size                        : 3666200 KB
+         Used Size                            : 1827840 MB
+         Unused Size                          : 64 KB
+         Total Size                           : 1831420 MB
+         Write Cache                          : Enabled (write-back)
+         FRU                                  : None
+         S.M.A.R.T.                           : No
+         S.M.A.R.T. warnings                  : 0
+         Power State                          : Full rpm
+         Supported Power States               : Full power,Powered off
+         SSD                                  : Yes
+         Temperature                          : Not Supported
+         NCQ status                           : Enabled
+      ----------------------------------------------------------------
+      Device Phy Information
+      ----------------------------------------------------------------
+         Phy #0
+            PHY Identifier                    : 0
+            SAS Address                       : 5000
+            Attached PHY Identifier           : 12
+            Attached SAS Address              : 5000
+
+      Device #1
+         Device is a Hard drive
+         State                                : Online
+         Block Size                           : 512 Bytes
+         Supported                            : Yes
+         Transfer Speed                       : SATA 6.0 Gb/s
+         Reported Channel,Device(T:L)         : 0,17(17:0)
+         Reported Location                    : Enclosure 0, Slot 1( Connector Unknown )
+         Reported ESD(T:L)                    : 2,0(0:0)
+         Vendor                               : ATA
+         Model                                : INTEL SSDSC2KB019T
+         Firmware                             : SCV10111
+         Serial number                        : XXXXXXXXXXXXXXXXXX
+         Reserved Size                        : 3666200 KB
+         Used Size                            : 1827840 MB
+         Unused Size                          : 64 KB
+         Total Size                           : 1831420 MB
+         Write Cache                          : Enabled (write-back)
+         FRU                                  : None
+         S.M.A.R.T.                           : No
+         S.M.A.R.T. warnings                  : 0
+         Power State                          : Full rpm
+         Supported Power States               : Full power,Powered off
+         SSD                                  : Yes
+         Temperature                          : Not Supported
+         NCQ status                           : Enabled
+      ----------------------------------------------------------------
+      Device Phy Information
+      ----------------------------------------------------------------
+         Phy #0
+            PHY Identifier                    : 0
+            SAS Address                       : 5000
+            Attached PHY Identifier           : 13
+            Attached SAS Address              : 5000
+
+      Device #2
+         Device is a Hard drive
+         State                                : Online
+         Block Size                           : 512 Bytes
+         Supported                            : Yes
+         Transfer Speed                       : SATA 6.0 Gb/s
+         Reported Channel,Device(T:L)         : 0,18(18:0)
+         Reported Location                    : Enclosure 0, Slot 2( Connector Unknown )
+         Reported ESD(T:L)                    : 2,0(0:0)
+         Vendor                               : ATA
+         Model                                : INTEL SSDSC2KB019T
+         Firmware                             : SCV10111
+         Serial number                        : XXXXXXXXXXXXXXXXXX
+         Reserved Size                        : 3666200 KB
+         Used Size                            : 1827840 MB
+         Unused Size                          : 64 KB
+         Total Size                           : 1831420 MB
+         Write Cache                          : Enabled (write-back)
+         FRU                                  : None
+         S.M.A.R.T.                           : No
+         S.M.A.R.T. warnings                  : 0
+         Power State                          : Full rpm
+         Supported Power States               : Full power,Powered off
+         SSD                                  : Yes
+         Temperature                          : Not Supported
+         NCQ status                           : Enabled
+      ----------------------------------------------------------------
+      Device Phy Information
+      ----------------------------------------------------------------
+         Phy #0
+            PHY Identifier                    : 0
+            SAS Address                       : 5000
+            Attached PHY Identifier           : 14
+            Attached SAS Address              : 5000
+
+      Device #3
+         Device is a Hard drive
+         State                                : Online
+         Block Size                           : 512 Bytes
+         Supported                            : Yes
+         Transfer Speed                       : SATA 6.0 Gb/s
+         Reported Channel,Device(T:L)         : 0,19(19:0)
+         Reported Location                    : Enclosure 0, Slot 3( Connector Unknown )
+         Reported ESD(T:L)                    : 2,0(0:0)
+         Vendor                               : ATA
+         Model                                : INTEL SSDSC2KB019T
+         Firmware                             : SCV10111
+         Serial number                        : XXXXXXXXXXXXXXXXXX
+         Reserved Size                        : 3666200 KB
+         Used Size                            : 1827840 MB
+         Unused Size                          : 64 KB
+         Total Size                           : 1831420 MB
+         Write Cache                          : Enabled (write-back)
+         FRU                                  : None
+         S.M.A.R.T.                           : No
+         S.M.A.R.T. warnings                  : 0
+         Power State                          : Full rpm
+         Supported Power States               : Full power,Powered off
+         SSD                                  : Yes
+         Temperature                          : Not Supported
+         NCQ status                           : Enabled
+      ----------------------------------------------------------------
+      Device Phy Information
+      ----------------------------------------------------------------
+         Phy #0
+            PHY Identifier                    : 0
+            SAS Address                       : 5000
+            Attached PHY Identifier           : 15
+            Attached SAS Address              : 5000
+
+      Device #4
+         Device is a Hard drive
+         State                                : Online
+         Block Size                           : 512 Bytes
+         Supported                            : Yes
+         Transfer Speed                       : SATA 6.0 Gb/s
+         Reported Channel,Device(T:L)         : 0,20(20:0)
+         Reported Location                    : Enclosure 0, Slot 4( Connector Unknown )
+         Reported ESD(T:L)                    : 2,0(0:0)
+         Vendor                               : ATA
+         Model                                : INTEL SSDSC2KB019T
+         Firmware                             : SCV10111
+         Serial number                        : XXXXXXXXXXXXXXXXXX
+         Reserved Size                        : 3666200 KB
+         Used Size                            : 1827840 MB
+         Unused Size                          : 64 KB
+         Total Size                           : 1831420 MB
+         Write Cache                          : Enabled (write-back)
+         FRU                                  : None
+         S.M.A.R.T.                           : No
+         S.M.A.R.T. warnings                  : 0
+         Power State                          : Full rpm
+         Supported Power States               : Full power,Powered off
+         SSD                                  : Yes
+         Temperature                          : Not Supported
+         NCQ status                           : Enabled
+      ----------------------------------------------------------------
+      Device Phy Information
+      ----------------------------------------------------------------
+         Phy #0
+            PHY Identifier                    : 0
+            SAS Address                       : 5000
+            Attached PHY Identifier           : 16
+            Attached SAS Address              : 5000
+
+      Device #5
+         Device is a Hard drive
+         State                                : Online
+         Block Size                           : 512 Bytes
+         Supported                            : Yes
+         Transfer Speed                       : SATA 6.0 Gb/s
+         Reported Channel,Device(T:L)         : 0,21(21:0)
+         Reported Location                    : Enclosure 0, Slot 5( Connector Unknown )
+         Reported ESD(T:L)                    : 2,0(0:0)
+         Vendor                               : ATA
+         Model                                : INTEL SSDSC2KB019T
+         Firmware                             : SCV10111
+         Serial number                        : XXXXXXXXXXXXXXXXXX
+         Reserved Size                        : 3666200 KB
+         Used Size                            : 1827840 MB
+         Unused Size                          : 64 KB
+         Total Size                           : 1831420 MB
+         Write Cache                          : Enabled (write-back)
+         FRU                                  : None
+         S.M.A.R.T.                           : No
+         S.M.A.R.T. warnings                  : 0
+         Power State                          : Full rpm
+         Supported Power States               : Full power,Powered off
+         SSD                                  : Yes
+         Temperature                          : Not Supported
+         NCQ status                           : Enabled
+      ----------------------------------------------------------------
+      Device Phy Information
+      ----------------------------------------------------------------
+         Phy #0
+            PHY Identifier                    : 0
+            SAS Address                       : 5000
+            Attached PHY Identifier           : 17
+            Attached SAS Address              : 5000
+
+      Device #6
+         Device is a Hard drive
+         State                                : Online
+         Block Size                           : 512 Bytes
+         Supported                            : Yes
+         Transfer Speed                       : SATA 6.0 Gb/s
+         Reported Channel,Device(T:L)         : 0,22(22:0)
+         Reported Location                    : Enclosure 0, Slot 6( Connector Unknown )
+         Reported ESD(T:L)                    : 2,0(0:0)
+         Vendor                               : ATA
+         Model                                : INTEL SSDSC2KB019T
+         Firmware                             : SCV10111
+         Serial number                        : XXXXXXXXXXXXXXXXXX
+         Reserved Size                        : 3666200 KB
+         Used Size                            : 1827840 MB
+         Unused Size                          : 64 KB
+         Total Size                           : 1831420 MB
+         Write Cache                          : Enabled (write-back)
+         FRU                                  : None
+         S.M.A.R.T.                           : No
+         S.M.A.R.T. warnings                  : 0
+         Power State                          : Full rpm
+         Supported Power States               : Full power,Powered off
+         SSD                                  : Yes
+         Temperature                          : Not Supported
+         NCQ status                           : Enabled
+      ----------------------------------------------------------------
+      Device Phy Information
+      ----------------------------------------------------------------
+         Phy #0
+            PHY Identifier                    : 0
+            SAS Address                       : 5000
+            Attached PHY Identifier           : 18
+            Attached SAS Address              : 5000
+
+      Device #7
+         Device is a Hard drive
+         State                                : Online
+         Block Size                           : 512 Bytes
+         Supported                            : Yes
+         Transfer Speed                       : SATA 6.0 Gb/s
+         Reported Channel,Device(T:L)         : 0,23(23:0)
+         Reported Location                    : Enclosure 0, Slot 7( Connector Unknown )
+         Reported ESD(T:L)                    : 2,0(0:0)
+         Vendor                               : ATA
+         Model                                : INTEL SSDSC2KB019T
+         Firmware                             : SCV10111
+         Serial number                        : XXXXXXXXXXXXXXXXXX
+         Reserved Size                        : 3666200 KB
+         Used Size                            : 1827840 MB
+         Unused Size                          : 64 KB
+         Total Size                           : 1831420 MB
+         Write Cache                          : Enabled (write-back)
+         FRU                                  : None
+         S.M.A.R.T.                           : No
+         S.M.A.R.T. warnings                  : 0
+         Power State                          : Full rpm
+         Supported Power States               : Full power,Powered off
+         SSD                                  : Yes
+         Temperature                          : Not Supported
+         NCQ status                           : Enabled
+      ----------------------------------------------------------------
+      Device Phy Information
+      ----------------------------------------------------------------
+         Phy #0
+            PHY Identifier                    : 0
+            SAS Address                       : 5000
+            Attached PHY Identifier           : 19
+            Attached SAS Address              : 5000
+
+      Device #8
+         Device is a Hard drive
+         State                                : Online
+         Block Size                           : 512 Bytes
+         Supported                            : Yes
+         Transfer Speed                       : SATA 6.0 Gb/s
+         Reported Channel,Device(T:L)         : 0,24(24:0)
+         Reported Location                    : Enclosure 0, Slot 8( Connector Unknown )
+         Reported ESD(T:L)                    : 2,0(0:0)
+         Vendor                               : ATA
+         Model                                : INTEL SSDSC2KB019T
+         Firmware                             : SCV10111
+         Serial number                        : XXXXXXXXXXXXXXXXXX
+         Reserved Size                        : 3666200 KB
+         Used Size                            : 1827840 MB
+         Unused Size                          : 64 KB
+         Total Size                           : 1831420 MB
+         Write Cache                          : Enabled (write-back)
+         FRU                                  : None
+         S.M.A.R.T.                           : No
+         S.M.A.R.T. warnings                  : 0
+         Power State                          : Full rpm
+         Supported Power States               : Full power,Powered off
+         SSD                                  : Yes
+         Temperature                          : Not Supported
+         NCQ status                           : Enabled
+      ----------------------------------------------------------------
+      Device Phy Information
+      ----------------------------------------------------------------
+         Phy #0
+            PHY Identifier                    : 0
+            SAS Address                       : 5000
+            Attached PHY Identifier           : 20
+            Attached SAS Address              : 5000
+
+      Device #9
+         Device is a Hard drive
+         State                                : Online
+         Block Size                           : 512 Bytes
+         Supported                            : Yes
+         Transfer Speed                       : SATA 6.0 Gb/s
+         Reported Channel,Device(T:L)         : 0,25(25:0)
+         Reported Location                    : Enclosure 0, Slot 9( Connector Unknown )
+         Reported ESD(T:L)                    : 2,0(0:0)
+         Vendor                               : ATA
+         Model                                : INTEL SSDSC2KB019T
+         Firmware                             : SCV10111
+         Serial number                        : XXXXXXXXXXXXXXXXXX
+         Reserved Size                        : 3666200 KB
+         Used Size                            : 1827840 MB
+         Unused Size                          : 64 KB
+         Total Size                           : 1831420 MB
+         Write Cache                          : Enabled (write-back)
+         FRU                                  : None
+         S.M.A.R.T.                           : No
+         S.M.A.R.T. warnings                  : 0
+         Power State                          : Full rpm
+         Supported Power States               : Full power,Powered off
+         SSD                                  : Yes
+         Temperature                          : Not Supported
+         NCQ status                           : Enabled
+      ----------------------------------------------------------------
+      Device Phy Information
+      ----------------------------------------------------------------
+         Phy #0
+            PHY Identifier                    : 0
+            SAS Address                       : 5000
+            Attached PHY Identifier           : 21
+            Attached SAS Address              : 5000
+
+      Device #10
+         Device is a Hard drive
+         State                                : Global Hot-Spare
+         Block Size                           : 512 Bytes
+         Supported                            : Yes
+         Transfer Speed                       : SATA 6.0 Gb/s
+         Reported Channel,Device(T:L)         : 0,26(26:0)
+         Reported Location                    : Enclosure 0, Slot 10( Connector Unknown )
+         Reported ESD(T:L)                    : 2,0(0:0)
+         Vendor                               : ATA
+         Model                                : INTEL SSDSC2KB019T
+         Firmware                             : SCV10111
+         Serial number                        : XXXXXXXXXXXXXXXXXX
+         Reserved Size                        : 3666200 KB
+         Used Size                            : 1827840 MB
+         Unused Size                          : 64 KB
+         Total Size                           : 1831420 MB
+         Write Cache                          : Enabled (write-back)
+         FRU                                  : None
+         S.M.A.R.T.                           : No
+         S.M.A.R.T. warnings                  : 0
+         Power State                          : Full rpm
+         Supported Power States               : Full power,Powered off
+         SSD                                  : Yes
+         Temperature                          : Not Supported
+         NCQ status                           : Enabled
+      ----------------------------------------------------------------
+      Device Phy Information
+      ----------------------------------------------------------------
+         Phy #0
+            PHY Identifier                    : 0
+            SAS Address                       : 5000
+            Attached PHY Identifier           : 22
+            Attached SAS Address              : 5000
+
+      Device #11
+         Device is a Hard drive
+         State                                : Global Hot-Spare
+         Block Size                           : 512 Bytes
+         Supported                            : Yes
+         Transfer Speed                       : SATA 6.0 Gb/s
+         Reported Channel,Device(T:L)         : 0,27(27:0)
+         Reported Location                    : Enclosure 0, Slot 11( Connector Unknown )
+         Reported ESD(T:L)                    : 2,0(0:0)
+         Vendor                               : ATA
+         Model                                : INTEL SSDSC2KB019T
+         Firmware                             : SCV10111
+         Serial number                        : XXXXXXXXXXXXXXXXXX
+         Reserved Size                        : 3666200 KB
+         Used Size                            : 1827840 MB
+         Unused Size                          : 64 KB
+         Total Size                           : 1831420 MB
+         Write Cache                          : Enabled (write-back)
+         FRU                                  : None
+         S.M.A.R.T.                           : No
+         S.M.A.R.T. warnings                  : 0
+         Power State                          : Full rpm
+         Supported Power States               : Full power,Powered off
+         SSD                                  : Yes
+         Temperature                          : Not Supported
+         NCQ status                           : Enabled
+      ----------------------------------------------------------------
+      Device Phy Information
+      ----------------------------------------------------------------
+         Phy #0
+            PHY Identifier                    : 0
+            SAS Address                       : 5000
+            Attached PHY Identifier           : 23
+            Attached SAS Address              : 5000
+
+      Device #12
+         Device is an Enclosure Services Device
+         Reported Channel,Device(T:L)         : 2,0(0:0)
+         Enclosure ID                         : 0
+         Enclosure Logical Identifier         : 5000
+         Expander ID                          : 0
+         Expander SAS Address                 : 5000
+         Type                                 : SES2
+         Vendor                               : LSI CORP
+         Model                                : SAS2X28
+         Firmware                             : 0717
+         Status of Enclosure Services Device
+            Fan 1 status                      : 0 rpm (Not Installed)
+            Fan 2 status                      : 0 rpm (Not Installed)
+            Fan 3 status                      : 0 rpm (Not Installed)
+            Power supply 1 status             : Not Installed
+            Power supply 2 status             : Not Installed
+            Temperature Sensor Status 1       : 24 C/ 75 F (Normal)
+            Speaker status                    : On
+
+
+Command completed successfully.


### PR DESCRIPTION
The arcconf getconfig PD output can include enclosure / SES entries (e.g. "Device is an Enclosure Services Device"). These have no State, S.M.A.R.T. or Temperature fields, so they were exposed as PD charts with empty values and reported as health_state_critical.

Filter the parser to only retain entries marked "Device is a Hard drive". Adds a test fixture covering the enclosed-SES case.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
