### PR TITLE
Disable compression for GHA artifact uploads of compressed files.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,7 @@ jobs:
         with:
           name: dist-tarball
           path: artifacts/*.tar.gz
+          compression-level: 0
           retention-days: 30
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
@@ -317,6 +318,7 @@ jobs:
         with:
           name: dist-static-${{ matrix.arch }}
           path: artifacts/*.gz.run
+          compression-level: 0
           retention-days: 30
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
@@ -422,6 +424,7 @@ jobs:
         with:
           name: windows-x86_64-installer
           path: packaging\windows\netdata*.msi
+          compression-level: 0
           retention-days: 30
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
@@ -581,6 +584,7 @@ jobs:
         with:
           name: final-artifacts
           path: artifacts/*
+          compression-level: 0
           retention-days: 30
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -354,6 +354,7 @@ jobs:
         with:
           name: ${{ matrix.distro }}-${{ matrix.version }}-${{ matrix.arch }}-packages
           path: ${{ github.workspace }}/artifacts/*${{ matrix.format }}
+          compression-level: 0
       - name: Test Packages
         id: test
         if: needs.file-check.outputs.run == 'true'


### PR DESCRIPTION
##### Summary

This speeds up the upload process itself, which in turn should provide a marginal improvement to CI job times.

##### Test Plan

CI still passes on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable compression for GitHub Actions artifact uploads of already-compressed files to speed uploads and reduce CI time. Sets compression-level: 0 on relevant upload-artifact steps in `build.yml` and `packaging.yml`.

<sup>Written for commit 5d65ef07fa10dd6ddcf7f46f8d06b13f7a90c3d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

