### PR TITLE
Fix SNMP topology index-derived endpoints

### DIFF
--- a/.agents/skills/project-snmp-profiles-authoring/SKILL.md
+++ b/.agents/skills/project-snmp-profiles-authoring/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: project-snmp-profiles-authoring
+description: Use when editing Netdata SNMP profile YAMLs, topology SNMP profiles, ddsnmp profile parsing, or profile-format documentation. Requires checking source MIB field accessibility, especially MAX-ACCESS not-accessible INDEX objects, before adding or changing profile symbols.
+---
+
+# SNMP Profile Authoring
+
+Use this skill before editing files under:
+
+- `src/go/plugin/go.d/config/go.d/snmp.profiles/`
+- `src/go/plugin/go.d/collector/snmp/ddsnmp/`
+- `src/go/plugin/go.d/collector/snmp/profile-format.md`
+- `src/go/plugin/go.d/collector/snmp_topology/`
+
+## Required Checks
+
+1. Identify the source MIB object for every profile field being added or changed.
+2. Check the object's `MAX-ACCESS`.
+3. If the object is `not-accessible`, do not configure it as a readable `symbol.OID`.
+4. If a `not-accessible` object appears in the table `INDEX`, derive it from the row OID index using `index` or `index_transform`.
+5. Keep index extraction and value formatting separate:
+   - use `index` for one index component;
+   - use `index_transform` for multiple components;
+   - use `symbol.format` only for final formatting such as `ip_address`, `mac_address`, or `hex`.
+
+## Index Rules
+
+- `index` is 1-based.
+- `index_transform.start` and `index_transform.end` are 0-based and inclusive.
+- `index_transform: [{start: N}]` keeps index component `N` through the last component when `N > 0`.
+- `index_transform: [{start: 0, end: 0}]` keeps only the first index component.
+- `drop_right` can be used when the right side has fixed trailing components.
+
+## Common Patterns
+
+Q-BRIDGE learned FDB MAC:
+
+```yaml
+- tag: dot1q_fdb_mac
+  symbol:
+    format: mac_address
+  index_transform:
+    - start: 1
+```
+
+IP-MIB `ipNetToPhysicalTable` address:
+
+```yaml
+- tag: arp_ip
+  symbol:
+    format: ip_address
+  index_transform:
+    - start: 3
+```
+
+The `start: 3` skips `ifIndex`, address type, and the InetAddress length byte.
+
+LLDP-MIB local management address:
+
+```yaml
+- tag: lldp_loc_mgmt_addr
+  symbol:
+    name: lldpLocManAddr
+    format: hex
+  index_transform:
+    - start: 2
+```
+
+The `start: 2` skips management-address subtype and length. Use `hex`, not
+`ip_address`, because LLDP management addresses can carry non-IP subtypes; the
+topology runtime normalizes IP-compatible bytes later.
+
+## Audit Recipe
+
+When a profile reads a table column, verify that the MIB object is readable:
+
+```bash
+rg -n -C 4 'OBJECT-TYPE|MAX-ACCESS[[:space:]]+not-accessible|ACCESS[[:space:]]+not-accessible' path/to/MIB
+```
+
+For known topology-sensitive symbols, scan profile YAMLs before committing:
+
+```bash
+rg -n 'name:[[:space:]]*(dot1qTpFdbAddress|ipNetToPhysicalIfIndex|ipNetToPhysicalNetAddressType|ipNetToPhysicalNetAddress|lldpLocManAddrSubtype|lldpLocManAddr)\b' src/go/plugin/go.d/config/go.d/snmp.profiles
+```
+
+Any hit must be reviewed. It is valid only when the tag is index-derived and does not declare `symbol.OID` for a `not-accessible` object.
+
+## Validation
+
+Run the narrow suites for the changed area:
+
+```bash
+cd src/go
+go test ./plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition
+go test ./plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector
+go test ./plugin/go.d/collector/snmp_topology
+```
+
+See `src/go/plugin/go.d/collector/snmp/profile-format.md` for the full profile syntax and the "Field accessibility" section.

