### PR TITLE
Check for missing program name when accepting a streaming connection

### DIFF
--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -541,7 +541,8 @@ static void rrdhost_update(RRDHOST *host
     UNUSED(guid);
 
     // Streaming children may omit the User-Agent header, leaving prog_name/prog_version NULL.
-    // Match the create path in rrdhost_create_initialize() so the strcmp/string_strdupz calls below are safe.
+    // Match the defaults assigned on the host create path (for example in set_host_properties()/rrdhost_create())
+    // so the strcmp/string_strdupz calls below are safe.
     if(!prog_name || !*prog_name)       prog_name = "unknown";
     if(!prog_version || !*prog_version) prog_version = "unknown";
 

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -540,6 +540,11 @@ static void rrdhost_update(RRDHOST *host
 {
     UNUSED(guid);
 
+    // Streaming children may omit the User-Agent header, leaving prog_name/prog_version NULL.
+    // Match the create path in rrdhost_create_initialize() so the strcmp/string_strdupz calls below are safe.
+    if(!prog_name || !*prog_name)       prog_name = "unknown";
+    if(!prog_version || !*prog_version) prog_version = "unknown";
+
     spinlock_lock(&host->rrdhost_update_lock);
 
     host->health.enabled = (mode == RRD_DB_MODE_NONE) ? 0 : health;


### PR DESCRIPTION
##### Summary
- Add check to prevent crash

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crash when accepting a streaming connection that omits the User-Agent. Normalize missing prog_name/prog_version to "unknown" in rrdhost_update(), matching host creation defaults so later strcmp/string_strdupz calls are safe.

<sup>Written for commit b945761035c05b17cf9031b30442658206f8ec6d. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22520?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

