### PR TITLE
Render flow integration content sections

### DIFF
--- a/.agents/skills/integrations-lifecycle/how-tos/adding-new-integration-type.md
+++ b/.agents/skills/integrations-lifecycle/how-tos/adding-new-integration-type.md
@@ -29,7 +29,7 @@ Examples that would NOT qualify (use an existing type instead):
 
 Clone the closest existing schema and trim/adjust:
 
-- For data-bearing types (something that produces records / metrics / events): start from `collector.json`. Trim fields that don't apply (e.g., flows have no `metrics` or `alerts` sections in the traditional sense).
+- For data-bearing types (something that produces records / metrics / events): start from `collector.json`. If the new type keeps collector-style sections such as `metrics`, `alerts`, or `functions`, those sections still need to be rendered to markdown before publication, even when they describe non-metric data or say that no alerts exist.
 - For thin types (a config target with overview + setup + troubleshooting): start from `logs.json` or `exporter.json`.
 
 The schema field set drives validation. Anything not in the schema is rejected as an unknown property when `additionalProperties: false` is set on the relevant object.
@@ -42,6 +42,14 @@ There are typically 3-5 places that need updating:
 - Schema dispatch (the function that picks which schema to validate against based on file location or `integration_type`).
 - The render-keys table — which sections (overview, setup, troubleshooting, alerts, metrics, ...) the type renders.
 - The categorisation in `integrations.js` — making sure the new type ends up in the flat `integrations` array with a correct `integration_type` field.
+
+Render keys are a downstream contract, not only a docs-output choice. Any
+section name that website or cloud-frontend treats as markdown content must
+be emitted as a string in `integrations.json` and `integrations.js`. If a new
+type reuses `collector.json`, default to the collector render keys unless
+there is evidence a key is invalid for that type. Publishing raw YAML
+objects or arrays under keys such as `metrics` or `alerts` breaks website
+Hugo templates and cloud-frontend integration tabs/checkers.
 
 ### 3. Pipeline rendering (`integrations/gen_docs_integrations.py`)
 
@@ -120,7 +128,7 @@ Three downstream repos may need touching, in roughly decreasing likelihood:
 
 - **`netdata/website`** (`~/src/netdata/website`): the daily `update-integrations.yml` workflow renders marketing cards from `integrations.json`. Cards usually appear automatically. But pages that reference the type explicitly (FAQ entries, solution pages) may need rewriting if the new type changes the story (e.g., "we don't do flows" → "we do flows natively").
 - **`netdata/learn`** (`~/src/netdata/learn`): no PR usually needed. Learn ingest reads `map.yaml` + the `<!--startmeta-->` markers in the generated `.md` files. Sidebar regenerates automatically. ~3 hours after netdata-repo merge.
-- **`netdata/dashboard/cloud-frontend`** (`~/src/dashboard/cloud-frontend`): no PR usually needed. The catalog rendering in `src/domains/integrations/` is fully data-driven from `integrations.js`. New `integration_type` values appear automatically. Special UI (a dedicated tab elsewhere in the dashboard) is a separate concern.
+- **`netdata/dashboard/cloud-frontend`** (`~/src/dashboard/cloud-frontend`): cards/categories are mostly data-driven, but content tabs and validation scripts still assume rendered markdown strings for standard section keys. Before merging a new type, inspect the generated `integrations.js` shape against `src/domains/integrations/components/content/integration/tabs.js`, `src/components/markdown/useRenderableTree.js`, and `scripts/checkIntegrations.js`. Special UI (a dedicated tab elsewhere in the dashboard) is a separate concern.
 
 ## Verification checklist
 
@@ -128,10 +136,12 @@ After all the changes:
 
 1. `python3 integrations/gen_integrations.py` — exits 0, regenerates `integrations.js` and `integrations.json`. The new type appears in the flat list, in the new top-level category, with the correct count.
 2. `python3 integrations/gen_docs_integrations.py` — exits 0, generates per-integration `.md` files. Each has `<!--startmeta-->` with the correct `learn_rel_path`.
