### PR TITLE
test(go.d/prometheus): add V1 compatibility manifest golden tests

### DIFF
--- a/src/go/plugin/go.d/collector/prometheus/manifest_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/manifest_test.go
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package prometheus
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/pkg/prometheus/selector"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+)
+
+// updateGolden, when set, makes the manifest test (re)write the golden files and
+// skip the comparison. The goldens are a frozen baseline of the V1 collector's
+// observable contract; the V2 migration (PR5) checks parity by diffing its render
+// against them. Regenerate ONLY when intentionally adding a fixture or accepting a
+// contract change, then review the git diff — never to silently absorb V2 drift,
+// which would defeat the baseline. Hand-editing the JSON is error-prone, so this is
+// the supported way to maintain them:
+//
+//	go test ./plugin/go.d/collector/prometheus/ -run TestCollector_compatManifest -update-golden
+var updateGolden = flag.Bool("update-golden", false, "regenerate the prometheus compat-manifest golden files")
+
+// The compat manifest captures the V1 collector's observable CONTRACT, so the V2
+// migration (PR5) can be verified to preserve it.
+//
+// manifestChart top-level fields are the HARD contract a V2 migration must
+// reproduce: the chart context, its labels (incl. label_prefix), and its dims by
+// semantic name with algo + the real (de-scaled) value. `soft` holds best-effort
+// fields autogen may derive differently (units/family/type). The V1 chart-ID
+// strings and the ×1000 / ×1e6 precision divisor are INTENTIONALLY excluded — both
+// change by design in V2 (autogen chart-IDs; float dimensions). Values are
+// de-scaled (mx ÷ Div) to the real number V2's float dims emit directly.
+//
+// Note: V1 scales values into int64 (×1000 / ×1e6), so sub-precision values are
+// truncated (0.00147889 → 1 → 0.001). The manifest records V1's truncated value;
+// the PR5 verification must diff values float-tolerantly (V2 is more precise).
+type manifestChart struct {
+	Context string            `json:"context"`
+	Labels  map[string]string `json:"labels,omitempty"`
+	Dims    []manifestDim     `json:"dims"`
+	Soft    manifestSoft      `json:"soft"`
+}
+
+type manifestDim struct {
+	Name  string  `json:"name"`
+	Algo  string  `json:"algo"`
+	Value float64 `json:"value"`
+}
+
+type manifestSoft struct {
+	Units  string `json:"units"`
+	Family string `json:"family"`
+	Type   string `json:"type"`
+}
+
+func renderManifest(charts *collectorapi.Charts, mx map[string]int64) []manifestChart {
+	out := make([]manifestChart, 0, len(*charts))
+
+	for _, ch := range *charts {
+		if ch.Obsolete {
+			continue
+		}
+
+		mc := manifestChart{
+			Context: ch.Ctx,
+			Soft:    manifestSoft{Units: ch.Units, Family: ch.Fam, Type: string(ch.Type)},
+		}
+		if len(ch.Labels) > 0 {
+			mc.Labels = make(map[string]string, len(ch.Labels))
+			for _, l := range ch.Labels {
+				mc.Labels[l.Key] = l.Value
+			}
+		}
+		for _, d := range ch.Dims {
+			div := d.Div
+			if div == 0 {
+				div = 1
+			}
+			algo := "absolute"
+			if d.Algo != "" {
+				algo = string(d.Algo)
+			}
+			mc.Dims = append(mc.Dims, manifestDim{
+				Name:  d.Name,
+				Algo:  algo,
+				Value: float64(mx[d.ID]) / float64(div),
+			})
+		}
+		sort.Slice(mc.Dims, func(i, j int) bool { return mc.Dims[i].Name < mc.Dims[j].Name })
+
+		out = append(out, mc)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Context != out[j].Context {
+			return out[i].Context < out[j].Context
+		}
+		return manifestLabelsKey(out[i].Labels) < manifestLabelsKey(out[j].Labels)
+	})
+
+	return out
+}
+
+func manifestLabelsKey(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var sb strings.Builder
+	for _, k := range keys {
+		sb.WriteString(k + "=" + m[k] + ";")
+	}
+	return sb.String()
+}
+
+func TestCollector_compatManifest(t *testing.T) {
+	tests := map[string]struct {
+		prepare func() *Collector
+		input   string
+	}{
+		"gauge": {
+			prepare: New,
+			input: `
+# HELP test_gauge_metric A gauge.
+# TYPE test_gauge_metric gauge
+test_gauge_metric{label1="value1"} 11
+test_gauge_metric{label1="value2"} 12.5
+`,
+		},
+		"counter": {
+			prepare: New,
+			input: `
+# TYPE test_counter_metric_total counter
+test_counter_metric_total{label1="value1"} 11
+`,
+		},
+		"summary": {
+			prepare: New,
+			input: `
+# TYPE test_summary_duration_seconds summary
+test_summary_duration_seconds{label1="value1",quantile="0.5"} 0.25
+test_summary_duration_seconds{label1="value1",quantile="0.99"} 0.5
+test_summary_duration_seconds_sum{label1="value1"} 12.5
+test_summary_duration_seconds_count{label1="value1"} 42
+`,
+		},
+		"histogram": {
+			prepare: New,
+			input: `
+# TYPE test_histogram_duration_seconds histogram
+test_histogram_duration_seconds_bucket{label1="value1",le="0.1"} 4
+test_histogram_duration_seconds_bucket{label1="value1",le="+Inf"} 6
+test_histogram_duration_seconds_sum{label1="value1"} 2.5
+test_histogram_duration_seconds_count{label1="value1"} 6
+`,
+		},
+		"untyped_total": {
+			prepare: New,
+			input: `
+test_untyped_metric_total{label1="value1"} 11
+`,
+		},
+		"app": {
+			prepare: func() *Collector { c := New(); c.Application = "custom_app"; return c },
+			input: `
+# TYPE test_gauge_metric gauge
+test_gauge_metric{label1="value1"} 11
+`,
+		},
+		"app_job_name": {
+			// Application empty -> the app segment falls back to the job Name (charts.go:238-241).
+			prepare: func() *Collector { c := New(); c.Name = "job_app"; return c },
+			input: `
+# TYPE test_gauge_metric gauge
+test_gauge_metric{label1="value1"} 11
+`,
+		},
+		"label_prefix": {
+			prepare: func() *Collector { c := New(); c.LabelPrefix = "px"; return c },
+			input: `
+# TYPE test_gauge_metric gauge
+test_gauge_metric{label1="value1"} 11
+`,
+		},
+		"snmp_units": {
+			// Special unit mappings (charts.go getChartUnits): uppercase snmp-exporter
+			// names octets->bytes, pkts->packets, mtu->octets, speed->bits; underscore
+			// suffix hertz->Hz.
+			prepare: New,
+			input: `
+# TYPE ifOutOctets gauge
+ifOutOctets{ifDescr="eth0"} 12345
+# TYPE ifOutUcastPkts gauge
+ifOutUcastPkts{ifDescr="eth0"} 678
+# TYPE ifMtu gauge
+ifMtu{ifDescr="eth0"} 1500
+# TYPE ifHighSpeed gauge
+ifHighSpeed{ifDescr="eth0"} 1000
+# TYPE test_clock_hertz gauge
+test_clock_hertz{cpu="0"} 2400
+`,
+		},
+		"selector": {
+			prepare: func() *Collector {
+				c := New()
+				c.Selector = selector.Expr{Allow: []string{"test_gauge_metric_keep"}}
+				return c
+			},
+			input: `
+# TYPE test_gauge_metric_keep gauge
+test_gauge_metric_keep{label1="value1"} 11
+# TYPE test_gauge_metric_drop gauge
+test_gauge_metric_drop{label1="value1"} 22
+`,
+		},
+		"info_skipped": {
+			prepare: New,
+			input: `
+# TYPE test_metric gauge
+test_metric{label1="value1"} 11
+# TYPE test_metric_info gauge
+test_metric_info{version="1.2.3"} 1
+`,
+		},
+		"fallback_gauge": {
+			prepare: func() *Collector {
+				c := New()
+				c.FallbackType.Gauge = []string{"test_untyped_metric"}
+				return c
+			},
+			input: `
+test_untyped_metric{label1="value1"} 11
+`,
+		},
+		"fallback_counter": {
+			// Untyped metric forced to counter by regex — a distinct path from the
+			// _total auto-counter (independent `if` at collect.go:176); algo incremental.
+			prepare: func() *Collector {
+				c := New()
+				c.FallbackType.Counter = []string{"test_untyped_metric"}
+				return c
+			},
+			input: `
+test_untyped_metric{label1="value1"} 11
+`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(tc.input)) }))
+			defer srv.Close()
+
+			collr := tc.prepare()
+			collr.URL = srv.URL
+			require.NoError(t, collr.Init(context.Background()))
+
+			mx := collr.Collect(context.Background())
+			require.NotNil(t, mx)
+
+			got := renderManifest(collr.Charts(), mx)
+			data, err := json.MarshalIndent(got, "", "  ")
+			require.NoError(t, err)
+			data = append(data, '\n')
+
+			path := filepath.Join("testdata", "golden", goldenName(name)+".json")
+			if *updateGolden {
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				require.NoError(t, os.WriteFile(path, data, 0o644))
+				return
+			}
+
+			want, err := os.ReadFile(path)
+			require.NoErrorf(t, err, "missing golden %q — run: go test -run TestCollector_compatManifest -update-golden ./...", path)
+			assert.Equal(t, string(want), string(data))
+		})
+	}
+}
+
+// Config defaults the V2 migration (PR5) must preserve: update_every is the
+// registered Creator default (collectorapi.Defaults); max_time_series[_per_metric]
+// are New() defaults. A V2 re-registration can silently drop them.
+func TestCollector_compatConfigDefaults(t *testing.T) {
+	creator, ok := collectorapi.DefaultRegistry.Lookup("prometheus")
+	require.True(t, ok, "prometheus collector must be registered")
+	assert.Equal(t, 10, creator.Defaults.UpdateEvery, "update_every default")
+
+	c := New()
+	assert.Equal(t, 2000, c.MaxTS, "max_time_series default")
+	assert.Equal(t, 200, c.MaxTSPerMetric, "max_time_series_per_metric default")
+}
+
+func goldenName(name string) string {
+	return strings.NewReplacer(" ", "_", "(", "", ")", "", ">", "", "-", "_", ".", "_", "/", "_", "<", "").Replace(name)
+}

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/app.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/app.json
@@ -1,0 +1,20 @@
+[
+  {
+    "context": "prometheus.custom_app.test_gauge_metric",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_gauge_metric",
+        "algo": "absolute",
+        "value": 11
+      }
+    ],
+    "soft": {
+      "units": "metric",
+      "family": "test_gauge",
+      "type": "line"
+    }
+  }
+]

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/app_job_name.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/app_job_name.json
@@ -1,0 +1,20 @@
+[
+  {
+    "context": "prometheus.job_app.test_gauge_metric",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_gauge_metric",
+        "algo": "absolute",
+        "value": 11
+      }
+    ],
+    "soft": {
+      "units": "metric",
+      "family": "test_gauge",
+      "type": "line"
+    }
+  }
+]

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/counter.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/counter.json
@@ -1,0 +1,20 @@
+[
+  {
+    "context": "prometheus.test_counter_metric_total",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_counter_metric_total",
+        "algo": "incremental",
+        "value": 11
+      }
+    ],
+    "soft": {
+      "units": "metric/s",
+      "family": "test_counter",
+      "type": "line"
+    }
+  }
+]

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/fallback_counter.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/fallback_counter.json
@@ -1,0 +1,20 @@
+[
+  {
+    "context": "prometheus.test_untyped_metric",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_untyped_metric",
+        "algo": "incremental",
+        "value": 11
+      }
+    ],
+    "soft": {
+      "units": "metric/s",
+      "family": "test_untyped",
+      "type": "line"
+    }
+  }
+]

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/fallback_gauge.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/fallback_gauge.json
@@ -1,0 +1,20 @@
+[
+  {
+    "context": "prometheus.test_untyped_metric",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_untyped_metric",
+        "algo": "absolute",
+        "value": 11
+      }
+    ],
+    "soft": {
+      "units": "metric",
+      "family": "test_untyped",
+      "type": "line"
+    }
+  }
+]

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/gauge.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/gauge.json
@@ -1,0 +1,38 @@
+[
+  {
+    "context": "prometheus.test_gauge_metric",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_gauge_metric",
+        "algo": "absolute",
+        "value": 11
+      }
+    ],
+    "soft": {
+      "units": "metric",
+      "family": "test_gauge",
+      "type": "line"
+    }
+  },
+  {
+    "context": "prometheus.test_gauge_metric",
+    "labels": {
+      "label1": "value2"
+    },
+    "dims": [
+      {
+        "name": "test_gauge_metric",
+        "algo": "absolute",
+        "value": 12.5
+      }
+    ],
+    "soft": {
+      "units": "metric",
+      "family": "test_gauge",
+      "type": "line"
+    }
+  }
+]

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/histogram.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/histogram.json
@@ -1,0 +1,61 @@
+[
+  {
+    "context": "prometheus.test_histogram_duration_seconds",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "bucket_+Inf",
+        "algo": "incremental",
+        "value": 6
+      },
+      {
+        "name": "bucket_0.1",
+        "algo": "incremental",
+        "value": 4
+      }
+    ],
+    "soft": {
+      "units": "observations/s",
+      "family": "test_histogram",
+      "type": ""
+    }
+  },
+  {
+    "context": "prometheus.test_histogram_duration_seconds_count",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_histogram_duration_seconds_count",
+        "algo": "incremental",
+        "value": 6
+      }
+    ],
+    "soft": {
+      "units": "events/s",
+      "family": "test_histogram",
+      "type": ""
+    }
+  },
+  {
+    "context": "prometheus.test_histogram_duration_seconds_sum",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_histogram_duration_seconds_sum",
+        "algo": "incremental",
+        "value": 2.5
+      }
+    ],
+    "soft": {
+      "units": "seconds",
+      "family": "test_histogram",
+      "type": ""
+    }
+  }
+]

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/info_skipped.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/info_skipped.json
@@ -1,0 +1,20 @@
+[
+  {
+    "context": "prometheus.test_metric",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_metric",
+        "algo": "absolute",
+        "value": 11
+      }
+    ],
+    "soft": {
+      "units": "metric",
+      "family": "test_metric",
+      "type": "line"
+    }
+  }
+]

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/label_prefix.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/label_prefix.json
@@ -1,0 +1,20 @@
+[
+  {
+    "context": "prometheus.test_gauge_metric",
+    "labels": {
+      "px_label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_gauge_metric",
+        "algo": "absolute",
+        "value": 11
+      }
+    ],
+    "soft": {
+      "units": "metric",
+      "family": "test_gauge",
+      "type": "line"
+    }
+  }
+]

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/selector.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/selector.json
@@ -1,0 +1,20 @@
+[
+  {
+    "context": "prometheus.test_gauge_metric_keep",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_gauge_metric_keep",
+        "algo": "absolute",
+        "value": 11
+      }
+    ],
+    "soft": {
+      "units": "keep",
+      "family": "test_gauge",
+      "type": "line"
+    }
+  }
+]

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/snmp_units.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/snmp_units.json
@@ -1,0 +1,92 @@
+[
+  {
+    "context": "prometheus.ifHighSpeed",
+    "labels": {
+      "ifDescr": "eth0"
+    },
+    "dims": [
+      {
+        "name": "ifHighSpeed",
+        "algo": "absolute",
+        "value": 1000
+      }
+    ],
+    "soft": {
+      "units": "bits",
+      "family": "ifHighSpeed",
+      "type": "line"
+    }
+  },
+  {
+    "context": "prometheus.ifMtu",
+    "labels": {
+      "ifDescr": "eth0"
+    },
+    "dims": [
+      {
+        "name": "ifMtu",
+        "algo": "absolute",
+        "value": 1500
+      }
+    ],
+    "soft": {
+      "units": "octets",
+      "family": "ifMtu",
+      "type": "line"
+    }
+  },
+  {
+    "context": "prometheus.ifOutOctets",
+    "labels": {
+      "ifDescr": "eth0"
+    },
+    "dims": [
+      {
+        "name": "ifOutOctets",
+        "algo": "absolute",
+        "value": 12345
+      }
+    ],
+    "soft": {
+      "units": "bytes",
+      "family": "ifOutOctets",
+      "type": "area"
+    }
+  },
+  {
+    "context": "prometheus.ifOutUcastPkts",
+    "labels": {
+      "ifDescr": "eth0"
+    },
+    "dims": [
+      {
+        "name": "ifOutUcastPkts",
+        "algo": "absolute",
+        "value": 678
+      }
+    ],
+    "soft": {
+      "units": "packets",
+      "family": "ifOutUcastPkts",
+      "type": "line"
+    }
+  },
+  {
+    "context": "prometheus.test_clock_hertz",
+    "labels": {
+      "cpu": "0"
+    },
+    "dims": [
+      {
+        "name": "test_clock_hertz",
+        "algo": "absolute",
+        "value": 2400
+      }
+    ],
+    "soft": {
+      "units": "Hz",
+      "family": "test_clock",
+      "type": "line"
+    }
+  }
+]

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/summary.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/summary.json
@@ -1,0 +1,61 @@
+[
+  {
+    "context": "prometheus.test_summary_duration_seconds",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "quantile_0.5",
+        "algo": "absolute",
+        "value": 0.25
+      },
+      {
+        "name": "quantile_0.99",
+        "algo": "absolute",
+        "value": 0.5
+      }
+    ],
+    "soft": {
+      "units": "seconds",
+      "family": "test_summary",
+      "type": ""
+    }
+  },
+  {
+    "context": "prometheus.test_summary_duration_seconds_count",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_summary_duration_seconds_count",
+        "algo": "incremental",
+        "value": 42
+      }
+    ],
+    "soft": {
+      "units": "events/s",
+      "family": "test_summary",
+      "type": ""
+    }
+  },
+  {
+    "context": "prometheus.test_summary_duration_seconds_sum",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_summary_duration_seconds_sum",
+        "algo": "incremental",
+        "value": 12.5
+      }
+    ],
+    "soft": {
+      "units": "seconds",
+      "family": "test_summary",
+      "type": ""
+    }
+  }
+]

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/untyped_total.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/untyped_total.json
@@ -1,0 +1,20 @@
+[
+  {
+    "context": "prometheus.test_untyped_metric_total",
+    "labels": {
+      "label1": "value1"
+    },
+    "dims": [
+      {
+        "name": "test_untyped_metric_total",
+        "algo": "incremental",
+        "value": 11
+      }
+    ],
+    "soft": {
+      "units": "metric/s",
+      "family": "test_untyped",
+      "type": "line"
+    }
+  }
+]


### PR DESCRIPTION
##### Summary

Part of #22635

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add golden tests that capture the V1 `go.d/prometheus` collector’s observable contract and config defaults to ensure parity during the upcoming V2 migration. Test-only; no runtime changes.

- **New Features**
  - Added `manifest_test.go` to render a V1 compatibility manifest (context, labels incl. `LabelPrefix`, dims with algo and de‑scaled values; soft units/family/type).
  - Added golden fixtures covering: gauge, counter, summary, histogram, untyped and `_total`, app and job-name fallback, selector allowlist, `_info` skip, SNMP unit mappings, and gauge/counter fallback types.
  - Asserted defaults preserved: `update_every=10`, `max_time_series=2000`, `max_time_series_per_metric=200`.

<sup>Written for commit 596bfbcaf1b7c92b577c3979563304dc89922bad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

