### PR TITLE
Improve error handling in the kickstart script when fetching files.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -702,14 +702,19 @@ handle_wget_result() {
       return "$?"
       ;;
     4)
+      [ -n "${dest}" ] && rm -f "${dest}"
       warning "Failed to connect to remote host when ${action} ${url}"
       return 2
       ;;
     5)
+      [ -n "${dest}" ] && rm -f "${dest}"
       warning "TLS error while connecting to remote host when ${action} ${url}"
       return 3
       ;;
-    *) fatal "Unknown error when ${action} ${url}" F0520 ;;
+    *)
+      [ -n "${dest}" ] && rm -f "${dest}"
+      fatal "Unknown error when ${action} ${url}" F0520
+      ;;
   esac
 }
 
@@ -812,7 +817,7 @@ get_redirect() {
         return 0
         ;;
       *)
-        handle_curl_result "${ret}" "${url}" "${dl_log}" "checking redirects for" "${output}"
+        handle_curl_result "${ret}" "${url}" "${output}" "checking redirects for"
         return "$?"
         ;;
     esac
@@ -821,14 +826,16 @@ get_redirect() {
   if [ -n "${WGET}" ]; then
     run "${WGET}" -S -o "${output}" -O /dev/null "${url}"
 
-    case "$?" in
+    ret="$?"
+
+    case "${ret}" in
       0)
         grep -m 1 Location "${output}" | grep -Eo '[^/]+/?$' | grep -Eo '[^/]+$'
         rm -f "${output}"
         return 0
         ;;
       *)
-        handle_wget_result "${ret}" "${url}" "${dl_log}" "checking redirects for" "${output}"
+        handle_wget_result "${ret}" "${url}" "${output}" "checking redirects for"
         return "$?"
         ;;
     esac

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Next unused error code: F052A
+# Next unused error code: F052D
 
 # ======================================================================
 # Constants
@@ -631,6 +631,10 @@ set_tmpdir() {
 check_for_remote_file() {
   url="${1}"
 
+  set_tmpdir
+  dl_log="${tmpdir}/download.log"
+  rm -f "${dl_log}"
+
   if echo "${url}" | grep -Eq "^file:///"; then
     [ -e "${url#file://}" ] || return 1
     return 0
@@ -639,11 +643,18 @@ check_for_remote_file() {
   fi
 
   if [ -n "${CURL}" ]; then
-    "${CURL}" --output /dev/null --silent --head --fail "${url}"
+    "${CURL}" --write-out "%{http_code}" --output /dev/null --silent --head --fail "${url}" > "${dl_log}"
 
     case "$?" in
         0) return 0 ;;
-        22|78) return 1 ;;
+        22|78)
+            case "$(tail -n 1 "${dl_log}")" in
+              403|404) return 1 ;;
+              4*) return 5 ;;
+              5*) return 6 ;;
+              *) return 4 ;;
+            esac
+            ;;
         5|6|7)
             error "Failed to connect to remote host when checking for remote file at ${url}"
             return 2
@@ -657,31 +668,28 @@ check_for_remote_file() {
   fi
 
   if [ -n "${WGET}" ]; then
-    output="$(mktemp)"
-    "${WGET}" -S --spider "${url}" > "${output}" 2>&1
+    "${WGET}" -S --spider "${url}" > "${dl_log}" 2>&1
 
     case "$?" in
       0)
-        if grep -q 'HTTP/1.1 200 OK' "${output}"; then
-          rm "${output}"
-          return 0
-        else
-          rm "${output}"
-          return 1
-        fi
+        case "$(grep "HTTP/" "${dl_log}" | tail -n 1 | awk '{ print $2 }')" in
+          200) return 0 ;;
+          404) return 1 ;;
+          4*) return 5 ;;
+          5*) return 6 ;;
+          *) return 4 ;;
+        esac
         ;;
       8)
-        rm "${output}"
-        return 1
+        case "$(grep "HTTP/" "${dl_log}" | tail -n 1 | awk '{ print $2 }')" in
+          404) return 1 ;;
+          4*) return 5 ;;
+          5*) return 6 ;;
+          *) return 4 ;;
+        esac
         ;;
-      4)
-        rm "${output}"
-        return 2
-        ;;
-      5)
-        rm "${output}"
-        return 3
-        ;;
+      4) return 2 ;;
+      5) return 3 ;;
       *) fatal "Unknown error when checking for remote file at ${url}" F0520 ;;
     esac
   fi
@@ -693,20 +701,41 @@ download() {
   url="${1}"
   dest="${2}"
 
+  set_tmpdir
+  dl_log="${tmpdir}/download.log"
+  rm -f "${dl_log}"
+
   if echo "${url}" | grep -Eq "^file:///"; then
     run cp "${url#file://}" "${dest}" || return 1
     return 0
   fi
 
   if [ -n "${CURL}" ]; then
-    run "${CURL}" --fail -q -sSL --connect-timeout 10 --retry 3 --output "${dest}" "${url}"
+    run "${CURL}" --fail -q -sSL --connect-timeout 10 --retry 3 --output "${dest}" "${url}" > "${dl_log}"
 
     case "$?" in
       0) return 0 ;;
       22|78)
-        error "Remote server reported error when downloading ${url}" F0522
         rm -f "${dest}"
