### PR TITLE
Fix label migration logic to handle key-value changes and duplicate removal

### DIFF
--- a/src/database/rrdhost-labels.c
+++ b/src/database/rrdhost-labels.c
@@ -5,6 +5,9 @@
 #include "streaming/stream.h"
 
 void rrdhost_set_is_parent_label(void) {
+    if (!localhost || !localhost->rrdlabels)
+        return;
+
     uint32_t count = stream_receivers_currently_connected();
 
     if (count == 0 || count == 1) {

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -711,6 +711,7 @@ bool rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src) {
     RRDLABEL *label;
     Pvoid_t *PValue;
     size_t added = 0;
+    size_t cleaned = 0;
 
     RRDLABEL_SRC ls;
     lfe_start_nolock(src, label, ls)
@@ -755,6 +756,7 @@ bool rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src) {
             int64_t old_judy_mem = JudyAllocThreadPulseGetAndReset();
             RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, old_judy_mem, 0);
             delete_label(old_label_with_same_key);
+            cleaned++;
         }
     }
     lfe_done_nolock();
@@ -765,7 +767,12 @@ bool rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src) {
     spinlock_unlock(&src->spinlock);
     spinlock_unlock(&dst->spinlock);
 
-    return (added > 0) || (removed > 0);
+    // cleaned counts duplicates dropped by the same-key cleanup loop above.
+    // Without it, a stale (key,*) duplicate removed while the desired
+    // (key,value) was already present would mutate dst silently -- callers
+    // gating on this return (e.g. rrdset_update_rrdlabels setting
+    // RRDSET_FLAG_PENDING_LABEL_RECHECK) would miss the change.
+    return (added > 0) || (removed > 0) || (cleaned > 0);
 }
 
 //
@@ -843,10 +850,15 @@ void rrdlabels_copy(RRDLABELS *dst, RRDLABELS *src)
             RRDLABEL *old_label_with_key = rrdlabels_find_label_with_key_unsafe(dst, label, false);
             if (!old_label_with_key)
                 break;
-            int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
             (void)JudyLDel(&dst->JudyL, (Word_t)old_label_with_key, PJE0);
+            int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
             RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, judy_mem, 0);
             delete_label((RRDLABEL *)old_label_with_key);
+            // Cleanup is itself a state mutation: bump version and request
+            // tail-stats accounting so version-based consumers and the
+            // memory pulse stay correct even when no new insert happened.
+            dst->version++;
+            update_statistics = true;
         }
     }
     lfe_done_nolock();

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -717,22 +717,39 @@ bool rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src) {
     {
         JudyAllocThreadPulseGetAndReset();
 
+        // labels->JudyL is keyed by the deduplicated RRDLABEL pointer produced by
+        // add_label_name_value(), which encodes BOTH key and value. A same-key
+        // value change in src therefore yields a different pointer than the one
+        // dst already has, so JudyLIns lands on an empty slot.
         PValue = JudyLIns(&dst->JudyL, (Word_t)label, PJE0);
         if(unlikely(!PValue || PValue == PJERR))
             fatal("RRDLABELS migrate: corrupted labels array");
 
-        RRDLABEL_SRC flag;
         if (!*PValue) {
-            flag = (ls & ~(RRDLABEL_FLAG_OLD | RRDLABEL_FLAG_NEW)) | RRDLABEL_FLAG_NEW;
+            // Write through PValue BEFORE any subsequent JudyLDel: Judy
+            // invalidates previously-returned PValue pointers when the array
+            // is modified. Same ordering as labels_add_already_sanitized().
+            *((RRDLABEL_SRC *)PValue) = (ls & ~(RRDLABEL_FLAG_OLD | RRDLABEL_FLAG_NEW)) | RRDLABEL_FLAG_NEW;
             dup_label(label);
             int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
             RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, judy_mem, 0);
             added++;
+
+            // Ensure at most one entry per key. The remove-unmarked sweep below
+            // preserves RRDLABEL_FLAG_DONT_DELETE, so a same-key replacement
+            // for a pinned entry would otherwise leave a stale duplicate
+            // (key, old-value) next to the fresh (key, new-value).
+            RRDLABEL *old_label_with_same_key = rrdlabels_find_label_with_key_unsafe(dst, label, false);
+            if (old_label_with_same_key) {
+                int del_result = JudyLDel(&dst->JudyL, (Word_t)old_label_with_same_key, PJE0);
+                (void)del_result;
+                int64_t old_judy_mem = JudyAllocThreadPulseGetAndReset();
+                RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, old_judy_mem, 0);
+                delete_label(old_label_with_same_key);
+            }
         }
         else
-            flag = RRDLABEL_FLAG_OLD;
-
-        *((RRDLABEL_SRC *)PValue) |= flag;
+            *((RRDLABEL_SRC *)PValue) |= RRDLABEL_FLAG_OLD;
     }
     lfe_done_nolock();
 