-3. Manual inspection of one generated `.md` — frontmatter complete (`custom_edit_url`, `meta_yaml`, `sidebar_label`, `learn_status: Published`, `learn_rel_path`, `keywords`, `message: "DO NOT EDIT..."`).
-4. `grep` the categories tree in `integrations.json` — the new top-level node exists with the new entries.
-5. Open `learn.netdata.cloud` after the next ingest cycle (~3 hours after merge) — confirm the new section renders in the sidebar.
-6. Open the in-app integrations catalog — confirm the new top-level filter appears in the sidebar with the correct entries.
+3. Type-check the generated artifacts — every standard content key consumed as markdown downstream (`overview`, `setup`, `troubleshooting`, `alerts`, `metrics`, `functions`, `related_resources`, and type-specific equivalents) is a string, not an object or array.
+4. Manual inspection of one generated `.md` — frontmatter complete (`custom_edit_url`, `meta_yaml`, `sidebar_label`, `learn_status: Published`, `learn_rel_path`, `keywords`, `message: "DO NOT EDIT..."`).
+5. `grep` the categories tree in `integrations.json` — the new top-level node exists with the new entries.
+6. Run or locally emulate the website integrations update/build when the new type introduces a new top-level category or a new section shape. The website PR must build with the Hugo version pinned in `netlify.toml`.
+7. Open `learn.netdata.cloud` after the next ingest cycle (~3 hours after merge) — confirm the new section renders in the sidebar.
+8. Open the in-app integrations catalog — confirm the new top-level filter appears in the sidebar with the correct entries and content tabs are not blank.
 
 ## What to commit, and where
 

--- a/.agents/skills/integrations-lifecycle/in-app-contract.md
+++ b/.agents/skills/integrations-lifecycle/in-app-contract.md
@@ -72,6 +72,16 @@ export const integrations = [
 ];
 ```
 
+All public content sections consumed by downstream renderers must be
+markdown strings in the generated artifacts, even when the source
+`metadata.yaml` stores them as structured YAML objects or arrays.
+Examples: collector-like `metrics`, `alerts`, `functions`, `overview`,
+`setup`, `troubleshooting`, and `related_resources` must pass through
+the renderer before reaching `integrations.js` / `integrations.json`.
+Leaving raw objects or arrays in these fields breaks the website Hugo
+renderer and produces blank tabs or link-check failures in
+cloud-frontend.
+
 The dashboard's renderer interprets the `{% details %}` /
 `{% /details %}` markers embedded in the rendered text (the
 `clean=False` variant is the one written into the `.js` file).
@@ -128,10 +138,16 @@ In practice this means:
    keys) is a contract. Avoid breaking changes; coordinate
    with the cloud-frontend team if a key must be renamed or
    removed.
-2. **Custom Jinja markers in metadata** (`{% details %}`,
+2. **Render structured metadata before publication**. A new
+   integration type that reuses collector-style sections must
+   include every structured content key in its render-key list.
+   Do not publish raw `metrics` objects, `alerts` arrays, or
+   similar YAML structures under the public markdown section
+   names.
+3. **Custom Jinja markers in metadata** (`{% details %}`,
    `{% relatedResource %}`, `{% if %}`) are part of the
    contract. The dashboard's renderer interprets them. Test
    any new marker against both surfaces before relying on it.
-3. **Do not commit `integrations.js` to this repo**. It is
+4. **Do not commit `integrations.js` to this repo**. It is
    gitignored on purpose; the dashboard pulls fresh on each
    build.

--- a/.agents/sow/done/SOW-0014-20260506-netflow-sflow-ipfix-documentation-guide.md
+++ b/.agents/sow/done/SOW-0014-20260506-netflow-sflow-ipfix-documentation-guide.md
@@ -8,6 +8,14 @@ Reopened 2026-05-07 after the netlify deploy preview for learn PR #2852 surfaced
 
 Reopened 2026-05-08 after PR #22449 review and CI reported additional issues after the SOW had been marked completed and moved to `done/`. The open items are tracked in `## Regression - 2026-05-08` and include automated review threads, `yamllint`, `check-documentation`, Codacy triage, a code-only review subagent requested by the user, and a new user-requested local Learn preview skill/workflow.
 
+Reopened 2026-05-08 after the merged integration artifacts broke downstream
+publishing contracts for the website and in-app integrations. The flow
+integration schema delegates to collector metadata, but the flow renderer did
+not render the collector-style `metrics` and `alerts` sections, leaving raw
+objects/arrays in `integrations.json` and `integrations.js`.
+The regression was repaired and revalidated on 2026-05-08; see
+`## Regression - 2026-05-08 - Flow Integration Section Rendering`.
+
 ## Requirements
 
 ### Purpose
