### PR TITLE
Fix dynamic configuration unittest 

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -607,9 +607,17 @@ int netdata_main(int argc, char **argv) {
                         }
                         else if(strcmp(optarg, "dyncfgtest") == 0) {
                             unittest_running = true;
-                            if(unittest_prepare_rrd(&user))
+                            if (sqlite_library_init())
                                 return 1;
-                            return dyncfg_unittest();
+                            rrdlabels_aral_init(false);
+
+                            int rc = unittest_prepare_rrd(&user);
+                            if(!rc)
+                                rc = dyncfg_unittest();
+
+                            sqlite_library_shutdown();
+                            rrdlabels_aral_destroy(false);
+                            return rc;
                         }
                         else if(strncmp(optarg, createdataset_string, strlen(createdataset_string)) == 0) {
                             optarg += strlen(createdataset_string);

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -612,7 +612,7 @@ int netdata_main(int argc, char **argv) {
                             rrdlabels_aral_init(false);
 
                             int rc = unittest_prepare_rrd(&user);
-                            if(!rc)
+                            if (!rc)
                                 rc = dyncfg_unittest();
 
                             sqlite_close_databases();

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -615,6 +615,7 @@ int netdata_main(int argc, char **argv) {
                             if(!rc)
                                 rc = dyncfg_unittest();
 
+                            sqlite_close_databases();
                             sqlite_library_shutdown();
                             rrdlabels_aral_destroy(false);
                             return rc;

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -607,7 +607,7 @@ int netdata_main(int argc, char **argv) {
                         }
                         else if(strcmp(optarg, "dyncfgtest") == 0) {
                             unittest_running = true;
-                            if (sqlite_library_init())
+                            if(sqlite_library_init())
                                 return 1;
                             rrdlabels_aral_init(false);
 


### PR DESCRIPTION
##### Summary
- Ensure proper initialization (sqlite, rrdlabels) and cleanup (sqlite, rrdlabels) around `unittest_prepare_rrd` and `dyncfg_unittest`.
- prevents crash
   ```
   src/libnetdata/aral/aral.c:886
   886	    __atomic_add_fetch(&ar->ops[idx].atomic.allocators, 1, __ATOMIC_RELAXED);
   ```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `--dyncfgtest` by initializing SQLite and rrdlabels before tests and always cleaning up afterward. `dyncfg_unittest()` now runs only if RRD preparation succeeds.

- **Bug Fixes**
  - Initialize with `sqlite_library_init()` and `rrdlabels_aral_init(false)` before tests.
  - Prepare RRD with `unittest_prepare_rrd(&user)`; run `dyncfg_unittest()` only on success and return the failing step’s code.
  - Always clean up with `sqlite_close_databases()`, `sqlite_library_shutdown()`, and `rrdlabels_aral_destroy(false)`.

<sup>Written for commit 5927095b1ef4f7567f755e2dfd57cad09636173e. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22506?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