@@ -800,8 +817,11 @@ void rrdlabels_copy(RRDLABELS *dst, RRDLABELS *src)
             fatal("RRDLABELS: corrupted labels array");
 
         if (!*PValue) {
+            // Write through PValue BEFORE the subsequent JudyLDel: Judy
+            // invalidates previously-returned PValue pointers when the array
+            // is modified. Same ordering as labels_add_already_sanitized().
+            *((RRDLABEL_SRC *)PValue) = (ls & ~(RRDLABEL_FLAG_OLD)) | RRDLABEL_FLAG_NEW;
             dup_label(label);
-            ls = (ls & ~(RRDLABEL_FLAG_OLD)) | RRDLABEL_FLAG_NEW;
             dst->version++;
             update_statistics = true;
             if (old_label_with_key) {
@@ -812,9 +832,7 @@ void rrdlabels_copy(RRDLABELS *dst, RRDLABELS *src)
             }
         }
         else
-            ls = (ls & ~(RRDLABEL_FLAG_NEW)) | RRDLABEL_FLAG_OLD;
-
-        *((RRDLABEL_SRC *)PValue) = ls;
+            *((RRDLABEL_SRC *)PValue) = (ls & ~(RRDLABEL_FLAG_NEW)) | RRDLABEL_FLAG_OLD;
     }
     lfe_done_nolock();
     if (update_statistics) {
@@ -1647,6 +1665,47 @@ static int rrdlabels_unittest_change_detection(void) {
               "migrate where the only diff is a DONT_DELETE label should return false");
     UT_EXPECT(rrdlabels_entries(dst) == 1,
               "DONT_DELETE label should be preserved after migrate");
+    rrdlabels_destroy(dst);
+    rrdlabels_destroy(src);
+
+    // Value change via migrate (no DONT_DELETE): dst ends with a single entry
+    // for the key, carrying the new value.
+    dst = rrdlabels_create();
+    src = rrdlabels_create();
+    rrdlabels_add(dst, "k1", "v1", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(src, "k1", "v2", RRDLABEL_SRC_CONFIG);
+    UT_EXPECT(rrdlabels_migrate_to_these(dst, src) == true,
+              "migrate with a value change should return true");
+    UT_EXPECT(rrdlabels_entries(dst) == 1,
+              "migrate with a value change should leave one entry per key");
+    {
+        char *v = NULL;
+        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
+        UT_EXPECT(v != NULL && strcmp(v, "v2") == 0,
+                  "migrate with a value change should leave the new value in dst");
+        freez(v);
+    }
+    rrdlabels_destroy(dst);
+    rrdlabels_destroy(src);
+
+    // Value change via migrate where dst pinned the old value with DONT_DELETE:
+    // the stale (key, old-value) must not survive, even though DONT_DELETE
+    // would otherwise protect it from the remove-unmarked sweep.
+    dst = rrdlabels_create();
+    src = rrdlabels_create();
+    rrdlabels_add(dst, "k1", "v1", RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE);
+    rrdlabels_add(src, "k1", "v2", RRDLABEL_SRC_CONFIG);
+    UT_EXPECT(rrdlabels_migrate_to_these(dst, src) == true,
+              "migrate with a value change for a DONT_DELETE key should return true");
+    UT_EXPECT(rrdlabels_entries(dst) == 1,
+              "migrate must not leave a duplicate (key,old-value) when DONT_DELETE was set");
+    {
+        char *v = NULL;
+        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
+        UT_EXPECT(v != NULL && strcmp(v, "v2") == 0,
+                  "migrate with a DONT_DELETE value change should leave the new value in dst");
+        freez(v);
+    }
     rrdlabels_destroy(dst);
     rrdlabels_destroy(src);
 

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -1783,16 +1783,21 @@ static int rrdlabels_unittest_change_detection(void) {
     // public add/migrate/copy paths so the pathological starting state can
     // be constructed for the test.
 
-    // Migrate: dst seeded with 3 pinned DONT_DELETE entries sharing "k1";
-    // src carries (k1, vc). After migrate, dst must have exactly one entry,
-    // value "vc", and the function must return true (cleanup counts as a
-    // mutation).
+    // Migrate (cleanup-only path): dst seeded with 3 pinned DONT_DELETE
+    // entries sharing "k1"; src carries (k1, vc) whose dedup pointer is
+    // ALREADY one of the planted entries, so JudyLIns lands on an existing
+    // slot, takes the else-branch (added stays 0), and the cleanup loop is
+    // the only mutation. Asserts that:
+    //   - the loop drains the OTHER two stale entries (not just the first);
+    //   - the function returns true even though added==0 and removed==0
+    //     (regression on the `cleaned` term in the return would fail here);
+    //   - dst ends with the single source entry.
     dst = rrdlabels_create();
     src = rrdlabels_create();
     {
         RRDLABEL *stale_a = add_label_name_value("k1", "va");
         RRDLABEL *stale_b = add_label_name_value("k1", "vb");
-        RRDLABEL *stale_c = add_label_name_value("k1", "vstale");
+        RRDLABEL *stale_c = add_label_name_value("k1", "vc");
         Pvoid_t *p;
         p = JudyLIns(&dst->JudyL, (Word_t)stale_a, PJE0);
         *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
@@ -1805,7 +1810,7 @@ static int rrdlabels_unittest_change_detection(void) {
               "test setup: dst should start with 3 manually-planted same-key entries");
     rrdlabels_add(src, "k1", "vc", RRDLABEL_SRC_CONFIG);
     UT_EXPECT(rrdlabels_migrate_to_these(dst, src) == true,
-              "migrate must return true when cleanup drains multi-duplicate state");
+              "migrate must return true when cleanup is the only mutation (added=0, removed=0, cleaned>0)");
     UT_EXPECT(rrdlabels_entries(dst) == 1,
               "migrate must drain all stale same-key duplicates, not just the first");
     {
@@ -1818,11 +1823,11 @@ static int rrdlabels_unittest_change_detection(void) {
     rrdlabels_destroy(dst);
     rrdlabels_destroy(src);
 
-    // Copy: same setup, exercise the copy loop's drain behavior. The src
-    // label's (key, value) is one of the planted duplicates here, so the
-    // copy hits the else-branch (already-present) and the cleanup is the
-    // ONLY mutation -- exercises both the loop drain AND the else-branch
-    // cleanup added in this PR.
+    // Copy (cleanup-only path): same setup; src's (k1, vc) matches one of
+    // the planted entries so the copy takes the else-branch and the cleanup
+    // is the ONLY mutation. Asserts dst entries+value AND that
+    // dst->version advances despite no insert -- regression on the
+    // version bump inside the cleanup loop would fail this check.
     dst = rrdlabels_create();
     src = rrdlabels_create();
     {
@@ -1840,9 +1845,12 @@ static int rrdlabels_unittest_change_detection(void) {
     UT_EXPECT(rrdlabels_entries(dst) == 3,
               "test setup: dst should start with 3 manually-planted same-key entries (copy)");
     rrdlabels_add(src, "k1", "vc", RRDLABEL_SRC_CONFIG);
+    uint32_t copy_version_before = rrdlabels_version(dst);
     rrdlabels_copy(dst, src);
     UT_EXPECT(rrdlabels_entries(dst) == 1,
               "copy must drain all stale same-key duplicates, not just the first");
+    UT_EXPECT(rrdlabels_version(dst) > copy_version_before,
+              "copy must advance dst->version when cleanup is the only mutation");
     {
         char *v = NULL;
         rrdlabels_get_value_strdup_or_null(dst, &v, "k1");

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -1632,6 +1632,27 @@ static int rrdlabels_unittest_mark_source_as_old(void) {
     }                                                                          \
 } while (0)
 
+// Returns true when labels[key] resolves to exactly `expected`.
+static bool rrdlabels_unittest_value_is(RRDLABELS *labels, const char *key, const char *expected) {
+    char *v = NULL;
+    rrdlabels_get_value_strdup_or_null(labels, &v, key);
+    bool ok = (v != NULL && strcmp(v, expected) == 0);
+    freez(v);
+    return ok;
+}
+
+// Plant `n` pinned DONT_DELETE entries that share `key` but carry distinct
+// `values`, writing them straight into labels->JudyL. This bypasses the
+// public add/migrate/copy paths so a multi-duplicate starting state -- which
+// the fixed code can no longer produce -- can be constructed for tests.
+static void rrdlabels_unittest_plant_dups(RRDLABELS *labels, const char *key, const char *const *values, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        RRDLABEL *stale = add_label_name_value(key, values[i]);
+        Pvoid_t *p = JudyLIns(&labels->JudyL, (Word_t)stale, PJE0);
+        *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
+    }
+}
+
 static int rrdlabels_unittest_change_detection(void) {
     fprintf(stderr, "\n%s() tests\n", __FUNCTION__);
     int errors = 0;
@@ -1705,13 +1726,8 @@ static int rrdlabels_unittest_change_detection(void) {
               "migrate with a value change should return true");
     UT_EXPECT(rrdlabels_entries(dst) == 1,
               "migrate with a value change should leave one entry per key");
-    {
-        char *v = NULL;
-        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
-        UT_EXPECT(v != NULL && strcmp(v, "v2") == 0,
-                  "migrate with a value change should leave the new value in dst");
-        freez(v);
-    }
+    UT_EXPECT(rrdlabels_unittest_value_is(dst, "k1", "v2"),
+              "migrate with a value change should leave the new value in dst");
     rrdlabels_destroy(dst);
     rrdlabels_destroy(src);
 
@@ -1726,13 +1742,8 @@ static int rrdlabels_unittest_change_detection(void) {
               "migrate with a value change for a DONT_DELETE key should return true");
     UT_EXPECT(rrdlabels_entries(dst) == 1,
               "migrate must not leave a duplicate (key,old-value) when DONT_DELETE was set");
-    {
-        char *v = NULL;
-        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
-        UT_EXPECT(v != NULL && strcmp(v, "v2") == 0,
-                  "migrate with a DONT_DELETE value change should leave the new value in dst");
-        freez(v);
-    }
+    UT_EXPECT(rrdlabels_unittest_value_is(dst, "k1", "v2"),
+              "migrate with a DONT_DELETE value change should leave the new value in dst");
     rrdlabels_destroy(dst);
     rrdlabels_destroy(src);
 
@@ -1747,13 +1758,8 @@ static int rrdlabels_unittest_change_detection(void) {
     rrdlabels_copy(dst, src);
     UT_EXPECT(rrdlabels_entries(dst) == 1,
               "copy with a value change should leave one entry per key");
-    {
-        char *v = NULL;
-        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
-        UT_EXPECT(v != NULL && strcmp(v, "v2") == 0,
-                  "copy with a value change should leave the new value in dst");
-        freez(v);
-    }
+    UT_EXPECT(rrdlabels_unittest_value_is(dst, "k1", "v2"),
+              "copy with a value change should leave the new value in dst");
     rrdlabels_destroy(dst);
     rrdlabels_destroy(src);
 
@@ -1765,13 +1771,8 @@ static int rrdlabels_unittest_change_detection(void) {
     rrdlabels_copy(dst, src);
     UT_EXPECT(rrdlabels_entries(dst) == 1,
               "copy must not leave a duplicate (key,old-value) when DONT_DELETE was set");
-    {
-        char *v = NULL;
-        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
-        UT_EXPECT(v != NULL && strcmp(v, "v2") == 0,
-                  "copy with a DONT_DELETE value change should leave the new value in dst");
-        freez(v);
-    }
+    UT_EXPECT(rrdlabels_unittest_value_is(dst, "k1", "v2"),
+              "copy with a DONT_DELETE value change should leave the new value in dst");
     rrdlabels_destroy(dst);
     rrdlabels_destroy(src);
 
@@ -1792,20 +1793,10 @@ static int rrdlabels_unittest_change_detection(void) {
     //   - the function returns true even though added==0 and removed==0
     //     (regression on the `cleaned` term in the return would fail here);
     //   - dst ends with the single source entry.
+    static const char *const planted_dups[] = { "va", "vb", "vc" };
     dst = rrdlabels_create();
     src = rrdlabels_create();
-    {
-        RRDLABEL *stale_a = add_label_name_value("k1", "va");
-        RRDLABEL *stale_b = add_label_name_value("k1", "vb");
-        RRDLABEL *stale_c = add_label_name_value("k1", "vc");
-        Pvoid_t *p;
-        p = JudyLIns(&dst->JudyL, (Word_t)stale_a, PJE0);
-        *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
-        p = JudyLIns(&dst->JudyL, (Word_t)stale_b, PJE0);
-        *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
-        p = JudyLIns(&dst->JudyL, (Word_t)stale_c, PJE0);
-        *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
-    }
+    rrdlabels_unittest_plant_dups(dst, "k1", planted_dups, 3);
     UT_EXPECT(rrdlabels_entries(dst) == 3,
               "test setup: dst should start with 3 manually-planted same-key entries");
     rrdlabels_add(src, "k1", "vc", RRDLABEL_SRC_CONFIG);
@@ -1813,13 +1804,8 @@ static int rrdlabels_unittest_change_detection(void) {
               "migrate must return true when cleanup is the only mutation (added=0, removed=0, cleaned>0)");
     UT_EXPECT(rrdlabels_entries(dst) == 1,
               "migrate must drain all stale same-key duplicates, not just the first");
-    {
-        char *v = NULL;
-        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
-        UT_EXPECT(v != NULL && strcmp(v, "vc") == 0,
-                  "migrate multi-duplicate drain should leave only the src value in dst");
-        freez(v);
-    }
+    UT_EXPECT(rrdlabels_unittest_value_is(dst, "k1", "vc"),
+              "migrate multi-duplicate drain should leave only the src value in dst");
     rrdlabels_destroy(dst);
     rrdlabels_destroy(src);
 
@@ -1830,18 +1816,7 @@ static int rrdlabels_unittest_change_detection(void) {
     // version bump inside the cleanup loop would fail this check.
     dst = rrdlabels_create();
     src = rrdlabels_create();
-    {
-        RRDLABEL *stale_a = add_label_name_value("k1", "va");
-        RRDLABEL *stale_b = add_label_name_value("k1", "vb");
-        RRDLABEL *stale_c = add_label_name_value("k1", "vc");
-        Pvoid_t *p;
-        p = JudyLIns(&dst->JudyL, (Word_t)stale_a, PJE0);
-        *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
-        p = JudyLIns(&dst->JudyL, (Word_t)stale_b, PJE0);
-        *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
-        p = JudyLIns(&dst->JudyL, (Word_t)stale_c, PJE0);
-        *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
-    }
+    rrdlabels_unittest_plant_dups(dst, "k1", planted_dups, 3);
     UT_EXPECT(rrdlabels_entries(dst) == 3,
               "test setup: dst should start with 3 manually-planted same-key entries (copy)");
     rrdlabels_add(src, "k1", "vc", RRDLABEL_SRC_CONFIG);
@@ -1851,13 +1826,8 @@ static int rrdlabels_unittest_change_detection(void) {
               "copy must drain all stale same-key duplicates, not just the first");
     UT_EXPECT(rrdlabels_version(dst) > copy_version_before,
               "copy must advance dst->version when cleanup is the only mutation");
-    {
-        char *v = NULL;
-        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
-        UT_EXPECT(v != NULL && strcmp(v, "vc") == 0,
-                  "copy multi-duplicate drain should leave only the src value in dst");
-        freez(v);
-    }
+    UT_EXPECT(rrdlabels_unittest_value_is(dst, "k1", "vc"),
+              "copy multi-duplicate drain should leave only the src value in dst");
     rrdlabels_destroy(dst);
     rrdlabels_destroy(src);
 
@@ -1876,18 +1846,10 @@ static int rrdlabels_unittest_change_detection(void) {
               "migrate with mixed-key DONT_DELETE dst must return true on k1 change");
     UT_EXPECT(rrdlabels_entries(dst) == 2,
               "migrate cleanup must leave the unrelated DONT_DELETE key intact");
-    {
-        char *v = NULL;
-        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
-        UT_EXPECT(v != NULL && strcmp(v, "v3") == 0,
-                  "migrate must update k1 to the src value");
-        freez(v);
-        v = NULL;
-        rrdlabels_get_value_strdup_or_null(dst, &v, "k2");
-        UT_EXPECT(v != NULL && strcmp(v, "v2") == 0,
-                  "migrate must preserve the unrelated DONT_DELETE key's value");
-        freez(v);
-    }
+    UT_EXPECT(rrdlabels_unittest_value_is(dst, "k1", "v3"),
+              "migrate must update k1 to the src value");
+    UT_EXPECT(rrdlabels_unittest_value_is(dst, "k2", "v2"),
+              "migrate must preserve the unrelated DONT_DELETE key's value");
     rrdlabels_destroy(dst);
     rrdlabels_destroy(src);
 
@@ -1900,18 +1862,10 @@ static int rrdlabels_unittest_change_detection(void) {
     rrdlabels_copy(dst, src);
     UT_EXPECT(rrdlabels_entries(dst) == 2,
               "copy cleanup must leave the unrelated DONT_DELETE key intact");
-    {
-        char *v = NULL;
-        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
-        UT_EXPECT(v != NULL && strcmp(v, "v3") == 0,
-                  "copy must update k1 to the src value");
-        freez(v);
-        v = NULL;
-        rrdlabels_get_value_strdup_or_null(dst, &v, "k2");
-        UT_EXPECT(v != NULL && strcmp(v, "v2") == 0,
-                  "copy must preserve the unrelated DONT_DELETE key's value");
-        freez(v);
-    }
+    UT_EXPECT(rrdlabels_unittest_value_is(dst, "k1", "v3"),
+              "copy must update k1 to the src value");
+    UT_EXPECT(rrdlabels_unittest_value_is(dst, "k2", "v2"),
+              "copy must preserve the unrelated DONT_DELETE key's value");
     rrdlabels_destroy(dst);
     rrdlabels_destroy(src);
 

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -1719,6 +1719,45 @@ static int rrdlabels_unittest_change_detection(void) {
     rrdlabels_destroy(dst);
     rrdlabels_destroy(src);
 
+    // ---- rrdlabels_copy: same-key cleanup path ----
+    // Value change via copy: dst ends with a single entry for the key,
+    // carrying the new value from src. Exercises the same-key cleanup loop
+    // that mirrors the migrate path.
+    dst = rrdlabels_create();
+    src = rrdlabels_create();
+    rrdlabels_add(dst, "k1", "v1", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(src, "k1", "v2", RRDLABEL_SRC_CONFIG);
+    rrdlabels_copy(dst, src);
+    UT_EXPECT(rrdlabels_entries(dst) == 1,
+              "copy with a value change should leave one entry per key");
+    {
+        char *v = NULL;
+        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
+        UT_EXPECT(v != NULL && strcmp(v, "v2") == 0,
+                  "copy with a value change should leave the new value in dst");
+        freez(v);
+    }
+    rrdlabels_destroy(dst);
+    rrdlabels_destroy(src);
+
+    // Value change via copy where dst pinned the old value with DONT_DELETE.
+    dst = rrdlabels_create();
+    src = rrdlabels_create();
+    rrdlabels_add(dst, "k1", "v1", RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE);
+    rrdlabels_add(src, "k1", "v2", RRDLABEL_SRC_CONFIG);
+    rrdlabels_copy(dst, src);
+    UT_EXPECT(rrdlabels_entries(dst) == 1,
+              "copy must not leave a duplicate (key,old-value) when DONT_DELETE was set");
+    {
+        char *v = NULL;
+        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
+        UT_EXPECT(v != NULL && strcmp(v, "v2") == 0,
+                  "copy with a DONT_DELETE value change should leave the new value in dst");
+        freez(v);
+    }
+    rrdlabels_destroy(dst);
+    rrdlabels_destroy(src);
+
     // ---- rrdlabels_remove_all_unmarked_and_changed: CLABEL-commit semantics ----
     // (1) unmark + re-add identical set => no change => false
     l = rrdlabels_create();

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -1775,6 +1775,84 @@ static int rrdlabels_unittest_change_detection(void) {
     rrdlabels_destroy(dst);
     rrdlabels_destroy(src);
 
+    // ---- Multi-duplicate drain ----
+    // The fixed code path can no longer produce a (key, *) duplicate state.
+    // To verify the same-key cleanup LOOP drains arbitrarily many duplicates
+    // (not just the first), plant multiple stale entries directly into
+    // dst->JudyL via add_label_name_value() + JudyLIns(). This bypasses the
+    // public add/migrate/copy paths so the pathological starting state can
+    // be constructed for the test.
+
+    // Migrate: dst seeded with 3 pinned DONT_DELETE entries sharing "k1";
+    // src carries (k1, vc). After migrate, dst must have exactly one entry,
+    // value "vc", and the function must return true (cleanup counts as a
+    // mutation).
+    dst = rrdlabels_create();
+    src = rrdlabels_create();
+    {
+        RRDLABEL *stale_a = add_label_name_value("k1", "va");
+        RRDLABEL *stale_b = add_label_name_value("k1", "vb");
+        RRDLABEL *stale_c = add_label_name_value("k1", "vstale");
+        Pvoid_t *p;
+        p = JudyLIns(&dst->JudyL, (Word_t)stale_a, PJE0);
+        *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
+        p = JudyLIns(&dst->JudyL, (Word_t)stale_b, PJE0);
+        *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
+        p = JudyLIns(&dst->JudyL, (Word_t)stale_c, PJE0);
+        *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
+    }
+    UT_EXPECT(rrdlabels_entries(dst) == 3,
+              "test setup: dst should start with 3 manually-planted same-key entries");
+    rrdlabels_add(src, "k1", "vc", RRDLABEL_SRC_CONFIG);
+    UT_EXPECT(rrdlabels_migrate_to_these(dst, src) == true,
+              "migrate must return true when cleanup drains multi-duplicate state");
+    UT_EXPECT(rrdlabels_entries(dst) == 1,
+              "migrate must drain all stale same-key duplicates, not just the first");
+    {
+        char *v = NULL;
+        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
+        UT_EXPECT(v != NULL && strcmp(v, "vc") == 0,
+                  "migrate multi-duplicate drain should leave only the src value in dst");
+        freez(v);
+    }
+    rrdlabels_destroy(dst);
+    rrdlabels_destroy(src);
+
+    // Copy: same setup, exercise the copy loop's drain behavior. The src
+    // label's (key, value) is one of the planted duplicates here, so the
+    // copy hits the else-branch (already-present) and the cleanup is the
+    // ONLY mutation -- exercises both the loop drain AND the else-branch
+    // cleanup added in this PR.
+    dst = rrdlabels_create();
+    src = rrdlabels_create();
+    {
+        RRDLABEL *stale_a = add_label_name_value("k1", "va");
+        RRDLABEL *stale_b = add_label_name_value("k1", "vb");
+        RRDLABEL *stale_c = add_label_name_value("k1", "vc");
+        Pvoid_t *p;
+        p = JudyLIns(&dst->JudyL, (Word_t)stale_a, PJE0);
+        *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
+        p = JudyLIns(&dst->JudyL, (Word_t)stale_b, PJE0);
+        *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
+        p = JudyLIns(&dst->JudyL, (Word_t)stale_c, PJE0);
+        *((RRDLABEL_SRC *)p) = RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE;
+    }
+    UT_EXPECT(rrdlabels_entries(dst) == 3,
+              "test setup: dst should start with 3 manually-planted same-key entries (copy)");
+    rrdlabels_add(src, "k1", "vc", RRDLABEL_SRC_CONFIG);
+    rrdlabels_copy(dst, src);
+    UT_EXPECT(rrdlabels_entries(dst) == 1,
+              "copy must drain all stale same-key duplicates, not just the first");
+    {
+        char *v = NULL;
+        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
+        UT_EXPECT(v != NULL && strcmp(v, "vc") == 0,
+                  "copy multi-duplicate drain should leave only the src value in dst");
+        freez(v);
+    }
+    rrdlabels_destroy(dst);
+    rrdlabels_destroy(src);
+
     // ---- rrdlabels_remove_all_unmarked_and_changed: CLABEL-commit semantics ----
     // (1) unmark + re-add identical set => no change => false
     l = rrdlabels_create();

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -738,9 +738,13 @@ bool rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src) {
             // Ensure at most one entry per key. The remove-unmarked sweep below
             // preserves RRDLABEL_FLAG_DONT_DELETE, so a same-key replacement
             // for a pinned entry would otherwise leave a stale duplicate
-            // (key, old-value) next to the fresh (key, new-value).
-            RRDLABEL *old_label_with_same_key = rrdlabels_find_label_with_key_unsafe(dst, label, false);
-            if (old_label_with_same_key) {
+            // (key, old-value) next to the fresh (key, new-value). Loop in
+            // case dst arrived with multiple same-key entries from prior
+            // buggy paths -- the find helper returns the first match only.
+            for (;;) {
+                RRDLABEL *old_label_with_same_key = rrdlabels_find_label_with_key_unsafe(dst, label, false);
+                if (!old_label_with_same_key)
+                    break;
                 int del_result = JudyLDel(&dst->JudyL, (Word_t)old_label_with_same_key, PJE0);
                 (void)del_result;
                 int64_t old_judy_mem = JudyAllocThreadPulseGetAndReset();
@@ -811,20 +815,26 @@ void rrdlabels_copy(RRDLABELS *dst, RRDLABELS *src)
     bool update_statistics = false;
     lfe_start_nolock(src, label, ls)
     {
-        RRDLABEL *old_label_with_key = rrdlabels_find_label_with_key_unsafe(dst, label, false);
         Pvoid_t *PValue = JudyLIns(&dst->JudyL, (Word_t)label, PJE0);
         if(unlikely(!PValue || PValue == PJERR))
             fatal("RRDLABELS: corrupted labels array");
 
         if (!*PValue) {
-            // Write through PValue BEFORE the subsequent JudyLDel: Judy
+            // Write through PValue BEFORE any subsequent JudyLDel: Judy
             // invalidates previously-returned PValue pointers when the array
             // is modified. Same ordering as labels_add_already_sanitized().
             *((RRDLABEL_SRC *)PValue) = (ls & ~(RRDLABEL_FLAG_OLD)) | RRDLABEL_FLAG_NEW;
             dup_label(label);
             dst->version++;
             update_statistics = true;
-            if (old_label_with_key) {
+
+            // Drop any other entry sharing this key. Loop in case dst arrived
+            // with multiple same-key entries from prior buggy paths -- the
+            // find helper returns the first match only.
+            for (;;) {
+                RRDLABEL *old_label_with_key = rrdlabels_find_label_with_key_unsafe(dst, label, false);
+                if (!old_label_with_key)
+                    break;
                 int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
                 (void)JudyLDel(&dst->JudyL, (Word_t)old_label_with_key, PJE0);
                 RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, judy_mem, 0);

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -734,26 +734,28 @@ bool rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src) {
             int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
             RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, judy_mem, 0);
             added++;
-
-            // Ensure at most one entry per key. The remove-unmarked sweep below
-            // preserves RRDLABEL_FLAG_DONT_DELETE, so a same-key replacement
-            // for a pinned entry would otherwise leave a stale duplicate
-            // (key, old-value) next to the fresh (key, new-value). Loop in
-            // case dst arrived with multiple same-key entries from prior
-            // buggy paths -- the find helper returns the first match only.
-            for (;;) {
-                RRDLABEL *old_label_with_same_key = rrdlabels_find_label_with_key_unsafe(dst, label, false);
-                if (!old_label_with_same_key)
-                    break;
-                int del_result = JudyLDel(&dst->JudyL, (Word_t)old_label_with_same_key, PJE0);
-                (void)del_result;
-                int64_t old_judy_mem = JudyAllocThreadPulseGetAndReset();
-                RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, old_judy_mem, 0);
-                delete_label(old_label_with_same_key);
-            }
         }
         else
             *((RRDLABEL_SRC *)PValue) |= RRDLABEL_FLAG_OLD;
+
+        // Ensure at most one entry per key. The remove-unmarked sweep below
+        // preserves RRDLABEL_FLAG_DONT_DELETE, so a stale (key, *) entry
+        // would otherwise survive next to the desired (key, value) entry.
+        // Runs in BOTH branches because the stale entry may pre-date this
+        // iteration (e.g. a duplicate left by a prior buggy path) and is
+        // independent of whether the current src label is a fresh insert
+        // or an already-present (key, value). The find helper skips the
+        // just-inserted/just-found entry via same_value=false.
+        for (;;) {
+            RRDLABEL *old_label_with_same_key = rrdlabels_find_label_with_key_unsafe(dst, label, false);
+            if (!old_label_with_same_key)
+                break;
+            int del_result = JudyLDel(&dst->JudyL, (Word_t)old_label_with_same_key, PJE0);
+            (void)del_result;
+            int64_t old_judy_mem = JudyAllocThreadPulseGetAndReset();
+            RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, old_judy_mem, 0);
+            delete_label(old_label_with_same_key);
+        }
     }
     lfe_done_nolock();
 
@@ -827,22 +829,25 @@ void rrdlabels_copy(RRDLABELS *dst, RRDLABELS *src)
             dup_label(label);
             dst->version++;
             update_statistics = true;
-
-            // Drop any other entry sharing this key. Loop in case dst arrived
-            // with multiple same-key entries from prior buggy paths -- the
-            // find helper returns the first match only.
-            for (;;) {
-                RRDLABEL *old_label_with_key = rrdlabels_find_label_with_key_unsafe(dst, label, false);
-                if (!old_label_with_key)
-                    break;
-                int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
-                (void)JudyLDel(&dst->JudyL, (Word_t)old_label_with_key, PJE0);
-                RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, judy_mem, 0);
-                delete_label((RRDLABEL *)old_label_with_key);
-            }
         }
         else
             *((RRDLABEL_SRC *)PValue) = (ls & ~(RRDLABEL_FLAG_NEW)) | RRDLABEL_FLAG_OLD;
+
+        // Drop any other entry sharing this key. Runs in BOTH branches so
+        // pre-existing same-key duplicates (e.g. left behind by a prior
+        // buggy path) get cleaned up even when the current src label is
+        // already present in dst. Loop because the find helper returns
+        // the first match only. The find skips the just-inserted /
+        // just-updated entry via same_value=false.
+        for (;;) {
+            RRDLABEL *old_label_with_key = rrdlabels_find_label_with_key_unsafe(dst, label, false);
+            if (!old_label_with_key)
+                break;
+            int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
+            (void)JudyLDel(&dst->JudyL, (Word_t)old_label_with_key, PJE0);
+            RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, judy_mem, 0);
+            delete_label((RRDLABEL *)old_label_with_key);
+        }
     }
     lfe_done_nolock();
     if (update_statistics) {

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -1861,6 +1861,60 @@ static int rrdlabels_unittest_change_detection(void) {
     rrdlabels_destroy(dst);
     rrdlabels_destroy(src);
 
+    // ---- Cleanup respects key boundaries ----
+    // The cleanup loop calls find_label_with_key_unsafe() which filters by
+    // STRING key pointer. Regressing that key check would make the loop
+    // delete entries with DIFFERENT keys. Plant pinned DONT_DELETE entries
+    // under TWO keys; mutate only the first key's value; the second key's
+    // entry must survive untouched.
+    dst = rrdlabels_create();
+    src = rrdlabels_create();
+    rrdlabels_add(dst, "k1", "v1", RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE);
+    rrdlabels_add(dst, "k2", "v2", RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE);
+    rrdlabels_add(src, "k1", "v3", RRDLABEL_SRC_CONFIG);
+    UT_EXPECT(rrdlabels_migrate_to_these(dst, src) == true,
+              "migrate with mixed-key DONT_DELETE dst must return true on k1 change");
+    UT_EXPECT(rrdlabels_entries(dst) == 2,
+              "migrate cleanup must leave the unrelated DONT_DELETE key intact");
+    {
+        char *v = NULL;
+        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
+        UT_EXPECT(v != NULL && strcmp(v, "v3") == 0,
+                  "migrate must update k1 to the src value");
+        freez(v);
+        v = NULL;
+        rrdlabels_get_value_strdup_or_null(dst, &v, "k2");
+        UT_EXPECT(v != NULL && strcmp(v, "v2") == 0,
+                  "migrate must preserve the unrelated DONT_DELETE key's value");
+        freez(v);
+    }
+    rrdlabels_destroy(dst);
+    rrdlabels_destroy(src);
+
+    // Same scenario for rrdlabels_copy().
+    dst = rrdlabels_create();
+    src = rrdlabels_create();
+    rrdlabels_add(dst, "k1", "v1", RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE);
+    rrdlabels_add(dst, "k2", "v2", RRDLABEL_SRC_CONFIG | RRDLABEL_FLAG_DONT_DELETE);
+    rrdlabels_add(src, "k1", "v3", RRDLABEL_SRC_CONFIG);
+    rrdlabels_copy(dst, src);
+    UT_EXPECT(rrdlabels_entries(dst) == 2,
+              "copy cleanup must leave the unrelated DONT_DELETE key intact");
+    {
+        char *v = NULL;
+        rrdlabels_get_value_strdup_or_null(dst, &v, "k1");
+        UT_EXPECT(v != NULL && strcmp(v, "v3") == 0,
+                  "copy must update k1 to the src value");
+        freez(v);
+        v = NULL;
+        rrdlabels_get_value_strdup_or_null(dst, &v, "k2");
+        UT_EXPECT(v != NULL && strcmp(v, "v2") == 0,
+                  "copy must preserve the unrelated DONT_DELETE key's value");
+        freez(v);
+    }
+    rrdlabels_destroy(dst);
+    rrdlabels_destroy(src);
+
     // ---- rrdlabels_remove_all_unmarked_and_changed: CLABEL-commit semantics ----
     // (1) unmark + re-add identical set => no change => false
     l = rrdlabels_create();


### PR DESCRIPTION
##### Summary
- Ensure proper handling of updated values during `rrdlabels_migrate_to_these`.
- Remove stale (key, old-value) entries for duplicate keys, even with `DONT_DELETE` set.
- Refactor memory handling and pointer updates for consistency.
- Add unit tests to validate migration edge cases and duplicate prevention logic.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes label migration and copy to replace same-key value changes and remove all stale duplicates (even with `DONT_DELETE`). Tightens Judy writes, adds a null-guard, and ensures cleanup runs in both insert and present paths while respecting key boundaries.

- **Bug Fixes**
  - In `rrdlabels_migrate_to_these` and `rrdlabels_copy`, insert/update then loop-delete all other same-key entries; ignore `DONT_DELETE` on stale ones; run in both branches; drain arbitrarily many duplicates; never touch unrelated keys.
  - Write through Judy `PValue` before any `JudyLDel`; use consistent `OLD`/`NEW` masking. Migration returns true on cleanup-only; copy bumps `version` and updates stats during cleanup.
  - Add early return in `rrdhost_set_is_parent_label` when `localhost` or `rrdlabels` is null.

- **Refactors**
  - Rework unit tests with `rrdlabels_unittest_value_is` and `rrdlabels_unittest_plant_dups` to simplify assertions and reliably simulate multi-duplicate states.

<sup>Written for commit 0b7798a344295bd04197c43c6b778d692ea4c8fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

