### PR TITLE
Do not coerce ints to doubles during flattening.

### DIFF
--- a/src/crates/netdata-otel/flatten_otel/src/lib.rs
+++ b/src/crates/netdata-otel/flatten_otel/src/lib.rs
@@ -43,9 +43,7 @@ fn json_from_any_value(any_value: &AnyValue) -> JsonValue {
     match &any_value.value {
         Some(Value::StringValue(s)) => JsonValue::String(s.clone()),
         Some(Value::BoolValue(b)) => JsonValue::Bool(*b),
-        Some(Value::IntValue(i)) => JsonValue::Number(
-            serde_json::Number::from_f64(*i as f64).unwrap_or_else(|| serde_json::Number::from(0)),
-        ),
+        Some(Value::IntValue(i)) => JsonValue::Number(serde_json::Number::from(*i)),
         Some(Value::DoubleValue(d)) => JsonValue::Number(
             serde_json::Number::from_f64(*d).unwrap_or_else(|| serde_json::Number::from(0)),
         ),


### PR DESCRIPTION
SSIA.

##### Test Plan

- CI jobs
- Wrote a small script that sends logs with integers/doubles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve integer types during OTEL flattening by mapping IntValue to JSON integers instead of doubles. This prevents precision loss and keeps event schemas stable.

<sup>Written for commit 9f9b26d4827ed95034c952e1a403bb780ecdb613. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

