### PR TITLE
Improve error handling in netdata-updater when fetching files.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -645,8 +645,9 @@ jobs:
         id: prepare
         if: needs.file-check.outputs.run == 'true'
         run: |
-          mkdir -p download/latest
+          mkdir -p download/latest latest
           mv artifacts/* download/latest
+          cp -a download/latest/* latest
           ls -al download/latest
       - name: Verify that artifacts work with installer
         id: verify
@@ -714,8 +715,9 @@ jobs:
         id: prepare
         if: needs.file-check.outputs.run == 'true'
         run: |
-          mkdir -p download/latest
+          mkdir -p download/latest latest
           mv artifacts/* download/latest
+          cp -a download/latest/* latest
           ls -al download/latest
       - name: Verify that artifacts work with installer
         id: verify
@@ -783,8 +785,9 @@ jobs:
         id: prepare
         if: needs.file-check.outputs.run == 'true'
         run: |
-          mkdir -p download/latest
+          mkdir -p download/latest latest
           mv artifacts/* download/latest
+          cp -a download/latest/* latest
           ls -al download/latest
       - name: Run Updater Check
         id: check

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -729,7 +729,7 @@ get_redirect() {
   if [ -n "${CURL}" ]; then
     checked=1
 
-    if run sh -c "${CURL} ${url} -s -L -I -o /dev/null -w '%{url_effective}' | grep -Eo '[^/]+$'"; then
+    if run sh -c "${CURL} ${url} -s -L -I -o /dev/null -w '%{url_effective}' | grep -Eo '[^/]+/?$' | grep -Eo '^[^/]+'"; then
       succeeded=1
     fi
   fi
@@ -738,7 +738,7 @@ get_redirect() {
     if command -v wget > /dev/null 2>&1; then
       checked=1
 
-      if run sh -c "wget -S -O /dev/null ${url} 2>&1 | grep -m 1 Location | grep -Eo '[^/]+$'"; then
+      if run sh -c "wget -S -O /dev/null ${url} 2>&1 | grep -m 1 Location | grep -Eo '[^/]+/?$' | grep -Eo '^[^/]+'"; then
         succeeded=1
       fi
     fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -589,17 +589,17 @@ create_exec_tmp_directory() {
 
 check_for_curl() {
   if [ -z "${curl}" ]; then
-    curl="$(PATH="${PATH}:/opt/netdata/bin" command -v curl 2>/dev/null && true)"
+    curl="$(PATH="${PATH}:/opt/netdata/bin" command -v curl 2>/dev/null || true)"
   fi
 }
 
 check_for_wget() {
   if [ -z "${wget}" ]; then
-    wget="$(command -v wget 2>/dev/null && true)"
+    wget="$(command -v wget 2>/dev/null || true)"
   fi
 
   if [ -z "${wget}" ]; then
-    wget="$(command -v wget2 2>/dev/null && true)"
+    wget="$(command -v wget2 2>/dev/null || true)"
   fi
 }
 

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -562,6 +562,7 @@ _cannot_use_tmpdir() {
   return "${ret}"
 }
 
+# This is idempotent, subsequent invocations will always return the same path
 create_exec_tmp_directory() {
   if [ -n "${NETDATA_TMPDIR_PATH}" ]; then
     echo "${NETDATA_TMPDIR_PATH}"
@@ -584,7 +585,8 @@ create_exec_tmp_directory() {
 
   TMPDIR="${root_dir}"
 
-  mktemp -d -p "${root_dir}" -t netdata-updater-XXXXXXXXXX
+  NETDATA_TMPDIR_PATH="$(mktemp -d -p "${root_dir}" -t netdata-updater-XXXXXXXXXX)"
+  echo "${NETDATA_TMPDIR_PATH}"
 }
 
 check_for_curl() {
@@ -733,9 +735,12 @@ get_netdata_latest_tag() {
 
   # Fallback case for simpler local testing.
   if echo "${tag}" | grep -Eq 'latest/?$'; then
+    set -e
     _safe_download "${url}/latest-version.txt" ./ndupdate-version.txt
+    result="$?"
+    set +e
 
-    case "$?" in
+    case "${result}" in
       0) tag="$(cat ./ndupdate-version.txt)" ;;
       *) tag='latest' ;;
     esac

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -736,10 +736,10 @@ get_netdata_latest_tag() {
 
   # Fallback case for simpler local testing.
   if echo "${tag}" | grep -Eq 'latest/?$'; then
-    set -e
+    set +e
     _safe_download "${url}/latest-version.txt" ./ndupdate-version.txt
     result="$?"
-    set +e
+    set -e
 
     case "${result}" in
       0) tag="$(cat ./ndupdate-version.txt)" ;;
@@ -772,11 +772,7 @@ else:
 
   if ! _safe_download "${commit_check_url}" "${commit_check_file}"; then
     warning "Failed to check for an updated updater script, skipping self-update check."
-
-    if [ -z "${NETDATA_TMPDIR_PATH}" ]; then
-      rm -rf "${ndtmpdir}" >&3 2>&3
-    fi
-
+    rm -f "${commit_check_file}" 2>/dev/null || true
     return 0
   fi
 
@@ -789,7 +785,7 @@ else:
   fi
 
   if [ -z "${NETDATA_TMPDIR_PATH}" ]; then
-    rm -rf "${ndtmpdir}" >&3 2>&3
+    rm -f "${commit_check_file}" 2>/dev/null || true
   fi
 
   if [ -z "${commit_date}" ] ; then

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -773,7 +773,7 @@ else:
   if ! _safe_download "${commit_check_url}" "${commit_check_file}"; then
     warning "Failed to check for an updated updater script, skipping self-update check."
     rm -f "${commit_check_file}" 2>/dev/null || true
-    return 0
+    return 1
   fi
 
   if command -v jq > /dev/null 2>&1; then

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -562,31 +562,32 @@ _cannot_use_tmpdir() {
   return "${ret}"
 }
 
-# This is idempotent, subsequent invocations will always return the same path
 create_exec_tmp_directory() {
-  if [ -n "${NETDATA_TMPDIR_PATH}" ]; then
-    echo "${NETDATA_TMPDIR_PATH}"
-    return
+  if [ -z "${ndtmpdir}" ]; then
+    if [ -n "${NETDATA_TMPDIR_PATH}" ]; then
+        ndtmpdir="${NETDATA_TMPDIR_PATH}"
+    else
+      root_dir=""
+
+      if [ -n "${NETDATA_TMPDIR}" ] && ! _cannot_use_tmpdir "${NETDATA_TMPDIR}"; then
+          root_dir="${NETDATA_TMPDIR}"
+      elif [ -n "${TMPDIR}" ] && ! _cannot_use_tmpdir "${TMPDIR}"; then
+          root_dir="${TMPDIR}"
+      elif ! _cannot_use_tmpdir /tmp; then
+          root_dir="/tmp"
+      elif ! _cannot_use_tmpdir "${PWD}"; then
+          root_dir="${PWD}"
+      else
+          fatal "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again." U0003
+      fi
+
+      TMPDIR="${root_dir}"
+
+      ndtmpdir="$(mktemp -d -p "${root_dir}" -t netdata-updater-XXXXXXXXXX)"
+    fi
   fi
 
-  root_dir=""
-
-  if [ -n "${NETDATA_TMPDIR}" ] && ! _cannot_use_tmpdir "${NETDATA_TMPDIR}"; then
-    root_dir="${NETDATA_TMPDIR}"
-  elif [ -n "${TMPDIR}" ] && ! _cannot_use_tmpdir "${TMPDIR}"; then
-    root_dir="${TMPDIR}"
-  elif ! _cannot_use_tmpdir /tmp; then
-    root_dir="/tmp"
-  elif ! _cannot_use_tmpdir "${PWD}"; then
-    root_dir="${PWD}"
-  else
-    fatal "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again." U0003
-  fi
-
-  TMPDIR="${root_dir}"
-
-  NETDATA_TMPDIR_PATH="$(mktemp -d -p "${root_dir}" -t netdata-updater-XXXXXXXXXX)"
-  echo "${NETDATA_TMPDIR_PATH}"
+  info "Putting temporary files in ${ndtmpdir}"
 }
 
 check_for_curl() {
@@ -616,7 +617,7 @@ _safe_download() {
 
   check_for_curl
   check_for_wget
-  ndtmpdir="$(create_exec_tmp_directory)"
+  create_exec_tmp_directory
   dl_log="${ndtmpdir}/download.log"
   rm -f "${dl_log}"
 
@@ -754,7 +755,7 @@ get_netdata_latest_tag() {
 newer_commit_date() {
   info "Checking if a newer version of the updater script is available."
 
-  ndtmpdir="$(create_exec_tmp_directory)"
+  create_exec_tmp_directory
   commit_check_file="${ndtmpdir}/latest-commit.json"
   commit_check_url="https://api.github.com/repos/netdata/netdata/commits?path=packaging%2Finstaller%2Fnetdata-updater.sh&page=1&per_page=1"
   python_version_check="
@@ -816,8 +817,8 @@ self_update() {
   if [ -z "${NETDATA_NO_UPDATER_SELF_UPDATE}" ] && newer_commit_date; then
     info "Downloading newest version of updater script."
 
-    ndtmpdir=$(create_exec_tmp_directory)
-    cd "$ndtmpdir" || exit 1
+    create_exec_tmp_directory
+    cd "${ndtmpdir}" || exit 1
 
     if _safe_download "https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/netdata-updater.sh" ./netdata-updater.sh; then
       chmod +x ./netdata-updater.sh || exit 1
@@ -981,7 +982,7 @@ update_build() {
   [ -z "${logfile}" ] && info "Running on a terminal - (this script also supports running headless from crontab)"
 
   RUN_INSTALLER=0
-  ndtmpdir=$(create_exec_tmp_directory)
+  create_exec_tmp_directory
   cd "$ndtmpdir" || fatal "Failed to change current working directory to ${ndtmpdir}" U0016
 
   install_build_dependencies
@@ -1080,7 +1081,7 @@ update_build() {
 }
 
 update_static() {
-  ndtmpdir="$(create_exec_tmp_directory)"
+  create_exec_tmp_directory
   PREVDIR="$(pwd)"
 
   info "Entering ${ndtmpdir}"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -22,7 +22,7 @@
 #  - TMPDIR (set to a usable temporary directory)
 #  - NETDATA_NIGHTLIES_BASEURL (set the base url for downloading the dist tarball)
 
-# Next unused error code: U0025
+# Next unused error code: U0029
 
 set -e
 
@@ -614,22 +614,30 @@ _safe_download() {
 
   check_for_curl
   check_for_wget
+  ndtmpdir="$(create_exec_tmp_directory)"
+  dl_log="${ndtmpdir}/download.log"
+  rm -f "${dl_log}"
 
   if [ -n "${curl}" ]; then
     set +e
-    "${curl}" -fsSL --connect-timeout 10 --retry 3 "${url}" > "${dest}"
+    "${curl}" --fail --location --write-out "%{http_code}" --connect-timeout 10 --retry 3 "${url}" --output "${dest}" > "${dl_log}"
     result="$?"
     set -e
 
     case "${result}" in
       0) return 0 ;;
+      22|78)
+          [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
+          case "$(tail -n 1 "${dl_log}")" in
+            404) return 1 ;;
+            4*) return 5 ;;
+            5*) return 6 ;;
+            *) return 4 ;;
+          esac
+          ;;
       5|6|7)
           [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
           return 2
-          ;;
-      22|78)
-          [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
-          return 1
           ;;
       35|60|83)
           [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
@@ -642,12 +650,22 @@ _safe_download() {
     esac
   elif [ -n "${wget}" ]; then
     set +e
-    "${wget}" -T 15 -O - "${url}" > "${dest}"
+    "${wget}" --timeout 15 --server-response --output-file "${dl_log}" --output-document "${dest}" "${url}"
     result="$?"
     set -e
 
     case "${result}" in
       0) return 0 ;;
+      8)
+          [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
+
+          case "$(grep "HTTP/" | awk '{ print $2 }')" in
+            404) return 1 ;;
+            4*) return 5 ;;
+            5*) return 6 ;;
+            *) return 4 ;;
+          esac
+          ;;
       4)
           [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
           return 2
@@ -655,10 +673,6 @@ _safe_download() {
       5)
           [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
           return 3
-          ;;
-      8)
-          [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
-          return 1
           ;;
       *)
           [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
@@ -683,7 +697,9 @@ download() {
     0) return 0 ;;
     1) fatal "File ${url} not found on remote server" U0022 ;;
     2) fatal "Unable to connect to remote host to download ${url}" U0023 ;;
-    3) fatal "TLS error connecting to remote host to download ${URL}" U0024 ;;
+    3) fatal "TLS error connecting to remote host to download ${url}" U0024 ;;
+    5) fatal "Client error when trying to download ${url}" U0027 ;;
+    6) fatal "Internal server error when trying to download ${url}" U0028 ;;
     255) fatal "I need curl or wget to proceed, but neither is available on this system." U0004 ;;
     *) fatal "Cannot download ${url}" U0005 ;;
   esac
@@ -693,14 +709,15 @@ get_netdata_latest_tag() {
   url="${1}/latest"
 
   check_for_curl
+  check_for_wget
 
   if [ -n "${curl}" ]; then
     tag=$("${curl}" "${url}" -s -L -I -o /dev/null -w '%{url_effective}')
   fi
 
   if [ -z "${tag}" ]; then
-    if command -v wget >/dev/null 2>&1; then
-      tag=$(wget -S -O /dev/null "${url}" 2>&1 | grep Location)
+    if [ -n "${wget}" ]; then
+      tag=$("${wget}" -S -O /dev/null "${url}" 2>&1 | grep Location)
     fi
   fi
 
@@ -1264,6 +1281,8 @@ update_binpkg() {
       2) fatal "Failed to connect to Netdata package repositories. This is most likely a result of networking problems with this system." U001F ;;
       3) fatal "TLS error when trying to connect to Netdata package repositories." U0020 ;;
       4) fatal "Unknown error when trying to connect to Netdata package repositories." U0021 ;;
+      5) fatal "Client error when trying to connect to Netdata package repositories." U0025 ;;
+      6) fatal "Internal server error when trying to connect to Netdata package repositories." U0026 ;;
       255) warning "Unable to check whether native packages are being published, wget or curl is required." ;;
     esac
   fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -659,7 +659,7 @@ _safe_download() {
       8)
           [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
 
-          case "$(grep "HTTP/" | awk '{ print $2 }')" in
+          case "$(grep "HTTP/" "${dl_log}" | awk '{ print $2 }')" in
             404) return 1 ;;
             4*) return 5 ;;
             5*) return 6 ;;
@@ -763,7 +763,15 @@ else:
     print(data[0]['commit']['committer']['date'] if isinstance(data, list) and data else '')
 "
 
-  download "${commit_check_url}" "${commit_check_file}"
+  if ! _safe_download "${commit_check_url}" "${commit_check_file}"; then
+    warning "Failed to check for an updated updater script, skipping self-update check."
+
+    if [ -z "${NETDATA_TMPDIR_PATH}" ]; then
+      rm -rf "${ndtmpdir}" >&3 2>&3
+    fi
+
+    return 0
+  fi
 
   if command -v jq > /dev/null 2>&1; then
     commit_date="$(jq '.[0].commit.committer.date' 2>/dev/null < "${commit_check_file}" | tr -d '"')"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -22,7 +22,7 @@
 #  - TMPDIR (set to a usable temporary directory)
 #  - NETDATA_NIGHTLIES_BASEURL (set the base url for downloading the dist tarball)
 
-# Next unused error code: U001F
+# Next unused error code: U0025
 
 set -e
 
@@ -593,11 +593,19 @@ check_for_curl() {
   fi
 }
 
+check_for_wget() {
+  if [ -z "${wget}" ]; then
+    wget="$(command -v wget 2>/dev/null && true)"
+  fi
+
+  if [ -z "${wget}" ]; then
+    wget="$(command -v wget2 2>/dev/null && true)"
+  fi
+}
+
 _safe_download() {
   url="${1}"
   dest="${2}"
-  succeeded=0
-  checked=0
 
   if echo "${url}" | grep -Eq "^file:///"; then
     cp "${url#file://}" "${dest}" || return 1
@@ -605,36 +613,61 @@ _safe_download() {
   fi
 
   check_for_curl
+  check_for_wget
 
   if [ -n "${curl}" ]; then
-    checked=1
+    set +e
+    "${curl}" -fsSL --connect-timeout 10 --retry 3 "${url}" > "${dest}"
+    result="$?"
+    set -e
 
-    if "${curl}" -fsSL --connect-timeout 10 --retry 3 "${url}" > "${dest}"; then
-      succeeded=1
-    elif [ "${dest}" != "/dev/null" ]; then
-      rm -f "${dest}"
-    fi
+    case "${result}" in
+      0) return 0 ;;
+      5|6|7)
+          [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
+          return 2
+          ;;
+      22|78)
+          [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
+          return 1
+          ;;
+      35|60|83)
+          [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
+          return 3
+          ;;
+      *)
+          [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
+          return 4
+          ;;
+    esac
+  elif [ -n "${wget}" ]; then
+    set +e
+    "${wget}" -T 15 -O - "${url}" > "${dest}"
+    result="$?"
+    set -e
+
+    case "${result}" in
+      0) return 0 ;;
+      4)
+          [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
+          return 2
+          ;;
+      5)
+          [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
+          return 3
+          ;;
+      8)
+          [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
+          return 1
+          ;;
+      *)
+          [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
+          return 4
+          ;;
+    esac
   fi
 
-  if [ "${succeeded}" -eq 0 ]; then
-    if command -v wget > /dev/null 2>&1; then
-      checked=1
-
-      if wget -T 15 -O - "${url}" > "${dest}"; then
-        succeeded=1
-      elif [ "${dest}" != "/dev/null" ]; then
-        rm -f "${dest}"
-      fi
-    fi
-  fi
-
-  if [ "${succeeded}" -eq 1 ]; then
-    return 0
-  elif [ "${checked}" -eq 1 ]; then
-    return 1
-  else
-    return 255
-  fi
+  return 255
 }
 
 download() {
@@ -646,13 +679,14 @@ download() {
   ret=$?
   set -e
 
-  if [ ${ret} -eq 0 ]; then
-    return 0
-  elif [ ${ret} -eq 255 ]; then
-    fatal "I need curl or wget to proceed, but neither is available on this system." U0004
-  else
-    fatal "Cannot download ${url}" U0005
-  fi
+  case "${ret}" in
+    0) return 0 ;;
+    1) fatal "File ${url} not found on remote server" U0022 ;;
+    2) fatal "Unable to connect to remote host to download ${url}" U0023 ;;
+    3) fatal "TLS error connecting to remote host to download ${URL}" U0024 ;;
+    255) fatal "I need curl or wget to proceed, but neither is available on this system." U0004 ;;
+    *) fatal "Cannot download ${url}" U0005 ;;
+  esac
 }
 
 get_netdata_latest_tag() {
@@ -712,7 +746,7 @@ else:
     print(data[0]['commit']['committer']['date'] if isinstance(data, list) and data else '')
 "
 
-  _safe_download "${commit_check_url}" "${commit_check_file}"
+  download "${commit_check_url}" "${commit_check_file}"
 
   if command -v jq > /dev/null 2>&1; then
     commit_date="$(jq '.[0].commit.committer.date' 2>/dev/null < "${commit_check_file}" | tr -d '"')"
@@ -1227,6 +1261,9 @@ update_binpkg() {
         error ""
         fatal "Unable to update due to native packages no longer being published for this platform" U001E
         ;;
+      2) fatal "Failed to connect to Netdata package repositories. This is most likely a result of networking problems with this system." U001F ;;
+      3) fatal "TLS error when trying to connect to Netdata package repositories." U0020 ;;
+      4) fatal "Unknown error when trying to connect to Netdata package repositories." U0021 ;;
       255) warning "Unable to check whether native packages are being published, wget or curl is required." ;;
     esac
   fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -650,7 +650,7 @@ _safe_download() {
     esac
   elif [ -n "${wget}" ]; then
     set +e
-    "${wget}" --timeout 15 --server-response --output-file "${dl_log}" --output-document "${dest}" "${url}"
+    "${wget}" -T 15 -S -o "${dl_log}" -O "${dest}" "${url}"
     result="$?"
     set -e
 
@@ -659,7 +659,7 @@ _safe_download() {
       8)
           [ "${dest}" != "/dev/null" ] && rm -f "${dest}"
 
-          case "$(grep "HTTP/" "${dl_log}" | awk '{ print $2 }')" in
+          case "$(grep "HTTP/" "${dl_log}" | tail -n 1 | awk '{ print $2 }')" in
             404) return 1 ;;
             4*) return 5 ;;
             5*) return 6 ;;

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -711,35 +711,36 @@ get_netdata_latest_tag() {
   check_for_curl
   check_for_wget
 
+  if [ -z "${curl}" ] && [ -z "${wget}" ]; then
+    fatal "I need curl or wget to proceed, but neither of them are available on this system." U0006
+  fi
+
   if [ -n "${curl}" ]; then
-    tag=$("${curl}" "${url}" -s -L -I -o /dev/null -w '%{url_effective}')
+    tag=$("${curl}" "${url}" -s -L -I -o /dev/null -w '%{url_effective}' || true)
   fi
 
   if [ -z "${tag}" ]; then
     if [ -n "${wget}" ]; then
-      tag=$("${wget}" -S -O /dev/null "${url}" 2>&1 | grep Location)
+      tag=$("${wget}" -S -O /dev/null "${url}" 2>&1 | grep Location || true)
     fi
   fi
 
   if [ -z "${tag}" ]; then
-    fatal "I need curl or wget to proceed, but neither of them are available on this system." U0006
+    tag='latest'
   fi
 
   tag="$(echo "${tag}" | grep -Eom 1 '[^/]*/?$')"
 
   # Fallback case for simpler local testing.
   if echo "${tag}" | grep -Eq 'latest/?$'; then
