### PR TITLE
Provide zstd compressed source archives and use them in the kickstart and updaer scripts when supported.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,8 @@ jobs:
     needs:
       - file-check
     outputs:
-      distfile: ${{ steps.build.outputs.distfile }}
+      gz_distfile: ${{ steps.build.outputs.gz_distfile }}
+      zst_distfile: ${{ steps.build.outputs.zst_distfile }}
     steps:
       - name: Skip Check
         id: skip
@@ -172,20 +173,17 @@ jobs:
         id: build
         if: needs.file-check.outputs.run == 'true'
         run: |
-          mkdir -p artifacts/
-          tar --create --file "artifacts/netdata-$(git describe).tar.gz" \
-              --sort=name --posix --auto-compress --exclude=artifacts --exclude=.git \
-              --exclude=.gitignore --exclude=.gitattributes --exclude=.gitmodules \
-              --transform "s/^\\.\\//netdata-$(git describe)\\//" --verbose .
+          packaging/create-source-archives.sh
           cd artifacts/
-          echo "distfile=$(find . -name 'netdata-*.tar.gz')" >> "${GITHUB_OUTPUT}"
+          echo "gz_distfile=$(find . -name 'netdata-*.tar.gz')" >> "${GITHUB_OUTPUT}"
+          echo "zst_distfile=$(find . -name 'netdata-*.tar.zst')" >> "${GITHUB_OUTPUT}"
       - name: Store
         id: store
         if: needs.file-check.outputs.run == 'true'
         uses: actions/upload-artifact@v7.0.1
         with:
           name: dist-tarball
