### PR TITLE
Add safeguards against ML database corruption and streamline recovery process

### DIFF
--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -47,6 +47,17 @@ void ml_db_mark_corrupt(int rc)
     }
 }
 
+// Flag ml.db as corrupt if `rc` is a corruption signal (SQLITE_CORRUPT or
+// SQLITE_NOTADB). Returns true when the rc indicated corruption (regardless
+// of whether the sentinel was successfully written).
+static inline bool ml_db_mark_if_corrupt(int rc)
+{
+    if (rc != SQLITE_CORRUPT && rc != SQLITE_NOTADB)
+        return false;
+    ml_db_mark_corrupt(rc);
+    return true;
+}
+
 static void __attribute__((constructor)) init_mutex(void) {
     netdata_mutex_init(&db_mutex);
 }
@@ -270,8 +281,7 @@ ml_dimension_add_model(const nd_uuid_t *metric_uuid, const ml_kmeans_inlined_t *
         rc = prepare_statement(ml_db, db_models_add_model, &res);
         if (unlikely(rc != SQLITE_OK)) {
             error_report("Failed to prepare statement to store model, rc = %d", rc);
-            if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
-                ml_db_mark_corrupt(rc);
+            ml_db_mark_if_corrupt(rc);
             return 1;
         }
     }
@@ -311,8 +321,7 @@ ml_dimension_add_model(const nd_uuid_t *metric_uuid, const ml_kmeans_inlined_t *
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE)) {
         error_report("Failed to store model, rc = %d", rc);
-        if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
-            ml_db_mark_corrupt(rc);
+        ml_db_mark_if_corrupt(rc);
         return rc;
     }
 
@@ -352,8 +361,7 @@ ml_dimension_delete_models(const nd_uuid_t *metric_uuid, time_t before)
         rc = prepare_statement(ml_db, db_models_delete, &res);
         if (unlikely(rc != SQLITE_OK)) {
             error_report("Failed to prepare statement to delete models, rc = %d", rc);
-            if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
-                ml_db_mark_corrupt(rc);
+            ml_db_mark_if_corrupt(rc);
             return rc;
         }
     }
@@ -369,8 +377,7 @@ ml_dimension_delete_models(const nd_uuid_t *metric_uuid, time_t before)
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE)) {
         error_report("Failed to delete models, rc = %d", rc);
-        if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
-            ml_db_mark_corrupt(rc);
+        ml_db_mark_if_corrupt(rc);
         return rc;
     }
 
@@ -410,8 +417,7 @@ ml_prune_old_models(size_t num_models_to_prune)
         rc = prepare_statement(ml_db, db_models_prune, &res);
         if (unlikely(rc != SQLITE_OK)) {
             error_report("Failed to prepare statement to prune models, rc = %d", rc);
-            if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
-                ml_db_mark_corrupt(rc);
+            ml_db_mark_if_corrupt(rc);
             return rc;
         }
     }
@@ -429,8 +435,7 @@ ml_prune_old_models(size_t num_models_to_prune)
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE)) {
         error_report("Failed to prune old models, rc = %d", rc);
-        if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
-            ml_db_mark_corrupt(rc);
+        ml_db_mark_if_corrupt(rc);
         return rc;
     }
 
@@ -482,8 +487,7 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
         rc = sqlite3_prepare_v2(ml_db, db_models_load, -1, &res, NULL);
         if (unlikely(rc != SQLITE_OK)) {
             error_report("Failed to prepare statement to load models, rc = %d", rc);
-            if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
-                ml_db_mark_corrupt(rc);
+            ml_db_mark_if_corrupt(rc);
             return 1;
         }
         if (active_stmt)
@@ -566,10 +570,9 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
     if (unlikely(rc != SQLITE_OK && rc != step_rc))
         error_report("Failed to %s statement when loading models, rc = %d", active_stmt ? "reset" : "finalize", rc);
 
-    if (step_rc == SQLITE_CORRUPT || step_rc == SQLITE_NOTADB) {
-        ml_db_mark_corrupt(step_rc);
-        return 1; // trip skip_models in metadata_scan_host so we stop hammering the bad DB
-    }
+    // trip skip_models in metadata_scan_host so we stop hammering the bad DB
+    if (ml_db_mark_if_corrupt(step_rc))
+        return 1;
 
     return 0;
 

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -69,16 +69,12 @@ void ml_db_mark_corrupt(int rc)
     }
 }
 
-// Flag ml.db as corrupt if `rc` is a corruption signal (SQLITE_CORRUPT or
-// SQLITE_NOTADB). Returns true when the rc indicated corruption (regardless
-// of whether the sentinel was successfully written).
-//
 // Mask with 0xFF to also catch SQLite extended result codes (e.g.
 // SQLITE_CORRUPT_VTAB, SQLITE_CORRUPT_INDEX, ...) which encode the primary
 // code in the low 8 bits. Extended codes are off by default but can be
 // enabled per-connection via sqlite3_extended_result_codes(); masking is
 // the canonical way to compare regardless of that setting.
-static inline bool ml_db_mark_if_corrupt(int rc)
+bool ml_db_mark_if_corrupt(int rc)
 {
     int primary = rc & 0xFF;
     if (primary != SQLITE_CORRUPT && primary != SQLITE_NOTADB)

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -45,14 +45,14 @@ void ml_db_mark_corrupt(int rc)
         close(fd);
         nd_log(NDLS_DAEMON, NDLP_WARNING,
                "ML: ml.db reported corruption (rc=%d); sentinel %s created. "
-               "ml.db will be renamed to ml.db.bad and recreated at next agent start. "
+               "ml.db will be renamed to a timestamped ml.db.bad.* and recreated at next agent start. "
                "Stored anomaly-detection models will be lost; ML will retrain.",
                rc, sentinel);
     }
     else if (oerr == EEXIST) {
         nd_log(NDLS_DAEMON, NDLP_WARNING,
                "ML: ml.db reported corruption (rc=%d); sentinel %s already present. "
-               "Quarantine will run at next agent start.",
+               "Quarantine to ml.db.bad.* will run at next agent start.",
                rc, sentinel);
     }
     else {

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -81,8 +81,7 @@ void ml_db_mark_corrupt(int rc)
 // the canonical way to compare regardless of that setting.
 bool ml_db_mark_if_corrupt(int rc)
 {
-    int primary = rc & 0xFF;
-    if (primary != SQLITE_CORRUPT && primary != SQLITE_NOTADB)
+    if (int primary = rc & 0xFF; primary != SQLITE_CORRUPT && primary != SQLITE_NOTADB)
         return false;
     ml_db_mark_corrupt(rc);
     return true;

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -18,7 +18,34 @@
 #define WORKER_TRAIN_FLUSH_MODELS      7
 
 sqlite3 *ml_db = NULL;
+bool ml_db_unusable = false;
 static netdata_mutex_t db_mutex;
+
+void ml_db_mark_corrupt(int rc)
+{
+    // Latch the flag first so concurrent callers stop hitting the bad DB
+    // even if the sentinel write fails. Use __ATOMIC_RELAXED -- this is a
+    // best-effort poison flag, not a synchronization primitive.
+    if (__atomic_exchange_n(&ml_db_unusable, true, __ATOMIC_RELAXED))
+        return; // already flagged, sentinel already attempted
+
+    char sentinel[FILENAME_MAX + 1];
+    snprintfz(sentinel, FILENAME_MAX, "%s/.ml.db.delete", netdata_configured_cache_dir);
+    int fd = open(sentinel, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
+    if (fd >= 0) {
+        close(fd);
+        nd_log(NDLS_DAEMON, NDLP_WARNING,
+               "ML: ml.db reported corruption (rc=%d); sentinel %s created. "
+               "ml.db will be renamed to ml.db.bad and recreated at next agent start. "
+               "Stored anomaly-detection models will be lost; ML will retrain.",
+               rc, sentinel);
+    }
+    else {
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "ML: ml.db reported corruption (rc=%d) but failed to create sentinel %s (errno=%d). "
+               "Operator must remove ml.db manually.", rc, sentinel, errno);
+    }
+}
 
 static void __attribute__((constructor)) init_mutex(void) {
     netdata_mutex_init(&db_mutex);
@@ -236,10 +263,15 @@ ml_dimension_add_model(const nd_uuid_t *metric_uuid, const ml_kmeans_inlined_t *
         return 1;
     }
 
+    if (unlikely(__atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED)))
+        return 1;
+
     if (unlikely(!res)) {
         rc = prepare_statement(ml_db, db_models_add_model, &res);
         if (unlikely(rc != SQLITE_OK)) {
             error_report("Failed to prepare statement to store model, rc = %d", rc);
+            if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
+                ml_db_mark_corrupt(rc);
             return 1;
         }
     }
@@ -279,6 +311,8 @@ ml_dimension_add_model(const nd_uuid_t *metric_uuid, const ml_kmeans_inlined_t *
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE)) {
         error_report("Failed to store model, rc = %d", rc);
+        if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
+            ml_db_mark_corrupt(rc);
         return rc;
     }
 
@@ -311,10 +345,15 @@ ml_dimension_delete_models(const nd_uuid_t *metric_uuid, time_t before)
         return 1;
     }
 