-        return 1
+
+        case "$(tail -n 1 "${dl_log}")" in
+          404)
+            error "Remote file not found when downloading ${url}" F0522
+            return 1
+            ;;
+          4*)
+            error "Remote server reported client error when downloading ${url}" F052A
+            return 5
+            ;;
+          5*)
+            error "Remote server reported internal error when downloading ${url}" F052B
+            return 6
+            ;;
+          *)
+            error "Remote server reported error when downloading ${url}" F052C
+            return 4
+            ;;
+        esac
         ;;
       5|6|7)
         error "Failed to connect to remote server to download ${url}" F0523
@@ -728,9 +757,25 @@ download() {
     case "$?" in
       0) return 0 ;;
       8)
-        error "Remote server reported error when downloading ${url}" F0522
         rm -f "${dest}"
-        return 1
+        case "$(grep "HTTP/" "${dl_log}" | tail -n 1 | awk '{ print $2 }')" in
+          404)
+            error "Remote file not found when downloading ${url}" F0522
+            return 1
+            ;;
+          4*)
+            error "Remote server reported client error when downloading ${url}" F052A
+            return 5
+            ;;
+          5*)
+            error "Remote server reported internal error when downloading ${url}" F052B
+            return 6
+            ;;
+          *)
+            error "Remote server reported error when downloading ${url}" F052C
+            return 4
+            ;;
+        esac
         ;;
       4)
         error "Failed to connect to remote server to download ${url}" F0523

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Next unused error code: F052D
+# Next unused error code: F0522
 
 # ======================================================================
 # Constants
@@ -628,6 +628,95 @@ set_tmpdir() {
   fi
 }
 
+handle_http_status() {
+  status="${1}"
+  url="${2}"
+  action="${3}"
+
+  warn_msg="Server returned ${status} when ${action} ${url}"
+  case "${status}" in
+    404)
+      warning "File not found when ${action} ${url}"
+      return 1
+      ;;
+    4*)
+      warning "${warn_msg}"
+      return 5
+      ;;
+    5*)
+      warning "${warn_msg}"
+      return 6
+      ;;
+    *)
+      warning "${warn_msg}"
+      return 4
+      ;;
+  esac
+}
+
+handle_curl_result() {
+  ret="${1}"
+  url="${2}"
+  dl_log="${3}"
+  action="${4}"
+  dest="${5}"
+
+  case "${ret}" in
+    0) return 0 ;;
+    22|78)
+      status="$(tail -n 1 "${dl_log}")"
+      [ -n "${dest}" ] && rm -f "${dest}"
+      handle_http_status "${status}" "${url}" "${action}"
+      return "$?"
+      ;;
+    5|6|7)
+      [ -n "${dest}" ] && rm -f "${dest}"
+      warning "Failed to connect to remote host when ${action} ${url}"
+      return 2
+      ;;
+    35|60|83)
+      [ -n "${dest}" ] && rm -f "${dest}"
+      warning "TLS error while connecting to remote host when ${action} ${url}"
+      return 3
+      ;;
+    *)
+      [ -n "${dest}" ] && rm -f "${dest}"
+      fatal "Unknown error when ${action} ${url}" F0520
+      ;;
+  esac
+}
+
+handle_wget_result() {
+  ret="${1}"
+  url="${2}"
+  dl_log="${3}"
+  action="${4}"
+  dest="${5}"
+
+  case "${ret}" in
+    0) return 0 ;;
+    8)
+      status="$(grep "HTTP/" "${dl_log}" | tail -n 1 | awk '{ print $2 }')"
+      [ -n "${dest}" ] && rm -f "${dest}"
+      handle_http_status "${status}" "${url}" "${action}"
+      return "$?"
+      ;;
+    4)
+      warning "Failed to connect to remote host when ${action} ${url}"
+      return 2
+      ;;
+    5)
+      warning "TLS error while connecting to remote host when ${action} ${url}"
+      return 3
+      ;;
+    *) fatal "Unknown error when ${action} ${url}" F0520 ;;
+  esac
+}
+
+# It’s unlikely that any caller of this function will care why exactly it
+# wasn’t possible to retrieve the requested URL, but it’s still useful
+# to log the differentiated warnings based on the actual result, so we do
+# still have the full logic for inspecting the return codes of curl/wget.
 check_for_remote_file() {
   url="${1}"
 
@@ -645,53 +734,15 @@ check_for_remote_file() {
   if [ -n "${CURL}" ]; then
     "${CURL}" --write-out "%{http_code}" --output /dev/null --silent --head --fail "${url}" > "${dl_log}"
 
-    case "$?" in
-        0) return 0 ;;
-        22|78)
-            case "$(tail -n 1 "${dl_log}")" in
-              403|404) return 1 ;;
-              4*) return 5 ;;
-              5*) return 6 ;;
-              *) return 4 ;;
-            esac
-            ;;
-        5|6|7)
-            error "Failed to connect to remote host when checking for remote file at ${url}"
-            return 2
-            ;;
-        35|60|83)
-            error "TLS error while connecting to remote host when checking for remote file at ${url}"
-            return 3
-            ;;
-        *) fatal "Unknown error when checking for remote file at ${url}" F0520 ;;
-    esac
+    handle_curl_result "$?" "${url}" "${dl_log}" "checking for remote file at"
+    return "$?"
   fi
 
   if [ -n "${WGET}" ]; then
     "${WGET}" -S -o "${dl_log}" --spider "${url}"
 