--- a/.agents/sow/done/SOW-0001-20260501-qbridge-fdb-mac-from-index.md
+++ b/.agents/sow/done/SOW-0001-20260501-qbridge-fdb-mac-from-index.md
@@ -1,0 +1,565 @@
+# SOW-0001 - SNMP topology: index-based extraction for not-accessible columns + observability + profile-engine macro
+
+## Status
+
+Status: completed
+
+Sub-state: implementation, regression fix, PR creation, first review-thread fix, Sonar duplication cleanup, and SOW close completed. Live-device validation against the originally reported affected device was not independently runnable in this workspace; residual runtime confirmation remains a PR/local-testing concern.
+
+## Requirements
+
+### Purpose
+
+Make the topology view show every L2 endpoint reachable through every managed switch on the network — laptops, IoT, printers, servers, AP-attached clients — across all common FDB protocol variations and vendor implementations, not just on the subset that happens to fit the path the code currently exercises. Today, on standards-compliant Q-BRIDGE-MIB-only switches, zero FDB endpoints surface. This is the dominant case in real enterprise LANs that skipped the legacy BRIDGE-MIB FDB.
+
+The work bundles three confirmed bug sites that share one root cause (profile asks for SNMP fields marked `MAX-ACCESS not-accessible` as if they were readable columns), small operational-visibility improvements that surface alongside the fix, and a profile-engine macro that prevents the bug class from recurring.
+
+### User Request
+
+After landing the Netgear-switch profile fix (PR #22366) and seeing LLDP work but FDB stay empty, the user asked for a comprehensive plan covering all FDB variations — not a narrow patch.
+
+Verbatim user request: *"Have you done a plan on what is needed to fix the issue and support all the variations of FDB properly?"*
+
+Subsequent user direction (recorded as locked decisions below): single PR, multiple isolated commits per group, full SOW documenting every issue, external verification by 5 multi-agent reviewers, cross-check against LibreNMS source code in mirrored repos.
+
+### Assistant Understanding
+
+Facts (verified):
+
+- Three SNMP table fields are walked in our profiles as if they were readable columns, but the source MIBs declare them `MAX-ACCESS not-accessible`. On strict-spec devices, the fields return no value; the runtime sinks then drop the rows because the relevant tag (MAC, IP, etc.) is empty.
+  - A1: Q-BRIDGE-MIB FDB MAC (`dot1qTpFdbAddress`) — RFC 4363, used as INDEX of `dot1qTpFdbEntry`.
+  - A2: IP-MIB modern ARP/ND — `ipNetToPhysicalIfIndex`, `ipNetToPhysicalNetAddressType`, `ipNetToPhysicalNetAddress` are all `not-accessible` per RFC 4293. Note that `ipNetToPhysicalPhysAddress` (the MAC itself) **is accessible** (`MAX-ACCESS read-create`); only the three index components are not-accessible.
+  - A3: LLDP-MIB local management address — `lldpLocManAddrSubtype` and `lldpLocManAddr` are `not-accessible` per IEEE 802.1AB-2005, used as INDEX of `lldpLocManAddrEntry`.
+- LibreNMS, OpenNMS, and `netdisco/snmp-info` all extract the MAC for Q-BRIDGE FDB **from the OID index, not from a column**. None of them read `dot1qTpFdbAddress` as a column. Verified directly in mirrored source:
+  - `librenms/librenms @ 90115d62d82a`: `includes/discovery/fdb-table/bridge.inc.php:31-98`
+  - `OpenNMS/opennms @ 032d82cc926f`: `features/enlinkd/adapters/collectors/bridge/src/main/java/org/opennms/netmgt/enlinkd/snmp/Dot1qTpFdbTableTracker.java:49-119`
+  - `netdisco/snmp-info @ 613d360b629d`: `lib/SNMP/Info/Bridge.pm:131-178`
+- The profile engine already supports `format: ip_address` on index-derived values (`index_tag_value.go:51-87`) and `format: mac_address` on column-derived values (`utils.go:61`, `value_processor.go:39`). Adding `format: mac_address` to the index-derived value path is a small additive change parallel to the existing `ip_address` case.
+- The existing `index_transform` mechanism (`{start: N, drop_right: M}`) already exists at `metrics.go:184` and is applied at `table_row_processor.go:107`. A2/A3 will use this same mechanism in addition to the new `mac_address` formatter.
+- Office field validation (sanitized): of four managed switches polled in a real LAN (vendors: MikroTik routerOS, MikroTik SwOS, Zyxel XS-class, Zyxel GS-class), three are backstopped by BRIDGE-MIB FDB (works), one is accidentally lenient by emitting `dot1qTpFdbAddress` as a column despite the spec (works by accident). None hit the strict-only-Q-BRIDGE failure mode. The originally reported failing device is in that strict-only failure mode.
+
+Inferences:
+
+- The Q-BRIDGE-MIB FDB profile, the modern IP-MIB ARP profile, and the LLDP local management address profile were likely shaped by mechanical extension of older profiles whose source MIB columns were accessible. Without per-author MIB-discipline awareness, the same mistake will recur.
+- The "lenient vendor returns the not-accessible column" hypothesis was previously unverified; it is now empirically confirmed against a real device but does not change the implementation choice (column-derived and index-derived MACs are byte-identical when both exist, per RFC 4363 §4 — both encode the same MAC address bytes).
+- Static FDB tables (`dot1qStaticUnicastTable`, `dot1dStaticTable`) are not just feature gaps; they have different semantics (filtering policy, multi-egress, allowed-port lists) that justify separate design rather than bundling here.
+
+Unknowns:
+
+- None block the locked decisions or implementation plan. Per-vendor support for proprietary FDB MIBs and the newer IEEE 802.1Q-2014 `IEEE8021-Q-BRIDGE-MIB` are deferred as listed in Followup.
+
+### Acceptance Criteria
+
+- A live SNMP poll of the originally reported affected device (Netgear GS110TP v3, sysObjectID `1.3.6.1.4.1.4526.100.4.19`) produces FDB endpoints whose count matches `dot1qTpFdbPort` row count from a fresh walk. Verification: `topology:snmp` function output + manual diff against the walk.
+- ARP/ND entries on a strict-spec L3 device are ingested with non-empty IP, ifIndex, and address type. Verification: regression fixture + targeted test, plus opportunistic real-device validation.
+- LLDP local management address is correctly populated on devices that implement the standards-compliant variant of `lldpLocManAddrTable`. Verification: regression fixture.
+- Existing behavior on devices that already work (BRIDGE-MIB FDB, lenient Q-BRIDGE-MIB devices, hybrid devices, Cisco-style per-VLAN context) is preserved bit-for-bit. Verification: existing `snmp_topology` and parity test suites pass without weakening; commit 7 includes a "lenient vendor" regression fixture (a Q-BRIDGE FDB walk where the column happens to populate) that exercises the no-regression path.
+- Engine macro `format: mac_address` is available for index-derived values. Output format: lowercase hex, colon-separated, two-digit per octet (`%02x` style), e.g. `aa:bb:cc:dd:ee:ff`. Octet validation: each component must be 0-255; on validation failure return empty string and let the row be dropped. Length-prefix tolerance: when the slice contains 7 components AND the first component equals 6 AND each of the remaining 6 components is a valid octet (0-255), treat as length-prefixed and use the trailing 6 components (defensive handling for F10).
+- **MAC output parity (column-side and index-side)**: column-side `format: mac_address` at `ddsnmp/ddsnmpcollector/utils.go:54` currently uses `%02X` (uppercase) and is exercised by tests at `collector_table_test.go:934-939` and `collector_device_meta_test.go:276-278` that expect uppercase output. As part of commit 1, switch the column-side format string to `%02x` (lowercase) and update those tests so both paths produce byte-identical lowercase output. Add an explicit column-vs-index parity unit test that runs both formatters on the same input and asserts byte equality. Rationale: `net.ParseMAC` and `normalizeMAC` (`topology_hex_normalization.go:18,31`) both lowercase, and industry tooling (LibreNMS, `ip` command, `ifconfig`) renders MACs lowercase — converging to lowercase is the natural shape.
+- Index-based extraction for A2 (modern ARP) handles RFC 4293 InetAddress encoding: a leading length octet (4 for IPv4, 16 for IPv6) preceding the address bytes. **The length octet is stripped at the profile level** via `index_transform: [{start: N, drop_right: M}]` on each affected tag (`arp_ip` tag uses positions after the length byte; `arp_addr_type` and `arp_if_index` use the earlier index positions). This keeps `formatIndexIPAddress` pure and documents the SNMP encoding where the MIB structure lives, rather than burying it in the formatter. (Alternative — extending `formatIndexIPAddress` to detect the prefix — was considered and rejected for keeping the formatter format-only.)
+- VLAN attribution falls back to `fdbID == VLAN_ID` when the `dot1qVlanCurrentTable` mapping is absent. Specifically: in `topology_cache_fdb.go:46-49`, if `c.fdbIDToVlanID[entry.fdbID]` returns empty, set `entry.vlanID = entry.fdbID`. This is a NEW fallback being ADDED alongside the existing mapping lookup, mirroring LibreNMS `bridge.inc.php:78`. Verification: unit test.
+- FDB rows referencing bridge ports without an `ifIndex` mapping are still ingested but tagged as unmapped. Implementation: an internal counter (not a chart) tracks unmapped-bridge-port FDB rows per poll cycle, plus a single rate-limited log line per poll cycle when the count is nonzero. Verification: unit test.
+- Warn-on-drop: when FDB rows are dropped due to empty MAC at `topology_cache_fdb.go:11-13`, emit at most ONE warning log per poll cycle with a count of dropped rows (not one log per row). Verification: unit test simulating a strict-Q-BRIDGE poll.
+- The profile-author guardrail exists as a project skill at `.agents/skills/project-snmp-profiles-authoring/SKILL.md` (note `project-` prefix per AGENTS.md:35,196,228 — runtime project skills MUST use this prefix) and as a new "Field accessibility" section in `src/go/plugin/go.d/collector/snmp/profile-format.md`. The profile-format.md section includes an audit recipe (a `grep` pattern for finding profile YAML symbols whose MIB declares `not-accessible`). Verification: file exists, links to profile-format.md from the skill, content reviewed in the multi-agent verification round.
+- All eight commits in the PR pass the existing `snmp_topology`, `pkg/topology/engine`, and `ddsnmp` test suites without regression.
+- Sensitive-data discipline: no community strings, bearer tokens, customer-identifying IPs, customer hostnames (sysName, sysDescr, ifAlias, ifDescr, LLDP remote names, LLDP port descriptions, chassis IDs, management addresses pointing to customer infrastructure), SNMPv3 usernames/auth/priv secrets, or community-member names appear in any committed file (SOW, profile YAMLs, code comments, tests, fixtures, commit messages, PR body, skill, profile-format.md update).
+
+## Analysis
+
+### Master gap & bug list (44 items)
+
+#### A. Confirmed parsing bugs — strict-spec devices return zero / incomplete data (3)
+
+| # | Site | Source MIB & spec | File:line | Effect |
+|---|---|---|---|---|
+| **A1** | Q-BRIDGE-MIB FDB MAC | RFC 4363 — `dot1qTpFdbAddress` is `MAX-ACCESS not-accessible`, INDEX of `dot1qTpFdbEntry` | `_std-topology-q-bridge-mib.yaml:21-25` (column read), drop at `topology_cache_fdb.go:10-13` | 0 FDB endpoints on strict-only-Q-BRIDGE devices (Netgear smart switches, parts of MikroTik SwOS, parts of Zyxel) |
+| **A2** | IP-MIB modern ARP/ND index components | RFC 4293 — `ipNetToPhysicalIfIndex`, `ipNetToPhysicalNetAddressType`, `ipNetToPhysicalNetAddress` are all `MAX-ACCESS not-accessible`. The MAC itself (`ipNetToPhysicalPhysAddress`) is `read-create` (accessible). | `_std-topology-fdb-arp-mib.yaml:192-217` reads three not-accessible columns | ARP entries on strict L3 devices lose IP, ifIndex, address type. MAC↔IP correlation breaks. The MAC value continues to be readable. |
+| **A3** | LLDP-MIB local management address | IEEE 802.1AB-2005 — `lldpLocManAddrSubtype` and `lldpLocManAddr` are `MAX-ACCESS not-accessible`, INDEX of `lldpLocManAddrEntry` | `_std-topology-lldp-mib.yaml:84-101` reads both not-accessible columns; no compat anchor (the *remote* table at `:184-319` has one — this one does not) | Local LLDP management address absent on strict devices |
+
+#### B. Latent parsing bugs — would surface if we add these tables (4)
+
+| # | Site | Why it'd repeat the pattern | Spec |
+|---|---|---|---|
+| **B1** | Q-BRIDGE static FDB `dot1qStaticUnicastTable` | `Address` AND `ReceivePort` both `not-accessible`. Only `AllowedToGoTo` is `read-write` | RFC 4363 |
+| **B2** | Q-BRIDGE multicast FDB `dot1qTpGroupTable` | `GroupAddress` `not-accessible` | RFC 4363 |
+| **B3** | IEEE8021-Q-BRIDGE-MIB FDB | Same shape, INDEX adds `ComponentId` (3-component INDEX) | IEEE 802.1Q-2018 |
+| **B4** | IP-MIB modern `ipAddressTable` | `AddrType` and `Addr` both `not-accessible` | RFC 4293 |
+
+#### C. Missing capabilities — not polled today (7)
+
+| # | Capability | Why it matters | Scope decision |
+|---|---|---|---|
+| **C1** | BRIDGE-MIB static FDB (`dot1dStaticTable`) | RFC 1493 SMIv1 — columns `read-write`, accessible. Different semantics (filtering policy). | **Defer** |
+| **C2** | Q-BRIDGE-MIB static FDB (`dot1qStaticUnicastTable`) | Needs index-based extraction (B1). Same semantics caveat as C1. | **Defer** |
+| **C3** | IEEE8021-Q-BRIDGE-MIB FDB | Modern alternative for IEEE 802.1Q-2014-only switches. | **Defer** |
+| **C4** | Modern `ipAddressTable` | For routers/firewalls running modern IP-MIB only. | **Defer** |
+| **C5** | Vendor proprietary FDB MIBs: HUAWEI-L2MAM-MIB, EXTREME-FDB-MIB, DLINKSW-L2FDB-MIB, HP-ICF-BRIDGE (Aruba/HPE), AX-FDB-MIB (AlaxalA), JUNIPER-VLAN/L2ALD-MIB, ALCATEL-IND1-MAC-ADDRESS-MIB (Nokia/Alcatel). LibreNMS also has handlers for EdgeSwitch (Ubiquiti), FortiSwitch (Fortinet), TiMOS (Nokia SR OS), AOS6/AOS7 (Alcatel-Lucent OmniSwitch), and VRP (Huawei). | LibreNMS handlers exist as references. Each is its own design problem. | **Defer** |
+| **C6** | CISCO-MAC-NOTIFICATION-MIB (trap-based) | Out-of-SNMP-poll scope | **Defer** |
+| **C7** | LLDP-MED, LLDP-EXT-DOT3, LLDP-EXT-DOT1 | Phone/PoE/voice-VLAN/inventory metadata. Out of scope; opt-in by-vendor. | **Defer** |
+
+#### D. Quality / attribution gaps — data appears, partially incomplete (6)
+
+| # | Gap | Evidence | Scope decision |
+|---|---|---|---|
+| **D1** | No `fdbID == VLAN_ID` fallback when `dot1qVlanCurrentTable` is absent. Today `topology_cache_fdb.go:46-49` only consults `c.fdbIDToVlanID`; if empty, `entry.vlanID` stays empty. The fix ADDS a fallback line that sets `entry.vlanID = entry.fdbID` when the mapping returns nothing | LibreNMS `bridge.inc.php:78` precedent (`$vlan = $vlan_fdb_dict[$vlanIndex] ?? $vlanIndex;`) | **In this PR** |
+| **D2** | FDB entries on unmapped bridge ports emit `IfIndex: 0` silently | `topology_observation_local_forwarding.go:29-42`. No counter or warning today | **In this PR** |
+| **D3** | No detection of FDB truncation by SNMP agent (large tables on small devices) | No `*counts vs walked* ` validation against `dot1qFdbDynamicCount` | **Defer** |
+| **D4** | No deduplication when same MAC is in LLDP remote AND FDB | Could produce two endpoint actors for one device | **Defer** |
+| **D5** | Port aggregation (LACP/LAG): FDB → member port ifIndex, no LAG rollup | `bridgePortToIf` is 1:1; LibreNMS also does not roll up | **Defer** |
+| **D6** | Cross-protocol freshness (LLDP age vs FDB age vs ARP age) not reconciled | Can produce ghost endpoints | **Defer** |
+
+#### E. Code smells / blind spots (6)
+
+| # | Issue | Where | Scope decision |
+|---|---|---|---|
+| **E1** | `macFromOIDIndexSuffix` lives in `_test.go`, not in production | `topology_snmprec_forwarding_test.go:546` | **In this PR** (helper logic folded into engine macro) |
+| **E2** | Test fixture parser has its own MAC-from-index fallback that bypasses production path | `topology_snmprec_forwarding_test.go:305-336` masks A1 | **In this PR** (resolved by adding fixtures that exercise profile→engine→cache end-to-end) |
+| **E3** | LLDP octet reassembly in `topology_management_address_normalization.go` is bespoke; no shared helper | Will duplicate when fixing A1/A3 | Engine macro replaces it (commit 1) |
+| **E4** | No logging when FDB rows are dropped due to empty MAC | `topology_cache_fdb.go:11-13` — silent data loss | **In this PR** (rate-limited per poll cycle, not per row) |
+| **E5** | Two anchors for `lldpRemManAddrTable` (primary `.1`/`.2` + compat `.3`) — unclear interaction with strict devices | `_std-topology-lldp-mib.yaml:184-319` — works in practice but warrants a comment | **In this PR** (one-line comment) |
+| **E6** | No engine-level `index_format: mac` macro | ddsnmp engine missing feature | **In this PR** (engine macro) |
+
+#### F. Vendor / firmware quirks (10)
+
+| # | Quirk | LibreNMS handler | Status in our code | Scope decision |
+|---|---|---|---|---|
+| **F1** | MikroTik LLDP RemManAddr exposes columns `.1`/`.2` despite spec | (unknown) | Handled (primary anchor in our profile) | n/a |
+| **F2** | Zyxel firmware emits malformed Q-BRIDGE indexes that need reshaping | `includes/discovery/fdb-table/zynos.inc.php:27-35` | Not handled | **Defer** |
+| **F3** | TP-Link JetStream ifIndex offset of `+49152` between BRIDGE-MIB and IF-MIB | `includes/discovery/fdb-table/jetstream.inc.php:38` | Not handled | **Defer** |
+| **F4** | Cisco IOS classic — per-VLAN BRIDGE-MIB via `community@<vlan>` | `includes/discovery/fdb-table/ios.inc.php:29` | Handled (`topology_vlan_context.go`) | n/a |
+| **F5** | Some Aruba IAP firmware — truncated Q-BRIDGE indexes | `arubaos.inc.php` partial | Not handled | **Defer** |
+| **F6** | Originally reported device firmware bug — 512-byte zero-filled `lldpLocSysCapSupported`/`Enabled` | (Netdata-specific finding) | Tolerated implicitly by `format: hex` | n/a |
+| **F7** | Stacked switches (Cisco StackWise, HP IRF) — aggregated FDB on master, per-member on others | Not handled in LibreNMS either | Not handled | **Defer** |
+| **F8** | Cisco SB / SF / SG Small Business — non-standard FDB shape | Cisco-SB-specific profile in our codebase | Partially handled | n/a |
+| **F9** | Lenient vendors return `dot1qTpFdbAddress` as a column despite spec | LibreNMS doesn't read the column at all (index-only) | Decision 1B (drop column) makes this irrelevant | n/a |
+| **F10** | Length-prefix byte in MAC index encoding — some agents (per LibreNMS comment, observed on Aruba CX, Comtrol) prepend a length octet (value 6) before the 6 MAC bytes, producing a 7-component index suffix | `includes/discovery/fdb-table/bridge.inc.php:80-96` | Not handled today | **In this PR** (defensive: when the slice has 7 components and the first equals 6, drop it; engine macro acceptance criterion above) |
+
+#### G. Engine / ddsnmp gaps (4)
+
+| # | Gap | Why it matters | Scope decision |
+|---|---|---|---|
+| **G1** | No `MAX-ACCESS` validation when authoring profiles | Lets the A-class bug be authored without warning | **In this PR** (skill + profile-format.md) |
+| **G2** | No native multi-position index extraction with format coercion | Forces ugly per-octet enumeration; the same fix shape we need for A1, A2, A3 | **In this PR** (engine macro `format: mac_address` for index-derived values) |
+| **G3** | No "fail-loud" when a column symbol returns no rows on a populated table | Silent data loss | **Defer** |
+| **G4** | No per-poll-cycle stats on rows-fetched vs rows-dropped per metric | Hard to diagnose A-class bugs in production | **Partial** — covered by E4 (warn-on-drop) for the FDB sink |
+
+#### H. Process / documentation gaps (4)
+
+| # | Gap | Scope decision |
+|---|---|---|
+| **H1** | No MIB-authoring spec or project skill — every author can repeat the not-accessible mistake | **In this PR** — `.agents/skills/project-snmp-profiles-authoring/SKILL.md` (note `project-` prefix per AGENTS.md:35,196,228) |
+| **H2** | No same-failure scan was performed at PR review time for this profile family | **In this PR** — reviewers ran the scan, results integrated; project skill encodes the rule for future PRs |
+| **H3** | Test fixtures cannot trivially be derived from real SNMP walks (snmprec format conversion not documented) | **Defer** |
+| **H4** | No reference table linking each topology MIB column we walk to its accessibility class | **In this PR** — `profile-format.md` MAX-ACCESS section, includes a `grep` audit recipe |
+
+### LibreNMS verification matrix
+
+For each issue, what LibreNMS does. File paths are relative to `librenms/librenms @ 90115d62d82a`.
+
+| Issue | LibreNMS handles? | Code path | Approach |
+|---|---|---|---|
+| A1 (Q-BRIDGE FDB MAC) | Yes | `includes/discovery/fdb-table/bridge.inc.php:31-35` (walk), `:98` (parse), `:80-96` (length-prefix tolerance) | Walk `dot1qTpFdbPort` (column .2, accessible); extract MAC from index. No column read. |
+| A2 (IP-MIB ARP `ipNetToPhysicalTable`) | Yes | `LibreNMS/Modules/ArpTable.php:104-118` | Walk `ipNetToPhysicalPhysAddress` and consume the **structured table keys** returned by `->table(1)` (a hierarchical ifIndex→addrType→address map; not a raw OID-suffix split). Shape repair at line 120. The MAC value comes from the column (which is accessible); IP/ifIndex/addrType come from the structured key path. |
+| A3 (LLDP local mgmt addr) | No | n/a — table not polled | LibreNMS sidesteps by not reading this table at all. We choose the right thing: index extraction. |
+| B1/C2 (Q-BRIDGE static FDB) | No | n/a — table not polled | Same gap |
+| B3/C3 (IEEE8021-Q-BRIDGE-MIB) | Partial | `LibreNMS/OS/Traits/QBridgeMib.php:50-58` | Used only for VLAN names; FDB extraction stays on classic Q-BRIDGE-MIB |
+| B4/C4 (modern `ipAddressTable`) | Partial | IPv4 still uses deprecated `ipAddrTable` (`LibreNMS/Modules/Ipv4Addresses.php:195`); IPv6 uses modern `ipAddressTable` (`LibreNMS/Modules/Ipv6Addresses.php:148`) | Mixed: deprecated for v4, modern for v6 |
+| C5 (vendor proprietary FDBs) | Yes (≥11 vendors) | `includes/discovery/fdb-table/{arubaos,vrp,ios,aos6,aos7,zynos,jetstream,edgeswitch,fortiswitch,timos,...}.inc.php` | Per-vendor override files |
+| D1 (VLAN fdbID==VLAN_ID fallback) | Yes | `bridge.inc.php:78` | `$vlan = $vlan_fdb_dict[$vlanIndex] ?? $vlanIndex;` |
+| F2 (Zyxel malformed Q-BRIDGE index) | Yes | `zynos.inc.php:27-35` | Reshape pass before normal parsing |
+| F3 (TP-Link JetStream offset) | Yes | `jetstream.inc.php:38` | Hardcoded `+49152` ifIndex offset |
+| F4 (Cisco per-VLAN context) | Yes | `ios.inc.php:29` | `SnmpQuery::context($vlan_raw, 'vlan-')->walk('BRIDGE-MIB::dot1dTpFdbPort')` |
+| F10 (length-prefix byte) | Yes | `bridge.inc.php:80-96` | Defensive: detect and strip the 7-byte index encoding |
+| Bridge-port → ifIndex | Yes | `bridge.inc.php:49-54` (build), `:108` (fallback to `basePort==ifIndex`) | Walks `dot1dBasePortIfIndex`; falls back when missing |
+| Stack / multi-component bridge | No | n/a | Same gap as ours |
+| LACP / port-channel rollup | No | n/a | Same gap as ours |
+| Test coverage / fixtures | Limited | `tests/data/timos_fdb-table.json`, `tests/snmpsim/zynos_gs1900-fdb.snmprec` | Two relevant fixtures |
+
+Cross-references:
+
+- `netdisco/snmp-info` `Bridge.pm:160-178` — `_qb_fdbtable_index` (lines 160-165) decodes MAC from index; `qb_fw_mac` (lines 167-178) walks `qb_fw_port` and applies the decoder. Never reads the not-accessible column.
+- OpenNMS `features/enlinkd/adapters/collectors/bridge/src/main/java/org/opennms/netmgt/enlinkd/snmp/Dot1qTpFdbTableTracker.java:64` (column collection: port + status only), `:113` (decodes address from row index).
+
+**Conclusion**: index-based extraction is the universal industry approach for A1. A2 and A3 are RFC-backed analogs with the same mechanical fix shape, but the three reference implementations do not directly cover them — A2 has a partial parallel in LibreNMS `ArpTable.php` (which uses the structured-table-key approach, semantically equivalent), A3 has no reference precedent (LibreNMS skips the table). Decision 1B is the right call for all three; A1 is independently proven, A2/A3 are RFC-driven.
+
+### Risks (cross-cutting)
+
+- **Engine macro added in this PR**: contained scope. The format handler extends `formatIndexTagValue` with `case "mac_address":` parallel to the existing `case "ip_address":`. Octet validation (each component 0-255) and length-prefix tolerance (drop a leading length-of-6 octet when the slice has 7 components) are part of the formatter, mirroring `formatIndexIPAddress` patterns and LibreNMS behavior. Engine has the existing `format: ip_address` precedent that exercises the same code path.
+- **A2/A3 implementation completeness**: the new `format: mac_address` formatter is necessary but not sufficient. A2 and A3 need correct `index` + `index_transform` declarations in the profile YAML to slice the OID suffix to the right components before formatting. For A2 in particular, the IP component of the OID index is RFC 4293 InetAddress-encoded (a length octet followed by address bytes); the length octet is **stripped at the profile level** via `index_transform` so the `format: ip_address` handler stays pure (format-only). The engine macro adds `format: mac_address` for index values; profile-level slicing handles SNMP encoding peculiarities.
+- **Removing the column read** (Decision 1B): index-derived MAC and column-derived MAC are byte-identical when both exist (RFC 4363 §4 — both encode the same MAC bytes). On lenient devices that today populate the column, behavior stays correct. On strict devices, FDB starts working. No device regresses. The lenient-vendor regression fixture in commit 7 verifies this.
+- **VLAN fallback (D1)** could over-attribute if a device uses `fdbID != VLAN_ID` mapping but doesn't expose `dot1qVlanCurrentTable`. LibreNMS accepts this trade-off; the fallback is a documented best-effort.
+- **Warn-on-drop (E4)** could be noisy. Implementation MUST be rate-limited to one log line per poll cycle with a count, not one per dropped row. This is in the acceptance criteria.
+
+## Pre-Implementation Gate
+
+Gate state at implementation start: decisions locked; implementation authorized after validation.
+
+Problem / root-cause model:
+
+- Three SNMP table fields are walked in our profiles as if they were readable columns, but the source MIBs declare them `MAX-ACCESS not-accessible`. Strict-spec devices correctly return no value for those columns. Our runtime sinks then drop the rows because the relevant tag (MAC, IP, etc.) is empty. The bug class repeats because there is no project-level rule requiring profile authors to consult MIB MAX-ACCESS, and no engine-level macro making the right way (index extraction with format coercion) ergonomic.
+
+Evidence reviewed:
+
+- RFCs 1493, 4188, 4293, 4363; IEEE 802.1AB-2005; IEEE 802.1Q-2018 (downloaded into `/tmp/sow-verify/`).
+- Profile YAMLs: `_std-topology-q-bridge-mib.yaml`, `_std-topology-fdb-arp-mib.yaml`, `_std-topology-lldp-mib.yaml`, `_std-topology-stp-mib.yaml`, `_std-topology-cisco-vtp-mib.yaml`.
+- Runtime sinks: `topology_cache_fdb.go`, `topology_cache_metric_dispatch.go`, `topology_cache_tags.go`, `topology_observation_local_forwarding.go`, `topology_vlan_context*.go`, `topology_observation_local_identity.go`.
+- Engine: `ddsnmp/ddprofiledefinition/{metrics.go,validation.go,selector.go}`, `ddsnmp/ddsnmpcollector/{table_row_processor.go,index_tag_value.go,utils.go,value_processor.go,cross_table_lookup.go}`.
+- `librenms/librenms @ 90115d62d82a` source (file:line citations in matrix above).
+- `netdisco/snmp-info @ 613d360b629d`: `lib/SNMP/Info/Bridge.pm` and `lib/SNMP/Info/IEEE802_Bridge.pm`.
+- `OpenNMS/opennms @ 032d82cc926f`: `features/enlinkd/.../Dot1qTpFdbTableTracker.java`.
+- Live SNMP walks from one originally reported affected device and four office-network managed switches (3 vendors).
+- Two rounds of external multi-agent reviews (5 reviewers per round: Codex, GLM, MiniMax, Qwen, Kimi). Round 2 produced 20 fixes that have been applied to this SOW.
+
+Affected contracts and surfaces:
+
+- Profile YAMLs: `_std-topology-q-bridge-mib.yaml`, `_std-topology-fdb-arp-mib.yaml`, `_std-topology-lldp-mib.yaml`.
+- Runtime: `topology_cache_fdb.go`, `topology_cache_tags.go`, `topology_observation_local_forwarding.go`.
+- Engine: `ddsnmp/ddsnmpcollector/index_tag_value.go` (extending `formatIndexTagValue`).
+- New skill: `.agents/skills/project-snmp-profiles-authoring/SKILL.md`.
+- Updated docs: `src/go/plugin/go.d/collector/snmp/profile-format.md` (new "Field accessibility" section + audit recipe).
+- Test data: new snmprec fixtures under `src/go/plugin/go.d/collector/snmp_topology/testdata/`.
+- No public/operator docs change beyond release notes.
+- No public CLI / UI / schema change.
+- No `AGENTS.md` change required (skill follows the `project-*` convention; no legacy registration needed).
+
+Existing patterns to reuse:
+
+- LLDP management-address octet decomposition in `_std-topology-lldp-mib.yaml:206-239` and the runtime reassembly in `topology_management_address_normalization.go:13-35` (`reconstructLldpRemMgmtAddrHex`) — supersedable once the engine macro lands; kept as production reference until then.
+- VLAN-context plumbing in `topology_vlan_context.go` is robust and need not change.
+- Test helper `macFromOIDIndexSuffix(parts []string)` at `topology_snmprec_forwarding_test.go:546` — its decode logic moves into production as part of the engine macro (commit 1).
+- LibreNMS `bridge.inc.php` "fdbID == vlanID" fallback at `:78` — directly mirrored.
+- Existing `formatIndexIPAddress` at `index_tag_value.go:58-87` — the new `formatIndexMACAddress` parallels it (validation, length-prefix tolerance, error path returning empty string).
+
+Risk and blast radius:
+
+- A1+A2+A3 fixes: low. Additive (column read removed, index extraction added). No device regresses (RFC 4363 §4 guarantees byte equivalence; lenient-vendor fixture in commit 7 verifies).
+- Engine `format: mac_address` for index-derived values: low. Mirrors existing `format: ip_address`; tests reuse the same harness.
+- D1 VLAN fallback: low. Documented best-effort matching LibreNMS.
+- D2 IfIndex tracking: low. Internal counter + one log line per poll cycle. No chart, no public metric.
+- E4 warn-on-drop: low. Rate-limited per poll cycle.
+- Static FDB additions: deferred — different semantics, separate SOW.
+- Per-vendor SOWs: deferred, no risk in this PR.
+
+Sensitive data handling plan:
+
+- All durable artifacts in this SOW (the SOW itself, profile YAMLs, code, code comments, tests, fixtures, commit messages, PR body, the new skill, the profile-format.md update) must contain zero raw sensitive data: no community member or customer names, no SNMP communities, no bearer tokens, no SNMPv3 usernames / authentication / privacy secrets, no customer-identifying IPs (private RFC1918 IPs are acceptable when used as illustrative examples in profile-format.md, never in fixtures derived from real walks), no customer-identifying device strings (real-world `sysName`, `sysDescr`, `ifAlias`, `ifDescr`, LLDP remote `sysName`, LLDP remote port descriptions, real chassis IDs, customer-pointing management addresses), no proprietary incident details.
+- Use placeholders (`[REDACTED]`, "the user", "the reporter", "originally reported affected device"), public product names (e.g. "Netgear GS110TP v3" is a publicly sold product, not PII), and file:line citations.
+- Test fixtures derived from real device walks must be sanitized: replace customer hostnames in port descriptions or sysName with neutral labels (`endpoint-1`, `port-A`, etc.), and strip or stub LLDP remote-name fields and LLDP port descriptions. Sanitization happens before the fixture is staged.
+- Pre-commit checklist (run before each commit and before opening the PR). Uses `rg -P` (ripgrep with PCRE) — POSIX `grep -E` does not support negative lookahead and would silently fail. The checklist scans **both staged and unstaged** content, plus commit messages and the PR body separately.
+  ```bash
+  # Helper: stream all uncommitted changes (staged + unstaged)
+  git_diff_all() { { git diff --cached; git diff; }; }
+
+  # 1. credentials and tokens in any uncommitted content
+  git_diff_all | rg -P '(community|bearer|token|secret|password|auth.?key|priv.?key|snmpv3)\s*[:=]'
+
+  # 2. customer-identifying IPv4 outside RFC1918, and IPv6 global-unicast-like
+  #    addresses (2000::/3). The OID-context exclusion
+  #    (^| [^0-9.])(?!1\.[0-3]\.6\.1\.) avoids flagging SNMP OIDs like
+  #    1.3.6.1.4.1.x. The lookahead chain after that excludes private IPv4
+  #    ranges. The IPv6 pattern is case-insensitive and intentionally excludes
+  #    ULA fc00::/7.
+  git_diff_all | rg -P '(?<![0-9.])(?!1\.[0-3]\.6\.1\.)(?!10\.)(?!172\.(1[6-9]|2[0-9]|3[01])\.)(?!192\.168\.)\b[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\b'
+  git_diff_all | rg -P '(?i)\b(?:2[0-9a-f]{3}|3[0-9a-f]{3}):[0-9a-f:]+\b'
+
+  # 3. customer-identifying device strings (replace with neutral labels in fixtures)
+  git_diff_all | rg -iP '(sysName|sysDescr|ifAlias|ifDescr|chassis.?id|mgmt.?addr|lldp.?rem.?(sys.?name|port.?desc))'
+
+  # 4. proper names that surfaced in chat or Slack during work on this SOW.
+  #    Maintain the personal-name list in a local environment file (.env or
+  #    AGENTS.local.md, both gitignored). Never embed names in this SOW.
+  #    Example: NAME_PATTERN="Firstname1|Firstname2|Surname1"; export NAME_PATTERN
+  git_diff_all | rg -iP "$NAME_PATTERN"
+
+  # 5. commit messages — three coverage paths because each catches a different point:
+  #    a) prepare-commit-msg hook: scan $1 (the in-progress message file)
+  #       before commit goes through.
+  #    b) post-commit verification of the most recent commit:
+  git log -1 --format='%B' | rg -iP '(community|bearer|token|secret|password|auth.?key|priv.?key|snmpv3)\s*[:=]|sysName|sysDescr|ifAlias|ifDescr|chassis.?id|mgmt.?addr'
+  git log -1 --format='%B' | rg -iP "$NAME_PATTERN"
+  #    c) range scan across all commits not yet merged to upstream/master,
+  #       just before opening the PR:
+  git log upstream/master..HEAD --format='%B' | rg -iP '(community|bearer|token|secret|password|auth.?key|priv.?key|snmpv3)\s*[:=]|sysName|sysDescr|ifAlias|ifDescr|chassis.?id|mgmt.?addr'
+
+  # 6. PR body — apply the same patterns to the body before `gh pr create` /
+  #    `gh pr edit --body-file`. If using a body file, run the patterns
+  #    against that file directly.
+  ```
+  Each `rg` invocation MUST return zero lines before commit / PR open. If `rg` is unavailable, the regex set requires it and the checklist cannot be satisfied with `grep` alone — install ripgrep first.
+
+Implementation plan: see "Plan" section below — 8 commits, single PR off `upstream/master`, branch `snmp-qbridge-fdb-mac-from-index`. Validation before implementation found one required engine prerequisite: current `index_transform` cannot express "start at N and keep the rest" (`validation.go` rejects `start > end`, and `applyIndexTransform` requires an explicit in-bounds `end`). The user accepted extending `index_transform` so `start > 0` with omitted/zero `end` means "through the last index component"; `start: 0, end: 0` keeps its existing "first component only" behavior.
+
+Validation plan:
+
+- Unit tests for: engine `format: mac_address` formatter (octet validation 0-255, length-prefix tolerance, output format `aa:bb:cc:dd:ee:ff`); A1+A2+A3 profile→engine→cache flow on synthetic strict-spec fixtures; D1 VLAN fallback; D2 unmapped-bridge-port counter; E4 rate-limited warn-on-drop.
+- Snmprec fixtures: at least one strict-spec Q-BRIDGE FDB fixture (sanitized derivative of the user-reported walk), one strict-spec modern ARP fixture (synthetic, RFC 4293 InetAddress-encoded), one strict-spec LLDP local mgmt addr fixture (synthetic), one **lenient-vendor** Q-BRIDGE FDB fixture (column populated; verifies no-regression on the path that already works).
+- Existing test suites must pass without weakened assertions: `snmp_topology`, `pkg/topology/engine`, `ddsnmp`.
+- Manual validation: live poll against the originally reported affected device showing FDB endpoint count matches walked row count.
+- Same-failure scan output: documented in this SOW under `## Validation` after commit 7. No further not-accessible-as-column sites detected by the multi-agent review.
+- Profile-format.md and skill content: reviewed in the multi-agent verification round before any commits.
+
+Artifact impact plan:
+
+- AGENTS.md: update required. The new runtime project skill follows the `project-*` convention, and the Project Skills Index must stop saying no `project-*` skills exist.
+- Runtime project skills: new `.agents/skills/project-snmp-profiles-authoring/SKILL.md` (in this PR).
+- Specs under `.agents/sow/specs/`: no expected change. The skill + profile-format.md cover the authoring rule.
+- End-user/operator docs: `profile-format.md` gets a new "Field accessibility" section with the rule + audit recipe.
+- End-user/operator skills: none.
+- SOW lifecycle plan at implementation start: move from `pending/` to `current/` after user authorization, then close after merge or explicit user request. Actual closure is recorded in the execution log and validation gate.
+
+Open decisions: none. All five locked below.
+
+## Locked Decisions
+
+### Decision 1 — MAC extraction approach for not-accessible columns
+
+**Locked: Option B — drop column read entirely, extract from index only.**
+
+Reasoning: For A1, three reference implementations (LibreNMS `bridge.inc.php`, SNMP::Info `Bridge.pm`, OpenNMS `Dot1qTpFdbTableTracker.java`) all use index-only extraction; none reads the not-accessible column. For A2 and A3, the same approach is RFC-backed and mechanically identical, though direct industry parallels are fewer (LibreNMS handles A2 via a structured-table-key path semantically equivalent to index extraction; A3 is sidestepped by not polling the table). The "lenient vendor returns the column" hypothesis is empirically true for at least one vendor (Zyxel GS-class) but does not change the choice — column-derived and index-derived MACs are byte-identical (RFC 4363 §4), so removing the column read produces identical bytes on lenient devices and starts working on strict devices. Two paths multiplied across 3 sites = unjustified maintenance burden.
+
+### Decision 2 — Authoring guardrail format and path
+
+**Locked: project skill at `.agents/skills/project-snmp-profiles-authoring/SKILL.md` (note `project-` prefix per AGENTS.md:35,196,228 — runtime project skills MUST use this prefix). Plus a new "Field accessibility" section in `src/go/plugin/go.d/collector/snmp/profile-format.md` containing the rule and a `grep` audit recipe. The skill links to profile-format.md.**
+
+Reasoning: The user requested skill-shape rather than spec-shape. profile-format.md is the canonical authoring reference (2046 lines, no current MAX-ACCESS mention) and is the right home for the rule itself. The skill points authors at it. The `project-` prefix follows the project convention; using a different prefix would require an explicit registration entry in AGENTS.md, which is unjustified for a new skill.
+
+### Decision 3 — Quality / observability improvements in this PR
+
+**Locked: Option A — include all three.**
+
+- D1 VLAN fallback: resolve `fdbID == VLAN_ID` as a late fallback when producing observations, after the `dot1qVlanCurrentTable` mapping has had a chance to populate. Do not eagerly store `entry.vlanID = entry.fdbID` in `updateFdbEntry`, because Q-BRIDGE FDB rows are processed before the VLAN mapping table in the current profile order and an eager fallback can block a later correct mapping.
+- D2 IfIndex tracking: when `parseIndex(c.bridgePortToIf[bridgePort])` returns 0, increment an internal per-poll counter; emit at most ONE log line per poll cycle if the counter is nonzero. No new chart or public metric.
+- E4 warn-on-drop: when `topology_cache_fdb.go:11-13` drops rows due to empty MAC, emit at most ONE rate-limited warning per poll cycle with a count of dropped rows (not one log per row).
+
+Reasoning: Each is file-local, additive, cheap, and ensures the next bug of this class is visible immediately rather than requiring forensic walks.
+
+### Decision 4 — Engine macro G2 in this PR; static FDB / IEEE8021-Q-BRIDGE-MIB / modern ipAddressTable / vendor proprietary deferred to child SOWs
+
+**Locked: engine macro IN this PR. Static FDB, IEEE8021-Q-BRIDGE-MIB, modern `ipAddressTable`, vendor-proprietary FDB MIBs all DEFERRED — child SOWs opened before this SOW closes.**
+
+Reasoning: Engine macro is a small additive change (extends `formatIndexTagValue` with `case "mac_address":` parallel to the existing `case "ip_address":`, plus octet validation and length-prefix tolerance). Static FDB has different semantics (filtering policy, multi-egress) and warrants its own design SOW. IEEE8021-Q-BRIDGE-MIB and modern `ipAddressTable` have no real-device evidence in this SOW justifying immediate work. Vendor-proprietary FDBs are each their own design problem.
+
+### Decision 5 — `index_transform` variable-tail support
+
+**Locked: Option A — extend `index_transform` semantics.**
+
+Reasoning: Q-BRIDGE MAC extraction and variable-length IP/LLDP management-address indexes need "slice from this index component through the end". Current `index_transform` can only select explicit inclusive ranges or drop a fixed number of right-side components. Duplicating tags for every possible IPv4/IPv6 or normal/length-prefixed shape would be brittle and order-sensitive because tag insertion does not overwrite an existing non-empty tag. Extending the engine is low risk because `start > 0, end == 0, drop_right == 0` is currently invalid, while existing `start: 0, end: 0` keeps its current first-component meaning.
+
+## Plan
+
+Single PR, branch `snmp-qbridge-fdb-mac-from-index` off `upstream/master`. Eight commits, isolated per group:
+
+| # | Commit | Files touched | Issues addressed |
+|---|---|---|---|
+| 1 | `engine: add format mac_address for index-derived tag values; converge column-side to lowercase` | `ddsnmp/ddsnmpcollector/index_tag_value.go` (new `formatIndexMACAddress` + switch case, lowercase output), `ddsnmp/ddsnmpcollector/table_row_processor.go` and `ddsnmp/ddprofiledefinition/validation.go` (extend `index_transform` so `start > 0` with omitted/zero `end` keeps the tail), `ddsnmp/ddsnmpcollector/utils.go:54` (flip `%02X` → `%02x` for parity), `ddsnmp/ddsnmpcollector/collector_table_test.go:934-939` and `collector_device_meta_test.go:276-278` (update existing assertions from uppercase to lowercase), unit tests including an explicit column-side ↔ index-side parity test | G2, E1 (folds in `macFromOIDIndexSuffix` decode logic), F10 (length-prefix tolerance with octet validation), MAC parity (column-side and index-side both produce lowercase `aa:bb:cc:dd:ee:ff`), variable-tail index extraction needed by A1/A2/A3 |
+| 2 | `profile + runtime: q-bridge fdb mac from index` | `_std-topology-q-bridge-mib.yaml` (replace octet enumeration with `format: mac_address` + `index_transform`), `topology_cache_tags.go` (rename/cleanup tag constants if needed), `topology_cache_fdb.go` (consume the new tag value), unit tests | A1 |
+| 3 | `profile + runtime: ip-mib modern arp from index` | `_std-topology-fdb-arp-mib.yaml` — replace not-accessible column reads with `index` + `index_transform` extraction. For `arp_if_index` and `arp_addr_type`: single `index: N` lookups. For `arp_ip`: `index_transform: [{start: <after-length-byte>}]` to skip the RFC 4293 InetAddress length octet *at the profile level*, then `format: ip_address` consumes a clean 4 / 16 octet sequence (formatter stays format-only; SNMP-encoding logic stays in the profile YAML where the MIB structure is documented). `topology_cache_stp_arp.go` and any tag consumer; unit tests including an IPv4 + IPv6 strict-spec fixture pair. | A2 |
+| 4 | `profile + runtime: lldp local management address from index` | `_std-topology-lldp-mib.yaml`, `topology_management_address.go` and/or `topology_management_address_normalization.go` (consumer), unit tests | A3, E5 (one-line comment near the dual anchors of `lldpRemManAddrTable`) |
+| 5 | `runtime: fdbID == VLAN_ID fallback when mapping table absent` | `topology_observation_local_forwarding.go` (late fallback to `entry.fdbID` only when no mapped VLAN ID exists at observation-output time), `topology_cache_fdb.go` (keep cache mutation compatible with late mapping), unit tests | D1 |
+| 6 | `runtime: warn-on-drop + unmapped-bridge-port counter` | `topology_cache_fdb.go:11-13` (rate-limited per-poll-cycle warning with count), `topology_observation_local_forwarding.go:29-42` (per-poll-cycle counter for `IfIndex == 0` cases + single log line when nonzero), unit tests verifying rate-limiting | D2, E4 |
+| 7 | `tests: snmprec fixtures + regression tests` | new fixtures under `src/go/plugin/go.d/collector/snmp_topology/testdata/`: strict-spec Q-BRIDGE FDB (sanitized from real walk), strict-spec ARP (synthetic), strict-spec LLDP local mgmt (synthetic), **lenient-vendor Q-BRIDGE FDB (column populated, verifies no-regression)**; forwarding tests that exercise all four | regression coverage for A1+A2+A3 |
+| 8 | `docs/skill: snmp profile authoring guardrail` | new `.agents/skills/project-snmp-profiles-authoring/SKILL.md` (links to profile-format.md), new "Field accessibility" section in `src/go/plugin/go.d/collector/snmp/profile-format.md` with the MAX-ACCESS rule + a `grep` audit recipe, update `AGENTS.md` Project Skills Index | H1, H4 |
+
+Order matters: commit 1 (engine) lands before 2-4 (profiles that consume the new format). 5-6 (observability) before 7 (tests can exercise them). 8 (docs) last so the skill reflects the final shape of the engine macro and profile pattern.
+
+Pre-commit checklist (Pre-Implementation Gate § Sensitive data plan) MUST pass before each commit and before PR open.
+
+## Execution Log
+
+### 2026-05-01
+
+- Created branch `snmp-qbridge-fdb-mac-from-index` off `upstream/master`.
+- Drafted initial narrow SOW; user pushed back asking for full survey across all FDB variations.
+- Re-investigated topology profiles, runtime sinks, ddsnmp engine, RFC 1493/4188/4293/4363 and IEEE 802.1AB-2005 / 802.1Q-2018.
+- Sent narrower SOW to 5 external reviewers (round 1: Codex, GLM, MiniMax, Qwen, Kimi). Codex independently identified A2 (IP-MIB ARP). User locked four decisions.
+- Verified user's office network: 3 of 4 managed switches backstopped by BRIDGE-MIB FDB; 1 lenient. Confirmed bug-affected population is "strict + Q-BRIDGE-only + no BRIDGE-MIB".
+- LibreNMS verification subagent ran; results integrated.
+- Sanitized SOW and `AGENTS.local.md`: no community member names, no SNMP communities, no bearer tokens.
+- Sent expanded SOW to the 5 reviewers (round 2). Findings consolidated:
+  - 4 of 5 confirmed Bridge.pm citation off (242-271 → 160-178). Fixed.
+  - Codex flagged Decision 2 skill path conflict with AGENTS.md (`project-*` convention). Fixed (path now `project-snmp-profiles-authoring`).
+  - Codex flagged catalog count "28" wrong (actual 43 + F10 = 44). Fixed.
+  - Codex flagged LibreNMS `ArpTable.php` mischaracterization (uses structured table keys, not raw index). Fixed.
+  - Codex flagged LibreNMS `ipAddressTable` claim wrong (IPv4 deprecated, IPv6 modern). Fixed.
+  - 4 of 5 flagged length-prefix byte edge case (F10). Added to catalog and engine macro acceptance.
+  - 5 of 5 flagged pre-commit checklist as too vague. Replaced with concrete grep commands.
+  - Codex + MiniMax flagged A2 phrasing — `ipNetToPhysicalPhysAddress` IS accessible. Fixed.
+  - MiniMax + Codex flagged D1 description ambiguity (must say "ADD a fallback", not "fix existing lookup"). Fixed in acceptance criteria + Decision 3 + commit 5.
+  - MiniMax flagged D4/D5/D6 explicit "Defer". Fixed (table now has scope column with explicit "Defer").
+  - Kimi + Qwen + GLM flagged engine macro output format (lowercase hex, colon-separated, octet validation). Added to acceptance criteria.
+  - Kimi flagged lenient-vendor regression fixture missing from commit 7. Added.
+  - Codex flagged commit 5 file list incomplete (D1 also touches `topology_cache_fdb.go`). Fixed.
+  - Codex flagged Decision 1 wording overclaim. Narrowed.
+  - Codex + GLM flagged D2/E4 metric type undefined. Specified as internal counter + rate-limited log line, no chart.
+  - Codex flagged vendor followup incomplete. Added EdgeSwitch, FortiSwitch, TiMOS, AOS6/7, VRP.
+  - Codex flagged OpenNMS direct citation missing. Added.
+  - Codex flagged sensitive-data checklist insufficient. Expanded to cover SNMPv3 creds, sysName/sysDescr/ifAlias/ifDescr, LLDP remote names/port descriptions, chassis IDs, mgmt addresses; added concrete grep one-liners.
+  - GLM flagged E4 rate-limit "per-cycle, not per-row" missing from acceptance. Added.
+  - GLM flagged profile-format.md MAX-ACCESS section should include audit recipe. Added.
+  - GLM flagged engine `mac_address` output format parity (column-side vs index-side). Both produce `aa:bb:cc:dd:ee:ff`; verification in commit 1 unit tests.
+- All 20 fixes applied. SOW v3 produced.
+- Sent v3 to the same 5 reviewers (round 3). Findings consolidated:
+  - 5 of 5 flagged **MAC output parity**: column-side `utils.go:54` uses `%02X` (uppercase); SOW spec requires `%02x` (lowercase). Existing tests at `collector_table_test.go:934-939` and `collector_device_meta_test.go:276-278` expect uppercase. Resolution (user pick A): converge to lowercase — flip column-side `utils.go:54` to `%02x`, update both test files, add explicit column-vs-index parity test. Folded into commit 1.
+  - 4 of 5 flagged **pre-commit checklist gaps** (commit messages not in `git diff --cached`). Resolution: added `git log -1 --format='%B' | rg ...` post-commit verification, range scan via `git log upstream/master..HEAD`, and a separate PR-body check.
+  - 2 of 5 (Codex, GLM) flagged **broken pre-commit IP regex** — used `(?!...)` PCRE lookahead under `grep -E` (POSIX ERE) → silently parses as a literal capture group → check passes spuriously. Resolution: switched the entire pre-commit checklist from `grep -E` to `rg -P` (ripgrep with PCRE).
+  - Codex flagged **OID false positives** in the public-IP regex (SNMP OIDs like `1.3.6.1.4.1.x` look like dotted-quad IPs). Resolution: added `(?!1\.[0-3]\.6\.1\.)` exclusion and a non-digit-or-dot left-context guard so the regex only flags genuine dotted-quad addresses, not OID fragments.
+  - Qwen flagged **A2 length-prefix path ambiguity** (does `index_transform` skip the byte, or does the formatter detect it?). Resolution: profile-level slicing via `index_transform` chosen — formatter stays pure (format-only). Explicit in commit 3 scope.
+  - 2 of 5 (MiniMax, Codex wording) flagged **F10 detection rule should explicitly require remaining-6-octets validation**. Resolution: acceptance criterion now reads "7 components AND first equals 6 AND each remaining 6 components is a valid octet (0-255)".
+  - GLM, Codex separately confirmed all 20 v2 fixes are present at the cited SOW lines.
+- All round-3 fixes applied to v4. Pre-commit checklist now uses `rg -P` (POSIX-incompatible — install ripgrep first) and has 6 sub-checks (uncommitted credentials, public IPv4 with OID exclusion, public IPv6, device strings, names from local env, commit messages, PR body).
+- SOW v4 ready for implementation.
+- Validation pass before implementation found two plan corrections:
+  - `index_transform` needs variable-tail support (`start > 0` with omitted/zero `end`) before A1/A2/A3 can be represented cleanly. User accepted option A: extend engine semantics.
+  - D1 VLAN fallback must be late at observation-output time, not an eager cache mutation, so a later real `dot1qVlanCurrentTable` mapping cannot be blocked.
+- Moved SOW from `pending/` to `current/`, changed status to `in-progress`, and started implementation.
+
+### 2026-05-02
+
+- Investigated local testing report that derived endpoints disappear briefly during some refreshes while SNMP devices and LLDP links remain visible.
+- Found the registered topology cache was used as the refresh write buffer and was cleared before replacement data was ready.
+- Changed refresh lifecycle to collect into an unregistered scratch cache and publish with `replaceWith()` only after full ingest/finalization.
+- Added a regression test that blocks refresh mid-collection and verifies the published snapshot still exposes prior FDB and ARP-derived endpoint data.
+- Addressed PR review thread `PRRT_kwDOAKPxd85_EfxH`: the IPv6 sensitive-data checklist regex contradicted its own `fc00::/7` exclusion and missed uppercase global-unicast IPv6 text. Fixed the checklist to scan `2000::/3` with `(?i)` case-insensitive matching and to exclude ULA.
+- Addressed SonarCloud duplication signal by collapsing duplicated Q-BRIDGE actual-profile tests into one table-driven test while preserving normal and length-prefixed MAC-index coverage.
+- User requested SOW close; marked status `completed` and moved the SOW to `done/`.
+- Addressed PR review thread `PRRT_kwDOAKPxd85_Eovf`: LLDP local management addresses were temporarily formatted as `ip_address`, which would drop valid non-IP LLDP management-address subtypes before topology normalization. Added index-derived `format: hex`, switched `lldpLocManAddr` to hex preservation, and added IPv4 plus non-IP-length actual-profile coverage.
+- Addressed PR review thread `PRRT_kwDOAKPxd85_Etpy`: `SOW_AUDIT_SENSITIVE_FULL_HISTORY=1` scanned fewer file types than `SOW_AUDIT_SENSITIVE_CHANGED=1`. Aligned full-history sensitive-data scanning with the changed-file code/config/documentation selector.
+
+## Validation
+
+Acceptance criteria evidence:
+
+- A1 Q-BRIDGE FDB MAC extraction is implemented in the actual shipped topology profile: `_std-topology-q-bridge-mib.yaml` derives `dot1q_fdb_mac` from the row index with `format: mac_address` and no `symbol.OID` for `dot1qTpFdbAddress`.
+- A2 IP-MIB ARP/ND index extraction is implemented in the actual shipped topology profile: `_std-topology-fdb-arp-mib.yaml` derives `arp_if_index` from `index: 1`, `arp_addr_type` from `index: 2` with top-level mapping, and `arp_ip` from `index_transform: [{start: 3}]` plus `format: ip_address`.
+- A3 LLDP local management address extraction is implemented in the actual shipped topology profile: `_std-topology-lldp-mib.yaml` anchors `lldpLocManAddrTable` on readable `lldpLocManAddrLen` and derives subtype/address from the index.
+- A3 preserves LLDP local management address bytes with `format: hex`; IP-compatible bytes are normalized by topology runtime, while non-IP subtype payloads are not dropped at collection time.
+- Engine support is implemented: `format: mac_address` works for index-derived values, accepts normal 6-octet suffixes and defensive 7-component length-prefixed suffixes, validates octets, and emits lowercase colon-separated MACs. Column-side MAC formatting is also lowercase for parity.
+- Runtime behavior is implemented: FDB rows with empty MAC increment a per-cycle drop counter; FDB rows with unmapped bridge ports increment a per-cycle diagnostic counter; VLAN attribution falls back to `fdbID` at observation-output time only after the mapping table has had a chance to populate.
+- Guardrails are implemented: `.agents/skills/project-snmp-profiles-authoring/SKILL.md`, the AGENTS.md Project Skills Index, and `src/go/plugin/go.d/collector/snmp/profile-format.md` now document the MAX-ACCESS rule and audit recipe.
+
+Tests or equivalent validation:
+
+- PASS: `cd src/go && go test -count=1 ./plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition`
+- PASS: `cd src/go && go test -count=1 ./plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector`
+- PASS: `cd src/go && go test -count=1 ./plugin/go.d/collector/snmp_topology`
+- PASS: `cd src/go && go test -count=1 ./pkg/topology/engine`
+- PASS: `cd src/go && go test -count=1 ./plugin/go.d/collector/snmp`
+- PASS: `git diff --check`
+- Added refresh-lifecycle regression coverage: `TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns` proves a registered cache is not cleared while a new collection is still running.
+- Added actual-profile collector tests loading `_std-topology-q-bridge-mib`, `_std-topology-fdb-arp-mib`, and `_std-topology-lldp-mib` through `ddsnmp.LoadProfileByName` and mocked strict-spec table walks. These verify the shipped YAML emits the index-derived Q-BRIDGE MAC, modern ARP IPv4/IPv6 fields, and LLDP local management address bytes, including a non-IP-length LLDP address payload.
+- Added focused unit tests for variable-tail `index_transform`, index-derived MAC formatting, length-prefixed MAC suffixes, invalid MAC octets, column-vs-index MAC parity, VLAN fallback, and FDB diagnostics.
+
+Real-use evidence:
+
+- Not run in this session. The originally reported affected Netgear GS110TP v3 live poll still needs access to that device and a fresh SNMP walk to compare `topology:snmp` FDB endpoint count against `dot1qTpFdbPort` row count. The SOW is completed by user request with this live-device check recorded as residual PR/local-testing risk, not as claimed validation evidence.
+
+Reviewer findings:
+
+- Pre-implementation review findings from the three multi-agent rounds are recorded in the execution log and were folded into the implementation plan before code changes.
+- No new external assistant review was run after implementation in this turn because the active repository instruction allows running external AI assistants only when the user asks for that explicitly.
+- PR review thread `PRRT_kwDOAKPxd85_EfxH` was valid and fixed: the IPv6 checklist now scans global-unicast-like `2000::/3` addresses case-insensitively and no longer includes ULA `fc00::/7`.
+- SonarCloud Quality Gate reported new-code duplication centered on `topology_profile_index_test.go`; the duplicated Q-BRIDGE test setup was made table-driven and revalidated with the focused `ddsnmpcollector` test package.
+- PR review thread `PRRT_kwDOAKPxd85_Eovf` was valid and fixed: LLDP local management address extraction now uses index `format: hex`, preserving non-IP subtype payloads for runtime normalization instead of dropping them during profile collection.
+- PR review thread `PRRT_kwDOAKPxd85_Etpy` was valid and fixed: full-history sensitive-data scanning now includes the same code/config/documentation file classes as changed-file scanning.
+
+Same-failure scan:
+
+- Command:
+  `rg -n 'name:[[:space:]]*(dot1qTpFdbAddress|ipNetToPhysicalIfIndex|ipNetToPhysicalNetAddressType|ipNetToPhysicalNetAddress|lldpLocManAddrSubtype|lldpLocManAddr)\b|\.1\.3\.6\.1\.2\.1\.(17\.7\.1\.2\.2\.1\.1|4\.35\.1\.4\.1\.(1|3|4)|8802\.1\.1\.2\.1\.3\.8\.1\.(1|2))' src/go/plugin/go.d/config/go.d/snmp.profiles`
+- Result: four expected name-only hits remain, all in the corrected profiles and all without a `symbol.OID` for the not-accessible object:
+  - `_std-topology-q-bridge-mib.yaml:23` — `dot1qTpFdbAddress`, index-derived MAC.
+  - `_std-topology-fdb-arp-mib.yaml:206` — `ipNetToPhysicalNetAddressType`, `index: 2`.
+  - `_std-topology-fdb-arp-mib.yaml:214` — `ipNetToPhysicalNetAddress`, index-derived IP.
+  - `_std-topology-lldp-mib.yaml:97` — `lldpLocManAddr`, index-derived management address.
+
+Sensitive data gate:
+
+- `.agents/sow/audit.sh` sensitive-data guardrail reports: scanned durable artifact files, including completed SOWs under `done/`; no sensitive-data patterns found.
+- Targeted diff scan for credential assignments returned zero hits.
+- Targeted device-string scan returned only synthetic test constants (`00:11:22:33:44:55`) and profile tag names, not real device identities.
+- Targeted dotted-quad scan returned only TEST-NET documentation context and MAC-index numeric suffixes in tests; no raw customer IPs, SNMP communities, bearer tokens, SNMPv3 secrets, customer names, personal data, private endpoints, or proprietary incident details were added.
+
+Artifact maintenance gate:
+
+- AGENTS.md: updated Project Skills Index to include `.agents/skills/project-snmp-profiles-authoring/`.
+- Runtime project skills: added `.agents/skills/project-snmp-profiles-authoring/SKILL.md`.
+- Specs: no `.agents/sow/specs/` update. This change is an SNMP profile authoring/runtime rule and is recorded in the project skill plus `profile-format.md`; no separate durable product contract was changed.
+- End-user/operator docs: updated `src/go/plugin/go.d/collector/snmp/profile-format.md` with a Field Accessibility section and audit recipe.
+- End-user/operator skills: none affected. `docs/netdata-ai/skills/` and `src/ai-skills/` are not involved in SNMP profile authoring.
+- SOW lifecycle: moved from `pending/` to `current/` during implementation; moved from `current/` to `done/` with status `completed` after PR creation, regression fix, review-thread fix, and explicit user request to close. Live-device validation against the originally reported affected device was not independently runnable in this workspace; this is recorded as residual runtime confirmation, not hidden as completed evidence.
+
+Specs update:
+
+- No spec update was needed. The durable behavior rule for future work is procedural/authoring guidance, covered by the new runtime project skill and profile-format documentation.
+
+Project skills update:
+
+- Added `.agents/skills/project-snmp-profiles-authoring/SKILL.md`.
+
+End-user/operator docs update:
+
+- Updated `src/go/plugin/go.d/collector/snmp/profile-format.md`.
+
+End-user/operator skills update:
+
+- No output/reference skills were affected by this SNMP collector/profile change.
+
+Lessons:
+
+- `index_transform` needed an explicit variable-tail semantic; otherwise standards-compliant INDEX-derived fields cannot be represented cleanly without brittle duplicate tags.
+- While adding actual-profile tests, existing behavior was confirmed: mappings nested under `symbol:` are not applied to same-table column tags. This SOW does not change that broader contract; the required ARP address-type mapping is top-level, and changing the generic mapping behavior would alter existing tag outputs outside this fix.
+- Topology refresh must be double-buffered. The global registry is a read surface for function calls, so registered caches must not be used as mutable write buffers during SNMP collection.
+
+Follow-up mapping:
+
+- Implemented in this SOW: A1, A2, A3, D1, D2, E4, F10, G2, H1, H4.
+- Rejected for this SOW: changing generic same-table `symbol.mapping` behavior, because it is broader than the root-cause fix and can alter existing status tag outputs.
+- Out of scope for SOW-0001 and requiring separate user-approved SOWs if prioritized later: static FDB tables, IEEE8021-Q-BRIDGE-MIB FDB, modern `ipAddressTable`, vendor proprietary FDB MIBs, D3-D6 attribution work, F2/F3/F5 vendor quirks, G3/G4 diagnostics, and H3 snmprec fixture authoring docs.
+
+## Outcome
+
+Completed. Implementation, focused validation, refresh-regression fix, PR creation, first review-thread fix, Sonar duplication cleanup, and SOW lifecycle close are done. The originally reported device was not directly available from this workspace for an independent live walk/count comparison, so that specific live confirmation remains a residual PR/local-testing risk rather than a claimed validation result.
+
+## Lessons Extracted
+
+- Future SNMP profile work must verify source MIB `MAX-ACCESS` before adding `symbol.OID` entries.
+- Actual-profile collector tests are necessary here; formatter-only tests would not prove the shipped YAML emits the topology tags.
+
+## Followup
+
+Child SOWs to open after this one closes (one per item):
+
+- **Static FDB tables** (B1, B2, C1, C2): coordinated SOW covering both BRIDGE-MIB and Q-BRIDGE-MIB static unicast/multicast tables. Different semantics from learned FDB (filtering policy, multi-egress, allowed-port lists). Needs design.
+- **IEEE8021-Q-BRIDGE-MIB FDB** (B3, C3): modern alternative, increasingly relevant. INDEX includes `ComponentId`. Profile + selector design.
+- **Modern `ipAddressTable`** (B4, C4): for L3 devices using only the new IP-MIB. Same not-accessible column pattern.
+- **Vendor proprietary FDB MIBs** (C5): one SOW per vendor as real demand surfaces — Aruba/HPE (HP-ICF-BRIDGE), Huawei (HUAWEI-L2MAM-MIB / VRP `hwDynFdbPort`), Extreme (EXTREME-FDB-MIB), Nokia/Alcatel (ALCATEL-IND1-MAC-ADDRESS-MIB / TiMOS), Juniper (JUNIPER-VLAN/L2ALD-MIB), AlaxalA (AX-FDB-MIB), Ubiquiti EdgeSwitch, Fortinet FortiSwitch, Alcatel-Lucent OmniSwitch (AOS6/AOS7). LibreNMS handlers serve as references.
+- **D3-D6 attribution work**: FDB truncation detection, LLDP-vs-FDB deduplication, LACP/LAG rollup, cross-protocol freshness reconciliation.
+- **F2/F3/F5 vendor quirks**: Zyxel malformed-index reshape, TP-Link JetStream offset, Aruba IAP truncation.
+- **G3 fail-loud, G4 per-poll stats**: engine-level diagnostic improvements beyond E4's FDB-specific coverage.
+- **H3 snmprec fixture authoring docs**: how to derive sanitized fixtures from real walks.
+- (Resolved in this PR — was previously listed as a follow-up.) Engine `mac_address` output format parity: column-side (`utils.go:54`) and index-side `format: mac_address` are converged to lowercase `aa:bb:cc:dd:ee:ff` in commit 1, with an explicit column-vs-index parity unit test.
+
+## Regression - 2026-05-02
+
+### Derived endpoints disappear during refresh windows
+
+Observed symptom:
+
+- Local PR testing showed that SNMP devices and LLDP links could remain visible while all derived FDB/ARP endpoints disappeared for a few seconds, then reappeared.
+
+Root cause:
+
+- `refreshDeviceTopology()` called `getOrCreateDeviceCache()` at the start of a refresh.
+- `getOrCreateDeviceCache()` reset the registered topology cache in place: it cleared FDB, ARP, bridge-port, LLDP/CDP, interface, VLAN, and STP maps and set `lastUpdate` to zero before the SNMP walk and topology ingest had completed.
+- The topology function reads from the global registry concurrently with refreshes. During that window, readers could observe the registered cache after it had been cleared but before the replacement data was ready.
+
+Fix:
+
+- Refresh now builds the next device snapshot in an unregistered scratch cache.
+- The previously published cache remains visible to function readers during SNMP collection and ingest.
+- After the scratch cache is finalized, `replaceWith()` publishes it into the registered cache under the registered cache lock.
+
+Validation:
+
+- Added `TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns`, which blocks a refresh mid-collection and verifies the published snapshot still contains the previous FDB and ARP-derived endpoint evidence.
+- Re-ran the focused SOW 1 validation suite after the fix; results are recorded under `## Validation`.

--- a/.agents/sow/pending/SOW-0002-20260501-unified-multi-layered-topology-schema.md
+++ b/.agents/sow/pending/SOW-0002-20260501-unified-multi-layered-topology-schema.md
@@ -1,0 +1,285 @@
+# SOW-0002 - Unified multi-layered topology schema and merge engine
+
+## Status
+
+Status: open
+
+Sub-state: scope captured, awaiting user decisions on merge semantics, identity-matching policy, conflict resolution, storage model, and scale targets before implementation planning advances.
+
+## Requirements
+
+### Purpose
+
+Make Netdata produce a single coherent topology view that unifies every source contributing topology evidence — at the same layer (e.g. multiple L2-speaking switches) and across layers (L2 ↔ L3 ↔ L7) — so users see one map of their network/infrastructure rather than four disconnected maps. This is foundational work: topology in Netdata is new, and the choice of merge semantics will shape every downstream consumer (UI, alerts, automation, AI agents).
+
+The work is fit-for-purpose for production observability on large enterprise networks where a single physical device routinely shows up under multiple identities at different layers (e.g. a server has a hostname, a Netdata machine GUID, several MAC addresses, multiple IP addresses, container IDs, Kubernetes pod/namespace identifiers, SNMP-discovered LLDP chassis ID).
+
+### User Request
+
+Verbatim user request: *"create a pending SOW for the Unified multi-layered topology schema, which should allow merging topologies of the same kind (L2 + L2), but also merge topologies of different kinds (L2 + L3, or L2 + L3 + L7)"*.
+
+This SOW captures the problem space, references existing prior planning (`TODO-UNIFIED-TOPOLOGY-SCHEMA.md`), and surfaces the decisions that must be locked before any implementation begins. It does not commit to a specific merge algorithm, identity-matching policy, or storage model — those are user decisions captured in `## Implications And Decisions` below.
+
+### Assistant Understanding
+
+Facts (verified):
+
+- The current schema already exists at `src/go/pkg/topology/types.go`. Each `Actor` has a `Layer` field, a `Source` field, and a `Match` struct with extended identity fields: `ChassisIDs`, `MacAddresses`, `IPAddresses`, `Hostnames`, `DNSNames`, `SysObjectID`, `SysName`, `NetdataNodeID`, `NetdataMachineGUID`, `CloudInstanceID`, `CloudAccountID`, `ContainerIDs`, `PodNames`, `NamespaceIDs` (`types.go:7-22`). Each `Link` carries `Layer`, `Protocol`, `LinkType`, source/destination endpoints, direction, state, timestamps, and metrics (`types.go:42-55`).
+- Topology data is produced today by four distinct sources (paths verified in repo):
+  1. **SNMP L2** — Go, in `src/go/pkg/topology/engine/` and `src/go/plugin/go.d/collector/snmp_topology/`. Produces actors of type `device` and `endpoint` with chassis IDs, MACs, IPs, sysName/sysObjectID. LLDP, CDP, FDB, ARP, STP.
+  2. **NetFlow / IPFIX / sFlow L3** — Rust, in `src/crates/netdata-netflow/`, plus Go plumbing in `src/go/`. Produces flow records with src/dst IP, ports, protocol, AS info, geolocation.
+  3. **Network-viewer L7** — C, in `src/collectors/network-viewer.plugin/`. eBPF-derived process-to-process connection observations with PIDs, container IDs, hostnames.
+  4. **Netdata streaming** — C, in `src/database/contexts/` and streaming subsystem. Produces parent ↔ child agent relationships with `NetdataNodeID`, `NetdataMachineGUID`.
+- A 6797-line prior-planning artifact exists at `TODO-UNIFIED-TOPOLOGY-SCHEMA.md` with extensive notes on the design space, source coverage, IP tracking policy, ASN/geo enrichment options, and several decision items already taken or pending. This SOW supersedes the unstructured TODO once committed; the TODO stays in place as historical reference until the SOW closes.
+- The codebase has helper code at `src/go/tools/topology-flow-merge/` and a per-poll merge implementation in `src/go/plugin/go.d/collector/snmp_topology/topology_output_merge.go` (sub-second scope: merging successive snapshots of the same SNMP topology). Cross-source / cross-layer merge does NOT exist today.
+- The `Match` struct is the right shape for cross-layer correlation in principle: each source contributes whatever identity fields it knows, and a downstream merge step can correlate any two actors that share at least one identity field. This is the "extended match fields, match on any overlapping field" principle stated in `TODO-UNIFIED-TOPOLOGY-SCHEMA.md:69-72`.
+
+Inferences:
+
+- "Same-kind merge" (L2 + L2) is the easier case: multiple SNMP-managed switches each produce their own L2 view; merging them means deduplicating actors by identity match and unioning their links. Most algorithmic complexity is in identity normalization (MAC formatting, hostname canonicalization, FQDN vs short-name).
+- "Cross-kind merge" (L2 + L3, or L2 + L3 + L7) is the harder case: actors are at different abstraction levels (a physical switch port at L2, an IP address at L3, a process at L7). Naive identity match works for some pairs (server's IP appears in both L3 flows and L2 ARP) but breaks for others (a process at L7 has no MAC; a switch at L2 has no PID). The schema must allow a parent-child or "lives-on" relationship rather than forcing every merge to a strict equality.
+- Conflict resolution policy is a real design problem: two sources legitimately disagree (e.g. an LLDP neighbor advertises a chassis ID that disagrees with what the device's own SNMP poll reports because of stale cache). Whichever policy is chosen affects every downstream consumer.
+- Performance and storage model interact: a memory-only merged view is simpler but limits historical queries and re-merge after configuration change; a persisted index enables more, at significant complexity cost.
+
+Unknowns (real, blocking design decisions):
+
+- Where does merge happen — agent-side per-source, agent-side cross-source, parent-side aggregating from multiple agents, or Cloud-side?
+- What's the identity-matching algorithm — strict any-overlap equality, canonicalized equality, probabilistic scoring with thresholds, or learned per-deployment?
+- What's the conflict-resolution policy when two sources disagree — newest wins, source-priority order, evidence-set union, or human-resolvable flag?
+- What scale targets must the design meet — actors-per-deployment, links-per-deployment, sources-per-actor, merge latency budget?
+- What's the storage and re-merge story — recompute on each request, persist a merged snapshot, persist an index of identities, or stream-update?
+- How does L7 process-level granularity surface in the merged graph without exploding actor count? (TODO-UNIFIED-TOPOLOGY-SCHEMA.md:1028 notes "L7 Detailed vs Aggregated Views" as an open question.)
+- How are stale entries aged out across sources whose freshness windows differ (LLDP cache ~120s, FDB ~5 min, NetFlow flow record duration, network-viewer eBPF connection lifetime)?
+
+### Acceptance Criteria
+
+(Final acceptance criteria are gated on user decisions in `## Implications And Decisions`. Until those decisions land, the criteria below are the high-level shape; they will be sharpened to specific verifiable outcomes once decisions are recorded.)
+
+- A single, documented unified topology schema is in production use by all four current sources (SNMP L2, NetFlow L3, network-viewer L7, Netdata streaming), with the existing `Match`/`Actor`/`Link` types as the canonical contract or a clearly evolved version.
+- A merge engine exists that takes N topology graphs (same-kind or cross-kind) and produces one merged graph following the chosen identity-match and conflict-resolution policies. Same-kind (L2 + L2) and cross-kind (L2 + L3, L2 + L3 + L7) cases each have explicit test coverage with expected merged output.
+- Identity-matching and conflict-resolution behavior is unit-tested with targeted fixtures covering: actors that should merge, actors that should NOT merge despite an incidental field overlap, sources that legitimately disagree, and stale entries aged across sources with different freshness windows.
+- A scale benchmark exists that exercises the merge engine at the chosen actors/links/sources targets and reports merge latency.
+- The merged graph can be served as a topology function output without breaking existing UI consumers; if a schema migration is needed, the migration plan is documented.
+- No customer-identifying data, community-member names, SNMP communities, bearer tokens, or PII appear in any committed artifact (SOW, code, code comments, tests, fixtures, commit messages, PR body).
+
+## Analysis
+
+Sources checked:
+
+- `src/go/pkg/topology/types.go` — current `Match`, `Actor`, `Link` schema.
+- `src/go/pkg/topology/engine/` — current SNMP L2 merge logic (within-source).
+- `src/go/plugin/go.d/collector/snmp_topology/topology_output_merge.go` — per-poll snapshot merge (within-source).
+- `src/go/tools/topology-flow-merge/` — standalone helper, not currently wired into the runtime path (see TODO-UNIFIED-TOPOLOGY-SCHEMA.md branch-cleanup audit).
+- `src/crates/netdata-netflow/` — L3 source.
+- `src/collectors/network-viewer.plugin/` — L7 source.
+- Streaming subsystem (parent/child agent topology) — under `src/database/contexts/` and adjacent.
+- `TODO-UNIFIED-TOPOLOGY-SCHEMA.md` — 6797 lines of prior thinking and partial decisions.
+- Adjacent TODOs not yet absorbed: `TODO-streaming-topology.md`, `TODO-TOPOLOGY-ENRICHMENT.md`, `TODO-TOPOLOGY-FLOWS-INCOMPLETE-INTEGRATIONS.md`, `TODO-topology-flows-sync.md`, `TODO-topology-library.md`, `TODO-topology-library-phase2-direct-port.md`, `TODO-topology-netflow-metadata.md`.
+
+Current state:
+
+- Schema shape is good. The extended-match principle is already encoded in `Match`. What's missing is the merge layer that uses these identity fields across sources.
+- Each source today produces its own topology output as a separate function. There is no merged endpoint.
+- Where merge does exist (same-source, per-poll snapshot fusion in the SNMP topology engine), it is implementation-internal — no shared abstraction, no reuse path for cross-source.
+- The codebase has hooks for layered presentation in the topology UI (the `PresentationActorType`, `PresentationLinkType` and friends in `types.go`), suggesting prior thinking about layered views, but no live data wiring.
+
+Risks (cross-cutting):
+
+- **Schema lock-in**: any merge engine that consumes the current `Match` shape effectively freezes that shape for downstream Cloud consumers. A future schema change costs two migrations (sources + merge + Cloud).
+- **Identity correlation false positives**: matching on "any overlapping field" is dangerous if a field is non-unique (e.g. private RFC1918 IP that recurs across customer subnets, hostname `localhost`). Without canonicalization and field-quality weighting, merge can fuse unrelated actors.
+- **Scale**: cross-layer merge expands actor count; L7 process granularity especially. If the design persists everything, storage grows; if it doesn't, historical queries degrade.
+- **Conflict noise**: two sources legitimately disagreeing produces user-visible warnings unless conflict resolution is automatic. Policy choice affects perceived data quality.
+- **Cross-version compatibility**: agents at different versions producing different schema versions. The merge engine must tolerate version drift gracefully.
+- **Sensitive data exposure**: merged topology surfaces hostnames, IPs, container/pod names, sysName, sysDescr — all potentially customer-identifying. The merge engine output is a public topology surface that the user sees; the produced data must not leak across tenants in any multi-tenant deployment scenario.
+
+## Pre-Implementation Gate
+
+Status: needs-user-decision
+
+Problem / root-cause model:
+
+- Topology evidence is produced by four distinct sources at three distinct layers (L2/L3/L7) plus a streaming hierarchy. Each source has its own view, none is reconciled with the others, and there is no merge engine that takes evidence from multiple sources and produces a single coherent graph. The schema (`Match`/`Actor`/`Link`) is already shaped for cross-layer correlation, but the runtime layer that performs the correlation does not exist. Implementation cannot start until merge semantics, identity-matching policy, conflict resolution, and storage model are locked.
+
+Evidence reviewed:
+
+- See "Sources checked" above. Direct evidence of the gap: no production code path correlates an SNMP-discovered L2 device with a NetFlow-observed L3 endpoint or a network-viewer-observed L7 process; the four topology functions are independent and produce four independent graphs.
+
+Affected contracts and surfaces:
+
+- `src/go/pkg/topology/types.go` — schema may evolve.
+- All four source producers (SNMP topology Go path, netflow Rust+Go, network-viewer C, streaming C) — output schema may need conformance changes.
+- Topology functions exposed to the UI — possibly a new "merged" function or the existing per-source functions extended.
+- Cloud-side consumers — the merged output schema becomes a Cloud contract.
+- Test fixtures — new cross-source fixtures required.
+- Documentation: `profile-format.md` is unrelated; topology UI documentation will need a section once merge ships.
+
+Existing patterns to reuse:
+
+- The `Match` extended-fields model in `types.go:7-22` is the right contract for identity. Reuse, possibly extend.
+- Per-source within-source merge logic in `topology_output_merge.go` and the SNMP topology engine — the same shape (deduplicate by identity, union links) likely generalizes; a candidate to lift to a shared package.
+- `src/go/tools/topology-flow-merge/` exists but is not wired in. Decide whether it's the seed of the cross-source merge engine or whether it gets retired.
+- The Netdata streaming hierarchy already establishes a parent/child actor relation — useful as a precedent for the "lives-on" cross-layer relationship.
+
+Risk and blast radius:
+
+- Schema evolution touches every consumer; needs a versioning story.
+- Cross-source merge is a new public-facing function; UI breakage risk if rolled out without a feature flag or staged rollout.
+- Identity-matching false positives are user-visible and erode trust faster than missing data; conservative defaults are safer.
+- Performance regressions on large deployments are likely if storage model isn't sized correctly.
+
+Sensitive data plan:
+
+- Same baseline as SOW-0001's plan: no community member names, no customer names, no SNMP communities, no bearer tokens, no SNMPv3 credentials, no customer-identifying IPs, hostnames, sysName/sysDescr/ifAlias/ifDescr, LLDP remote names, port descriptions, chassis IDs, management addresses, container/pod/namespace names.
+- Topology fixtures derived from real environments must be sanitized: replace customer-pointing strings with neutral labels (`switch-a`, `endpoint-1`, `service-x`).
+- Pre-commit checklist: same `rg -P` rules adopted for SOW-0001 (TBD after SOW-0001 cleanup pass), extended for the additional layer-3 / layer-7 surface (process names, container IDs, k8s pod/namespace names, ASN/geo data).
+- Cross-tenant data isolation in the merge engine itself is a runtime concern: the merge function output must respect Cloud tenant boundaries; this is an explicit acceptance check.
+
+Implementation plan:
+
+To be filled after the user decisions below are recorded. The plan will likely have these phases (illustrative, not committed):
+
+1. Lock the schema (extend `Match`/`Actor`/`Link` if needed; document version semantics).
+2. Build a shared `topology/merge` package implementing the chosen identity-match + conflict-resolution policy. Unit-test thoroughly with same-kind and cross-kind fixtures.
+3. Wire the merge engine behind a new topology function (`topology:unified` or similar). Keep per-source functions intact; the merged function is additive.
+4. Add Cloud-side consumer integration plus migration notes for existing UI surfaces.
+5. Add scale benchmark + observability counters (rows merged, conflicts detected, identity-match hit/miss rates).
+6. Iterate on real-deployment validation: at least two distinct deployments (different vendor mix, different layer mix) should produce coherent merged graphs.
+
+Validation plan:
+
+- Unit tests on the merge package with fixture matrices covering same-kind and cross-kind, identity overlaps and disagreements, age-out scenarios.
+- Integration test that wires a synthetic L2 + L3 + L7 input set and verifies the merged graph matches a hand-curated expected output.
+- Scale benchmark at the chosen targets.
+- Real-deployment validation in at least two environments.
+
+Artifact impact plan:
+
+- `AGENTS.md`: no expected change.
+- Runtime project skills: no expected change.
+- Specs under `.agents/sow/specs/`: a new spec documenting the unified-topology contract and identity-match algorithm is likely warranted on close (not at open).
+- End-user/operator docs: topology UI section(s) updated when the new function ships.
+- End-user/operator skills: none.
+- SOW lifecycle: this SOW absorbs `TODO-UNIFIED-TOPOLOGY-SCHEMA.md` once user decisions are recorded; the TODO stays in place as historical reference until this SOW closes.
+
+Open decisions: see `## Implications And Decisions` below — six decisions are outstanding.
+
+## Implications And Decisions
+
+The decisions below are unresolved and block implementation. Each is presented with options, pros/cons/implications/risks, and a recommendation that the user can accept or override.
+
+### Decision 1 — Where does the merge happen?
+
+**Options:**
+- **A. Agent-side, per-source.** Each source produces an already-merged-within-itself graph. No cross-source merge.
+- **B. Agent-side, cross-source on the same node.** The local agent merges all sources it produces. Cross-agent merge happens elsewhere (parent or Cloud).
+- **C. Parent-side aggregation.** Streaming parents merge children's contributions. Cloud receives an aggregated view.
+- **D. Cloud-side.** All raw evidence flows up, Cloud merges. Maximum flexibility, maximum bandwidth and storage cost.
+- **E. Hybrid.** Local same-source merge (A) + parent same-kind merge (C) + Cloud cross-kind merge (D).
+
+**Implications/Risks:** D leaks raw evidence to Cloud (cardinality concerns), C requires every parent to know all children's sources, A produces nothing useful for cross-source queries, B is the cleanest for single-host deployments but can't unify a fleet. E is the most flexible but has the largest blast radius.
+
+**Recommendation: B for now, plan E as the long-term shape.** Start by merging on the local agent for sources the local agent produces; defer cross-agent merge until single-agent merge is solid. This minimizes Cloud schema lock-in and lets the merge engine evolve based on real local-agent feedback.
+
+### Decision 2 — Identity-matching algorithm
+
+**Options:**
+- **A. Strict any-overlap equality on raw `Match` fields.** Two actors merge if any one of their `Match` slices intersects.
+- **B. Canonicalized equality.** MACs lowercased / colon-stripped, hostnames lowercased / FQDN-normalized, IPs canonicalized, before equality check.
+- **C. Field-quality-weighted scoring.** Each `Match` field has a discriminator weight (high for chassis ID, low for hostname `localhost`). Merge above a threshold.
+- **D. Probabilistic / learned per deployment.** A model decides; tunable per environment.
+
+**Implications/Risks:** A produces false positives on ambient identifiers (`localhost`, RFC1918 reuse). B handles 90% of false positives at low complexity. C handles ambiguity well but introduces a tuning knob users must understand. D is overkill for opening this work.
+
+**Recommendation: B as MVP; C as a follow-up SOW once real deployments produce telemetry on false-positive rates.** B is implementable, debuggable, and predictable.
+
+### Decision 3 — Conflict-resolution policy when sources disagree
+
+**Options:**
+- **A. Newest wins (timestamp-based).** Last evidence supersedes earlier.
+- **B. Source-priority order.** A defined priority — e.g. SNMP managed > LLDP-derived inferred > NetFlow-implied > network-viewer-implied. Highest priority wins.
+- **C. Evidence-set union, no resolution.** Both values are kept, exposed to the consumer as a multi-valued field.
+- **D. Human-resolvable flag.** Conflicts produce a UI warning, user picks.
+
+**Implications/Risks:** A loses provenance; B requires getting the priority right and is hard to change later; C grows attribute payloads without bound but never silently drops information; D produces UX friction.
+
+**Recommendation: C for `Match` fields, B for `Attributes`/`Derived` fields.** Identity should be inclusive (preserve all evidence so future merges can still match); attributes should be resolvable (one displayed value at a time). Provenance in either case is preserved as a per-value `source` tag.
+
+### Decision 4 — Storage model
+
+**Options:**
+- **A. Memory-only, recompute every request.** Simplest. No persistence.
+- **B. Persisted merged snapshot, recomputed on schedule.** One canonical view, served from cache.
+- **C. Persisted identity index.** Identity → actor lookup is persisted; the merged graph is computed on demand from raw source evidence using the index.
+- **D. Stream-updated.** Each source emits deltas; the merge engine maintains a live merged graph.
+
+**Implications/Risks:** A doesn't scale to large fleets; B trades freshness for cost; C is the right shape for query-heavy workloads but is a bigger build; D is a real-time pipeline with all the operational complexity that implies.
+
+**Recommendation: A for MVP within a single agent (minimal complexity, fast to ship), with the design ensuring the merge engine is deterministic so future migration to B or C is straightforward.**
+
+### Decision 5 — Scale targets
+
+**Options (illustrative):**
+- **A. Modest.** ≤ 1000 actors, ≤ 5000 links, ≤ 4 sources per actor.
+- **B. Mid.** ≤ 10000 actors, ≤ 50000 links, ≤ 8 sources per actor.
+- **C. High.** ≤ 100000 actors, ≤ 1M links, ≤ 16 sources per actor.
+
+**Implications/Risks:** Picking too small understates real enterprise networks; picking too large bloats the design. The right pick depends on whether L7 processes are first-class actors (then C) or aggregated to host level (then B).
+
+**Recommendation: B as initial target, with the design able to scale to C without re-architecture.** Validates against real enterprise mid-tier deployments and leaves room for L7-detail growth.
+
+### Decision 6 — L7 process granularity
+
+**Options:**
+- **A. L7 process is a first-class actor.** Each process gets its own actor; potentially explodes count.
+- **B. L7 aggregates to host actor with process-level attributes / sub-table.** One actor per host; processes are children or attributes.
+- **C. Two views: detailed and aggregated.** UI toggles between per-process and per-host.
+
+**Implications/Risks:** A is most informative but punishing at scale; B loses detail; C is the most flexible but requires two code paths. (TODO-UNIFIED-TOPOLOGY-SCHEMA.md:1028 notes this as an open item.)
+
+**Recommendation: B for MVP, C as a follow-up once UI and scale targets are validated.**
+
+## Plan
+
+Filled after Decisions 1-6 are recorded. Default skeleton (assuming the recommendations above):
+
+1. Lock and document the schema (extend `Match` if a decision requires it; otherwise leave as-is). Add a per-value `source` provenance tag mechanism to support Decision 3.
+2. Implement a `topology/merge` package on the agent side with the chosen identity-match (Decision 2) and conflict-resolution (Decision 3) policies. Unit tests cover same-kind and cross-kind matrices.
+3. Wire the merge engine behind a new topology function on the local agent. Per-source functions remain available unchanged.
+4. Sanitized fixture set covering at least: a 2-switch L2 same-kind merge, an L2 + L3 cross-kind merge, an L2 + L3 + L7 cross-kind merge with a host-level L7 aggregation per Decision 6.
+5. Scale benchmark at the chosen target (Decision 5).
+6. Documentation: add a "Topology unified view" section to user-facing docs; add a project-level spec under `.agents/sow/specs/` describing the unified contract and the merge algorithm.
+7. Real-deployment validation across two distinct environments before declaring done.
+
+## Execution Log
+
+### 2026-05-01
+
+- SOW opened in `pending/` per user request following completion of the third review round on SOW-0001.
+- Existing prior planning artifact (`TODO-UNIFIED-TOPOLOGY-SCHEMA.md`, 6797 lines) noted as historical context; this SOW is the canonical replacement once user decisions are locked.
+- Six open decisions recorded; no implementation work begins until they are resolved.
+
+## Validation
+
+Pending — gated on locked decisions and implementation.
+
+## Outcome
+
+Pending.
+
+## Lessons Extracted
+
+Pending until validation.
+
+## Followup
+
+Adjacent TODOs to absorb or supersede when this SOW progresses:
+
+- `TODO-streaming-topology.md` — streaming-source contributions to the merged graph.
+- `TODO-TOPOLOGY-ENRICHMENT.md` — geo / ASN / vendor enrichment as cross-cutting attributes.
+- `TODO-TOPOLOGY-FLOWS-INCOMPLETE-INTEGRATIONS.md` — flows-side integration gaps surfaced during the original split-PR cleanup.
+- `TODO-topology-flows-sync.md` — flows-side sync semantics.
+- `TODO-topology-library.md` — shared-library packaging considerations.
+- `TODO-topology-library-phase2-direct-port.md` — phase-2 port plan (likely a separate SOW once this one progresses).
+- `TODO-topology-netflow-metadata.md` — netflow metadata fields for cross-layer correlation.
+- `src/go/tools/topology-flow-merge/` — decide retirement vs absorb-as-merge-package-seed.
+- Possible child SOWs after this one progresses: identity-match scoring (Decision 2C as follow-up), persisted merge index (Decision 4C as follow-up), L7 detailed view (Decision 6C as follow-up), Cloud-side merge (Decision 1D/E as follow-up).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,11 +41,39 @@ Before non-trivial work:
 
 Assistants must not create git worktrees on their own. Create a git worktree only when the user explicitly asks for it or approves it.
 
+### Sensitive Data In Durable Artifacts
+
+SOWs, specs, documentation, project skills, agent instructions, and code comments are commit-ready artifacts. Treat them as public unless a repository-specific policy explicitly says otherwise.
+
+CRITICAL: Never write raw sensitive data to durable artifacts. This includes passwords, API keys, bearer tokens, SNMP communities, private keys, connection strings with embedded credentials, session cookies, community member names, customer names, customer identifiers, personal data, non-private IP addresses that can identify customers, private endpoints, account IDs, and proprietary incident details.
+
+Write only sanitized evidence:
+
+- use placeholders such as `[REDACTED_SECRET]`, `[CUSTOMER]`, `[ACCOUNT]`, `[PRIVATE_ENDPOINT]`;
+- use stable aliases such as `customer-a` only when the real mapping is not stored in the repository;
+- cite file paths, line numbers, command names, schema fields, or error classes instead of copying sensitive values;
+- summarize logs and traces; include only minimal redacted snippets.
+
+If sensitive data is required to continue, stop and ask the user for a secure handling path. If sensitive data is found in a durable artifact, sanitize it before any commit. If sensitive data was already committed, tell the user and do not rewrite history without explicit approval.
+
+### Open-Source Reference Evidence
+
+When SOW evidence comes from local mirrored open-source repositories under `/opt/baddisk/monitoring/repos/`, cite the upstream repository and checked commit instead of the workstation absolute path.
+
+Use:
+
+```text
+owner/repo @ commit
+relative/path/inside/repo:line
+```
+
+Resolve `owner/repo` from the repository remote, record the checked commit, and keep paths relative to the upstream repository root. Never write `/opt/baddisk/monitoring/repos/...` paths into SOW evidence.
+
 ### Pre-Implementation Gate
 
 Implementation must not begin until the active SOW contains a concrete `## Pre-Implementation Gate` section. Before moving a SOW from `pending/open` to `current/in-progress`, or before continuing implementation in an existing current SOW that lacks this section, fill the gate.
 
-The gate must record the problem/root-cause model, evidence reviewed, affected contracts and surfaces, existing patterns to reuse, risk and blast radius, implementation plan, validation plan, artifact impact plan, and open decisions. Generic placeholders such as `TBD`, `N/A`, or "to be checked later" are invalid unless the SOW explains why the item truly does not apply. If the gate exposes an unknown that cannot be resolved by investigation, stop and ask the user before implementation.
+The gate must record the problem/root-cause model, evidence reviewed, affected contracts and surfaces, existing patterns to reuse, risk and blast radius, sensitive data handling plan, implementation plan, validation plan, artifact impact plan, and open decisions. The sensitive data plan must cover SOWs, specs, documentation, project skills, agent instructions, and code comments. Generic placeholders such as `TBD`, `N/A`, or "to be checked later" are invalid unless the SOW explains why the item truly does not apply. If the gate exposes an unknown that cannot be resolved by investigation, stop and ask the user before implementation.
 
 ### When A SOW Is Required
 
@@ -156,14 +184,18 @@ Map every remaining item to implemented, rejected, or tracked.
 
 ### Regressions
 
+A regression is discovered after a SOW was considered completed or closed, later testing or use finds broken behavior, and the original SOW's claimed outcome is no longer true.
+
 When behavior that a completed SOW claimed working stops working:
 
 1. Find the original SOW in `done/`.
 2. Move it back to `current/`.
-3. Mark it `in-progress` with a regression note.
-4. Add a `## Regression` section.
-5. Fix and validate there.
+3. Mark it `in-progress` with a regression note in `## Status`.
+4. Append a new dated `## Regression - YYYY-MM-DD` section at the end of the file, after the original outcome, lessons, and follow-up content.
+5. In that appended section, record what broke, evidence, why previous validation missed it, the repair plan, validation, and updates needed to specs, skills, docs, audits, or follow-up SOWs.
+6. Fix and validate there.
 
+Never prepend regression content above the original SOW narrative. The original requirements, analysis, plan, validation, outcome, lessons, and follow-up must remain readable first.
 Do not create a new SOW for a true regression.
 
 ### Validation Gate
@@ -235,6 +267,9 @@ Output/reference skills may also exist under product documentation or generated 
 
 Runtime input skills:
 
+- `.agents/skills/project-snmp-profiles-authoring/`
+  Trigger: editing SNMP profile YAMLs, topology SNMP profiles, ddsnmp profile parsing, or SNMP profile-format documentation.
+  Purpose: require MIB `MAX-ACCESS` checks and index-derived extraction for `not-accessible` INDEX objects.
 - `.agents/skills/project-writing-collectors/`
   Trigger: authoring or modifying any Netdata data-collection plugin or module (Go go.d / ibm.d, Rust crates, internal C plugins, external plugins via PLUGINSD). Read before adding a new collector, modifying an existing one, working on NetFlow/sFlow/IPFIX, OTEL ingestion, topology, SNMP profiles, or interactive Functions.
   Status: live. Updates that close gaps or fix outdated pointers must ship in the same PR that exposed the issue.

--- a/src/go/AGENTS.md
+++ b/src/go/AGENTS.md
@@ -1,5 +1,7 @@
 # Collector Authoring Checklist
 
+CRITICAL: Never write raw sensitive data to durable artifacts. This includes passwords, API keys, bearer tokens, SNMP communities, private keys, connection strings with embedded credentials, session cookies, community member names, customer names, customer identifiers, personal data, non-private IP addresses that can identify customers, private endpoints, account IDs, and proprietary incident details.
+
 This file is a quick landing page for humans and AI assistants contributing to the IBM.d plugin. For the full documentation follow these links:
 
 - [Plugin overview & build instructions](README.md)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation.go
@@ -418,7 +418,7 @@ func validateEnrichMetricTag(metricTag *MetricTagConfig) error {
 		if transform.DropRight != 0 && transform.End != 0 {
 			errs = append(errs, fmt.Errorf("transform rule cannot define both end and drop_right. Invalid rule: %#v", transform))
 		}
-		if transform.DropRight == 0 && transform.Start > transform.End {
+		if transform.DropRight == 0 && transform.Start > transform.End && transform.End != 0 {
 			errs = append(errs, fmt.Errorf("transform rule end should be greater than start. Invalid rule: %#v", transform))
 		}
 	}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition/validation_test.go
@@ -1116,6 +1116,19 @@ func Test_validateEnrichMetricTags(t *testing.T) {
 				},
 			},
 		},
+		"raw index transform to tail": {
+			wantError: false,
+			metrics: []MetricTagConfig{
+				{
+					Tag: "fdb_mac",
+					IndexTransform: []MetricIndexTransform{
+						{
+							Start: 1,
+						},
+					},
+				},
+			},
+		},
 		"raw index transform cannot combine end and drop_right": {
 			wantError: true,
 			metrics: []MetricTagConfig{

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_device_meta_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_device_meta_test.go
@@ -274,7 +274,7 @@ func TestDeviceMetadataCollector_Collect(t *testing.T) {
 				)
 			},
 			expectedResult: map[string]ddsnmp.MetaTag{
-				"mac_address": {Value: "00:50:56:AB:CD:EF", IsExactMatch: false},
+				"mac_address": {Value: "00:50:56:ab:cd:ef", IsExactMatch: false},
 			},
 			expectedError: false,
 		},

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_test.go
@@ -935,7 +935,7 @@ func TestTableCollector_Collect(t *testing.T) {
 				{
 					Name:       "devClientCount",
 					Value:      10,
-					Tags:       map[string]string{"mac_address": "00:50:56:AB:CD:EF"},
+					Tags:       map[string]string{"mac_address": "00:50:56:ab:cd:ef"},
 					MetricType: "rate",
 					IsTable:    true,
 					Table:      "devTable",

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/index_tag_value.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/index_tag_value.go
@@ -3,6 +3,7 @@
 package ddsnmpcollector
 
 import (
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
@@ -50,9 +51,53 @@ func formatIndexTagValue(raw string, format string) (string, error) {
 		return raw, nil
 	case "ip_address":
 		return formatIndexIPAddress(raw)
+	case "mac_address":
+		return formatIndexMACAddress(raw)
+	case "hex":
+		return formatIndexHex(raw)
 	default:
 		return raw, nil
 	}
+}
+
+func formatIndexHex(raw string) (string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return "", fmt.Errorf("cannot convert transformed index '%s' to hex", raw)
+	}
+
+	parts := strings.Split(raw, ".")
+
+	bytes := make([]byte, 0, len(parts))
+	for _, part := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil || n < 0 || n > 255 {
+			return "", fmt.Errorf("cannot convert transformed index '%s' to hex", raw)
+		}
+		bytes = append(bytes, byte(n))
+	}
+
+	return hex.EncodeToString(bytes), nil
+}
+
+func formatIndexMACAddress(raw string) (string, error) {
+	parts := strings.Split(raw, ".")
+	if len(parts) == 7 && strings.TrimSpace(parts[0]) == "6" {
+		parts = parts[1:]
+	}
+	if len(parts) != 6 {
+		return "", fmt.Errorf("cannot convert transformed index '%s' to MAC address", raw)
+	}
+
+	octets := make([]string, 0, len(parts))
+	for _, part := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil || n < 0 || n > 255 {
+			return "", fmt.Errorf("cannot convert transformed index '%s' to MAC address", raw)
+		}
+		octets = append(octets, fmt.Sprintf("%02x", n))
+	}
+
+	return strings.Join(octets, ":"), nil
 }
 
 func formatIndexIPAddress(raw string) (string, error) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/index_tag_value_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/index_tag_value_test.go
@@ -5,6 +5,7 @@ package ddsnmpcollector
 import (
 	"testing"
 
+	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -32,6 +33,130 @@ func TestTableRowProcessor_ProcessIndexTag_DropRightIPAddress(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "neighbor", tagName)
 	assert.Equal(t, "192.0.2.1", tagValue)
+}
+
+func TestTableRowProcessor_ProcessIndexTag_TailMACAddress(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	tagName, tagValue, err := p.processIndexTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "fdb_mac",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			Name:   "dot1qTpFdbAddress",
+			Format: "mac_address",
+		},
+		IndexTransform: []ddprofiledefinition.MetricIndexTransform{
+			{Start: 1},
+		},
+	}, "7.0.80.86.171.205.239")
+
+	require.NoError(t, err)
+	assert.Equal(t, "fdb_mac", tagName)
+	assert.Equal(t, "00:50:56:ab:cd:ef", tagValue)
+}
+
+func TestTableRowProcessor_ProcessIndexTag_LengthPrefixedMACAddress(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	_, tagValue, err := p.processIndexTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "fdb_mac",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			Name:   "dot1qTpFdbAddress",
+			Format: "mac_address",
+		},
+		IndexTransform: []ddprofiledefinition.MetricIndexTransform{
+			{Start: 1},
+		},
+	}, "7.6.0.80.86.171.205.239")
+
+	require.NoError(t, err)
+	assert.Equal(t, "00:50:56:ab:cd:ef", tagValue)
+}
+
+func TestTableRowProcessor_ProcessIndexTag_InvalidMACAddress(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	_, _, err := p.processIndexTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "fdb_mac",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			Name:   "dot1qTpFdbAddress",
+			Format: "mac_address",
+		},
+		IndexTransform: []ddprofiledefinition.MetricIndexTransform{
+			{Start: 1},
+		},
+	}, "7.0.80.86.171.205.999")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot convert transformed index")
+}
+
+func TestFormatMACAddress_ColumnAndIndexParity(t *testing.T) {
+	columnValue, err := convPhysAddressToString(gosnmp.SnmpPDU{
+		Type:  gosnmp.OctetString,
+		Value: []byte{0x00, 0x50, 0x56, 0xab, 0xcd, 0xef},
+	})
+	require.NoError(t, err)
+
+	indexValue, err := formatIndexTagValue("0.80.86.171.205.239", "mac_address")
+	require.NoError(t, err)
+
+	assert.Equal(t, columnValue, indexValue)
+	assert.Equal(t, "00:50:56:ab:cd:ef", indexValue)
+}
+
+func TestTableRowProcessor_ProcessIndexTag_Hex(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	tagName, tagValue, err := p.processIndexTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "lldp_loc_mgmt_addr",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			Name:   "lldpLocManAddr",
+			Format: "hex",
+		},
+		IndexTransform: []ddprofiledefinition.MetricIndexTransform{
+			{Start: 2},
+		},
+	}, "1.4.10.0.0.1")
+
+	require.NoError(t, err)
+	assert.Equal(t, "lldp_loc_mgmt_addr", tagName)
+	assert.Equal(t, "0a000001", tagValue)
+}
+
+func TestTableRowProcessor_ProcessIndexTag_HexPreservesNonIPLength(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	_, tagValue, err := p.processIndexTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "lldp_loc_mgmt_addr",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			Name:   "lldpLocManAddr",
+			Format: "hex",
+		},
+		IndexTransform: []ddprofiledefinition.MetricIndexTransform{
+			{Start: 2},
+		},
+	}, "6.6.0.80.86.171.205.239")
+
+	require.NoError(t, err)
+	assert.Equal(t, "005056abcdef", tagValue)
+}
+
+func TestTableRowProcessor_ProcessIndexTag_InvalidHex(t *testing.T) {
+	p := newTableRowProcessor(logger.New())
+
+	_, _, err := p.processIndexTag(ddprofiledefinition.MetricTagConfig{
+		Tag: "lldp_loc_mgmt_addr",
+		Symbol: ddprofiledefinition.SymbolConfigCompat{
+			Name:   "lldpLocManAddr",
+			Format: "hex",
+		},
+		IndexTransform: []ddprofiledefinition.MetricIndexTransform{
+			{Start: 2},
+		},
+	}, "1.4.10.0.0.999")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot convert transformed index")
 }
 
 func TestTableRowProcessor_ProcessIndexTag_RegexMappedFamily(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
@@ -336,6 +336,8 @@ func (r *crossTableResolver) applyIndexTransform(index string, transforms []ddpr
 				return ""
 			}
 			end = uint(len(parts) - int(transform.DropRight) - 1)
+		} else if transform.Start > 0 && transform.End == 0 {
+			end = uint(len(parts) - 1)
 		}
 
 		if int(start) >= len(parts) || end < start || int(end) >= len(parts) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_row_processor.go
