### PR TITLE
Fix systemd journal plugin OTEL log directory discovery

### DIFF
--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -866,12 +866,12 @@ void nd_journal_init_files_and_directories(void)
         journal_directories[d++].path = string_strdupz(path);
     }
 
-    const char *netdata_configured_log_dir = getenv("NETDATA_LOG_DIR");
-    if (netdata_configured_log_dir != NULL) {
+    const char *log_dir = getenv("NETDATA_LOG_DIR");
+    if (log_dir && *log_dir) {
         char path[PATH_MAX];
-        snprintfz(path, sizeof(path), "%s/otel", netdata_configured_host_prefix);
+        snprintfz(path, sizeof(path), "%s/otel", log_dir);
         journal_directories[d++].path = string_strdupz(path);
-    };
+    }
 
     // terminate the list
     journal_directories[d].path = NULL;


### PR DESCRIPTION
##### Summary
- Fixes OTEL journal discovery in systemd-journal.plugin.
- The plugin already checked NETDATA_LOG_DIR, but incorrectly built the scan path from NETDATA_HOST_PREFIX.
- This caused it to scan /otel or `<host-prefix>/otel` instead of `<log-dir>/otel`.
- The fix builds the OTEL journal scan path from NETDATA_LOG_DIR, so default `<log-dir>/otel/v1` files are discovered, including custom log directory installs.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OTEL journal discovery in the systemd-journal plugin by building the scan path from `NETDATA_LOG_DIR` instead of `NETDATA_HOST_PREFIX`. The plugin now scans `$NETDATA_LOG_DIR/otel` and finds the default `$NETDATA_LOG_DIR/otel/v1` journals, including when a custom log directory is used.

<sup>Written for commit 0670b70a4999abf4aaf753e0c7ceff4f1cf5cee0. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22569?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

