### PR TITLE
Assorted CI fixes for IBM MQ library handlign in packaging workflow.

### DIFF
--- a/.github/scripts/prep-ibm-mq-libs.sh
+++ b/.github/scripts/prep-ibm-mq-libs.sh
@@ -13,6 +13,7 @@ dl_log="${tmp_dir}/dl.log"
 cache_path="${cache_dir}/${file}"
 extract_path="${tmp_dir}/ibm_mq"
 retry_delay=90
+max_tries=5
 need_to_fetch=1
 
 rm -rf "${extract_path}"
@@ -21,7 +22,7 @@ mkdir -p "${tmp_dir}" "${cache_dir}" "${extract_path}"
 fetch_url() {
     success=0
 
-    for i in $(seq 5) ; do
+    for i in $(seq "${max_tries}") ; do
         echo "Download attempt ${i}"
         set +e
         rm -f "${dl_log}"
@@ -60,7 +61,9 @@ fetch_url() {
                 ;;
         esac
 
-        sleep "${retry_delay}"
+        if [ "${i}" -ne "${max_tries}" ]; then
+            sleep "${retry_delay}"
+        fi
     done
 
     if [ "${success}" -ne 1 ]; then

--- a/.github/scripts/prep-ibm-mq-libs.sh
+++ b/.github/scripts/prep-ibm-mq-libs.sh
@@ -39,6 +39,7 @@ fetch_url() {
         case "${ret}" in
             0)
                 echo "Download successful."
+                success=1
                 break
                 ;;
             22|78)
@@ -61,6 +62,11 @@ fetch_url() {
 
         sleep "${retry_delay}"
     done
+
+    if [ "${success}" -ne 1 ]; then
+        echo "Exhausted all retry attempts."
+        exit 1
+    fi
 }
 
 hash_valid() {

--- a/.github/scripts/prep-ibm-mq-libs.sh
+++ b/.github/scripts/prep-ibm-mq-libs.sh
@@ -9,12 +9,57 @@ cache_dir="artifacts/cache"
 tmp_dir="tmp"
 hash_path="${tmp_dir}/hash"
 dl_path="${tmp_dir}/${file}"
+dl_log="${tmp_dir}/dl.log"
 cache_path="${cache_dir}/${file}"
 extract_path="${tmp_dir}/ibm_mq"
+retry_delay=90
 need_to_fetch=1
 
 rm -rf "${extract_path}"
 mkdir -p "${tmp_dir}" "${cache_dir}" "${extract_path}"
+
+fetch_url() {
+    success=0
+
+    for i in $(seq 5) ; do
+        echo "Download attempt ${i}"
+        set +e
+        rm -f "${dl_log}"
+        curl --output "${dl_path}" \
+             --fail \
+             --location \
+             --max-time 300 \
+             --connect-timeout 90 \
+             --remote-time \
+             --write-out "%{http_code}" \
+             "${url}" > "${dl_log}"
+        ret="$?"
+        set -e
+
+        case "${ret}" in
+            0)
+                echo "Download successful."
+                break
+                ;;
+            22|78)
+                status="$(tail -n 1 "${dl_log}")"
+                case "${status}" in
+                    403|404)
+                        echo "Download failed, got ${status} from remote server."
+                        exit 1
+                        ;;
+                    *) echo "Download failed, got ${status} from remote server, retrying in ${retry_delay} seconds." ;;
+                esac
+                ;;
+            5|6|7) echo "Failed to connect to remote server, retrying in ${retry_delay} seconds." ;;
+            35|60|83) echo "TLS error connecting to remote server, retrying in ${retry_delay} seconds." ;;
+            *)
+                echo "Unknown error (exit code ${ret}) downloading remote file."
+                exit 1
+                ;;
+        esac
+    done
+}
 
 hash_valid() {
     local path="${1}"
@@ -36,19 +81,8 @@ fi
 
 if [ "${need_to_fetch}" -eq 1 ]; then
     rm -f "${dl_path}"
-    curl --output "${dl_path}" \
-         --fail \
-         --location \
-         --max-time 300 \
-         --connect-timeout 90 \
-         --retry 5 \
-         --retry-all-errors \
-         --retry-delay 90 \
-         --remote-time \
-         "${url}"
-
+    fetch_url
     hash_valid "${dl_path}"
-
     cp "${dl_path}" "${cache_path}"
 fi
 

--- a/.github/scripts/prep-ibm-mq-libs.sh
+++ b/.github/scripts/prep-ibm-mq-libs.sh
@@ -58,6 +58,8 @@ fetch_url() {
                 exit 1
                 ;;
         esac
+
+        sleep "${retry_delay}"
     done
 }
 

--- a/.github/scripts/prep-ibm-mq-libs.sh
+++ b/.github/scripts/prep-ibm-mq-libs.sh
@@ -20,7 +20,9 @@ rm -rf "${extract_path}"
 mkdir -p "${tmp_dir}" "${cache_dir}" "${extract_path}"
 
 fetch_url() {
-    success=0
+    local success=0
+    local ret
+    local status
 
     for i in $(seq "${max_tries}") ; do
         echo "Download attempt ${i}"
@@ -53,6 +55,9 @@ fetch_url() {
                     *) echo "Download failed, got ${status} from remote server, retrying in ${retry_delay} seconds." ;;
                 esac
                 ;;
+            28) echo "Operation timed out, retrying in ${retry_delay} seconds." ;;
+            18|52) echo "Incorrect amount of data returned, retrying in ${retry_delay} seconds." ;;
+            56|92|95) echo "Network communications error, retrying in ${retry_delay} seconds." ;;
             5|6|7) echo "Failed to connect to remote server, retrying in ${retry_delay} seconds." ;;
             35|60|83) echo "TLS error connecting to remote server, retrying in ${retry_delay} seconds." ;;
             *)

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -218,7 +218,7 @@ jobs:
         with:
           name: ibm-mq-libs
           path: ${{ github.workspace }}/tmp/ibm_mq
