### PR TITLE
Fix shutdown race when restoring alert information from the database

### DIFF
--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -674,7 +674,7 @@ void sql_health_alarm_log_load(RRDHOST *host)
     foreach_rrdcalc_in_rrdhost_done(rc);
 
     param = 0;
-    rw_spinlock_read_lock(&host->health_log.spinlock);
+    rw_spinlock_write_lock(&host->health_log.spinlock);
 
     while (service_running(SERVICE_HEALTH) && sqlite3_step_monitored(res) == SQLITE_ROW) {
         ALARM_ENTRY *ae = NULL;
@@ -806,7 +806,7 @@ void sql_health_alarm_log_load(RRDHOST *host)
         loaded++;
     }
 
-    rw_spinlock_read_unlock(&host->health_log.spinlock);
+    rw_spinlock_write_unlock(&host->health_log.spinlock);
 
     dictionary_destroy(all_rrdcalcs);
     all_rrdcalcs = NULL;

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -676,7 +676,7 @@ void sql_health_alarm_log_load(RRDHOST *host)
     param = 0;
     rw_spinlock_read_lock(&host->health_log.spinlock);
 
-    while (sqlite3_step_monitored(res) == SQLITE_ROW) {
+    while (service_running(SERVICE_HEALTH) && sqlite3_step_monitored(res) == SQLITE_ROW) {
         ALARM_ENTRY *ae = NULL;
 
         // check that we have valid ids

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -244,8 +244,8 @@ static void health_initialize_rrdhost(RRDHOST *host) {
     host->health_log.next_log_id = get_uint32_id();
     host->health_log.next_alarm_id = 0;
 
-    sql_health_alarm_log_load(host);
     rw_spinlock_init(&host->health_log.spinlock);
+    sql_health_alarm_log_load(host);
     rrdhost_flag_set(host, RRDHOST_FLAG_INITIALIZED_HEALTH);
 
 


### PR DESCRIPTION
##### Summary
- Fix shutdown race: HEALTH crashed in sqlite `pcache1Unpin` (fault at `0x30`) when `sqlite_close_databases()` ran while `sql_health_alarm_log_load()` was still inside `sqlite3_step`.                                                                                                                            
  - Bail the row loop on `!service_running(SERVICE_HEALTH)` so the early `service_signal_exit(SERVICE_HEALTH)` at shutdown is honored before sqlite is closed.                                                                                                                                                                  
  - Initialize `host->health_log.spinlock` before `sql_health_alarm_log_load()` instead of after — the load already takes that lock. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a shutdown race in the HEALTH service that could crash while restoring alert logs if SQLite closes mid-iteration. Also switches health log access to a write lock during load to avoid concurrent writes.

- **Bug Fixes**
  - Exit the row loop early when the service is stopping: `service_running(SERVICE_HEALTH) && sqlite3_step_monitored(res) == SQLITE_ROW`.
  - Initialize `host->health_log.spinlock` before `sql_health_alarm_log_load(host)` and use a write lock (`rw_spinlock_write_lock/unlock`) during load.

<sup>Written for commit 371b50e43dd6a6624ac6ad375183738d2fbea77e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