-    case "$?" in
-      0)
-        case "$(grep "HTTP/" "${dl_log}" | tail -n 1 | awk '{ print $2 }')" in
-          200) return 0 ;;
-          404) return 1 ;;
-          4*) return 5 ;;
-          5*) return 6 ;;
-          *) return 4 ;;
-        esac
-        ;;
-      8)
-        case "$(grep "HTTP/" "${dl_log}" | tail -n 1 | awk '{ print $2 }')" in
-          404) return 1 ;;
-          4*) return 5 ;;
-          5*) return 6 ;;
-          *) return 4 ;;
-        esac
-        ;;
-      4) return 2 ;;
-      5) return 3 ;;
-      *) fatal "Unknown error when checking for remote file at ${url}" F0520 ;;
-    esac
+    handle_wget_result "$?" "${url}" "${dl_log}" "checking for remote file at"
+    return "$?"
   fi
 
   fatal "${ERROR_F0003}" F0003
@@ -711,84 +762,17 @@ download() {
   fi
 
   if [ -n "${CURL}" ]; then
-    run sh -c '"${1}" --fail -q -sSL --connect-timeout 10 --retry 3 --output "${2}" "${3}" > "${4}"' _ "${CURL}" "${dest}" "${url}" "${dl_log}"
+    run sh -c '"${1}" --fail -q -sSL --connect-timeout 10 --retry 3 --write-out "%{http_code}" --output "${2}" "${3}" > "${4}"' _ "${CURL}" "${dest}" "${url}" "${dl_log}"
 
-    case "$?" in
-      0) return 0 ;;
-      22|78)
-        rm -f "${dest}"
-
-        case "$(tail -n 1 "${dl_log}")" in
-          404)
-            error "Remote file not found when downloading ${url}" F0522
-            return 1
-            ;;
-          4*)
-            error "Remote server reported client error when downloading ${url}" F052A
-            return 5
-            ;;
-          5*)
-            error "Remote server reported internal error when downloading ${url}" F052B
-            return 6
-            ;;
-          *)
-            error "Remote server reported error when downloading ${url}" F052C
-            return 4
-            ;;
-        esac
-        ;;
-      5|6|7)
-        error "Failed to connect to remote server to download ${url}" F0523
-        rm -f "${dest}"
-        return 2
-        ;;
-      35|60|83)
-        error "TLS error while connecting to remote server to download ${url}" F0524
-        rm -f "${dest}"
-        return 3
-        ;;
-      *) fatal "Unknown error when downloading ${url}" F0521 ;;
-    esac
+    handle_curl_result "$?" "${url}" "${dl_log}" "downloading" "${dest}"
+    return "$?"
   fi
 
   if [ -n "${WGET}" ]; then
     run "${WGET}" -T 15 -o "${dl_log}" -O "${dest}" "${url}"
 
-    case "$?" in
-      0) return 0 ;;
-      8)
-        rm -f "${dest}"
-        case "$(grep "HTTP/" "${dl_log}" | tail -n 1 | awk '{ print $2 }')" in
-          404)
-            error "Remote file not found when downloading ${url}" F0522
-            return 1
-            ;;
-          4*)
-            error "Remote server reported client error when downloading ${url}" F052A
-            return 5
-            ;;
-          5*)
-            error "Remote server reported internal error when downloading ${url}" F052B
-            return 6
-            ;;
-          *)
-            error "Remote server reported error when downloading ${url}" F052C
-            return 4
-            ;;
-        esac
-        ;;
-      4)
-        error "Failed to connect to remote server to download ${url}" F0523
-        rm -f "${dest}"
-        return 2
-        ;;
-      5)
-        error "TLS error while connecting to remote server to download ${url}" F0524
-        rm -f "${dest}"
-        return 3
-        ;;
-      *) fatal "Unknown error when downloading ${url}" F0521 ;;
-    esac
+    handle_wget_result "$?" "${url}" "${dl_log}" "downloading" "${dest}"
+    return "$?"
   fi
 
   fatal "${ERROR_F0003}" F0003
@@ -819,28 +803,18 @@ get_redirect() {
   if [ -n "${CURL}" ]; then
     run sh -c '"${1}" "${2}" -s -L -I -o /dev/null -w "%{url_effective}" > "${3}"' _ "${CURL}" "${url}" "${output}"
 
-    case "$?" in
+    ret="$?"
+
+    case "${ret}" in
       0)
         grep -Eo '[^/]+/?$' "${output}" | grep -Eo '^[^/]+'
         rm -f "${output}"
         return 0
         ;;
-      22|78)
-        error "Remote server reported error when checking redirects for ${url}" F0525
-        rm -f "${output}"
-        return 1
+      *)
+        handle_curl_result "${ret}" "${url}" "${dl_log}" "checking redirects for" "${output}"
+        return "$?"
         ;;
