### PR TITLE
chore(go.d): add topology overlay helpers for vSphere

### DIFF
--- a/.agents/skills/project-create-topology/SKILL.md
+++ b/.agents/skills/project-create-topology/SKILL.md
@@ -102,6 +102,23 @@ developer-facing and must stay in this project skill, not under
    - Use overlay templates once per payload or type.
    - Links and actors carry compact refs and parameters only.
    - Do not put full metric query payloads on every row.
+   - Build Go producer refs with `topologyv1.NewActorOverlayRefsBuilder` or
+     `topologyv1.NewLinkOverlayRefsBuilder` instead of hand-assembling compact
+     tables.
+   - Overlay refs use a `template` column, exactly one convention owner column
+     (`actor` with type `actor_ref` or `link` with type `link_ref`), and one
+     column for each selector param required by the referenced template. Do not
+     add any other `actor_ref` or `link_ref` columns to overlay refs. Every row
+     must have a non-null owner value.
+   - The `template` column and required selector-param columns must be `string`
+     or `string_ref`; required selector-param row values must resolve to
+     non-empty strings.
+   - Do not use `template`, `actor`, or `link` as selector params; those names
+     are reserved refs-table convention columns.
+   - For `netdata.metrics`, `node_id` means node scope, `collect_job` maps to
+     chart label `_collect_job`, and other selector params map to same-named
+     chart labels. In go.d producers, pass `job.Name()` for `collect_job`; do
+     not use `job.FullName()`.
 
 7. Define correlation semantics when actors can be resolved across payloads.
    - Declare whether the topology needs loose-side resolution, actor
@@ -400,6 +417,11 @@ For SNMP/L2 managed device actor modals:
   high-cardinality evidence rows.
 - Raw JSON columns are hidden/debug-only unless a schema-declared projection
   renders a scalar value.
+- Overlay templates and refs validate global template references, required
+  selector-param columns, selector-param string types and values, reserved
+  selector-param names, exactly one convention actor/link owner column, no extra
+  actor/link ref owner columns, non-null owner row values, provider/merge enum
+  membership, and link-type `overlay_templates` references.
 - Payload size is measured on realistic or captured data.
 - Raw sensitive captures remain under `.local/`.
 

--- a/.agents/sow/specs/topology-function-schema.md
+++ b/.agents/sow/specs/topology-function-schema.md
@@ -426,8 +426,44 @@ graph relationships.
 Refreshable traffic, state, error, packet, or utilization data is represented by
 overlay templates and per-actor/per-link refs.
 
-Templates define the query mechanism once. Refs provide only template ids and
-parameters. Aggregated links merge refs according to the template merge policy.
+Templates define the query mechanism once. Refs provide only template ids, one
+owner reference, and selector parameters. The refs table uses schema ids for
+column names, so template ids, selector params, and refs column ids must match
+the topology `$defs/id` contract: start with a letter and then use only letters,
+digits, `_`, `.`, `:`, or `-`.
+
+The refs-table convention is:
+
+- `template`: string or string_ref template name resolving to
+  `data.types.overlay_templates`;
+- exactly one convention owner column: `actor` with type `actor_ref` or `link`
+  with type `link_ref`; every row must have a non-null owner value;
+- one column for each selector param required by the referenced template.
+
+Selector params must not use reserved refs-table convention column names:
+`template`, `actor`, or `link`.
+
+No other `actor_ref` or `link_ref` columns are valid in overlay refs. Consumers
+can identify ownership from the fixed `actor` / `link` column ids instead of
+scanning all columns by type.
+
+The `template` column and all selector-param columns required by a row's
+resolved template must be `string` or `string_ref`. Required selector-param row
+values must resolve to non-empty strings. Selector-param columns used by other
+templates may be nullable and null on rows whose template does not require them.
+Future selectors that need `ip_ref`, `mac_ref`, or empty-string matching must
+relax this contract explicitly.
+
+For `provider: "netdata.metrics"`, selector params are interpreted as:
+
+- `node_id`: node-scope selector, not a chart label;
+- `collect_job`: chart label `_collect_job`;
+- other params: same-named chart labels.
+
+Aggregated actors or links merge overlay refs according to the template merge
+policy. `merge.refs` controls ref-list handling, currently `append` or `set`.
+`merge.values` controls how multiple matching metric values collapse, currently
+`sum`, `min`, `max`, `avg`, `last`, or `none`.
 
 ## Compatibility
 

--- a/src/go/pkg/topology/v1/overlay.go
+++ b/src/go/pkg/topology/v1/overlay.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package topologyv1
+
+import "fmt"
+
+const (
+	OverlayProviderNetdataMetrics  = "netdata.metrics"
+	OverlayProviderNetdataFunction = "netdata.function"
+	OverlayProviderExternal        = "external"
+
+	OverlayMergeRefsAppend = "append"
+	OverlayMergeRefsSet    = "set"
+
+	OverlayMergeValuesSum  = "sum"
+	OverlayMergeValuesMin  = "min"
+	OverlayMergeValuesMax  = "max"
+	OverlayMergeValuesAvg  = "avg"
+	OverlayMergeValuesLast = "last"
+	OverlayMergeValuesNone = "none"
+
+	OverlayRefsTemplateColumn = "template"
+	OverlayRefsActorColumn    = "actor"
+	OverlayRefsLinkColumn     = "link"
+)
+
+type OverlayTemplateOption func(*OverlayTemplate)
+
+func NewOverlayTemplate(provider string, merge OverlayMerge, opts ...OverlayTemplateOption) OverlayTemplate {
+	template := OverlayTemplate{
+		Provider: provider,
+		Merge:    merge,
+	}
+	for _, opt := range opts {
+		opt(&template)
+	}
+	return template
+}
+
+func WithOverlayContexts(contexts ...string) OverlayTemplateOption {
+	return func(template *OverlayTemplate) {
+		template.Contexts = append([]string(nil), contexts...)
+	}
+}
+
+func WithOverlayDimensions(dimensions ...string) OverlayTemplateOption {
+	return func(template *OverlayTemplate) {
+		template.Dimensions = append([]string(nil), dimensions...)
+	}
+}
+
+func WithOverlaySelectorParams(params ...string) OverlayTemplateOption {
+	return func(template *OverlayTemplate) {
+		template.SelectorParams = append([]string(nil), params...)
+	}
+}
+
+func NewOverlayMerge(refs, values string) OverlayMerge {
+	return OverlayMerge{
+		Refs:   refs,
+		Values: values,
+	}
+}
+
+type OverlayRefsBuilder struct {
+	strings       *StringDictionary
+	selectorNames []string
+	builder       *TableBuilder
+	err           error
+}
+
+func NewActorOverlayRefsBuilder(strings *StringDictionary, selectorNames ...string) *OverlayRefsBuilder {
+	return newOverlayRefsBuilder(strings, NewColumn(OverlayRefsActorColumn, "actor_ref", WithRole("reference")), selectorNames...)
+}
+
+func NewLinkOverlayRefsBuilder(strings *StringDictionary, selectorNames ...string) *OverlayRefsBuilder {
+	return newOverlayRefsBuilder(strings, NewColumn(OverlayRefsLinkColumn, "link_ref", WithRole("reference")), selectorNames...)
+}
+
+func newOverlayRefsBuilder(strings *StringDictionary, ownerColumn Column, selectorNames ...string) *OverlayRefsBuilder {
+	columns := []Column{
+		NewColumn(OverlayRefsTemplateColumn, "string_ref", WithDictionary("strings")),
+		ownerColumn,
+	}
+	for _, name := range selectorNames {
+		columns = append(columns, NewColumn(name, "string_ref", WithDictionary("strings")))
+	}
+
+	return &OverlayRefsBuilder{
+		strings:       strings,
+		selectorNames: append([]string(nil), selectorNames...),
+		builder:       NewTableBuilder(columns...),
+	}
+}
+
+func (b *OverlayRefsBuilder) Add(template string, owner int, selectorValues ...string) int {
+	row := b.builder.Rows()
+	if b.err != nil {
+		return row
+	}
+	if b.strings == nil {
+		b.err = fmt.Errorf("overlay refs builder requires string dictionary")
+		return row
+	}
+	if len(selectorValues) != len(b.selectorNames) {
+		b.err = fmt.Errorf("overlay ref has %d selector values for %d selector params", len(selectorValues), len(b.selectorNames))
+		return row
+	}
+
+	values := make([]any, 0, len(selectorValues)+2)
+	values = append(values, b.strings.Ref(template), owner)
+	for _, value := range selectorValues {
+		values = append(values, b.strings.Ref(value))
+	}
+	return b.builder.Add(values...)
+}
+
+func (b *OverlayRefsBuilder) Rows() int {
+	return b.builder.Rows()
+}
+
+func (b *OverlayRefsBuilder) OverlayRefs() (*OverlayRefs, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+	if b.Rows() == 0 {
+		return nil, nil
+	}
+	table, err := b.builder.Table()
+	if err != nil {
+		return nil, err
+	}
+	return &OverlayRefs{Refs: &table}, nil
+}