-          include_hidden_files: true
+          include-hidden-files: true
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -190,6 +190,57 @@ jobs:
             && github.repository == 'netdata/netdata'
           }}
 
+  prepare-ibm-mq-libs:
+    name: Prepare IBM MQ client libraries for build
+    runs-on: ubuntu-latest
+    needs:
+      - file-check
+    steps:
+      - name: Skip Check
+        id: skip
+        if: needs.file-check.outputs.run != 'true'
+        run: echo "SKIPPED"
+      - name: Checkout
+        id: checkout
+        if: needs.file-check.outputs.run == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          submodules: false
+      - name: Fetch IBM MQ libs
+        id: fetch-ibm-mq
+        if: needs.file-check.outputs.run == 'true'
+        run: .github/scripts/prep-ibm-mq-libs.sh
+      - name: Upload IBM MQ libs artifact
+        id: upload-ibm-mq
+        if: needs.file-check.outputs.run == 'true'
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: ibm-mq-libs
+          path: ${{ github.workspace }}/tmp/ibm_mq
+          include_hidden_files: true
+      - name: Failure Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'danger'
+          SLACK_ICON_EMOJI: ':github-actions:'
+          SLACK_TITLE: 'Packaging IBM MQ libs fetch failed:'
+          SLACK_USERNAME: 'GitHub Actions'
+          SLACK_MESSAGE: |-
+              ${{ github.repository }}: Failed to fetch IBM MQ libs for package builds.
+              Checkout: ${{ steps.checkout.outcome }}
+              Fetch IBM MQ libs: ${{ steps.fetch-ibm-mq.outcome }}
+              Upload IBM MQ libs: ${{ steps.upload-ibm-mq.outcome }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: >-
+          ${{
+            failure()
+            && github.event_name != 'pull_request'
+            && startsWith(github.ref, 'refs/heads/master')
+            && github.repository == 'netdata/netdata'
+            && needs.file-check.outputs.run == 'true'
+          }}
+
   prepare-topology-ip-intel-stock:
     name: Prepare topology-ip-intel stock payload
     runs-on: ubuntu-latest
@@ -273,6 +324,7 @@ jobs:
       - matrix
       - version-check
       - file-check
+      - prepare-ibm-mq-libs
       - prepare-topology-ip-intel-stock
     strategy:
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
@@ -323,10 +375,13 @@ jobs:
           command: |
             docker pull --platform ${{ matrix.platform }} ${{ matrix.base_image }}
             docker pull --platform ${{ matrix.platform }} netdata/package-builders:${{ matrix.distro }}${{ matrix.version }}-${{ matrix.builder_rev }}
-      - name: Fetch IBM MQ libs
+      - name: Download IBM MQ libs
         id: fetch-ibm-mq
         if: (matrix.arch == 'amd64' || matrix.arch == 'x86_64') && needs.file-check.outputs.run == 'true'
-        run: .github/scripts/prep-ibm-mq-libs.sh
+        uses: actions/download-artifact@v8
+        with:
+          name: ibm-mq-libs
+          path: ${{ github.workspace }}/tmp/ibm_mq
       - name: Download topology-ip-intel stock payload
         id: fetch-topology-stock
         if: needs.file-check.outputs.run == 'true'


### PR DESCRIPTION
##### Summary

- Improve error reporting for failed downloads.
-  Use a single shared download for all the package builds instead of downloading individually for each distro and version. This should eliminate the issue we currently have of single platforms failing to build due to failed downloads, but in exchange means that a failure will block all packages from being published.

##### Test Plan

CI passes on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes IBM MQ client library downloads into a single CI prep job and artifact, with stronger retry logic and error reporting to reduce flaky packaging builds. If the shared download fails, all package builds are blocked for consistency.

- **Refactors**
  - Adds `prepare-ibm-mq-libs` job that fetches once and uploads `ibm-mq-libs` via `actions/upload-artifact@v7.0.0`; packaging jobs depend on it and download via `actions/download-artifact@v8` (amd64/x86_64 only).
  - Gated by `file-check` to skip when packaging isn’t needed; removes per-distro IBM MQ fetch in builders.
  - Sends Slack notification on fetch failures for `master` non-PR runs via `rtCamp/action-slack-notify@v2`, including step outcomes.

- **Bug Fixes**
  - Replaces direct curl with `fetch_url`: bounded retries (`max_tries`, `retry_delay`), fail-fast on 403/404, clearer network/TLS handling, writes HTTP status to `dl.log`, and hard-fails after exhausting retries.
  - Verifies SHA-256 and uses a shared cache to avoid redundant fetches.

<sup>Written for commit b065430f323bdc7b7d62a3a85e2f4dce08687caf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

