### PR TITLE
Improve hosts load on agent startup

### DIFF
--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -107,8 +107,14 @@ static RRDHOST *load_archived_host_from_row(sqlite3_stmt *res)
                    sqlite3_column_count(res), COL_FETCH_IS_REGISTERED + 1);
 
     nd_uuid_t host_uuid;
-    if (!sqlite3_column_uuid_copy(res, COL_FETCH_HOST_ID, host_uuid))
+    if (!sqlite3_column_uuid_copy(res, COL_FETCH_HOST_ID, host_uuid)) {
+        nd_log_daemon(
+            NDLP_ERR,
+            "Skipping archived host: host_id column is not a valid 16-byte UUID blob (type=%d, bytes=%d). Possible DB corruption.",
+            sqlite3_column_type(res, COL_FETCH_HOST_ID),
+            sqlite3_column_bytes(res, COL_FETCH_HOST_ID));
         return NULL;
+    }
 
     char guid[UUID_STR_LEN];
     uuid_unparse_lower(host_uuid, guid);
@@ -1095,10 +1101,22 @@ void aclk_synchronization_init(void)
         int step_rc;
         while ((step_rc = sqlite3_step_monitored(res_inst)) == SQLITE_ROW) {
             nd_uuid_t host_uuid, node_uuid;
-            if (!sqlite3_column_uuid_copy(res_inst, 0, host_uuid))
+            if (!sqlite3_column_uuid_copy(res_inst, 0, host_uuid)) {
+                nd_log_daemon(
+                    NDLP_ERR,
+                    "Skipping node_instance row: host_id (col 0) is not a valid 16-byte UUID blob (type=%d, bytes=%d). ACLK config not configured for this host.",
+                    sqlite3_column_type(res_inst, 0),
+                    sqlite3_column_bytes(res_inst, 0));
                 continue;
-            if (!sqlite3_column_uuid_copy(res_inst, 1, node_uuid))
+            }
+            if (!sqlite3_column_uuid_copy(res_inst, 1, node_uuid)) {
+                nd_log_daemon(
+                    NDLP_ERR,
+                    "Skipping node_instance row: node_id (col 1) is not a valid 16-byte UUID blob (type=%d, bytes=%d). ACLK config not configured for this host.",
+                    sqlite3_column_type(res_inst, 1),
+                    sqlite3_column_bytes(res_inst, 1));
                 continue;
+            }
 
             char uuid_str[UUID_STR_LEN];
             uuid_unparse_lower(host_uuid, uuid_str);

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -72,87 +72,95 @@ static bool aclk_database_enq_cmd(cmd_data_t *cmd, bool wait_on_full)
     return added;
 }
 
-enum {
-    IDX_HOST_ID,
-    IDX_HOSTNAME,
-    IDX_REGISTRY,
-    IDX_UPDATE_EVERY,
-    IDX_OS,
-    IDX_TIMEZONE,
-    IDX_HOPS,
-    IDX_MEMORY_MODE,
-    IDX_ABBREV_TIMEZONE,
-    IDX_UTC_OFFSET,
-    IDX_PROGRAM_NAME,
-    IDX_PROGRAM_VERSION,
-    IDX_ENTRIES,
-    IDX_HEALTH_ENABLED,
-    IDX_LAST_CONNECTED,
-    IDX_IS_EPHEMERAL,
-    IDX_IS_REGISTERED,
-};
-
 struct children {
     int vnodes;
     int normal;
 };
 
