### PR TITLE
Fix stack buffer overflow in macOS mach_smi collector

### DIFF
--- a/src/collectors/macos.plugin/macos_mach_smi.c
+++ b/src/collectors/macos.plugin/macos_mach_smi.c
@@ -88,10 +88,10 @@ int do_macos_mach_smi(int update_every, usec_t dt) {
 
     if (likely(do_ram || do_swapio || do_pgfaults)) {
 #if (defined __MAC_OS_X_VERSION_MIN_REQUIRED && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1060)
-        count = sizeof(vm_statistics64_data_t);
+        count = HOST_VM_INFO64_COUNT;
         kr = host_statistics64(host, HOST_VM_INFO64, (host_info64_t)&vm_statistics, &count);
 #else
-        count = sizeof(vm_statistics_data_t);
+        count = HOST_VM_INFO_COUNT;
         kr = host_statistics(host, HOST_VM_INFO, (host_info_t)&vm_statistics, &count);
 #endif
         if (unlikely(kr != KERN_SUCCESS)) {


### PR DESCRIPTION
##### Summary
Fix stack buffer overflow in macOS mach_smi collector

Fixes #22552

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a stack buffer overflow in the macOS `mach_smi` collector by passing the correct element count to the VM stats APIs. This prevents crashes and memory corruption during RAM/swap/page-fault collection.

- **Bug Fixes**
  - Use `HOST_VM_INFO64_COUNT` and `HOST_VM_INFO_COUNT` instead of `sizeof(...)` when calling `host_statistics64`/`host_statistics`.

<sup>Written for commit 96e162c1e77a582fa376711f56e1b95b357d804a. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22553?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

