### PR TITLE
Remove redundant per-host replication gate from obsolete chart cleanup

### DIFF
--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -110,25 +110,34 @@ static inline size_t svc_rrdhost_cleanup_charts_marked_obsolete(RRDHOST *host) {
     time_t now = now_realtime_sec();
     RRDSET *st;
     rrdset_foreach_reentrant(st, host) {
-        if(rrdset_is_replicating(st))
-            continue;
-
+        bool is_replicating = rrdset_is_replicating(st);
         RRDSET_FLAGS flags = rrdset_flag_get(st);
+
+        // A replicating chart with pending obsolete work must still be
+        // counted as a candidate, even though we cannot archive it this
+        // pass. The PENDING_OBSOLETE_* host flags are cleared up-front;
+        // if we did not count this chart, candidates == archives == 0
+        // for it and the host flag would not be re-armed -- the cleanup
+        // would never retry once replication finishes. Counting it as a
+        // candidate without an archive forces archives != candidates at
+        // end-of-loop, which re-arms the host flag for the next pass.
 
         if(flags & RRDSET_FLAG_OBSOLETE_DIMENSIONS) {
             partial_candidates++;
 
-            archived_items += svc_rrdset_archive_obsolete_dimensions(st, false);
+            if(!is_replicating) {
+                archived_items += svc_rrdset_archive_obsolete_dimensions(st, false);
 
-            // "all candidates archived" -> flag was not re-set inside.
-            if(!rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS))
-                partial_archives++;
+                // "all candidates archived" -> flag was not re-set inside.
+                if(!rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS))
+                    partial_archives++;
+            }
         }
 
         if(flags & RRDSET_FLAG_OBSOLETE) {
             full_candidates++;
 
-            if(svc_rrdset_lock_for_deletion(st, now)) {
+            if(!is_replicating && svc_rrdset_lock_for_deletion(st, now)) {
                 archived_items += svc_rrdset_archive_obsolete_dimensions(st, true);
 
                 if(!rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS)) {

--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -175,9 +175,13 @@ static void svc_rrd_cleanup_obsolete_charts_from_all_hosts() {
 
     RRDHOST *host;
     rrdhost_foreach_read(host) {
-        if(rrdhost_receiver_replicating_charts(host) || rrdhost_sender_replicating_charts(host))
-            continue;
-
+        // Per-chart correctness gate is rrdset_is_replicating(st) inside
+        // svc_rrdhost_cleanup_charts_marked_obsolete. The previous host-level
+        // gate here (rrdhost_*_replicating_charts(host) > 0) was a defensive
+        // holdover from before the sender replication counter was accurate;
+        // on streaming children with continuous chart churn it permanently
+        // tripped and blocked all obsolete-chart cleanup on the host, piling
+        // up obsolete-but-still-live charts and their RAM-mode dim mmaps.
         archived += svc_rrdhost_cleanup_charts_marked_obsolete(host);
 
         if (rrdhost_is_local(host) || IS_VIRTUAL_HOST_OS(host))

--- a/src/database/rrdset.c
+++ b/src/database/rrdset.c
@@ -131,9 +131,9 @@ void rrdset_is_obsolete___safe_from_collector_thread(RRDSET *st) {
         // "replication finished" decrement at stream-replication-sender.c will
         // never fire for this chart. Release any pending replication slot now,
         // otherwise rrdhost_sender_replicating_charts pins above zero and
-        // permanently blocks svc_rrd_cleanup_obsolete_charts_from_all_hosts.
-        // Mirror the natural-finalize path's pulse-status flip on the 0/1
-        // boundary so SND_REPLICATING -> SND_RUNNING is observed by pulse.
+        // observability (SND_REPLICATING vs SND_RUNNING) stays stuck on the
+        // wrong state. Mirror the natural-finalize path's pulse-status flip on
+        // the 0/1 boundary so SND_REPLICATING -> SND_RUNNING is observed.
         RRDSET_FLAGS old_repl = rrdset_flag_set_and_clear(
             st,
             RRDSET_FLAG_SENDER_REPLICATION_FINISHED,

--- a/src/streaming/protocol/command-chart-definition.c
+++ b/src/streaming/protocol/command-chart-definition.c
@@ -119,8 +119,9 @@ bool stream_sender_send_rrdset_definition(BUFFER *wb, RRDSET *st) {
 
         // The receiver skips replication for obsolete charts (stream-receiver.c),
         // so do not enter the replication bookkeeping here either: it would pin
-        // rrdhost_sender_replicating_charts and permanently gate the cleanup loop
-        // in svc_rrd_cleanup_obsolete_charts_from_all_hosts.
+        // rrdhost_sender_replicating_charts above zero and keep the host's
+        // pulse SND_REPLICATING / SND_RUNNING observability stuck on the wrong
+        // state.
         if(!rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE)) {
             // Claim before publish: increment the host counter BEFORE setting
             // RRDSET_FLAG_SENDER_REPLICATION_IN_PROGRESS, so any concurrent


### PR DESCRIPTION
##### Summary
  `svc_rrd_cleanup_obsolete_charts_from_all_hosts` skipped a whole host when
  `rrdhost_*_replicating_charts(host) > 0`. The per-chart `rrdset_is_replicating(st)`
  gate inside `svc_rrdhost_cleanup_charts_marked_obsolete` is the authoritative
  correctness boundary; the host-level gate was a defensive holdover from before
  #22428 made the sender counter accurate. On hosts with sustained replication
  activity it could skip cleanup of unrelated obsolete charts on the same host.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the host-level replication gate and harden per-chart cleanup so obsolete charts are processed even while some charts replicate. Prevents buildup on streaming children and keeps sender counters and pulse state accurate.

- **Bug Fixes**
  - Removed `rrdhost_*_replicating_charts(host)` skip in `svc_rrd_cleanup_obsolete_charts_from_all_hosts`.
  - In `svc_rrdhost_cleanup_charts_marked_obsolete`, count replicating charts as candidates, defer archiving until replication ends, and re-arm host flags to retry.
  - Avoid counter/observability pinning: skip replication bookkeeping for obsolete charts in `stream_sender_send_rrdset_definition()` and release pending sender slots in `rrdset_is_obsolete___safe_from_collector_thread()`; prevents `rrdhost_sender_replicating_charts` from sticking and wrong SND_REPLICATING state.

<sup>Written for commit 1bf005e997de96bd1bbaeb5922777af29d818617. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

