### PR TITLE
Fix concurrency issues in ARAL page pointer handling

### DIFF
--- a/src/libnetdata/aral/aral.c
+++ b/src/libnetdata/aral/aral.c
@@ -1010,18 +1010,31 @@ void aral_unmark_allocation(ARAL *ar, void *ptr) {
 
     if(unlikely(!ptr)) return;
 
-    // get the page pointer
-    bool marked;
-    ARAL_PAGE *page = aral_get_page_pointer_after_element___do_NOT_have_aral_lock(ar, ptr, &marked);
+    // Must be a CAS, not load-then-store: aral_freez_internal can concurrently
+    // atomic-exchange the trailer to 0, and a non-atomic store here would
+    // overwrite that 0 and leave the slot on the free list with a non-zero
+    // trailer pointing back at its old page.
+    //
+    // On CAS failure (freez won, or already unmarked, or slot was reallocated)
+    // we must NOT touch page counters - freez's atomic claim is the sole owner
+    // of the decrement on the racing path.
+    uint8_t *data = ptr;
+    uintptr_t *page_ptr = (uintptr_t *)&data[ar->config.element_ptr_offset];
+    uintptr_t expected = __atomic_load_n(page_ptr, __ATOMIC_ACQUIRE);
+    if(!(expected & 1))
+        return;
 
-    internal_fatal(!marked, "This allocation does is not marked");
+    uintptr_t desired = expected & ~(uintptr_t)1;
+    if(!__atomic_compare_exchange_n(page_ptr, &expected, desired,
+                                    false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+        return;
 
-    if(marked)
-        aral_set_page_pointer_after_element___do_NOT_have_aral_lock(ar, page, ptr, false);
+    ARAL_PAGE *page = (ARAL_PAGE *)desired;
+    internal_fatal((uintptr_t)page % SYSTEM_REQUIRED_ALIGNMENT != 0, "Pointer is not aligned properly");
 
     aral_page_lock(ar, page);
-    internal_fatal(marked && !page->page_lock.marked_elements, "Marked counter going negative.");
-    bool unmark = marked && --page->page_lock.marked_elements == 0 && page->page_lock.used_elements;
+    internal_fatal(!page->page_lock.marked_elements, "Marked counter going negative.");
+    bool unmark = (--page->page_lock.marked_elements == 0) && page->page_lock.used_elements;
 
     if(unmark) {
         aral_lock(ar);

--- a/src/libnetdata/aral/aral.c
+++ b/src/libnetdata/aral/aral.c
@@ -1011,9 +1011,9 @@ void aral_unmark_allocation(ARAL *ar, void *ptr) {
     if(unlikely(!ptr)) return;
 
     // Must be a CAS, not load-then-store: aral_freez_internal can concurrently
-    // atomic-exchange the trailer to 0, and a non-atomic store here would
-    // overwrite that 0 and leave the slot on the free list with a non-zero
-    // trailer pointing back at its old page.
+    // atomic-exchange the trailer to 0, and a store based on an earlier load
+    // (even an atomic store) could overwrite that 0 and leave the slot on the
+    // free list with a non-zero trailer pointing back at its old page.
     //
     // On CAS failure (freez won, or already unmarked, or slot was reallocated)
     // we must NOT touch page counters - freez's atomic claim is the sole owner
@@ -1029,9 +1029,13 @@ void aral_unmark_allocation(ARAL *ar, void *ptr) {
                                     false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
         return;
 
-    ARAL_PAGE *page = (ARAL_PAGE *)desired;
-    internal_fatal(!page, "Trailer had marked bit set but no page pointer");
-    internal_fatal((uintptr_t)page % SYSTEM_REQUIRED_ALIGNMENT != 0, "Pointer is not aligned properly");
+    // Decode from the pre-CAS tagged value to keep the standard validation
+    // (NULL check, ARAL-address-space check under NETDATA_ARAL_INTERNAL_CHECKS,
+    //  alignment check). marked is guaranteed true here - we just CAS'd from a
+    //  value with the marked bit set.
+    bool was_marked;
+    ARAL_PAGE *page = aral_decode_page_pointer_after_element___do_NOT_have_aral_lock(ar, ptr, expected, &was_marked);
+    (void)was_marked;
 
     aral_page_lock(ar, page);
     internal_fatal(!page->page_lock.marked_elements, "Marked counter going negative.");

--- a/src/libnetdata/aral/aral.c
+++ b/src/libnetdata/aral/aral.c
@@ -1030,6 +1030,7 @@ void aral_unmark_allocation(ARAL *ar, void *ptr) {
         return;
 
     ARAL_PAGE *page = (ARAL_PAGE *)desired;
+    internal_fatal(!page, "Trailer had marked bit set but no page pointer");
     internal_fatal((uintptr_t)page % SYSTEM_REQUIRED_ALIGNMENT != 0, "Pointer is not aligned properly");
 
     aral_page_lock(ar, page);


### PR DESCRIPTION
##### Summary
- Fix aral_unmark_allocation memory-ordering race with aral_freez_internal — CAS replaces non-atomic load+store, eliminating free-list corruption