-      5|6|7)
-        error "Failed to connect to remote server to check redirects for ${url}" F0526
-        rm -f "${output}"
-        return 2
-        ;;
-      35|60|83)
-        error "TLS error while connecting to remote server to check redirects for ${url}" F0527
-        rm -f "${output}"
-        return 3
-        ;;
-      *) fatal "Unknown error when checking redirect for ${url}" F0528 ;;
     esac
   fi
 
@@ -853,22 +827,10 @@ get_redirect() {
         rm -f "${output}"
         return 0
         ;;
-      8)
-        error "Remote server reported error when checking redirects for ${url}" F0525
-        rm -f "${output}"
-        return 1
+      *)
+        handle_wget_result "${ret}" "${url}" "${dl_log}" "checking redirects for" "${output}"
+        return "$?"
         ;;
-      4)
-        error "Failed to connect to remote server to check redirects for ${url}" F0526
-        rm -f "${output}"
-        return 2
-        ;;
-      5)
-        error "TLS error while connecting to remote server to check redirects for ${url}" F0527
-        rm -f "${output}"
-        return 3
-        ;;
-      *) fatal "Unknown error when checking redirect for ${url}" F0528 ;;
     esac
   fi
 
@@ -1898,6 +1860,8 @@ try_package_install() {
       ;;
   esac
 
+  # Due to the check above for pub_check_url, it’s safe to assume here
+  # that the only error we’re going to get is a missing file.
   if ! check_for_remote_file "${pkg_meta_url}"; then
     warning "Native packages have not yet been published for this system."
     return 4
@@ -2051,10 +2015,6 @@ try_static_install() {
       return 1
       ;;
   esac
-
-  if ! check_for_remote_file "${NETDATA_TARBALL_BASEURL}"; then
-    NETDATA_ASSUME_REMOTE_FILES_ARE_PRESENT=1
-  fi
 
   # Check status code first, so that we can provide nicer fallback for dry runs.
   if check_for_remote_file "${NETDATA_STATIC_ARCHIVE_URL}"; then

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -711,7 +711,7 @@ download() {
   fi
 
   if [ -n "${CURL}" ]; then
-    run sh -c "'${CURL}' --fail -q -sSL --connect-timeout 10 --retry 3 --output '${dest}' '${url}' > '${dl_log}'"
+    run sh -c '"${1}" --fail -q -sSL --connect-timeout 10 --retry 3 --output "${2}" "${3}" > "${4}"' _ "${CURL}" "${dest}" "${url}" "${dl_log}"
 
     case "$?" in
       0) return 0 ;;
@@ -817,7 +817,7 @@ get_redirect() {
   rm -f "${output}"
 
   if [ -n "${CURL}" ]; then
-    run sh -c "'${CURL}' '${url}' -s -L -I -o /dev/null -w '%{url_effective}' > '${output}'"
+    run sh -c '"${1}" "${2}" -s -L -I -o /dev/null -w "%{url_effective}" > "${3}"' _ "${CURL}" "${url}" "${output}"
 
     case "$?" in
       0)

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -711,7 +711,7 @@ download() {
   fi
 
   if [ -n "${CURL}" ]; then
-    run "${CURL}" --fail -q -sSL --connect-timeout 10 --retry 3 --output "${dest}" "${url}" > "${dl_log}"
+    run sh -c "${CURL} --fail -q -sSL --connect-timeout 10 --retry 3 --output ${dest} ${url} > ${dl_log}"
 
     case "$?" in
       0) return 0 ;;
@@ -817,7 +817,7 @@ get_redirect() {
   rm -f "${output}"
 
   if [ -n "${CURL}" ]; then
-    run "${CURL}" "${url}" -s -L -I -o /dev/null -w '%{url_effective}' > "${output}"
+    run sh -c "${CURL} ${url} -s -L -I -o /dev/null -w '%{url_effective}' > ${output}"
 
     case "$?" in
       0)
@@ -845,7 +845,7 @@ get_redirect() {
   fi
 
   if [ -n "${WGET}" ]; then
-    run "${WGET}" -S -o "${dl_log}" -O /dev/null "${url}"
+    run "${WGET}" -S -o "${output}" -O /dev/null "${url}"
 
     case "$?" in
       0)

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -774,7 +774,7 @@ download() {
   fi
 
   if [ -n "${WGET}" ]; then
-    run "${WGET}" -T 15 -o "${dl_log}" -O "${dest}" "${url}"
+    run "${WGET}" -S -T 15 -o "${dl_log}" -O "${dest}" "${url}"
 
     handle_wget_result "$?" "${url}" "${dl_log}" "downloading" "${dest}"
     return "$?"
@@ -787,10 +787,13 @@ get_actual_version() {
     major="${1}"
     channel="${2}"
     url="${RELEASE_INFO_URL}/${channel}/${major}"
+    set_tmpdir
+    tmp_file="${tmpdir}/version-info"
 
     if check_for_remote_file "${RELEASE_INFO_URL}"; then
         if check_for_remote_file "${url}"; then
-            download "${url}" -
+            download "${url}" "${tmp_file}"
+            cat "${tmp_file}"
         else
             echo "NONE"
         fi
@@ -1847,7 +1850,7 @@ try_package_install() {
     0) ;;
     1) NETDATA_ASSUME_REMOTE_FILES_ARE_PRESENT=1 ;;
     *)
-      error "Unable to communicate with Netdata package repositories"
+      warning "Unable to communicate with Netdata package repositories"
       return 1
       ;;
   esac
@@ -1862,7 +1865,7 @@ try_package_install() {
       return 3
       ;;
     *)
-      error "Unable to determine if native packages are being published for this system."
+      warning "Unable to determine if native packages are being published for this system."
       return 1
       ;;
   esac
@@ -2018,7 +2021,7 @@ try_static_install() {
     0) ;;
     1) NETDATA_ASSUME_REMOTE_FILES_ARE_PRESENT=1 ;;
     *)
