### PR TITLE
Reapply alert prototypes when host or chart labels change

### DIFF
--- a/src/daemon/analytics.c
+++ b/src/daemon/analytics.c
@@ -1298,9 +1298,11 @@ void refresh_system_timezone(const char *timezone, bool is_tzdb_name) {
         if (rrdhost_update_timezone(localhost, timezone, new_abbrev, new_offset)) {
             // Timezone changed — update the two labels directly, persist, and notify.
             if (localhost->rrdlabels) {
-                rrdlabels_add(localhost->rrdlabels, "_timezone", timezone, RRDLABEL_SRC_AUTO);
-                rrdlabels_add(localhost->rrdlabels, "_abbrev_timezone", new_abbrev, RRDLABEL_SRC_AUTO);
+                bool labels_changed = rrdlabels_add_changed(localhost->rrdlabels, "_timezone", timezone, RRDLABEL_SRC_AUTO);
+                labels_changed |= rrdlabels_add_changed(localhost->rrdlabels, "_abbrev_timezone", new_abbrev, RRDLABEL_SRC_AUTO);
                 rrdhost_flag_set(localhost, RRDHOST_FLAG_METADATA_LABELS | RRDHOST_FLAG_METADATA_UPDATE);
+                if(labels_changed)
+                    rrdhost_flag_set(localhost, RRDHOST_FLAG_PENDING_LABEL_RECHECK);
                 stream_send_host_labels(localhost);
             }
             aclk_queue_node_info(localhost, false);

--- a/src/database/rrdhost-labels.c
+++ b/src/database/rrdhost-labels.c
@@ -9,7 +9,8 @@ void rrdhost_set_is_parent_label(void) {
 
     if (count == 0 || count == 1) {
         RRDLABELS *labels = localhost->rrdlabels;
-        rrdlabels_add(labels, "_is_parent", (count) ? "true" : "false", RRDLABEL_SRC_AUTO);
+        if(rrdlabels_add_changed(labels, "_is_parent", (count) ? "true" : "false", RRDLABEL_SRC_AUTO))
+            rrdhost_flag_set(localhost, RRDHOST_FLAG_PENDING_LABEL_RECHECK);
 
         // queue a node info
         aclk_queue_node_info(localhost, false);
@@ -202,7 +203,8 @@ void reload_host_labels(void) {
     // RRDLABEL_FLAG_DONT_DELETE entries are preserved.
     rrdlabels_remove_all_unmarked(localhost->rrdlabels);
 
-    rrdhost_flag_set(localhost,RRDHOST_FLAG_METADATA_LABELS | RRDHOST_FLAG_METADATA_UPDATE);
+    rrdhost_flag_set(localhost,
+                     RRDHOST_FLAG_METADATA_LABELS | RRDHOST_FLAG_METADATA_UPDATE | RRDHOST_FLAG_PENDING_LABEL_RECHECK);
 
     stream_send_host_labels(localhost);
 }

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -103,8 +103,10 @@ typedef enum __attribute__ ((__packed__)) rrdhost_flags {
                                                              // without holding receiver_lock so readers stay unblocked.
 
     RRDHOST_FLAG_PENDING_LABEL_RECHECK          = (1U << 31), // host labels changed since the last health prototype
-                                                              // evaluation; the health thread must fan out by setting
-                                                              // RRDSET_FLAG_PENDING_LABEL_RECHECK on every chart.
+                                                              // evaluation; on its next pass the health thread treats
+                                                              // every chart of this host as needing a recheck, in
+                                                              // addition to charts that have RRDSET_FLAG_PENDING_LABEL_RECHECK
+                                                              // set individually (no per-chart flag fan-out).
 } RRDHOST_FLAGS;
 
 #define rrdhost_flag_get(host)                         atomic_flags_get(&((host)->flags))

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -101,6 +101,10 @@ typedef enum __attribute__ ((__packed__)) rrdhost_flags {
                                                              // gates rrdhost_set_receiver() so a reconnect cannot attach
                                                              // mid-pass. Set under receiver_lock; the heavy work runs
                                                              // without holding receiver_lock so readers stay unblocked.
+
+    RRDHOST_FLAG_PENDING_LABEL_RECHECK          = (1U << 31), // host labels changed since the last health prototype
+                                                              // evaluation; the health thread must fan out by setting
+                                                              // RRDSET_FLAG_PENDING_LABEL_RECHECK on every chart.
 } RRDHOST_FLAGS;
 
 #define rrdhost_flag_get(host)                         atomic_flags_get(&((host)->flags))

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -252,9 +252,9 @@ static RRDLABEL *rrdlabels_find_label_with_key_unsafe(RRDLABELS *labels, RRDLABE
 // ----------------------------------------------------------------------------
 // rrdlabels_add()
 
-static void labels_add_already_sanitized(RRDLABELS *labels, const char *key, const char *value, RRDLABEL_SRC ls)
+static bool labels_add_already_sanitized(RRDLABELS *labels, const char *key, const char *value, RRDLABEL_SRC ls)
 {
-    if (unlikely(!labels || !key)) return;
+    if (unlikely(!labels || !key)) return false;
 
     RRDLABEL *new_label = add_label_name_value(key, value);
 
@@ -271,11 +271,13 @@ static void labels_add_already_sanitized(RRDLABELS *labels, const char *key, con
     int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
     RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, judy_mem, 0);
 
+    bool changed;
     if(*PValue) {
         new_ls |= RRDLABEL_FLAG_OLD;
         *((RRDLABEL_SRC *)PValue) = new_ls;
 
         delete_label(new_label);
+        changed = false;
     }
     else {
         new_ls |= RRDLABEL_FLAG_NEW;
@@ -289,6 +291,7 @@ static void labels_add_already_sanitized(RRDLABELS *labels, const char *key, con
             RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, judy_mem, 0);
             delete_label(old_label_with_same_key);
         }
+        changed = true;
     }
 
     labels->version++;
@@ -297,13 +300,20 @@ static void labels_add_already_sanitized(RRDLABELS *labels, const char *key, con
 //    RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, judy_mem, 0);
 
     spinlock_unlock(&labels->spinlock);
+
+    return changed;
 }
 
 void rrdlabels_add(RRDLABELS *labels, const char *name, const char *value, RRDLABEL_SRC ls)
 {
+    (void)rrdlabels_add_changed(labels, name, value, ls);
+}
+
+bool rrdlabels_add_changed(RRDLABELS *labels, const char *name, const char *value, RRDLABEL_SRC ls)
+{
     if(!labels) {
         netdata_log_error("%s(): called with NULL dictionary.", __FUNCTION__ );
-        return;
+        return false;
     }
 
     char n[RRDLABELS_MAX_NAME_LENGTH + 1], v[RRDLABELS_MAX_VALUE_LENGTH + 1];
@@ -312,10 +322,10 @@ void rrdlabels_add(RRDLABELS *labels, const char *name, const char *value, RRDLA
 
     if(!*n) {
         netdata_log_error("%s: cannot add name '%s' (value '%s') which is sanitized as empty string", __FUNCTION__, name, value);
-        return;
+        return false;
     }
 
-    labels_add_already_sanitized(labels, n, v, ls);
+    return labels_add_already_sanitized(labels, n, v, ls);
 }
 
 bool rrdlabels_exist(RRDLABELS *labels, const char *key)
@@ -550,11 +560,12 @@ void rrdlabels_unmark_all(RRDLABELS *labels)
     spinlock_unlock(&labels->spinlock);
 }
 
-static void rrdlabels_remove_all_unmarked_unsafe(RRDLABELS *labels)
+static size_t rrdlabels_remove_all_unmarked_unsafe(RRDLABELS *labels)
 {
     Pvoid_t *PValue;
     Word_t Index = 0;
     bool first_then_next = true;
+    size_t removed = 0;
 
     while ((PValue = JudyLFirstThenNext(labels->JudyL, &Index, &first_then_next))) {
         if (!((*((RRDLABEL_SRC *)PValue)) & (RRDLABEL_FLAG_INTERNAL))) {
@@ -566,18 +577,21 @@ static void rrdlabels_remove_all_unmarked_unsafe(RRDLABELS *labels)
             RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, judy_mem, 0);
 
             delete_label((RRDLABEL *)Index);
+            removed++;
             if (labels->JudyL != (Pvoid_t) NULL) {
                 Index = 0;
                 first_then_next = true;
             }
         }
     }
+
+    return removed;
 }
 
 void rrdlabels_remove_all_unmarked(RRDLABELS *labels)
 {
     spinlock_lock(&labels->spinlock);
-    rrdlabels_remove_all_unmarked_unsafe(labels);
+    (void)rrdlabels_remove_all_unmarked_unsafe(labels);
     spinlock_unlock(&labels->spinlock);
 }
 
@@ -597,6 +611,28 @@ void rrdlabels_mark_source_as_old(RRDLABELS *labels, RRDLABEL_SRC src_match)
     }
 
     spinlock_unlock(&labels->spinlock);
+}
+
+bool rrdlabels_remove_all_unmarked_and_changed(RRDLABELS *labels)
+{
+    if(!labels) return false;
+
+    spinlock_lock(&labels->spinlock);
+
+    size_t added = 0;
+    Pvoid_t *PValue;
+    Word_t Index = 0;
+    bool first_then_next = true;
+    while ((PValue = JudyLFirstThenNext(labels->JudyL, &Index, &first_then_next))) {
+        if ((*((RRDLABEL_SRC *)PValue)) & RRDLABEL_FLAG_NEW)
+            added++;
+    }
+
+    size_t removed = rrdlabels_remove_all_unmarked_unsafe(labels);
+
+    spinlock_unlock(&labels->spinlock);
+
+    return (added > 0) || (removed > 0);
 }
 
 // ----------------------------------------------------------------------------
@@ -663,9 +699,9 @@ static SIMPLE_PATTERN_RESULT rrdlabels_walkthrough_read_sp(RRDLABELS *labels, SI
 // rrdlabels_migrate_to_these()
 // migrate an existing label list to a new list
 
-void rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src) {
+bool rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src) {
     if (!dst || !src || (dst == src))
-        return;
+        return false;
 
     spinlock_lock(&dst->spinlock);
     spinlock_lock(&src->spinlock);
@@ -674,6 +710,7 @@ void rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src) {
 
     RRDLABEL *label;
     Pvoid_t *PValue;
+    size_t added = 0;
 
     RRDLABEL_SRC ls;
     lfe_start_nolock(src, label, ls)
@@ -690,6 +727,7 @@ void rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src) {
             dup_label(label);
             int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
             RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, judy_mem, 0);
+            added++;
         }
         else
             flag = RRDLABEL_FLAG_OLD;
@@ -698,11 +736,13 @@ void rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src) {
     }
     lfe_done_nolock();
 
