### PR TITLE
Fix rw-spinlock writer starvation

### DIFF
--- a/src/libnetdata/locks/benchmark-rw.c
+++ b/src/libnetdata/locks/benchmark-rw.c
@@ -5,7 +5,145 @@
 #define MAX_THREADS 64
 #define TEST_DURATION_SEC 1
 #define STOP_SIGNAL UINT64_MAX
-#define MAX_CONFIGS 10
+#define MAX_CONFIGS 20
+
+// ----------------------------------------------------------------------------
+// Runtime knobs, read from the environment so the benchmark stays reachable
+// through the plain `netdata -W rwlockstest` entrypoint (no CLI plumbing).
+//
+//   RWBENCH_SECS            seconds per configuration          (default 1)
+//   RWBENCH_CS_WORK         work units inside the critical section (default 0)
+//   RWBENCH_PROBE_SECS      seconds per writer-latency probe    (default 5)
+//   RWBENCH_WRITER_GAP_US   probe writer idle gap between acquisitions (default 1000)
+//   RWBENCH_SKIP_MATRIX     set to 1 to run only the latency probe
+//   RWBENCH_SKIP_PROBE      set to 1 to run only the throughput/latency matrix
+
+static unsigned long env_ulong(const char *name, unsigned long def) {
+    const char *v = getenv(name);
+    if(!v || !*v) return def;
+
+    char *end = NULL;
+    errno_clear();
+    unsigned long r = strtoul(v, &end, 10);
+    if(errno || !end || *end) {
+        fprintf(stderr, "RWBENCH: ignoring invalid %s='%s', using %lu\n", name, v, def);
+        return def;
+    }
+
+    return r;
+}
+
+// ----------------------------------------------------------------------------
+// Nanosecond clock.
+//
+// libnetdata's clocks API exposes microseconds only (clocks.h), which cannot
+// resolve an uncontended read-lock acquisition (tens of nanoseconds). This is
+// kept file-local instead of added to libnetdata/clocks because the benchmark is
+// its only consumer; promote it if a second one appears.
+
+static ALWAYS_INLINE nsec_t bench_now_nsec(void) {
+    struct timespec ts;
+    if(unlikely(clock_gettime(CLOCK_MONOTONIC, &ts) == -1))
+        return 0;
+
+    return (nsec_t)ts.tv_sec * NSEC_PER_SEC + (nsec_t)ts.tv_nsec;
+}
+
+// ----------------------------------------------------------------------------
+// Latency histogram.
+//
+// Power-of-two buckets over nanoseconds: bucket i counts samples in
+// [2^i, 2^(i+1)) ns. The question this benchmark answers is whether a lock
+// acquisition costs tens of nanoseconds, ~50us (one nanosleep of timer slack) or
+// ~512us (the top of the back-off ramp) - those are orders of magnitude apart,
+// so power-of-two resolution is enough and needs no per-sample storage.
+// Exact max and sum are kept alongside.
+
+#define LAT_BUCKETS 48  // up to 2^48 ns ~ 78 hours
+
+typedef struct {
+    uint64_t count;
+    uint64_t sum_ns;
+    uint64_t max_ns;
+    uint64_t buckets[LAT_BUCKETS];
+} latency_hist_t;
+
+static ALWAYS_INLINE void lat_record(latency_hist_t *h, nsec_t ns) {
+    h->count++;
+    h->sum_ns += ns;
+    if(ns > h->max_ns) h->max_ns = ns;
+
+    // bucket = floor(log2(ns)); 0 and 1 both land in bucket 0
+    size_t b = 0;
+    if(ns > 1) {
+        b = (size_t)(63 - __builtin_clzll((unsigned long long)ns));
+        if(b >= LAT_BUCKETS) b = LAT_BUCKETS - 1;
+    }
+    h->buckets[b]++;
+}
+
+static void lat_merge(latency_hist_t *dst, const latency_hist_t *src) {
+    dst->count += src->count;
+    dst->sum_ns += src->sum_ns;
+    if(src->max_ns > dst->max_ns) dst->max_ns = src->max_ns;
+    for(size_t i = 0; i < LAT_BUCKETS; i++)
+        dst->buckets[i] += src->buckets[i];
+}
+
+// Upper bound (in ns) of the bucket holding the requested percentile.
+static uint64_t lat_percentile_ns(const latency_hist_t *h, double p) {
+    if(!h->count) return 0;
+
+    uint64_t target = (uint64_t)((double)h->count * p);
+    if(target < 1) target = 1;
+
+    uint64_t seen = 0;
+    for(size_t i = 0; i < LAT_BUCKETS; i++) {
+        seen += h->buckets[i];
+        if(seen >= target)
+            return 2ULL << i;   // upper bound of [2^i, 2^(i+1))
+    }
+
+    return h->max_ns;
+}
+
+static double lat_mean_us(const latency_hist_t *h) {
+    if(!h->count) return 0.0;
+    return (double)h->sum_ns / (double)h->count / 1000.0;
+}
+
+static void lat_print_line(const char *label, const latency_hist_t *h) {
+    fprintf(stderr, "%-26s %10"PRIu64" %10.3f %10.3f %10.3f %10.3f %12.3f\n",
+            label,
+            h->count,
+            lat_mean_us(h),
+            (double)lat_percentile_ns(h, 0.50) / 1000.0,
+            (double)lat_percentile_ns(h, 0.99) / 1000.0,
+            (double)lat_percentile_ns(h, 0.999) / 1000.0,
+            (double)h->max_ns / 1000.0);
+}
+
+static void lat_print_header(const char *what) {
+    fprintf(stderr, "\n%s (microseconds; percentiles are power-of-two bucket upper bounds)\n", what);
+    fprintf(stderr, "%-26s %10s %10s %10s %10s %10s %12s\n",
+            "SERIES", "SAMPLES", "MEAN", "P50<=", "P99<=", "P99.9<=", "MAX");
+    fprintf(stderr, "-------------------------------------------------------------------------------------------------\n");
+}
+
+// Distribution dump - the bimodality of writer acquisition is the point, and a
+// mean hides it completely.
+static void lat_print_distribution(const latency_hist_t *h) {
+    if(!h->count) return;
+
+    fprintf(stderr, "    distribution: ");
+    for(size_t i = 0; i < LAT_BUCKETS; i++) {
+        if(!h->buckets[i]) continue;
+        fprintf(stderr, "[<%.3gus]=%.1f%% ",
+                (double)(2ULL << i) / 1000.0,
+                (double)h->buckets[i] * 100.0 / (double)h->count);
+    }
+    fprintf(stderr, "\n");
+}
 
 // Structure to store summary statistics
 typedef struct {
@@ -31,7 +169,13 @@ typedef struct {
         uint64_t operations;        // Number of read/write operations
         usec_t test_time;          // Time spent in test
         volatile int ready;         // Thread completed flag
+        latency_hist_t lat;         // Lock-acquisition latency (when measured)
+        uint64_t sink;              // Per-thread accumulator for critical-section work
     } stats[MAX_THREADS];
+
+    // Per-run knobs, set by run_test() before the threads are released
+    uint32_t cs_work;               // work units executed inside the critical section
+    bool measure_latency;           // time every lock acquisition
 
     // Per-thread control
     struct {
@@ -106,6 +250,21 @@ static void wait_for_start(netdata_cond_t *cond, netdata_mutex_t *mutex, uint64_
     netdata_mutex_unlock(mutex);
 }
 
+// Work performed inside the critical section.
+//
+// Writers do the shared counter increment the original benchmark did - it is
+// exclusive, so it is a legitimate write. Readers only read: the original code
+// had every reader do control->counter++ under a READ lock, which is a genuine
+// data race between concurrent readers and made the shared cacheline bounce for
+// reasons unrelated to the lock being measured.
+static ALWAYS_INLINE void do_critical_section_work(rwlock_control_t *control, thread_context_t *ctx) {
+    if(ctx->type == THREAD_WRITER)
+        control->counter++;
+
+    for(uint32_t i = 0; i < control->cs_work; i++)
+        control->stats[ctx->thread_id].sink += __atomic_load_n(&control->counter, __ATOMIC_RELAXED);
+}
+
 static void benchmark_thread(void *arg) {
     thread_context_t *ctx = (thread_context_t *)arg;
     rwlock_control_t *control = ctx->control;
@@ -122,20 +281,31 @@ static void benchmark_thread(void *arg) {
         usec_t start = now_monotonic_high_precision_usec();
         uint64_t operations = 0;
 
+        // The latency pass reads the clock twice per acquisition, which costs
+        // more than an uncontended acquisition itself. That is why it is a
+        // separate pass: the throughput pass below stays clock-free so its
+        // numbers remain comparable.
+        const bool measure = control->measure_latency;
+        latency_hist_t *lat = &control->stats[ctx->thread_id].lat;
+
         while (control->thread_controls[ctx->thread_id].run_flag) {
+            nsec_t t0 = measure ? bench_now_nsec() : 0;
+
             if(ctx->is_spinlock) {
                 RW_SPINLOCK *spinlock = ctx->lock;
                 if(ctx->type == THREAD_READER) {
                     rw_spinlock_read_lock(spinlock);
+                    if(measure) lat_record(lat, bench_now_nsec() - t0);
                     check_access_safety(control, THREAD_READER);
-                    control->counter++;  // Just to do some work
+                    do_critical_section_work(control, ctx);
                     release_access(control, THREAD_READER);
                     rw_spinlock_read_unlock(spinlock);
                 }
                 else {
                     rw_spinlock_write_lock(spinlock);
+                    if(measure) lat_record(lat, bench_now_nsec() - t0);
                     check_access_safety(control, THREAD_WRITER);
-                    control->counter++;
+                    do_critical_section_work(control, ctx);
                     release_access(control, THREAD_WRITER);
                     rw_spinlock_write_unlock(spinlock);
                 }
@@ -144,17 +314,22 @@ static void benchmark_thread(void *arg) {
                 netdata_rwlock_t *rwlock = ctx->lock;
                 if(ctx->type == THREAD_READER) {
                     netdata_rwlock_rdlock(rwlock);
+                    if(measure) lat_record(lat, bench_now_nsec() - t0);
                     check_access_safety(control, THREAD_READER);
-                    control->counter++;
+                    do_critical_section_work(control, ctx);
                     release_access(control, THREAD_READER);
                     netdata_rwlock_rdunlock(rwlock);
                 }
                 else {
                     netdata_rwlock_wrlock(rwlock);
+                    if(measure) lat_record(lat, bench_now_nsec() - t0);
                     check_access_safety(control, THREAD_WRITER);
-                    control->counter++;
+                    do_critical_section_work(control, ctx);
                     release_access(control, THREAD_WRITER);
-                    netdata_rwlock_rdunlock(rwlock);
+                    // was rdunlock(): a write lock must be released with
+                    // wrunlock(), they are different libuv calls, so the
+                    // netdata_rwlock writer column was invalid before this.
+                    netdata_rwlock_wrunlock(rwlock);
                 }
             }
             operations++;
@@ -237,6 +412,23 @@ static void print_thread_stats(const char *test_name, int readers, int writers,
     fprintf(stderr, "%4s %8s %12"PRIu64" %12.0f\n",
             "TOT", "", total_ops, total_ops_per_sec);
 
+    if(control->measure_latency) {
+        latency_hist_t rd = {0}, wr = {0};
+        for(int i = 0; i < readers + writers; i++) {
+            if(contexts[i].type == THREAD_READER)
+                lat_merge(&rd, &control->stats[i].lat);
+            else
+                lat_merge(&wr, &control->stats[i].lat);
+        }
+
+        lat_print_header("  acquisition latency");
+        if(rd.count) lat_print_line("  readers", &rd);
+        if(wr.count) {
+            lat_print_line("  writers", &wr);
+            lat_print_distribution(&wr);
+        }
+    }
+
     // Store in summary
     summary->ops_per_sec[lock_type][config_idx] = total_ops_per_sec;
     summary->reader_ops_per_sec[lock_type][config_idx] = reader_ops_per_sec;
@@ -254,7 +446,7 @@ static void run_test(const char *name, int readers, int writers,
     fprintf(stderr, "\nRunning test: %s with %d readers and %d writers...\n",
             name, readers, writers);
 
-    // Reset all stats and control
+    // Reset all stats and control (clears the per-thread latency histograms too)
     memset(&control->stats, 0, sizeof(control->stats));
     control->counter = 0;
     control->readers = 0;
@@ -272,7 +464,7 @@ static void run_test(const char *name, int readers, int writers,
     }
 
     // Wait for test duration
-    sleep_usec(TEST_DURATION_SEC * USEC_PER_SEC);
+    sleep_usec(env_ulong("RWBENCH_SECS", TEST_DURATION_SEC) * USEC_PER_SEC);
 
     // Signal threads to stop
     for(int i = 0; i < total_threads; i++) {
@@ -286,6 +478,188 @@ static void run_test(const char *name, int readers, int writers,
     }
 
     print_thread_stats(name, readers, writers, contexts, control, summary, config_idx, lock_type);
+}
+
+
+// ====================================================================================================================
+// Layer 2 probe: writer acquisition latency under continuous reader churn.
+//
+// This is the scenario the writer-priority change targets: one writer arrives
+// periodically into a stream of readers that never stops. It answers two
+// questions the throughput matrix cannot:
+//
+//   1. how long does a writer wait to acquire, at the tail, not the mean; and
+//   2. what does the blocking reader path cost while a writer is pending.
+//
+// The readers use the BLOCKING rw_spinlock_read_lock() deliberately. The
+// rw-spinlock unittest churns with rw_spinlock_tryread_lock(), which returns
+// immediately and therefore never exercises the reader back-off ramp
+// (microsleep 1us -> 512us) that a pending writer forces readers onto.
+
+#define PROBE_MAX_READERS 32
+
+typedef struct {
+    void *lock;
+    bool is_spinlock;
+    uint32_t stop;
+    uint32_t gap_us;        // writer only: idle time between acquisitions
+    uint32_t finished;      // writer only: set when the thread has exited its loop
+    uint64_t ops;
+    latency_hist_t lat;
+} probe_ctx_t;
+
+static void probe_reader_thread(void *arg) {
+    probe_ctx_t *ctx = (probe_ctx_t *)arg;
+
+    while(!__atomic_load_n(&ctx->stop, __ATOMIC_ACQUIRE)) {
+        nsec_t t0 = bench_now_nsec();
+
+        if(ctx->is_spinlock) {
+            rw_spinlock_read_lock((RW_SPINLOCK *)ctx->lock);
+            lat_record(&ctx->lat, bench_now_nsec() - t0);
+            rw_spinlock_read_unlock((RW_SPINLOCK *)ctx->lock);
+        }
+        else {
+            netdata_rwlock_rdlock((netdata_rwlock_t *)ctx->lock);
+            lat_record(&ctx->lat, bench_now_nsec() - t0);
+            netdata_rwlock_rdunlock((netdata_rwlock_t *)ctx->lock);
+        }
+
+        ctx->ops++;
+    }
+}
+
+static void probe_writer_thread(void *arg) {
+    probe_ctx_t *ctx = (probe_ctx_t *)arg;
+
+    while(!__atomic_load_n(&ctx->stop, __ATOMIC_ACQUIRE)) {
+        // Stay out of the lock between acquisitions, so every sample measures a
+        // writer ARRIVING into an established reader stream. Back-to-back
+        // acquisitions would keep the lock writer-held and measure nothing.
+        microsleep(ctx->gap_us);
+
+        nsec_t t0 = bench_now_nsec();
+
+        if(ctx->is_spinlock) {
+            rw_spinlock_write_lock((RW_SPINLOCK *)ctx->lock);
+            lat_record(&ctx->lat, bench_now_nsec() - t0);
+            rw_spinlock_write_unlock((RW_SPINLOCK *)ctx->lock);
+        }
+        else {
+            netdata_rwlock_wrlock((netdata_rwlock_t *)ctx->lock);
+            lat_record(&ctx->lat, bench_now_nsec() - t0);
+            netdata_rwlock_wrunlock((netdata_rwlock_t *)ctx->lock);
+        }
+
+        ctx->ops++;
+    }
+
+    __atomic_store_n(&ctx->finished, 1, __ATOMIC_RELEASE);
+}
+
+static void run_writer_latency_probe(const char *lock_name, void *lock, bool is_spinlock,
+                                     int nreaders, unsigned long secs, unsigned long gap_us) {
+    probe_ctx_t readers[PROBE_MAX_READERS];
+    probe_ctx_t writer = { .lock = lock, .is_spinlock = is_spinlock, .gap_us = (uint32_t)gap_us };
+    ND_THREAD *reader_threads[PROBE_MAX_READERS];
+    char thr_name[32];
+
+    fprintf(stderr, "\n%s: 1 writer (every %luus) vs %d churning readers, %lus\n",
+            lock_name, gap_us, nreaders, secs);
+
+    usec_t readers_started_ut = now_monotonic_usec();
+    for(int i = 0; i < nreaders; i++) {
+        readers[i] = (probe_ctx_t){ .lock = lock, .is_spinlock = is_spinlock };
+        snprintf(thr_name, sizeof(thr_name), "probe_rd%d", i);
+        reader_threads[i] = nd_thread_create(thr_name, NETDATA_THREAD_OPTION_DONT_LOG,
+                                             probe_reader_thread, &readers[i]);
+    }
+
+    // Let the reader stream establish itself before the writer arrives, so the
+    // first samples are not measuring an empty lock.
+    sleep_usec(100 * USEC_PER_MS);
+
+    ND_THREAD *writer_thread = nd_thread_create("probe_wr", NETDATA_THREAD_OPTION_DONT_LOG,
+                                                probe_writer_thread, &writer);
+
+    sleep_usec(secs * USEC_PER_SEC);
+
+    // Stop the writer first: readers must outlive it, otherwise the last writer
+    // acquisition is measured against a draining reader set instead of a full one.
+    __atomic_store_n(&writer.stop, 1, __ATOMIC_RELEASE);
+
+    // The writer can be parked inside write_lock. On an implementation that
+    // starves writers it never returns while the readers churn, so joining it
+    // here would hang the benchmark forever - which IS the finding, but it has
+    // to be reported rather than hung on. Give it a bounded grace period, then
+    // release the readers so it can always complete.
+    usec_t grace_deadline = now_monotonic_usec() + 5 * USEC_PER_SEC;
+    while(!__atomic_load_n(&writer.finished, __ATOMIC_ACQUIRE) &&
+          now_monotonic_usec() < grace_deadline)
+        yield_the_processor();
+
+    bool writer_starved = !__atomic_load_n(&writer.finished, __ATOMIC_ACQUIRE);
+
+    for(int i = 0; i < nreaders; i++)
+        __atomic_store_n(&readers[i].stop, 1, __ATOMIC_RELEASE);
+
+    nd_thread_join(writer_thread);
+    for(int i = 0; i < nreaders; i++)
+        nd_thread_join(reader_threads[i]);
+
+    // Measured, not nominal: when the writer starves, the readers keep running
+    // through the whole grace period, and dividing by `secs` would understate
+    // their throughput by exactly that much - in the one case we care about.
+    usec_t readers_ran_ut = now_monotonic_usec() - readers_started_ut;
+
+    latency_hist_t rd = {0};
+    uint64_t reader_ops = 0;
+    for(int i = 0; i < nreaders; i++) {
+        lat_merge(&rd, &readers[i].lat);
+        reader_ops += readers[i].ops;
+    }
+
+    if(writer_starved)
+        fprintf(stderr, "    *** WRITER STARVED: still parked in the lock 5s after stop;"
+                        " its last sample only completed once the readers were stopped ***\n");
+
+    lat_print_header("  latency");
+    lat_print_line("  writer acquire", &writer.lat);
+    lat_print_distribution(&writer.lat);
+    lat_print_line("  reader acquire", &rd);
+    fprintf(stderr, "    reader throughput: %.3f M ops/sec across %d readers (over %.2fs measured)\n",
+            (double)reader_ops * USEC_PER_SEC / (double)readers_ran_ut / 1000000.0,
+            nreaders,
+            (double)readers_ran_ut / (double)USEC_PER_SEC);
+
+    if(is_spinlock) {
+        RW_SPINLOCK *sp = (RW_SPINLOCK *)lock;
+        if(sp->counter != 0 || sp->writer != 0)
+            fprintf(stderr, "    FATAL: lock not free after probe (counter=%u writer=%d)\n",
+                    sp->counter, sp->writer);
+    }
+}
+
+static void writer_latency_probe(void) {
+    unsigned long secs = env_ulong("RWBENCH_PROBE_SECS", 5);
+    unsigned long gap_us = env_ulong("RWBENCH_WRITER_GAP_US", 1000);
+    int reader_counts[] = { 1, 4, 8, 16, 32 };
+
+    fprintf(stderr, "\n\n====================================================================\n");
+    fprintf(stderr, "WRITER ACQUISITION LATENCY UNDER READER CHURN\n");
+    fprintf(stderr, "====================================================================\n");
+
+    for(size_t i = 0; i < sizeof(reader_counts) / sizeof(reader_counts[0]); i++) {
+        int nreaders = reader_counts[i];
+
+        RW_SPINLOCK rw_spinlock = RW_SPINLOCK_INITIALIZER;
+        run_writer_latency_probe("rw_spinlock", &rw_spinlock, true, nreaders, secs, gap_us);
+
+        netdata_rwlock_t rwlock;
+        netdata_rwlock_init(&rwlock);
+        run_writer_latency_probe("netdata_rwlock", &rwlock, false, nreaders, secs, gap_us);
+        netdata_rwlock_destroy(&rwlock);
+    }
 }
 
 int rwlocks_stress_test(void) {
@@ -319,19 +693,25 @@ int rwlocks_stress_test(void) {
 
     // Test configurations: [readers, writers]
     int configs[][2] = {
-        {1, 0},   // Single reader
-        {0, 1},   // Single writer
+        {1, 0},   // Single reader                  - uncontended reader guard
+        {0, 1},   // Single writer                  - uncontended writer guard
         {1, 1},   // One reader + one writer
         {2, 1},   // Two readers + one writer
         {1, 2},   // One reader + two writers
         {2, 2},   // Two readers + two writers
         {4, 1},   // Four readers + one writer
-        {1, 4},   // One reader + four writers
+        {1, 4},   // One reader + four writers      - writer->writer handoff
         {4, 4},   // Four readers + four writers
+        {8, 1},   // Eight readers + one writer     - reader pressure on one writer
+        {16, 1},  // 16 readers + one writer
+        {32, 1},  // 32 readers + one writer        - oversubscribed below 33 cores
+        {16, 4},  // 16 readers + four writers      - reader pressure + handoff
     };
 
     const int num_configs = sizeof(configs) / sizeof(configs[0]);
     summary.config_count = num_configs;
+    const bool skip_matrix = env_ulong("RWBENCH_SKIP_MATRIX", 0) != 0;
+    const bool skip_probe  = env_ulong("RWBENCH_SKIP_PROBE", 0) != 0;
 
     // Create all threads
     for(int i = 0; i < MAX_THREADS; i++) {
@@ -363,6 +743,25 @@ int rwlocks_stress_test(void) {
         spinlock_contexts[i].thread =
             nd_thread_create(thr_name, NETDATA_THREAD_OPTION_DONT_LOG, benchmark_thread, &spinlock_contexts[i]);
     }
+
+    // Two passes over the matrix. Pass 0 is clock-free and measures throughput.
+    // Pass 1 times every acquisition: two clock reads per operation cost more
+    // than an uncontended acquisition, so its throughput is NOT comparable with
+    // pass 0 - only its latency distribution is meaningful.
+    for(int pass = 0; pass < 2 && !skip_matrix; pass++) {
+    bool measure_latency = (pass == 1);
+    uint32_t cs_work = (uint32_t)env_ulong("RWBENCH_CS_WORK", 0);
+
+    netdata_control.measure_latency = spinlock_control.measure_latency = measure_latency;
+    netdata_control.cs_work = spinlock_control.cs_work = cs_work;
+    memset(&summary, 0, sizeof(summary));
+    summary.config_count = num_configs;
+
+    fprintf(stderr, "\n\n====================================================================\n");
+    fprintf(stderr, "PASS %d: %s (cs_work=%u)\n", pass,
+            measure_latency ? "LATENCY (clock-instrumented, throughput not comparable)"
+                            : "THROUGHPUT (clock-free)", cs_work);
+    fprintf(stderr, "====================================================================\n");
 
     // Run all configurations
     for(int i = 0; i < num_configs; i++) {
@@ -396,6 +795,7 @@ int rwlocks_stress_test(void) {
 
     // Print the summary table
     print_summary(&summary);
+    } // pass
 
     // Stop all threads
     fprintf(stderr, "\nStopping threads...\n");
@@ -429,6 +829,9 @@ int rwlocks_stress_test(void) {
     }
 
     netdata_rwlock_destroy(&netdata_rwlock);
+
+    if(!skip_probe)
+        writer_latency_probe();
 
     return 0;
 }

--- a/src/libnetdata/locks/rw-spinlock-unittest.c
+++ b/src/libnetdata/locks/rw-spinlock-unittest.c
@@ -149,6 +149,7 @@ static int rw_spinlock_writer_mutex_test(void) {
 typedef struct {
     RW_SPINLOCK *lock;
     uint32_t stop;
+    uint32_t active;   // count of readers that have taken the read lock at least once
 } rw_spinlock_churn_ctx_t;
 
 typedef struct {
@@ -158,9 +159,16 @@ typedef struct {
 
 static void rw_spinlock_reader_churn(void *arg) {
     rw_spinlock_churn_ctx_t *ctx = (rw_spinlock_churn_ctx_t *)arg;
+    bool counted = false;
     while (!__atomic_load_n(&ctx->stop, __ATOMIC_ACQUIRE)) {
-        if (rw_spinlock_tryread_lock(ctx->lock))
+        if (rw_spinlock_tryread_lock(ctx->lock)) {
+            if (!counted) {
+                // signal (once) that this reader is actively churning
+                __atomic_add_fetch(&ctx->active, 1, __ATOMIC_RELEASE);
+                counted = true;
+            }
             rw_spinlock_read_unlock(ctx->lock);
+        }
     }
 }
 
@@ -174,7 +182,7 @@ static void rw_spinlock_liveness_writer(void *arg) {
 static int rw_spinlock_writer_liveness_test(void) {
     int errors = 0;
     RW_SPINLOCK lock = RW_SPINLOCK_INITIALIZER;
-    rw_spinlock_churn_ctx_t rctx = { .lock = &lock, .stop = 0 };
+    rw_spinlock_churn_ctx_t rctx = { .lock = &lock, .stop = 0, .active = 0 };
     rw_spinlock_liveness_writer_ctx_t wctx = { .lock = &lock, .acquired = 0 };
 
     fprintf(stderr, "  - writer liveness: a writer must acquire despite %d churning readers\n",
@@ -184,6 +192,19 @@ static int rw_spinlock_writer_liveness_test(void) {
     for (int i = 0; i < RW_SPINLOCK_TEST_READERS; i++)
         readers[i] = nd_thread_create("rwsp_rd", NETDATA_THREAD_OPTION_DONT_LOG,
                                       rw_spinlock_reader_churn, &rctx);
+
+    // Do not start the writer until every reader is actively churning (each has
+    // taken the read lock at least once). Otherwise the writer could acquire a
+    // free, uncontended lock before the readers exist and the test would pass
+    // vacuously, exercising none of the writer-vs-readers contention. Bounded
+    // deadline is only a hang-guard, not a correctness signal.
+    usec_t ready_deadline = now_monotonic_usec() + 5 * USEC_PER_SEC;
+    while (__atomic_load_n(&rctx.active, __ATOMIC_ACQUIRE) < RW_SPINLOCK_TEST_READERS &&
+           now_monotonic_usec() < ready_deadline) {
+        ; // spin until all readers are churning
+    }
+    RW_TEST(__atomic_load_n(&rctx.active, __ATOMIC_ACQUIRE) == RW_SPINLOCK_TEST_READERS,
+            "all readers are churning before the writer starts");
 
     ND_THREAD *writer = nd_thread_create("rwsp_wr", NETDATA_THREAD_OPTION_DONT_LOG,
                                          rw_spinlock_liveness_writer, &wctx);

--- a/src/libnetdata/locks/rw-spinlock-unittest.c
+++ b/src/libnetdata/locks/rw-spinlock-unittest.c
@@ -17,6 +17,202 @@
         }                                                                       \
     } while(0)
 
+// Writer-priority thread: blocks on the write lock (parking behind a reader the
+// caller holds), then immediately releases once it acquires.
+static void rw_spinlock_wp_writer(void *arg) {
+    RW_SPINLOCK *lock = (RW_SPINLOCK *)arg;
+    rw_spinlock_write_lock(lock);
+    rw_spinlock_write_unlock(lock);
+}
+
+// Writer-priority invariant (multi-threaded, deterministic): while a writer is
+// parked waiting for an existing reader to drain, new readers must back off and
+// must not be admitted. This is the no-writer-starvation guarantee. It cannot be
+// observed single-threaded, and it does NOT hold on the pre-writer-priority
+// implementation (which cleared the writer bit and retried, admitting readers).
+static int rw_spinlock_writer_priority_test(void) {
+    int errors = 0;
+    RW_SPINLOCK lock = RW_SPINLOCK_INITIALIZER;
+
+    fprintf(stderr, "  - writer-priority invariant: new readers back off while a writer is pending\n");
+
+    // hold a reader so an incoming writer must wait
+    rw_spinlock_read_lock(&lock);
+
+    ND_THREAD *writer = nd_thread_create("rwsp_wp", NETDATA_THREAD_OPTION_DONT_LOG,
+                                         rw_spinlock_wp_writer, &lock);
+
+    // Wait until the writer has parked. Detected purely through the public API:
+    // once the writer marks itself pending, tryread starts failing. Bounded
+    // deadline is only a hang-guard, not a correctness signal.
+    bool writer_parked = false;
+    usec_t deadline = now_monotonic_usec() + 5 * USEC_PER_SEC;
+    while (now_monotonic_usec() < deadline) {
+        if (rw_spinlock_tryread_lock(&lock)) {
+            // still admitted => writer not pending yet; release and retry
+            rw_spinlock_read_unlock(&lock);
+        }
+        else {
+            writer_parked = true;
+            break;
+        }
+    }
+    RW_TEST(writer_parked, "a writer parks (pending) while a reader is held");
+
+    // While the writer is pending and our reader is still held, no new reader may
+    // be admitted. The held reader keeps the writer parked, so the pending state
+    // is stable for the whole burst.
+    int admitted = 0;
+    for (int i = 0; i < 100000; i++) {
+        if (rw_spinlock_tryread_lock(&lock)) {
+            admitted++;
+            rw_spinlock_read_unlock(&lock);
+        }
+    }
+    RW_TEST(admitted == 0, "no reader admitted while a writer is pending (writer-priority)");
+
+    // release our reader so the parked writer can finally acquire and exit
+    rw_spinlock_read_unlock(&lock);
+    nd_thread_join(writer);
+
+    RW_TEST(lock.counter == 0, "lock is free after the writer released");
+    RW_TEST(lock.writer == 0, "writer tid cleared after release");
+
+    return errors;
+}
+
+// ----------------------------------------------------------------------------
+// Multiple writers serialize: each writer increments a plain (non-atomic) shared
+// counter under the write lock. The final value can only equal the expected
+// total if the lock provides true mutual exclusion among concurrent writers; a
+// lost update means writers overlapped.
+
+#define RW_SPINLOCK_TEST_WRITERS 8
+#define RW_SPINLOCK_TEST_INCREMENTS 10000
+
+typedef struct {
+    RW_SPINLOCK *lock;
+    int *shared;      // intentionally non-atomic; protected only by the lock
+    int increments;
+} rw_spinlock_mutex_ctx_t;
+
+static void rw_spinlock_mutex_writer(void *arg) {
+    rw_spinlock_mutex_ctx_t *ctx = (rw_spinlock_mutex_ctx_t *)arg;
+    for (int i = 0; i < ctx->increments; i++) {
+        rw_spinlock_write_lock(ctx->lock);
+        (*ctx->shared)++;
+        rw_spinlock_write_unlock(ctx->lock);
+    }
+}
+
+static int rw_spinlock_writer_mutex_test(void) {
+    int errors = 0;
+    RW_SPINLOCK lock = RW_SPINLOCK_INITIALIZER;
+    int shared = 0;
+
+    fprintf(stderr, "  - mutual exclusion: %d concurrent writers must produce no lost updates\n",
+            RW_SPINLOCK_TEST_WRITERS);
+
+    rw_spinlock_mutex_ctx_t ctx = {
+        .lock = &lock,
+        .shared = &shared,
+        .increments = RW_SPINLOCK_TEST_INCREMENTS,
+    };
+
+    ND_THREAD *threads[RW_SPINLOCK_TEST_WRITERS];
+    for (int i = 0; i < RW_SPINLOCK_TEST_WRITERS; i++)
+        threads[i] = nd_thread_create("rwsp_mx", NETDATA_THREAD_OPTION_DONT_LOG,
+                                      rw_spinlock_mutex_writer, &ctx);
+    for (int i = 0; i < RW_SPINLOCK_TEST_WRITERS; i++)
+        nd_thread_join(threads[i]);
+
+    RW_TEST(shared == RW_SPINLOCK_TEST_WRITERS * RW_SPINLOCK_TEST_INCREMENTS,
+            "concurrent writers serialize with no lost updates");
+    RW_TEST(lock.counter == 0, "lock is free after concurrent writers");
+    RW_TEST(lock.writer == 0, "writer tid cleared after concurrent writers");
+
+    return errors;
+}
+
+// ----------------------------------------------------------------------------
+// Writer liveness under reader churn: a pool of readers continuously acquires
+// and releases the read lock while a single writer blocks on the write lock.
+// Under writer-priority the writer must acquire promptly despite the churn (the
+// robust assertion). On the pre-writer-priority implementation a writer can be
+// starved by the reader stream; this test would then fail at the deadline, but
+// because starvation is timing-dependent this fail-on-old-master signal is
+// best-effort, not deterministic (the deterministic guards are the back-off
+// invariant and mutual-exclusion tests).
+
+#define RW_SPINLOCK_TEST_READERS 4
+
+typedef struct {
+    RW_SPINLOCK *lock;
+    uint32_t stop;
+} rw_spinlock_churn_ctx_t;
+
+typedef struct {
+    RW_SPINLOCK *lock;
+    uint32_t acquired;
+} rw_spinlock_liveness_writer_ctx_t;
+
+static void rw_spinlock_reader_churn(void *arg) {
+    rw_spinlock_churn_ctx_t *ctx = (rw_spinlock_churn_ctx_t *)arg;
+    while (!__atomic_load_n(&ctx->stop, __ATOMIC_ACQUIRE)) {
+        if (rw_spinlock_tryread_lock(ctx->lock))
+            rw_spinlock_read_unlock(ctx->lock);
+    }
+}
+
+static void rw_spinlock_liveness_writer(void *arg) {
+    rw_spinlock_liveness_writer_ctx_t *ctx = (rw_spinlock_liveness_writer_ctx_t *)arg;
+    rw_spinlock_write_lock(ctx->lock);
+    __atomic_store_n(&ctx->acquired, 1, __ATOMIC_RELEASE);
+    rw_spinlock_write_unlock(ctx->lock);
+}
+
+static int rw_spinlock_writer_liveness_test(void) {
+    int errors = 0;
+    RW_SPINLOCK lock = RW_SPINLOCK_INITIALIZER;
+    rw_spinlock_churn_ctx_t rctx = { .lock = &lock, .stop = 0 };
+    rw_spinlock_liveness_writer_ctx_t wctx = { .lock = &lock, .acquired = 0 };
+
+    fprintf(stderr, "  - writer liveness: a writer must acquire despite %d churning readers\n",
+            RW_SPINLOCK_TEST_READERS);
+
+    ND_THREAD *readers[RW_SPINLOCK_TEST_READERS];
+    for (int i = 0; i < RW_SPINLOCK_TEST_READERS; i++)
+        readers[i] = nd_thread_create("rwsp_rd", NETDATA_THREAD_OPTION_DONT_LOG,
+                                      rw_spinlock_reader_churn, &rctx);
+
+    ND_THREAD *writer = nd_thread_create("rwsp_wr", NETDATA_THREAD_OPTION_DONT_LOG,
+                                         rw_spinlock_liveness_writer, &wctx);
+
+    // Bounded wait for the writer to acquire. Generous deadline so this never
+    // false-fails on writer-priority (acquisition takes microseconds there).
+    bool acquired = false;
+    usec_t deadline = now_monotonic_usec() + 5 * USEC_PER_SEC;
+    while (now_monotonic_usec() < deadline) {
+        if (__atomic_load_n(&wctx.acquired, __ATOMIC_ACQUIRE)) {
+            acquired = true;
+            break;
+        }
+    }
+    RW_TEST(acquired, "writer acquires despite continuous reader churn (no starvation)");
+
+    // Stop the readers so the writer is guaranteed to finish even if it was
+    // starved past the deadline (the failure case), preventing any hang.
+    __atomic_store_n(&rctx.stop, 1, __ATOMIC_RELEASE);
+    nd_thread_join(writer);
+    for (int i = 0; i < RW_SPINLOCK_TEST_READERS; i++)
+        nd_thread_join(readers[i]);
+
+    RW_TEST(lock.counter == 0, "lock is free after liveness test");
+    RW_TEST(lock.writer == 0, "writer tid cleared after liveness test");
+
+    return errors;
+}
+
 int rw_spinlock_unittest(void) {
     int errors = 0;
 
@@ -26,6 +222,7 @@ int rw_spinlock_unittest(void) {
     // initialization: a freshly initialized lock has no writer and no readers,
     // and a static initializer produces the same state.
     {
+        fprintf(stderr, "  - initialization: init() and the static initializer clear writer and counter\n");
         RW_SPINLOCK lock;
         rw_spinlock_init(&lock);
         RW_TEST(lock.writer == 0, "init clears writer");
@@ -39,6 +236,7 @@ int rw_spinlock_unittest(void) {
     // ----------------------------------------------------------------------
     // tryread on a free lock succeeds, and read_unlock restores the free state.
     {
+        fprintf(stderr, "  - tryread: succeeds on a free lock and read_unlock restores free state\n");
         RW_SPINLOCK lock = RW_SPINLOCK_INITIALIZER;
         RW_TEST(rw_spinlock_tryread_lock(&lock) == true, "tryread succeeds on free lock");
         rw_spinlock_read_unlock(&lock);
@@ -51,6 +249,7 @@ int rw_spinlock_unittest(void) {
     // thread can take the read lock repeatedly; each acquisition succeeds and
     // each unlock is balanced.
     {
+        fprintf(stderr, "  - readers: multiple/recursive read holders allowed; writer excluded while readers held\n");
         RW_SPINLOCK lock = RW_SPINLOCK_INITIALIZER;
         const int readers = 5;
 
@@ -75,6 +274,7 @@ int rw_spinlock_unittest(void) {
     // blocking read_lock path (non-contended): read_lock/read_unlock balance
     // and admit multiple holders just like tryread.
     {
+        fprintf(stderr, "  - read_lock: blocking read path balances and admits multiple holders\n");
         RW_SPINLOCK lock = RW_SPINLOCK_INITIALIZER;
         rw_spinlock_read_lock(&lock);
         rw_spinlock_read_lock(&lock);
@@ -88,6 +288,7 @@ int rw_spinlock_unittest(void) {
     // trywrite on a free lock succeeds and records the writer; write_unlock
     // clears the writer and the writer bit.
     {
+        fprintf(stderr, "  - trywrite: succeeds on a free lock, records writer tid, write_unlock clears it\n");
         RW_SPINLOCK lock = RW_SPINLOCK_INITIALIZER;
         RW_TEST(rw_spinlock_trywrite_lock(&lock) == true, "trywrite succeeds on free lock");
         RW_TEST(lock.writer == gettid_cached(), "trywrite records the writer tid");
@@ -100,6 +301,7 @@ int rw_spinlock_unittest(void) {
     // writer exclusivity: while a writer holds the lock, neither a reader nor
     // another writer may enter.
     {
+        fprintf(stderr, "  - writer exclusivity: readers and other writers are excluded while a writer holds\n");
         RW_SPINLOCK lock = RW_SPINLOCK_INITIALIZER;
         rw_spinlock_write_lock(&lock);
         RW_TEST(rw_spinlock_tryread_lock(&lock) == false, "tryread fails while writer held");
@@ -113,6 +315,17 @@ int rw_spinlock_unittest(void) {
         rw_spinlock_write_unlock(&lock);
         RW_TEST(lock.counter == 0, "lock free after exclusivity test");
     }
+
+    // ----------------------------------------------------------------------
+    // writer-priority invariant (multi-threaded): new readers back off while a
+    // writer is pending, preventing writer starvation.
+    errors += rw_spinlock_writer_priority_test();
+
+    // concurrent writers serialize with no lost updates.
+    errors += rw_spinlock_writer_mutex_test();
+
+    // a blocked writer makes progress under continuous reader churn.
+    errors += rw_spinlock_writer_liveness_test();
 
     if (errors)
         fprintf(stderr, "rw-spinlock unittest: %d ERROR(S)\n", errors);

--- a/src/libnetdata/locks/rw-spinlock-unittest.c
+++ b/src/libnetdata/locks/rw-spinlock-unittest.c
@@ -2,12 +2,19 @@
 
 #include "libnetdata/libnetdata.h"
 
-// Deterministic unit tests for the baseline rw-spinlock API semantics that
-// already hold on master. These tests intentionally avoid timing/sleep-based
-// concurrency assertions (kept in the rwlockstest benchmark) so they stay
-// reproducible. They also intentionally do NOT assert writer-priority,
-// writer-starvation prevention, or writer-pending reader blocking; those
-// behaviors belong with the PR that introduces them.
+// Unit tests for the rw-spinlock API semantics.
+//
+// The single-threaded cases cover the baseline API contract (initialization,
+// reader admission, reader/writer exclusion, lock/unlock balance). The
+// multi-threaded cases cover the writer-priority contract: a pending writer
+// blocks new readers (rw_spinlock_writer_priority_test), concurrent writers are
+// mutually exclusive (rw_spinlock_writer_mutex_test), and a writer is not
+// starved by a continuous reader stream (rw_spinlock_writer_liveness_test).
+//
+// All assertions are on states reached through explicit handshakes, not on
+// sleeps or timings; every deadline here is a hang-guard only, never the thing
+// being asserted. Throughput/timing comparisons live in the rwlockstest
+// benchmark, not here.
 
 #define RW_TEST(condition, msg) do {                                            \
         if (!(condition)) {                                                     \
@@ -137,19 +144,30 @@ static int rw_spinlock_writer_mutex_test(void) {
 // ----------------------------------------------------------------------------
 // Writer liveness under reader churn: a pool of readers continuously acquires
 // and releases the read lock while a single writer blocks on the write lock.
-// Under writer-priority the writer must acquire promptly despite the churn (the
-// robust assertion). On the pre-writer-priority implementation a writer can be
-// starved by the reader stream; this test would then fail at the deadline, but
-// because starvation is timing-dependent this fail-on-old-master signal is
-// best-effort, not deterministic (the deterministic guards are the back-off
-// invariant and mutual-exclusion tests).
+// Under writer-priority the writer must acquire promptly despite the churn.
+//
+// The contention is established by a handshake rather than by hoping the threads
+// overlap: every reader first takes the read lock and HOLDS it, then waits for a
+// go signal. Only once all readers are holding is the writer started, and only
+// once the writer has parked (observable through the public API: tryread starts
+// failing) are the readers released into their churn loop. That ordering
+// guarantees the writer is already queued behind held readers before any reader
+// can release, so the writer can never acquire a free, uncontended lock and the
+// test cannot pass vacuously.
+//
+// On the pre-writer-priority implementation (which cleared the writer bit and
+// retried) the churn stream can starve the writer and this test fails at the
+// deadline; because starvation is timing-dependent that fail-on-old-master
+// signal is best-effort, while the deterministic guards remain the back-off
+// invariant and mutual-exclusion tests.
 
 #define RW_SPINLOCK_TEST_READERS 4
 
 typedef struct {
     RW_SPINLOCK *lock;
     uint32_t stop;
-    uint32_t active;   // count of readers that have taken the read lock at least once
+    uint32_t holding; // count of readers currently parked while holding the read lock
+    uint32_t go;      // set by the main thread to release the holding readers into churn
 } rw_spinlock_churn_ctx_t;
 
 typedef struct {
@@ -159,16 +177,20 @@ typedef struct {
 
 static void rw_spinlock_reader_churn(void *arg) {
     rw_spinlock_churn_ctx_t *ctx = (rw_spinlock_churn_ctx_t *)arg;
-    bool counted = false;
+
+    // Phase 1: take the read lock and HOLD it, then announce we are holding and
+    // wait for the go signal. This keeps the lock reader-held so the writer the
+    // main thread starts is forced to park behind us.
+    rw_spinlock_read_lock(ctx->lock);
+    __atomic_add_fetch(&ctx->holding, 1, __ATOMIC_RELEASE);
+    while (!__atomic_load_n(&ctx->go, __ATOMIC_ACQUIRE))
+        ; // spin until released into churn
+
+    // Phase 2: release into a continuous acquire/release churn stream.
+    rw_spinlock_read_unlock(ctx->lock);
     while (!__atomic_load_n(&ctx->stop, __ATOMIC_ACQUIRE)) {
-        if (rw_spinlock_tryread_lock(ctx->lock)) {
-            if (!counted) {
-                // signal (once) that this reader is actively churning
-                __atomic_add_fetch(&ctx->active, 1, __ATOMIC_RELEASE);
-                counted = true;
-            }
+        if (rw_spinlock_tryread_lock(ctx->lock))
             rw_spinlock_read_unlock(ctx->lock);
-        }
     }
 }
 
@@ -182,7 +204,7 @@ static void rw_spinlock_liveness_writer(void *arg) {
 static int rw_spinlock_writer_liveness_test(void) {
     int errors = 0;
     RW_SPINLOCK lock = RW_SPINLOCK_INITIALIZER;
-    rw_spinlock_churn_ctx_t rctx = { .lock = &lock, .stop = 0, .active = 0 };
+    rw_spinlock_churn_ctx_t rctx = { .lock = &lock, .stop = 0, .holding = 0, .go = 0 };
     rw_spinlock_liveness_writer_ctx_t wctx = { .lock = &lock, .acquired = 0 };
 
     fprintf(stderr, "  - writer liveness: a writer must acquire despite %d churning readers\n",
@@ -193,21 +215,39 @@ static int rw_spinlock_writer_liveness_test(void) {
         readers[i] = nd_thread_create("rwsp_rd", NETDATA_THREAD_OPTION_DONT_LOG,
                                       rw_spinlock_reader_churn, &rctx);
 
-    // Do not start the writer until every reader is actively churning (each has
-    // taken the read lock at least once). Otherwise the writer could acquire a
-    // free, uncontended lock before the readers exist and the test would pass
-    // vacuously, exercising none of the writer-vs-readers contention. Bounded
+    // Wait until every reader is parked while HOLDING the read lock. Bounded
     // deadline is only a hang-guard, not a correctness signal.
     usec_t ready_deadline = now_monotonic_usec() + 5 * USEC_PER_SEC;
-    while (__atomic_load_n(&rctx.active, __ATOMIC_ACQUIRE) < RW_SPINLOCK_TEST_READERS &&
+    while (__atomic_load_n(&rctx.holding, __ATOMIC_ACQUIRE) < RW_SPINLOCK_TEST_READERS &&
            now_monotonic_usec() < ready_deadline) {
-        ; // spin until all readers are churning
+        ; // spin until all readers hold the read lock
     }
-    RW_TEST(__atomic_load_n(&rctx.active, __ATOMIC_ACQUIRE) == RW_SPINLOCK_TEST_READERS,
-            "all readers are churning before the writer starts");
+    RW_TEST(__atomic_load_n(&rctx.holding, __ATOMIC_ACQUIRE) == RW_SPINLOCK_TEST_READERS,
+            "all readers hold the read lock before the writer starts");
 
     ND_THREAD *writer = nd_thread_create("rwsp_wr", NETDATA_THREAD_OPTION_DONT_LOG,
                                          rw_spinlock_liveness_writer, &wctx);
+
+    // Wait until the writer has parked behind the held readers, detected through
+    // the public API only: once the writer marks itself pending, tryread fails.
+    // The readers are still holding, so the pending state is stable.
+    bool writer_parked = false;
+    usec_t park_deadline = now_monotonic_usec() + 5 * USEC_PER_SEC;
+    while (now_monotonic_usec() < park_deadline) {
+        if (rw_spinlock_tryread_lock(&lock)) {
+            // still admitted => writer not pending yet; release and retry
+            rw_spinlock_read_unlock(&lock);
+        }
+        else {
+            writer_parked = true;
+            break;
+        }
+    }
+    RW_TEST(writer_parked, "the writer parks behind the held readers before the churn starts");
+
+    // Release the readers into the churn stream. From here the writer is already
+    // queued, so it must win against a continuous stream of new readers.
+    __atomic_store_n(&rctx.go, 1, __ATOMIC_RELEASE);
 
     // Bounded wait for the writer to acquire. Generous deadline so this never
     // false-fails on writer-priority (acquisition takes microseconds there).

--- a/src/libnetdata/locks/rw-spinlock-unittest.c
+++ b/src/libnetdata/locks/rw-spinlock-unittest.c
@@ -184,13 +184,18 @@ static void rw_spinlock_reader_churn(void *arg) {
     rw_spinlock_read_lock(ctx->lock);
     __atomic_add_fetch(&ctx->holding, 1, __ATOMIC_RELEASE);
     while (!__atomic_load_n(&ctx->go, __ATOMIC_ACQUIRE))
-        ; // spin until released into churn
+        yield_the_processor(); // wait to be released into churn, without hogging a core
 
     // Phase 2: release into a continuous acquire/release churn stream.
     rw_spinlock_read_unlock(ctx->lock);
     while (!__atomic_load_n(&ctx->stop, __ATOMIC_ACQUIRE)) {
         if (rw_spinlock_tryread_lock(ctx->lock))
             rw_spinlock_read_unlock(ctx->lock);
+
+        // Yield (not sleep) between attempts: the churn stays continuous, but the
+        // parked writer and the other threads still get CPU time on a box with
+        // fewer cores than this test has spinning threads.
+        yield_the_processor();
     }
 }
 
@@ -220,7 +225,7 @@ static int rw_spinlock_writer_liveness_test(void) {
     usec_t ready_deadline = now_monotonic_usec() + 5 * USEC_PER_SEC;
     while (__atomic_load_n(&rctx.holding, __ATOMIC_ACQUIRE) < RW_SPINLOCK_TEST_READERS &&
            now_monotonic_usec() < ready_deadline) {
-        ; // spin until all readers hold the read lock
+        yield_the_processor(); // let the readers run
     }
     RW_TEST(__atomic_load_n(&rctx.holding, __ATOMIC_ACQUIRE) == RW_SPINLOCK_TEST_READERS,
             "all readers hold the read lock before the writer starts");
@@ -237,6 +242,7 @@ static int rw_spinlock_writer_liveness_test(void) {
         if (rw_spinlock_tryread_lock(&lock)) {
             // still admitted => writer not pending yet; release and retry
             rw_spinlock_read_unlock(&lock);
+            yield_the_processor(); // let the writer reach the write lock
         }
         else {
             writer_parked = true;
@@ -258,6 +264,9 @@ static int rw_spinlock_writer_liveness_test(void) {
             acquired = true;
             break;
         }
+
+        // Never spin hot here: this loop competes with the writer we are timing.
+        yield_the_processor();
     }
     RW_TEST(acquired, "writer acquires despite continuous reader churn (no starvation)");
 

--- a/src/libnetdata/locks/rw-spinlock.c
+++ b/src/libnetdata/locks/rw-spinlock.c
@@ -97,37 +97,53 @@ ALWAYS_INLINE void rw_spinlock_write_lock_with_trace(RW_SPINLOCK *rw_spinlock, c
     usec_t usec = 1;
     usec_t deadlock_timestamp = 0;
 
+    // Writer-priority state. Once this writer flips WRITER_BIT from 0 to 1,
+    // it keeps the bit set across subsequent iterations and just polls for
+    // readers to drain. New readers see WRITER_BIT and back off in the
+    // reader path, so they cannot starve a queued writer.
+    bool i_own_writer_bit = false;
+
     while (1) {
-        // Optimistically set writer bit
-        uint32_t old = __atomic_fetch_or(&rw_spinlock->counter, WRITER_BIT, __ATOMIC_ACQUIRE);
+        if (!i_own_writer_bit) {
+            uint32_t old = __atomic_fetch_or(&rw_spinlock->counter, WRITER_BIT, __ATOMIC_ACQUIRE);
 
-        // Check if we were the only one
-        if (old == 0) {
-            rw_spinlock->writer = gettid_cached();
-            worker_spinlock_contention(func, spins);
-            nd_thread_rwspinlock_write_locked();
-            return;
-        }
+            if (old == 0)
+                // no readers, no writers - we acquired
+                goto acquired;
 
-        // Check if we were the only one
-        if (old & WRITER_BIT) {
-            // there is a writer inside (keep the writer bit there)
+            if (old & WRITER_BIT) {
+                // another writer already had WRITER_BIT set; we did not flip it.
+                // Spin without modifying state until that writer releases.
+            }
+            else /* (old & READER_MASK) != 0 */ {
+                // only readers were present and WE just flipped WRITER_BIT.
+                // Keep it set so new readers back off; wait for existing
+                // readers to drain.
+                i_own_writer_bit = true;
+            }
         }
-        else /* if ((old & READER_MASK) != 0) */ {
-            // there are readers inside, remove the writer bit we added
-            __atomic_and_fetch(&rw_spinlock->counter, ~WRITER_BIT, __ATOMIC_RELEASE);
+        else if (__atomic_load_n(&rw_spinlock->counter, __ATOMIC_ACQUIRE) == WRITER_BIT) {
+            // We own WRITER_BIT and readers have drained. New readers see
+            // WRITER_BIT and back off; existing readers decremented the
+            // counter as they released.
+            goto acquired;
         }
 
         spins++;
-        
+
         // Check for deadlock every SPINS_BEFORE_DEADLOCK_CHECK iterations
         if ((spins % SPINS_BEFORE_DEADLOCK_CHECK) == 0) {
             spinlock_deadlock_detect(&deadlock_timestamp, "rw-spinlock write lock", func);
         }
-        
+
         microsleep(usec);
         usec = usec >= MAX_USEC ? MAX_USEC : usec * 2;
     }
+
+acquired:
+    rw_spinlock->writer = gettid_cached();
+    worker_spinlock_contention(func, spins);
+    nd_thread_rwspinlock_write_locked();
 }
 
 ALWAYS_INLINE void rw_spinlock_write_unlock_with_trace(RW_SPINLOCK *rw_spinlock, const char *func __maybe_unused) {

--- a/src/libnetdata/locks/rw-spinlock.c
+++ b/src/libnetdata/locks/rw-spinlock.c
@@ -2,13 +2,52 @@
 
 #include "libnetdata/libnetdata.h"
 
-#define MAX_USEC 512 // Maximum backoff limit in microseconds
+// Back-off tuning.
+//
+// YIELDS_BEFORE_SLEEP: how many yields a waiter performs before it starts
+// sleeping. microsleep(1) is a nanosleep() whose real cost is the kernel timer
+// slack (~65us on Linux), three orders of magnitude longer than the critical
+// sections these locks protect, so sleeping must not be the FIRST response to
+// contention. Measured: with sleep-first, 94.9% of writer acquisitions behind 8
+// churning readers landed in the 65-131us bucket - the slack, not the drain.
+//
+// MAX_USEC: the sleep ceiling. Under writer priority every wait in this file is
+// bounded by a single critical section rather than by a queue of waiters, so the
+// old 512us ceiling was mis-sized: it made a losing reader retry only ~2000
+// times per second, which is what turned writer priority into a reader lockout.
+//
+// yield_the_processor() (sched_yield) rather than a busy spin: Netdata runs on
+// single-CPU appliances, where spinning prevents the lock holder from running at
+// all.
+#define YIELDS_BEFORE_SLEEP 16
+#define MAX_USEC 32 // Maximum backoff limit in microseconds
 
 #define WRITER_BIT (1U << 31)
 #define READER_MASK (~WRITER_BIT)
 
 // ----------------------------------------------------------------------------
 // rw_spinlock implementation
+
+// One back-off step for a waiter. Yields while `yields` is below the threshold,
+// then falls back to sleeping with an exponential ramp capped at MAX_USEC.
+// Callers that change what they are waiting for reset both counters, so the
+// cheap yields are re-tried for the new wait.
+//
+// Deliberately NEVER_INLINE. The lock functions are always_inline and LTO is on
+// (USE_LTO), so anything inlined here is duplicated into every one of the ~100
+// lock call sites in the tree. This code runs only after a waiter has already
+// lost the lock, where the cost of a call is nothing next to a yield or a sleep,
+// while the .text it would add is paid by every caller - including the
+// uncontended fast paths that never reach it.
+static NEVER_INLINE void rw_spinlock_backoff(size_t *yields, usec_t *usec) {
+    if((*yields)++ < YIELDS_BEFORE_SLEEP) {
+        yield_the_processor();
+        return;
+    }
+
+    microsleep(*usec);
+    *usec = (*usec >= MAX_USEC) ? MAX_USEC : *usec * 2;
+}
 
 void rw_spinlock_init_with_trace(RW_SPINLOCK *rw_spinlock, const char *func __maybe_unused) {
     rw_spinlock->writer = 0;
@@ -34,6 +73,7 @@ ALWAYS_INLINE bool rw_spinlock_tryread_lock_with_trace(RW_SPINLOCK *rw_spinlock,
 
 ALWAYS_INLINE void rw_spinlock_read_lock_with_trace(RW_SPINLOCK *rw_spinlock, const char *func) {
     size_t spins = 0;
+    size_t yields = 0;
     usec_t usec = 1;
     usec_t deadlock_timestamp = 0;
 
@@ -58,9 +98,8 @@ ALWAYS_INLINE void rw_spinlock_read_lock_with_trace(RW_SPINLOCK *rw_spinlock, co
         if ((spins % SPINS_BEFORE_DEADLOCK_CHECK) == 0) {
             spinlock_deadlock_detect(&deadlock_timestamp, "rw-spinlock read lock", func);
         }
-        
-        microsleep(usec);
-        usec = usec >= MAX_USEC ? MAX_USEC : usec * 2;
+
+        rw_spinlock_backoff(&yields, &usec);
     }
 }
 
@@ -94,6 +133,7 @@ ALWAYS_INLINE bool rw_spinlock_trywrite_lock_with_trace(RW_SPINLOCK *rw_spinlock
 
 ALWAYS_INLINE void rw_spinlock_write_lock_with_trace(RW_SPINLOCK *rw_spinlock, const char *func) {
     size_t spins = 0;
+    size_t yields = 0;
     usec_t usec = 1;
     usec_t deadlock_timestamp = 0;
 
@@ -121,10 +161,12 @@ ALWAYS_INLINE void rw_spinlock_write_lock_with_trace(RW_SPINLOCK *rw_spinlock, c
                 // readers to drain.
                 i_own_writer_bit = true;
 
-                // Restart the backoff ramp: from here on nobody can enter the
-                // lock (new readers see WRITER_BIT, other writers see it too),
-                // so a long sleep would keep the lock idle-but-blocked after
-                // the last reader drains. Poll the drain from the bottom again.
+                // Restart the back-off from the bottom: from here on nobody can
+                // enter the lock (new readers see WRITER_BIT, other writers see
+                // it too), so a long sleep would keep the lock idle-but-blocked
+                // after the last reader drains. The drain is typically a few
+                // nanoseconds away, so the yields matter most here.
+                yields = 0;
                 usec = 1;
             }
         }
@@ -142,8 +184,7 @@ ALWAYS_INLINE void rw_spinlock_write_lock_with_trace(RW_SPINLOCK *rw_spinlock, c
             spinlock_deadlock_detect(&deadlock_timestamp, "rw-spinlock write lock", func);
         }
 
-        microsleep(usec);
-        usec = usec >= MAX_USEC ? MAX_USEC : usec * 2;
+        rw_spinlock_backoff(&yields, &usec);
     }
 
 acquired:

--- a/src/libnetdata/locks/rw-spinlock.c
+++ b/src/libnetdata/locks/rw-spinlock.c
@@ -120,6 +120,12 @@ ALWAYS_INLINE void rw_spinlock_write_lock_with_trace(RW_SPINLOCK *rw_spinlock, c
                 // Keep it set so new readers back off; wait for existing
                 // readers to drain.
                 i_own_writer_bit = true;
+
+                // Restart the backoff ramp: from here on nobody can enter the
+                // lock (new readers see WRITER_BIT, other writers see it too),
+                // so a long sleep would keep the lock idle-but-blocked after
+                // the last reader drains. Poll the drain from the bottom again.
+                usec = 1;
             }
         }
         else if (__atomic_load_n(&rw_spinlock->counter, __ATOMIC_ACQUIRE) == WRITER_BIT) {

--- a/src/libnetdata/locks/rw-spinlock.h
+++ b/src/libnetdata/locks/rw-spinlock.h
@@ -13,6 +13,27 @@ typedef struct netdata_rw_spinlock {
 
 #define RW_SPINLOCK_INITIALIZER { .counter = 0, .writer = 0, }
 
+// This rw-spinlock is writer-priority: once a writer is waiting, it holds
+// WRITER_BIT set while it waits for the current readers to drain, and new
+// readers back off until the writer has acquired and released the lock. This is
+// what prevents a continuous reader stream from starving a writer.
+//
+// PRECONDITION - recursive read locks:
+// A thread that already holds the read lock MUST NOT take the read lock again
+// on the same rw-spinlock. It is safe only while no writer is pending, which
+// the caller cannot control, so it must not be relied upon. If a writer becomes
+// pending between the two acquisitions, the second rw_spinlock_read_lock()
+// backs off waiting for that writer, while the writer waits for the caller's
+// first read reference to drain: both block forever.
+//
+// Traversal helpers that release the read lock around each callback (for
+// example the dictionary's DICTIONARY_LOCK_REENTRANT mode, which unlocks before
+// returning each item and re-locks in dictionary_foreach_next()) do not hold a
+// read reference across the body and therefore do not create this cycle.
+//
+// Use rw_spinlock_tryread_lock() when a nested read is genuinely needed: it
+// fails instead of blocking when a writer is pending.
+
 void rw_spinlock_init_with_trace(RW_SPINLOCK *rw_spinlock, const char *func);
 void rw_spinlock_read_lock_with_trace(RW_SPINLOCK *rw_spinlock, const char *func);
 void rw_spinlock_read_unlock_with_trace(RW_SPINLOCK *rw_spinlock, const char *func);


### PR DESCRIPTION
##### Summary
Under heavy read contention on a hot lock (like dbengine's per-partition metric registry or a busy dictionary), a writer could spin indefinitely. 

After ~60 minutes the deadlock detector would shutdown the agent. This PR fixes this issue

- Keep WRITER_BIT set after a writer claims it while readers are active.
- Let existing readers drain while new readers back off through the existing reader path.
- Prevent indefinite writer starvation on hot read-heavy rw-spinlocks.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent writer starvation in `rw-spinlock` by giving writers priority and avoiding long spins and deadlock shutdowns. Tests now cover reader back-off, writer exclusivity/mutual exclusion, and writer liveness; the liveness test waits for active reader churn before starting the writer.

- **Bug Fixes**
  - Keep `WRITER_BIT` set when a writer flips it with active readers so new readers back off; acquire once the counter drains to `WRITER_BIT`. If another writer already set it, spin without modifying the counter.
  - Remove the flip-and-clear path; preserve immediate acquire when the lock is free.

<sup>Written for commit 3499a43e7b2301ef76ceaa04c5830e01b1129f02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read/write lock behavior when writers compete with active readers.
  * Prevented new readers from entering while a writer is waiting, helping writers make progress reliably.
  * Improved writer mutual exclusion and lock contention handling.

* **Documentation**
  * Clarified writer-priority behavior, recursive read-lock risks, and safe approaches for nested reads.

* **Tests**
  * Added deterministic coverage for writer priority, concurrent writer exclusion, and writer progress during continuous reader activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->