### PR TITLE
Prevent host status stalls during obsolete-chart cleanup

### DIFF
--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -196,17 +196,30 @@ static void svc_rrd_cleanup_obsolete_charts_from_all_hosts() {
         if (rrdhost_is_local(host) || IS_VIRTUAL_HOST_OS(host))
             continue;
 
+        // Two-phase obsolete-all: decide under receiver_lock (short held),
+        // run the O(charts) walk + ml_host_disconnected without the lock,
+        // gated by RRDHOST_FLAG_OBSOLETE_ALL_IN_PROGRESS so a reconnecting
+        // receiver bails out in rrdhost_set_receiver() instead of overlapping.
+        bool obsolete_all = false;
+
         rrdhost_receiver_lock(host);
 
         time_t now = now_realtime_sec();
 
         if (!host->receiver &&
             host->stream.rcv.status.last_connected == 0 &&
-            (host->stream.rcv.status.last_disconnected + rrdset_free_obsolete_time_s < now)) {
-            svc_rrdhost_obsolete_all_charts(host);
+            (host->stream.rcv.status.last_disconnected + rrdset_free_obsolete_time_s < now) &&
+            !rrdhost_flag_check(host, RRDHOST_FLAG_OBSOLETE_ALL_IN_PROGRESS)) {
+            rrdhost_flag_set(host, RRDHOST_FLAG_OBSOLETE_ALL_IN_PROGRESS);
+            obsolete_all = true;
         }
 
         rrdhost_receiver_unlock(host);
+
+        if (obsolete_all) {
+            svc_rrdhost_obsolete_all_charts(host);
+            rrdhost_flag_clear(host, RRDHOST_FLAG_OBSOLETE_ALL_IN_PROGRESS);
+        }
     }
 
     rrd_rdunlock();

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -96,6 +96,11 @@ typedef enum __attribute__ ((__packed__)) rrdhost_flags {
 
     RRDHOST_FLAG_GLOBAL_FUNCTIONS_UPDATED       = (1 << 28), // set when the host has updated global functions
     RRDHOST_FLAG_RRDCONTEXT_GET_RETENTION       = (1 << 29), // set when rrdcontext needs to update the retention of the host
+
+    RRDHOST_FLAG_OBSOLETE_ALL_IN_PROGRESS       = (1 << 30), // svc_rrdhost_obsolete_all_charts() is running on this host;
+                                                             // gates rrdhost_set_receiver() so a reconnect cannot attach
+                                                             // mid-pass. Set under receiver_lock; the heavy work runs
+                                                             // without holding receiver_lock so readers stay unblocked.
 } RRDHOST_FLAGS;
 
 #define rrdhost_flag_get(host)                         atomic_flags_get(&((host)->flags))
