### PR TITLE
Fix rrdcontext metadata leak on non-dbengine hosts

### DIFF
--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -135,7 +135,11 @@ static inline size_t svc_rrdhost_cleanup_charts_marked_obsolete(RRDHOST *host) {
     if(full_archives != full_candidates)
         rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_OBSOLETE_CHARTS);
 
-    return full_archives;
+    // Both partial dim-archive (svc_rrdset_archive_obsolete_dimensions)
+    // and full chart-free (rrdset_free) produce archived RRDMETRIC and/or
+    // RRDINSTANCE entries in rrdcontext. Either kind of archival warrants
+    // a deep rrdcontext GC pass on non-dbengine hosts.
+    return partial_archives + full_archives;
 }
 
 void svc_rrdhost_obsolete_all_charts(RRDHOST *host) {
@@ -153,14 +157,14 @@ static void svc_rrd_cleanup_obsolete_charts_from_all_hosts() {
 
     rrd_rdlock();
 
-    size_t charts_freed = 0;
+    size_t archived = 0;
 
     RRDHOST *host;
     rrdhost_foreach_read(host) {
         if(rrdhost_receiver_replicating_charts(host) || rrdhost_sender_replicating_charts(host))
             continue;
 
-        charts_freed += svc_rrdhost_cleanup_charts_marked_obsolete(host);
+        archived += svc_rrdhost_cleanup_charts_marked_obsolete(host);
 
         if (rrdhost_is_local(host) || IS_VIRTUAL_HOST_OS(host))
             continue;
@@ -180,11 +184,12 @@ static void svc_rrd_cleanup_obsolete_charts_from_all_hosts() {
 
     rrd_rdunlock();
 
-    // If we actually freed any chart, schedule a deep rrdcontext GC pass.
-    // On non-dbengine hosts, dbengine rotation never triggers it, so archived
+    // If anything was archived (a chart freed, or just dimensions archived
+    // on a still-live chart), schedule a deep rrdcontext GC pass. On
+    // non-dbengine hosts, dbengine rotation never triggers it, so archived
     // RRDINSTANCE / RRDMETRIC entries would otherwise accumulate forever in
     // host->rrdctx.contexts -> rc->rrdinstances / ri->rrdmetrics.
-    if(charts_freed)
+    if(archived)
         rrdcontext_request_full_gc();
 }
 

--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -82,9 +82,9 @@ static bool svc_rrdset_lock_for_deletion(RRDSET *st, time_t now) {
     return false;
 }
 
-static inline void svc_rrdhost_cleanup_charts_marked_obsolete(RRDHOST *host) {
+static inline size_t svc_rrdhost_cleanup_charts_marked_obsolete(RRDHOST *host) {
     if(!rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_OBSOLETE_CHARTS|RRDHOST_FLAG_PENDING_OBSOLETE_DIMENSIONS))
-        return;
+        return 0;
 
     worker_is_busy(UV_EVENT_CLEANUP_OBSOLETE_CHARTS);
 
@@ -134,6 +134,8 @@ static inline void svc_rrdhost_cleanup_charts_marked_obsolete(RRDHOST *host) {
 
     if(full_archives != full_candidates)
         rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_OBSOLETE_CHARTS);
+
+    return full_archives;
 }
 
 void svc_rrdhost_obsolete_all_charts(RRDHOST *host) {
@@ -151,12 +153,14 @@ static void svc_rrd_cleanup_obsolete_charts_from_all_hosts() {
 
     rrd_rdlock();
 
+    size_t charts_freed = 0;
+
     RRDHOST *host;
     rrdhost_foreach_read(host) {
         if(rrdhost_receiver_replicating_charts(host) || rrdhost_sender_replicating_charts(host))
             continue;
 
-        svc_rrdhost_cleanup_charts_marked_obsolete(host);
+        charts_freed += svc_rrdhost_cleanup_charts_marked_obsolete(host);
 
         if (rrdhost_is_local(host) || IS_VIRTUAL_HOST_OS(host))
             continue;
@@ -175,6 +179,13 @@ static void svc_rrd_cleanup_obsolete_charts_from_all_hosts() {
     }
 
     rrd_rdunlock();
+
+    // If we actually freed any chart, schedule a deep rrdcontext GC pass.
+    // On non-dbengine hosts, dbengine rotation never triggers it, so archived
+    // RRDINSTANCE / RRDMETRIC entries would otherwise accumulate forever in
+    // host->rrdctx.contexts -> rc->rrdinstances / ri->rrdmetrics.
+    if(charts_freed)
+        rrdcontext_request_full_gc();
 }
 
 static void svc_rrdhost_cleanup_orphan_hosts(RRDHOST *protected_host) {

--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -28,9 +28,13 @@ static bool svc_rrddim_obsolete_to_archive(RRDDIM *rd) {
     return true;
 }
 
-static inline bool svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool all_dimensions) {
+// Returns the number of dimensions actually archived this call. The
+// caller can detect "all candidates archived" by checking
+// RRDSET_FLAG_OBSOLETE_DIMENSIONS afterwards: it is cleared on entry and
+// re-set only when some candidate could not be archived this pass.
+static inline size_t svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool all_dimensions) {
     if(!all_dimensions && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS))
-        return true;
+        return 0;
 
     worker_is_busy(UV_EVENT_ARCHIVE_CHART_DIMENSIONS);
 
@@ -59,12 +63,10 @@ static inline bool svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool all_d
     }
     dfe_done(rd);
 
-    if(dim_archives != dim_candidates) {
+    if(dim_archives != dim_candidates)
         rrdset_flag_set(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS);
-        return false;
-    }
 
-    return true;
+    return dim_archives;
 }
 
 static bool svc_rrdset_lock_for_deletion(RRDSET *st, time_t now) {
@@ -94,6 +96,11 @@ static inline size_t svc_rrdhost_cleanup_charts_marked_obsolete(RRDHOST *host) {
     size_t full_archives = 0;
     size_t partial_candidates = 0;
     size_t partial_archives = 0;
+    // Total archived metadata items (RRDMETRIC + RRDINSTANCE). Used by the
+    // caller to decide whether to schedule a deep rrdcontext GC pass.
+    // Counts every dimension archived (each produces an archived RRDMETRIC)
+    // plus every chart freed (each produces an archived RRDINSTANCE).
+    size_t archived_items = 0;
 
     time_t now = now_realtime_sec();
     RRDSET *st;
@@ -106,7 +113,10 @@ static inline size_t svc_rrdhost_cleanup_charts_marked_obsolete(RRDHOST *host) {
         if(flags & RRDSET_FLAG_OBSOLETE_DIMENSIONS) {
             partial_candidates++;
 
-            if(svc_rrdset_archive_obsolete_dimensions(st, false))
+            archived_items += svc_rrdset_archive_obsolete_dimensions(st, false);
+
+            // "all candidates archived" -> flag was not re-set inside.
+            if(!rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS))
                 partial_archives++;
         }
 
@@ -114,8 +124,11 @@ static inline size_t svc_rrdhost_cleanup_charts_marked_obsolete(RRDHOST *host) {
             full_candidates++;
 
             if(svc_rrdset_lock_for_deletion(st, now)) {
-                if(svc_rrdset_archive_obsolete_dimensions(st, true)) {
+                archived_items += svc_rrdset_archive_obsolete_dimensions(st, true);
+
+                if(!rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS)) {
                     full_archives++;
+                    archived_items++;       // rrdset_free archives the RRDINSTANCE
 
                     worker_is_busy(UV_EVENT_FREE_CHART);
                     rrdset_free(st);
@@ -135,11 +148,7 @@ static inline size_t svc_rrdhost_cleanup_charts_marked_obsolete(RRDHOST *host) {
     if(full_archives != full_candidates)
         rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_OBSOLETE_CHARTS);
 
-    // Both partial dim-archive (svc_rrdset_archive_obsolete_dimensions)
-    // and full chart-free (rrdset_free) produce archived RRDMETRIC and/or
-    // RRDINSTANCE entries in rrdcontext. Either kind of archival warrants
-    // a deep rrdcontext GC pass on non-dbengine hosts.
-    return partial_archives + full_archives;
+    return archived_items;
 }
 
 void svc_rrdhost_obsolete_all_charts(RRDHOST *host) {

--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -28,13 +28,15 @@ static bool svc_rrddim_obsolete_to_archive(RRDDIM *rd) {
     return true;
 }
 
-// Returns the number of dimensions actually archived this call. When the
-// function does any work (i.e. the early return below didn't fire), it
-// clears RRDSET_FLAG_OBSOLETE_DIMENSIONS on entry and only re-sets it
-// when some candidate could not be archived this pass. Callers can
-// therefore detect "all candidates archived" by checking the flag after
-// the call -- but only on the path that actually scanned (all_dimensions
-// is true, or the flag was set on entry).
+// Returns the number of dimensions actually archived this call.
+//
+// Two callable shapes:
+//   1. all_dimensions == false and RRDSET_FLAG_OBSOLETE_DIMENSIONS unset:
+//      early-return path. Nothing scanned, flag not touched, returns 0.
+//   2. Any other case: scans the dimensions. The flag is cleared up
+//      front, then re-set at the end iff some candidate could not be
+//      archived this pass. Callers on this path can detect "all
+//      candidates archived" by reading the flag after the call.
 static inline size_t svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool all_dimensions) {
     if(!all_dimensions && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS))
         return 0;

--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -28,10 +28,13 @@ static bool svc_rrddim_obsolete_to_archive(RRDDIM *rd) {
     return true;
 }
 
-// Returns the number of dimensions actually archived this call. The
-// caller can detect "all candidates archived" by checking
-// RRDSET_FLAG_OBSOLETE_DIMENSIONS afterwards: it is cleared on entry and
-// re-set only when some candidate could not be archived this pass.
+// Returns the number of dimensions actually archived this call. When the
+// function does any work (i.e. the early return below didn't fire), it
+// clears RRDSET_FLAG_OBSOLETE_DIMENSIONS on entry and only re-sets it
+// when some candidate could not be archived this pass. Callers can
+// therefore detect "all candidates archived" by checking the flag after
+// the call -- but only on the path that actually scanned (all_dimensions
+// is true, or the flag was set on entry).
 static inline size_t svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool all_dimensions) {
     if(!all_dimensions && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS))
         return 0;

--- a/src/database/contexts/rrdcontext-internal.h
+++ b/src/database/contexts/rrdcontext-internal.h
@@ -529,6 +529,12 @@ void rrdcontext_initial_processing_after_loading(RRDCONTEXT *rc);
 
 RRDLABELS *rrdinstance_labels(RRDINSTANCE *ri);
 
+// Bump the dbengine-rotations counter that gates extreme-cardinality
+// protection. Called from rrdcontext_db_rotation(); the chart-cleanup
+// trigger (rrdcontext_request_full_gc) deliberately does NOT bump it,
+// so the guard activates only on real dbengine rotations as before.
+void rrdcontext_count_db_rotation(void);
+
 bool rrdcontext_post_process_updates(RRDCONTEXT *rc, bool force, RRD_FLAGS reason, bool worker_jobs);
 void rrdcontext_post_process_queued_contexts(RRDHOST *host);
 void rrdcontext_dispatch_queued_contexts_to_hub(RRDHOST *host, usec_t now_ut);

--- a/src/database/contexts/rrdcontext-worker.c
+++ b/src/database/contexts/rrdcontext-worker.c
@@ -4,7 +4,7 @@
 
 static struct {
     bool enabled;
-    size_t db_rotations;
+    size_t db_rotations;            // count of actual dbengine rotations only
     size_t instances_count;
     size_t active_vs_archived_percentage;
 } extreme_cardinality = {
@@ -13,6 +13,10 @@ static struct {
     .instances_count = 1000,
     .active_vs_archived_percentage = 50,
 };
+
+void rrdcontext_count_db_rotation(void) {
+    __atomic_add_fetch(&extreme_cardinality.db_rotations, 1, __ATOMIC_RELAXED);
+}
 
 static uint64_t rrdcontext_get_next_version(RRDCONTEXT *rc);
 
@@ -1065,7 +1069,11 @@ void rrdcontext_main(void *ptr) {
 
         usec_t deadline = __atomic_load_n(&rrdcontext_next_db_rotation_ut, __ATOMIC_RELAXED);
         if(deadline && now_ut > deadline) {
-            extreme_cardinality.db_rotations++;
+            // db_rotations is bumped by rrdcontext_count_db_rotation() from
+            // rrdcontext_db_rotation() only -- the chart-cleanup trigger
+            // (rrdcontext_request_full_gc) does NOT bump it, so the
+            // extreme-cardinality guard at line ~700 still activates only
+            // after a real dbengine rotation.
             rrdcontext_recalculate_retention_all_hosts();
             rrdcontext_garbage_collect_for_all_hosts();
             // Clear the slot only if it still holds the deadline we

--- a/src/database/contexts/rrdcontext-worker.c
+++ b/src/database/contexts/rrdcontext-worker.c
@@ -1069,10 +1069,12 @@ void rrdcontext_main(void *ptr) {
             rrdcontext_recalculate_retention_all_hosts();
             rrdcontext_garbage_collect_for_all_hosts();
             // Clear the slot only if it still holds the deadline we
-            // processed. If a concurrent rrdcontext_request_full_gc() has
-            // armed a NEW deadline during this pass (it CAS'd 0 -> Y while
-            // we ran), leave it in place so the next iteration fires for
-            // the archives we may have missed.
+            // processed. rrdcontext_request_full_gc() cannot land mid-pass
+            // (the slot is non-zero, so its CAS 0 -> Y fails -- requests
+            // during a pass coalesce silently). rrdcontext_db_rotation(),
+            // however, does an unconditional store of a fresh deadline; if
+            // it fires during this pass, the CAS here fails and the new
+            // deadline survives to drive the next iteration.
             __atomic_compare_exchange_n(&rrdcontext_next_db_rotation_ut,
                                         &deadline, 0,
                                         false,

--- a/src/database/contexts/rrdcontext-worker.c
+++ b/src/database/contexts/rrdcontext-worker.c
@@ -23,6 +23,7 @@ static uint64_t rrdcontext_get_next_version(RRDCONTEXT *rc);
 static void rrdcontext_garbage_collect_for_all_hosts(void);
 
 extern usec_t rrdcontext_next_db_rotation_ut;
+extern size_t rrdcontext_full_gc_rerun_requested;
 
 // ----------------------------------------------------------------------------
 // version hash calculation
@@ -699,7 +700,7 @@ bool rrdcontext_post_process_updates(RRDCONTEXT *rc, bool force, RRD_FLAGS reaso
         dfe_done(ri);
 
         if(extreme_cardinality.enabled &&
-            extreme_cardinality.db_rotations &&
+            __atomic_load_n(&extreme_cardinality.db_rotations, __ATOMIC_RELAXED) &&
             instances_active &&
             instances_no_tier0 >= extreme_cardinality.instances_count) {
             size_t percent = (100 * instances_no_tier0 / instances_active);
@@ -1090,6 +1091,22 @@ void rrdcontext_main(void *ptr) {
                                         &deadline, 0,
                                         false,
                                         __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+
+            // If a rrdcontext_request_full_gc() landed mid-pass (its CAS
+            // failed because the slot was non-zero with an expired
+            // deadline), the host whose archive motivated it may have
+            // already been walked in this pass. Schedule a follow-up:
+            // arm a fresh deadline iff the slot is currently zero. If
+            // another path (e.g. dbengine rotation) just armed a new
+            // deadline, the CAS leaves it alone.
+            if(__atomic_exchange_n(&rrdcontext_full_gc_rerun_requested, 0, __ATOMIC_RELAXED)) {
+                usec_t expected = 0;
+                usec_t fresh = now_realtime_usec() + FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS * USEC_PER_SEC;
+                __atomic_compare_exchange_n(&rrdcontext_next_db_rotation_ut,
+                                            &expected, fresh,
+                                            false,
+                                            __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+            }
         }
 
         size_t hub_queued_contexts_for_all_hosts = 0;

--- a/src/database/contexts/rrdcontext-worker.c
+++ b/src/database/contexts/rrdcontext-worker.c
@@ -133,7 +133,7 @@ void rrdcontext_recalculate_host_retention(RRDHOST *host, RRD_FLAGS reason, bool
 }
 
 static void rrdcontext_recalculate_retention_all_hosts(void) {
-    rrdcontext_next_db_rotation_ut = 0;
+    __atomic_store_n(&rrdcontext_next_db_rotation_ut, 0, __ATOMIC_RELAXED);
     RRDHOST *host;
     dfe_start_reentrant(rrdhost_root_index, host) {
         worker_is_busy(WORKER_JOB_RETENTION);
@@ -1058,11 +1058,12 @@ void rrdcontext_main(void *ptr) {
 
         usec_t now_ut = now_realtime_usec();
 
-        if(rrdcontext_next_db_rotation_ut && now_ut > rrdcontext_next_db_rotation_ut) {
+        usec_t deadline = __atomic_load_n(&rrdcontext_next_db_rotation_ut, __ATOMIC_RELAXED);
+        if(deadline && now_ut > deadline) {
             extreme_cardinality.db_rotations++;
             rrdcontext_recalculate_retention_all_hosts();
             rrdcontext_garbage_collect_for_all_hosts();
-            rrdcontext_next_db_rotation_ut = 0;
+            __atomic_store_n(&rrdcontext_next_db_rotation_ut, 0, __ATOMIC_RELAXED);
         }
 
         size_t hub_queued_contexts_for_all_hosts = 0;

--- a/src/database/contexts/rrdcontext-worker.c
+++ b/src/database/contexts/rrdcontext-worker.c
@@ -133,7 +133,12 @@ void rrdcontext_recalculate_host_retention(RRDHOST *host, RRD_FLAGS reason, bool
 }
 
 static void rrdcontext_recalculate_retention_all_hosts(void) {
-    __atomic_store_n(&rrdcontext_next_db_rotation_ut, 0, __ATOMIC_RELAXED);
+    // Don't pre-clear rrdcontext_next_db_rotation_ut here -- the caller in
+    // rrdcontext_main clears it via CAS at the end of the pass, expecting
+    // the same deadline value it observed. Pre-clearing would let a
+    // concurrent rrdcontext_request_full_gc() arm a new deadline that the
+    // caller's unconditional store-to-zero would then silently overwrite,
+    // dropping the request.
     RRDHOST *host;
     dfe_start_reentrant(rrdhost_root_index, host) {
         worker_is_busy(WORKER_JOB_RETENTION);
@@ -1063,7 +1068,15 @@ void rrdcontext_main(void *ptr) {
             extreme_cardinality.db_rotations++;
             rrdcontext_recalculate_retention_all_hosts();
             rrdcontext_garbage_collect_for_all_hosts();
-            __atomic_store_n(&rrdcontext_next_db_rotation_ut, 0, __ATOMIC_RELAXED);
+            // Clear the slot only if it still holds the deadline we
+            // processed. If a concurrent rrdcontext_request_full_gc() has
+            // armed a NEW deadline during this pass (it CAS'd 0 -> Y while
+            // we ran), leave it in place so the next iteration fires for
+            // the archives we may have missed.
+            __atomic_compare_exchange_n(&rrdcontext_next_db_rotation_ut,
+                                        &deadline, 0,
+                                        false,
+                                        __ATOMIC_RELAXED, __ATOMIC_RELAXED);
         }
 
         size_t hub_queued_contexts_for_all_hosts = 0;

--- a/src/database/contexts/rrdcontext-worker.c
+++ b/src/database/contexts/rrdcontext-worker.c
@@ -1069,12 +1069,15 @@ void rrdcontext_main(void *ptr) {
             rrdcontext_recalculate_retention_all_hosts();
             rrdcontext_garbage_collect_for_all_hosts();
             // Clear the slot only if it still holds the deadline we
-            // processed. rrdcontext_request_full_gc() cannot land mid-pass
-            // (the slot is non-zero, so its CAS 0 -> Y fails -- requests
-            // during a pass coalesce silently). rrdcontext_db_rotation(),
-            // however, does an unconditional store of a fresh deadline; if
-            // it fires during this pass, the CAS here fails and the new
-            // deadline survives to drive the next iteration.
+            // processed. Two writers can race this pass:
+            //   - rrdcontext_request_full_gc() arms only when the slot is
+            //     zero, but the slot stays non-zero throughout this pass,
+            //     so any such request during the pass is coalesced into
+            //     the in-flight pass and does not arm a new deadline.
+            //   - rrdcontext_db_rotation() stores unconditionally. If it
+            //     fires during this pass, the slot now holds a fresh
+            //     deadline; the CAS here fails and that deadline drives
+            //     the next iteration.
             __atomic_compare_exchange_n(&rrdcontext_next_db_rotation_ut,
                                         &deadline, 0,
                                         false,

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -118,10 +118,16 @@ ALWAYS_INLINE void rrdcontext_request_full_gc(void) {
     // hosts also drop archived rrdinstance / rrdmetric entries -- otherwise
     // those grow unbounded with chart churn (k8s cgroups, etc.) because the
     // dbengine rotation trigger never fires on them.
-    // Reuses rrdcontext_next_db_rotation_ut as the schedule slot; multiple
-    // requests within FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS
-    // coalesce into a single deep GC pass.
-    rrdcontext_next_db_rotation_ut = now_realtime_usec() + FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS * USEC_PER_SEC;
+    //
+    // The maintenance loop runs every 10 s; under continuous churn it would
+    // free charts on every pass. Unconditionally rewriting the deadline
+    // would push it out by another 120 s on every call, so under sustained
+    // churn the deep GC would never actually fire. Only arm the deadline if
+    // no pass is already scheduled; the worker resets the slot to 0 after
+    // it runs, at which point the next chart-free arms a fresh window.
+    // Multiple requests within that window coalesce into a single GC pass.
+    if(rrdcontext_next_db_rotation_ut == 0)
+        rrdcontext_next_db_rotation_ut = now_realtime_usec() + FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS * USEC_PER_SEC;
 }
 
 int rrdcontext_find_dimension_uuid(RRDSET *st, const char *id, nd_uuid_t *store_uuid) {

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -119,6 +119,10 @@ ALWAYS_INLINE void rrdcontext_db_rotation(void) {
     __atomic_store_n(&rrdcontext_next_db_rotation_ut,
                      now_realtime_usec() + FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS * USEC_PER_SEC,
                      __ATOMIC_RELAXED);
+    // Count only real dbengine rotations (not chart-cleanup-driven scans),
+    // so the extreme-cardinality guard in the rrdcontext worker preserves
+    // its original "wait for first rotation" semantics.
+    rrdcontext_count_db_rotation();
 }
 
 ALWAYS_INLINE void rrdcontext_request_full_gc(void) {

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -106,10 +106,19 @@ ALWAYS_INLINE void rrdcontext_host_child_connected(RRDHOST *host) {
     rrdset_foreach_done(st);
 }
 
+// Cross-thread schedule slot for the deep rrdcontext GC pass. Written by
+// rrdcontext_db_rotation() (dbengine rotation), rrdcontext_request_full_gc()
+// (chart-cleanup), and the rrdcontext worker (reset to 0 after a pass).
+// All accesses go through __atomic_* so 32-bit platforms cannot tear the
+// 64-bit value, and the request_full_gc() check-then-set is a real CAS
+// rather than a TOCTOU race.
 usec_t rrdcontext_next_db_rotation_ut = 0;
+
 ALWAYS_INLINE void rrdcontext_db_rotation(void) {
     // called when the db rotates its database
-    rrdcontext_next_db_rotation_ut = now_realtime_usec() + FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS * USEC_PER_SEC;
+    __atomic_store_n(&rrdcontext_next_db_rotation_ut,
+                     now_realtime_usec() + FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS * USEC_PER_SEC,
+                     __ATOMIC_RELAXED);
 }
 
 ALWAYS_INLINE void rrdcontext_request_full_gc(void) {
@@ -126,8 +135,12 @@ ALWAYS_INLINE void rrdcontext_request_full_gc(void) {
     // no pass is already scheduled; the worker resets the slot to 0 after
     // it runs, at which point the next chart-free arms a fresh window.
     // Multiple requests within that window coalesce into a single GC pass.
-    if(rrdcontext_next_db_rotation_ut == 0)
-        rrdcontext_next_db_rotation_ut = now_realtime_usec() + FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS * USEC_PER_SEC;
+    usec_t expected = 0;
+    usec_t deadline = now_realtime_usec() + FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS * USEC_PER_SEC;
+    __atomic_compare_exchange_n(&rrdcontext_next_db_rotation_ut,
+                                &expected, deadline,
+                                false,
+                                __ATOMIC_RELAXED, __ATOMIC_RELAXED);
 }
 
 int rrdcontext_find_dimension_uuid(RRDSET *st, const char *id, nd_uuid_t *store_uuid) {

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -114,6 +114,13 @@ ALWAYS_INLINE void rrdcontext_host_child_connected(RRDHOST *host) {
 // rather than a TOCTOU race.
 usec_t rrdcontext_next_db_rotation_ut = 0;
 
+// Companion flag for rrdcontext_request_full_gc(): set when its CAS
+// failed because the worker was already mid-pass with the deadline in
+// the past. The worker reads-and-clears this after each pass and arms
+// a follow-up if set, so an archive that landed mid-pass (after the
+// worker had already walked its host) doesn't get stranded.
+size_t rrdcontext_full_gc_rerun_requested = 0;
+
 ALWAYS_INLINE void rrdcontext_db_rotation(void) {
     // called when the db rotates its database
     __atomic_store_n(&rrdcontext_next_db_rotation_ut,
@@ -139,12 +146,22 @@ ALWAYS_INLINE void rrdcontext_request_full_gc(void) {
     // no pass is already scheduled; the worker resets the slot to 0 after
     // it runs, at which point the next chart-free arms a fresh window.
     // Multiple requests within that window coalesce into a single GC pass.
+    usec_t now = now_realtime_usec();
     usec_t expected = 0;
-    usec_t deadline = now_realtime_usec() + FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS * USEC_PER_SEC;
-    __atomic_compare_exchange_n(&rrdcontext_next_db_rotation_ut,
-                                &expected, deadline,
-                                false,
-                                __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+    usec_t deadline = now + FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS * USEC_PER_SEC;
+    if(!__atomic_compare_exchange_n(&rrdcontext_next_db_rotation_ut,
+                                    &expected, deadline,
+                                    false,
+                                    __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+        // CAS failed -- expected now holds the slot's actual value.
+        // If that deadline is in the past, the worker is mid-pass and
+        // may already have walked the host whose archive triggered this
+        // request. Mark for a follow-up so the worker schedules another
+        // pass after the current one. Future-armed deadlines need no
+        // follow-up: their upcoming pass will see the archive.
+        if(expected && expected <= now)
+            __atomic_store_n(&rrdcontext_full_gc_rerun_requested, 1, __ATOMIC_RELAXED);
+    }
 }
 
 int rrdcontext_find_dimension_uuid(RRDSET *st, const char *id, nd_uuid_t *store_uuid) {

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -112,6 +112,18 @@ ALWAYS_INLINE void rrdcontext_db_rotation(void) {
     rrdcontext_next_db_rotation_ut = now_realtime_usec() + FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS * USEC_PER_SEC;
 }
 
+ALWAYS_INLINE void rrdcontext_request_full_gc(void) {
+    // Schedule a deep rrdcontext GC pass. Called from chart-cleanup paths
+    // (e.g. svc_rrd_cleanup_obsolete_charts_from_all_hosts) so non-dbengine
+    // hosts also drop archived rrdinstance / rrdmetric entries -- otherwise
+    // those grow unbounded with chart churn (k8s cgroups, etc.) because the
+    // dbengine rotation trigger never fires on them.
+    // Reuses rrdcontext_next_db_rotation_ut as the schedule slot; multiple
+    // requests within FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS
+    // coalesce into a single deep GC pass.
+    rrdcontext_next_db_rotation_ut = now_realtime_usec() + FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS * USEC_PER_SEC;
+}
+
 int rrdcontext_find_dimension_uuid(RRDSET *st, const char *id, nd_uuid_t *store_uuid) {
     if(!st->rrdhost) return 1;
     if(!st->context) return 2;

--- a/src/database/contexts/rrdcontext.h
+++ b/src/database/contexts/rrdcontext.h
@@ -128,6 +128,7 @@ void rrdcontext_hub_pending_checkpoint_replay(RRDHOST *host);
 // public API for threads
 
 void rrdcontext_db_rotation(void);
+void rrdcontext_request_full_gc(void);
 void rrdcontext_main(void *);
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
On RAM-mode agents (eg k8s iot children), the deep rrdcontext GC that drops archived `RRDINSTANCE` / `RRDMETRIC` entries was only scheduled   by dbengine on database rotation. 

With no dbengine, that schedule never fires, so context metadata piles up forever as charts churn

This PR adds `rrdcontext_request_full_gc()` and calls it from the chart-cleanup pass whenever at least one chart was actually freed. It reuses the existing 120 s debouncer slot so concurrent triggers coalesce and dbengine hosts behave identically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a rrdcontext metadata leak on non-dbengine hosts by scheduling deep GC whenever chart cleanup archives charts or dimensions. Prevents unbounded growth of archived `RRDINSTANCE`/`RRDMETRIC` on RAM‑mode hosts (e.g., k8s).

- **Bug Fixes**
  - Added `rrdcontext_request_full_gc()`; reuses the 120 s debounce and arms only when the slot is 0, so churn can’t push it out forever.
  - Chart cleanup now counts actual archives (each dimension archived + 1 per chart freed) across hosts and requests GC when >0, including partial‑dimension archives on live charts.
  - Hardened the GC schedule slot: atomic load/store/CAS, no pre‑clear during a pass, and the worker clears via CAS only if the same deadline; mid‑pass requests set a rerun flag so a follow‑up is armed; the extreme‑cardinality guard now activates only on real dbengine rotations with `db_rotations` updated and read atomically.

<sup>Written for commit e811cf67fb641d68b9cad17d47aa4940d1806dc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

