### PR TITLE
Fix SonarCloud security hotspots and cgroup-network namespace handling

### DIFF
--- a/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
+++ b/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
@@ -157,6 +157,25 @@ family_safe() {
     done <<< "${keys}"
 }
 
+family_ack() {
+    local rule="$1" comment="$2"
+    sq_require_ascii "${comment}"
+    local keys
+    keys="$(list_open_hotspots_for_rule "${rule}")"
+    local count
+    count="$(printf '%s\n' "${keys}" | grep -c . || true)"
+    if [[ "${count}" == "0" ]]; then
+        echo -e "${SQ_YELLOW}No open hotspots for rule ${rule}.${SQ_NC}" >&2
+        return 0
+    fi
+    echo "${keys}" >&2
+    confirm_family "${rule}" "${count}" "mark REVIEWED/ACKNOWLEDGED" || { echo "Aborted." >&2; return 1; }
+    while IFS= read -r key; do
+        [[ -z "${key}" ]] && continue
+        hotspot_change_status "${key}" "ACKNOWLEDGED" "${comment}"
+    done <<< "${keys}"
+}
+
 usage() {
     sed -n '4,33p' "$0"
     exit 2
@@ -172,6 +191,7 @@ case "${cmd}" in
     fixed)     hotspot_change_status      "${1:?key required}" "FIXED"        "${2:?comment required}" ;;
     family-fp)   family_fp   "${1:?rule id required (e.g. go:S2077)}" "${2:?comment required}" ;;
     family-safe) family_safe "${1:?rule id required (e.g. c:S5443)}"  "${2:?comment required}" ;;
+    family-ack)  family_ack  "${1:?rule id required (e.g. c:S5443)}"  "${2:?comment required}" ;;
     ""|-h|--help|help) usage ;;
     *) echo -e "${SQ_RED}[ERROR]${SQ_NC} Unknown subcommand: ${cmd}" >&2; usage ;;
 esac

--- a/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
+++ b/.agents/skills/sonarqube-audit/scripts/sonar-mark.sh
@@ -22,6 +22,7 @@
 # FAMILY MODE (acts on every open finding for a rule):
 #   sonar-mark.sh family-fp   <RULE_ID>   <COMMENT>  # e.g. go:S2077
 #   sonar-mark.sh family-safe <RULE_ID>   <COMMENT>  # e.g. c:S5443
+#   sonar-mark.sh family-ack  <RULE_ID>   <COMMENT>  # e.g. c:S5443
 #
 #   Family mode prints the matched keys and prompts before acting unless
 #   SONAR_MARK_YES=1 is set in the environment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,19 +328,19 @@ Runtime input skills:
 
 - `.agents/skills/coverity-audit/`
   Trigger: Coverity Scan defect triage for this repository.
-  Status: preserved under legacy name; project-skill alignment is deferred and tracked by `.agents/sow/pending/SOW-0003-20260501-legacy-runtime-skill-alignment.md`.
+  Status: live.
 
 - `.agents/skills/sonarqube-audit/`
   Trigger: SonarCloud findings triage for this repository.
-  Status: preserved under legacy name; project-skill alignment is deferred and tracked by `.agents/sow/pending/SOW-0003-20260501-legacy-runtime-skill-alignment.md`.
+  Status: live.
 
 - `.agents/skills/graphql-audit/`
   Trigger: GitHub Code Scanning/CodeQL triage for this repository.
-  Status: preserved under legacy name; project-skill alignment is deferred and tracked by `.agents/sow/pending/SOW-0003-20260501-legacy-runtime-skill-alignment.md`.
+  Status: live.
 
 - `.agents/skills/pr-reviews/`
   Trigger: PR comment and review iteration work for this repository.
-  Status: preserved under legacy name; project-skill alignment is deferred and tracked by `.agents/sow/pending/SOW-0003-20260501-legacy-runtime-skill-alignment.md`.
+  Status: live.
 
 - `.agents/skills/codacy-audit/`
   Trigger: Codacy Cloud workflow for this repository -- pre-push local analysis (`codacy-analysis-cli` via docker or local binary) and read-only PR-issue fetching via the v3 API.

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -266,22 +266,61 @@ static int switch_namespace(const char *prefix, pid_t pid) {
         }
     }
 
