### PR TITLE
dbengine: expose engine stats via a published-state struct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1795,6 +1795,7 @@ if(ENABLE_DBENGINE)
             src/database/engine/rrdenginelib.h
             src/database/engine/rrdengineapi.c
             src/database/engine/rrdengineapi.h
+            src/database/engine/dbengine-stats.h
             src/database/engine/pagecache.c
             src/database/engine/pagecache.h
             src/database/engine/page_test.cc

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -9,6 +9,7 @@
 #include "web/mcp/mcp.h"
 
 #include "database/engine/page_test.h"
+#include "database/engine/dbengine-stats.h"
 #include "database/rrdset-slots.h"
 #include <curl/curl.h>
 
@@ -1025,6 +1026,15 @@ int netdata_main(int argc, char **argv) {
         if(st->global_variable)
             *st->global_variable = (st->enabled) ? true : false;
     }
+
+#ifdef ENABLE_DBENGINE
+    // Mirror the final pulse flag states into the engine so cache
+    // creation tracks pulse_enabled and gorilla hot-path counters
+    // tick only when pulse_extended_enabled is on (matching the
+    // pre-refactor behavior of pulse_gorilla_*).
+    dbengine_set_collect_stats(pulse_enabled);
+    dbengine_set_collect_extended_stats(pulse_extended_enabled);
+#endif
 
     // ----------------------------------------------------------------------------------------------------------------
     delta_startup_time("web server api");

--- a/src/daemon/pulse/pulse-aral.c
+++ b/src/daemon/pulse/pulse-aral.c
@@ -2,6 +2,7 @@
 
 #define PULSE_INTERNALS 1
 #include "pulse-aral.h"
