### PR TITLE
chore: clarify the SOW lifecycle and strengthen the Mandatory Development Principles

### DIFF
--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -153,7 +153,7 @@ Sensitive data gate:
 
 - <Confirm durable artifacts contain no raw secrets, credentials, bearer tokens, SNMP communities, community member names, customer names, personal data, non-private customer-identifying IPs, private endpoints, or proprietary incident details; note redactions used.>
 
-Artifact maintenance gate:
+## Artifact Maintenance Gate
 
 - AGENTS.md: <updated path or evidence-backed reason no update was needed>
 - Runtime project skills: <updated .agents/skills/project-*/ path or evidence-backed reason no update was needed>

--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -5,9 +5,9 @@
 Status: planning | ready | in-progress | paused | completed
 
 `planning` means analysis or decisions are incomplete. `ready` means the
-Pre-Implementation Gate is complete and implementation can start. `completed`
-is a transient branch-local state before deleting this SOW working file before
-merge. SOW files live only under `.agents/sow/active/` on feature branches and
+Pre-Implementation Gate is complete and, where the goal-approval round ("Plan
+before non-trivial work") applies, the user has approved the goal and plan. `completed` is a
+transient branch-local state before deleting this SOW working file before merge. SOW files live only under `.agents/sow/active/` on feature branches and
 MUST NOT be merged to `master`.
 
 Sub-state: <short current truth>
@@ -68,11 +68,18 @@ Problem / root-cause model:
 Evidence reviewed:
 
 - <Specs, code, docs, tests, logs, traces, prior PRs/issues, external references.>
-- <For mirrored open-source repositories: cite `owner/repo @ commit` and repository-relative paths; never paste `/opt/baddisk/monitoring/repos/...` absolute paths.>
+- <For mirrored open-source repositories: cite `owner/repo @ commit` and repository-relative paths; never paste machine-specific absolute mirror paths (the mirror lives at `${NETDATA_REPOS_DIR}`).>
 
 Affected contracts and surfaces:
 
 - <APIs, schemas, files, commands, UI, docs, specs, skills, tests, integrations, operators, users.>
+
+Clean-end-state target:
+
+- <The structure the codebase should have once the approved scope is fully delivered.>
+- Removed as redundant (i): <code/config/docs/tests this change makes redundant.>
+- Excluded coupled items (ii): <coupled items NOT part of this clean end state, each with reason + scope source.>
+- Reference search (when a path/contract is replaced): <command(s) run + result; every surviving reference mapped to (i)/(ii), or the target is incomplete.>
 
 Existing patterns to reuse:
 
@@ -106,7 +113,7 @@ Artifact impact plan:
 
 Open-source reference evidence:
 
-- <If local mirrored repositories under `/opt/baddisk/monitoring/repos/` were checked, list each as `owner/repo @ commit` plus repository-relative paths. If none were checked, record why external OSS references were not relevant.>
+- <If local mirrored repositories under `${NETDATA_REPOS_DIR}` were checked, list each as `owner/repo @ commit` plus repository-relative paths. If none were checked, record why external OSS references were not relevant.>
 
 Open decisions:
 

--- a/.agents/sow/audit.sh
+++ b/.agents/sow/audit.sh
@@ -83,6 +83,7 @@ required_sections=(
   "### Roles"
   "### Git Worktrees"
   "### Sensitive Data In Durable Artifacts"
+  "### Durable AI-Facing Artifact Formatting"
   "### Open-Source Reference Evidence"
   "### Pre-Implementation Gate"
   "### SOW Completion And Merge"

--- a/.github/workflows/sow.yml
+++ b/.github/workflows/sow.yml
@@ -30,7 +30,7 @@ jobs:
 
           while IFS= read -r file; do
             [ -n "$file" ] || continue
-            echo "::error file=${file}::SOW working files are branch-local and must be deleted before merge."
+            echo "::error file=${file}::SOW working files may be committed for takeover/handoff and must be deleted before merge."
             found=1
           done < <(
             {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,11 +33,28 @@ CRITICAL RULES:
 These principles are mandatory for every task in this repository:
 
 1. **Clean end state over less churn.**
-   You MUST always aim for the clean end state, not the smallest diff. While
-   designing and implementing, actively search for the structure that should
-   exist after the work is complete. You MUST periodically re-evaluate
-   already-written changes against that target; do not keep a compromise only
-   because it already exists in the branch.
+   - Target: you MUST always aim for the clean end state, not the smallest diff.
+     While designing and implementing, actively search for the structure that
+     should exist after the work is complete.
+   - Re-evaluation: you MUST periodically re-evaluate already-written changes
+     against that target. Do not keep a compromise only because it already
+     exists in the branch.
+   - Recommendation default: when options include a clean end state and a
+     lower-churn partial state, you MUST recommend the clean end state unless it
+     is technically impossible, unsafe, or explicitly outside the approved
+     scope.
+   - Exception handling: technical impossibility, safety risk, or scope conflict
+     are pause conditions, not permission to choose the partial route
+     automatically. Present the evidence, interrupt the work, and get explicit
+     human approval before proceeding with a temporary non-clean state.
+   - Staged delivery: if recommending staged delivery, explain why the staged
+     plan still reaches the clean end state for the approved work, or explicitly
+     state that you are asking the user to accept a temporary non-clean state.
+   - Invalid justification: risk reduction, review convenience, or issue staging
+     is not enough justification for recommending a partial end state.
+   - Deferral check: before recommending deferral, check the issue, SOW,
+     acceptance criteria, and affected migration scope for evidence that the
+     deferred work is genuinely outside the approved clean end state.
 
 2. **Scope discipline at every step.**
    At each milestone, you MUST check whether the work has drifted outside the
@@ -65,11 +82,16 @@ Project SOW status: initialized
 
 This project uses a local Statement of Work system.
 
-SOWs are branch-local working memory, not product artifacts. A SOW lives on the
-feature branch for the duration of the work so it preserves the root-cause
-model, decisions, evidence, and validation for PR takeover. It is removed before
-the branch merges. `master` MUST contain no SOW working files; durable memory
-belongs in `.agents/sow/specs/`, project skills, docs, code, and tests.
+SOWs are branch-local working memory, not product artifacts. During active work,
+including draft PR and ready-for-review takeover work, a SOW may live on the
+feature branch so it preserves the root-cause model, decisions, evidence, and
+validation for PR takeover. Commit the active SOW on the feature branch when
+takeover or handoff is expected. When no takeover is expected, keeping the
+active SOW local and uncommitted is acceptable, but the SOW still MUST be used
+as working memory. Before merge, complete the SOW, transfer durable knowledge,
+and delete the active SOW file. `master` and the final merge head MUST contain
+no SOW working files; durable memory belongs in `.agents/sow/specs/`, project
+skills, docs, code, and tests.
 
 The SOW system is self-contained in this repository. Normal SOW work must not depend on `~/.agents`, `~/.AGENTS.md`, global skills, global templates, or global scripts. Use this `AGENTS.md`, the branch-local SOW, project-local specs, and project-local skills.
 
@@ -107,6 +129,34 @@ Write only sanitized evidence:
 - summarize logs and traces; include only minimal redacted snippets.
 
 If sensitive data is required to continue, stop and ask the user for a secure handling path. If sensitive data is found in a durable artifact, sanitize it before any commit. If sensitive data was already committed, tell the user and do not rewrite history without explicit approval.
+
+### Durable AI-Facing Artifact Formatting
+
+AI-facing durable artifacts include `AGENTS.md`, SOW specs, runtime project
+skills, public/operator skills, SOW templates, instruction bridge files, and
+other docs primarily written so future AI agents can execute repository rules
+correctly.
+
+When writing or updating these artifacts:
+
+- Structure for retrieval and scanning. Use headings, short sections, labeled
+  bullets, and numbered procedures so both humans and AI agents can find the
+  exact rule quickly.
+- Avoid dense multi-rule paragraphs. If a paragraph contains multiple
+  requirements, exceptions, or decision branches, split it into bullets or a
+  table.
+- Use tables only for matrices or comparisons where the cells stay short. Use
+  bullets for rules, workflows, checklists, and exception handling.
+- Put RFC-style requirement words (`MUST`, `MUST NOT`, `SHOULD`, `MAY`) close
+  to the action they govern. Do not hide mandatory behavior in explanatory
+  prose.
+- Prefer labeled bullets for operational guardrails, such as `Target`,
+  `Exception handling`, `Validation`, or `Failure mode`.
+- Keep one durable idea per bullet. If a bullet needs multiple sentences, the
+  first sentence states the rule and later sentences provide evidence,
+  rationale, or examples.
+- Preserve precision over brevity. Formatting is for readability, not for
+  weakening contracts or removing necessary evidence.
 
 ### Open-Source Reference Evidence
 
@@ -164,7 +214,8 @@ When unsure, treat the work as non-trivial.
 
 There is no `done/` directory and no committed pending queue. On `master`,
 `.agents/sow/active/` is empty except for `.gitkeep`; real SOW files exist only
-on feature branches and are deleted before merge.
+on feature branches. Feature branches and PRs may commit active SOW files when
+takeover or handoff is expected, but active SOW files are deleted before merge.
 
 Create new SOW files from `.agents/sow/SOW.template.md`. The template is project-local and may be customized for this repository.
 
@@ -191,8 +242,9 @@ Deferred work has two valid tracking paths:
 - public or team-visible follow-up: GitHub issue;
 - private or local follow-up: `<repo-root>/.local/sow/`.
 
-Active implementation work still MUST use `.agents/sow/active/`, and active SOW
-files still MUST be deleted before merge.
+Active implementation work still MUST use `.agents/sow/active/`. Active SOW
+files MAY be committed for takeover or handoff and still MUST be deleted before
+merge.
 
 Filename:
 
@@ -222,7 +274,11 @@ When a SOW's work is ready to merge:
 3. Update the SOW to `Status: completed`.
 4. Delete the SOW working file before merge.
 
-The branch HEAD that merges MUST contain no `.agents/sow/active/SOW-*.md` file. CI enforces this.
+Draft and ready-for-review PRs MAY temporarily contain
+`.agents/sow/active/SOW-*.md` files when takeover or handoff is expected. The
+SOW CI job still rejects committed active SOW files; that red check is an
+intentional merge guard, not a sign that handoff or takeover is forbidden. The
+branch HEAD that merges MUST contain no `.agents/sow/active/SOW-*.md` file.
 
 ### Enforcement
 
@@ -234,7 +290,9 @@ The SOW system is enforced by local audit tooling and CI:
   local audit and CI.
 - `.github/workflows/sow.yml` rejects pull requests that contain branch-local
   SOW working files under `.agents/sow/active/SOW-*.md` or legacy SOW working
-  files under `.agents/sow/{pending,current,done}/SOW-*.md`.
+  files under `.agents/sow/{pending,current,done}/SOW-*.md`. This failure is
+  expected when an active SOW is intentionally committed for takeover or
+  handoff; it MUST be cleared before merge.
 - The same workflow scans changed SOW, spec, instruction, and cross-tool
   bridge files for raw sensitive data.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,38 +30,221 @@ CRITICAL RULES:
 
 ## Mandatory Development Principles
 
-These principles are mandatory for every task in this repository:
+These principles are mandatory for every task. Code is cheap to add and
+expensive to live with, so a larger diff that removes debt beats a smaller one
+that preserves it.
+
+**Core (read first; the bullets under each principle are the authority for forks
+and edge cases):**
+
+- Deliver the **clean end state** of the approved scope, not the smallest diff —
+  including removing what the change makes redundant; refactor low-risk mess in
+  code you touch.
+- **Record that target in the SOW first** (what you remove; any coupled item you
+  exclude, with its reason). When you replace a path or contract, record a
+  reference search proving the list is complete.
+- **You are not the scope authority.** Coupled cleanup is in scope: do the
+  low-risk part and disclose it; never silently drop it or relabel it
+  "independent."
+- Falling short of the recorded target — or any user-owned **fork** (competing
+  designs, a public-contract or destructive change, unclear scope) — triggers a
+  **Mandatory pause**: stop, state the trade-off, get explicit approval.
+- **Plan before non-trivial work:** establish the user-approved end state plus
+  acceptance criteria, then ordered steps; re-evaluate against the target at each
+  step, before any PR, and before completion.
+- **Default on doubt:** if unsure whether something is in scope, trivial, or a
+  user-owned fork, treat it as in-scope / non-trivial / user-owned and ask.
 
 1. **Clean end state over less churn.**
-   - Target: you MUST always aim for the clean end state, not the smallest diff.
-     While designing and implementing, actively search for the structure that
-     should exist after the work is complete.
-   - Re-evaluation: you MUST periodically re-evaluate already-written changes
-     against that target. Do not keep a compromise only because it already
-     exists in the branch.
-   - Recommendation default: when options include a clean end state and a
-     lower-churn partial state, you MUST recommend the clean end state unless it
-     is technically impossible, unsafe, or explicitly outside the approved
-     scope.
-   - Exception handling: technical impossibility, safety risk, or scope conflict
-     are pause conditions, not permission to choose the partial route
-     automatically. Present the evidence, interrupt the work, and get explicit
-     human approval before proceeding with a temporary non-clean state.
-   - Staged delivery: if recommending staged delivery, explain why the staged
-     plan still reaches the clean end state for the approved work, or explicitly
-     state that you are asking the user to accept a temporary non-clean state.
-   - Invalid justification: risk reduction, review convenience, or issue staging
-     is not enough justification for recommending a partial end state.
-   - Deferral check: before recommending deferral, check the issue, SOW,
-     acceptance criteria, and affected migration scope for evidence that the
-     deferred work is genuinely outside the approved clean end state.
+   - Binding rule (read first): you MUST recommend and deliver the clean end
+     state — the structure the codebase SHOULD have once the approved scope is
+     fully delivered, including removing the code, config, docs, and tests the
+     change makes redundant — not the smallest diff. You MUST NOT relabel the
+     smallest working diff as "the clean end state."
+   - Record the target: before generating options, record that clean end state in
+     the SOW. The recorded target is the clean end state of this SOW's approved
+     scope; for staged work, each stage's SOW records that stage's target and the
+     stages together MUST reach the full target. Any option that does not match
+     the recorded target is a non-clean state and triggers the Mandatory pause.
+   - Open design decision: when the clean end state is itself an open design
+     decision that is the user's to make, do not invent a fixed target; record a
+     provisional target plus the open design question and resolve it with the
+     user first.
+   - Approved scope: "the approved scope" is the union of (a) the issue or user
+     request, (b) the SOW Purpose and Acceptance Criteria, and (c) the
+     migration/contract surface they imply. If it is unclear whether work is in
+     scope, treat it as in-scope and raise it with the user; never silently
+     exclude it.
+   - You are not the scope authority:
+     - A "coupled item" is code, config, docs, or tests the current change makes
+       redundant or leaves inconsistent (for example a replaced path, its
+       callers, or its tests).
+     - You MUST NOT reclassify in-scope or coupled work as "independent" or "out
+       of scope" to avoid doing it, and you MUST NOT silently drop coupled work.
+     - When you only suspect something is coupled and including it is low-risk and
+       confined to what you are changing, include it and disclose it rather than
+       stopping to ask.
+     - Pause for the user only when including it would expand the blast radius,
+       change a user-visible contract, or the boundary is itself a genuine scope
+       fork.
+     - This overrides any reading of "Scope discipline" that would defer coupled
+       cleanup.
+   - Disclose exclusions: in the recorded target you MUST list (i) what you will
+     remove as redundant, and (ii) any coupled item you are treating as NOT part
+     of this clean end state, each with its reason and the scope source it rests
+     on. Excluding an in-scope or coupled item without recording it there is
+     silent scope-narrowing and is prohibited, so a reviewer or the next agent can
+     check your exclusions against those sources.
+   - Touch-the-mess-you-touch: when your change modifies code that already
+     contains adjacent duplication, dead code, or a clear pre-existing defect, you
+     SHOULD clean that adjacent mess as part of this work rather than build on top
+     of it, provided the cleanup is low-risk and confined to the code you are
+     already modifying. Cleanup that would reach into unrelated code is
+     independent work (Scope discipline) — track it, do not silently bundle it. If you
+     choose NOT to clean adjacent mess you touched, record why under the
+     disclosure list (ii).
+   - Reference search (when replacing a path or altering a contract):
+     - You MUST run and record in the SOW a reference search for remaining
+       references to the replaced path or contract.
+     - Search construction sites and prefixes too, not only literal final names —
+       identifiers here are often built dynamically (for example via
+       `fmt.Sprintf`).
+     - Every surviving reference MUST appear in (i) or (ii) with its scope source,
+       or the target is incomplete; an item you did not search for counts as
+       silent scope-narrowing.
+     - A repository-wide search cannot prove safety for consumers outside this
+       repo (Netdata Cloud, exporters, streaming, ML, the docs pipeline); treat
+       renaming a shipped public contract as a user-owned breaking decision (an
+       Allowed-exceptions pause), not something the search clears.
+   - Allowed exceptions (pause conditions, not auto-routes): recommend a
+     non-clean route ONLY for one of:
+     - (a) technically impossible — impossible to implement correctly at all, NOT
+       impossible within a preferred diff size;
+     - (b) a concrete, evidenced safety risk — a named hazard such as data loss
+       or a security/production-stability regression, NOT "a larger diff is
+       riskier";
+     - (c) confirmed by the user as outside the approved scope; or
+     - (d) accepted by the user, through the Mandatory pause, as an in-scope
+       partial to ship now.
 
-2. **Scope discipline at every step.**
-   At each milestone, you MUST check whether the work has drifted outside the
-   approved scope. If the new work is valid but independent, you MUST defer it
-   to a later step or pause and submit the independent work first, then rebase
-   the current branch after it merges. Complex features MUST be delivered in
-   coherent steps where each step builds on the previous one.
+     For (a)/(b) you MUST cite specific evidence (file/line, failure class, or
+     test) and route through the Mandatory pause — you do not self-certify
+     "unsafe." For (d) track the remainder per "Followup Discipline" with why
+     deferral is acceptable and when it lands; repeatedly shipping partials is
+     debt accumulation, not delivery. Risk reduction, review convenience, smaller
+     diff, and issue staging are NEVER valid and MUST NOT be relabeled "unsafe"
+     or "independent."
+   - Mandatory pause: if the delivered state will fall short of its recorded
+     target for any reason other than approved staged delivery, you MUST present
+     the evidence, STOP, and obtain explicit user approval (see Approval bar)
+     before proceeding, before requesting non-draft review, and before marking
+     the work complete.
+   - Approval bar (used by every gate): approval means the user explicitly
+     accepts a trade-off, goal, or plan that you stated in your own words (what
+     stays redundant or partial, and why). A bare "ok" or "sounds good" to a
+     one-sided pitch is not approval.
+   - Re-evaluation: at the completion of each planned step, before opening or
+     updating a PR, and before marking a SOW completed (the Re-evaluation
+     checkpoints), you MUST re-evaluate already-written changes against the
+     recorded target; you SHOULD also re-evaluate whenever you pause to report
+     progress. Do not keep a compromise only because it already exists in the
+     branch.
+   - Staged delivery: allowed ONLY when every stage is an in-scope decomposition
+     of one approved clean end state and the stages together reach it. The user
+     approval recorded for the staged plan covers the intermediate states, so an
+     approved stage does not re-trigger the Mandatory pause; every later stage
+     MUST be tracked per "Followup Discipline" (implemented here, rejected with
+     evidence, or a linked GitHub issue) before an earlier stage merges. A
+     self-certified "a later stage will finish it" with no tracked item is not
+     acceptable.
+   - Deferral check: before recommending deferral, check the issue, SOW,
+     acceptance criteria, and affected migration scope. Silence or ambiguity MUST
+     NOT be read as permission to defer; if those sources do not clearly place
+     the work outside the approved clean end state, treat it as in-scope and
+     either complete it or pause for a user decision.
+   - Trivial-work exemption: trivial work (per "When A SOW Is Required") has no
+     SOW and is exempt from the record-the-target, disclosure, and
+     reference-search bullets above; the clean-end-state preference still applies.
+     When unsure, treat the work as non-trivial.
+
+2. **Plan before non-trivial work.**
+   - Plan first: non-trivial work (see "When A SOW Is Required") MUST start with
+     a plan recorded in the SOW before any implementation-file change and before
+     any implementation-equivalent action — migrations, deletions, pushes,
+     non-draft PRs, or external-state mutations via tools. Trivial work is exempt;
+     when unsure, treat the work as non-trivial.
+   - Human-owned goal: the desired end state — the goal, or coherent goal set, the
+     work must reach — MUST be created with or approved by the user. You MUST NOT
+     finalize the goal unilaterally (same user-owned target as Clean end state).
+   - End state first: you MUST establish the desired end state — including its
+     acceptance criteria — before planning the steps; the goal drives the work,
+     not a first diff. If you cannot yet state the end state, keep investigating
+     until you can; do not start work against an unknown target. When the end
+     state is itself a user-owned design decision, record a provisional target
+     plus the open question and resolve it with the user first (Clean end state).
+     Then plan the steps to move from the current state toward that end state.
+   - Decompose into steps: split the work into ordered steps, each with its own
+     clean end state and acceptance criteria, each building on the previous one
+     toward the desired end state. A single coherent step is a valid decomposition
+     when the work is atomic; do not invent artificial sub-steps.
+   - Resolve huge or vague work: if the deliverable is large or vague, keep
+     refining the plan until every step has a clean end state and acceptance
+     criteria. Do not start implementation while steps are still unclear.
+   - Reachability: the plan MUST either reach the desired end state through its
+     steps, or produce evidence that it is not achievable; an unachievable goal
+     is a pause condition for a user decision, not a silent partial result.
+   - Human approval gate: when a goal-approval round is required (see "Approval is
+     for goal-decisions" below), the whole plan — the desired end state and the
+     step breakdown — MUST be explicitly approved by the user before
+     implementation. The assistant proposes and investigates; the user approves.
+     State the goal and step breakdown being accepted, and get confirmation that
+     meets the Approval bar (Clean end state). If the user rejects or edits the
+     plan, revise and re-seek approval; the SOW stays in `planning` until an
+     explicit approval is recorded, then reaches `Status: ready`. This gate is the
+     canonical statement of the approval requirement that the Pre-Implementation
+     Gate and Required First Checks reference.
+   - Approval is for goal-decisions, not work categories:
+     - The goal-approval round fires ONLY when the end state is a genuine
+       user-owned fork — competing designs, a public-contract change, a
+       destructive or irreversible step, or unclear scope.
+     - Other non-trivial work whose end state is already fixed by the triggering
+       request, an existing project skill, or an established repository pattern
+       (for example a clear bug fix, a metadata/docs edit with no contract change,
+       or a collector's skeleton and wiring fixed by its authoring skill — though
+       its Function surface, vnode/host-scope design, and new public config
+       options remain user-owned forks) still needs a recorded plan and the
+       Pre-Implementation Gate, but the triggering request IS the recorded goal
+       approval — no separate round, which also satisfies the resume re-check and
+       the progress rule.
+     - When it is unclear whether a real fork exists, treat it as user-owned and
+       seek approval.
+   - Approval persists; re-check on resume: before continuing an `in-progress` or
+     `paused` SOW you did not personally take through this gate — including
+     takeover or handoff — you MUST confirm the SOW records explicit approval of
+     the current goal and plan. If it does not, or the plan changed materially
+     since approval, treat the SOW as `planning` and re-obtain approval before
+     further implementation.
+
+3. **Scope discipline at every step.**
+   - Drift check: at each Re-evaluation checkpoint (Clean end state), you MUST
+     also check whether the work has drifted outside the approved scope, not only
+     whether the diff still matches the recorded target.
+   - Independence test: new work is "genuinely independent" only if ALL hold —
+     (a) the approved clean end state is still complete and correct without it,
+     (b) it is not a coupled item or a remaining reference recorded under Clean
+     end state, and (c) it has its own separable acceptance criteria. If any test
+     fails, or you are unsure, treat the work as coupled, not independent, and
+     handle it under Clean end state (do the low-risk part and disclose it; pause
+     only for a genuine fork) — you are not the scope authority.
+   - Disposition of independent work:
+     - Do NOT silently bundle it.
+     - Submit it as a separate PR first and rebase the current branch after it
+       merges, or track it as a GitHub issue per "Followup Discipline."
+     - Do NOT fold it into this SOW's steps — Clean-end-state staged-delivery
+       stages must be a decomposition of one clean end state.
+   - Governed elsewhere: coupled cleanup is in scope (Clean end state), and
+     non-trivial work is delivered in coherent incremental steps (Plan before
+     non-trivial work); this principle does not restate them.
 
 USER COMMUNICATION:
 
@@ -109,7 +292,7 @@ Before non-trivial work:
 3. Inspect `.agents/skills/*/SKILL.md` if any exist, and load every runtime project skill whose trigger matches the work.
 4. Inspect legacy runtime skills listed below when the user request matches their frontmatter trigger.
 5. Inspect code, docs, tests, and existing project instructions as ground truth.
-6. Ask the user only for irreducible product/design/risk decisions.
+6. Ask the user only for irreducible product/design/risk decisions. For non-trivial work, the goal and plan are user-owned decisions gated by the "Plan before non-trivial work" Human approval gate.
 
 ### Git Worktrees
 
@@ -155,6 +338,9 @@ When writing or updating these artifacts:
 - Keep one durable idea per bullet. If a bullet needs multiple sentences, the
   first sentence states the rule and later sentences provide evidence,
   rationale, or examples.
+- For a guardrail with several distinct requirements, use a labeled parent
+  bullet with an indented sub-list — one requirement per sub-bullet — rather than
+  a multi-requirement paragraph; keep a single rule-plus-rationale as one bullet.
 - Preserve precision over brevity. Formatting is for readability, not for
   weakening contracts or removing necessary evidence.
 
@@ -173,9 +359,9 @@ Resolve `owner/repo` from the repository remote, record the checked commit, and 
 
 ### Pre-Implementation Gate
 
-Implementation must not begin until the branch-local SOW contains a concrete `## Pre-Implementation Gate` section with `Status: ready` or `Status: in-progress`. Before changing implementation files, or before continuing implementation in an existing SOW that lacks this section, fill the gate.
+Implementation must not begin until the branch-local SOW contains a concrete `## Pre-Implementation Gate` section with `Status: ready` or `Status: in-progress`. Before changing implementation files, or before continuing implementation in an existing SOW that lacks this section, fill the gate. Reaching `Status: ready` additionally requires the "Plan before non-trivial work" Human approval gate (explicit user approval of the goal and plan).
 
-The gate must record the problem/root-cause model, evidence reviewed, affected contracts and surfaces, existing patterns to reuse, risk and blast radius, sensitive data handling plan, implementation plan, validation plan, artifact impact plan, and open decisions. The sensitive data plan must cover SOWs, specs, documentation, project skills, agent instructions, and code comments. Generic placeholders such as `TBD`, `N/A`, or "to be checked later" are invalid unless the SOW explains why the item truly does not apply. If the gate exposes an unknown that cannot be resolved by investigation, stop and ask the user before implementation.
+The gate must record the problem/root-cause model, evidence reviewed, affected contracts and surfaces, the clean-end-state target (its removed-redundant and excluded-coupled items, and the reference search where a path or contract is replaced), existing patterns to reuse, risk and blast radius, sensitive data handling plan, implementation plan, validation plan, artifact impact plan, and open decisions. The sensitive data plan must cover SOWs, specs, documentation, project skills, agent instructions, and code comments. Generic placeholders such as `TBD`, `N/A`, or "to be checked later" are invalid unless the SOW explains why the item truly does not apply. If the gate exposes an unknown that cannot be resolved by investigation, stop and ask the user before implementation.
 
 ### When A SOW Is Required
 
@@ -201,7 +387,7 @@ Trivial work does not need a SOW:
 - typo fixes;
 - formatting-only changes;
 - mechanical rename with no behavior change;
-- simple search/replace with low risk.
+- simple search/replace with low risk (still grep for the old token to confirm no call sites are missed).
 
 When unsure, treat the work as non-trivial.
 
@@ -258,7 +444,7 @@ counter because it cannot be allocated safely across parallel branches.
 SOW state lives in the file's `Status:` field:
 
 - `planning` - analysis or decisions are incomplete; implementation is blocked.
-- `ready` - the Pre-Implementation Gate is complete and implementation can start.
+- `ready` - the Pre-Implementation Gate is complete and, where the goal-approval round ("Plan before non-trivial work") applies, the user has approved the goal and plan; implementation can start.
 - `in-progress` - implementation is underway.
 - `paused` - work is intentionally stopped but may resume on the branch.
 - `completed` - work is validated and durable memory has been transferred; this is a transient state before deleting the SOW file.
@@ -310,7 +496,7 @@ If work overlaps:
 - merge or consolidate branches before implementation; or
 - split into separate SOWs and complete one before starting the next.
 
-Progress reports are not stop points. Once a SOW is in progress, continue until it is delivered, failed with evidence, blocked on a real user decision/approval, or superseded by newer user instructions.
+Progress reports are not stop points (re-evaluating against the target per the Clean-end-state rule is not itself a stop point). Once a SOW is in progress and its goal/plan approval is recorded ("Plan before non-trivial work"), continue until it is delivered, failed with evidence, blocked on a real user decision/approval, or superseded by newer user instructions.
 
 ### User Decisions
 
@@ -320,7 +506,7 @@ When user decisions are needed:
 2. Provide numbered options.
 3. Explain pros, cons, implications, and risks.
 4. Recommend one option with reasoning.
-5. Record the user's decision in the SOW before implementation.
+5. Record the user's decision in the SOW before implementation. For the goal/plan approval round, the bar is the "Plan before non-trivial work" Human approval gate.
 
 ### Followup Discipline
 
@@ -362,6 +548,8 @@ Do not attempt to resurrect or mutate a prior SOW.
 A SOW cannot be completed until Validation records:
 
 - acceptance criteria evidence;
+- clean-end-state evidence: the delivered state matches the clean end state recorded in the SOW, including its recorded list of removed-redundant and excluded coupled items (and, where a path or contract was replaced, the recorded reference search), or an explicit user approval for a non-clean state is recorded and linked;
+- deferred clean-end-state remainder: any clean-end-state work deferred under an approved partial (exception (d)) or otherwise tracked rather than done is listed with why deferral was acceptable and when (or under what condition) it lands;
 - tests or equivalent validation;
 - real-use evidence when a runnable path exists;
 - reviewer findings and how they were handled;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,102 @@ and edge cases):**
      non-trivial work is delivered in coherent incremental steps (Plan before
      non-trivial work); this principle does not restate them.
 
+**Flow diagrams (human reading aid, non-normative):** the bullets above are
+authoritative; the diagrams below summarize the flow for human readers and MUST
+be kept in sync when the principles change.
+
+<details>
+<summary>Show per-principle flow diagrams</summary>
+
+How the three principles connect (lifecycle order):
+
+```mermaid
+flowchart LR
+    A("1. Clean end state<br/>defines the target (what 'done' means)")
+    B("2. Plan before non-trivial work<br/>establish the target + steps; user approves real forks")
+    C("3. Scope discipline<br/>stay on the target while executing each step")
+    A --> B --> C
+    C -->|re-evaluate vs target| A
+```
+
+1. Clean end state over less churn:
+
+```mermaid
+flowchart TD
+    A("Approved scope = issue + SOW Purpose/Acceptance + implied surface")
+    B("Define the clean end state, incl. removing what the change makes redundant")
+    C("Record target in SOW: exclusions list + reference search if a path/contract is replaced")
+    D{"Matches recorded target?"}
+    E("Deliver the clean end state")
+    F{"Allowed exception?"}
+    Fx("Only: a) impossible, b) evidenced safety risk, c) out of scope, d) user-accepted partial")
+    G("NOT allowed: risk reduction, smaller diff, or staging")
+    H("Mandatory pause: present evidence, STOP")
+    I{"Explicit approval?"}
+    Ix("Approval bar: a bare 'ok' is not approval")
+    J("Proceed; track remainder per Followup Discipline")
+    K("Re-evaluate vs target: each step, before a PR, before complete")
+    A --> B --> C --> D
+    D -->|yes| E
+    D -->|no| F
+    F -->|no| G --> B
+    F -->|yes| H --> I
+    I -->|no| B
+    I -->|yes| J
+    F -.- Fx
+    I -.- Ix
+    E --> K
+    J --> K
+```
+
+2. Plan before non-trivial work:
+
+```mermaid
+flowchart TD
+    A("Task")
+    B{"Trivial?"}
+    C("Exempt: just do it (clean-end-state preference still applies)")
+    D("Establish the desired end state + acceptance criteria FIRST; keep investigating until you can")
+    E("Decompose into ordered steps, each with its own clean end state + criteria; move current toward desired")
+    F{"End state a user-owned fork?"}
+    Fk("Fork = competing designs, public-contract/destructive change, or unclear scope")
+    G("Fixed by request/skill/pattern: the request IS the approval (recorded plan + gate, no separate round)")
+    H("Goal-approval round: explicit user approval of the whole plan (Approval bar)")
+    I("Status: ready, implement")
+    J("Pause for a user decision (not a silent partial)")
+    A --> B
+    B -->|yes| C
+    B -->|no| D
+    D --> E --> F
+    F -->|no| G
+    F -->|yes| H
+    F -.- Fk
+    G --> I
+    H --> I
+    D -->|goal unreachable| J
+```
+
+3. Scope discipline at every step:
+
+```mermaid
+flowchart TD
+    A("At each Re-evaluation checkpoint")
+    B{"Drifted outside approved scope?"}
+    C("Continue")
+    D{"Genuinely independent?"}
+    Dx("Independent only if ALL: end state complete without it; not a coupled item/reference; separable acceptance criteria")
+    E("Treat as COUPLED: handle under Clean end state (do the low-risk part + disclose); pause only for a genuine fork")
+    F("Do NOT bundle silently: separate PR + rebase, or track as a GitHub issue; never fold into this SOW's steps")
+    A --> B
+    B -->|no| C
+    B -->|new work| D
+    D -->|no or unsure| E
+    D -->|yes| F
+    D -.- Dx
+```
+
+</details>
+
 USER COMMUNICATION:
 
 1. ALWAYS DO YOUR HOMEWORK BEFORE ASKING QUESTIONS OR REQUESTING USER DECISIONS.


### PR DESCRIPTION
 ## Summary

  Process/instruction change to the repository's AI-agent working rules
  (`AGENTS.md`) and the local SOW framework. **No runtime, code, schema, or
  product behavior changes** — this only updates contributor/agent guidance and
  the SOW template/tooling text.

  Two themes:
  1. Clarify the SOW lifecycle so branch-local SOWs can support PR
     takeover/handoff without ever reaching the merge head.
  2. Strengthen, recalibrate, and reorganize the three **Mandatory Development
     Principles** to minimize tech-debt accumulation while keeping human
     involvement at the genuinely critical decision points.

  ## What changed

  **SOW lifecycle** (`AGENTS.md`, `SOW.template.md`, `audit.sh`, `sow.yml`)
  - Distinguish "no active SOW in the **merge head**" from "no active SOW in
    **any PR**": an active SOW MAY be committed on a feature branch for
    takeover/handoff through ready-for-review, and MUST be deleted before merge.
  - Keep the SOW CI guard strict and document that a committed-handoff SOW's
    failing check is **intentional** until merge cleanup.
  - Add a **Durable AI-Facing Artifact Formatting** standard (scannable headings,
    labeled bullets, one durable idea per bullet, nested sub-lists for
    multi-requirement guardrails).

  **Mandatory Development Principles** (`AGENTS.md`)
  - **Clean end state over less churn:** explicit approved-scope definition,
    exclusion disclosure, a scoped reference search, *touch-the-mess-you-touch*
    cleanup, a single canonical *Approval bar*, evidence-gated exceptions, and an
    explicit pause + approval before shipping any non-clean state.
  - **Plan before non-trivial work (new principle):** establish the user-approved
    end state + acceptance criteria first, decompose into steps, and require the
    goal-approval round **only for genuine design/scope forks** — reactive,
    fixed-objective work proceeds on the triggering request.
  - **Scope discipline at every step:** a positive "genuinely independent" test;
    bias to include-and-disclose low-risk coupled cleanup instead of pausing.
  - **Reordered to lifecycle order:** Clean end state → Plan → Scope discipline.
  - **Readability:** a short "Core" checklist up front, sub-lists for
    multi-requirement rules, principles referenced by name (reorder-proof), and a
    collapsible, non-normative set of human-facing Mermaid flow diagrams.

  ## Motivation

  `AGENTS.md` is read by both AI agents and humans. The aim is to reduce the tech
  debt that accumulates quickly when code is added fast, keep the rules
  followable (so they are actually applied), and concentrate human review on the
  critical forks rather than every step.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the SOW lifecycle to allow branch-local SOWs for PR takeover/handoff and strengthens the development principles to reduce tech debt. No runtime or product behavior changes; updates are to `AGENTS.md`, the SOW template, and CI messaging.

- **Refactors**
  - Rewrote Mandatory Development Principles in `AGENTS.md`: prioritize the clean end state, add a new “Plan before non-trivial work” gate, tighten scope discipline, consolidate the approval bar, and evidence-gate exceptions; added a short Core checklist and human-facing flow diagrams.
  - SOW lifecycle: active SOWs may be committed on feature branches/PRs for handoff and MUST be deleted before merge; CI stays strict and the error message in `sow.yml` now clarifies this intentional guard.
  - Template/tooling: `SOW.template.md` adds a “Clean-end-state target” (with exclusion disclosure and reference search when replacing paths/contracts) and clarifies `Status: ready` requires goal/plan approval when applicable; mirror paths use `${NETDATA_REPOS_DIR}`; `audit.sh` now checks the new “Durable AI-Facing Artifact Formatting” section.

- **Migration**
  - For takeover/handoff, you may commit active SOWs; expect the SOW CI check to fail until you delete the SOW before merge.
  - Use the updated template: fill the clean-end-state target, run/record reference searches when replacing paths/contracts, and record explicit user approval for the goal/plan when a real design/scope fork exists.
  - Format AI-facing durable docs (e.g., `AGENTS.md`, specs, skills) with scannable headings and labeled bullets per the new formatting standard.

<sup>Written for commit 428def8288fe1fb176b5059e3e0a587b517fdbe0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

