### PR TITLE
Remove OTel journal discovery from systemd-journal.plugin

### DIFF
--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -866,13 +866,6 @@ void nd_journal_init_files_and_directories(void)
         journal_directories[d++].path = string_strdupz(path);
     }
 
-    const char *log_dir = getenv("NETDATA_LOG_DIR");
-    if (log_dir && *log_dir) {
-        char path[PATH_MAX];
-        snprintfz(path, sizeof(path), "%s/otel", log_dir);
-        journal_directories[d++].path = string_strdupz(path);
-    }
-
     // terminate the list
     journal_directories[d].path = NULL;
 


### PR DESCRIPTION
##### Summary
 Follow-up to #22569 per @vkalintiris review:

  > Actually, we want to remove this. The systemd-journal plugin is no longer responsible for reading OTel logs.

  OTel logs are served by the `otel-logs` Function (Rust `otel-signal-viewer.plugin` under `src/crates/netdata-log-viewer/`). The C systemd-journal plugin no longer needs to discover
  `<log-dir>/otel/v1/*.journal` files.

  This drops the OTel discovery block in `nd_journal_init_files_and_directories()` that #22569 had just re-pointed at `NETDATA_LOG_DIR`. Deleting the code path supersedes that fix.

 ##### Behavior change
 - Systemd-journal Function no longer lists OTel journals.
 - `otel-logs` Function continues to list them (unchanged).
 - No env-var contract change, no schema/config/alert/metadata change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed OTel journal discovery from `systemd-journal.plugin` since OTel logs are handled by the `otel-logs` Function (`otel-signal-viewer.plugin`). The plugin no longer scans `NETDATA_LOG_DIR/otel`; `otel-logs` continues to list OTel journals, and there are no config or schema changes.

<sup>Written for commit 389b61b69a1a46fa043b66e6f9b449b92750d911. Summary will update on new commits. <a href="https://cubic.dev/pr/netdata/netdata/pull/22572?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