+#include "database/engine/dbengine-stats.h"
 
 struct aral_info {
     const char *name;
@@ -67,8 +68,29 @@ void pulse_aral_init(void) {
     pulse_aral_register_statistics(uuidmap_aral_statistics(), "uuidmap");
 }
 
+#ifdef ENABLE_DBENGINE
+// Pull engine-published ARAL registrations into the pulse dedup
+// registry. dbengine_stats_snapshot_arals copies live (stats, name)
+// pairs under the engine's lock, so each pair in the snapshot is
+// consistent even if the engine concurrently registers, unregisters,
+// or reuses a slot. pulse_aral_register_statistics is idempotent on
+// the stats pointer, so calling it every cycle is safe.
+static void pulse_aral_import_dbengine_registrations(void) {
+    dbengine_aral_snapshot_t snap[DBENGINE_MAX_ARAL_REGISTRATIONS];
+    size_t n = dbengine_stats_snapshot_arals(snap);
+    for(size_t i = 0; i < n; i++) {
+        if(snap[i].stats && snap[i].name)
+            pulse_aral_register_statistics(snap[i].stats, snap[i].name);
+    }
+}
+#endif
+
 void pulse_aral_do(bool extended) {
     if(!extended) return;
+
+#ifdef ENABLE_DBENGINE
+    pulse_aral_import_dbengine_registrations();
+#endif
 
     spinlock_lock(&globals.spinlock);
     Word_t s = 0;

--- a/src/daemon/pulse/pulse-gorilla.c
+++ b/src/daemon/pulse/pulse-gorilla.c
@@ -2,45 +2,17 @@
 
 #define PULSE_INTERNALS 1
 #include "pulse-gorilla.h"
-
-static struct gorilla_statistics {
-    bool enabled;
-
-    PAD64(uint64_t) tier0_hot_gorilla_buffers;
-
-    PAD64(uint64_t) gorilla_tier0_disk_actual_bytes;
-    PAD64(uint64_t) gorilla_tier0_disk_optimal_bytes;
-    PAD64(uint64_t) gorilla_tier0_disk_original_bytes;
-} gorilla_statistics = { 0 };
-
-void pulse_gorilla_hot_buffer_added() {
-    if(!gorilla_statistics.enabled) return;
-
-    __atomic_fetch_add(&gorilla_statistics.tier0_hot_gorilla_buffers, 1, __ATOMIC_RELAXED);
-}
-
-void pulse_gorilla_tier0_page_flush(uint32_t actual, uint32_t optimal, uint32_t original) {
-    if(!gorilla_statistics.enabled) return;
-
-    __atomic_fetch_add(&gorilla_statistics.gorilla_tier0_disk_actual_bytes, actual, __ATOMIC_RELAXED);
-    __atomic_fetch_add(&gorilla_statistics.gorilla_tier0_disk_optimal_bytes, optimal, __ATOMIC_RELAXED);
-    __atomic_fetch_add(&gorilla_statistics.gorilla_tier0_disk_original_bytes, original, __ATOMIC_RELAXED);
-}
-
-static inline void global_statistics_copy(struct gorilla_statistics *gs) {
-    gs->tier0_hot_gorilla_buffers     = __atomic_load_n(&gorilla_statistics.tier0_hot_gorilla_buffers, __ATOMIC_RELAXED);
-    gs->gorilla_tier0_disk_actual_bytes = __atomic_load_n(&gorilla_statistics.gorilla_tier0_disk_actual_bytes, __ATOMIC_RELAXED);
-    gs->gorilla_tier0_disk_optimal_bytes = __atomic_load_n(&gorilla_statistics.gorilla_tier0_disk_optimal_bytes, __ATOMIC_RELAXED);
-    gs->gorilla_tier0_disk_original_bytes = __atomic_load_n(&gorilla_statistics.gorilla_tier0_disk_original_bytes, __ATOMIC_RELAXED);
-}
+#include "database/engine/dbengine-stats.h"
 
 void pulse_gorilla_do(bool extended __maybe_unused) {
 #ifdef ENABLE_DBENGINE
     if(!extended) return;
-    gorilla_statistics.enabled = true;
 
-    struct gorilla_statistics gs;
-    global_statistics_copy(&gs);
+    const dbengine_stats_t *s = dbengine_get_stats();
+    uint64_t hot_buffers    = __atomic_load_n(&s->gorilla.hot_buffers_added,        __ATOMIC_RELAXED);
+    uint64_t actual_bytes   = __atomic_load_n(&s->gorilla.tier0_disk_actual_bytes,  __ATOMIC_RELAXED);
+    uint64_t optimal_bytes  = __atomic_load_n(&s->gorilla.tier0_disk_optimal_bytes, __ATOMIC_RELAXED);
+    uint64_t original_bytes = __atomic_load_n(&s->gorilla.tier0_disk_original_bytes, __ATOMIC_RELAXED);
 
     if (tier_page_type[0] == RRDENG_PAGE_TYPE_GORILLA_32BIT)
     {
@@ -66,7 +38,7 @@ void pulse_gorilla_do(bool extended __maybe_unused) {
             rd_num_gorilla_pages = rrddim_add(st_tier0_gorilla_pages, "count", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
         }
 
-        rrddim_set_by_pointer(st_tier0_gorilla_pages, rd_num_gorilla_pages, (collected_number)gs.tier0_hot_gorilla_buffers);
+        rrddim_set_by_pointer(st_tier0_gorilla_pages, rd_num_gorilla_pages, (collected_number)hot_buffers);
 
         rrdset_done(st_tier0_gorilla_pages);
     }
@@ -100,9 +72,9 @@ void pulse_gorilla_do(bool extended __maybe_unused) {
             rd_uncompressed_bytes = rrddim_add(st_tier0_compression_info, "uncompressed", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
         }
 
-        rrddim_set_by_pointer(st_tier0_compression_info, rd_actual_bytes, (collected_number)gs.gorilla_tier0_disk_actual_bytes);
-        rrddim_set_by_pointer(st_tier0_compression_info, rd_optimal_bytes, (collected_number)gs.gorilla_tier0_disk_optimal_bytes);
-        rrddim_set_by_pointer(st_tier0_compression_info, rd_uncompressed_bytes, (collected_number)gs.gorilla_tier0_disk_original_bytes);
+        rrddim_set_by_pointer(st_tier0_compression_info, rd_actual_bytes, (collected_number)actual_bytes);
+        rrddim_set_by_pointer(st_tier0_compression_info, rd_optimal_bytes, (collected_number)optimal_bytes);
+        rrddim_set_by_pointer(st_tier0_compression_info, rd_uncompressed_bytes, (collected_number)original_bytes);
 
         rrdset_done(st_tier0_compression_info);
     }

--- a/src/daemon/pulse/pulse-gorilla.h
+++ b/src/daemon/pulse/pulse-gorilla.h
@@ -5,9 +5,6 @@
 
 #include "daemon/common.h"
 
-void pulse_gorilla_hot_buffer_added();
-void pulse_gorilla_tier0_page_flush(uint32_t actual, uint32_t optimal, uint32_t original);
-
 #if defined(PULSE_INTERNALS)
 void pulse_gorilla_do(bool extended);
 #endif

--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -613,7 +613,7 @@ static void pgc_section_pages_static_aral_init(void) {
             "pgc-sections", sizeof(struct section_pages), 0, 0, &pgc_aral_statistics,
             NULL, NULL, false, false, false);
 
-        pulse_aral_register_statistics(&pgc_aral_statistics, "pgc");
+        dbengine_stats_register_aral_statistics(&pgc_aral_statistics, "pgc");
     }
 
     spinlock_unlock(&spinlock);
@@ -2030,7 +2030,7 @@ PGC *pgc_create(const char *name,
 
     cache->config.options = options;
     cache->config.additional_bytes_per_page = additional_bytes_per_page;
-    cache->config.stats = pulse_enabled;
+    cache->config.stats = dbengine_collect_stats();
 
     // flushing
     cache->config.max_flushes_inline            = (max_flushes_inline == 0) ? 2 : max_flushes_inline;

--- a/src/database/engine/dbengine-stats.h
+++ b/src/database/engine/dbengine-stats.h
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_DBENGINE_STATS_H
+#define NETDATA_DBENGINE_STATS_H
+
+// libnetdata.h provides PAD64 plus the fixed-width integer and bool
+// typedefs the struct fields use.
+#include "libnetdata/libnetdata.h"
+
+// Forward decls keep this header from pulling in libnetdata's aral.h.
+// Engine and daemon TUs that consume the struct already have the real
+// types reachable through their own include graphs.
+struct aral;
+struct aral_statistics;
+
+// Engine-published statistics, read by the daemon's pulse subsystem once
+// per pulse cycle and forwarded into its existing charts. The engine
+// owns the storage (file-static in rrdengineapi.c); external readers
+// must treat the pointer returned by dbengine_get_stats() as read-only.
+//
+// This replaces direct calls from the engine into pulse_aral_*,
+// pulse_gorilla_*, and pulse_enabled. Engine sources stay free of any
+// pulse_ symbol.
+
+typedef struct dbengine_aral_registration {
+    struct aral *ar;                 // may be NULL for stats-only registrations
+    struct aral_statistics *stats;   // NULL means the slot is unused -- either
+                                     // never registered yet, or a tombstone
+                                     // left by a previous unregister. Either
+                                     // way, register_slot may reuse it.
+    const char *name;
+} dbengine_aral_registration_t;
+
+// 13 callsites today; 16 leaves headroom for one or two more before any
+// future re-tuning is needed.
+#define DBENGINE_MAX_ARAL_REGISTRATIONS 16
+
+typedef struct dbengine_stats {
+    // ARAL registrations populated at engine init time. The engine
+    // serializes all writes (and the daemon's snapshot reads) under an
+    // internal spinlock -- callers must not touch this array directly;
+    // use dbengine_stats_snapshot_arals() instead.
+    dbengine_aral_registration_t arals[DBENGINE_MAX_ARAL_REGISTRATIONS];
+    size_t aral_count;
+
+    // Hot-path Gorilla counters: engine increments atomically, daemon
+    // pulse-gorilla.c reads atomically. PAD64 prevents false sharing.
+    struct {
+        PAD64(uint64_t) hot_buffers_added;
+        PAD64(uint64_t) tier0_disk_actual_bytes;
+        PAD64(uint64_t) tier0_disk_optimal_bytes;
+        PAD64(uint64_t) tier0_disk_original_bytes;
+    } gorilla;
+} dbengine_stats_t;
+
+// Read-only view for daemon-side consumers. Pointer is stable for the
+// lifetime of the process. Use dbengine_stats_snapshot_arals() for the
+// ARAL array; the gorilla counters can be read directly with atomic
+// loads.
+const dbengine_stats_t *dbengine_get_stats(void);
+
+// One element of an ARAL registration snapshot.
+typedef struct dbengine_aral_snapshot {
+    struct aral_statistics *stats;
+    const char *name;
+} dbengine_aral_snapshot_t;
+
+// Atomically snapshot the live (non-tombstone) ARAL registrations into
+// out_buf, which must point to an array of at least
+// DBENGINE_MAX_ARAL_REGISTRATIONS elements. Returns the number of
+// entries written. Takes the engine's internal lock for the duration
+// of the copy so each (stats, name) pair in the snapshot is consistent;
+// the caller iterates the local snapshot without further locking.
+size_t dbengine_stats_snapshot_arals(dbengine_aral_snapshot_t *out_buf);
+
+// Mirrors the daemon's pulse_enabled flag into the engine. Called by
+// the daemon at the same points it sets pulse_enabled. Defaults to true
+// so a standalone link (no daemon) collects stats unless told otherwise.
+void dbengine_set_collect_stats(bool enabled);
+
+// Read at cache creation to decide whether to maintain expensive
+// per-page statistics. Replaces the engine's previous direct read of
+// pulse_enabled.
+bool dbengine_collect_stats(void);
+
+// Mirrors the daemon's pulse_extended_enabled flag into the engine.
+// Gates the gorilla hot-path counters so they only perform atomic
+// increments when the daemon is collecting extended pulse data.
+// Defaults to false to match the daemon's pulse_extended_enabled
+// startup default; a standalone link that wants gorilla counters
+// active must call this setter explicitly.
+void dbengine_set_collect_extended_stats(bool enabled);
+
+// Read on the gorilla hot path. Cheap RELAXED load.
+bool dbengine_collect_extended_stats(void);
+
+// Engine-internal helpers, called from engine init paths and hot paths
+// in place of the previous pulse_aral_* / pulse_gorilla_* calls.
+void dbengine_stats_register_aral(struct aral *ar, const char *name);
+void dbengine_stats_register_aral_statistics(struct aral_statistics *stats, const char *name);
+void dbengine_stats_unregister_aral_statistics(struct aral_statistics *stats);
+void dbengine_stats_gorilla_hot_buffer_added(void);
+void dbengine_stats_gorilla_tier0_page_flush(uint32_t actual, uint32_t optimal, uint32_t original);
+
+#endif // NETDATA_DBENGINE_STATS_H

--- a/src/database/engine/mrg.c
+++ b/src/database/engine/mrg.c
@@ -19,7 +19,7 @@ static MRG *mrg_create_internal(bool load_from_db) {
         mrg->index[i].aral = aral_create(buf, sizeof(METRIC), 0, 16384, &mrg_aral_statistics, NULL, NULL,
                                          false, false, true);
     }
-    pulse_aral_register_statistics(&mrg_aral_statistics, "mrg");
+    dbengine_stats_register_aral_statistics(&mrg_aral_statistics, "mrg");
 
     if(load_from_db)
         mrg_load(mrg);
@@ -103,7 +103,7 @@ size_t mrg_destroy(MRG *mrg) {
     }
 
     // Unregister the aral statistics
-    pulse_aral_unregister_statistics(&mrg_aral_statistics);
+    dbengine_stats_unregister_aral_statistics(&mrg_aral_statistics);
 
     // Free the MRG structure
     freez(mrg);

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -329,7 +329,7 @@ void pgd_init_arals(void) {
     pgd_alloc_globals.sizeof_gorilla_writer_t = aral_actual_element_size(pgd_alloc_globals.aral_gorilla_writer[0]);
     pgd_alloc_globals.sizeof_gorilla_buffer_32bit = aral_actual_element_size(pgd_alloc_globals.aral_gorilla_buffer[0]);
 
-    pulse_aral_register_statistics(&pgd_aral_statistics, "pgd");
+    dbengine_stats_register_aral_statistics(&pgd_aral_statistics, "pgd");
 }
 
 static ARAL *pgd_get_aral_by_size_and_partition(size_t size, size_t partition) {
@@ -463,7 +463,7 @@ ALWAYS_INLINE PGD *pgd_create(uint8_t type, uint32_t slots) {
             // allocate new gorilla buffer
             gorilla_buffer_t *gbuf = pgd_gorilla_buffer_alloc(pg->partition);
             memset(gbuf, 0, RRDENG_GORILLA_32BIT_BUFFER_SIZE);
-            pulse_gorilla_hot_buffer_added();
+            dbengine_stats_gorilla_hot_buffer_added();
 
             *pg->gorilla.writer = gorilla_writer_init(gbuf, RRDENG_GORILLA_32BIT_BUFFER_SLOTS);
             pg->gorilla.num_buffers = 1;
@@ -808,7 +808,7 @@ uint32_t pgd_disk_footprint(PGD *pg)
                 size = pg->gorilla.num_buffers * RRDENG_GORILLA_32BIT_BUFFER_SIZE;
 
                 if (pg->states & PGD_STATE_CREATED_FROM_COLLECTOR)
-                    pulse_gorilla_tier0_page_flush(
+                    dbengine_stats_gorilla_tier0_page_flush(
                         gorilla_writer_actual_nbytes(pg->gorilla.writer),
                         gorilla_writer_optimal_nbytes(pg->gorilla.writer),
                         tier_page_size[0]);
@@ -933,7 +933,7 @@ size_t pgd_append_point(
 
                 gorilla_writer_add_buffer(pg->gorilla.writer, new_buffer, RRDENG_GORILLA_32BIT_BUFFER_SLOTS);
                 pg->gorilla.num_buffers += 1;
-                pulse_gorilla_hot_buffer_added();
+                dbengine_stats_gorilla_hot_buffer_added();
 
                 ok = gorilla_writer_write(pg->gorilla.writer, t);
                 internal_fatal(ok == false, "Failed to writer value in newly allocated gorilla buffer.");

--- a/src/database/engine/pdc.c
+++ b/src/database/engine/pdc.c
@@ -60,7 +60,7 @@ void pdc_init(void) {
             NULL, NULL, false, false, true
             );
 
-    pulse_aral_register(pdc_globals.pdc.ar, "pdc");
+    dbengine_stats_register_aral(pdc_globals.pdc.ar, "pdc");
 }
 
 ALWAYS_INLINE PDC *pdc_get(void) {
@@ -89,7 +89,7 @@ void page_details_init(void) {
             NULL,
             NULL, NULL, false, false, true
     );
-    pulse_aral_register(pdc_globals.pd.ar, "pd");
+    dbengine_stats_register_aral(pdc_globals.pd.ar, "pd");
 }
 
 ALWAYS_INLINE struct page_details *page_details_get(void) {
@@ -118,7 +118,7 @@ void epdl_init(void) {
             NULL,
             NULL, NULL, false, false, true
     );
-    pulse_aral_register(pdc_globals.epdl.ar, "epdl");
+    dbengine_stats_register_aral(pdc_globals.epdl.ar, "epdl");
 }
 
 static ALWAYS_INLINE EPDL *epdl_get(void) {
@@ -148,7 +148,7 @@ void deol_init(void) {
             NULL, NULL, false, false, true
     );
 
-    pulse_aral_register(pdc_globals.deol.ar, "deol");
+    dbengine_stats_register_aral(pdc_globals.deol.ar, "deol");
 }
 
 static ALWAYS_INLINE DEOL *deol_get(void) {
@@ -178,7 +178,7 @@ void epdl_extent_init(void) {
             NULL, NULL, false, false, true
     );
 
-    pulse_aral_register(pdc_globals.epdl_extent.ar, "epdl_extent");
+    dbengine_stats_register_aral(pdc_globals.epdl_extent.ar, "epdl_extent");
 }
 
 static ALWAYS_INLINE EPDL_EXTENT *epdl_extent_get(void) {

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -183,7 +183,7 @@ static void work_request_init(void) {
         NULL, NULL, false, false, true
     );
 
-    pulse_aral_register(rrdeng_main.work_cmd.ar, "workers");
+    dbengine_stats_register_aral(rrdeng_main.work_cmd.ar, "workers");
 }
 
 enum LIBUV_WORKERS_STATUS {
@@ -323,7 +323,7 @@ void page_descriptors_init(void) {
             NULL,
             NULL, NULL, false, false, true);
 
-    pulse_aral_register(rrdeng_main.descriptors.ar, "descriptors");
+    dbengine_stats_register_aral(rrdeng_main.descriptors.ar, "descriptors");
 }
 
 struct page_descr_with_data *page_descriptor_get(void) {
@@ -350,7 +350,7 @@ static void extent_io_descriptor_init(void) {
             NULL, NULL, false, false, true
             );
 
-    pulse_aral_register(rrdeng_main.xt_io_descr.ar, "extent io");
+    dbengine_stats_register_aral(rrdeng_main.xt_io_descr.ar, "extent io");
 }
 
 static struct extent_io_descriptor *extent_io_descriptor_get(void) {
@@ -375,7 +375,7 @@ void rrdeng_query_handle_init(void) {
             NULL,
             NULL, NULL, false, false, true);
 
-    pulse_aral_register(rrdeng_main.handles.ar, "query handles");
+    dbengine_stats_register_aral(rrdeng_main.handles.ar, "query handles");
 }
 
 ALWAYS_INLINE struct rrdeng_query_handle *rrdeng_query_handle_get(void) {
@@ -495,7 +495,7 @@ static void rrdeng_cmd_queue_init(void) {
                                            NULL,
                                            NULL, NULL, false, false, true);
 
-    pulse_aral_register(rrdeng_main.cmd_queue.ar, "opcodes");
+    dbengine_stats_register_aral(rrdeng_main.cmd_queue.ar, "opcodes");
 }
 
 static inline STORAGE_PRIORITY rrdeng_enq_cmd_map_opcode_to_priority(enum rrdeng_opcode opcode, STORAGE_PRIORITY priority) {

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -77,6 +77,152 @@ int default_rrdeng_extent_cache_mb = 0;
 #endif
 
 // ----------------------------------------------------------------------------
+// engine-published statistics
+//
+// dbengine_stats_storage holds the published struct; dbengine_stats_lock
+// guards the ARAL registration array. Gorilla counters are updated via
+// __atomic_fetch_add and read via __atomic_load_n, so they need no lock.
+// collect_stats defaults to true so a standalone link (no daemon to call
+// the setter) still collects.
+
+static SPINLOCK dbengine_stats_lock = SPINLOCK_INITIALIZER;
+static dbengine_stats_t dbengine_stats_storage = { 0 };
+static bool dbengine_collect_stats_flag = true;
+static bool dbengine_collect_extended_stats_flag = false;
+
+const dbengine_stats_t *dbengine_get_stats(void) {
+    return &dbengine_stats_storage;
+}
+
+void dbengine_set_collect_stats(bool enabled) {
+    __atomic_store_n(&dbengine_collect_stats_flag, enabled, __ATOMIC_RELAXED);
+}
+
+bool dbengine_collect_stats(void) {
+    return __atomic_load_n(&dbengine_collect_stats_flag, __ATOMIC_RELAXED);
+}
+
+void dbengine_set_collect_extended_stats(bool enabled) {
+    __atomic_store_n(&dbengine_collect_extended_stats_flag, enabled, __ATOMIC_RELAXED);
+}
+
+bool dbengine_collect_extended_stats(void) {
+    return __atomic_load_n(&dbengine_collect_extended_stats_flag, __ATOMIC_RELAXED);
+}
+
+// Idempotent on the stats pointer. Reuses tombstone slots (where a
+// previous registration was unregistered) before extending aral_count,
+// so an engine that cycles through init/exit in the same process won't
+// exhaust DBENGINE_MAX_ARAL_REGISTRATIONS.
+//
+// All accesses to the slot array and aral_count go through
+// dbengine_stats_lock; the daemon reads via dbengine_stats_snapshot_arals
+// which takes the same lock, so callers always observe a consistent
+// (stats, name, ar) tuple per slot.
+static void dbengine_stats_register_slot(struct aral *ar,
+                                         struct aral_statistics *stats,
+                                         const char *name) {
+    if(!stats || !name) return;
+
+    bool exhausted = false;
+
+    spinlock_lock(&dbengine_stats_lock);
+
+    size_t free_slot = SIZE_MAX;
+    bool already_registered = false;
+
+    for(size_t i = 0; i < dbengine_stats_storage.aral_count; i++) {
+        if(dbengine_stats_storage.arals[i].stats == stats) {
+            already_registered = true;
+            break;
+        }
+        if(free_slot == SIZE_MAX && !dbengine_stats_storage.arals[i].stats)
+            free_slot = i;
+    }
+
+    if(!already_registered) {
+        size_t target;
+        if(free_slot != SIZE_MAX) {
+            target = free_slot;
+        }
+        else if(dbengine_stats_storage.aral_count < DBENGINE_MAX_ARAL_REGISTRATIONS) {
+            target = dbengine_stats_storage.aral_count;
+            dbengine_stats_storage.aral_count = target + 1;
+        }
+        else {
+            exhausted = true;
+            target = 0; // unused
+        }
+
+        if(!exhausted) {
+            dbengine_stats_storage.arals[target].ar = ar;
+            dbengine_stats_storage.arals[target].name = name;
+            dbengine_stats_storage.arals[target].stats = stats;
+        }
+    }
+
+    spinlock_unlock(&dbengine_stats_lock);
+
+    if(exhausted)
+        nd_log(NDLS_DAEMON, NDLP_WARNING,
+               "DBENGINE: ARAL registration slots exhausted (max %d); dropping '%s'.",
+               DBENGINE_MAX_ARAL_REGISTRATIONS, name);
+}
+
+void dbengine_stats_register_aral_statistics(struct aral_statistics *stats, const char *name) {
+    dbengine_stats_register_slot(NULL, stats, name);
+}
+
+void dbengine_stats_register_aral(struct aral *ar, const char *name) {
+    if(!ar) return;
+    if(!name) name = aral_name(ar);
+    dbengine_stats_register_slot(ar, aral_get_statistics(ar), name);
+}
+
+void dbengine_stats_unregister_aral_statistics(struct aral_statistics *stats) {
+    if(!stats) return;
+
+    spinlock_lock(&dbengine_stats_lock);
+    for(size_t i = 0; i < dbengine_stats_storage.aral_count; i++) {
+        if(dbengine_stats_storage.arals[i].stats == stats) {
+            dbengine_stats_storage.arals[i].ar = NULL;
+            dbengine_stats_storage.arals[i].name = NULL;
+            dbengine_stats_storage.arals[i].stats = NULL;
+            break;
+        }
+    }
+    spinlock_unlock(&dbengine_stats_lock);
+}
+
+size_t dbengine_stats_snapshot_arals(dbengine_aral_snapshot_t *out_buf) {
+    if(!out_buf) return 0;
+
+    size_t n = 0;
+    spinlock_lock(&dbengine_stats_lock);
+    for(size_t i = 0; i < dbengine_stats_storage.aral_count; i++) {
+        struct aral_statistics *stats = dbengine_stats_storage.arals[i].stats;
+        if(!stats) continue;
+        out_buf[n].stats = stats;
+        out_buf[n].name = dbengine_stats_storage.arals[i].name;
+        n++;
+    }
+    spinlock_unlock(&dbengine_stats_lock);
+    return n;
+}
+
+void dbengine_stats_gorilla_hot_buffer_added(void) {
+    if(!dbengine_collect_extended_stats()) return;
+    __atomic_fetch_add(&dbengine_stats_storage.gorilla.hot_buffers_added, 1, __ATOMIC_RELAXED);
+}
+
+void dbengine_stats_gorilla_tier0_page_flush(uint32_t actual, uint32_t optimal, uint32_t original) {
+    if(!dbengine_collect_extended_stats()) return;
+    __atomic_fetch_add(&dbengine_stats_storage.gorilla.tier0_disk_actual_bytes, actual, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&dbengine_stats_storage.gorilla.tier0_disk_optimal_bytes, optimal, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&dbengine_stats_storage.gorilla.tier0_disk_original_bytes, original, __ATOMIC_RELAXED);
+}
+
+// ----------------------------------------------------------------------------
 // metrics groups
 
 static inline void rrdeng_page_alignment_acquire(struct pg_alignment *pa) {

--- a/src/database/engine/rrdengineapi.h
+++ b/src/database/engine/rrdengineapi.h
@@ -4,6 +4,7 @@
 #define NETDATA_RRDENGINEAPI_H
 
 #include "rrdengine.h"
+#include "dbengine-stats.h"
 
 #define RRDENG_MIN_PAGE_CACHE_SIZE_MB (8)
 #define RRDENG_MIN_DISK_SPACE_MB (25)


### PR DESCRIPTION
## Summary

- Replace dbengine's 17 direct calls into the daemon's `pulse_*` symbols (`pulse_aral_register*`, `pulse_aral_unregister_statistics`, `pulse_gorilla_hot_buffer_added`, `pulse_gorilla_tier0_page_flush`, `pulse_enabled`) with a pull-style published-state struct (`dbengine_stats_t`) owned by the engine.
- The daemon's pulse subsystem reads from `dbengine_get_stats()` once per cycle and forwards into the existing `aral_*` and gorilla charts. Chart names and counter semantics are preserved.
- After this change, `src/database/engine/*.c` contains zero `pulse_aral_*`, `pulse_gorilla_*`, or `pulse_enabled` references — removing the only structural pulse coupling that blocks a standalone link of `libdbengine.a`.

Sibling of #22528 (`libnetdata: make standalone-linkable`); independent and lands in parallel.

## Test plan

- [ ] `cmake -DENABLE_DBENGINE=ON && ninja` succeeds (verified locally).
- [ ] `cmake -DENABLE_DBENGINE=OFF && ninja` succeeds (verified locally — daemon-side call sites guarded with `#ifdef ENABLE_DBENGINE`).
- [ ] `nm` on every engine `.c.o`: zero `pulse_aral`, `pulse_gorilla`, or `pulse_enabled` references (verified locally).
- [ ] Live run: `netdata.aral_*` and `netdata.tier0_gorilla_*` charts populate with the same values as on master (verified locally: `aral_mrg_memory` shows live `malloc used`/`structures` values; `tier0_gorilla_pages` counts ticking when `pulse_extended_enabled=true`).
- [ ] CI green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decoupled dbengine from the daemon’s pulse by publishing engine stats via `dbengine_stats_t`, read once per cycle by pulse. Charts and counter semantics are unchanged, and `libdbengine.a` can now be linked standalone.

- **Refactors**
  - Added `dbengine_stats_t` with `dbengine_get_stats()`, `dbengine_set_collect_stats()`, and `dbengine_set_collect_extended_stats()` (defaults: stats on, extended off); main mirrors `pulse_enabled` flags into the engine.
  - Exposed ARAL registrations via `dbengine_stats_snapshot_arals()`; pulse imports them each cycle.
  - Replaced all engine `pulse_aral_*`/`pulse_gorilla_*` calls with `dbengine_stats_register_*`, `dbengine_stats_unregister_aral_statistics()`, and `dbengine_stats_gorilla_*`; engine no longer references pulse symbols.
  - Cache creation now checks `dbengine_collect_stats()`; Gorilla hot-path counters are gated by `dbengine_collect_extended_stats()`.
  - Added `src/database/engine/dbengine-stats.h` and wired it in CMake; guarded daemon call sites with `#ifdef ENABLE_DBENGINE`.

<sup>Written for commit f774b3461a70f0af0d2da39ff53c13eb277bb31a. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22538?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

