### PR TITLE
Network Flows: fix MDX deploy preview + capture MDX gotchas in skills

### DIFF
--- a/.agents/skills/integrations-lifecycle/gotchas.md
+++ b/.agents/skills/integrations-lifecycle/gotchas.md
@@ -365,3 +365,51 @@ after fetching each logo and analyzing its luminance. The
 result is cached per-URL within a single run. CI runs may
 trip over rate limits or transient network errors; per-request
 timeout is hardcoded.
+
+## metadata.yaml prose lands in MDX -- author it MDX-safe
+
+Anything you put in `description`, `setup`, `troubleshooting`,
+related-resources blurbs, or any free-text field in
+`metadata.yaml` flows through `gen_integrations.py` -> per-
+integration `.md` -> learn ingest -> MDX 3 build on Netlify.
+The escape battery in `learn/ingest/ingest.py:1721-1799` only
+handles bare `{`, the three exact-substring operators
+(`<=`, `%<`, `<->`), and `<details><summary>`. The following
+break the MDX build silently in netdata land but loudly on
+the next learn ingest preview deploy:
+
+| Pattern in metadata.yaml | What MDX does | Fix |
+|---|---|---|
+| `<service-name>` placeholder | parses as JSX open, demands close | wrap in backticks: `` `<service-name>` `` or `<SERVICE_NAME>` in code |
+| `<aws-region>`, `<scope>`, `<app>` | same | same |
+| `Vec<u32>`, `HashMap<K,V>` (Rust/C++/Java generics in prose) | same | wrap in backticks |
+| `<100 ms`, `<5 seconds`, `<10 connections` | `Unexpected character '1' before name` | rephrase as "under 100 ms" or escape with `&lt;` |
+| Smart quotes (`"`, `"`, `'`, `'`) in YAML auto-converted by some editors | depends on context | use ASCII quotes |
+| Unbalanced single backtick on a line | breaks code-fence detection | balance or remove |
+
+Real-world hit: 2026-05-07 netflow-plugin metadata.yaml had
+`description: Sets tenant=amazon, region=<aws-region>, role=<service-name>.`
+for the AWS IP Ranges card and similar for GCP and phpIPAM.
+Netdata CI passed (no MDX layer there), `gen_integrations.py`
+generated the `.md` files cleanly, learn ingest produced the
+`.mdx` files cleanly, the Netlify deploy preview failed with
+`Expected a closing tag for \`<service-name>\` ...`. Fix
+landed at the metadata.yaml source by wrapping placeholders
+in backticks; gen_integrations.py was re-run to regenerate
+the integration cards.
+
+Cross-reference: `learn-site-structure/mdx-rules.md` ("Patterns
+that the escape battery does NOT cover") and
+`learn-site-structure/pitfalls-and-gotchas.md` document the
+MDX side; this entry is the metadata-author-side mirror.
+
+Practical recipe when authoring metadata.yaml prose:
+
+- Wrap every angle-bracketed placeholder in backticks.
+- Wrap every code-type expression in backticks.
+- Avoid `<` immediately followed by a digit; use "under" or
+  `&lt;`.
+- Avoid generics syntax in prose; if necessary, backtick it.
+
+The integrations pipeline does not validate this on its own.
+The next learn ingest deploy preview is what will catch you.

--- a/.agents/skills/learn-site-structure/mdx-rules.md
+++ b/.agents/skills/learn-site-structure/mdx-rules.md
@@ -71,6 +71,44 @@ these as JSX tags. Note these are **exact-substring** rules;
 near-variants like `< =` (with space) or `<---->` (multi-dash)
 are NOT covered. See `pitfalls-and-gotchas.md`.
 
+### Patterns that the escape battery does NOT cover
+
+- **`<word>` placeholders in prose** (e.g. `<service-name>`,
+  `<scope>`, `<app>`). MDX 3 parses anything that lexically
+  looks like an open tag and then expects a matching close tag.
+  Without one, the build fails with
+  `Expected a closing tag for \`<word>\` ... before the end of \`paragraph\``.
+- **`<` followed by a digit** (e.g. `<100 minutes`,
+  `<5 seconds`). MDX rejects this with
+  `Unexpected character '1' (U+0031) before name, expected a
+  character that can start a name, such as a letter, $, or _`.
+  This pattern is common in lists describing thresholds.
+- **`Type<param>` Rust/C++/Java generic syntax** (e.g.
+  `Vec<u32>`, `HashMap<String, Vec<u8>>`, `unique_ptr<T>`).
+  Same JSX-tag issue.
+
+The safe options, in order of preference:
+
+1. **Wrap in inline code with backticks** -- rule 4
+   preserves inline code, so `\`<service-name>\``,
+   `\`Vec<u32>\``, `\`<APP>\`` all survive intact. This is
+   the standard fix for our Netdata integration content.
+2. **Rephrase the sentence** -- e.g. `< 100 minutes`
+   becomes `under 100 minutes`. Often clearer than the
+   original anyway.
+3. **Backslash-escape the `<`** -- `\<word>`. Works but
+   uglier than backticks. Use only when the `<` must remain
+   visibly a less-than operator, not a placeholder.
+
+These three were exercised in the netflow-plugin docs
+(2026-05-07 ingest preview deploy failure):
+`docs/network-flows/retention-querying.md` had `<100 minutes`,
+fixed by rephrasing; `aws_ip_ranges.md`, `gcp_ip_ranges.md`,
+and `generic_json-over-http_ipam.md` (generated from
+`metadata.yaml`) had `<service-name>`, `<scope>`, `<app>`,
+fixed by wrapping the placeholders in backticks at the
+`metadata.yaml` source.
+
 ## 6. Bare URL angle-bracket links
 
 Converted to markdown links (`ingest.py:1797-1799`):
@@ -124,6 +162,9 @@ The escape rules cover the most common breakage patterns:
 | `< =` (with space) | NOT covered | rule 5 is exact-substring |
 | `<---->` (long arrow) | NOT covered | rule 5 is exact-substring |
 | `<htmltag>` body content | NOT escaped | breaks MDX unless wrapped in code |
+| `<word>` placeholders in prose | NOT escaped | breaks MDX; wrap in backticks or rephrase |
+| `<` + digit (`<100`, `<5s`) | NOT escaped | breaks MDX; rephrase as "under N" or escape |
+| `Vec<u32>`, `HashMap<K,V>` generics | NOT escaped | breaks MDX; wrap in backticks |
 | `<details>` inline summary | fixed | rule 3 |
 | `<details class="x">` | NOT fixed | rule 3 only knows two forms |
 | `}` closing brace alone | NOT escaped | rule 4 only escapes `{` |

--- a/.agents/skills/learn-site-structure/pitfalls-and-gotchas.md
+++ b/.agents/skills/learn-site-structure/pitfalls-and-gotchas.md
@@ -61,6 +61,30 @@ thing.
   `sanitize_page` only as those exact substrings; near-variants
   like `< =`, `<---->`, or `< -` aren't covered.
 
+- **`<word>` placeholders in prose break MDX silently
+  through ingest** -- patterns like `<service-name>`,
+  `<scope>`, `<app>`, `<aws-region>` look like JSX open
+  tags to MDX 3 and demand a closing tag. Build fails with
+  `Expected a closing tag for \`<word>\` ... before the end of
+  \`paragraph\``. The escape battery does NOT touch these.
+  Fix: wrap in backticks (`\`<service-name>\``) or rephrase.
+  Hit 2026-05-07 in netflow-plugin `metadata.yaml`
+  descriptions for AWS / GCP / phpIPAM IPAM sources.
+
+- **`<` immediately followed by a digit** -- patterns like
+  `<100 minutes`, `<5 seconds`, `<10ms` make MDX try to parse
+  a JSX tag and fail with `Unexpected character '1' (U+0031)
+  before name, expected a character that can start a name,
+  such as a letter, $, or _`. Common in threshold descriptions.
+  Fix: rephrase as `under 100 minutes` or `&lt;100 minutes`.
+  Hit 2026-05-07 in
+  `docs/network-flows/retention-querying.md`.
+
+- **Generic-type syntax `Type<Param>`** -- Rust `Vec<u32>`,
+  C++ `unique_ptr<T>`, Java `List<String>`, etc. parse as
+  unbalanced JSX opens. Always wrap in backticks when
+  documenting code types.
+
 - **`meta_yaml: "<url>"` rewrite** -- silently rewrites
   `custom_edit_url` for any file containing `meta_yaml: "..."`,
   even if the author didn't intend it

--- a/docs/network-flows/retention-querying.md
+++ b/docs/network-flows/retention-querying.md
@@ -39,7 +39,7 @@ For every query the dashboard sends to the plugin, the planner makes a single de
 2. **A non-empty full-text search → raw tier.** Full-text search runs as a regex against the raw journal payload, which only the raw tier carries.
 3. **Otherwise, pick the coarsest tier that satisfies the time range and bucket-count requirement.**
    - Time-Series view needs at least 100 buckets in the window. So:
-     - <100 minutes → 1-minute tier
+     - under 100 minutes → 1-minute tier
      - 100 minutes to 8h20m → 5-minute tier
      - 8h20m and longer → 1-hour tier
    - Table / Sankey / Maps don't have a bucket-count constraint, but the configured query-window guardrails (`query_1m_max_window` default 6h, `query_5m_max_window` default 24h) skip a tier when the window is too wide.

--- a/src/crates/netflow-plugin/integrations/aws_ip_ranges.md
+++ b/src/crates/netflow-plugin/integrations/aws_ip_ranges.md
@@ -112,7 +112,7 @@ sudo ./edit-config netflow.yaml
 
 ###### Tag all AWS prefixes by region and service
 
-Sets tenant=amazon, region=<aws-region>, role=<service-name>.
+Sets tenant=amazon, region=`aws-region`, role=`service-name`.
 
 ```yaml
 enrichment:

--- a/src/crates/netflow-plugin/integrations/gcp_ip_ranges.md
+++ b/src/crates/netflow-plugin/integrations/gcp_ip_ranges.md
@@ -104,7 +104,7 @@ sudo ./edit-config netflow.yaml
 
 ###### Tag all GCP prefixes by service and scope
 
-Sets tenant=gcp, role=<service>, region=<scope>.
+Sets tenant=gcp, role=`service`, region=`scope`.
 
 ```yaml
 enrichment:

--- a/src/crates/netflow-plugin/integrations/generic_json-over-http_ipam.md
+++ b/src/crates/netflow-plugin/integrations/generic_json-over-http_ipam.md
@@ -125,7 +125,7 @@ sudo ./edit-config netflow.yaml
 
 ###### phpIPAM with API token
 
-phpIPAM exposes /api/<app>/subnets/. Use the standard transform.
+phpIPAM exposes `/api/<APP>/subnets/`. Replace `<APP>` with your phpIPAM app name. Use the standard transform.
 
 ```yaml
 enrichment:

--- a/src/crates/netflow-plugin/metadata.yaml
+++ b/src/crates/netflow-plugin/metadata.yaml
@@ -1511,7 +1511,7 @@ modules:
             - name: Tag all AWS prefixes by region and service
               folding:
                 enabled: false
-              description: Sets tenant=amazon, region=<aws-region>, role=<service-name>.
+              description: "Sets tenant=amazon, region=`aws-region`, role=`service-name`."
               config: |
                 enrichment:
                   network_sources:
@@ -1655,7 +1655,7 @@ modules:
             - name: Tag all GCP prefixes by service and scope
               folding:
                 enabled: false
-              description: Sets tenant=gcp, role=<service>, region=<scope>.
+              description: "Sets tenant=gcp, role=`service`, region=`scope`."
               config: |
                 enrichment:
                   network_sources:
@@ -2135,7 +2135,7 @@ modules:
             - name: phpIPAM with API token
               folding:
                 enabled: false
-              description: phpIPAM exposes /api/<app>/subnets/. Use the standard transform.
+              description: "phpIPAM exposes `/api/<APP>/subnets/`. Replace `<APP>` with your phpIPAM app name. Use the standard transform."
               config: |
                 enrichment:
                   network_sources:


### PR DESCRIPTION
## Summary

The post-merge learn ingest deploy preview for #22439 failed with four MDX 3 build errors. This PR fixes them and captures the lessons in the relevant agent-input skills so the next author / agent does not repeat the round-trip.

## What was breaking

| File | Pattern | MDX error |
|---|---|---|
| `aws_ip_ranges.md` | `<aws-region>`, `<service-name>` | `Expected a closing tag for \`<service-name>\`` |
| `gcp_ip_ranges.md` | `<service>`, `<scope>` | `Expected a closing tag for \`<scope>\`` |
| `generic_json-over-http_ipam.md` | `<app>` | `Expected a closing tag for \`<app>\`` |
| `retention-querying.md` | `<100 minutes` | `Unexpected character '1' before name` |

The first three are generated from `metadata.yaml` descriptions. The fourth is hand-authored prose.

## Fixes

- **metadata.yaml** — wrapped every angle-bracketed placeholder in backticks. `gen_integrations.py` re-run to regenerate the three affected integration cards.
- **retention-querying.md** — rephrased `<100 minutes` as `under 100 minutes`.

## Skill updates

These three patterns were not previously documented in the agent-input skills, so the next author had no prior warning:

- **`.agents/skills/learn-site-structure/mdx-rules.md`** — new "Patterns that the escape battery does NOT cover" section, three table rows in "What survives, what doesn't".
- **`.agents/skills/learn-site-structure/pitfalls-and-gotchas.md`** — three new entries with literal MDX error messages and source contexts.
- **`.agents/skills/integrations-lifecycle/gotchas.md`** — new "metadata.yaml prose lands in MDX" entry, with the seven patterns that break, a fix table, and an author-side recipe. Notes that netdata CI does NOT validate this; the next learn ingest preview is what catches it.

## Test plan

- [x] Re-run `gen_integrations.py` — clean exit, regenerated cards no longer contain bare `<word>` placeholders.
- [x] Local sanity-check on the three patterns: `<service-name>`, `<scope>`, `<app>` all wrapped in backticks; `<100 minutes` rephrased.
- [ ] Verify the next learn ingest deploy preview goes green after this lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MDX 3 build errors in Network Flows docs and generated integration cards by making angle-bracket placeholders safe and rephrasing one threshold line. Adds MDX gotchas to agent skills to prevent repeat failures.

- **Bug Fixes**
  - Wrapped angle-bracket placeholders in `metadata.yaml` and regenerated integration cards: `aws_ip_ranges.md`, `gcp_ip_ranges.md`, `generic_json-over-http_ipam.md` (e.g., `<aws-region>`, `<service-name>`, `<service>`, `<scope>`, `/api/<app>/subnets/` → backticked or clarified).
  - Rephrased `<100 minutes` to “under 100 minutes” in `docs/network-flows/retention-querying.md`.
  - Documented MDX patterns not covered by ingest escape rules and the fixes in agent skills: `learn-site-structure/mdx-rules.md`, `learn-site-structure/pitfalls-and-gotchas.md`, `integrations-lifecycle/gotchas.md`.

<sup>Written for commit b925e2444c7cd63c15ca356a86f6b2763226b0db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