@@ -2876,3 +2884,118 @@ Repairs:
 - **SOW lifecycle**: SOW 14 repair is complete; status is `completed`, and
   the file is moved back to `.agents/sow/done/` in the same commit as the
   repair.
+
+## Regression - 2026-05-08 - Flow Integration Section Rendering
+
+### What broke
+
+The merged network-flow integration artifacts expose `metrics` as a JSON object
+and `alerts` as a JSON array for `integration_type: flows` entries. Downstream
+surfaces expect rendered markdown strings for integration content sections.
+
+Evidence:
+
+- `integrations/schemas/flows.json` delegates to `collector.json`, so flow
+  metadata legitimately contains collector-style `metrics` and `alerts`.
+- `integrations/gen_integrations.py` `FLOWS_RENDER_KEYS` rendered only
+  `overview`, `related_resources`, `setup`, and `troubleshooting`, leaving
+  `metrics` and `alerts` in their source YAML shape.
+- The website PR generated from the merged artifacts failed production-pinned
+  Hugo `0.140.0` because `themes/tailwind/layouts/partials/integration-tabs.html`
+  calls `markdownify` on `.integration.metrics`.
+- The in-app integrations renderer in cloud-frontend adds tabs for truthy
+  `metrics` and `alerts`, while its Markdoc wrapper parses only string input.
+  The result would be blank Metrics and Alerts tabs after the next data sync.
+- The cloud-frontend integration link checker calls `.match()` on markdown
+  fields, so raw objects/arrays in `metrics`/`alerts` can break that check too.
+
+### Why previous validation missed it
+
+The earlier closeout validated the Netdata integrations generator and local
+Learn ingest/build, but did not validate the website Hugo renderer or the
+cloud-frontend integrations consumer against the newly introduced
+`integration_type: flows` artifacts. `gen_integrations.py` itself accepted the
+raw structured fields because they are schema-valid before rendering.
+
+### Repair plan
+
+Render flow `metrics` and `alerts` through the same markdown templates used by
+collector integrations. This keeps the source metadata schema unchanged and
+restores the downstream contract: content sections in `integrations.json` and
+`integrations.js` are markdown strings.
+
+### Validation plan
+
+- Run `python3 integrations/gen_integrations.py`.
+- Verify all `flows` entries in `integrations/integrations.json` have string
+  `metrics` and string `alerts`.
+- Run `python3 integrations/gen_docs_integrations.py`.
+- Run `python3 integrations/gen_doc_collector_page.py`.
+- Rebuild the website PR artifacts with the repaired generated
+  `integrations.json` and production-pinned Hugo `0.140.0`.
+- Verify cloud-frontend's current renderer and link checker receive strings
+  for `flows` `metrics` and `alerts`.
+
+### Artifact updates needed
+
+- **Code**: update `integrations/gen_integrations.py` flow render keys.
+- **Generated artifacts**: regenerate `integrations/integrations.json`,
+  `integrations/integrations.js`, per-integration markdown, and
+  `src/collectors/COLLECTORS.md` if the generator changes them.
+- **Runtime project skills**: update `integrations-lifecycle` if the durable
+  downstream contract was not already documented clearly enough.
+- **Specs**: no product behavior change is expected; this repairs generated
+  publishing artifacts.
+- **End-user/operator docs**: no content change is expected beyond generated
+  artifacts.
+
+### Repair completed
+
+`integrations/gen_integrations.py` now renders the flow `alerts`, `metrics`,
+and `functions` sections through the standard templates, matching the
+collector-like schema that `flows.json` delegates to.
+
+### Validation evidence
+
+- `python3 integrations/gen_integrations.py` passed.
+- `python3 integrations/gen_docs_integrations.py` passed.
+- `python3 integrations/gen_doc_collector_page.py` passed.
+- Flow artifact type check passed: every `integration_type: flows` entry in
+  `integrations/integrations.json` has string `metrics`, string `alerts`, and
+  string `functions`.
+- Non-deploy markdown-field type check passed: no non-deploy integration emits
+  raw object or array values for `overview`, `setup`, `troubleshooting`,
+  `alerts`, `metrics`, `functions`, or `related_resources`.
+- Website validation passed in a temporary copy of PR #1212 using the repaired
+  `integrations.json` and production-pinned Hugo `0.140.0`: `hugo --gc
+  --minify` built 3141 pages successfully.
+- Cloud-frontend compatibility check passed against the repaired
+  `integrations.json`: all flow markdown fields inspected by
+  `scripts/checkIntegrations.js` were strings, and `getMarkdownUrls()` extracted
+  52 markdown URLs without throwing.
+- `git diff --check` passed.
+- `.agents/sow/audit.sh` exited 2 because of a pre-existing unrelated
+  sensitive-pattern warning in
+  `.agents/skills/mirror-netdata-repos/SKILL.md`; SOW status/directory
+  consistency passed and SOW 14 reports `completed` in `.agents/sow/done/`.
+
+### Artifact maintenance gate
+
+- **AGENTS.md**: no update needed; this does not change repo-wide workflow.
+- **Runtime project skills**: updated `integrations-lifecycle` with the
+  downstream markdown-string contract and the new-integration-type validation
+  checklist.
+- **Specs**: no update needed; product behavior and public data semantics did
+  not change.
+- **End-user/operator docs**: no hand-authored user docs changed; this repairs
+  generated publishing artifacts.
+- **End-user/operator skills**: no update needed; no operator workflow changed.
+- **SOW lifecycle**: SOW 14 reopened as a regression, status returned to
+  `completed`, and the file is moved back to `.agents/sow/done/` in the same
+  commit as the repair.
+
+### Follow-up mapping
+
+No deferred follow-up remains for this regression. The website integration PR
+must be regenerated after this repair reaches `netdata/master`; that is the
+normal downstream propagation path rather than a separate source-code TODO.

