### PR TITLE
Fix query tier selection for sub-resolution windows

### DIFF
--- a/.agents/sow/current/SOW-0016-20260510-collector-taxonomy-unification.md
+++ b/.agents/sow/current/SOW-0016-20260510-collector-taxonomy-unification.md
@@ -3,9 +3,9 @@
 
 ## Status
 
-Status: in-progress
+Status: paused
 
-Sub-state: one-PR framework+POC scope locked by user on 2026-05-11 after the audit-phase start. SOW moved from `pending/` to `current/`; on 2026-05-14 the user superseded the "structural taxonomy only" v1 boundary and required v1 to cover full cloud-frontend TOC shapes, including grids, context/table widgets, ordered alternatives, and nested groups. The full-shape v1 contract was redesigned, adversarially reviewed, amended, and re-reviewed as READY TO IMPLEMENT. Implementation has resumed under the full-shape contract. Full collector taxonomy coverage, global all-collector fatality, production ibm.d sweep, and cloud-frontend consumption are follow-up work unless explicitly pulled into the POC by user decision. After each major implementation step, if an external Claude review would add value, provide a focused prompt with exact files and questions.
+Sub-state: paused on 2026-05-17 by user priority switch to SOW-0017. Prior state: one-PR framework+POC scope locked by user on 2026-05-11 after the audit-phase start. SOW moved from `pending/` to `current/`; on 2026-05-14 the user superseded the "structural taxonomy only" v1 boundary and required v1 to cover full cloud-frontend TOC shapes, including grids, context/table widgets, ordered alternatives, and nested groups. The full-shape v1 contract was redesigned, adversarially reviewed, amended, and re-reviewed as READY TO IMPLEMENT. Implementation has resumed under the full-shape contract. Full collector taxonomy coverage, global all-collector fatality, production ibm.d sweep, and cloud-frontend consumption are follow-up work unless explicitly pulled into the POC by user decision. After each major implementation step, if an external Claude review would add value, provide a focused prompt with exact files and questions.
 
 Implementation progress 2026-05-11: framework, schemas, generator/checker/seed tooling, CI wiring, docs/spec/skills updates, and five go.d POC collector taxonomies were implemented locally and committed as a framework POC snapshot. 2026-05-14: structural-only implementation was paused, full-shape v1 was redesigned/reviewed, and the framework/POC files were updated locally to the ordered recursive `items:` contract.
 

