### PR TITLE
Add slot bounds check and unit tests for pluginsd_parser

### DIFF
--- a/src/database/rrdset-pluginsd-array.h
+++ b/src/database/rrdset-pluginsd-array.h
@@ -48,7 +48,13 @@ typedef struct pluginsd_rrddim_array {
 // --------------------------------------------------------------------------------------------------------------------
 
 // Create a new array with the specified size and refcount=1
+// size is expected to be bounded by the caller: pluginsd slot input is capped at
+// the parser (PLUGINSD_DIMENSION_SLOT_MAX) and the no-slots path uses the dimension
+// count, so the size multiplication below cannot overflow. The check documents and
+// guards that invariant against any future unbounded caller (debug builds only).
 static inline PRD_ARRAY *prd_array_create(size_t size) {
+    internal_fatal(size > (SIZE_MAX - sizeof(PRD_ARRAY)) / sizeof(struct pluginsd_rrddim),
+                   "PRD_ARRAY: requested size %zu would overflow the allocation", size);
     PRD_ARRAY *arr = callocz(1, sizeof(PRD_ARRAY) + size * sizeof(struct pluginsd_rrddim));
     arr->refcount = 1;
     arr->size = size;

--- a/src/plugins.d/pluginsd_internals.h
+++ b/src/plugins.d/pluginsd_internals.h
@@ -369,17 +369,17 @@ static inline RRDSET *pluginsd_find_chart(RRDHOST *host, const char *chart, cons
     return st;
 }
 
-static ALWAYS_INLINE ssize_t pluginsd_parse_rrd_slot(char **words, size_t num_words) {
+static ALWAYS_INLINE ssize_t pluginsd_parse_rrd_slot(char **words, size_t num_words, size_t max_slot) {
     ssize_t slot = -1;
     char *id = get_word(words, num_words, 1);
     if(id && id[0] == PLUGINSD_KEYWORD_SLOT[0] && id[1] == PLUGINSD_KEYWORD_SLOT[1] &&
        id[2] == PLUGINSD_KEYWORD_SLOT[2] && id[3] == PLUGINSD_KEYWORD_SLOT[3] && id[4] == ':') {
         unsigned long long parsed_slot = str2ull_encoded(&id[5]);
-        if(unlikely(parsed_slot > PLUGINSD_SLOT_MAX)) {
+        if(unlikely(parsed_slot > max_slot)) {
             nd_log_limit_static_global_var(erl_slot, 1, 0);
             nd_log_limit(&erl_slot, NDLS_COLLECTORS, NDLP_WARNING,
-                         "PLUGINSD: ignoring invalid SLOT value '%s' above the supported maximum %d",
-                         &id[5], PLUGINSD_SLOT_MAX);
+                         "PLUGINSD: ignoring invalid SLOT value '%s' above the supported maximum %zu",
+                         &id[5], max_slot);
             slot = 0;
         }
         else

--- a/src/plugins.d/pluginsd_internals.h
+++ b/src/plugins.d/pluginsd_internals.h
@@ -372,6 +372,10 @@ static inline RRDSET *pluginsd_find_chart(RRDHOST *host, const char *chart, cons
 static ALWAYS_INLINE ssize_t pluginsd_parse_rrd_slot(char **words, size_t num_words, size_t max_slot) {
     ssize_t slot = -1;
     char *id = get_word(words, num_words, 1);
+    // Words are NUL-terminated and && short-circuits left-to-right, so each id[k]
+    // is read only after id[0..k-1] matched the non-NUL "SLOT" chars. A shorter word
+    // (e.g. "X" or "SLOT") fails an earlier comparison or hits the terminator at id[4],
+    // so these fixed-index reads never go past the token's NUL. No bounds check needed.
     if(id && id[0] == PLUGINSD_KEYWORD_SLOT[0] && id[1] == PLUGINSD_KEYWORD_SLOT[1] &&
        id[2] == PLUGINSD_KEYWORD_SLOT[2] && id[3] == PLUGINSD_KEYWORD_SLOT[3] && id[4] == ':') {
         unsigned long long parsed_slot = str2ull_encoded(&id[5]);
@@ -380,6 +384,9 @@ static ALWAYS_INLINE ssize_t pluginsd_parse_rrd_slot(char **words, size_t num_wo
             nd_log_limit(&erl_slot, NDLS_COLLECTORS, NDLP_WARNING,
                          "PLUGINSD: ignoring invalid SLOT value '%s' above the supported maximum %zu",
                          &id[5], max_slot);
+            // slot 0 means: the SLOT word was present (so the caller still advances its
+            // word index), but the value is unusable as a cache index. Downstream cache
+            // paths treat slot < 1 as "uncached" and fall back to lookup by id.
             slot = 0;
         }
         else

--- a/src/plugins.d/pluginsd_internals.h
+++ b/src/plugins.d/pluginsd_internals.h
@@ -391,8 +391,10 @@ static ALWAYS_INLINE ssize_t pluginsd_parse_rrd_slot(char **words, size_t num_wo
                          "PLUGINSD: ignoring invalid SLOT value '%s' above the supported maximum %zu",
                          &id[5], max_slot);
             // slot 0 means: the SLOT word was present (so the caller still advances its
-            // word index), but the value is unusable as a cache index. Downstream cache
-            // paths treat slot < 1 as "uncached" and fall back to lookup by id.
+            // word index), but the value is unusable as a cache index. Each caller
+            // handles slot < 1 per its own path -- chart lookups fall back to finding
+            // the chart by id, and dimension caching switches to the non-slotted
+            // (by-position) path (pluginsd_rrddim_put_to_slot sets dims_with_slots=false).
             slot = 0;
         }
         else

--- a/src/plugins.d/pluginsd_internals.h
+++ b/src/plugins.d/pluginsd_internals.h
@@ -370,6 +370,12 @@ static inline RRDSET *pluginsd_find_chart(RRDHOST *host, const char *chart, cons
 }
 
 static ALWAYS_INLINE ssize_t pluginsd_parse_rrd_slot(char **words, size_t num_words, size_t max_slot) {
+    // Contract: max_slot must fit in ssize_t so the (ssize_t) cast below stays
+    // non-negative. All callers pass small compile-time caps (PLUGINSD_*_SLOT_MAX),
+    // so for the inlined constant this check is folded away by the compiler.
+    internal_fatal(max_slot > (size_t)SSIZE_MAX,
+                   "PLUGINSD: max_slot %zu exceeds SSIZE_MAX", max_slot);
+
     ssize_t slot = -1;
     char *id = get_word(words, num_words, 1);
     // Words are NUL-terminated and && short-circuits left-to-right, so each id[k]

--- a/src/plugins.d/pluginsd_internals.h
+++ b/src/plugins.d/pluginsd_internals.h
@@ -374,8 +374,16 @@ static ALWAYS_INLINE ssize_t pluginsd_parse_rrd_slot(char **words, size_t num_wo
     char *id = get_word(words, num_words, 1);
     if(id && id[0] == PLUGINSD_KEYWORD_SLOT[0] && id[1] == PLUGINSD_KEYWORD_SLOT[1] &&
        id[2] == PLUGINSD_KEYWORD_SLOT[2] && id[3] == PLUGINSD_KEYWORD_SLOT[3] && id[4] == ':') {
-        slot = (ssize_t) str2ull_encoded(&id[5]);
-        if(slot < 0) slot = 0; // to make the caller increment its idx of the words
+        unsigned long long parsed_slot = str2ull_encoded(&id[5]);
+        if(unlikely(parsed_slot > PLUGINSD_SLOT_MAX)) {
+            nd_log_limit_static_global_var(erl_slot, 1, 0);
+            nd_log_limit(&erl_slot, NDLS_COLLECTORS, NDLP_WARNING,
+                         "PLUGINSD: ignoring invalid SLOT value '%s' above the supported maximum %d",
+                         &id[5], PLUGINSD_SLOT_MAX);
+            slot = 0;
+        }
+        else
+            slot = (ssize_t)parsed_slot;
     }
 
     return slot;

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -6,7 +6,7 @@
 
 static inline PARSER_RC pluginsd_set(char **words, size_t num_words, PARSER *parser) {
     int idx = 1;
-    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words);
+    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words, PLUGINSD_DIMENSION_SLOT_MAX);
     if(slot >= 0) idx++;
 
     char *dimension = get_word(words, num_words, idx++);
@@ -39,7 +39,7 @@ static inline PARSER_RC pluginsd_set(char **words, size_t num_words, PARSER *par
 
 static inline PARSER_RC pluginsd_begin(char **words, size_t num_words, PARSER *parser) {
     int idx = 1;
-    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words);
+    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words, PLUGINSD_CHART_SLOT_MAX);
     if(slot >= 0) idx++;
 
     char *id = get_word(words, num_words, idx++);
@@ -356,7 +356,7 @@ static inline PARSER_RC pluginsd_chart(char **words, size_t num_words, PARSER *p
     if(!host) return PLUGINSD_DISABLE_PLUGIN(parser, NULL, NULL);
 
     int idx = 1;
-    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words);
+    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words, PLUGINSD_CHART_SLOT_MAX);
     if(slot >= 0) idx++;
 
     char *type = get_word(words, num_words, idx++);
@@ -473,7 +473,7 @@ static inline PARSER_RC pluginsd_chart(char **words, size_t num_words, PARSER *p
 
 static inline PARSER_RC pluginsd_dimension(char **words, size_t num_words, PARSER *parser) {
     int idx = 1;
-    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words);
+    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words, PLUGINSD_DIMENSION_SLOT_MAX);
     if(slot >= 0) idx++;
 
     char *id = get_word(words, num_words, idx++);
@@ -804,7 +804,7 @@ static ALWAYS_INLINE PARSER_RC pluginsd_begin_v2(char **words, size_t num_words,
     timing_init();
 
     int idx = 1;
-    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words);
+    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words, PLUGINSD_CHART_SLOT_MAX);
     if(slot >= 0) idx++;
 
     char *id = get_word(words, num_words, idx++);
@@ -949,7 +949,7 @@ static ALWAYS_INLINE PARSER_RC pluginsd_set_v2(char **words, size_t num_words, P
     timing_init();
 
     int idx = 1;
-    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words);
+    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words, PLUGINSD_DIMENSION_SLOT_MAX);
     if(slot >= 0) idx++;
 
     char *dimension = get_word(words, num_words, idx++);
@@ -1513,7 +1513,7 @@ void parser_init_repertoire(PARSER *parser, PARSER_REPERTOIRE repertoire) {
     }
 }
 
-static int pluginsd_parser_unittest_slot_bounds(void) {
+static int pluginsd_parser_unittest_slot_bounds(size_t max_slot) {
     struct slot_test_case {
         char slot_word[64];
         ssize_t expected;
@@ -1528,11 +1528,11 @@ static int pluginsd_parser_unittest_slot_bounds(void) {
     };
 
     snprintfz(cases[5].slot_word, sizeof(cases[5].slot_word) - 1,
-              PLUGINSD_KEYWORD_SLOT ":%d", PLUGINSD_SLOT_MAX);
-    cases[5].expected = PLUGINSD_SLOT_MAX;
+              PLUGINSD_KEYWORD_SLOT ":%zu", max_slot);
+    cases[5].expected = (ssize_t)max_slot;
 
     snprintfz(cases[6].slot_word, sizeof(cases[6].slot_word) - 1,
-              PLUGINSD_KEYWORD_SLOT ":%d", PLUGINSD_SLOT_MAX + 1);
+              PLUGINSD_KEYWORD_SLOT ":%zu", max_slot + 1);
     cases[6].expected = 0;
 
     for(size_t i = 0; i < _countof(cases); i++) {
@@ -1540,7 +1540,7 @@ static int pluginsd_parser_unittest_slot_bounds(void) {
         char *words[] = { command, cases[i].slot_word[0] ? cases[i].slot_word : NULL };
         size_t num_words = words[1] ? 2 : 1;
 
-        ssize_t slot = pluginsd_parse_rrd_slot(words, num_words);
+        ssize_t slot = pluginsd_parse_rrd_slot(words, num_words, max_slot);
         if(slot != cases[i].expected) {
             netdata_log_error("PLUGINSD: slot parser unittest failed for '%s': expected %zd, got %zd",
                               words[1] ? words[1] : "(unset)", cases[i].expected, slot);
@@ -1552,7 +1552,10 @@ static int pluginsd_parser_unittest_slot_bounds(void) {
 }
 
 int pluginsd_parser_unittest(void) {
-    if(pluginsd_parser_unittest_slot_bounds())
+    if(pluginsd_parser_unittest_slot_bounds(PLUGINSD_DIMENSION_SLOT_MAX))
+        return 1;
+
+    if(pluginsd_parser_unittest_slot_bounds(PLUGINSD_CHART_SLOT_MAX))
         return 1;
 
     PARSER *p = parser_init(NULL, -1, -1, PARSER_INPUT_SPLIT, NULL);

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -1514,26 +1514,40 @@ void parser_init_repertoire(PARSER *parser, PARSER_REPERTOIRE repertoire) {
 }
 
 static int pluginsd_parser_unittest_slot_bounds(size_t max_slot) {
+    // Note on initialization: every element below is given an explicit
+    // initializer, so C zero-fills the remainder of each slot_word array. The
+    // trailing three entries start empty and are filled from max_slot at runtime.
     struct slot_test_case {
         char slot_word[64];
         ssize_t expected;
     } cases[] = {
-        { "", -1 },
-        { PLUGINSD_KEYWORD_SLOT ":0", 0 },
-        { PLUGINSD_KEYWORD_SLOT ":1", 1 },
-        { PLUGINSD_KEYWORD_SLOT ":0x0AAAAAAAAAAAAAAB", 0 },
-        { PLUGINSD_KEYWORD_SLOT ":0x40000000", 0 },
-        { "", 0 },
-        { "", 0 },
+        { "", -1 },                                          // no SLOT word -> -1 (caller must not advance idx)
+        { PLUGINSD_KEYWORD_SLOT ":0", 0 },                   // explicit zero -> uncached
+        { PLUGINSD_KEYWORD_SLOT ":1", 1 },                   // smallest cached slot
+        { PLUGINSD_KEYWORD_SLOT ":-1", 0 },                  // negative parses as unsigned 0 -> uncached
+        { PLUGINSD_KEYWORD_SLOT ":abc", 0 },                 // malformed decimal -> 0 -> uncached
+        { PLUGINSD_KEYWORD_SLOT ":0xZZ", 0 },                // malformed hex -> 0 -> uncached
+        { PLUGINSD_KEYWORD_SLOT ":0x0AAAAAAAAAAAAAAB", 0 },  // over cap; cast stays positive, would wrap allocation
+        { PLUGINSD_KEYWORD_SLOT ":0xFFFFFFFFFFFFFFFF", 0 },  // u64 max -> over cap -> uncached
+        { PLUGINSD_KEYWORD_SLOT ":0x40000000", 0 },          // over both caps -> uncached (the reported OOM value)
+        { "", 0 },                                           // filled below: max_slot - 1 (accepted)
+        { "", 0 },                                           // filled below: max_slot     (accepted, boundary)
+        { "", 0 },                                           // filled below: max_slot + 1 (rejected, boundary)
     };
 
-    snprintfz(cases[5].slot_word, sizeof(cases[5].slot_word) - 1,
-              PLUGINSD_KEYWORD_SLOT ":%zu", max_slot);
-    cases[5].expected = (ssize_t)max_slot;
+    const size_t n = _countof(cases);
 
-    snprintfz(cases[6].slot_word, sizeof(cases[6].slot_word) - 1,
+    snprintfz(cases[n - 3].slot_word, sizeof(cases[n - 3].slot_word) - 1,
+              PLUGINSD_KEYWORD_SLOT ":%zu", max_slot - 1);
+    cases[n - 3].expected = (ssize_t)(max_slot - 1);
+
+    snprintfz(cases[n - 2].slot_word, sizeof(cases[n - 2].slot_word) - 1,
+              PLUGINSD_KEYWORD_SLOT ":%zu", max_slot);
+    cases[n - 2].expected = (ssize_t)max_slot;
+
+    snprintfz(cases[n - 1].slot_word, sizeof(cases[n - 1].slot_word) - 1,
               PLUGINSD_KEYWORD_SLOT ":%zu", max_slot + 1);
-    cases[6].expected = 0;
+    cases[n - 1].expected = 0;
 
     for(size_t i = 0; i < _countof(cases); i++) {
         char command[] = "DIMENSION";

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -1514,6 +1514,13 @@ void parser_init_repertoire(PARSER *parser, PARSER_REPERTOIRE repertoire) {
 }
 
 static int pluginsd_parser_unittest_slot_bounds(size_t max_slot) {
+    // The boundary cases below build "max_slot - 1", so a zero cap would underflow.
+    // All real callers pass nonzero compile-time caps; guard against misuse anyway.
+    if(max_slot < 1) {
+        netdata_log_error("PLUGINSD: slot bounds unittest requires max_slot >= 1, got %zu", max_slot);
+        return 1;
+    }
+
     // Note on initialization: every element below is given an explicit
     // initializer, so C zero-fills the remainder of each slot_word array. The
     // trailing three entries start empty and are filled from max_slot at runtime.
@@ -1537,15 +1544,15 @@ static int pluginsd_parser_unittest_slot_bounds(size_t max_slot) {
 
     const size_t n = _countof(cases);
 
-    snprintfz(cases[n - 3].slot_word, sizeof(cases[n - 3].slot_word) - 1,
+    snprintfz(cases[n - 3].slot_word, sizeof(cases[n - 3].slot_word),
               PLUGINSD_KEYWORD_SLOT ":%zu", max_slot - 1);
     cases[n - 3].expected = (ssize_t)(max_slot - 1);
 
-    snprintfz(cases[n - 2].slot_word, sizeof(cases[n - 2].slot_word) - 1,
+    snprintfz(cases[n - 2].slot_word, sizeof(cases[n - 2].slot_word),
               PLUGINSD_KEYWORD_SLOT ":%zu", max_slot);
     cases[n - 2].expected = (ssize_t)max_slot;
 
-    snprintfz(cases[n - 1].slot_word, sizeof(cases[n - 1].slot_word) - 1,
+    snprintfz(cases[n - 1].slot_word, sizeof(cases[n - 1].slot_word),
               PLUGINSD_KEYWORD_SLOT ":%zu", max_slot + 1);
     cases[n - 1].expected = 0;
 

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -1513,7 +1513,48 @@ void parser_init_repertoire(PARSER *parser, PARSER_REPERTOIRE repertoire) {
     }
 }
 
+static int pluginsd_parser_unittest_slot_bounds(void) {
+    struct slot_test_case {
+        char slot_word[64];
+        ssize_t expected;
+    } cases[] = {
+        { "", -1 },
+        { PLUGINSD_KEYWORD_SLOT ":0", 0 },
+        { PLUGINSD_KEYWORD_SLOT ":1", 1 },
+        { PLUGINSD_KEYWORD_SLOT ":0x0AAAAAAAAAAAAAAB", 0 },
+        { PLUGINSD_KEYWORD_SLOT ":0x40000000", 0 },
+        { "", 0 },
+        { "", 0 },
+    };
+
+    snprintfz(cases[5].slot_word, sizeof(cases[5].slot_word) - 1,
+              PLUGINSD_KEYWORD_SLOT ":%d", PLUGINSD_SLOT_MAX);
+    cases[5].expected = PLUGINSD_SLOT_MAX;
+
+    snprintfz(cases[6].slot_word, sizeof(cases[6].slot_word) - 1,
+              PLUGINSD_KEYWORD_SLOT ":%d", PLUGINSD_SLOT_MAX + 1);
+    cases[6].expected = 0;
+
+    for(size_t i = 0; i < _countof(cases); i++) {
+        char command[] = "DIMENSION";
+        char *words[] = { command, cases[i].slot_word[0] ? cases[i].slot_word : NULL };
+        size_t num_words = words[1] ? 2 : 1;
+
+        ssize_t slot = pluginsd_parse_rrd_slot(words, num_words);
+        if(slot != cases[i].expected) {
+            netdata_log_error("PLUGINSD: slot parser unittest failed for '%s': expected %zd, got %zd",
+                              words[1] ? words[1] : "(unset)", cases[i].expected, slot);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
 int pluginsd_parser_unittest(void) {
+    if(pluginsd_parser_unittest_slot_bounds())
+        return 1;
+
     PARSER *p = parser_init(NULL, -1, -1, PARSER_INPUT_SPLIT, NULL);
     pluginsd_keywords_init(p, PARSER_INIT_PLUGINSD | PARSER_INIT_STREAMING);
 

--- a/src/plugins.d/pluginsd_parser.h
+++ b/src/plugins.d/pluginsd_parser.h
@@ -19,7 +19,8 @@
 
 #define PLUGINSD_MIN_RRDSET_POINTERS_CACHE 1024
 // Slots are cache indexes. Larger values are treated as uncached input to avoid sparse cache allocations.
-#define PLUGINSD_SLOT_MAX 65535
+#define PLUGINSD_CHART_SLOT_MAX 1000000
+#define PLUGINSD_DIMENSION_SLOT_MAX 65535
 
 // PARSER return codes
 typedef enum __attribute__ ((__packed__)) parser_rc {

--- a/src/plugins.d/pluginsd_parser.h
+++ b/src/plugins.d/pluginsd_parser.h
@@ -18,6 +18,8 @@
 #define PLUGINSD_MAX_DEFERRED_SIZE (100 * 1024 * 1024)
 
 #define PLUGINSD_MIN_RRDSET_POINTERS_CACHE 1024
+// Slots are cache indexes. Larger values are treated as uncached input to avoid sparse cache allocations.
+#define PLUGINSD_SLOT_MAX 65535
 
 // PARSER return codes
 typedef enum __attribute__ ((__packed__)) parser_rc {

--- a/src/plugins.d/pluginsd_replication.c
+++ b/src/plugins.d/pluginsd_replication.c
@@ -111,7 +111,7 @@ PARSER_RC pluginsd_chart_definition_end(char **words, size_t num_words, PARSER *
 
 ALWAYS_INLINE PARSER_RC pluginsd_replay_begin(char **words, size_t num_words, PARSER *parser) {
     int idx = 1;
-    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words);
+    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words, PLUGINSD_CHART_SLOT_MAX);
     if(slot >= 0) idx++;
 
     char *id = get_word(words, num_words, idx++);
@@ -216,7 +216,7 @@ ALWAYS_INLINE PARSER_RC pluginsd_replay_begin(char **words, size_t num_words, PA
 
 ALWAYS_INLINE PARSER_RC pluginsd_replay_set(char **words, size_t num_words, PARSER *parser) {
     int idx = 1;
-    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words);
+    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words, PLUGINSD_DIMENSION_SLOT_MAX);
     if(slot >= 0) idx++;
 
     char *dimension = get_word(words, num_words, idx++);
@@ -284,7 +284,7 @@ ALWAYS_INLINE PARSER_RC pluginsd_replay_rrddim_collection_state(char **words, si
         return PARSER_RC_OK;
 
     int idx = 1;
-    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words);
+    ssize_t slot = pluginsd_parse_rrd_slot(words, num_words, PLUGINSD_DIMENSION_SLOT_MAX);
     if(slot >= 0) idx++;
 
     char *dimension = get_word(words, num_words, idx++);


### PR DESCRIPTION
##### Summary
 - Fixes parent-agent crashes caused by bad SLOT: values in streaming/pluginsd data.
  - A misbehaving or malicious child/plugin could send a huge slot number, making the parent try to grab a massive chunk of memory (crash) or write past the end of an array (corruption).
  This PR puts sensible upper limits on those values.
  - Oversized slots are now safely ignored (with a rate-limited warning) and the data still gets processed normally via the regular lookup path — nothing is dropped.
  - Separate, generous limits for charts (1,000,000) and dimensions (65,535), so real-world setups are never affected.
  - Added tests that confirm valid slots still work and out-of-range values are rejected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds slot bounds checking in the pluginsd parser to prevent crashes from oversized SLOT values, plus a guard against array allocation overflows. Clarifies fallback behavior when slots are invalid so charts and dimensions keep working without data loss.

- **Bug Fixes**
  - Enforce per-command max slot caps (charts 1,000,000; dimensions 65,535) across begin/chart/dimension/set and replication paths.
  - Validate `max_slot` in `pluginsd_parse_rrd_slot` (must fit `ssize_t`) and treat over-limit values as uncached with a rate-limited warning.
  - Clarify `slot < 1` handling: charts fall back to id lookup; dimensions use the non-slotted path.
  - Add allocation overflow guard in `prd_array_create`.

- **Tests**
  - Add slot-bounds unit tests covering valid, boundary, malformed/negative/hex, and overflow cases for both chart and dimension limits.
  - Add guard for `max_slot >= 1` to prevent underflow in boundary tests and simplify `snprintfz` usage.

<sup>Written for commit 9f9a1782de408f8b92dd35198ac1847088275af1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

