### PR TITLE
chore(go/pkg/prometheus):  unified single-pass stream parser

### DIFF
--- a/src/go/pkg/prometheus/client.go
+++ b/src/go/pkg/prometheus/client.go
@@ -23,6 +23,17 @@ type (
 		// ScrapeSeries and parse prometheus format metrics
 		ScrapeSeries() (Series, error)
 		Scrape() (MetricFamilies, error)
+		// ScrapeStream scrapes and invokes onSample for every sample — a flat
+		// [Sample] stream before typed-family assembly — with the selector (if
+		// any) already applied; onHelp, if non-nil, receives per-family HELP. It
+		// stops and returns the first error from a callback.
+		//
+		// Order is exposition order, with one exception: a _sum/_count sample
+		// whose family type is not yet known (its # TYPE, first bucket, or first
+		// quantile has not appeared) is deferred and emitted once the type
+		// resolves, or at end of stream — so it may arrive after a later,
+		// unrelated sample. Each sample's Kind and FamilyType are always correct.
+		ScrapeStream(onHelp func(name, help string), onSample func(Sample) error) error
 		HTTPClient() *http.Client
 	}
 

--- a/src/go/pkg/prometheus/client_test.go
+++ b/src/go/pkg/prometheus/client_test.go
@@ -5,6 +5,7 @@ package prometheus
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -128,6 +129,42 @@ func TestPrometheusReadFromFile(t *testing.T) {
 		res, err := prom.ScrapeSeries()
 		assert.NoError(t, err)
 		verifyTestData(t, res)
+	}
+}
+
+func TestPrometheusScrapeStream(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	tests := map[string]struct {
+		onSampleErr error // returned by onSample (nil = stream everything)
+		wantErr     error
+	}{
+		"streams all samples and help": {},
+		"onSample error propagates":    {onSampleErr: errBoom, wantErr: errBoom},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			prom := New(http.DefaultClient, web.RequestConfig{URL: "file://testdata/testdata.txt"})
+
+			var samples int
+			var help []string
+			err := prom.ScrapeStream(
+				func(name, _ string) { help = append(help, name) },
+				func(Sample) error {
+					samples++
+					return tc.onSampleErr
+				},
+			)
+
+			if tc.wantErr != nil {
+				assert.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Positive(t, samples)
+			assert.Contains(t, help, "go_gc_duration_seconds")
+		})
 	}
 }
 

--- a/src/go/pkg/prometheus/doc.go
+++ b/src/go/pkg/prometheus/doc.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package prometheus scrapes and parses the Prometheus text exposition format.
+//
+// One parse pass drives three outputs from a single [New] / [NewWithSelector]
+// instance:
+//
+//   - [Prometheus.Scrape] assembles typed [MetricFamilies] — gauges, counters,
+//     summaries, and histograms — folding _sum/_count/_bucket and quantile series
+//     into their families.
+//   - [Prometheus.ScrapeSeries] returns the raw [Series]: one [SeriesSample] per
+//     scraped series, with labels in textparse-sorted order.
+//   - [Prometheus.ScrapeStream] exposes a flat [Sample] stream before typed
+//     assembly — the form a Prometheus metric-relabeling step operates on.
+//
+// Results are valid only until the next scrape on the same instance; buffers are
+// reused across scrapes. An optional selector (see the selector subpackage)
+// filters series during the parse.
+package prometheus