--- a/.agents/sow/done/SOW-0017-20260516-query-duration-below-collection-frequency.md
+++ b/.agents/sow/done/SOW-0017-20260516-query-duration-below-collection-frequency.md
@@ -1,0 +1,491 @@
+# SOW-0017 - Query duration below collection frequency returns no data
+
+## Status
+
+Status: completed
+
+Sub-state: completed on 2026-05-17 after implementation, installation, focused unit validation, and live direct-agent API validation.
+
+## Requirements
+
+### Purpose
+
+Make Netdata metric queries fit for troubleshooting narrow historical windows: when data exists in the requested time area, querying a duration shorter than the metric collection frequency must not silently return an empty result only because the requested window sits between collection-aligned timestamps.
+
+### User Request
+
+The user reported a hypothesis:
+
+- Metrics such as SNMP or go.d charts are often collected every 10 seconds.
+- A 10-minute query with 60 points should show the 10-second samples exist.
+- A 5-second absolute query around 5 minutes in the past, fully inside one 10-second alignment interval, returns empty data even though nearby data exists.
+- The first step must verify the hypothesis before creating a SOW or implementing anything.
+
+### Assistant Understanding
+
+Facts:
+
+- Local Netdata Agent was reachable at `127.0.0.1:19999`.
+- Local Netdata Agent version was reported by `/api/v1/info` as `v2.10.0-199-g532b0ceef2`.
+- `/api/v3/contexts` does not expose collection `update_every`; it exposes context metadata, labels, dimensions, instances, retention, and liveness depending on options.
+- `/api/v3/contexts?contexts=smartctl.device_temperature&options=labels,instances,retention,liveness,minify` confirmed the selected context is collected by `_collect_plugin=go.d` and `_collect_module=smartctl`.
+- `/api/v1/context?context=smartctl.device_temperature&options=instances` confirmed instances of `smartctl.device_temperature` have `update_every=10`.
+- Direct local `/api/v3/data` in this checkout is query-string driven; POSTing the JSON body documented by the skill was ignored for local direct-agent calls.
+
+- The verified symptom is in automatic tier selection/planning, not in collector emission or storage execution, because forced `tier=0` and forced `tier=1` return data for the same narrow window.
+- The empty result is not caused by retention absence: tier 0 retention covers the tested timestamps.
+- The broader hypothesis that any tier-2-only query shorter than tier-2 resolution returns empty was not reproduced on the local agent. Tier-2-only 5-minute windows returned data for both `system.cpu` and `smartctl.device_temperature`.
+
+Unknowns:
+
+- Relative-window variants were not exhaustively tested. The traced trigger is based on the effective window after query-window normalization, so any request form that produces the same effective window can hit it.
+
+### Acceptance Criteria
+
+- Root cause is traced in code with file:line evidence before patching.
+- `/api/v3/data` returns meaningful data for a historical sub-frequency window when a sample exists in the surrounding collection interval, or a deliberate product decision explains why it should not.
+- Existing aligned 10-second queries for 10-second go.d metrics continue to return all expected points.
+- Tests cover the empty-result regression using a lower-frequency metric or a query-engine fixture.
+- Validation records exact commands/results for baseline, failing pre-fix case, and fixed post-fix case.
+- Public/end-user skill documentation is changed only if a user/operator workflow changes; internal query-planner findings stay in SOW/spec artifacts.
+
+## Analysis
+
+Sources checked:
+
+- `docs/netdata-ai/skills/query-netdata-agents/SKILL.md`
+- `docs/netdata-ai/skills/query-netdata-agents/query-metrics.md`
+- `src/web/api/v2/api_v2_contexts.c`
+- `src/database/contexts/api_v2_contexts.c`
+- `src/web/api/maps/contexts_options.c`
+- `src/database/contexts/api_v1_contexts.c`
+- `src/web/api/v2/api_v2_data.c`
+- `src/web/api/queries/query-window.c`
+- `src/web/api/queries/query-plan.c`
+- `src/database/contexts/query_target.c`
+- `src/database/contexts/rrdcontext.h`
+- Local Netdata Agent API at `127.0.0.1:19999`
+
+Current state:
+
+- v3 context metadata can identify go.d/SNMP-style collector ownership via labels, but not collection cadence.
+- v1 context metadata exposes per-instance `update_every`.
+- v3 data responses expose `db.per_tier[].update_every`, which is database tier resolution for the query, not general context metadata.
+- Direct local v3 data request parsing reads URL parameters in `api_v23_data_internal()`; the parser does not read the POST JSON body in the inspected path.
+
+Risks:
+
+- A query-window fix may affect all `/api/v2/data` and `/api/v3/data` users, including Cloud-proxied metrics queries.
+- A naive widening fix could return data outside the user's requested interval and surprise callers expecting strict time boundaries.
+- A strict no-widening interpretation preserves mathematical precision but makes sub-frequency historical inspection unreliable for real troubleshooting workflows.
+- Tier-selection behavior may differ across tier 0, tier 1, and tier 2, so tests must not cover only tier 0.
+
+## Pre-Implementation Gate
+
+Status: diagnosis complete for the verified local reproduction
+
+Problem / root-cause model:
+
+- Verified symptom: for a 10-second go.d metric, every tested 5-second absolute query across a full 10-second cadence cycle selects the right target objects but returns no data and performs zero tier queries, while adjacent/wider windows return data from tier 0.
+- Corrected phase split: query-target selects the matching context, instances, and dimension; the queryable metric / planner path does not create any tier plan for them.
+- Root-cause model: automatic per-metric tier selection gives every overlapping tier a sentinel "unusable" weight when the requested effective duration is shorter than the tier update interval. The same sentinel is also used for non-overlapping tiers. The `>=` tie-break then selects the highest numbered tier among tied sentinel weights.
+- Forced-tier controls prove the query engine can answer the exact narrow window when the planner is told to use a covering tier.
+- The empty result is only one outcome of the trigger. If the highest tied tier covers the requested window, the query returns data from that higher/coarser tier. If the highest tied tier does not cover the requested window, planning returns false and the response is empty.
+
+Evidence reviewed:
+
+- v3 collector identity:
+  - Request: `/api/v3/contexts?contexts=smartctl.device_temperature&options=labels,instances,retention,liveness,minify`
+  - Result: selected context has `_collect_plugin=go.d` and `_collect_module=smartctl`.
+- v1 update frequency:
+  - Request: `/api/v1/context?context=smartctl.device_temperature&options=instances`
+  - Result: `smartctl.device_temperature` instances include `update_every=10`.
+- Baseline 10-minute query:
+  - Request: `/api/v3/data?contexts=smartctl.device_temperature&after=1778958670&before=1778959270&points=60&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned&timeout=30000`
+  - Result: `result.data` length was `60`; first timestamp `1778959270`; last timestamp `1778958680`; tier 0 `update_every=10`.
+- Failing 5-second sub-frequency query around 5 minutes in the past:
+  - Request: `/api/v3/data?contexts=smartctl.device_temperature&after=1778958983&before=1778958988&points=5&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned&timeout=30000`
+  - Result: `result.data` length was `0`; `db.per_tier[0].queries=0`; tier 0 retention covered the window.
+- Same failing window with `points=1` and with default points also returned `result.data` length `0`.
+- Adjacent wider window:
+  - Request: `/api/v3/data?contexts=smartctl.device_temperature&after=1778958980&before=1778958990&points=1&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned&timeout=30000`
+  - Result: `result.data` length was `1`, with a sample at timestamp `1778958990`.
+- Wider 30-second window:
+  - Request: `/api/v3/data?contexts=smartctl.device_temperature&after=1778958970&before=1778959000&points=3&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned&timeout=30000`
+  - Result: `result.data` length was `3`, with timestamps `1778959000`, `1778958990`, and `1778958980`.
+- Full 10-second shifted 5-second-window scan:
+  - Common request shape: `/api/v3/data?contexts=smartctl.device_temperature&after=<after>&before=<before>&points=5&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned&timeout=30000`
+  - `0-5`: `after=1778958980`, `before=1778958985` -> `result.data` length `0`, tier 0 `queries=0`.
+  - `1-6`: `after=1778958981`, `before=1778958986` -> `result.data` length `0`, tier 0 `queries=0`.
+  - `2-7`: `after=1778958982`, `before=1778958987` -> `result.data` length `0`, tier 0 `queries=0`.
+  - `3-8`: `after=1778958983`, `before=1778958988` -> `result.data` length `0`, tier 0 `queries=0`.
+  - `4-9`: `after=1778958984`, `before=1778958989` -> `result.data` length `0`, tier 0 `queries=0`.
+  - `5-0`: `after=1778958985`, `before=1778958990` -> `result.data` length `0`, tier 0 `queries=0`.
+  - `6-1`: `after=1778958986`, `before=1778958991` -> `result.data` length `0`, tier 0 `queries=0`.
+  - `7-2`: `after=1778958987`, `before=1778958992` -> `result.data` length `0`, tier 0 `queries=0`.
+  - `8-3`: `after=1778958988`, `before=1778958993` -> `result.data` length `0`, tier 0 `queries=0`.
+  - `9-4`: `after=1778958989`, `before=1778958994` -> `result.data` length `0`, tier 0 `queries=0`.
+- Planner/debug output:
+  - `options=debug` and `options=plan` both map to `RRDR_OPTION_DEBUG` in `src/web/api/maps/rrdr_options.c`.
+  - v3 emits request/debug fields with `options=jsonwrap,debug`.
+  - v3 emits per-metric `plans` only inside `detailed` output with debug, under `detailed.nodes...dimensions.<metric>.plans`.
+  - The failing 5-second query has no selected dimensions, so there are no per-metric plans to print.
+  - A nearby non-empty query (`after=1778958980`, `before=1778958990`, `points=1`, `options=jsonwrap,debug,details`) prints per-metric plans such as tier 0 `af=1778958985`, `bf=1778958995`.
+- Corrected interpretation from the failing debug response:
+  - `summary` and `totals` prove the matching target objects were selected.
+  - The failing response has no query-plan objects and `db.per_tier[0].queries=0`, proving no tier query was initialized.
+  - Therefore the failure is after target-object selection and before storage execution.
+- Tier-2-only hypothesis check, using old data where only tier 2 covered the selected window:
+  - Baseline tier-retention request: `/api/v3/data?contexts=system.cpu&after=0&before=0&points=1&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,debug&timeout=30000`
+  - Result: `system.cpu` had tier 0 retention beginning at `1778940602`, tier 1 retention beginning at `1778817840`, and tier 2 retention beginning at `1778086800`.
+  - One-hour tier-2-only baseline: `/api/v3/data?contexts=system.cpu&after=1778798400&before=1778802000&points=1&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned,debug,details&timeout=30000`
+  - Result: `result.data` length was `1`; tier 2 `queries=153`; tier 0 and tier 1 `queries=0`.
+  - Five-minute tier-2-only query: `/api/v3/data?contexts=system.cpu&after=1778800200&before=1778800500&points=5&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned,debug,details&timeout=30000`
+  - Result: `result.data` length was `5`; timestamps were `1778800500`, `1778800440`, `1778800380`, `1778800320`, `1778800260`; tier 2 `queries=153`; tier 0 and tier 1 `queries=0`.
+  - Five-second tier-2-only query: `/api/v3/data?contexts=system.cpu&after=1778800203&before=1778800208&points=5&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned,debug,details&timeout=30000`
+  - Result: `result.data` length was `5`; timestamps were `1778800208`, `1778800207`, `1778800206`, `1778800205`, `1778800204`; tier 2 `queries=153`; tier 0 and tier 1 `queries=0`.
+  - Five-minute tier-2-only query for the original go.d context: `/api/v3/data?contexts=smartctl.device_temperature&after=1778800200&before=1778800500&points=5&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned,debug,details&timeout=30000`
+  - Result: `result.data` length was `5`; tier 2 `queries=18`; tier 0 and tier 1 `queries=0`.
+  - Five-second tier-2-only query for the original go.d context: `/api/v3/data?contexts=smartctl.device_temperature&after=1778800203&before=1778800208&points=5&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned,debug,details&timeout=30000`
+  - Result: `result.data` length was `5`; timestamps were `1778800208`, `1778800207`, `1778800206`, `1778800205`, `1778800204`; tier 2 `queries=18`; tier 0 and tier 1 `queries=0`.
+  - Finding: the broad tier-2 hypothesis was not reproduced. Sub-resolution tier-2-only windows can return data when auto-selection lands on tier 2 and tier 2 covers the window.
+- Forced-tier controls for the original failing 5-second query:
+  - Auto-tier failing request: `/api/v3/data?contexts=smartctl.device_temperature&after=1778958983&before=1778958988&points=5&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned,debug,details&timeout=30000`
+  - Result: `result.data` length was `0`; no per-metric plans; all `db.per_tier[].queries=0`; tier 0 and tier 1 retention covered the window, tier 2 did not.
+  - Forced tier 0 request: `/api/v3/data?contexts=smartctl.device_temperature&after=1778958983&before=1778958988&points=5&group_by=dimension&aggregation=average&time_group=average&format=json2&tier=0&options=jsonwrap,minify,unaligned,debug,details&timeout=30000`
+  - Result: `result.data` length was `5`; tier 0 `queries=18`; per-metric plans used tier 0.
+  - Forced tier 1 request: `/api/v3/data?contexts=smartctl.device_temperature&after=1778958983&before=1778958988&points=5&group_by=dimension&aggregation=average&time_group=average&format=json2&tier=1&options=jsonwrap,minify,unaligned,debug,details&timeout=30000`
+  - Result: `result.data` length was `5`; tier 1 `queries=18`; per-metric plans used tier 1.
+  - Forced tier 2 request: `/api/v3/data?contexts=smartctl.device_temperature&after=1778958983&before=1778958988&points=5&group_by=dimension&aggregation=average&time_group=average&format=json2&tier=2&options=jsonwrap,minify,unaligned,debug,details&timeout=30000`
+  - Result: `result.data` length was `0`; no per-metric plans; tier 2 did not cover the window.
+- Wrong-tier-but-not-empty control where tier 0, tier 1, and tier 2 all covered the narrow window:
+  - Auto-tier request: `/api/v3/data?contexts=smartctl.device_temperature&after=1778935003&before=1778935008&points=5&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned,debug,details&timeout=30000`
+  - Result: `result.data` length was `5`; tier 2 `queries=7`; tier 0 and tier 1 `queries=0`; per-metric plans used tier 2.
+  - Forced tier 0 request: `/api/v3/data?contexts=smartctl.device_temperature&after=1778935003&before=1778935008&points=5&group_by=dimension&aggregation=average&time_group=average&format=json2&tier=0&options=jsonwrap,minify,unaligned,debug,details&timeout=30000`
+  - Result: `result.data` length was `5`; tier 0 `queries=3`; per-metric plans used tier 0.
+  - Finding: when all tiers overlap but the effective window is shorter than every tier update interval, auto-selection picks the highest tier instead of the most detailed covering tier. This may return data, but it is still the wrong tier choice for a narrow troubleshooting window.
+- Code evidence:
+  - `src/database/contexts/query_target.c:325` to `src/database/contexts/query_target.c:328` uses broad retention matching to decide whether a metric can enter the query target.
+  - `src/database/contexts/rrdcontext.h:721` to `src/database/contexts/rrdcontext.h:723` allows a two-`update_every` tolerance when checking retention overlap.
+  - `src/web/api/queries/query-plan.c:30` to `src/web/api/queries/query-plan.c:36` returns `-LONG_MAX` for invalid/no-overlap tiers.
+  - `src/web/api/queries/query-plan.c:44` to `src/web/api/queries/query-plan.c:52` also returns `-LONG_MAX` when `points_available <= 0`, which happens when the requested window is shorter than the tier update interval.
+  - `src/web/api/queries/query-plan.c:90` to `src/web/api/queries/query-plan.c:99` marks non-overlapping tiers with the same `-LONG_MAX` value.
+  - `src/web/api/queries/query-plan.c:108` to `src/web/api/queries/query-plan.c:112` chooses the later tier on equal weights because it uses `>=`.
+  - `src/web/api/queries/query-plan.c:117` to `src/web/api/queries/query-plan.c:176` has a separate all-invalid fallback to tier 0 for natural update-every selection, but the per-metric selector at `src/web/api/queries/query-plan.c:57` to `src/web/api/queries/query-plan.c:115` does not have the same fallback.
+  - `src/web/api/queries/query-plan.c:361` to `src/web/api/queries/query-plan.c:365` returns false if the selected tier does not cover the requested window, so no plan reaches `query_planer_initialize_plans()`.
+
+Trigger conditions:
+
+1. The request does not explicitly select a tier, so `query_metric_best_tier_for_timeframe()` is used.
+2. More than one storage tier exists.
+3. After `query_target_calculate_window()`, the effective planner window is shorter than the update interval of every tier that overlaps it:
+   - for the verified failing request, the API request was `after=1778958983`, `before=1778958988`, `points=5`;
+   - query-window normalized it to `after=1778958984`, `before=1778958988`, so the planner duration was `4` seconds for `5` output slots;
+   - tier 0 update interval for the metric was `10` seconds, tier 1 was `600` seconds, and tier 2 was `36000` seconds.
+4. Because `points_available = (common_last_t - common_first_t) / db_update_every_s`, each overlapping tier with an update interval larger than the effective duration gets `points_available=0` and weight `-LONG_MAX`.
+5. Non-overlapping tiers also get weight `-LONG_MAX`.
+6. The tie-break uses `>=`, so the highest-numbered tied tier is selected.
+7. Outcome split:
+   - if the selected highest tier covers the window, the query returns data from that tier;
+   - if the selected highest tier does not cover the window, `query_plan()` returns false, no tier query is initialized, and the response is empty.
+
+Tier switching behavior:
+
+- `query_plan()` can switch tiers in both directions in the same query, but only around the initially selected tier and only to fill coverage gaps.
+- If the selected tier starts after the requested `after`, the planner searches higher-numbered tiers (`selected_tier + 1` upward) to fill the older/beginning part of the query.
+- If the selected tier ends before the requested `before`, the planner searches lower-numbered tiers (`selected_tier - 1` downward) to fill the newer/end part of the query.
+- Both checks are independent, so a middle selected tier can have coarser plans prepended and finer plans appended in the same query.
+- The plan entries are sorted by start time before execution.
+- Limitation: switching is not a per-segment resolution optimizer. If the selected tier covers the whole requested window, the planner does not split the query just because another tier would provide better point density for a subsection.
+- Limitation: explicit `tier=` disables switching because `switch_tiers=false`.
+- Limitation relevant to the verified bug: the selected tier must overlap the requested window before switching can help. If automatic selection picks a non-overlapping tier, `query_plan()` returns false before the gap-filling loops run.
+- Code evidence:
+  - `src/web/api/queries/query-plan.c:367` to `src/web/api/queries/query-plan.c:370` starts with one selected-tier plan clipped to that tier's retention.
+  - `src/web/api/queries/query-plan.c:377` to `src/web/api/queries/query-plan.c:408` fills the beginning by scanning higher-numbered tiers.
+  - `src/web/api/queries/query-plan.c:411` to `src/web/api/queries/query-plan.c:445` fills the end by scanning lower-numbered tiers.
+  - `src/web/api/queries/query-plan.c:448` to `src/web/api/queries/query-plan.c:450` sorts multiple plan entries by start time.
+  - `src/web/api/queries/query-plan.c:349` to `src/web/api/queries/query-plan.c:353` disables switching for explicit selected-tier requests.
+
+Related tier-selection functions:
+
+- `query_metric_best_tier_for_timeframe()` is the execution planner selector. It is `static` and is called only by `query_plan()` when no explicit `tier=` is selected.
+- This execution selector already partially matches the desired model:
+  - it excludes zero-overlap tiers before scoring;
+  - it computes `min_first_time_s` and `max_last_time_s` across all tiers;
+  - it passes that union range plus each tier's `db_update_every_s` into `query_plan_points_coverage_weight()`;
+  - therefore each overlapping tier is effectively scored for resolution as if it could cover the full union/requested window.
+- The verified bug is in the scoring and tie-break, not in the gap-fill planner:
+  - sub-resolution tiers collapse to `-LONG_MAX`;
+  - the `+25000 * tier` bias and `>=` tie-break favor higher/coarser tiers.
+- `rrddim_find_best_tier_for_timeframe()` is a separate aggregate helper in the same file. It also uses `query_plan_points_coverage_weight()`, but it is not the execution planner selector.
+- The only call to `rrdset_find_natural_update_every_for_timeframe()` is from `query_target_calculate_window()` when `natural_points`, explicit `selected-tier`, and `tier > 0` are all set. Because the same `selected-tier` option is passed through, the aggregate `rrddim_find_best_tier_for_timeframe()` branch is not reached from the current code path.
+- Implication: changing the shared `query_plan_points_coverage_weight()` is less surgical because it also changes the aggregate helper if that helper becomes reachable later. Changing `query_metric_best_tier_for_timeframe()` is the narrow execution-planner change.
+- API/data paths using automatic execution planner selection:
+  - `/api/v1/data`, `/api/v2/data`, and `/api/v3/data` when no explicit `tier=` is provided;
+  - MCP metric queries when no explicit `tier` parameter is provided;
+  - weights queries and value helper paths that call `rrd2rrdr()` without `RRDR_OPTION_SELECTED_TIER`.
+- Paths verified not to depend on automatic tier selection:
+  - health database lookups pass `points=1` and `RRDR_OPTION_SELECTED_TIER` with tier `0`;
+  - exporting reads storage tier 0 directly through `storage_engine_query_init(rd->tiers[0]...)`;
+  - explicit API/MCP `tier=` requests bypass automatic selection and disable tier switching.
+
+Why the aggregate helper path exists:
+
+- Historical evidence: commit `3fefd03b94458c9f6ad4164a82b1da6fc4fa435c` (`automatic selection of tier`) introduced automatic tier selection in the old single-chart query engine.
+- In that first design, `rrddim_find_best_tier_for_timeframe()` served two real purposes:
+  - it selected the execution tier for `rrd2rrdr_do_dimension()`;
+  - it selected the natural-points `update_every` through `rrdset_find_natural_update_every_for_timeframe()` whenever natural points and multiple storage tiers were available.
+- Historical evidence: commit `41e14c83e22ed54c8e48a7b637315bbb556c3185` (`natural points should only be offered on tier 0, except a specific tier is selected`) changed the natural-points call site from `natural_points && storage_tiers > 1` to `natural_points && selected-tier && tier > 0 && storage_tiers > 1`.
+- That change made the automatic natural-points branch effectively unreachable, because `rrdset_find_natural_update_every_for_timeframe()` is now only called when selected-tier is already set, and therefore it returns the explicit tier instead of calling `rrddim_find_best_tier_for_timeframe()`.
+- Commit `00712b351b3c83a54a147ca23365458acbef3105` (`QUERY_TARGET: new query engine for Netdata Agent`) ported the logic into the query-target engine:
+  - execution-tier selection became `query_metric_best_tier_for_timeframe()`;
+  - aggregate natural update-every selection remained as `rrddim_find_best_tier_for_timeframe()` behind `rrdset_find_natural_update_every_for_timeframe()`.
+- Implication: the other path exists because it is legacy from the original natural-points auto-tier design and was preserved through the query-target port, but the current call site no longer exercises its automatic branch.
+- The user's concern is valid: if a future caller exercises the aggregate helper, it does not have the execution planner's gap-fill semantics. It chooses one tier/update_every for the query window, so coverage-sensitive scoring there could produce poor natural-points granularity decisions unless it is reviewed separately.
+
+Affected contracts and surfaces:
+
+- `/api/v2/data` and `/api/v3/data` query behavior.
+- Cloud-proxied metrics queries, if they use the same agent-side query path.
+- Query target preparation, storage tier selection, retention matching, and data grouping semantics.
+- Public AI skills under `docs/netdata-ai/skills/` are affected only if the user/operator query workflow changes. Internal planner diagnostics are out of scope for those artifacts.
+
+Existing patterns to reuse:
+
+- Existing query target and data API test patterns after they are located.
+- Existing `RRDR_OPTION_UNALIGNED` behavior must be preserved.
+- Existing v2/v3 data query-string parser in `src/web/api/v2/api_v2_data.c`.
+
+Risk and blast radius:
+
+- High enough to require focused tests before patching: data query semantics are user-facing and shared across dashboards, APIs, Cloud, and troubleshooting workflows.
+- Security risk is low for the bug itself; evidence must still avoid raw secrets and sensitive label values.
+- Performance risk exists if a fix expands storage scans for many narrow queries.
+
+Sensitive data handling plan:
+
+- Durable artifacts must not include raw secrets, bearer tokens, SNMP communities, customer identifiers, private endpoints, non-private customer-identifying IPs, personal data, or device serial numbers.
+- The verification API responses contained hardware labels. This SOW records only sanitized collector identity and metric names, not raw serial numbers or full hardware-identifying label values.
+- Future logs or traces added to this SOW must be summarized or redacted before being written.
+
+Implementation plan:
+
+1. Choose the tier-selection fix semantics before patching.
+2. Implement the smallest fix in the automatic per-metric tier selector so a covering tier is selected for sub-resolution windows.
+3. Add regression tests for sub-frequency historical windows, forced-tier behavior, tier-2-only sub-resolution windows, and unchanged aligned-window behavior.
+4. Re-run the exact local API verification commands after the fix.
+5. Update query skill/docs if the local direct-agent `/api/v3/data` request contract differs from the current skill text.
+
+Validation plan:
+
+- Run targeted query-engine/data API tests found during tracing.
+- Add a regression test that fails before the fix.
+- Re-run the exact local API verification commands after the fix.
+- Search for same-failure risks around tier 1/tier 2, relative windows, absolute windows, `points=0`, `points=1`, and `points>duration`.
+
+Artifact impact plan:
+
+- AGENTS.md: likely unaffected unless the fix exposes a durable project-wide query workflow rule.
+- Runtime project skills: likely unaffected unless a codebase workflow lesson emerges.
+- Specs: likely add or update a query/data API spec if no existing spec covers sub-frequency windows.
+- End-user/operator docs: possibly affected if public query semantics are documented.
+- End-user/operator skills: no planned update for internal query-planner diagnostics. The user clarified that `docs/netdata-ai/skills/` is for user/operator how-tos, not maintainer implementation notes.
+- SOW lifecycle: this SOW moved to `current/` after the user explicitly prioritized it, and will move to `done/` with `Status: completed` when committed.
+
+Open-source reference evidence:
+
+- None checked. This is an internal Netdata query-engine/API behavior issue; external observability implementations are not needed until a semantic design fork appears.
+
+Open decisions:
+
+- None before implementation.
+
+## Implications And Decisions
+
+- User decision already applied: verify the hypothesis before creating this SOW.
+- User decision on 2026-05-17: choose option `1A`, cleanup the dormant natural-points aggregate tier-selection path instead of leaving it commented or reactivating it.
+- Implication: implementation should remove or simplify the unreachable `rrddim_find_best_tier_for_timeframe()` path so future maintainers do not confuse it with the execution planner selector.
+- User decision on 2026-05-17: implement the planner change in addition to cleanup.
+- User-approved planner semantics: zero-overlap tiers are non-candidates; among overlapping tiers, score point density as if the tier had full-window coverage; select the sparsest tier that can provide at least 50% of requested point density; if no tier can provide 50%, select the densest overlapping tier.
+- Boundary: existing explicit `tier=` semantics remain unchanged.
+- User clarification on 2026-05-17: do not put internal/developer query-planner findings in `docs/netdata-ai/skills/`; use `.agents/sow/` specs or project runtime skills for maintainer-facing memory.
+
+## Plan
+
+1. Pause SOW-0016 and move SOW-0017 to `current/`.
+2. Remove or simplify the dormant natural-points aggregate tier-selection path.
+3. Replace automatic execution-tier scoring with the user-approved point-density semantics.
+4. Add focused regression tests or equivalent validation.
+5. Re-run local API reproduction URLs after installing/restarting a patched agent, or record the approval blocker.
+6. Update internal artifacts before close.
+
+## Execution Log
+
+### 2026-05-16
+
+- Verified the symptom using local direct-agent API requests.
+- Created this pending SOW after verification only.
+- Verified that tier-2-only sub-resolution windows return data in the tested cases, so the broader tier-2 hypothesis was not reproduced.
+- Traced the observed empty result to automatic tier selection choosing a non-covering tier when all tier weights tie at `-LONG_MAX`.
+- Verified a second outcome of the same trigger: when all tiers cover a narrow sub-resolution window, automatic selection chooses tier 2 and returns data from tier 2 instead of tier 0.
+- No code changes made.
+
+### 2026-05-17
+
+- Paused SOW-0016 and moved SOW-0017 to `current/` after the user explicitly prioritized SOW-0017.
+- Removed the dormant automatic aggregate-tier path:
+  - deleted `query_plan_points_coverage_weight()`;
+  - deleted `rrddim_find_best_tier_for_timeframe()`;
+  - replaced `rrdset_find_natural_update_every_for_timeframe()` with `query_target_min_update_every_for_tier()`, which only computes the minimum update-every for an explicit selected tier.
+- Implemented automatic execution-tier selection using the approved density model:
+  - zero-overlap tiers get sentinel weight and cannot win;
+  - candidate tiers use fixed-point point-density weights, so sub-resolution windows do not collapse to zero;
+  - if any tier can provide at least 50% of requested point density, the sparsest acceptable tier wins;
+  - if none can provide 50%, the densest overlapping tier wins.
+- Hardened the automatic selector to treat reversed or zero-duration windows as invalid before adjusting `points_wanted`.
+- Added `query_plan_unittest()` and `-W queryplantest` coverage for:
+  - sub-resolution window with a non-overlapping coarser tier;
+  - sub-resolution window where all tiers overlap;
+  - 50% tolerance choosing a sparse acceptable tier;
+  - under-resolution requests choosing the densest tier;
+  - zero-overlap tiers not being candidates;
+  - selected-tier natural-points update-every cleanup.
+- Added internal spec `.agents/sow/specs/query-planner-tier-selection.md`.
+- Did not update `docs/netdata-ai/skills/`; those are end-user/operator skills and this work is maintainer/internal query-planner behavior.
+- Ran `./install.sh` after explicit user request, and reran it after the final selector guard. Result: install completed and restarted the local `netdata`; non-fatal `git fetch -t` failed due local GitHub SSH permission, but the installer continued and completed.
+- Verified the installed local agent reports `v2.10.0-215-ge6e45f29ee` at `/api/v1/info`.
+- Ran `/usr/sbin/netdata -W queryplantest`; result: passed all six focused query planner checks.
+- Re-ran the live direct-agent `/api/v3/data` baseline and short-window checks against the installed agent. The original failing 5-second automatic-tier query now returns 5 points and uses tier 0.
+
+## Validation
+
+Acceptance criteria evidence:
+
+- Root cause was traced before patching and is recorded in the Pre-Implementation Gate with code evidence.
+- The implementation changes `src/web/api/queries/query-plan.c` so sub-resolution overlapping tiers remain candidates with fractional density weights instead of being assigned the same sentinel as non-overlapping tiers.
+- Explicit tier behavior remains unchanged: `query_plan()` still disables tier switching for valid `RRDR_OPTION_SELECTED_TIER`.
+- Live post-fix API validation against the installed local agent passed. The original failing automatic-tier 5-second query now returns 5 points and initializes tier 0 storage queries.
+
+Tests or equivalent validation:
+
+- `git diff --check -- src/web/api/queries/query-plan.c src/web/api/queries/query-window.c src/web/api/queries/query-internal.h src/daemon/main.c`
+  - Result: passed.
+- `cmake --build build-clion --target netdata -j 8`
+  - Result: configure/build did not reach the changed code. CMake attempted to refresh bundled Sentry crashpad content and failed fetching `mini_chromium` from the external submodule with HTTP 400.
+- `cmake -S . -B .local/build-sow17 -G Ninja -DENABLE_SENTRY=OFF -DENABLE_ML=OFF -DCMAKE_BUILD_TYPE=Debug`
+  - Result: failed because the fresh cache enabled `ENABLE_PLUGIN_XENSTAT=ON` and local `xenstat` dependencies were not available.
+- `cmake -S . -B .local/build-sow17 -G Ninja -DENABLE_SENTRY=OFF -DENABLE_ML=OFF -DENABLE_PLUGIN_XENSTAT=OFF -DCMAKE_BUILD_TYPE=Debug`
+  - Result: passed.
+- `cmake --build .local/build-sow17 --target netdata -j 8`
+  - Result: passed. The changed files `src/daemon/main.c`, `src/web/api/queries/query-window.c`, and `src/web/api/queries/query-plan.c` compiled and linked into `.local/build-sow17/netdata`.
+- `.local/build-sow17/netdata -W queryplantest`
+  - Result: passed all six focused query planner checks.
+- `cmake --build .local/build-sow17 --target netdata -j 8` after the final selector guard
+  - Result: passed; `src/web/api/queries/query-plan.c` rebuilt and linked.
+- `.local/build-sow17/netdata -W queryplantest` after the final selector guard
+  - Result: passed all six focused query planner checks.
+- `./install.sh`
+  - Result: passed twice; local `netdata` was restarted. A non-fatal `git fetch -t` step failed due local GitHub SSH permission, but the install completed both times.
+- `curl -sS 'http://127.0.0.1:19999/api/v1/info' | jq -r '.version'`
+  - Result: `v2.10.0-215-ge6e45f29ee`.
+- `/usr/sbin/netdata -W queryplantest`
+  - Result: passed all six focused query planner checks.
+- `/usr/sbin/netdata -W queryplantest` after the final reinstall
+  - Result: passed all six focused query planner checks.
+
+Real-use evidence:
+
+- Pre-fix local direct-agent `/api/v3/data` calls reproduced the symptom against `smartctl.device_temperature`.
+- Post-fix 10-minute baseline:
+  - Request: `/api/v3/data?contexts=smartctl.device_temperature&after=1778958670&before=1778959270&points=60&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned&timeout=30000`
+  - Result: `result.data` length `60`; first timestamp `1778959270`; last timestamp `1778958680`; tier 0 `queries=18`, `update_every=10`; tier 1 and tier 2 `queries=0`.
+- Post-fix original failing 5-second automatic-tier query:
+  - Request: `/api/v3/data?contexts=smartctl.device_temperature&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned,debug,details&timeout=30000&after=1778958983&before=1778958988&points=5`
+  - Result: `result.data` length `5`; timestamps `1778958988,1778958987,1778958986,1778958985,1778958984`; tier 0 `queries=18`; tier 1 and tier 2 `queries=0`.
+- Post-fix forced tier 0 control for the same 5-second window:
+  - Request: `/api/v3/data?contexts=smartctl.device_temperature&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned,debug,details&timeout=30000&after=1778958983&before=1778958988&points=5&tier=0`
+  - Result: `result.data` length `5`; timestamps `1778958988,1778958987,1778958986,1778958985,1778958984`; tier 0 `queries=18`; tier 1 and tier 2 `queries=0`.
+- Post-fix shifted 5-second automatic-tier scan across one 10-second cadence interval:
+  - Common request shape: `/api/v3/data?contexts=smartctl.device_temperature&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned,debug,details&timeout=30000&after=<after>&before=<before>&points=5`
+  - `0-5`: `after=1778958980`, `before=1778958985` -> `result.data` length `5`, tier 0 `queries=18`.
+  - `1-6`: `after=1778958981`, `before=1778958986` -> `result.data` length `5`, tier 0 `queries=18`.
+  - `2-7`: `after=1778958982`, `before=1778958987` -> `result.data` length `5`, tier 0 `queries=18`.
+  - `3-8`: `after=1778958983`, `before=1778958988` -> `result.data` length `5`, tier 0 `queries=18`.
+  - `4-9`: `after=1778958984`, `before=1778958989` -> `result.data` length `5`, tier 0 `queries=18`.
+  - `5-0`: `after=1778958985`, `before=1778958990` -> `result.data` length `5`, tier 0 `queries=18`.
+  - `6-1`: `after=1778958986`, `before=1778958991` -> `result.data` length `5`, tier 0 `queries=18`.
+  - `7-2`: `after=1778958987`, `before=1778958992` -> `result.data` length `5`, tier 0 `queries=18`.
+  - `8-3`: `after=1778958988`, `before=1778958993` -> `result.data` length `5`, tier 0 `queries=18`.
+  - `9-4`: `after=1778958989`, `before=1778958994` -> `result.data` length `5`, tier 0 `queries=18`.
+- Post-fix older two-tier overlap check:
+  - Request: `/api/v3/data?contexts=smartctl.device_temperature&after=1778935003&before=1778935008&points=5&group_by=dimension&aggregation=average&time_group=average&format=json2&options=jsonwrap,minify,unaligned,debug,details&timeout=30000`
+  - Result: `result.data` length `5`; tier 0 `queries=0`, `first_entry=1778948390`; tier 1 `queries=18`, `update_every=600`; tier 2 `queries=0`, `last_entry=1778940000`.
+  - Interpretation: after install/restart, tier 0 and tier 2 no longer overlap on the local database, so the earlier all-three-overlap control is no longer reproducible. This check validates that when only tier 1 and tier 2 overlap a sub-resolution window, the denser overlapping tier 1 wins.
+
+Reviewer findings:
+
+- Self-review found one additional hardening point: the automatic selector should treat reversed windows the same as zero-duration windows before adjusting `points_wanted`. This guard was added and revalidated.
+- External AI reviewers were not run; the user did not request them for this PR.
+
+Same-failure scan:
+
+- Source-code search found no remaining references to `query_plan_points_coverage_weight()`, `rrddim_find_best_tier_for_timeframe()`, or `rrdset_find_natural_update_every_for_timeframe()`.
+- Automatic execution-tier selection call sites remain centralized through `query_metric_best_tier_for_timeframe()`.
+
+Sensitive data gate:
+
+- This SOW records no raw secrets, bearer tokens, SNMP communities, private endpoints, customer data, personal names, or device serial numbers.
+- Hardware-identifying labels observed during verification were not copied into this durable artifact.
+
+Artifact maintenance gate:
+
+- AGENTS.md: no update. Existing artifact-boundary instructions already distinguish internal specs/project skills from public end-user/operator skills.
+- Runtime project skills: no update. This change adds project behavior, not a new "how to work here" workflow.
+- Specs: added `.agents/sow/specs/query-planner-tier-selection.md`.
+- End-user/operator docs: no update. The behavior is internal planner selection; no user-facing API parameter or documented workflow changed.
+- End-user/operator skills: no update. Public skills under `docs/netdata-ai/skills/` are for user/operator work, not maintainer debugging notes.
+- SOW lifecycle: `Status: completed` and file move to `.agents/sow/done/` are part of this commit.
+
+Specs update:
+
+- Added `.agents/sow/specs/query-planner-tier-selection.md`.
+
+Project skills update:
+
+- No project skill update needed; no durable assistant workflow changed.
+
+End-user/operator docs update:
+
+- No end-user/operator docs update needed; the user-visible API contract did not gain a new parameter or required workflow.
+
+End-user/operator skills update:
+
+- No end-user/operator skill update needed; this is not a public/operator AI skill workflow.
+
+Lessons:
+
+- Internal query-planner diagnostics and maintainer implementation notes belong in the SOW/spec layer, not under `docs/netdata-ai/skills/`.
+- The direct-agent public skills may still need separate product-doc review, but that is not part of this internal planner SOW unless a user/operator workflow changes.
+
+Follow-up mapping:
+
+- No remaining behavioral follow-up identified.
+
+## Outcome
+
+Completed. Automatic tier selection now uses overlapping-tier point density, so sub-resolution query windows pick the densest overlapping tier instead of collapsing overlapping and non-overlapping tiers to the same sentinel score.
+
+## Lessons Extracted
+
+- Sub-resolution query windows must be ordered by fractional point density, not by integer point counts, because integer division collapses valid overlapping tiers to the same sentinel value as non-overlapping tiers.
+- Internal maintainer findings belong in `.agents/sow/` specs and SOWs; public skills under `docs/netdata-ai/skills/` should only change for user/operator workflows.
+
+## Followup
+
+No behavioral follow-up identified.
+
+## Regression Log
+
+None yet.
+
+Append regression entries here only after this SOW was completed or closed and later testing or use found broken behavior. Use a dated `## Regression - YYYY-MM-DD` heading at the end of the file. Never prepend regression content above the original SOW narrative.

