### PR TITLE
Avoid returning uninitialized packet_id on ACLK publish failure

### DIFF
--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -25,7 +25,7 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
 #ifndef ACLK_LOG_CONVERSATION_DIR
     UNUSED(msgname);
 #endif
-    uint16_t packet_id;
+    uint16_t packet_id = 0;
     const char *topic = aclk_get_topic(subtopic);
 
     if (unlikely(!topic)) {
@@ -33,7 +33,9 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
         return 0;
     }
 
-    mqtt_wss_publish5(client, (char *)topic, NULL, msg, &freez_aclk_publish5a, msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
+    int rc = mqtt_wss_publish5(client, (char *)topic, NULL, msg, &freez_aclk_publish5a, msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
+    if (rc != MQTT_WSS_OK)
+        packet_id = 0;
 
     if (aclklog_enabled) {
         char *json = protomsg_to_json(msg, msg_len, msgname);
@@ -47,7 +49,7 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
 #define V2_BIN_PAYLOAD_SEPARATOR "\x0D\x0A\x0D\x0A"
 static short aclk_send_message_with_bin_payload(mqtt_wss_client client, json_object *msg, const char *topic, const void *payload, size_t payload_len)
 {
-    uint16_t packet_id;
+    uint16_t packet_id = 0;
     const char *str;
     char *full_msg = NULL;
     size_t len;

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -33,15 +33,15 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
         return 0;
     }
 
-    int rc = mqtt_wss_publish5(client, (char *)topic, NULL, msg, &freez_aclk_publish5a, msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
-    if (rc != MQTT_WSS_OK)
-        packet_id = 0;
-
     if (aclklog_enabled) {
         char *json = protomsg_to_json(msg, msg_len, msgname);
         log_aclk_message_bin(json, strlen(json), 1, topic, msgname);
         freez(json);
     }
+
+    int rc = mqtt_wss_publish5(client, (char *)topic, NULL, msg, &freez_aclk_publish5a, msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
+    if (rc != MQTT_WSS_OK)
+        packet_id = 0;
 
     return packet_id;
 }

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -1311,7 +1311,8 @@ int mqtt_ng_publish(struct mqtt_ng_client *client,
     } else {
         // generator may have written *packet_id before rolling back; clear it so callers
         // don't observe a stale id on failure
-        *packet_id = 0;
+        if (packet_id)
+            *packet_id = 0;
         if (msg_free) {
             // mqtt_ng_generate_publish has no fail_rollback path after frag_set_external_data
             // succeeds, so on non-OK return msg was never linked to a fragment and the rollback

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -1313,8 +1313,11 @@ int mqtt_ng_publish(struct mqtt_ng_client *client,
         // don't observe a stale id on failure
         *packet_id = 0;
         if (msg_free) {
-            // generator rolled back without attaching msg to a fragment; free here so the
-            // publish-layer contract (msg freed on every non-OK return) holds for all callers
+            // mqtt_ng_generate_publish has no fail_rollback path after frag_set_external_data
+            // succeeds, so on non-OK return msg was never linked to a fragment and the rollback
+            // cannot have freed it. Free here to keep the publish-layer contract (msg freed on
+            // every non-OK return) holding for all callers. If a future change adds a fallible
+            // step after frag_set_external_data, this branch will double-free and must be revisited.
             msg_free(msg);
         }
     }

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -1306,8 +1306,13 @@ int mqtt_ng_publish(struct mqtt_ng_client *client,
     }
 
     int rc = TRY_GENERATE_MESSAGE(mqtt_ng_generate_publish, topic, topic_free, msg, msg_free, msg_len, publish_flags, packet_id, topic_id);
-    if (rc == MQTT_NG_MSGGEN_OK)
+    if (rc == MQTT_NG_MSGGEN_OK) {
         add_packet_to_timeout_monitor_list(client, *packet_id);
+    } else if (msg_free) {
+        // generator rolled back without attaching msg to a fragment; free here so the
+        // publish-layer contract (msg freed on every non-OK return) holds for all callers
+        msg_free(msg);
+    }
     return rc;
 }
 

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -1300,6 +1300,8 @@ int mqtt_ng_publish(struct mqtt_ng_client *client,
 
     if (client->max_msg_size && PUBLISH_SP_SIZE + mqtt_ng_publish_size(topic, msg_len, topic_id) > client->max_msg_size) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "Message too big for server: %zu", msg_len);
+        if (packet_id)
+            *packet_id = 0;
         if (msg_free)
             msg_free(msg);
         return MQTT_NG_MSGGEN_MSG_TOO_BIG;

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -1308,10 +1308,15 @@ int mqtt_ng_publish(struct mqtt_ng_client *client,
     int rc = TRY_GENERATE_MESSAGE(mqtt_ng_generate_publish, topic, topic_free, msg, msg_free, msg_len, publish_flags, packet_id, topic_id);
     if (rc == MQTT_NG_MSGGEN_OK) {
         add_packet_to_timeout_monitor_list(client, *packet_id);
-    } else if (msg_free) {
-        // generator rolled back without attaching msg to a fragment; free here so the
-        // publish-layer contract (msg freed on every non-OK return) holds for all callers
-        msg_free(msg);
+    } else {
+        // generator may have written *packet_id before rolling back; clear it so callers
+        // don't observe a stale id on failure
+        *packet_id = 0;
+        if (msg_free) {
+            // generator rolled back without attaching msg to a fragment; free here so the
+            // publish-layer contract (msg freed on every non-OK return) holds for all callers
+            msg_free(msg);
+        }
     }
     return rc;
 }


### PR DESCRIPTION
##### Summary
  - `aclk_send_bin_message_subtopic_pid` was returning an uninitialized `packet_id` whenever the MQTT publish failed, since `mqtt_wss_publish5` only writes the out-param on success.
  - That garbage value gets stored as the expected shutdown ack id in `aclk_graceful_disconnect`, and the PUBACK handler compares incoming ids against it — so a random match can falsely
  declare the shutdown ack'd and exit the agent early.
  - Fix: initialize `packet_id` to 0 (the existing "no message" sentinel) and force it back to 0 on any non-OK publish return; same defensive init applied to
  `aclk_send_message_with_bin_payload`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where failed publishes could return an uninitialized or stale `packet_id`, and hardens the publish path to prevent leaks and use-after-free. `packet_id` is now 0 on error (including oversize), logging happens before send, and messages are freed on generator failures.

- **Bug Fixes**
  - `aclk_send_bin_message_subtopic_pid`: initialize `packet_id=0`; reset to 0 when `mqtt_wss_publish5` != `MQTT_WSS_OK`.
  - `aclk_send_message_with_bin_payload`: initialize `packet_id=0`; publish after logging to avoid use-after-free.
  - `mqtt_ng_publish`: on oversized messages or non-OK from `mqtt_ng_generate_publish`, null-check and set `*packet_id=0`; call `msg_free(msg)` on failure; only add to timeout list on success.
  - Prevents false shutdown ACK detection and early exit.

<sup>Written for commit 33bdf6aa65a137c915c6e0cb1d7cf93d3de804bc. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22504?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

