### PR TITLE
Fix vnode take over crash

### DIFF
--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -1135,7 +1135,7 @@ bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {
     rrdhost_receiver_lock(host);
 
     if (!host->receiver) {
-        object_state_activate(&host->state_id);
+        object_state_activate_if_not_activated(&host->state_id);
 
         rrdhost_flag_clear(host, RRDHOST_FLAG_ORPHAN);
         rrdhost_set_health_evloop_iteration(host);


### PR DESCRIPTION
##### Summary
rrdhost_set_receiver() called object_state_activate() on host->state_id, which fatals if the state is already activated. 

A vnode created via  HOST_DEFINE_END activates state_id; when the vnode goes stale, pluginsd_host clears RRDHOST_OPTION_VIRTUAL_HOST but leaves state_id activated. 

A subsequent streaming connection for the same machine_guid bypasses the rrdhost_is_virtual() reject, reaches set_receiver, and  crashes on the second activate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crash when a stale vnode reconnects for the same machine_guid by making receiver activation idempotent. rrdhost_set_receiver() now calls object_state_activate_if_not_activated(&host->state_id) to avoid fatal errors when state_id is already active.

<sup>Written for commit 3a20af273cc193c5323c9e82b69b4bbc84cc84bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