--- a/.agents/sow/specs/query-planner-tier-selection.md
+++ b/.agents/sow/specs/query-planner-tier-selection.md
@@ -1,0 +1,78 @@
+# Spec - Query planner tier selection
+
+## Status
+
+Active. Added by SOW-0017.
+
+## Scope
+
+This spec describes automatic storage-tier selection for metric data
+queries when the caller does not explicitly request `tier=`.
+
+It applies to the query-target planner used by `/api/v1/data`,
+`/api/v2/data`, `/api/v3/data`, MCP metric queries, weights/value
+helpers, and other callers that reach `rrd2rrdr()` without
+`RRDR_OPTION_SELECTED_TIER`.
+
+Explicit `tier=` requests are outside this automatic selection rule.
+They keep the existing behavior: the requested tier is used when valid,
+and automatic tier switching is disabled.
+
+## Contract
+
+Automatic tier selection is resolution-driven among tiers that overlap
+the requested effective query window.
+
+1. A tier with no overlap with the requested effective window is not a
+   candidate.
+2. A candidate tier is scored by point density as if it had full-window
+   coverage:
+
+   ```text
+   candidate_points = effective_duration / tier_update_every
+   ```
+
+   The implementation uses fixed-point integer weights so sub-resolution
+   windows retain fractional ordering instead of collapsing to zero.
+
+3. The acceptable-density threshold is 50% of the requested output point
+   count.
+4. If one or more candidate tiers meet the 50% threshold, select the
+   sparsest acceptable tier. This avoids reading much denser data when a
+   coarser tier can satisfy the requested output density well enough.
+5. If no candidate tier meets the 50% threshold, select the densest
+   candidate tier. This handles short windows below every tier's
+   resolution and preserves the best available fidelity.
+6. After the initial tier is selected, the existing query planner may
+   fill beginning/end coverage gaps with neighboring tiers. Tier
+   switching is a coverage-gap mechanism, not a full per-segment
+   resolution optimizer.
+
+## Important Edge Cases
+
+- A requested window shorter than a 10-second collector cadence must not
+  make all overlapping tiers unusable. The densest overlapping tier wins
+  when no tier reaches the 50% threshold.
+- A non-overlapping tier must never win just because every tier has poor
+  density.
+- When all tiers cover a narrow sub-resolution window, automatic
+  selection should choose the densest tier, not the highest-numbered
+  tier.
+- When a coarser tier can provide at least 50% of the requested point
+  density, it may be selected over a much denser tier to reduce source
+  reads while preserving acceptable output fidelity.
+
+## Natural Points
+
+The legacy automatic aggregate-tier helper is not part of this contract.
+Natural-points update-every selection for an explicit selected tier uses
+the minimum `db_update_every_s` for that selected tier across the query
+target metrics.
+
+## Code References
+
+- `src/web/api/queries/query-plan.c` - automatic per-metric tier
+  selection and planner gap-fill.
+- `src/web/api/queries/query-window.c` - selected-tier natural-points
+  update-every calculation.
+

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -226,6 +226,7 @@ int health_config_unittest(void);
 int utf8_sanitizer_unittest(void);
 int yaml_unittest(void);
 int json_c_parser_unittest(void);
