### PR TITLE
Assorted CI updates and fixes

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -23,12 +23,12 @@ arch_order:  # sort order for per-architecture jobs in CI
 arch_data:  # Mapping of per-architecture matrix behavior.
   amd64: &amd64
     qemu: false
-    runner: &x86-runner ubuntu-22.04
+    runner: &x86-runner ubuntu-24.04
   x86_64: *amd64
   i386: *amd64
   armhf: &arm
     qemu: false
-    runner: &arm-runner ubuntu-22.04-arm
+    runner: &arm-runner ubuntu-24.04-arm
   armhfp: *arm
   armv6l: *arm
   armv7l: *arm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
         run: |
           mkdir -p artifacts/
           tar --create --file "artifacts/netdata-$(git describe).tar.gz" \
-              --sort=name --posix --auto-compress --exclude=artifacts/ --exclude=.git \
+              --sort=name --posix --auto-compress --exclude=artifacts --exclude=.git \
               --exclude=.gitignore --exclude=.gitattributes --exclude=.gitmodules \
               --transform "s/^\\.\\//netdata-$(git describe)\\//" --verbose .
           cd artifacts/


### PR DESCRIPTION
##### Summary

- Update the GHA runner images used for builds from Ubuntu 22.04 to Ubuntu 24.04.
- Fix exclude option in source tarball build job.

##### Test Plan

CI passes on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move CI builds to Ubuntu 24.04 runners and fix the source tarball so it doesn’t include the artifacts directory.

- **Dependencies**
  - Switch GitHub Actions runners from ubuntu-22.04 to ubuntu-24.04 for x86 and ARM jobs.

- **Bug Fixes**
  - Correct tarball packaging by excluding `artifacts` (not `artifacts/`), preventing it from being bundled.

<sup>Written for commit c2c87633e3b3a56ebf7d2b9881ae73f5bd50fd15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