+    if (unlikely(__atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED)))
+        return 1;
+
     if (unlikely(!res)) {
         rc = prepare_statement(ml_db, db_models_delete, &res);
         if (unlikely(rc != SQLITE_OK)) {
             error_report("Failed to prepare statement to delete models, rc = %d", rc);
+            if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
+                ml_db_mark_corrupt(rc);
             return rc;
         }
     }
@@ -330,6 +369,8 @@ ml_dimension_delete_models(const nd_uuid_t *metric_uuid, time_t before)
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE)) {
         error_report("Failed to delete models, rc = %d", rc);
+        if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
+            ml_db_mark_corrupt(rc);
         return rc;
     }
 
@@ -362,10 +403,15 @@ ml_prune_old_models(size_t num_models_to_prune)
         return 1;
     }
 
+    if (unlikely(__atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED)))
+        return 1;
+
     if (unlikely(!res)) {
         rc = prepare_statement(ml_db, db_models_prune, &res);
         if (unlikely(rc != SQLITE_OK)) {
             error_report("Failed to prepare statement to prune models, rc = %d", rc);
+            if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
+                ml_db_mark_corrupt(rc);
             return rc;
         }
     }
@@ -383,6 +429,8 @@ ml_prune_old_models(size_t num_models_to_prune)
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE)) {
         error_report("Failed to prune old models, rc = %d", rc);
+        if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
+            ml_db_mark_corrupt(rc);
         return rc;
     }
 
@@ -419,6 +467,7 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
     sqlite3_stmt *res = active_stmt ? *active_stmt : NULL;
     int rc = 0;
     int param = 0;
+    int step_rc = 0;
 
     if (unlikely(!ml_db)) {
         nd_log_limit_static_global_var(erl, 1, 0);
@@ -426,10 +475,15 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
         return 1;
     }
 
+    if (unlikely(__atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED)))
+        return 1;
+
     if (unlikely(!res)) {
         rc = sqlite3_prepare_v2(ml_db, db_models_load, -1, &res, NULL);
         if (unlikely(rc != SQLITE_OK)) {
             error_report("Failed to prepare statement to load models, rc = %d", rc);
+            if (rc == SQLITE_CORRUPT || rc == SQLITE_NOTADB)
+                ml_db_mark_corrupt(rc);
             return 1;
         }
         if (active_stmt)
@@ -499,15 +553,23 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
 
     spinlock_unlock(&dim->slock);
 
-    if (unlikely(rc != SQLITE_DONE))
-        error_report("Failed to load models, rc = %d", rc);
+    step_rc = rc;
+    if (unlikely(step_rc != SQLITE_DONE))
+        error_report("Failed to load models, rc = %d", step_rc);
 
     if (active_stmt)
         rc = sqlite3_reset(res);
     else
         rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    // sqlite3_reset returns the prior step error if step failed; only log if
+    // reset reports a new error beyond what we already logged for step.
+    if (unlikely(rc != SQLITE_OK && rc != step_rc))
         error_report("Failed to %s statement when loading models, rc = %d", active_stmt ? "reset" : "finalize", rc);
+
+    if (step_rc == SQLITE_CORRUPT || step_rc == SQLITE_NOTADB) {
+        ml_db_mark_corrupt(step_rc);
+        return 1; // trip skip_models in metadata_scan_host so we stop hammering the bad DB
+    }
 
     return 0;
 
@@ -1207,6 +1269,11 @@ void ml_detect_main(void *arg)
 static void ml_flush_pending_models(ml_worker_t *worker) {
     static time_t next_vacuum_run = 0;
     int op_no = 1;
+
+    if (unlikely(__atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED))) {
+        worker->pending_model_info.clear();
+        return;
+    }
 
     // begin transaction
     int rc = db_execute(ml_db, "BEGIN TRANSACTION;", NULL);

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -87,6 +87,47 @@ bool ml_db_mark_if_corrupt(int rc)
     return true;
 }
 
+// Execute a prepared model-table statement (INSERT/DELETE/UPDATE) and reset
+// it. Latches ml.db corruption on either step so the sentinel is dropped
+// regardless of which call surfaces the bad page. `action_name` is the
+// infinitive used in "Failed to <action_name>" ("store model",
+// "delete models", "prune old models"); `gerund_name` is the form used in
+// "Failed to reset statement when <gerund_name>" ("storing model",
+// "deleting models", "pruning old models"). The exact wording is preserved
+// so operator log searches keep matching.
+static int execute_and_reset_model_stmt(sqlite3_stmt *res,
+                                        const char *action_name,
+                                        const char *gerund_name)
+{
+    int rc = execute_insert(res);
+    if (unlikely(rc != SQLITE_DONE)) {
+        error_report("Failed to %s, rc = %d", action_name, rc);
+        ml_db_mark_if_corrupt(rc);
+        return rc;
+    }
+
+    rc = sqlite3_reset(res);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to reset statement when %s, rc = %d", gerund_name, rc);
+        ml_db_mark_if_corrupt(rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+// Common bind-failure handler for model-table statements. Reports which
+// parameter failed, attempts a reset (logging separately if reset also
+// fails), and returns the original bind rc.
+static int handle_model_bind_fail(sqlite3_stmt *res, int param, int rc, const char *action_name)
+{
+    error_report("Failed to bind parameter %d to %s, rc = %d", param, action_name, rc);
+    int reset_rc = sqlite3_reset(res);
+    if (unlikely(reset_rc != SQLITE_OK))
+        error_report("Failed to reset statement to %s, rc = %d", action_name, reset_rc);
+    return rc;
+}
+
 static void __attribute__((constructor)) init_mutex(void) {
     netdata_mutex_init(&db_mutex);
 }
@@ -347,28 +388,10 @@ ml_dimension_add_model(const nd_uuid_t *metric_uuid, const ml_kmeans_inlined_t *
         }
     }
 
-    rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
-        error_report("Failed to store model, rc = %d", rc);
-        ml_db_mark_if_corrupt(rc);
-        return rc;
-    }
-
-    rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to reset statement when storing model, rc = %d", rc);
-        ml_db_mark_if_corrupt(rc);
-        return rc;
-    }
-
-    return 0;
+    return execute_and_reset_model_stmt(res, "store model", "storing model");
 
 bind_fail:
-    error_report("Failed to bind parameter %d to store model, rc = %d", param, rc);
-    rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK))
-        error_report("Failed to reset statement to store model, rc = %d", rc);
-    return rc;
+    return handle_model_bind_fail(res, param, rc, "store model");
 }
 
 static int
@@ -404,28 +427,10 @@ ml_dimension_delete_models(const nd_uuid_t *metric_uuid, time_t before)
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
-        error_report("Failed to delete models, rc = %d", rc);
-        ml_db_mark_if_corrupt(rc);
-        return rc;
-    }
-
-    rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to reset statement when deleting models, rc = %d", rc);
-        ml_db_mark_if_corrupt(rc);
-        return rc;
-    }
-
-    return 0;
+    return execute_and_reset_model_stmt(res, "delete models", "deleting models");
 
 bind_fail:
-    error_report("Failed to bind parameter %d to delete models, rc = %d", param, rc);
-    rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK))
-        error_report("Failed to reset statement to delete models, rc = %d", rc);
-    return rc;
+    return handle_model_bind_fail(res, param, rc, "delete models");
 }
 
 static int
@@ -463,28 +468,10 @@ ml_prune_old_models(size_t num_models_to_prune)
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
-        error_report("Failed to prune old models, rc = %d", rc);
-        ml_db_mark_if_corrupt(rc);
-        return rc;
-    }
-
-    rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to reset statement when pruning old models, rc = %d", rc);
-        ml_db_mark_if_corrupt(rc);
-        return rc;
-    }
-
-    return 0;
+    return execute_and_reset_model_stmt(res, "prune old models", "pruning old models");
 
 bind_fail:
-    error_report("Failed to bind parameter %d to prune old models, rc = %d", param, rc);
-    rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK))
-        error_report("Failed to reset statement to prune old models, rc = %d", rc);
-    return rc;
+    return handle_model_bind_fail(res, param, rc, "prune old models");
 }
 
 int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -488,6 +488,8 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
     int rc = 0;
     int param = 0;
     int step_rc = 0;