--- a/src/go/pkg/topology/v1/response_test.go
+++ b/src/go/pkg/topology/v1/response_test.go
@@ -1413,6 +1413,436 @@ func TestValidateDecodedResponseAllowsUnusedCorrelationRuleColumns(t *testing.T)
 	require.NoError(t, err)
 }
 
+func TestValidateDecodedResponseRejectsInvalidOverlaySemantics(t *testing.T) {
+	cases := map[string]struct {
+		mutate func(*Data)
+		want   string
+	}{
+		"unknown refs template": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsTemplateColumn, "string"),
+						NewColumn(OverlayRefsActorColumn, "actor_ref"),
+						NewColumn("collect_job", "string"),
+						NewColumn("id", "string"),
+					},
+					[]ColumnEncoding{
+						Const("missing"),
+						Const(0),
+						Const("job"),
+						Const("node-a"),
+					},
+				)}
+			},
+			want: "references unknown overlay template",
+		},
+		"missing selector param column": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsTemplateColumn, "string"),
+						NewColumn(OverlayRefsActorColumn, "actor_ref"),
+						NewColumn("id", "string"),
+					},
+					[]ColumnEncoding{
+						Const("node_cpu"),
+						Const(0),
+						Const("node-a"),
+					},
+				)}
+			},
+			want: "missing selector param column \"collect_job\"",
+		},
+		"reserved selector param column": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				template := data.Types.OverlayTemplates["node_cpu"]
+				template.SelectorParams = []string{OverlayRefsTemplateColumn}
+				data.Types.OverlayTemplates["node_cpu"] = template
+			},
+			want: "uses reserved overlay refs column",
+		},
+		"missing template column": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsActorColumn, "actor_ref"),
+						NewColumn("collect_job", "string"),
+						NewColumn("id", "string"),
+					},
+					[]ColumnEncoding{
+						Const(0),
+						Const("job"),
+						Const("node-a"),
+					},
+				)}
+			},
+			want: "missing required template column",
+		},
+		"template column non-string type": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsTemplateColumn, "uint"),
+						NewColumn(OverlayRefsActorColumn, "actor_ref"),
+						NewColumn("collect_job", "string"),
+						NewColumn("id", "string"),
+					},
+					[]ColumnEncoding{
+						Const(0),
+						Const(0),
+						Const("job"),
+						Const("node-a"),
+					},
+				)}
+			},
+			want: "data.overlays.refs.template column must be string or string_ref",
+		},
+		"missing owner column": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsTemplateColumn, "string"),
+						NewColumn("collect_job", "string"),
+						NewColumn("id", "string"),
+					},
+					[]ColumnEncoding{
+						Const("node_cpu"),
+						Const("job"),
+						Const("node-a"),
+					},
+				)}
+			},
+			want: "must contain exactly one owner column: actor actor_ref or link link_ref",
+		},
+		"non-convention owner column": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsTemplateColumn, "string"),
+						NewColumn("owner", "actor_ref"),
+						NewColumn("collect_job", "string"),
+						NewColumn("id", "string"),
+					},
+					[]ColumnEncoding{
+						Const("node_cpu"),
+						Const(0),
+						Const("job"),
+						Const("node-a"),
+					},
+				)}
+			},
+			want: "data.overlays.refs.owner uses non-convention actor_ref owner column",
+		},
+		"actor owner column wrong type": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsTemplateColumn, "string"),
+						NewColumn(OverlayRefsActorColumn, "link_ref"),
+						NewColumn("collect_job", "string"),
+						NewColumn("id", "string"),
+					},
+					[]ColumnEncoding{
+						Const("node_cpu"),
+						Const(0),
+						Const("job"),
+						Const("node-a"),
+					},
+				)}
+			},
+			want: "data.overlays.refs.actor column must be actor_ref",
+		},
+		"link owner column wrong type": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsTemplateColumn, "string"),
+						NewColumn(OverlayRefsLinkColumn, "actor_ref"),
+						NewColumn("collect_job", "string"),
+						NewColumn("id", "string"),
+					},
+					[]ColumnEncoding{
+						Const("node_cpu"),
+						Const(0),
+						Const("job"),
+						Const("node-a"),
+					},
+				)}
+			},
+			want: "data.overlays.refs.link column must be link_ref",
+		},
+		"multiple owner columns": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsTemplateColumn, "string"),
+						NewColumn(OverlayRefsActorColumn, "actor_ref"),
+						NewColumn(OverlayRefsLinkColumn, "link_ref"),
+						NewColumn("collect_job", "string"),
+						NewColumn("id", "string"),
+					},
+					[]ColumnEncoding{
+						Const("node_cpu"),
+						Const(0),
+						Const(0),
+						Const("job"),
+						Const("node-a"),
+					},
+				)}
+			},
+			want: "must contain exactly one owner column: actor actor_ref or link link_ref",
+		},
+		"null actor owner value": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsTemplateColumn, "string"),
+						NewColumn(OverlayRefsActorColumn, "actor_ref", WithNullable()),
+						NewColumn("collect_job", "string"),
+						NewColumn("id", "string"),
+					},
+					[]ColumnEncoding{
+						Const("node_cpu"),
+						Const(nil),
+						Const("job"),
+						Const("node-a"),
+					},
+				)}
+			},
+			want: "data.overlays.refs.actor[0] is not a non-null owner reference",
+		},
+		"null link owner value": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsTemplateColumn, "string"),
+						NewColumn(OverlayRefsLinkColumn, "link_ref", WithNullable()),
+						NewColumn("collect_job", "string"),
+						NewColumn("id", "string"),
+					},
+					[]ColumnEncoding{
+						Const("node_cpu"),
+						Const(nil),
+						Const("job"),
+						Const("node-a"),
+					},
+				)}
+			},
+			want: "data.overlays.refs.link[0] is not a non-null owner reference",
+		},
+		"selector column non-string type": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsTemplateColumn, "string"),
+						NewColumn(OverlayRefsActorColumn, "actor_ref"),
+						NewColumn("collect_job", "string"),
+						NewColumn("id", "uint"),
+					},
+					[]ColumnEncoding{
+						Const("node_cpu"),
+						Const(0),
+						Const("job"),
+						Const(7),
+					},
+				)}
+			},
+			want: "data.overlays.refs.id column must be string or string_ref",
+		},
+		"empty selector value": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsTemplateColumn, "string"),
+						NewColumn(OverlayRefsActorColumn, "actor_ref"),
+						NewColumn("collect_job", "string"),
+						NewColumn("id", "string"),
+					},
+					[]ColumnEncoding{
+						Const("node_cpu"),
+						Const(0),
+						Const("job"),
+						Const(""),
+					},
+				)}
+			},
+			want: "data.overlays.refs.id[0] is not a non-empty string",
+		},
+		"null selector value": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+					[]Column{
+						NewColumn(OverlayRefsTemplateColumn, "string"),
+						NewColumn(OverlayRefsActorColumn, "actor_ref"),
+						NewColumn("collect_job", "string"),
+						NewColumn("id", "string", WithNullable()),
+					},
+					[]ColumnEncoding{
+						Const("node_cpu"),
+						Const(0),
+						Const("job"),
+						Const(nil),
+					},
+				)}
+			},
+			want: "data.overlays.refs.id[0] is not a non-empty string",
+		},
+		"link type references unknown template": {
+			mutate: func(data *Data) {
+				data.Types.LinkTypes["dependency"] = LinkType{
+					Orientation:      "directed",
+					DirectionRole:    "dependency",
+					Aggregation:      LinkAggregation{Direction: "preserve"},
+					OverlayTemplates: []string{"missing"},
+				}
+			},
+			want: "references unknown overlay template",
+		},
+		"invalid provider": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				template := data.Types.OverlayTemplates["node_cpu"]
+				template.Provider = "unknown"
+				data.Types.OverlayTemplates["node_cpu"] = template
+			},
+			want: "provider has unsupported value",
+		},
+		"invalid merge refs": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				template := data.Types.OverlayTemplates["node_cpu"]
+				template.Merge.Refs = "replace"
+				data.Types.OverlayTemplates["node_cpu"] = template
+			},
+			want: "merge.refs has unsupported value",
+		},
+		"invalid merge values": {
+			mutate: func(data *Data) {
+				data.Types.OverlayTemplates = testOverlayTemplates()
+				template := data.Types.OverlayTemplates["node_cpu"]
+				template.Merge.Values = "median"
+				data.Types.OverlayTemplates["node_cpu"] = template
+			},
+			want: "merge.values has unsupported value",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := minimalValidationData(nil)
+			tc.mutate(&data)
+
+			err := validateResponseData(t, data)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestValidateDecodedResponseAcceptsValidOverlaySemantics(t *testing.T) {
+	data := minimalValidationData(nil)
+	data.Types.OverlayTemplates = testOverlayTemplates()
+	data.Types.LinkTypes["dependency"] = LinkType{
+		Orientation:      "directed",
+		DirectionRole:    "dependency",
+		Aggregation:      LinkAggregation{Direction: "preserve"},
+		OverlayTemplates: []string{"node_cpu"},
+	}
+	data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+		[]Column{
+			NewColumn(OverlayRefsTemplateColumn, "string"),
+			NewColumn(OverlayRefsLinkColumn, "link_ref"),
+			NewColumn("collect_job", "string"),
+			NewColumn("id", "string"),
+		},
+		[]ColumnEncoding{
+			Const("node_cpu"),
+			Const(0),
+			Const("job"),
+			Const("node-a"),
+		},
+	)}
+
+	err := validateResponseData(t, data)
+
+	require.NoError(t, err)
+}
+
+func TestValidateDecodedResponseAcceptsZeroSelectorOverlaySemantics(t *testing.T) {
+	data := minimalValidationData(nil)
+	data.Types.OverlayTemplates = map[string]OverlayTemplate{
+		"node_state": NewOverlayTemplate(
+			OverlayProviderNetdataMetrics,
+			NewOverlayMerge(OverlayMergeRefsSet, OverlayMergeValuesLast),
+		),
+	}
+	data.Overlays = &OverlayRefs{Refs: testOverlayRefsTable(
+		[]Column{
+			NewColumn(OverlayRefsTemplateColumn, "string"),
+			NewColumn(OverlayRefsActorColumn, "actor_ref"),
+		},
+		[]ColumnEncoding{
+			Const("node_state"),
+			Const(0),
+		},
+	)}
+
+	err := validateResponseData(t, data)
+
+	require.NoError(t, err)
+}
+
+func TestValidateDecodedResponseAcceptsMultiTemplateOverlaySelectorScoping(t *testing.T) {
+	data := minimalValidationData(nil)
+	data.Types.OverlayTemplates = map[string]OverlayTemplate{
+		"node_cpu": NewOverlayTemplate(
+			OverlayProviderNetdataMetrics,
+			NewOverlayMerge(OverlayMergeRefsSet, OverlayMergeValuesLast),
+			WithOverlaySelectorParams("cpu_id"),
+		),
+		"node_mem": NewOverlayTemplate(
+			OverlayProviderNetdataMetrics,
+			NewOverlayMerge(OverlayMergeRefsSet, OverlayMergeValuesLast),
+			WithOverlaySelectorParams("mem_id"),
+		),
+	}
+	data.Overlays = &OverlayRefs{Refs: testOverlayRefsTableRows(2,
+		[]Column{
+			NewColumn(OverlayRefsTemplateColumn, "string"),
+			NewColumn(OverlayRefsActorColumn, "actor_ref"),
+			NewColumn("cpu_id", "string", WithNullable()),
+			NewColumn("mem_id", "string", WithNullable()),
+		},
+		[]ColumnEncoding{
+			Values("node_cpu", "node_mem"),
+			Const(0),
+			Values("cpu0", nil),
+			Values(nil, "mem0"),
+		},
+	)}
+
+	err := validateResponseData(t, data)
+
+	require.NoError(t, err)
+}
+
 func TestPresentationTokenEnumsMatchSchema(t *testing.T) {
 	schemaDoc := loadTopologySchema(t)
 
@@ -1424,6 +1854,9 @@ func TestPresentationTokenEnumsMatchSchema(t *testing.T) {
 	assert.ElementsMatch(t, actorSizeScaleTokens, schemaEnum(t, schemaDoc, "actor_size_scale_token"))
 	assert.ElementsMatch(t, linkSemanticRoleTokens, schemaEnum(t, schemaDoc, "link_semantic_role"))
 	assert.ElementsMatch(t, iconTokens, schemaEnum(t, schemaDoc, "icon_token"))
+	assert.ElementsMatch(t, overlayProviderTokens, schemaEnumAtPath(t, schemaDoc, "$defs", "overlay_template", "properties", "provider"))
+	assert.ElementsMatch(t, overlayMergeRefsTokens, schemaEnumAtPath(t, schemaDoc, "$defs", "overlay_merge", "properties", "refs"))
+	assert.ElementsMatch(t, overlayMergeValuesTokens, schemaEnumAtPath(t, schemaDoc, "$defs", "overlay_merge", "properties", "values"))
 }
 
 func TestValidateDecodedResponseRejectsInvalidActorReference(t *testing.T) {
@@ -1565,6 +1998,27 @@ func dependencyLinkTableWith(rows int, extraColumns []Column, extraValues []Colu
 	return MustTable(rows, columns, values)
 }
 
+func testOverlayTemplates() map[string]OverlayTemplate {
+	return map[string]OverlayTemplate{
+		"node_cpu": NewOverlayTemplate(
+			OverlayProviderNetdataMetrics,
+			NewOverlayMerge(OverlayMergeRefsSet, OverlayMergeValuesLast),
+			WithOverlayContexts("system.cpu"),
+			WithOverlayDimensions("user"),
+			WithOverlaySelectorParams("collect_job", "id"),
+		),
+	}
+}
+
+func testOverlayRefsTable(columns []Column, values []ColumnEncoding) *Table {
+	return testOverlayRefsTableRows(1, columns, values)
+}
+
+func testOverlayRefsTableRows(rows int, columns []Column, values []ColumnEncoding) *Table {
+	table := MustTable(rows, columns, values)
+	return &table
+}
+
 func withActors(actors Table) func(*Data) {
 	return func(data *Data) {
 		data.Actors = actors
@@ -1625,9 +2079,20 @@ func loadTopologySchema(t *testing.T) map[string]any {
 func schemaEnum(t *testing.T, schemaDoc map[string]any, defName string) []string {
 	t.Helper()
 
-	defs, ok := schemaDoc["$defs"].(map[string]any)
-	require.True(t, ok)
-	definition, ok := defs[defName].(map[string]any)
+	return schemaEnumAtPath(t, schemaDoc, "$defs", defName)
+}
+
+func schemaEnumAtPath(t *testing.T, schemaDoc map[string]any, path ...string) []string {
+	t.Helper()
+
+	var current any = schemaDoc
+	for _, element := range path {
+		obj, ok := current.(map[string]any)
+		require.True(t, ok)
+		current, ok = obj[element]
+		require.True(t, ok)
+	}
+	definition, ok := current.(map[string]any)
 	require.True(t, ok)
 	rawEnum, ok := definition["enum"].([]any)
 	require.True(t, ok)

--- a/src/go/pkg/topology/v1/validate.go
+++ b/src/go/pkg/topology/v1/validate.go
@@ -28,7 +28,12 @@ type topologyShape struct {
 	tableTypeOwners    map[string]string
 	actorTables        map[string]map[string]string
 	relationshipTables map[string]map[string]string
+	overlayTemplates   map[string]overlayTemplateShape
 	scaleKeys          map[string]struct{}
+}
+
+type overlayTemplateShape struct {
+	selectorParams []string
 }
 
 // ValidateDecodedResponse validates a full topology v1 Function response.
@@ -96,6 +101,9 @@ func ValidateDecodedData(data map[string]any) error {
 	}
 	shape, err := collectTopologyShape(data)
 	if err != nil {
+		return err
+	}
+	if err := validateOverlaySemantics(data, shape, ctx); err != nil {
 		return err
 	}
 	if err := validateTypeColumns(data, shape); err != nil {
@@ -270,6 +278,193 @@ func validateOverlayRefs(raw any, ctx validationContext) error {
 		return err
 	}
 	return nil
+}
+
+func validateOverlaySemantics(data map[string]any, shape topologyShape, ctx validationContext) error {
+	types, _ := data["types"].(map[string]any)
+	if err := validateLinkTypeOverlayTemplates(types["link_types"], shape.overlayTemplates); err != nil {
+		return err
+	}
+	return validateOverlayRefRows(data["overlays"], shape.overlayTemplates, ctx.dictionaries)
+}
+
+func validateLinkTypeOverlayTemplates(raw any, templates map[string]overlayTemplateShape) error {
+	linkTypes, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("data.types.link_types is not an object")
+	}
+	known := make(map[string]struct{}, len(templates))
+	for id := range templates {
+		known[id] = struct{}{}
+	}
+	for typeID, rawType := range linkTypes {
+		linkType, ok := rawType.(map[string]any)
+		if !ok {
+			return fmt.Errorf("data.types.link_types.%s is not an object", typeID)
+		}
+		if err := validateOptionalIDArrayRefs("data.types.link_types."+typeID+".overlay_templates", linkType["overlay_templates"], known, "overlay template"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateOverlayRefRows(raw any, templates map[string]overlayTemplateShape, dictionaries map[string]any) error {
+	if raw == nil {
+		return nil
+	}
+	overlays, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("data.overlays is not an object")
+	}
+	refs, ok := overlays["refs"]
+	if !ok {
+		return nil
+	}
+
+	rows, columns, err := decodedColumnsFromCompactTable("data.overlays.refs", refs)
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return nil
+	}
+
+	templateColumn, ok := columns[OverlayRefsTemplateColumn]
+	if !ok {
+		return fmt.Errorf("data.overlays.refs is missing required %s column", OverlayRefsTemplateColumn)
+	}
+	if !isOverlayRefsStringColumn(templateColumn) {
+		return fmt.Errorf("data.overlays.refs.%s column must be string or string_ref", OverlayRefsTemplateColumn)
+	}
+	ownerColumn, err := validateOverlayOwnerColumns(columns)
+	if err != nil {
+		return err
+	}
+
+	for row := range rows {
+		if ownerColumn.values[row] == nil {
+			return fmt.Errorf("data.overlays.refs.%s[%d] is not a non-null owner reference", ownerColumn.id, row)
+		}
+		templateID, ok := resolveStringValue(templateColumn.values[row], templateColumn.columnType, templateColumn.dictionary, dictionaries)
+		if !ok || templateID == "" {
+			return fmt.Errorf("data.overlays.refs.template[%d] is not a non-empty string", row)
+		}
+		template, ok := templates[templateID]
+		if !ok {
+			return fmt.Errorf("data.overlays.refs.template[%d] references unknown overlay template %q", row, templateID)
+		}
+		for _, param := range template.selectorParams {
+			column, ok := columns[param]
+			if !ok {
+				return fmt.Errorf("data.overlays.refs row %d template %q is missing selector param column %q", row, templateID, param)
+			}
+			if !isOverlayRefsStringColumn(column) {
+				return fmt.Errorf("data.overlays.refs.%s column must be string or string_ref", param)
+			}
+			value, ok := resolveStringValue(column.values[row], column.columnType, column.dictionary, dictionaries)
+			if !ok || value == "" {
+				return fmt.Errorf("data.overlays.refs.%s[%d] is not a non-empty string", param, row)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateOverlayOwnerColumns(columns map[string]decodedCompactColumn) (decodedCompactColumn, error) {
+	owners := 0
+	ownerColumn := decodedCompactColumn{}
+	if column, ok := columns[OverlayRefsActorColumn]; ok {
+		if column.columnType != "actor_ref" {
+			return decodedCompactColumn{}, fmt.Errorf("data.overlays.refs.%s column must be actor_ref", OverlayRefsActorColumn)
+		}
+		ownerColumn = column
+		owners++
+	}
+	if column, ok := columns[OverlayRefsLinkColumn]; ok {
+		if column.columnType != "link_ref" {
+			return decodedCompactColumn{}, fmt.Errorf("data.overlays.refs.%s column must be link_ref", OverlayRefsLinkColumn)
+		}
+		ownerColumn = column
+		owners++
+	}
+	for id, column := range columns {
+		if id == OverlayRefsActorColumn || id == OverlayRefsLinkColumn {
+			continue
+		}
+		if column.columnType == "actor_ref" || column.columnType == "link_ref" {
+			return decodedCompactColumn{}, fmt.Errorf("data.overlays.refs.%s uses non-convention %s owner column", id, column.columnType)
+		}
+	}
+	if owners != 1 {
+		return decodedCompactColumn{}, fmt.Errorf("data.overlays.refs must contain exactly one owner column: actor actor_ref or link link_ref")
+	}
+	return ownerColumn, nil
+}
+
+func isOverlayRefsStringColumn(column decodedCompactColumn) bool {
+	return column.columnType == "string" || column.columnType == "string_ref"
+}
+
+type decodedCompactColumn struct {
+	id         string
+	columnType string
+	dictionary string
+	values     []any
+}
+
+func decodedColumnsFromCompactTable(path string, raw any) (int, map[string]decodedCompactColumn, error) {
+	table, ok := raw.(map[string]any)
+	if !ok {
+		return 0, nil, fmt.Errorf("%s is not an object", path)
+	}
+	rows, err := decodedTableRows(table)
+	if err != nil {
+		return 0, nil, fmt.Errorf("%s: %w", path, err)
+	}
+	rawColumns, ok := table["columns"].([]any)
+	if !ok {
+		return 0, nil, fmt.Errorf("%s.columns is not an array", path)
+	}
+	rawValues, ok := table["values"].([]any)
+	if !ok {
+		return 0, nil, fmt.Errorf("%s.values is not an array", path)
+	}
+	if len(rawColumns) != len(rawValues) {
+		return 0, nil, fmt.Errorf("%s columns/values length mismatch: %d columns, %d values", path, len(rawColumns), len(rawValues))
+	}
+
+	columns := make(map[string]decodedCompactColumn, len(rawColumns))
+	for i, rawColumn := range rawColumns {
+		column, ok := rawColumn.(map[string]any)
+		if !ok {
+			return 0, nil, fmt.Errorf("%s.columns[%d] is not an object", path, i)
+		}
+		columnID, _ := column["id"].(string)
+		if columnID == "" {
+			return 0, nil, fmt.Errorf("%s.columns[%d].id is required", path, i)
+		}
+		if _, ok := columns[columnID]; ok {
+			return 0, nil, fmt.Errorf("%s.columns[%d].id duplicates column %q", path, i, columnID)
+		}
+		columnType, _ := column["type"].(string)
+		if columnType == "" {
+			return 0, nil, fmt.Errorf("%s.columns[%d].type is required", path, i)
+		}
+		values, err := decodeColumn(path, i, rows, rawValues[i])
+		if err != nil {
+			return 0, nil, err
+		}
+		dictionary, _ := column["dictionary"].(string)
+		columns[columnID] = decodedCompactColumn{
+			id:         columnID,
+			columnType: columnType,
+			dictionary: dictionary,
+			values:     values,
+		}
+	}
+	return rows, columns, nil
 }
 
 func validateCompactTable(path string, raw any, ctx validationContext) (int, error) {
@@ -501,6 +696,10 @@ func collectTopologyShape(data map[string]any) (topologyShape, error) {
 	if err != nil {
 		return topologyShape{}, err
 	}
+	overlayTemplates, err := collectOverlayTemplates(types["overlay_templates"])
+	if err != nil {
+		return topologyShape{}, err
+	}
 
 	return topologyShape{
 		actorColumns:       actorColumns,
@@ -513,6 +712,7 @@ func collectTopologyShape(data map[string]any) (topologyShape, error) {
 		tableTypeOwners:    tableTypeOwners,
 		actorTables:        actorTables,
 		relationshipTables: relationshipTables,
+		overlayTemplates:   overlayTemplates,
 		scaleKeys:          scaleKeys,
 	}, nil
 }
@@ -2162,6 +2362,96 @@ func collectScaleKeys(raw any) (map[string]struct{}, error) {
 	return keys, nil
 }
 
+func collectOverlayTemplates(raw any) (map[string]overlayTemplateShape, error) {
+	templates := make(map[string]overlayTemplateShape)
+	if raw == nil {
+		return templates, nil
+	}
+	rawTemplates, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("data.types.overlay_templates is not an object")
+	}
+	for templateID, rawTemplate := range rawTemplates {
+		template, ok := rawTemplate.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("data.types.overlay_templates.%s is not an object", templateID)
+		}
+		if _, err := requiredEnum("data.types.overlay_templates."+templateID+".provider", template["provider"], overlayProviderTokens...); err != nil {
+			return nil, err
+		}
+		if err := validateStringList("data.types.overlay_templates."+templateID+".contexts", template["contexts"], true); err != nil {
+			return nil, err
+		}
+		if err := validateStringList("data.types.overlay_templates."+templateID+".dimensions", template["dimensions"], true); err != nil {
+			return nil, err
+		}
+		selectorParams, err := collectStringList("data.types.overlay_templates."+templateID+".selector_params", template["selector_params"], true)
+		if err != nil {
+			return nil, err
+		}
+		for i, param := range selectorParams {
+			if isOverlayRefsConventionColumn(param) {
+				return nil, fmt.Errorf("data.types.overlay_templates.%s.selector_params[%d] uses reserved overlay refs column %q", templateID, i, param)
+			}
+		}
+		merge, ok := template["merge"].(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("data.types.overlay_templates.%s.merge is not an object", templateID)
+		}
+		if _, err := requiredEnum("data.types.overlay_templates."+templateID+".merge.refs", merge["refs"], overlayMergeRefsTokens...); err != nil {
+			return nil, err
+		}
+		if _, err := requiredEnum("data.types.overlay_templates."+templateID+".merge.values", merge["values"], overlayMergeValuesTokens...); err != nil {
+			return nil, err
+		}
+		templates[templateID] = overlayTemplateShape{
+			selectorParams: selectorParams,
+		}
+	}
+	return templates, nil
+}
+
+func isOverlayRefsConventionColumn(column string) bool {
+	switch column {
+	case OverlayRefsTemplateColumn, OverlayRefsActorColumn, OverlayRefsLinkColumn:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateStringList(path string, raw any, optional bool) error {
+	_, err := collectStringList(path, raw, optional)
+	return err
+}
+
+func collectStringList(path string, raw any, optional bool) ([]string, error) {
+	if raw == nil {
+		if optional {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%s is not an array", path)
+	}
+	rawValues, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s is not an array", path)
+	}
+	values := make([]string, 0, len(rawValues))
+	seen := make(map[string]struct{}, len(rawValues))
+	for i, rawValue := range rawValues {
+		value, ok := rawValue.(string)
+		if !ok || value == "" {
+			return nil, fmt.Errorf("%s[%d] is not a non-empty string", path, i)
+		}
+		if _, ok := seen[value]; ok {
+			return nil, fmt.Errorf("%s[%d] duplicates value %q", path, i, value)
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
 func requiredEnum(path string, raw any, allowed ...string) (string, error) {
 	value, ok := raw.(string)
 	if !ok || value == "" {
@@ -2223,13 +2513,18 @@ var (
 		"info", "structural", "warning", "success", "danger", "blue", "green", "orange",
 		"purple", "cyan", "yellow", "teal", "gray",
 	}
-	opacityTokens          = []string{"normal", "muted", "faded"}
-	widthTokens            = []string{"thin", "normal", "thick", "emphasis"}
-	layoutStrengthTokens   = []string{"weakest", "weaker", "normal", "stronger", "strongest"}
-	layoutDistanceTokens   = []string{"closest", "closer", "normal", "farther", "farthest"}
-	actorSizeScaleTokens   = []string{"compact", "normal", "emphasized"}
-	linkSemanticRoleTokens = []string{"normal", "discovery", "ownership", "traffic", "correlation", "control"}
-	iconTokens             = []string{
+	opacityTokens            = []string{"normal", "muted", "faded"}
+	widthTokens              = []string{"thin", "normal", "thick", "emphasis"}
+	layoutStrengthTokens     = []string{"weakest", "weaker", "normal", "stronger", "strongest"}
+	layoutDistanceTokens     = []string{"closest", "closer", "normal", "farther", "farthest"}
+	actorSizeScaleTokens     = []string{"compact", "normal", "emphasized"}
+	linkSemanticRoleTokens   = []string{"normal", "discovery", "ownership", "traffic", "correlation", "control"}
+	overlayProviderTokens    = []string{OverlayProviderNetdataMetrics, OverlayProviderNetdataFunction, OverlayProviderExternal}
+	overlayMergeRefsTokens   = []string{OverlayMergeRefsAppend, OverlayMergeRefsSet}
+	overlayMergeValuesTokens = []string{
+		OverlayMergeValuesSum, OverlayMergeValuesMin, OverlayMergeValuesMax, OverlayMergeValuesAvg, OverlayMergeValuesLast, OverlayMergeValuesNone,
+	}
+	iconTokens = []string{
 		"router", "switch", "firewall", "access_point", "server", "storage", "load_balancer",
 		"printer", "phone", "ups", "camera", "process", "agent", "netdata-agent", "parent",
 		"remote-endpoint", "local-endpoint", "segment", "self", "ip", "cloud", "container",

--- a/src/go/plugin/go.d/collector/vsphere/func_readiness.go
+++ b/src/go/plugin/go.d/collector/vsphere/func_readiness.go
@@ -125,7 +125,7 @@ func vsphereMethodHandler(job collectorapi.RuntimeJob) funcapi.MethodHandler {
 	}
 	return &funcVSphere{
 		readiness: &funcReadiness{collector: c},
-		topology:  &funcTopology{collector: c, agentID: job.FullName()},
+		topology:  &funcTopology{collector: c, agentID: job.FullName(), jobName: job.Name()},
 	}
 }
 

--- a/src/go/plugin/go.d/collector/vsphere/func_topology.go
+++ b/src/go/plugin/go.d/collector/vsphere/func_topology.go
@@ -27,11 +27,16 @@ const (
 	vsphereOwnershipEvidenceType     = "vsphere_ownership_evidence"
 	vsphereRunsOnEvidenceType        = "vsphere_runs_on_evidence"
 	vsphereNetworkConnectionEvidence = "vsphere_network_connection_evidence"
+
+	vsphereDatastoreUtilizationOverlay = "datastore_space_utilization"
+	vsphereOverlaySelectorCollectJob   = "collect_job"
+	vsphereOverlaySelectorID           = "id"
 )
 
 type funcTopology struct {
 	collector *Collector
 	agentID   string
+	jobName   string
 }
 
 var _ funcapi.MethodHandler = (*funcTopology)(nil)
@@ -60,7 +65,7 @@ func (f *funcTopology) Handle(_ context.Context, method string, _ funcapi.Resolv
 		return funcapi.UnavailableResponse("collector is not initialized")
 	}
 
-	data, ok := f.collector.topologyData(f.agentID)
+	data, ok := f.collector.topologyData(f.agentID, f.jobName)
 	if !ok {
 		return funcapi.UnavailableResponse("topology data not available yet, please retry after discovery")
 	}
@@ -77,7 +82,7 @@ func (f *funcTopology) Cleanup(context.Context) {
 	// No per-invocation resources are allocated by the topology function.
 }
 
-func (c *Collector) topologyData(agentID string) (topologyv1.Data, bool) {
+func (c *Collector) topologyData(agentID, jobName string) (topologyv1.Data, bool) {
 	c.collectionLock.RLock()
 	defer c.collectionLock.RUnlock()
 
@@ -85,7 +90,7 @@ func (c *Collector) topologyData(agentID string) (topologyv1.Data, bool) {
 		return topologyv1.Data{}, false
 	}
 
-	builder := newVSphereTopologyBuilder()
+	builder := newVSphereTopologyBuilder(jobName)
 
 	for _, dc := range sortedDatacenters(c.resources.DataCenters) {
 		builder.addActor("vsphere_datacenter", dc.ID, dc.Name, "", vsphereActorDetail{
@@ -175,7 +180,7 @@ func (c *Collector) topologyData(agentID string) (topologyv1.Data, bool) {
 		}
 	}
 	for _, datastore := range sortedDatastores(c.resources.Datastores) {
-		builder.addActor("vsphere_datastore", datastore.ID, datastore.Name, datastore.Hier.DC.ID, vsphereActorDetail{
+		actor := builder.addActor("vsphere_datastore", datastore.ID, datastore.Name, datastore.Hier.DC.ID, vsphereActorDetail{
 			objectType:         "datastore",
 			datacenter:         datastore.Hier.DC.Name,
 			overallStatus:      datastore.OverallStatus,
@@ -190,6 +195,7 @@ func (c *Collector) topologyData(agentID string) (topologyv1.Data, bool) {
 			"datacenter": datastore.Hier.DC.Name,
 			"type":       datastore.Type,
 		}))
+		builder.addDatastoreUtilizationOverlay(actor, datastore.ID)
 		if c.resources.DataCenters.Get(datastore.Hier.DC.ID) != nil {
 			builder.addLink(datastore.Hier.DC.ID, datastore.ID, vsphereTopologyOwnershipLink, "contains")
 		}

--- a/src/go/plugin/go.d/collector/vsphere/func_topology_test.go
+++ b/src/go/plugin/go.d/collector/vsphere/func_topology_test.go
@@ -42,8 +42,10 @@ func TestFuncTopology_Handle(t *testing.T) {
 				validateVSphereTopologyV1Data(t, data)
 				require.Equal(t, 0, data.Actors.Rows)
 				require.Equal(t, 0, data.Links.Rows)
+				require.Nil(t, data.Overlays)
 				require.EqualValues(t, 0, data.Stats["hosts"])
 				require.EqualValues(t, 0, data.Stats["vms"])
+				require.EqualValues(t, 0, data.Stats["overlay_refs"])
 			},
 		},
 		"unknown method": {
@@ -55,7 +57,7 @@ func TestFuncTopology_Handle(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			handler := &funcTopology{collector: tc.collector(), agentID: "vsphere_vcenter1"}
+			handler := &funcTopology{collector: tc.collector(), agentID: "vsphere_vcenter1", jobName: "vsphere_vcenter1"}
 
 			resp := handler.Handle(context.Background(), tc.method, nil)
 
@@ -151,7 +153,7 @@ func newVSphereTopologyTestCollector() *Collector {
 
 func TestFuncTopology_HandleWithInventoryCache(t *testing.T) {
 	collr := newVSphereTopologyTestCollector()
-	handler := &funcTopology{collector: collr, agentID: "vsphere_vcenter1"}
+	handler := &funcTopology{collector: collr, agentID: "vsphere_vcenter1", jobName: "vsphere_vcenter1"}
 
 	resp := handler.Handle(context.Background(), "topology:vsphere", nil)
 
@@ -167,12 +169,14 @@ func TestFuncTopology_HandleWithInventoryCache(t *testing.T) {
 	require.Equal(t, "virtualization", data.Types.ActorTypes["vsphere_vm"].Layer)
 	require.Equal(t, 8, data.Actors.Rows)
 	require.Equal(t, 9, data.Links.Rows)
+	require.EqualValues(t, 1, data.Stats["overlay_refs"])
 
 	actors := topologyTableRows(t, data.Actors, data.Dictionaries)
 	requireTopologyRow(t, actors, "vsphere_moid", "datacenter-1")
 	requireTopologyRow(t, actors, "vsphere_moid", "domain-c1")
 	requireTopologyRow(t, actors, "vsphere_moid", "host-1")
 	vm := requireTopologyRow(t, actors, "vsphere_moid", "vm-1")
+	datastore := requireTopologyRow(t, actors, "vsphere_moid", "datastore-1")
 	network := requireTopologyRow(t, actors, "vsphere_moid", "network-1")
 	require.Equal(t, "vsphere_vm", vm["type"])
 	require.Equal(t, "vm", vm["object_type"])
@@ -200,6 +204,21 @@ func TestFuncTopology_HandleWithInventoryCache(t *testing.T) {
 	require.Equal(t, "vm-1", runEvidence["source_moid"])
 	require.Equal(t, "host", runEvidence["target_type"])
 	require.Equal(t, "host-1", runEvidence["target_moid"])
+
+	template := data.Types.OverlayTemplates[vsphereDatastoreUtilizationOverlay]
+	require.Equal(t, topologyv1.OverlayProviderNetdataMetrics, template.Provider)
+	require.Equal(t, []string{"vsphere.datastore_space_utilization"}, template.Contexts)
+	require.Equal(t, []string{"used"}, template.Dimensions)
+	require.Equal(t, []string{vsphereOverlaySelectorCollectJob, vsphereOverlaySelectorID}, template.SelectorParams)
+	require.Equal(t, topologyv1.NewOverlayMerge(topologyv1.OverlayMergeRefsSet, topologyv1.OverlayMergeValuesLast), template.Merge)
+
+	require.NotNil(t, data.Overlays)
+	require.NotNil(t, data.Overlays.Refs)
+	refs := topologyTableRows(t, *data.Overlays.Refs, data.Dictionaries)
+	ref := requireTopologyRow(t, refs, vsphereOverlaySelectorID, "datastore-1")
+	require.Equal(t, vsphereDatastoreUtilizationOverlay, ref[topologyv1.OverlayRefsTemplateColumn])
+	require.Equal(t, topologyIntValue(t, datastore["_row"]), topologyIntValue(t, ref[topologyv1.OverlayRefsActorColumn]))
+	require.Equal(t, "vsphere_vcenter1", ref[vsphereOverlaySelectorCollectJob])
 }
 
 func TestFuncTopology_DoesNotLinkToFilteredActors(t *testing.T) {
@@ -232,7 +251,7 @@ func TestFuncTopology_DoesNotLinkToFilteredActors(t *testing.T) {
 		},
 	}
 
-	data, ok := collr.topologyData("agent")
+	data, ok := collr.topologyData("agent", "job")
 
 	require.True(t, ok)
 	validateVSphereTopologyV1Data(t, data)
@@ -243,6 +262,21 @@ func TestFuncTopology_DoesNotLinkToFilteredActors(t *testing.T) {
 	require.Contains(t, keys, "datacenter:datacenter-1->vm:vm-1:vsphere_ownership")
 	require.NotContains(t, keys, "cluster:domain-c-filtered->host:host-1:vsphere_ownership")
 	require.NotContains(t, keys, "vm:vm-1->host:host-filtered:vsphere_runs_on")
+}
+
+func TestFuncTopology_SanitizesOverlayCollectJobLikeChartLabels(t *testing.T) {
+	collr := newVSphereTopologyTestCollector()
+
+	data, ok := collr.topologyData("vsphere_vcenter1", "job'\nname\x00")
+
+	require.True(t, ok)
+	validateVSphereTopologyV1Data(t, data)
+	require.Equal(t, "vsphere_vcenter1", data.Producer.Instance)
+	require.NotNil(t, data.Overlays)
+	require.NotNil(t, data.Overlays.Refs)
+	refs := topologyTableRows(t, *data.Overlays.Refs, data.Dictionaries)
+	ref := requireTopologyRow(t, refs, vsphereOverlaySelectorID, "datastore-1")
+	require.Equal(t, "job name", ref[vsphereOverlaySelectorCollectJob])
 }
 
 func validateVSphereTopologyV1Data(t *testing.T, data topologyv1.Data) {

--- a/src/go/plugin/go.d/collector/vsphere/func_topology_v1_builder.go
+++ b/src/go/plugin/go.d/collector/vsphere/func_topology_v1_builder.go
@@ -58,6 +58,7 @@ type vsphereActorDetail struct {
 
 type vsphereTopologyBuilder struct {
 	strings          *topologyv1.StringDictionary
+	collectJob       string
 	actorIndexes     map[string]int
 	actorObjectTypes map[string]string
 	actors           *topologyv1.TableBuilder
@@ -65,11 +66,14 @@ type vsphereTopologyBuilder struct {
 	evidence         map[string]*topologyv1.TableBuilder
 	details          *topologyv1.TableBuilder
 	labels           *topologyv1.TableBuilder
+	overlays         *topologyv1.OverlayRefsBuilder
 }
 
-func newVSphereTopologyBuilder() *vsphereTopologyBuilder {
+func newVSphereTopologyBuilder(jobName string) *vsphereTopologyBuilder {
+	strings := topologyv1.NewStringDictionary()
 	return &vsphereTopologyBuilder{
-		strings:          topologyv1.NewStringDictionary(),
+		strings:          strings,
+		collectJob:       sanitizeTopologyLabelValue(cleanTopologyString(jobName)),
 		actorIndexes:     make(map[string]int),
 		actorObjectTypes: make(map[string]string),
 		actors:           topologyv1.NewTableBuilder(vsphereTopologyActorColumns()...),
@@ -79,8 +83,9 @@ func newVSphereTopologyBuilder() *vsphereTopologyBuilder {
 			vsphereRunsOnEvidenceType:        topologyv1.NewTableBuilder(vsphereTopologyEvidenceColumns()...),
 			vsphereNetworkConnectionEvidence: topologyv1.NewTableBuilder(vsphereTopologyEvidenceColumns()...),
 		},
-		details: topologyv1.NewTableBuilder(vsphereTopologyDetailColumns()...),
-		labels:  topologyv1.NewTableBuilder(vsphereTopologyLabelColumns()...),
+		details:  topologyv1.NewTableBuilder(vsphereTopologyDetailColumns()...),
+		labels:   topologyv1.NewTableBuilder(vsphereTopologyLabelColumns()...),
+		overlays: topologyv1.NewActorOverlayRefsBuilder(strings, vsphereOverlaySelectorCollectJob, vsphereOverlaySelectorID),
 	}
 }
 
@@ -194,6 +199,10 @@ func (b *vsphereTopologyBuilder) data(agentID string, collectedAt time.Time, res
 	if err != nil {
 		return topologyv1.Data{}, fmt.Errorf("build vSphere topology labels table: %w", err)
 	}
+	overlays, err := b.overlays.OverlayRefs()
+	if err != nil {
+		return topologyv1.Data{}, fmt.Errorf("build vSphere topology overlay refs: %w", err)
+	}
 
 	evidence, evidenceRows, err := b.evidenceMap()
 	if err != nil {
@@ -213,6 +222,10 @@ func (b *vsphereTopologyBuilder) data(agentID string, collectedAt time.Time, res
 	stats["evidence_rows"] = evidenceRows
 	stats["detail_rows"] = detailTable.Rows
 	stats["label_rows"] = labelTable.Rows
+	stats["overlay_refs"] = 0
+	if overlays != nil && overlays.Refs != nil {
+		stats["overlay_refs"] = overlays.Refs.Rows
+	}
 
 	return topologyv1.Data{
 		SchemaVersion: topologyv1.SchemaVersion,
@@ -250,7 +263,8 @@ func (b *vsphereTopologyBuilder) data(agentID string, collectedAt time.Time, res
 				},
 			},
 		},
-		Stats: stats,
+		Stats:    stats,
+		Overlays: overlays,
 	}, nil
 }
 
@@ -354,6 +368,14 @@ func (b *vsphereTopologyBuilder) addActorLabel(actor int, key, value, source, ki
 		b.nullableStringRef(kind),
 		nullableUint(valueIndex),
 	)
+}
+
+func (b *vsphereTopologyBuilder) addDatastoreUtilizationOverlay(actor int, moid string) {
+	moid = cleanTopologyString(moid)
+	if actor < 0 || b.collectJob == "" || moid == "" {
+		return
+	}
+	b.overlays.Add(vsphereDatastoreUtilizationOverlay, actor, b.collectJob, moid)
 }
 
 func (b *vsphereTopologyBuilder) stringRef(value string) int {
@@ -507,6 +529,15 @@ func vsphereTopologyTypes() topologyv1.TypeRegistry {
 			vsphereTopologyDetailTable: vsphereDetailTableType(),
 			vsphereTopologyLabelsTable: vsphereLabelsTableType(),
 		},
+		OverlayTemplates: map[string]topologyv1.OverlayTemplate{
+			vsphereDatastoreUtilizationOverlay: topologyv1.NewOverlayTemplate(
+				topologyv1.OverlayProviderNetdataMetrics,
+				topologyv1.NewOverlayMerge(topologyv1.OverlayMergeRefsSet, topologyv1.OverlayMergeValuesLast),
+				topologyv1.WithOverlayContexts("vsphere.datastore_space_utilization"),
+				topologyv1.WithOverlayDimensions("used"),
+				topologyv1.WithOverlaySelectorParams(vsphereOverlaySelectorCollectJob, vsphereOverlaySelectorID),
+			),
+		},
 	}
 }
 
@@ -644,6 +675,18 @@ func sortedStrings(values []string) []string {
 
 func cleanTopologyString(value string) string {
 	return strings.TrimSpace(value)
+}
+
+// Keep in sync with chartemit.wireValueReplacer so overlay refs match chart labels.
+var topologyLabelValueReplacer = strings.NewReplacer(
+	"'", "",
+	"\n", " ",
+	"\r", " ",
+	"\x00", "",
+)
+
+func sanitizeTopologyLabelValue(value string) string {
+	return topologyLabelValueReplacer.Replace(value)
 }
 
 func nullableBool(value any) any {

--- a/src/go/plugin/go.d/collector/vsphere/integrations/vmware_vcenter_server.md
+++ b/src/go/plugin/go.d/collector/vsphere/integrations/vmware_vcenter_server.md
@@ -881,7 +881,7 @@ No additional configuration is required.
 
 #### Returns
 
-Cached vSphere inventory topology payload using the netdata.topology.v1 schema. Actors represent discovered inventory objects and links represent inventory ownership, VM-to-host runtime placement, and host/VM network attachment relationships.
+Cached vSphere inventory topology payload using the netdata.topology.v1 schema. Actors represent discovered inventory objects, links represent inventory ownership, VM-to-host runtime placement, and host/VM network attachment relationships, and overlays expose refreshable datastore utilization metrics.
 
 | Column | Type | Unit | Visibility | Description |
 |:-------|:-----|:-----|:-----------|:------------|
@@ -896,7 +896,8 @@ Cached vSphere inventory topology payload using the netdata.topology.v1 schema. 
 | links | object |  |  | Compact link table for relationships between vSphere inventory actors. |
 | evidence | object |  |  | Relationship evidence tables backing the rendered links. |
 | tables | object |  |  | Actor detail and label tables used by topology modals. |
-| stats | object |  |  | Counts of discovered inventory objects, actors, and links included in the response. |
+| overlays | object |  |  | Telemetry overlay refs for refreshable metrics, including datastore used-space utilization selected by collector job and vSphere managed object ID. |
+| stats | object |  |  | Counts of discovered inventory objects, actors, links, and overlay refs included in the response. |
 
 
 

--- a/src/go/plugin/go.d/collector/vsphere/metadata.yaml
+++ b/src/go/plugin/go.d/collector/vsphere/metadata.yaml
@@ -503,7 +503,7 @@ modules:
               default: ""
               options: []
           returns:
-            description: Cached vSphere inventory topology payload using the netdata.topology.v1 schema. Actors represent discovered inventory objects and links represent inventory ownership, VM-to-host runtime placement, and host/VM network attachment relationships.
+            description: Cached vSphere inventory topology payload using the netdata.topology.v1 schema. Actors represent discovered inventory objects, links represent inventory ownership, VM-to-host runtime placement, and host/VM network attachment relationships, and overlays expose refreshable datastore utilization metrics.
             columns:
               - name: schema_version
                 type: string
@@ -549,10 +549,14 @@ modules:
                 type: object
                 unit: ""
                 description: Actor detail and label tables used by topology modals.
+              - name: overlays
+                type: object
+                unit: ""
+                description: Telemetry overlay refs for refreshable metrics, including datastore used-space utilization selected by collector job and vSphere managed object ID.
               - name: stats
                 type: object
                 unit: ""
-                description: Counts of discovered inventory objects, actors, and links included in the response.
+                description: Counts of discovered inventory objects, actors, links, and overlay refs included in the response.
           performance: |
             Uses cached collector state only:<br/>• No additional vCenter or ESXi API requests are triggered by the function<br/>• Response size grows with discovered inventory object count<br/>• `collect_network_topology` adds Network discovery during normal collector discovery cycles when enabled
           security: |

--- a/src/go/tools/functions-validation/fixtures/topology-v1/vsphere.json
+++ b/src/go/tools/functions-validation/fixtures/topology-v1/vsphere.json
@@ -64,6 +64,8 @@
         "normal",
         "VMFS",
         "type",
+        "datastore_space_utilization",
+        "vsphere_vcenter1",
         "vsphere_network",
         "network",
         "network-1",
@@ -5426,6 +5428,25 @@
             ]
           }
         }
+      },
+      "overlay_templates": {
+        "datastore_space_utilization": {
+          "provider": "netdata.metrics",
+          "contexts": [
+            "vsphere.datastore_space_utilization"
+          ],
+          "dimensions": [
+            "used"
+          ],
+          "selector_params": [
+            "collect_job",
+            "id"
+          ],
+          "merge": {
+            "refs": "set",
+            "values": "last"
+          }
+        }
       }
     },
     "presentation": {
@@ -5551,9 +5572,9 @@
             18,
             24,
             30,
-            37,
-            44,
-            48
+            39,
+            46,
+            50
           ]
         },
         {
@@ -5564,9 +5585,9 @@
             19,
             25,
             31,
-            38,
-            45,
-            49
+            40,
+            47,
+            51
           ]
         },
         {
@@ -5577,9 +5598,9 @@
             20,
             26,
             32,
-            39,
-            46,
-            50
+            41,
+            48,
+            52
           ]
         },
         {
@@ -5590,9 +5611,9 @@
             21,
             27,
             33,
-            40,
-            47,
-            51
+            42,
+            49,
+            53
           ]
         },
         {
@@ -5718,8 +5739,8 @@
             28,
             16,
             16,
-            42,
-            42,
+            44,
+            44,
             16,
             16
           ]
@@ -5732,8 +5753,8 @@
             29,
             17,
             17,
-            43,
-            43,
+            45,
+            45,
             17,
             17
           ]
@@ -5821,22 +5842,22 @@
             {
               "codec": "values",
               "values": [
-                38,
-                38
+                40,
+                40
               ]
             },
             {
               "codec": "values",
               "values": [
-                39,
-                39
+                41,
+                41
               ]
             },
             {
               "codec": "values",
               "values": [
-                43,
-                43
+                45,
+                45
               ]
             }
           ]
@@ -5923,9 +5944,9 @@
                 10,
                 19,
                 31,
-                38,
-                45,
-                49
+                40,
+                47,
+                51
               ]
             },
             {
@@ -5934,9 +5955,9 @@
                 11,
                 20,
                 32,
-                39,
-                46,
-                50
+                41,
+                48,
+                52
               ]
             },
             {
@@ -6185,10 +6206,10 @@
                   8,
                   1,
                   10,
-                  49,
+                  51,
                   10,
                   1,
-                  49
+                  51
                 ]
               },
               {
@@ -6224,26 +6245,26 @@
                   3,
                   3,
                   35,
+                  42,
                   40,
-                  38,
-                  39,
-                  3,
-                  3,
                   41,
-                  47,
-                  45,
-                  46,
                   3,
                   3,
-                  51,
+                  43,
                   49,
-                  50,
+                  47,
+                  48,
                   3,
-                  12,
+                  3,
+                  53,
                   51,
+                  52,
+                  3,
+                  12,
+                  53,
                   12,
                   3,
-                  51
+                  53
                 ]
               },
               {
@@ -6733,9 +6754,9 @@
                   19,
                   25,
                   31,
-                  38,
-                  45,
-                  49
+                  40,
+                  47,
+                  51
                 ]
               },
               {
@@ -6746,9 +6767,9 @@
                   20,
                   26,
                   32,
-                  39,
-                  46,
-                  50
+                  41,
+                  48,
+                  52
                 ]
               },
               {
@@ -6759,9 +6780,9 @@
                   21,
                   27,
                   33,
-                  40,
-                  47,
-                  51
+                  42,
+                  49,
+                  53
                 ]
               },
               {
@@ -6839,7 +6860,7 @@
                   null,
                   null,
                   null,
-                  51
+                  53
                 ]
               },
               {
@@ -6941,7 +6962,7 @@
                   null,
                   null,
                   null,
-                  41,
+                  43,
                   null,
                   null
                 ]
@@ -7263,6 +7284,59 @@
         }
       }
     },
+    "overlays": {
+      "refs": {
+        "rows": 1,
+        "columns": [
+          {
+            "id": "template",
+            "type": "string_ref",
+            "dictionary": "strings"
+          },
+          {
+            "id": "actor",
+            "type": "actor_ref",
+            "role": "reference"
+          },
+          {
+            "id": "collect_job",
+            "type": "string_ref",
+            "dictionary": "strings"
+          },
+          {
+            "id": "id",
+            "type": "string_ref",
+            "dictionary": "strings"
+          }
+        ],
+        "values": [
+          {
+            "codec": "values",
+            "values": [
+              37
+            ]
+          },
+          {
+            "codec": "values",
+            "values": [
+              4
+            ]
+          },
+          {
+            "codec": "values",
+            "values": [
+              38
+            ]
+          },
+          {
+            "codec": "values",
+            "values": [
+              32
+            ]
+          }
+        ]
+      }
+    },
     "stats": {
       "actor_rows": 8,
       "clusters": 1,
@@ -7275,6 +7349,7 @@
       "label_rows": 50,
       "link_rows": 9,
       "networks": 1,
+      "overlay_refs": 1,
       "resource_pools": 1,
       "vms": 1
     }

--- a/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
@@ -952,8 +952,15 @@ underlying canonical table.
 Topology should be refreshable without recomputing topology. Overlay templates
 define how the UI or Cloud can query metrics for an actor or link.
 
-Templates live once in the type registry. Overlay refs carry only template ids
-and parameters.
+Templates live once in the type registry. Overlay refs carry only template ids,
+one owner reference, and selector parameters.
+
+For `provider: "netdata.metrics"`, selector params are interpreted by the
+consumer:
+
+- `node_id` scopes the metric query to a node;
+- `collect_job` maps to the chart label `_collect_job`;
+- other params map to same-named chart labels.
 
 Example:
 
@@ -965,7 +972,7 @@ Example:
         "provider": "netdata.metrics",
         "contexts": ["snmp.interface_traffic"],
         "dimensions": ["received", "sent"],
-        "selector_params": ["node_id", "interface_id"],
+        "selector_params": ["node_id", "if_name"],
         "merge": {
           "refs": "set",
           "values": "sum"
@@ -977,17 +984,37 @@ Example:
     "refs": {
       "rows": 1,
       "columns": [
-        {"id": "owner_kind", "type": "string_ref", "dictionary": "strings"},
-        {"id": "owner", "type": "link_ref"},
         {"id": "template", "type": "string_ref", "dictionary": "strings"},
+        {"id": "link", "type": "link_ref", "role": "reference"},
         {"id": "node_id", "type": "string_ref", "dictionary": "strings"},
-        {"id": "interface_id", "type": "string_ref", "dictionary": "strings"}
+        {"id": "if_name", "type": "string_ref", "dictionary": "strings"}
       ],
-      "values": []
+      "values": [
+        {"codec": "const", "value": 0},
+        {"codec": "const", "value": 0},
+        {"codec": "const", "value": 1},
+        {"codec": "const", "value": 2}
+      ]
     }
   }
 }
 ```
+
+Overlay refs use schema ids for column names, so selector params and ref column
+ids must start with a letter and contain only letters, digits, `_`, `.`, `:`,
+or `-`. The `template` column identifies the template by name. Exactly one
+convention owner column must be present: `actor` with type `actor_ref` or `link`
+with type `link_ref`. No other `actor_ref` or `link_ref` columns are valid in
+overlay refs. Every row must have a non-null value in the owner column. Each
+selector param used by a referenced template must have a same-named refs-table
+column.
+Selector params must not use the reserved refs-table convention column names
+`template`, `actor`, or `link`.
+
+The `template` column and selector-param columns required by a row's resolved
+template must be `string` or `string_ref`. Required selector-param values must
+resolve to non-empty strings. Selector-param columns used by other templates may
+be nullable and null on rows whose template does not require them.
 
 Overlay refs are optional. Do not fabricate per-link bandwidth if the producer
 does not have it. For network sockets, current evidence may include snapshot


### PR DESCRIPTION
## Summary

Fixes: #22617

Add reusable topology v1 overlay helpers and validation, then use them to emit the first vSphere metric overlay.

## What changed

- Added topology v1 overlay helper APIs for templates, merge policies, and actor/link overlay refs.
- Added semantic validation for overlay templates and refs:
  - template existence
  - exactly one actor/link owner column
  - required selector-param columns
  - reserved selector-param names
  - string/string_ref selector types and non-empty selector values
  - link-type overlay template references
  - provider/merge enum membership
- Added a vSphere datastore utilization overlay:
  - context: `vsphere.datastore_space_utilization`
  - dimension: `used`
  - selector params: `collect_job`, `id`
- Documented `collect_job -> _collect_job` mapping for `netdata.metrics` overlays.
- Updated vSphere topology fixture, metadata, generated integration docs, topology developer guide, topology spec, and topology project skill.

## Why

Topology v1 already had overlay schema fields, but Go producers did not have reusable helper APIs and validation did not catch malformed overlay refs/templates. This establishes the clean producer pattern and proves it with a real vSphere overlay without adding broader overlay product scope in the same PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reusable topology v1 overlay helpers and end-to-end validation, and emits a vSphere datastore used-space overlay via netdata.metrics. The topology response now includes overlay refs and a new overlay_refs stat. Addresses #22617.

- New Features
  - Added `topologyv1` overlay APIs: `NewOverlayTemplate`, `NewOverlayMerge`, `WithOverlayContexts`, `WithOverlayDimensions`, `WithOverlaySelectorParams`, `NewActorOverlayRefsBuilder`, `NewLinkOverlayRefsBuilder`.
  - Enforced overlay validation: known template ids; exactly one convention owner column (`actor`/`link`) with non-null values; required selector-param columns; reserved names (`template`, `actor`, `link`) blocked; `string`/`string_ref` types and non-empty selector values; no extra `actor_ref`/`link_ref` columns; link-type `overlay_templates` references; and provider/merge enums.
  - vSphere: added `datastore_space_utilization` overlay (context `vsphere.datastore_space_utilization`, dimension `used`; selectors `collect_job`, `id`) and emit refs per datastore; `collect_job` uses sanitized `job.Name()`; new `overlay_refs` stat.
  - Updated fixtures, integration docs, topology schema/spec, and developer guide to document refs-table conventions and `netdata.metrics` selector behavior.

<sup>Written for commit 421e6e193419911ba5d4327177ac814f5e85443a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

