### PR TITLE
Close ML database after metasync workers finish

### DIFF
--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -239,7 +239,11 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
     watcher_step_complete(WATCHER_STEP_ID_STOP_REPLICATION_THREADS);
 
     ml_stop_threads();
-    ml_fini();
+    // ml_fini() (which closes ml_db) is deferred until after
+    // metadata_sync_shutdown() drains the metasync workers below. Those
+    // workers call ml_dimension_load_models() which uses ml_db; closing it
+    // here exposes the metasync worker to a use-after-free on the SQLite
+    // handle and triggers SIGSEGV inside sqlite3_prepare_v2 -> findElementWithHash.
     watcher_step_complete(WATCHER_STEP_ID_DISABLE_ML_DETEC_AND_TRAIN_THREADS);
 
     service_wait_exit(SERVICE_CONTEXT, 5 * USEC_PER_SEC);
@@ -307,6 +311,7 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
 #endif
 
         metadata_sync_shutdown();
+        ml_fini();
         watcher_step_complete(WATCHER_STEP_ID_STOP_METASYNC_THREADS);
     }
 


### PR DESCRIPTION

##### Summary
Root cause: ml_fini() closed and NULL'd ml_db immediately after ml_stop_threads() in daemon-shutdown.c, but metadata_sync_shutdown() (which actually drains the metasync UV_WORKER threads)  could access the ml_db handle

- Fix: defer ml_fini() until after metadata_sync_shutdown() returns. ml_stop_threads() still joins DETECT/TRAIN at the original line so no producer touches ml_db after that; the deferred
  close just guarantees no reader is in flight either.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix shutdown order to stop crashes by closing the ML database only after metasync workers finish. We now defer `ml_fini()` (closes `ml_db`) until after `metadata_sync_shutdown()` drains those workers.

<sup>Written for commit e43b135b761c39d69233fe497e05c162cbe72088. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22562?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