@@ -319,8 +319,12 @@ func (r *crossTableResolver) lookupValue(tagCfg ddprofiledefinition.MetricTagCon
 	return pdu, nil
 }
 
-// applyTransform applies index transformation rules to extract a subset of the index
-// Example: index "1.6.0.36.155.53.3.246", transform [{start: 1, end: 7}] → "6.0.36.155.53.3.246"
+// applyTransform applies index transformation rules to extract a subset of the index.
+// Indices are 0-based; end is inclusive.
+// Examples:
+//   - index "1.6.0.36.155.53.3.246", transform [{start: 1, end: 7}]    → "6.0.36.155.53.3.246"
+//   - index "7.0.80.86.171.205.239", transform [{start: 1}]            → "0.80.86.171.205.239"  (start>0, end==0 ⇒ to tail)
+//   - index "1.4.10.0.0.1.99",       transform [{start: 0, drop_right: 1}] → "1.4.10.0.0.1"
 func (r *crossTableResolver) applyIndexTransform(index string, transforms []ddprofiledefinition.MetricIndexTransform) string {
 	if len(transforms) == 0 {
 		return index

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/topology_profile_index_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/topology_profile_index_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+)
+
+func TestTopologyProfile_QBridgeFDBUsesMACFromIndex(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		indexSuffix string
+	}{
+		{name: "normal_mac_index", indexSuffix: "7.0.80.86.171.205.239"},
+		{name: "length_prefixed_mac_index", indexSuffix: "7.6.0.80.86.171.205.239"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl, mockHandler := setupMockHandler(t)
+			defer ctrl.Finish()
+
+			expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.17.7.1.2.2.1", []gosnmp.SnmpPDU{
+				createIntegerPDU("1.3.6.1.2.1.17.7.1.2.2.1.2."+tc.indexSuffix, 5),
+				createIntegerPDU("1.3.6.1.2.1.17.7.1.2.2.1.3."+tc.indexSuffix, 3),
+			})
+			expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.17.7.1.4.2.1", nil)
+
+			actual := collectTopologyProfileTables(t, mockHandler, "_std-topology-q-bridge-mib")
+
+			assertTableMetricsEqual(t, []ddsnmp.Metric{qBridgeFDBMetric()}, actual)
+		})
+	}
+}
+
+func TestTopologyProfile_IPNetToPhysicalUsesIndexFields(t *testing.T) {
+	ctrl, mockHandler := setupMockHandler(t)
+	defer ctrl.Finish()
+
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.31.1.1", nil)
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.2.2", nil)
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.10.7.2", nil)
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.20", nil)
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.17.1.4", nil)
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.17.4.3", nil)
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.35.1", []gosnmp.SnmpPDU{
+		createPDU("1.3.6.1.2.1.4.35.1.4.2.1.4.10.0.2.10", gosnmp.OctetString, []byte{0x00, 0x50, 0x56, 0xab, 0xcd, 0xef}),
+		createIntegerPDU("1.3.6.1.2.1.4.35.1.6.2.1.4.10.0.2.10", 1),
+		createPDU("1.3.6.1.2.1.4.35.1.4.3.2.16.254.128.0.0.0.0.0.0.0.0.0.0.0.0.0.1", gosnmp.OctetString, []byte{0x00, 0x50, 0x56, 0xab, 0xcd, 0xf0}),
+		createIntegerPDU("1.3.6.1.2.1.4.35.1.6.3.2.16.254.128.0.0.0.0.0.0.0.0.0.0.0.0.0.1", 2),
+	})
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.22", nil)
+
+	actual := collectTopologyProfileTables(t, mockHandler, "_std-topology-fdb-arp-mib")
+
+	assertTableMetricsEqual(t, []ddsnmp.Metric{
+		{
+			Name:       "_topology_arp_entry",
+			Value:      1,
+			Tags:       map[string]string{"arp_if_index": "2", "arp_addr_type": "ipv4", "arp_ip": "10.0.2.10", "arp_mac": "005056abcdef", "arp_state": "1"},
+			MetricType: "gauge",
+			IsTable:    true,
+			Table:      "ipNetToPhysicalTable",
+		},
+		{
+			Name:       "_topology_arp_entry",
+			Value:      2,
+			Tags:       map[string]string{"arp_if_index": "3", "arp_addr_type": "ipv6", "arp_ip": "fe80::1", "arp_mac": "005056abcdf0", "arp_state": "2"},
+			MetricType: "gauge",
+			IsTable:    true,
+			Table:      "ipNetToPhysicalTable",
+		},
+	}, actual)
+}
+
+func TestTopologyProfile_LLDPManagementAddressUsesIndexFields(t *testing.T) {
+	ctrl, mockHandler := setupMockHandler(t)
+	defer ctrl.Finish()
+
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.0.8802.1.1.2.1.3.7", nil)
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.0.8802.1.1.2.1.3.8", []gosnmp.SnmpPDU{
+		createIntegerPDU("1.0.8802.1.1.2.1.3.8.1.3.1.4.10.0.0.1", 4),
+		createIntegerPDU("1.0.8802.1.1.2.1.3.8.1.4.1.4.10.0.0.1", 2),
+		createIntegerPDU("1.0.8802.1.1.2.1.3.8.1.5.1.4.10.0.0.1", 12),
+		createStringPDU("1.0.8802.1.1.2.1.3.8.1.6.1.4.10.0.0.1", "0.0"),
+		createIntegerPDU("1.0.8802.1.1.2.1.3.8.1.3.6.6.0.80.86.171.205.239", 6),
+		createIntegerPDU("1.0.8802.1.1.2.1.3.8.1.4.6.6.0.80.86.171.205.239", 2),
+		createIntegerPDU("1.0.8802.1.1.2.1.3.8.1.5.6.6.0.80.86.171.205.239", 12),
+		createStringPDU("1.0.8802.1.1.2.1.3.8.1.6.6.6.0.80.86.171.205.239", "0.0"),
+	})
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.0.8802.1.1.2.1.4.1", nil)
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.0.8802.1.1.2.1.4.2", nil)
+
+	actual := collectTopologyProfileTables(t, mockHandler, "_std-topology-lldp-mib")
+
+	assertTableMetricsEqual(t, []ddsnmp.Metric{
+		{
+			Name:       "_topology_lldp_loc_man_addr_entry",
+			Value:      4,
+			Tags:       map[string]string{"lldp_loc_mgmt_addr_subtype": "1", "lldp_loc_mgmt_addr": "0a000001", "lldp_loc_mgmt_addr_if_subtype": "2", "lldp_loc_mgmt_addr_if_id": "12", "lldp_loc_mgmt_addr_oid": "0.0"},
+			MetricType: "gauge",
+			IsTable:    true,
+			Table:      "lldpLocManAddrTable",
+		},
+		{
+			Name:       "_topology_lldp_loc_man_addr_entry",
+			Value:      6,
+			Tags:       map[string]string{"lldp_loc_mgmt_addr_subtype": "6", "lldp_loc_mgmt_addr": "005056abcdef", "lldp_loc_mgmt_addr_if_subtype": "2", "lldp_loc_mgmt_addr_if_id": "12", "lldp_loc_mgmt_addr_oid": "0.0"},
+			MetricType: "gauge",
+			IsTable:    true,
+			Table:      "lldpLocManAddrTable",
+		},
+	}, actual)
+}
+
+func collectTopologyProfileTables(t *testing.T, mockHandler gosnmp.Handler, profileName string) []ddsnmp.Metric {
+	t.Helper()
+
+	profile, err := ddsnmp.LoadProfileByName(profileName)
+	require.NoError(t, err)
+
+	missingOIDs := make(map[string]bool)
+	tcache := newTableCache(0, 0)
+	collector := newTableCollector(mockHandler, missingOIDs, tcache, logger.New(), false)
+
+	var stats ddsnmp.CollectionStats
+	actual, err := collector.collect(profile, &stats)
+	require.NoError(t, err)
+
+	return actual
+}
+
+func qBridgeFDBMetric() ddsnmp.Metric {
+	return ddsnmp.Metric{
+		Name:       "_topology_qbridge_fdb_entry",
+		Value:      5,
+		Tags:       map[string]string{"dot1q_fdb_id": "7", "dot1q_fdb_mac": "00:50:56:ab:cd:ef", "dot1q_fdb_bridge_port": "5", "dot1q_fdb_status": "3"},
+		MetricType: "gauge",
+		IsTable:    true,
+		Table:      "dot1qTpFdbTable",
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
@@ -51,7 +51,7 @@ func convPhysAddressToString(pdu gosnmp.SnmpPDU) (string, error) {
 
 	parts := make([]string, 0, len(address))
 	for _, v := range address {
-		parts = append(parts, fmt.Sprintf("%02X", v))
+		parts = append(parts, fmt.Sprintf("%02x", v))
 	}
 	return strings.Join(parts, ":"), nil
 }

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -1246,6 +1246,20 @@ Rules:
 - Keep SNMP index slicing in the profile YAML; keep format conversion in
   `symbol.format`.
 
+The two index extraction mechanisms use different counting bases:
+
+- `index: N` is **1-based**: `index: 1` selects the first index component,
+  `index: 2` the second, and so on. Use this to pick a single component.
+- `index_transform: [{start: M, end: K}]` is **0-based** over the row index
+  parts. `start: 0` is the first component. `end` is inclusive. Setting
+  `end: 0` together with `start: N > 0` slices to the tail (`start: N` to the
+  last index part) - useful for length-prefixed `OCTET STRING` index columns
+  whose width depends on a sibling index component (e.g.
+  `LLDP-MIB::lldpLocManAddr`, `IP-MIB::ipNetToPhysicalNetAddress`).
+
+So `index: 1` and `index_transform: [{start: 0, end: 0}]` both extract the
+first index component.
+
 Examples:
 
 - `Q-BRIDGE-MIB::dot1qTpFdbAddress` is `not-accessible` and is part of the

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -1230,6 +1230,48 @@ If the current row index is `1.192.0.2.1.1.128`, the collector:
 - formats it as an IP address
 - emits `neighbor="192.0.2.1"`
 
+### Field Accessibility
+
+SNMP profile symbols must only read objects that the source MIB exposes as
+readable columns. Before adding or changing a `symbol.OID`, check the source
+MIB object's `MAX-ACCESS` (SMIv2) or `ACCESS` (SMIv1).
+
+Rules:
+
+- `read-only`, `read-write`, and `read-create` objects can be read as
+  `symbol.OID` values.
+- `not-accessible` objects must not be read as `symbol.OID` values.
+- A `not-accessible` object that is part of a table `INDEX` can be derived from
+  the row OID index using `index` or `index_transform`.
+- Keep SNMP index slicing in the profile YAML; keep format conversion in
+  `symbol.format`.
+
+Examples:
+
+- `Q-BRIDGE-MIB::dot1qTpFdbAddress` is `not-accessible` and is part of the
+  `dot1qTpFdbEntry` index. Derive it from the row index and use
+  `format: mac_address`.
+- `IP-MIB::ipNetToPhysicalIfIndex`,
+  `IP-MIB::ipNetToPhysicalNetAddressType`, and
+  `IP-MIB::ipNetToPhysicalNetAddress` are `not-accessible` index components.
+  Derive them from the row index. The physical MAC value,
+  `ipNetToPhysicalPhysAddress`, is readable and can stay as a column symbol.
+- `LLDP-MIB::lldpLocManAddrSubtype` and `LLDP-MIB::lldpLocManAddr` are
+  `not-accessible` index components. Anchor the row on a readable column such as
+  `lldpLocManAddrLen`, then derive subtype and address from the row index. Use
+  `format: hex` for the address bytes so non-IP management-address subtypes are
+  preserved; topology normalization converts IP-compatible bytes later.
+
+Audit recipe:
+
+```bash
+rg -n -C 4 'OBJECT-TYPE|MAX-ACCESS[[:space:]]+not-accessible|ACCESS[[:space:]]+not-accessible' path/to/MIB
+rg -n 'name:[[:space:]]*(dot1qTpFdbAddress|ipNetToPhysicalIfIndex|ipNetToPhysicalNetAddressType|ipNetToPhysicalNetAddress|lldpLocManAddrSubtype|lldpLocManAddr)\b' src/go/plugin/go.d/config/go.d/snmp.profiles
+```
+
+Any profile hit for a `not-accessible` object is valid only when the tag is
+index-derived and does not declare a `symbol.OID` for that object.
+
 ## Tag Transformation
 
 Tag transformations let you **modify or extract parts of SNMP values** to produce clear, human-readable tags.

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -171,13 +171,12 @@ func (c *Collector) refreshDeviceTopology(key string, dev ddsnmp.DeviceConnectio
 	// previous complete snapshot until this collection is fully ingested.
 	next := c.newDeviceCollectionCache(dev)
 	c.topologyCache = next
+	defer func() { c.topologyCache = nil }()
 
 	c.updateTopologyProfileTags(pms)
 	c.ingestTopologyProfileMetrics(pms)
 	c.collectTopologyVTPVLANContexts(dev)
 	c.finalizeTopologyCache()
-
-	c.topologyCache = nil
 
 	cache := c.getOrCreateDeviceCache(key)
 	cache.mu.Lock()

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -134,8 +134,6 @@ func (c *Collector) Cleanup(context.Context) {
 
 // refreshDeviceTopology collects topology data for a single device into its own cache.
 func (c *Collector) refreshDeviceTopology(key string, dev ddsnmp.DeviceConnectionInfo) {
-	cache := c.getOrCreateDeviceCache(key, dev)
-
 	snmpClient, err := newSNMPClientFromDeviceInfo(c.newSnmpClient, dev)
 	if err != nil {
 		c.Warningf("device '%s': failed to create SNMP client: %v", dev.Hostname, err)
@@ -169,8 +167,10 @@ func (c *Collector) refreshDeviceTopology(key string, dev ddsnmp.DeviceConnectio
 		return
 	}
 
-	// Point c.topologyCache at this device's cache so the ingestion methods work.
-	c.topologyCache = cache
+	// Build the next snapshot off-registry. Function readers keep seeing the
+	// previous complete snapshot until this collection is fully ingested.
+	next := c.newDeviceCollectionCache(dev)
+	c.topologyCache = next
 
 	c.updateTopologyProfileTags(pms)
 	c.ingestTopologyProfileMetrics(pms)
@@ -178,41 +178,29 @@ func (c *Collector) refreshDeviceTopology(key string, dev ddsnmp.DeviceConnectio
 	c.finalizeTopologyCache()
 
 	c.topologyCache = nil
+
+	cache := c.getOrCreateDeviceCache(key)
+	cache.mu.Lock()
+	cache.replaceWith(next)
+	cache.mu.Unlock()
 }
 
-func (c *Collector) getOrCreateDeviceCache(key string, dev ddsnmp.DeviceConnectionInfo) *topologyCache {
+func (c *Collector) getOrCreateDeviceCache(key string) *topologyCache {
 	cache, ok := c.deviceCaches[key]
 	if !ok {
 		cache = newTopologyCache()
 		c.deviceCaches[key] = cache
 		snmpTopologyRegistry.register(cache)
 	}
+	return cache
+}
 
-	// Reset cache for fresh collection cycle.
-	cache.mu.Lock()
+func (c *Collector) newDeviceCollectionCache(dev ddsnmp.DeviceConnectionInfo) *topologyCache {
+	cache := newTopologyCache()
 	cache.updateTime = time.Now()
-	cache.lastUpdate = time.Time{}
 	cache.staleAfter = c.refreshEvery() + time.Duration(c.UpdateEvery*2)*time.Second
 	cache.agentID = dev.Hostname
 	cache.localDevice = buildLocalTopologyDevice(dev)
-	cache.lldpLocPorts = make(map[string]*lldpLocPort)
-	cache.lldpRemotes = make(map[string]*lldpRemote)
-	cache.cdpRemotes = make(map[string]*cdpRemote)
-	cache.ifNamesByIndex = make(map[string]string)
-	cache.ifStatusByIndex = make(map[string]ifStatus)
-	cache.ifIndexByIP = make(map[string]string)
-	cache.ifNetmaskByIP = make(map[string]string)
-	cache.bridgePortToIf = make(map[string]string)
-	cache.fdbEntries = make(map[string]*fdbEntry)
-	cache.fdbIDToVlanID = make(map[string]string)
-	cache.vlanIDToName = make(map[string]string)
-	cache.vtpVersion = ""
-	cache.stpBaseBridgeAddress = ""
-	cache.stpDesignatedRoot = ""
-	cache.stpPorts = make(map[string]*stpPortEntry)
-	cache.arpEntries = make(map[string]*arpEntry)
-	cache.mu.Unlock()
-
 	return cache
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/gosnmp/gosnmp"
+	snmpmock "github.com/gosnmp/gosnmp/mocks"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+)
+
+func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T) {
+	previousRegistry := snmpTopologyRegistry
+	registry := newTopologyRegistry()
+	snmpTopologyRegistry = registry
+	t.Cleanup(func() { snmpTopologyRegistry = previousRegistry })
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dev := ddsnmp.DeviceConnectionInfo{
+		Hostname:    "10.0.0.10",
+		Port:        161,
+		SysObjectID: "1.3.6.1.4.1.9.1.1",
+	}
+	mockHandler := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClient(mockHandler, dev)
+
+	key := "10.0.0.10:161"
+	published := newTopologyCache()
+	seedPublishedEndpointSnapshot(published)
+	registry.register(published)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+
+	coll := New()
+	coll.deviceCaches[key] = published
+	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
+	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+		return &blockingTopologyCollector{
+			started: started,
+			release: release,
+			result:  replacementEndpointProfileMetrics(),
+		}
+	}
+
+	go func() {
+		defer close(done)
+		coll.refreshDeviceTopology(key, dev)
+	}()
+
+	<-started
+
+	snapshot, ok := published.snapshotEngineObservations()
+	require.True(t, ok)
+	require.Len(t, snapshot.l2Observations, 1)
+	require.Len(t, snapshot.l2Observations[0].FDBEntries, 1)
+	require.Len(t, snapshot.l2Observations[0].ARPNDEntries, 1)
+
+	close(release)
+	<-done
+}
+
+type blockingTopologyCollector struct {
+	started chan<- struct{}
+	release <-chan struct{}
+	result  []*ddsnmp.ProfileMetrics
+}
+
+func (c *blockingTopologyCollector) Collect() ([]*ddsnmp.ProfileMetrics, error) {
+	close(c.started)
+	<-c.release
+	return c.result, nil
+}
+
+func expectTopologyRefreshSNMPClient(mockHandler *snmpmock.MockHandler, dev ddsnmp.DeviceConnectionInfo) {
+	mockHandler.EXPECT().SetTarget(dev.Hostname)
+	mockHandler.EXPECT().SetPort(uint16(dev.Port))
+	mockHandler.EXPECT().SetRetries(dev.Retries)
+	mockHandler.EXPECT().SetTimeout(time.Duration(dev.Timeout) * time.Second)
+	mockHandler.EXPECT().SetMaxOids(dev.MaxOIDs)
+	mockHandler.EXPECT().SetMaxRepetitions(uint32(dev.MaxRepetitions))
+	mockHandler.EXPECT().SetCommunity(dev.Community)
+	mockHandler.EXPECT().SetVersion(gosnmp.Version2c)
+	mockHandler.EXPECT().Connect().Return(nil)
+	mockHandler.EXPECT().Close().Return(nil)
+}
+
+func seedPublishedEndpointSnapshot(cache *topologyCache) {
+	now := time.Now()
+	cache.updateTime = now
+	cache.lastUpdate = now
+	cache.staleAfter = time.Hour
+	cache.agentID = "agent-1"
+	cache.localDevice = topologyDevice{
+		ManagementIP:  "10.0.0.10",
+		ChassisID:     "00:11:22:33:44:55",
+		ChassisIDType: "macAddress",
+		SysName:       "switch-a",
+	}
+	cache.bridgePortToIf["5"] = "5"
+	cache.fdbEntries["00:50:56:ab:cd:ef|5||"] = &fdbEntry{
+		mac:        "00:50:56:ab:cd:ef",
+		bridgePort: "5",
+		status:     "learned",
+	}
+	cache.arpEntries["5|10.0.0.20|00:50:56:ab:cd:ef"] = &arpEntry{
+		ifIndex:  "5",
+		ip:       "10.0.0.20",
+		mac:      "00:50:56:ab:cd:ef",
+		addrType: "ipv4",
+	}
+}
+
+func replacementEndpointProfileMetrics() []*ddsnmp.ProfileMetrics {
+	return []*ddsnmp.ProfileMetrics{{
+		HiddenMetrics: []ddsnmp.Metric{
+			{
+				Name: metricBridgePortMapEntry,
+				Tags: map[string]string{
+					tagBridgeBasePort: "5",
+					tagBridgeIfIndex:  "5",
+				},
+			},
+			{
+				Name: metricDot1qFdbEntry,
+				Tags: map[string]string{
+					tagDot1qFdbID:   "7",
+					tagDot1qFdbMac:  "00:50:56:ab:cd:ef",
+					tagDot1qFdbPort: "5",
+				},
+			},
+			{
+				Name: metricArpEntry,
+				Tags: map[string]string{
+					tagArpIfIndex:  "5",
+					tagArpIP:       "10.0.0.20",
+					tagArpMac:      "005056abcdef",
+					tagArpAddrType: "ipv4",
+				},
+			},
+		},
+	}}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache.go
@@ -28,6 +28,8 @@ type topologyCache struct {
 	fdbEntries           map[string]*fdbEntry
 	fdbIDToVlanID        map[string]string
 	vlanIDToName         map[string]string
+	fdbRowsDroppedNoMAC  int
+	fdbRowsUnmappedPort  int
 	vtpVersion           string
 	stpBaseBridgeAddress string
 	stpDesignatedRoot    string

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_fdb.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_fdb.go
@@ -9,6 +9,7 @@ func (c *topologyCache) updateFdbEntry(tags map[string]string) {
 
 	mac := normalizeMAC(firstNonEmpty(tags[tagFdbMac], tags[tagDot1qFdbMac]))
 	if mac == "" {
+		c.fdbRowsDroppedNoMAC++
 		return
 	}
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
@@ -2,7 +2,10 @@
 
 package snmptopology
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 func newTopologyCache() *topologyCache {
 	return &topologyCache{
@@ -43,6 +46,8 @@ func (c *topologyCache) replaceWith(src *topologyCache) {
 	c.fdbEntries = src.fdbEntries
 	c.fdbIDToVlanID = src.fdbIDToVlanID
 	c.vlanIDToName = src.vlanIDToName
+	c.fdbRowsDroppedNoMAC = src.fdbRowsDroppedNoMAC
+	c.fdbRowsUnmappedPort = src.fdbRowsUnmappedPort
 	c.vtpVersion = src.vtpVersion
 	c.stpBaseBridgeAddress = src.stpBaseBridgeAddress
 	c.stpDesignatedRoot = src.stpDesignatedRoot
@@ -61,12 +66,39 @@ func (c *topologyCache) hasFreshSnapshotAt(now time.Time) bool {
 }
 
 func (c *Collector) finalizeTopologyCache() {
-	if c.topologyCache == nil {
+	cache := c.topologyCache
+	if cache == nil {
 		return
 	}
 
-	c.topologyCache.mu.Lock()
-	defer c.topologyCache.mu.Unlock()
+	cache.mu.Lock()
+	cache.updateFDBDiagnostics()
+	droppedNoMAC := cache.fdbRowsDroppedNoMAC
+	unmappedPort := cache.fdbRowsUnmappedPort
+	agentID := cache.agentID
+	cache.lastUpdate = cache.updateTime
+	cache.mu.Unlock()
 
-	c.topologyCache.lastUpdate = c.topologyCache.updateTime
+	if droppedNoMAC > 0 {
+		c.Warningf("device '%s': dropped %d topology FDB row(s) with empty MAC", agentID, droppedNoMAC)
+	}
+	if unmappedPort > 0 {
+		c.Warningf("device '%s': observed %d topology FDB row(s) with bridge ports missing ifIndex mapping", agentID, unmappedPort)
+	}
+}
+
+func (c *topologyCache) updateFDBDiagnostics() {
+	c.fdbRowsUnmappedPort = 0
+	for _, entry := range c.fdbEntries {
+		if entry == nil || strings.TrimSpace(entry.mac) == "" {
+			continue
+		}
+		bridgePort := strings.TrimSpace(entry.bridgePort)
+		if bridgePort == "" || bridgePort == "0" {
+			continue
+		}
+		if parseIndex(c.bridgePortToIf[bridgePort]) == 0 {
+			c.fdbRowsUnmappedPort++
+		}
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
@@ -623,6 +623,60 @@ func TestTopologyCache_Dot1qVLANEnrichment(t *testing.T) {
 	require.Equal(t, "70:49:a2:65:72:cd", obs.FDBEntries[0].MAC)
 }
 
+func TestTopologyCache_Dot1qVLANFallbackUsesFDBIDWhenMapMissing(t *testing.T) {
+	cache := newTopologyCache()
+	cache.updateTime = time.Now()
+	cache.lastUpdate = cache.updateTime
+	cache.agentID = "agent1"
+	cache.localDevice = topologyDevice{
+		ChassisID:     "00:11:22:33:44:55",
+		ChassisIDType: "macAddress",
+		ManagementIP:  "10.0.0.1",
+	}
+
+	cache.updateBridgePortMap(map[string]string{
+		tagBridgeBasePort: "7",
+		tagBridgeIfIndex:  "3",
+	})
+	cache.updateFdbEntry(map[string]string{
+		tagDot1qFdbID:     "100",
+		tagDot1qFdbMac:    "7049a26572cd",
+		tagDot1qFdbPort:   "7",
+		tagDot1qFdbStatus: "learned",
+	})
+
+	obs := cache.buildEngineObservation(cache.localDevice)
+	require.Len(t, obs.FDBEntries, 1)
+	require.Equal(t, "100", obs.FDBEntries[0].VLANID)
+}
+
+func TestTopologyCache_FDBDiagnostics(t *testing.T) {
+	cache := newTopologyCache()
+
+	cache.updateFdbEntry(map[string]string{
+		tagDot1qFdbID:     "100",
+		tagDot1qFdbPort:   "7",
+		tagDot1qFdbStatus: "learned",
+	})
+	require.Equal(t, 1, cache.fdbRowsDroppedNoMAC)
+
+	cache.updateFdbEntry(map[string]string{
+		tagDot1qFdbID:     "100",
+		tagDot1qFdbMac:    "7049a26572cd",
+		tagDot1qFdbPort:   "7",
+		tagDot1qFdbStatus: "learned",
+	})
+	cache.updateFDBDiagnostics()
+	require.Equal(t, 1, cache.fdbRowsUnmappedPort)
+
+	cache.updateBridgePortMap(map[string]string{
+		tagBridgeBasePort: "7",
+		tagBridgeIfIndex:  "3",
+	})
+	cache.updateFDBDiagnostics()
+	require.Equal(t, 0, cache.fdbRowsUnmappedPort)
+}
+
 func TestTopologyCache_VTPVLANNameEnrichment(t *testing.T) {
 	cache := newTopologyCache()
 	cache.updateTime = time.Now()

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local_forwarding.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local_forwarding.go
@@ -29,7 +29,11 @@ func (c *topologyCache) appendObservedFDBEntries(observation *topologyengine.L2O
 		ifIndex := parseIndex(c.bridgePortToIf[strings.TrimSpace(entry.bridgePort)])
 		vlanID := strings.TrimSpace(entry.vlanID)
 		if vlanID == "" && strings.TrimSpace(entry.fdbID) != "" {
-			vlanID = strings.TrimSpace(c.fdbIDToVlanID[strings.TrimSpace(entry.fdbID)])
+			fdbID := strings.TrimSpace(entry.fdbID)
+			vlanID = strings.TrimSpace(c.fdbIDToVlanID[fdbID])
+			if vlanID == "" {
+				vlanID = fdbID
+			}
 		}
 		observation.FDBEntries = append(observation.FDBEntries, topologyengine.FDBObservation{
 			MAC:        strings.TrimSpace(entry.mac),

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-fdb-arp-mib.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-fdb-arp-mib.yaml
@@ -191,9 +191,7 @@ metrics:
         name: _topology_arp_entry
     metric_tags:
       - tag: arp_if_index
-        symbol:
-          OID: 1.3.6.1.2.1.4.35.1.1
-          name: ipNetToPhysicalIfIndex
+        index: 1
       - tag: arp_if_name
         table: ifXTable
         symbol:
@@ -203,18 +201,20 @@ metrics:
           - start: 0
             end: 0
       - tag: arp_addr_type
+        index: 2
         symbol:
-          OID: 1.3.6.1.2.1.4.35.1.2
           name: ipNetToPhysicalNetAddressType
-          mapping:
-            0: unknown
-            1: ipv4
-            2: ipv6
-            16: dns
+        mapping:
+          0: unknown
+          1: ipv4
+          2: ipv6
+          16: dns
       - tag: arp_ip
         symbol:
-          OID: 1.3.6.1.2.1.4.35.1.3
           name: ipNetToPhysicalNetAddress
+          format: ip_address
+        index_transform:
+          - start: 3
       - tag: arp_mac
         symbol:
           OID: 1.3.6.1.2.1.4.35.1.4

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-lldp-mib.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-lldp-mib.yaml
@@ -179,6 +179,15 @@ metrics:
           name: lldpRemSysCapEnabled
           format: hex
 
+  # TODO: lldpRemManAddrTable still reads INDEX columns directly:
+  #   - .1.1 lldpRemManAddrSubtype (not-accessible per LLDP-MIB)
+  #   - .1.2 lldpRemManAddr        (not-accessible per LLDP-MIB)
+  # Standards-conformant LLDP agents will not return these columns. The two
+  # blocks below are kept as vendor-specific fallbacks (MikroTik / XS1930)
+  # that historically expose them anyway. Follow-up: rebuild both blocks the
+  # same way as lldpLocManAddrTable - anchor on a readable column (.1.3
+  # lldpRemManAddrIfSubtype) and derive subtype/address from the row index
+  # via index_transform with format: hex.
   - MIB: LLDP-MIB
     table:
       OID: 1.0.8802.1.1.2.1.4.2

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-lldp-mib.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-lldp-mib.yaml
@@ -87,18 +87,17 @@ metrics:
       OID: 1.0.8802.1.1.2.1.3.8
       name: lldpLocManAddrTable
     symbols:
-      - OID: 1.0.8802.1.1.2.1.3.8.1.1
+      - OID: 1.0.8802.1.1.2.1.3.8.1.3
         name: _topology_lldp_loc_man_addr_entry
     metric_tags:
       - tag: lldp_loc_mgmt_addr_subtype
-        symbol:
-          OID: 1.0.8802.1.1.2.1.3.8.1.1
-          name: lldpLocManAddrSubtype
+        index: 1
       - tag: lldp_loc_mgmt_addr
         symbol:
-          OID: 1.0.8802.1.1.2.1.3.8.1.2
           name: lldpLocManAddr
           format: hex
+        index_transform:
+          - start: 2
       - tag: lldp_loc_mgmt_addr_if_subtype
         symbol:
           OID: 1.0.8802.1.1.2.1.3.8.1.4

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-q-bridge-mib.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-q-bridge-mib.yaml
@@ -20,9 +20,10 @@ metrics:
         index: 1
       - tag: dot1q_fdb_mac
         symbol:
-          OID: 1.3.6.1.2.1.17.7.1.2.2.1.1
           name: dot1qTpFdbAddress
-          format: hex
+          format: mac_address
+        index_transform:
+          - start: 1
       - tag: dot1q_fdb_bridge_port
         symbol:
           OID: 1.3.6.1.2.1.17.7.1.2.2.1.2

--- a/src/go/plugin/ibm.d/AGENTS.md
+++ b/src/go/plugin/ibm.d/AGENTS.md
@@ -1,5 +1,7 @@
 # IBM.d Plugin Developer Guide
 
+CRITICAL: Never write raw sensitive data to durable artifacts. This includes passwords, API keys, bearer tokens, SNMP communities, private keys, connection strings with embedded credentials, session cookies, community member names, customer names, customer identifiers, personal data, non-private IP addresses that can identify customers, private endpoints, account IDs, and proprietary incident details.
+
 This guide is for developers contributing to the IBM.d plugin. For end-user documentation, see [README.md](./README.md).
 
 ## Architecture Overview


### PR DESCRIPTION
## Summary
- Derive Q-BRIDGE FDB MACs, IP-MIB ARP/ND index fields, and LLDP local management address fields from row indexes instead of non-accessible table columns.
- Add index-derived MAC formatting and variable-tail index transforms for SNMP profile tags.
- Publish SNMP topology cache snapshots atomically so refreshes do not temporarily clear derived endpoints.
- Add SNMP profile authoring guardrails, SOW records, and regression coverage for index extraction and refresh behavior.

## Root Cause
Standards-compliant SNMP agents do not return `not-accessible` INDEX objects as readable table columns. The previous topology profiles depended on those values as symbols, so compliant devices could produce empty FDB, ARP/ND, or LLDP-derived endpoint data.

A second refresh issue cleared the registered topology cache before the next collection had finished. Function readers could observe the empty cache until the replacement snapshot was rebuilt.

## Validation
- `git diff --cached --check`
- `.agents/sow/audit.sh`
- `go test -count=1 ./plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition ./plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector ./plugin/go.d/collector/snmp_topology ./pkg/topology/engine ./plugin/go.d/collector/snmp`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing SNMP topology endpoints by deriving FDB, ARP/ND, and LLDP fields from table indexes, and makes refresh atomic and safer. Adds MAC/hex index formatting, lowercase MACs, stricter LLDP hex parsing, open‑ended index transforms, and authoring guardrails.

- **Bug Fixes**
  - Index‑derive Q‑BRIDGE FDB MACs, IP‑MIB ARP keys, and LLDP local management address; preserve LLDP address index slices; handle length‑prefixed MACs; tighten hex validation.
  - Keep the previous topology snapshot published while building the next, and defer‑reset the in‑flight cache so a panic cannot leak state.
  - Normalize MAC tags to lowercase; fall back to FDBID when VLAN map is missing.

- **New Features**
  - Added `mac_address` and `hex` index formatters and tail‑only `index_transform` (`start: N`); documented `index` (1‑based) vs `index_transform` (0‑based) and the to‑tail form; updated default profiles (`_std-topology-q-bridge-mib.yaml`, `_std-topology-fdb-arp-mib.yaml`, `_std-topology-lldp-mib.yaml`).
  - Validation for open‑ended index transforms; docs/guardrails on MIB `MAX-ACCESS`; new SNMP profile authoring runtime skill; sensitive‑data guidance in `AGENTS.md`; FDB diagnostics counters; new tests for index extraction, VLAN fallback, and refresh behavior.

<sup>Written for commit 87645a75e57b0a0b6cf0abad6c55b484ae2316dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

