### PR TITLE
Add Markdown copy of Windows package EULA.

### DIFF
--- a/packaging/windows/eula.md
+++ b/packaging/windows/eula.md
@@ -1,0 +1,113 @@
+# Netdata for Windows End User License Agreement (EULA)
+
+**IMPORTANT: USE OF THIS NETDATA PACKAGE REQUIRES AN ACTIVE NETDATA
+CLOUD COMMERCIAL SUBSCRIPTION. PLEASE REVIEW SECTION 3 BELOW FOR
+DETAILS.**
+
+This End User License Agreement ("EULA") is a legal agreement between you
+(either an individual or entity, "You" or "Licensee") and Netdata,
+Inc. ("Netdata") regarding the Netdata software package for Microsoft
+Windows, including the Netdata Agent, Netdata UI, associated media,
+printed materials, and online or electronic documentation (collectively,
+the "Software").
+
+BY INSTALLING OR USING THE SOFTWARE, YOU AGREE TO BE BOUND BY THIS EULA.
+IF YOU DO NOT AGREE, DO NOT INSTALL OR USE THE SOFTWARE.
+
+1\. **SOFTWARE COMPONENTS AND LICENSING**
+
+The Software includes distinct components governed by separate licenses:
+
+\(a\) **Netdata Agent**: Licensed under GNU General Public License v3 or
+later ("GPLv3+". Your rights to use, modify, and distribute the Agent are
+solely governed by GPLv3+. A copy is included or available at:
+<https://www.gnu.org/licenses/gpl-3.0.en.html>. Obtain
+source code via Netdata' GitHub repository:
+<https://github.com/netdata/netdata>.
+
+\(b\) **Netdata UI**: Licensed under Netdata Cloud UI License v1.0
+("NCUL1". Rights for use and distribution of the UI are governed solely
+by NCUL1, available
+at: <https://app.netdata.cloud/LICENSE.txt>.
+
+\(c\) **Third-party Components**: Governed by respective licenses
+included with the Software, as described in
+<https://github.com/netdata/netdata/blob/master/REDISTRIBUTED.md>.
+
+2\. **LICENSE GRANT**
+
+Subject to compliance with this EULA and Section 3, Netdata grants You a
+non-exclusive, non-transferable license to install and use the Software
+solely in conjunction with an active Netdata Cloud subscription that
+explicitly authorizes such use.
+
+3\. **NETDATA CLOUD SUBSCRIPTION REQUIREMENT**
+
+\(a\) **Commercial Use**: Use of this Software requires an active paid
+commercial Netdata Cloud subscription ("Netdata Cloud Subscription".
+
+\(b\) **Enforcement**: Certain features, including the Netdata UI, may
+require authentication against your Netdata Cloud Subscription.
+
+\(c\) **No Subscription, No License**: Without an active Netdata Cloud
+Subscription explicitly permitting this Software, no license is granted
+under this EULA. Your license terminates immediately if your
+subscription expires, is terminated, or no longer qualifies.
+
+\(d\) **Netdata Cloud Terms**: Your subscription is governed by the
+Netdata Cloud Terms of Service, incorporated herein by reference:
+<https://www.netdata.cloud/terms/>.
+
+4\. **RESTRICTIONS**
+
+Except as permitted by GPLv3+ (Agent) and NCUL1 (UI), You may not:
+
+• Reverse engineer, decompile, or disassemble the Software, unless
+expressly permitted by law.
+
+• Rent, lease, lend, or sublicense the Software.
+
+• Use the Software in violation of the subscription requirement.
+
+• Remove or obscure proprietary notices in the Software.
+
+5\. **TERM AND TERMINATION**
+
+This EULA remains effective until terminated. It terminates immediately
+upon your non-compliance, including loss of your Netdata Cloud
+Subscription. Upon termination, cease using and destroy all copies of
+the Software. Termination of this EULA does not affect your rights to
+individual components under their respective licenses if obtained
+separately.
+
+6\. **DISCLAIMER OF WARRANTIES**
+
+THE SOFTWARE IS PROVIDED "S IS,"WITHOUT ANY WARRANTY, EXPRESS OR
+IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE, OR NON-INFRINGEMENT. NETDATA DOES NOT WARRANT
+UNINTERRUPTED OR ERROR-FREE SOFTWARE OPERATION.
+
+7\. **LIMITATION OF LIABILITY**
+
+NETDATA AND ITS SUPPLIERS SHALL NOT BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, CONSEQUENTIAL, OR SPECIAL DAMAGES, INCLUDING LOSS OF
+PROFITS, BUSINESS INTERRUPTION, OR LOSS OF DATA, ARISING FROM SOFTWARE
+USE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. APPLICABILITY
+OF LIMITATIONS MAY VARY BY JURISDICTION.
+
+8\. **GOVERNING LAW**
+
+This EULA is governed by the laws of the State of Delaware, USA, without
+regard to conflict of law principles.
+
+9\. **ENTIRE AGREEMENT**
+
+This EULA, including incorporated Netdata Cloud Terms of Service and
+relevant component licenses (GPLv3+, NCUL1), constitutes the complete
+agreement between You and Netdata concerning this Software package,
+superseding prior communications and agreements.
+
+10\. **CONTACT INFORMATION**
+
+Questions or communications regarding this EULA may be directed to
+Netdata: <https://www.netdata.cloud/contact/>.

--- a/packaging/windows/eula.md
+++ b/packaging/windows/eula.md
@@ -19,14 +19,14 @@ IF YOU DO NOT AGREE, DO NOT INSTALL OR USE THE SOFTWARE.
 The Software includes distinct components governed by separate licenses:
 
 \(a\) **Netdata Agent**: Licensed under GNU General Public License v3 or
-later ("GPLv3+". Your rights to use, modify, and distribute the Agent are
+later ("GPLv3+"). Your rights to use, modify, and distribute the Agent are
 solely governed by GPLv3+. A copy is included or available at:
 <https://www.gnu.org/licenses/gpl-3.0.en.html>. Obtain
-source code via Netdata' GitHub repository:
+source code via Netdata's GitHub repository:
 <https://github.com/netdata/netdata>.
 
 \(b\) **Netdata UI**: Licensed under Netdata Cloud UI License v1.0
-("NCUL1". Rights for use and distribution of the UI are governed solely
+("NCUL1"). Rights for use and distribution of the UI are governed solely
 by NCUL1, available
 at: <https://app.netdata.cloud/LICENSE.txt>.
 
@@ -44,7 +44,7 @@ explicitly authorizes such use.
 3\. **NETDATA CLOUD SUBSCRIPTION REQUIREMENT**
 
 \(a\) **Commercial Use**: Use of this Software requires an active paid
-commercial Netdata Cloud subscription ("Netdata Cloud Subscription".
+commercial Netdata Cloud subscription ("Netdata Cloud Subscription").
 
 \(b\) **Enforcement**: Certain features, including the Netdata UI, may
 require authentication against your Netdata Cloud Subscription.
@@ -82,7 +82,7 @@ separately.
 
 6\. **DISCLAIMER OF WARRANTIES**
 
-THE SOFTWARE IS PROVIDED "S IS,"WITHOUT ANY WARRANTY, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS," WITHOUT ANY WARRANTY, EXPRESS OR
 IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
 PARTICULAR PURPOSE, OR NON-INFRINGEMENT. NETDATA DOES NOT WARRANT
 UNINTERRUPTED OR ERROR-FREE SOFTWARE OPERATION.


### PR DESCRIPTION
##### Summary

This provides a way for us to link to a human readable copy of the EULA itself, which is useful for integration with external packaging platforms.

##### Test Plan

n/a

##### Additional Information

Generated using Pandoc and then hand-edited to fix a few issues with the resulting markdown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Markdown copy of the Windows EULA at `packaging/windows/eula.md` so external packaging platforms can link to a human-readable license. Also fixed remaining translation errors from the conversion.

<sup>Written for commit c45d7d7571016fb0f93e8b893ecd0ccaf7f6730c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

