### PR TITLE
Fix eBPF FD PID map iteration

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -778,6 +778,8 @@ static void ebpf_read_fd_apps_table(int maps_per_core)
         if (ebpf_plugin_stop())
             break;
 
+        key = next_key;
+
         if (bpf_map_lookup_elem(fd, &key, fv)) {
             netdata_log_error("Failed to lookup PID %u in FD map", key);
             goto end_fd_loop;
@@ -804,7 +806,6 @@ static void ebpf_read_fd_apps_table(int maps_per_core)
     end_fd_loop:
         // We are cleaning to avoid passing data read from one process to other.
         memset(fv, 0, length);
-        key = next_key;
     }
 }
 


### PR DESCRIPTION
##### Summary
Fix the eBPF FD collector's per-PID map iteration so it consumes the key returned by `bpf_map_get_next_key()` before looking up the map entry.

The previous loop seeded `key` with `0`, received the first real PID in `next_key`, but still attempted to look up PID `0`. When PID `0` was not present in the FD map, `ebpf.plugin`
  logged:

  ```
  Failed to lookup PID 0 in FD map
  ```

  once per collection cycle.

#### Root Cause

  ebpf_read_fd_apps_table() used the stale input key after a successful bpf_map_get_next_key() call instead of the returned next_key.

  #### Changes

  - Assign key = next_key before bpf_map_lookup_elem() in the FD apps table reader.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix per-PID map iteration in the eBPF FD collector by assigning `key = next_key` before `bpf_map_lookup_elem()` lookups. This eliminates incorrect PID 0 lookups and the repeated "Failed to lookup PID 0 in FD map" log.

<sup>Written for commit ee2ad7dd9a202abcd94e83992baf27a896d5e5fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

