### PR TITLE
Remove stale labels after host label reload

### DIFF
--- a/src/database/rrdhost-labels.c
+++ b/src/database/rrdhost-labels.c
@@ -181,6 +181,11 @@ void reload_host_labels(void) {
     rrdhost_load_kubernetes_labels();
     rrdhost_load_auto_labels();
 
+    // drop entries that the loaders did not re-add (e.g. a label removed from
+    // netdata.conf, or no longer returned by get-kubernetes-labels.sh).
+    // RRDLABEL_FLAG_DONT_DELETE entries are preserved.
+    rrdlabels_remove_all_unmarked(localhost->rrdlabels);
+
     rrdhost_flag_set(localhost,RRDHOST_FLAG_METADATA_LABELS | RRDHOST_FLAG_METADATA_UPDATE);
 
     stream_send_host_labels(localhost);

--- a/src/database/rrdhost-labels.c
+++ b/src/database/rrdhost-labels.c
@@ -111,7 +111,11 @@ static void rrdhost_load_config_labels(void) {
     inicfg_foreach_value_in_section(&netdata_config, CONFIG_SECTION_HOST_LABEL, config_label_cb, NULL);
 }
 
-static void rrdhost_load_kubernetes_labels(void) {
+// Returns true if the kubernetes labels script ran to a clean exit. A false
+// return tells the caller the refresh was best-effort: callers must preserve
+// the previously-loaded k8s labels (see reload_host_labels()) so a transient
+// script failure does not silently delete them.
+static bool rrdhost_load_kubernetes_labels(void) {
     char label_script[sizeof(char) * (strlen(netdata_configured_primary_plugins_dir) + strlen("get-kubernetes-labels.sh") + 2)];
     sprintf(label_script, "%s/%s", netdata_configured_primary_plugins_dir, "get-kubernetes-labels.sh");
 
@@ -120,11 +124,11 @@ static void rrdhost_load_kubernetes_labels(void) {
                "Kubernetes pod label fetching script %s not found.",
                label_script);
 
-        return;
+        return false;
     }
 
     POPEN_INSTANCE *instance = spawn_popen_run(label_script);
-    if(!instance) return;
+    if(!instance) return false;
 
     char buffer[1000 + 1];
     while (fgets(buffer, 1000, spawn_popen_stdout(instance)) != NULL)
@@ -133,10 +137,14 @@ static void rrdhost_load_kubernetes_labels(void) {
     // Non-zero exit code means that all the script output is error messages. We've shown already any message that didn't include a ':'
     // Here we'll inform with an ERROR that the script failed, show whatever (if anything) was added to the list of labels, free the memory and set the return to null
     int rc = spawn_popen_wait(instance);
-    if(rc)
+    if(rc) {
         nd_log(NDLS_DAEMON, NDLP_ERR,
                "%s exited abnormally. Failed to get kubernetes labels.",
                label_script);
+        return false;
+    }
+
+    return true;
 }
 
 static void rrdhost_load_auto_labels(void) {
@@ -178,8 +186,16 @@ void reload_host_labels(void) {
 
     // priority is important here
     rrdhost_load_config_labels();
-    rrdhost_load_kubernetes_labels();
+    bool k8s_loaded = rrdhost_load_kubernetes_labels();
     rrdhost_load_auto_labels();
+
+    // If the kubernetes loader did not run cleanly (script missing, spawn
+    // failure, or non-zero exit), the previously-loaded k8s labels were not
+    // refreshed and must survive the prune below -- otherwise a transient
+    // script failure would silently delete them. Re-mark them so the next
+    // step keeps them.
+    if (!k8s_loaded)
+        rrdlabels_mark_source_as_old(localhost->rrdlabels, RRDLABEL_SRC_K8S);
 
     // drop entries that the loaders did not re-add (e.g. a label removed from
     // netdata.conf, or no longer returned by get-kubernetes-labels.sh).

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -1455,6 +1455,84 @@ static int rrdlabels_unittest_migrate_check()
     return rc;
 }
 
+// Exercises the unmark + re-add + remove_all_unmarked cycle that
+// reload_host_labels() relies on, plus the rrdlabels_mark_source_as_old()
+// preservation path used when the kubernetes loader fails.
+static int rrdlabels_unittest_mark_source_as_old(void) {
+    fprintf(stderr, "\n%s() tests\n", __FUNCTION__);
+    int errors = 0;
+
+    // Subtest A: the prune drops entries that no loader re-added.
+    {
+        RRDLABELS *l = rrdlabels_create();
+        rrdlabels_add(l, "cfg_key",  "cv", RRDLABEL_SRC_CONFIG);
+        rrdlabels_add(l, "k8s_key",  "kv", RRDLABEL_SRC_AUTO | RRDLABEL_SRC_K8S);
+        rrdlabels_add(l, "aclk_key", "av", RRDLABEL_SRC_AUTO | RRDLABEL_SRC_ACLK);
+
+        rrdlabels_unmark_all(l);
+        // simulate a successful config + aclk loader; the k8s loader added nothing
+        rrdlabels_add(l, "cfg_key",  "cv", RRDLABEL_SRC_CONFIG);
+        rrdlabels_add(l, "aclk_key", "av", RRDLABEL_SRC_AUTO | RRDLABEL_SRC_ACLK);
+        rrdlabels_remove_all_unmarked(l);
+
+        if (rrdlabels_exist(l, "k8s_key")) {
+            fprintf(stderr, "  FAIL (A): k8s_key should have been pruned (not re-added, not preserved)\n");
+            errors++;
+        }
+        if (!rrdlabels_exist(l, "cfg_key") || !rrdlabels_exist(l, "aclk_key")) {
+            fprintf(stderr, "  FAIL (A): re-added labels should have survived the prune\n");
+            errors++;
+        }
+        rrdlabels_destroy(l);
+    }
+
+    // Subtest B: mark_source_as_old(K8S) preserves k8s entries through the prune
+    // (the k8s-loader-failure preservation path in reload_host_labels()).
+    {
+        RRDLABELS *l = rrdlabels_create();
+        rrdlabels_add(l, "cfg_key",  "cv",  RRDLABEL_SRC_CONFIG);
+        rrdlabels_add(l, "k8s_key",  "kv",  RRDLABEL_SRC_AUTO | RRDLABEL_SRC_K8S);
+        rrdlabels_add(l, "k8s_key2", "kv2", RRDLABEL_SRC_AUTO | RRDLABEL_SRC_K8S);
+
+        rrdlabels_unmark_all(l);
+        // simulate successful config loader; k8s loader failed
+        rrdlabels_add(l, "cfg_key", "cv", RRDLABEL_SRC_CONFIG);
+        rrdlabels_mark_source_as_old(l, RRDLABEL_SRC_K8S);
+        rrdlabels_remove_all_unmarked(l);
+
+        if (!rrdlabels_exist(l, "k8s_key") || !rrdlabels_exist(l, "k8s_key2")) {
+            fprintf(stderr, "  FAIL (B): K8S labels should be preserved via mark_source_as_old\n");
+            errors++;
+        }
+        if (!rrdlabels_exist(l, "cfg_key")) {
+            fprintf(stderr, "  FAIL (B): cfg_key should still be present after the prune\n");
+            errors++;
+        }
+        rrdlabels_destroy(l);
+    }
+
+    // Subtest C: mark_source_as_old(K8S) only preserves labels whose source
+    // mask intersects K8S; entries with other-only sources are still pruned.
+    {
+        RRDLABELS *l = rrdlabels_create();
+        rrdlabels_add(l, "aclk_key", "av", RRDLABEL_SRC_AUTO | RRDLABEL_SRC_ACLK);
+        rrdlabels_add(l, "cfg_key",  "cv", RRDLABEL_SRC_CONFIG);
+
+        rrdlabels_unmark_all(l);
+        rrdlabels_mark_source_as_old(l, RRDLABEL_SRC_K8S);
+        rrdlabels_remove_all_unmarked(l);
+
+        if (rrdlabels_exist(l, "aclk_key") || rrdlabels_exist(l, "cfg_key")) {
+            fprintf(stderr, "  FAIL (C): non-K8S labels must not be preserved by mark_source_as_old(K8S)\n");
+            errors++;
+        }
+        rrdlabels_destroy(l);
+    }
+
+    fprintf(stderr, "%s: %d errors\n", __FUNCTION__, errors);
+    return errors;
+}
+
 struct pattern_array *trim_and_add_key_to_values(struct pattern_array *pa, const char *key, STRING *input);
 static int rrdlabels_unittest_check_pattern_list(RRDLABELS *labels, const char *pattern, bool expected) {
     fprintf(stderr, "rrdlabels_match_simple_pattern(labels, \"%s\") ... ", pattern);
@@ -1637,6 +1715,7 @@ int rrdlabels_unittest(void) {
     errors += rrdlabels_unittest_host_chart_labels();
     errors += rrdlabels_unittest_double_check();
     errors += rrdlabels_unittest_migrate_check();
+    errors += rrdlabels_unittest_mark_source_as_old();
     errors += rrdlabels_unittest_pattern_check();
 
     fprintf(stderr, "%d errors found\n", errors);

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -581,6 +581,24 @@ void rrdlabels_remove_all_unmarked(RRDLABELS *labels)
     spinlock_unlock(&labels->spinlock);
 }
 
+void rrdlabels_mark_source_as_old(RRDLABELS *labels, RRDLABEL_SRC src_match)
+{
+    if (!labels) return;
+
+    Pvoid_t *PValue;
+    Word_t Index = 0;
+    bool first_then_next = true;
+
+    spinlock_lock(&labels->spinlock);
+
+    while ((PValue = JudyLFirstThenNext(labels->JudyL, &Index, &first_then_next))) {
+        if ((*((RRDLABEL_SRC *)PValue)) & src_match)
+            *((RRDLABEL_SRC *)PValue) |= RRDLABEL_FLAG_OLD;
+    }
+
+    spinlock_unlock(&labels->spinlock);
+}
+
 // ----------------------------------------------------------------------------
 // rrdlabels_walkthrough_read()
 

--- a/src/database/rrdlabels.h
+++ b/src/database/rrdlabels.h
@@ -46,6 +46,12 @@ void rrdlabels_get_value_strcpyz(RRDLABELS *labels, char *dst, size_t dst_len, c
 void rrdlabels_unmark_all(RRDLABELS *labels);
 void rrdlabels_remove_all_unmarked(RRDLABELS *labels);
 
+// OR RRDLABEL_FLAG_OLD onto every entry whose source bits intersect src_match.
+// Used after a best-effort loader (e.g. the kubernetes labels script) fails,
+// so labels from that source survive the next rrdlabels_remove_all_unmarked()
+// prune even though the loader did not re-add them this round.
+void rrdlabels_mark_source_as_old(RRDLABELS *labels, RRDLABEL_SRC src_match);
+
 int rrdlabels_walkthrough_read(RRDLABELS *labels, int (*callback)(const char *name, const char *value, RRDLABEL_SRC ls, void *data), void *data);
 int rrdlabels_walkthrough_read_string(RRDLABELS *labels, int (*callback)(STRING *name, STRING *value, RRDLABEL_SRC ls, void *data), void *data);
 void rrdlabels_log_to_buffer(RRDLABELS *labels, BUFFER *wb);


### PR DESCRIPTION
##### Summary
- reload_host_labels() unmarked all labels and re-added what the config / k8s / auto sources provided, but never removed unmarked entries. 
- Labels dropped from netdata.conf or no longer returned by get-kubernetes-labels.sh persisted indefinitely. 
- Fix: Add rrdlabels_remove_all_unmarked() call
  - RRDLABEL_FLAG_DONT_DELETE entries are still preserved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stale host labels on reload so metadata matches current config, Kubernetes, and auto sources.
Prune unmarked entries with rrdlabels_remove_all_unmarked(); if get-kubernetes-labels.sh fails, re-mark K8s labels so they survive; add unit tests to cover this; RRDLABEL_FLAG_DONT_DELETE honored.

<sup>Written for commit 5ad04b49302c20f0912170123b6a23a45f73b95b. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22571?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

