### PR TITLE
Improve ML chart access

### DIFF
--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1080,7 +1080,7 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
         rrdset_foreach_read(rsp, host->rh) {
             RRDSET *rs = static_cast<RRDSET *>(rsp);
 
-            ml_chart_t *chart = (ml_chart_t *) rs->ml_chart;
+            ml_chart_t *chart = (ml_chart_t *) __atomic_load_n(&rs->ml_chart, __ATOMIC_ACQUIRE);
             if (!chart)
                 continue;
 

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -315,7 +315,7 @@ void ml_chart_new(RRDSET *rs)
     // concurrent reader would see chart != NULL with chart->rs still NULL
     // (from value-init in `new ml_chart_t()`), producing the SIGSEGV /
     // MAPERR / 0x80 fault inside ml_chart_is_available_for_ml.
-    __atomic_store_n((rrd_ml_chart_t **)&rs->ml_chart, (rrd_ml_chart_t *)chart, __ATOMIC_RELEASE);
+    __atomic_store_n(&rs->ml_chart, (rrd_ml_chart_t *)chart, __ATOMIC_RELEASE);
 }
 
 void ml_chart_delete(RRDSET *rs)
@@ -329,7 +329,7 @@ void ml_chart_delete(RRDSET *rs)
     // Unpublish BEFORE freeing so a concurrent reader that loads rs->ml_chart
     // observes either the live chart (with chart->rs set) or NULL -- never
     // the freed chart memory.
-    __atomic_store_n((rrd_ml_chart_t **)&rs->ml_chart, (rrd_ml_chart_t *)NULL, __ATOMIC_RELEASE);
+    __atomic_store_n(&rs->ml_chart, (rrd_ml_chart_t *)NULL, __ATOMIC_RELEASE);
     delete chart;
 }
 

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -169,7 +169,7 @@ void ml_host_stop(RRDHOST *rh) {
     rrdset_foreach_read(rsp, host->rh) {
         RRDSET *rs = static_cast<RRDSET *>(rsp);
 
-        ml_chart_t *chart = (ml_chart_t *) rs->ml_chart;
+        ml_chart_t *chart = (ml_chart_t *) __atomic_load_n(&rs->ml_chart, __ATOMIC_ACQUIRE);
         if (!chart)
             continue;
 
@@ -308,7 +308,14 @@ void ml_chart_new(RRDSET *rs)
     chart->rs = rs;
     chart->mls = ml_machine_learning_stats_t();
 
-    rs->ml_chart = (rrd_ml_chart_t *) chart;
+    // Publish with release semantics so readers that load rs->ml_chart with
+    // acquire semantics observe the chart's `rs` and `mls` fields as fully
+    // initialized. Without this, the C++ compiler may reorder the plain
+    // `chart->rs = rs` store after the publish store of rs->ml_chart, and a
+    // concurrent reader would see chart != NULL with chart->rs still NULL
+    // (from value-init in `new ml_chart_t()`), producing the SIGSEGV /
+    // MAPERR / 0x80 fault inside ml_chart_is_available_for_ml.
+    __atomic_store_n((rrd_ml_chart_t **)&rs->ml_chart, (rrd_ml_chart_t *)chart, __ATOMIC_RELEASE);
 }
 
 void ml_chart_delete(RRDSET *rs)
@@ -317,15 +324,18 @@ void ml_chart_delete(RRDSET *rs)
     if (!host)
         return;
 
-    ml_chart_t *chart = (ml_chart_t *) rs->ml_chart;
+    ml_chart_t *chart = (ml_chart_t *) __atomic_load_n(&rs->ml_chart, __ATOMIC_ACQUIRE);
 
+    // Unpublish BEFORE freeing so a concurrent reader that loads rs->ml_chart
+    // observes either the live chart (with chart->rs set) or NULL -- never
+    // the freed chart memory.
+    __atomic_store_n((rrd_ml_chart_t **)&rs->ml_chart, (rrd_ml_chart_t *)NULL, __ATOMIC_RELEASE);
     delete chart;
-    rs->ml_chart = NULL;
 }
 
 ALWAYS_INLINE_ONLY bool ml_chart_update_begin(RRDSET *rs)
 {
-    ml_chart_t *chart = (ml_chart_t *)rs->ml_chart;
+    ml_chart_t *chart = (ml_chart_t *) __atomic_load_n(&rs->ml_chart, __ATOMIC_ACQUIRE);
     if (!chart)
         return false;
 
@@ -335,14 +345,14 @@ ALWAYS_INLINE_ONLY bool ml_chart_update_begin(RRDSET *rs)
 
 void ml_chart_update_end(RRDSET *rs)
 {
-    ml_chart_t *chart = (ml_chart_t *) rs->ml_chart;
+    ml_chart_t *chart = (ml_chart_t *) __atomic_load_n(&rs->ml_chart, __ATOMIC_ACQUIRE);
     if (!chart)
         return;
 }
 
 void ml_dimension_new(RRDDIM *rd)
 {
-    ml_chart_t *chart = (ml_chart_t *) rd->rrdset->ml_chart;
+    ml_chart_t *chart = (ml_chart_t *) __atomic_load_n(&rd->rrdset->ml_chart, __ATOMIC_ACQUIRE);
     if (!chart)
         return;
 
@@ -425,7 +435,9 @@ ALWAYS_INLINE_ONLY void ml_dimension_received_anomaly(RRDDIM *rd, bool is_anomal
     if (!host->ml_running)
         return;
 
-    ml_chart_t *chart = (ml_chart_t *) rd->rrdset->ml_chart;
+    ml_chart_t *chart = (ml_chart_t *) __atomic_load_n(&rd->rrdset->ml_chart, __ATOMIC_ACQUIRE);
+    if (!chart)
+        return;
 
     ml_chart_update_dimension(chart, dim, is_anomalous);
 }
@@ -442,7 +454,9 @@ bool ml_dimension_is_anomalous(RRDDIM *rd, time_t curr_time, double value, bool 
     if (!host->ml_running)
         return false;
 
-    ml_chart_t *chart = (ml_chart_t *) rd->rrdset->ml_chart;
+    ml_chart_t *chart = (ml_chart_t *) __atomic_load_n(&rd->rrdset->ml_chart, __ATOMIC_ACQUIRE);
+    if (!chart)
+        return false;
 
     bool is_anomalous = ml_dimension_predict(dim, value, exists);
     ml_chart_update_dimension(chart, dim, is_anomalous);


### PR DESCRIPTION
##### Summary
- Ensure atomic operations for safe access and updates to `ml_chart` fields in ML code path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `ml_chart` access atomic to prevent races and rare crashes in the ML path. Uses acquire/release semantics so readers never see a partially initialized or freed chart.

- **Bug Fixes**
  - Read `rs->ml_chart` with `__atomic_load_n(..., __ATOMIC_ACQUIRE)` across ML code.
  - Publish/unpublish with `__atomic_store_n(..., __ATOMIC_RELEASE)` in `ml_chart_new` and `ml_chart_delete`, unpublishing before delete.
  - Add null checks after loads in dimension/anomaly paths to avoid UAF/null deref.

- **Refactors**
  - Simplify `__atomic_store_n` calls by removing unnecessary casts.

<sup>Written for commit 57c9bbfc475072cb307b8f427c222ca99d251977. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22530?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

