### PR TITLE
Fix SIGSEGV in ctx_hosts_load during shutdown    

### DIFF
--- a/src/database/contexts/rrdcontext-loading.c
+++ b/src/database/contexts/rrdcontext-loading.c
@@ -156,8 +156,16 @@ void rrdhost_load_rrdcontext_data(RRDHOST *host) {
     th_ignored_metrics = th_ignored_instances = th_zero_retention_metrics = 0;
 
     ctx_get_context_list(&host->host_id.uuid, rrdcontext_load_context_callback, host);
+    if (unlikely(exit_initiated_get()))
+        return;
+
     ctx_get_chart_list(&host->host_id.uuid, rrdinstance_load_instance_callback, host);
+    if (unlikely(exit_initiated_get()))
+        return;
+
     ctx_get_dimension_list(&host->host_id.uuid, rrdinstance_load_dimension_callback, host);
+    if (unlikely(exit_initiated_get()))
+        return;
 
     size_t ignored_metrics = th_ignored_metrics, ignored_instances = th_ignored_instances, zero_retention_metrics = th_zero_retention_metrics;
     size_t loaded_metrics = 0, loaded_instances = 0, loaded_contexts = 0;
@@ -165,6 +173,9 @@ void rrdhost_load_rrdcontext_data(RRDHOST *host) {
 
     RRDCONTEXT *rc;
     dfe_start_read(host->rrdctx.contexts, rc) {
+        if (unlikely(exit_initiated_get()))
+            break;
+
         size_t instances = 0;
 
         RRDINSTANCE *ri;

--- a/src/database/sqlite/sqlite_context.c
+++ b/src/database/sqlite/sqlite_context.c
@@ -104,6 +104,9 @@ void ctx_get_chart_list(nd_uuid_t *host_uuid, void (*dict_cb)(SQL_CHART_DATA *, 
     param = 0;
     SQL_CHART_DATA chart_data = { 0 };
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
+        if (unlikely(exit_initiated_get()))
+            break;
+
         if (unlikely(!sqlite3_column_uuid_copy(res, 0, chart_data.chart_id))) {
             error_report("CTX [%s]: Got invalid chart id in column 0. Ignoring it.", host_guid);
             continue;
@@ -146,6 +149,9 @@ void ctx_get_dimension_list(nd_uuid_t *host_uuid, void (*dict_cb)(SQL_DIMENSION_
 
     param = 0;
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
+        if (unlikely(exit_initiated_get()))
+            break;
+
         if (unlikely(!sqlite3_column_uuid_copy(res, 0, dimension_data.dim_id))) {
             error_report("CTX [%s]: Got invalid dimension id in column 0. Ignoring it.", host_guid);
             continue;
@@ -213,6 +219,9 @@ void ctx_get_context_list(nd_uuid_t *host_uuid, void (*dict_cb)(VERSIONED_CONTEX
     param = 0;
 
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
+        if (unlikely(exit_initiated_get()))
+            break;
+
         context_data.id = (char *) sqlite3_column_text(res, 0);
         context_data.version = sqlite3_column_int64(res, 1);
         context_data.title = (char *) sqlite3_column_text(res, 2);

--- a/src/database/sqlite/sqlite_functions.c
+++ b/src/database/sqlite/sqlite_functions.c
@@ -455,6 +455,22 @@ void sql_close_database(sqlite3 *database, const char *database_name)
 
 extern sqlite3 *db_context_meta;
 
+// Close a thread-local sqlite3 handle while serializing against sqlite_library_shutdown().
+// If the SQLite library is no longer initialized, the handle is leaked deliberately; the OS
+// will reclaim it at process exit, which is strictly safer than crashing inside pcache1.
+void sql_close_thread_db_safe(sqlite3 **database)
+{
+    if (unlikely(!database || !*database))
+        return;
+
+    spinlock_lock(&sqlite_spinlock);
+    if (sqlite_library_initialized)
+        (void) sqlite3_close_v2(*database);
+    spinlock_unlock(&sqlite_spinlock);
+
+    *database = NULL;
+}
+
 void sqlite_close_databases(void)
 {
     // In case we have statements in the main thread (we should not)

--- a/src/database/sqlite/sqlite_functions.h
+++ b/src/database/sqlite/sqlite_functions.h
@@ -166,6 +166,7 @@ int sqlite_library_init(void);
 void sqlite_library_shutdown(void);
 
 void sql_close_database(sqlite3 *database, const char *database_name);
+void sql_close_thread_db_safe(sqlite3 **database);
 void sqlite_close_databases(void);
 uint64_t get_total_database_space(void);
 int sqlite_release_memory(int bytes);

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -1895,6 +1895,11 @@ static void restore_host_context(void *arg)
     if (!host)
         return;
 
+    if (unlikely(exit_initiated_get())) {
+        __atomic_store_n(&hclt->finished, true, __ATOMIC_RELEASE);
+        return;
+    }
+
     if (!db_meta_thread) {
         if (hclt->db_meta_thread) {
             db_meta_thread = hclt->db_meta_thread;
@@ -1903,17 +1908,13 @@ static void restore_host_context(void *arg)
             char sqlite_database[FILENAME_MAX + 1];
             snprintfz(sqlite_database, sizeof(sqlite_database) - 1, "%s/netdata-meta.db", netdata_configured_cache_dir);
             int rc = sqlite3_open_v2(sqlite_database, &db_meta_thread, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, NULL);
-            if (rc != SQLITE_OK) {
-                sqlite3_close_v2(db_meta_thread);
-                db_meta_thread = NULL;
-            }
+            if (rc != SQLITE_OK)
+                sql_close_thread_db_safe(&db_meta_thread);
 
             snprintfz(sqlite_database, sizeof(sqlite_database) - 1, "%s/context-meta.db", netdata_configured_cache_dir);
             rc = sqlite3_open_v2(sqlite_database, &db_context_thread, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, NULL);
-            if (rc != SQLITE_OK) {
-                sqlite3_close_v2(db_context_thread);
-                db_context_thread = NULL;
-            }
+            if (rc != SQLITE_OK)
+                sql_close_thread_db_safe(&db_context_thread);
 
             hclt->db_meta_thread = db_meta_thread;
             hclt->db_context_thread = db_context_thread;
@@ -2069,11 +2070,8 @@ static void ctx_hosts_load(uv_work_t *req)
 
     if (should_clean_threads) {
         for (size_t index = 0; index < max_threads; index++) {
-            if (hclt[index].db_meta_thread)
-                sqlite3_close_v2(hclt[index].db_meta_thread);
-
-            if (hclt[index].db_context_thread)
-                sqlite3_close_v2(hclt[index].db_context_thread);
+            sql_close_thread_db_safe(&hclt[index].db_meta_thread);
+            sql_close_thread_db_safe(&hclt[index].db_context_thread);
         }
     }
 
@@ -2090,12 +2088,9 @@ static void ctx_hosts_load(uv_work_t *req)
         sync_exec,
         load_duration);
 
-    if (db_meta_thread) {
-        sqlite3_close_v2(db_meta_thread);
-        sqlite3_close_v2(db_context_thread);
-        db_meta_thread = NULL;
-        db_context_thread = NULL;
-    }
+    sql_close_thread_db_safe(&db_meta_thread);
+    sql_close_thread_db_safe(&db_context_thread);
+
     freez(hclt);
     worker_is_idle();
 }


### PR DESCRIPTION
#### Summary                                                                                                                                                                                  
                                                                                                                                                                                              
  Shutting down while context loading is in flight crashes inside SQLite's
  pcache1 teardown:

  pcache1EnforceMaxPage  <- pcache1Destroy  <- sqlite3PcacheClose
    <- sqlite3_close_v2  <- ctx_hosts_load (sqlite_metadata.c)

  Root cause: the libuv worker running `ctx_hosts_load` has only a single shutdown check between hosts. 
  A host with many dimensions keeps the SQL row loops busy past the metadata thread's 15s wait, so the daemon   proceeds to `sqlite_library_shutdown()` -> `sqlite3_shutdown()` while the worker is still alive. 
 The worker's later `sqlite3_close_v2()`  then walks pcache1's freed LRU.

  #### Fix

  - Propagate `exit_initiated_get()` into `ctx_get_chart_list` /
    `ctx_get_dimension_list` / `ctx_get_context_list` row loops, between
    the three list calls in `rrdhost_load_rrdcontext_data`, inside its
    outer trigger loop, and at the top of `restore_host_context`.
  - Route every per-thread `sqlite3_close_v2` in the worker through a new
    `sql_close_thread_db_safe()` that holds `sqlite_spinlock` and
    skips the close once `sqlite_library_initialized` is false. This
    is the same spinlock `sqlite_library_shutdown()` holds around
    `sqlite3_shutdown()`, so the close either completes before global
    teardown or is skipped after it.

  #### Test plan

 - [ ] Verify shutdown during a large ctx load no longer crashes
 -  [ ] Confirm normal startup ctx load still completes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a shutdown crash in context loading by stopping long-running SQLite row loops on exit and safely closing per-thread DB handles during global SQLite teardown. Prevents a SIGSEGV in pcache1 when `ctx_hosts_load` overlaps with `sqlite3_shutdown()`.

- **Bug Fixes**
  - Added `exit_initiated_get()` checks inside `ctx_get_chart_list`, `ctx_get_dimension_list`, `ctx_get_context_list` row loops, after each list call in `rrdhost_load_rrdcontext_data`, during context iteration, and at the start of `restore_host_context`.
  - Introduced `sql_close_thread_db_safe()` that takes `sqlite_spinlock` and skips `sqlite3_close_v2()` once `sqlite_library_initialized` is false; replaced all worker close calls and open-error cleanup with this helper.
  - Ensures `ctx_hosts_load` does not race with `sqlite3_shutdown()` and avoids crashes in pcache1.

<sup>Written for commit 3d96f308f8acbf4a3fec6db93d56323bbf5170ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

