### PR TITLE
Replace deprecated bzero and usleep with portable wrappers

### DIFF
--- a/src/collectors/macos.plugin/macos_fw.c
+++ b/src/collectors/macos.plugin/macos_fw.c
@@ -118,7 +118,7 @@ int do_macos_iokit(int update_every, usec_t dt) {
             properties = 0;
             statistics = 0;
             number = 0;
-            bzero(&diskstat, sizeof(diskstat));
+            memset(&diskstat, 0, sizeof(diskstat));
 
             /* Get drive media object. */
             status = IORegistryEntryGetChildEntry(drive, kIOServicePlane, &drive_media);

--- a/src/database/sqlite/sqlite_functions.c
+++ b/src/database/sqlite/sqlite_functions.c
@@ -55,7 +55,7 @@ SQLITE_API int sqlite3_step_monitored(sqlite3_stmt *stmt) {
             case SQLITE_BUSY:
             case SQLITE_LOCKED:
                 pulse_sqlite3_query_completed(false, rc == SQLITE_BUSY, rc == SQLITE_LOCKED);
-                usleep(SQLITE_INSERT_DELAY * USEC_PER_MS);
+                sleep_usec(SQLITE_INSERT_DELAY * USEC_PER_MS);
                 continue;
             default:
                 break;
@@ -347,7 +347,7 @@ int db_execute(sqlite3 *db, const char *cmd, int *sqlite_rc)
         }
 
         if (likely(rc == SQLITE_BUSY || rc == SQLITE_LOCKED)) {
-            usleep(SQLITE_INSERT_DELAY * USEC_PER_MS);
+            sleep_usec(SQLITE_INSERT_DELAY * USEC_PER_MS);
             continue;
         }
 

--- a/src/web/rtc/webrtc.c
+++ b/src/web/rtc/webrtc.c
@@ -697,7 +697,7 @@ int webrtc_new_connection(const char *sdp, BUFFER *wb) {
             logged = true;
             internal_error(true, "WEBRTC[%d]: Waiting for gathering to complete", conn->pc);
         }
-        usleep(1000);
+        sleep_usec(1000);
     }
 
     if(logged)


### PR DESCRIPTION
##### Summary
- POSIX.1-2008 removed bzero and deprecated usleep. Both still work today, but the project already has portable replacements: memset(..., 0, ...) and the cross-platform sleep_usec()
  wrapper (uses nanosleep on POSIX, Sleep() on Windows).
- macos.plugin's IOKit collector: bzero(&diskstat, sizeof(diskstat)) → memset(&diskstat, 0, sizeof(diskstat)).
- SQLite retry loops in sqlite3_step_monitored and db_execute: usleep(SQLITE_INSERT_DELAY * USEC_PER_MS) → sleep_usec(...).
- WebRTC ICE gathering wait: usleep(1000) → sleep_usec(1000).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced deprecated bzero/usleep with portable `memset(..., 0, ...)` and `sleep_usec()` to improve cross-platform compatibility and remove POSIX deprecations. Ensures consistent timing on POSIX and Windows.

- **Refactors**
  - macOS IOKit collector: bzero → memset for `diskstat`.
  - SQLite retry loops: usleep → sleep_usec in `sqlite3_step_monitored` and `db_execute`.
  - WebRTC ICE gathering: usleep(1000) → sleep_usec(1000).

<sup>Written for commit 1bb95873e4020f1ce30dcc3366f0a09a3486d7b0. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22566?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