-static int create_host_callback(void *data, int argc, char **argv, char **column)
+// Column indices for SQL_FETCH_ALL_HOSTS — keep in lock-step with the SELECT list.
+enum {
+    COL_FETCH_HOST_ID = 0,
+    COL_FETCH_HOSTNAME,
+    COL_FETCH_REGISTRY,
+    COL_FETCH_UPDATE_EVERY,
+    COL_FETCH_OS,
+    COL_FETCH_TIMEZONE,
+    COL_FETCH_HOPS,
+    COL_FETCH_ABBREV_TIMEZONE,
+    COL_FETCH_UTC_OFFSET,
+    COL_FETCH_PROGRAM_NAME,
+    COL_FETCH_PROGRAM_VERSION,
+    COL_FETCH_ENTRIES,
+    COL_FETCH_LAST_CONNECTED,
+    COL_FETCH_IS_EPHEMERAL,
+    COL_FETCH_IS_REGISTERED,
+};
+
+// Materialise one archived host row from SQL_FETCH_ALL_HOSTS into rrdhost_root_index.
+// Returns the host (or NULL if creation skipped/failed) so the caller can update counters.
+static RRDHOST *load_archived_host_from_row(sqlite3_stmt *res)
 {
-    struct children *node_data = data;
-    UNUSED(argc);
-    UNUSED(column);
+    nd_uuid_t host_uuid;
+    if (!sqlite3_column_uuid_copy(res, COL_FETCH_HOST_ID, host_uuid))
+        return NULL;
 
-    time_t last_connected =
-        (time_t)(argv[IDX_LAST_CONNECTED] ? str2uint64_t(argv[IDX_LAST_CONNECTED], NULL) : 0);
+    char guid[UUID_STR_LEN];
+    uuid_unparse_lower(host_uuid, guid);
 
+    const char *hostname     = (const char *)sqlite3_column_text(res, COL_FETCH_HOSTNAME);
+    const char *registry     = (const char *)sqlite3_column_text(res, COL_FETCH_REGISTRY);
+    const char *os           = (const char *)sqlite3_column_text(res, COL_FETCH_OS);
+    const char *timezone     = (const char *)sqlite3_column_text(res, COL_FETCH_TIMEZONE);
+    const char *abbrev_tz    = (const char *)sqlite3_column_text(res, COL_FETCH_ABBREV_TIMEZONE);
+    const char *prog_name    = (const char *)sqlite3_column_text(res, COL_FETCH_PROGRAM_NAME);
+    const char *prog_version = (const char *)sqlite3_column_text(res, COL_FETCH_PROGRAM_VERSION);
+    int hops          = sqlite3_column_int(res, COL_FETCH_HOPS);
+    int utc_offset    = sqlite3_column_int(res, COL_FETCH_UTC_OFFSET);
+    int entries       = sqlite3_column_int(res, COL_FETCH_ENTRIES);
+    // update_every defaults to 1 when the row stored 0/NULL (preserves the
+    // pre-refactor `argv[i] ? ... : 1` fallback).
+    int update_every  = sqlite3_column_int(res, COL_FETCH_UPDATE_EVERY);
+    if (!update_every) update_every = 1;
+    int64_t last_connected_db = sqlite3_column_int64(res, COL_FETCH_LAST_CONNECTED);
+    int is_ephemeral  = sqlite3_column_int(res, COL_FETCH_IS_EPHEMERAL);
+    int is_registered = sqlite3_column_int(res, COL_FETCH_IS_REGISTERED);
+
+    time_t last_connected = (time_t)last_connected_db;
     if (!last_connected)
         last_connected = now_realtime_sec();
 
     time_t age = now_realtime_sec() - last_connected;
-    int is_ephemeral = 0;
-    int is_registered = 0;
 
-    if (argv[IDX_IS_EPHEMERAL])
-        is_ephemeral = str2i(argv[IDX_IS_EPHEMERAL]);
-
-    if (argv[IDX_IS_REGISTERED])
-        is_registered = str2i(argv[IDX_IS_REGISTERED]);
-
-    char guid[UUID_STR_LEN];
-    uuid_unparse_lower(*(nd_uuid_t *)argv[IDX_HOST_ID], guid);
-
-    if (is_ephemeral && ((!is_registered && last_connected == 1) || (rrdhost_free_ephemeral_time_s && age > rrdhost_free_ephemeral_time_s))) {
+    if (is_ephemeral && ((!is_registered && last_connected == 1) ||
+                         (rrdhost_free_ephemeral_time_s && age > rrdhost_free_ephemeral_time_s))) {
         netdata_log_info(
             "%s ephemeral hostname \"%s\" with GUID \"%s\", age = %ld seconds (limit %ld seconds)",
             is_registered ? "Loading registered" : "Skipping unregistered",
-            (const char *)argv[IDX_HOSTNAME],
+            hostname,
             guid,
             age,
             rrdhost_free_ephemeral_time_s);
 
         if (!is_registered)
-           goto done;
+           return NULL;
     }
 
     struct rrdhost_system_info *system_info = rrdhost_system_info_create();
-
-    rrdhost_system_info_hops_set(system_info, (int16_t)str2i((const char *) argv[IDX_HOPS]));
-
-    sql_build_host_system_info((nd_uuid_t *)argv[IDX_HOST_ID], system_info);
+    rrdhost_system_info_hops_set(system_info, (int16_t)hops);
+    sql_build_host_system_info(&host_uuid, system_info);
 
     RRDHOST *host = rrdhost_find_or_create(
-        (const char *)argv[IDX_HOSTNAME],
-        (const char *)argv[IDX_REGISTRY],
+        hostname,
+        registry,
         guid,
-        (const char *)argv[IDX_OS],
-        (const char *)argv[IDX_TIMEZONE],
-        (const char *)argv[IDX_ABBREV_TIMEZONE],
-        (int32_t)(argv[IDX_UTC_OFFSET] ? str2uint32_t(argv[IDX_UTC_OFFSET], NULL) : 0),
-        (const char *)(argv[IDX_PROGRAM_NAME] ? argv[IDX_PROGRAM_NAME] : "unknown"),
-        (const char *)(argv[IDX_PROGRAM_VERSION] ? argv[IDX_PROGRAM_VERSION] : "unknown"),
-        argv[IDX_UPDATE_EVERY] ? str2i(argv[IDX_UPDATE_EVERY]) : 1,
-        argv[IDX_ENTRIES] ? str2i(argv[IDX_ENTRIES]) : 0,
+        os,
+        timezone,
+        abbrev_tz,
+        (int32_t)utc_offset,
+        prog_name    ? prog_name    : "unknown",
+        prog_version ? prog_version : "unknown",
+        update_every,
+        entries,
         default_rrd_memory_mode,
         0,              // health
         0,              // rrdpush enabled
@@ -168,23 +176,17 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
     rrdhost_system_info_free(system_info);
 
     if (unlikely(!host))
-        return 0;
+        return NULL;
 
-    if (is_ephemeral)
+    if (is_ephemeral) {
         rrdhost_option_set(host, RRDHOST_OPTION_EPHEMERAL_HOST);
-
-    if (is_ephemeral)
         host->stream.rcv.status.last_disconnected = now_realtime_sec();
+    }
 
-    host->rrdlabels = sql_load_host_labels((nd_uuid_t *)argv[IDX_HOST_ID]);
+    host->rrdlabels = sql_load_host_labels(&host_uuid);
     host->stream.snd.status.last_connected = last_connected;
 
     pulse_host_status(host, 0, 0); // this will detect the receiver status
-
-    if (IS_VIRTUAL_HOST_OS(host))
-        node_data->vnodes++;
-    else
-        node_data->normal++;
 
 #ifdef NETDATA_INTERNAL_CHECKS
     char node_str[UUID_STR_LEN] = "<none>";
@@ -194,8 +196,7 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
                    rrdhost_hostname(host), host->machine_guid, node_str, is_ephemeral);
 #endif
 
-done:
-    return 0;
+    return host;
 }
 
 
@@ -283,17 +284,6 @@ done:
     SQLITE_FINALIZE(res);
 skip:
     freez(machine_guid);
-}
-
-static int aclk_config_parameters(void *data __maybe_unused, int argc __maybe_unused, char **argv, char **column __maybe_unused)
-{
-    char uuid_str[UUID_STR_LEN];
-    uuid_unparse_lower(*((nd_uuid_t *) argv[0]), uuid_str);
-
-    RRDHOST *host = rrdhost_find_by_guid(uuid_str);
-    if (host != localhost)
-        create_aclk_config(host, (nd_uuid_t *)argv[0], (nd_uuid_t *)argv[1]);
-    return 0;
 }
 
 struct judy_list_t {
@@ -1015,14 +1005,20 @@ void create_aclk_config(RRDHOST *host, nd_uuid_t *host_uuid __maybe_unused, nd_u
     }
 }
 
