### PR TITLE
Adjust vnodes dyncfg availability

### DIFF
--- a/src/daemon/dyncfg/dyncfg.c
+++ b/src/daemon/dyncfg/dyncfg.c
@@ -467,7 +467,7 @@ void dyncfg_add_streaming(BUFFER *wb) {
 }
 
 bool dyncfg_available_for_rrdhost(RRDHOST *host) {
-    if(host == localhost || rrdhost_option_check(host, RRDHOST_OPTION_VIRTUAL_HOST))
+    if(host == localhost)
         return true;
 
     return rrd_function_available(host, PLUGINSD_FUNCTION_CONFIG);


### PR DESCRIPTION
##### Summary
- Do not enable dyncfg for vnodes by default



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable dynamic config for vnode hosts by default to avoid unintended config on virtual hosts. Now dyncfg is available only on the local host; other hosts must expose `PLUGINSD_FUNCTION_CONFIG` to enable it.

<sup>Written for commit 895ad16ae597a0f63bb797ec2a5413183ce6018d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