+    bool step_corrupt = false;
+    bool cleanup_corrupt = false;
 
     if (unlikely(!ml_db)) {
         nd_log_limit_static_global_var(erl, 1, 0);
@@ -589,8 +591,8 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
     // sqlite3_finalize can surface SQLITE_CORRUPT / SQLITE_NOTADB even when
     // step succeeded; without both checks, cleanup-only corruption would log
     // but never trip ml_db_unusable. Both calls are idempotent.
-    bool step_corrupt    = ml_db_mark_if_corrupt(step_rc);
-    bool cleanup_corrupt = ml_db_mark_if_corrupt(rc);
+    step_corrupt    = ml_db_mark_if_corrupt(step_rc);
+    cleanup_corrupt = ml_db_mark_if_corrupt(rc);
 
     // Partial step results may be polluting dim state -- roll back when step
     // itself errored. The training-enqueue gate in ml_public.cc only requeues

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -343,6 +343,7 @@ ml_dimension_add_model(const nd_uuid_t *metric_uuid, const ml_kmeans_inlined_t *
     rc = sqlite3_reset(res);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to reset statement when storing model, rc = %d", rc);
+        ml_db_mark_if_corrupt(rc);
         return rc;
     }
 
@@ -399,6 +400,7 @@ ml_dimension_delete_models(const nd_uuid_t *metric_uuid, time_t before)
     rc = sqlite3_reset(res);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to reset statement when deleting models, rc = %d", rc);
+        ml_db_mark_if_corrupt(rc);
         return rc;
     }
 
@@ -457,6 +459,7 @@ ml_prune_old_models(size_t num_models_to_prune)
     rc = sqlite3_reset(res);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to reset statement when pruning old models, rc = %d", rc);
+        ml_db_mark_if_corrupt(rc);
         return rc;
     }
 
@@ -594,14 +597,17 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
     step_corrupt    = ml_db_mark_if_corrupt(step_rc);
     cleanup_corrupt = ml_db_mark_if_corrupt(rc);
 
-    // Partial step results may be polluting dim state -- roll back when step
-    // itself errored. The training-enqueue gate in ml_public.cc only requeues
-    // UNTRAINED dims, so leaving ts=TRAINED with a partial km_contexts locks
-    // the dim onto stale models until the next agent restart. Cleanup-only
-    // corruption (step=DONE, reset/finalize=CORRUPT) does NOT need this:
-    // step returned DONE so the rows already loaded are structurally valid;
-    // only the DB-level flag needs setting for future calls.
-    if (step_corrupt) {
+    // Partial step results may be polluting dim state -- roll back whenever
+    // step did NOT cleanly return SQLITE_DONE, not only on CORRUPT/NOTADB.
+    // SQLITE_BUSY-after-retries, SQLITE_IOERR, SQLITE_INTERRUPT etc. all
+    // leave a partial km_contexts behind, and the training-enqueue gate in
+    // ml_public.cc only requeues UNTRAINED dims -- so leaving ts=TRAINED
+    // with a truncated context locks the dim onto stale models until the
+    // next agent restart. Cleanup-only corruption (step=DONE, reset/
+    // finalize=CORRUPT) does NOT trigger this: step returned DONE so the
+    // rows already loaded are structurally valid; only the DB-level flag
+    // needs setting for future calls.
+    if (step_rc != SQLITE_DONE) {
         spinlock_lock(&dim->slock);
         dim->km_contexts.clear();
         dim->ts = TRAINING_STATUS_UNTRAINED;

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -570,9 +570,19 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
     if (unlikely(rc != SQLITE_OK && rc != step_rc))
         error_report("Failed to %s statement when loading models, rc = %d", active_stmt ? "reset" : "finalize", rc);
 
-    // trip skip_models in metadata_scan_host so we stop hammering the bad DB
-    if (ml_db_mark_if_corrupt(step_rc))
+    // On corruption: discard whatever partial rows the step loop managed to
+    // pull from the bad DB and put the dimension back into UNTRAINED. The
+    // training-enqueue gate in ml_public.cc only requeues UNTRAINED dims, so
+    // leaving ts=TRAINED with a partial km_contexts locks the dim onto stale
+    // models until the next agent restart. Also trips skip_models in
+    // metadata_scan_host so we stop hammering the bad DB.
+    if (ml_db_mark_if_corrupt(step_rc)) {
+        spinlock_lock(&dim->slock);
+        dim->km_contexts.clear();
+        dim->ts = TRAINING_STATUS_UNTRAINED;
+        spinlock_unlock(&dim->slock);
         return 1;
+    }
 
     return 0;
 
@@ -1309,8 +1319,13 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
         rc = db_execute(ml_db, "COMMIT TRANSACTION;", NULL);
     }
 
+    // If corruption was detected mid-loop (add/delete/prune set ml_db_unusable
+    // before returning), skip rollback and vacuum -- the DB is already flagged
+    // and will be quarantined at next restart; further SQL only spams errors.
+    bool became_unusable = __atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED);
+
     // rollback transaction on failure
-    if (rc) {
+    if (rc && !became_unusable) {
         netdata_log_error("Trying to rollback ML transaction because it failed with rc=%d, op_no=%d", rc, op_no);
         op_no++;
         rc = db_execute(ml_db, "ROLLBACK;", NULL);
@@ -1323,7 +1338,8 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
         worker->num_models_to_prune += worker->pending_model_info.size();
     }
 
-    vacuum_database(ml_db, "ML", 0, 0, &next_vacuum_run);
+    if (likely(!became_unusable))
+        vacuum_database(ml_db, "ML", 0, 0, &next_vacuum_run);
 
     worker->pending_model_info.clear();
 }

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -28,6 +28,11 @@ bool ml_db_is_unusable(void)
     return __atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED);
 }
 