+// Replaces two correlated subqueries (host_label, node_instance) with LEFT JOINs
+// so the planner does the lookup once per row instead of 2N extra index probes.
+// memory_mode and health_enabled are intentionally omitted — they were SELECTed
+// in the previous shape but never read by the consumer.
 #define SQL_FETCH_ALL_HOSTS                                                                                            \
-    "SELECT host_id, hostname, registry_hostname, update_every, os, "                                                  \
-    "timezone, hops, memory_mode, abbrev_timezone, utc_offset, program_name, "                                         \
-    "program_version, entries, health_enabled, last_connected, "                                                       \
-    "(SELECT CASE WHEN hl.label_value = 'true' THEN 1 ELSE 0 END FROM "                                                \
-    "host_label hl WHERE hl.host_id = h.host_id AND hl.label_key = '_is_ephemeral'),  "                                \
-    "(SELECT CASE WHEN ni.node_id is NULL THEN 0 ELSE 1 END FROM "                                                     \
-    "node_instance ni WHERE ni.host_id = h.host_id) FROM host h WHERE hops > 0"
+    "SELECT h.host_id, h.hostname, h.registry_hostname, h.update_every, h.os, "                                        \
+    "h.timezone, h.hops, h.abbrev_timezone, h.utc_offset, h.program_name, "                                            \
+    "h.program_version, h.entries, h.last_connected, "                                                                 \
+    "CASE WHEN hl.label_value = 'true' THEN 1 ELSE 0 END, "                                                            \
+    "CASE WHEN ni.node_id IS NULL THEN 0 ELSE 1 END "                                                                  \
+    "FROM host h "                                                                                                     \
+    "LEFT JOIN host_label hl ON hl.host_id = h.host_id AND hl.label_key = '_is_ephemeral' "                            \
+    "LEFT JOIN node_instance ni ON ni.host_id = h.host_id "                                                            \
+    "WHERE h.hops > 0"
 
 #define SQL_FETCH_ALL_INSTANCES                                                                                        \
     "SELECT ni.host_id, ni.node_id FROM host h, node_instance ni "                                                     \
