### PR TITLE
Add engineering task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ENGINEERING_TASK.yml
+++ b/.github/ISSUE_TEMPLATE/ENGINEERING_TASK.yml
@@ -1,0 +1,94 @@
+name: "Netdata Agent: Engineering task"
+description: "Track refactors, technical debt, and engineering follow-ups for the Netdata Agent"
+title: "[Task]: "
+labels: ["needs triage"]
+type: "task"
+body:
+  - type: markdown
+    attributes:
+      value: "### Thank you for contributing to our project!"
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for internal engineering work, refactors, technical debt,
+        and follow-ups discovered during development. Please include concrete
+        evidence such as file paths, line references, pull requests, issue links,
+        review comments, or failing checks.
+
+        For user-facing features, use the Feature request template. For defects,
+        use the Bug report template.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / root cause
+      description: |
+        What is wrong or risky about the current state, and why? Include concrete evidence where possible.
+    validations:
+      required: true
+  - type: textarea
+    id: clean-end-state
+    attributes:
+      label: Clean end state
+      description: |
+        What should the codebase, workflow, or project structure look like once this task is complete?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: |
+        List observable, checkable conditions for this task to be considered done.
+      value: |
+        -
+        -
+        -
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: |
+        Select the closest category if one applies.
+      options:
+        - "refactor"
+        - "technical debt"
+        - "test debt"
+        - "docs debt"
+        - "build / CI"
+        - "follow-up from prior work"
+    validations:
+      required: false
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope boundaries
+      description: |
+        What is in scope, and what is explicitly out of scope?
+    validations:
+      required: false
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: |
+        Which tests, scans, documentation checks, or other verification should prove the task is complete?
+    validations:
+      required: false
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / compatibility
+      description: |
+        Note any behavior, API/schema, documentation, packaging, migration, or user-impact risks.
+    validations:
+      required: false
+  - type: textarea
+    id: related-context
+    attributes:
+      label: Related context
+      description: |
+        Link related issues, pull requests, SOWs, review comments, CI findings, or discussions.
+    validations:
+      required: false


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a GitHub issue template for engineering tasks in the Netdata Agent to standardize tracking of refactors, technical debt, and follow-ups. It requires clear problem, end state, and acceptance criteria to improve triage and planning.

- **New Features**
  - New template at `.github/ISSUE_TEMPLATE/ENGINEERING_TASK.yml` with default title "[Task]: " and `labels: ["needs triage"]`.
  - Optional fields for category (refactor, technical/test/docs debt, build/CI, follow-up), scope, validation, risks, and related context.

<sup>Written for commit 77302cc10aaa78734248897b28aef2f453e7d0c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

