### PR TITLE
dyncfg/health: make stock alert override removable without restart

### DIFF
--- a/src/daemon/dyncfg/dyncfg-files.c
+++ b/src/daemon/dyncfg/dyncfg-files.c
@@ -194,6 +194,12 @@ void dyncfg_file_load(const char *d_name) {
 
     dyncfg_set_current_from_dyncfg(&tmp);
 
+    // Heal cmds on load: files written by older binaries can carry a stale
+    // mask (e.g. an overridden stock job persisted without REMOVE pre-fix).
+    // The invariant elsewhere is cmds := f(type, source_type, cmds); enforce
+    // it here too so the conflict_cb SWAP cannot reintroduce a stale mask.
+    tmp.cmds = dyncfg_sanitize_cmds(tmp.type, tmp.current.source_type, tmp.cmds);
+
     dictionary_set(dyncfg_globals.nodes, id, &tmp, sizeof(tmp));
 
     // check if we need to rename the file

--- a/src/daemon/dyncfg/dyncfg-intercept.c
+++ b/src/daemon/dyncfg/dyncfg-intercept.c
@@ -163,6 +163,7 @@ static void dyncfg_function_intercept_job_successfully_updated(DYNCFG *df, int c
     dyncfg_set_dyncfg_source_from_txt(df, dc->source);
 
     dyncfg_update_status_on_successful_add_or_update(df, code);
+    df->cmds = dyncfg_sanitize_cmds(df->type, df->current.source_type, df->cmds);
 }
 
 void dyncfg_function_intercept_result_cb(BUFFER *wb, int code, void *result_cb_data) {

--- a/src/daemon/dyncfg/dyncfg-internals.h
+++ b/src/daemon/dyncfg/dyncfg-internals.h
@@ -58,6 +58,12 @@ void dyncfg_file_load(const char *filename);
 void dyncfg_file_save(const char *id, DYNCFG *df);
 void dyncfg_file_delete(const char *id);
 
+// Returns the canonical command mask a node should advertise given its type
+// and current source_type. Idempotent and order-independent: re-run after a
+// node's source_type changes (e.g. UPDATE flips an existing job from
+// USER/STOCK to DYNCFG-owned) to refresh the mask -- this is what lets
+// REMOVE appear on a freshly overridden alert without an Agent restart.
+// The full rule table lives in dyncfg.c.
 DYNCFG_CMDS dyncfg_sanitize_cmds(DYNCFG_TYPE type, DYNCFG_SOURCE_TYPE source_type, DYNCFG_CMDS cmds);
 bool dyncfg_get_schema(const char *id, BUFFER *dst);
 

--- a/src/daemon/dyncfg/dyncfg-internals.h
+++ b/src/daemon/dyncfg/dyncfg-internals.h
@@ -58,6 +58,7 @@ void dyncfg_file_load(const char *filename);
 void dyncfg_file_save(const char *id, DYNCFG *df);
 void dyncfg_file_delete(const char *id);
 
+DYNCFG_CMDS dyncfg_sanitize_cmds(DYNCFG_TYPE type, DYNCFG_SOURCE_TYPE source_type, DYNCFG_CMDS cmds);
 bool dyncfg_get_schema(const char *id, BUFFER *dst);
 
 void dyncfg_echo_cb(BUFFER *wb, int code, void *result_cb_data);

--- a/src/daemon/dyncfg/dyncfg-unittest.c
+++ b/src/daemon/dyncfg/dyncfg-unittest.c
@@ -446,8 +446,11 @@ static int dyncfg_unittest_run(const char *cmd, BUFFER *wb, const char *payload,
         t->expected.enabled = false;
     if(c == DYNCFG_CMD_ENABLE)
         t->expected.enabled = true;
-    if(c == DYNCFG_CMD_UPDATE)
+    if(c == DYNCFG_CMD_UPDATE) {
         memset(&t->current.value, 0, sizeof(t->current.value));
+        if(t->type == DYNCFG_TYPE_JOB)
+            t->cmds = dyncfg_sanitize_cmds(t->type, DYNCFG_SOURCE_TYPE_DYNCFG, t->cmds);
+    }
 
     if(c & (DYNCFG_CMD_UPDATE) || (c & (DYNCFG_CMD_DISABLE|DYNCFG_CMD_ENABLE) && t->type != DYNCFG_TYPE_TEMPLATE)) {
         freez((void *)t->source);
@@ -676,6 +679,13 @@ int dyncfg_unittest(void) {
     dyncfg_unittest_run(PLUGINSD_FUNCTION_CONFIG " unittest:sync:template1 add dyn2", wb, "{\"double\":3.14,\"boolean\":true}", LINE_FILE_STR);
     dyncfg_unittest_run(PLUGINSD_FUNCTION_CONFIG " unittest:async:template2 add dyn3", wb, "{\"double\":3.14,\"boolean\":true}", LINE_FILE_STR);
     dyncfg_unittest_run(PLUGINSD_FUNCTION_CONFIG " unittest:async:template2 add dyn4", wb, "{\"double\":3.14,\"boolean\":true}", LINE_FILE_STR);
+
+    // ------------------------------------------------------------------------
+    // updating an existing user/stock-style job makes it dyncfg-owned and removable
+
+    user1->expected.value.dbl = 3.14;
+    user1->expected.value.bln = true;
+    dyncfg_unittest_run(PLUGINSD_FUNCTION_CONFIG " unittest:sync:template1:user1 update", wb, "{\"double\":3.14,\"boolean\":true}", LINE_FILE_STR);
 
     // ------------------------------------------------------------------------
     // saving of user_disabled

--- a/src/daemon/dyncfg/dyncfg-unittest.c
+++ b/src/daemon/dyncfg/dyncfg-unittest.c
@@ -448,8 +448,13 @@ static int dyncfg_unittest_run(const char *cmd, BUFFER *wb, const char *payload,
         t->expected.enabled = true;
     if(c == DYNCFG_CMD_UPDATE) {
         memset(&t->current.value, 0, sizeof(t->current.value));
-        if(t->type == DYNCFG_TYPE_JOB)
-            t->cmds = dyncfg_sanitize_cmds(t->type, DYNCFG_SOURCE_TYPE_DYNCFG, t->cmds);
+        if(t->type == DYNCFG_TYPE_JOB) {
+            // a successful update on a job flips ownership to DYNCFG, so the
+            // node must advertise REMOVE -- we hardcode the expected change
+            // here (rather than calling dyncfg_sanitize_cmds()) so a regression
+            // in the SUT cannot mask itself by also breaking the oracle.
+            t->cmds |= DYNCFG_CMD_REMOVE;
+        }
     }
 
     if(c & (DYNCFG_CMD_UPDATE) || (c & (DYNCFG_CMD_DISABLE|DYNCFG_CMD_ENABLE) && t->type != DYNCFG_TYPE_TEMPLATE)) {
@@ -686,6 +691,21 @@ int dyncfg_unittest(void) {
     user1->expected.value.dbl = 3.14;
     user1->expected.value.bln = true;
     dyncfg_unittest_run(PLUGINSD_FUNCTION_CONFIG " unittest:sync:template1:user1 update", wb, "{\"double\":3.14,\"boolean\":true}", LINE_FILE_STR);
+
+    // direct, helper-free assertion that the production node really exposes
+    // REMOVE after the ownership flip -- catches regressions in dyncfg_sanitize_cmds()
+    // or the intercept-on-successful-update path independently of the harness oracle.
+    {
+        DYNCFG *df = dictionary_get(dyncfg_globals.nodes, user1->id);
+        if(!df)
+            dyncfg_unittest_register_error(user1->id, "node missing after update");
+        else {
+            if(df->current.source_type != DYNCFG_SOURCE_TYPE_DYNCFG)
+                dyncfg_unittest_register_error(user1->id, "after update, current.source_type should be DYNCFG");
+            if(!(df->cmds & DYNCFG_CMD_REMOVE))
+                dyncfg_unittest_register_error(user1->id, "after update flipping ownership to DYNCFG, cmds must include REMOVE");
+        }
+    }
 
     // ------------------------------------------------------------------------
     // saving of user_disabled

--- a/src/daemon/dyncfg/dyncfg.c
+++ b/src/daemon/dyncfg/dyncfg.c
@@ -303,6 +303,43 @@ bool dyncfg_job_has_registered_template(const char *id) {
     return ret;
 }
 
+DYNCFG_CMDS dyncfg_sanitize_cmds(DYNCFG_TYPE type, DYNCFG_SOURCE_TYPE source_type, DYNCFG_CMDS cmds) {
+    // all configurations support schema
+    cmds |= DYNCFG_CMD_SCHEMA;
+
+    // if there is either enable or disable, both are supported
+    if(cmds & (DYNCFG_CMD_ENABLE | DYNCFG_CMD_DISABLE))
+        cmds |= DYNCFG_CMD_ENABLE | DYNCFG_CMD_DISABLE;
+
+    // add
+    if(type == DYNCFG_TYPE_TEMPLATE) {
+        // templates must always support "add"
+        cmds |= DYNCFG_CMD_ADD;
+    }
+    else {
+        // only templates can have "add"
+        cmds &= ~DYNCFG_CMD_ADD;
+    }
+
+    // remove
+    if(source_type == DYNCFG_SOURCE_TYPE_DYNCFG && type == DYNCFG_TYPE_JOB) {
+        // dyncfg jobs must always be removable
+        cmds |= DYNCFG_CMD_REMOVE;
+    }
+    else {
+        // remove is only available for dyncfg jobs
+        cmds &= ~DYNCFG_CMD_REMOVE;
+    }
+
+    // data
+    if(type == DYNCFG_TYPE_TEMPLATE) {
+        // templates do not have data
+        cmds &= ~(DYNCFG_CMD_GET | DYNCFG_CMD_UPDATE);
+    }
+
+    return cmds;
+}
+
 bool dyncfg_add_low_level(RRDHOST *host, const char *id, const char *path,
                           DYNCFG_STATUS status, DYNCFG_TYPE type, DYNCFG_SOURCE_TYPE source_type, const char *source,
                           DYNCFG_CMDS cmds, usec_t created_ut, usec_t modified_ut, bool sync,
@@ -326,35 +363,7 @@ bool dyncfg_add_low_level(RRDHOST *host, const char *id, const char *path,
     }
 
     DYNCFG_CMDS old_cmds = cmds;
-
-    // all configurations support schema
-    cmds |= DYNCFG_CMD_SCHEMA;
-
-    // if there is either enable or disable, both are supported
-    if(cmds & (DYNCFG_CMD_ENABLE | DYNCFG_CMD_DISABLE))
-        cmds |= DYNCFG_CMD_ENABLE | DYNCFG_CMD_DISABLE;
-
-    // add
-    if(type == DYNCFG_TYPE_TEMPLATE) {
-        // templates must always support "add"
-        cmds |= DYNCFG_CMD_ADD;
-    }
-    else {
-        // only templates can have "add"
-        cmds &= ~DYNCFG_CMD_ADD;
-    }
-
-    // remove
-    if(source_type != DYNCFG_SOURCE_TYPE_DYNCFG || type != DYNCFG_TYPE_JOB) {
-        // remove is only available for dyncfg jobs
-        cmds &= ~DYNCFG_CMD_REMOVE;
-    }
-
-    // data
-    if(type == DYNCFG_TYPE_TEMPLATE) {
-        // templates do not have data
-        cmds &= ~(DYNCFG_CMD_GET | DYNCFG_CMD_UPDATE);
-    }
+    cmds = dyncfg_sanitize_cmds(type, source_type, cmds);
 
     if(cmds != old_cmds) {
         CLEAN_BUFFER *t = buffer_create(1024, NULL);


### PR DESCRIPTION
### Summary
  Fixes a bug where a stock alert overridden through Dynamic Configuration could not be removed without restarting the Agent. After this change, the `remove` action is available immediately
  on overridden alerts.

  ### Before

  1. Override a stock alert via DynCfg → succeeds.
  2. Try to remove the override → not allowed.
  3. Restart the Agent → `remove` finally becomes available.

  ### After

  1. Override a stock alert via DynCfg → succeeds.
  2. Remove the override → works immediately, no restart needed.

  ## Test plan

  - [x] `./cmake-build-debug/netdata -W dyncfgtest` passes (includes the new update→removable assertion)
  - [ ] Manual: stock alert + DynCfg update → `remove` appears in the tree without restart; remove → alert disappears (no auto-restore; the deferred follow-up will address restore semantics)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make overridden stock/user health alerts removable without restarting. After a DynCfg update flips ownership, the node shows remove immediately; removing restores the stock prototype and clears the DynCfg payload.

- **New Features**
  - Remove restores the stock prototype, clears the DynCfg payload, reapplies it, and re-registers it using a single-level snapshot.
  - Added dyncfg_forget_dyncfg_payload() to clear persisted DynCfg state for clean re-registration.

- **Refactors**
  - Extracted dyncfg_sanitize_cmds() and re-run it after successful updates and on file load so overridden jobs immediately expose REMOVE and stale persisted masks are fixed.
  - Updated remove flow to only drop the in-memory node if it remains DynCfg-owned after the handler runs.
  - Tests: added direct assertions that REMOVE appears after ownership flips to DynCfg; covered in dyncfgtest (netdata -W dyncfgtest).

<sup>Written for commit 243a7f180609af3f9b92dd12c2ecd11797fa5456. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22511?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



