### PR TITLE
Fix pipe cleanup logic during shutdown to handle ENOENT case

### DIFF
--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -326,8 +326,11 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
         netdata_log_error("EXIT: cannot unlink pidfile '%s'.", pidfile);
 
     // unlink the pipe
+    // libuv's uv__pipe_close() already unlinks it when commands_exit() runs
+    // (signal-handler path); for other exit paths the command thread keeps
+    // running and we must clean it up here. ENOENT just means libuv beat us.
     const char *pipe = daemon_pipename();
-    if(pipe && *pipe && unlink(pipe) != 0)
+    if(pipe && *pipe && unlink(pipe) != 0 && errno != ENOENT)
         netdata_log_error("EXIT: cannot unlink netdatacli socket file '%s'.", pipe);
 
     watcher_step_complete(WATCHER_STEP_ID_REMOVE_PID_FILE);

--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -326,9 +326,10 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
         netdata_log_error("EXIT: cannot unlink pidfile '%s'.", pidfile);
 
     // unlink the pipe
-    // libuv's uv__pipe_close() already unlinks it when commands_exit() runs
-    // (signal-handler path); for other exit paths the command thread keeps
-    // running and we must clean it up here. ENOENT just means libuv beat us.
+    // During the commands_exit() signal-handler path, libuv may already
+    // have unlinked the pipe on close. For other exit paths the command
+    // thread keeps running and we must clean it up here. ENOENT just means
+    // libuv beat us to removing it.
     const char *pipe = daemon_pipename();
     if(pipe && *pipe && unlink(pipe) != 0 && errno != ENOENT)
         netdata_log_error("EXIT: cannot unlink netdatacli socket file '%s'.", pipe);


### PR DESCRIPTION
##### Summary
-  Updated `unlink()` logic to avoid logging errors when the pipe is already removed by libuv in certain exit paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop logging false errors when unlinking the `netdatacli` pipe during shutdown. We now ignore ENOENT since libuv may have already removed the socket on some exit paths; other unlink failures still log.

<sup>Written for commit 228730ae65b6c6314c88a47c35f78cc904bfd0a0. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22509?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