-    rrdlabels_remove_all_unmarked_unsafe(dst);
+    size_t removed = rrdlabels_remove_all_unmarked_unsafe(dst);
     dst->version = src->version;
 
     spinlock_unlock(&src->spinlock);
     spinlock_unlock(&dst->spinlock);
+
+    return (added > 0) || (removed > 0);
 }
 
 //
@@ -1011,15 +1051,22 @@ uint32_t rrdlabels_version(RRDLABELS *labels __maybe_unused)
 }
 
 void rrdset_update_rrdlabels(RRDSET *st, RRDLABELS *new_rrdlabels) {
+    bool labels_changed = false;
+
     if(!st->rrdlabels)
         st->rrdlabels = rrdlabels_create();
 
     if (new_rrdlabels)
-        rrdlabels_migrate_to_these(st->rrdlabels, new_rrdlabels);
+        labels_changed = rrdlabels_migrate_to_these(st->rrdlabels, new_rrdlabels);
 
     rrdset_flag_set(st, RRDSET_FLAG_METADATA_UPDATE);
     rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_METADATA_UPDATE);
     rrdset_metadata_updated(st);
+
+    if(labels_changed) {
+        rrdset_flag_set(st, RRDSET_FLAG_PENDING_LABEL_RECHECK);
+        rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -1580,6 +1580,122 @@ static int rrdlabels_unittest_mark_source_as_old(void) {
     return errors;
 }
 
+#define UT_EXPECT(_cond, _msg) do {                                            \
+    if (!(_cond)) {                                                            \
+        fprintf(stderr, "  FAIL: %s\n", (_msg));                               \
+        errors++;                                                              \
+    }                                                                          \
+} while (0)
+
+static int rrdlabels_unittest_change_detection(void) {
+    fprintf(stderr, "\n%s() tests\n", __FUNCTION__);
+    int errors = 0;
+
+    // ---- rrdlabels_add_changed: new vs same vs value-change ----
+    RRDLABELS *l = rrdlabels_create();
+    UT_EXPECT(rrdlabels_add_changed(l, "k1", "v1", RRDLABEL_SRC_CONFIG) == true,
+              "add of new label should return true");
+    UT_EXPECT(rrdlabels_add_changed(l, "k1", "v1", RRDLABEL_SRC_CONFIG) == false,
+              "re-add of identical key+value should return false");
+    UT_EXPECT(rrdlabels_add_changed(l, "k1", "v2", RRDLABEL_SRC_CONFIG) == true,
+              "value change for an existing key should return true");
+    UT_EXPECT(rrdlabels_add_changed(l, "k2", "v2", RRDLABEL_SRC_CONFIG) == true,
+              "add of a different new key should return true");
+    rrdlabels_destroy(l);
+
+    // ---- rrdlabels_migrate_to_these: empty/identical/diff/DONT_DELETE ----
+    RRDLABELS *dst = rrdlabels_create();
+    RRDLABELS *src = rrdlabels_create();
+
+    // empty dst, empty src => no add, no remove => false
+    UT_EXPECT(rrdlabels_migrate_to_these(dst, src) == false,
+              "migrate of two empty label sets should return false");
+
+    // populate src; dst empty => added > 0 => true
+    rrdlabels_add(src, "k1", "v1", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(src, "k2", "v2", RRDLABEL_SRC_CONFIG);
+    UT_EXPECT(rrdlabels_migrate_to_these(dst, src) == true,
+              "migrate to empty dst should return true when src has labels");
+
+    // identical content now (dst was populated from src) => false
+    UT_EXPECT(rrdlabels_migrate_to_these(dst, src) == false,
+              "migrate with identical key/value sets should return false");
+
+    // src adds one => true
+    rrdlabels_add(src, "k3", "v3", RRDLABEL_SRC_CONFIG);
+    UT_EXPECT(rrdlabels_migrate_to_these(dst, src) == true,
+              "migrate that adds a label should return true");
+
+    // src drops one => true (removed > 0)
+    {
+        RRDLABELS *trimmed = rrdlabels_create();
+        rrdlabels_add(trimmed, "k1", "v1", RRDLABEL_SRC_CONFIG);
+        rrdlabels_add(trimmed, "k2", "v2", RRDLABEL_SRC_CONFIG);
+        UT_EXPECT(rrdlabels_migrate_to_these(dst, trimmed) == true,
+                  "migrate that removes a label should return true");
+        rrdlabels_destroy(trimmed);
+    }
+    rrdlabels_destroy(dst);
+    rrdlabels_destroy(src);
+
+    // DONT_DELETE: a label that is not in src remains in dst; nothing added or
+    // removed, so the function returns false even though dst != src.
+    dst = rrdlabels_create();
+    src = rrdlabels_create();
+    rrdlabels_add(dst, "k1", "v1", RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE);
+    UT_EXPECT(rrdlabels_migrate_to_these(dst, src) == false,
+              "migrate where the only diff is a DONT_DELETE label should return false");
+    UT_EXPECT(rrdlabels_entries(dst) == 1,
+              "DONT_DELETE label should be preserved after migrate");
+    rrdlabels_destroy(dst);
+    rrdlabels_destroy(src);
+
+    // ---- rrdlabels_remove_all_unmarked_and_changed: CLABEL-commit semantics ----
+    // (1) unmark + re-add identical set => no change => false
+    l = rrdlabels_create();
+    rrdlabels_add(l, "k1", "v1", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(l, "k2", "v2", RRDLABEL_SRC_CONFIG);
+    rrdlabels_unmark_all(l);
+    rrdlabels_add(l, "k1", "v1", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(l, "k2", "v2", RRDLABEL_SRC_CONFIG);
+    UT_EXPECT(rrdlabels_remove_all_unmarked_and_changed(l) == false,
+              "remove_all_unmarked_and_changed: identical re-commit should return false");
+    rrdlabels_destroy(l);
+
+    // (2) unmark + add a new label => added > 0 => true
+    l = rrdlabels_create();
+    rrdlabels_add(l, "k1", "v1", RRDLABEL_SRC_CONFIG);
+    rrdlabels_unmark_all(l);
+    rrdlabels_add(l, "k1", "v1", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(l, "k2", "v2", RRDLABEL_SRC_CONFIG);
+    UT_EXPECT(rrdlabels_remove_all_unmarked_and_changed(l) == true,
+              "remove_all_unmarked_and_changed: adding a label should return true");
+    rrdlabels_destroy(l);
+
+    // (3) unmark + commit a subset => removed > 0 => true
+    l = rrdlabels_create();
+    rrdlabels_add(l, "k1", "v1", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(l, "k2", "v2", RRDLABEL_SRC_CONFIG);
+    rrdlabels_unmark_all(l);
+    rrdlabels_add(l, "k1", "v1", RRDLABEL_SRC_CONFIG);
+    UT_EXPECT(rrdlabels_remove_all_unmarked_and_changed(l) == true,
+              "remove_all_unmarked_and_changed: dropping a label should return true");
+    rrdlabels_destroy(l);
+
+    // (4) unmark + change a value => true (the changed entry is NEW)
+    l = rrdlabels_create();
+    rrdlabels_add(l, "k1", "v1", RRDLABEL_SRC_CONFIG);
+    rrdlabels_unmark_all(l);
+    rrdlabels_add(l, "k1", "v2", RRDLABEL_SRC_CONFIG);
+    UT_EXPECT(rrdlabels_remove_all_unmarked_and_changed(l) == true,
+              "remove_all_unmarked_and_changed: value change should return true");
+    rrdlabels_destroy(l);
+
+    return errors;
+}
+
+#undef UT_EXPECT
+
 struct pattern_array *trim_and_add_key_to_values(struct pattern_array *pa, const char *key, STRING *input);
 static int rrdlabels_unittest_check_pattern_list(RRDLABELS *labels, const char *pattern, bool expected) {
     fprintf(stderr, "rrdlabels_match_simple_pattern(labels, \"%s\") ... ", pattern);
@@ -1763,6 +1879,7 @@ int rrdlabels_unittest(void) {
     errors += rrdlabels_unittest_double_check();
     errors += rrdlabels_unittest_migrate_check();
     errors += rrdlabels_unittest_mark_source_as_old();
+    errors += rrdlabels_unittest_change_detection();
     errors += rrdlabels_unittest_pattern_check();
 
     fprintf(stderr, "%d errors found\n", errors);

--- a/src/database/rrdlabels.h
+++ b/src/database/rrdlabels.h
@@ -32,6 +32,10 @@ RRDLABELS *rrdlabels_create(void);
 void rrdlabels_destroy(RRDLABELS *labels_dict);
 void rrdlabels_flush(RRDLABELS *labels);
 void rrdlabels_add(RRDLABELS *labels, const char *name, const char *value, RRDLABEL_SRC ls);
+// like rrdlabels_add() but returns true when the call actually changed the
+// label set (new key, or value changed for an existing key); false when the
+// key already existed with the same value.
+bool rrdlabels_add_changed(RRDLABELS *labels, const char *name, const char *value, RRDLABEL_SRC ls);
 void rrdlabels_add_pair(RRDLABELS *labels, const char *string, RRDLABEL_SRC ls);
 void rrdlabels_value_to_buffer_array_item_or_null(RRDLABELS *labels, BUFFER *wb, const char *key);
 void rrdlabels_key_to_buffer_array_item(RRDLABELS *labels, BUFFER *wb);
@@ -72,7 +76,14 @@ int rrdlabels_to_buffer(RRDLABELS *labels, BUFFER *wb, const char *before_each, 
                         void (*value_sanitizer)(char *dst, const char *src, size_t dst_size));
 void rrdlabels_to_buffer_json_members(RRDLABELS *labels, BUFFER *wb);
 
-void rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src);
+// returns true when dst was modified (at least one label added or removed),
+// false when dst already matched src and no labels changed.
+bool rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src);
+
+// finalize a CLABEL stream commit: remove unmarked entries and report whether
+// the resulting label set differs from the pre-commit set (added, removed, or
+// value-changed entries).
+bool rrdlabels_remove_all_unmarked_and_changed(RRDLABELS *labels);
 void rrdlabels_copy(RRDLABELS *dst, RRDLABELS *src);
 size_t rrdlabels_common_count(RRDLABELS *labels1, RRDLABELS *labels2);
 

--- a/src/database/rrdlabels.h
+++ b/src/database/rrdlabels.h
@@ -76,8 +76,13 @@ int rrdlabels_to_buffer(RRDLABELS *labels, BUFFER *wb, const char *before_each, 
                         void (*value_sanitizer)(char *dst, const char *src, size_t dst_size));
 void rrdlabels_to_buffer_json_members(RRDLABELS *labels, BUFFER *wb);
 
-// returns true when dst was modified (at least one label added or removed),
-// false when dst already matched src and no labels changed.
+// migrate dst toward src by key/value: labels present in src but missing from
+// dst are added, labels present in dst but missing from src are removed
+// (entries flagged RRDLABEL_FLAG_DONT_DELETE are preserved). The RRDLABEL_SRC
+// bits on entries that are already present in both are NOT reconciled to src.
+// Returns true when at least one label was added or removed, false otherwise.
+// A false return does not imply dst equals src bit-for-bit (preserved
+// DONT_DELETE entries and unchanged RRDLABEL_SRC bits can still differ).
 bool rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src);
 
 // finalize a CLABEL stream commit: remove unmarked entries and report whether

--- a/src/database/rrdset.h
+++ b/src/database/rrdset.h
@@ -63,6 +63,10 @@ typedef enum __attribute__ ((__packed__)) rrdset_flags {
     RRDSET_FLAG_COLLECTION_FINISHED              = (1 << 25), // when set, data collection is not available for this chart
 
     RRDSET_FLAG_HAS_RRDCALC_LINKED               = (1 << 26), // this chart has at least one rrdcal linked
+
+    RRDSET_FLAG_PENDING_LABEL_RECHECK            = (1 << 27), // chart labels changed since the last health
+                                                              // prototype evaluation; the health thread must
+                                                              // detach + reattach alerts for this chart.
 } RRDSET_FLAGS;
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -208,18 +208,37 @@ static void health_execute_delayed_initializations(RRDHOST *host) {
 
     RRDSET *st;
 
-    if (!rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION)) return;
-    rrdhost_flag_clear(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+    bool host_pending_init    = rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+    bool host_pending_recheck = rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_LABEL_RECHECK);
+
+    if (!host_pending_init && !host_pending_recheck) return;
+
+    if (host_pending_init)
+        rrdhost_flag_clear(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+    if (host_pending_recheck)
+        rrdhost_flag_clear(host, RRDHOST_FLAG_PENDING_LABEL_RECHECK);
 
     rrdset_foreach_reentrant(st, host) {
-        if (!rrdset_flag_check(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION))
+        bool needs_init    = rrdset_flag_check(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
+        bool needs_recheck = host_pending_recheck || rrdset_flag_check(st, RRDSET_FLAG_PENDING_LABEL_RECHECK);
+
+        if (!needs_init && !needs_recheck)
             continue;
 
-        rrdset_flag_clear(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
+        if (needs_init)
+            rrdset_flag_clear(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
+        if (needs_recheck)
+            rrdset_flag_clear(st, RRDSET_FLAG_PENDING_LABEL_RECHECK);
 
         worker_is_busy(WORKER_HEALTH_JOB_DELAYED_INIT_RRDSET);
 
-        health_prototype_alerts_for_rrdset_incrementally(st);
+        // recheck path subsumes init: reset detaches all current alerts on the
+        // chart and reattaches by re-evaluating every prototype against the
+        // current labels, which also picks up first-attach matches.
+        if (needs_recheck)
+            health_prototype_reset_alerts_for_rrdset(st);
+        else
+            health_prototype_alerts_for_rrdset_incrementally(st);
 
         if (!service_running(SERVICE_HEALTH))
             break;

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -208,27 +208,31 @@ static void health_execute_delayed_initializations(RRDHOST *host) {
 
     RRDSET *st;
 
-    bool host_pending_init    = rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
-    bool host_pending_recheck = rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_LABEL_RECHECK);
+    // Atomically snapshot + clear the host pending flags. A separate check-then-clear
+    // would race with concurrent setters (e.g. label updaters in plugins/streaming),
+    // and a flag set between check and clear would be lost.
+    RRDHOST_FLAGS old_host_flags = rrdhost_flag_set_and_clear(
+        host, 0,
+        RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION | RRDHOST_FLAG_PENDING_LABEL_RECHECK);
+
+    bool host_pending_init    = old_host_flags & RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION;
+    bool host_pending_recheck = old_host_flags & RRDHOST_FLAG_PENDING_LABEL_RECHECK;
 
     if (!host_pending_init && !host_pending_recheck) return;
 
-    if (host_pending_init)
-        rrdhost_flag_clear(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
-    if (host_pending_recheck)
-        rrdhost_flag_clear(host, RRDHOST_FLAG_PENDING_LABEL_RECHECK);
-
     rrdset_foreach_reentrant(st, host) {
-        bool needs_init    = rrdset_flag_check(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
-        bool needs_recheck = host_pending_recheck || rrdset_flag_check(st, RRDSET_FLAG_PENDING_LABEL_RECHECK);
+        // Same race applies per-chart: snapshot + clear atomically so a concurrent
+        // CLABEL stream commit or rrdset_update_rrdlabels() cannot have its
+        // pending-recheck request swallowed by a separate clear.
+        RRDSET_FLAGS old_st_flags = rrdset_flag_set_and_clear(
+            st, 0,
+            RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION | RRDSET_FLAG_PENDING_LABEL_RECHECK);
+
+        bool needs_init    = old_st_flags & RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION;
+        bool needs_recheck = host_pending_recheck || (old_st_flags & RRDSET_FLAG_PENDING_LABEL_RECHECK);
 
         if (!needs_init && !needs_recheck)
             continue;
-
-        if (needs_init)
-            rrdset_flag_clear(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
-        if (needs_recheck)
-            rrdset_flag_clear(st, RRDSET_FLAG_PENDING_LABEL_RECHECK);
 
         worker_is_busy(WORKER_HEALTH_JOB_DELAYED_INIT_RRDSET);
 

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -183,7 +183,8 @@ static inline PARSER_RC pluginsd_host_labels(char **words, size_t num_words, PAR
                                     PLUGINSD_KEYWORD_HOST_LABEL);
 }
 
-static inline void pluginsd_update_host_ephemerality(RRDHOST *host) {
+// returns true when the _is_ephemeral label was added or its value changed.
+static inline bool pluginsd_update_host_ephemerality(RRDHOST *host) {
     char value[64];
     rrdlabels_get_value_strcpyz(host->rrdlabels, value, sizeof(value), HOST_LABEL_IS_EPHEMERAL);
     if(value[0] && inicfg_test_boolean_value(value)) {
@@ -196,7 +197,7 @@ static inline void pluginsd_update_host_ephemerality(RRDHOST *host) {
     }
 
     // Set or replace current label as needed
-    rrdlabels_add(host->rrdlabels, HOST_LABEL_IS_EPHEMERAL, value, RRDLABEL_SRC_CONFIG);
+    return rrdlabels_add_changed(host->rrdlabels, HOST_LABEL_IS_EPHEMERAL, value, RRDLABEL_SRC_CONFIG);
 }
 
 #define VNODE_BASE_EPOCH (1704067200L)  // Jan 1, 2024 00:00:00 UTC
@@ -241,21 +242,26 @@ static inline PARSER_RC pluginsd_host_define_end(char **words __maybe_unused, si
     ml_host_start(host);
     pulse_host_status(host, 0, 0); // this will detect the receiver status
 
+    bool labels_changed;
     if(host->rrdlabels) {
-        rrdlabels_migrate_to_these(host->rrdlabels, parser->user.host_define.rrdlabels);
+        labels_changed = rrdlabels_migrate_to_these(host->rrdlabels, parser->user.host_define.rrdlabels);
     }
     else {
         host->rrdlabels = parser->user.host_define.rrdlabels;
         parser->user.host_define.rrdlabels = NULL;
+        labels_changed = true;
     }
 
     if(SERVING_PLUGINSD(parser)) {
-        rrdlabels_add(host->rrdlabels, "_collector_machine_guid",
+        labels_changed |= rrdlabels_add_changed(host->rrdlabels, "_collector_machine_guid",
                       localhost->machine_guid, RRDLABEL_SRC_AUTO);
     }
 
-    pluginsd_update_host_ephemerality(host);
+    labels_changed |= pluginsd_update_host_ephemerality(host);
     pluginsd_host_define_cleanup(parser);
+
+    if(labels_changed)
+        rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_LABEL_RECHECK);
 
     parser->user.host = host;
     pluginsd_clear_scope_chart(parser, PLUGINSD_KEYWORD_HOST_DEFINE_END, NULL);
@@ -725,16 +731,18 @@ static inline PARSER_RC pluginsd_overwrite(char **words __maybe_unused, size_t n
     if(unlikely(!host->rrdlabels))
         host->rrdlabels = rrdlabels_create();
 
-    rrdlabels_migrate_to_these(host->rrdlabels, parser->user.new_host_labels);
-    pluginsd_update_host_ephemerality(host);
+    bool labels_changed = rrdlabels_migrate_to_these(host->rrdlabels, parser->user.new_host_labels);
+    labels_changed |= pluginsd_update_host_ephemerality(host);
 
     if(!rrdlabels_exist(host->rrdlabels, "_os"))
-        rrdlabels_add(host->rrdlabels, "_os", string2str(host->os), RRDLABEL_SRC_AUTO);
+        labels_changed |= rrdlabels_add_changed(host->rrdlabels, "_os", string2str(host->os), RRDLABEL_SRC_AUTO);
 
     if(!rrdlabels_exist(host->rrdlabels, "_hostname"))
-        rrdlabels_add(host->rrdlabels, "_hostname", string2str(host->hostname), RRDLABEL_SRC_AUTO);
+        labels_changed |= rrdlabels_add_changed(host->rrdlabels, "_hostname", string2str(host->hostname), RRDLABEL_SRC_AUTO);
 
     rrdhost_flag_set(host, RRDHOST_FLAG_METADATA_LABELS | RRDHOST_FLAG_METADATA_UPDATE);
+    if(labels_changed)
+        rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_LABEL_RECHECK);
 
     rrdlabels_destroy(parser->user.new_host_labels);
     parser->user.new_host_labels = NULL;
@@ -776,11 +784,16 @@ static inline PARSER_RC pluginsd_clabel_commit(char **words __maybe_unused, size
         return PLUGINSD_DISABLE_PLUGIN(parser, NULL, NULL);
     }
 
-    rrdlabels_remove_all_unmarked(st->rrdlabels);
+    bool labels_changed = rrdlabels_remove_all_unmarked_and_changed(st->rrdlabels);
 
     rrdset_flag_set(st, RRDSET_FLAG_METADATA_UPDATE);
     rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_METADATA_UPDATE);
     rrdset_metadata_updated(st);
+
+    if(labels_changed) {
+        rrdset_flag_set(st, RRDSET_FLAG_PENDING_LABEL_RECHECK);
+        rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+    }
 
     parser->user.clabel_count = 0;
 


### PR DESCRIPTION
##### Summary
- Introduced `rrdlabels_add_changed` to check and indicate if label additions modify existing labels.
- Updated `rrdlabels_migrate_to_these` and related functions to detect changes in label sets.
- Added `RRDSET_FLAG_PENDING_LABEL_RECHECK` and `RRDHOST_FLAG_PENDING_LABEL_RECHECK` to signal health evaluation requirements based on label changes.
- Enhanced health event loop to handle label-related rechecks alongside initialization.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically re-evaluates health alert prototypes when host or chart labels change, detaching/reattaching alerts to match the latest labels. Detects and reacts to real label-set changes in timezone, ephemerality, `_is_parent`, pluginsd host define/overwrite, and CLABEL commits.

- **New Features**
  - Added `rrdlabels_add_changed`, `rrdlabels_migrate_to_these` (returns bool), and `rrdlabels_remove_all_unmarked_and_changed` to detect real label-set changes, with unit tests for add/migrate/commit scenarios.
  - Introduced `RRDSET_FLAG_PENDING_LABEL_RECHECK` and `RRDHOST_FLAG_PENDING_LABEL_RECHECK`; the host-level flag rechecks all charts without per-chart fan-out.
  - Health loop now atomically snapshots-and-clears pending flags on host and charts, and resets/re-applies alert prototypes on recheck; this path subsumes init.
  - Change-aware updates wire pending flags into timezone changes, host label reload, `_is_parent`, `_is_ephemeral`, `_collector_machine_guid`, `_os`, `_hostname`, `rrdset_update_rrdlabels`, and CLABEL commits, setting recheck/init flags only when label sets truly change.

<sup>Written for commit 7bad81ff017586edf70cd766fcad1a12b6488500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22570?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