-      error "Unable to communicate with GitHub. ${GITHUB_BADNET_MSG}"
+      warning "Unable to communicate with GitHub. ${GITHUB_BADNET_MSG}"
       return 1
       ;;
   esac
@@ -2273,7 +2276,7 @@ prepare_offline_install_source() {
         0) ;;
         1) NETDATA_ASSUME_REMOTE_FILES_ARE_PRESENT=1 ;;
         *)
-          error "Unable to communicate with GitHub. ${GITHUB_BADNET_MSG}"
+          warning "Unable to communicate with GitHub. ${GITHUB_BADNET_MSG}"
           return 1
           ;;
       esac

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Next unused error code: F0520
+# Next unused error code: F052A
 
 # ======================================================================
 # Constants
@@ -95,6 +95,8 @@ else
 fi
 
 CURL="$(PATH="${PATH}:/opt/netdata/bin" command -v curl 2>/dev/null && true)"
+WGET="$(command -v wget 2>/dev/null && true)"
+[ -z "${WGET}" ] && WGET="$(command -v wget2 2>/dev/null && true)"
 
 # ======================================================================
 # Shared messages used in multiple places throughout the script.
@@ -103,6 +105,7 @@ BADCACHE_MSG="Usually this is a result of an older copy of the file being cached
 BADNET_MSG="This is usually a result of a networking issue"
 ERROR_F0003="Could not find a usable HTTP client. Either curl or wget is required to proceed with installation."
 BADOPT_MSG="If you are following a third-party guide online, please see ${INSTALL_DOC_URL} for current instructions for using this script. If you are using a local copy of this script instead of fetching it from our servers, consider updating it. If you intended to pass this option to the installer code, please use either --local-build-options or --static-install-options to specify it instead."
+GITHUB_BADNET_MSG="This usually means there is some networking issue preventing access to https://github.com/ from this system."
 
 # ======================================================================
 # Core program logic
@@ -332,16 +335,16 @@ EOF
   fi
 
   if [ "${succeeded}" -eq 0 ]; then
-    if command -v wget > /dev/null 2>&1; then
-      if wget --help 2>&1 | grep BusyBox > /dev/null 2>&1; then
+    if [ -n "${WGET}" ]; then
+      if "${WGET}" --help 2>&1 | grep BusyBox > /dev/null 2>&1; then
         # BusyBox-compatible version of wget, there is no --no-check-certificate option
-        wget -q -O - \
+        "${WGET}" -q -O - \
         -T 1 \
         --header 'Content-Type: application/json' \
         --post-data "${REQ_BODY}" \
         "${TELEMETRY_URL}" > /dev/null
       else
-        wget -q -O - --no-check-certificate \
+        "${WGET}" -q -O - --no-check-certificate \
         --method POST \
         --timeout=1 \
         --header 'Content-Type: application/json' \
@@ -627,8 +630,6 @@ set_tmpdir() {
 
 check_for_remote_file() {
   url="${1}"
-  succeeded=0
-  checked=0
 
   if echo "${url}" | grep -Eq "^file:///"; then
     [ -e "${url#file://}" ] || return 1
@@ -638,71 +639,114 @@ check_for_remote_file() {
   fi
 
   if [ -n "${CURL}" ]; then
-    checked=1
+    "${CURL}" --output /dev/null --silent --head --fail "${url}"
 
-    if "${CURL}" --output /dev/null --silent --head --fail "${url}"; then
-      succeeded=1
-    fi
+    case "$?" in
+        0) return 0 ;;
+        22|78) return 1 ;;
+        5|6|7)
+            error "Failed to connect to remote host when checking for remote file at ${url}"
+            return 2
+            ;;
+        35|60|83)
+            error "TLS error while connecting to remote host when checking for remote file at ${url}"
+            return 3
+            ;;
+        *) fatal "Unknown error when checking for remote file at ${url}" F0520 ;;
+    esac
   fi
 
-  if [ "${succeeded}" -eq 0 ]; then
-    if command -v wget > /dev/null 2>&1; then
-      checked=1
+  if [ -n "${WGET}" ]; then
+    output="$(mktemp)"
+    "${WGET}" -S --spider "${url}" > "${output}" 2>&1
 
-      if wget -S --spider "${url}" 2>&1 | grep -q 'HTTP/1.1 200 OK'; then
-        succeeded=1
-      fi
-    fi
+    case "$?" in
+      0)
+        if grep -q 'HTTP/1.1 200 OK' "${output}"; then
+          rm "${output}"
+          return 0
+        else
+          rm "${output}"
+          return 1
+        fi
+        ;;
+      8)
+        rm "${output}"
+        return 1
+        ;;
+      4)
+        rm "${output}"
+        return 2
+        ;;
+      5)
+        rm "${output}"
+        return 3
+        ;;
+      *) fatal "Unknown error when checking for remote file at ${url}" F0520 ;;
+    esac
   fi
 
