### PR TITLE
Protect v2 journal populate walk from SIGBUS

### DIFF
--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1067,10 +1067,24 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
     // pattern as journalfile_v2_validate() in journalfile_v2_load().
     PROTECTED_ACCESS_SETUP(data_start, journalfile->mmap.size, path_v2, "mrg-load");
     if(no_signal_received) {
-        if (journalfile->v2.flags & JOURNALFILE_FLAG_METRIC_CRC_CHECK) {
+        // Validate header-controlled offsets against the actual mapping size
+        // BEFORE reading through them. PROTECTED_ACCESS_SETUP only catches
+        // faults whose address falls within [data_start, data_start+mmap.size);
+        // an over-read driven by a corrupted offset past the registered range
+        // would not be recovered and the process would still abort. Out-of-
+        // range offsets are treated as a rebuild trigger (same outcome as a
+        // CRC failure).
+        size_t mmap_size = journalfile->mmap.size;
+        size_t metric_list_bytes = (size_t)j2_header->metric_count * sizeof(struct journal_metric_list);
+        if ((size_t)j2_header->metric_offset > mmap_size ||
+            metric_list_bytes > mmap_size - (size_t)j2_header->metric_offset ||
+            (size_t)j2_header->metric_trailer_offset > mmap_size - sizeof(struct journal_v2_block_trailer)) {
+            // header offsets out of range -- needs rebuild
+            failed = true;
+        }
+        else if (journalfile->v2.flags & JOURNALFILE_FLAG_METRIC_CRC_CHECK) {
             journalfile->v2.flags &= ~JOURNALFILE_FLAG_METRIC_CRC_CHECK;
             if (journalfile_check_v2_metric_list(data_start, j2_header->journal_v2_file_size)) {
-                journalfile->v2.flags &= ~JOURNALFILE_FLAG_IS_AVAILABLE;
                 // needs rebuild
                 failed = true;
             }
@@ -1101,23 +1115,25 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
         }
     }
     else {
-        // SIGBUS/SIGSEGV inside the mmap walk -- mark the file as not-available
-        // so the next pass rebuilds it. The PROTECTED_ACCESS_SETUP macro
-        // already rate-limits the error log.
-        journalfile->v2.flags &= ~JOURNALFILE_FLAG_IS_AVAILABLE;
+        // SIGBUS/SIGSEGV inside the mmap walk. The PROTECTED_ACCESS_SETUP
+        // macro already rate-limits the error log.
         failed = true;
     }
 
     journalfile_v2_data_release(journalfile);
 
     if (unlikely(failed)) {
-        // The journalfile is marked not-available but its fd/mmap are still
-        // bound and it is still registered in njfv2idx. If we leave it in this
-        // state, journalfile_close()/journalfile_destroy_unsafe() will skip
-        // journalfile_v2_data_unmap_permanently() (they gate on IS_AVAILABLE)
-        // and the rebuild path's journalfile_v2_data_set() will overwrite the
-        // fd/mmap and add a second njfv2idx entry. Tear it down now so a
-        // subsequent rebuild starts from a clean slate.
+        // Single point for the not-available transition: clear IS_AVAILABLE
+        // under the data spinlock, then unmap permanently. Without
+        // unmap_permanently, the fd/mmap stay bound and the journalfile
+        // stays in njfv2idx; later teardown (journalfile_close /
+        // journalfile_destroy_unsafe) gates the unmap on IS_AVAILABLE and
+        // would skip it, leaving a dangling index entry, an unclosed fd, and
+        // an unmapped region. Centralizing here keeps the CRC, bounds, and
+        // signal-recovery paths in lockstep.
+        spinlock_lock(&journalfile->data_spinlock);
+        journalfile->v2.flags &= ~JOURNALFILE_FLAG_IS_AVAILABLE;
+        spinlock_unlock(&journalfile->data_spinlock);
         journalfile_v2_data_unmap_permanently(journalfile);
         return;
     }

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1075,9 +1075,13 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
         // range offsets are treated as a rebuild trigger (same outcome as a
         // CRC failure).
         size_t mmap_size = journalfile->mmap.size;
-        size_t metric_list_bytes = (size_t)j2_header->metric_count * sizeof(struct journal_metric_list);
+        // Order matters: short-circuit on metric_offset > mmap_size first so the
+        // subtraction below cannot underflow, then compare metric_count against
+        // the available slot capacity via division rather than multiplying out
+        // metric_count * sizeof(...), which would wrap size_t on 32-bit builds
+        // and silently pass a malformed header.
         if ((size_t)j2_header->metric_offset > mmap_size ||
-            metric_list_bytes > mmap_size - (size_t)j2_header->metric_offset ||
+            (size_t)j2_header->metric_count > (mmap_size - (size_t)j2_header->metric_offset) / sizeof(struct journal_metric_list) ||
             (size_t)j2_header->metric_trailer_offset > mmap_size - sizeof(struct journal_v2_block_trailer)) {
             // header offsets out of range -- needs rebuild
             failed = true;

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -497,6 +497,7 @@ static void journalfile_v2_data_unmap_permanently(struct rrdengine_journalfile *
             journalfile->v2.first_time_s = 0;
             journalfile->v2.last_time_s = 0;
             journalfile->v2.flags = 0;
+            has_references = false;
         }
         else {
             has_references = true;

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1110,8 +1110,17 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
 
     journalfile_v2_data_release(journalfile);
 
-    if (unlikely(failed))
+    if (unlikely(failed)) {
+        // The journalfile is marked not-available but its fd/mmap are still
+        // bound and it is still registered in njfv2idx. If we leave it in this
+        // state, journalfile_close()/journalfile_destroy_unsafe() will skip
+        // journalfile_v2_data_unmap_permanently() (they gate on IS_AVAILABLE)
+        // and the rebuild path's journalfile_v2_data_set() will overwrite the
+        // fd/mmap and add a second njfv2idx entry. Tear it down now so a
+        // subsequent rebuild starts from a clean slate.
+        journalfile_v2_data_unmap_permanently(journalfile);
         return;
+    }
 
     __atomic_add_fetch(&ctx->atomic.samples, journal_samples, __ATOMIC_RELAXED);
 

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1079,16 +1079,27 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
         // subtraction below cannot underflow, then compare metric_count against
         // the available slot capacity via division rather than multiplying out
         // metric_count * sizeof(...), which would wrap size_t on 32-bit builds
-        // and silently pass a malformed header.
+        // and silently pass a malformed header. Only after those two checks is
+        // metric_count * sizeof(...) known to fit in size_t, which lets the
+        // trailer-ordering check below compute the expected trailer offset
+        // safely. The on-disk layout (see journalfile_migrate_to_v2_callback)
+        // places the metric-list trailer immediately after the metric list, so
+        // any deviation indicates a corrupted header that would otherwise let
+        // the CRC compare against bytes inside the metric list itself.
         if ((size_t)j2_header->metric_offset > mmap_size ||
             (size_t)j2_header->metric_count > (mmap_size - (size_t)j2_header->metric_offset) / sizeof(struct journal_metric_list) ||
-            (size_t)j2_header->metric_trailer_offset > mmap_size - sizeof(struct journal_v2_block_trailer)) {
+            (size_t)j2_header->metric_trailer_offset > mmap_size - sizeof(struct journal_v2_block_trailer) ||
+            (size_t)j2_header->metric_trailer_offset != (size_t)j2_header->metric_offset + (size_t)j2_header->metric_count * sizeof(struct journal_metric_list)) {
             // header offsets out of range -- needs rebuild
             failed = true;
         }
         else if (journalfile->v2.flags & JOURNALFILE_FLAG_METRIC_CRC_CHECK) {
             journalfile->v2.flags &= ~JOURNALFILE_FLAG_METRIC_CRC_CHECK;
-            if (journalfile_check_v2_metric_list(data_start, j2_header->journal_v2_file_size)) {
+            // Pass the verified mmap_size, not the header-controlled
+            // j2_header->journal_v2_file_size; the helper currently ignores the
+            // size argument (UNUSED) but the value at the call site should
+            // still reflect the trusted bound for clarity and future-proofing.
+            if (journalfile_check_v2_metric_list(data_start, mmap_size)) {
                 // needs rebuild
                 failed = true;
             }
@@ -1124,20 +1135,24 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
         failed = true;
     }
 
-    journalfile_v2_data_release(journalfile);
-
     if (unlikely(failed)) {
-        // Single point for the not-available transition: clear IS_AVAILABLE
-        // under the data spinlock, then unmap permanently. Without
-        // unmap_permanently, the fd/mmap stay bound and the journalfile
-        // stays in njfv2idx; later teardown (journalfile_close /
-        // journalfile_destroy_unsafe) gates the unmap on IS_AVAILABLE and
-        // would skip it, leaving a dangling index entry, an unclosed fd, and
-        // an unmapped region. Centralizing here keeps the CRC, bounds, and
-        // signal-recovery paths in lockstep.
+        // Clear IS_AVAILABLE under the data spinlock BEFORE releasing our
+        // refcount, so no concurrent journalfile_v2_data_acquire_with_hint()
+        // can succeed and walk the (potentially corrupted) mmap between here
+        // and the permanent unmap. The bounds, CRC, and signal-recovery paths
+        // all converge through this single transition; without it, teardown
+        // (journalfile_close / journalfile_destroy_unsafe) would gate on
+        // IS_AVAILABLE and skip journalfile_v2_data_unmap_permanently(),
+        // leaving a dangling njfv2idx entry, an unclosed fd, and an unmapped
+        // region.
         spinlock_lock(&journalfile->data_spinlock);
         journalfile->v2.flags &= ~JOURNALFILE_FLAG_IS_AVAILABLE;
         spinlock_unlock(&journalfile->data_spinlock);
+    }
+
+    journalfile_v2_data_release(journalfile);
+
+    if (unlikely(failed)) {
         journalfile_v2_data_unmap_permanently(journalfile);
         return;
     }

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1052,47 +1052,61 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
 
     uint8_t *data_start = (uint8_t *)j2_header;
 
-    if (journalfile->v2.flags & JOURNALFILE_FLAG_METRIC_CRC_CHECK) {
-        journalfile->v2.flags &= ~JOURNALFILE_FLAG_METRIC_CRC_CHECK;
-        if (journalfile_check_v2_metric_list(data_start, j2_header->journal_v2_file_size)) {
-            journalfile->v2.flags &= ~JOURNALFILE_FLAG_IS_AVAILABLE;
-            // needs rebuild
-            return;
-        }
-    }
-
     char path_v2[RRDENG_PATH_MAX];
     journalfile_v2_generate_path(journalfile->datafile, path_v2, sizeof(path_v2));
-    time_t global_first_time_s;
+    time_t global_first_time_s = 0;
     bool failed = false;
-    uint32_t entries;
+    uint32_t entries = 0;
     // Calculate number of samples here and update once the file is loaded
     uint64_t journal_samples = 0;
+
+    // Protect the whole walk -- both the optional CRC check and the mrg update
+    // read into the mmap'd v2 journal. If a backing page cannot be paged in
+    // (file truncated, sparse hole, transient I/O error) the kernel raises
+    // SIGBUS; without a protected region active the process aborts. Same
+    // pattern as journalfile_v2_validate() in journalfile_v2_load().
     PROTECTED_ACCESS_SETUP(data_start, journalfile->mmap.size, path_v2, "mrg-load");
     if(no_signal_received) {
-        entries = j2_header->metric_count;
-        struct journal_metric_list *metric = (struct journal_metric_list *) (data_start + j2_header->metric_offset);
-        time_t header_start_time_s  = (time_t) (j2_header->start_time_ut / USEC_PER_SEC);
-        global_first_time_s = header_start_time_s;
-        time_t now_s = max_acceptable_collected_time();
-        for (size_t i=0; i < entries; i++) {
-            time_t start_time_s = header_start_time_s + metric->delta_start_s;
-            time_t end_time_s = header_start_time_s + metric->delta_end_s;
-
-            mrg_update_metric_retention_and_granularity_by_uuid(
-                main_mrg,
-                (Word_t)ctx,
-                &metric->uuid,
-                start_time_s,
-                end_time_s,
-                metric->update_every_s,
-                now_s,
-                &journal_samples);
-
-            metric++;
+        if (journalfile->v2.flags & JOURNALFILE_FLAG_METRIC_CRC_CHECK) {
+            journalfile->v2.flags &= ~JOURNALFILE_FLAG_METRIC_CRC_CHECK;
+            if (journalfile_check_v2_metric_list(data_start, j2_header->journal_v2_file_size)) {
+                journalfile->v2.flags &= ~JOURNALFILE_FLAG_IS_AVAILABLE;
+                // needs rebuild
+                failed = true;
+            }
         }
-    } else
+
+        if (!failed) {
+            entries = j2_header->metric_count;
+            struct journal_metric_list *metric = (struct journal_metric_list *) (data_start + j2_header->metric_offset);
+            time_t header_start_time_s  = (time_t) (j2_header->start_time_ut / USEC_PER_SEC);
+            global_first_time_s = header_start_time_s;
+            time_t now_s = max_acceptable_collected_time();
+            for (size_t i=0; i < entries; i++) {
+                time_t start_time_s = header_start_time_s + metric->delta_start_s;
+                time_t end_time_s = header_start_time_s + metric->delta_end_s;
+
+                mrg_update_metric_retention_and_granularity_by_uuid(
+                    main_mrg,
+                    (Word_t)ctx,
+                    &metric->uuid,
+                    start_time_s,
+                    end_time_s,
+                    metric->update_every_s,
+                    now_s,
+                    &journal_samples);
+
+                metric++;
+            }
+        }
+    }
+    else {
+        // SIGBUS/SIGSEGV inside the mmap walk -- mark the file as not-available
+        // so the next pass rebuilds it. The PROTECTED_ACCESS_SETUP macro
+        // already rate-limits the error log.
+        journalfile->v2.flags &= ~JOURNALFILE_FLAG_IS_AVAILABLE;
         failed = true;
+    }
 
     journalfile_v2_data_release(journalfile);
 

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1089,7 +1089,8 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
         // the CRC compare against bytes inside the metric list itself.
         if ((size_t)j2_header->metric_offset > mmap_size ||
             (size_t)j2_header->metric_count > (mmap_size - (size_t)j2_header->metric_offset) / sizeof(struct journal_metric_list) ||
-            (size_t)j2_header->metric_trailer_offset > mmap_size - sizeof(struct journal_v2_block_trailer) ||
+            (size_t)j2_header->metric_trailer_offset > mmap_size ||
+            mmap_size - (size_t)j2_header->metric_trailer_offset < sizeof(struct journal_v2_block_trailer) ||
             (size_t)j2_header->metric_trailer_offset != (size_t)j2_header->metric_offset + (size_t)j2_header->metric_count * sizeof(struct journal_metric_list)) {
             // header offsets out of range -- needs rebuild
             failed = true;

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1093,6 +1093,15 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
             mmap_size - (size_t)j2_header->metric_trailer_offset < sizeof(struct journal_v2_block_trailer) ||
             (size_t)j2_header->metric_trailer_offset != (size_t)j2_header->metric_offset + (size_t)j2_header->metric_count * sizeof(struct journal_metric_list)) {
             // header offsets out of range -- needs rebuild
+            nd_log_daemon(NDLP_ERR,
+                          "DBENGINE: journal v2 \"%s\" has out-of-range header offsets "
+                          "(metric_offset=%u, metric_count=%u, metric_trailer_offset=%u, mmap_size=%zu); "
+                          "marking unavailable for rebuild",
+                          path_v2,
+                          j2_header->metric_offset,
+                          j2_header->metric_count,
+                          j2_header->metric_trailer_offset,
+                          mmap_size);
             failed = true;
         }
         else if (journalfile->v2.flags & JOURNALFILE_FLAG_METRIC_CRC_CHECK) {

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1066,7 +1066,7 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
     // (file truncated, sparse hole, transient I/O error) the kernel raises
     // SIGBUS; without a protected region active the process aborts. Same
     // pattern as journalfile_v2_validate() in journalfile_v2_load().
-    PROTECTED_ACCESS_SETUP(data_start, journalfile->mmap.size, path_v2, "mrg-load");
+    PROTECTED_ACCESS_SETUP(journalfile->mmap.data, journalfile->mmap.size, path_v2, "mrg-load");
     if(no_signal_received) {
         // Validate header-controlled offsets against the actual mapping size
         // BEFORE reading through them. PROTECTED_ACCESS_SETUP only catches
@@ -1114,16 +1114,25 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
             global_first_time_s = header_start_time_s;
             time_t now_s = max_acceptable_collected_time();
             for (size_t i=0; i < entries; i++) {
+                // Copy uuid out of the mmap onto the stack BEFORE calling mrg.
+                // If a backing page is unreadable, uuid_copy SIGBUSes here and
+                // the protected region recovers cleanly; the mrg call then
+                // never executes. If we passed &metric->uuid into mrg, a
+                // SIGBUS could fire INSIDE mrg while it holds internal locks,
+                // and siglongjmp would skip mrg's unlock paths.
+                nd_uuid_t local_uuid;
+                uuid_copy(local_uuid, metric->uuid);
                 time_t start_time_s = header_start_time_s + metric->delta_start_s;
                 time_t end_time_s = header_start_time_s + metric->delta_end_s;
+                uint32_t update_every_s = metric->update_every_s;
 
                 mrg_update_metric_retention_and_granularity_by_uuid(
                     main_mrg,
                     (Word_t)ctx,
-                    &metric->uuid,
+                    &local_uuid,
                     start_time_s,
                     end_time_s,
-                    metric->update_every_s,
+                    update_every_s,
                     now_s,
                     &journal_samples);
 

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1391,9 +1391,16 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
     journalfile_v2_generate_path(datafile_to_delete, file_path, sizeof(file_path));
 
     struct uuid_first_time_s *uuid_first_t_entry;
-    struct uuid_first_time_s *uuid_first_entry_list = NULL;
-    size_t count = 0;
-    size_t added = 0;
+    // PROTECTED_ACCESS_SETUP below uses sigsetjmp/siglongjmp (see
+    // src/daemon/protected-access.h). Per C11 7.13.2.1, non-volatile locals
+    // that are modified between setjmp and longjmp have indeterminate values
+    // on the recovery path. uuid_first_entry_list / count / added are all
+    // mutated inside the protected region and then read afterwards (the
+    // unconditional log line and the journal_access_failed cleanup loop), so
+    // they must be volatile to keep the recovery path well-defined.
+    struct uuid_first_time_s * volatile uuid_first_entry_list = NULL;
+    volatile size_t count = 0;
+    volatile size_t added = 0;
     bool journal_access_failed = false;
 
     // Protect the mmap walk: reading j2_header->metric_offset, metric_count,

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1387,24 +1387,58 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
 
     __atomic_add_fetch(&rrdeng_cache_efficiency_stats.metrics_retention_started, 1, __ATOMIC_RELAXED);
 
-    struct journal_metric_list *uuid_list = (struct journal_metric_list *)((uint8_t *) j2_header + j2_header->metric_offset);
+    char file_path[RRDENG_PATH_MAX];
+    journalfile_v2_generate_path(datafile_to_delete, file_path, sizeof(file_path));
 
-    size_t count = j2_header->metric_count;
     struct uuid_first_time_s *uuid_first_t_entry;
-    struct uuid_first_time_s *uuid_first_entry_list = callocz(count, sizeof(struct uuid_first_time_s));
-
+    struct uuid_first_time_s *uuid_first_entry_list = NULL;
+    size_t count = 0;
     size_t added = 0;
-    for (size_t index = 0; index < count; ++index) {
-        METRIC *metric = mrg_metric_get_and_acquire_by_uuid(main_mrg, &uuid_list[index].uuid, (Word_t)ctx);
-        if (!metric)
-            continue;
+    bool journal_access_failed = false;
 
-        uuid_first_entry_list[added].metric = metric;
-        uuid_first_entry_list[added].first_time_s = LONG_MAX;
-        uuid_first_entry_list[added].df_matched = 0;
-        uuid_first_entry_list[added].df_index_oldest = 0;
-        uuid_first_entry_list[added].uuid = mrg_metric_uuid(main_mrg, metric);
-        added++;
+    // Protect the mmap walk: reading j2_header->metric_offset, metric_count,
+    // and the per-metric uuid_list[] entries can SIGBUS if the underlying v2
+    // file has any unreadable page (truncated, sparse hole, transient I/O
+    // error). Without a protected region active the process aborts. Same
+    // pattern as find_uuid_first_time() added by commit 26b26ac25a (#22310);
+    // this caller was missed at the time.
+    PROTECTED_ACCESS_SETUP(journalfile->mmap.data, journalfile->mmap.size, file_path, "mrg-retention");
+    if(no_signal_received) {
+        size_t journal_v2_file_size = journalfile->mmap.size;
+        size_t metric_offset = j2_header->metric_offset;
+        count = j2_header->metric_count;
+        size_t metric_list_size;
+        if (__builtin_mul_overflow(count, sizeof(struct journal_metric_list), &metric_list_size) ||
+            metric_offset > journal_v2_file_size ||
+            metric_list_size > journal_v2_file_size - metric_offset) {
+            nd_log_daemon(NDLP_ERR,
+                          "DBENGINE: metric list exceeds journal file size in journalfile \"%s\" "
+                          "(metric_offset=%zu, list_size=%zu, file_size=%zu), skipping retention update",
+                          file_path, metric_offset, metric_list_size, journal_v2_file_size);
+            journal_access_failed = true;
+        }
+        else {
+            struct journal_metric_list *uuid_list = (struct journal_metric_list *)((uint8_t *) j2_header + metric_offset);
+            uuid_first_entry_list = callocz(count, sizeof(struct uuid_first_time_s));
+
+            for (size_t index = 0; index < count; ++index) {
+                METRIC *metric = mrg_metric_get_and_acquire_by_uuid(main_mrg, &uuid_list[index].uuid, (Word_t)ctx);
+                if (!metric)
+                    continue;
+
+                uuid_first_entry_list[added].metric = metric;
+                uuid_first_entry_list[added].first_time_s = LONG_MAX;
+                uuid_first_entry_list[added].df_matched = 0;
+                uuid_first_entry_list[added].df_index_oldest = 0;
+                uuid_first_entry_list[added].uuid = mrg_metric_uuid(main_mrg, metric);
+                added++;
+            }
+        }
+    }
+    else {
+        // SIGBUS/SIGSEGV inside the mmap walk -- bail cleanly. The
+        // PROTECTED_ACCESS_SETUP macro already rate-limits the error log.
+        journal_access_failed = true;
     }
 
     netdata_log_info(
@@ -1414,6 +1448,14 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
         first_datafile_remaining ? first_datafile_remaining->fileno : 0);
 
     journalfile_v2_data_release(journalfile);
+
+    if (unlikely(journal_access_failed)) {
+        // Release any partially-acquired metrics; uuid_first_entry_list may
+        // be NULL (signal received before callocz).
+        for (size_t index = 0; index < added; ++index)
+            mrg_metric_release(main_mrg, uuid_first_entry_list[index].metric);
+        goto done;
+    }
 
     // Update the first time / last time for all metrics we plan to delete
 

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1398,10 +1398,13 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
     // mutated inside the protected region and then read afterwards (the
     // unconditional log line and the journal_access_failed cleanup loop), so
     // they must be volatile to keep the recovery path well-defined.
+    // journal_access_failed is also marked volatile defensively: although it
+    // is only assigned on a path that does not subsequently SIGBUS, future
+    // edits could break that invariant, and the bool is read once on cleanup.
     struct uuid_first_time_s * volatile uuid_first_entry_list = NULL;
     volatile size_t count = 0;
     volatile size_t added = 0;
-    bool journal_access_failed = false;
+    volatile bool journal_access_failed = false;
 
     // Protect the mmap walk: reading j2_header->metric_offset, metric_count,
     // and the per-metric uuid_list[] entries can SIGBUS if the underlying v2
@@ -1415,7 +1418,14 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
         size_t metric_offset = j2_header->metric_offset;
         count = j2_header->metric_count;
         size_t metric_list_size;
+        size_t entry_list_size;
+        // Also check count * sizeof(uuid_first_time_s) -- the allocation below
+        // sizes the working array by count, and on 32-bit builds count can
+        // pass the metric_list_size bound while still overflowing the entry
+        // list multiplication (struct uuid_first_time_s is larger than
+        // struct journal_metric_list).
         if (__builtin_mul_overflow(count, sizeof(struct journal_metric_list), &metric_list_size) ||
+            __builtin_mul_overflow(count, sizeof(struct uuid_first_time_s), &entry_list_size) ||
             metric_offset > journal_v2_file_size ||
             metric_list_size > journal_v2_file_size - metric_offset) {
             nd_log_daemon(NDLP_ERR,

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1439,7 +1439,16 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
             uuid_first_entry_list = callocz(count, sizeof(struct uuid_first_time_s));
 
             for (size_t index = 0; index < count; ++index) {
-                METRIC *metric = mrg_metric_get_and_acquire_by_uuid(main_mrg, &uuid_list[index].uuid, (Word_t)ctx);
+                // Copy uuid out of the mmap onto the stack BEFORE calling mrg.
+                // If a backing page is unreadable, uuid_copy SIGBUSes here and
+                // the protected region recovers cleanly; the mrg call then
+                // never executes. If we passed &uuid_list[index].uuid into
+                // mrg, a SIGBUS could fire INSIDE mrg while it holds internal
+                // locks, and siglongjmp would skip mrg's unlock paths.
+                nd_uuid_t local_uuid;
+                uuid_copy(local_uuid, uuid_list[index].uuid);
+
+                METRIC *metric = mrg_metric_get_and_acquire_by_uuid(main_mrg, &local_uuid, (Word_t)ctx);
                 if (!metric)
                     continue;
 

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1412,59 +1412,71 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
     // error). Without a protected region active the process aborts. Same
     // pattern as find_uuid_first_time() added by commit 26b26ac25a (#22310);
     // this caller was missed at the time.
-    PROTECTED_ACCESS_SETUP(journalfile->mmap.data, journalfile->mmap.size, file_path, "mrg-retention");
-    if(no_signal_received) {
-        size_t journal_v2_file_size = journalfile->mmap.size;
-        size_t metric_offset = j2_header->metric_offset;
-        count = j2_header->metric_count;
-        size_t metric_list_size;
-        size_t entry_list_size;
-        // Also check count * sizeof(uuid_first_time_s) -- the allocation below
-        // sizes the working array by count, and on 32-bit builds count can
-        // pass the metric_list_size bound while still overflowing the entry
-        // list multiplication (struct uuid_first_time_s is larger than
-        // struct journal_metric_list).
-        if (__builtin_mul_overflow(count, sizeof(struct journal_metric_list), &metric_list_size) ||
-            __builtin_mul_overflow(count, sizeof(struct uuid_first_time_s), &entry_list_size) ||
-            metric_offset > journal_v2_file_size ||
-            metric_list_size > journal_v2_file_size - metric_offset) {
-            nd_log_daemon(NDLP_ERR,
-                          "DBENGINE: metric list exceeds journal file size in journalfile \"%s\" "
-                          "(metric_offset=%zu, list_size=%zu, file_size=%zu), skipping retention update",
-                          file_path, metric_offset, metric_list_size, journal_v2_file_size);
-            journal_access_failed = true;
-        }
-        else {
-            struct journal_metric_list *uuid_list = (struct journal_metric_list *)((uint8_t *) j2_header + metric_offset);
-            uuid_first_entry_list = callocz(count, sizeof(struct uuid_first_time_s));
+    // Scope the protected frame tightly to the mmap walk only. The
+    // PROTECTED_ACCESS_AUTO_CLEANUP() guard inside PROTECTED_ACCESS_SETUP
+    // declares a __attribute__((cleanup)) local; when this inner block exits
+    // (normally or via the SIGBUS recovery else-branch falling through), the
+    // cleanup runs and the protected-access depth drops back to its prior
+    // value. Without this scoping, the frame would stay live through the
+    // post-walk log, the data_release, the cleanup loop, the nested
+    // find_uuid_first_time() (which registers its own frame), and the final
+    // cleanup -- masking unrelated faults that might land in the mmap range
+    // and inflating nesting depth unnecessarily.
+    {
+        PROTECTED_ACCESS_SETUP(journalfile->mmap.data, journalfile->mmap.size, file_path, "mrg-retention");
+        if(no_signal_received) {
+            size_t journal_v2_file_size = journalfile->mmap.size;
+            size_t metric_offset = j2_header->metric_offset;
+            count = j2_header->metric_count;
+            size_t metric_list_size;
+            size_t entry_list_size;
+            // Also check count * sizeof(uuid_first_time_s) -- the allocation below
+            // sizes the working array by count, and on 32-bit builds count can
+            // pass the metric_list_size bound while still overflowing the entry
+            // list multiplication (struct uuid_first_time_s is larger than
+            // struct journal_metric_list).
+            if (__builtin_mul_overflow(count, sizeof(struct journal_metric_list), &metric_list_size) ||
+                __builtin_mul_overflow(count, sizeof(struct uuid_first_time_s), &entry_list_size) ||
+                metric_offset > journal_v2_file_size ||
+                metric_list_size > journal_v2_file_size - metric_offset) {
+                nd_log_daemon(NDLP_ERR,
+                              "DBENGINE: metric list exceeds journal file size in journalfile \"%s\" "
+                              "(metric_offset=%zu, list_size=%zu, file_size=%zu), skipping retention update",
+                              file_path, metric_offset, metric_list_size, journal_v2_file_size);
+                journal_access_failed = true;
+            }
+            else {
+                struct journal_metric_list *uuid_list = (struct journal_metric_list *)((uint8_t *) j2_header + metric_offset);
+                uuid_first_entry_list = callocz(count, sizeof(struct uuid_first_time_s));
 
-            for (size_t index = 0; index < count; ++index) {
-                // Copy uuid out of the mmap onto the stack BEFORE calling mrg.
-                // If a backing page is unreadable, uuid_copy SIGBUSes here and
-                // the protected region recovers cleanly; the mrg call then
-                // never executes. If we passed &uuid_list[index].uuid into
-                // mrg, a SIGBUS could fire INSIDE mrg while it holds internal
-                // locks, and siglongjmp would skip mrg's unlock paths.
-                nd_uuid_t local_uuid;
-                uuid_copy(local_uuid, uuid_list[index].uuid);
+                for (size_t index = 0; index < count; ++index) {
+                    // Copy uuid out of the mmap onto the stack BEFORE calling mrg.
+                    // If a backing page is unreadable, uuid_copy SIGBUSes here and
+                    // the protected region recovers cleanly; the mrg call then
+                    // never executes. If we passed &uuid_list[index].uuid into
+                    // mrg, a SIGBUS could fire INSIDE mrg while it holds internal
+                    // locks, and siglongjmp would skip mrg's unlock paths.
+                    nd_uuid_t local_uuid;
+                    uuid_copy(local_uuid, uuid_list[index].uuid);
 
-                METRIC *metric = mrg_metric_get_and_acquire_by_uuid(main_mrg, &local_uuid, (Word_t)ctx);
-                if (!metric)
-                    continue;
+                    METRIC *metric = mrg_metric_get_and_acquire_by_uuid(main_mrg, &local_uuid, (Word_t)ctx);
+                    if (!metric)
+                        continue;
 
-                uuid_first_entry_list[added].metric = metric;
-                uuid_first_entry_list[added].first_time_s = LONG_MAX;
-                uuid_first_entry_list[added].df_matched = 0;
-                uuid_first_entry_list[added].df_index_oldest = 0;
-                uuid_first_entry_list[added].uuid = mrg_metric_uuid(main_mrg, metric);
-                added++;
+                    uuid_first_entry_list[added].metric = metric;
+                    uuid_first_entry_list[added].first_time_s = LONG_MAX;
+                    uuid_first_entry_list[added].df_matched = 0;
+                    uuid_first_entry_list[added].df_index_oldest = 0;
+                    uuid_first_entry_list[added].uuid = mrg_metric_uuid(main_mrg, metric);
+                    added++;
+                }
             }
         }
-    }
-    else {
-        // SIGBUS/SIGSEGV inside the mmap walk -- bail cleanly. The
-        // PROTECTED_ACCESS_SETUP macro already rate-limits the error log.
-        journal_access_failed = true;
+        else {
+            // SIGBUS/SIGSEGV inside the mmap walk -- bail cleanly. The
+            // PROTECTED_ACCESS_SETUP macro already rate-limits the error log.
+            journal_access_failed = true;
+        }
     }
 
     netdata_log_info(

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -1298,62 +1298,78 @@ static void populate_v2_statistics(struct rrdengine_datafile *datafile, RRDENG_S
     if(unlikely(!j2_header))
         return;
 
-    stats->extents += j2_header->extent_count;
+    char file_path[RRDENG_PATH_MAX];
+    journalfile_v2_generate_path(datafile, file_path, sizeof(file_path));
 
-    unsigned entries;
-    struct journal_extent_list *extent_list = (void *) (data_start + j2_header->extent_offset);
-    for (entries = 0; entries < j2_header->extent_count; entries++) {
-        stats->extents_compressed_bytes += extent_list->datafile_size;
-        stats->extents_pages += extent_list->pages;
-        extent_list++;
-    }
+    // Protect the mmap walk: every j2_header->*, extent_list, metric, and
+    // descr access reads the mmap'd v2 journal. If the underlying file has
+    // any unreadable page (truncated, sparse hole, transient I/O error), the
+    // walk SIGBUSes and the process aborts. Same pattern as the sister sites
+    // (populate_retention_to_mrg, find_uuid_first_time, update_metrics_first_time_s).
+    // Partial accumulator increments on signal recovery are acceptable:
+    // size statistics are best-effort across datafiles, the caller continues
+    // to the next datafile in rrdeng_size_statistics().
+    PROTECTED_ACCESS_SETUP(datafile->journalfile->mmap.data, datafile->journalfile->mmap.size, file_path, "size-stats");
+    if(no_signal_received) {
+        stats->extents += j2_header->extent_count;
 
-    struct journal_metric_list *metric = (void *) (data_start + j2_header->metric_offset);
-    time_t journal_start_time_s = (time_t) (j2_header->start_time_ut / USEC_PER_SEC);
-
-    stats->metrics += j2_header->metric_count;
-    for (entries = 0; entries < j2_header->metric_count; entries++) {
-
-        struct journal_page_header *metric_list_header = (void *) (data_start + metric->page_offset);
-        stats->metrics_pages += metric_list_header->entries;
-        struct journal_page_list *descr =  (void *) (data_start + metric->page_offset + sizeof(struct journal_page_header));
-        for (uint32_t idx=0; idx < metric_list_header->entries; idx++) {
-
-            time_t update_every_s;
-
-            size_t points = descr->page_length / CTX_POINT_SIZE_BYTES(datafile_ctx(datafile));
-
-            time_t start_time_s = journal_start_time_s + descr->delta_start_s;
-            time_t end_time_s = journal_start_time_s + descr->delta_end_s;
-
-            if(likely(points > 1))
-                update_every_s = (time_t) ((end_time_s - start_time_s) / (points - 1));
-            else {
-                update_every_s = (time_t) (nd_profile.update_every * get_tier_grouping(datafile_ctx(datafile)->config.tier));
-                stats->single_point_pages++;
-            }
-
-            time_t duration_s = (time_t)((end_time_s - start_time_s + update_every_s));
-
-            stats->pages_uncompressed_bytes += descr->page_length;
-            stats->pages_duration_secs += duration_s;
-            stats->points += points;
-
-            stats->page_types[descr->type].pages++;
-            stats->page_types[descr->type].pages_uncompressed_bytes += descr->page_length;
-            stats->page_types[descr->type].pages_duration_secs += duration_s;
-            stats->page_types[descr->type].points += points;
-
-            if(!stats->first_time_s || (start_time_s - update_every_s) < stats->first_time_s)
-                stats->first_time_s = (start_time_s - update_every_s);
-
-            if(!stats->last_time_s || end_time_s > stats->last_time_s)
-                stats->last_time_s = end_time_s;
-
-            descr++;
+        unsigned entries;
+        struct journal_extent_list *extent_list = (void *) (data_start + j2_header->extent_offset);
+        for (entries = 0; entries < j2_header->extent_count; entries++) {
+            stats->extents_compressed_bytes += extent_list->datafile_size;
+            stats->extents_pages += extent_list->pages;
+            extent_list++;
         }
-        metric++;
+
+        struct journal_metric_list *metric = (void *) (data_start + j2_header->metric_offset);
+        time_t journal_start_time_s = (time_t) (j2_header->start_time_ut / USEC_PER_SEC);
+
+        stats->metrics += j2_header->metric_count;
+        for (entries = 0; entries < j2_header->metric_count; entries++) {
+
+            struct journal_page_header *metric_list_header = (void *) (data_start + metric->page_offset);
+            stats->metrics_pages += metric_list_header->entries;
+            struct journal_page_list *descr =  (void *) (data_start + metric->page_offset + sizeof(struct journal_page_header));
+            for (uint32_t idx=0; idx < metric_list_header->entries; idx++) {
+
+                time_t update_every_s;
+
+                size_t points = descr->page_length / CTX_POINT_SIZE_BYTES(datafile_ctx(datafile));
+
+                time_t start_time_s = journal_start_time_s + descr->delta_start_s;
+                time_t end_time_s = journal_start_time_s + descr->delta_end_s;
+
+                if(likely(points > 1))
+                    update_every_s = (time_t) ((end_time_s - start_time_s) / (points - 1));
+                else {
+                    update_every_s = (time_t) (nd_profile.update_every * get_tier_grouping(datafile_ctx(datafile)->config.tier));
+                    stats->single_point_pages++;
+                }
+
+                time_t duration_s = (time_t)((end_time_s - start_time_s + update_every_s));
+
+                stats->pages_uncompressed_bytes += descr->page_length;
+                stats->pages_duration_secs += duration_s;
+                stats->points += points;
+
+                stats->page_types[descr->type].pages++;
+                stats->page_types[descr->type].pages_uncompressed_bytes += descr->page_length;
+                stats->page_types[descr->type].pages_duration_secs += duration_s;
+                stats->page_types[descr->type].points += points;
+
+                if(!stats->first_time_s || (start_time_s - update_every_s) < stats->first_time_s)
+                    stats->first_time_s = (start_time_s - update_every_s);
+
+                if(!stats->last_time_s || end_time_s > stats->last_time_s)
+                    stats->last_time_s = end_time_s;
+
+                descr++;
+            }
+            metric++;
+        }
     }
+    // On SIGBUS/SIGSEGV the PROTECTED_ACCESS_SETUP macro already
+    // rate-limits the error log; fall through to release the journal.
 
     journalfile_v2_data_release(datafile->journalfile);
 }

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -1293,7 +1293,7 @@ void rrdeng_quiesce(struct rrdengine_instance *ctx)
 static void populate_v2_statistics(struct rrdengine_datafile *datafile, RRDENG_SIZE_STATS *stats)
 {
     struct journal_v2_header *j2_header = journalfile_v2_data_acquire(datafile->journalfile, NULL, 0, 0);
-    void *data_start = (void *)j2_header;
+    uint8_t *data_start = (uint8_t *)j2_header;
 
     if(unlikely(!j2_header))
         return;

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -1311,23 +1311,55 @@ static void populate_v2_statistics(struct rrdengine_datafile *datafile, RRDENG_S
     // to the next datafile in rrdeng_size_statistics().
     PROTECTED_ACCESS_SETUP(datafile->journalfile->mmap.data, datafile->journalfile->mmap.size, file_path, "size-stats");
     if(no_signal_received) {
-        stats->extents += j2_header->extent_count;
+        size_t mmap_size = datafile->journalfile->mmap.size;
 
-        unsigned entries;
-        struct journal_extent_list *extent_list = (void *) (data_start + j2_header->extent_offset);
-        for (entries = 0; entries < j2_header->extent_count; entries++) {
-            stats->extents_compressed_bytes += extent_list->datafile_size;
-            stats->extents_pages += extent_list->pages;
-            extent_list++;
+        // Bounds-check the extent list array against the mapping size before
+        // walking through header-controlled offsets. PROTECTED_ACCESS_SETUP
+        // only catches faults in [data_start, data_start+mmap_size); a
+        // corrupted offset that points past mmap_size would over-read into
+        // unrelated memory and abort. Same idiom as the bounds check in
+        // journalfile_v2_populate_retention_to_mrg.
+        bool extents_in_bounds = (size_t)j2_header->extent_offset <= mmap_size &&
+                                 (size_t)j2_header->extent_count <= (mmap_size - (size_t)j2_header->extent_offset) / sizeof(struct journal_extent_list);
+        if (extents_in_bounds) {
+            stats->extents += j2_header->extent_count;
+
+            struct journal_extent_list *extent_list = (void *) (data_start + j2_header->extent_offset);
+            for (unsigned entries = 0; entries < j2_header->extent_count; entries++) {
+                stats->extents_compressed_bytes += extent_list->datafile_size;
+                stats->extents_pages += extent_list->pages;
+                extent_list++;
+            }
         }
+
+        bool metrics_in_bounds = (size_t)j2_header->metric_offset <= mmap_size &&
+                                 (size_t)j2_header->metric_count <= (mmap_size - (size_t)j2_header->metric_offset) / sizeof(struct journal_metric_list);
+        if (!metrics_in_bounds)
+            goto release;
 
         struct journal_metric_list *metric = (void *) (data_start + j2_header->metric_offset);
         time_t journal_start_time_s = (time_t) (j2_header->start_time_ut / USEC_PER_SEC);
 
         stats->metrics += j2_header->metric_count;
-        for (entries = 0; entries < j2_header->metric_count; entries++) {
+        for (unsigned entries = 0; entries < j2_header->metric_count; entries++) {
+
+            // Per-metric: page_offset is header-controlled. Validate it points
+            // into the mapping and that there is room for the page_header AND
+            // its trailing page_list[] before dereferencing through it.
+            if ((size_t)metric->page_offset > mmap_size ||
+                mmap_size - (size_t)metric->page_offset < sizeof(struct journal_page_header)) {
+                metric++;
+                continue;
+            }
 
             struct journal_page_header *metric_list_header = (void *) (data_start + metric->page_offset);
+
+            size_t page_list_room = mmap_size - (size_t)metric->page_offset - sizeof(struct journal_page_header);
+            if ((size_t)metric_list_header->entries > page_list_room / sizeof(struct journal_page_list)) {
+                metric++;
+                continue;
+            }
+
             stats->metrics_pages += metric_list_header->entries;
             struct journal_page_list *descr =  (void *) (data_start + metric->page_offset + sizeof(struct journal_page_header));
             for (uint32_t idx=0; idx < metric_list_header->entries; idx++) {
@@ -1371,6 +1403,7 @@ static void populate_v2_statistics(struct rrdengine_datafile *datafile, RRDENG_S
     // On SIGBUS/SIGSEGV the PROTECTED_ACCESS_SETUP macro already
     // rate-limits the error log; fall through to release the journal.
 
+release:
     journalfile_v2_data_release(datafile->journalfile);
 }
 

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -1384,6 +1384,10 @@ static void populate_v2_statistics(struct rrdengine_datafile *datafile, RRDENG_S
                 stats->pages_duration_secs += duration_s;
                 stats->points += points;
 
+                // descr->type is uint8_t (range [0, 255]); page_types is sized
+                // [256]. The index is bounded by the type width, so no runtime
+                // check is needed -- a `descr->type < 256` guard would be a
+                // tautology. Note for static analyzers flagging this site.
                 stats->page_types[descr->type].pages++;
                 stats->page_types[descr->type].pages_uncompressed_bytes += descr->page_length;
                 stats->page_types[descr->type].pages_duration_secs += duration_s;


### PR DESCRIPTION
##### Summary
The startup walk of v2 journal files reads through `mmap`. If a page is unreadable, the kernel raises SIGBUS. 

- Apply the project's SIGBUS-safe wrapper to the default-on CRC check that runs first, so one bad journal does not crash the agent on every restart. 
- Fix  a refcount leak on the CRC-failure early-return.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened v2 journal startup, retention, and size-stats walks against SIGBUS by guarding mmap reads, validating header/trailer offsets, copying UUIDs before `mrg` calls, and tearing down failed journals immediately. Adds clearer error logs for bad headers, keeps protected regions tightly scoped, and prevents crashes on unreadable/corrupt pages while avoiding fd/mmap/index duplication by forcing a clean rebuild.

- **Bug Fixes**
  - Wrapped both the CRC scan and MRG update in `journalfile_v2_populate_retention_to_mrg()` with `PROTECTED_ACCESS_SETUP`; on signal/CRC/bounds failure, clear `JOURNALFILE_FLAG_IS_AVAILABLE` under the data spinlock and `journalfile_v2_data_unmap_permanently()` to rebuild without fd/mmap/index leaks.
  - Tightened v2 header checks: validate metric/trailer offsets and placement against `mmap.size`, order checks to avoid underflow/32-bit wrap, and pass `mmap.size` to `journalfile_check_v2_metric_list`; fixed CRC early-return refcount leak; improved error logging for out-of-range headers.
  - Protected retention updates (`update_metrics_first_time_s`) with bounds/overflow checks and `PROTECTED_ACCESS_SETUP`, scoped tightly to the mmap walk; on failure or SIGBUS, release partially acquired metrics and exit cleanly.
  - Copied UUIDs from the mmap to the stack before `mrg_*` calls to avoid SIGBUS inside `mrg` and prevent lock-state corruption.
  - Marked `uuid_first_entry_list`, `count`, `added`, and `journal_access_failed` as `volatile` to keep setjmp/longjmp recovery defined.
  - Guarded size-stats walk (`populate_v2_statistics`) with `PROTECTED_ACCESS_SETUP` and bounds checks for extent/metric lists and per-metric page headers; keep best-effort totals and always release the journal; switched `data_start` to `uint8_t*` and clarified the bounded `descr->type` index for analyzers.
  - Explicitly set `has_references = false` during v2 journal cleanup to avoid stale reference tracking after failures.

<sup>Written for commit c44849ed9e7487e8a39e3fafbdd70cff9b7f1730. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22514?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

