### PR TITLE
Fix sum on incremental dimensions for archived dims

### DIFF
--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -2,6 +2,7 @@
 
 #include "common.h"
 #include "web/api/formatters/rrd2json.h"
+#include "database/contexts/rrdcontext-internal.h"
 
 static bool cmd_arg_sanitization_test(const char *expected, const char *src, char *dst, size_t dst_size) {
     bool ok = sanitize_command_argument_string(dst, src, dst_size);
@@ -1518,6 +1519,40 @@ static int test_incremental_sum_lookup_respects_update_every(void) {
     return rc;
 }
 
+static int test_rrdmetric_algorithm_follows_rrddim(void) {
+    fprintf(stderr, "%s() running...\n", __FUNCTION__);
+
+    RRD_DB_MODE old_default_rrd_memory_mode = default_rrd_memory_mode;
+    default_rrd_memory_mode = RRD_DB_MODE_ALLOC;
+
+    RRDSET *st = rrdset_create_localhost(
+        "netdata", "unittest-algo-track", "unittest-algo-track", "netdata", NULL,
+        "Unit Testing", "x", "unittest", NULL, 1,
+        nd_profile.update_every, RRDSET_TYPE_LINE);
+    RRDDIM *rd = rrddim_add(st, "d", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+
+    int rc = 0;
+    RRDMETRIC *rm = rrdmetric_acquired_value(rd->rrdcontexts.rrdmetric);
+    if(!rm || rrdmetric_algorithm_atomic_load(rm) != RRD_ALGORITHM_INCREMENTAL) {
+        fprintf(stderr, "%s: after rrddim_add INCREMENTAL, rm->algorithm = %d (want %d)\n",
+                __FUNCTION__, rm ? (int)rrdmetric_algorithm_atomic_load(rm) : -1,
+                (int)RRD_ALGORITHM_INCREMENTAL);
+        rc = 1;
+    }
+
+    rrddim_set_algorithm(st, rd, RRD_ALGORITHM_ABSOLUTE);
+    rm = rrdmetric_acquired_value(rd->rrdcontexts.rrdmetric);
+    if(!rm || rrdmetric_algorithm_atomic_load(rm) != RRD_ALGORITHM_ABSOLUTE) {
+        fprintf(stderr, "%s: after rrddim_set_algorithm ABSOLUTE, rm->algorithm = %d (want %d)\n",
+                __FUNCTION__, rm ? (int)rrdmetric_algorithm_atomic_load(rm) : -1,
+                (int)RRD_ALGORITHM_ABSOLUTE);
+        rc = 1;
+    }
+
+    default_rrd_memory_mode = old_default_rrd_memory_mode;
+    return rc;
+}
+
 int run_all_mockup_tests(void)
 {
     fprintf(stderr, "%s() running...\n", __FUNCTION__ );
@@ -1531,6 +1566,9 @@ int run_all_mockup_tests(void)
         return 1;
 
     if(test_incremental_sum_lookup_respects_update_every())
+        return 1;
+
+    if(test_rrdmetric_algorithm_follows_rrddim())
         return 1;
 
     if(!test_variable_renames())

--- a/src/database/contexts/query_target.c
+++ b/src/database/contexts/query_target.c
@@ -270,7 +270,7 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
     } tier_retention[nd_profile.storage_tiers];
 
     RRDDIM *rd = rrdmetric_rrddim_get_and_lock(rm);
-    bool values_stored_as_rates = rd && rd->algorithm == RRD_ALGORITHM_INCREMENTAL;
+    bool values_stored_as_rates = rrdmetric_algorithm_atomic_load(rm) == RRD_ALGORITHM_INCREMENTAL;
 
     for (size_t tier = 0; tier < nd_profile.storage_tiers; tier++) {
         STORAGE_ENGINE *eng = qn->rrdhost->db[tier].eng;

--- a/src/database/contexts/rrdcontext-internal.h
+++ b/src/database/contexts/rrdcontext-internal.h
@@ -220,6 +220,7 @@ typedef struct rrdmetric {
     STRING *name;
 
     RRDDIM *rrddim;
+    RRD_ALGORITHM algorithm;            // atomic load/store; survives RRDDIM archive so query paths don't need a live rrddim
 
     time_t first_time_s;
     time_t last_time_s;
@@ -233,6 +234,14 @@ static ALWAYS_INLINE RRDDIM *rrdmetric_rrddim_atomic_load(RRDMETRIC *rm) {
 
 static ALWAYS_INLINE void rrdmetric_rrddim_atomic_store(RRDMETRIC *rm, RRDDIM *rd) {
     __atomic_store_n(&rm->rrddim, rd, __ATOMIC_RELEASE);
+}
+
+static ALWAYS_INLINE RRD_ALGORITHM rrdmetric_algorithm_atomic_load(RRDMETRIC *rm) {
+    return __atomic_load_n(&rm->algorithm, __ATOMIC_ACQUIRE);
+}
+
+static ALWAYS_INLINE void rrdmetric_algorithm_atomic_store(RRDMETRIC *rm, RRD_ALGORITHM algorithm) {
+    __atomic_store_n(&rm->algorithm, algorithm, __ATOMIC_RELEASE);
 }
 
 static ALWAYS_INLINE RRDDIM *rrdmetric_rrddim_get_and_lock(RRDMETRIC *rm) {
@@ -437,6 +446,7 @@ static ALWAYS_INLINE void rrdmetric_release(RRDMETRIC_ACQUIRED *rma) {
 
 void rrdmetric_rrddim_is_freed(RRDDIM *rd);
 void rrdmetric_updated_rrddim_flags(RRDDIM *rd);
+void rrdmetric_updated_rrddim_algorithm(RRDDIM *rd);
 void rrdmetric_collected_rrddim(RRDDIM *rd);
 void rrdmetric_not_collected_rrddim(RRDDIM *rd);
 

--- a/src/database/contexts/rrdcontext-loading.c
+++ b/src/database/contexts/rrdcontext-loading.c
@@ -60,6 +60,7 @@ static void rrdinstance_load_dimension_callback(SQL_DIMENSION_DATA *sd, void *da
         .id = string_strdupz(sd->id),
         .name = string_strdupz(sd->name),
         .flags = RRD_FLAG_ARCHIVED | RRD_FLAG_UPDATE_REASON_LOAD_SQL, // no need for atomic
+        .algorithm = (RRD_ALGORITHM)sd->algorithm,
     };
     if(sd->hidden) trm.flags |= RRD_FLAG_HIDDEN;
 

--- a/src/database/contexts/rrdcontext-metric.c
+++ b/src/database/contexts/rrdcontext-metric.c
@@ -170,6 +170,11 @@ static bool rrdmetric_conflict_callback(const DICTIONARY_ITEM *item __maybe_unus
         rrd_flag_set_updated(rm, RRD_FLAG_UPDATE_REASON_CHANGED_METADATA);
     }
 
+    if(rrdmetric_algorithm_atomic_load(rm) != rm_new->algorithm) {
+        rrdmetric_algorithm_atomic_store(rm, rm_new->algorithm);
+        rrd_flag_set_updated(rm, RRD_FLAG_UPDATE_REASON_CHANGED_METADATA);
+    }
+
     if(!rm->first_time_s || (rm_new->first_time_s && rm_new->first_time_s < rm->first_time_s)) {
         rm->first_time_s = rm_new->first_time_s;
         rrd_flag_set_updated(rm, RRD_FLAG_UPDATE_REASON_CHANGED_FIRST_TIME_T);
@@ -256,6 +261,7 @@ void rrdmetric_from_rrddim(RRDDIM *rd) {
             .name = string_dup(rd->name),
             .flags = RRD_FLAG_NONE, // no need for atomics
             .rrddim = rd,
+            .algorithm = rd->algorithm,
     };
 
     RRDMETRIC_ACQUIRED *rma = (RRDMETRIC_ACQUIRED *)dictionary_set_and_acquire_item(ri->rrdmetrics, string2str(trm.id), &trm, sizeof(trm));
@@ -309,6 +315,20 @@ inline void rrdmetric_updated_rrddim_flags(RRDDIM *rd) {
     if(unlikely(rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE))) {
         if(unlikely(rrd_flag_is_collected(rm)))
             rrdmetric_set_archived(rm);
+    }
+
+    rrdmetric_trigger_updates(rm, __FUNCTION__ );
+}
+
+inline void rrdmetric_updated_rrddim_algorithm(RRDDIM *rd) {
+    rrdmetric_not_collected_rrddim(rd);
+
+    RRDMETRIC *rm = rrddim_get_rrdmetric(rd);
+    if(unlikely(!rm)) return;
+
+    if(rrdmetric_algorithm_atomic_load(rm) != rd->algorithm) {
+        rrdmetric_algorithm_atomic_store(rm, rd->algorithm);
+        rrd_flag_set_updated(rm, RRD_FLAG_UPDATE_REASON_CHANGED_METADATA);
     }
 
     rrdmetric_trigger_updates(rm, __FUNCTION__ );

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -50,7 +50,7 @@ ALWAYS_INLINE void rrdcontext_removed_rrddim(RRDDIM *rd) {
 }
 
 ALWAYS_INLINE void rrdcontext_updated_rrddim_algorithm(RRDDIM *rd) {
-    rrdmetric_updated_rrddim_flags(rd);
+    rrdmetric_updated_rrddim_algorithm(rd);
 }
 
 ALWAYS_INLINE void rrdcontext_updated_rrddim_multiplier(RRDDIM *rd) {

--- a/src/database/sqlite/sqlite_context.c
+++ b/src/database/sqlite/sqlite_context.c
@@ -130,7 +130,7 @@ done:
 }
 
 // Dimension list
-#define CTX_GET_DIMENSION_LIST  "SELECT d.dim_id, d.id, d.name, CASE WHEN INSTR(d.options,\"hidden\") > 0 THEN 1 ELSE 0 END, c.type||'.'||c.id, c.context " \
+#define CTX_GET_DIMENSION_LIST  "SELECT d.dim_id, d.id, d.name, CASE WHEN INSTR(d.options,\"hidden\") > 0 THEN 1 ELSE 0 END, c.type||'.'||c.id, c.context, d.algorithm " \
     "FROM dimension d, chart c WHERE c.host_id = @host_id AND d.chart_id = c.chart_id AND d.dim_id IS NOT NULL ORDER BY d.rowid ASC"
 void ctx_get_dimension_list(nd_uuid_t *host_uuid, void (*dict_cb)(SQL_DIMENSION_DATA *, void *), void *data)
 {
@@ -162,6 +162,7 @@ void ctx_get_dimension_list(nd_uuid_t *host_uuid, void (*dict_cb)(SQL_DIMENSION_
         dimension_data.hidden = sqlite3_column_int(res, 3);
         dimension_data.chart_id = (char *) sqlite3_column_text(res, 4);
         dimension_data.context = (char *) sqlite3_column_text(res, 5);
+        dimension_data.algorithm = sqlite3_column_int(res, 6);
         dict_cb(&dimension_data, data);
     }
 

--- a/src/database/sqlite/sqlite_context.h
+++ b/src/database/sqlite/sqlite_context.h
@@ -25,6 +25,7 @@ typedef struct ctx_dimension {
     char *id;
     char *name;
     bool hidden;
+    int algorithm;
 
     char *context;
     char *chart_id;


### PR DESCRIPTION
##### Summary
query_target.c reads the algorithm from the live RRDDIM, so SUM grouping on incremental dims whose RRDDIM was no longer in memory (host disconnected, chart obsoleted, parent-side child history) skipped the rate->volume  scaling and returned raw rate sums, off by source_update_every.

- Add RRD_ALGORITHM on RRDMETRIC, populate it from the live RRDDIM also the SQL dimension row at startup, and rrddim_set_algorithm at runtime. 
- Switch query_target.c to read it atomically from RRDMETRIC, no live RRDDIM required.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SUM on incremental metrics when a dimension’s `RRDDIM` is archived by persisting the algorithm on `RRDMETRIC` and reading it atomically during queries. Prevents wrong totals when the live dimension isn’t in memory.

- **Bug Fixes**
  - Store `RRD_ALGORITHM` on `RRDMETRIC`; populate from live `RRDDIM` and SQL at startup; update on `rrddim_set_algorithm`.
  - Query path now reads the algorithm from `RRDMETRIC` (atomic), so no live `RRDDIM` is required.
  - Added a unit test to ensure algorithm tracking and rate→volume scaling work as expected.
  - Include `d.algorithm` in the dimension list SQL and wire it through context loading; no schema migration needed.

<sup>Written for commit 5c5ab6ab0b209da339ca2c5dff50b7bef7aad41e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22580?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

