### PR TITLE
Reduce memory copies when processing cloud requests

### DIFF
--- a/src/aclk/aclk_query.c
+++ b/src/aclk/aclk_query.c
@@ -112,7 +112,6 @@ int http_api_v2(mqtt_wss_client client, aclk_query_t *query)
     ND_LOG_STACK_PUSH(lgs);
 
     int retval = 0;
-    BUFFER *local_buffer = NULL;
     usec_t dt_ut = 0;
 
     int z_ret;
@@ -191,30 +190,18 @@ int http_api_v2(mqtt_wss_client client, aclk_query_t *query)
     }
 
     web_client_build_http_header(w);
-    local_buffer = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE, &netdata_buffers_statistics.buffers_aclk);
-    local_buffer->content_type = CT_APPLICATION_JSON;
 
-    buffer_strcat(local_buffer, w->response.header_output->buffer);
-
-    if (w->response.data->len) {
-        if (w->response.zinitialized) {
-            buffer_need_bytes(local_buffer, w->response.data->len);
-            memcpy(&local_buffer->buffer[local_buffer->len], w->response.data->buffer, w->response.data->len);
-            local_buffer->len += w->response.data->len;
-        } else
-            buffer_strcat(local_buffer, w->response.data->buffer);
-    }
-
-    // send msg.
-    w->response.code = (short)aclk_http_msg_v2(
+    w->response.code = (short)aclk_http_msg_v2_direct(
         client,
         query->callback_topic,
         query->msg_id,
         dt_ut,
         query->created,
         w->response.code,
-        local_buffer->buffer,
-        local_buffer->len);
+        w->response.header_output->buffer,
+        w->response.header_output->len,
+        w->response.data->buffer,
+        w->response.data->len);
 
 cleanup:
     web_client_log_completed_request(w, false);
@@ -223,7 +210,6 @@ cleanup:
     pending_req_list_rm(query->msg_id);
 
     buffer_free(z_buffer);