-    if _safe_download "${url}/latest-version.txt" ./ndupdate-version.txt; then
-      tag="$(cat ./ndupdate-version.txt)"
+    _safe_download "${url}/latest-version.txt" ./ndupdate-version.txt
 
-      if grep -q 'Not Found' ./ndupdate-version.txt; then
-        tag="latest"
-      fi
+    case "$?" in
+      0) tag="$(cat ./ndupdate-version.txt)" ;;
+      *) tag='latest' ;;
+    esac
 
-      rm -f ./ndupdate-version.txt
-    else
-      tag="latest"
-    fi
+    rm -f ./ndupdate-version.txt
   fi
 
   echo "${tag}"
@@ -961,11 +962,11 @@ set_tarball_urls() {
     export NETDATA_TARBALL_URL="file://${path}/${filename}"
     export NETDATA_TARBALL_CHECKSUM_URL="file://${path}/sha256sums.txt"
   elif [ "$1" = "stable" ]; then
-    latest="$(get_netdata_latest_tag "${NETDATA_STABLE_BASE_URL}")"
+    latest="$(get_latest_tag)"
     export NETDATA_TARBALL_URL="${NETDATA_STABLE_BASE_URL}/download/$latest/${filename}"
     export NETDATA_TARBALL_CHECKSUM_URL="${NETDATA_STABLE_BASE_URL}/download/$latest/sha256sums.txt"
   else
-    tag="$(get_netdata_latest_tag "${NETDATA_NIGHTLY_BASE_URL}")"
+    tag="$(get_latest_tag)"
     export NETDATA_TARBALL_URL="${NETDATA_NIGHTLY_BASE_URL}/download/${tag}/${filename}"
     export NETDATA_TARBALL_CHECKSUM_URL="${NETDATA_NIGHTLY_BASE_URL}/download/${tag}/sha256sums.txt"
   fi


### PR DESCRIPTION
##### Summary

This adds code to properly differentiate between:

- Failure to connect to the remote host.
- TLS errors (such as failed certificate validation).
- The file not existing on the server.
- Failure to download a file due to a 4xx error code other than 404.
- Failure to download a file due to a 5xx error code.
- Everything else.

That, in turn, lets us give more accurate error information when we fail to download a file.

This also adds support for systems with GNU wget2 installed that do not include a `wget` compatibility link or a copy of `curl` (these systems should be rare, but a number of distros we support do technically allow for such a setup).

##### Test Plan

Requires manual verification to cross-check the error codes that are being matched.

##### Additional Information

Equivalent changes for the kickstart.sh script will be handled as a separate PR, as they will need to be significantly more complex.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves netdata-updater download error handling with clear causes and resilient fallback to `wget`/`wget2`. Also fixes the self-update flow and unblocks CI installer/updater tests by mirroring artifacts and correcting kickstart redirect parsing.

- New Features
  - Map `curl`/`wget`/`wget2` results to: 404, other 4xx, 5xx, connection, TLS, unknown.
  - Emit fatal codes: U0022 (404), U0023 (connect), U0024 (TLS), U0027 (client), U0028 (server); propagate in package repo checks (U001F–U0026).
  - Detect and use `wget2` when `wget` is missing; use `wget`/`wget2` when `curl` is unavailable, and handle missing binaries safely.
  - Latest tag and self-update checks are robust: resolve via `curl` or `wget`/`wget2`, fall back to "latest" on failure, and warn/skip when commit fetch fails.

- Bug Fixes
  - Reuse a single temporary directory per run and clean up files safely.
  - Kickstart: fix redirect parsing for `curl`/`wget` to handle trailing slashes; unblocks tests.
  - CI: copy artifacts to both `download/latest` and `latest` so installer/kickstart/updater tests work.

<sup>Written for commit 69a4ae02aafd1225ee3f53cfb48150160814b8b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



