### PR TITLE
Add offline Function test modes for NetFlow and systemd journal

### DIFF
--- a/src/collectors/systemd-journal.plugin/README.md
+++ b/src/collectors/systemd-journal.plugin/README.md
@@ -52,6 +52,8 @@ Requirements:
 - `--timeout <seconds>` controls the offline Function execution timeout. It
   defaults to `60`; use `--timeout 0` to map to a very large finite timeout for
   long-running fixture comparisons.
+- The plugin executable must not be world-executable. Test mode refuses to run
+  when the executable has the `others execute` permission bit set.
 - stdout contains only the raw JSON Function response.
 - errors are written to stderr and return non-zero.
 

--- a/src/collectors/systemd-journal.plugin/README.md
+++ b/src/collectors/systemd-journal.plugin/README.md
@@ -36,6 +36,31 @@ This plugin is a Netdata Function Plugin. A free Netdata Cloud account is requir
 
 The plugin is designed for native package installations, source installations, and Docker installations (Debian-based). If using Docker, make sure you're using the Debian-based containers.
 
+## Offline Function test mode
+
+Fixture harnesses can execute the Function query path directly against an existing
+journal directory:
+
+```sh
+systemd-journal.plugin --test systemd-journal --dir <journal-dir> --request <payload.json>
+```
+
+Requirements:
+
+- `<journal-dir>` is scanned recursively for systemd journal files.
+- `<payload.json>` is the JSON Function request body.
+- stdout contains only the raw JSON Function response.
+- errors are written to stderr and return non-zero.
+
+For example, an info request can use this payload:
+
+```json
+{"info":true}
+```
+
+Function output includes volatile fields such as versions and timing-derived values.
+Test harnesses should normalize those fields before comparing fixture outputs.
+
 ## Journal sources
 
 The plugin automatically detects available journal sources based on the journal files in `/var/log/journal` (persistent logs) and `/run/log/journal` (volatile logs).

--- a/src/collectors/systemd-journal.plugin/README.md
+++ b/src/collectors/systemd-journal.plugin/README.md
@@ -48,7 +48,7 @@ systemd-journal.plugin --test systemd-journal --dir <journal-dir> [--timeout <se
 Requirements:
 
 - `<journal-dir>` is scanned recursively for systemd journal files.
-- stdin is the JSON Function request body.
+- stdin is the JSON Function request body (non-empty, maximum 16 MiB).
 - `--request` is not supported and fails with usage output.
 - `--timeout <seconds>` controls the offline Function execution timeout. It
   defaults to `60`; use `--timeout 0` to map to a very large finite timeout for

--- a/src/collectors/systemd-journal.plugin/README.md
+++ b/src/collectors/systemd-journal.plugin/README.md
@@ -42,18 +42,17 @@ Fixture harnesses can execute the Function query path directly against an existi
 journal directory:
 
 ```sh
-systemd-journal.plugin --test systemd-journal --dir <journal-dir> --request <payload.json> [--timeout <seconds>]
+systemd-journal.plugin --test systemd-journal --dir <journal-dir> [--timeout <seconds>] < payload.json
 ```
 
 Requirements:
 
 - `<journal-dir>` is scanned recursively for systemd journal files.
-- `<payload.json>` is the JSON Function request body.
+- stdin is the JSON Function request body.
+- `--request` is not supported and fails with usage output.
 - `--timeout <seconds>` controls the offline Function execution timeout. It
   defaults to `60`; use `--timeout 0` to map to a very large finite timeout for
   long-running fixture comparisons.
-- The plugin executable must not be world-executable. Test mode refuses to run
-  when the executable has the `others execute` permission bit set.
 - stdout contains only the raw JSON Function response.
 - errors are written to stderr and return non-zero.
 

--- a/src/collectors/systemd-journal.plugin/README.md
+++ b/src/collectors/systemd-journal.plugin/README.md
@@ -42,13 +42,16 @@ Fixture harnesses can execute the Function query path directly against an existi
 journal directory:
 
 ```sh
-systemd-journal.plugin --test systemd-journal --dir <journal-dir> --request <payload.json>
+systemd-journal.plugin --test systemd-journal --dir <journal-dir> --request <payload.json> [--timeout <seconds>]
 ```
 
 Requirements:
 
 - `<journal-dir>` is scanned recursively for systemd journal files.
 - `<payload.json>` is the JSON Function request body.
+- `--timeout <seconds>` controls the offline Function execution timeout. It
+  defaults to `60`; use `--timeout 0` to map to a very large finite timeout for
+  long-running fixture comparisons.
 - stdout contains only the raw JSON Function response.
 - errors are written to stderr and return non-zero.
 

--- a/src/collectors/systemd-journal.plugin/systemd-internals.h
+++ b/src/collectors/systemd-journal.plugin/systemd-internals.h
@@ -97,6 +97,8 @@ void available_journal_file_sources_to_json_array(BUFFER *wb);
 bool nd_journal_files_completed_once(void);
 void nd_journal_files_registry_update(void);
 void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, const char *dirname, int depth);
+void nd_journal_set_scan_progress_enabled(bool enabled);
+void nd_journal_use_single_directory(const char *path);
 
 FACET_ROW_SEVERITY syslog_priority_to_facet_severity(FACETS *facets, FACET_ROW *row, void *data);
 
@@ -124,6 +126,15 @@ struct journal_directory {
 extern struct journal_directory journal_directories[MAX_JOURNAL_DIRECTORIES];
 
 void nd_journal_init_files_and_directories(void);
+BUFFER *function_systemd_journal_result(
+    const char *transaction,
+    char *function,
+    usec_t *stop_monotonic_ut,
+    bool *cancelled,
+    BUFFER *payload,
+    HTTP_ACCESS access,
+    const char *source,
+    void *data);
 void function_systemd_journal(
     const char *transaction,
     char *function,

--- a/src/collectors/systemd-journal.plugin/systemd-internals.h
+++ b/src/collectors/systemd-journal.plugin/systemd-internals.h
@@ -132,9 +132,9 @@ BUFFER *function_systemd_journal_result(
     usec_t *stop_monotonic_ut,
     bool *cancelled,
     BUFFER *payload,
-    HTTP_ACCESS access,
-    const char *source,
-    void *data);
+    HTTP_ACCESS access __maybe_unused,
+    const char *source __maybe_unused,
+    void *data __maybe_unused);
 void function_systemd_journal(
     const char *transaction,
     char *function,

--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -11,6 +11,29 @@ DICTIONARY *nd_journal_files_registry = NULL;
 DICTIONARY *used_hashes_registry = NULL;
 
 static usec_t systemd_journal_session = 0;
+static bool nd_journal_scan_progress_enabled = true;
+
+void nd_journal_set_scan_progress_enabled(bool enabled)
+{
+    nd_journal_scan_progress_enabled = enabled;
+}
+
+static void nd_journal_scan_progress(void)
+{
+    if (nd_journal_scan_progress_enabled)
+        send_newline_and_flush(&stdout_mutex);
+}
+
+void nd_journal_use_single_directory(const char *path)
+{
+    string_freez(journal_directories[0].path);
+    journal_directories[0].path = string_strdupz(path);
+
+    for (size_t i = 1; i < MAX_JOURNAL_DIRECTORIES; i++) {
+        string_freez(journal_directories[i].path);
+        journal_directories[i].path = NULL;
+    }
+}
 
 void buffer_json_journal_versions(BUFFER *wb)
 {
@@ -659,7 +682,7 @@ void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, 
             if (files)
                 dictionary_set(files, full_path, NULL, 0);
 
-            send_newline_and_flush(&stdout_mutex);
+            nd_journal_scan_progress();
         } else if (entry->d_type == DT_LNK) {
             struct stat info;
             if (stat(full_path, &info) == -1)
@@ -675,7 +698,7 @@ void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, 
                 if (files)
                     dictionary_set(files, full_path, NULL, 0);
 
-                send_newline_and_flush(&stdout_mutex);
+                nd_journal_scan_progress();
             }
         }
     }

--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -688,8 +688,8 @@ void nd_journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, 
             if (stat(full_path, &info) == -1)
                 continue;
 
