### PR TITLE
Add escaped secretstore references

### DIFF
--- a/integrations/gen_doc_secrets_page.py
+++ b/integrations/gen_doc_secrets_page.py
@@ -57,9 +57,9 @@ SECRETS_PAGE = {
         },
         {
             "resolver": "Secretstore",
-            "syntax": "`${store:<kind>:<name>:<operand>}`",
+            "syntax": "`${store:<kind>:<name>:<operand>[:escape]}`",
             "best_for": "Secrets stored in remote backends such as Vault, AWS, Azure, or GCP",
-            "notes": "Configure the secretstore first, then reference it from collector configs.",
+            "notes": "Configure the secretstore first. Add `:escape` when embedding the value in a URI.",
         },
     ],
     "choosing_a_resolver": [
@@ -118,11 +118,12 @@ jobs:
         "heading": "## Secretstores",
         "body": "Use secretstores when you want Netdata collectors to fetch secrets from remote backends at runtime instead of storing them locally in collector configs.",
         "reference_intro": "Configure a secretstore first, then reference it from collector configs with:",
-        "reference_syntax": "${store:<kind>:<name>:<operand>}",
+        "reference_syntax": "${store:<kind>:<name>:<operand>[:escape]}",
         "reference_parts": [
             {"name": "`kind`", "description": "Secretstore backend kind, such as `vault` or `aws-sm`."},
             {"name": "`name`", "description": "The store name you configured in Netdata, such as `vault_prod`."},
             {"name": "`operand`", "description": "Backend-specific identifier for the secret you want to read."},
+            {"name": "`escape`", "description": "Optional suffix that percent-encodes the resolved value for URI contexts."},
         ],
         "example": """```yaml
 jobs:
@@ -157,7 +158,8 @@ jobs:
             "  - name: mysql_prod\n"
             '    dsn: "${env:MYSQL_USER}:${store:vault:vault_prod:secret/data/netdata/mysql#password}@tcp(127.0.0.1:3306)/"\n'
             "```\n\n"
-            "Different jobs within the same collector config file can also use different resolver types."
+            "Different jobs within the same collector config file can also use different resolver types. "
+            "If you embed a secretstore value inside a URI, append `:escape` to percent-encode delimiter characters in the resolved value."
         ),
         "multiple_stores": (
             "Each secretstore config file can contain multiple `jobs` entries, each with a unique store name. "

--- a/src/collectors/SECRETS.md
+++ b/src/collectors/SECRETS.md
@@ -16,7 +16,7 @@ Netdata lets you reference secret values in collector configs instead of storing
 | Environment variable | `${env:VAR_NAME}` | Secrets already injected into the Netdata service environment | Value is trimmed. The variable must exist. |
 | File | `${file:/absolute/path}` | Secrets stored in local files on disk | The path must be absolute. File contents are trimmed. |
 | Command | `${cmd:/absolute/path/to/command args}` | Secrets returned by a trusted local command | The command path must be absolute. Netdata uses a 10-second timeout. |
-| Secretstore | `${store:<kind>:<name>:<operand>}` | Secrets stored in remote backends such as Vault, AWS, Azure, or GCP | Configure the secretstore first, then reference it from collector configs. |
+| Secretstore | `${store:<kind>:<name>:<operand>[:escape]}` | Secrets stored in remote backends such as Vault, AWS, Azure, or GCP | Configure the secretstore first. Add `:escape` when embedding the value in a URI. |
 
 ## Choosing a Resolver
 
@@ -76,7 +76,7 @@ Use secretstores when you want Netdata collectors to fetch secrets from remote b
 Configure a secretstore first, then reference it from collector configs with:
 
 ```text
-${store:<kind>:<name>:<operand>}
+${store:<kind>:<name>:<operand>[:escape]}
 ```
 
 | Part | Description |
@@ -84,6 +84,7 @@ ${store:<kind>:<name>:<operand>}
 | `kind` | Secretstore backend kind, such as `vault` or `aws-sm`. |
 | `name` | The store name you configured in Netdata, such as `vault_prod`. |
 | `operand` | Backend-specific identifier for the secret you want to read. |
+| `escape` | Optional suffix that percent-encodes the resolved value for URI contexts. |
 
 Example:
 
@@ -147,7 +148,7 @@ jobs:
     dsn: "${env:MYSQL_USER}:${store:vault:vault_prod:secret/data/netdata/mysql#password}@tcp(127.0.0.1:3306)/"
 ```
 
-Different jobs within the same collector config file can also use different resolver types.
+Different jobs within the same collector config file can also use different resolver types. If you embed a secretstore value inside a URI, append `:escape` to percent-encode delimiter characters in the resolved value.
 
 ## Supported Secretstore Backends
 

--- a/src/go/plugin/agent/jobmgr/secretstore_flow_test.go
+++ b/src/go/plugin/agent/jobmgr/secretstore_flow_test.go
@@ -101,6 +101,23 @@ func TestApplyConfig_ResolvesStoreReferenceWithKindAndName(t *testing.T) {
 	assert.Equal(t, 7, module.Config.OptionInt)
 }
 
+func TestApplyConfig_ResolvesEscapedStoreReferenceInDSN(t *testing.T) {
+	svc := newTestSecretStoreService()
+	raw := newSecretStoreConfigWithSource(t, secretstore.KindVault, "vault_prod", map[string]any{"value": "pa/ss+word: a@"}, confgroup.TypeDyncfg, confgroup.TypeDyncfg)
+	require.NoError(t, svc.Add(context.Background(), raw))
+
+	cfg := prepareDyncfgCfg("success", "secret-job").
+		Set("option_str", "postgresql://postgres:${store:vault:vault_prod:value:escape}@db.example/postgres").
+		Set("option_int", 7)
+
+	module := &collectorapi.MockCollectorV1{}
+	err := applyConfig(t.Context(), cfg, module, secretresolver.New(), svc, svc.Capture())
+	require.NoError(t, err)
+
+	assert.Equal(t, "postgresql://postgres:pa%2Fss%2Bword%3A%20a%40@db.example/postgres", module.Config.OptionStr)
+	assert.Equal(t, 7, module.Config.OptionInt)
+}
+
 func TestRun_StartupLoadedSecretStoreIsAvailableToFirstCollectorStart(t *testing.T) {
 	initial := newSecretStoreConfigWithSource(t, secretstore.KindVault, "vault_prod", map[string]any{"value": "good"}, "file=/etc/netdata/go.d/ss/vault.conf", confgroup.TypeUser)
 	mgr := New(Config{

--- a/src/go/plugin/agent/secrets/secretstore/runtime_resolver.go
+++ b/src/go/plugin/agent/secrets/secretstore/runtime_resolver.go
@@ -35,6 +35,7 @@ func (r *runtimeResolver) resolveContext(ctx context.Context, snapshot *Snapshot
 	kind := StoreKind(strings.TrimSpace(kindPart))
 	name := strings.TrimSpace(namePart)
 	operand = strings.TrimSpace(operand)
+	operand, escapeValue := parseStoreOperandOption(operand)
 	if !kind.IsValid() || name == "" || operand == "" {
 		return "", fmt.Errorf("resolving secret '%s': store reference must be in format 'kind:name:operand'", original)
 	}
@@ -51,11 +52,46 @@ func (r *runtimeResolver) resolveContext(ctx context.Context, snapshot *Snapshot
 		return "", fmt.Errorf("resolving secret '%s': secretstore '%s' has no published resolver state", original, storeKey)
 	}
 
-	return store.published.Resolve(ctx, ResolveRequest{
+	value, err := store.published.Resolve(ctx, ResolveRequest{
 		StoreKey:  storeKey,
 		StoreKind: kind,
 		StoreName: name,
 		Operand:   operand,
 		Original:  original,
 	})
+	if err != nil {
+		return "", err
+	}
+	if escapeValue {
+		return percentEncodeStoreValue(value), nil
+	}
+	return value, nil
+}
+
+func parseStoreOperandOption(operand string) (string, bool) {
+	const escapeSuffix = ":escape"
+	if !strings.HasSuffix(operand, escapeSuffix) {
+		return operand, false
+	}
+	return strings.TrimSpace(strings.TrimSuffix(operand, escapeSuffix)), true
+}
+
+func percentEncodeStoreValue(value string) string {
+	var out strings.Builder
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		if isRFC3986Unreserved(c) {
+			out.WriteByte(c)
+			continue
+		}
+		fmt.Fprintf(&out, "%%%02X", c)
+	}
+	return out.String()
+}
+
+func isRFC3986Unreserved(c byte) bool {
+	return (c >= 'A' && c <= 'Z') ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= '0' && c <= '9') ||
+		c == '-' || c == '.' || c == '_' || c == '~'
 }

--- a/src/go/plugin/agent/secrets/secretstore/runtime_resolver_test.go
+++ b/src/go/plugin/agent/secrets/secretstore/runtime_resolver_test.go
@@ -4,6 +4,7 @@ package secretstore_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
@@ -48,6 +49,100 @@ func TestRuntimeResolverResolveErrors(t *testing.T) {
 			_, err := enabledSvc.Resolve(t.Context(), tc.snapshot, tc.ref, tc.original)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantErrContains)
+		})
+	}
+}
+
+type runtimeOptionStoreConfig struct {
+	Value string `yaml:"value" json:"value"`
+}
+
+type runtimeOptionStore struct {
+	runtimeOptionStoreConfig `yaml:",inline" json:""`
+	seenOperands             *[]string
+}
+
+func (s *runtimeOptionStore) Configuration() any { return &s.runtimeOptionStoreConfig }
+
+func (s *runtimeOptionStore) Init(context.Context) error {
+	if s.Value == "" {
+		return fmt.Errorf("value is required")
+	}
+	return nil
+}
+
+func (s *runtimeOptionStore) Publish() secretstore.PublishedStore {
+	return &runtimeOptionPublishedStore{value: s.Value, seenOperands: s.seenOperands}
+}
+
+type runtimeOptionPublishedStore struct {
+	value        string
+	seenOperands *[]string
+}
+
+func (s *runtimeOptionPublishedStore) Resolve(_ context.Context, req secretstore.ResolveRequest) (string, error) {
+	if s.seenOperands != nil {
+		*s.seenOperands = append(*s.seenOperands, req.Operand)
+	}
+	return s.value, nil
+}
+
+func newRuntimeOptionService(t *testing.T, value string, seenOperands *[]string) secretstore.Service {
+	t.Helper()
+
+	svc := secretstore.NewService(secretstore.Creator{
+		Kind:        secretstore.KindVault,
+		DisplayName: "Vault",
+		Schema:      `{"jsonSchema":{"type":"object","properties":{"value":{"type":"string"}}},"uiSchema":[]}`,
+		Create: func() secretstore.Store {
+			return &runtimeOptionStore{seenOperands: seenOperands}
+		},
+	})
+	cfg := newStoreFromConfig(t, svc, secretstore.KindVault, map[string]any{
+		"name":  "vault_prod",
+		"value": value,
+	})
+	require.NoError(t, svc.Add(context.Background(), cfg))
+	return svc
+}
+
+func TestRuntimeResolverResolveOptions(t *testing.T) {
+	tests := map[string]struct {
+		ref         string
+		original    string
+		wantValue   string
+		wantOperand string
+	}{
+		"raw reference keeps raw value": {
+			ref:         "vault:vault_prod:secret/data/app#password",
+			original:    "${store:vault:vault_prod:secret/data/app#password}",
+			wantValue:   "pa/ss+word: a@~",
+			wantOperand: "secret/data/app#password",
+		},
+		"escape option percent encodes resolved value": {
+			ref:         "vault:vault_prod:secret/data/app#password:escape",
+			original:    "${store:vault:vault_prod:secret/data/app#password:escape}",
+			wantValue:   "pa%2Fss%2Bword%3A%20a%40~",
+			wantOperand: "secret/data/app#password",
+		},
+		"unrecognized suffix remains part of operand": {
+			ref:         "vault:vault_prod:secret/data/app#password:literal",
+			original:    "${store:vault:vault_prod:secret/data/app#password:literal}",
+			wantValue:   "pa/ss+word: a@~",
+			wantOperand: "secret/data/app#password:literal",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			seenOperands := []string{}
+			svc := newRuntimeOptionService(t, "pa/ss+word: a@~", &seenOperands)
+
+			got, err := svc.Resolve(t.Context(), svc.Capture(), tc.ref, tc.original)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantValue, got)
+			assert.Equal(t, []string{tc.wantOperand}, seenOperands)
 		})
 	}
 }


### PR DESCRIPTION
##### Summary
Fixes #22507.

This adds an opt-in `:escape` suffix for secretstore references, for example `${store:vault:vault_prod:path#key:escape}`. The default remains raw, so existing references keep their current behavior, while URI/DSN contexts can percent-encode delimiter characters in the resolved secret value.

The secretstore runtime resolver strips only the recognized `:escape` suffix before calling the backend, then percent-encodes the resolved value using RFC 3986 unreserved characters as the safe set. The docs generator and generated `src/collectors/SECRETS.md` are updated with the new syntax.

##### Test Plan

- Red before fix: `go test ./plugin/agent/secrets/secretstore -run TestRuntimeResolverResolveOptions -count=1`
- Red before fix: `go test ./plugin/agent/jobmgr -run TestApplyConfig_ResolvesEscapedStoreReferenceInDSN -count=1`
- `go test ./plugin/agent/secrets/secretstore -run TestRuntimeResolverResolveOptions -count=1`
- `go test ./plugin/agent/jobmgr -run TestApplyConfig_ResolvesEscapedStoreReferenceInDSN -count=1`
- `go test ./plugin/agent/secrets/secretstore -count=1`
- `go test ./plugin/agent/jobmgr -run 'TestApplyConfig|TestRun_StartupLoadedSecretStoreIsAvailableToFirstCollectorStart|TestDyncfgSecretStoreUpdate_DependentRestartBehavior' -count=1`
- `python3 -m venv ./virtualenv && . ./virtualenv/bin/activate && ./integrations/pip.sh && python3 integrations/gen_integrations.py && python3 integrations/gen_doc_secrets_page.py`
- `go test ./plugin/agent/secrets/... -count=1`
- `go test ./plugin/agent/jobmgr -count=1`
- `python3 -m py_compile integrations/gen_doc_secrets_page.py`
- `git diff --check`

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>

Collectors using plain `${store:<kind>:<name>:<operand>}` references keep receiving raw secret values. When a secretstore value is embedded inside a URI or DSN, append `:escape` to percent-encode delimiter characters before interpolation.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `:escape` suffix for secretstore references to safely embed secrets in URIs/DSNs by percent-encoding special characters. Existing references keep returning raw values.

- **New Features**
  - New syntax: `${store:<kind>:<name>:<operand>[:escape]}`.
  - With `:escape`, the resolver percent-encodes the resolved value using RFC 3986 (unreserved chars pass through).
  - The resolver strips `:escape` before calling the backend, so the operand sent to the store is unchanged.
  - Tests cover runtime resolver options and DSN usage; a DSN example validates correct encoding.
  - Docs updated in `SECRETS.md` and `integrations/gen_doc_secrets_page.py` with syntax and guidance.

<sup>Written for commit 50204957072ba61ffc2cc9c8cb323ea7a90b969a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

