### PR TITLE
fix(packaging): correct rust macro name in spec _have_rust gate

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -80,7 +80,7 @@ AutoReqProv: yes
 %{?rhel:%global centos_ver %rhel}
 
 # Only try to build OTEL plugin if we have rust
-%global _nd_rust_cmd %(command -v rustc)
+%global _nd_rustc_cmd %(command -v rustc)
 
 %if "%{_nd_rustc_cmd}" == ""
 %global _have_rust 0


### PR DESCRIPTION
SSIA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the Rust detection macro in `netdata.spec.in` so the `_have_rust` gate works and the OTEL plugin builds only when `rustc` is present. Renames `%{_nd_rust_cmd}` to `%{_nd_rustc_cmd}` to match the `%if` check and prevent always enabling Rust.

<sup>Written for commit d64102702843425c22e5519199f06bbdc7a10ced. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22515?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