+void ml_db_force_unusable(void)
+{
+    __atomic_store_n(&ml_db_unusable, true, __ATOMIC_RELAXED);
+}
+
 void ml_db_mark_corrupt(int rc)
 {
     // Latch the flag first so concurrent callers stop hitting the bad DB
@@ -99,18 +104,28 @@ static int execute_and_reset_model_stmt(sqlite3_stmt *res,
                                         const char *action_name,
                                         const char *gerund_name)
 {
-    int rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
-        error_report("Failed to %s, rc = %d", action_name, rc);
-        ml_db_mark_if_corrupt(rc);
-        return rc;
+    int step_rc = execute_insert(res);
+    if (unlikely(step_rc != SQLITE_DONE)) {
+        error_report("Failed to %s, rc = %d", action_name, step_rc);
+        ml_db_mark_if_corrupt(step_rc);
+
+        // SQLite requires the statement to be reset before it can be reused
+        // after a failed sqlite3_step(). Without this, the next call that
+        // reuses the cached prepared statement (e.g. next flush iteration
+        // on a transient BUSY/IOERR) would re-bind onto a statement in an
+        // undefined state. Best-effort reset; latch separately if it
+        // surfaces corruption the step didn't.
+        int reset_rc = sqlite3_reset(res);
+        if (unlikely(reset_rc != SQLITE_OK && reset_rc != step_rc))
+            ml_db_mark_if_corrupt(reset_rc);
+        return step_rc;
     }
 
-    rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to reset statement when %s, rc = %d", gerund_name, rc);
-        ml_db_mark_if_corrupt(rc);
-        return rc;
+    int reset_rc = sqlite3_reset(res);
+    if (unlikely(reset_rc != SQLITE_OK)) {
+        error_report("Failed to reset statement when %s, rc = %d", gerund_name, reset_rc);
+        ml_db_mark_if_corrupt(reset_rc);
+        return reset_rc;
     }
 
     return 0;
@@ -123,8 +138,10 @@ static int handle_model_bind_fail(sqlite3_stmt *res, int param, int rc, const ch
 {
     error_report("Failed to bind parameter %d to %s, rc = %d", param, action_name, rc);
     int reset_rc = sqlite3_reset(res);
-    if (unlikely(reset_rc != SQLITE_OK))
+    if (unlikely(reset_rc != SQLITE_OK)) {
         error_report("Failed to reset statement to %s, rc = %d", action_name, reset_rc);
+        ml_db_mark_if_corrupt(reset_rc);
+    }
     return rc;
 }
 
@@ -1333,7 +1350,11 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
     // flag if BEGIN/COMMIT/ROLLBACK themselves trip CORRUPT or NOTADB --
     // db_execute() returns only 0/1, the actual rc is exposed via the
     // out-param.
-    int sqlite_rc = 0;
+    // Reset sqlite_rc before every db_execute() call: db_execute() returns
+    // early without writing the out-param if its `db` argument is NULL, so
+    // a stale value from a prior call could otherwise survive and be fed
+    // to ml_db_mark_if_corrupt().
+    int sqlite_rc = SQLITE_OK;
     int rc = db_execute(ml_db, "BEGIN TRANSACTION;", &sqlite_rc);
     ml_db_mark_if_corrupt(sqlite_rc);
 
@@ -1362,6 +1383,7 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
     // commit transaction
     if (!rc) {
         op_no++;
+        sqlite_rc = SQLITE_OK;
         rc = db_execute(ml_db, "COMMIT TRANSACTION;", &sqlite_rc);
         ml_db_mark_if_corrupt(sqlite_rc);
     }
@@ -1375,6 +1397,7 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
     if (rc && !became_unusable) {
         netdata_log_error("Trying to rollback ML transaction because it failed with rc=%d, op_no=%d", rc, op_no);
         op_no++;
+        sqlite_rc = SQLITE_OK;
         rc = db_execute(ml_db, "ROLLBACK;", &sqlite_rc);
         ml_db_mark_if_corrupt(sqlite_rc);
         if (rc)

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -43,23 +43,28 @@ void ml_db_mark_corrupt(int rc)
     // the sentinel path cannot redirect a O_TRUNC write to an attacker-
     // chosen target. EEXIST is treated as success-equivalent: the desired
     // post-condition is "next agent start will see something at this path
-    // and trigger quarantine", and that is satisfied whether the path
-    // holds our sentinel or any other file/symlink (startup unlink()s it
-    // unconditionally before quarantine).
+    // and try to quarantine", and that is satisfied whether the path holds
+    // our sentinel or any other file/symlink. Startup attempts unlink()
+    // before quarantine; if unlink fails with anything other than ENOENT
+    // (e.g. EISDIR on a directory, EACCES on a permission-denied path,
+    // EROFS on a read-only mount), quarantine is deferred and the operator
+    // is logged at NDLP_ERR -- we cannot promise quarantine, only "will be
+    // attempted".
     int fd = open(sentinel, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
     int oerr = errno;
     if (fd >= 0) {
         close(fd);
         nd_log(NDLS_DAEMON, NDLP_WARNING,
                "ML: ml.db reported corruption (rc=%d); sentinel %s created. "
-               "ml.db will be renamed to a timestamped ml.db.bad.* and recreated at next agent start. "
+               "Quarantine to a timestamped ml.db.bad.* will be attempted at next agent start. "
                "Stored anomaly-detection models will be lost; ML will retrain.",
                rc, sentinel);
     }
     else if (oerr == EEXIST) {
         nd_log(NDLS_DAEMON, NDLP_WARNING,
                "ML: ml.db reported corruption (rc=%d); sentinel %s already present. "
-               "Quarantine to ml.db.bad.* will run at next agent start.",
+               "Quarantine to ml.db.bad.* will be attempted at next agent start "
+               "(deferred if the sentinel path cannot be unlinked then).",
                rc, sentinel);
     }
     else {
@@ -1328,7 +1333,12 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
     static time_t next_vacuum_run = 0;
     int op_no = 1;
 
-    if (unlikely(ml_db_is_unusable())) {
+    // Bail when ml.db is missing OR poisoned. The NULL check covers
+    // non-corruption init failures (sqlite3_open ENOSPC/EACCES, ...) that
+    // leave ml_db == NULL without setting the unusable flag -- without it
+    // we'd drive db_execute(NULL, ...) / vacuum_database(NULL, ...) every
+    // flush and spam the log.
+    if (unlikely(!ml_db || ml_db_is_unusable())) {
         worker->pending_model_info.clear();
         return;
     }

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -585,19 +585,31 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
     if (unlikely(rc != SQLITE_OK && rc != step_rc))
         error_report("Failed to %s statement when loading models, rc = %d", active_stmt ? "reset" : "finalize", rc);
 
-    // On corruption: discard whatever partial rows the step loop managed to
-    // pull from the bad DB and put the dimension back into UNTRAINED. The
-    // training-enqueue gate in ml_public.cc only requeues UNTRAINED dims, so
-    // leaving ts=TRAINED with a partial km_contexts locks the dim onto stale
-    // models until the next agent restart. Also trips skip_models in
-    // metadata_scan_host so we stop hammering the bad DB.
-    if (ml_db_mark_if_corrupt(step_rc)) {
+    // Latch on either step-time OR cleanup-time corruption. sqlite3_reset /
+    // sqlite3_finalize can surface SQLITE_CORRUPT / SQLITE_NOTADB even when
+    // step succeeded; without both checks, cleanup-only corruption would log
+    // but never trip ml_db_unusable. Both calls are idempotent.
+    bool step_corrupt    = ml_db_mark_if_corrupt(step_rc);
+    bool cleanup_corrupt = ml_db_mark_if_corrupt(rc);
+
+    // Partial step results may be polluting dim state -- roll back when step
+    // itself errored. The training-enqueue gate in ml_public.cc only requeues
+    // UNTRAINED dims, so leaving ts=TRAINED with a partial km_contexts locks
+    // the dim onto stale models until the next agent restart. Cleanup-only
+    // corruption (step=DONE, reset/finalize=CORRUPT) does NOT need this:
+    // step returned DONE so the rows already loaded are structurally valid;
+    // only the DB-level flag needs setting for future calls.
+    if (step_corrupt) {
         spinlock_lock(&dim->slock);
         dim->km_contexts.clear();
         dim->ts = TRAINING_STATUS_UNTRAINED;
         spinlock_unlock(&dim->slock);
-        return 1;
     }
+
+    // Either signal trips skip_models in metadata_scan_host so we stop
+    // hammering the bad DB.
+    if (step_corrupt || cleanup_corrupt)
+        return 1;
 
     return 0;
 

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -31,7 +31,16 @@ void ml_db_mark_corrupt(int rc)
 
     char sentinel[FILENAME_MAX + 1];
     snprintfz(sentinel, FILENAME_MAX, "%s/.ml.db.delete", netdata_configured_cache_dir);
-    int fd = open(sentinel, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
+
+    // Use O_CREAT|O_EXCL (atomic create-or-fail) so a malicious symlink at
+    // the sentinel path cannot redirect a O_TRUNC write to an attacker-
+    // chosen target. EEXIST is treated as success-equivalent: the desired
+    // post-condition is "next agent start will see something at this path
+    // and trigger quarantine", and that is satisfied whether the path
+    // holds our sentinel or any other file/symlink (startup unlink()s it
+    // unconditionally before quarantine).
+    int fd = open(sentinel, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
+    int oerr = errno;
     if (fd >= 0) {
         close(fd);
         nd_log(NDLS_DAEMON, NDLP_WARNING,
@@ -40,10 +49,16 @@ void ml_db_mark_corrupt(int rc)
                "Stored anomaly-detection models will be lost; ML will retrain.",
                rc, sentinel);
     }
+    else if (oerr == EEXIST) {
+        nd_log(NDLS_DAEMON, NDLP_WARNING,
+               "ML: ml.db reported corruption (rc=%d); sentinel %s already present. "
+               "Quarantine will run at next agent start.",
+               rc, sentinel);
+    }
     else {
         nd_log(NDLS_DAEMON, NDLP_ERR,
                "ML: ml.db reported corruption (rc=%d) but failed to create sentinel %s (errno=%d). "
-               "Operator must remove ml.db manually.", rc, sentinel, errno);
+               "Operator must remove ml.db manually.", rc, sentinel, oerr);
     }
 }
 
@@ -1288,8 +1303,13 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
         return;
     }
 
-    // begin transaction
-    int rc = db_execute(ml_db, "BEGIN TRANSACTION;", NULL);
+    // begin transaction. Capture the SQLite rc so we can latch the corrupt
+    // flag if BEGIN/COMMIT/ROLLBACK themselves trip CORRUPT or NOTADB --
+    // db_execute() returns only 0/1, the actual rc is exposed via the
+    // out-param.
+    int sqlite_rc = 0;
+    int rc = db_execute(ml_db, "BEGIN TRANSACTION;", &sqlite_rc);
+    ml_db_mark_if_corrupt(sqlite_rc);
 
     // add/delete models
     if (!rc) {
@@ -1316,7 +1336,8 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
     // commit transaction
     if (!rc) {
         op_no++;
-        rc = db_execute(ml_db, "COMMIT TRANSACTION;", NULL);
+        rc = db_execute(ml_db, "COMMIT TRANSACTION;", &sqlite_rc);
+        ml_db_mark_if_corrupt(sqlite_rc);
     }
 
     // If corruption was detected mid-loop (add/delete/prune set ml_db_unusable
@@ -1328,7 +1349,8 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
     if (rc && !became_unusable) {
         netdata_log_error("Trying to rollback ML transaction because it failed with rc=%d, op_no=%d", rc, op_no);
         op_no++;
-        rc = db_execute(ml_db, "ROLLBACK;", NULL);
+        rc = db_execute(ml_db, "ROLLBACK;", &sqlite_rc);
+        ml_db_mark_if_corrupt(sqlite_rc);
         if (rc)
             netdata_log_error("ML transaction rollback failed with rc=%d", rc);
     }

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -18,8 +18,15 @@
 #define WORKER_TRAIN_FLUSH_MODELS      7
 
 sqlite3 *ml_db = NULL;
-bool ml_db_unusable = false;
+// File-private. Accessed exclusively via __atomic_* operations -- callers
+// in other TUs must go through ml_db_is_unusable() / ml_db_mark_corrupt().
+static bool ml_db_unusable = false;
 static netdata_mutex_t db_mutex;
+
+bool ml_db_is_unusable(void)
+{
+    return __atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED);
+}
 
 void ml_db_mark_corrupt(int rc)
 {
@@ -30,7 +37,7 @@ void ml_db_mark_corrupt(int rc)
         return; // already flagged, sentinel already attempted
 
     char sentinel[FILENAME_MAX + 1];
-    snprintfz(sentinel, FILENAME_MAX, "%s/.ml.db.delete", netdata_configured_cache_dir);
+    snprintfz(sentinel, sizeof(sentinel), "%s/.ml.db.delete", netdata_configured_cache_dir);
 
     // Use O_CREAT|O_EXCL (atomic create-or-fail) so a malicious symlink at
     // the sentinel path cannot redirect a O_TRUNC write to an attacker-
@@ -65,9 +72,16 @@ void ml_db_mark_corrupt(int rc)
 // Flag ml.db as corrupt if `rc` is a corruption signal (SQLITE_CORRUPT or
 // SQLITE_NOTADB). Returns true when the rc indicated corruption (regardless
 // of whether the sentinel was successfully written).
+//
+// Mask with 0xFF to also catch SQLite extended result codes (e.g.
+// SQLITE_CORRUPT_VTAB, SQLITE_CORRUPT_INDEX, ...) which encode the primary
+// code in the low 8 bits. Extended codes are off by default but can be
+// enabled per-connection via sqlite3_extended_result_codes(); masking is
+// the canonical way to compare regardless of that setting.
 static inline bool ml_db_mark_if_corrupt(int rc)
 {
-    if (rc != SQLITE_CORRUPT && rc != SQLITE_NOTADB)
+    int primary = rc & 0xFF;
+    if (primary != SQLITE_CORRUPT && primary != SQLITE_NOTADB)
         return false;
     ml_db_mark_corrupt(rc);
     return true;
@@ -289,7 +303,7 @@ ml_dimension_add_model(const nd_uuid_t *metric_uuid, const ml_kmeans_inlined_t *
         return 1;
     }
 
-    if (unlikely(__atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED)))
+    if (unlikely(ml_db_is_unusable()))
         return 1;
 
     if (unlikely(!res)) {
@@ -370,7 +384,7 @@ ml_dimension_delete_models(const nd_uuid_t *metric_uuid, time_t before)
         return 1;
     }
 
-    if (unlikely(__atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED)))
+    if (unlikely(ml_db_is_unusable()))
         return 1;
 
     if (unlikely(!res)) {
@@ -427,7 +441,7 @@ ml_prune_old_models(size_t num_models_to_prune)
         return 1;
     }
 
-    if (unlikely(__atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED)))
+    if (unlikely(ml_db_is_unusable()))
         return 1;
 
     if (unlikely(!res)) {
@@ -500,7 +514,7 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
         return 1;
     }
 
-    if (unlikely(__atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED)))
+    if (unlikely(ml_db_is_unusable()))
         return 1;
 
     if (unlikely(!res)) {
@@ -1318,7 +1332,7 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
     static time_t next_vacuum_run = 0;
     int op_no = 1;
 
-    if (unlikely(__atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED))) {
+    if (unlikely(ml_db_is_unusable())) {
         worker->pending_model_info.clear();
         return;
     }
@@ -1363,7 +1377,7 @@ static void ml_flush_pending_models(ml_worker_t *worker) {
     // If corruption was detected mid-loop (add/delete/prune set ml_db_unusable
     // before returning), skip rollback and vacuum -- the DB is already flagged
     // and will be quarantined at next restart; further SQL only spams errors.
-    bool became_unusable = __atomic_load_n(&ml_db_unusable, __ATOMIC_RELAXED);
+    bool became_unusable = ml_db_is_unusable();
 
     // rollback transaction on failure
     if (rc && !became_unusable) {

--- a/src/ml/ml_private.h
+++ b/src/ml/ml_private.h
@@ -48,5 +48,11 @@ bool ml_db_mark_if_corrupt(int rc);
 // atomic contract self-enforcing.
 bool ml_db_is_unusable(void);
 
+// Force the "ml.db unusable" flag on without dropping a sentinel or
+// writing to disk. Used at startup when we know ml.db is poisoned
+// (e.g., a sentinel from a prior session exists but couldn't be
+// consumed) and want to skip opening the bad DB for this session.
+void ml_db_force_unusable(void);
+
 
 #endif /* NETDATA_ML_PRIVATE_H */

--- a/src/ml/ml_private.h
+++ b/src/ml/ml_private.h
@@ -29,9 +29,18 @@ extern const char *db_models_create_table;
 // subsequent ml.db access short-circuits for the rest of the session. The
 // sentinel is consumed at next startup, which renames
 // ml.db -> ml.db.bad.<usec-timestamp> and creates a fresh DB.
-// `rc` is the SQLite error code that triggered the call (SQLITE_CORRUPT or
-// SQLITE_NOTADB); logged for diagnostics.
+// `rc` is the SQLite error code that triggered the call; logged raw for
+// diagnostics. It may be a primary code (SQLITE_CORRUPT, SQLITE_NOTADB) or
+// an extended variant (SQLITE_CORRUPT_VTAB, SQLITE_CORRUPT_INDEX, ...).
+// Callers should normally route through ml_db_mark_if_corrupt() rather than
+// invoking this directly.
 void ml_db_mark_corrupt(int rc);
+
+// Flag ml.db as corrupt if `rc` is a corruption signal (SQLITE_CORRUPT or
+// SQLITE_NOTADB, including extended variants which encode the primary code
+// in the low 8 bits). Returns true when `rc` indicated corruption,
+// regardless of whether the sentinel was successfully written.
+bool ml_db_mark_if_corrupt(int rc);
 
 // True if ml.db has been flagged unusable in this session by an earlier
 // CORRUPT/NOTADB detection. The flag is read/written via __atomic_* on the

--- a/src/ml/ml_private.h
+++ b/src/ml/ml_private.h
@@ -22,7 +22,16 @@ bool ml_should_publish_model_update(bool host_running,
                                     bool *training_in_progress);
 
 extern sqlite3 *ml_db;
+extern bool ml_db_unusable;
 extern const char *db_models_create_table;
+
+// Mark ml.db as corrupt: drops a `.ml.db.delete` sentinel in the cache dir
+// (best-effort, idempotent) and latches `ml_db_unusable` so subsequent ml.db
+// access short-circuits for the rest of the session. The sentinel is consumed
+// at next startup, which renames ml.db -> ml.db.bad and creates a fresh DB.
+// `rc` is the SQLite error code that triggered the call (SQLITE_CORRUPT or
+// SQLITE_NOTADB); logged for diagnostics.
+void ml_db_mark_corrupt(int rc);
 
 
 #endif /* NETDATA_ML_PRIVATE_H */

--- a/src/ml/ml_private.h
+++ b/src/ml/ml_private.h
@@ -22,17 +22,22 @@ bool ml_should_publish_model_update(bool host_running,
                                     bool *training_in_progress);
 
 extern sqlite3 *ml_db;
-extern bool ml_db_unusable;
 extern const char *db_models_create_table;
 
 // Mark ml.db as corrupt: drops a `.ml.db.delete` sentinel in the cache dir
-// (best-effort, idempotent) and latches `ml_db_unusable` so subsequent ml.db
-// access short-circuits for the rest of the session. The sentinel is consumed
-// at next startup, which renames ml.db -> ml.db.bad.<usec-timestamp> and
-// creates a fresh DB.
+// (best-effort, idempotent) and latches the "ml.db unusable" flag so
+// subsequent ml.db access short-circuits for the rest of the session. The
+// sentinel is consumed at next startup, which renames
+// ml.db -> ml.db.bad.<usec-timestamp> and creates a fresh DB.
 // `rc` is the SQLite error code that triggered the call (SQLITE_CORRUPT or
 // SQLITE_NOTADB); logged for diagnostics.
 void ml_db_mark_corrupt(int rc);
+
+// True if ml.db has been flagged unusable in this session by an earlier
+// CORRUPT/NOTADB detection. The flag is read/written via __atomic_* on the
+// underlying storage; access only through this accessor to keep the
+// atomic contract self-enforcing.
+bool ml_db_is_unusable(void);
 
 
 #endif /* NETDATA_ML_PRIVATE_H */

--- a/src/ml/ml_private.h
+++ b/src/ml/ml_private.h
@@ -28,7 +28,8 @@ extern const char *db_models_create_table;
 // Mark ml.db as corrupt: drops a `.ml.db.delete` sentinel in the cache dir
 // (best-effort, idempotent) and latches `ml_db_unusable` so subsequent ml.db
 // access short-circuits for the rest of the session. The sentinel is consumed
-// at next startup, which renames ml.db -> ml.db.bad and creates a fresh DB.
+// at next startup, which renames ml.db -> ml.db.bad.<usec-timestamp> and
+// creates a fresh DB.
 // `rc` is the SQLite error code that triggered the call (SQLITE_CORRUPT or
 // SQLITE_NOTADB); logged for diagnostics.
 void ml_db_mark_corrupt(int rc);

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -519,11 +519,19 @@ void ml_init()
     //                      operator must remove the sentinel manually.
     int unlink_rc = unlink(sentinel);
     if (int unlink_err = errno; unlink_rc == -1 && unlink_err != ENOENT) {
+        // The sentinel from a prior session is on disk but we can't remove
+        // it (EACCES, EROFS, EISDIR, ...). The DB was previously flagged
+        // corrupt; falling through to open it would just retrigger CORRUPT
+        // errors all session long. Mark the DB unusable in-memory and skip
+        // the open entirely -- ML runs without persistence until the
+        // operator removes the sentinel manually.
         nd_log(NDLS_DAEMON, NDLP_ERR,
                "ML: sentinel %s exists but unlink() failed (errno=%d). "
-               "Skipping quarantine to avoid re-quarantining a healthy ml.db on every restart. "
-               "Operator must remove %s manually.",
+               "Marking ml.db unusable for this session and skipping the open. "
+               "ML will run without persistence; operator must remove %s manually.",
                sentinel, unlink_err, sentinel);
+        ml_db_force_unusable();
+        return;
     }
     if (unlink_rc == 0) {
         char bad_path[FILENAME_MAX + 1];

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -494,31 +494,29 @@ void ml_init()
     snprintfz(path, FILENAME_MAX - 1, "%s/%s", netdata_configured_cache_dir, "ml.db");
 
     // Consume the quarantine sentinel dropped by ml_db_mark_corrupt() in a
-    // prior session: rename the corrupt ml.db to ml.db.bad and drop the WAL
-    // siblings so sqlite3_open recreates a fresh DB. No .recover variant --
-    // ml.db only holds k-means models and is cheap to rebuild.
-    // The sentinel is removed ONLY after the rename succeeds, so a failure
-    // (permission, FS error, Windows refusing to overwrite an existing
-    // ml.db.bad) leaves the sentinel in place to retry on the next start.
+    // prior session: rename the corrupt ml.db to a timestamped ml.db.bad.*
+    // and drop the WAL siblings so sqlite3_open recreates a fresh DB.
+    // No .recover variant -- ml.db only holds k-means models and is cheap
+    // to rebuild.
+    //
+    // Use unlink() itself as the existence check (no separate stat/access
+    // probe) to avoid a TOCTOU race between check and use. If the
+    // quarantine rename then fails, restore the sentinel so the next start
+    // retries. Always use a timestamped destination so rename() never
+    // collides with a pre-existing ml.db.bad on Windows (which refuses to
+    // overwrite) and never silently overwrites one on POSIX.
     char sentinel[FILENAME_MAX + 1];
     snprintfz(sentinel, FILENAME_MAX, "%s/.ml.db.delete", netdata_configured_cache_dir);
-    if (access(sentinel, F_OK) == 0) {
+    if (unlink(sentinel) == 0) {
         char bad_path[FILENAME_MAX + 1];
-        snprintfz(bad_path, FILENAME_MAX, "%s/ml.db.bad", netdata_configured_cache_dir);
-
-        // If a prior ml.db.bad still exists (operator hasn't cleaned it),
-        // rotate to a unique timestamped suffix so rename() doesn't fail on
-        // overwrite -- POSIX allows overwrite but Windows does not.
-        if (access(bad_path, F_OK) == 0)
-            snprintfz(bad_path, FILENAME_MAX, "%s/ml.db.bad.%lld",
-                      netdata_configured_cache_dir, (long long) now_realtime_sec());
+        snprintfz(bad_path, FILENAME_MAX, "%s/ml.db.bad.%lld",
+                  netdata_configured_cache_dir, (long long) now_realtime_sec());
 
         int rename_rc = rename(path, bad_path);
-        if (rename_rc == 0 || (rename_rc == -1 && errno == ENOENT)) {
+        if (rename_rc == 0 || errno == ENOENT) {
             // Quarantine succeeded, or there was nothing to quarantine
-            // (ml.db didn't exist). Either way, safe to consume the sentinel
-            // and clean up the WAL/SHM siblings.
-            (void) unlink(sentinel);
+            // (ml.db didn't exist). Either way, clean up the WAL/SHM
+            // siblings so the fresh sqlite3_open() starts clean.
             char wal_path[FILENAME_MAX + 1];
             snprintfz(wal_path, FILENAME_MAX, "%s-wal", path);
             (void) unlink(wal_path);
@@ -531,8 +529,14 @@ void ml_init()
                        path, bad_path);
             }
         } else {
+            // Quarantine failed for a reason other than "source doesn't
+            // exist". Restore the sentinel so we retry on next start
+            // instead of silently re-opening the same corrupt file.
+            int fd = open(sentinel, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
+            if (fd >= 0)
+                close(fd);
             nd_log(NDLS_DAEMON, NDLP_ERR,
-                   "ML: failed to quarantine %s to %s (errno=%d); leaving sentinel %s in place to retry on next start.",
+                   "ML: failed to quarantine %s to %s (errno=%d); sentinel %s restored, will retry on next start.",
                    path, bad_path, errno, sentinel);
         }
     }

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -591,6 +591,10 @@ void ml_init()
     int rc = sqlite3_open(path, &ml_db);
     if (rc != SQLITE_OK) {
         error_report("Failed to initialize database at %s, due to \"%s\"", path, sqlite3_errstr(rc));
+        // Drop the sentinel now so the next start quarantines the file;
+        // otherwise a corrupt header here leaves ml.db on disk and we'd
+        // hit the same open() failure forever.
+        ml_db_mark_if_corrupt(rc);
         sqlite3_close(ml_db);
         ml_db = NULL;
     }
@@ -599,7 +603,12 @@ void ml_init()
     if (ml_db) {
         int target_version = perform_ml_database_migration(ml_db, ML_METADATA_VERSION);
         if (configure_sqlite_database(ml_db, target_version, "ml_config")) {
-            error_report("Failed to setup ML database");
+            // configure_sqlite_database() returns 0/1 and loses the SQLite rc;
+            // recover the last error from the connection before close() so
+            // corruption surfaced by PRAGMA/migration drops the sentinel too.
+            int errc = sqlite3_extended_errcode(ml_db);
+            error_report("Failed to setup ML database (errcode=%d)", errc);
+            ml_db_mark_if_corrupt(errc);
             sqlite3_close(ml_db);
             ml_db = NULL;
         }
@@ -608,6 +617,7 @@ void ml_init()
             int rc = sqlite3_exec(ml_db, db_models_create_table, NULL, NULL, &err);
             if (rc != SQLITE_OK) {
                 error_report("Failed to create models table (%s, %s)", sqlite3_errstr(rc), err ? err : "");
+                ml_db_mark_if_corrupt(rc);
                 sqlite3_close(ml_db);
                 sqlite3_free(err);
                 ml_db = NULL;

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -509,8 +509,12 @@ void ml_init()
     snprintfz(sentinel, FILENAME_MAX, "%s/.ml.db.delete", netdata_configured_cache_dir);
     if (unlink(sentinel) == 0) {
         char bad_path[FILENAME_MAX + 1];
-        snprintfz(bad_path, FILENAME_MAX, "%s/ml.db.bad.%lld",
-                  netdata_configured_cache_dir, (long long) now_realtime_sec());
+        // Microsecond resolution so back-to-back restarts within the same
+        // wall-clock second don't collide: a second-resolution suffix would
+        // either silently overwrite the prior .bad on POSIX (forensic loss)
+        // or fail rename() with EEXIST on Windows (sentinel kept restoring).
+        snprintfz(bad_path, FILENAME_MAX, "%s/ml.db.bad.%llu",
+                  netdata_configured_cache_dir, (unsigned long long) now_realtime_usec());
 
         int rename_rc = rename(path, bad_path);
         if (rename_rc == 0 || errno == ENOENT) {

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -541,15 +541,31 @@ void ml_init()
             // O_CREAT|O_TRUNC so a symlink swap between our earlier
             // unlink() and this open() cannot redirect the write -- if
             // anything (legitimate or hostile) re-created the path in
-            // that window, open() fails with EEXIST and we leave it
-            // alone. The desired post-condition is "sentinel exists",
-            // which is satisfied either way.
+            // that window, open() fails with EEXIST.
             int rerr = errno;
-            if (int fd = open(sentinel, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0600); fd >= 0)
+            int fd = open(sentinel, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
+            int oerr = errno;
+            if (fd >= 0) {
                 close(fd);
-            nd_log(NDLS_DAEMON, NDLP_ERR,
-                   "ML: failed to quarantine %s to %s (errno=%d); sentinel %s restored, will retry on next start.",
-                   path, bad_path, rerr, sentinel);
+                nd_log(NDLS_DAEMON, NDLP_ERR,
+                       "ML: failed to quarantine %s to %s (errno=%d); sentinel %s restored, will retry on next start.",
+                       path, bad_path, rerr, sentinel);
+            } else if (oerr == EEXIST) {
+                // Something occupies the path already (race or stale file).
+                // Next start's unlink() will remove it and trigger quarantine
+                // regardless of what it is, so retry is still effective.
+                nd_log(NDLS_DAEMON, NDLP_ERR,
+                       "ML: failed to quarantine %s to %s (errno=%d); sentinel path %s already occupied, will retry on next start.",
+                       path, bad_path, rerr, sentinel);
+            } else {
+                // Sentinel restore actually failed (permission, ENOSPC,
+                // read-only FS, etc.). Retry on next start is NOT guaranteed
+                // -- be honest with the operator.
+                nd_log(NDLS_DAEMON, NDLP_ERR,
+                       "ML: failed to quarantine %s to %s (rename errno=%d) AND failed to restore sentinel %s (open errno=%d). "
+                       "Retry will NOT happen on next start; remove ml.db or recreate the sentinel manually.",
+                       path, bad_path, rerr, sentinel, oerr);
+            }
         }
     }
 

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -492,6 +492,33 @@ void ml_init()
     // open sqlite db
     char path[FILENAME_MAX];
     snprintfz(path, FILENAME_MAX - 1, "%s/%s", netdata_configured_cache_dir, "ml.db");
+
+    // Consume the quarantine sentinel dropped by ml_db_mark_corrupt() in a
+    // prior session: rename the corrupt ml.db to ml.db.bad and drop the WAL
+    // siblings so sqlite3_open recreates a fresh DB. No .recover variant --
+    // ml.db only holds k-means models and is cheap to rebuild.
+    char sentinel[FILENAME_MAX + 1];
+    snprintfz(sentinel, FILENAME_MAX, "%s/.ml.db.delete", netdata_configured_cache_dir);
+    if (unlink(sentinel) == 0) {
+        char bad_path[FILENAME_MAX + 1];
+        snprintfz(bad_path, FILENAME_MAX, "%s/ml.db.bad", netdata_configured_cache_dir);
+        if (rename(path, bad_path) == 0) {
+            nd_log(NDLS_DAEMON, NDLP_WARNING,
+                   "ML: quarantined corrupt %s as %s; a fresh ml.db will be created. "
+                   "Inspect or remove the .bad file manually.",
+                   path, bad_path);
+        } else if (errno != ENOENT) {
+            nd_log(NDLS_DAEMON, NDLP_ERR,
+                   "ML: failed to rename %s to %s (errno=%d); leaving as-is.",
+                   path, bad_path, errno);
+        }
+        char wal_path[FILENAME_MAX + 1];
+        snprintfz(wal_path, FILENAME_MAX, "%s-wal", path);
+        (void) unlink(wal_path);
+        snprintfz(wal_path, FILENAME_MAX, "%s-shm", path);
+        (void) unlink(wal_path);
+    }
+
     int rc = sqlite3_open(path, &ml_db);
     if (rc != SQLITE_OK) {
         error_report("Failed to initialize database at %s, due to \"%s\"", path, sqlite3_errstr(rc));

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -507,7 +507,27 @@ void ml_init()
     // overwrite) and never silently overwrites one on POSIX.
     char sentinel[FILENAME_MAX + 1];
     snprintfz(sentinel, FILENAME_MAX, "%s/.ml.db.delete", netdata_configured_cache_dir);
-    if (unlink(sentinel) == 0) {
+
+    // Attempt to consume the sentinel via unlink(). Three outcomes:
+    //  - unlink() == 0:     sentinel existed, removed -> proceed with quarantine.
+    //  - errno == ENOENT:   no sentinel -> normal startup, no quarantine.
+    //  - any other errno:   sentinel exists but couldn't be removed (EACCES,
+    //                       EROFS, EISDIR, ...). Log loudly and attempt the
+    //                       quarantine anyway -- the rename may still succeed
+    //                       (different file, different perms), and either way
+    //                       the operator gets a clear diagnostic instead of a
+    //                       silent re-open of the corrupt DB.
+    int unlink_rc = unlink(sentinel);
+    int unlink_err = errno;
+    bool sentinel_was_present = (unlink_rc == 0) || (unlink_rc == -1 && unlink_err != ENOENT);
+    if (unlink_rc == -1 && unlink_err != ENOENT) {
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "ML: sentinel %s exists but unlink() failed (errno=%d). "
+               "Attempting quarantine anyway; if rename also fails the sentinel "
+               "will remain in place and retry next start.",
+               sentinel, unlink_err);
+    }
+    if (sentinel_was_present) {
         char bad_path[FILENAME_MAX + 1];
         // Microsecond resolution so back-to-back restarts within the same
         // wall-clock second don't collide: a second-resolution suffix would

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -518,8 +518,7 @@ void ml_init()
     //                      ml.db, looping indefinitely. Log loudly and skip;
     //                      operator must remove the sentinel manually.
     int unlink_rc = unlink(sentinel);
-    int unlink_err = errno;
-    if (unlink_rc == -1 && unlink_err != ENOENT) {
+    if (int unlink_err = errno; unlink_rc == -1 && unlink_err != ENOENT) {
         nd_log(NDLS_DAEMON, NDLP_ERR,
                "ML: sentinel %s exists but unlink() failed (errno=%d). "
                "Skipping quarantine to avoid re-quarantining a healthy ml.db on every restart. "

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -491,7 +491,7 @@ void ml_init()
 
     // open sqlite db
     char path[FILENAME_MAX];
-    snprintfz(path, FILENAME_MAX - 1, "%s/%s", netdata_configured_cache_dir, "ml.db");
+    snprintfz(path, sizeof(path), "%s/%s", netdata_configured_cache_dir, "ml.db");
 
     // Consume the quarantine sentinel dropped by ml_db_mark_corrupt() in a
     // prior session: rename the corrupt ml.db to a timestamped ml.db.bad.*
@@ -506,34 +506,33 @@ void ml_init()
     // collides with a pre-existing ml.db.bad on Windows (which refuses to
     // overwrite) and never silently overwrites one on POSIX.
     char sentinel[FILENAME_MAX + 1];
-    snprintfz(sentinel, FILENAME_MAX, "%s/.ml.db.delete", netdata_configured_cache_dir);
+    snprintfz(sentinel, sizeof(sentinel), "%s/.ml.db.delete", netdata_configured_cache_dir);
 
     // Attempt to consume the sentinel via unlink(). Three outcomes:
-    //  - unlink() == 0:     sentinel existed, removed -> proceed with quarantine.
-    //  - errno == ENOENT:   no sentinel -> normal startup, no quarantine.
-    //  - any other errno:   sentinel exists but couldn't be removed (EACCES,
-    //                       EROFS, EISDIR, ...). Log loudly and attempt the
-    //                       quarantine anyway -- the rename may still succeed
-    //                       (different file, different perms), and either way
-    //                       the operator gets a clear diagnostic instead of a
-    //                       silent re-open of the corrupt DB.
+    //  - unlink() == 0:    sentinel existed, removed -> proceed with quarantine.
+    //  - errno == ENOENT:  no sentinel -> normal startup, no quarantine.
+    //  - any other errno:  sentinel exists but couldn't be removed (EACCES,
+    //                      EROFS, EISDIR, ...). DO NOT proceed -- if we
+    //                      quarantine without consuming the sentinel, the next
+    //                      startup would re-quarantine the freshly created
+    //                      ml.db, looping indefinitely. Log loudly and skip;
+    //                      operator must remove the sentinel manually.
     int unlink_rc = unlink(sentinel);
     int unlink_err = errno;
-    bool sentinel_was_present = (unlink_rc == 0) || (unlink_rc == -1 && unlink_err != ENOENT);
     if (unlink_rc == -1 && unlink_err != ENOENT) {
         nd_log(NDLS_DAEMON, NDLP_ERR,
                "ML: sentinel %s exists but unlink() failed (errno=%d). "
-               "Attempting quarantine anyway; if rename also fails the sentinel "
-               "will remain in place and retry next start.",
-               sentinel, unlink_err);
+               "Skipping quarantine to avoid re-quarantining a healthy ml.db on every restart. "
+               "Operator must remove %s manually.",
+               sentinel, unlink_err, sentinel);
     }
-    if (sentinel_was_present) {
+    if (unlink_rc == 0) {
         char bad_path[FILENAME_MAX + 1];
         // Microsecond resolution so back-to-back restarts within the same
         // wall-clock second don't collide: a second-resolution suffix would
         // either silently overwrite the prior .bad on POSIX (forensic loss)
         // or fail rename() with EEXIST on Windows (sentinel kept restoring).
-        snprintfz(bad_path, FILENAME_MAX, "%s/ml.db.bad.%llu",
+        snprintfz(bad_path, sizeof(bad_path), "%s/ml.db.bad.%llu",
                   netdata_configured_cache_dir, (unsigned long long) now_realtime_usec());
 
         int rename_rc = rename(path, bad_path);
@@ -542,9 +541,9 @@ void ml_init()
             // (ml.db didn't exist). Either way, clean up the WAL/SHM
             // siblings so the fresh sqlite3_open() starts clean.
             char wal_path[FILENAME_MAX + 1];
-            snprintfz(wal_path, FILENAME_MAX, "%s-wal", path);
+            snprintfz(wal_path, sizeof(wal_path), "%s-wal", path);
             (void) unlink(wal_path);
-            snprintfz(wal_path, FILENAME_MAX, "%s-shm", path);
+            snprintfz(wal_path, sizeof(wal_path), "%s-shm", path);
             (void) unlink(wal_path);
             if (rename_rc == 0) {
                 nd_log(NDLS_DAEMON, NDLP_WARNING,

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -532,12 +532,20 @@ void ml_init()
             // Quarantine failed for a reason other than "source doesn't
             // exist". Restore the sentinel so we retry on next start
             // instead of silently re-opening the same corrupt file.
-            int fd = open(sentinel, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
-            if (fd >= 0)
+            //
+            // Use O_CREAT|O_EXCL (atomic create-or-fail) rather than
+            // O_CREAT|O_TRUNC so a symlink swap between our earlier
+            // unlink() and this open() cannot redirect the write -- if
+            // anything (legitimate or hostile) re-created the path in
+            // that window, open() fails with EEXIST and we leave it
+            // alone. The desired post-condition is "sentinel exists",
+            // which is satisfied either way.
+            int rerr = errno;
+            if (int fd = open(sentinel, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0600); fd >= 0)
                 close(fd);
             nd_log(NDLS_DAEMON, NDLP_ERR,
                    "ML: failed to quarantine %s to %s (errno=%d); sentinel %s restored, will retry on next start.",
-                   path, bad_path, errno, sentinel);
+                   path, bad_path, rerr, sentinel);
         }
     }
 

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -497,26 +497,44 @@ void ml_init()
     // prior session: rename the corrupt ml.db to ml.db.bad and drop the WAL
     // siblings so sqlite3_open recreates a fresh DB. No .recover variant --
     // ml.db only holds k-means models and is cheap to rebuild.
+    // The sentinel is removed ONLY after the rename succeeds, so a failure
+    // (permission, FS error, Windows refusing to overwrite an existing
+    // ml.db.bad) leaves the sentinel in place to retry on the next start.
     char sentinel[FILENAME_MAX + 1];
     snprintfz(sentinel, FILENAME_MAX, "%s/.ml.db.delete", netdata_configured_cache_dir);
-    if (unlink(sentinel) == 0) {
+    if (access(sentinel, F_OK) == 0) {
         char bad_path[FILENAME_MAX + 1];
         snprintfz(bad_path, FILENAME_MAX, "%s/ml.db.bad", netdata_configured_cache_dir);
-        if (rename(path, bad_path) == 0) {
-            nd_log(NDLS_DAEMON, NDLP_WARNING,
-                   "ML: quarantined corrupt %s as %s; a fresh ml.db will be created. "
-                   "Inspect or remove the .bad file manually.",
-                   path, bad_path);
-        } else if (errno != ENOENT) {
+
+        // If a prior ml.db.bad still exists (operator hasn't cleaned it),
+        // rotate to a unique timestamped suffix so rename() doesn't fail on
+        // overwrite -- POSIX allows overwrite but Windows does not.
+        if (access(bad_path, F_OK) == 0)
+            snprintfz(bad_path, FILENAME_MAX, "%s/ml.db.bad.%lld",
+                      netdata_configured_cache_dir, (long long) now_realtime_sec());
+
+        int rename_rc = rename(path, bad_path);
+        if (rename_rc == 0 || (rename_rc == -1 && errno == ENOENT)) {
+            // Quarantine succeeded, or there was nothing to quarantine
+            // (ml.db didn't exist). Either way, safe to consume the sentinel
+            // and clean up the WAL/SHM siblings.
+            (void) unlink(sentinel);
+            char wal_path[FILENAME_MAX + 1];
+            snprintfz(wal_path, FILENAME_MAX, "%s-wal", path);
+            (void) unlink(wal_path);
+            snprintfz(wal_path, FILENAME_MAX, "%s-shm", path);
+            (void) unlink(wal_path);
+            if (rename_rc == 0) {
+                nd_log(NDLS_DAEMON, NDLP_WARNING,
+                       "ML: quarantined corrupt %s as %s; a fresh ml.db will be created. "
+                       "Inspect or remove the .bad file manually.",
+                       path, bad_path);
+            }
+        } else {
             nd_log(NDLS_DAEMON, NDLP_ERR,
-                   "ML: failed to rename %s to %s (errno=%d); leaving as-is.",
-                   path, bad_path, errno);
+                   "ML: failed to quarantine %s to %s (errno=%d); leaving sentinel %s in place to retry on next start.",
+                   path, bad_path, errno, sentinel);
         }
-        char wal_path[FILENAME_MAX + 1];
-        snprintfz(wal_path, FILENAME_MAX, "%s-wal", path);
-        (void) unlink(wal_path);
-        snprintfz(wal_path, FILENAME_MAX, "%s-shm", path);
-        (void) unlink(wal_path);
     }
 
     int rc = sqlite3_open(path, &ml_db);


### PR DESCRIPTION
##### Summary
- Introduced `ml_db_unusable` flag to prevent further operations on a corrupted database.
- Added `ml_db_mark_corrupt()` to handle SQLite corruption errors (`SQLITE_CORRUPT`, `SQLITE_NOTADB`).
- Implemented logic to quarantine and replace corrupt ML databases, including WAL file cleanup.
- Updated database operation functions to detect corruption and bail gracefully, preserving log details for diagnostics.
- Enhanced session behavior by ensuring a fresh ML database is recreated upon restart after corruption detection.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds robust corruption detection and safe recovery for the ML SQLite database so the agent keeps running and retrains instead of crashing. Startup now consumes a sentinel, quarantines `ml.db` to `ml.db.bad.<usec>`, cleans WAL/SHM, and avoids re-quarantine loops by marking the DB unusable in-memory when needed.

- **New Features**
  - `ml_db_mark_if_corrupt(rc)` handles primary and extended SQLite errors; all open/migrate/prepare/step/reset/finalize and transaction paths use it and gate on `ml_db_is_unusable()`.
  - TOCTOU-safe quarantine: unlink sentinel, rename to `ml.db.bad.<usec>`, clean WAL/SHM, restore sentinel with `O_CREAT|O_EXCL` on rename failure; `ml_db_force_unusable()` skips opening poisoned DBs when the sentinel can’t be removed.
  - Model load marks corruption on step- or cleanup-time errors and sets the dimension to UNTRAINED on any non-`SQLITE_DONE` step to discard partial results.

- **Refactors**
  - Centralized model-table execution/reset and bind-failure handling via `execute_and_reset_model_stmt()` and `handle_model_bind_fail()`.
  - Transactions capture SQLite rcs for BEGIN/COMMIT/ROLLBACK; when `ml_db == NULL` or unusable, pending work is cleared and rollback/vacuum are skipped.
  - Replaced hardcoded `snprintfz()` sizes with `sizeof` and improved logs for deferred quarantine and retry paths.

<sup>Written for commit 9023c688a007475debb77eac17a864ea3cfae2eb. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22478?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

