### PR TITLE
Improve ML host access

### DIFF
--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -633,12 +633,21 @@ ml_dimension_deserialize_kmeans(const char *json_str)
         return true;
     }
 
+    // ml_host may have been unpublished by ml_host_delete() concurrently;
+    // the acquired RRDHOST keeps RH alive but not RH->ml_host.
+    ml_host_t *host = AcqDim.host();
+    if (!host) {
+        pulse_ml_models_ignored();
+        json_object_put(root);
+        return true;
+    }
+
     ml_queue_item_t item;
     item.type = ML_QUEUE_ITEM_TYPE_ADD_EXISTING_MODEL;
     item.add_existing_model = {
         DLI, inlined_km
     };
-    ml_queue_push(AcqDim.queue(), item);
+    ml_queue_push(host->queue, item);
 
     json_object_put(root);
     return true;

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -723,7 +723,7 @@ static bool ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim,
 
     spinlock_lock(&dim->slock);
 
-    ml_host_t *host = (ml_host_t *) dim->rd->rrdset->rrdhost->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&dim->rd->rrdset->rrdhost->ml_host, __ATOMIC_ACQUIRE);
     if (!ml_should_publish_model_update(host && host->ml_running,
                                         dim->reset_generation,
                                         expected_generation,
@@ -1174,13 +1174,14 @@ void ml_detect_main(void *arg)
         RRDHOST *rh;
         rrd_rdlock();
         rrdhost_foreach_read(rh) {
-            if (!rh->ml_host)
+            ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
+            if (!host)
                 continue;
 
             if (!service_running(SERVICE_COLLECTORS))
                 break;
 
-            ml_host_detect_once((ml_host_t *) rh->ml_host, detect_owa);
+            ml_host_detect_once(host, detect_owa);
         }
         rrd_rdunlock();
 
@@ -1282,7 +1283,7 @@ static enum ml_worker_result ml_worker_add_existing_model(ml_worker_t *worker, m
         return ML_WORKER_RESULT_OK;
     }
 
-    ml_host_t *host = (ml_host_t *) Dim->rd->rrdset->rrdhost->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&Dim->rd->rrdset->rrdhost->ml_host, __ATOMIC_ACQUIRE);
     if (!host || !host->ml_running) {
         pulse_ml_models_ignored();
         return ML_WORKER_RESULT_OK;

--- a/src/ml/ml_dimension.h
+++ b/src/ml/ml_dimension.h
@@ -134,7 +134,7 @@ public:
     ml_host_t *host() const {
         assert(acquired());
         RRDHOST *RH = rrdhost_acquired_to_rrdhost(AcqRH);
-        return reinterpret_cast<ml_host_t *>(RH->ml_host);
+        return reinterpret_cast<ml_host_t *>(__atomic_load_n(&RH->ml_host, __ATOMIC_ACQUIRE));
     }
 
     ml_queue_t *queue() const {

--- a/src/ml/ml_dimension.h
+++ b/src/ml/ml_dimension.h
@@ -137,11 +137,6 @@ public:
         return reinterpret_cast<ml_host_t *>(__atomic_load_n(&RH->ml_host, __ATOMIC_ACQUIRE));
     }
 
-    ml_queue_t *queue() const {
-        assert(acquired());
-        return host()->queue;
-    }
-
     ml_dimension_t *dimension() const {
         assert(acquired());
         return Dim;

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -108,13 +108,15 @@ void ml_host_new(RRDHOST *rh)
 
 void ml_host_delete(RRDHOST *rh)
 {
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
+    // Atomically detach `rh->ml_host` and obtain the previous pointer in a
+    // single RMW. Using exchange (rather than separate load + store) keeps
+    // the unpublish and the freeing on this thread strictly ordered: no
+    // store/operation that follows can be reordered before the unpublish,
+    // so concurrent readers observe either the live host or NULL -- never
+    // the freed host memory.
+    ml_host_t *host = (ml_host_t *) __atomic_exchange_n(&rh->ml_host, (rrd_ml_host_t *)NULL, __ATOMIC_ACQ_REL);
     if (!host)
         return;
-
-    // Unpublish BEFORE freeing so a concurrent reader that loads rh->ml_host
-    // observes either the live host or NULL -- never the freed host memory.
-    __atomic_store_n(&rh->ml_host, (rrd_ml_host_t *)NULL, __ATOMIC_RELEASE);
 
     ml_host_clear_context_anomaly_rate(host);
     netdata_mutex_destroy(&host->mutex);
@@ -335,12 +337,13 @@ void ml_chart_delete(RRDSET *rs)
     if (!host)
         return;
 
-    ml_chart_t *chart = (ml_chart_t *) __atomic_load_n(&rs->ml_chart, __ATOMIC_ACQUIRE);
-
-    // Unpublish BEFORE freeing so a concurrent reader that loads rs->ml_chart
-    // observes either the live chart (with chart->rs set) or NULL -- never
-    // the freed chart memory.
-    __atomic_store_n(&rs->ml_chart, (rrd_ml_chart_t *)NULL, __ATOMIC_RELEASE);
+    // Atomically detach `rs->ml_chart` and obtain the previous pointer in a
+    // single RMW. Using exchange (rather than separate load + store) keeps
+    // the unpublish and the freeing on this thread strictly ordered: no
+    // store/operation that follows can be reordered before the unpublish,
+    // so concurrent readers observe either the live chart (with chart->rs
+    // set) or NULL -- never the freed chart memory.
+    ml_chart_t *chart = (ml_chart_t *) __atomic_exchange_n(&rs->ml_chart, (rrd_ml_chart_t *)NULL, __ATOMIC_ACQ_REL);
     delete chart;
 }
 

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -22,7 +22,7 @@ static void ml_host_clear_context_anomaly_rate(ml_host_t *host)
 
 static void ml_dimension_enqueue_create_model(RRDHOST *rh, RRDDIM *rd)
 {
-    ml_host_t *host = (ml_host_t *) rh->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
     if (!host)
         return;
 
@@ -95,24 +95,35 @@ void ml_host_new(RRDHOST *rh)
     spinlock_init(&host->context_anomaly_rate_spinlock);
 
     host->ml_running = false;
-    rh->ml_host = (rrd_ml_host_t *) host;
+
+    // Publish with release semantics so readers that load rh->ml_host with
+    // acquire semantics observe the host's `rh`, `ml_running`, `mutex`,
+    // `queue`, etc. as fully initialized. Without this, the C++ compiler
+    // may reorder field stores after the publish store of rh->ml_host, and
+    // a concurrent reader would see host != NULL with partially-initialized
+    // fields, producing SIGSEGV faults inside ml_dimension_is_anomalous and
+    // similar readers.
+    __atomic_store_n(&rh->ml_host, (rrd_ml_host_t *)host, __ATOMIC_RELEASE);
 }
 
 void ml_host_delete(RRDHOST *rh)
 {
-    ml_host_t *host = (ml_host_t *) rh->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
     if (!host)
         return;
+
+    // Unpublish BEFORE freeing so a concurrent reader that loads rh->ml_host
+    // observes either the live host or NULL -- never the freed host memory.
+    __atomic_store_n(&rh->ml_host, (rrd_ml_host_t *)NULL, __ATOMIC_RELEASE);
 
     ml_host_clear_context_anomaly_rate(host);
     netdata_mutex_destroy(&host->mutex);
 
     delete host;
-    rh->ml_host = NULL;
 }
 
 void ml_host_start(RRDHOST *rh) {
-    ml_host_t *host = (ml_host_t *) rh->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
     if (!host)
         return;
 
@@ -146,7 +157,7 @@ void ml_host_start(RRDHOST *rh) {
 }
 
 void ml_host_stop(RRDHOST *rh) {
-    ml_host_t *host = (ml_host_t *) rh->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
     if (!host || !host->ml_running)
         return;
 
@@ -210,7 +221,7 @@ void ml_host_stop(RRDHOST *rh) {
 
 void ml_host_get_info(RRDHOST *rh, BUFFER *wb)
 {
-    ml_host_t *host = (ml_host_t *) rh->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
     if (!host) {
         buffer_json_member_add_boolean(wb, "enabled", false);
         return;
@@ -243,7 +254,7 @@ void ml_host_get_info(RRDHOST *rh, BUFFER *wb)
 
 void ml_host_get_detection_info(RRDHOST *rh, BUFFER *wb)
 {
-    ml_host_t *host = (ml_host_t *) rh->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
     if (!host)
         return;
 
@@ -261,7 +272,7 @@ void ml_host_get_detection_info(RRDHOST *rh, BUFFER *wb)
 }
 
 bool ml_host_get_host_status(RRDHOST *rh, struct ml_metrics_statistics *mlm) {
-    ml_host_t *host = (ml_host_t *) rh->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
     if (!host) {
         memset(mlm, 0, sizeof(*mlm));
         return false;
@@ -281,7 +292,7 @@ bool ml_host_get_host_status(RRDHOST *rh, struct ml_metrics_statistics *mlm) {
 }
 
 bool ml_host_running(RRDHOST *rh) {
-    ml_host_t *host = (ml_host_t *) rh->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
     if(!host)
         return false;
 
@@ -299,7 +310,7 @@ void ml_host_get_models(RRDHOST *rh, BUFFER *wb)
 
 void ml_chart_new(RRDSET *rs)
 {
-    ml_host_t *host = (ml_host_t *) rs->rrdhost->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rs->rrdhost->ml_host, __ATOMIC_ACQUIRE);
     if (!host)
         return;
 
@@ -320,7 +331,7 @@ void ml_chart_new(RRDSET *rs)
 
 void ml_chart_delete(RRDSET *rs)
 {
-    ml_host_t *host = (ml_host_t *) rs->rrdhost->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rs->rrdhost->ml_host, __ATOMIC_ACQUIRE);
     if (!host)
         return;
 
@@ -389,7 +400,7 @@ void ml_dimension_new(RRDDIM *rd)
     // will sweep all untrained dimensions and enqueue them when it runs.
     // This avoids double-enqueueing the same dim from both paths.
     RRDHOST *rh = rd->rrdset->rrdhost;
-    ml_host_t *host = (ml_host_t *) rh->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
     if (host && host->ml_running)
         ml_dimension_enqueue_create_model(rh, rd);
 }
@@ -431,8 +442,8 @@ ALWAYS_INLINE_ONLY void ml_dimension_received_anomaly(RRDDIM *rd, bool is_anomal
     if (!dim)
         return;
 
-    ml_host_t *host = (ml_host_t *) rd->rrdset->rrdhost->ml_host;
-    if (!host->ml_running)
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rd->rrdset->rrdhost->ml_host, __ATOMIC_ACQUIRE);
+    if (!host || !host->ml_running)
         return;
 
     ml_chart_t *chart = (ml_chart_t *) __atomic_load_n(&rd->rrdset->ml_chart, __ATOMIC_ACQUIRE);
@@ -450,8 +461,8 @@ bool ml_dimension_is_anomalous(RRDDIM *rd, time_t curr_time, double value, bool 
     if (!dim)
         return false;
 
-    ml_host_t *host = (ml_host_t *) rd->rrdset->rrdhost->ml_host;
-    if (!host->ml_running)
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rd->rrdset->rrdhost->ml_host, __ATOMIC_ACQUIRE);
+    if (!host || !host->ml_running)
         return false;
 
     ml_chart_t *chart = (ml_chart_t *) __atomic_load_n(&rd->rrdset->ml_chart, __ATOMIC_ACQUIRE);
@@ -622,7 +633,7 @@ bool ml_model_received_from_child(RRDHOST *host, const char *json)
 }
 
 void ml_host_disconnected(RRDHOST *rh) {
-    ml_host_t *host = (ml_host_t *) rh->ml_host;
+    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
     if (!host)
         return;
 


### PR DESCRIPTION
##### Summary
Plugin data ingestion was crashing in ml_dimension_is_anomalous with SIGSEGV / SEGV_MAPERR / 0x3c91d — a wild-pointer dereference of host->ml_running when rh->ml_host was read mid-publish or read after free. 

The non-atomic publish in ml_host_new (plain rh->ml_host = host) and the free-before-NULL ordering in ml_host_delete (delete host; rh->ml_host = NULL) leave a window where a concurrent reader sees a partially-initialized or already-freed pointer.

- Fixes ML host publication races by using acquire/release atomic loads and stores for RRDHOST::ml_host, ensuring ML readers either see a fully initialized host or NULL instead of partially initialized or freed memory.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make ML host and chart publication/detachment atomic to stop rare crashes in ML paths. Readers now see a fully initialized object or NULL, preventing use-after-free and partial-init SIGSEGVs (e.g., in `ml_dimension_is_anomalous`).

- **Bug Fixes**
  - Publish `rh->ml_host` with release in `ml_host_new`; detach with `__atomic_exchange_n` (acq_rel) in `ml_host_delete` before free to ensure strict ordering.
  - Replace direct `rh->ml_host` reads with acquire loads via `__atomic_load_n` across `ml.cc`, `ml_public.cc`, and `ml_dimension.h` (including `AcquiredDimension::host()`); add NULL checks in anomaly handlers, detection/worker paths, and model deserialization/enqueueing; remove `AcquiredDimension::queue()` and push via `host->queue`.
  - Unpublish `rs->ml_chart` with `__atomic_exchange_n` in `ml_chart_delete` so readers observe a valid chart or NULL, never freed memory.

<sup>Written for commit 3125e045af8ccf591f02f5bc3dfa3d7e99ab2357. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22559?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

