### PR TITLE
fix(journal-index): avoid ValueGuardInUse when indexing otel journals

### DIFF
--- a/src/crates/journal-index/src/file_indexer.rs
+++ b/src/crates/journal-index/src/file_indexer.rs
@@ -473,6 +473,19 @@ impl FileIndexer {
         // silently flow into the index.
         let field_data_iterator = journal_file.field_data_objects(marker_field)?;
 
+        // Phase 1: collect the inlined cursor of every ND_REMAPPING=1 data
+        // object.
+        //
+        // Each iterator item is a `ValueGuard<DataObject>` that holds the
+        // journal file's window-manager borrow for as long as it is alive.
+        // `InlinedCursor` is a small `Copy` value, so we copy it out and let
+        // the data-object guard drop at the end of each iteration. We must
+        // NOT call `collect_offsets()` here: when a data object is referenced
+        // by more than one entry it walks the entry-array chain, which
+        // re-borrows the window manager. Doing that while a data-object guard
+        // is still live fails with `ValueGuardInUse`. This mirrors the
+        // two-phase approach in `collect_source_field_info`.
+        let mut remapping_cursors = Vec::new();
         for data_object in field_data_iterator {
             let data_object = data_object?;
 
@@ -485,6 +498,12 @@ impl FileIndexer {
                 continue;
             };
 
+            remapping_cursors.push(inlined_cursor);
+        }
+
+        // Phase 2: walk each cursor's entry-array chain. No data-object guard
+        // is held at this point, so re-borrowing the window manager is safe.
+        for inlined_cursor in remapping_cursors {
             self.entry_offsets.clear();
             inlined_cursor.collect_offsets(journal_file, &mut self.entry_offsets)?;
 

--- a/src/crates/journal-index/tests/remapping_indexing.rs
+++ b/src/crates/journal-index/tests/remapping_indexing.rs
@@ -1,0 +1,103 @@
+//! Regression test for indexing journals that contain the otel-plugin's
+//! `ND_REMAPPING=1` bookkeeping field.
+//!
+//! `FileIndexer::collect_remapping_entry_offsets` used to hold a
+//! `ValueGuard<DataObject>` (which keeps the journal file's window-manager
+//! borrow alive) while calling `InlinedCursor::collect_offsets`. When the
+//! `ND_REMAPPING=1` data object is referenced by more than one entry,
+//! `collect_offsets` walks the entry-array chain, re-borrows the window
+//! manager, and fails with `JournalError::ValueGuardInUse` ("previous object
+//! is still in use"). That aborted indexing of every otel-plugin journal.
+//!
+//! Regular systemd journals do not contain the `ND_REMAPPING` field, so the
+//! existing tests never exercised this path. This test reproduces the
+//! multi-entry shape that triggered the bug and asserts indexing succeeds.
+
+use journal_common::Seconds;
+use journal_core::field_map::REMAPPING_MARKER;
+use journal_core::file::{JournalFile, JournalFileOptions, JournalWriter};
+use journal_core::repository::File;
+use journal_index::{FieldName, FileIndexer};
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+fn create_test_journal_path(temp_dir: &TempDir) -> PathBuf {
+    let machine_id = Uuid::from_u128(0x12345678_1234_1234_1234_123456789abc);
+    let machine_dir = temp_dir.path().join(machine_id.to_string());
+    fs::create_dir_all(&machine_dir).expect("create machine dir");
+    machine_dir.join("system.journal")
+}
+
+/// Build a journal that mirrors an otel-plugin journal: a handful of
+/// `ND_REMAPPING=1` bookkeeping entries plus normal log entries.
+///
+/// The bookkeeping entries all share one `ND_REMAPPING=1` DATA object (journald
+/// dedups by payload), so with `num_marker_entries >= 2` that object's
+/// entry-array chain is non-empty — the shape that made
+/// `collect_remapping_entry_offsets` re-borrow the window manager and fail.
+///
+/// The normal entries (which carry no marker) are excluded neither from the
+/// histogram nor the bitmaps, so a fixed indexer produces a non-empty index
+/// instead of erroring with `EmptyHistogramInput`.
+fn create_remapping_journal(num_marker_entries: u64, num_real_entries: u64) -> (TempDir, File) {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let journal_path = create_test_journal_path(&temp_dir);
+    let file = File::from_path(&journal_path).expect("File::from_path");
+
+    let machine_id = Uuid::from_u128(0x12345678_1234_1234_1234_123456789abc);
+    let boot_id = Uuid::from_u128(0x11111111_1111_1111_1111_111111111111);
+    let seqnum_id = Uuid::from_u128(0x22222222_2222_2222_2222_222222222222);
+
+    let options = JournalFileOptions::new(machine_id, boot_id, seqnum_id);
+    let mut journal_file = JournalFile::create(&file, options).expect("create journal");
+    let mut writer = JournalWriter::new(&mut journal_file, 1, boot_id).expect("writer");
+
+    let mut timestamp = 1_000_000u64; // microseconds, strictly increasing
+
+    // Bookkeeping entries: timestamp + the shared ND_REMAPPING=1 marker.
+    for _ in 0..num_marker_entries {
+        timestamp += 1;
+        let ts_field = format!("_SOURCE_REALTIME_TIMESTAMP={timestamp}").into_bytes();
+        let items: Vec<&[u8]> = vec![ts_field.as_slice(), REMAPPING_MARKER];
+        writer
+            .add_entry(&mut journal_file, &items, timestamp, timestamp)
+            .expect("add marker entry");
+    }
+
+    // Real log entries: no marker, so they survive into the index.
+    for i in 0..num_real_entries {
+        timestamp += 1;
+        let ts_field = format!("_SOURCE_REALTIME_TIMESTAMP={timestamp}").into_bytes();
+        let message = format!("MESSAGE=log entry {i}").into_bytes();
+        let items: Vec<&[u8]> = vec![ts_field.as_slice(), message.as_slice()];
+        writer
+            .add_entry(&mut journal_file, &items, timestamp, timestamp)
+            .expect("add real entry");
+    }
+
+    (temp_dir, file)
+}
+
+/// Indexing a journal whose `ND_REMAPPING=1` object spans multiple entries
+/// must not fail with `ValueGuardInUse`.
+#[test]
+fn index_journal_with_multi_entry_remapping_marker() {
+    // Two marker entries already produce an entry-array chain (one inlined
+    // offset + one array object), the minimal shape that triggered the bug;
+    // use a few more to be robust against array-layout changes.
+    let (_temp_dir, file) = create_remapping_journal(3, 5);
+
+    let mut indexer = FileIndexer::default();
+    let source = FieldName::new("_SOURCE_REALTIME_TIMESTAMP").unwrap();
+    let message = FieldName::new("MESSAGE").unwrap();
+
+    let result = indexer.index(&file, Some(&source), &[message], Seconds(15));
+
+    assert!(
+        result.is_ok(),
+        "indexing a journal with a multi-entry ND_REMAPPING marker must succeed, got: {:?}",
+        result.err()
+    );
+}


### PR DESCRIPTION
## Problem

The `otel-signal-viewer-plugin` "Otel-logs" view shows **no data** for otel-plugin journals, even though the journals are written correctly and the viewer finds them in the query time range. Regular systemd journals (`Systemd-journal` function) are unaffected.

The signal-viewer logs the failure for every query:

```
found 1 files in time range
file index computation failed for file=...: Index error: journal error: previous object is still in use
retrieved 0/1 file indexes for histogram buckets and log entries
retrieved 0 log entries
```

## Root cause

`FileIndexer::collect_remapping_entry_offsets()` held a `ValueGuard<DataObject>` — which keeps the journal file's window-manager borrow alive — while calling `InlinedCursor::collect_offsets()` in the same scope.

When the `ND_REMAPPING=1` bookkeeping data object is referenced by more than one entry, `collect_offsets()` walks the entry-array chain, which re-borrows the window manager and returns `JournalError::ValueGuardInUse`. Indexing aborts in its first step, so the whole file yields zero entries.

Only otel-plugin journals contain the `ND_REMAPPING` field, so the loop body never runs for regular systemd journals — which is why only the Otel-logs view was broken.

## Fix

Split the loop into two phases, mirroring the already-correct pattern in `collect_source_field_info()`:

1. Iterate the data objects and copy out each `InlinedCursor` (a small `Copy` value), letting the `DataObject` guard drop at the end of each iteration.
2. Walk the cursors' entry-array chains afterward, when no guard is held.

## Verification

- Reproduced `Journal(ValueGuardInUse)` running the real `FileIndexer::index()` against a live otel-plugin journal; confirmed the failure is in `collect_remapping_entry_offsets`.
- After the fix, `index()` succeeds on the same journal.
- `cargo test -p journal-index` passes (66 tests + doctests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes “no data” in the `otel-signal-viewer-plugin` Otel-logs view by preventing `JournalError::ValueGuardInUse` when indexing otel-plugin journals. Adds a regression test covering multi-entry `ND_REMAPPING` journals.

- **Bug Fixes**
  - Root cause: `FileIndexer::collect_remapping_entry_offsets()` held a `ValueGuard<DataObject>` while calling `InlinedCursor::collect_offsets()`, which re-borrows the window manager when `ND_REMAPPING` spans multiple entries, causing `ValueGuardInUse`.
  - Change: copy each `InlinedCursor` out of the data objects (dropping the guard per item), then iterate the copied cursors to collect offsets.
  - Result: otel-plugin journals index correctly and the Otel-logs view shows data; systemd journals remain unaffected.
  - Regression test: added `tests/remapping_indexing.rs` to build a journal with multi-entry `ND_REMAPPING=1` and assert `FileIndexer::index()` succeeds.

<sup>Written for commit d2b860a42ca14877285946f4427c57053770a350. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

