### PR TITLE
snmp profiles: fix Netgear switch topology discovery (LLDP/FDB/STP)

### DIFF
--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/netgear-switch.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/netgear-switch.yaml
@@ -8,8 +8,16 @@ extends:
 selector:
   - sysobjectid:
       include:
-        - 1.3.6.1.4.1.4526.100.1.28
-        - 1.3.6.1.4.1.4526.100.1.31
+        # Netgear switch product families (NETGEAR-INVENTORY-MIB).
+        # See metadata/netgear.yaml for the full per-OID model list.
+        # Excludes non-switch families: 100.5/100.6 (router/firewall),
+        # 100.7 (access point), 100.8 (wireless controller), 100.16 (NAS).
+        - 1.3.6.1.4.1.4526.100.1.*
+        - 1.3.6.1.4.1.4526.100.2.*
+        - 1.3.6.1.4.1.4526.100.3.*
+        - 1.3.6.1.4.1.4526.100.4.*
+        - 1.3.6.1.4.1.4526.100.10.*
+        - 1.3.6.1.4.1.4526.100.11.*
 
 metadata:
   device:

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/netgear-switch.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/netgear-switch.yaml
@@ -1,5 +1,9 @@
 extends:
   - netgear.yaml
+  - _std-lldp-mib.yaml
+  - _std-topology-fdb-arp-mib.yaml
+  - _std-topology-q-bridge-mib.yaml
+  - _std-topology-stp-mib.yaml
 
 selector:
   - sysobjectid:


### PR DESCRIPTION
## Summary

Two related fixes so managed Netgear switches actually appear with LLDP neighbors, FDB and VLAN context in the topology view (today they show up as `SNMP` only).

1. **Add the missing topology extends.** `netgear-switch.yaml` only extended `netgear.yaml` (system-base + IF-MIB), so we never polled the topology MIBs on these devices. Bring it in line with `dlink-dgs-switch` and `zyxel-switch`, which extend the four standard topology profiles.
2. **Widen the selector.** The previous selector only matched two specific sysObjectIDs (`1.3.6.1.4.1.4526.100.1.28`, `.1.31`). Almost every Netgear smart switch — including the GS110TP at `100.4.19` — falls outside that pair, so even with the topology extends in place, the profile would never have applied to them. Match all six Netgear switch families documented in `metadata/netgear.yaml`.

## Change

```yaml
extends:
  - netgear.yaml
  - _std-lldp-mib.yaml
  - _std-topology-fdb-arp-mib.yaml
  - _std-topology-q-bridge-mib.yaml
  - _std-topology-stp-mib.yaml

selector:
  - sysobjectid:
      include:
        - 1.3.6.1.4.1.4526.100.1.*
        - 1.3.6.1.4.1.4526.100.2.*
        - 1.3.6.1.4.1.4526.100.3.*
        - 1.3.6.1.4.1.4526.100.4.*
        - 1.3.6.1.4.1.4526.100.10.*
        - 1.3.6.1.4.1.4526.100.11.*
```

Non-switch Netgear families keep their own profiles and are intentionally excluded:
- `100.5.*` / `100.6.*` — firewalls and routers
- `100.7.*` — access points (`netgear-access-point.yaml`)
- `100.8.*` — wireless LAN controllers
- `100.16.*` — self-contained NAS

## Verified against a real Netgear GS110TP v3

Two SNMP walks (LLDP subtree + BRIDGE/P-BRIDGE/Q-BRIDGE subtree) confirm the device exposes the data the new profiles poll.

**LLDP-MIB (`1.0.8802.1.1.2.1`)**

- `lldpRemTable` populated — 4 neighbors on multiple ports with full chassis ID, port ID, sysName, sysDesc and capabilities.
- `lldpRemManAddrTable` exposes columns `.3`/`.4` only (no `.1`/`.2`). This is already covered by the compatibility anchor in `_std-topology-lldp-mib.yaml` (originally added for XS1930 and similar implementations).

**BRIDGE-MIB (`1.3.6.1.2.1.17.1`/`.4`)**

- `dot1dBaseBridgeAddress` matches the LLDP chassis ID (same device).
- `dot1dBaseNumPorts = 15`, `dot1dBasePort` and `dot1dBasePortIfIndex` populated with a clean base-port → ifIndex 1:1 mapping.
- `dot1dTpPort` table populated with frame counters per port.

**Q-BRIDGE-MIB (`1.3.6.1.2.1.17.7`)**

- `dot1qTpFdbPort` and `dot1qTpFdbStatus` — 27 FDB entries (26 `learned`, 1 `mgmt`).
- FDB port distribution aligns with the LLDP neighbors (e.g. port 8 = upstream router, ports 3/4/5 = APs with attached clients).
- `dot1qVlanFdbId`, `dot1qVlanCurrentEgressPorts`, `dot1qVlanCurrentUntaggedPorts`, `dot1qPvid` per port — VLAN tables present.

**STP**

- `dot1dStp*` is not populated on this particular device — likely just because STP is not configured on a single-switch network, not a profile or device limitation. Polling the STP profile is harmless: empty walks simply produce no STP data.

## Test plan

- [ ] Run `snmp_topology` against the live Netgear GS110TP v3 and confirm the topology view shows LLDP neighbors and the device's `data sources` chip lists `lldp` and `fdb`.
- [ ] Verify the wider selector matches representative Netgear switches by sysObjectID (e.g. `100.1.28`, `100.4.19`, `100.10.*`, `100.11.*`).
- [ ] Confirm no regression for non-switch Netgear devices: `netgear-access-point.yaml` (`100.7.*`) and `netgear-readynas.yaml` selectors are unchanged.