### PR TITLE
Fix DBENGINE PGC races in pgc_page_add and pgc_queue_del

### DIFF
--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -1394,6 +1394,14 @@ static PGC_PAGE *pgc_page_add(PGC *cache, PGC_ENTRY *entry, bool *added) {
     internal_fatal(entry->start_time_s < 0 || entry->end_time_s < 0,
                    "DBENGINE CACHE: timestamps are negative");
 
+    // Clamp before any read of entry->start_time_s / entry->end_time_s so the
+    // PGC_PAGE struct and the Judy index key are built from the same value.
+    if(unlikely(entry->start_time_s < 0))
+        entry->start_time_s = 0;
+
+    if(unlikely(entry->end_time_s < 0))
+        entry->end_time_s = 0;
+
     p2_add_fetch(&cache->stats.p2_workers_add, 1);
 
     size_t partition = pgc_indexing_partition(cache, entry->metric_id);
@@ -1403,7 +1411,7 @@ static PGC_PAGE *pgc_page_add(PGC *cache, PGC_ENTRY *entry, bool *added) {
 #else
     PGC_PAGE *allocation = mallocz(sizeof(PGC_PAGE) + cache->config.additional_bytes_per_page);
 #endif
-    
+
     allocation->refcount = 1;
     allocation->accesses = (entry->hot) ? 0 : 1;
     allocation->flags = 0;
@@ -1417,22 +1425,16 @@ static PGC_PAGE *pgc_page_add(PGC *cache, PGC_ENTRY *entry, bool *added) {
     spinlock_init(&allocation->transition_spinlock);
     allocation->link.prev = NULL;
     allocation->link.next = NULL;
-    
+
     if(cache->config.additional_bytes_per_page) {
         if(entry->custom_data)
             memcpy(allocation->custom_data, entry->custom_data, cache->config.additional_bytes_per_page);
         else
             memset(allocation->custom_data, 0, cache->config.additional_bytes_per_page);
     }
-    
+
     PGC_PAGE *page;
     size_t spins = 0;
-
-    if(unlikely(entry->start_time_s < 0))
-        entry->start_time_s = 0;
-
-    if(unlikely(entry->end_time_s < 0))
-        entry->end_time_s = 0;
 
     do {
         spins++;

--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -719,8 +719,6 @@ static ALWAYS_INLINE void pgc_queue_del(PGC *cache __maybe_unused, struct pgc_qu
                    page_get_status_flags(page),
         q->flags);
 
-    page_flag_clear(page, q->flags);
-
     struct section_pages *sp_to_free = NULL;
 
     if(q->linked_list_in_sections_judy) {
@@ -755,6 +753,13 @@ static ALWAYS_INLINE void pgc_queue_del(PGC *cache __maybe_unused, struct pgc_qu
         DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(q->base, page, link.prev, link.next);
         q->version++;
     }
+
+    // Clear the queue flag only after the unlink, while still under the queue
+    // lock. A lockless reader that sees the queue flag set is guaranteed the
+    // page is still on this queue's list; once we clear the flag below, the
+    // page is also no longer on the list. This matches the re-validation
+    // pattern added to page_has_been_accessed by commit 2733e6fc60 (#21793).
+    page_flag_clear(page, q->flags);
 
     if(!having_lock)
         pgc_queue_unlock(cache, q);

--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -755,10 +755,12 @@ static ALWAYS_INLINE void pgc_queue_del(PGC *cache __maybe_unused, struct pgc_qu
     }
 
     // Clear the queue flag only after the unlink, while still under the queue
-    // lock. A lockless reader that sees the queue flag set is guaranteed the
-    // page is still on this queue's list; once we clear the flag below, the
-    // page is also no longer on the list. This matches the re-validation
-    // pattern added to page_has_been_accessed by commit 2733e6fc60 (#21793).
+    // lock. This guarantees that "flag cleared" implies "page already unlinked",
+    // so a lockless reader observing "no longer on this queue" cannot race
+    // with an in-progress unlink. The reciprocal (flag set implies on the
+    // list) is intentionally not provided; readers that act on link pointers
+    // must re-validate under the queue lock, as commit 2733e6fc60 (#21793)
+    // does in page_has_been_accessed.
     page_flag_clear(page, q->flags);
 
     if(!having_lock)
@@ -1399,8 +1401,8 @@ static PGC_PAGE *pgc_page_add(PGC *cache, PGC_ENTRY *entry, bool *added) {
     internal_fatal(entry->start_time_s < 0 || entry->end_time_s < 0,
                    "DBENGINE CACHE: timestamps are negative");
 
-    // Clamp before any read of entry->start_time_s / entry->end_time_s so the
-    // PGC_PAGE struct and the Judy index key are built from the same value.
+    // Clamp before the values are copied into the new PGC_PAGE and used as
+    // the Judy index key, so the struct and the index agree.
     if(unlikely(entry->start_time_s < 0))
         entry->start_time_s = 0;
 


### PR DESCRIPTION
##### Summary
- **`pgc_page_add`**: clamp `entry->start_time_s` / `end_time_s` to non-negative *before* writing them into the new `PGC_PAGE`. 
    
 - **`pgc_queue_del`**: clear the queue flag *after* the linked-list unlink (still under the queue lock). 
    Pre-fix, a lockless flag reader could observe "no longer on this queue" while `link.prev`/`link.next` still pointed into the queue base, racing the in-progress unlink. Same re-validation pattern as #21793 applied to the writer side.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two DB cache races: clamp negative `entry` timestamps in `pgc_page_add` before writing to the new `PGC_PAGE` and building the Judy key; clear the queue flag in `pgc_queue_del` only after the page is unlinked under the queue lock. Comments now document the "flag‑cleared implies already unlinked" invariant and the required reader re-validation.

- **Bug Fixes**
  - `pgc_page_add`: Clamp `start_time_s`/`end_time_s` right after the fatal check so the struct and Judy index use the same values, preventing remove misses and the cache fatal.
  - `pgc_queue_del`: Move `page_flag_clear(...)` after the unlink (and sections‑Judy delete), still under the lock, so lockless readers can’t race an in-progress unlink.

<sup>Written for commit 24a9cb47fb0cef5909be7ff0100a195b1801c621. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