@@ -341,6 +346,17 @@ struct rrdhost {
 
 extern RRDHOST *localhost;
 
+// receiver_lock protects host->receiver and the host->stream.rcv.status fields.
+//
+// Hold time must stay short-bounded: no caller may hold receiver_lock across
+// O(charts), I/O, sends, ML stop/start, or any wait on other subsystems. The
+// obsolete-all cleanup pass (service.c) used to violate this; it now sets
+// RRDHOST_FLAG_OBSOLETE_ALL_IN_PROGRESS under the lock and runs the heavy
+// work without holding it. rrdhost_set_receiver() checks that flag under
+// the lock and returns false on contention; the child reconnects via normal
+// backoff. With cleanup off the lock, all other readers (status, ACLK,
+// capabilities, paths, event-driven sends) keep blocking-lock semantics and
+// stay truthful.
 #define rrdhost_receiver_lock(host) spinlock_lock(&(host)->receiver_lock)
 #define rrdhost_receiver_unlock(host) spinlock_unlock(&(host)->receiver_lock)
 

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -353,10 +353,11 @@ extern RRDHOST *localhost;
 // obsolete-all cleanup pass (service.c) used to violate this; it now sets
 // RRDHOST_FLAG_OBSOLETE_ALL_IN_PROGRESS under the lock and runs the heavy
 // work without holding it. rrdhost_set_receiver() checks that flag under
-// the lock and returns false on contention; the child reconnects via normal
-// backoff. With cleanup off the lock, all other readers (status, ACLK,
-// capabilities, paths, event-driven sends) keep blocking-lock semantics and
-// stay truthful.
+// the lock and returns RRDHOST_SET_RECEIVER_CLEANUP_BUSY when the cleanup
+// pass is in progress; the caller answers the child with BUSY_TRY_LATER and
+// the child reconnects via normal backoff. With cleanup off the lock, all
+// other readers (status, ACLK, capabilities, paths, event-driven sends)
+// keep blocking-lock semantics and stay truthful.
 #define rrdhost_receiver_lock(host) spinlock_lock(&(host)->receiver_lock)
 #define rrdhost_receiver_unlock(host) spinlock_unlock(&(host)->receiver_lock)
 

--- a/src/streaming/stream-receiver-connection.c
+++ b/src/streaming/stream-receiver-connection.c
@@ -229,7 +229,17 @@ static bool stream_receiver_send_first_response(struct receiver_state *rpt) {
 //            return false;
 //        }
 
-        if(!rrdhost_set_receiver(host, rpt)) {
+        RRDHOST_SET_RECEIVER_RESULT result = rrdhost_set_receiver(host, rpt);
+        if (result == RRDHOST_SET_RECEIVER_CLEANUP_BUSY) {
+            stream_receiver_log_status(
+                rpt,
+                "rejecting streaming connection; internal cleanup is in progress for this node, please retry shortly",
+                STREAM_HANDSHAKE_PARENT_BUSY_TRY_LATER, NDLP_INFO);
+
+            stream_send_error_on_taken_over_connection(rpt, START_STREAMING_ERROR_BUSY_TRY_LATER);
+            return false;
+        }
+        if (result == RRDHOST_SET_RECEIVER_ALREADY_ATTACHED) {
             stream_receiver_log_status(
                 rpt,
                 "rejecting streaming connection; host is already served by another receiver",

--- a/src/streaming/stream-receiver-internals.h
+++ b/src/streaming/stream-receiver-internals.h
@@ -101,7 +101,13 @@ struct receiver_state {
 #endif
 };
 
-bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt);
+typedef enum {
+    RRDHOST_SET_RECEIVER_OK,                // attached
+    RRDHOST_SET_RECEIVER_ALREADY_ATTACHED,  // another receiver already attached
+    RRDHOST_SET_RECEIVER_CLEANUP_BUSY,      // obsolete-all cleanup is running; caller should answer BUSY_TRY_LATER
+} RRDHOST_SET_RECEIVER_RESULT;
+
+RRDHOST_SET_RECEIVER_RESULT rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt);
 void rrdhost_clear_receiver(struct receiver_state *rpt, STREAM_HANDSHAKE reason);
 void stream_receiver_log_status(struct receiver_state *rpt, const char *msg, STREAM_HANDSHAKE reason, ND_LOG_FIELD_PRIORITY priority);
 

--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -1134,6 +1134,16 @@ bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {
 
     rrdhost_receiver_lock(host);
 
+    // If the obsolete-all cleanup is running on this host, refuse the attach.
+    // The cleanup walks all charts marking them obsolete without holding
+    // receiver_lock; attaching mid-pass would let it mark the new receiver's
+    // charts obsolete and call ml_host_disconnected() on a connected host.
+    // The child reconnects via normal backoff; by then the pass is done.
+    if (rrdhost_flag_check(host, RRDHOST_FLAG_OBSOLETE_ALL_IN_PROGRESS)) {
+        rrdhost_receiver_unlock(host);
+        return false;
+    }
+
     if (!host->receiver) {
         object_state_activate_if_not_activated(&host->state_id);
 

--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -1128,7 +1128,7 @@ static void stream_receiver_replication_reset(RRDHOST *host) {
     __atomic_store_n(&host->stream.rcv.status.replication.backfill_pending, 0, __ATOMIC_RELAXED);
 }
 
-bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {
+RRDHOST_SET_RECEIVER_RESULT rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {
     bool signal_rrdcontext = false;
     bool set_this = false;
 
@@ -1141,7 +1141,7 @@ bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {
     // The child reconnects via normal backoff; by then the pass is done.
     if (rrdhost_flag_check(host, RRDHOST_FLAG_OBSOLETE_ALL_IN_PROGRESS)) {
         rrdhost_receiver_unlock(host);
-        return false;
+        return RRDHOST_SET_RECEIVER_CLEANUP_BUSY;
     }
 
     if (!host->receiver) {
@@ -1198,7 +1198,7 @@ bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {
     if(set_this)
         ml_host_start(host);
 
-    return set_this;
+    return set_this ? RRDHOST_SET_RECEIVER_OK : RRDHOST_SET_RECEIVER_ALREADY_ATTACHED;
 }
 
 void rrdhost_clear_receiver(struct receiver_state *rpt, STREAM_HANDSHAKE reason) {


### PR DESCRIPTION
##### Summary
When a child disconnects from a streaming parent and stays offline long enough, the parent runs a per-host cleanup that marks every chart on that host obsolete. 

On parents with many charts this pass can take minutes — and the old code held host->receiver_lock for the whole time.

This PR moves the heavy work off the lock. Cleanup takes the lock briefly, decides it's eligible, sets a new RRDHOST_FLAG_OBSOLETE_ALL_IN_PROGRESS flag, and releases. 

The chart-obsoletion walk runs without the lock. A reconnecting child sees the flag in rrdhost_set_receiver() and bails out; it reconnects through normal backoff once the pass is done. 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent host stalls during obsolete-chart cleanup by moving O(charts) work out from under `receiver_lock` and gating reconnects during the pass. This keeps status reads responsive and prevents races if a child reconnects mid-cleanup.

- **Bug Fixes**
  - Two-phase cleanup using `RRDHOST_FLAG_OBSOLETE_ALL_IN_PROGRESS`: set under `receiver_lock`, run the heavy walk without the lock, then clear.
  - `rrdhost_set_receiver()` now returns a result enum; it rejects attaches with CLEANUP_BUSY (handshake replies BUSY_TRY_LATER) and distinguishes ALREADY_ATTACHED from OK to avoid marking new charts obsolete or triggering `ml_host_disconnected()` on a connected host.
  - Clarified `receiver_lock` contract in `rrdhost.h`: keep hold times short; never span O(charts) or I/O.

<sup>Written for commit 135b73bfd40c81bdc2124cb859c5df14db5e50ea. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22539?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