-  if [ "${succeeded}" -eq 1 ]; then
-    return 0
-  elif [ "${checked}" -eq 1 ]; then
-    return 1
-  else
-    fatal "${ERROR_F0003}" F0003
-  fi
+  fatal "${ERROR_F0003}" F0003
 }
 
 download() {
   url="${1}"
   dest="${2}"
-  succeeded=0
-  checked=0
 
   if echo "${url}" | grep -Eq "^file:///"; then
     run cp "${url#file://}" "${dest}" || return 1
     return 0
   fi
 
-
   if [ -n "${CURL}" ]; then
-    checked=1
+    run "${CURL}" --fail -q -sSL --connect-timeout 10 --retry 3 --output "${dest}" "${url}"
 
-    if run "${CURL}" --fail -q -sSL --connect-timeout 10 --retry 3 --output "${dest}" "${url}"; then
-      succeeded=1
-    else
-      rm -f "${dest}"
-    fi
+    case "$?" in
+      0) return 0 ;;
+      22|78)
+        error "Remote server reported error when downloading ${url}" F0522
+        rm -f "${dest}"
+        return 1
+        ;;
+      5|6|7)
+        error "Failed to connect to remote server to download ${url}" F0523
+        rm -f "${dest}"
+        return 2
+        ;;
+      35|60|83)
+        error "TLS error while connecting to remote server to download ${url}" F0524
+        rm -f "${dest}"
+        return 3
+        ;;
+      *) fatal "Unknown error when downloading ${url}" F0521 ;;
+    esac
   fi
 
-  if [ "${succeeded}" -eq 0 ]; then
-    if command -v wget > /dev/null 2>&1; then
-      checked=1
+  if [ -n "${WGET}" ]; then
+    run "${WGET}" -T 15 -O "${dest}" "${url}"
 
-      if run wget -T 15 -O "${dest}" "${url}"; then
-        succeeded=1
-      fi
-    fi
+    case "$?" in
+      0) return 0 ;;
+      8)
+        error "Remote server reported error when downloading ${url}" F0522
+        rm -f "${dest}"
+        return 1
+        ;;
+      4)
+        error "Failed to connect to remote server to download ${url}" F0523
+        rm -f "${dest}"
+        return 2
+        ;;
+      5)
+        error "TLS error while connecting to remote server to download ${url}" F0524
+        rm -f "${dest}"
+        return 3
+        ;;
+      *) fatal "Unknown error when downloading ${url}" F0521 ;;
+    esac
   fi
 
-  if [ "${succeeded}" -eq 1 ]; then
-    return 0
-  elif [ "${checked}" -eq 1 ]; then
-    return 1
-  else
-    fatal "${ERROR_F0003}" F0003
-  fi
+  fatal "${ERROR_F0003}" F0003
 }
 
 get_actual_version() {
@@ -723,34 +767,66 @@ get_actual_version() {
 
 get_redirect() {
   url="${1}"
-  succeeded=0
-  checked=0
 
   if [ -n "${CURL}" ]; then
-    checked=1
+    output="$(mktemp)"
+    run "${CURL}" "${url}" -s -L -I -o /dev/null -w '%{url_effective}' > "${output}"
 
-    if run sh -c "${CURL} ${url} -s -L -I -o /dev/null -w '%{url_effective}' | grep -Eo '[^/]+/?$' | grep -Eo '^[^/]+'"; then
-      succeeded=1
-    fi
+    case "$?" in
+      0)
+        grep -Eo '[^/]+/?$' "${output}" | grep -Eo '^[^/]+'
+        rm -f "${output}"
+        return 0
+        ;;
+      22|78)
+        error "Remote server reported error when checking redirects for ${url}" F0525
+        rm -f "${output}"
+        return 1
+        ;;
+      5|6|7)
+        error "Failed to connect to remote server to check redirects for ${url}" F0526
+        rm -f "${output}"
+        return 2
+        ;;
+      35|60|83)
+        error "TLS error while connecting to remote server to check redirects for ${url}" F0527
+        rm -f "${output}"
+        return 3
+        ;;
+      *) fatal "Unknown error when checking redirect for ${url}" F0528 ;;
+    esac
   fi
 
-  if [ "${succeeded}" -eq 0 ]; then
-    if command -v wget > /dev/null 2>&1; then
-      checked=1
+  if [ -n "${WGET}" ]; then
+    output="$(mktemp)"
+    run sh -c "${WGET}" -S -O /dev/null "${url}" > "${output}" 2>&1
 
-      if run sh -c "wget -S -O /dev/null ${url} 2>&1 | grep -m 1 Location | grep -Eo '[^/]+/?$' | grep -Eo '^[^/]+'"; then
-        succeeded=1
-      fi
-    fi
+    case "$?" in
+      0)
+        grep -m 1 Location "${output}" | grep -Eo '[^/]+/?$' | grep -Eo '[^/]+$'
+        rm -f "${output}"
+        return 0
+        ;;
+      8)
+        error "Remote server reported error when checking redirects for ${url}" F0525
+        rm -f "${output}"
+        return 1
+        ;;
+      4)
+        error "Failed to connect to remote server to check redirects for ${url}" F0526
+        rm -f "${output}"
+        return 2
+        ;;
+      5)
+        error "TLS error while connecting to remote server to check redirects for ${url}" F0527
+        rm -f "${output}"
+        return 3
+        ;;
+      *) fatal "Unknown error when checking redirect for ${url}" F0528 ;;
+    esac
   fi
 
