### PR TITLE
docs: fix documentation typos

### DIFF
--- a/docs/netdata-enterprise-evaluation-corrected.md
+++ b/docs/netdata-enterprise-evaluation-corrected.md
@@ -60,7 +60,7 @@ When connected to a Netdata Parent (the agent is in `child` mode), these require
 | standalone | 3k - 10k | 4% - 20% of single core | 150 - 500 MiB | none | varies based on retention |
 | child      | 3k - 10k | 2% - 10% of single core | 100 - 300 MiB | \<1 Mbps | none |
 
-For more information and ways to further reduce Agent resource utilization, see [Agent Resource Utilization](hhttps://github.com/netdata/netdata/blob/master/docs/netdata-agent/sizing-netdata-agents/README.md).
+For more information and ways to further reduce Agent resource utilization, see [Agent Resource Utilization](https://github.com/netdata/netdata/blob/master/docs/netdata-agent/sizing-netdata-agents/README.md).
 
 ### Parent Node Requirements (Centralization Points)
 

--- a/docs/welcome-to-netdata.md
+++ b/docs/welcome-to-netdata.md
@@ -248,7 +248,7 @@ For Netdata, scalability is inherent to the architecture, not an add-on. Designe
 - **Consistent performance**: Query response times remain the same whether you have 10 or 10,000 nodes.
 - **Resource predictability**: Resource usage scales linearly with infrastructure size.
 - **High availability**: Streaming and replication provide high-availability to Netdata deployments.
-- **Clustering**: Netdata Parents can be clustered to replicate all their data localy, or cross region for disaster recovery.
+- **Clustering**: Netdata Parents can be clustered to replicate all their data locally, or cross region for disaster recovery.
 - **Fail-over**: Netdata Cloud dynamically routes queries to Netdata Parents and Agents based on their availability.
 
 ### Open Ecosystem


### PR DESCRIPTION
Summary:
- Fixes clear spelling or wording mistakes in documentation.
- Keeps the change text-only with no behavior impact.

Testing:
- `git diff --check`
- `uvx codespell` on the changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two documentation typos to improve clarity and link accuracy. Corrects the Agent Resource Utilization link (hhttps → https) and changes “localy” to “locally” in the clustering description.

<sup>Written for commit 48142f2b9c709c892b56a17c8af27560fc60c9cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