+int query_plan_unittest(void);
 #ifdef ENABLE_ML
 int ml_unittest(void);
 #endif
@@ -441,6 +442,7 @@ int netdata_main(int argc, char **argv) {
                             if (rrdlabels_unittest()) return 1;
                             if (rrdhost_labels_unittest()) return 1;
                             if (ctx_unittest()) return 1;
+                            if (query_plan_unittest()) return 1;
                             if (uuid_unittest()) return 1;
                             if (dyncfg_unittest()) return 1;
                             if (eval_unittest()) return 1;
@@ -549,6 +551,10 @@ int netdata_main(int argc, char **argv) {
                         else if(strcmp(optarg, "utf8sanitizertest") == 0) {
                             unittest_running = true;
                             return utf8_sanitizer_unittest();
+                        }
+                        else if(strcmp(optarg, "queryplantest") == 0) {
+                            unittest_running = true;
+                            return query_plan_unittest();
                         }
 #ifdef ENABLE_DBENGINE
                         else if(strcmp(optarg, "mctest") == 0) {

--- a/src/web/api/queries/query-internal.h
+++ b/src/web/api/queries/query-internal.h
@@ -87,7 +87,8 @@ bool query_planer_next_plan(QUERY_ENGINE_OPS *ops, time_t now, time_t last_point
 void query_planer_finalize_remaining_plans(QUERY_ENGINE_OPS *ops);
 QUERY_ENGINE_OPS *rrd2rrdr_query_ops_prep(RRDR *r, size_t query_metric_id);
 void rrd2rrdr_query_ops_release(QUERY_ENGINE_OPS *ops);
-time_t rrdset_find_natural_update_every_for_timeframe(QUERY_TARGET *qt, time_t after_wanted, time_t before_wanted, size_t points_wanted, RRDR_OPTIONS options, size_t tier);
+time_t query_target_min_update_every_for_tier(QUERY_TARGET *qt, size_t tier);
+int query_plan_unittest(void);
 void rrd2rrdr_query_ops_freeall(RRDR *r);
 
 // query execution

--- a/src/web/api/queries/query-plan.c
+++ b/src/web/api/queries/query-plan.c
@@ -27,176 +27,265 @@ static size_t query_metric_first_working_tier(QUERY_METRIC *qm) {
     return 0;
 }
 
-long query_plan_points_coverage_weight(time_t db_first_time_s, time_t db_last_time_s, time_t db_update_every_s, time_t after_wanted, time_t before_wanted, size_t points_wanted, size_t tier __maybe_unused) {
-    if(db_first_time_s == 0 ||
-        db_last_time_s == 0 ||
-        db_update_every_s == 0 ||
-        db_first_time_s > before_wanted ||
-        db_last_time_s < after_wanted)
+#define QUERY_PLAN_POINTS_WEIGHT_SCALE 1000000ULL
+#define QUERY_PLAN_ACCEPTABLE_POINTS_NUMERATOR 1ULL
+#define QUERY_PLAN_ACCEPTABLE_POINTS_DENOMINATOR 2ULL
+
+static bool query_metric_tier_overlaps_timeframe(QUERY_METRIC *qm, size_t tier, time_t after_wanted, time_t before_wanted) {
+    if(!query_metric_is_valid_tier(qm, tier))
+        return false;
+
+    return qm->tiers[tier].db_first_time_s <= before_wanted &&
+           qm->tiers[tier].db_last_time_s >= after_wanted;
+}
+
+static long query_plan_points_density_weight(time_t db_update_every_s, time_t after_wanted, time_t before_wanted) {
+    if(db_update_every_s <= 0 || before_wanted <= after_wanted)
         return -LONG_MAX;
 
-    long long common_first_t = MAX(db_first_time_s, after_wanted);
-    long long common_last_t = MIN(db_last_time_s, before_wanted);
+    uint64_t duration_s = (uint64_t)(before_wanted - after_wanted);
 
-    long long time_coverage = (common_last_t - common_first_t) * 1000000LL / (before_wanted - after_wanted);
-    long long points_wanted_in_coverage = (long long)points_wanted * time_coverage / 1000000LL;
+    if(duration_s > (uint64_t)LONG_MAX / QUERY_PLAN_POINTS_WEIGHT_SCALE)
+        return LONG_MAX;
 
-    long long points_available = (common_last_t - common_first_t) / db_update_every_s;
-    long long points_delta = (long)(points_available - points_wanted_in_coverage);
-    long long points_coverage = (points_delta < 0) ? (long)(points_available * time_coverage / points_wanted_in_coverage) : time_coverage;
+    return (long)((duration_s * QUERY_PLAN_POINTS_WEIGHT_SCALE) / (uint64_t)db_update_every_s);
+}
 
-    // a way to benefit higher tiers
-    // points_coverage += (long)tier * 10000;
+static long query_plan_minimum_acceptable_points_weight(size_t points_wanted) {
+    if(!points_wanted)
+        return 0;
 
-    if(points_available <= 0)
-        return -LONG_MAX;
+    if((uint64_t)points_wanted > (uint64_t)LONG_MAX / QUERY_PLAN_POINTS_WEIGHT_SCALE)
+        return LONG_MAX;
 
-    return (long)(points_coverage + (25000LL * tier)); // 2.5% benefit for each higher tier
+    uint64_t wanted_scaled = (uint64_t)points_wanted * QUERY_PLAN_POINTS_WEIGHT_SCALE;
+
+    if(wanted_scaled > UINT64_MAX / QUERY_PLAN_ACCEPTABLE_POINTS_NUMERATOR)
+        return LONG_MAX;
+
+    uint64_t acceptable_scaled =
+        (wanted_scaled * QUERY_PLAN_ACCEPTABLE_POINTS_NUMERATOR + QUERY_PLAN_ACCEPTABLE_POINTS_DENOMINATOR - 1) /
+        QUERY_PLAN_ACCEPTABLE_POINTS_DENOMINATOR;
+
+    if(acceptable_scaled > (uint64_t)LONG_MAX)
+        return LONG_MAX;
+
+    return (long)acceptable_scaled;
+}
+
+static bool query_plan_points_density_is_better(
+    size_t tier, long weight, bool acceptable,
+    size_t best_tier, long best_weight, bool best_acceptable) {
+    if(acceptable) {
+        if(!best_acceptable)
+            return true;
+
+        if(weight < best_weight)
+            return true;
+
+        return weight == best_weight && tier > best_tier;
+    }
+
+    if(best_acceptable)
+        return false;
+
+    if(weight > best_weight)
+        return true;
+
+    return weight == best_weight && tier < best_tier;
 }
 
 static size_t query_metric_best_tier_for_timeframe(QUERY_METRIC *qm, time_t after_wanted, time_t before_wanted, size_t points_wanted) {
     if(unlikely(nd_profile.storage_tiers < 2))
         return 0;
 
-    if(unlikely(after_wanted == before_wanted || points_wanted <= 0))
+    if(unlikely(before_wanted <= after_wanted || points_wanted <= 0))
         return query_metric_first_working_tier(qm);
 
     if(points_wanted < QUERY_PLAN_MIN_POINTS)
         // when selecting tiers, aim for a resolution of at least QUERY_PLAN_MIN_POINTS points
         points_wanted = (before_wanted - after_wanted) > QUERY_PLAN_MIN_POINTS ? QUERY_PLAN_MIN_POINTS : before_wanted - after_wanted;
 
-    time_t min_first_time_s = 0;
-    time_t max_last_time_s = 0;
+    long minimum_acceptable_weight = query_plan_minimum_acceptable_points_weight(points_wanted);
 
-    for(size_t tier = 0; tier < nd_profile.storage_tiers; tier++) {
-        time_t first_time_s = qm->tiers[tier].db_first_time_s;
-        time_t last_time_s  = qm->tiers[tier].db_last_time_s;
-
-        if(!min_first_time_s || (first_time_s && first_time_s < min_first_time_s))
-            min_first_time_s = first_time_s;
-
-        if(!max_last_time_s || (last_time_s && last_time_s > max_last_time_s))
-            max_last_time_s = last_time_s;
-    }
+    size_t best_tier = 0;
+    long best_weight = -LONG_MAX;
+    bool best_acceptable = false;
+    bool found_candidate = false;
 
     for(size_t tier = 0; tier < nd_profile.storage_tiers; tier++) {
 
-        // find the db time-range for this tier for all metrics
-        STORAGE_METRIC_HANDLE *smh = qm->tiers[tier].smh;
-        time_t first_time_s = qm->tiers[tier].db_first_time_s;
-        time_t last_time_s  = qm->tiers[tier].db_last_time_s;
         time_t update_every_s = qm->tiers[tier].db_update_every_s;
 
-        if( !smh ||
-            !first_time_s ||
-            !last_time_s ||
-            !update_every_s ||
-            first_time_s > before_wanted ||
-            last_time_s < after_wanted
-        ) {
+        if(!query_metric_tier_overlaps_timeframe(qm, tier, after_wanted, before_wanted)) {
             qm->tiers[tier].weight = -LONG_MAX;
             continue;
         }
 
-        internal_fatal(first_time_s > before_wanted || last_time_s < after_wanted, "QUERY: invalid db durations");
+        qm->tiers[tier].weight = query_plan_points_density_weight(update_every_s, after_wanted, before_wanted);
+        if(qm->tiers[tier].weight == -LONG_MAX)
+            continue;
 
-        qm->tiers[tier].weight = query_plan_points_coverage_weight(
-            min_first_time_s, max_last_time_s, update_every_s,
-            after_wanted, before_wanted, points_wanted, tier);
-    }
+        bool acceptable = qm->tiers[tier].weight >= minimum_acceptable_weight;
 
-    size_t best_tier = 0;
-    for(size_t tier = 1; tier < nd_profile.storage_tiers; tier++) {
-        if(qm->tiers[tier].weight >= qm->tiers[best_tier].weight)
+        if(!found_candidate ||
+           query_plan_points_density_is_better(
+               tier, qm->tiers[tier].weight, acceptable,
+               best_tier, best_weight, best_acceptable)) {
             best_tier = tier;
-    }
-
-    return best_tier;
-}
-
-static size_t rrddim_find_best_tier_for_timeframe(QUERY_TARGET *qt, time_t after_wanted, time_t before_wanted, size_t points_wanted) {
-    if(unlikely(nd_profile.storage_tiers < 2))
-        return 0;
-
-    if(unlikely(after_wanted == before_wanted || points_wanted <= 0)) {
-        internal_error(true, "QUERY: '%s' has invalid params to tier calculation", qt->id);
-        return 0;
-    }
-
-    long weight[RRD_STORAGE_TIERS];
-
-    // cap at the compile-time maximum to guard the fixed-size weight[] array
-    size_t tiers = MIN(nd_profile.storage_tiers, RRD_STORAGE_TIERS);
-
-    for(size_t tier = 0; tier < tiers; tier++) {
-
-        time_t common_first_time_s = 0;
-        time_t common_last_time_s = 0;
-        time_t common_update_every_s = 0;
-
-        // find the db time-range for this tier for all metrics
-        for(size_t i = 0, used = qt->query.used; i < used ; i++) {
-            QUERY_METRIC *qm = query_metric(qt, i);
-
-            time_t first_time_s = qm->tiers[tier].db_first_time_s;
-            time_t last_time_s  = qm->tiers[tier].db_last_time_s;
-            time_t update_every_s = qm->tiers[tier].db_update_every_s;
-
-            if(!first_time_s || !last_time_s || !update_every_s)
-                continue;
-
-            if(!common_first_time_s)
-                common_first_time_s = first_time_s;
-            else
-                common_first_time_s = MIN(first_time_s, common_first_time_s);
-
-            if(!common_last_time_s)
-                common_last_time_s = last_time_s;
-            else
-                common_last_time_s = MAX(last_time_s, common_last_time_s);
-
-            if(!common_update_every_s)
-                common_update_every_s = update_every_s;
-            else
-                common_update_every_s = MIN(update_every_s, common_update_every_s);
+            best_weight = qm->tiers[tier].weight;
+            best_acceptable = acceptable;
+            found_candidate = true;
         }
-
-        weight[tier] = query_plan_points_coverage_weight(common_first_time_s, common_last_time_s, common_update_every_s, after_wanted, before_wanted, points_wanted, tier);
     }
 
-    size_t best_tier = 0;
-    for(size_t tier = 1; tier < tiers; tier++) {
-        if(weight[tier] >= weight[best_tier])
-            best_tier = tier;
-    }
-
-    if(weight[best_tier] == -LONG_MAX)
-        best_tier = 0;
-
-    return best_tier;
+    return found_candidate ? best_tier : query_metric_first_working_tier(qm);
 }
 
-time_t rrdset_find_natural_update_every_for_timeframe(QUERY_TARGET *qt, time_t after_wanted, time_t before_wanted, size_t points_wanted, RRDR_OPTIONS options, size_t tier) {
-    size_t best_tier;
-    if((options & RRDR_OPTION_SELECTED_TIER) && tier < nd_profile.storage_tiers)
-        best_tier = tier;
-    else
-        best_tier = rrddim_find_best_tier_for_timeframe(qt, after_wanted, before_wanted, points_wanted);
+time_t query_target_min_update_every_for_tier(QUERY_TARGET *qt, size_t tier) {
+    if(tier >= nd_profile.storage_tiers)
+        return nd_profile.update_every;
 
     // find the db minimum update every for this tier for all metrics
-    time_t common_update_every_s = nd_profile.update_every;
+    time_t common_update_every_s = 0;
     for(size_t i = 0, used = qt->query.used; i < used ; i++) {
         QUERY_METRIC *qm = query_metric(qt, i);
 
-        time_t update_every_s = qm->tiers[best_tier].db_update_every_s;
+        time_t update_every_s = qm->tiers[tier].db_update_every_s;
+        if(!update_every_s)
+            continue;
 
-        if(!i)
+        if(!common_update_every_s)
             common_update_every_s = update_every_s;
         else
             common_update_every_s = MIN(update_every_s, common_update_every_s);
     }
 
-    return common_update_every_s;
+    return common_update_every_s ? common_update_every_s : nd_profile.update_every;
+}
+
+static void query_plan_unittest_set_tier(
+    QUERY_METRIC *qm, size_t tier, time_t first_time_s, time_t last_time_s, time_t update_every_s) {
+    static char smh_stub;
+
+    qm->tiers[tier].smh = (STORAGE_METRIC_HANDLE *)&smh_stub;
+    qm->tiers[tier].db_first_time_s = first_time_s;
+    qm->tiers[tier].db_last_time_s = last_time_s;
+    qm->tiers[tier].db_update_every_s = update_every_s;
+}
+
+static int query_plan_unittest_expect_best_tier(
+    const char *name, QUERY_METRIC *qm, time_t after, time_t before, size_t points, size_t expected) {
+    size_t got = query_metric_best_tier_for_timeframe(qm, after, before, points);
+    if(got == expected) {
+        fprintf(stderr, "OK query plan tier selection: %s\n", name);
+        return 0;
+    }
+
+    fprintf(stderr,
+            "FAILED query plan tier selection: %s, expected tier %zu, got tier %zu\n",
+            name, expected, got);
+
+    for(size_t tier = 0; tier < nd_profile.storage_tiers; tier++)
+        fprintf(stderr,
+                " tier %zu: first %ld, last %ld, update_every %ld, weight %ld\n",
+                tier,
+                qm->tiers[tier].db_first_time_s,
+                qm->tiers[tier].db_last_time_s,
+                qm->tiers[tier].db_update_every_s,
+                qm->tiers[tier].weight);
+
+    return 1;
+}
+
+static int query_plan_unittest_expect_update_every(QUERY_TARGET *qt, size_t tier, time_t expected) {
+    time_t got = query_target_min_update_every_for_tier(qt, tier);
+    if(got == expected) {
+        fprintf(stderr, "OK query plan selected-tier natural update_every\n");
+        return 0;
+    }
+
+    fprintf(stderr,
+            "FAILED query plan selected-tier natural update_every: expected %ld, got %ld\n",
+            expected, got);
+
+    return 1;
+}
+
+int query_plan_unittest(void) {
+    size_t old_storage_tiers = nd_profile.storage_tiers;
+    time_t old_update_every = nd_profile.update_every;
+    int errors = 0;
+
+    nd_profile.storage_tiers = 3;
+    nd_profile.update_every = 1;
+
+    {
+        QUERY_METRIC qm = {0};
+        query_plan_unittest_set_tier(&qm, 0, 1, 200, 10);
+        query_plan_unittest_set_tier(&qm, 1, 1, 200, 600);
+        query_plan_unittest_set_tier(&qm, 2, 1, 100, 36000);
+
+        errors += query_plan_unittest_expect_best_tier(
+            "sub-resolution window ignores non-overlapping coarser tier", &qm, 103, 108, 5, 0);
+    }
+
+    {
+        QUERY_METRIC qm = {0};
+        query_plan_unittest_set_tier(&qm, 0, 1, 200, 10);
+        query_plan_unittest_set_tier(&qm, 1, 1, 200, 600);
+        query_plan_unittest_set_tier(&qm, 2, 1, 200, 36000);
+
+        errors += query_plan_unittest_expect_best_tier(
+            "sub-resolution window chooses densest overlapping tier", &qm, 103, 108, 5, 0);
+    }
+
+    {
+        QUERY_METRIC qm = {0};
+        query_plan_unittest_set_tier(&qm, 0, 1, 400000, 1);
+        query_plan_unittest_set_tier(&qm, 1, 1, 400000, 600);
+        query_plan_unittest_set_tier(&qm, 2, 1, 400000, 36000);
+
+        errors += query_plan_unittest_expect_best_tier(
+            "50 percent tolerance chooses sparsest acceptable tier", &qm, 1000, 301000, 500, 1);
+    }
+
+    {
+        QUERY_METRIC qm = {0};
+        query_plan_unittest_set_tier(&qm, 0, 1, 1000, 10);
+        query_plan_unittest_set_tier(&qm, 1, 1, 1000, 600);
+        query_plan_unittest_set_tier(&qm, 2, 1, 1000, 36000);
+
+        errors += query_plan_unittest_expect_best_tier(
+            "under-resolution request chooses densest tier", &qm, 100, 700, 600, 0);
+    }
+
+    {
+        QUERY_METRIC qm = {0};
+        query_plan_unittest_set_tier(&qm, 0, 1, 50, 10);
+        query_plan_unittest_set_tier(&qm, 1, 100, 200, 600);
+        query_plan_unittest_set_tier(&qm, 2, 1, 50, 36000);
+
+        errors += query_plan_unittest_expect_best_tier(
+            "zero-overlap tiers are not candidates", &qm, 103, 108, 5, 1);
+    }
+
+    {
+        QUERY_METRIC metrics[2] = {0};
+        QUERY_TARGET qt = {0};
+
+        metrics[0].tiers[1].db_update_every_s = 600;
+        metrics[1].tiers[1].db_update_every_s = 300;
+        qt.query.array = metrics;
+        qt.query.used = 2;
+
+        errors += query_plan_unittest_expect_update_every(&qt, 1, 300);
+    }
+
+    nd_profile.storage_tiers = old_storage_tiers;
+    nd_profile.update_every = old_update_every;
+
+    return errors;
 }
 
 static size_t query_planer_expand_duration_in_points(time_t this_update_every, time_t next_update_every) {

--- a/src/web/api/queries/query-window.c
+++ b/src/web/api/queries/query-window.c
@@ -131,9 +131,9 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
     rrdr_relative_window_to_absolute_query(&after_wanted, &before_wanted, NULL, unittest_running);
     query_debug_log(":relative2absolute after %ld, before %ld", after_wanted, before_wanted);
 
-    if (natural_points && (options & RRDR_OPTION_SELECTED_TIER) && tier > 0 && nd_profile.storage_tiers > 1) {
-        update_every = rrdset_find_natural_update_every_for_timeframe(
-                qt, after_wanted, before_wanted, points_wanted, options, tier);
+    if (natural_points && (options & RRDR_OPTION_SELECTED_TIER) &&
+        tier > 0 && tier < nd_profile.storage_tiers && nd_profile.storage_tiers > 1) {
+        update_every = query_target_min_update_every_for_tier(qt, tier);
 
         if (update_every <= 0) update_every = qt->db.minimum_latest_update_every_s;
         query_debug_log(":natural update every %ld", update_every);


### PR DESCRIPTION
## Summary

- Fix automatic storage-tier selection for query windows shorter than the tier resolution.
- Score only tiers that overlap the requested effective window.
- Use fixed-point point-density scoring so sub-resolution windows keep ordering instead of collapsing to zero.
- Remove the dormant aggregate natural-points auto-tier path and keep selected-tier natural update-every calculation explicit.

## Root cause

The automatic tier selector assigned the same sentinel score to overlapping tiers with zero integer points and to non-overlapping tiers. A tie-break then favored the highest-numbered tier. For a narrow historical window this could select a non-covering coarse tier, so no storage query was initialized and the response was empty.

## Validation

- `git diff --check -- src/daemon/main.c src/web/api/queries/query-internal.h src/web/api/queries/query-plan.c src/web/api/queries/query-window.c .agents/sow/current/SOW-0016-20260510-collector-taxonomy-unification.md .agents/sow/done/SOW-0017-20260516-query-duration-below-collection-frequency.md .agents/sow/specs/query-planner-tier-selection.md`
- `cmake -S . -B .local/build-sow17 -G Ninja -DENABLE_SENTRY=OFF -DENABLE_ML=OFF -DENABLE_PLUGIN_XENSTAT=OFF -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build .local/build-sow17 --target netdata -j 8`
- `.local/build-sow17/netdata -W queryplantest`
- `./install.sh`
- `/usr/sbin/netdata -W queryplantest`
- Live `/api/v3/data` check: the original 5-second automatic-tier query now returns 5 points from tier 0.
- SOW audit: SOW-0017 is status/directory consistent; pre-existing unrelated SOW/skill warnings remain.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix automatic storage-tier selection for sub-resolution query windows so narrow requests return data from a covering tier instead of empty or the wrong tier. Selection now uses overlapping-tier point density across `/api/v1|v2|v3/data` and related paths.

- **Bug Fixes**
  - Score only overlapping tiers; exclude non-overlapping tiers from candidates.
  - Use fixed-point point-density weights so short windows keep ordering.
  - Selection: pick the sparsest tier meeting ≥50% of requested point density; otherwise pick the densest overlapping tier.
  - Preserve explicit `tier=` semantics and existing tier-switching behavior.
  - Add `-W queryplantest` unit tests for sub-resolution and edge cases.

- **Refactors**
  - Remove the dormant aggregate auto-tier path; delete the old helper and shared weight function.
  - Replace natural-points update-every with `query_target_min_update_every_for_tier()` for a selected tier; update `query-window` to use it.

<sup>Written for commit 4481a03893f8d711527ed7f1d059585b22e9538a. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22494?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