--- a/src/go/pkg/prometheus/model.go
+++ b/src/go/pkg/prometheus/model.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package prometheus
+
+import (
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// SampleKind classifies a streamed [Sample] by the role it plays in its typed
+// family. The driver assigns it as it parses, so a consumer can re-assemble
+// typed families (or relabel) without re-deriving the role from the name.
+type SampleKind uint8
+
+const (
+	// SampleKindScalar is a plain sample (gauge, counter, untyped, or the base
+	// series of a summary/histogram). Interpret it together with FamilyType.
+	SampleKindScalar SampleKind = iota
+	SampleKindHistogramBucket
+	SampleKindHistogramSum
+	SampleKindHistogramCount
+	SampleKindSummaryQuantile
+	SampleKindSummarySum
+	SampleKindSummaryCount
+)
+
+// Sample is a single scraped series exposed before typed-family assembly.
+//
+// Name is the __name__ label value (found by lookup, not by position — do not
+// assume label index 0). Labels holds every other label, including structural
+// labels such as "le" (histogram buckets) and "quantile" (summary quantiles) —
+// textparse canonicalizes these to floats (e.g. "1" -> "1.0") only when the family
+// type is known from # TYPE, otherwise leaving them raw, so do not assume a fixed
+// form when matching. Labels never contains __name__. Value is the sample value.
+// Kind and FamilyType carry the classification the driver derived for this sample.
+//
+// Sample is the unit a Prometheus metric-relabeling step operates on.
+type Sample struct {
+	Name       string
+	Labels     labels.Labels
+	Value      float64
+	Kind       SampleKind
+	FamilyType model.MetricType
+}

--- a/src/go/pkg/prometheus/parse.go
+++ b/src/go/pkg/prometheus/parse.go
@@ -1,10 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package prometheus
 
 import (
 	"errors"
 	"fmt"
 	"io"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -26,56 +27,45 @@ const (
 	bucketSuffix = "_bucket"
 )
 
+// promTextParser orchestrates a single parse pass. The driver parses the
+// exposition once into a flat sample stream; the assembler folds that stream
+// into typed MetricFamilies. Scrape() (families), ScrapeSeries() (Series), and
+// the exported sample stream are all produced from this one model.
 type promTextParser struct {
-	metrics MetricFamilies
-	series  Series
-
 	sr selector.Selector
 
-	currMF     *MetricFamily
-	currSeries labels.Labels
+	driver parseDriver
+	asm    assembler
+	series Series
+}
 
-	summaries  map[uint64]*Summary
-	histograms map[uint64]*Histogram
+func (p *promTextParser) parseToMetricFamilies(text []byte) (MetricFamilies, error) {
+	p.driver.sr = p.sr
+	p.asm.reset()
 
-	isCount    bool
-	isSum      bool
-	isQuantile bool
-	isBucket   bool
+	// ownLabels=false: the assembler copies labels into its own buffers, so the
+	// driver may lend the scratch label set (the no-allocation fast path).
+	if err := p.driver.parseSamples(text, false, p.asm.applyHelp, p.asm.applySample); err != nil {
+		return nil, err
+	}
 
-	currQuantile float64
-	currBucket   float64
+	return p.asm.families(), nil
 }
 
 func (p *promTextParser) parseToSeries(text []byte) (Series, error) {
+	p.driver.sr = p.sr
 	p.series.Reset()
 
-	parser := textparse.NewPromParser(text, labels.NewSymbolTable())
-	for {
-		entry, err := parser.Next()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			if entry == textparse.EntryInvalid && strings.HasPrefix(err.Error(), "invalid metric type") {
-				continue
-			}
-			return nil, fmt.Errorf("failed to parse prometheus metrics: %v", err)
-		}
-
-		switch entry {
-		case textparse.EntrySeries:
-			p.currSeries = p.currSeries[:0]
-
-			parser.Metric(&p.currSeries)
-
-			if p.sr != nil && !p.sr.Matches(p.currSeries) {
-				continue
-			}
-
-			_, _, val := parser.Series()
-			p.series.Add(SeriesSample{Labels: copyLabels(p.currSeries), Value: val})
-		}
+	// Series keeps the raw label set straight from textparse (sorted, with __name__
+	// in its sorted position) — identical to the legacy parser. It does NOT go
+	// through the Sample model (which separates __name__), so there is no deferral,
+	// no reordering, and the sorted-label invariant is preserved.
+	err := p.driver.iterate(text, nil, nil, func(series labels.Labels, value float64) error {
+		p.series.Add(SeriesSample{Labels: copyLabels(series), Value: value})
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	p.series.Sort()
@@ -83,11 +73,56 @@ func (p *promTextParser) parseToSeries(text []byte) (Series, error) {
 	return p.series, nil
 }
 
-var reSpace = regexp.MustCompile(`\s+`)
+func (p *promTextParser) parseToStream(text []byte, onHelp func(name, help string), onSample func(Sample) error) error {
+	if onSample == nil {
+		return nil
+	}
+	p.driver.sr = p.sr
 
-func (p *promTextParser) parseToMetricFamilies(text []byte) (MetricFamilies, error) {
-	p.reset()
+	// ownLabels=true: each Sample must own its labels because the consumer may
+	// retain or mutate them (e.g. relabeling) past the next sample.
+	return p.driver.parseSamples(text, true, onHelp, onSample)
+}
 
+// parseDriver runs the single exposition parse pass (iterate). On top of it,
+// parseSamples emits a flat, classified sample stream, deferring a _sum/_count
+// whose family type is not yet known and back-resolving it once the type appears
+// (a later # TYPE, _bucket, or quantile series) or at EOF. familyTypes/pending
+// hold that deferral state.
+type parseDriver struct {
+	sr selector.Selector
+
+	familyTypes map[string]model.MetricType
+	pending     []pendingSample
+	currSeries  labels.Labels
+}
+
+type pendingSample struct {
+	baseName string
+	sample   Sample
+	role     pendingRole
+}
+
+type pendingRole uint8
+
+const (
+	pendingNone pendingRole = iota
+	pendingSum
+	pendingCount
+)
+
+// iterate runs the shared single-pass exposition loop. For every series it calls
+// onSeries with the raw label set (textparse order — sorted, __name__ in its
+// sorted position) and value, after applying the selector; onHelp/onType deliver
+// per-family metadata. This is the one parse loop: ScrapeSeries consumes it
+// directly (raw labels, byte-identical to the legacy parser), while the flat
+// sample stream is layered on top by parseSamples.
+func (d *parseDriver) iterate(
+	text []byte,
+	onHelp func(name, help string),
+	onType func(name string, typ model.MetricType) error,
+	onSeries func(series labels.Labels, value float64) error,
+) error {
 	parser := textparse.NewPromParser(text, labels.NewSymbolTable())
 	for {
 		entry, err := parser.Next()
@@ -98,310 +133,578 @@ func (p *promTextParser) parseToMetricFamilies(text []byte) (MetricFamilies, err
 			if entry == textparse.EntryInvalid && strings.HasPrefix(err.Error(), "invalid metric type") {
 				continue
 			}
-			return nil, fmt.Errorf("failed to parse prometheus metrics: %v", err)
+			return fmt.Errorf("failed to parse prometheus metrics: %v", err)
 		}
 
 		switch entry {
 		case textparse.EntryHelp:
-			name, help := parser.Help()
-			p.setMetricFamilyByName(string(name))
-			p.currMF.help = string(help)
-			if strings.IndexByte(p.currMF.help, '\n') != -1 {
-				// convert multiline to one line because HELP is used as the chart title.
-				p.currMF.help = reSpace.ReplaceAllString(strings.TrimSpace(p.currMF.help), " ")
+			if onHelp != nil {
+				name, help := parser.Help()
+				onHelp(string(name), sanitizeHelp(string(help)))
 			}
 		case textparse.EntryType:
-			name, typ := parser.Type()
-			p.setMetricFamilyByName(string(name))
-			p.currMF.typ = typ
+			if onType != nil {
+				name, typ := parser.Type()
+				if err := onType(string(name), typ); err != nil {
+					return err
+				}
+			}
 		case textparse.EntrySeries:
-			p.currSeries = p.currSeries[:0]
+			d.currSeries = d.currSeries[:0]
+			parser.Metric(&d.currSeries)
 
-			parser.Metric(&p.currSeries)
-
-			if p.sr != nil && !p.sr.Matches(p.currSeries) {
+			if d.sr != nil && !d.sr.Matches(d.currSeries) {
 				continue
 			}
 
-			p.setMetricFamilyBySeries()
-
 			_, _, value := parser.Series()
 
-			switch p.currMF.typ {
-			case model.MetricTypeGauge:
-				p.addGauge(value)
-			case model.MetricTypeCounter:
-				p.addCounter(value)
-			case model.MetricTypeSummary:
-				p.addSummary(value)
-			case model.MetricTypeHistogram:
-				p.addHistogram(value)
-			case model.MetricTypeUnknown:
-				p.addUnknown(value)
+			if onSeries != nil {
+				if err := onSeries(d.currSeries, value); err != nil {
+					return err
+				}
 			}
 		}
 	}
 
-	for k, v := range p.metrics {
-		if len(v.Metrics()) == 0 {
-			delete(p.metrics, k)
-		}
-	}
-
-	return p.metrics, nil
+	return nil
 }
 
-func (p *promTextParser) setMetricFamilyByName(name string) {
-	mf, ok := p.metrics[name]
-	if !ok {
-		mf = &MetricFamily{name: name, typ: model.MetricTypeUnknown}
-		p.metrics[name] = mf
-	}
-	p.currMF = mf
-}
+// parseSamples layers the flat, classified sample stream on top of iterate. It
+// turns each series into a Sample (Kind + FamilyType) and defers a _sum/_count
+// whose family type is not yet known, back-resolving it once the type appears (a
+// later # TYPE, _bucket, or quantile series) or flushing it at EOF. Deferral can
+// emit a _sum/_count after a later, unrelated series — see ScrapeStream's doc.
+func (d *parseDriver) parseSamples(text []byte, ownLabels bool, onHelp func(name, help string), onSample func(Sample) error) error {
+	d.reset()
 
-func (p *promTextParser) setMetricFamilyBySeries() {
-	p.isSum, p.isCount, p.isQuantile, p.isBucket = false, false, false, false
-	p.currQuantile, p.currBucket = 0, 0
-
-	name, ok := metricNameValue(p.currSeries)
-	if !ok {
-		p.currMF = nil
-		return
-	}
-
-	if p.currMF != nil && p.currMF.name == name {
-		if p.currMF.typ == model.MetricTypeSummary {
-			p.setQuantile()
-		}
-		return
-	}
-
-	typ := model.MetricTypeUnknown
-
-	switch {
-	case strings.HasSuffix(name, sumSuffix):
-		n := strings.TrimSuffix(name, sumSuffix)
-		if mf, ok := p.metrics[n]; ok && isSummaryOrHistogram(mf.typ) {
-			p.isSum = true
-			_ = setLabelValue(p.currSeries, labels.MetricName, n)
-			p.currMF = mf
-			return
-		}
-	case strings.HasSuffix(name, countSuffix):
-		n := strings.TrimSuffix(name, countSuffix)
-		if mf, ok := p.metrics[n]; ok && isSummaryOrHistogram(mf.typ) {
-			p.isCount = true
-			_ = setLabelValue(p.currSeries, labels.MetricName, n)
-			p.currMF = mf
-			return
-		}
-	case strings.HasSuffix(name, bucketSuffix):
-		n := strings.TrimSuffix(name, bucketSuffix)
-		if mf, ok := p.metrics[n]; ok && isSummaryOrHistogram(mf.typ) {
-			_ = setLabelValue(p.currSeries, labels.MetricName, n)
-			p.setBucket()
-			p.currMF = mf
-			return
-		}
-		if p.currSeries.Has(bucketLabel) {
-			_ = setLabelValue(p.currSeries, labels.MetricName, n)
-			p.setBucket()
-			name = n
-			typ = model.MetricTypeHistogram
-		}
-	case p.currSeries.Has(quantileLabel):
-		typ = model.MetricTypeSummary
-		p.setQuantile()
-	}
-
-	p.setMetricFamilyByName(name)
-	if p.currMF.typ == "" || p.currMF.typ == model.MetricTypeUnknown {
-		p.currMF.typ = typ
-	}
-}
-
-func (p *promTextParser) setQuantile() {
-	if lbs, v, ok := removeLabel(p.currSeries, quantileLabel); ok {
-		p.isQuantile = true
-		p.currSeries = lbs
-		p.currQuantile, _ = strconv.ParseFloat(v, 64)
-	}
-}
-
-func (p *promTextParser) setBucket() {
-	if lbs, v, ok := removeLabel(p.currSeries, bucketLabel); ok {
-		p.isBucket = true
-		p.currSeries = lbs
-		p.currBucket, _ = strconv.ParseFloat(v, 64)
-	}
-}
-
-func (p *promTextParser) addGauge(value float64) {
-	p.currSeries, _, _ = removeLabel(p.currSeries, labels.MetricName)
-
-	if v := len(p.currMF.metrics); v == cap(p.currMF.metrics) {
-		p.currMF.metrics = append(p.currMF.metrics, Metric{
-			labels: copyLabels(p.currSeries),
-			gauge:  &Gauge{value: value},
-		})
-	} else {
-		p.currMF.metrics = p.currMF.metrics[:v+1]
-		if p.currMF.metrics[v].gauge == nil {
-			p.currMF.metrics[v].gauge = &Gauge{}
-		}
-		p.currMF.metrics[v].gauge.value = value
-		p.currMF.metrics[v].labels = p.currMF.metrics[v].labels[:0]
-		p.currMF.metrics[v].labels = append(p.currMF.metrics[v].labels, p.currSeries...)
-	}
-}
-
-func (p *promTextParser) addCounter(value float64) {
-	p.currSeries, _, _ = removeLabel(p.currSeries, labels.MetricName)
-
-	if v := len(p.currMF.metrics); v == cap(p.currMF.metrics) {
-		p.currMF.metrics = append(p.currMF.metrics, Metric{
-			labels:  copyLabels(p.currSeries),
-			counter: &Counter{value: value},
-		})
-	} else {
-		p.currMF.metrics = p.currMF.metrics[:v+1]
-		if p.currMF.metrics[v].counter == nil {
-			p.currMF.metrics[v].counter = &Counter{}
-		}
-		p.currMF.metrics[v].counter.value = value
-		p.currMF.metrics[v].labels = p.currMF.metrics[v].labels[:0]
-		p.currMF.metrics[v].labels = append(p.currMF.metrics[v].labels, p.currSeries...)
-	}
-}
-
-func (p *promTextParser) addUnknown(value float64) {
-	p.currSeries, _, _ = removeLabel(p.currSeries, labels.MetricName)
-
-	if v := len(p.currMF.metrics); v == cap(p.currMF.metrics) {
-		p.currMF.metrics = append(p.currMF.metrics, Metric{
-			labels:  copyLabels(p.currSeries),
-			untyped: &Untyped{value: value},
-		})
-	} else {
-		p.currMF.metrics = p.currMF.metrics[:v+1]
-		if p.currMF.metrics[v].untyped == nil {
-			p.currMF.metrics[v].untyped = &Untyped{}
-		}
-		p.currMF.metrics[v].untyped.value = value
-		p.currMF.metrics[v].labels = p.currMF.metrics[v].labels[:0]
-		p.currMF.metrics[v].labels = append(p.currMF.metrics[v].labels, p.currSeries...)
-	}
-}
-
-func (p *promTextParser) addSummary(value float64) {
-	hash := p.currSeries.Hash()
-
-	p.currSeries, _, _ = removeLabel(p.currSeries, labels.MetricName)
-
-	s, ok := p.summaries[hash]
-	if !ok {
-		if v := len(p.currMF.metrics); v == cap(p.currMF.metrics) {
-			s = &Summary{}
-			p.currMF.metrics = append(p.currMF.metrics, Metric{
-				labels:  copyLabels(p.currSeries),
-				summary: s,
-			})
-		} else {
-			p.currMF.metrics = p.currMF.metrics[:v+1]
-			if p.currMF.metrics[v].summary == nil {
-				p.currMF.metrics[v].summary = &Summary{}
+	err := d.iterate(text, onHelp,
+		func(name string, typ model.MetricType) error {
+			d.familyTypes[name] = typ
+			var err error
+			d.pending, err = emitResolvedPending(d.pending, name, typ, onSample)
+			return err
+		},
+		func(series labels.Labels, value float64) error {
+			sample, baseName, role, ok := d.makeSample(series, value, ownLabels)
+			if !ok {
+				return nil
 			}
-			p.currMF.metrics[v].summary.sum = 0
-			p.currMF.metrics[v].summary.count = 0
-			p.currMF.metrics[v].summary.quantiles = p.currMF.metrics[v].summary.quantiles[:0]
-			p.currMF.metrics[v].labels = p.currMF.metrics[v].labels[:0]
-			p.currMF.metrics[v].labels = append(p.currMF.metrics[v].labels, p.currSeries...)
-			s = p.currMF.metrics[v].summary
-		}
 
-		p.summaries[hash] = s
-	}
-
-	switch {
-	case p.isQuantile:
-		s.quantiles = append(s.quantiles, Quantile{quantile: p.currQuantile, value: value})
-	case p.isSum:
-		s.sum = value
-	case p.isCount:
-		s.count = value
-	}
-}
-
-func (p *promTextParser) addHistogram(value float64) {
-	hash := p.currSeries.Hash()
-
-	p.currSeries, _, _ = removeLabel(p.currSeries, labels.MetricName)
-
-	h, ok := p.histograms[hash]
-	if !ok {
-		if v := len(p.currMF.metrics); v == cap(p.currMF.metrics) {
-			h = &Histogram{}
-			p.currMF.metrics = append(p.currMF.metrics, Metric{
-				labels:    copyLabels(p.currSeries),
-				histogram: h,
-			})
-		} else {
-			p.currMF.metrics = p.currMF.metrics[:v+1]
-			if p.currMF.metrics[v].histogram == nil {
-				p.currMF.metrics[v].histogram = &Histogram{}
+			// A quantile/bucket series reveals the family type; back-resolve any
+			// _sum/_count buffered before it.
+			switch sample.Kind {
+			case SampleKindSummaryQuantile:
+				var err error
+				d.pending, err = emitResolvedPending(d.pending, sample.Name, model.MetricTypeSummary, onSample)
+				if err != nil {
+					return err
+				}
+			case SampleKindHistogramBucket:
+				var err error
+				d.pending, err = emitResolvedPending(d.pending, strings.TrimSuffix(sample.Name, bucketSuffix), model.MetricTypeHistogram, onSample)
+				if err != nil {
+					return err
+				}
 			}
-			p.currMF.metrics[v].histogram.sum = 0
-			p.currMF.metrics[v].histogram.count = 0
-			p.currMF.metrics[v].histogram.buckets = p.currMF.metrics[v].histogram.buckets[:0]
-			p.currMF.metrics[v].labels = p.currMF.metrics[v].labels[:0]
-			p.currMF.metrics[v].labels = append(p.currMF.metrics[v].labels, p.currSeries...)
-			h = p.currMF.metrics[v].histogram
+
+			if role != pendingNone {
+				if !ownLabels {
+					sample.Labels = copyLabels(sample.Labels)
+				}
+				d.pending = append(d.pending, pendingSample{
+					baseName: baseName,
+					sample:   sample,
+					role:     role,
+				})
+				return nil
+			}
+
+			return onSample(sample)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	// Flush still-unresolved _sum/_count as plain scalars (matches the legacy
+	// behavior for a _sum/_count whose family type never appears).
+	for _, ps := range d.pending {
+		if err := onSample(ps.sample); err != nil {
+			return err
 		}
-
-		p.histograms[hash] = h
 	}
+	d.pending = d.pending[:0]
 
-	switch {
-	case p.isBucket:
-		h.buckets = append(h.buckets, Bucket{upperBound: p.currBucket, cumulativeCount: value})
-	case p.isSum:
-		h.sum = value
-	case p.isCount:
-		h.count = value
-	}
+	return nil
 }
 
-func (p *promTextParser) reset() {
-	p.currMF = nil
-	p.currSeries = p.currSeries[:0]
-
-	if p.metrics == nil {
-		p.metrics = make(MetricFamilies)
+func (d *parseDriver) makeSample(series labels.Labels, value float64, ownLabels bool) (Sample, string, pendingRole, bool) {
+	name, ok := metricNameValue(series)
+	if !ok {
+		return Sample{}, "", pendingNone, false
 	}
-	for _, mf := range p.metrics {
+
+	var lbs labels.Labels
+	if ownLabels {
+		lbs = copyLabelsWithoutName(series)
+	} else {
+		lbs, _, _ = removeLabel(series, labels.MetricName)
+	}
+
+	sample := Sample{
+		Name:       name,
+		Labels:     lbs,
+		Value:      value,
+		Kind:       SampleKindScalar,
+		FamilyType: d.familyTypes[name],
+	}
+	if sample.FamilyType == "" {
+		sample.FamilyType = model.MetricTypeUnknown
+	}
+
+	if sample.Labels.Has(quantileLabel) {
+		if sample.FamilyType != model.MetricTypeUnknown && sample.FamilyType != model.MetricTypeSummary {
+			return sample, "", pendingNone, true
+		}
+		sample.Kind = SampleKindSummaryQuantile
+		sample.FamilyType = model.MetricTypeSummary
+		d.familyTypes[name] = model.MetricTypeSummary
+		return sample, "", pendingNone, true
+	}
+
+	// A histogram bucket requires an "le" label. A _bucket-named series without le
+	// is malformed: it is NOT treated as a bucket but falls through to a plain
+	// metric, preserving its value. (The legacy parser folded such a series into
+	// the histogram family and dropped its value; valid buckets always carry le,
+	// so real input is unaffected.)
+	if strings.HasSuffix(name, bucketSuffix) && sample.Labels.Has(bucketLabel) {
+		if sample.FamilyType != model.MetricTypeUnknown && sample.FamilyType != model.MetricTypeHistogram {
+			return sample, "", pendingNone, true
+		}
+		baseName := strings.TrimSuffix(name, bucketSuffix)
+		sample.Kind = SampleKindHistogramBucket
+		sample.FamilyType = model.MetricTypeHistogram
+		d.familyTypes[baseName] = model.MetricTypeHistogram
+		return sample, "", pendingNone, true
+	}
+
+	if strings.HasSuffix(name, sumSuffix) {
+		if sample.FamilyType != model.MetricTypeUnknown &&
+			sample.FamilyType != model.MetricTypeSummary &&
+			sample.FamilyType != model.MetricTypeHistogram {
+			return sample, "", pendingNone, true
+		}
+
+		baseName := strings.TrimSuffix(name, sumSuffix)
+		switch d.familyTypes[baseName] {
+		case model.MetricTypeSummary:
+			sample.Kind = SampleKindSummarySum
+			sample.FamilyType = model.MetricTypeSummary
+			return sample, "", pendingNone, true
+		case model.MetricTypeHistogram:
+			sample.Kind = SampleKindHistogramSum
+			sample.FamilyType = model.MetricTypeHistogram
+			return sample, "", pendingNone, true
+		default:
+			return sample, baseName, pendingSum, true
+		}
+	}
+
+	if strings.HasSuffix(name, countSuffix) {
+		if sample.FamilyType != model.MetricTypeUnknown &&
+			sample.FamilyType != model.MetricTypeSummary &&
+			sample.FamilyType != model.MetricTypeHistogram {
+			return sample, "", pendingNone, true
+		}
+
+		baseName := strings.TrimSuffix(name, countSuffix)
+		switch d.familyTypes[baseName] {
+		case model.MetricTypeSummary:
+			sample.Kind = SampleKindSummaryCount
+			sample.FamilyType = model.MetricTypeSummary
+			return sample, "", pendingNone, true
+		case model.MetricTypeHistogram:
+			sample.Kind = SampleKindHistogramCount
+			sample.FamilyType = model.MetricTypeHistogram
+			return sample, "", pendingNone, true
+		default:
+			return sample, baseName, pendingCount, true
+		}
+	}
+
+	return sample, "", pendingNone, true
+}
+
+func (d *parseDriver) reset() {
+	d.currSeries = d.currSeries[:0]
+
+	if d.familyTypes == nil {
+		d.familyTypes = make(map[string]model.MetricType)
+	}
+	for k := range d.familyTypes {
+		delete(d.familyTypes, k)
+	}
+
+	d.pending = d.pending[:0]
+}
+
+// emitResolvedPending flushes buffered _sum/_count samples for baseName now that
+// its family type is known, emitting them in buffered (exposition) order.
+func emitResolvedPending(pending []pendingSample, baseName string, typ model.MetricType, onSample func(Sample) error) ([]pendingSample, error) {
+	if len(pending) == 0 {
+		return pending, nil
+	}
+
+	out := pending[:0]
+	for _, ps := range pending {
+		if ps.baseName != baseName {
+			out = append(out, ps)
+			continue
+		}
+
+		sample := ps.sample
+		sample.FamilyType = typ
+		switch typ {
+		case model.MetricTypeSummary:
+			if ps.role == pendingSum {
+				sample.Kind = SampleKindSummarySum
+			} else {
+				sample.Kind = SampleKindSummaryCount
+			}
+		case model.MetricTypeHistogram:
+			if ps.role == pendingSum {
+				sample.Kind = SampleKindHistogramSum
+			} else {
+				sample.Kind = SampleKindHistogramCount
+			}
+		default:
+			sample.Kind = SampleKindScalar
+			sample.FamilyType = model.MetricTypeUnknown
+		}
+
+		if err := onSample(sample); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
+// assembler folds the driver's classified sample stream into typed
+// MetricFamilies. Grouping of summary quantiles / histogram buckets with their
+// _sum/_count is keyed by (family name, hash of the base labels). Buffers are
+// reused across cycles via reset().
+type assembler struct {
+	metrics    MetricFamilies
+	summaries  map[assemblyKey]*Summary
+	histograms map[assemblyKey]*Histogram
+	scratch    labels.Labels
+
+	// currName/currFamily cache the most recent family to skip the metrics map
+	// lookup for the common case of consecutive samples in the same family.
+	currName   string
+	currFamily *MetricFamily
+}
+
+type assemblyKey struct {
+	name string
+	hash uint64
+}
+
+func (a *assembler) reset() {
+	a.currName = ""
+	a.currFamily = nil
+
+	if a.metrics == nil {
+		a.metrics = make(MetricFamilies)
+	}
+	for _, mf := range a.metrics {
 		mf.help = ""
 		mf.typ = ""
 		mf.metrics = mf.metrics[:0]
 	}
 
-	if p.summaries == nil {
-		p.summaries = make(map[uint64]*Summary)
+	if a.summaries == nil {
+		a.summaries = make(map[assemblyKey]*Summary)
 	}
-	for k := range p.summaries {
-		delete(p.summaries, k)
+	for k := range a.summaries {
+		delete(a.summaries, k)
 	}
 
-	if p.histograms == nil {
-		p.histograms = make(map[uint64]*Histogram)
+	if a.histograms == nil {
+		a.histograms = make(map[assemblyKey]*Histogram)
 	}
-	for k := range p.histograms {
-		delete(p.histograms, k)
+	for k := range a.histograms {
+		delete(a.histograms, k)
 	}
+}
+
+func (a *assembler) applyHelp(name, help string) {
+	mf := a.ensureFamily(name)
+	mf.help = help
+}
+
+func (a *assembler) applySample(sample Sample) error {
+	switch sample.Kind {
+	case SampleKindSummaryQuantile:
+		a.addSummaryQuantile(sample)
+	case SampleKindSummarySum:
+		a.addSummarySum(sample)
+	case SampleKindSummaryCount:
+		a.addSummaryCount(sample)
+	case SampleKindHistogramBucket:
+		a.addHistogramBucket(sample)
+	case SampleKindHistogramSum:
+		a.addHistogramSum(sample)
+	case SampleKindHistogramCount:
+		a.addHistogramCount(sample)
+	default:
+		switch sample.FamilyType {
+		case model.MetricTypeSummary:
+			mf := a.summaryFamily(sample.Name)
+			a.summaryFor(mf, assemblyKey{name: sample.Name, hash: sample.Labels.Hash()}, sample.Labels)
+		case model.MetricTypeHistogram:
+			mf := a.histogramFamily(sample.Name)
+			a.histogramFor(mf, assemblyKey{name: sample.Name, hash: sample.Labels.Hash()}, sample.Labels)
+		default:
+			a.addScalar(sample)
+		}
+	}
+	return nil
+}
+
+func (a *assembler) families() MetricFamilies {
+	for name, mf := range a.metrics {
+		if len(mf.metrics) == 0 {
+			delete(a.metrics, name)
+		}
+	}
+	return a.metrics
+}
+
+func (a *assembler) addScalar(sample Sample) {
+	mf := a.ensureFamily(sample.Name)
+
+	typ := sample.FamilyType
+	if typ == "" {
+		typ = model.MetricTypeUnknown
+	}
+	if mf.typ == "" || mf.typ == model.MetricTypeUnknown {
+		mf.typ = typ
+	}
+
+	m := a.appendMetric(mf, sample.Labels)
+
+	switch typ {
+	case model.MetricTypeGauge:
+		if m.gauge == nil {
+			m.gauge = &Gauge{}
+		}
+		m.gauge.value = sample.Value
+	case model.MetricTypeCounter:
+		if m.counter == nil {
+			m.counter = &Counter{}
+		}
+		m.counter.value = sample.Value
+	default:
+		if m.untyped == nil {
+			m.untyped = &Untyped{}
+		}
+		m.untyped.value = sample.Value
+	}
+}
+
+func (a *assembler) addSummaryQuantile(sample Sample) {
+	mf := a.summaryFamily(sample.Name)
+	base, qv, ok := a.stripLabel(sample.Labels, quantileLabel)
+	key := assemblyKey{name: sample.Name}
+	if ok {
+		key.hash = labels.Labels(base).Hash()
+	} else {
+		base = sample.Labels
+		key.hash = sample.Labels.Hash()
+	}
+
+	s := a.summaryFor(mf, key, base)
+	if !ok {
+		return
+	}
+	quantile, _ := strconv.ParseFloat(qv, 64)
+	s.quantiles = append(s.quantiles, Quantile{quantile: quantile, value: sample.Value})
+}
+
+func (a *assembler) addSummarySum(sample Sample) {
+	name := strings.TrimSuffix(sample.Name, sumSuffix)
+	mf := a.summaryFamily(name)
+	s := a.summaryFor(mf, assemblyKey{name: name, hash: sample.Labels.Hash()}, sample.Labels)
+	s.sum = sample.Value
+}
+
+func (a *assembler) addSummaryCount(sample Sample) {
+	name := strings.TrimSuffix(sample.Name, countSuffix)
+	mf := a.summaryFamily(name)
+	s := a.summaryFor(mf, assemblyKey{name: name, hash: sample.Labels.Hash()}, sample.Labels)
+	s.count = sample.Value
+}
+
+func (a *assembler) addHistogramBucket(sample Sample) {
+	name := strings.TrimSuffix(sample.Name, bucketSuffix)
+	mf := a.histogramFamily(name)
+	base, lev, ok := a.stripLabel(sample.Labels, bucketLabel)
+	key := assemblyKey{name: name}
+	if ok {
+		key.hash = labels.Labels(base).Hash()
+	} else {
+		base = sample.Labels
+		key.hash = sample.Labels.Hash()
+	}
+
+	h := a.histogramFor(mf, key, base)
+	if !ok {
+		return
+	}
+	bound, _ := strconv.ParseFloat(lev, 64)
+	h.buckets = append(h.buckets, Bucket{upperBound: bound, cumulativeCount: sample.Value})
+}
+
+func (a *assembler) addHistogramSum(sample Sample) {
+	name := strings.TrimSuffix(sample.Name, sumSuffix)
+	mf := a.histogramFamily(name)
+	h := a.histogramFor(mf, assemblyKey{name: name, hash: sample.Labels.Hash()}, sample.Labels)
+	h.sum = sample.Value
+}
+
+func (a *assembler) addHistogramCount(sample Sample) {
+	name := strings.TrimSuffix(sample.Name, countSuffix)
+	mf := a.histogramFamily(name)
+	h := a.histogramFor(mf, assemblyKey{name: name, hash: sample.Labels.Hash()}, sample.Labels)
+	h.count = sample.Value
+}
+
+func (a *assembler) summaryFamily(name string) *MetricFamily {
+	mf := a.ensureFamily(name)
+	mf.typ = model.MetricTypeSummary
+	return mf
+}
+
+func (a *assembler) histogramFamily(name string) *MetricFamily {
+	mf := a.ensureFamily(name)
+	mf.typ = model.MetricTypeHistogram
+	return mf
+}
+
+func (a *assembler) summaryFor(mf *MetricFamily, key assemblyKey, lbs labels.Labels) *Summary {
+	if s, ok := a.summaries[key]; ok {
+		return s
+	}
+
+	m := a.appendMetric(mf, lbs)
+	if m.summary == nil {
+		m.summary = &Summary{}
+	} else {
+		m.summary.sum = 0
+		m.summary.count = 0
+		m.summary.quantiles = m.summary.quantiles[:0]
+	}
+
+	a.summaries[key] = m.summary
+	return m.summary
+}
+
+func (a *assembler) histogramFor(mf *MetricFamily, key assemblyKey, lbs labels.Labels) *Histogram {
+	if h, ok := a.histograms[key]; ok {
+		return h
+	}
+
+	m := a.appendMetric(mf, lbs)
+	if m.histogram == nil {
+		m.histogram = &Histogram{}
+	} else {
+		m.histogram.sum = 0
+		m.histogram.count = 0
+		m.histogram.buckets = m.histogram.buckets[:0]
+	}
+
+	a.histograms[key] = m.histogram
+	return m.histogram
+}
+
+// appendMetric grows mf.metrics by one, reusing the backing array across cycles
+// and storing a copy of lbs. Instrument pointers on a reused slot are left in
+// place: a family keeps a stable type across scrapes, so the caller reuses the
+// existing instrument and allocates only when its pointer is nil. This preserves
+// the legacy allocation profile (no per-scrape instrument churn).
+func (a *assembler) appendMetric(mf *MetricFamily, lbs labels.Labels) *Metric {
+	idx := len(mf.metrics)
+	if idx == cap(mf.metrics) {
+		mf.metrics = append(mf.metrics, Metric{})
+	} else {
+		mf.metrics = mf.metrics[:idx+1]
+	}
+
+	m := &mf.metrics[idx]
+	m.labels = m.labels[:0]
+	m.labels = append(m.labels, lbs...)
+	return m
+}
+
+func (a *assembler) ensureFamily(name string) *MetricFamily {
+	if a.currFamily != nil && a.currName == name {
+		return a.currFamily
+	}
+	mf, ok := a.metrics[name]
+	if !ok {
+		mf = &MetricFamily{name: name, typ: model.MetricTypeUnknown}
+		a.metrics[name] = mf
+	}
+	a.currName = name
+	a.currFamily = mf
+	return mf
+}
+
+// stripLabel returns the label set without name and the removed value, using a
+// reusable scratch buffer. The result is valid only until the next stripLabel.
+func (a *assembler) stripLabel(lbs labels.Labels, name string) (labels.Labels, string, bool) {
+	a.scratch = a.scratch[:0]
+	var (
+		value string
+		found bool
+	)
+	for _, lb := range lbs {
+		if lb.Name == name {
+			value = lb.Value
+			found = true
+			continue
+		}
+		a.scratch = append(a.scratch, lb)
+	}
+	if !found {
+		return nil, "", false
+	}
+	return a.scratch, value, true
 }
 
 func copyLabels(lbs []labels.Label) []labels.Label {
 	return append([]labels.Label(nil), lbs...)
+}
+
+// copyLabelsWithoutName returns a fresh copy of lbs with __name__ removed. In the
+// common case __name__ sorts first (it precedes lowercase label names), so the
+// remainder is contiguous and copied directly; otherwise a rare label that sorts
+// before __name__ (e.g. "UUID") is skipped element by element.
+func copyLabelsWithoutName(lbs labels.Labels) labels.Labels {
+	if len(lbs) > 0 && lbs[0].Name == labels.MetricName {
+		return copyLabels(lbs[1:])
+	}
+	out := make([]labels.Label, 0, len(lbs))
+	for _, lb := range lbs {
+		if lb.Name == labels.MetricName {
+			continue
+		}
+		out = append(out, lb)
+	}
+	return out
 }
 
 func removeLabel(lbs labels.Labels, name string) (labels.Labels, string, bool) {
@@ -422,16 +725,10 @@ func metricNameValue(lbs labels.Labels) (string, bool) {
 	return "", false
 }
 
-func setLabelValue(lbs labels.Labels, name, value string) bool {
-	for i, v := range lbs {
-		if v.Name == name {
-			lbs[i].Value = value
-			return true
-		}
+func sanitizeHelp(help string) string {
+	if strings.IndexByte(help, '\n') == -1 {
+		return help
 	}
-	return false
-}
-
-func isSummaryOrHistogram(typ model.MetricType) bool {
-	return typ == model.MetricTypeSummary || typ == model.MetricTypeHistogram
+	// HELP is used as a chart title; collapse multiline help to one line.
+	return strings.Join(strings.Fields(help), " ")
 }

--- a/src/go/pkg/prometheus/parse_bench_test.go
+++ b/src/go/pkg/prometheus/parse_bench_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package prometheus
+
+import (
+	"os"
+	"testing"
+)
+
+// pkg/prometheus parses an exposition on every scrape across ~19 importing
+// collectors, so it is a hot path. Keep these results updated before/after parser
+// changes so regressions stay visible.
+//
+// The payload is the real exposition fixtures the parser tests use:
+// testdata/testdata.txt (a go-process scrape of gauges/counters/summaries) plus
+// testdata/histogram-meta.txt (the histogram path), so the benchmark exercises
+// every assembler branch on representative data.
+//
+// Command:
+//
+//	go test ./pkg/prometheus -run '^$' -bench parseTo -benchmem
+//
+// Measured on a developer laptop (Apple M-series, 14 logical CPUs), not CI, so the
+// absolute numbers are machine-specific — compare relative before/after deltas.
+//
+// Legacy fused parser (master, pre-rewrite — captured 2026-06-05):
+//
+//	parseToMetricFamilies   127868 ns/op    73404 B/op   1314 allocs/op
+//	parseToSeries           111382 ns/op   100444 B/op   1584 allocs/op
+//
+// Unified driver+assembler stream parser (this rewrite — captured 2026-06-05):
+//
+//	parseToMetricFamilies   133911 ns/op    73408 B/op   1314 allocs/op
+//	parseToSeries           112803 ns/op   100448 B/op   1584 allocs/op
+//	parseToStream           113248 ns/op   102807 B/op   1644 allocs/op
+//
+// No allocation win and no allocation regression: the legacy parser already
+// parsed once per call and reused buffers, and both Scrape and ScrapeSeries match
+// it exactly (flat allocs). ScrapeSeries uses the raw-label path (identical to
+// legacy), so it is essentially free. Scrape/stream are a few percent slower on
+// CPU — the per-sample Sample struct + the shared iterate indirection + assembler
+// dispatch on the families/stream path (profiled: makeSample + applySample,
+// inherent to the single-driver model, not a fixable hotspot). The win is the
+// sample stream that metric relabeling consumes, not raw speed.
+
+func readBenchData(tb testing.TB) []byte {
+	tb.Helper()
+	var data []byte
+	for _, f := range []string{"testdata/testdata.txt", "testdata/histogram-meta.txt"} {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		data = append(data, b...)
+		data = append(data, '\n') // keep files separated when concatenated
+	}
+	return data
+}
+
+func BenchmarkPromTextParser_parseToMetricFamilies(b *testing.B) {
+	data := readBenchData(b)
+	var p promTextParser
+	b.ReportAllocs()
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for range b.N {
+		if _, err := p.parseToMetricFamilies(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPromTextParser_parseToSeries(b *testing.B) {
+	data := readBenchData(b)
+	var p promTextParser
+	b.ReportAllocs()
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for range b.N {
+		if _, err := p.parseToSeries(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPromTextParser_parseToStream(b *testing.B) {
+	data := readBenchData(b)
+	var p promTextParser
+	b.ReportAllocs()
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for range b.N {
+		if err := p.parseToStream(data, nil, func(Sample) error { return nil }); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/src/go/pkg/prometheus/stream.go
+++ b/src/go/pkg/prometheus/stream.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package prometheus
+
+// ScrapeStream implements [Prometheus]. See the interface for the ordering and
+// callback contract. onHelp may be nil when per-family HELP is not needed.
+func (p *prometheus) ScrapeStream(onHelp func(name, help string), onSample func(Sample) error) error {
+	p.buf.Reset()
+
+	if err := p.fetch(p.buf); err != nil {
+		return err
+	}
+
+	return p.parser.parseToStream(p.buf.Bytes(), onHelp, onSample)
+}

--- a/src/go/pkg/prometheus/stream_test.go
+++ b/src/go/pkg/prometheus/stream_test.go
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package prometheus
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromTextParser_parseToStream(t *testing.T) {
+	type wantSample struct {
+		name       string
+		labels     string
+		value      float64
+		kind       SampleKind
+		familyType model.MetricType
+	}
+
+	tests := map[string]struct {
+		input    []byte
+		wantHelp []string
+		want     []wantSample
+	}{
+		"all metric types are classified in exposition order": {
+			input: []byte(`# HELP test_gauge A gauge metric.
+# TYPE test_gauge gauge
+test_gauge{label="a"} 1
+# TYPE test_counter_total counter
+test_counter_total 5
+# TYPE test_hist histogram
+test_hist_bucket{le="0.1"} 1
+test_hist_bucket{le="+Inf"} 2
+test_hist_sum 3
+test_hist_count 2
+# TYPE test_summary summary
+test_summary{quantile="0.5"} 0.2
+test_summary_sum 1
+test_summary_count 10
+`),
+			wantHelp: []string{"test_gauge=A gauge metric."},
+			want: []wantSample{
+				{"test_gauge", `{label="a"}`, 1, SampleKindScalar, model.MetricTypeGauge},
+				{"test_counter_total", `{}`, 5, SampleKindScalar, model.MetricTypeCounter},
+				{"test_hist_bucket", `{le="0.1"}`, 1, SampleKindHistogramBucket, model.MetricTypeHistogram},
+				{"test_hist_bucket", `{le="+Inf"}`, 2, SampleKindHistogramBucket, model.MetricTypeHistogram},
+				{"test_hist_sum", `{}`, 3, SampleKindHistogramSum, model.MetricTypeHistogram},
+				{"test_hist_count", `{}`, 2, SampleKindHistogramCount, model.MetricTypeHistogram},
+				{"test_summary", `{quantile="0.5"}`, 0.2, SampleKindSummaryQuantile, model.MetricTypeSummary},
+				{"test_summary_sum", `{}`, 1, SampleKindSummarySum, model.MetricTypeSummary},
+				{"test_summary_count", `{}`, 10, SampleKindSummaryCount, model.MetricTypeSummary},
+			},
+		},
+		"__name__ is delivered via Name and excluded from Labels": {
+			input: []byte("# TYPE m gauge\nm{a=\"1\",b=\"2\"} 7\n"),
+			want: []wantSample{
+				{"m", `{a="1", b="2"}`, 7, SampleKindScalar, model.MetricTypeGauge},
+			},
+		},
+		"deferred sum/count before # TYPE are buffered and back-resolved": {
+			input: []byte(`my_summary_sum 10
+my_summary_count 2
+# TYPE my_summary summary
+my_summary{quantile="0.5"} 0.5
+`),
+			want: []wantSample{
+				{"my_summary_sum", `{}`, 10, SampleKindSummarySum, model.MetricTypeSummary},
+				{"my_summary_count", `{}`, 2, SampleKindSummaryCount, model.MetricTypeSummary},
+				{"my_summary", `{quantile="0.5"}`, 0.5, SampleKindSummaryQuantile, model.MetricTypeSummary},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var p promTextParser
+
+			for i := range 10 {
+				t.Run(fmt.Sprintf("parse num %d", i+1), func(t *testing.T) {
+					var got []wantSample
+					var help []string
+
+					err := p.parseToStream(test.input,
+						func(name, h string) { help = append(help, name+"="+h) },
+						func(s Sample) error {
+							assert.Falsef(t, s.Labels.Has(labels.MetricName),
+								"sample %q must not carry __name__ in Labels", s.Name)
+							got = append(got, wantSample{s.Name, s.Labels.String(), s.Value, s.Kind, s.FamilyType})
+							return nil
+						},
+					)
+					require.NoError(t, err)
+					assert.Equal(t, test.want, got)
+					for _, h := range test.wantHelp {
+						assert.Contains(t, help, h)
+					}
+				})
+			}
+		})
+	}
+}
+
+// Deferred _sum/_count (emitted before the family type is known) fold into the
+// typed family once it is resolved — criterion #5 at the assembled level.
+func TestPromTextParser_parseToMetricFamilies_deferredClassification(t *testing.T) {
+	tests := map[string]struct {
+		input []byte
+		want  MetricFamilies
+	}{
+		"summary _sum/_count before # TYPE fold into one summary": {
+			input: []byte(`my_summary_sum{label1="value1"} 10
+my_summary_count{label1="value1"} 2
+# TYPE my_summary summary
+my_summary{label1="value1",quantile="0.5"} 0.5
+`),
+			want: MetricFamilies{
+				"my_summary": {
+					name: "my_summary",
+					typ:  model.MetricTypeSummary,
+					metrics: []Metric{
+						{
+							labels: labels.Labels{{Name: "label1", Value: "value1"}},
+							summary: &Summary{
+								sum:       10,
+								count:     2,
+								quantiles: []Quantile{{quantile: 0.5, value: 0.5}},
+							},
+						},
+					},
+				},
+			},
+		},
+		"histogram _sum/_count before _bucket (no # TYPE) fold into one histogram": {
+			input: []byte(`my_hist_sum{label1="value1"} 5
+my_hist_count{label1="value1"} 3
+my_hist_bucket{label1="value1",le="0.1"} 1
+my_hist_bucket{label1="value1",le="+Inf"} 3
+`),
+			want: MetricFamilies{
+				"my_hist": {
+					name: "my_hist",
+					typ:  model.MetricTypeHistogram,
+					metrics: []Metric{
+						{
+							labels: labels.Labels{{Name: "label1", Value: "value1"}},
+							histogram: &Histogram{
+								sum:   5,
+								count: 3,
+								buckets: []Bucket{
+									{upperBound: 0.1, cumulativeCount: 1},
+									{upperBound: math.Inf(1), cumulativeCount: 3},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var p promTextParser
+
+			for i := range 10 {
+				t.Run(fmt.Sprintf("parse num %d", i+1), func(t *testing.T) {
+					mfs, err := p.parseToMetricFamilies(test.input)
+					require.NoError(t, err)
+					assert.Equal(t, test.want, mfs)
+				})
+			}
+		})
+	}
+}
+
+// The stream supports Prometheus-style relabeling on __name__/le/quantile.
+// ownLabels=true isolates each sample's labels, so a transform can rename via
+// Name and mutate Labels in place without affecting later samples.
+func TestPromTextParser_parseToStream_relabelStyle(t *testing.T) {
+	data := []byte(`# TYPE req_seconds histogram
+req_seconds_bucket{le="0.1",path="/a"} 1
+req_seconds_bucket{le="+Inf",path="/a"} 3
+# TYPE rpc summary
+rpc{quantile="0.99",path="/a"} 0.5
+`)
+
+	type out struct {
+		name     string
+		le       string
+		quantile string
+		labels   string
+	}
+
+	var p promTextParser
+	var got []out
+	err := p.parseToStream(data, nil, func(s Sample) error {
+		o := out{
+			name:     s.Name + ":relabeled", // __name__ is mutable via Name
+			le:       s.Labels.Get(bucketLabel),
+			quantile: s.Labels.Get(quantileLabel),
+		}
+		// Drop the "path" target label in place (this sample owns its labels).
+		kept := s.Labels[:0]
+		for _, l := range s.Labels {
+			if l.Name == "path" {
+				continue
+			}
+			kept = append(kept, l)
+		}
+		o.labels = labels.Labels(kept).String()
+		got = append(got, o)
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []out{
+		{name: "req_seconds_bucket:relabeled", le: "0.1", quantile: "", labels: `{le="0.1"}`},
+		{name: "req_seconds_bucket:relabeled", le: "+Inf", quantile: "", labels: `{le="+Inf"}`},
+		{name: "rpc:relabeled", le: "", quantile: "0.99", labels: `{quantile="0.99"}`},
+	}, got)
+}
+
+func TestPromTextParser_parseToStream_nilCallbackIsNoop(t *testing.T) {
+	var p promTextParser
+	require.NoError(t, p.parseToStream([]byte("metric 1\n"), nil, nil))
+}
+
+// Byte-identical series ordering: textparse sorts labels, so __name__ is NOT
+// always first — a label like "UUID" (0x55) sorts before "__name__" (0x5f).
+// ScrapeSeries must preserve that raw sorted order (same as the legacy parser),
+// not force __name__ first, which would also break the labels.Labels sorted
+// invariant.
+func TestPromTextParser_parseToSeries_labelOrderMatchesTextparse(t *testing.T) {
+	var p promTextParser
+	series, err := p.parseToSeries([]byte("m{UUID=\"x\",gpu=\"0\"} 5\n"))
+	require.NoError(t, err)
+	require.Len(t, series, 1)
+	assert.Equal(t, `{UUID="x", __name__="m", gpu="0"}`, series[0].Labels.String())
+}
+
+// The deferred _sum/_count buffer (criterion #5) can emit a _sum after a later,
+// unrelated sample: here a_sum is buffered (type unknown), b is emitted, then
+// a_sum resolves on "# TYPE a summary". Documents the ScrapeStream order caveat.
+func TestPromTextParser_parseToStream_deferralReordersAcrossMetrics(t *testing.T) {
+	data := []byte("a_sum 1\nb 2\n# TYPE a summary\na{quantile=\"0.5\"} 3\n")
+
+	var p promTextParser
+	var names []string
+	err := p.parseToStream(data, nil, func(s Sample) error {
+		names = append(names, s.Name)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"b", "a_sum", "a"}, names)
+}
+
+// A _bucket-named series is a histogram bucket only if it carries an "le" label.
+// Without le it is malformed and is kept as a plain metric (value preserved) — not
+// folded into the histogram family. (Legacy folded it and dropped the value;
+// valid buckets always have le, so real histograms are unaffected.)
+func TestPromTextParser_parseToMetricFamilies_bucketRequiresLe(t *testing.T) {
+	tests := map[string]struct {
+		input    []byte
+		wantFam  string
+		wantType model.MetricType
+	}{
+		"valid _bucket (has le) folds into the histogram family": {
+			input:    []byte("# TYPE h histogram\nh_bucket{le=\"1\",label=\"x\"} 1\n"),
+			wantFam:  "h",
+			wantType: model.MetricTypeHistogram,
+		},
+		"_bucket without le is a plain metric, not a histogram bucket": {
+			input:    []byte("# TYPE h histogram\nh_bucket{label=\"x\"} 1\n"),
+			wantFam:  "h_bucket",
+			wantType: model.MetricTypeUnknown,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var p promTextParser
+			mfs, err := p.parseToMetricFamilies(tc.input)
+			require.NoError(t, err)
+
+			mf := mfs.Get(tc.wantFam)
+			require.NotNilf(t, mf, "expected family %q", tc.wantFam)
+			assert.Equal(t, tc.wantType, mf.Type())
+			assert.Len(t, mf.Metrics(), 1)
+		})
+	}
+}


### PR DESCRIPTION
Rewrite src/go/pkg/prometheus into one parse driver plus an assembler.

Fixes: #22634

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the `src/go/pkg/prometheus` parser into a single-pass driver + assembler and added a streaming API for raw samples. Scrape/ScrapeSeries outputs are preserved; typed assembly now defers _sum/_count until the family type is known.

- New Features
  - Added `ScrapeStream(onHelp, onSample)` to stream per-sample data with per-family HELP.
  - Introduced `Sample` and `SampleKind` so consumers can relabel or reassemble without re-deriving roles.
  - Ordering matches exposition, with one caveat: a deferred _sum/_count can emit after a later sample once the type is resolved. If you implement the `Prometheus` interface, add this new method.

- Refactors
  - Unified parsing into a single iterate loop that powers `Scrape`, `ScrapeSeries`, and the new stream.
  - `ScrapeSeries` returns raw, textparse-sorted labels (byte-identical to before).
  - Deferred classification/back-resolve for _sum/_count; buckets/quantiles set family type; `_bucket` requires an `le` label; HELP text is normalized to one line.
  - Benchmarks show flat allocations vs previous parser; small CPU variance only.

<sup>Written for commit da11ea48a1dfd3e54a91d646bc5ba5f2e5879705. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