-  if [ "${succeeded}" -eq 1 ]; then
-    return 0
-  elif [ "${checked}" -eq 1 ]; then
-    return 1
-  else
-    fatal "${ERROR_F0003}" F0003
-  fi
+  fatal "${ERROR_F0003}" F0003
 }
 
 safe_sha256sum() {
@@ -973,16 +1049,19 @@ uninstall() {
     fi
   else
     if [ "${DRY_RUN}" -eq 1 ]; then
-      progress "Would download installer script from: ${uninstaller_url}"
+      progress "Would download uninstaller script from: ${uninstaller_url}"
       progress "Would attempt to uninstall existing install with downloaded uninstaller script."
       return 0
     else
       progress "Downloading netdata-uninstaller ..."
-      download "${uninstaller_url}" "${tmpdir}/netdata-uninstaller.sh"
-      chmod +x "${tmpdir}/netdata-uninstaller.sh"
-      # shellcheck disable=SC2086
-      if ! run_script "${tmpdir}/netdata-uninstaller.sh" ${FLAGS}; then
-        warning "Uninstaller failed. Some parts of Netdata may still be present on the system."
+      if download "${uninstaller_url}" "${tmpdir}/netdata-uninstaller.sh"
+        chmod +x "${tmpdir}/netdata-uninstaller.sh"
+        # shellcheck disable=SC2086
+        if ! run_script "${tmpdir}/netdata-uninstaller.sh" ${FLAGS}; then
+            warning "Uninstaller failed. Some parts of Netdata may still be present on the system."
+        fi
+      else
+        fatal "Failed to fetch uninstaller script" F0529
       fi
     fi
   fi
@@ -1747,15 +1826,31 @@ try_package_install() {
       ;;
   esac
 
-  if ! check_for_remote_file "${ref_check_url}"; then
-    NETDATA_ASSUME_REMOTE_FILES_ARE_PRESENT=1
-  fi
+  check_for_remote_file "${ref_check_url}"
+
+  case "$?" in
+    0) ;;
+    1) NETDATA_ASSUME_REMOTE_FILES_ARE_PRESENT=1 ;;
+    *)
+      error "Unable to communicate with Netdata package repositories"
+      return 1
+      ;;
+  esac
 
   progress "Checking if native packages are being published for this platform."
-  if ! check_for_remote_file "${pub_check_url}"; then
-    warning "Native packages are not being published for this system."
-    return 3
-  fi
+  check_for_remote_file "${pub_check_url}"
+
+  case "$?" in
+    0) ;;
+    1)
+      warning "Native packages are not being published for this system."
+      return 3
+      ;;
+    2|3)
+      error "Unable to determine if native packages are being published for this system."
+      return 1
+      ;;
+  esac
 
   if ! check_for_remote_file "${pkg_meta_url}"; then
     warning "Native packages have not yet been published for this system."
@@ -1900,6 +1995,17 @@ try_static_install() {
     progress "Attempting to install using static build..."
   fi
 
+  check_for_remote_file "${NETDATA_TARBALL_BASEURL}"
+
+  case "$?" in
+    0) ;;
+    1) NETDATA_ASSUME_REMOTE_FILES_ARE_PRESENT=1 ;;
+    *)
+      error "Unable to communicate with GitHub. ${GITHUB_BADNET_MSG}"
+      return 1
+      ;;
+  esac
+
   if ! check_for_remote_file "${NETDATA_TARBALL_BASEURL}"; then
     NETDATA_ASSUME_REMOTE_FILES_ARE_PRESENT=1
   fi
@@ -1911,7 +2017,7 @@ try_static_install() {
     netdata_agent="${NETDATA_STATIC_ARCHIVE_OLD_NAME}"
     export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_STATIC_ARCHIVE_OLD_URL}"
   else
-    warning "Could not find a ${SELECTED_RELEASE_CHANNEL} static build for ${SYSARCH} CPUs. This usually means there is some networking issue preventing access to https://github.com/ from this system."
+    warning "Could not find a ${SELECTED_RELEASE_CHANNEL} static build for ${SYSARCH} CPUs. ${GITHUB_BADNET_MSG}"
     return 2
   fi
 
@@ -2148,9 +2254,16 @@ prepare_offline_install_source() {
     static|auto|any)
       set_static_archive_urls "${SELECTED_RELEASE_CHANNEL}" "x86_64"
 
