### PR TITLE
Silence output from curl and use long options for wget in netdata-updater.sh

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -623,7 +623,7 @@ _safe_download() {
 
   if [ -n "${curl}" ]; then
     set +e
-    "${curl}" --fail --location --write-out "%{http_code}" --connect-timeout 10 --retry 3 "${url}" --output "${dest}" > "${dl_log}"
+    "${curl}" --silent --fail --location --write-out "%{http_code}" --connect-timeout 10 --retry 3 "${url}" --output "${dest}" > "${dl_log}"
     result="$?"
     set -e
 
@@ -653,7 +653,7 @@ _safe_download() {
     esac
   elif [ -n "${wget}" ]; then
     set +e
-    "${wget}" -T 15 -S -o "${dl_log}" -O "${dest}" "${url}"
+    "${wget}" --timeout=15 --server-response --output-file="${dl_log}" --output-document="${dest}" "${url}"
     result="$?"
     set -e
 


### PR DESCRIPTION
##### Summary

Output from curl run in `netdata-updater.sh` via cron results in junk output being sent by email.

Successful cron jobs should produce no output.
Unsuccessful cron jobs should produce appropriate output.

Added `--silent` to `curl` to suppress inappropriate output.

While unrelated to this, changed `wget` to use long options for both consistency with `curl` and for improved maintainability.


##### Test Plan

Have netdata installed on a platform with `netdata-updater.sh` run via cron, e.g. as `/etc/cron.daily/netdata-updater`.

Wait for email with cron output to arrive.

##### Additional Information

Successful cron jobs should produce no output.

Unsuccessful cron jobs should produce appropriate output.


<details> <summary>For users: How does this change affect me?</summary>

- This affects the default scheduled Netdata update process.
- This change does not affect the update function, but fixes a flaw in the process.
- This change saves the user time, effort, and cost of handling inappropriate email.

Example output from email:
```/etc/cron.daily/netdata-updater:
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0 100  7716  100  7716    0     0  73642      0 --:--:-- --:--:-- --:--:-- 74192
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 100  1390  100  1390    0     0  10547      0 --:--:-- --:--:-- --:--:-- 10547
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
   7  189M    7 13.3M    0     0  21.1M      0  0:00:08 --:--:--  0:00:08 21.1M  27  189M   27 51.6M    0     0  31.6M      0  0:00:05  0:00:01  0:00:04 38.2M  46  189M   46 88.8M    0     0  33.7M      0  0:00:05  0:00:02  0:00:03 37.7M  66  189M   66  125M    0     0  34.4M      0  0:00:05  0:00:03  0:00:02 37.2M  83  189M   83  158M    0     0  34.2M      0  0:00:05  0:00:04  0:00:01 36.2M 100  189M  100  189M    0     0  34.8M      0  0:00:05  0:00:05 --:--:-- 36.6M
```
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences `curl` progress output in `netdata-updater.sh` to stop noisy cron emails on success, and switches `wget` to long options for consistency and readability.

- **Bug Fixes**
  - Added `--silent` to `curl` so successful cron runs produce no output; failures still emit useful errors.

- **Refactors**
  - Replaced `wget` short flags with long forms: `--timeout=15 --server-response --output-file=... --output-document=...`.

<sup>Written for commit e4049ea4543996774e69254846ecf7cfba7d6a2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