-    buffer_free(local_buffer);
     return retval;
 }
 

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -229,8 +229,9 @@ short aclk_http_msg_v2_direct(mqtt_wss_client client, const char *topic, const c
     size_t json_len = strlen(json_str);
 
     const size_t sep_len = sizeof(V2_BIN_PAYLOAD_SEPARATOR) - 1;
+    const int has_payload = (http_headers_len || body_len);
 
-    size_t total = json_len + sep_len + http_headers_len + body_len;
+    size_t total = json_len + (has_payload ? sep_len : 0) + http_headers_len + body_len;
     char *raw = mallocz(total);
 
     size_t pos = 0;
@@ -238,8 +239,10 @@ short aclk_http_msg_v2_direct(mqtt_wss_client client, const char *topic, const c
     pos += json_len;
     json_object_put(msg);
 
-    memcpy(raw + pos, V2_BIN_PAYLOAD_SEPARATOR, sep_len);
-    pos += sep_len;
+    if (has_payload) {
+        memcpy(raw + pos, V2_BIN_PAYLOAD_SEPARATOR, sep_len);
+        pos += sep_len;
+    }
 
     if (http_headers_len) {
         memcpy(raw + pos, http_headers, http_headers_len);

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -264,7 +264,7 @@ short aclk_http_msg_v2_direct(mqtt_wss_client client, const char *topic, const c
     if (body_len)
         memcpy(raw + pos, body, body_len);
 
-    uint16_t packet_id;
+    uint16_t packet_id = 0;
     int rc = mqtt_wss_publish5(client, (char *)topic, NULL, raw, &freez_aclk_publish_msg, total, MQTT_WSS_PUB_QOS1, &packet_id);
 
     if (rc == MQTT_WSS_ERR_MSG_TOO_BIG) {

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -225,8 +225,8 @@ short aclk_http_msg_v2_direct(mqtt_wss_client client, const char *topic, const c
     tmp = json_object_new_int(http_code);
     json_object_object_add(msg, "http-code", tmp);
 
-    const char *json_str = json_object_to_json_string_ext(msg, JSON_C_TO_STRING_PLAIN);
-    size_t json_len = strlen(json_str);
+    size_t json_len;
+    const char *json_str = json_object_to_json_string_length(msg, JSON_C_TO_STRING_PLAIN, &json_len);
 
     const size_t sep_len = sizeof(V2_BIN_PAYLOAD_SEPARATOR) - 1;
     const int has_payload = (http_headers_len || body_len);

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -18,6 +18,15 @@ static void freez_aclk_publish5b(void *ptr) {
     freez(ptr);
 }
 
+static bool aclk_size_add_overflow(size_t *total, size_t add)
+{
+    if (add > SIZE_MAX - *total)
+        return true;
+
+    *total += add;
+    return false;
+}
+
 #define ACLK_HEADER_VERSION (2)
 
 uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname)
@@ -209,7 +218,6 @@ short aclk_http_msg_v2_direct(mqtt_wss_client client, const char *topic, const c
 {
     if (unlikely(!topic || topic[0] != '/')) {
         netdata_log_error("Full topic required!");
-        aclk_http_msg_v2_err(client, topic, msg_id, HTTP_RESP_INTERNAL_SERVER_ERROR, CLOUD_EC_FAIL_TOPIC, CLOUD_EMSG_FAIL_TOPIC, NULL, 0);
         return HTTP_RESP_INTERNAL_SERVER_ERROR;
     }
 
@@ -231,7 +239,16 @@ short aclk_http_msg_v2_direct(mqtt_wss_client client, const char *topic, const c
     const size_t sep_len = sizeof(V2_BIN_PAYLOAD_SEPARATOR) - 1;
     const int has_payload = (http_headers_len || body_len);
 
-    size_t total = json_len + (has_payload ? sep_len : 0) + http_headers_len + body_len;
+    size_t total = json_len;
+    if (unlikely(
+            (has_payload && aclk_size_add_overflow(&total, sep_len)) ||
+            aclk_size_add_overflow(&total, http_headers_len) ||
+            aclk_size_add_overflow(&total, body_len))) {
+        json_object_put(msg);
+        aclk_http_msg_v2_err(client, topic, msg_id, HTTP_RESP_CONTENT_TOO_LONG, CLOUD_EC_REQ_REPLY_TOO_BIG, CLOUD_EMSG_REQ_REPLY_TOO_BIG, NULL, 0);
+        return HTTP_RESP_CONTENT_TOO_LONG;
+    }
+
     char *raw = mallocz(total);
 
     size_t pos = 0;
@@ -258,6 +275,11 @@ short aclk_http_msg_v2_direct(mqtt_wss_client client, const char *topic, const c
     if (rc == MQTT_WSS_ERR_MSG_TOO_BIG) {
         aclk_http_msg_v2_err(client, topic, msg_id, HTTP_RESP_CONTENT_TOO_LONG, CLOUD_EC_REQ_REPLY_TOO_BIG, CLOUD_EMSG_REQ_REPLY_TOO_BIG, NULL, 0);
         return HTTP_RESP_CONTENT_TOO_LONG;
+    }
+
+    if (rc != MQTT_WSS_OK) {
+        aclk_http_msg_v2_err(client, topic, msg_id, HTTP_RESP_INTERNAL_SERVER_ERROR, CLOUD_EC_SND_TIMEOUT, CLOUD_EMSG_SND_TIMEOUT, NULL, 0);
+        return HTTP_RESP_INTERNAL_SERVER_ERROR;
     }
 
     return http_code;

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -39,15 +39,13 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
         return 0;
     }
 
-    mqtt_wss_publish5(client, (char *)topic, NULL, msg, &freez_aclk_publish_msg, msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
-
     if (aclklog_enabled) {
         char *json = protomsg_to_json(msg, msg_len, msgname);
         log_aclk_message_bin(json, strlen(json), 1, topic, msgname);
         freez(json);
     }
 
-    int rc = mqtt_wss_publish5(client, (char *)topic, NULL, msg, &freez_aclk_publish5a, msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
+    int rc = mqtt_wss_publish5(client, (char *)topic, NULL, msg, &freez_aclk_publish_msg, msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
     if (rc != MQTT_WSS_OK)
         packet_id = 0;
 

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -11,10 +11,7 @@
 #pragma region aclk_tx_msgs helper functions
 #endif
 
-static void freez_aclk_publish5a(void *ptr) {
-    freez(ptr);
-}
-static void freez_aclk_publish5b(void *ptr) {
+static void freez_aclk_publish_msg(void *ptr) {
     freez(ptr);
 }
 
@@ -41,6 +38,8 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
         netdata_log_error("Couldn't get topic. Aborting message send.");
         return 0;
     }
+
+    mqtt_wss_publish5(client, (char *)topic, NULL, msg, &freez_aclk_publish_msg, msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
 
     if (aclklog_enabled) {
         char *json = protomsg_to_json(msg, msg_len, msgname);
@@ -86,7 +85,7 @@ static short aclk_send_message_with_bin_payload(mqtt_wss_client client, json_obj
         memcpy(&full_msg[len], payload, payload_len);
     }
 
-    int rc = mqtt_wss_publish5(client, (char*)topic, NULL, full_msg, &freez_aclk_publish5b, full_msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
+    int rc = mqtt_wss_publish5(client, (char*)topic, NULL, full_msg, &freez_aclk_publish_msg, full_msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
 
     if (rc == MQTT_WSS_ERR_MSG_TOO_BIG)
         return HTTP_RESP_CONTENT_TOO_LONG;
@@ -207,10 +206,6 @@ short aclk_http_msg_v2(mqtt_wss_client client, const char *topic, const char *ms
     return rc;
 }
 
-static void freez_aclk_publish5c(void *ptr) {
-    freez(ptr);
-}
-
 short aclk_http_msg_v2_direct(mqtt_wss_client client, const char *topic, const char *msg_id,
                                usec_t t_exec, usec_t created, short http_code,
                                const char *http_headers, size_t http_headers_len,
@@ -237,7 +232,7 @@ short aclk_http_msg_v2_direct(mqtt_wss_client client, const char *topic, const c
     const char *json_str = json_object_to_json_string_length(msg, JSON_C_TO_STRING_PLAIN, &json_len);
 
     const size_t sep_len = sizeof(V2_BIN_PAYLOAD_SEPARATOR) - 1;
-    const int has_payload = (http_headers_len || body_len);
+    const bool has_payload = (http_headers_len != 0 || body_len != 0);
 
     size_t total = json_len;
     if (unlikely(
@@ -270,7 +265,7 @@ short aclk_http_msg_v2_direct(mqtt_wss_client client, const char *topic, const c
         memcpy(raw + pos, body, body_len);
 
     uint16_t packet_id;
-    int rc = mqtt_wss_publish5(client, (char *)topic, NULL, raw, &freez_aclk_publish5c, total, MQTT_WSS_PUB_QOS1, &packet_id);
+    int rc = mqtt_wss_publish5(client, (char *)topic, NULL, raw, &freez_aclk_publish_msg, total, MQTT_WSS_PUB_QOS1, &packet_id);
 
     if (rc == MQTT_WSS_ERR_MSG_TOO_BIG) {
         aclk_http_msg_v2_err(client, topic, msg_id, HTTP_RESP_CONTENT_TOO_LONG, CLOUD_EC_REQ_REPLY_TOO_BIG, CLOUD_EMSG_REQ_REPLY_TOO_BIG, NULL, 0);

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -87,6 +87,8 @@ static short aclk_send_message_with_bin_payload(mqtt_wss_client client, json_obj
 
     if (rc == MQTT_WSS_ERR_MSG_TOO_BIG)
         return HTTP_RESP_CONTENT_TOO_LONG;
+    if (rc != MQTT_WSS_OK)
+        return HTTP_RESP_INTERNAL_SERVER_ERROR;
 
     return 0;
 }

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -216,6 +216,12 @@ short aclk_http_msg_v2_direct(mqtt_wss_client client, const char *topic, const c
         return HTTP_RESP_INTERNAL_SERVER_ERROR;
     }
 
+    // normalize NULL-with-len so the allocation size and the memcpys stay in sync
+    if (!http_headers)
+        http_headers_len = 0;
+    if (!body)
+        body_len = 0;
+
     json_object *msg = create_hdr("http", msg_id);
     json_object *tmp;
 

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -198,6 +198,68 @@ short aclk_http_msg_v2(mqtt_wss_client client, const char *topic, const char *ms
     return rc;
 }
 
+static void freez_aclk_publish5c(void *ptr) {
+    freez(ptr);
+}
+
+short aclk_http_msg_v2_direct(mqtt_wss_client client, const char *topic, const char *msg_id,
+                               usec_t t_exec, usec_t created, short http_code,
+                               const char *http_headers, size_t http_headers_len,
+                               const char *body, size_t body_len)
+{
+    if (unlikely(!topic || topic[0] != '/')) {
+        netdata_log_error("Full topic required!");
+        aclk_http_msg_v2_err(client, topic, msg_id, HTTP_RESP_INTERNAL_SERVER_ERROR, CLOUD_EC_FAIL_TOPIC, CLOUD_EMSG_FAIL_TOPIC, NULL, 0);
+        return HTTP_RESP_INTERNAL_SERVER_ERROR;
+    }
+
+    json_object *msg = create_hdr("http", msg_id);
+    json_object *tmp;
+
+    tmp = json_object_new_int64(t_exec);
+    json_object_object_add(msg, "t-exec", tmp);
+
+    tmp = json_object_new_int64(created);
+    json_object_object_add(msg, "t-rx", tmp);
+
+    tmp = json_object_new_int(http_code);
+    json_object_object_add(msg, "http-code", tmp);
+
+    const char *json_str = json_object_to_json_string_ext(msg, JSON_C_TO_STRING_PLAIN);
+    size_t json_len = strlen(json_str);
+
+    const size_t sep_len = sizeof(V2_BIN_PAYLOAD_SEPARATOR) - 1;
+
+    size_t total = json_len + sep_len + http_headers_len + body_len;
+    char *raw = mallocz(total);
+
+    size_t pos = 0;
+    memcpy(raw + pos, json_str, json_len);
+    pos += json_len;
+    json_object_put(msg);
+
+    memcpy(raw + pos, V2_BIN_PAYLOAD_SEPARATOR, sep_len);
+    pos += sep_len;
+
+    if (http_headers_len) {
+        memcpy(raw + pos, http_headers, http_headers_len);
+        pos += http_headers_len;
+    }
+
+    if (body_len)
+        memcpy(raw + pos, body, body_len);
+
+    uint16_t packet_id;
+    int rc = mqtt_wss_publish5(client, (char *)topic, NULL, raw, &freez_aclk_publish5c, total, MQTT_WSS_PUB_QOS1, &packet_id);
+
+    if (rc == MQTT_WSS_ERR_MSG_TOO_BIG) {
+        aclk_http_msg_v2_err(client, topic, msg_id, HTTP_RESP_CONTENT_TOO_LONG, CLOUD_EC_REQ_REPLY_TOO_BIG, CLOUD_EMSG_REQ_REPLY_TOO_BIG, NULL, 0);
+        return HTTP_RESP_CONTENT_TOO_LONG;
+    }
+
+    return http_code;
+}
+
 uint16_t aclk_send_agent_connection_update(mqtt_wss_client client, int reachable) {
     size_t len;
     uint16_t pid;

--- a/src/aclk/aclk_tx_msgs.h
+++ b/src/aclk/aclk_tx_msgs.h
@@ -13,6 +13,10 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
 void aclk_http_msg_v2_err(mqtt_wss_client client, const char *topic, const char *msg_id, int http_code, int ec, const char* emsg, const char *payload, size_t payload_len);
 short aclk_http_msg_v2(mqtt_wss_client client, const char *topic, const char *msg_id, usec_t t_exec, usec_t created,
     short http_code, const char *payload, size_t payload_len);
+short aclk_http_msg_v2_direct(mqtt_wss_client client, const char *topic, const char *msg_id,
+                               usec_t t_exec, usec_t created, short http_code,
+                               const char *http_headers, size_t http_headers_len,
+                               const char *body, size_t body_len);
 
 uint16_t aclk_send_agent_connection_update(mqtt_wss_client client, int reachable);
 char *aclk_generate_lwt(size_t *size);

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -1300,30 +1300,17 @@ int mqtt_ng_publish(struct mqtt_ng_client *client,
 
     if (client->max_msg_size && PUBLISH_SP_SIZE + mqtt_ng_publish_size(topic, msg_len, topic_id) > client->max_msg_size) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "Message too big for server: %zu", msg_len);
-        if (packet_id)
-            *packet_id = 0;
-        if (msg_free)
-            msg_free(msg);
         return MQTT_NG_MSGGEN_MSG_TOO_BIG;
     }
 
+    // Ownership contract on failure: do NOT free msg or clear *packet_id here.
+    // The sole caller (mqtt_wss_publish5) owns cleanup on every non-OK return.
+    // On MQTT_NG_MSGGEN_OK, msg is attached to a buffer fragment and freed by
+    // the transaction-buffer GC after ack; *packet_id has been written by the
+    // generator. See the long comment in mqtt_wss_publish5 for the invariant.
     int rc = TRY_GENERATE_MESSAGE(mqtt_ng_generate_publish, topic, topic_free, msg, msg_free, msg_len, publish_flags, packet_id, topic_id);
-    if (rc == MQTT_NG_MSGGEN_OK) {
+    if (rc == MQTT_NG_MSGGEN_OK)
         add_packet_to_timeout_monitor_list(client, *packet_id);
-    } else {
-        // generator may have written *packet_id before rolling back; clear it so callers
-        // don't observe a stale id on failure
-        if (packet_id)
-            *packet_id = 0;
-        if (msg_free) {
-            // mqtt_ng_generate_publish has no fail_rollback path after frag_set_external_data
-            // succeeds, so on non-OK return msg was never linked to a fragment and the rollback
-            // cannot have freed it. Free here to keep the publish-layer contract (msg freed on
-            // every non-OK return) holding for all callers. If a future change adds a fallible
-            // step after frag_set_external_data, this branch will double-free and must be revisited.
-            msg_free(msg);
-        }
-    }
     return rc;
 }
 

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -1309,7 +1309,7 @@ int mqtt_ng_publish(struct mqtt_ng_client *client,
     // the transaction-buffer GC after ack; *packet_id has been written by the
     // generator. See the long comment in mqtt_wss_publish5 for the invariant.
     int rc = TRY_GENERATE_MESSAGE(mqtt_ng_generate_publish, topic, topic_free, msg, msg_free, msg_len, publish_flags, packet_id, topic_id);
-    if (rc == MQTT_NG_MSGGEN_OK)
+    if (rc == MQTT_NG_MSGGEN_OK && packet_id)
         add_packet_to_timeout_monitor_list(client, *packet_id);
     return rc;
 }

--- a/src/aclk/mqtt_websockets/mqtt_ng.h
+++ b/src/aclk/mqtt_websockets/mqtt_ng.h
@@ -51,8 +51,10 @@ int mqtt_ng_connect(struct mqtt_ng_client *client,
  *    via msg_free after the packet is ack'd; *packet_id is set to the queued
  *    packet id. The caller must not free msg.
  *  - Any non-OK return (MQTT_NG_MSGGEN_MSG_TOO_BIG, MQTT_NG_MSGGEN_BUFFER_OOM,
- *    ...): msg is NOT consumed and *packet_id is NOT written. The caller owns
- *    msg and must invoke msg_free and reset packet_id as appropriate.
+ *    ...): msg is NOT consumed -- ownership stays with the caller, who must
+ *    invoke msg_free. *packet_id must be treated as undefined: the generator
+ *    may have written a transient value before rolling back, so callers that
+ *    care should reset it to a sentinel (e.g. 0) on the failure path.
  *
  * topic_free: ownership of topic is handled internally by the transaction
  *  buffer on the success path. On failure the topic may or may not have been

--- a/src/aclk/mqtt_websockets/mqtt_ng.h
+++ b/src/aclk/mqtt_websockets/mqtt_ng.h
@@ -44,6 +44,21 @@ int mqtt_ng_connect(struct mqtt_ng_client *client,
                     struct mqtt_lwt_properties *lwt,
                     uint16_t keep_alive);
 
+/* Publish an MQTT message.
+ *
+ * Ownership and cleanup on return:
+ *  - MQTT_NG_MSGGEN_OK: msg is attached to the transaction buffer and freed
+ *    via msg_free after the packet is ack'd; *packet_id is set to the queued
+ *    packet id. The caller must not free msg.
+ *  - Any non-OK return (MQTT_NG_MSGGEN_MSG_TOO_BIG, MQTT_NG_MSGGEN_BUFFER_OOM,
+ *    ...): msg is NOT consumed and *packet_id is NOT written. The caller owns
+ *    msg and must invoke msg_free and reset packet_id as appropriate.
+ *
+ * topic_free: ownership of topic is handled internally by the transaction
+ *  buffer on the success path. On failure the topic may or may not have been
+ *  attached depending on where generation failed; current callers must pass
+ *  topic_free=NULL until the rollback path is made symmetric.
+ */
 int mqtt_ng_publish(struct mqtt_ng_client *client,
                     char *topic,
                     free_fnc_t topic_free,

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -852,6 +852,8 @@ int mqtt_wss_publish5(mqtt_wss_client client,
     int rc = mqtt_ng_publish(client->mqtt, topic, topic_free, msg, msg_free, msg_len, mqtt_flags, packet_id);
     if (rc == MQTT_NG_MSGGEN_MSG_TOO_BIG)
         return MQTT_WSS_ERR_MSG_TOO_BIG;
+    if (rc != MQTT_WSS_OK && msg_free)
+        msg_free(msg);
 
     mqtt_wss_wakeup(client);
 

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -838,6 +838,8 @@ int mqtt_wss_publish5(mqtt_wss_client client,
 
     if (fail_reason) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "%s", fail_reason);
+        if (packet_id)
+            *packet_id = 0;
         if (msg_free)
             msg_free(msg);
         return 1;

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -852,7 +852,7 @@ int mqtt_wss_publish5(mqtt_wss_client client,
     int rc = mqtt_ng_publish(client->mqtt, topic, topic_free, msg, msg_free, msg_len, mqtt_flags, packet_id);
     if (rc == MQTT_NG_MSGGEN_MSG_TOO_BIG)
         return MQTT_WSS_ERR_MSG_TOO_BIG;
-    if (rc != MQTT_WSS_OK && msg_free)
+    if (rc != MQTT_NG_MSGGEN_OK && msg_free)
         msg_free(msg);
 
     mqtt_wss_wakeup(client);

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -889,7 +889,7 @@ int mqtt_wss_publish5(mqtt_wss_client client,
     }
 
     mqtt_wss_wakeup(client);
-    return MQTT_NG_MSGGEN_OK;
+    return MQTT_WSS_OK;
 }
 
 int mqtt_wss_subscribe(mqtt_wss_client client, char *topic, int max_qos_level)

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -852,6 +852,18 @@ int mqtt_wss_publish5(mqtt_wss_client client,
     //    transaction buffer will call msg_free after the message is ack'd.
     //  - On any non-OK return, msg is never attached, so ownership stays with
     //    us and we must call msg_free here.
+    //
+    //    Single-free invariant: msg is attached to a fragment only at the
+    //    final frag_set_external_data() inside mqtt_ng_generate_publish(),
+    //    after which the function commits unconditionally -- there is no
+    //    `goto fail_rollback` between attachment and commit. Every reachable
+    //    fail_rollback site therefore runs with msg unattached, so the
+    //    rollback walks no msg-bearing fragment and msg_free() is only ever
+    //    called by us. If a future change inserts a failure exit after
+    //    attaching msg but before commit, the rollback would also invoke
+    //    msg_free and this branch would double-free; preserve the invariant
+    //    or move responsibility entirely into mqtt_ng_publish().
+    //
     //  - topic_free is intentionally NOT handled here. mqtt_ng_publish may
     //    attach topic to a fragment via optimized_add() before failing, in
     //    which case the rollback already invokes topic_free; if it fails

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -873,6 +873,8 @@ int mqtt_wss_publish5(mqtt_wss_client client,
     //    pass topic_free=NULL, so this asymmetry is harmless today.
     int rc = mqtt_ng_publish(client->mqtt, topic, topic_free, msg, msg_free, msg_len, mqtt_flags, packet_id);
     if (rc != MQTT_NG_MSGGEN_OK) {
+        if (packet_id)
+            *packet_id = 0;
         if (msg_free)
             msg_free(msg);
         if (rc == MQTT_NG_MSGGEN_MSG_TOO_BIG)

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -830,6 +830,12 @@ int mqtt_wss_publish5(mqtt_wss_client client,
                       uint8_t publish_flags,
                       uint16_t *packet_id)
 {
+    // topic_free is not yet supported: the rollback path inside mqtt_ng_publish
+    // can free topic asymmetrically across failure modes (see contract notes in
+    // mqtt_ng.h and the long comment below). Enforce NULL until that is fixed
+    // so callers don't silently leak a borrowed/allocated topic on failure.
+    internal_fatal(topic_free != NULL, "mqtt_wss_publish5: topic_free must be NULL until rollback ownership is made symmetric");
+
     const char *fail_reason = NULL;
     if (client->mqtt_disconnecting)
         fail_reason = "mqtt_wss is disconnecting can't publish";

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -830,34 +830,44 @@ int mqtt_wss_publish5(mqtt_wss_client client,
                       uint8_t publish_flags,
                       uint16_t *packet_id)
 {
-    if (client->mqtt_disconnecting) {
-        nd_log(NDLS_DAEMON, NDLP_ERR, "mqtt_wss is disconnecting can't publish");
+    const char *fail_reason = NULL;
+    if (client->mqtt_disconnecting)
+        fail_reason = "mqtt_wss is disconnecting can't publish";
+    else if (!client->mqtt_connected)
+        fail_reason = "MQTT is offline. Can't send message.";
+
+    if (fail_reason) {
+        nd_log(NDLS_DAEMON, NDLP_ERR, "%s", fail_reason);
         if (msg_free)
             msg_free(msg);
         return 1;
     }
 
-    if (!client->mqtt_connected) {
-        nd_log(NDLS_DAEMON, NDLP_ERR, "MQTT is offline. Can't send message.");
-        if (msg_free)
-            msg_free(msg);
-        return 1;
-    }
-    uint8_t mqtt_flags = 0;
-
-    mqtt_flags = (publish_flags & MQTT_WSS_PUB_QOSMASK) << 1;
+    uint8_t mqtt_flags = (publish_flags & MQTT_WSS_PUB_QOSMASK) << 1;
     if (publish_flags & MQTT_WSS_PUB_RETAIN)
         mqtt_flags |= MQTT_PUBLISH_RETAIN;
 
+    // Failure-path ownership contract with mqtt_ng_publish:
+    //  - On MQTT_NG_MSGGEN_OK, msg is attached to a buffer fragment and the
+    //    transaction buffer will call msg_free after the message is ack'd.
+    //  - On any non-OK return, msg is never attached, so ownership stays with
+    //    us and we must call msg_free here.
+    //  - topic_free is intentionally NOT handled here. mqtt_ng_publish may
+    //    attach topic to a fragment via optimized_add() before failing, in
+    //    which case the rollback already invokes topic_free; if it fails
+    //    earlier, topic_free is never invoked at all. The current callers all
+    //    pass topic_free=NULL, so this asymmetry is harmless today.
     int rc = mqtt_ng_publish(client->mqtt, topic, topic_free, msg, msg_free, msg_len, mqtt_flags, packet_id);
-    if (rc == MQTT_NG_MSGGEN_MSG_TOO_BIG)
-        return MQTT_WSS_ERR_MSG_TOO_BIG;
-    if (rc != MQTT_NG_MSGGEN_OK && msg_free)
-        msg_free(msg);
+    if (rc != MQTT_NG_MSGGEN_OK) {
+        if (msg_free)
+            msg_free(msg);
+        if (rc == MQTT_NG_MSGGEN_MSG_TOO_BIG)
+            return MQTT_WSS_ERR_MSG_TOO_BIG;
+        return rc;
+    }
 
     mqtt_wss_wakeup(client);
-
-    return rc;
+    return MQTT_NG_MSGGEN_OK;
 }
 
 int mqtt_wss_subscribe(mqtt_wss_client client, char *topic, int max_qos_level)


### PR DESCRIPTION
##### Summary
- Previously the processing used  (web_client -> local_buffer -> full_msg). 
- Add aclk_http_msg_v2_direct() which assembles JSON header + separator + HTTP headers + body into a single buffer and transfers ownership to MQTT via the existing freefnc zero-copy path. 
- Drops body copies from 3 to 1, and peak coexistent copies from 3 to 2. 
- The error paths remain the same

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce memory copies in HTTP API v2 publishing by building the payload once and handing it to MQTT via a zero-copy path. Adds overflow checks and tightens MQTT publish ownership/cleanup for safer error handling, with no on-wire changes.

- **Refactors**
  - Add `aclk_http_msg_v2_direct(...)` to assemble JSON header + separator + HTTP headers + body into one buffer and publish with a free callback.
  - Update `http_api_v2()` to drop `local_buffer`; publish from `header_output` + `data`.
  - Validate inputs and sizes: require full topic; NULL headers/body → len 0; guard size overflows; allocation failure/oversize → 413; on publish failure send 500 (standardized in `aclk_tx_msgs`).
  - Serialize JSON using `json_object_to_json_string_length(...)` to compute length during serialization.
  - Centralize MQTT publish error handling/ownership in `mqtt_wss_publish5`: fix return checks; free payload and clear `packet_id` on any non-OK; map oversize to `MQTT_WSS_ERR_MSG_TOO_BIG`; move failure cleanup out of `mqtt_ng_publish`; enforce `topic_free == NULL` to avoid asymmetric rollback; document ownership/rollback contract and single-free invariant in `mqtt_ng.h`; consolidate free callbacks to `freez_aclk_publish_msg`.
  - Guard `packet_id` writes with null checks and reset to 0 on failure or when offline/disconnecting.
  - Normalize `mqtt_wss_wakeup` to return `MQTT_WSS_OK` for consistency.

<sup>Written for commit 36ce49d687d0caef2d342b66d965a1d0559fc37e. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22493?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