-          path: artifacts/*.tar.gz
+          path: artifacts/*.tar.*
           retention-days: 30
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
@@ -570,7 +568,8 @@ jobs:
         working-directory: ./artifacts/
         run: |
           mv ../dist-artifacts/* . || exit 1
-          ln -s ${{ needs.build-dist.outputs.distfile }} netdata-latest.tar.gz || exit 1
+          ln -s ${{ needs.build-dist.outputs.gz_distfile }} netdata-latest.tar.gz || exit 1
+          ln -s ${{ needs.build-dist.outputs.zst_distfile }} netdata-latest.tar.zst || exit 1
           cp ../packaging/version ./latest-version.txt || exit 1
           sha256sum -b ./* > sha256sums.txt || exit 1
           cat sha256sums.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,8 @@ jobs:
     needs:
       - file-check
     outputs:
-      distfile: ${{ steps.build.outputs.distfile }}
+      gz_distfile: ${{ steps.build.outputs.gz_distfile }}
+      zst_distfile: ${{ steps.build.outputs.zst_distfile }}
     steps:
       - name: Skip Check
         id: skip
@@ -180,20 +181,17 @@ jobs:
         id: build
         if: needs.file-check.outputs.run == 'true'
         run: |
-          mkdir -p artifacts/
-          tar --create --file "artifacts/netdata-$(git describe).tar.gz" \
-              --sort=name --posix --auto-compress --exclude=artifacts --exclude=.git \
-              --exclude=.gitignore --exclude=.gitattributes --exclude=.gitmodules \
-              --transform "s/^\\.\\//netdata-$(git describe)\\//" --verbose .
+          packaging/create-source-archives.sh
           cd artifacts/
-          echo "distfile=$(find . -name 'netdata-*.tar.gz')" >> "${GITHUB_OUTPUT}"
+          echo "gz_distfile=$(find . -name 'netdata-*.tar.gz')" >> "${GITHUB_OUTPUT}"
+          echo "zst_distfile=$(find . -name 'netdata-*.tar.zst')" >> "${GITHUB_OUTPUT}"
       - name: Store
         id: store
         if: needs.file-check.outputs.run == 'true'
         uses: actions/upload-artifact@v7.0.1
         with:
           name: dist-tarball
-          path: artifacts/*.tar.gz
+          path: artifacts/*.tar.*
           compression-level: 0
           retention-days: 30
       - name: Failure Notification
@@ -699,7 +697,8 @@ jobs:
         working-directory: ./artifacts/
         run: |
           mv ../dist-artifacts/* . || exit 1
-          ln -s ${{ needs.build-dist.outputs.distfile }} netdata-latest.tar.gz || exit 1
+          ln -s ${{ needs.build-dist.outputs.gz_distfile }} netdata-latest.tar.gz || exit 1
+          ln -s ${{ needs.build-dist.outputs.zst_distfile }} netdata-latest.tar.zst || exit 1
           cp ../packaging/version ./latest-version.txt || exit 1
           sha256sum -b ./* > sha256sums.txt || exit 1
           cat sha256sums.txt

--- a/packaging/create-source-archives.sh
+++ b/packaging/create-source-archives.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+set -e
+
+SCRIPT_SOURCE="$(
+    self=${0}
+    while [ -L "${self}" ]
+    do
+        cd "${self%/*}" || exit 1
+        self=$(readlink "${self}")
+    done
+    cd "${self%/*}" || exit 1
+    echo "$(pwd -P)/${self##*/}"
+)"
+SOURCE_DIR="$(dirname "$(dirname "${SCRIPT_SOURCE}")")"
+
+cd "${SOURCE_DIR}" || exit 1
+
+tar="$(command -v tar 2>/dev/null || true)"
+gzip="$(command -v gzip 2>/dev/null || true)"
+zstd="$(command -v zstd 2>/dev/null || true)"
+
+[ -n "${tar}" ] || exit 1
+[ -n "${gzip}" ] || exit 1
+[ -n "${zstd}" ] || exit 1
+
+mkdir -p artifacts artifacts/tmp
+
+echo "Determining archive name..."
+
+archive_name="netdata"
+[ -d ./.git ] && archive_name="netdata-$(git describe)"
+archive_tmp="artifacts/tmp/${archive_name}.tar"
+
+echo "::group::Generating tar archive"
+
+${tar} --create \
+       --file "${archive_tmp}" \
+       --sort=name \
+       --posix \
+       --exclude=./artifacts \
+       --exclude=.git \
+       --exclude=.gitignore \
+       --exclude=.gitatributes \
+       --exclude=.gitmodules \
+       --transform "s/^\\.\\//${archive_name}\\//" \
+       --verbose \
+       .
+
+echo "::endgroup::"
+
+echo "::group::Creating gzip compressed archive"
+
+${gzip} -v -k -9 "${archive_tmp}"
+
+mv -v "${archive_tmp}.gz" "./artifacts"
+
+echo "::endgroup::"
+
+echo "::group::Creating zstd compressed archive"
+
+${zstd} -v -19 -T0 "${archive_tmp}"
+
+mv -v "${archive_tmp}.zst" "./artifacts"
+
+echo "::endgroup::"
+
+rm -v "${archive_tmp}"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1975,20 +1975,24 @@ try_static_install() {
 set_source_archive_urls() {
   if [ "$1" = "stable" ]; then
     if [ -n "${INSTALL_VERSION}" ]; then
-      export NETDATA_SOURCE_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/netdata-v${INSTALL_VERSION}.tar.gz"
+      export NETDATA_SOURCE_ARCHIVE_BASE_NAME="netdata-v${INSTALL_VERSION}.tar"
+      export NETDATA_SOURCE_ARCHIVE_BASEURL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/${NETDATA_SOURCE_ARCHIVE_BASE_NAME}"
       export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/sha256sums.txt"
     else
       latest="$(get_redirect "https://github.com/netdata/netdata/releases/latest")"
-      export NETDATA_SOURCE_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/${latest}/netdata-${latest}.tar.gz"
+      export NETDATA_SOURCE_ARCHIVE_BASE_NAME="netdata-v${latest}.tar"
+      export NETDATA_SOURCE_ARCHIVE_BASEURL="https://github.com/netdata/netdata/releases/download/${latest}/${NETDATA_SOURCE_ARCHIVE_BASE_NAME}"
       export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/${latest}/sha256sums.txt"
     fi
   else
+    export NETDATA_SOURCE_ARCHIVE_BASE_NAME="netdata-latest.tar"
+
     if [ -n "${INSTALL_VERSION}" ]; then
-      export NETDATA_SOURCE_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/netdata-latest.tar.gz"
+      export NETDATA_SOURCE_ARCHIVE_BASEURL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/${NETDATA_SOURCE_ARCHIVE_BASE_NAME}"
       export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/sha256sums.txt"
     else
       tag="$(get_redirect "${NETDATA_TARBALL_BASEURL}/latest")"
-      export NETDATA_SOURCE_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/download/${tag}/netdata-latest.tar.gz"
+      export NETDATA_SOURCE_ARCHIVE_BASEURL="${NETDATA_TARBALL_BASEURL}/download/${tag}/${NETDATA_SOURCE_ARCHIVE_BASE_NAME}"
       export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/download/${tag}/sha256sums.txt"
     fi
   fi
@@ -2079,12 +2083,26 @@ try_build_install() {
   fi
 
   set_source_archive_urls "${SELECTED_RELEASE_CHANNEL}"
+  zstd="$(command -v zstd 2>/dev/null || true)"
+  archive_name=""
 
-  if [ -n "${INSTALL_VERSION}" ]; then
-    if ! download "${NETDATA_SOURCE_ARCHIVE_URL}" "./netdata-v${INSTALL_VERSION}.tar.gz"; then
-      fatal "Failed to download source tarball for local build. ${BADNET_MSG}." F000B
+  if [ -n "${zstd}" ]; then
+    if download "${NETDATA_SOURCE_ARCHIVE_BASEURL}.zst"; then
+      archive_name="${NETDATA_SOURCE_ARCHIVE_BASE_NAME}.zst"
+      decompress="${zstd} -dcf"
+    else
+      warning "Unable to fetch zstd compressed source tarball, trying gzip compressed tarball instead."
     fi
-  elif ! download "${NETDATA_SOURCE_ARCHIVE_URL}" "./netdata-latest.tar.gz"; then
+  fi
+
+  if [ -z "${archive_name}" ]; then
+    if download "${NETDATA_SOURCE_ARCHIVE_BASEURL}.gz"; then
+      archive_name="${NETDATA_SOURCE_ARCHIVE_BASE_NAME}.gz"
+      decompress="$(command -v gzip 2>/dev/null) -dc"
+    fi
+  fi
+
+  if [ -z "${archive_name}" ]; then
     fatal "Failed to download source tarball for local build. ${BADNET_MSG}." F000B
   fi
 
@@ -2095,22 +2113,14 @@ try_build_install() {
   if [ "${DRY_RUN}" -eq 1 ]; then
     progress "Would validate SHA256 checksum of downloaded source archive."
   else
-    if [ -z "${INSTALL_VERSION}" ]; then
-      # shellcheck disable=SC2086
-      if ! grep netdata-latest.tar.gz "./sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
-        bad_sums_report="$(report_bad_sha256sum netdata-latest.tar.gz "./sha256sum.txt")"
-        fatal "Tarball checksum validation failed.\n${bad_sums_report}\n${BADCACHE_MSG}." F0005
-      fi
+    if ! grep "${archive_name}" ./sha256sum.txt | safe_sha256sum -c - > /dev/null 2>&1; then
+      bad_sums_report="$(report_bad_sha256sum "${archive_name}" ./sha256sum.txt)"
+      fatal "Tarball checksum validation failed.\n${bad_sums_report}\n${BADCACHE_MSG}." F0005
     fi
   fi
 
-  if [ -n "${INSTALL_VERSION}" ]; then
-    run tar -xf "./netdata-v${INSTALL_VERSION}.tar.gz" -C "${tmpdir}"
-    rm -rf "./netdata-v${INSTALL_VERSION}.tar.gz" > /dev/null 2>&1
-  else
-    run tar -xf "./netdata-latest.tar.gz" -C "${tmpdir}"
-    rm -rf "./netdata-latest.tar.gz" > /dev/null 2>&1
-  fi
+  run ${decompress} | tar -xf - -C "${tmpdir}"
+  rm -rf "${archive_name}" > /dev/null 2>&1
 
   if [ "${DRY_RUN}" -ne 1 ]; then
     netdata_src_dir="$(find "${tmpdir}" -mindepth 1 -maxdepth 1 -type d -name 'netdata-*' | head -n 1)"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2161,20 +2161,24 @@ try_static_install() {
 set_source_archive_urls() {
   if [ "$1" = "stable" ]; then
     if [ -n "${INSTALL_VERSION}" ]; then
-      export NETDATA_SOURCE_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/netdata-v${INSTALL_VERSION}.tar.gz"
+      export NETDATA_SOURCE_ARCHIVE_BASE_NAME="netdata-v${INSTALL_VERSION}.tar"
+      export NETDATA_SOURCE_ARCHIVE_BASEURL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/${NETDATA_SOURCE_ARCHIVE_BASE_NAME}"
       export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/sha256sums.txt"
     else
       latest="$(get_redirect "https://github.com/netdata/netdata/releases/latest")"
-      export NETDATA_SOURCE_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/${latest}/netdata-${latest}.tar.gz"
+      export NETDATA_SOURCE_ARCHIVE_BASE_NAME="netdata-v${latest}.tar"
+      export NETDATA_SOURCE_ARCHIVE_BASEURL="https://github.com/netdata/netdata/releases/download/${latest}/${NETDATA_SOURCE_ARCHIVE_BASE_NAME}"
       export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/${latest}/sha256sums.txt"
     fi
   else
+    export NETDATA_SOURCE_ARCHIVE_BASE_NAME="netdata-latest.tar"
+
     if [ -n "${INSTALL_VERSION}" ]; then
-      export NETDATA_SOURCE_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/netdata-latest.tar.gz"
+      export NETDATA_SOURCE_ARCHIVE_BASEURL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/${NETDATA_SOURCE_ARCHIVE_BASE_NAME}"
       export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/sha256sums.txt"
     else
       tag="$(get_redirect "${NETDATA_TARBALL_BASEURL}/latest")"
-      export NETDATA_SOURCE_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/download/${tag}/netdata-latest.tar.gz"
+      export NETDATA_SOURCE_ARCHIVE_BASEURL="${NETDATA_TARBALL_BASEURL}/download/${tag}/${NETDATA_SOURCE_ARCHIVE_BASE_NAME}"
       export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/download/${tag}/sha256sums.txt"
     fi
   fi
@@ -2265,12 +2269,26 @@ try_build_install() {
   fi
 
   set_source_archive_urls "${SELECTED_RELEASE_CHANNEL}"
+  zstd="$(command -v zstd 2>/dev/null || true)"
+  archive_name=""
 
-  if [ -n "${INSTALL_VERSION}" ]; then
-    if ! download "${NETDATA_SOURCE_ARCHIVE_URL}" "./netdata-v${INSTALL_VERSION}.tar.gz"; then
-      fatal "Failed to download source tarball for local build. ${BADNET_MSG}." F000B
+  if [ -n "${zstd}" ]; then
+    if download "${NETDATA_SOURCE_ARCHIVE_BASEURL}.zst"; then
+      archive_name="${NETDATA_SOURCE_ARCHIVE_BASE_NAME}.zst"
+      decompress="${zstd} -dcf"
+    else
+      warning "Unable to fetch zstd compressed source tarball, trying gzip compressed tarball instead."
     fi
-  elif ! download "${NETDATA_SOURCE_ARCHIVE_URL}" "./netdata-latest.tar.gz"; then
+  fi
+
+  if [ -z "${archive_name}" ]; then
+    if download "${NETDATA_SOURCE_ARCHIVE_BASEURL}.gz"; then
+      archive_name="${NETDATA_SOURCE_ARCHIVE_BASE_NAME}.gz"
+      decompress="$(command -v gzip 2>/dev/null) -dc"
+    fi
+  fi
+
+  if [ -z "${archive_name}" ]; then
     fatal "Failed to download source tarball for local build. ${BADNET_MSG}." F000B
   fi
 
@@ -2281,22 +2299,14 @@ try_build_install() {
   if [ "${DRY_RUN}" -eq 1 ]; then
     progress "Would validate SHA256 checksum of downloaded source archive."
   else
-    if [ -z "${INSTALL_VERSION}" ]; then
-      # shellcheck disable=SC2086
-      if ! grep netdata-latest.tar.gz "./sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
-        bad_sums_report="$(report_bad_sha256sum netdata-latest.tar.gz "./sha256sum.txt")"
-        fatal "Tarball checksum validation failed.\n${bad_sums_report}\n${BADCACHE_MSG}." F0005
-      fi
+    if ! grep "${archive_name}" ./sha256sum.txt | safe_sha256sum -c - > /dev/null 2>&1; then
+      bad_sums_report="$(report_bad_sha256sum "${archive_name}" ./sha256sum.txt)"
+      fatal "Tarball checksum validation failed.\n${bad_sums_report}\n${BADCACHE_MSG}." F0005
     fi
   fi
 
-  if [ -n "${INSTALL_VERSION}" ]; then
-    run tar -xf "./netdata-v${INSTALL_VERSION}.tar.gz" -C "${tmpdir}"
-    rm -rf "./netdata-v${INSTALL_VERSION}.tar.gz" > /dev/null 2>&1
-  else
-    run tar -xf "./netdata-latest.tar.gz" -C "${tmpdir}"
-    rm -rf "./netdata-latest.tar.gz" > /dev/null 2>&1
-  fi
+  run ${decompress} | tar -xf - -C "${tmpdir}"
+  rm -rf "${archive_name}" > /dev/null 2>&1
 
   if [ "${DRY_RUN}" -ne 1 ]; then
     netdata_src_dir="$(find "${tmpdir}" -mindepth 1 -maxdepth 1 -type d -name 'netdata-*' | head -n 1)"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2273,7 +2273,7 @@ try_build_install() {
   archive_name=""
 
   if [ -n "${zstd}" ]; then
-    if download "${NETDATA_SOURCE_ARCHIVE_BASEURL}.zst"; then
+    if download "${NETDATA_SOURCE_ARCHIVE_BASEURL}.zst" "${NETDATA_SOURCE_ARCHIVE_BASE_NAME}.zst"; then
       archive_name="${NETDATA_SOURCE_ARCHIVE_BASE_NAME}.zst"
       decompress="${zstd} -dcf"
     else
@@ -2282,7 +2282,7 @@ try_build_install() {
   fi
 
   if [ -z "${archive_name}" ]; then
-    if download "${NETDATA_SOURCE_ARCHIVE_BASEURL}.gz"; then
+    if download "${NETDATA_SOURCE_ARCHIVE_BASEURL}.gz" "${NETDATA_SOURCE_ARCHIVE_BASE_NAME}.gz"; then
       archive_name="${NETDATA_SOURCE_ARCHIVE_BASE_NAME}.gz"
       decompress="$(command -v gzip 2>/dev/null) -dc"
     fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -20,9 +20,9 @@
 # Optional environment options:
 #
 #  - TMPDIR (set to a usable temporary directory)
-#  - NETDATA_NIGHTLIES_BASEURL (set the base url for downloading the dist tarball)
+#  - NETDATA_BASE_URL (set the base url for downloading the dist tarball)
 
-# Next unused error code: U001F
+# Next unused error code: U0020
 
 set -e
 
@@ -919,22 +919,58 @@ update_build() {
   ndtmpdir=$(create_exec_tmp_directory)
   cd "$ndtmpdir" || fatal "Failed to change current working directory to ${ndtmpdir}" U0016
 
+  archive_base_name="netdata-latest.tar"
+
+  case "${RELEASE_CHANNEL}" in
+    stable)
+      latest="$(get_netdata_latest_tag "${NETDATA_STABLE_BASE_URL}")"
+      NETDATA_TARBALL_BASE_URL="${NETDATA_STABLE_BASE_URL}/download/${latest}/${archive_base_name}"
+      NETDATA_TARBALL_CHECKSUM_URL="${NETDATA_STABLE_BASE_URL}/download/${latest}/sha256sums.txt"
+      ;;
+    nightly)
+      latest="$(get_netdata_latest_tag "${NETDATA_NIGHTLY_BASE_URL}")"
+      NETDATA_TARBALL_BASE_URL="${NETDATA_NIGHTLY_BASE_URL}/download/${latest}/${archive_base_name}"
+      NETDATA_TARBALL_CHECKSUM_URL="${NETDATA_NIGHTLY_BASE_URL}/download/${latest}/sha256sums.txt"
+      ;;
+    *) fatal "Unknown release channel ${RELEASE_CHANNEL}, unable to update" U001F ;;
+  esac
+
+  zstd="$(command -v zstd 2>/dev/null || true)"
+
   install_build_dependencies
 
   if update_available; then
     download "${NETDATA_TARBALL_CHECKSUM_URL}" "${ndtmpdir}/sha256sum.txt" >&3 2>&3
-    download "${NETDATA_TARBALL_URL}" "${ndtmpdir}/netdata-latest.tar.gz"
+
+    archive_name=""
+
+    if [ -n "${zstd}" ]; then
+      if download "${NETDATA_TARBALL_BASE_URL}.zst" "${ndtmpdir}/${archive_base_name}.zst"; then
+        archive_name="${archive_base_name}.zst"
+        decompress="${zstd} -dc"
+      else
+        warning "Failed to download zstd compressed source archive, trying gzip compressed source archive as a fallback."
+      fi
+    fi
+
+    if [ -z "${archive_name}" ]; then
+      if download "${NETDATA_TARBALL_BASE_URL}.gz" "${ndtmpdir}/${archive_base_name}.gz"; then
+        archive_name="${archive_base_name}.gz"
+        decompress="$(command -v gzip 2>/dev/null) -dc"
+      fi
+    fi
+
     if [ -n "${NETDATA_TARBALL_CHECKSUM}" ] &&
       grep "${NETDATA_TARBALL_CHECKSUM}" sha256sum.txt >&3 2>&3 &&
       [ "$NETDATA_FORCE_UPDATE" != "1" ]; then
       info "Newest version is already installed"
     else
-      if ! grep netdata-latest.tar.gz sha256sum.txt | safe_sha256sum -c - >&3 2>&3; then
+      if ! grep "${archive_name}" sha256sum.txt | safe_sha256sum -c - >&3 2>&3; then
         fatal "Tarball checksum validation failed. Stopping netdata upgrade and leaving tarball in ${ndtmpdir}\nUsually this is a result of an older copy of the tarball or checksum file being cached somewhere upstream and can be resolved by retrying in an hour." U0008
       fi
-      NEW_CHECKSUM="$(safe_sha256sum netdata-latest.tar.gz 2> /dev/null | cut -d' ' -f1)"
-      tar -xf netdata-latest.tar.gz >&3 2>&3
-      rm netdata-latest.tar.gz >&3 2>&3
+      NEW_CHECKSUM="$(safe_sha256sum "${archive_name}" 2> /dev/null | cut -d' ' -f1)"
+      ${decompress} "${archive_name}" | tar -xf - >&3 2>&3
+      rm "${archive_name}" >&3 2>&3
       if [ -z "$path_version" ]; then
         latest_tag="$(get_latest_tag)"
         path_version="$(echo "${latest_tag}" | cut -f 1 -d "-")"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -20,9 +20,9 @@
 # Optional environment options:
 #
 #  - TMPDIR (set to a usable temporary directory)
-#  - NETDATA_NIGHTLIES_BASEURL (set the base url for downloading the dist tarball)
+#  - NETDATA_BASE_URL (set the base url for downloading the dist tarball)
 
-# Next unused error code: U0029
+# Next unused error code: U002A
 
 set -e
 
@@ -1060,22 +1060,58 @@ update_build() {
   create_exec_tmp_directory
   cd "$ndtmpdir" || fatal "Failed to change current working directory to ${ndtmpdir}" U0016
 
+  archive_base_name="netdata-latest.tar"
+
+  case "${RELEASE_CHANNEL}" in
+    stable)
+      latest="$(get_netdata_latest_tag "${NETDATA_STABLE_BASE_URL}")"
+      NETDATA_TARBALL_BASE_URL="${NETDATA_STABLE_BASE_URL}/download/${latest}/${archive_base_name}"
+      NETDATA_TARBALL_CHECKSUM_URL="${NETDATA_STABLE_BASE_URL}/download/${latest}/sha256sums.txt"
+      ;;
+    nightly)
+      latest="$(get_netdata_latest_tag "${NETDATA_NIGHTLY_BASE_URL}")"
+      NETDATA_TARBALL_BASE_URL="${NETDATA_NIGHTLY_BASE_URL}/download/${latest}/${archive_base_name}"
+      NETDATA_TARBALL_CHECKSUM_URL="${NETDATA_NIGHTLY_BASE_URL}/download/${latest}/sha256sums.txt"
+      ;;
+    *) fatal "Unknown release channel ${RELEASE_CHANNEL}, unable to update" U0029 ;;
+  esac
+
+  zstd="$(command -v zstd 2>/dev/null || true)"
+
   install_build_dependencies
 
   if update_available; then
     download "${NETDATA_TARBALL_CHECKSUM_URL}" "${ndtmpdir}/sha256sum.txt" >&3 2>&3
-    download "${NETDATA_TARBALL_URL}" "${ndtmpdir}/netdata-latest.tar.gz"
+
+    archive_name=""
+
+    if [ -n "${zstd}" ]; then
+      if download "${NETDATA_TARBALL_BASE_URL}.zst" "${ndtmpdir}/${archive_base_name}.zst"; then
+        archive_name="${archive_base_name}.zst"
+        decompress="${zstd} -dc"
+      else
+        warning "Failed to download zstd compressed source archive, trying gzip compressed source archive as a fallback."
+      fi
+    fi
+
+    if [ -z "${archive_name}" ]; then
+      if download "${NETDATA_TARBALL_BASE_URL}.gz" "${ndtmpdir}/${archive_base_name}.gz"; then
+        archive_name="${archive_base_name}.gz"
+        decompress="$(command -v gzip 2>/dev/null) -dc"
+      fi
+    fi
+
     if [ -n "${NETDATA_TARBALL_CHECKSUM}" ] &&
       grep "${NETDATA_TARBALL_CHECKSUM}" sha256sum.txt >&3 2>&3 &&
       [ "$NETDATA_FORCE_UPDATE" != "1" ]; then
       info "Newest version is already installed"
     else
-      if ! grep netdata-latest.tar.gz sha256sum.txt | safe_sha256sum -c - >&3 2>&3; then
+      if ! grep "${archive_name}" sha256sum.txt | safe_sha256sum -c - >&3 2>&3; then
         fatal "Tarball checksum validation failed. Stopping netdata upgrade and leaving tarball in ${ndtmpdir}\nUsually this is a result of an older copy of the tarball or checksum file being cached somewhere upstream and can be resolved by retrying in an hour." U0008
       fi
-      NEW_CHECKSUM="$(safe_sha256sum netdata-latest.tar.gz 2> /dev/null | cut -d' ' -f1)"
-      tar -xf netdata-latest.tar.gz >&3 2>&3
-      rm netdata-latest.tar.gz >&3 2>&3
+      NEW_CHECKSUM="$(safe_sha256sum "${archive_name}" 2> /dev/null | cut -d' ' -f1)"
+      ${decompress} "${archive_name}" | tar -xf - >&3 2>&3
+      rm "${archive_name}" >&3 2>&3
       if [ -z "$path_version" ]; then
         latest_tag="$(get_latest_tag)"
         path_version="$(echo "${latest_tag}" | cut -f 1 -d "-")"


### PR DESCRIPTION
##### Summary

This updates our build infrastructure to provide zstd compressed source archives for install/update purposes alongside the existing gzip compressed ones we already provide. `zstd -19` produces roughly 30% smaller source archives than `gzip -9` does, and the resultant archives also decompress faster (by anywhere from a few percent to a few dozen percent faster depending on the hardware), which should be particularly beneficial for users on low powered systems not supported by our native packages or static builds.

The updates to the kickstart and updater script will check for the presence of the `zstd` command on the local system when attempting a source-based install, and if found will try to use zstd compressed source archives instead of gzip compressed source archives. If the download of the zstd compressed source archive fails, the gzip compressed one will be used as a fallback (thus providing support for the case of zstd compressed source archives not being published yet).

This also fixes a bug in the kickstart script which caused source archive verification to be skipped when installing a user-specified version of the agent instead of the latest version.

##### Test Plan

Basic testing involves confirming that CI passes on this PR.

More rigorous testing is ideally required to confirm that the changed versions of the updater and kickstart script still function correctly.

##### Additional Information

Similar changes are planned for the static builds, but will be handled as a separate PR as they will likely be significantly more complicated to implement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI now builds and publishes `.tar.zst` source archives (~30% smaller than `.tar.gz`), and the installer/updater prefer them when `zstd` is available, falling back to `gzip`. This also fixes checksum verification when installing a specific version and makes the updater default to the nightly channel when none is set.

- **New Features**
  - Added `packaging/create-source-archives.sh` to generate both `.tar.gz` (gzip `-9`) and `.tar.zst` (zstd `-19`) archives.
  - Updated build workflow to upload both archives and create `netdata-latest.tar.gz` and `netdata-latest.tar.zst` symlinks.
  - `kickstart.sh` and `netdata-updater.sh` detect `zstd`, try `.zst` first, fall back to `.gz`, and stream-decompress to `tar`.

- **Bug Fixes**
  - `kickstart.sh` now validates SHA256 for user-specified versions.
  - `netdata-updater.sh` now errors on unknown release channels.

<sup>Written for commit e963629e62cee900423ac4212810b79e3dc5938f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Source distributions are available in gzip (`.tar.gz`) and zstd (`.tar.zst`) formats.
  - Installation and update workflows support zstd archives, with automatic fallback to gzip.
  - Downloaded archives are checksum-validated before extraction.

- **Bug Fixes**
  - Release downloads now include zstd archives alongside gzip archives.
  - Local source archive installations consistently handle archive naming, extraction, and cleanup.
  - Invalid release channels now produce a clear update error instead of being treated as nightly releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->