### PR TITLE
Address eBPF and Cgroup exit and messages

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/src/collectors/cgroups.plugin/cgroup-discovery.c
@@ -24,6 +24,7 @@ struct cgroup *discovered_cgroup_root = NULL;
 char cgroup_chart_id_prefix[] = "cgroup_";
 char services_chart_id_prefix[] = "systemd_";
 const char *cgroups_rename_script = NULL;
+static DICTIONARY *discovery_walkdir_open_errors = NULL;
 
 // (legacy SHM globals removed — replaced by netipc in cgroup-netipc.c)
 
@@ -349,6 +350,18 @@ static inline struct cgroup *discovery_cgroup_find(const char *id) {
     return cg;
 }
 
+static inline bool discovery_walkdir_open_error_first(const char *dirpath) {
+    if (unlikely(!discovery_walkdir_open_errors))
+        discovery_walkdir_open_errors = dictionary_create(DICT_OPTION_SINGLE_THREADED);
+
+    if (dictionary_get(discovery_walkdir_open_errors, dirpath))
+        return false;
+
+    uint8_t logged = 1;
+    dictionary_set(discovery_walkdir_open_errors, dirpath, &logged, sizeof(logged));
+    return true;
+}
+
 static int calc_cgroup_depth(const char *id) {
     int depth = 0;
     const char *s;
@@ -407,10 +420,16 @@ static inline int discovery_find_walkdir(const char *base, const char *dirpath) 
 
     DIR *dir = opendir(dirpath);
     if(!dir) {
-        if(errno == EACCES && strcmp(dirpath, base) != 0)
-            nd_log_collector(NDLP_DEBUG, "CGROUP: cannot open directory '%s': %s", dirpath, strerror(errno));
-        else
-            collector_error("CGROUP: cannot open directory '%s': %s", dirpath, strerror(errno));
+        int err = errno;
+        bool first_log_for_path = discovery_walkdir_open_error_first(dirpath);
+
+        if(err == EACCES && strcmp(dirpath, base) != 0) {
+            if (first_log_for_path)
+                nd_log_collector(NDLP_DEBUG, "CGROUP: cannot open directory '%s': %s", dirpath, strerror(err));
+        }
+        else if (first_log_for_path) {
+            collector_error("CGROUP: cannot open directory '%s': %s", dirpath, strerror(err));
+        }
         return ret;
     }
     ret = 1;

--- a/src/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/src/collectors/cgroups.plugin/cgroup-discovery.c
@@ -25,6 +25,9 @@ char cgroup_chart_id_prefix[] = "cgroup_";
 char services_chart_id_prefix[] = "systemd_";
 const char *cgroups_rename_script = NULL;
 static DICTIONARY *discovery_walkdir_open_errors = NULL;
+static size_t discovery_walkdir_open_errors_count = 0;
+
+#define DISCOVERY_WALKDIR_OPEN_ERRORS_MAX 256
 
 // (legacy SHM globals removed — replaced by netipc in cgroup-netipc.c)
 
@@ -350,6 +353,23 @@ static inline struct cgroup *discovery_cgroup_find(const char *id) {
     return cg;
 }
 
+struct discovery_walkdir_open_error_prune {
+    size_t remaining;
+};
+
+static int discovery_walkdir_open_error_prune_cb(const DICTIONARY_ITEM *item, void *value __maybe_unused, void *data) {
+    struct discovery_walkdir_open_error_prune *prune = data;
+
+    if (!prune->remaining)
+        return -1;
+
+    dictionary_del(discovery_walkdir_open_errors, dictionary_acquired_item_name(item));
+    discovery_walkdir_open_errors_count--;
+    prune->remaining--;
+
+    return prune->remaining ? 0 : -1;
+}
+
 static inline bool discovery_walkdir_open_error_first(const char *dirpath) {
     if (unlikely(!discovery_walkdir_open_errors))
         discovery_walkdir_open_errors = dictionary_create(DICT_OPTION_SINGLE_THREADED);
@@ -357,9 +377,28 @@ static inline bool discovery_walkdir_open_error_first(const char *dirpath) {
     if (dictionary_get(discovery_walkdir_open_errors, dirpath))
         return false;
 
+    if (discovery_walkdir_open_errors_count >= DISCOVERY_WALKDIR_OPEN_ERRORS_MAX) {
+        struct discovery_walkdir_open_error_prune prune = {
+            .remaining = discovery_walkdir_open_errors_count - DISCOVERY_WALKDIR_OPEN_ERRORS_MAX + 1,
+        };
+
+        dictionary_walkthrough_write(discovery_walkdir_open_errors, discovery_walkdir_open_error_prune_cb, &prune);
+    }
+
     uint8_t logged = 1;
     dictionary_set(discovery_walkdir_open_errors, dirpath, &logged, sizeof(logged));
+    discovery_walkdir_open_errors_count++;
+
     return true;
+}
+
+static inline void discovery_walkdir_open_errors_cleanup(void) {
+    if (!discovery_walkdir_open_errors)
+        return;
+
+    dictionary_destroy(discovery_walkdir_open_errors);
+    discovery_walkdir_open_errors = NULL;
+    discovery_walkdir_open_errors_count = 0;
 }
 
 static int calc_cgroup_depth(const char *id) {
@@ -1206,6 +1245,7 @@ void cgroup_discovery_worker(void *ptr)
 
     // Stop the netipc server first so its worker threads cannot iterate cgroup_root while we free it.
     cgroup_netipc_cleanup();
+    discovery_walkdir_open_errors_cleanup();
 
     // free all cgroups
     netdata_mutex_lock(&cgroup_root_mutex);

--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -1015,7 +1015,7 @@ static inline void ebpf_check_before2go()
 /**
  * Close the collector gracefully
  */
-static void ebpf_exit()
+static void ebpf_cleanup(void)
 {
 #ifdef LIBBPF_MAJOR_VERSION
     netdata_mutex_lock(&ebpf_exit_cleanup);
@@ -1043,8 +1043,12 @@ static void ebpf_exit()
     }
     ebpf_cgroup_cache_cleanup();
     netdata_integration_cleanup_shm();
+}
 
-    exit(0);
+static void ebpf_exit(int exit_code)
+{
+    ebpf_cleanup();
+    exit(exit_code);
 }
 
 /**
@@ -1162,7 +1166,7 @@ void ebpf_stop_threads(int sig)
 #endif
     netdata_mutex_unlock(&mutex_cgroup_shm);
 
-    // Join the cgroup integration thread before ebpf_exit() tears down the netipc cache it reads.
+    // Join the cgroup integration thread before cleanup tears down the netipc cache it reads.
     if (cgroup_integration_thread.thread) {
         nd_thread_join(cgroup_integration_thread.thread);
         cgroup_integration_thread.thread = NULL;
@@ -1186,7 +1190,7 @@ void ebpf_stop_threads(int sig)
     netdata_log_info(
         "EBPF SHUTDOWN: total stop duration %llums.", (unsigned long long)(total_duration_ut / USEC_PER_MS));
 
-    ebpf_exit();
+    ebpf_cleanup();
 }
 
 /**
@@ -1546,7 +1550,7 @@ static void ebpf_parse_args(int argc, char **argv)
             netdata_log_error(
                 "Cannot read process groups '%s/apps_groups.conf'. There are no internal defaults. Failing.",
                 ebpf_stock_config_dir);
-            ebpf_exit();
+            ebpf_exit(1);
         }
     } else
         netdata_log_info("Loaded config file '%s/apps_groups.conf'", ebpf_user_config_dir);
@@ -2365,7 +2369,7 @@ int main(int argc, char **argv)
 
     netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
     if (verify_netdata_host_prefix(true) == -1)
-        ebpf_exit();
+        ebpf_exit(1);
 
     ebpf_allocate_common_vectors();
 

--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -34,6 +34,7 @@ uint32_t integration_with_collectors = NETDATA_EBPF_INTEGRATION_DISABLED;
 ND_THREAD *socket_ipc = NULL;
 static size_t global_iterations_counter = 1;
 bool publish_internal_metrics = true;
+bool ebpf_program_loaded_any = false;
 
 netdata_mutex_t lock;
 netdata_mutex_t ebpf_exit_cleanup;
@@ -2295,6 +2296,26 @@ static void ebpf_signal_stop_handler(int sig)
         ebpf_stop_signal = (sig > 0) ? sig : 1;
 }
 
+static bool ebpf_all_enabled_threads_stopped(void)
+{
+    bool any_enabled = false;
+
+    for (size_t i = 0; ebpf_threads[i].name != NULL; i++) {
+        if (!ebpf_threads[i].enabled)
+            continue;
+
+        any_enabled = true;
+
+        if (!ebpf_threads[i].thread)
+            continue;
+
+        if (ebpf_module_enabled_get(&ebpf_modules[i]) < NETDATA_THREAD_EBPF_STOPPING)
+            return false;
+    }
+
+    return any_enabled;
+}
+
 /**
  * Entry point
  *
@@ -2402,6 +2423,7 @@ int main(int argc, char **argv)
     heartbeat_init(&hb, USEC_PER_SEC);
     int update_apps_every = (int)EBPF_CFG_UPDATE_APPS_EVERY_DEFAULT;
     int update_apps_list = update_apps_every - 1;
+    int exit_code = 0;
     //Plugin will be killed when it receives a signal
     for (; !ebpf_plugin_stop(); global_iterations_counter++) {
         (void)heartbeat_next(&hb);
@@ -2413,6 +2435,12 @@ int main(int argc, char **argv)
         // shutdown time when fd/process/socket/vfs modules are enabled.
         if (ebpf_plugin_stop())
             break;
+
+        if (!ebpf_program_loaded() && ebpf_all_enabled_threads_stopped()) {
+            netdata_log_error("EBPF: failed to load any eBPF program, shutting down.");
+            exit_code = 1;
+            break;
+        }
 
         if (global_iterations_counter % EBPF_DEFAULT_UPDATE_EVERY == 0) {
             netdata_mutex_lock(&lock);
@@ -2438,5 +2466,5 @@ int main(int argc, char **argv)
 
     ebpf_stop_threads((int)ebpf_stop_signal);
 
-    return 0;
+    return exit_code;
 }

--- a/src/collectors/ebpf.plugin/ebpf.h
+++ b/src/collectors/ebpf.plugin/ebpf.h
@@ -121,6 +121,7 @@ typedef struct netdata_ebpf_judy_pid_stats {
 } netdata_ebpf_judy_pid_stats_t;
 
 extern ebpf_module_t ebpf_modules[];
+extern bool ebpf_program_loaded_any;
 
 typedef struct ebpf_tracepoint {
     bool enabled;
@@ -365,6 +366,16 @@ static inline bool ebpf_plugin_stop(void)
     return __atomic_load_n(&ebpf_plugin_exit, __ATOMIC_ACQUIRE) ||
            ebpf_stop_signal ||
            nd_thread_signaled_to_cancel();
+}
+
+static inline void ebpf_mark_program_loaded(void)
+{
+    __atomic_store_n(&ebpf_program_loaded_any, true, __ATOMIC_RELEASE);
+}
+
+static inline bool ebpf_program_loaded(void)
+{
+    return __atomic_load_n(&ebpf_program_loaded_any, __ATOMIC_ACQUIRE);
 }
 
 // `enabled` is sampled from stats/shutdown paths without a single shared mutex.

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -1850,6 +1850,7 @@ void ebpf_cachestat_thread(void *ptr)
     if (ebpf_cachestat_load_bpf(em)) {
         goto endcachestat;
     }
+    ebpf_mark_program_loaded();
 
     ebpf_cachestat_allocate_global_vectors();
 

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -1590,6 +1590,7 @@ void ebpf_dcstat_thread(void *ptr)
     if (ebpf_dcstat_load_bpf(em)) {
         goto enddcstat;
     }
+    ebpf_mark_program_loaded();
 
     ebpf_dcstat_allocate_global_vectors();
 

--- a/src/collectors/ebpf.plugin/ebpf_disk.c
+++ b/src/collectors/ebpf.plugin/ebpf_disk.c
@@ -925,6 +925,7 @@ void ebpf_disk_thread(void *ptr)
     if (ebpf_disk_load_bpf(em)) {
         goto enddisk;
     }
+    ebpf_mark_program_loaded();
 
     int algorithms[NETDATA_EBPF_HIST_MAX_BINS];
     ebpf_fill_algorithms(algorithms, NETDATA_EBPF_HIST_MAX_BINS, NETDATA_EBPF_INCREMENTAL_IDX);

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -1689,6 +1689,7 @@ void ebpf_fd_thread(void *ptr)
     if (ebpf_fd_load_bpf(em)) {
         goto endfd;
     }
+    ebpf_mark_program_loaded();
 
     ebpf_fd_allocate_global_vectors();
 

--- a/src/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/src/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -621,6 +621,9 @@ int ebpf_filesystem_initialize_ebpf_data(ebpf_module_t *em)
     bool loaded_any = false;
     for (i = 0; localfs[i].filesystem; i++) {
         ebpf_filesystem_partitions_t *efp = &localfs[i];
+        if (efp->flags & NETDATA_FILESYSTEM_FLAG_HAS_PARTITION)
+            loaded_any = true;
+
         if (efp->load_failed)
             continue;
 

--- a/src/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/src/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -618,8 +618,12 @@ int ebpf_filesystem_initialize_ebpf_data(ebpf_module_t *em)
     int i;
     const char *saved_name = em->info.thread_name;
     uint64_t kernels = em->kernels;
+    bool loaded_any = false;
     for (i = 0; localfs[i].filesystem; i++) {
         ebpf_filesystem_partitions_t *efp = &localfs[i];
+        if (efp->load_failed)
+            continue;
+
         if (!efp->probe_links && efp->flags & NETDATA_FILESYSTEM_LOAD_EBPF_PROGRAM) {
             em->info.thread_name = efp->filesystem;
             em->kernels = efp->kernels;
@@ -630,34 +634,36 @@ int ebpf_filesystem_initialize_ebpf_data(ebpf_module_t *em)
             if (em->load & EBPF_LOAD_LEGACY) {
                 efp->probe_links = ebpf_load_program(ebpf_plugin_dir, em, running_on_kernel, isrh, &efp->objects);
                 if (!efp->probe_links) {
+                    efp->load_failed = true;
                     em->info.thread_name = saved_name;
                     em->kernels = kernels;
                     em->maps = NULL;
-                    netdata_mutex_unlock(&lock);
-                    return -1;
+                    continue;
                 }
             }
 #ifdef LIBBPF_MAJOR_VERSION
             else {
                 efp->fs_obj = filesystem_bpf__open();
                 if (!efp->fs_obj) {
+                    efp->load_failed = true;
                     em->info.thread_name = saved_name;
                     em->kernels = kernels;
                     em->maps = NULL;
-                    netdata_mutex_unlock(&lock);
-                    return -1;
+                    continue;
                 } else if (ebpf_fs_load_and_attach(em->maps, efp->fs_obj, efp->functions, NULL)) {
+                    efp->load_failed = true;
                     filesystem_bpf__destroy(efp->fs_obj);
                     efp->fs_obj = NULL;
                     em->info.thread_name = saved_name;
                     em->kernels = kernels;
                     em->maps = NULL;
-                    netdata_mutex_unlock(&lock);
-                    return -1;
+                    continue;
                 }
             }
 #endif
             efp->flags |= NETDATA_FILESYSTEM_FLAG_HAS_PARTITION;
+            loaded_any = true;
+            ebpf_mark_program_loaded();
             ebpf_update_kernel_memory(&plugin_statistics, efp->fs_maps, EBPF_ACTION_STAT_ADD);
 
             // Needed for filesystems like btrfs
@@ -682,7 +688,7 @@ int ebpf_filesystem_initialize_ebpf_data(ebpf_module_t *em)
         filesystem_hash_values = callocz(ebpf_nprocs, sizeof(netdata_idx_t));
     }
 
-    return 0;
+    return loaded_any ? 0 : -1;
 }
 
 /**

--- a/src/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/src/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -696,6 +696,7 @@ void ebpf_hardirq_thread(void *ptr)
     if (ebpf_hardirq_load_bpf(em)) {
         goto endhardirq;
     }
+    ebpf_mark_program_loaded();
 
     ebpf_hardirq_allocate_global_vectors();
 

--- a/src/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/src/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -418,6 +418,7 @@ void ebpf_mdflush_thread(void *ptr)
         netdata_log_error("Cannot load eBPF software.");
         goto endmdflush;
     }
+    ebpf_mark_program_loaded();
 
     mdflush_safe_clean = true;
     mdflush_collector(em);

--- a/src/collectors/ebpf.plugin/ebpf_mount.c
+++ b/src/collectors/ebpf.plugin/ebpf_mount.c
@@ -527,6 +527,7 @@ void ebpf_mount_thread(void *ptr)
     if (ebpf_mount_load_bpf(em)) {
         goto endmount;
     }
+    ebpf_mark_program_loaded();
 
     int algorithms[NETDATA_EBPF_MOUNT_SYSCALL] = {NETDATA_EBPF_INCREMENTAL_IDX, NETDATA_EBPF_INCREMENTAL_IDX};
 

--- a/src/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/src/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -590,6 +590,7 @@ void ebpf_oomkill_thread(void *ptr)
     if (!em->probe_links) {
         goto endoomkill;
     }
+    ebpf_mark_program_loaded();
 
     netdata_mutex_lock(&lock);
     ebpf_update_stats(&plugin_statistics, em);

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -1825,6 +1825,8 @@ void ebpf_process_thread(void *ptr)
     if (ebpf_process_load_bpf(em)) {
         em->global_charts = em->apps_charts = em->cgroup_charts = NETDATA_THREAD_EBPF_STOPPING;
         ebpf_module_enabled_set(em, NETDATA_THREAD_EBPF_STOPPING);
+    } else {
+        ebpf_mark_program_loaded();
     }
 
     int algorithms[NETDATA_KEY_PUBLISH_PROCESS_END] = {

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -1447,6 +1447,7 @@ void ebpf_shm_thread(void *ptr)
     if (ebpf_shm_load_bpf(em)) {
         goto endshm;
     }
+    ebpf_mark_program_loaded();
 
     ebpf_shm_allocate_global_vectors();
 

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -3126,6 +3126,7 @@ void ebpf_socket_thread(void *ptr)
     if (ebpf_socket_load_bpf(em)) {
         goto endsocket;
     }
+    ebpf_mark_program_loaded();
 
     int algorithms[NETDATA_MAX_SOCKET_VECTOR] = {
         NETDATA_EBPF_ABSOLUTE_IDX,

--- a/src/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/src/collectors/ebpf.plugin/ebpf_softirq.c
@@ -263,6 +263,7 @@ void ebpf_softirq_thread(void *ptr)
     if (!em->probe_links) {
         goto endsoftirq;
     }
+    ebpf_mark_program_loaded();
 
     softirq_safe_clean = true;
     softirq_collector(em);

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -1332,6 +1332,7 @@ void ebpf_swap_thread(void *ptr)
     if (ebpf_swap_load_bpf(em)) {
         goto endswap;
     }
+    ebpf_mark_program_loaded();
 
     ebpf_swap_allocate_global_vectors();
 

--- a/src/collectors/ebpf.plugin/ebpf_sync.c
+++ b/src/collectors/ebpf.plugin/ebpf_sync.c
@@ -360,6 +360,8 @@ static int ebpf_sync_initialize_syscall(ebpf_module_t *em)
             if (em->load & EBPF_LOAD_LEGACY) {
                 if (ebpf_sync_load_legacy(w, em))
                     errors++;
+                else
+                    ebpf_mark_program_loaded();
 
                 em->info.thread_name = saved_name;
             }
@@ -378,6 +380,8 @@ static int ebpf_sync_initialize_syscall(ebpf_module_t *em)
                             w->sync_obj = NULL;
                             w->enabled = false;
                             errors++;
+                        } else {
+                            ebpf_mark_program_loaded();
                         }
                     }
                 } else {

--- a/src/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/src/collectors/ebpf.plugin/ebpf_vfs.c
@@ -2985,6 +2985,7 @@ void ebpf_vfs_thread(void *ptr)
     if (ebpf_vfs_load_bpf(em)) {
         goto endvfs;
     }
+    ebpf_mark_program_loaded();
 
     int algorithms[NETDATA_KEY_PUBLISH_VFS_END] = {
         NETDATA_EBPF_INCREMENTAL_IDX,

--- a/src/collectors/ebpf.plugin/libbpf_api/ebpf.h
+++ b/src/collectors/ebpf.plugin/libbpf_api/ebpf.h
@@ -418,6 +418,7 @@ typedef struct ebpf_filesystem_partitions {
     char *family_name;
     struct bpf_object *objects;
     struct bpf_link **probe_links;
+    bool load_failed;
 
     netdata_ebpf_histogram_t hread;
     netdata_ebpf_histogram_t hwrite;


### PR DESCRIPTION
##### Summary
Some users have reported a flood of repeated messages when plugins are not allowed to run. This PR addresses both issues.

##### Test Plan

1. Compile locally
2. Verify both plugins are running.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce noisy cgroup discovery logs when permissions block access and make the eBPF plugin exit with code 1 when it can’t run. Also improves per-filesystem probing and tracks successful eBPF loads to prevent false shutdowns.

- **Bug Fixes**
  - Cgroups: log directory open errors once per path; EACCES at debug; cap cache to 256 paths; free on shutdown.
  - eBPF exit: exit(1) if no programs load and all enabled threads stop; separate cleanup from exit and join the cgroup integration thread before cleanup; exit(1) on startup failures (invalid host prefix, missing `apps_groups.conf`).
  - Filesystem (eBPF): keep probing other filesystems on individual failures; mark failed entries; set “loaded” when any program attaches; fail overall only if none load.
  - Load tracking: mark successful loads across all eBPF modules to avoid premature shutdown.

<sup>Written for commit 64dcebdf01192064a94f3116f16a811509fa06d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22574?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