--- a/integrations/gen_integrations.py
+++ b/integrations/gen_integrations.py
@@ -83,6 +83,9 @@ COLLECTOR_RENDER_KEYS = [
 ]
 
 FLOWS_RENDER_KEYS = [
+    'alerts',
+    'metrics',
+    'functions',
     'overview',
     'related_resources',
     'setup',


### PR DESCRIPTION
## Summary

- render flow integration `alerts`, `metrics`, and `functions` through the standard integration templates
- keep generated `integrations.json` and `integrations.js` markdown content sections compatible with website and cloud-frontend consumers
- update the integrations lifecycle skill with the downstream markdown-string contract
- record the SOW 14 regression repair and validation

## Validation

- `python3 integrations/gen_integrations.py`
- `python3 integrations/gen_docs_integrations.py`
- `python3 integrations/gen_doc_collector_page.py`
- flow artifact type check: `metrics`, `alerts`, and `functions` are strings for every `integration_type: flows` entry
- non-deploy markdown-field type check: no raw object/array values under standard markdown fields
- website PR 1212 temp rebuild with repaired `integrations.json` and Hugo 0.140.0: `hugo --gc --minify`
- cloud-frontend compatibility check: `getMarkdownUrls()` extracted flow markdown URLs without throwing
- `git diff --check`

## Notes

The website integrations PR generated before this fix still contains the old raw object/array fields. After this merges, the website integration update should be rerun so PR 1212 is regenerated from the repaired source artifact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders flow integration `alerts`, `metrics`, and `functions` with the standard templates so `integrations.json` and `integrations.js` contain markdown strings, fixing website and cloud-frontend content tabs. Updates lifecycle docs to codify the markdown-string contract and records the SOW-0014 regression repair.

- **Bug Fixes**
  - Added `alerts`, `metrics`, and `functions` to `FLOWS_RENDER_KEYS` in `integrations/gen_integrations.py` so flow sections render to markdown.
  - Ensured generated `integrations.json` and `integrations.js` keep standard content keys as strings for website Hugo and cloud-frontend.
  - Updated `integrations-lifecycle` docs with the downstream markdown-string contract and validation checklist.
  - Logged repair and validation in SOW-0014.

- **Migration**
  - Regenerate the website integrations update so it rebuilds with the repaired `integrations.json` (Hugo pinned version).
  - After sync, verify flow content tabs render in cloud-frontend and no link-check errors occur.

<sup>Written for commit e1ea104cfde55477f393de1d41d983f80eeae3a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