-      if ! check_for_remote_file "${NETDATA_TARBALL_BASEURL}"; then
-        NETDATA_ASSUME_REMOTE_FILES_ARE_PRESENT=1
-      fi
+      check_for_remote_file "${NETDATA_TARBALL_BASEURL}"
+
+      case "$?" in
+        0) ;;
+        1) NETDATA_ASSUME_REMOTE_FILES_ARE_PRESENT=1 ;;
+        *)
+          error "Unable to communicate with GitHub. ${GITHUB_BADNET_MSG}"
+          return 1
+          ;;
+      esac
 
       if check_for_remote_file "${NETDATA_STATIC_ARCHIVE_URL}"; then
         for arch in $(echo "${NETDATA_OFFLINE_ARCHES:-${STATIC_INSTALL_ARCHES}}" | awk '{for (i=1;i<=NF;i++) if (!a[$i]++) printf("%s%s",$i,FS)}{printf("\n")}'); do

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -711,7 +711,7 @@ download() {
   fi
 
   if [ -n "${CURL}" ]; then
-    run sh -c "${CURL} --fail -q -sSL --connect-timeout 10 --retry 3 --output ${dest} ${url} > ${dl_log}"
+    run sh -c "'${CURL}' --fail -q -sSL --connect-timeout 10 --retry 3 --output '${dest}' '${url}' > '${dl_log}'"
 
     case "$?" in
       0) return 0 ;;
@@ -817,7 +817,7 @@ get_redirect() {
   rm -f "${output}"
 
   if [ -n "${CURL}" ]; then
-    run sh -c "${CURL} ${url} -s -L -I -o /dev/null -w '%{url_effective}' > ${output}"
+    run sh -c "'${CURL}' '${url}' -s -L -I -o /dev/null -w '%{url_effective}' > '${output}'"
 
     case "$?" in
       0)

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -668,7 +668,7 @@ check_for_remote_file() {
   fi
 
   if [ -n "${WGET}" ]; then
-    "${WGET}" -S --spider "${url}" > "${dl_log}" 2>&1
+    "${WGET}" -S -o "${dl_log}" --spider "${url}"
 
     case "$?" in
       0)
@@ -752,7 +752,7 @@ download() {
   fi
 
   if [ -n "${WGET}" ]; then
-    run "${WGET}" -T 15 -O "${dest}" "${url}"
+    run "${WGET}" -T 15 -o "${dl_log}" -O "${dest}" "${url}"
 
     case "$?" in
       0) return 0 ;;
@@ -812,9 +812,11 @@ get_actual_version() {
 
 get_redirect() {
   url="${1}"
+  set_tmpdir
+  output="${tmpdir}/download.log"
+  rm -f "${output}"
 
   if [ -n "${CURL}" ]; then
-    output="$(mktemp)"
     run "${CURL}" "${url}" -s -L -I -o /dev/null -w '%{url_effective}' > "${output}"
 
     case "$?" in
@@ -843,8 +845,7 @@ get_redirect() {
   fi
 
   if [ -n "${WGET}" ]; then
-    output="$(mktemp)"
-    run sh -c "${WGET}" -S -O /dev/null "${url}" > "${output}" 2>&1
+    run "${WGET}" -S -o "${dl_log}" -O /dev/null "${url}"
 
     case "$?" in
       0)
@@ -1099,7 +1100,7 @@ uninstall() {
       return 0
     else
       progress "Downloading netdata-uninstaller ..."
-      if download "${uninstaller_url}" "${tmpdir}/netdata-uninstaller.sh"
+      if download "${uninstaller_url}" "${tmpdir}/netdata-uninstaller.sh"; then
         chmod +x "${tmpdir}/netdata-uninstaller.sh"
         # shellcheck disable=SC2086
         if ! run_script "${tmpdir}/netdata-uninstaller.sh" ${FLAGS}; then

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1861,7 +1861,7 @@ try_package_install() {
       warning "Native packages are not being published for this system."
       return 3
       ;;
-    2|3)
+    *)
       error "Unable to determine if native packages are being published for this system."
       return 1
       ;;


### PR DESCRIPTION
##### Summary

This adds code to differentiate between:

- Failures to connect to the remote server
- TLS errors
- Inability to actually fetch the file due to a 4xx or 5xx error
- Everything else

That, in turn, lets us give more accurate error information when we fail to download a file.

This also adds support for systems with GNU wget2 installed that do not include a `wget` compatibility link or a copy of `curl` (these systems should be rare, but a number of distros we support do technically allow for such a setup).

##### Test Plan

Requires manual testing to verify that everything still works.

##### Additional Information

Functionally equivalent to #22422, just for the kickstart script instead of the updater.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the kickstart script’s fetch logic with centralized handlers, precise error classification, safer cleanup, clearer messages, and more robust redirect handling. Adds `wget2` support and correct fallbacks in GitHub/package repo checks to avoid misleading "not published/not found" errors.

- **Bug Fixes**
  - `check_for_remote_file`, `download`, and `get_redirect` now share handlers that read status from client logs and map `curl`/`wget` results to distinct exit codes (404, other 4xx, 5xx, connection, TLS); partial files are removed on failure and redirects are resolved reliably.
  - Pre-flight checks and the package publishing probe now treat network/TLS issues as communication problems, not "not published": clear messages ("Unable to communicate with Netdata package repositories", "Unable to communicate with GitHub", "Unable to determine if native packages are being published ...").
  - Fails fast with a clear error if the uninstaller cannot be fetched; fixes "uninstaller" progress text.

- **New Features**
  - Detects and uses `wget2` when `wget` is missing; keeps BusyBox `wget` handling and uses the selected client consistently (including telemetry).

<sup>Written for commit 30a88493bcedec4320619355cdd214ab3176e766. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

