### PR TITLE
fix health sum lookup for incremental dimensions

### DIFF
--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -1460,6 +1460,8 @@ static int test_incremental_sum_lookup_respects_update_every(void) {
     const time_t update_every = 10;
     const collected_number increment = 100;
     const size_t samples = 6;
+    RRD_DB_MODE old_default_rrd_memory_mode = default_rrd_memory_mode;
+    time_t old_update_every = nd_profile.update_every;
 
     default_rrd_memory_mode = RRD_DB_MODE_ALLOC;
     nd_profile.update_every = update_every;
@@ -1501,16 +1503,19 @@ static int test_incremental_sum_lookup_respects_update_every(void) {
     onewayalloc_destroy(owa);
 
     NETDATA_DOUBLE expected = (NETDATA_DOUBLE)(samples * increment);
+    int rc = 0;
     if(ret != HTTP_RESP_OK || value_is_null || fabsndd(value - expected) > 0.000001) {
         fprintf(
             stderr,
             "incremental sum lookup failed: ret=%d, null=%d, expected " NETDATA_DOUBLE_FORMAT
             ", got " NETDATA_DOUBLE_FORMAT "\n",
             ret, value_is_null, expected, value);
-        return 1;
+        rc = 1;
     }
 
-    return 0;
+    default_rrd_memory_mode = old_default_rrd_memory_mode;
+    nd_profile.update_every = old_update_every;
+    return rc;
 }
 
 int run_all_mockup_tests(void)

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "common.h"
+#include "web/api/formatters/rrd2json.h"
 
 static bool cmd_arg_sanitization_test(const char *expected, const char *src, char *dst, size_t dst_size) {
     bool ok = sanitize_command_argument_string(dst, src, dst_size);
@@ -1453,6 +1454,65 @@ int check_strdupz_path_subpath() {
     return 0;
 }
 
+static int test_incremental_sum_lookup_respects_update_every(void) {
+    fprintf(stderr, "%s() running...\n", __FUNCTION__);
+
+    const time_t update_every = 10;
+    const collected_number increment = 100;
+    const size_t samples = 6;
+
+    default_rrd_memory_mode = RRD_DB_MODE_ALLOC;
+    nd_profile.update_every = update_every;
+
+    char name[101];
+    snprintfz(name, sizeof(name) - 1, "unittest-incremental-sum-lookup");
+
+    RRDSET *st = rrdset_create_localhost(
+        "netdata", name, name, "netdata", NULL, "Unit Testing", "requests", "unittest", NULL, 1,
+        update_every, RRDSET_TYPE_LINE);
+    RRDDIM *rd = rrddim_add(st, "requests", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+
+    time_t first_update_s = MAX(2 * API_RELATIVE_TIME_MAX, 200000000);
+    st->last_collected_time.tv_sec = st->last_updated.tv_sec = first_update_s - update_every;
+    st->last_collected_time.tv_usec = st->last_updated.tv_usec = 0;
+    rd->collector.last_collected_time = st->last_collected_time;
+
+    for(size_t i = 0; i <= samples; i++) {
+        struct timeval now = {
+            .tv_sec = first_update_s + (time_t)(i * update_every),
+            .tv_usec = 0,
+        };
+
+        st->usec_since_last_update = update_every * USEC_PER_SEC;
+        rrddim_timed_set_by_pointer(st, rd, now, (collected_number)(i * increment));
+        rrdset_timed_done(st, now, false);
+    }
+
+    time_t before = rrdset_last_entry_s(st);
+    time_t after = before - (time_t)(samples * update_every);
+
+    ONEWAYALLOC *owa = onewayalloc_create(0);
+    NETDATA_DOUBLE value = NAN;
+    int value_is_null = 0;
+    int ret = rrdset2value_api_v1_with_owa(
+        owa, st, NULL, &value, "requests", 1, after, before, RRDR_GROUPING_SUM, NULL, 0,
+        RRDR_OPTION_NOT_ALIGNED | RRDR_OPTION_SELECTED_TIER | RRDR_OPTION_MATCH_IDS, NULL, NULL, NULL, NULL,
+        NULL, &value_is_null, NULL, 0, 0, QUERY_SOURCE_UNITTEST, STORAGE_PRIORITY_SYNCHRONOUS);
+    onewayalloc_destroy(owa);
+
+    NETDATA_DOUBLE expected = (NETDATA_DOUBLE)(samples * increment);
+    if(ret != HTTP_RESP_OK || value_is_null || fabsndd(value - expected) > 0.000001) {
+        fprintf(
+            stderr,
+            "incremental sum lookup failed: ret=%d, null=%d, expected " NETDATA_DOUBLE_FORMAT
+            ", got " NETDATA_DOUBLE_FORMAT "\n",
+            ret, value_is_null, expected, value);
+        return 1;
+    }
+
+    return 0;
+}
+
 int run_all_mockup_tests(void)
 {
     fprintf(stderr, "%s() running...\n", __FUNCTION__ );
@@ -1463,6 +1523,9 @@ int run_all_mockup_tests(void)
         return 1;
 
     if(check_rrdcalc_comparisons())
+        return 1;
+
+    if(test_incremental_sum_lookup_respects_update_every())
         return 1;
 
     if(!test_variable_renames())

--- a/src/database/contexts/query_target.c
+++ b/src/database/contexts/query_target.c
@@ -270,6 +270,7 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
     } tier_retention[nd_profile.storage_tiers];
 
     RRDDIM *rd = rrdmetric_rrddim_get_and_lock(rm);
+    bool values_stored_as_rates = rd && rd->algorithm == RRD_ALGORITHM_INCREMENTAL;
 
     for (size_t tier = 0; tier < nd_profile.storage_tiers; tier++) {
         STORAGE_ENGINE *eng = qn->rrdhost->db[tier].eng;
@@ -343,6 +344,7 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
         memset(qm, 0, sizeof(*qm));
 
         qm->status = options;
+        qm->values_stored_as_rates = values_stored_as_rates;
 
         qm->link.query_node_id = qn->slot;
         qm->link.query_context_id = qc->slot;

--- a/src/database/contexts/rrdcontext.h
+++ b/src/database/contexts/rrdcontext.h
@@ -214,6 +214,7 @@ typedef struct _query_dimension {
 
 typedef struct _query_metric {
     RRDR_DIMENSION_FLAGS status;
+    bool values_stored_as_rates;
 
     struct query_metric_tier {
         STORAGE_METRIC_HANDLE *smh;

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -30,6 +30,22 @@ static long rrdr_line_init(RRDR *r __maybe_unused, time_t t __maybe_unused, long
     return rrdr_line;
 }
 
+ALWAYS_INLINE
+static NETDATA_DOUBLE query_point_grouping_value(
+    QUERY_POINT point, QUERY_ENGINE_OPS *ops, RRDR_TIME_GROUPING add_flush) {
+    if(likely(add_flush != RRDR_GROUPING_SUM || !ops->qm->values_stored_as_rates))
+        return point.value;
+
+    if(unlikely(storage_point_is_unset(point.sp) || storage_point_is_gap(point.sp) || !point.sp.count))
+        return point.value;
+
+    time_t duration = point.sp.end_time_s - point.sp.start_time_s;
+    if(unlikely(duration <= 0))
+        return point.value;
+
+    return point.value * (NETDATA_DOUBLE)duration / (NETDATA_DOUBLE)point.sp.count;
+}
+
 // ----------------------------------------------------------------------------
 // dimension level query engine
 
@@ -59,7 +75,9 @@ static long rrdr_line_init(RRDR *r __maybe_unused, time_t t __maybe_unused, long
         if(unlikely((point).sp.flags & SN_FLAG_RESET))                  \
             (ops)->group_value_flags |= RRDR_VALUE_RESET;               \
                                                                         \
-        time_grouping_add(r, (point).value, add_flush);                 \
+        NETDATA_DOUBLE grouping_value =                                    \
+            query_point_grouping_value(point, ops, add_flush);             \
+        time_grouping_add(r, grouping_value, add_flush);                   \
                                                                         \
         storage_point_merge_to((ops)->group_point, (point).sp);         \
         if(!(point).added)                                              \


### PR DESCRIPTION
##### Summary

Fixes #22112.

`lookup: sum` on incremental dimensions was summing stored rate values directly. For charts with `update_every > 1`, this under-counted the real total volume because incremental samples are stored as per-second rates.

This change tracks when queried dimensions are backed by incremental values and converts `sum` contributions back to volume using the storage point duration/count. Non-incremental dimensions keep the existing sample-sum behavior.

##### Test Plan

- Added regression coverage for an incremental dimension with `update_every=10`.
- The test verifies that summing six counter increments of `100` returns `600`, not the previous under-counted `60`.
- Ran `git diff --check`.

##### Additional Information

The fix is implemented in the shared RRDR query path, so it applies to health lookups and API value queries using the same aggregation logic.

<details> <summary>For users: How does this change affect me?</summary>

This affects health lookups and data queries using `sum` on incremental/counter-style metrics. Users with alerts over incremental dimensions collected less often than once per second should see the correct total volume instead of a value divided by the collection interval.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes under-counted sums for incremental/counter dimensions by converting stored per-second rates back to volume during SUM grouping. Health lookups and API queries now return correct totals when update_every > 1.

- **Bug Fixes**
  - Detect dimensions using `RRD_ALGORITHM_INCREMENTAL` and scale SUM contributions by point duration/count to compute true volume.
  - Applies to the shared query path used by health lookups and API value queries.
  - Adds a regression test (6×100 with update_every=10 → 600) and restores modified globals after the test.

<sup>Written for commit 7c68a3d87358cb1cd84dbfc8fa12dff63e0dca95. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22554?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