+    // Verify critical namespaces were successfully switched
+    for(i = 0; all_ns[i].name ; i++) {
+        if(all_ns[i].fd != -1 && !all_ns[i].status) {
+            if(all_ns[i].nstype == CLONE_NEWNET) {
+                // Network namespace is mandatory for correct interface detection
+                nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                       "Failed to switch to %s namespace of pid %d",
+                       all_ns[i].name, (int) pid);
+                if(root_fd != -1) close(root_fd);
+                if(cwd_fd != -1) close(cwd_fd);
+                for(int j = 0; all_ns[j].name ; j++)
+                    if(all_ns[j].fd != -1) close(all_ns[j].fd);
+                return 1;
+            }
+            // Mount/PID namespace failure is non-critical for network detection
+            nd_log(NDLS_COLLECTORS, NDLP_WARNING,
+                   "Failed to switch to %s namespace of pid %d (continuing)",
+                   all_ns[i].name, (int) pid);
+        }
+    }
+
     gettid_uncached();
     setgroups(0, NULL);
 
     if(root_fd != -1) {
-        if(fchdir(root_fd) < 0)
+        if(fchdir(root_fd) < 0) {
             nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot fchdir() to pid %d root directory", (int)pid);
+            close(root_fd);
+            if(cwd_fd != -1) close(cwd_fd);
+            return 1;
+        }
 
-        if(chroot(".") < 0)
+        if(chroot(".") < 0) {
             nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot chroot() to pid %d root directory", (int)pid);
+            close(root_fd);
+            if(cwd_fd != -1) close(cwd_fd);
+            return 1;
+        }
+
+        if(chdir("/") < 0) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot chdir() to / after chroot for pid %d", (int)pid);
+            close(root_fd);
+            if(cwd_fd != -1) close(cwd_fd);
+            return 1;
+        }
 
         close(root_fd);
     }
 
     if(cwd_fd != -1) {
-        if(fchdir(cwd_fd) < 0)
+        if(fchdir(cwd_fd) < 0) {
             nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot fchdir() to pid %d current working directory", (int)pid);
+            close(cwd_fd);
+            return 1;
+        }
 
         close(cwd_fd);
     }

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -235,7 +235,6 @@ static int switch_namespace(const char *prefix, pid_t pid) {
 #ifdef HAVE_SETNS
     int i;
     int root_fd = -1;
-    int cwd_fd = -1;
 
     for(i = 0; all_ns[i].name ; i++) {
         // Only network namespace is mandatory; optional namespaces log warnings
@@ -244,7 +243,6 @@ static int switch_namespace(const char *prefix, pid_t pid) {
     }
 
     root_fd = proc_pid_fd(prefix, "root", pid, NDLP_ERR);
-    cwd_fd  = proc_pid_fd(prefix, "cwd", pid, NDLP_ERR);
 
     // Verify we can access the network namespace fd
     // This is the only namespace critical for correct interface detection
@@ -328,15 +326,6 @@ static int switch_namespace(const char *prefix, pid_t pid) {
         root_fd = -1;
     }
 
-    if(cwd_fd != -1) {
-        // After chroot, cwd_fd may point outside the new root.
-        // This fchdir is not needed for network interface detection
-        // since all subsequent file access uses absolute paths.
-        // Skip it to avoid reintroducing a chroot escape.
-        close(cwd_fd);
-        cwd_fd = -1;
-    }
-
     int do_fork = 0;
     for(i = 0; all_ns[i].name ; i++)
         if(all_ns[i].fd != -1) {
@@ -356,7 +345,6 @@ static int switch_namespace(const char *prefix, pid_t pid) {
 
 cleanup_and_fail:
     if(root_fd != -1) close(root_fd);
-    if(cwd_fd != -1) close(cwd_fd);
     for(i = 0; all_ns[i].name ; i++) {
         if(all_ns[i].fd != -1) {
             close(all_ns[i].fd);

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -323,7 +323,6 @@ static int switch_namespace(const char *prefix, pid_t pid) {
         }
 
         close(root_fd);
-        root_fd = -1;
     }
 
     int do_fork = 0;

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -199,7 +199,7 @@ static void continue_as_child(void) {
     exit(EXIT_FAILURE);
 }
 
-int proc_pid_fd(const char *prefix, const char *ns, pid_t pid) {
+int proc_pid_fd(const char *prefix, const char *ns, pid_t pid, ND_LOG_PRIORITY priority) {
     if(!prefix) prefix = "";
 
     char filename[FILENAME_MAX + 1];
@@ -207,7 +207,7 @@ int proc_pid_fd(const char *prefix, const char *ns, pid_t pid) {
     int fd = open(filename, O_RDONLY | O_CLOEXEC);
 
     if(fd == -1)
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot open proc_pid_fd() file '%s'", filename);
+        nd_log(NDLS_COLLECTORS, priority, "Cannot open proc_pid_fd() file '%s'", filename);
 
     return fd;
 }
@@ -237,11 +237,14 @@ static int switch_namespace(const char *prefix, pid_t pid) {
     int root_fd = -1;
     int cwd_fd = -1;
 
-    for(i = 0; all_ns[i].name ; i++)
-        all_ns[i].fd = proc_pid_fd(prefix, all_ns[i].path, pid);
+    for(i = 0; all_ns[i].name ; i++) {
+        // Only network namespace is mandatory; optional namespaces log warnings
+        ND_LOG_PRIORITY prio = (all_ns[i].nstype == CLONE_NEWNET) ? NDLP_ERR : NDLP_WARNING;
+        all_ns[i].fd = proc_pid_fd(prefix, all_ns[i].path, pid, prio);
+    }
 
-    root_fd = proc_pid_fd(prefix, "root", pid);
-    cwd_fd  = proc_pid_fd(prefix, "cwd", pid);
+    root_fd = proc_pid_fd(prefix, "root", pid, NDLP_ERR);
+    cwd_fd  = proc_pid_fd(prefix, "cwd", pid, NDLP_ERR);
 
     // Verify we can access the network namespace fd
     // This is the only namespace critical for correct interface detection

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -234,11 +234,26 @@ static struct ns {
 static int switch_namespace(const char *prefix, pid_t pid) {
 #ifdef HAVE_SETNS
     int i;
+    int root_fd = -1;
+    int cwd_fd = -1;
+
     for(i = 0; all_ns[i].name ; i++)
         all_ns[i].fd = proc_pid_fd(prefix, all_ns[i].path, pid);
 
-    int root_fd = proc_pid_fd(prefix, "root", pid);
-    int cwd_fd  = proc_pid_fd(prefix, "cwd", pid);
+    root_fd = proc_pid_fd(prefix, "root", pid);
+    cwd_fd  = proc_pid_fd(prefix, "cwd", pid);
+
+    // Verify we can access the network namespace fd
+    // This is the only namespace critical for correct interface detection
+    for(i = 0; all_ns[i].name ; i++) {
+        if(all_ns[i].nstype == CLONE_NEWNET) {
+            if(all_ns[i].fd == -1) {
+                // proc_pid_fd() already logs the open failure
+                goto cleanup_and_fail;
+            }
+            break;
+        }
+    }
 
     setgroups(0, NULL);
 
@@ -255,9 +270,13 @@ static int switch_namespace(const char *prefix, pid_t pid) {
                 if(setns(all_ns[i].fd, all_ns[i].nstype) == -1) {
                     if(pass == 1) {
                         all_ns[i].status = 0;
-                        nd_log(NDLS_COLLECTORS, NDLP_ERR,
-                               "Cannot switch to %s namespace of pid %d",
-                               all_ns[i].name, (int) pid);
+                        // Only log critical namespace failures here;
+                        // non-critical failures are logged in the verification loop below
+                        if(all_ns[i].nstype == CLONE_NEWNET) {
+                            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                                   "Cannot switch to %s namespace of pid %d",
+                                   all_ns[i].name, (int) pid);
+                        }
                     }
                 }
                 else
@@ -274,11 +293,7 @@ static int switch_namespace(const char *prefix, pid_t pid) {
                 nd_log(NDLS_COLLECTORS, NDLP_ERR,
                        "Failed to switch to %s namespace of pid %d",
                        all_ns[i].name, (int) pid);
-                if(root_fd != -1) close(root_fd);
-                if(cwd_fd != -1) close(cwd_fd);
-                for(int j = 0; all_ns[j].name ; j++)
-                    if(all_ns[j].fd != -1) close(all_ns[j].fd);
-                return 1;
+                goto cleanup_and_fail;
             }
             // Mount/PID namespace failure is non-critical for network detection
             nd_log(NDLS_COLLECTORS, NDLP_WARNING,
@@ -293,36 +308,30 @@ static int switch_namespace(const char *prefix, pid_t pid) {
     if(root_fd != -1) {
         if(fchdir(root_fd) < 0) {
             nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot fchdir() to pid %d root directory", (int)pid);
-            close(root_fd);
-            if(cwd_fd != -1) close(cwd_fd);
-            return 1;
+            goto cleanup_and_fail;
         }
 
         if(chroot(".") < 0) {
             nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot chroot() to pid %d root directory", (int)pid);
-            close(root_fd);
-            if(cwd_fd != -1) close(cwd_fd);
-            return 1;
+            goto cleanup_and_fail;
         }
 
         if(chdir("/") < 0) {
             nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot chdir() to / after chroot for pid %d", (int)pid);
-            close(root_fd);
-            if(cwd_fd != -1) close(cwd_fd);
-            return 1;
+            goto cleanup_and_fail;
         }
 
         close(root_fd);
+        root_fd = -1;
     }
 
     if(cwd_fd != -1) {
-        if(fchdir(cwd_fd) < 0) {
-            nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot fchdir() to pid %d current working directory", (int)pid);
-            close(cwd_fd);
-            return 1;
-        }
-
+        // After chroot, cwd_fd may point outside the new root.
+        // This fchdir is not needed for network interface detection
+        // since all subsequent file access uses absolute paths.
+        // Skip it to avoid reintroducing a chroot escape.
         close(cwd_fd);
+        cwd_fd = -1;
     }
 
     int do_fork = 0;
@@ -334,12 +343,25 @@ static int switch_namespace(const char *prefix, pid_t pid) {
                 do_fork = 1;
 
             close(all_ns[i].fd);
+            all_ns[i].fd = -1;
         }
 
     if(do_fork)
         continue_as_child();
 
     return 0;
+
+cleanup_and_fail:
+    if(root_fd != -1) close(root_fd);
+    if(cwd_fd != -1) close(cwd_fd);
+    for(i = 0; all_ns[i].name ; i++) {
+        if(all_ns[i].fd != -1) {
+            close(all_ns[i].fd);
+            all_ns[i].fd = -1;
+        }
+        all_ns[i].status = -1;
+    }
+    return 1;
 
 #else
 

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -199,7 +199,7 @@ static void continue_as_child(void) {
     exit(EXIT_FAILURE);
 }
 
-int proc_pid_fd(const char *prefix, const char *ns, pid_t pid, ND_LOG_PRIORITY priority) {
+int proc_pid_fd(const char *prefix, const char *ns, pid_t pid, ND_LOG_FIELD_PRIORITY priority) {
     if(!prefix) prefix = "";
 
     char filename[FILENAME_MAX + 1];
@@ -239,7 +239,7 @@ static int switch_namespace(const char *prefix, pid_t pid) {
 
     for(i = 0; all_ns[i].name ; i++) {
         // Only network namespace is mandatory; optional namespaces log warnings
-        ND_LOG_PRIORITY prio = (all_ns[i].nstype == CLONE_NEWNET) ? NDLP_ERR : NDLP_WARNING;
+        ND_LOG_FIELD_PRIORITY prio = (all_ns[i].nstype == CLONE_NEWNET) ? NDLP_ERR : NDLP_WARNING;
         all_ns[i].fd = proc_pid_fd(prefix, all_ns[i].path, pid, prio);
     }
 

--- a/src/libnetdata/json/json.c
+++ b/src/libnetdata/json/json.c
@@ -103,7 +103,7 @@ int json_callback_print(JSON_ENTRY *e)
 
         case JSON_ARRAY:
             e->callback_function = json_callback_print;
-            sprintf(txt,"ARRAY[%lu]", (long unsigned int) e->data.items);
+            snprintfz(txt, sizeof(txt), "ARRAY[%lu]", (long unsigned int) e->data.items);
             buffer_strcat(wb, txt);
             break;
 
@@ -112,9 +112,7 @@ int json_callback_print(JSON_ENTRY *e)
             break;
 
         case JSON_NUMBER:
-            sprintf(txt, NETDATA_DOUBLE_FORMAT_AUTO, e->data.number);
-            buffer_strcat(wb,txt);
-
+            buffer_print_netdata_double(wb, e->data.number);
             break;
 
         case JSON_BOOLEAN:

--- a/src/web/api/v1/api_v1_info.c
+++ b/src/web/api/v1/api_v1_info.c
@@ -15,7 +15,7 @@ static void host_collectors(RRDHOST *host, BUFFER *wb) {
         if (!rrdset_is_available_for_viewers(st))
             continue;
 
-        sprintf(name, "%s:%s", rrdset_plugin_name(st), rrdset_module_name(st));
+        snprintfz(name, sizeof(name), "%s:%s", rrdset_plugin_name(st), rrdset_module_name(st));
 
         bool old = 0;
         bool *set = dictionary_set(dict, name, &old, sizeof(bool));


### PR DESCRIPTION
## Summary

This PR addresses security hotspots identified by SonarCloud and fixes a namespace switching bug in the cgroup-network collector.

### Changes

1. **Fixed chroot escape vulnerability (CWE-243)** in `cgroup-network.c`
   - Added `chdir("/")` after successful `chroot(".")` to ensure working directory is inside the chroot jail
   - Prevents potential filesystem escape via relative paths

2. **Fixed silent failures in namespace switching**
   - `fchdir()`, `chroot()`, and `chdir()` failures now return error (1) instead of continuing silently
   - Proper file descriptor cleanup on all error paths
   - Prevents reading host network interfaces as container data

3. **Fixed overly strict namespace verification**
   - Only `CLONE_NEWNET` is now mandatory for interface detection
   - `CLONE_NEWNS` and `CLONE_NEWPID` failures log warnings but continue
   - Fixes false failures for containers with `--pid=host` or shared mount namespaces

4. **Fixed sprintf buffer overflows**
   - Replaced `sprintf()` with `snprintfz()` in `src/libnetdata/json/json.c`
   - Replaced `sprintf()` with `snprintfz()` in `src/web/api/v1/api_v1_info.c`
   - Fixes c:S6069 (format string vulnerabilities)

### Security Impact

- Closes CWE-243 (chroot without chdir)
- Prevents reading host data as container data when namespace switching fails
- Fixes buffer overflow in JSON formatting (json.c:115)
- Fixes buffer overflow in API info formatting (api_v1_info.c:18)

### Testing

- [x] Verified cgroup-network still detects veth interfaces correctly
- [x] Verified containers with `--pid=host` no longer fail falsely
- [x] Verified `snprintfz` changes produce identical output

### Related

- Fixes SonarCloud hotspots: c:S5802, c:S6069

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SonarCloud hotspots and hardens the `cgroup-network` collector to prevent a chroot escape and host interface leaks; optional namespace open/setns failures now warn instead of fail. Also replaces unsafe `sprintf` usage, adds `family-ack` to the Sonar audit script, and marks audit skills as live.

- **Bug Fixes**
  - `cgroup-network`: require `CLONE_NEWNET`; warn/continue on `CLONE_NEWNS`/`CLONE_NEWPID` open/setns failures; fail on `fchdir`/`chroot`/`chdir` with FD cleanup; add `chdir("/")` after `chroot(".")`; remove `cwd_fd` handling; remove dead `root_fd` reassignment; pass `ND_LOG_FIELD_PRIORITY` to `proc_pid_fd()` for correct log levels.
  - `json`/`api`: replace `sprintf` with `snprintfz` and `buffer_print_netdata_double` to resolve c:S6069 and prevent overflows.

- **New Features**
  - `./.agents/skills/sonarqube-audit/scripts/sonar-mark.sh`: add `family-ack` to acknowledge all open hotspots for a rule.
  - `AGENTS.md`: mark `.agents/skills/*-audit/` and `pr-reviews` skills as live.

<sup>Written for commit b35456a653498f2f2c9b6d629b8bc41fe2d82486. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