+            // Journal discovery intentionally follows symlinked journal directories.
             if (S_ISDIR(info.st_mode)) {
-                // The symbolic link points to a directory
                 char resolved_path[FILENAME_MAX + 1];
                 if (realpath(full_path, resolved_path) != NULL) {
                     nd_journal_directory_scan_recursively(files, dirs, resolved_path, depth + 1);

--- a/src/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal.c
@@ -257,7 +257,7 @@ void systemd_journal_register_transformations(LOGS_QUERY_STATUS *lqs) {
         NULL);
 }
 
-void function_systemd_journal(
+BUFFER *function_systemd_journal_result(
     const char *transaction,
     char *function,
     usec_t *stop_monotonic_ut,
@@ -292,7 +292,7 @@ void function_systemd_journal(
     };
     LOGS_QUERY_STATUS *lqs = &tmp_fqs;
 
-    CLEAN_BUFFER *wb = lqs_create_output_buffer();
+    BUFFER *wb = lqs_create_output_buffer();
 
     // ------------------------------------------------------------------------
     // parse the parameters
@@ -317,9 +317,27 @@ void function_systemd_journal(
         }
     }
 
+    lqs_cleanup(lqs);
+
+    return wb;
+}
+
+void function_systemd_journal(
+    const char *transaction,
+    char *function,
+    usec_t *stop_monotonic_ut,
+    bool *cancelled,
+    BUFFER *payload,
+    HTTP_ACCESS access,
+    const char *source,
+    void *data)
+{
+    BUFFER *wb =
+        function_systemd_journal_result(transaction, function, stop_monotonic_ut, cancelled, payload, access, source, data);
+
     netdata_mutex_lock(&stdout_mutex);
     pluginsd_function_result_to_stdout(transaction, wb);
     netdata_mutex_unlock(&stdout_mutex);
 
-    lqs_cleanup(lqs);
+    buffer_free(wb);
 }

--- a/src/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal.c
@@ -16,8 +16,8 @@
 #define JOURNAL_KEY_ND_JOURNAL_PROCESS "ND_JOURNAL_PROCESS"
 
 // functions needed by LQS
-static __always_inline
-SD_JOURNAL_FILE_SOURCE_TYPE get_internal_source_type(const char *value) {
+static __always_inline SD_JOURNAL_FILE_SOURCE_TYPE get_internal_source_type(const char *value)
+{
     if (strcmp(value, ND_SD_JF_SOURCE_ALL_NAME) == 0)
         return ND_SD_JF_ALL;
     else if (strcmp(value, ND_SD_JF_SOURCE_LOCAL_NAME) == 0)
@@ -87,8 +87,7 @@ SD_JOURNAL_FILE_SOURCE_TYPE get_internal_source_type(const char *value) {
     "|_UID"                                                                                                                    \
     "|_GID"                                                                                                                    \
     "|_COMM"                                                                                                                   \
-    "|_EXE"           /* "|_CMDLINE" */                                                                                        \
-    "|_CAP_EFFECTIVE" /* "|_AUDIT_SESSION" */                                                                                  \
+    "|_EXE" /* "|_CMDLINE" "|_CAP_EFFECTIVE" "|_AUDIT_SESSION" */                                                              \
     "|_AUDIT_LOGINUID"                                                                                                         \
     "|_SYSTEMD_CGROUP"                                                                                                         \
     "|_SYSTEMD_SLICE"                                                                                                          \
@@ -101,8 +100,7 @@ SD_JOURNAL_FILE_SOURCE_TYPE get_internal_source_type(const char *value) {
     "|_BOOT_ID"                                                                                                                \
     "|_MACHINE_ID" /* "|_SYSTEMD_INVOCATION_ID" */                                                                             \
     "|_HOSTNAME"                                                                                                               \
-    "|_TRANSPORT"                                                                                                              \
-    "|_STREAM_ID" /* "|LINE_BREAK" */                                                                                          \
+    "|_TRANSPORT" /* "|_STREAM_ID" "|LINE_BREAK" */                                                                            \
     "|_NAMESPACE"                                                                                                              \
     "|_RUNTIME_SCOPE"                                                                                                          \
                                                                                                                                \
@@ -155,8 +153,8 @@ SD_JOURNAL_FILE_SOURCE_TYPE get_internal_source_type(const char *value) {
 
 #include "systemd-journal-execute.h"
 
-static
-void systemd_journal_register_transformations(LOGS_QUERY_STATUS *lqs) {
+static void systemd_journal_register_transformations(LOGS_QUERY_STATUS *lqs)
+{
     FACETS *facets = lqs->facets;
     LOGS_QUERY_REQUEST *rq = &lqs->rq;
 
@@ -332,8 +330,8 @@ void function_systemd_journal(
     const char *source,
     void *data)
 {
-    BUFFER *wb =
-        function_systemd_journal_result(transaction, function, stop_monotonic_ut, cancelled, payload, access, source, data);
+    BUFFER *wb = function_systemd_journal_result(
+        transaction, function, stop_monotonic_ut, cancelled, payload, access, source, data);
 
     netdata_mutex_lock(&stdout_mutex);
     pluginsd_function_result_to_stdout(transaction, wb);

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -25,7 +25,6 @@ struct systemd_journal_test_command {
     bool enabled;
     const char *function_name;
     const char *backend_dir;
-    const char *request_path;
     uint64_t timeout_seconds;
     bool timeout_seconds_set;
 };
@@ -34,7 +33,7 @@ static void systemd_journal_test_usage(FILE *stream)
 {
     fprintf(
         stream,
-        "usage: systemd-journal.plugin --test systemd-journal --dir <journal-dir> --request <payload.json> [--timeout <seconds>]\n");
+        "usage: systemd-journal.plugin --test systemd-journal --dir <journal-dir> [--timeout <seconds>] < payload.json\n");
 }
 
 static bool test_option_present(int argc, char **argv)
@@ -146,17 +145,14 @@ static int parse_systemd_journal_test_command(int argc, char **argv, struct syst
                 return rc;
         }
         else if (strcmp(arg, "--request") == 0) {
-            if (++i >= argc)
-                return set_required_option_once(&cmd->request_path, NULL, "--request");
-
-            int rc = set_required_option_once(&cmd->request_path, argv[i], "--request");
-            if (rc)
-                return rc;
+            fprintf(stderr, "--request is no longer supported; pass the request payload on stdin\n");
+            systemd_journal_test_usage(stderr);
+            return 2;
         }
         else if (strncmp(arg, "--request=", strlen("--request=")) == 0) {
-            int rc = set_required_option_once(&cmd->request_path, arg + strlen("--request="), "--request");
-            if (rc)
-                return rc;
+            fprintf(stderr, "--request is no longer supported; pass the request payload on stdin\n");
+            systemd_journal_test_usage(stderr);
+            return 2;
         }
         else if (strcmp(arg, "--timeout") == 0) {
             if (++i >= argc)
@@ -195,12 +191,6 @@ static int parse_systemd_journal_test_command(int argc, char **argv, struct syst
         return 2;
     }
 
-    if (!cmd->request_path) {
-        fprintf(stderr, "missing required --request\n");
-        systemd_journal_test_usage(stderr);
-        return 2;
-    }
-
     if (!cmd->timeout_seconds_set)
         cmd->timeout_seconds = ND_SD_JOURNAL_DEFAULT_TIMEOUT;
 
@@ -224,113 +214,37 @@ static usec_t systemd_journal_test_stop_monotonic_usec(uint64_t timeout_seconds)
     return now_ut + effective_timeout_seconds * USEC_PER_SEC;
 }
 
-static int validate_systemd_journal_test_executable_permissions(void)
-{
-    CLEAN_CHAR_P *plugin_path = os_get_process_path();
-    if (!plugin_path || !*plugin_path) {
-        fprintf(stderr, "refusing systemd journal test mode: failed to resolve plugin executable path\n");
-        return 2;
-    }
-
-    struct stat st;
-    if (stat(plugin_path, &st) != 0) {
-        fprintf(
-            stderr,
-            "refusing systemd journal test mode: failed to inspect plugin executable '%s': %s\n",
-            plugin_path,
-            strerror(errno));
-        return 2;
-    }
-
-    if (st.st_mode & S_IXOTH) {
-        fprintf(
-            stderr,
-            "refusing systemd journal test mode: plugin executable '%s' is world-executable\n",
-            plugin_path);
-        return 2;
-    }
-
-    return 0;
-}
-
 static bool path_is_directory(const char *path)
 {
     struct stat st;
     return path && stat(path, &st) == 0 && S_ISDIR(st.st_mode);
 }
 
-static BUFFER *read_request_payload(const char *filename)
+static BUFFER *read_request_payload_from_stdin(void)
 {
-#if !defined(O_NOFOLLOW) || !defined(O_NONBLOCK)
-    fprintf(
-        stderr,
-        "refusing request payload '%s': platform does not support safe request payload open flags\n",
-        filename);
-    return NULL;
-#else
-
-    // O_NONBLOCK protects the open/fstat boundary if the path races to a FIFO; regular-file reads still block.
-    int flags = O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK;
-    int fd = open(filename, flags);
-    if (fd == -1) {
-        fprintf(stderr, "failed to open request payload '%s': %s\n", filename, strerror(errno));
-        return NULL;
-    }
-
-    CLEAN_CHAR_P *resolved = realpath(filename, NULL);
-    const char *display_path = resolved ? resolved : filename;
-
-    struct stat st;
-    if (fstat(fd, &st) == -1) {
-        fprintf(stderr, "failed to inspect request payload '%s': %s\n", display_path, strerror(errno));
-        close(fd);
-        return NULL;
-    }
-
-    if (!S_ISREG(st.st_mode)) {
-        fprintf(stderr, "request payload '%s' is not a regular file\n", display_path);
-        close(fd);
-        return NULL;
-    }
-
-    if (st.st_size <= 0) {
-        fprintf(stderr, "request payload '%s' is empty\n", display_path);
-        close(fd);
-        return NULL;
-    }
-
-    if ((uint64_t)st.st_size > ND_SD_JOURNAL_TEST_MAX_REQUEST_BYTES) {
-        fprintf(
-            stderr,
-            "request payload '%s' is too large: %llu bytes, max %llu bytes\n",
-            display_path,
-            (unsigned long long)st.st_size,
-            (unsigned long long)ND_SD_JOURNAL_TEST_MAX_REQUEST_BYTES);
-        close(fd);
-        return NULL;
-    }
-
-    BUFFER *payload = buffer_create((size_t)st.st_size + 1, NULL);
+    BUFFER *payload = buffer_create(8192, NULL);
     size_t total = 0;
-    while (total < (size_t)st.st_size) {
+    while (true) {
         char buffer[8192];
-        size_t remaining = (size_t)st.st_size - total;
-        size_t wanted = MIN(remaining, sizeof(buffer));
-        ssize_t bytes_read = read(fd, buffer, wanted);
+        ssize_t bytes_read = read(STDIN_FILENO, buffer, sizeof(buffer));
         if (bytes_read == -1) {
             if (errno == EINTR)
                 continue;
 
-            fprintf(stderr, "failed to read request payload '%s': %s\n", display_path, strerror(errno));
+            fprintf(stderr, "failed to read request payload from stdin: %s\n", strerror(errno));
             buffer_free(payload);
-            close(fd);
             return NULL;
         }
 
-        if (bytes_read == 0) {
-            fprintf(stderr, "request payload '%s' changed while reading\n", display_path);
+        if (bytes_read == 0)
+            break;
+
+        if ((uint64_t)total + (uint64_t)bytes_read > ND_SD_JOURNAL_TEST_MAX_REQUEST_BYTES) {
+            fprintf(
+                stderr,
+                "request payload from stdin is too large: max %llu bytes\n",
+                (unsigned long long)ND_SD_JOURNAL_TEST_MAX_REQUEST_BYTES);
             buffer_free(payload);
-            close(fd);
             return NULL;
         }
 
@@ -338,11 +252,15 @@ static BUFFER *read_request_payload(const char *filename)
         total += (size_t)bytes_read;
     }
 
-    close(fd);
+    if (total == 0) {
+        fprintf(stderr, "request payload from stdin is empty\n");
+        buffer_free(payload);
+        return NULL;
+    }
+
     payload->content_type = CT_APPLICATION_JSON;
 
     return payload;
-#endif
 }
 
 static int run_systemd_journal_test_command(const struct systemd_journal_test_command *cmd)
@@ -361,12 +279,7 @@ static int run_systemd_journal_test_command(const struct systemd_journal_test_co
         return 1;
     }
 
-    // The request path is intentionally caller-selected for offline fixtures. Test mode refuses world-executable
-    // privileged plugin binaries, and the path is opened with no-final-symlink and nonblocking flags, size-limited,
-    // and checked as a regular file.
-    //
-    // codeql[cpp/path-injection]
-    CLEAN_BUFFER *payload = read_request_payload(cmd->request_path);
+    CLEAN_BUFFER *payload = read_request_payload_from_stdin();
     if (!payload)
         return 1;
 
@@ -416,12 +329,6 @@ int main(int argc, char **argv)
     int test_parse_rc = parse_systemd_journal_test_command(argc, argv, &test_command);
     if (test_parse_rc)
         exit(test_parse_rc);
-
-    if (test_command.enabled) {
-        int permissions_rc = validate_systemd_journal_test_executable_permissions();
-        if (permissions_rc)
-            exit(permissions_rc);
-    }
 
     nd_thread_tag_set("sd-jrnl.plugin");
     nd_log_initialize_for_external_plugins("systemd-journal.plugin");

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -2,10 +2,6 @@
 
 #include "systemd-internals.h"
 
-#include <dirent.h>
-#include <errno.h>
-#include <limits.h>
-
 #define ND_SD_JOURNAL_WORKER_THREADS 5
 #define ND_SD_JOURNAL_TEST_TIMEOUT_DISABLED_SECONDS (100ULL * 365ULL * 24ULL * 60ULL * 60ULL)
 #define ND_SD_JOURNAL_TEST_MAX_REQUEST_BYTES (16ULL * 1024ULL * 1024ULL)

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -218,6 +218,7 @@ static DIR *open_systemd_journal_test_backend_directory(const char *path, char *
 {
     struct stat path_st, dir_st;
 
+    // Pin the explicit --dir backend root; symlinked journal trees are handled by the shared scanner.
     if (!path || !*path) {
         errno = EINVAL;
         return NULL;

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -349,12 +349,13 @@ static int run_systemd_journal_test_command(const struct systemd_journal_test_co
         return 1;
     }
 
+    bool cancelled = false;
+    usec_t stop_monotonic_ut = systemd_journal_test_stop_monotonic_usec(cmd->timeout_seconds);
+
     nd_journal_set_scan_progress_enabled(false);
     nd_journal_use_single_directory(backend_dir_path);
     nd_journal_files_registry_update();
 
-    bool cancelled = false;
-    usec_t stop_monotonic_ut = systemd_journal_test_stop_monotonic_usec(cmd->timeout_seconds);
     char *function = strdupz(cmd->function_name);
     BUFFER *result = function_systemd_journal_result(
         "test", function, &stop_monotonic_ut, &cancelled, payload, HTTP_ACCESS_ALL, "test-cli", NULL);

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -2,8 +2,8 @@
 
 #include "systemd-internals.h"
 
-#include <dirent.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <limits.h>
 
 #define ND_SD_JOURNAL_WORKER_THREADS 5
@@ -218,18 +218,40 @@ static usec_t systemd_journal_test_stop_monotonic_usec(uint64_t timeout_seconds)
     return now_ut + effective_timeout_seconds * USEC_PER_SEC;
 }
 
-static bool path_is_directory(const char *path)
+static int open_systemd_journal_test_backend_directory(const char *path, char *fd_path, size_t fd_path_size)
 {
     struct stat st;
-    if (!path || !*path || stat(path, &st) != 0 || !S_ISDIR(st.st_mode))
-        return false;
 
-    DIR *dir = opendir(path);
-    if (!dir)
-        return false;
+    if (!path || !*path) {
+        errno = EINVAL;
+        return -1;
+    }
 
-    closedir(dir);
-    return true;
+    int fd = open(path, O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW);
+    if (fd == -1)
+        return -1;
+
+    if (fstat(fd, &st) == -1) {
+        int saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return -1;
+    }
+
+    if (!S_ISDIR(st.st_mode)) {
+        close(fd);
+        errno = ENOTDIR;
+        return -1;
+    }
+
+    int written = snprintfz(fd_path, fd_path_size, "/proc/self/fd/%d", fd);
+    if (written < 0 || (size_t)written >= fd_path_size) {
+        close(fd);
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+
+    return fd;
 }
 
 static BUFFER *read_request_payload_from_stdin(void)
@@ -286,17 +308,26 @@ static int run_systemd_journal_test_command(const struct systemd_journal_test_co
         return 2;
     }
 
-    if (!path_is_directory(cmd->backend_dir)) {
-        fprintf(stderr, "systemd journal backend directory '%s' does not exist\n", cmd->backend_dir);
+    char backend_dir_path[FILENAME_MAX];
+    int backend_dir_fd =
+        open_systemd_journal_test_backend_directory(cmd->backend_dir, backend_dir_path, sizeof(backend_dir_path));
+    if (backend_dir_fd == -1) {
+        fprintf(
+            stderr,
+            "systemd journal backend directory '%s' cannot be opened: %s\n",
+            cmd->backend_dir,
+            strerror(errno));
         return 1;
     }
 
     CLEAN_BUFFER *payload = read_request_payload_from_stdin();
-    if (!payload)
+    if (!payload) {
+        close(backend_dir_fd);
         return 1;
+    }
 
     nd_journal_set_scan_progress_enabled(false);
-    nd_journal_use_single_directory(cmd->backend_dir);
+    nd_journal_use_single_directory(backend_dir_path);
     nd_journal_files_registry_update();
 
     bool cancelled = false;
@@ -322,6 +353,7 @@ static int run_systemd_journal_test_command(const struct systemd_journal_test_co
         fprintf(stderr, "systemd journal test function returned no result\n");
     }
 
+    close(backend_dir_fd);
     return rc;
 }
 

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -2,6 +2,7 @@
 
 #include "systemd-internals.h"
 
+#include <dirent.h>
 #include <errno.h>
 #include <limits.h>
 
@@ -220,7 +221,15 @@ static usec_t systemd_journal_test_stop_monotonic_usec(uint64_t timeout_seconds)
 static bool path_is_directory(const char *path)
 {
     struct stat st;
-    return path && *path && stat(path, &st) == 0 && S_ISDIR(st.st_mode) && access(path, R_OK | X_OK) == 0;
+    if (!path || !*path || stat(path, &st) != 0 || !S_ISDIR(st.st_mode))
+        return false;
+
+    DIR *dir = opendir(path);
+    if (!dir)
+        return false;
+
+    closedir(dir);
+    return true;
 }
 
 static BUFFER *read_request_payload_from_stdin(void)

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -261,22 +261,15 @@ static bool path_is_directory(const char *path)
 
 static BUFFER *read_request_payload(const char *filename)
 {
-    int flags = O_RDONLY | O_CLOEXEC;
-#ifdef O_NOFOLLOW
-    flags |= O_NOFOLLOW;
+#if !defined(O_NOFOLLOW) || !defined(O_NONBLOCK)
+    fprintf(
+        stderr,
+        "refusing request payload '%s': platform does not support safe request payload open flags\n",
+        filename);
+    return NULL;
 #else
-    struct stat lst;
-    if (lstat(filename, &lst) == -1) {
-        fprintf(stderr, "failed to inspect request payload '%s': %s\n", filename, strerror(errno));
-        return NULL;
-    }
 
-    if (S_ISLNK(lst.st_mode)) {
-        fprintf(stderr, "request payload '%s' is a symbolic link\n", filename);
-        return NULL;
-    }
-#endif
-
+    int flags = O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK;
     int fd = open(filename, flags);
     if (fd == -1) {
         fprintf(stderr, "failed to open request payload '%s': %s\n", filename, strerror(errno));
@@ -348,6 +341,7 @@ static BUFFER *read_request_payload(const char *filename)
     payload->content_type = CT_APPLICATION_JSON;
 
     return payload;
+#endif
 }
 
 static int run_systemd_journal_test_command(const struct systemd_journal_test_command *cmd)
@@ -367,8 +361,8 @@ static int run_systemd_journal_test_command(const struct systemd_journal_test_co
     }
 
     // The request path is intentionally caller-selected for offline fixtures. Test mode refuses world-executable
-    // privileged plugin binaries, and the path is opened without following the final symlink, size-limited, and
-    // checked as a regular file.
+    // privileged plugin binaries, and the path is opened with no-final-symlink and nonblocking flags, size-limited,
+    // and checked as a regular file.
     //
     // codeql[cpp/path-injection]
     CLEAN_BUFFER *payload = read_request_payload(cmd->request_path);

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -107,6 +107,13 @@ static int set_timeout_option_once(uint64_t *slot, bool *slot_set, const char *v
     return 0;
 }
 
+static int reject_request_option(void)
+{
+    fprintf(stderr, "--request is no longer supported; pass the request payload on stdin\n");
+    systemd_journal_test_usage(stderr);
+    return 2;
+}
+
 static int parse_systemd_journal_test_command(int argc, char **argv, struct systemd_journal_test_command *cmd)
 {
     *cmd = (struct systemd_journal_test_command){0};
@@ -145,14 +152,10 @@ static int parse_systemd_journal_test_command(int argc, char **argv, struct syst
                 return rc;
         }
         else if (strcmp(arg, "--request") == 0) {
-            fprintf(stderr, "--request is no longer supported; pass the request payload on stdin\n");
-            systemd_journal_test_usage(stderr);
-            return 2;
+            return reject_request_option();
         }
         else if (strncmp(arg, "--request=", strlen("--request=")) == 0) {
-            fprintf(stderr, "--request is no longer supported; pass the request payload on stdin\n");
-            systemd_journal_test_usage(stderr);
-            return 2;
+            return reject_request_option();
         }
         else if (strcmp(arg, "--timeout") == 0) {
             if (++i >= argc)
@@ -217,7 +220,7 @@ static usec_t systemd_journal_test_stop_monotonic_usec(uint64_t timeout_seconds)
 static bool path_is_directory(const char *path)
 {
     struct stat st;
-    return path && stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+    return path && *path && stat(path, &st) == 0 && S_ISDIR(st.st_mode) && access(path, R_OK | X_OK) == 0;
 }
 
 static BUFFER *read_request_payload_from_stdin(void)

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -16,6 +16,203 @@ static void __attribute__((destructor)) destroy_mutex(void) {
 
 static bool plugin_should_exit = false;
 
+struct systemd_journal_test_command {
+    bool enabled;
+    const char *function_name;
+    const char *backend_dir;
+    const char *request_path;
+};
+
+static void systemd_journal_test_usage(FILE *stream)
+{
+    fprintf(
+        stream,
+        "usage: systemd-journal.plugin --test systemd-journal --dir <journal-dir> --request <payload.json>\n");
+}
+
+static bool test_option_present(int argc, char **argv)
+{
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--test") == 0 || strncmp(argv[i], "--test=", strlen("--test=")) == 0)
+            return true;
+    }
+
+    return false;
+}
+
+static int set_required_option_once(const char **slot, const char *value, const char *option)
+{
+    if (*slot) {
+        fprintf(stderr, "duplicate %s\n", option);
+        systemd_journal_test_usage(stderr);
+        return 2;
+    }
+
+    if (!value || !*value) {
+        fprintf(stderr, "missing value for %s\n", option);
+        systemd_journal_test_usage(stderr);
+        return 2;
+    }
+
+    *slot = value;
+    return 0;
+}
+
+static int parse_systemd_journal_test_command(int argc, char **argv, struct systemd_journal_test_command *cmd)
+{
+    *cmd = (struct systemd_journal_test_command){0};
+    if (!test_option_present(argc, argv))
+        return 0;
+
+    cmd->enabled = true;
+
+    for (int i = 1; i < argc; i++) {
+        const char *arg = argv[i];
+
+        if (strcmp(arg, "--test") == 0) {
+            if (++i >= argc)
+                return set_required_option_once(&cmd->function_name, NULL, "--test");
+
+            int rc = set_required_option_once(&cmd->function_name, argv[i], "--test");
+            if (rc)
+                return rc;
+        }
+        else if (strncmp(arg, "--test=", strlen("--test=")) == 0) {
+            int rc = set_required_option_once(&cmd->function_name, arg + strlen("--test="), "--test");
+            if (rc)
+                return rc;
+        }
+        else if (strcmp(arg, "--dir") == 0) {
+            if (++i >= argc)
+                return set_required_option_once(&cmd->backend_dir, NULL, "--dir");
+
+            int rc = set_required_option_once(&cmd->backend_dir, argv[i], "--dir");
+            if (rc)
+                return rc;
+        }
+        else if (strncmp(arg, "--dir=", strlen("--dir=")) == 0) {
+            int rc = set_required_option_once(&cmd->backend_dir, arg + strlen("--dir="), "--dir");
+            if (rc)
+                return rc;
+        }
+        else if (strcmp(arg, "--request") == 0) {
+            if (++i >= argc)
+                return set_required_option_once(&cmd->request_path, NULL, "--request");
+
+            int rc = set_required_option_once(&cmd->request_path, argv[i], "--request");
+            if (rc)
+                return rc;
+        }
+        else if (strncmp(arg, "--request=", strlen("--request=")) == 0) {
+            int rc = set_required_option_once(&cmd->request_path, arg + strlen("--request="), "--request");
+            if (rc)
+                return rc;
+        }
+        else if (strcmp(arg, "-h") == 0 || strcmp(arg, "--help") == 0) {
+            systemd_journal_test_usage(stderr);
+            return 2;
+        }
+        else {
+            fprintf(stderr, "unsupported systemd journal test option '%s'\n", arg);
+            systemd_journal_test_usage(stderr);
+            return 2;
+        }
+    }
+
+    if (!cmd->function_name) {
+        fprintf(stderr, "missing required --test\n");
+        systemd_journal_test_usage(stderr);
+        return 2;
+    }
+
+    if (!cmd->backend_dir) {
+        fprintf(stderr, "missing required --dir\n");
+        systemd_journal_test_usage(stderr);
+        return 2;
+    }
+
+    if (!cmd->request_path) {
+        fprintf(stderr, "missing required --request\n");
+        systemd_journal_test_usage(stderr);
+        return 2;
+    }
+
+    return 0;
+}
+
+static bool path_is_directory(const char *path)
+{
+    struct stat st;
+    return path && stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
+static BUFFER *read_request_payload(const char *filename)
+{
+    long file_size = 0;
+    char *contents = read_by_filename(filename, &file_size);
+    if (!contents)
+        return NULL;
+
+    BUFFER *payload = buffer_create((size_t)file_size + 1, NULL);
+    buffer_memcat(payload, contents, (size_t)file_size);
+    payload->content_type = CT_APPLICATION_JSON;
+    freez(contents);
+
+    return payload;
+}
+
+static int run_systemd_journal_test_command(const struct systemd_journal_test_command *cmd)
+{
+    if (strcmp(cmd->function_name, ND_SD_JOURNAL_FUNCTION_NAME) != 0) {
+        fprintf(
+            stderr,
+            "unsupported systemd journal test function '%s' (expected '%s')\n",
+            cmd->function_name,
+            ND_SD_JOURNAL_FUNCTION_NAME);
+        return 2;
+    }
+
+    if (!path_is_directory(cmd->backend_dir)) {
+        fprintf(stderr, "systemd journal backend directory '%s' does not exist\n", cmd->backend_dir);
+        return 1;
+    }
+
+    CLEAN_BUFFER *payload = read_request_payload(cmd->request_path);
+    if (!payload) {
+        fprintf(stderr, "failed to read request payload '%s'\n", cmd->request_path);
+        return 1;
+    }
+
+    nd_journal_set_scan_progress_enabled(false);
+    nd_journal_use_single_directory(cmd->backend_dir);
+    nd_journal_files_registry_update();
+
+    bool cancelled = false;
+    usec_t stop_monotonic_ut = now_monotonic_usec() + ND_SD_JOURNAL_DEFAULT_TIMEOUT * USEC_PER_SEC;
+    char *function = strdupz(cmd->function_name);
+    BUFFER *result = function_systemd_journal_result(
+        "test", function, &stop_monotonic_ut, &cancelled, payload, HTTP_ACCESS_ALL, "test-cli", NULL);
+    freez(function);
+
+    int rc = 1;
+    if (result) {
+        if (buffer_strlen(result))
+            fwrite(buffer_tostring(result), buffer_strlen(result), 1, stdout);
+        fprintf(stdout, "\n");
+        fflush(stdout);
+
+        if (result->response_code >= HTTP_RESP_OK && result->response_code < 300)
+            rc = 0;
+
+        buffer_free(result);
+    }
+    else {
+        fprintf(stderr, "systemd journal test function returned no result\n");
+    }
+
+    return rc;
+}
+
 static bool journal_data_directories_exist()
 {
     struct stat st;
@@ -26,8 +223,13 @@ static bool journal_data_directories_exist()
     return false;
 }
 
-int main(int argc __maybe_unused, char **argv __maybe_unused)
+int main(int argc, char **argv)
 {
+    struct systemd_journal_test_command test_command = {0};
+    int test_parse_rc = parse_systemd_journal_test_command(argc, argv, &test_command);
+    if (test_parse_rc)
+        exit(test_parse_rc);
+
     nd_thread_tag_set("sd-jrnl.plugin");
     nd_log_initialize_for_external_plugins("systemd-journal.plugin");
     netdata_threads_init_for_external_plugins(0);
@@ -41,6 +243,9 @@ int main(int argc __maybe_unused, char **argv __maybe_unused)
 
     nd_sd_journal_annotations_init();
     nd_journal_init_files_and_directories();
+
+    if (test_command.enabled)
+        exit(run_systemd_journal_test_command(&test_command));
 
     if (!journal_data_directories_exist()) {
         nd_log_collector(NDLP_INFO, "unable to locate journal data directories. Exiting...");

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -269,6 +269,7 @@ static BUFFER *read_request_payload(const char *filename)
     return NULL;
 #else
 
+    // O_NONBLOCK protects the open/fstat boundary if the path races to a FIFO; regular-file reads still block.
     int flags = O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK;
     int fd = open(filename, flags);
     if (fd == -1) {

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -7,6 +7,7 @@
 
 #define ND_SD_JOURNAL_WORKER_THREADS 5
 #define ND_SD_JOURNAL_TEST_TIMEOUT_DISABLED_SECONDS (100ULL * 365ULL * 24ULL * 60ULL * 60ULL)
+#define ND_SD_JOURNAL_TEST_MAX_REQUEST_BYTES (16ULL * 1024ULL * 1024ULL)
 
 netdata_mutex_t stdout_mutex;
 
@@ -260,15 +261,83 @@ static bool path_is_directory(const char *path)
 
 static BUFFER *read_request_payload(const char *filename)
 {
-    long file_size = 0;
-    char *contents = read_by_filename(filename, &file_size);
-    if (!contents)
+    CLEAN_CHAR_P *resolved = realpath(filename, NULL);
+    if (!resolved) {
+        fprintf(stderr, "failed to resolve request payload '%s': %s\n", filename, strerror(errno));
         return NULL;
+    }
 
-    BUFFER *payload = buffer_create((size_t)file_size + 1, NULL);
-    buffer_memcat(payload, contents, (size_t)file_size);
+    int flags = O_RDONLY | O_CLOEXEC;
+#ifdef O_NOFOLLOW
+    flags |= O_NOFOLLOW;
+#endif
+
+    int fd = open(resolved, flags);
+    if (fd == -1) {
+        fprintf(stderr, "failed to open request payload '%s': %s\n", resolved, strerror(errno));
+        return NULL;
+    }
+
+    struct stat st;
+    if (fstat(fd, &st) == -1) {
+        fprintf(stderr, "failed to inspect request payload '%s': %s\n", resolved, strerror(errno));
+        close(fd);
+        return NULL;
+    }
+
+    if (!S_ISREG(st.st_mode)) {
+        fprintf(stderr, "request payload '%s' is not a regular file\n", resolved);
+        close(fd);
+        return NULL;
+    }
+
+    if (st.st_size <= 0) {
+        fprintf(stderr, "request payload '%s' is empty\n", resolved);
+        close(fd);
+        return NULL;
+    }
+
+    if ((uint64_t)st.st_size > ND_SD_JOURNAL_TEST_MAX_REQUEST_BYTES) {
+        fprintf(
+            stderr,
+            "request payload '%s' is too large: %llu bytes, max %llu bytes\n",
+            resolved,
+            (unsigned long long)st.st_size,
+            (unsigned long long)ND_SD_JOURNAL_TEST_MAX_REQUEST_BYTES);
+        close(fd);
+        return NULL;
+    }
+
+    BUFFER *payload = buffer_create((size_t)st.st_size + 1, NULL);
+    size_t total = 0;
+    while (total < (size_t)st.st_size) {
+        char buffer[8192];
+        size_t remaining = (size_t)st.st_size - total;
+        size_t wanted = MIN(remaining, sizeof(buffer));
+        ssize_t bytes_read = read(fd, buffer, wanted);
+        if (bytes_read == -1) {
+            if (errno == EINTR)
+                continue;
+
+            fprintf(stderr, "failed to read request payload '%s': %s\n", resolved, strerror(errno));
+            buffer_free(payload);
+            close(fd);
+            return NULL;
+        }
+
+        if (bytes_read == 0) {
+            fprintf(stderr, "request payload '%s' changed while reading\n", resolved);
+            buffer_free(payload);
+            close(fd);
+            return NULL;
+        }
+
+        buffer_memcat(payload, buffer, (size_t)bytes_read);
+        total += (size_t)bytes_read;
+    }
+
+    close(fd);
     payload->content_type = CT_APPLICATION_JSON;
-    freez(contents);
 
     return payload;
 }
@@ -289,11 +358,13 @@ static int run_systemd_journal_test_command(const struct systemd_journal_test_co
         return 1;
     }
 
+    // The request path is intentionally caller-selected for offline fixtures. Test mode refuses world-executable
+    // privileged plugin binaries, and the path is canonicalized, size-limited, and checked as a regular file.
+    //
+    // codeql[cpp/path-injection]
     CLEAN_BUFFER *payload = read_request_payload(cmd->request_path);
-    if (!payload) {
-        fprintf(stderr, "failed to read request payload '%s'\n", cmd->request_path);
+    if (!payload)
         return 1;
-    }
 
     nd_journal_set_scan_progress_enabled(false);
     nd_journal_use_single_directory(cmd->backend_dir);

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -2,7 +2,11 @@
 
 #include "systemd-internals.h"
 
+#include <errno.h>
+#include <limits.h>
+
 #define ND_SD_JOURNAL_WORKER_THREADS 5
+#define ND_SD_JOURNAL_TEST_TIMEOUT_DISABLED_SECONDS (100ULL * 365ULL * 24ULL * 60ULL * 60ULL)
 
 netdata_mutex_t stdout_mutex;
 
@@ -21,13 +25,15 @@ struct systemd_journal_test_command {
     const char *function_name;
     const char *backend_dir;
     const char *request_path;
+    uint64_t timeout_seconds;
+    bool timeout_seconds_set;
 };
 
 static void systemd_journal_test_usage(FILE *stream)
 {
     fprintf(
         stream,
-        "usage: systemd-journal.plugin --test systemd-journal --dir <journal-dir> --request <payload.json>\n");
+        "usage: systemd-journal.plugin --test systemd-journal --dir <journal-dir> --request <payload.json> [--timeout <seconds>]\n");
 }
 
 static bool test_option_present(int argc, char **argv)
@@ -55,6 +61,49 @@ static int set_required_option_once(const char **slot, const char *value, const 
     }
 
     *slot = value;
+    return 0;
+}
+
+static int set_timeout_option_once(uint64_t *slot, bool *slot_set, const char *value)
+{
+    if (*slot_set) {
+        fprintf(stderr, "duplicate --timeout\n");
+        systemd_journal_test_usage(stderr);
+        return 2;
+    }
+
+    if (!value || !*value) {
+        fprintf(stderr, "missing value for --timeout\n");
+        systemd_journal_test_usage(stderr);
+        return 2;
+    }
+
+    for (const char *s = value; *s; s++) {
+        if (*s < '0' || *s > '9') {
+            fprintf(stderr, "invalid value for --timeout '%s'; expected seconds\n", value);
+            systemd_journal_test_usage(stderr);
+            return 2;
+        }
+    }
+
+    errno = 0;
+    unsigned long long parsed = strtoull(value, NULL, 10);
+    if (errno == ERANGE) {
+        fprintf(stderr, "invalid value for --timeout '%s'; expected seconds\n", value);
+        systemd_journal_test_usage(stderr);
+        return 2;
+    }
+
+#if ULLONG_MAX > UINT64_MAX
+    if (parsed > UINT64_MAX) {
+        fprintf(stderr, "invalid value for --timeout '%s'; expected seconds\n", value);
+        systemd_journal_test_usage(stderr);
+        return 2;
+    }
+#endif
+
+    *slot = (uint64_t)parsed;
+    *slot_set = true;
     return 0;
 }
 
@@ -108,6 +157,20 @@ static int parse_systemd_journal_test_command(int argc, char **argv, struct syst
             if (rc)
                 return rc;
         }
+        else if (strcmp(arg, "--timeout") == 0) {
+            if (++i >= argc)
+                return set_timeout_option_once(&cmd->timeout_seconds, &cmd->timeout_seconds_set, NULL);
+
+            int rc = set_timeout_option_once(&cmd->timeout_seconds, &cmd->timeout_seconds_set, argv[i]);
+            if (rc)
+                return rc;
+        }
+        else if (strncmp(arg, "--timeout=", strlen("--timeout=")) == 0) {
+            int rc = set_timeout_option_once(
+                &cmd->timeout_seconds, &cmd->timeout_seconds_set, arg + strlen("--timeout="));
+            if (rc)
+                return rc;
+        }
         else if (strcmp(arg, "-h") == 0 || strcmp(arg, "--help") == 0) {
             systemd_journal_test_usage(stderr);
             return 2;
@@ -137,7 +200,27 @@ static int parse_systemd_journal_test_command(int argc, char **argv, struct syst
         return 2;
     }
 
+    if (!cmd->timeout_seconds_set)
+        cmd->timeout_seconds = ND_SD_JOURNAL_DEFAULT_TIMEOUT;
+
     return 0;
+}
+
+static uint64_t systemd_journal_effective_timeout_seconds(uint64_t timeout_seconds)
+{
+    return timeout_seconds ? timeout_seconds : ND_SD_JOURNAL_TEST_TIMEOUT_DISABLED_SECONDS;
+}
+
+static usec_t systemd_journal_test_stop_monotonic_usec(uint64_t timeout_seconds)
+{
+    usec_t now_ut = now_monotonic_usec();
+    uint64_t effective_timeout_seconds = systemd_journal_effective_timeout_seconds(timeout_seconds);
+    uint64_t max_timeout_seconds = (UINT64_MAX - now_ut) / USEC_PER_SEC;
+
+    if (effective_timeout_seconds > max_timeout_seconds)
+        return UINT64_MAX;
+
+    return now_ut + effective_timeout_seconds * USEC_PER_SEC;
 }
 
 static bool path_is_directory(const char *path)
@@ -188,7 +271,7 @@ static int run_systemd_journal_test_command(const struct systemd_journal_test_co
     nd_journal_files_registry_update();
 
     bool cancelled = false;
-    usec_t stop_monotonic_ut = now_monotonic_usec() + ND_SD_JOURNAL_DEFAULT_TIMEOUT * USEC_PER_SEC;
+    usec_t stop_monotonic_ut = systemd_journal_test_stop_monotonic_usec(cmd->timeout_seconds);
     char *function = strdupz(cmd->function_name);
     BUFFER *result = function_systemd_journal_result(
         "test", function, &stop_monotonic_ut, &cancelled, payload, HTTP_ACCESS_ALL, "test-cli", NULL);

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -223,6 +223,35 @@ static usec_t systemd_journal_test_stop_monotonic_usec(uint64_t timeout_seconds)
     return now_ut + effective_timeout_seconds * USEC_PER_SEC;
 }
 
+static int validate_systemd_journal_test_executable_permissions(void)
+{
+    CLEAN_CHAR_P *plugin_path = os_get_process_path();
+    if (!plugin_path || !*plugin_path) {
+        fprintf(stderr, "refusing systemd journal test mode: failed to resolve plugin executable path\n");
+        return 2;
+    }
+
+    struct stat st;
+    if (stat(plugin_path, &st) != 0) {
+        fprintf(
+            stderr,
+            "refusing systemd journal test mode: failed to inspect plugin executable '%s': %s\n",
+            plugin_path,
+            strerror(errno));
+        return 2;
+    }
+
+    if (st.st_mode & S_IXOTH) {
+        fprintf(
+            stderr,
+            "refusing systemd journal test mode: plugin executable '%s' is world-executable\n",
+            plugin_path);
+        return 2;
+    }
+
+    return 0;
+}
+
 static bool path_is_directory(const char *path)
 {
     struct stat st;
@@ -312,6 +341,12 @@ int main(int argc, char **argv)
     int test_parse_rc = parse_systemd_journal_test_command(argc, argv, &test_command);
     if (test_parse_rc)
         exit(test_parse_rc);
+
+    if (test_command.enabled) {
+        int permissions_rc = validate_systemd_journal_test_executable_permissions();
+        if (permissions_rc)
+            exit(permissions_rc);
+    }
 
     nd_thread_tag_set("sd-jrnl.plugin");
     nd_log_initialize_for_external_plugins("systemd-journal.plugin");

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -261,38 +261,46 @@ static bool path_is_directory(const char *path)
 
 static BUFFER *read_request_payload(const char *filename)
 {
-    CLEAN_CHAR_P *resolved = realpath(filename, NULL);
-    if (!resolved) {
-        fprintf(stderr, "failed to resolve request payload '%s': %s\n", filename, strerror(errno));
-        return NULL;
-    }
-
     int flags = O_RDONLY | O_CLOEXEC;
 #ifdef O_NOFOLLOW
     flags |= O_NOFOLLOW;
-#endif
-
-    int fd = open(resolved, flags);
-    if (fd == -1) {
-        fprintf(stderr, "failed to open request payload '%s': %s\n", resolved, strerror(errno));
+#else
+    struct stat lst;
+    if (lstat(filename, &lst) == -1) {
+        fprintf(stderr, "failed to inspect request payload '%s': %s\n", filename, strerror(errno));
         return NULL;
     }
 
+    if (S_ISLNK(lst.st_mode)) {
+        fprintf(stderr, "request payload '%s' is a symbolic link\n", filename);
+        return NULL;
+    }
+#endif
+
+    int fd = open(filename, flags);
+    if (fd == -1) {
+        fprintf(stderr, "failed to open request payload '%s': %s\n", filename, strerror(errno));
+        return NULL;
+    }
+
+    CLEAN_CHAR_P *resolved = realpath(filename, NULL);
+    const char *display_path = resolved ? resolved : filename;
+
     struct stat st;
     if (fstat(fd, &st) == -1) {
-        fprintf(stderr, "failed to inspect request payload '%s': %s\n", resolved, strerror(errno));
+        fprintf(stderr, "failed to inspect request payload '%s': %s\n", display_path, strerror(errno));
         close(fd);
         return NULL;
     }
 
     if (!S_ISREG(st.st_mode)) {
-        fprintf(stderr, "request payload '%s' is not a regular file\n", resolved);
+        fprintf(stderr, "request payload '%s' is not a regular file\n", display_path);
         close(fd);
         return NULL;
     }
 
     if (st.st_size <= 0) {
-        fprintf(stderr, "request payload '%s' is empty\n", resolved);
+        fprintf(stderr, "request payload '%s' is empty\n", display_path);
         close(fd);
         return NULL;
     }
@@ -301,7 +309,7 @@ static BUFFER *read_request_payload(const char *filename)
         fprintf(
             stderr,
             "request payload '%s' is too large: %llu bytes, max %llu bytes\n",
-            resolved,
+            display_path,
             (unsigned long long)st.st_size,
             (unsigned long long)ND_SD_JOURNAL_TEST_MAX_REQUEST_BYTES);
         close(fd);
@@ -319,14 +327,14 @@ static BUFFER *read_request_payload(const char *filename)
             if (errno == EINTR)
                 continue;
 
-            fprintf(stderr, "failed to read request payload '%s': %s\n", resolved, strerror(errno));
+            fprintf(stderr, "failed to read request payload '%s': %s\n", display_path, strerror(errno));
             buffer_free(payload);
             close(fd);
             return NULL;
         }
 
         if (bytes_read == 0) {
-            fprintf(stderr, "request payload '%s' changed while reading\n", resolved);
+            fprintf(stderr, "request payload '%s' changed while reading\n", display_path);
             buffer_free(payload);
             close(fd);
             return NULL;
@@ -359,7 +367,8 @@ static int run_systemd_journal_test_command(const struct systemd_journal_test_co
     }
 
     // The request path is intentionally caller-selected for offline fixtures. Test mode refuses world-executable
-    // privileged plugin binaries, and the path is canonicalized, size-limited, and checked as a regular file.
+    // privileged plugin binaries, and the path is opened without following the final symlink, size-limited, and
+    // checked as a regular file.
     //
     // codeql[cpp/path-injection]
     CLEAN_BUFFER *payload = read_request_payload(cmd->request_path);

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -2,8 +2,8 @@
 
 #include "systemd-internals.h"
 
+#include <dirent.h>
 #include <errno.h>
-#include <fcntl.h>
 #include <limits.h>
 
 #define ND_SD_JOURNAL_WORKER_THREADS 5
@@ -218,40 +218,67 @@ static usec_t systemd_journal_test_stop_monotonic_usec(uint64_t timeout_seconds)
     return now_ut + effective_timeout_seconds * USEC_PER_SEC;
 }
 
-static int open_systemd_journal_test_backend_directory(const char *path, char *fd_path, size_t fd_path_size)
+static DIR *open_systemd_journal_test_backend_directory(const char *path, char *fd_path, size_t fd_path_size)
 {
-    struct stat st;
+    struct stat path_st, dir_st;
 
     if (!path || !*path) {
         errno = EINVAL;
-        return -1;
+        return NULL;
     }
 
-    int fd = open(path, O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW);
-    if (fd == -1)
-        return -1;
+    if (lstat(path, &path_st) == -1)
+        return NULL;
 
-    if (fstat(fd, &st) == -1) {
-        int saved_errno = errno;
-        close(fd);
-        errno = saved_errno;
-        return -1;
+    if (S_ISLNK(path_st.st_mode)) {
+        errno = ELOOP;
+        return NULL;
     }
 
-    if (!S_ISDIR(st.st_mode)) {
-        close(fd);
+    if (!S_ISDIR(path_st.st_mode)) {
         errno = ENOTDIR;
-        return -1;
+        return NULL;
+    }
+
+    DIR *dir = opendir(path);
+    if (!dir)
+        return NULL;
+
+    int fd = dirfd(dir);
+    if (fd == -1) {
+        int saved_errno = errno;
+        closedir(dir);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    if (fstat(fd, &dir_st) == -1) {
+        int saved_errno = errno;
+        closedir(dir);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    if (!S_ISDIR(dir_st.st_mode)) {
+        closedir(dir);
+        errno = ENOTDIR;
+        return NULL;
+    }
+
+    if (path_st.st_dev != dir_st.st_dev || path_st.st_ino != dir_st.st_ino) {
+        closedir(dir);
+        errno = EAGAIN;
+        return NULL;
     }
 
     int written = snprintfz(fd_path, fd_path_size, "/proc/self/fd/%d", fd);
     if (written < 0 || (size_t)written >= fd_path_size) {
-        close(fd);
+        closedir(dir);
         errno = ENAMETOOLONG;
-        return -1;
+        return NULL;
     }
 
-    return fd;
+    return dir;
 }
 
 static BUFFER *read_request_payload_from_stdin(void)
@@ -309,9 +336,9 @@ static int run_systemd_journal_test_command(const struct systemd_journal_test_co
     }
 
     char backend_dir_path[FILENAME_MAX];
-    int backend_dir_fd =
+    DIR *backend_dir =
         open_systemd_journal_test_backend_directory(cmd->backend_dir, backend_dir_path, sizeof(backend_dir_path));
-    if (backend_dir_fd == -1) {
+    if (!backend_dir) {
         fprintf(
             stderr,
             "systemd journal backend directory '%s' cannot be opened: %s\n",
@@ -322,7 +349,7 @@ static int run_systemd_journal_test_command(const struct systemd_journal_test_co
 
     CLEAN_BUFFER *payload = read_request_payload_from_stdin();
     if (!payload) {
-        close(backend_dir_fd);
+        closedir(backend_dir);
         return 1;
     }
 
@@ -353,7 +380,7 @@ static int run_systemd_journal_test_command(const struct systemd_journal_test_co
         fprintf(stderr, "systemd journal test function returned no result\n");
     }
 
-    close(backend_dir_fd);
+    closedir(backend_dir);
     return rc;
 }
 

--- a/src/crates/netflow-plugin/README.md
+++ b/src/crates/netflow-plugin/README.md
@@ -7,6 +7,31 @@ Rust NetFlow/IPFIX/sFlow ingestion and query plugin.
 It stores flow entries in journal tiers under the Netdata cache directory and exposes
 `flows:netflow`.
 
+## Offline Function test mode
+
+Fixture harnesses can execute the Function query path directly against an existing
+NetFlow backend directory:
+
+```sh
+netflow-plugin --test flows:netflow --dir <flows-dir> --request <payload.json> [--no-persist]
+```
+
+Requirements:
+
+- `<flows-dir>` is the NetFlow backend root containing the `raw`, `1m`, `5m`, and `1h` tier directories.
+- `<payload.json>` is the JSON Function request body.
+- stdout contains only the raw JSON Function response.
+- errors are written to stderr and return non-zero.
+
+Use `--no-persist` for shared fixture datasets. It prevents the test run from writing
+facet state or sidecar files under `<flows-dir>` while keeping facet data in memory for
+the Function response. Without `--no-persist`, the plugin may refresh facet state under
+the backend directory, matching normal runtime behavior.
+
+Function output includes volatile fields such as collection timestamps and runtime
+statistics. Test harnesses should normalize those fields before comparing fixture
+outputs.
+
 ## Configuration
 
 When running under Netdata, config is loaded from `netflow.yaml` in:

--- a/src/crates/netflow-plugin/README.md
+++ b/src/crates/netflow-plugin/README.md
@@ -13,13 +13,16 @@ Fixture harnesses can execute the Function query path directly against an existi
 NetFlow backend directory:
 
 ```sh
-netflow-plugin --test flows:netflow --dir <flows-dir> --request <payload.json> [--no-persist]
+netflow-plugin --test flows:netflow --dir <flows-dir> --request <payload.json> [--timeout <seconds>] [--no-persist]
 ```
 
 Requirements:
 
 - `<flows-dir>` is the NetFlow backend root containing the `raw`, `1m`, `5m`, and `1h` tier directories.
 - `<payload.json>` is the JSON Function request body.
+- `--timeout <seconds>` controls the offline Function execution timeout. It
+  defaults to `30`; use `--timeout 0` to map to a very large finite timeout for
+  long-running fixture comparisons.
 - stdout contains only the raw JSON Function response.
 - errors are written to stderr and return non-zero.
 

--- a/src/crates/netflow-plugin/README.md
+++ b/src/crates/netflow-plugin/README.md
@@ -13,13 +13,14 @@ Fixture harnesses can execute the Function query path directly against an existi
 NetFlow backend directory:
 
 ```sh
-netflow-plugin --test flows:netflow --dir <flows-dir> --request <payload.json> [--timeout <seconds>] [--no-persist]
+netflow-plugin --test flows:netflow --dir <flows-dir> [--timeout <seconds>] [--no-persist] < payload.json
 ```
 
 Requirements:
 
 - `<flows-dir>` is the NetFlow backend root containing the `raw`, `1m`, `5m`, and `1h` tier directories.
-- `<payload.json>` is the JSON Function request body.
+- stdin is the JSON Function request body.
+- `--request` is not supported and fails with usage output.
 - `--timeout <seconds>` controls the offline Function execution timeout. It
   defaults to `30`; use `--timeout 0` to map to a very large finite timeout for
   long-running fixture comparisons.

--- a/src/crates/netflow-plugin/README.md
+++ b/src/crates/netflow-plugin/README.md
@@ -19,7 +19,7 @@ netflow-plugin --test flows:netflow --dir <flows-dir> [--timeout <seconds>] [--n
 Requirements:
 
 - `<flows-dir>` is the NetFlow backend root containing the `raw`, `1m`, `5m`, and `1h` tier directories.
-- stdin is the JSON Function request body.
+- stdin is the JSON Function request body (non-empty, maximum 16 MiB).
 - `--request` is not supported and fails with usage output.
 - `--timeout <seconds>` controls the offline Function execution timeout. It
   defaults to `30`; use `--timeout 0` to map to a very large finite timeout for

--- a/src/crates/netflow-plugin/src/api.rs
+++ b/src/crates/netflow-plugin/src/api.rs
@@ -1,8 +1,6 @@
 mod flows;
 
 pub(crate) use flows::NetflowFlowsHandler;
+pub(crate) use flows::{FLOWS_FUNCTION_NAME, FlowsFunctionResponse};
 #[cfg(test)]
-pub(crate) use flows::{
-    FLOWS_FUNCTION_VERSION, FLOWS_UPDATE_EVERY_SECONDS, FlowsFunctionResponse,
-    flows_required_params,
-};
+pub(crate) use flows::{FLOWS_FUNCTION_VERSION, FLOWS_UPDATE_EVERY_SECONDS, flows_required_params};

--- a/src/crates/netflow-plugin/src/api/flows.rs
+++ b/src/crates/netflow-plugin/src/api/flows.rs
@@ -3,7 +3,8 @@ mod model;
 mod params;
 
 pub(crate) use handler::NetflowFlowsHandler;
+pub(crate) use model::{FLOWS_FUNCTION_NAME, FlowsFunctionResponse};
 #[cfg(test)]
-pub(crate) use model::{FLOWS_FUNCTION_VERSION, FLOWS_UPDATE_EVERY_SECONDS, FlowsFunctionResponse};
+pub(crate) use model::{FLOWS_FUNCTION_VERSION, FLOWS_UPDATE_EVERY_SECONDS};
 #[cfg(test)]
 pub(crate) use params::flows_required_params;

--- a/src/crates/netflow-plugin/src/api/flows/handler.rs
+++ b/src/crates/netflow-plugin/src/api/flows/handler.rs
@@ -9,9 +9,9 @@ use std::sync::Arc;
 use tokio::task;
 
 use super::model::{
-    FLOWS_FUNCTION_VERSION, FLOWS_SCHEMA_VERSION, FLOWS_UPDATE_EVERY_SECONDS, FlowAutocompleteData,
-    FlowAutocompleteResponse, FlowMetricsData, FlowMetricsResponse, FlowsData,
-    FlowsFunctionResponse, FlowsResponse,
+    FLOWS_FUNCTION_NAME, FLOWS_FUNCTION_VERSION, FLOWS_SCHEMA_VERSION, FLOWS_UPDATE_EVERY_SECONDS,
+    FlowAutocompleteData, FlowAutocompleteResponse, FlowMetricsData, FlowMetricsResponse,
+    FlowsData, FlowsFunctionResponse, FlowsResponse,
 };
 use super::params::{accepted_params, flows_required_params};
 
@@ -264,8 +264,10 @@ impl FunctionHandler for NetflowFlowsHandler {
     }
 
     fn declaration(&self) -> FunctionDeclaration {
-        let mut func_decl =
-            FunctionDeclaration::new("flows:netflow", "NetFlow/IPFIX/sFlow flow analysis data");
+        let mut func_decl = FunctionDeclaration::new(
+            FLOWS_FUNCTION_NAME,
+            "NetFlow/IPFIX/sFlow flow analysis data",
+        );
         func_decl.global = true;
         func_decl.tags = Some("flows".to_string());
         func_decl.access =

--- a/src/crates/netflow-plugin/src/api/flows/model.rs
+++ b/src/crates/netflow-plugin/src/api/flows/model.rs
@@ -129,3 +129,13 @@ pub(crate) enum FlowsFunctionResponse {
     Metrics(FlowMetricsResponse),
     Autocomplete(FlowAutocompleteResponse),
 }
+
+impl FlowsFunctionResponse {
+    pub(crate) fn status(&self) -> u32 {
+        match self {
+            Self::Table(response) => response.status,
+            Self::Metrics(response) => response.status,
+            Self::Autocomplete(response) => response.status,
+        }
+    }
+}

--- a/src/crates/netflow-plugin/src/api/flows/model.rs
+++ b/src/crates/netflow-plugin/src/api/flows/model.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 pub(crate) const FLOWS_SCHEMA_VERSION: &str = "2.0";
+pub(crate) const FLOWS_FUNCTION_NAME: &str = "flows:netflow";
 pub(crate) const FLOWS_FUNCTION_VERSION: u32 = 4;
 pub(crate) const FLOWS_UPDATE_EVERY_SECONDS: u32 = 60;
 

--- a/src/crates/netflow-plugin/src/facet_runtime.rs
+++ b/src/crates/netflow-plugin/src/facet_runtime.rs
@@ -97,10 +97,31 @@ pub(crate) struct FacetRuntime {
     ready: AtomicBool,
     ready_notify: Notify,
     state_path: PathBuf,
+    persistence: FacetPersistence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FacetPersistence {
+    Enabled,
+    ReadOnly,
+}
+
+impl FacetPersistence {
+    fn writes_enabled(self) -> bool {
+        matches!(self, Self::Enabled)
+    }
 }
 
 impl FacetRuntime {
     pub(crate) fn new(base_dir: &Path) -> Self {
+        Self::with_persistence(base_dir, FacetPersistence::Enabled)
+    }
+
+    pub(crate) fn new_read_only(base_dir: &Path) -> Self {
+        Self::with_persistence(base_dir, FacetPersistence::ReadOnly)
+    }
+
+    fn with_persistence(base_dir: &Path, persistence: FacetPersistence) -> Self {
         let state_path = base_dir.join(FACET_STATE_FILE_NAME);
         let loaded = load_persisted_state(&state_path);
         let ready = loaded.is_some();
@@ -115,6 +136,7 @@ impl FacetRuntime {
             ready: AtomicBool::new(ready),
             ready_notify: Notify::new(),
             state_path,
+            persistence,
         }
     }
 
@@ -221,7 +243,9 @@ impl FacetRuntime {
             .collect::<Vec<_>>();
         for path in removed_archived {
             state.indexed_archived_paths.remove(&path);
-            delete_sidecar_files(Path::new(&path));
+            if self.persistence.writes_enabled() {
+                delete_sidecar_files(Path::new(&path));
+            }
             state.rebuild_archived = true;
             state.dirty = true;
         }
@@ -233,7 +257,9 @@ impl FacetRuntime {
 
         for (path, contribution) in archived_scans {
             merge_global_contribution(&mut state.archived_fields, &contribution);
-            write_sidecar_files(Path::new(&path), &contribution)?;
+            if self.persistence.writes_enabled() {
+                write_sidecar_files(Path::new(&path), &contribution)?;
+            }
             if state.indexed_archived_paths.insert(path) {
                 state.dirty = true;
             }
@@ -248,7 +274,7 @@ impl FacetRuntime {
         state.rebuild_archived = false;
 
         publish_locked(&self.snapshot, &state);
-        persist_state_locked(&self.state_path, &mut state)?;
+        self.persist_state_locked(&mut state)?;
         drop(state);
         self.mark_ready();
         Ok(())
@@ -314,11 +340,13 @@ impl FacetRuntime {
         if let Some(contribution) = contribution {
             merge_global_contribution(&mut state.archived_fields, &contribution);
             rebuild_published_fields(&mut state);
-            write_sidecar_files(archived_path, &contribution)?;
+            if self.persistence.writes_enabled() {
+                write_sidecar_files(archived_path, &contribution)?;
+            }
             state.indexed_archived_paths.insert(archived_path_str);
             state.dirty = true;
             publish_locked(&self.snapshot, &state);
-            persist_state_locked(&self.state_path, &mut state)?;
+            self.persist_state_locked(&mut state)?;
         }
 
         Ok(())
@@ -342,7 +370,9 @@ impl FacetRuntime {
                 state.rebuild_archived = true;
                 changed = true;
             }
-            delete_sidecar_files(path);
+            if self.persistence.writes_enabled() {
+                delete_sidecar_files(path);
+            }
         }
 
         if changed {
@@ -351,7 +381,7 @@ impl FacetRuntime {
                 publish_locked(&self.snapshot, &state);
             }
             state.dirty = true;
-            persist_state_locked(&self.state_path, &mut state)?;
+            self.persist_state_locked(&mut state)?;
         }
 
         Ok(())
@@ -363,6 +393,7 @@ impl FacetRuntime {
             return Ok(Vec::new());
         };
         let match_kind = spec.autocomplete_match;
+        let sidecars_enabled = self.persistence.writes_enabled();
 
         let (promoted, mut matches, archived_paths) = {
             let state = self
@@ -378,17 +409,18 @@ impl FacetRuntime {
                 term,
                 match_kind,
             );
-            let archived_matches = if !spec.uses_sidecar || !published.autocomplete {
-                state
-                    .archived_fields
-                    .get(normalized.as_str())
-                    .map(|store| {
-                        store.autocomplete_matches(term, FACET_AUTOCOMPLETE_LIMIT, match_kind)
-                    })
-                    .unwrap_or_default()
-            } else {
-                Vec::new()
-            };
+            let archived_matches =
+                if !spec.uses_sidecar || !published.autocomplete || !sidecars_enabled {
+                    state
+                        .archived_fields
+                        .get(normalized.as_str())
+                        .map(|store| {
+                            store.autocomplete_matches(term, FACET_AUTOCOMPLETE_LIMIT, match_kind)
+                        })
+                        .unwrap_or_default()
+                } else {
+                    Vec::new()
+                };
             let archived_paths = state
                 .indexed_archived_paths
                 .iter()
@@ -401,7 +433,11 @@ impl FacetRuntime {
             )
         };
 
-        if spec.uses_sidecar && promoted && matches.len() < FACET_AUTOCOMPLETE_LIMIT {
+        if sidecars_enabled
+            && spec.uses_sidecar
+            && promoted
+            && matches.len() < FACET_AUTOCOMPLETE_LIMIT
+        {
             for path in archived_paths {
                 let needed = FACET_AUTOCOMPLETE_LIMIT.saturating_sub(matches.len());
                 if needed == 0 {
@@ -429,13 +465,22 @@ impl FacetRuntime {
             .state
             .lock()
             .map_err(|_| anyhow::anyhow!("facet runtime lock poisoned"))?;
-        persist_state_locked(&self.state_path, &mut state)
+        self.persist_state_locked(&mut state)
     }
 
     fn mark_ready(&self) {
         let was_ready = self.ready.swap(true, Ordering::AcqRel);
         if !was_ready {
             self.ready_notify.notify_waiters();
+        }
+    }
+
+    fn persist_state_locked(&self, state: &mut FacetState) -> Result<()> {
+        if self.persistence.writes_enabled() {
+            persist_state_locked(&self.state_path, state)
+        } else {
+            state.dirty = false;
+            Ok(())
         }
     }
 }
@@ -1214,6 +1259,47 @@ mod tests {
         assert!(
             results.iter().any(|value| value == "AS110 EXAMPLE"),
             "expected promoted sidecar autocomplete to return archived values"
+        );
+    }
+
+    #[test]
+    fn read_only_runtime_does_not_write_state_or_sidecars() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let runtime = FacetRuntime::new_read_only(tmp.path());
+        let archived_path = tmp.path().join("flows-promoted.journal");
+
+        for value in 0..120 {
+            let mut fields = FlowFields::new();
+            fields.insert("SRC_AS_NAME", format!("AS{value:03} EXAMPLE"));
+            let contribution = facet_contribution_from_flow_fields(&fields);
+            runtime
+                .observe_active_contribution(&archived_path, &contribution)
+                .expect("observe contribution");
+        }
+
+        runtime
+            .observe_rotation(
+                &archived_path,
+                &tmp.path().join("flows-promoted-next.journal"),
+            )
+            .expect("rotate file");
+
+        assert!(
+            !tmp.path().join(FACET_STATE_FILE_NAME).exists(),
+            "read-only facet runtime must not write facet state"
+        );
+        assert!(
+            !super::sidecar::sidecar_path(&archived_path, "SRC_AS_NAME").exists(),
+            "read-only facet runtime must not write sidecars"
+        );
+
+        let results = runtime
+            .autocomplete("SRC_AS_NAME", "AS11")
+            .expect("autocomplete values");
+
+        assert!(
+            results.iter().any(|value| value == "AS110 EXAMPLE"),
+            "read-only mode should search promoted archived values from memory"
         );
     }
 

--- a/src/crates/netflow-plugin/src/facet_runtime.rs
+++ b/src/crates/netflow-plugin/src/facet_runtime.rs
@@ -31,7 +31,7 @@ pub(crate) use contribution::{
     FacetFileContribution, FacetValueSink, append_record_facet_values,
     facet_contribution_from_flow_fields,
 };
-use sidecar::{delete_sidecar_files, search_sidecar, write_sidecar_files};
+use sidecar::{delete_sidecar_files, search_sidecar, sidecar_path, write_sidecar_files};
 use store::{FacetStore, FacetStoreValueRef, PersistedFacetStore};
 
 const FACET_STATE_VERSION: u32 = 5;
@@ -393,9 +393,8 @@ impl FacetRuntime {
             return Ok(Vec::new());
         };
         let match_kind = spec.autocomplete_match;
-        let sidecars_enabled = self.persistence.writes_enabled();
 
-        let (promoted, mut matches, archived_paths) = {
+        let (use_sidecars, mut matches, archived_paths) = {
             let state = self
                 .state
                 .lock()
@@ -409,8 +408,57 @@ impl FacetRuntime {
                 term,
                 match_kind,
             );
-            let archived_matches =
-                if !spec.uses_sidecar || !published.autocomplete || !sidecars_enabled {
+            let use_sidecars = spec.uses_sidecar && published.autocomplete;
+            let archived_matches = if use_sidecars {
+                Vec::new()
+            } else {
+                state
+                    .archived_fields
+                    .get(normalized.as_str())
+                    .map(|store| {
+                        store.autocomplete_matches(term, FACET_AUTOCOMPLETE_LIMIT, match_kind)
+                    })
+                    .unwrap_or_default()
+            };
+            let archived_paths = state
+                .indexed_archived_paths
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>();
+            (
+                use_sidecars,
+                merge_autocomplete_values(active_matches, archived_matches),
+                archived_paths,
+            )
+        };
+
+        if use_sidecars && matches.len() < FACET_AUTOCOMPLETE_LIMIT {
+            let mut missing_sidecar = false;
+            for path in &archived_paths {
+                let journal_path = Path::new(path);
+                if !sidecar_path(journal_path, normalized.as_str()).exists() {
+                    missing_sidecar = true;
+                    continue;
+                }
+
+                let needed = FACET_AUTOCOMPLETE_LIMIT.saturating_sub(matches.len());
+                if needed == 0 {
+                    break;
+                }
+                let sidecar_matches =
+                    search_sidecar(journal_path, normalized.as_str(), term, needed, match_kind)?;
+                matches = merge_autocomplete_values(matches, sidecar_matches);
+                if matches.len() >= FACET_AUTOCOMPLETE_LIMIT {
+                    break;
+                }
+            }
+
+            if missing_sidecar && matches.len() < FACET_AUTOCOMPLETE_LIMIT {
+                let archived_matches = {
+                    let state = self
+                        .state
+                        .lock()
+                        .map_err(|_| anyhow::anyhow!("facet runtime lock poisoned"))?;
                     state
                         .archived_fields
                         .get(normalized.as_str())
@@ -418,42 +466,8 @@ impl FacetRuntime {
                             store.autocomplete_matches(term, FACET_AUTOCOMPLETE_LIMIT, match_kind)
                         })
                         .unwrap_or_default()
-                } else {
-                    Vec::new()
                 };
-            let archived_paths = state
-                .indexed_archived_paths
-                .iter()
-                .cloned()
-                .collect::<Vec<_>>();
-            (
-                published.autocomplete,
-                merge_autocomplete_values(active_matches, archived_matches),
-                archived_paths,
-            )
-        };
-
-        if sidecars_enabled
-            && spec.uses_sidecar
-            && promoted
-            && matches.len() < FACET_AUTOCOMPLETE_LIMIT
-        {
-            for path in archived_paths {
-                let needed = FACET_AUTOCOMPLETE_LIMIT.saturating_sub(matches.len());
-                if needed == 0 {
-                    break;
-                }
-                let sidecar_matches = search_sidecar(
-                    Path::new(&path),
-                    normalized.as_str(),
-                    term,
-                    needed,
-                    match_kind,
-                )?;
-                matches = merge_autocomplete_values(matches, sidecar_matches);
-                if matches.len() >= FACET_AUTOCOMPLETE_LIMIT {
-                    break;
-                }
+                matches = merge_autocomplete_values(matches, archived_matches);
             }
         }
 
@@ -1300,6 +1314,44 @@ mod tests {
         assert!(
             results.iter().any(|value| value == "AS110 EXAMPLE"),
             "read-only mode should search promoted archived values from memory"
+        );
+    }
+
+    #[test]
+    fn read_only_runtime_reads_existing_sidecar_files() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let archived_path = tmp.path().join("flows-promoted.journal");
+        let runtime = FacetRuntime::new(tmp.path());
+
+        for value in 0..120 {
+            let mut fields = FlowFields::new();
+            fields.insert("SRC_AS_NAME", format!("AS{value:03} EXAMPLE"));
+            let contribution = facet_contribution_from_flow_fields(&fields);
+            runtime
+                .observe_active_contribution(&archived_path, &contribution)
+                .expect("observe contribution");
+        }
+
+        runtime
+            .observe_rotation(
+                &archived_path,
+                &tmp.path().join("flows-promoted-next.journal"),
+            )
+            .expect("rotate file");
+
+        let runtime = FacetRuntime::new_read_only(tmp.path());
+        {
+            let mut state = runtime.state.lock().expect("lock facet state");
+            state.archived_fields.clear();
+        }
+
+        let results = runtime
+            .autocomplete("SRC_AS_NAME", "AS11")
+            .expect("autocomplete values");
+
+        assert!(
+            results.iter().any(|value| value == "AS110 EXAMPLE"),
+            "read-only mode should search existing sidecar files"
         );
     }
 

--- a/src/crates/netflow-plugin/src/main.rs
+++ b/src/crates/netflow-plugin/src/main.rs
@@ -22,6 +22,7 @@ mod rollup;
 mod routing;
 #[cfg(test)]
 mod startup_memory_tests;
+mod test_cli;
 mod tiering;
 
 pub(crate) use api::NetflowFlowsHandler;
@@ -44,6 +45,30 @@ fn main() {
     if let Err(err) = journal_core::install_sigbus_handler() {
         eprintln!("failed to install SIGBUS handler: {}", err);
         std::process::exit(1);
+    }
+
+    match test_cli::TestCommand::parse_from_env_args() {
+        Ok(Some(command)) => {
+            let worker_threads = runtime_worker_threads();
+            let max_blocking_threads = runtime_blocking_threads(worker_threads);
+            let runtime = match build_tokio_runtime(worker_threads, max_blocking_threads) {
+                Ok(runtime) => runtime,
+                Err(err) => {
+                    eprintln!("failed to build tokio runtime: {}", err);
+                    std::process::exit(1);
+                }
+            };
+            if let Err(err) = runtime.block_on(test_cli::run(command)) {
+                eprintln!("{err:#}");
+                std::process::exit(1);
+            }
+            return;
+        }
+        Ok(None) => {}
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(2);
+        }
     }
 
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
@@ -79,12 +104,7 @@ fn main() {
         "configured netflow tokio runtime"
     );
 
-    let runtime = match tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .worker_threads(worker_threads)
-        .max_blocking_threads(max_blocking_threads)
-        .build()
-    {
+    let runtime = match build_tokio_runtime(worker_threads, max_blocking_threads) {
         Ok(runtime) => runtime,
         Err(err) => {
             eprintln!("failed to build tokio runtime: {}", err);
@@ -368,6 +388,17 @@ fn runtime_worker_threads() -> usize {
 
 fn runtime_blocking_threads(worker_threads: usize) -> usize {
     MIN_RUNTIME_BLOCKING_THREADS.max(worker_threads)
+}
+
+fn build_tokio_runtime(
+    worker_threads: usize,
+    max_blocking_threads: usize,
+) -> std::io::Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(worker_threads)
+        .max_blocking_threads(max_blocking_threads)
+        .build()
 }
 
 #[cfg(test)]

--- a/src/crates/netflow-plugin/src/plugin_config/runtime.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/runtime.rs
@@ -20,9 +20,9 @@ impl PluginConfig {
         Ok(cfg)
     }
 
-    pub(crate) fn for_test_backend_dir(journal_dir: &Path) -> Result<Self> {
+    pub(crate) fn for_test_backend_dir(backend_dir: &Path) -> Result<Self> {
         let mut cfg = Self::default();
-        cfg.journal.journal_dir = journal_dir.to_string_lossy().to_string();
+        cfg.journal.journal_dir = backend_dir.to_string_lossy().to_string();
         cfg.validate()?;
         Ok(cfg)
     }

--- a/src/crates/netflow-plugin/src/plugin_config/runtime.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/runtime.rs
@@ -20,6 +20,13 @@ impl PluginConfig {
         Ok(cfg)
     }
 
+    pub(crate) fn for_test_backend_dir(journal_dir: &Path) -> Result<Self> {
+        let mut cfg = Self::default();
+        cfg.journal.journal_dir = journal_dir.to_string_lossy().to_string();
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
     pub(super) fn auto_detect_geoip_databases(&mut self) {
         let intel_dirs = [
             self.inferred_cache_dir().join(TOPOLOGY_IP_INTEL_DIR),

--- a/src/crates/netflow-plugin/src/plugin_config/runtime.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/runtime.rs
@@ -22,7 +22,15 @@ impl PluginConfig {
 
     pub(crate) fn for_test_backend_dir(backend_dir: &Path) -> Result<Self> {
         let mut cfg = Self::default();
-        cfg.journal.journal_dir = backend_dir.to_string_lossy().to_string();
+        cfg.journal.journal_dir = backend_dir
+            .to_str()
+            .with_context(|| {
+                format!(
+                    "netflow test backend directory {} is not valid UTF-8",
+                    backend_dir.display()
+                )
+            })?
+            .to_string();
         cfg.validate()?;
         Ok(cfg)
     }

--- a/src/crates/netflow-plugin/src/test_cli.rs
+++ b/src/crates/netflow-plugin/src/test_cli.rs
@@ -1,0 +1,321 @@
+use crate::api::{FLOWS_FUNCTION_NAME, FlowsFunctionResponse, NetflowFlowsHandler};
+use crate::{facet_runtime, ingest, plugin_config, query};
+use anyhow::{Context, Result, bail};
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+const USAGE: &str = "usage: netflow-plugin --test flows:netflow --dir <flows-dir> --request <payload.json> [--no-persist]";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TestCommand {
+    pub(crate) function_name: String,
+    pub(crate) backend_dir: PathBuf,
+    pub(crate) request_path: PathBuf,
+    pub(crate) no_persist: bool,
+}
+
+impl TestCommand {
+    pub(crate) fn parse_from_env_args() -> std::result::Result<Option<Self>, String> {
+        parse_from(std::env::args().skip(1))
+    }
+}
+
+pub(crate) async fn run(command: TestCommand) -> Result<()> {
+    let response = execute(command).await?;
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    write_json_response(&response, &mut handle)
+}
+
+pub(crate) async fn execute(command: TestCommand) -> Result<FlowsFunctionResponse> {
+    if command.function_name != FLOWS_FUNCTION_NAME {
+        bail!(
+            "unsupported netflow test function `{}` (expected `{}`)",
+            command.function_name,
+            FLOWS_FUNCTION_NAME
+        );
+    }
+
+    let request_bytes = fs::read(&command.request_path).with_context(|| {
+        format!(
+            "failed to read request payload {}",
+            command.request_path.display()
+        )
+    })?;
+    let request =
+        serde_json::from_slice::<query::FlowsRequest>(&request_bytes).with_context(|| {
+            format!(
+                "failed to parse request payload {}",
+                command.request_path.display()
+            )
+        })?;
+
+    let config = plugin_config::PluginConfig::for_test_backend_dir(&command.backend_dir)?;
+    ensure_tier_directories_exist(&config)?;
+
+    let facet_runtime = if command.no_persist {
+        facet_runtime::FacetRuntime::new_read_only(&config.journal.base_dir())
+    } else {
+        facet_runtime::FacetRuntime::new(&config.journal.base_dir())
+    };
+    let facet_runtime = Arc::new(facet_runtime);
+    let (query_service, _notify_rx) =
+        query::FlowQueryService::new_with_facet_runtime(&config, Arc::clone(&facet_runtime))
+            .await?;
+    let query_service = Arc::new(query_service);
+    query_service.initialize_facets().await?;
+
+    let handler = NetflowFlowsHandler::new(
+        Arc::new(ingest::IngestMetrics::default()),
+        Arc::clone(&query_service),
+    );
+    handler.handle_request(request).await.map_err(Into::into)
+}
+
+pub(crate) fn write_json_response(
+    response: &FlowsFunctionResponse,
+    writer: &mut impl Write,
+) -> Result<()> {
+    serde_json::to_writer(&mut *writer, response).context("failed to write JSON response")?;
+    writer
+        .write_all(b"\n")
+        .context("failed to finish JSON response")?;
+    writer.flush().context("failed to flush JSON response")
+}
+
+fn ensure_tier_directories_exist(config: &plugin_config::PluginConfig) -> Result<()> {
+    for tier_dir in config.journal.all_tier_dirs() {
+        if !tier_dir.is_dir() {
+            bail!(
+                "netflow backend tier directory {} does not exist",
+                tier_dir.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn parse_from(
+    args: impl IntoIterator<Item = String>,
+) -> std::result::Result<Option<TestCommand>, String> {
+    let args = args.into_iter().collect::<Vec<_>>();
+    if !args
+        .iter()
+        .any(|arg| arg == "--test" || arg.starts_with("--test="))
+    {
+        return Ok(None);
+    }
+
+    let mut function_name = None;
+    let mut backend_dir = None;
+    let mut request_path = None;
+    let mut no_persist = false;
+    let mut idx = 0;
+
+    while idx < args.len() {
+        let arg = &args[idx];
+        match arg.as_str() {
+            "--test" => {
+                idx += 1;
+                let value = args
+                    .get(idx)
+                    .ok_or_else(|| format!("missing value for --test\n{USAGE}"))?;
+                set_once(&mut function_name, value.clone(), "--test")?;
+            }
+            "--dir" => {
+                idx += 1;
+                let value = args
+                    .get(idx)
+                    .ok_or_else(|| format!("missing value for --dir\n{USAGE}"))?;
+                set_once(&mut backend_dir, PathBuf::from(value), "--dir")?;
+            }
+            "--request" => {
+                idx += 1;
+                let value = args
+                    .get(idx)
+                    .ok_or_else(|| format!("missing value for --request\n{USAGE}"))?;
+                set_once(&mut request_path, PathBuf::from(value), "--request")?;
+            }
+            "--no-persist" => {
+                if no_persist {
+                    return Err(format!("duplicate --no-persist\n{USAGE}"));
+                }
+                no_persist = true;
+            }
+            _ if arg.starts_with("--test=") => {
+                set_once(
+                    &mut function_name,
+                    arg.trim_start_matches("--test=").to_string(),
+                    "--test",
+                )?;
+            }
+            _ if arg.starts_with("--dir=") => {
+                set_once(
+                    &mut backend_dir,
+                    PathBuf::from(arg.trim_start_matches("--dir=")),
+                    "--dir",
+                )?;
+            }
+            _ if arg.starts_with("--request=") => {
+                set_once(
+                    &mut request_path,
+                    PathBuf::from(arg.trim_start_matches("--request=")),
+                    "--request",
+                )?;
+            }
+            "-h" | "--help" => {
+                return Err(USAGE.to_string());
+            }
+            _ => {
+                return Err(format!("unsupported netflow test option `{arg}`\n{USAGE}"));
+            }
+        }
+        idx += 1;
+    }
+
+    Ok(Some(TestCommand {
+        function_name: required(function_name, "--test")?,
+        backend_dir: required(backend_dir, "--dir")?,
+        request_path: required(request_path, "--request")?,
+        no_persist,
+    }))
+}
+
+fn set_once<T>(slot: &mut Option<T>, value: T, option: &str) -> std::result::Result<(), String> {
+    if slot.is_some() {
+        return Err(format!("duplicate {option}\n{USAGE}"));
+    }
+    *slot = Some(value);
+    Ok(())
+}
+
+fn required<T>(slot: Option<T>, option: &str) -> std::result::Result<T, String> {
+    slot.ok_or_else(|| format!("missing required {option}\n{USAGE}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn parse(args: &[&str]) -> std::result::Result<Option<TestCommand>, String> {
+        parse_from(args.iter().map(|arg| (*arg).to_string()))
+    }
+
+    #[test]
+    fn parser_ignores_normal_plugin_arguments_when_test_is_absent() {
+        assert_eq!(parse(&["--netflow-enabled", "false"]).unwrap(), None);
+    }
+
+    #[test]
+    fn parser_accepts_file_based_test_command() {
+        let command = parse(&[
+            "--test",
+            "flows:netflow",
+            "--dir",
+            "flows",
+            "--request",
+            "payload.json",
+            "--no-persist",
+        ])
+        .unwrap()
+        .expect("test command");
+
+        assert_eq!(command.function_name, "flows:netflow");
+        assert_eq!(command.backend_dir, Path::new("flows"));
+        assert_eq!(command.request_path, Path::new("payload.json"));
+        assert!(command.no_persist);
+    }
+
+    #[test]
+    fn parser_accepts_equals_form() {
+        let command = parse(&[
+            "--test=flows:netflow",
+            "--dir=flows",
+            "--request=payload.json",
+        ])
+        .unwrap()
+        .expect("test command");
+
+        assert_eq!(command.function_name, "flows:netflow");
+        assert_eq!(command.backend_dir, Path::new("flows"));
+        assert_eq!(command.request_path, Path::new("payload.json"));
+        assert!(!command.no_persist);
+    }
+
+    #[test]
+    fn parser_rejects_missing_required_options() {
+        let err = parse(&["--test", "flows:netflow"])
+            .expect_err("missing options should fail")
+            .to_string();
+        assert!(err.contains("missing required --dir"));
+    }
+
+    #[test]
+    fn parser_rejects_unknown_test_options() {
+        let err = parse(&[
+            "--test",
+            "flows:netflow",
+            "--dir",
+            "flows",
+            "--request",
+            "payload.json",
+            "--unknown",
+        ])
+        .expect_err("unknown option should fail");
+
+        assert!(err.contains("unsupported netflow test option"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execute_empty_backend_writes_raw_json_without_persisting_facets() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let backend_dir = tmp.path().join("flows");
+        for tier in ["raw", "1m", "5m", "1h"] {
+            fs::create_dir_all(backend_dir.join(tier)).expect("create tier dir");
+        }
+
+        let request_path = tmp.path().join("flows-request.json");
+        fs::write(
+            &request_path,
+            r#"{"after":1,"before":2,"group_by":["PROTOCOL"],"top_n":"100"}"#,
+        )
+        .expect("write request payload");
+
+        let response = execute(TestCommand {
+            function_name: FLOWS_FUNCTION_NAME.to_string(),
+            backend_dir: backend_dir.clone(),
+            request_path,
+            no_persist: true,
+        })
+        .await
+        .expect("execute test CLI request");
+
+        let mut stdout = Vec::new();
+        write_json_response(&response, &mut stdout).expect("write JSON response");
+        let output = String::from_utf8(stdout).expect("stdout should be UTF-8 JSON");
+
+        assert!(
+            output.trim_start().starts_with('{'),
+            "test CLI stdout should start with JSON object, got {output:?}"
+        );
+        assert!(
+            !output.starts_with("TRUST_DURATIONS"),
+            "test CLI stdout must not include PLUGINSD protocol lines"
+        );
+
+        let value = serde_json::from_str::<serde_json::Value>(&output).expect("parse JSON output");
+        assert_eq!(value["status"], 200);
+        assert_eq!(value["type"], "flows");
+        assert!(
+            value["data"]["flows"].as_array().is_some_and(Vec::is_empty),
+            "empty backend should return an empty flows array"
+        );
+        assert!(
+            !backend_dir.join("facet-state.bin").exists(),
+            "--no-persist must not write facet state under the fixture backend"
+        );
+    }
+}

--- a/src/crates/netflow-plugin/src/test_cli.rs
+++ b/src/crates/netflow-plugin/src/test_cli.rs
@@ -2,14 +2,13 @@ use crate::api::{FLOWS_FUNCTION_NAME, FlowsFunctionResponse, NetflowFlowsHandler
 use crate::{facet_runtime, ingest, plugin_config, query};
 use anyhow::{Context, Result, bail};
 use rt::ProgressState;
-use std::fs;
 use std::io::{self, Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-const USAGE: &str = "usage: netflow-plugin --test flows:netflow --dir <flows-dir> --request <payload.json> [--timeout <seconds>] [--no-persist]";
+const USAGE: &str = "usage: netflow-plugin --test flows:netflow --dir <flows-dir> [--timeout <seconds>] [--no-persist] < payload.json";
 const DEFAULT_TIMEOUT_SECONDS: u64 = 30;
 const DISABLED_TIMEOUT_SECONDS: u64 = 100 * 365 * 24 * 60 * 60;
 const MAX_REQUEST_BYTES: u64 = 16 * 1024 * 1024;
@@ -18,7 +17,6 @@ const MAX_REQUEST_BYTES: u64 = 16 * 1024 * 1024;
 pub(crate) struct TestCommand {
     pub(crate) function_name: String,
     pub(crate) backend_dir: PathBuf,
-    pub(crate) request_path: PathBuf,
     pub(crate) timeout_seconds: u64,
     pub(crate) no_persist: bool,
 }
@@ -30,14 +28,18 @@ impl TestCommand {
 }
 
 pub(crate) async fn run(command: TestCommand) -> Result<()> {
-    let response = execute(command).await?;
+    let request_bytes = read_request_payload_from_stdin(io::stdin().lock())?;
+    let response = execute(command, &request_bytes).await?;
     let stdout = io::stdout();
     let mut handle = stdout.lock();
     write_json_response(&response, &mut handle)?;
     ensure_success_status(response.status())
 }
 
-pub(crate) async fn execute(command: TestCommand) -> Result<FlowsFunctionResponse> {
+pub(crate) async fn execute(
+    command: TestCommand,
+    request_bytes: &[u8],
+) -> Result<FlowsFunctionResponse> {
     if command.function_name != FLOWS_FUNCTION_NAME {
         bail!(
             "unsupported netflow test function `{}` (expected `{}`)",
@@ -46,14 +48,8 @@ pub(crate) async fn execute(command: TestCommand) -> Result<FlowsFunctionRespons
         );
     }
 
-    let request_bytes = read_request_payload(&command.request_path)?;
-    let request =
-        serde_json::from_slice::<query::FlowsRequest>(&request_bytes).with_context(|| {
-            format!(
-                "failed to parse request payload {}",
-                command.request_path.display()
-            )
-        })?;
+    let request = serde_json::from_slice::<query::FlowsRequest>(request_bytes)
+        .context("failed to parse request payload from stdin")?;
 
     let config = plugin_config::PluginConfig::for_test_backend_dir(&command.backend_dir)?;
     ensure_tier_directories_exist(&config)?;
@@ -140,78 +136,25 @@ fn ensure_success_status(status: u32) -> Result<()> {
     Ok(())
 }
 
-fn read_request_payload(path: &Path) -> Result<Vec<u8>> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("failed to inspect request payload {}", path.display()))?;
-    validate_request_payload_metadata(path, &metadata)?;
-
-    let file = open_request_payload_file(path)?;
-    let metadata = file
-        .metadata()
-        .with_context(|| format!("failed to inspect request payload {}", path.display()))?;
-    validate_request_payload_metadata(path, &metadata)?;
-
-    let mut request_bytes = Vec::with_capacity(metadata.len() as usize);
-    file.take(MAX_REQUEST_BYTES + 1)
+fn read_request_payload_from_stdin(reader: impl Read) -> Result<Vec<u8>> {
+    let mut request_bytes = Vec::new();
+    reader
+        .take(MAX_REQUEST_BYTES + 1)
         .read_to_end(&mut request_bytes)
-        .with_context(|| format!("failed to read request payload {}", path.display()))?;
+        .context("failed to read request payload from stdin")?;
 
     if request_bytes.is_empty() {
-        bail!("request payload {} is empty", path.display());
+        bail!("request payload from stdin is empty");
     }
 
     if request_bytes.len() as u64 > MAX_REQUEST_BYTES {
         bail!(
-            "request payload {} is too large: more than {} bytes",
-            path.display(),
+            "request payload from stdin is too large: more than {} bytes",
             MAX_REQUEST_BYTES
         );
     }
 
     Ok(request_bytes)
-}
-
-fn open_request_payload_file(path: &Path) -> Result<fs::File> {
-    #[cfg(not(unix))]
-    {
-        bail!("netflow test request payloads require Unix safe-open flags");
-    }
-
-    #[cfg(unix)]
-    {
-        let mut options = fs::OpenOptions::new();
-        options.read(true);
-        use std::os::unix::fs::OpenOptionsExt;
-
-        // O_NOFOLLOW rejects a final symlink race. O_NONBLOCK avoids blocking if the path races to a FIFO before
-        // fstat() rejects it as non-regular.
-        options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
-
-        options
-            .open(path)
-            .with_context(|| format!("failed to open request payload {}", path.display()))
-    }
-}
-
-fn validate_request_payload_metadata(path: &Path, metadata: &fs::Metadata) -> Result<()> {
-    if !metadata.is_file() {
-        bail!("request payload {} is not a regular file", path.display());
-    }
-
-    if metadata.len() == 0 {
-        bail!("request payload {} is empty", path.display());
-    }
-
-    if metadata.len() > MAX_REQUEST_BYTES {
-        bail!(
-            "request payload {} is too large: {} bytes, max {} bytes",
-            path.display(),
-            metadata.len(),
-            MAX_REQUEST_BYTES
-        );
-    }
-
-    Ok(())
 }
 
 fn parse_from(
@@ -227,7 +170,6 @@ fn parse_from(
 
     let mut function_name = None;
     let mut backend_dir = None;
-    let mut request_path = None;
     let mut timeout_seconds = None;
     let mut no_persist = false;
     let mut idx = 0;
@@ -258,15 +200,9 @@ fn parse_from(
                 )?;
             }
             "--request" => {
-                idx += 1;
-                let value = args
-                    .get(idx)
-                    .ok_or_else(|| format!("missing value for --request\n{USAGE}"))?;
-                set_once(
-                    &mut request_path,
-                    PathBuf::from(required_option_value(value, "--request")?),
-                    "--request",
-                )?;
+                return Err(format!(
+                    "--request is no longer supported; pass the request payload on stdin\n{USAGE}"
+                ));
             }
             "--timeout" => {
                 idx += 1;
@@ -303,14 +239,9 @@ fn parse_from(
                 )?;
             }
             _ if arg.starts_with("--request=") => {
-                set_once(
-                    &mut request_path,
-                    PathBuf::from(required_option_value(
-                        arg.trim_start_matches("--request="),
-                        "--request",
-                    )?),
-                    "--request",
-                )?;
+                return Err(format!(
+                    "--request is no longer supported; pass the request payload on stdin\n{USAGE}"
+                ));
             }
             _ if arg.starts_with("--timeout=") => {
                 set_once(
@@ -332,7 +263,6 @@ fn parse_from(
     Ok(Some(TestCommand {
         function_name: required(function_name, "--test")?,
         backend_dir: required(backend_dir, "--dir")?,
-        request_path: required(request_path, "--request")?,
         timeout_seconds: timeout_seconds.unwrap_or(DEFAULT_TIMEOUT_SECONDS),
         no_persist,
     }))
@@ -367,7 +297,7 @@ fn parse_timeout_seconds(value: &str) -> std::result::Result<u64, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
+    use std::fs;
 
     fn parse(args: &[&str]) -> std::result::Result<Option<TestCommand>, String> {
         parse_from(args.iter().map(|arg| (*arg).to_string()))
@@ -379,40 +309,25 @@ mod tests {
     }
 
     #[test]
-    fn parser_accepts_file_based_test_command() {
-        let command = parse(&[
-            "--test",
-            "flows:netflow",
-            "--dir",
-            "flows",
-            "--request",
-            "payload.json",
-            "--no-persist",
-        ])
-        .unwrap()
-        .expect("test command");
+    fn parser_accepts_stdin_test_command() {
+        let command = parse(&["--test", "flows:netflow", "--dir", "flows", "--no-persist"])
+            .unwrap()
+            .expect("test command");
 
         assert_eq!(command.function_name, "flows:netflow");
-        assert_eq!(command.backend_dir, Path::new("flows"));
-        assert_eq!(command.request_path, Path::new("payload.json"));
+        assert_eq!(command.backend_dir, PathBuf::from("flows"));
         assert_eq!(command.timeout_seconds, DEFAULT_TIMEOUT_SECONDS);
         assert!(command.no_persist);
     }
 
     #[test]
     fn parser_accepts_equals_form() {
-        let command = parse(&[
-            "--test=flows:netflow",
-            "--dir=flows",
-            "--request=payload.json",
-            "--timeout=0",
-        ])
-        .unwrap()
-        .expect("test command");
+        let command = parse(&["--test=flows:netflow", "--dir=flows", "--timeout=0"])
+            .unwrap()
+            .expect("test command");
 
         assert_eq!(command.function_name, "flows:netflow");
-        assert_eq!(command.backend_dir, Path::new("flows"));
-        assert_eq!(command.request_path, Path::new("payload.json"));
+        assert_eq!(command.backend_dir, PathBuf::from("flows"));
         assert_eq!(command.timeout_seconds, 0);
         assert_eq!(
             effective_timeout_seconds(command.timeout_seconds),
@@ -428,8 +343,6 @@ mod tests {
             "flows:netflow",
             "--dir",
             "flows",
-            "--request",
-            "payload.json",
             "--timeout",
             "120",
         ])
@@ -451,18 +364,10 @@ mod tests {
     #[test]
     fn parser_rejects_empty_required_values() {
         for args in [
-            ["--test=", "--dir=flows", "--request=payload.json"].as_slice(),
-            ["--test", "", "--dir=flows", "--request=payload.json"].as_slice(),
-            ["--test=flows:netflow", "--dir=", "--request=payload.json"].as_slice(),
-            [
-                "--test=flows:netflow",
-                "--dir",
-                "",
-                "--request=payload.json",
-            ]
-            .as_slice(),
-            ["--test=flows:netflow", "--dir=flows", "--request="].as_slice(),
-            ["--test=flows:netflow", "--dir=flows", "--request", ""].as_slice(),
+            ["--test=", "--dir=flows"].as_slice(),
+            ["--test", "", "--dir=flows"].as_slice(),
+            ["--test=flows:netflow", "--dir="].as_slice(),
+            ["--test=flows:netflow", "--dir", ""].as_slice(),
         ] {
             let err = parse(args).expect_err("empty required option should fail");
             assert!(err.contains("missing value for --"));
@@ -470,17 +375,31 @@ mod tests {
     }
 
     #[test]
+    fn parser_rejects_request_option() {
+        for args in [
+            [
+                "--test=flows:netflow",
+                "--dir=flows",
+                "--request=payload.json",
+            ]
+            .as_slice(),
+            [
+                "--test=flows:netflow",
+                "--dir=flows",
+                "--request",
+                "payload.json",
+            ]
+            .as_slice(),
+        ] {
+            let err = parse(args).expect_err("--request should fail");
+            assert!(err.contains("--request is no longer supported"));
+        }
+    }
+
+    #[test]
     fn parser_rejects_unknown_test_options() {
-        let err = parse(&[
-            "--test",
-            "flows:netflow",
-            "--dir",
-            "flows",
-            "--request",
-            "payload.json",
-            "--unknown",
-        ])
-        .expect_err("unknown option should fail");
+        let err = parse(&["--test", "flows:netflow", "--dir", "flows", "--unknown"])
+            .expect_err("unknown option should fail");
 
         assert!(err.contains("unsupported netflow test option"));
     }
@@ -492,8 +411,6 @@ mod tests {
             "flows:netflow",
             "--dir",
             "flows",
-            "--request",
-            "payload.json",
             "--timeout",
             "-1",
         ])
@@ -509,8 +426,6 @@ mod tests {
             "flows:netflow",
             "--dir",
             "flows",
-            "--request",
-            "payload.json",
             "--timeout",
             "30",
             "--timeout=60",
@@ -533,56 +448,25 @@ mod tests {
     }
 
     #[test]
-    fn read_request_payload_rejects_empty_file() {
-        let tmp = tempfile::tempdir().expect("create temp dir");
-        let path = tmp.path().join("empty.json");
-        fs::write(&path, []).expect("write empty request");
-
-        let err = read_request_payload(&path).expect_err("empty request should fail");
+    fn read_request_payload_from_stdin_rejects_empty_input() {
+        let err = read_request_payload_from_stdin(io::Cursor::new(Vec::new()))
+            .expect_err("empty request should fail");
         assert!(err.to_string().contains("is empty"));
     }
 
     #[test]
-    fn read_request_payload_rejects_oversized_file() {
-        let tmp = tempfile::tempdir().expect("create temp dir");
-        let path = tmp.path().join("oversized.json");
-        let file = fs::File::create(&path).expect("create oversized request");
-        file.set_len(MAX_REQUEST_BYTES + 1)
-            .expect("size oversized request");
-
-        let err = read_request_payload(&path).expect_err("oversized request should fail");
+    fn read_request_payload_from_stdin_rejects_oversized_input() {
+        let oversized = vec![b' '; (MAX_REQUEST_BYTES + 1) as usize];
+        let err = read_request_payload_from_stdin(io::Cursor::new(oversized))
+            .expect_err("oversized request should fail");
         assert!(err.to_string().contains("is too large"));
     }
 
-    #[cfg(unix)]
     #[test]
-    fn read_request_payload_rejects_fifo() {
-        use std::ffi::CString;
-        use std::os::unix::ffi::OsStrExt;
-
-        let tmp = tempfile::tempdir().expect("create temp dir");
-        let path = tmp.path().join("request.fifo");
-        let c_path = CString::new(path.as_os_str().as_bytes()).expect("fifo path has no nul byte");
-        let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
-        assert_eq!(rc, 0, "mkfifo {} failed", path.display());
-
-        let err = read_request_payload(&path).expect_err("fifo request should fail");
-        assert!(err.to_string().contains("not a regular file"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn read_request_payload_rejects_symlink() {
-        use std::os::unix::fs::symlink;
-
-        let tmp = tempfile::tempdir().expect("create temp dir");
-        let target_path = tmp.path().join("target.json");
-        fs::write(&target_path, "{}").expect("write request target");
-        let symlink_path = tmp.path().join("request.json");
-        symlink(&target_path, &symlink_path).expect("create request symlink");
-
-        let err = read_request_payload(&symlink_path).expect_err("symlink request should fail");
-        assert!(err.to_string().contains("not a regular file"));
+    fn read_request_payload_from_stdin_reads_payload() {
+        let request = read_request_payload_from_stdin(io::Cursor::new(br#"{"after":1}"#))
+            .expect("read request payload");
+        assert_eq!(request, br#"{"after":1}"#);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -593,20 +477,15 @@ mod tests {
             fs::create_dir_all(backend_dir.join(tier)).expect("create tier dir");
         }
 
-        let request_path = tmp.path().join("flows-request.json");
-        fs::write(
-            &request_path,
-            r#"{"after":1,"before":2,"group_by":["PROTOCOL"],"top_n":"100"}"#,
+        let response = execute(
+            TestCommand {
+                function_name: FLOWS_FUNCTION_NAME.to_string(),
+                backend_dir: backend_dir.clone(),
+                timeout_seconds: DEFAULT_TIMEOUT_SECONDS,
+                no_persist: true,
+            },
+            br#"{"after":1,"before":2,"group_by":["PROTOCOL"],"top_n":"100"}"#,
         )
-        .expect("write request payload");
-
-        let response = execute(TestCommand {
-            function_name: FLOWS_FUNCTION_NAME.to_string(),
-            backend_dir: backend_dir.clone(),
-            request_path,
-            timeout_seconds: DEFAULT_TIMEOUT_SECONDS,
-            no_persist: true,
-        })
         .await
         .expect("execute test CLI request");
 

--- a/src/crates/netflow-plugin/src/test_cli.rs
+++ b/src/crates/netflow-plugin/src/test_cli.rs
@@ -48,6 +48,30 @@ pub(crate) async fn execute(
         );
     }
 
+    let effective_timeout = effective_timeout_seconds(command.timeout_seconds);
+    let cancellation = CancellationToken::new();
+    match tokio::time::timeout(
+        Duration::from_secs(effective_timeout),
+        execute_inner(command, request_bytes, cancellation.clone()),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            cancellation.cancel();
+            bail!(
+                "netflow test function timed out after {} seconds",
+                effective_timeout
+            );
+        }
+    }
+}
+
+async fn execute_inner(
+    command: TestCommand,
+    request_bytes: &[u8],
+    cancellation: CancellationToken,
+) -> Result<FlowsFunctionResponse> {
     let request = serde_json::from_slice::<query::FlowsRequest>(request_bytes)
         .context("failed to parse request payload from stdin")?;
 
@@ -70,7 +94,6 @@ pub(crate) async fn execute(
         Arc::new(ingest::IngestMetrics::default()),
         Arc::clone(&query_service),
     );
-    let cancellation = CancellationToken::new();
     let execution = if request.is_autocomplete_mode() {
         None
     } else {
@@ -80,21 +103,10 @@ pub(crate) async fn execute(
         ))
     };
 
-    match tokio::time::timeout(
-        Duration::from_secs(effective_timeout_seconds(command.timeout_seconds)),
-        handler.handle_request_with_execution(execution, request),
-    )
-    .await
-    {
-        Ok(result) => result.map_err(Into::into),
-        Err(_) => {
-            cancellation.cancel();
-            bail!(
-                "netflow test function timed out after {} seconds",
-                effective_timeout_seconds(command.timeout_seconds)
-            );
-        }
-    }
+    handler
+        .handle_request_with_execution(execution, request)
+        .await
+        .map_err(Into::into)
 }
 
 pub(crate) fn write_json_response(

--- a/src/crates/netflow-plugin/src/test_cli.rs
+++ b/src/crates/netflow-plugin/src/test_cli.rs
@@ -2,6 +2,7 @@ use crate::api::{FLOWS_FUNCTION_NAME, FlowsFunctionResponse, NetflowFlowsHandler
 use crate::{facet_runtime, ingest, plugin_config, query};
 use anyhow::{Context, Result, bail};
 use rt::ProgressState;
+use std::ffi::{OsStr, OsString};
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -169,13 +170,20 @@ fn read_request_payload_from_stdin(reader: impl Read) -> Result<Vec<u8>> {
     Ok(request_bytes)
 }
 
+#[cfg(test)]
 fn parse_from(
     args: impl IntoIterator<Item = String>,
+) -> std::result::Result<Option<TestCommand>, String> {
+    parse_from_os(args.into_iter().map(OsString::from))
+}
+
+fn parse_from_os(
+    args: impl IntoIterator<Item = OsString>,
 ) -> std::result::Result<Option<TestCommand>, String> {
     let args = args.into_iter().collect::<Vec<_>>();
     if !args
         .iter()
-        .any(|arg| arg == "--test" || arg.starts_with("--test="))
+        .any(|arg| arg == OsStr::new("--test") || strip_os_prefix(arg, "--test=").is_some())
     {
         return Ok(None);
     }
@@ -188,86 +196,74 @@ fn parse_from(
 
     while idx < args.len() {
         let arg = &args[idx];
-        match arg.as_str() {
-            "--test" => {
-                idx += 1;
-                let value = args
-                    .get(idx)
-                    .ok_or_else(|| format!("missing value for --test\n{USAGE}"))?;
-                set_once(
-                    &mut function_name,
-                    required_option_value(value, "--test")?.to_string(),
-                    "--test",
-                )?;
+        if arg == OsStr::new("--test") {
+            idx += 1;
+            let value = args
+                .get(idx)
+                .ok_or_else(|| format!("missing value for --test\n{USAGE}"))?;
+            set_once(
+                &mut function_name,
+                required_os_string_value(value, "--test")?,
+                "--test",
+            )?;
+        } else if arg == OsStr::new("--dir") {
+            idx += 1;
+            let value = args
+                .get(idx)
+                .ok_or_else(|| format!("missing value for --dir\n{USAGE}"))?;
+            set_once(
+                &mut backend_dir,
+                PathBuf::from(required_os_string_value(value, "--dir")?),
+                "--dir",
+            )?;
+        } else if arg == OsStr::new("--request") {
+            return Err(format!(
+                "--request is no longer supported; pass the request payload on stdin\n{USAGE}"
+            ));
+        } else if arg == OsStr::new("--timeout") {
+            idx += 1;
+            let value = args
+                .get(idx)
+                .ok_or_else(|| format!("missing value for --timeout\n{USAGE}"))?;
+            set_once(
+                &mut timeout_seconds,
+                parse_timeout_seconds(&required_os_string_value(value, "--timeout")?)?,
+                "--timeout",
+            )?;
+        } else if arg == OsStr::new("--no-persist") {
+            if no_persist {
+                return Err(format!("duplicate --no-persist\n{USAGE}"));
             }
-            "--dir" => {
-                idx += 1;
-                let value = args
-                    .get(idx)
-                    .ok_or_else(|| format!("missing value for --dir\n{USAGE}"))?;
-                set_once(
-                    &mut backend_dir,
-                    PathBuf::from(required_option_value(value, "--dir")?),
-                    "--dir",
-                )?;
-            }
-            "--request" => {
-                return Err(format!(
-                    "--request is no longer supported; pass the request payload on stdin\n{USAGE}"
-                ));
-            }
-            "--timeout" => {
-                idx += 1;
-                let value = args
-                    .get(idx)
-                    .ok_or_else(|| format!("missing value for --timeout\n{USAGE}"))?;
-                set_once(
-                    &mut timeout_seconds,
-                    parse_timeout_seconds(value)?,
-                    "--timeout",
-                )?;
-            }
-            "--no-persist" => {
-                if no_persist {
-                    return Err(format!("duplicate --no-persist\n{USAGE}"));
-                }
-                no_persist = true;
-            }
-            _ if arg.starts_with("--test=") => {
-                set_once(
-                    &mut function_name,
-                    required_option_value(arg.trim_start_matches("--test="), "--test")?.to_string(),
-                    "--test",
-                )?;
-            }
-            _ if arg.starts_with("--dir=") => {
-                set_once(
-                    &mut backend_dir,
-                    PathBuf::from(required_option_value(
-                        arg.trim_start_matches("--dir="),
-                        "--dir",
-                    )?),
-                    "--dir",
-                )?;
-            }
-            _ if arg.starts_with("--request=") => {
-                return Err(format!(
-                    "--request is no longer supported; pass the request payload on stdin\n{USAGE}"
-                ));
-            }
-            _ if arg.starts_with("--timeout=") => {
-                set_once(
-                    &mut timeout_seconds,
-                    parse_timeout_seconds(arg.trim_start_matches("--timeout="))?,
-                    "--timeout",
-                )?;
-            }
-            "-h" | "--help" => {
-                return Err(USAGE.to_string());
-            }
-            _ => {
-                return Err(format!("unsupported netflow test option `{arg}`\n{USAGE}"));
-            }
+            no_persist = true;
+        } else if let Some(value) = strip_os_prefix(arg, "--test=") {
+            set_once(
+                &mut function_name,
+                required_os_string_value(&value, "--test")?,
+                "--test",
+            )?;
+        } else if let Some(value) = strip_os_prefix(arg, "--dir=") {
+            set_once(
+                &mut backend_dir,
+                PathBuf::from(required_os_string_value(&value, "--dir")?),
+                "--dir",
+            )?;
+        } else if strip_os_prefix(arg, "--request=").is_some() {
+            return Err(format!(
+                "--request is no longer supported; pass the request payload on stdin\n{USAGE}"
+            ));
+        } else if let Some(value) = strip_os_prefix(arg, "--timeout=") {
+            set_once(
+                &mut timeout_seconds,
+                parse_timeout_seconds(&required_os_string_value(&value, "--timeout")?)?,
+                "--timeout",
+            )?;
+        } else if arg == OsStr::new("-h") || arg == OsStr::new("--help") {
+            return Err(USAGE.to_string());
+        } else {
+            return Err(format!(
+                "unsupported netflow test option `{}`\n{USAGE}",
+                arg.to_string_lossy()
+            ));
         }
         idx += 1;
     }
@@ -280,15 +276,6 @@ fn parse_from(
     }))
 }
 
-fn parse_from_os(
-    args: impl IntoIterator<Item = std::ffi::OsString>,
-) -> std::result::Result<Option<TestCommand>, String> {
-    parse_from(
-        args.into_iter()
-            .map(|arg| arg.to_string_lossy().into_owned()),
-    )
-}
-
 fn set_once<T>(slot: &mut Option<T>, value: T, option: &str) -> std::result::Result<(), String> {
     if slot.is_some() {
         return Err(format!("duplicate {option}\n{USAGE}"));
@@ -297,12 +284,23 @@ fn set_once<T>(slot: &mut Option<T>, value: T, option: &str) -> std::result::Res
     Ok(())
 }
 
-fn required_option_value<'a>(value: &'a str, option: &str) -> std::result::Result<&'a str, String> {
+fn required_os_option_value<'a>(
+    value: &'a OsStr,
+    option: &str,
+) -> std::result::Result<&'a OsStr, String> {
     if value.is_empty() {
         return Err(format!("missing value for {option}\n{USAGE}"));
     }
 
     Ok(value)
+}
+
+fn required_os_string_value(value: &OsStr, option: &str) -> std::result::Result<String, String> {
+    let value = required_os_option_value(value, option)?;
+    value
+        .to_str()
+        .map(ToString::to_string)
+        .ok_or_else(|| format!("invalid value for {option}; expected UTF-8\n{USAGE}"))
 }
 
 fn required<T>(slot: Option<T>, option: &str) -> std::result::Result<T, String> {
@@ -313,6 +311,21 @@ fn parse_timeout_seconds(value: &str) -> std::result::Result<u64, String> {
     value
         .parse::<u64>()
         .map_err(|_| format!("invalid value for --timeout `{value}`; expected seconds\n{USAGE}"))
+}
+
+#[cfg(unix)]
+fn strip_os_prefix(value: &OsStr, prefix: &str) -> Option<OsString> {
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+    value
+        .as_bytes()
+        .strip_prefix(prefix.as_bytes())
+        .map(|suffix| OsString::from_vec(suffix.to_vec()))
+}
+
+#[cfg(not(unix))]
+fn strip_os_prefix(value: &OsStr, prefix: &str) -> Option<OsString> {
+    value.to_str()?.strip_prefix(prefix).map(OsString::from)
 }
 
 #[cfg(test)]
@@ -341,6 +354,41 @@ mod tests {
         ];
 
         assert_eq!(parse_from_os(args).unwrap(), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parser_rejects_non_utf8_spaced_backend_dir() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let err = parse_from_os([
+            OsString::from("--test"),
+            OsString::from("flows:netflow"),
+            OsString::from("--dir"),
+            OsString::from_vec(b"flows-\xff".to_vec()),
+        ])
+        .expect_err("non-UTF-8 backend directory should fail");
+
+        assert!(err.contains("invalid value for --dir; expected UTF-8"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parser_rejects_non_utf8_equals_backend_dir() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let mut dir_arg = b"--dir=".to_vec();
+        dir_arg.extend_from_slice(b"flows-\xff");
+
+        let err = parse_from_os([
+            OsString::from("--test=flows:netflow"),
+            OsString::from_vec(dir_arg),
+        ])
+        .expect_err("non-UTF-8 backend directory should fail");
+
+        assert!(err.contains("invalid value for --dir; expected UTF-8"));
     }
 
     #[test]
@@ -548,5 +596,26 @@ mod tests {
             !backend_dir.join("facet-state.bin").exists(),
             "--no-persist must not write facet state under the fixture backend"
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execute_rejects_non_utf8_backend_dir() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let err = execute(
+            TestCommand {
+                function_name: FLOWS_FUNCTION_NAME.to_string(),
+                backend_dir: PathBuf::from(OsString::from_vec(b"flows-\xff".to_vec())),
+                timeout_seconds: DEFAULT_TIMEOUT_SECONDS,
+                no_persist: true,
+            },
+            br#"{"after":1,"before":2,"group_by":["PROTOCOL"],"top_n":"100"}"#,
+        )
+        .await
+        .expect_err("non-UTF-8 backend directory should fail");
+
+        assert!(err.to_string().contains("is not valid UTF-8"));
     }
 }

--- a/src/crates/netflow-plugin/src/test_cli.rs
+++ b/src/crates/netflow-plugin/src/test_cli.rs
@@ -33,7 +33,8 @@ pub(crate) async fn run(command: TestCommand) -> Result<()> {
     let response = execute(command).await?;
     let stdout = io::stdout();
     let mut handle = stdout.lock();
-    write_json_response(&response, &mut handle)
+    write_json_response(&response, &mut handle)?;
+    ensure_success_status(response.status())
 }
 
 pub(crate) async fn execute(command: TestCommand) -> Result<FlowsFunctionResponse> {
@@ -129,6 +130,14 @@ fn effective_timeout_seconds(timeout_seconds: u64) -> u64 {
     } else {
         timeout_seconds
     }
+}
+
+fn ensure_success_status(status: u32) -> Result<()> {
+    if !(200..300).contains(&status) {
+        bail!("netflow test function returned status {status}");
+    }
+
+    Ok(())
 }
 
 fn read_request_payload(path: &Path) -> Result<Vec<u8>> {
@@ -231,21 +240,33 @@ fn parse_from(
                 let value = args
                     .get(idx)
                     .ok_or_else(|| format!("missing value for --test\n{USAGE}"))?;
-                set_once(&mut function_name, value.clone(), "--test")?;
+                set_once(
+                    &mut function_name,
+                    required_option_value(value, "--test")?.to_string(),
+                    "--test",
+                )?;
             }
             "--dir" => {
                 idx += 1;
                 let value = args
                     .get(idx)
                     .ok_or_else(|| format!("missing value for --dir\n{USAGE}"))?;
-                set_once(&mut backend_dir, PathBuf::from(value), "--dir")?;
+                set_once(
+                    &mut backend_dir,
+                    PathBuf::from(required_option_value(value, "--dir")?),
+                    "--dir",
+                )?;
             }
             "--request" => {
                 idx += 1;
                 let value = args
                     .get(idx)
                     .ok_or_else(|| format!("missing value for --request\n{USAGE}"))?;
-                set_once(&mut request_path, PathBuf::from(value), "--request")?;
+                set_once(
+                    &mut request_path,
+                    PathBuf::from(required_option_value(value, "--request")?),
+                    "--request",
+                )?;
             }
             "--timeout" => {
                 idx += 1;
@@ -267,21 +288,27 @@ fn parse_from(
             _ if arg.starts_with("--test=") => {
                 set_once(
                     &mut function_name,
-                    arg.trim_start_matches("--test=").to_string(),
+                    required_option_value(arg.trim_start_matches("--test="), "--test")?.to_string(),
                     "--test",
                 )?;
             }
             _ if arg.starts_with("--dir=") => {
                 set_once(
                     &mut backend_dir,
-                    PathBuf::from(arg.trim_start_matches("--dir=")),
+                    PathBuf::from(required_option_value(
+                        arg.trim_start_matches("--dir="),
+                        "--dir",
+                    )?),
                     "--dir",
                 )?;
             }
             _ if arg.starts_with("--request=") => {
                 set_once(
                     &mut request_path,
-                    PathBuf::from(arg.trim_start_matches("--request=")),
+                    PathBuf::from(required_option_value(
+                        arg.trim_start_matches("--request="),
+                        "--request",
+                    )?),
                     "--request",
                 )?;
             }
@@ -317,6 +344,14 @@ fn set_once<T>(slot: &mut Option<T>, value: T, option: &str) -> std::result::Res
     }
     *slot = Some(value);
     Ok(())
+}
+
+fn required_option_value<'a>(value: &'a str, option: &str) -> std::result::Result<&'a str, String> {
+    if value.is_empty() {
+        return Err(format!("missing value for {option}\n{USAGE}"));
+    }
+
+    Ok(value)
 }
 
 fn required<T>(slot: Option<T>, option: &str) -> std::result::Result<T, String> {
@@ -414,6 +449,27 @@ mod tests {
     }
 
     #[test]
+    fn parser_rejects_empty_required_values() {
+        for args in [
+            ["--test=", "--dir=flows", "--request=payload.json"].as_slice(),
+            ["--test", "", "--dir=flows", "--request=payload.json"].as_slice(),
+            ["--test=flows:netflow", "--dir=", "--request=payload.json"].as_slice(),
+            [
+                "--test=flows:netflow",
+                "--dir",
+                "",
+                "--request=payload.json",
+            ]
+            .as_slice(),
+            ["--test=flows:netflow", "--dir=flows", "--request="].as_slice(),
+            ["--test=flows:netflow", "--dir=flows", "--request", ""].as_slice(),
+        ] {
+            let err = parse(args).expect_err("empty required option should fail");
+            assert!(err.contains("missing value for --"));
+        }
+    }
+
+    #[test]
     fn parser_rejects_unknown_test_options() {
         let err = parse(&[
             "--test",
@@ -462,6 +518,18 @@ mod tests {
         .expect_err("duplicate timeout should fail");
 
         assert!(err.contains("duplicate --timeout"));
+    }
+
+    #[test]
+    fn success_status_accepts_2xx() {
+        ensure_success_status(200).expect("200 should pass");
+        ensure_success_status(299).expect("299 should pass");
+    }
+
+    #[test]
+    fn success_status_rejects_non_2xx() {
+        let err = ensure_success_status(400).expect_err("400 should fail");
+        assert!(err.to_string().contains("returned status 400"));
     }
 
     #[test]

--- a/src/crates/netflow-plugin/src/test_cli.rs
+++ b/src/crates/netflow-plugin/src/test_cli.rs
@@ -98,7 +98,7 @@ pub(crate) async fn execute(command: TestCommand) -> Result<FlowsFunctionRespons
             cancellation.cancel();
             bail!(
                 "netflow test function timed out after {} seconds",
-                command.timeout_seconds
+                effective_timeout_seconds(command.timeout_seconds)
             );
         }
     }

--- a/src/crates/netflow-plugin/src/test_cli.rs
+++ b/src/crates/netflow-plugin/src/test_cli.rs
@@ -1,18 +1,24 @@
 use crate::api::{FLOWS_FUNCTION_NAME, FlowsFunctionResponse, NetflowFlowsHandler};
 use crate::{facet_runtime, ingest, plugin_config, query};
 use anyhow::{Context, Result, bail};
+use rt::ProgressState;
 use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 
-const USAGE: &str = "usage: netflow-plugin --test flows:netflow --dir <flows-dir> --request <payload.json> [--no-persist]";
+const USAGE: &str = "usage: netflow-plugin --test flows:netflow --dir <flows-dir> --request <payload.json> [--timeout <seconds>] [--no-persist]";
+const DEFAULT_TIMEOUT_SECONDS: u64 = 30;
+const DISABLED_TIMEOUT_SECONDS: u64 = 100 * 365 * 24 * 60 * 60;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TestCommand {
     pub(crate) function_name: String,
     pub(crate) backend_dir: PathBuf,
     pub(crate) request_path: PathBuf,
+    pub(crate) timeout_seconds: u64,
     pub(crate) no_persist: bool,
 }
 
@@ -71,7 +77,31 @@ pub(crate) async fn execute(command: TestCommand) -> Result<FlowsFunctionRespons
         Arc::new(ingest::IngestMetrics::default()),
         Arc::clone(&query_service),
     );
-    handler.handle_request(request).await.map_err(Into::into)
+    let cancellation = CancellationToken::new();
+    let execution = if request.is_autocomplete_mode() {
+        None
+    } else {
+        Some(query::QueryExecutionContext::new(
+            ProgressState::default(),
+            cancellation.clone(),
+        ))
+    };
+
+    match tokio::time::timeout(
+        Duration::from_secs(effective_timeout_seconds(command.timeout_seconds)),
+        handler.handle_request_with_execution(execution, request),
+    )
+    .await
+    {
+        Ok(result) => result.map_err(Into::into),
+        Err(_) => {
+            cancellation.cancel();
+            bail!(
+                "netflow test function timed out after {} seconds",
+                command.timeout_seconds
+            );
+        }
+    }
 }
 
 pub(crate) fn write_json_response(
@@ -97,6 +127,14 @@ fn ensure_tier_directories_exist(config: &plugin_config::PluginConfig) -> Result
     Ok(())
 }
 
+fn effective_timeout_seconds(timeout_seconds: u64) -> u64 {
+    if timeout_seconds == 0 {
+        DISABLED_TIMEOUT_SECONDS
+    } else {
+        timeout_seconds
+    }
+}
+
 fn parse_from(
     args: impl IntoIterator<Item = String>,
 ) -> std::result::Result<Option<TestCommand>, String> {
@@ -111,6 +149,7 @@ fn parse_from(
     let mut function_name = None;
     let mut backend_dir = None;
     let mut request_path = None;
+    let mut timeout_seconds = None;
     let mut no_persist = false;
     let mut idx = 0;
 
@@ -137,6 +176,17 @@ fn parse_from(
                     .get(idx)
                     .ok_or_else(|| format!("missing value for --request\n{USAGE}"))?;
                 set_once(&mut request_path, PathBuf::from(value), "--request")?;
+            }
+            "--timeout" => {
+                idx += 1;
+                let value = args
+                    .get(idx)
+                    .ok_or_else(|| format!("missing value for --timeout\n{USAGE}"))?;
+                set_once(
+                    &mut timeout_seconds,
+                    parse_timeout_seconds(value)?,
+                    "--timeout",
+                )?;
             }
             "--no-persist" => {
                 if no_persist {
@@ -165,6 +215,13 @@ fn parse_from(
                     "--request",
                 )?;
             }
+            _ if arg.starts_with("--timeout=") => {
+                set_once(
+                    &mut timeout_seconds,
+                    parse_timeout_seconds(arg.trim_start_matches("--timeout="))?,
+                    "--timeout",
+                )?;
+            }
             "-h" | "--help" => {
                 return Err(USAGE.to_string());
             }
@@ -179,6 +236,7 @@ fn parse_from(
         function_name: required(function_name, "--test")?,
         backend_dir: required(backend_dir, "--dir")?,
         request_path: required(request_path, "--request")?,
+        timeout_seconds: timeout_seconds.unwrap_or(DEFAULT_TIMEOUT_SECONDS),
         no_persist,
     }))
 }
@@ -193,6 +251,12 @@ fn set_once<T>(slot: &mut Option<T>, value: T, option: &str) -> std::result::Res
 
 fn required<T>(slot: Option<T>, option: &str) -> std::result::Result<T, String> {
     slot.ok_or_else(|| format!("missing required {option}\n{USAGE}"))
+}
+
+fn parse_timeout_seconds(value: &str) -> std::result::Result<u64, String> {
+    value
+        .parse::<u64>()
+        .map_err(|_| format!("invalid value for --timeout `{value}`; expected seconds\n{USAGE}"))
 }
 
 #[cfg(test)]
@@ -226,6 +290,7 @@ mod tests {
         assert_eq!(command.function_name, "flows:netflow");
         assert_eq!(command.backend_dir, Path::new("flows"));
         assert_eq!(command.request_path, Path::new("payload.json"));
+        assert_eq!(command.timeout_seconds, DEFAULT_TIMEOUT_SECONDS);
         assert!(command.no_persist);
     }
 
@@ -235,6 +300,7 @@ mod tests {
             "--test=flows:netflow",
             "--dir=flows",
             "--request=payload.json",
+            "--timeout=0",
         ])
         .unwrap()
         .expect("test command");
@@ -242,7 +308,31 @@ mod tests {
         assert_eq!(command.function_name, "flows:netflow");
         assert_eq!(command.backend_dir, Path::new("flows"));
         assert_eq!(command.request_path, Path::new("payload.json"));
+        assert_eq!(command.timeout_seconds, 0);
+        assert_eq!(
+            effective_timeout_seconds(command.timeout_seconds),
+            DISABLED_TIMEOUT_SECONDS
+        );
         assert!(!command.no_persist);
+    }
+
+    #[test]
+    fn parser_accepts_spaced_timeout() {
+        let command = parse(&[
+            "--test",
+            "flows:netflow",
+            "--dir",
+            "flows",
+            "--request",
+            "payload.json",
+            "--timeout",
+            "120",
+        ])
+        .unwrap()
+        .expect("test command");
+
+        assert_eq!(command.timeout_seconds, 120);
+        assert_eq!(effective_timeout_seconds(command.timeout_seconds), 120);
     }
 
     #[test]
@@ -269,6 +359,41 @@ mod tests {
         assert!(err.contains("unsupported netflow test option"));
     }
 
+    #[test]
+    fn parser_rejects_invalid_timeout() {
+        let err = parse(&[
+            "--test",
+            "flows:netflow",
+            "--dir",
+            "flows",
+            "--request",
+            "payload.json",
+            "--timeout",
+            "-1",
+        ])
+        .expect_err("invalid timeout should fail");
+
+        assert!(err.contains("invalid value for --timeout"));
+    }
+
+    #[test]
+    fn parser_rejects_duplicate_timeout() {
+        let err = parse(&[
+            "--test",
+            "flows:netflow",
+            "--dir",
+            "flows",
+            "--request",
+            "payload.json",
+            "--timeout",
+            "30",
+            "--timeout=60",
+        ])
+        .expect_err("duplicate timeout should fail");
+
+        assert!(err.contains("duplicate --timeout"));
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_empty_backend_writes_raw_json_without_persisting_facets() {
         let tmp = tempfile::tempdir().expect("create temp dir");
@@ -288,6 +413,7 @@ mod tests {
             function_name: FLOWS_FUNCTION_NAME.to_string(),
             backend_dir: backend_dir.clone(),
             request_path,
+            timeout_seconds: DEFAULT_TIMEOUT_SECONDS,
             no_persist: true,
         })
         .await

--- a/src/crates/netflow-plugin/src/test_cli.rs
+++ b/src/crates/netflow-plugin/src/test_cli.rs
@@ -132,28 +132,15 @@ fn effective_timeout_seconds(timeout_seconds: u64) -> u64 {
 }
 
 fn read_request_payload(path: &Path) -> Result<Vec<u8>> {
-    let file = fs::File::open(path)
-        .with_context(|| format!("failed to open request payload {}", path.display()))?;
+    let metadata = fs::metadata(path)
+        .with_context(|| format!("failed to inspect request payload {}", path.display()))?;
+    validate_request_payload_metadata(path, &metadata)?;
+
+    let file = open_request_payload_file(path)?;
     let metadata = file
         .metadata()
         .with_context(|| format!("failed to inspect request payload {}", path.display()))?;
-
-    if !metadata.is_file() {
-        bail!("request payload {} is not a regular file", path.display());
-    }
-
-    if metadata.len() == 0 {
-        bail!("request payload {} is empty", path.display());
-    }
-
-    if metadata.len() > MAX_REQUEST_BYTES {
-        bail!(
-            "request payload {} is too large: {} bytes, max {} bytes",
-            path.display(),
-            metadata.len(),
-            MAX_REQUEST_BYTES
-        );
-    }
+    validate_request_payload_metadata(path, &metadata)?;
 
     let mut request_bytes = Vec::with_capacity(metadata.len() as usize);
     file.take(MAX_REQUEST_BYTES + 1)
@@ -173,6 +160,43 @@ fn read_request_payload(path: &Path) -> Result<Vec<u8>> {
     }
 
     Ok(request_bytes)
+}
+
+fn open_request_payload_file(path: &Path) -> Result<fs::File> {
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        // Avoid blocking if the path changes to a FIFO between metadata validation and open.
+        options.custom_flags(libc::O_NONBLOCK);
+    }
+
+    options
+        .open(path)
+        .with_context(|| format!("failed to open request payload {}", path.display()))
+}
+
+fn validate_request_payload_metadata(path: &Path, metadata: &fs::Metadata) -> Result<()> {
+    if !metadata.is_file() {
+        bail!("request payload {} is not a regular file", path.display());
+    }
+
+    if metadata.len() == 0 {
+        bail!("request payload {} is empty", path.display());
+    }
+
+    if metadata.len() > MAX_REQUEST_BYTES {
+        bail!(
+            "request payload {} is too large: {} bytes, max {} bytes",
+            path.display(),
+            metadata.len(),
+            MAX_REQUEST_BYTES
+        );
+    }
+
+    Ok(())
 }
 
 fn parse_from(
@@ -454,6 +478,22 @@ mod tests {
 
         let err = read_request_payload(&path).expect_err("oversized request should fail");
         assert!(err.to_string().contains("is too large"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_request_payload_rejects_fifo() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let path = tmp.path().join("request.fifo");
+        let c_path = CString::new(path.as_os_str().as_bytes()).expect("fifo path has no nul byte");
+        let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(rc, 0, "mkfifo {} failed", path.display());
+
+        let err = read_request_payload(&path).expect_err("fifo request should fail");
+        assert!(err.to_string().contains("not a regular file"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/crates/netflow-plugin/src/test_cli.rs
+++ b/src/crates/netflow-plugin/src/test_cli.rs
@@ -23,7 +23,7 @@ pub(crate) struct TestCommand {
 
 impl TestCommand {
     pub(crate) fn parse_from_env_args() -> std::result::Result<Option<Self>, String> {
-        parse_from(std::env::args().skip(1))
+        parse_from_os(std::env::args_os().skip(1))
     }
 }
 
@@ -280,6 +280,15 @@ fn parse_from(
     }))
 }
 
+fn parse_from_os(
+    args: impl IntoIterator<Item = std::ffi::OsString>,
+) -> std::result::Result<Option<TestCommand>, String> {
+    parse_from(
+        args.into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned()),
+    )
+}
+
 fn set_once<T>(slot: &mut Option<T>, value: T, option: &str) -> std::result::Result<(), String> {
     if slot.is_some() {
         return Err(format!("duplicate {option}\n{USAGE}"));
@@ -318,6 +327,20 @@ mod tests {
     #[test]
     fn parser_ignores_normal_plugin_arguments_when_test_is_absent() {
         assert_eq!(parse(&["--netflow-enabled", "false"]).unwrap(), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parser_ignores_non_utf8_normal_arguments_when_test_is_absent() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let args = [
+            OsString::from("--netflow-enabled"),
+            OsString::from_vec(vec![0xff]),
+        ];
+
+        assert_eq!(parse_from_os(args).unwrap(), None);
     }
 
     #[test]

--- a/src/crates/netflow-plugin/src/test_cli.rs
+++ b/src/crates/netflow-plugin/src/test_cli.rs
@@ -3,8 +3,8 @@ use crate::{facet_runtime, ingest, plugin_config, query};
 use anyhow::{Context, Result, bail};
 use rt::ProgressState;
 use std::fs;
-use std::io::{self, Write};
-use std::path::PathBuf;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
@@ -12,6 +12,7 @@ use tokio_util::sync::CancellationToken;
 const USAGE: &str = "usage: netflow-plugin --test flows:netflow --dir <flows-dir> --request <payload.json> [--timeout <seconds>] [--no-persist]";
 const DEFAULT_TIMEOUT_SECONDS: u64 = 30;
 const DISABLED_TIMEOUT_SECONDS: u64 = 100 * 365 * 24 * 60 * 60;
+const MAX_REQUEST_BYTES: u64 = 16 * 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TestCommand {
@@ -44,12 +45,7 @@ pub(crate) async fn execute(command: TestCommand) -> Result<FlowsFunctionRespons
         );
     }
 
-    let request_bytes = fs::read(&command.request_path).with_context(|| {
-        format!(
-            "failed to read request payload {}",
-            command.request_path.display()
-        )
-    })?;
+    let request_bytes = read_request_payload(&command.request_path)?;
     let request =
         serde_json::from_slice::<query::FlowsRequest>(&request_bytes).with_context(|| {
             format!(
@@ -133,6 +129,50 @@ fn effective_timeout_seconds(timeout_seconds: u64) -> u64 {
     } else {
         timeout_seconds
     }
+}
+
+fn read_request_payload(path: &Path) -> Result<Vec<u8>> {
+    let file = fs::File::open(path)
+        .with_context(|| format!("failed to open request payload {}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("failed to inspect request payload {}", path.display()))?;
+
+    if !metadata.is_file() {
+        bail!("request payload {} is not a regular file", path.display());
+    }
+
+    if metadata.len() == 0 {
+        bail!("request payload {} is empty", path.display());
+    }
+
+    if metadata.len() > MAX_REQUEST_BYTES {
+        bail!(
+            "request payload {} is too large: {} bytes, max {} bytes",
+            path.display(),
+            metadata.len(),
+            MAX_REQUEST_BYTES
+        );
+    }
+
+    let mut request_bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_REQUEST_BYTES + 1)
+        .read_to_end(&mut request_bytes)
+        .with_context(|| format!("failed to read request payload {}", path.display()))?;
+
+    if request_bytes.is_empty() {
+        bail!("request payload {} is empty", path.display());
+    }
+
+    if request_bytes.len() as u64 > MAX_REQUEST_BYTES {
+        bail!(
+            "request payload {} is too large: more than {} bytes",
+            path.display(),
+            MAX_REQUEST_BYTES
+        );
+    }
+
+    Ok(request_bytes)
 }
 
 fn parse_from(
@@ -392,6 +432,28 @@ mod tests {
         .expect_err("duplicate timeout should fail");
 
         assert!(err.contains("duplicate --timeout"));
+    }
+
+    #[test]
+    fn read_request_payload_rejects_empty_file() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let path = tmp.path().join("empty.json");
+        fs::write(&path, []).expect("write empty request");
+
+        let err = read_request_payload(&path).expect_err("empty request should fail");
+        assert!(err.to_string().contains("is empty"));
+    }
+
+    #[test]
+    fn read_request_payload_rejects_oversized_file() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let path = tmp.path().join("oversized.json");
+        let file = fs::File::create(&path).expect("create oversized request");
+        file.set_len(MAX_REQUEST_BYTES + 1)
+            .expect("size oversized request");
+
+        let err = read_request_payload(&path).expect_err("oversized request should fail");
+        assert!(err.to_string().contains("is too large"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/crates/netflow-plugin/src/test_cli.rs
+++ b/src/crates/netflow-plugin/src/test_cli.rs
@@ -132,7 +132,7 @@ fn effective_timeout_seconds(timeout_seconds: u64) -> u64 {
 }
 
 fn read_request_payload(path: &Path) -> Result<Vec<u8>> {
-    let metadata = fs::metadata(path)
+    let metadata = fs::symlink_metadata(path)
         .with_context(|| format!("failed to inspect request payload {}", path.display()))?;
     validate_request_payload_metadata(path, &metadata)?;
 
@@ -163,19 +163,25 @@ fn read_request_payload(path: &Path) -> Result<Vec<u8>> {
 }
 
 fn open_request_payload_file(path: &Path) -> Result<fs::File> {
-    let mut options = fs::OpenOptions::new();
-    options.read(true);
-    #[cfg(unix)]
+    #[cfg(not(unix))]
     {
-        use std::os::unix::fs::OpenOptionsExt;
-
-        // Avoid blocking if the path changes to a FIFO between metadata validation and open.
-        options.custom_flags(libc::O_NONBLOCK);
+        bail!("netflow test request payloads require Unix safe-open flags");
     }
 
-    options
-        .open(path)
-        .with_context(|| format!("failed to open request payload {}", path.display()))
+    #[cfg(unix)]
+    {
+        let mut options = fs::OpenOptions::new();
+        options.read(true);
+        use std::os::unix::fs::OpenOptionsExt;
+
+        // O_NOFOLLOW rejects a final symlink race. O_NONBLOCK avoids blocking if the path races to a FIFO before
+        // fstat() rejects it as non-regular.
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+
+        options
+            .open(path)
+            .with_context(|| format!("failed to open request payload {}", path.display()))
+    }
 }
 
 fn validate_request_payload_metadata(path: &Path, metadata: &fs::Metadata) -> Result<()> {
@@ -493,6 +499,21 @@ mod tests {
         assert_eq!(rc, 0, "mkfifo {} failed", path.display());
 
         let err = read_request_payload(&path).expect_err("fifo request should fail");
+        assert!(err.to_string().contains("not a regular file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_request_payload_rejects_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let target_path = tmp.path().join("target.json");
+        fs::write(&target_path, "{}").expect("write request target");
+        let symlink_path = tmp.path().join("request.json");
+        symlink(&target_path, &symlink_path).expect("create request symlink");
+
+        let err = read_request_payload(&symlink_path).expect_err("symlink request should fail");
         assert!(err.to_string().contains("not a regular file"));
     }
 


### PR DESCRIPTION
## Summary
- add `--test ... --dir ... --request ...` raw JSON Function execution for `systemd-journal.plugin`
- add the same offline Function test mode for `netflow-plugin`, including `--no-persist`
- document both command contracts and add NetFlow coverage for parser, raw JSON output, and read-only facet behavior

## Validation
- `cargo fmt -p netflow-plugin -- --check`
- `cargo test -p netflow-plugin`
- `cargo build -p netflow-plugin`
- `cmake --build build-clion-optimized --target systemd-journal.plugin`
- manual `systemd-journal.plugin --test systemd-journal --dir <temp> --request <payload>` JSON stdout check
- manual `netflow-plugin --test flows:netflow --dir <temp> --request <payload> --no-persist` JSON stdout/no-persist check
- `.agents/sow/scan-sensitive.sh ...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds offline Function test modes for `systemd-journal.plugin` and `netflow-plugin` to run queries against on-disk fixtures, with strict stdin JSON, timeouts, and hardened backend path handling. Output is raw JSON + newline; non‑2xx statuses exit non‑zero.

- **New Features**
  - `systemd-journal.plugin`
    - CLI: `systemd-journal.plugin --test systemd-journal --dir <journal-dir> [--timeout <seconds>] < payload.json`
    - Reads JSON from stdin (non‑empty, ≤16 MiB); suppresses scan progress; rejects `--request`; default timeout 60s (`--timeout 0` maps to a very large finite timeout). Backend root is pinned via its dirfd path and rejects symlinks; discovery follows symlinked subdirs safely.
  - `netflow-plugin`
    - CLI: `netflow-plugin --test flows:netflow --dir <flows-dir> [--timeout <seconds>] [--no-persist] < payload.json`
    - Validates tier dirs; reads JSON from stdin (non‑empty, ≤16 MiB); rejects `--request`; default timeout 30s (`--timeout 0` disables). `--no-persist` provides read‑only facets, reading existing sidecars and falling back to in‑memory data. Test mode requires UTF‑8 `--dir`.

- **Refactors**
  - Journal: split `function_systemd_journal_result()`; added scan progress toggle and single‑dir helper; removed `_STREAM_ID` and `_CAP_EFFECTIVE` from default facets.
  - NetFlow: exposed and used `FLOWS_FUNCTION_NAME`; added `PluginConfig::for_test_backend_dir()`; added a shared Tokio runtime builder; read‑only facet runtime avoids writes and falls back to memory/sidecars for autocomplete.

<sup>Written for commit 097acc0dbf8e3938abb55bec825084d09fcb96d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

