### PR TITLE
Fix payload memory leak

### DIFF
--- a/src/aclk/aclk_rx_msgs.c
+++ b/src/aclk/aclk_rx_msgs.c
@@ -17,6 +17,13 @@
 struct aclk_request {
     bool has_type;
     bool is_http;
+    // Heap-allocated string fields below are owned by the local instance in
+    // aclk_handle_cloud_cmd_message. On the v2 success path, msg_id and
+    // callback_topic are transferred into the query and released by
+    // aclk_query_free; payload is not consumed by v2 (the HTTP body is
+    // re-derived from the raw frame) and must be freed by the caller on both
+    // success and error paths. Any new owned field added here must extend
+    // both cleanup paths to preserve this invariant.
     char *msg_id;
     char *callback_topic;
     char *payload;
@@ -205,8 +212,11 @@ int aclk_handle_cloud_cmd_message(char *payload)
     }
 
     if (likely(!aclk_handle_cloud_http_request_v2(&cloud_to_agent, payload))) {
-        // aclk_handle_cloud_request takes ownership of the pointers
-        // (to avoid copying) in case of success
+        // aclk_handle_cloud_http_request_v2 takes ownership of msg_id and
+        // callback_topic on success. The JSON-parsed payload field is not
+        // consumed by v2 (the HTTP body comes from the raw frame), so free
+        // it here to avoid leaking when the cmd JSON included a "payload" key.
+        freez(cloud_to_agent.payload);
         return 0;
     }
 


### PR DESCRIPTION
##### Summary
aclk_handle_cloud_cmd_message parsed the cmd JSON into a local struct aclk_request. The
error path freed payload, msg_id and callback_topic, but the v2 success path returned
without freeing the JSON-parsed payload field. msg_id and callback_topic are transferred
into the query and released by aclk_query_free; the v2 handler derives the HTTP body from
the raw frame and never consumes the parsed payload, so it was leaked whenever the cmd JSON
included a payload key.

Free cloud_to_agent.payload after the success branch and document the ownership invariant
on struct aclk_request so future field additions extend both cleanup paths.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix a memory leak in `aclk_handle_cloud_cmd_message` by freeing the JSON-parsed `payload` on the v2 success path, preventing leaks when the cmd JSON includes a `payload` key. Clarify ownership rules in `struct aclk_request` so heap fields are freed on both success and error paths.

<sup>Written for commit 434257a7e260ba6ba598db90f7f74361019b5c04. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22492?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