@@ -1033,18 +1029,31 @@ uv_sem_t ctx_sem;
 
 void aclk_synchronization_init(void)
 {
-    char *err_msg = NULL;
-    int rc;
-
     nd_log_daemon(NDLP_INFO, "Creating archived hosts");
-    struct children node_data = { 0, 0};
+    struct children node_data = { 0, 0 };
 
-    rc = sqlite3_exec_monitored(db_meta, SQL_FETCH_ALL_HOSTS, create_host_callback, &node_data, &err_msg);
-
-    if (rc != SQLITE_OK) {
-        nd_log_daemon(NDLP_ERR, "SQLite error when loading archived hosts, rc = %d (%s)", rc, err_msg);
-        sqlite3_free(err_msg);
+    sqlite3_stmt *res = NULL;
+    if (PREPARE_STATEMENT(db_meta, SQL_FETCH_ALL_HOSTS, &res)) {
+        int step_rc;
+        while ((step_rc = sqlite3_step_monitored(res)) == SQLITE_ROW) {
+            RRDHOST *host = load_archived_host_from_row(res);
+            if (!host)
+                continue;
+            if (IS_VIRTUAL_HOST_OS(host))
+                node_data.vnodes++;
+            else
+                node_data.normal++;
+        }
+        if (step_rc != SQLITE_DONE)
+            nd_log_daemon(
+                NDLP_ERR,
+                "SQLite error while loading archived hosts, rc = %d (%s); load may be partial",
+                step_rc,
+                sqlite3_errmsg(db_meta));
+        SQLITE_FINALIZE(res);
     }
+    else
+        nd_log_daemon(NDLP_ERR, "SQLite error when loading archived hosts");
 
     nd_log_daemon(
         NDLP_INFO,
@@ -1065,12 +1074,32 @@ void aclk_synchronization_init(void)
         sem_init = false;
     }
 
-    rc = sqlite3_exec_monitored(db_meta, SQL_FETCH_ALL_INSTANCES, aclk_config_parameters, NULL, &err_msg);
+    sqlite3_stmt *res_inst = NULL;
+    if (PREPARE_STATEMENT(db_meta, SQL_FETCH_ALL_INSTANCES, &res_inst)) {
+        int step_rc;
+        while ((step_rc = sqlite3_step_monitored(res_inst)) == SQLITE_ROW) {
+            nd_uuid_t host_uuid, node_uuid;
+            if (!sqlite3_column_uuid_copy(res_inst, 0, host_uuid))
+                continue;
+            if (!sqlite3_column_uuid_copy(res_inst, 1, node_uuid))
+                continue;
 
-    if (rc != SQLITE_OK) {
-        nd_log_daemon(NDLP_ERR, "SQLite error when configuring host ACLK synchonization parameters, rc = %d (%s)", rc, err_msg);
-        sqlite3_free(err_msg);
+            char uuid_str[UUID_STR_LEN];
+            uuid_unparse_lower(host_uuid, uuid_str);
+            RRDHOST *host = rrdhost_find_by_guid(uuid_str);
+            if (host != localhost)
+                create_aclk_config(host, &host_uuid, &node_uuid);
+        }
+        if (step_rc != SQLITE_DONE)
+            nd_log_daemon(
+                NDLP_ERR,
+                "SQLite error while configuring host ACLK synchronization parameters, rc = %d (%s); some configs may be missing",
+                step_rc,
+                sqlite3_errmsg(db_meta));
+        SQLITE_FINALIZE(res_inst);
     }
+    else
+        nd_log_daemon(NDLP_ERR, "SQLite error when configuring host ACLK synchronization parameters");
 
     aclk_initialize_event_loop();
 

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -1011,6 +1011,12 @@ void create_aclk_config(RRDHOST *host, nd_uuid_t *host_uuid __maybe_unused, nd_u
 // so the planner does the lookup once per row instead of 2N extra index probes.
 // memory_mode and health_enabled are intentionally omitted — they were SELECTed
 // in the previous shape but never read by the consumer.
+//
+// Both LEFT JOINs are guaranteed to match at most one row per host by the
+// schema (sqlite_metadata.c database_config[]): host_label has
+// PRIMARY KEY (host_id, label_key), and node_instance has host_id PRIMARY KEY.
+// Row multiplication is therefore impossible here without a SQLite invariant
+// violation; no DISTINCT / GROUP BY / EXISTS wrapper needed.
 #define SQL_FETCH_ALL_HOSTS                                                                                            \
     "SELECT h.host_id, h.hostname, h.registry_hostname, h.update_every, h.os, "                                        \
     "h.timezone, h.hops, h.abbrev_timezone, h.utc_offset, h.program_name, "                                            \

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -117,10 +117,12 @@ static RRDHOST *load_archived_host_from_row(sqlite3_stmt *res)
     int hops          = sqlite3_column_int(res, COL_FETCH_HOPS);
     int utc_offset    = sqlite3_column_int(res, COL_FETCH_UTC_OFFSET);
     int entries       = sqlite3_column_int(res, COL_FETCH_ENTRIES);
-    // update_every defaults to 1 when the row stored 0/NULL (preserves the
-    // pre-refactor `argv[i] ? ... : 1` fallback).
-    int update_every  = sqlite3_column_int(res, COL_FETCH_UPDATE_EVERY);
-    if (!update_every) update_every = 1;
+    // update_every defaults to 1 only when the column is SQL NULL — preserves
+    // the pre-refactor `argv[i] ? str2i(argv[i]) : 1` fallback exactly. A
+    // stored 0 stays 0 (matches the original str2i path).
+    int update_every = (sqlite3_column_type(res, COL_FETCH_UPDATE_EVERY) == SQLITE_NULL)
+        ? 1
+        : sqlite3_column_int(res, COL_FETCH_UPDATE_EVERY);
     int64_t last_connected_db = sqlite3_column_int64(res, COL_FETCH_LAST_CONNECTED);
     int is_ephemeral  = sqlite3_column_int(res, COL_FETCH_IS_EPHEMERAL);
     int is_registered = sqlite3_column_int(res, COL_FETCH_IS_REGISTERED);
@@ -1053,7 +1055,9 @@ void aclk_synchronization_init(void)
         SQLITE_FINALIZE(res);
     }
     else
-        nd_log_daemon(NDLP_ERR, "SQLite error when loading archived hosts");
+        nd_log_daemon(NDLP_ERR,
+                      "SQLite error when preparing statement to load archived hosts: %s",
+                      sqlite3_errmsg(db_meta));
 
     nd_log_daemon(
         NDLP_INFO,
@@ -1099,7 +1103,9 @@ void aclk_synchronization_init(void)
         SQLITE_FINALIZE(res_inst);
     }
     else
-        nd_log_daemon(NDLP_ERR, "SQLite error when configuring host ACLK synchronization parameters");
+        nd_log_daemon(NDLP_ERR,
+                      "SQLite error when preparing statement to configure host ACLK synchronization parameters: %s",
+                      sqlite3_errmsg(db_meta));
 
     aclk_initialize_event_loop();
 

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -122,7 +122,7 @@ static RRDHOST *load_archived_host_from_row(sqlite3_stmt *res)
     const char *hostname     = (const char *)sqlite3_column_text(res, COL_FETCH_HOSTNAME);
     const char *registry     = (const char *)sqlite3_column_text(res, COL_FETCH_REGISTRY);
     const char *os           = (const char *)sqlite3_column_text(res, COL_FETCH_OS);
-    const char *timezone     = (const char *)sqlite3_column_text(res, COL_FETCH_TIMEZONE);
+    const char *host_tz      = (const char *)sqlite3_column_text(res, COL_FETCH_TIMEZONE);
     const char *abbrev_tz    = (const char *)sqlite3_column_text(res, COL_FETCH_ABBREV_TIMEZONE);
     const char *prog_name    = (const char *)sqlite3_column_text(res, COL_FETCH_PROGRAM_NAME);
     const char *prog_version = (const char *)sqlite3_column_text(res, COL_FETCH_PROGRAM_VERSION);
@@ -168,7 +168,7 @@ static RRDHOST *load_archived_host_from_row(sqlite3_stmt *res)
         registry,
         guid,
         os,
-        timezone,
+        host_tz,
         abbrev_tz,
         (int32_t)utc_offset,
         prog_name    ? prog_name    : "unknown",

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -100,6 +100,12 @@ enum {
 // Returns the host (or NULL if creation skipped/failed) so the caller can update counters.
 static RRDHOST *load_archived_host_from_row(sqlite3_stmt *res)
 {
+    // The COL_FETCH_* enum is in lock-step with SQL_FETCH_ALL_HOSTS' SELECT list.
+    // Catch drift early in debug builds; release builds compile this out.
+    internal_fatal(sqlite3_column_count(res) != COL_FETCH_IS_REGISTERED + 1,
+                   "SQL_FETCH_ALL_HOSTS column count (%d) does not match COL_FETCH_* enum (%d)",
+                   sqlite3_column_count(res), COL_FETCH_IS_REGISTERED + 1);
+
     nd_uuid_t host_uuid;
     if (!sqlite3_column_uuid_copy(res, COL_FETCH_HOST_ID, host_uuid))
         return NULL;
@@ -1097,7 +1103,9 @@ void aclk_synchronization_init(void)
             char uuid_str[UUID_STR_LEN];
             uuid_unparse_lower(host_uuid, uuid_str);
             RRDHOST *host = rrdhost_find_by_guid(uuid_str);
-            if (host != localhost)
+            // create_aclk_config() already null-checks `host`, but the explicit
+            // guard makes the intent clear and skips the call for unknown GUIDs.
+            if (host && host != localhost)
                 create_aclk_config(host, &host_uuid, &node_uuid);
         }
         if (step_rc != SQLITE_DONE)


### PR DESCRIPTION
##### Summary
  - SQL_FETCH_ALL_HOSTS: two correlated subqueries (host_label, node_instance) rewritten as two LEFT JOINs — one planned lookup instead of 2N extra index probes per startup. Dropped memory_mode and health_enabled columns (selected but not consumed).
  - Both sqlite3_exec_monitored sites in aclk_synchronization_init use prepared statements + sqlite3_column_* accessors; uuid columns go through sqlite3_column_uuid_copy.
  - Removed create_host_callback, aclk_config_parameters, the IDX_* enum; added load_archived_host_from_row() helper.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up agent startup by optimizing archived host loading in `sqlite_aclk`. Uses LEFT JOINs and prepared statements, adds a column-count check, and improves error logs with explicit UUID validation.

- **Refactors**
  - Rewrote `SQL_FETCH_ALL_HOSTS` with LEFT JOINs; dropped unused columns; added a column-count sanity check.
  - Replaced `sqlite3_exec_monitored` with prepared statements; added `load_archived_host_from_row()`; removed obsolete callbacks and the old IDX enum; renamed `timezone` var to `host_tz`.

- **Bug Fixes**
  - Treats NULL `update_every` as 1 (0 remains 0) to match prior behavior.
  - Improves SQLite error logging for prepare/step failures; warns when loads/config may be partial.
  - Logs invalid UUID blobs (type and byte count) during archived-host load and `node_instance` processing to surface possible DB corruption.

<sup>Written for commit bb3f96fee1b83009ef26416715f924e08fb92c79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

