### PR TITLE
go.d/postgres: allow pg_ls_dir execute privilege for repl slot files

### DIFF
--- a/src/go/plugin/go.d/collector/postgres/collect.go
+++ b/src/go/plugin/go.d/collector/postgres/collect.go
@@ -50,6 +50,15 @@ func (c *Collector) collect() (map[string]int64, error) {
 		c.Debugf("connected as super user: %v", *c.superUser)
 	}
 
+	if c.canExecutePgLsDir == nil && c.pgVersion >= pgVersion10 {
+		v, err := c.doQueryCanExecutePgLsDir()
+		if err != nil {
+			return nil, fmt.Errorf("querying can execute pg_ls_dir() error: %v", err)
+		}
+		c.canExecutePgLsDir = &v
+		c.Debugf("connected as can execute pg_ls_dir(): %v", *c.canExecutePgLsDir)
+	}
+
 	if c.pgIsInRecovery == nil {
 		v, err := c.doQueryPGIsInRecovery()
 		if err != nil {
@@ -224,6 +233,10 @@ func (c *Collector) azureADBeforeConnect(ctx context.Context, cfg *pgx.ConnConfi
 }
 
 func (c *Collector) isSuperUser() bool { return c.superUser != nil && *c.superUser }
+
+func (c *Collector) canQueryReplicationSlotFiles() bool {
+	return c.isSuperUser() || (c.canExecutePgLsDir != nil && *c.canExecutePgLsDir)
+}
 
 func (c *Collector) isPGInRecovery() bool { return c.pgIsInRecovery != nil && *c.pgIsInRecovery }
 

--- a/src/go/plugin/go.d/collector/postgres/collect.go
+++ b/src/go/plugin/go.d/collector/postgres/collect.go
@@ -56,7 +56,7 @@ func (c *Collector) collect() (map[string]int64, error) {
 			return nil, fmt.Errorf("querying can execute pg_ls_dir() error: %v", err)
 		}
 		c.canExecutePgLsDir = &v
-		c.Debugf("connected as can execute pg_ls_dir(): %v", *c.canExecutePgLsDir)
+		c.Debugf("can execute pg_ls_dir(): %v", *c.canExecutePgLsDir)
 	}
 
 	if c.pgIsInRecovery == nil {

--- a/src/go/plugin/go.d/collector/postgres/collector.go
+++ b/src/go/plugin/go.d/collector/postgres/collector.go
@@ -118,6 +118,7 @@ type (
 		dbConns map[string]*dbConn
 
 		superUser               *bool
+		canExecutePgLsDir       *bool
 		pgIsInRecovery          *bool
 		pgVersion               int
 		pgStatStatementsAvail   bool            // cached positive result only

--- a/src/go/plugin/go.d/collector/postgres/collector_test.go
+++ b/src/go/plugin/go.d/collector/postgres/collector_test.go
@@ -185,6 +185,7 @@ func TestCollector_Check(t *testing.T) {
 
 				mockExpect(t, m, queryServerVersion(), dataVer140004ServerVersionNum)
 				mockExpect(t, m, queryIsSuperUser(), dataVer140004IsSuperUserTrue)
+				mockExpect(t, m, queryCanExecutePgLsDir(), dataVer140004IsSuperUserTrue)
 				mockExpect(t, m, queryPGIsInRecovery(), dataVer140004PGIsInRecoveryTrue)
 
 				mockExpect(t, m, querySettingsMaxConnections(), dataVer140004SettingsMaxConnections)
@@ -225,6 +226,7 @@ func TestCollector_Check(t *testing.T) {
 			prepareMock: func(t *testing.T, collr *Collector, m sqlmock.Sqlmock) {
 				mockExpect(t, m, queryServerVersion(), dataVer140004ServerVersionNum)
 				mockExpect(t, m, queryIsSuperUser(), dataVer140004IsSuperUserTrue)
+				mockExpect(t, m, queryCanExecutePgLsDir(), dataVer140004IsSuperUserTrue)
 				mockExpect(t, m, queryPGIsInRecovery(), dataVer140004PGIsInRecoveryTrue)
 
 				mockExpect(t, m, querySettingsMaxConnections(), dataVer140004ServerVersionNum)
@@ -245,6 +247,7 @@ func TestCollector_Check(t *testing.T) {
 			prepareMock: func(t *testing.T, collr *Collector, m sqlmock.Sqlmock) {
 				mockExpect(t, m, queryServerVersion(), dataVer140004ServerVersionNum)
 				mockExpect(t, m, queryIsSuperUser(), dataVer140004IsSuperUserTrue)
+				mockExpect(t, m, queryCanExecutePgLsDir(), dataVer140004IsSuperUserTrue)
 				mockExpect(t, m, queryPGIsInRecovery(), dataVer140004PGIsInRecoveryTrue)
 
 				mockExpectErr(m, querySettingsMaxConnections())
@@ -289,6 +292,7 @@ func TestCollector_Collect(t *testing.T) {
 					collr.dbSr = matcher.TRUE()
 					mockExpect(t, m, queryServerVersion(), dataVer140004ServerVersionNum)
 					mockExpect(t, m, queryIsSuperUser(), dataVer140004IsSuperUserTrue)
+					mockExpect(t, m, queryCanExecutePgLsDir(), dataVer140004IsSuperUserTrue)
 					mockExpect(t, m, queryPGIsInRecovery(), dataVer140004PGIsInRecoveryTrue)
 
 					mockExpect(t, m, querySettingsMaxConnections(), dataVer140004SettingsMaxConnections)
@@ -657,6 +661,7 @@ func TestCollector_Collect(t *testing.T) {
 				prepareMock: func(t *testing.T, collr *Collector, m sqlmock.Sqlmock) {
 					mockExpect(t, m, queryServerVersion(), dataVer140004ServerVersionNum)
 					mockExpect(t, m, queryIsSuperUser(), dataVer140004IsSuperUserTrue)
+					mockExpect(t, m, queryCanExecutePgLsDir(), dataVer140004IsSuperUserTrue)
 					mockExpect(t, m, queryPGIsInRecovery(), dataVer140004PGIsInRecoveryTrue)
 
 					mockExpectErr(m, querySettingsMaxConnections())
@@ -673,6 +678,7 @@ func TestCollector_Collect(t *testing.T) {
 				prepareMock: func(t *testing.T, collr *Collector, m sqlmock.Sqlmock) {
 					mockExpect(t, m, queryServerVersion(), dataVer140004ServerVersionNum)
 					mockExpect(t, m, queryIsSuperUser(), dataVer140004IsSuperUserTrue)
+					mockExpect(t, m, queryCanExecutePgLsDir(), dataVer140004IsSuperUserTrue)
 					mockExpect(t, m, queryPGIsInRecovery(), dataVer140004PGIsInRecoveryTrue)
 
 					mockExpect(t, m, querySettingsMaxConnections(), dataVer140004SettingsMaxConnections)

--- a/src/go/plugin/go.d/collector/postgres/collector_test.go
+++ b/src/go/plugin/go.d/collector/postgres/collector_test.go
@@ -719,6 +719,57 @@ func TestCollector_Collect(t *testing.T) {
 	}
 }
 
+func TestCollector_doQueryReplicationMetrics_replSlotFilesGate(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+
+	tests := map[string]struct {
+		superUser           *bool
+		canExecutePgLsDir   *bool
+		expectSlotFilesCall bool
+	}{
+		"superuser collects slot files even without pg_ls_dir privilege": {
+			superUser:           boolPtr(true),
+			canExecutePgLsDir:   boolPtr(false),
+			expectSlotFilesCall: true,
+		},
+		"non-superuser with pg_ls_dir privilege collects slot files": {
+			superUser:           boolPtr(false),
+			canExecutePgLsDir:   boolPtr(true),
+			expectSlotFilesCall: true,
+		},
+		"non-superuser without pg_ls_dir privilege skips slot files": {
+			superUser:           boolPtr(false),
+			canExecutePgLsDir:   boolPtr(false),
+			expectSlotFilesCall: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			require.NoError(t, err)
+			defer func() { _ = db.Close() }()
+
+			collr := New()
+			collr.db = db
+			require.NoError(t, collr.Init(context.Background()))
+
+			collr.pgVersion = 140004
+			collr.superUser = test.superUser
+			collr.canExecutePgLsDir = test.canExecutePgLsDir
+
+			mockExpect(t, mock, queryReplicationStandbyAppDelta(collr.pgVersion), dataVer140004ReplStandbyAppDelta)
+			mockExpect(t, mock, queryReplicationStandbyAppLag(), dataVer140004ReplStandbyAppLag)
+			if test.expectSlotFilesCall {
+				mockExpect(t, mock, queryReplicationSlotFiles(collr.pgVersion), dataVer140004ReplSlotFiles)
+			}
+
+			assert.NoError(t, collr.doQueryReplicationMetrics())
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
 func mockExpect(t *testing.T, mock sqlmock.Sqlmock, query string, rows []byte) {
 	mock.ExpectQuery(query).WillReturnRows(mustMockRows(t, rows)).RowsWillBeClosed()
 }

--- a/src/go/plugin/go.d/collector/postgres/do_query_misc.go
+++ b/src/go/plugin/go.d/collector/postgres/do_query_misc.go
@@ -31,6 +31,17 @@ func (c *Collector) doQueryIsSuperUser() (bool, error) {
 	return v, nil
 }
 
+func (c *Collector) doQueryCanExecutePgLsDir() (bool, error) {
+	q := queryCanExecutePgLsDir()
+
+	var v bool
+	if err := c.doQueryRow(q, &v); err != nil {
+		return false, err
+	}
+
+	return v, nil
+}
+
 func (c *Collector) doQueryPGIsInRecovery() (bool, error) {
 	q := queryPGIsInRecovery()
 

--- a/src/go/plugin/go.d/collector/postgres/do_query_replication.go
+++ b/src/go/plugin/go.d/collector/postgres/do_query_replication.go
@@ -17,7 +17,7 @@ func (c *Collector) doQueryReplicationMetrics() error {
 		}
 	}
 
-	if c.pgVersion >= pgVersion10 && c.isSuperUser() {
+	if c.pgVersion >= pgVersion10 && c.canQueryReplicationSlotFiles() {
 		if err := c.doQueryReplSlotFiles(); err != nil {
 			return fmt.Errorf("querying replication slot files error: %v", err)
 		}

--- a/src/go/plugin/go.d/collector/postgres/queries.go
+++ b/src/go/plugin/go.d/collector/postgres/queries.go
@@ -11,7 +11,7 @@ func queryIsSuperUser() string {
 }
 
 func queryCanExecutePgLsDir() string {
-	return "SELECT has_function_privilege(current_user, 'pg_ls_dir(text)', 'EXECUTE');"
+	return "SELECT has_function_privilege(current_user, 'pg_catalog.pg_ls_dir(text)', 'EXECUTE');"
 }
 
 func queryPGIsInRecovery() string {

--- a/src/go/plugin/go.d/collector/postgres/queries.go
+++ b/src/go/plugin/go.d/collector/postgres/queries.go
@@ -10,6 +10,10 @@ func queryIsSuperUser() string {
 	return "SELECT current_setting('is_superuser') = 'on' AS is_superuser;"
 }
 
+func queryCanExecutePgLsDir() string {
+	return "SELECT has_function_privilege(current_user, 'pg_ls_dir(text)', 'EXECUTE');"
+}
+
 func queryPGIsInRecovery() string {
 	return "SELECT pg_is_in_recovery();"
 }


### PR DESCRIPTION
##### Summary

The PostgreSQL collector previously gated `pg_ls_dir()`-based replication slot file metrics behind `is_superuser()`. That meant the monitoring user had to be a superuser just to collect per-slot file counts and sizes, which is an
unnecessarily broad privilege.

This change adds a separate capability probe - `has_function_privilege(current_user, 'pg_ls_dir(text)', 'EXECUTE')` - cached at startup alongside the existing superuser probe. The replication slot files query now runs when either the
user is a superuser or has been granted `EXECUTE` on `pg_ls_dir(text)`. Result on non-superuser deployments: the collector picks up replication slot files metrics as soon as the DBA grants the function privilege, without requiring `SUPERUSER` on the monitoring role.

Fixes #22487 

Behavior for existing superuser-based setups is unchanged.

##### Test Plan

- Unit tests in `src/go/plugin/go.d/collector/postgres/collector_test.go` updated to include the new `queryCanExecutePgLsDir()` mock expectation in every path that previously expected `queryIsSuperUser()`. CI runs the standard `go test ./...` for the collector.
- Manually verified against PostgreSQL 14:
  - Non-superuser without `EXECUTE` on `pg_ls_dir(text)` -> replication slot files metrics skipped (no errors, same as before).
  - Same user after `GRANT EXECUTE ON FUNCTION pg_ls_dir(text) TO netdata;` -> replication slot files metrics collected.
  - Superuser -> unchanged.

##### Additional Information

The probe uses `has_function_privilege` so it works regardless of how the privilege was granted (direct, via a role, or by ownership), and it is queried once per collector lifetime (cached in `c.canExecutePgLsDir`), so there is no per-cycle overhead.
