### PR TITLE
feat(go.d/framework/chartengine): apply context_namespace to autogen chart contexts

### DIFF
--- a/src/go/plugin/framework/chartengine/README.md
+++ b/src/go/plugin/framework/chartengine/README.md
@@ -168,6 +168,7 @@ Default lifecycle policy when template omits lifecycle:
 | Topic                 | Behavior                                                                                                                                       |
 |-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
 | Trigger               | Unmatched series only when autogen is enabled                                                                                                  |
+| Context namespace     | Autogen context = top-level `context_namespace` + the full metric name (which includes any `SnapshotMeter` prefix); empty namespace leaves the bare name. A non-empty meter prefix stacks after `context_namespace`, so pair `context_namespace` with `SnapshotMeter("")` to avoid a doubled prefix |
 | Structured families   | Autogen has dedicated source builders for flattened `Histogram`, `Summary`, `StateSet`, and `MeasureSet` families                              |
 | Metric metadata usage | Uses `metrix.MetricMeta` hints for title/family/unit where allowed                                                                             |
 | Type ID budget        | Enforced via `AutogenPolicy.MaxTypeIDLen` + effective emit type-id prefix (`WithEmitTypeIDBudgetPrefix(...)`)                                  |

--- a/src/go/plugin/framework/chartengine/autogen.go
+++ b/src/go/plugin/framework/chartengine/autogen.go
@@ -79,6 +79,8 @@ func (e *Engine) resolveAutogenRoute(
 		return nil, false, nil
 	}
 
+	namespace := e.state.cfg.autogenContextNamespace
+
 	route, ok, err := buildAutogenRoute(metricName, labels, meta, policy, e.state.cfg.autogenTypeID)
 	if err != nil {
 		return nil, false, err
@@ -112,7 +114,7 @@ func (e *Engine) resolveAutogenRoute(
 			Meta: program.ChartMeta{
 				Title:     title,
 				Family:    route.family,
-				Context:   getAutogenChartContext(route.contextName),
+				Context:   getAutogenChartContext(namespace, route.contextName),
 				Units:     route.units,
 				Algorithm: route.algorithm,
 				Type:      route.chartType,
@@ -601,10 +603,16 @@ func getAutogenChartTitle(metricName string) string {
 	return fmt.Sprintf("Metric \"%s\"", metricName)
 }
 
-func getAutogenChartContext(metricName string) string {
+// getAutogenChartContext builds an autogen chart context, prefixed by the spec's root
+// context_namespace when set ("prometheus" + "foo" -> "prometheus.foo"), matching the
+// template compiler's "." join. Empty namespace -> the bare metric name (unchanged).
+func getAutogenChartContext(namespace, metricName string) string {
 	metricName = strings.TrimSpace(metricName)
 	if metricName == "" {
-		return "metric"
+		metricName = "metric"
+	}
+	if namespace = strings.TrimSpace(namespace); namespace != "" {
+		return namespace + "." + metricName
 	}
 	return metricName
 }

--- a/src/go/plugin/framework/chartengine/autogen_test.go
+++ b/src/go/plugin/framework/chartengine/autogen_test.go
@@ -372,6 +372,27 @@ func TestFitsTypeIDBudget(t *testing.T) {
 	}
 }
 
+func TestGetAutogenChartContext(t *testing.T) {
+	tests := map[string]struct {
+		namespace string
+		metric    string
+		want      string
+	}{
+		"empty namespace returns bare metric":        {namespace: "", metric: "foo", want: "foo"},
+		"single-segment namespace is prefixed":       {namespace: "prometheus", metric: "foo", want: "prometheus.foo"},
+		"multi-segment namespace composes with dot":  {namespace: "prometheus.app", metric: "foo", want: "prometheus.app.foo"},
+		"whitespace-only namespace is treated empty": {namespace: "  ", metric: "foo", want: "foo"},
+		"empty metric falls back to metric":          {namespace: "", metric: "", want: "metric"},
+		"namespace with empty metric":                {namespace: "prometheus", metric: "", want: "prometheus.metric"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, getAutogenChartContext(tc.namespace, tc.metric))
+		})
+	}
+}
+
 func sortedLabelView(labels map[string]string) metrix.LabelView {
 	items := make([]metrix.Label, 0, len(labels))
 	for key, value := range labels {

--- a/src/go/plugin/framework/chartengine/engine.go
+++ b/src/go/plugin/framework/chartengine/engine.go
@@ -72,6 +72,7 @@ func (e *Engine) Load(spec *charttpl.Spec, revision uint64) error {
 	e.mu.Lock()
 	e.state.cfg.autogen = autogenPolicy
 	e.state.cfg.selector = selectorPolicy
+	e.state.cfg.autogenContextNamespace = spec.ContextNamespace
 	e.state.program = compiled
 	e.state.matchIndex = buildMatchIndex(compiled.Charts())
 	// Template revision change resets routing/materialization internals.

--- a/src/go/plugin/framework/chartengine/options.go
+++ b/src/go/plugin/framework/chartengine/options.go
@@ -12,17 +12,20 @@ import (
 )
 
 type engineConfig struct {
-	autogen          AutogenPolicy
-	autogenTypeID    string
-	selector         metrixselector.Selector
-	autogenOverride  policyOverride[AutogenPolicy]
-	selectorOverride policyOverride[metrixselector.Selector]
-	runtimeStore     metrix.RuntimeStore
-	runtimeStoreSet  bool
-	runtimeObserver  func(PlanRuntimeSample)
-	log              *logger.Logger
-	seriesSelection  seriesSelectionMode
-	runtimePlanner   bool
+	autogen       AutogenPolicy
+	autogenTypeID string
+	// autogenContextNamespace prefixes autogen chart contexts (the spec's root
+	// context_namespace), so autogen and template charts share one namespace.
+	autogenContextNamespace string
+	selector                metrixselector.Selector
+	autogenOverride         policyOverride[AutogenPolicy]
+	selectorOverride        policyOverride[metrixselector.Selector]
+	runtimeStore            metrix.RuntimeStore
+	runtimeStoreSet         bool
+	runtimeObserver         func(PlanRuntimeSample)
+	log                     *logger.Logger
+	seriesSelection         seriesSelectionMode
+	runtimePlanner          bool
 }
 
 type policyOverride[T any] struct {

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -233,6 +233,8 @@ func TestBuildPlanLegacySingleScenarioCases(t *testing.T) {
 		"BuildPlanAutogenRemovalLifecycleExpiry":                       {run: runTestBuildPlanAutogenRemovalLifecycleExpiry},
 		"BuildPlanFirstWriterWinsAndAccumulatesRepeatedRoutes":         {run: runTestBuildPlanFirstWriterWinsAndAccumulatesRepeatedRoutes},
 		"BuildPlanEmptyEmissionAndScratchReusePruneAcrossCycles":       {run: runTestBuildPlanEmptyEmissionAndScratchReusePruneAcrossCycles},
+		"BuildPlanAutogenContextNamespacePrefixesContext":              {run: runTestBuildPlanAutogenContextNamespacePrefixesContext},
+		"BuildPlanAutogenContextNamespaceStubGroupOnly":                {run: runTestBuildPlanAutogenContextNamespaceStubGroupOnly},
 	}
 
 	for name, tc := range tests {
@@ -997,6 +999,80 @@ groups:
 	require.Len(t, update.Values, 1)
 	assert.Equal(t, "errors_total", update.Values[0].Name)
 	assert.Equal(t, float64(10), update.Values[0].Float64)
+}
+
+func runTestBuildPlanAutogenContextNamespacePrefixesContext(t *testing.T) {
+	e, err := New(WithEnginePolicy(EnginePolicy{Autogen: &AutogenPolicy{Enabled: true}}))
+	require.NoError(t, err)
+
+	// Root context_namespace must prefix autogen (unmatched-series) chart contexts,
+	// joined with "." like the template compiler ("prometheus" + "svc.errors_total").
+	yaml := `
+version: v1
+context_namespace: prometheus
+groups:
+  - family: Service
+    metrics:
+      - svc.requests_total
+    charts:
+      - title: Requests
+        context: requests
+        units: requests/s
+        dimensions:
+          - selector: svc.requests_total
+            name: total
+`
+	require.NoError(t, e.LoadYAML([]byte(yaml), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := mustCycleController(t, store)
+	sm := store.Write().SnapshotMeter("svc")
+	unmatched := sm.Counter("errors_total")
+	methodGET := sm.LabelSet(metrix.Label{Key: "method", Value: "GET"})
+
+	cc.BeginCycle()
+	unmatched.ObserveTotal(10, methodGET)
+	cc.CommitCycleSuccess()
+
+	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+
+	create := findCreateChartAction(plan)
+	require.NotNil(t, create)
+	assert.Equal(t, "prometheus.svc.errors_total", create.Meta.Context)
+}
+
+// Mirrors the autogen-only collector shape: a stub group satisfies the
+// required groups[] but declares no charts, so every series is unmatched and handled by autogen,
+// with contexts prefixed by the top-level context_namespace.
+func runTestBuildPlanAutogenContextNamespaceStubGroupOnly(t *testing.T) {
+	e, err := New(WithEnginePolicy(EnginePolicy{Autogen: &AutogenPolicy{Enabled: true}}))
+	require.NoError(t, err)
+
+	yaml := `
+version: v1
+context_namespace: prometheus
+groups:
+  - family: Prometheus
+`
+	require.NoError(t, e.LoadYAML([]byte(yaml), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := mustCycleController(t, store)
+	sm := store.Write().SnapshotMeter("")
+	unmatched := sm.Counter("requests_total")
+	methodGET := sm.LabelSet(metrix.Label{Key: "method", Value: "GET"})
+
+	cc.BeginCycle()
+	unmatched.ObserveTotal(10, methodGET)
+	cc.CommitCycleSuccess()
+
+	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+
+	create := findCreateChartAction(plan)
+	require.NotNil(t, create)
+	assert.Equal(t, "prometheus.requests_total", create.Meta.Context)
 }
 
 func runTestBuildPlanAutogenUsesMetricMetadataForScalar(t *testing.T) {

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -268,6 +268,18 @@ For example:
 | Chart `context`               | `queries`           |
 | **Resulting context**         | **`mysql.queries`** |
 
+**Autogen charts** — the **top-level** `context_namespace` also prefixes the contexts of charts
+created by `engine.autogen` (metrics not matched by any template dimension), joined with the same
+`.`. Group-level `context_namespace` does not apply to autogen, since unmatched series belong to
+no group. For example, with top-level `context_namespace: nagios`, an unmatched metric
+`check_load` autogenerates the context `nagios.check_load`.
+
+The autogen context is `context_namespace` joined with the **full metric name**, and a metric's name
+includes any `SnapshotMeter("<prefix>")` prefix (`<prefix>.<instrument>`). So a non-empty meter prefix
+**stacks after** `context_namespace` — e.g. `context_namespace: app` with `SnapshotMeter("app")` and
+instrument `foo` yields `app.app.foo`. When you set `context_namespace`, write metrics with
+`SnapshotMeter("")` so the namespace has a single source; do not also encode it in the meter prefix.
+
 ### 3. engine
 
 Template-level policy that controls metric filtering and autogeneration.

--- a/src/go/plugin/scripts.d/collector/nagios/charts.yaml
+++ b/src/go/plugin/scripts.d/collector/nagios/charts.yaml
@@ -10,11 +10,11 @@ groups:
     groups:
       - family: Execution
         metrics:
-          - nagios.job.execution_state
-          - nagios.job.perfdata.threshold_state
-          - nagios.job.execution_duration
-          - nagios.job.execution_cpu_total
-          - nagios.job.execution_max_rss
+          - job.execution_state
+          - job.perfdata.threshold_state
+          - job.execution_duration
+          - job.execution_cpu_total
+          - job.execution_max_rss
         charts:
           - id: job_execution_state
             title: Job Execution State
@@ -24,7 +24,7 @@ groups:
             instances:
               by_labels: [nagios_job]
             dimensions:
-              - selector: nagios.job.execution_state
+              - selector: job.execution_state
           - id: job_perfdata_threshold_state
             title: Job Perfdata Threshold State
             context: perfdata_threshold_state
@@ -33,7 +33,7 @@ groups:
             instances:
               by_labels: [nagios_job, perfdata_value]
             dimensions:
-              - selector: nagios.job.perfdata.threshold_state
+              - selector: job.perfdata.threshold_state
           - id: job_execution_duration
             title: Execution Duration
             context: execution_duration
@@ -42,7 +42,7 @@ groups:
             instances:
               by_labels: [nagios_job]
             dimensions:
-              - selector: nagios.job.execution_duration
+              - selector: job.execution_duration
                 name: duration
                 options:
                   float: true
@@ -54,7 +54,7 @@ groups:
             instances:
               by_labels: [nagios_job]
             dimensions:
-              - selector: nagios.job.execution_cpu_total
+              - selector: job.execution_cpu_total
                 name: total
                 options:
                   float: true
@@ -66,5 +66,5 @@ groups:
             instances:
               by_labels: [nagios_job]
             dimensions:
-              - selector: nagios.job.execution_max_rss
+              - selector: job.execution_max_rss
                 name: rss

--- a/src/go/plugin/scripts.d/collector/nagios/collect.go
+++ b/src/go/plugin/scripts.d/collector/nagios/collect.go
@@ -69,7 +69,9 @@ func (c *Collector) completeDueCheck(now time.Time, res checkRunResult) {
 }
 
 func (c *Collector) emitMetrics(execMetrics executionMetrics) {
-	sm := c.store.Write().SnapshotMeter("nagios")
+	// Empty meter prefix: the namespace comes from charts.yaml context_namespace (nagios),
+	// which also prefixes autogen perfdata contexts. A "nagios" meter prefix would double it.
+	sm := c.store.Write().SnapshotMeter("")
 
 	jobName := c.job.config.Name
 	if jobName == "" {

--- a/src/go/plugin/scripts.d/collector/nagios/collector_test.go
+++ b/src/go/plugin/scripts.d/collector/nagios/collector_test.go
@@ -43,17 +43,17 @@ func TestCollector_ChartTemplateYAML(t *testing.T) {
 	}{
 		"execution duration dimension is float": {
 			context:   "execution_duration",
-			selector:  "nagios.job.execution_duration",
+			selector:  "job.execution_duration",
 			wantFloat: true,
 		},
 		"execution cpu dimension is float": {
 			context:   "execution_cpu",
-			selector:  "nagios.job.execution_cpu_total",
+			selector:  "job.execution_cpu_total",
 			wantFloat: true,
 		},
 		"execution memory dimension is integer": {
 			context:   "execution_memory",
-			selector:  "nagios.job.execution_max_rss",
+			selector:  "job.execution_max_rss",
 			wantFloat: false,
 		},
 	}
@@ -360,22 +360,22 @@ func TestCollector_Collect(t *testing.T) {
 
 				read := coll.MetricStore().Read(metrix.ReadRaw())
 				flat := coll.MetricStore().Read(metrix.ReadFlatten())
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "check_disk", "nagios.job.execution_state": "ok"}, 1)
-				assertMetricValue(t, flat, "nagios.perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "check_disk", "nagios.perfdata.true.job.execution_state": "ok"}, 1)
-				assertMetricChartFamily(t, flat, "nagios.perfdata.true.job.execution_state", "Perfdata/true")
-				assertMetricValue(t, flat, "nagios.job.execution_duration", metrix.Labels{"nagios_job": "check_disk"}, 2.5)
-				assertMetricMeta(t, flat, "nagios.job.execution_duration", "seconds", true)
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "check_disk", "job.execution_state": "ok"}, 1)
+				assertMetricValue(t, flat, "perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "check_disk", "perfdata.true.job.execution_state": "ok"}, 1)
+				assertMetricChartFamily(t, flat, "perfdata.true.job.execution_state", "Perfdata/true")
+				assertMetricValue(t, flat, "job.execution_duration", metrix.Labels{"nagios_job": "check_disk"}, 2.5)
+				assertMetricMeta(t, flat, "job.execution_duration", "seconds", true)
 				if runtime.GOOS != "windows" {
-					assertMetricValue(t, flat, "nagios.job.execution_cpu_total", metrix.Labels{"nagios_job": "check_disk"}, 0.5)
-					assertMetricValue(t, flat, "nagios.job.execution_max_rss", metrix.Labels{"nagios_job": "check_disk"}, 12345)
-					assertMetricMeta(t, flat, "nagios.job.execution_cpu_total", "seconds", true)
-					assertMetricMeta(t, flat, "nagios.job.execution_max_rss", "bytes", false)
+					assertMetricValue(t, flat, "job.execution_cpu_total", metrix.Labels{"nagios_job": "check_disk"}, 0.5)
+					assertMetricValue(t, flat, "job.execution_max_rss", metrix.Labels{"nagios_job": "check_disk"}, 12345)
+					assertMetricMeta(t, flat, "job.execution_cpu_total", "seconds", true)
+					assertMetricMeta(t, flat, "job.execution_max_rss", "bytes", false)
 				} else {
-					assertMetricMissing(t, flat, "nagios.job.execution_cpu_total", metrix.Labels{"nagios_job": "check_disk"})
-					assertMetricMissing(t, flat, "nagios.job.execution_max_rss", metrix.Labels{"nagios_job": "check_disk"})
+					assertMetricMissing(t, flat, "job.execution_cpu_total", metrix.Labels{"nagios_job": "check_disk"})
+					assertMetricMissing(t, flat, "job.execution_max_rss", metrix.Labels{"nagios_job": "check_disk"})
 				}
-				assertMetricValue(t, flat, "nagios.perfdata.true.bytes_used_value", metrix.Labels{"nagios_job": "check_disk", metrix.MeasureSetFieldLabel: "value"}, 30000)
-				point, ok := read.MeasureSet("nagios.perfdata.true.bytes_used", metrix.Labels{"nagios_job": "check_disk"})
+				assertMetricValue(t, flat, "perfdata.true.bytes_used_value", metrix.Labels{"nagios_job": "check_disk", metrix.MeasureSetFieldLabel: "value"}, 30000)
+				point, ok := read.MeasureSet("perfdata.true.bytes_used", metrix.Labels{"nagios_job": "check_disk"})
 				require.True(t, ok)
 				assert.Equal(t, 30000.0, point.Values[0])
 
@@ -384,15 +384,15 @@ func TestCollector_Collect(t *testing.T) {
 				assert.Equal(t, 1, runner.calls)
 
 				flat = coll.MetricStore().Read(metrix.ReadFlatten())
-				assertMetricValue(t, flat, "nagios.job.execution_duration", metrix.Labels{"nagios_job": "check_disk"}, 0)
+				assertMetricValue(t, flat, "job.execution_duration", metrix.Labels{"nagios_job": "check_disk"}, 0)
 				if runtime.GOOS != "windows" {
-					assertMetricValue(t, flat, "nagios.job.execution_cpu_total", metrix.Labels{"nagios_job": "check_disk"}, 0)
-					assertMetricValue(t, flat, "nagios.job.execution_max_rss", metrix.Labels{"nagios_job": "check_disk"}, 0)
+					assertMetricValue(t, flat, "job.execution_cpu_total", metrix.Labels{"nagios_job": "check_disk"}, 0)
+					assertMetricValue(t, flat, "job.execution_max_rss", metrix.Labels{"nagios_job": "check_disk"}, 0)
 				} else {
-					assertMetricMissing(t, flat, "nagios.job.execution_cpu_total", metrix.Labels{"nagios_job": "check_disk"})
-					assertMetricMissing(t, flat, "nagios.job.execution_max_rss", metrix.Labels{"nagios_job": "check_disk"})
+					assertMetricMissing(t, flat, "job.execution_cpu_total", metrix.Labels{"nagios_job": "check_disk"})
+					assertMetricMissing(t, flat, "job.execution_max_rss", metrix.Labels{"nagios_job": "check_disk"})
 				}
-				assertMetricValue(t, flat, "nagios.perfdata.true.bytes_used_value", metrix.Labels{"nagios_job": "check_disk", metrix.MeasureSetFieldLabel: "value"}, 30000)
+				assertMetricValue(t, flat, "perfdata.true.bytes_used_value", metrix.Labels{"nagios_job": "check_disk", metrix.MeasureSetFieldLabel: "value"}, 30000)
 			},
 		},
 		"uses explicit check name for perfdata namespace": {
@@ -426,11 +426,11 @@ func TestCollector_Collect(t *testing.T) {
 				assert.Equal(t, 1, runner.calls)
 
 				flat := coll.MetricStore().Read(metrix.ReadFlatten())
-				assertMetricValue(t, flat, "nagios.perfdata.check_service.job.execution_state", metrix.Labels{"nagios_job": "check_service_job", "nagios.perfdata.check_service.job.execution_state": "ok"}, 1)
-				assertMetricChartFamily(t, flat, "nagios.perfdata.check_service.job.execution_state", "Perfdata/check_service")
-				assertMetricValue(t, flat, "nagios.perfdata.check_service.bytes_used_value", metrix.Labels{"nagios_job": "check_service_job", metrix.MeasureSetFieldLabel: "value"}, 30000)
-				assertMetricMissing(t, flat, "nagios.perfdata.pwsh.job.execution_state", metrix.Labels{"nagios_job": "check_service_job", "nagios.perfdata.pwsh.job.execution_state": "ok"})
-				assertMetricMissing(t, flat, "nagios.perfdata.pwsh.bytes_used_value", metrix.Labels{"nagios_job": "check_service_job", metrix.MeasureSetFieldLabel: "value"})
+				assertMetricValue(t, flat, "perfdata.check_service.job.execution_state", metrix.Labels{"nagios_job": "check_service_job", "perfdata.check_service.job.execution_state": "ok"}, 1)
+				assertMetricChartFamily(t, flat, "perfdata.check_service.job.execution_state", "Perfdata/check_service")
+				assertMetricValue(t, flat, "perfdata.check_service.bytes_used_value", metrix.Labels{"nagios_job": "check_service_job", metrix.MeasureSetFieldLabel: "value"}, 30000)
+				assertMetricMissing(t, flat, "perfdata.pwsh.job.execution_state", metrix.Labels{"nagios_job": "check_service_job", "perfdata.pwsh.job.execution_state": "ok"})
+				assertMetricMissing(t, flat, "perfdata.pwsh.bytes_used_value", metrix.Labels{"nagios_job": "check_service_job", metrix.MeasureSetFieldLabel: "value"})
 
 				*now = now.Add(1 * time.Second)
 			},
@@ -506,22 +506,22 @@ func TestCollector_Collect(t *testing.T) {
 				assert.Equal(t, 1, runner.calls)
 
 				flat := coll.MetricStore().Read(metrix.ReadFlatten())
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "period_job", "nagios.job.execution_state": "ok"}, 1)
-				assertMetricValue(t, flat, "nagios.perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "period_job", "nagios.perfdata.true.job.execution_state": "ok"}, 1)
-				assertMetricValue(t, flat, "nagios.perfdata.true.bytes_used_value", metrix.Labels{"nagios_job": "period_job", metrix.MeasureSetFieldLabel: "value"}, 30000)
-				assertMetricValue(t, flat, "nagios.job.perfdata.threshold_state", metrix.Labels{
-					"nagios_job":                          "period_job",
-					perfdataValueLabelKey:                 "bytes_used",
-					"nagios.job.perfdata.threshold_state": perfThresholdStateWarning,
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "period_job", "job.execution_state": "ok"}, 1)
+				assertMetricValue(t, flat, "perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "period_job", "perfdata.true.job.execution_state": "ok"}, 1)
+				assertMetricValue(t, flat, "perfdata.true.bytes_used_value", metrix.Labels{"nagios_job": "period_job", metrix.MeasureSetFieldLabel: "value"}, 30000)
+				assertMetricValue(t, flat, "job.perfdata.threshold_state", metrix.Labels{
+					"nagios_job":                   "period_job",
+					perfdataValueLabelKey:          "bytes_used",
+					"job.perfdata.threshold_state": perfThresholdStateWarning,
 				}, 1)
 
 				raw := coll.MetricStore().Read()
-				thresholdMetric := "nagios.perfdata.true.bytes_used_threshold_state"
+				thresholdMetric := "perfdata.true.bytes_used_threshold_state"
 				thresholdLabels := metrix.Labels{"nagios_job": "period_job"}
 				point, ok := raw.StateSet(thresholdMetric, thresholdLabels)
 				require.True(t, ok)
 				assert.True(t, point.States[perfThresholdStateWarning])
-				alertThresholdMetric := "nagios.job.perfdata.threshold_state"
+				alertThresholdMetric := "job.perfdata.threshold_state"
 				alertThresholdLabels := metrix.Labels{"nagios_job": "period_job", perfdataValueLabelKey: "bytes_used"}
 				alertPoint, ok := raw.StateSet(alertThresholdMetric, alertThresholdLabels)
 				require.True(t, ok)
@@ -532,11 +532,11 @@ func TestCollector_Collect(t *testing.T) {
 				assert.Equal(t, 1, runner.calls)
 
 				flat = coll.MetricStore().Read(metrix.ReadFlatten())
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "period_job", "nagios.job.execution_state": "paused"}, 1)
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "period_job", "nagios.job.execution_state": "retry"}, 0)
-				assertMetricValue(t, flat, "nagios.perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "period_job", "nagios.perfdata.true.job.execution_state": "paused"}, 1)
-				assertMetricValue(t, flat, "nagios.perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "period_job", "nagios.perfdata.true.job.execution_state": "retry"}, 0)
-				assertMetricValue(t, flat, "nagios.perfdata.true.bytes_used_value", metrix.Labels{"nagios_job": "period_job", metrix.MeasureSetFieldLabel: "value"}, 30000)
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "period_job", "job.execution_state": "paused"}, 1)
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "period_job", "job.execution_state": "retry"}, 0)
+				assertMetricValue(t, flat, "perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "period_job", "perfdata.true.job.execution_state": "paused"}, 1)
+				assertMetricValue(t, flat, "perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "period_job", "perfdata.true.job.execution_state": "retry"}, 0)
+				assertMetricValue(t, flat, "perfdata.true.bytes_used_value", metrix.Labels{"nagios_job": "period_job", metrix.MeasureSetFieldLabel: "value"}, 30000)
 				assertMetricValue(t, flat, thresholdMetric, metrix.Labels{"nagios_job": "period_job", thresholdMetric: perfThresholdStateWarning}, 0)
 				assertMetricValue(t, flat, thresholdMetric, metrix.Labels{"nagios_job": "period_job", thresholdMetric: perfThresholdStateOK}, 0)
 				assertMetricValue(t, flat, thresholdMetric, metrix.Labels{"nagios_job": "period_job", thresholdMetric: perfThresholdStateCritical}, 0)
@@ -567,9 +567,9 @@ func TestCollector_Collect(t *testing.T) {
 				assert.Equal(t, 2, runner.calls)
 
 				flat = coll.MetricStore().Read(metrix.ReadFlatten())
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "period_job", "nagios.job.execution_state": "ok"}, 1)
-				assertMetricValue(t, flat, "nagios.perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "period_job", "nagios.perfdata.true.job.execution_state": "ok"}, 1)
-				assertMetricValue(t, flat, "nagios.perfdata.true.bytes_used_value", metrix.Labels{"nagios_job": "period_job", metrix.MeasureSetFieldLabel: "value"}, 10000)
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "period_job", "job.execution_state": "ok"}, 1)
+				assertMetricValue(t, flat, "perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "period_job", "perfdata.true.job.execution_state": "ok"}, 1)
+				assertMetricValue(t, flat, "perfdata.true.bytes_used_value", metrix.Labels{"nagios_job": "period_job", metrix.MeasureSetFieldLabel: "value"}, 10000)
 
 				raw = coll.MetricStore().Read()
 				point, ok = raw.StateSet(thresholdMetric, thresholdLabels)
@@ -647,19 +647,19 @@ func TestCollector_Collect(t *testing.T) {
 				assert.Equal(t, 1, runner.calls)
 				assert.Equal(t, 2, coll.state.currentAttempt())
 				flat := coll.MetricStore().Read(metrix.ReadFlatten())
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "retry_job", "nagios.job.execution_state": "warning"}, 1)
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "retry_job", "nagios.job.execution_state": "retry"}, 1)
-				assertMetricValue(t, flat, "nagios.perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "retry_job", "nagios.perfdata.true.job.execution_state": "warning"}, 1)
-				assertMetricValue(t, flat, "nagios.perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "retry_job", "nagios.perfdata.true.job.execution_state": "retry"}, 1)
-				assertMetricValue(t, flat, "nagios.job.perfdata.threshold_state", metrix.Labels{
-					"nagios_job":                          "retry_job",
-					perfdataValueLabelKey:                 "bytes_used",
-					"nagios.job.perfdata.threshold_state": perfThresholdStateWarning,
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "retry_job", "job.execution_state": "warning"}, 1)
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "retry_job", "job.execution_state": "retry"}, 1)
+				assertMetricValue(t, flat, "perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "retry_job", "perfdata.true.job.execution_state": "warning"}, 1)
+				assertMetricValue(t, flat, "perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "retry_job", "perfdata.true.job.execution_state": "retry"}, 1)
+				assertMetricValue(t, flat, "job.perfdata.threshold_state", metrix.Labels{
+					"nagios_job":                   "retry_job",
+					perfdataValueLabelKey:          "bytes_used",
+					"job.perfdata.threshold_state": perfThresholdStateWarning,
 				}, 1)
-				assertMetricValue(t, flat, "nagios.job.perfdata.threshold_state", metrix.Labels{
-					"nagios_job":                          "retry_job",
-					perfdataValueLabelKey:                 "bytes_used",
-					"nagios.job.perfdata.threshold_state": perfThresholdStateRetry,
+				assertMetricValue(t, flat, "job.perfdata.threshold_state", metrix.Labels{
+					"nagios_job":                   "retry_job",
+					perfdataValueLabelKey:          "bytes_used",
+					"job.perfdata.threshold_state": perfThresholdStateRetry,
 				}, 1)
 
 				*now = now.Add(9 * time.Second)
@@ -671,17 +671,17 @@ func TestCollector_Collect(t *testing.T) {
 				assert.Equal(t, 2, runner.calls)
 				assert.Equal(t, 1, coll.state.currentAttempt())
 				flat = coll.MetricStore().Read(metrix.ReadFlatten())
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "retry_job", "nagios.job.execution_state": "ok"}, 1)
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "retry_job", "nagios.job.execution_state": "retry"}, 0)
-				assertMetricValue(t, flat, "nagios.job.perfdata.threshold_state", metrix.Labels{
-					"nagios_job":                          "retry_job",
-					perfdataValueLabelKey:                 "bytes_used",
-					"nagios.job.perfdata.threshold_state": perfThresholdStateOK,
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "retry_job", "job.execution_state": "ok"}, 1)
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "retry_job", "job.execution_state": "retry"}, 0)
+				assertMetricValue(t, flat, "job.perfdata.threshold_state", metrix.Labels{
+					"nagios_job":                   "retry_job",
+					perfdataValueLabelKey:          "bytes_used",
+					"job.perfdata.threshold_state": perfThresholdStateOK,
 				}, 1)
-				assertMetricValue(t, flat, "nagios.job.perfdata.threshold_state", metrix.Labels{
-					"nagios_job":                          "retry_job",
-					perfdataValueLabelKey:                 "bytes_used",
-					"nagios.job.perfdata.threshold_state": perfThresholdStateRetry,
+				assertMetricValue(t, flat, "job.perfdata.threshold_state", metrix.Labels{
+					"nagios_job":                   "retry_job",
+					perfdataValueLabelKey:          "bytes_used",
+					"job.perfdata.threshold_state": perfThresholdStateRetry,
 				}, 0)
 			},
 		},
@@ -739,17 +739,17 @@ func TestCollector_Collect(t *testing.T) {
 				assert.Equal(t, 1, runner.calls)
 
 				flat := coll.MetricStore().Read(metrix.ReadFlatten())
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "paused_retry_job", "nagios.job.execution_state": "warning"}, 1)
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "paused_retry_job", "nagios.job.execution_state": "retry"}, 1)
-				assertMetricValue(t, flat, "nagios.job.perfdata.threshold_state", metrix.Labels{
-					"nagios_job":                          "paused_retry_job",
-					perfdataValueLabelKey:                 "bytes_used",
-					"nagios.job.perfdata.threshold_state": perfThresholdStateWarning,
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "paused_retry_job", "job.execution_state": "warning"}, 1)
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "paused_retry_job", "job.execution_state": "retry"}, 1)
+				assertMetricValue(t, flat, "job.perfdata.threshold_state", metrix.Labels{
+					"nagios_job":                   "paused_retry_job",
+					perfdataValueLabelKey:          "bytes_used",
+					"job.perfdata.threshold_state": perfThresholdStateWarning,
 				}, 1)
-				assertMetricValue(t, flat, "nagios.job.perfdata.threshold_state", metrix.Labels{
-					"nagios_job":                          "paused_retry_job",
-					perfdataValueLabelKey:                 "bytes_used",
-					"nagios.job.perfdata.threshold_state": perfThresholdStateRetry,
+				assertMetricValue(t, flat, "job.perfdata.threshold_state", metrix.Labels{
+					"nagios_job":                   "paused_retry_job",
+					perfdataValueLabelKey:          "bytes_used",
+					"job.perfdata.threshold_state": perfThresholdStateRetry,
 				}, 1)
 
 				*now = time.Date(2026, 3, 23, 20, 0, 0, 0, time.UTC)
@@ -757,20 +757,20 @@ func TestCollector_Collect(t *testing.T) {
 				assert.Equal(t, 1, runner.calls)
 
 				flat = coll.MetricStore().Read(metrix.ReadFlatten())
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "paused_retry_job", "nagios.job.execution_state": "paused"}, 1)
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "paused_retry_job", "nagios.job.execution_state": "retry"}, 0)
-				assertMetricValue(t, flat, "nagios.perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "paused_retry_job", "nagios.perfdata.true.job.execution_state": "paused"}, 1)
-				assertMetricValue(t, flat, "nagios.perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "paused_retry_job", "nagios.perfdata.true.job.execution_state": "retry"}, 0)
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "paused_retry_job", "job.execution_state": "paused"}, 1)
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "paused_retry_job", "job.execution_state": "retry"}, 0)
+				assertMetricValue(t, flat, "perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "paused_retry_job", "perfdata.true.job.execution_state": "paused"}, 1)
+				assertMetricValue(t, flat, "perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "paused_retry_job", "perfdata.true.job.execution_state": "retry"}, 0)
 				for _, state := range perfThresholdAlertStateNames {
-					assertMetricValue(t, flat, "nagios.job.perfdata.threshold_state", metrix.Labels{
-						"nagios_job":                          "paused_retry_job",
-						perfdataValueLabelKey:                 "bytes_used",
-						"nagios.job.perfdata.threshold_state": state,
+					assertMetricValue(t, flat, "job.perfdata.threshold_state", metrix.Labels{
+						"nagios_job":                   "paused_retry_job",
+						perfdataValueLabelKey:          "bytes_used",
+						"job.perfdata.threshold_state": state,
 					}, 0)
 				}
 
 				raw := coll.MetricStore().Read()
-				alertPoint, ok := raw.StateSet("nagios.job.perfdata.threshold_state", metrix.Labels{
+				alertPoint, ok := raw.StateSet("job.perfdata.threshold_state", metrix.Labels{
 					"nagios_job":          "paused_retry_job",
 					perfdataValueLabelKey: "bytes_used",
 				})
@@ -808,10 +808,10 @@ func TestCollector_Collect(t *testing.T) {
 				assert.Equal(t, jobStateTimeout, coll.state.currentJobState())
 
 				flat := coll.MetricStore().Read(metrix.ReadFlatten())
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "timeout_job", "nagios.job.execution_state": "timeout"}, 1)
-				assertMetricValue(t, flat, "nagios.job.execution_state", metrix.Labels{"nagios_job": "timeout_job", "nagios.job.execution_state": "retry"}, 1)
-				assertMetricValue(t, flat, "nagios.perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "timeout_job", "nagios.perfdata.true.job.execution_state": "timeout"}, 1)
-				assertMetricValue(t, flat, "nagios.perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "timeout_job", "nagios.perfdata.true.job.execution_state": "retry"}, 1)
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "timeout_job", "job.execution_state": "timeout"}, 1)
+				assertMetricValue(t, flat, "job.execution_state", metrix.Labels{"nagios_job": "timeout_job", "job.execution_state": "retry"}, 1)
+				assertMetricValue(t, flat, "perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "timeout_job", "perfdata.true.job.execution_state": "timeout"}, 1)
+				assertMetricValue(t, flat, "perfdata.true.job.execution_state", metrix.Labels{"nagios_job": "timeout_job", "perfdata.true.job.execution_state": "retry"}, 1)
 
 				*now = now.Add(11 * time.Second)
 				runCollectCycle(t, coll)

--- a/src/go/plugin/scripts.d/collector/nagios/v2_gate_test.go
+++ b/src/go/plugin/scripts.d/collector/nagios/v2_gate_test.go
@@ -79,7 +79,7 @@ func TestV2Gate_G2_PerfdataRouting(t *testing.T) {
 	store := metrix.NewCollectorStore()
 	cc := gateCycleController(t, store)
 	cc.BeginCycle()
-	sm := store.Write().SnapshotMeter("nagios")
+	sm := store.Write().SnapshotMeter("")
 	labels := sm.LabelSet(
 		metrix.Label{Key: "nagios_job", Value: "gate_job"},
 	)
@@ -121,35 +121,35 @@ func TestV2Gate_G2_PerfdataRouting(t *testing.T) {
 	cc.CommitCycleSuccess()
 
 	reader := store.Read(metrix.ReadFlatten())
-	assertMetricMeta(t, reader, "nagios.perfdata.check_gate.time_latency_value", "seconds", true)
-	assertMetricMeta(t, reader, "nagios.perfdata.check_gate.bytes_throughput_value", "bytes", true)
-	assertMetricMeta(t, reader, "nagios.perfdata.check_gate.bits_wire_rate_value", "bits", true)
-	assertMetricMeta(t, reader, "nagios.perfdata.check_gate.percent_free_pct_value", "%", true)
-	assertMetricMeta(t, reader, "nagios.perfdata.check_gate.counter_requests_value", "c", true)
-	assertMetricMeta(t, reader, "nagios.perfdata.check_gate.generic_custom_value", "generic", true)
-	assertMetricMeta(t, reader, "nagios.perfdata.check_gate.time_latency_threshold_state", "state", false)
-	assertMetricMeta(t, reader, "nagios.job.perfdata.threshold_state", "state", false)
-	assertMetricChartFamily(t, reader, "nagios.perfdata.check_gate.time_latency_value", "Perfdata/check_gate")
-	assertMetricChartFamily(t, reader, "nagios.perfdata.check_gate.time_latency_threshold_state", "Perfdata/check_gate")
-	assertMetricValue(t, reader, "nagios.perfdata.check_gate.time_latency_threshold_state", metrix.Labels{
+	assertMetricMeta(t, reader, "perfdata.check_gate.time_latency_value", "seconds", true)
+	assertMetricMeta(t, reader, "perfdata.check_gate.bytes_throughput_value", "bytes", true)
+	assertMetricMeta(t, reader, "perfdata.check_gate.bits_wire_rate_value", "bits", true)
+	assertMetricMeta(t, reader, "perfdata.check_gate.percent_free_pct_value", "%", true)
+	assertMetricMeta(t, reader, "perfdata.check_gate.counter_requests_value", "c", true)
+	assertMetricMeta(t, reader, "perfdata.check_gate.generic_custom_value", "generic", true)
+	assertMetricMeta(t, reader, "perfdata.check_gate.time_latency_threshold_state", "state", false)
+	assertMetricMeta(t, reader, "job.perfdata.threshold_state", "state", false)
+	assertMetricChartFamily(t, reader, "perfdata.check_gate.time_latency_value", "Perfdata/check_gate")
+	assertMetricChartFamily(t, reader, "perfdata.check_gate.time_latency_threshold_state", "Perfdata/check_gate")
+	assertMetricValue(t, reader, "perfdata.check_gate.time_latency_threshold_state", metrix.Labels{
 		"nagios_job": "gate_job",
-		"nagios.perfdata.check_gate.time_latency_threshold_state": perfThresholdStateWarning,
+		"perfdata.check_gate.time_latency_threshold_state": perfThresholdStateWarning,
 	}, 1)
-	assertMetricValue(t, reader, "nagios.job.perfdata.threshold_state", metrix.Labels{
-		"nagios_job":                          "gate_job",
-		perfdataValueLabelKey:                 "time_latency",
-		"nagios.job.perfdata.threshold_state": perfThresholdStateWarning,
+	assertMetricValue(t, reader, "job.perfdata.threshold_state", metrix.Labels{
+		"nagios_job":                   "gate_job",
+		perfdataValueLabelKey:          "time_latency",
+		"job.perfdata.threshold_state": perfThresholdStateWarning,
 	}, 1)
-	assertMetricValue(t, reader, "nagios.job.perfdata.threshold_state", metrix.Labels{
-		"nagios_job":                          "gate_job",
-		perfdataValueLabelKey:                 "time_latency",
-		"nagios.job.perfdata.threshold_state": perfThresholdStateRetry,
+	assertMetricValue(t, reader, "job.perfdata.threshold_state", metrix.Labels{
+		"nagios_job":                   "gate_job",
+		perfdataValueLabelKey:          "time_latency",
+		"job.perfdata.threshold_state": perfThresholdStateRetry,
 	}, 0)
-	assertSeriesKind(t, reader, "nagios.perfdata.check_gate.time_latency_value", metrix.Labels{
+	assertSeriesKind(t, reader, "perfdata.check_gate.time_latency_value", metrix.Labels{
 		"nagios_job":                "gate_job",
 		metrix.MeasureSetFieldLabel: perfFieldValue,
 	}, metrix.MetricKindGauge)
-	assertSeriesKind(t, reader, "nagios.perfdata.check_gate.counter_requests_value", metrix.Labels{
+	assertSeriesKind(t, reader, "perfdata.check_gate.counter_requests_value", metrix.Labels{
 		"nagios_job":                "gate_job",
 		metrix.MeasureSetFieldLabel: perfFieldValue,
 	}, metrix.MetricKindCounter)
@@ -172,7 +172,7 @@ func TestV2Gate_G3_ChartLifecycleChurn(t *testing.T) {
 		emit := func(includeB bool) chartengine.Plan {
 			cc := gateCycleController(t, store)
 			cc.BeginCycle()
-			sm := store.Write().SnapshotMeter("nagios")
+			sm := store.Write().SnapshotMeter("")
 			ls := sm.LabelSet(
 				metrix.Label{Key: "nagios_job", Value: "gate_job"},
 			)
@@ -211,7 +211,7 @@ func TestV2Gate_G3_ChartLifecycleChurn(t *testing.T) {
 
 		cc := gateCycleController(t, store)
 		cc.BeginCycle()
-		sm := store.Write().SnapshotMeter("nagios")
+		sm := store.Write().SnapshotMeter("")
 		ls := sm.LabelSet(
 			metrix.Label{Key: "nagios_job", Value: "gate_job"},
 		)
@@ -238,12 +238,12 @@ func TestV2Gate_G3_ChartLifecycleChurn(t *testing.T) {
 		assert.NotZero(t, countActions[chartengine.CreateChartAction](plan1.Actions))
 		plan2 := emit(false)
 		assert.Zero(t, removeActionsCount(plan2.Actions))
-		assertPlanHasUpdateForTarget(t, plan2, "nagios.perfdata.check_gate.bytes_a")
-		assertPlanHasNoRemoveForTarget(t, plan2, "nagios.perfdata.check_gate.bytes_b")
+		assertPlanHasUpdateForTarget(t, plan2, "perfdata.check_gate.bytes_a")
+		assertPlanHasNoRemoveForTarget(t, plan2, "perfdata.check_gate.bytes_b")
 
 		cc := gateCycleController(t, store)
 		cc.BeginCycle()
-		sm := store.Write().SnapshotMeter("nagios")
+		sm := store.Write().SnapshotMeter("")
 		ls := sm.LabelSet(
 			metrix.Label{Key: "nagios_job", Value: "gate_job"},
 		)
@@ -260,8 +260,8 @@ func TestV2Gate_G3_ChartLifecycleChurn(t *testing.T) {
 
 		plan3 := emit(false)
 		assert.Zero(t, removeActionsCount(plan3.Actions))
-		assertPlanHasUpdateForTarget(t, plan3, "nagios.perfdata.check_gate.bytes_a")
-		assertPlanHasNoRemoveForTarget(t, plan3, "nagios.perfdata.check_gate.bytes_b")
+		assertPlanHasUpdateForTarget(t, plan3, "perfdata.check_gate.bytes_a")
+		assertPlanHasNoRemoveForTarget(t, plan3, "perfdata.check_gate.bytes_b")
 		plan4 := emit(false)
 		assert.Zero(t, removeActionsCount(plan4.Actions))
 	})
@@ -318,7 +318,7 @@ func TestV2Gate_G5_ScalingPrecisionEquivalence(t *testing.T) {
 			store := metrix.NewCollectorStore()
 			cc := gateCycleController(t, store)
 			cc.BeginCycle()
-			sm := store.Write().SnapshotMeter("nagios")
+			sm := store.Write().SnapshotMeter("")
 			for _, measureSet := range samples.values {
 				fields := perfMeasureSetValues(measureSet.value)
 				if measureSet.counter {
@@ -339,10 +339,54 @@ func TestV2Gate_G5_ScalingPrecisionEquivalence(t *testing.T) {
 			}
 			cc.CommitCycleSuccess()
 			flat := store.Read(metrix.ReadFlatten())
-			assertMetricMeta(t, flat, "nagios."+candidateKey, tc.expectedUnit, true)
-			assertMetricChartFamily(t, flat, "nagios."+candidateKey, "Perfdata/check_gate")
+			assertMetricMeta(t, flat, candidateKey, tc.expectedUnit, true)
+			assertMetricChartFamily(t, flat, candidateKey, "Perfdata/check_gate")
 		})
 	}
+}
+
+// With an empty meter prefix and context_namespace: nagios, an autogen perfdata chart's context
+// is single-namespaced (nagios.perfdata.*) — never doubled (nagios.nagios.*) and never bare
+// (perfdata.*). The chart ID intentionally drops the redundant nagios. prefix; the collector
+// identity is already in the chart type (the job full name).
+func TestV2Gate_AutogenPerfdataContextSingleNamespaced(t *testing.T) {
+	engine, err := chartengine.New()
+	require.NoError(t, err)
+	require.NoError(t, engine.LoadYAML([]byte(New().ChartTemplateYAML()), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := gateCycleController(t, store)
+	cc.BeginCycle()
+	sm := store.Write().SnapshotMeter("")
+	ls := sm.LabelSet(metrix.Label{Key: "nagios_job", Value: "check_mem"})
+	fields := defaultPerfMeasureSetValues()
+	fields[perfFieldValue] = 30000
+	sm.MeasureSetGauge(
+		"perfdata.check_memory.bytes_used",
+		metrix.WithMeasureSetFields(perfMeasureSetFieldSpecs()...),
+		metrix.WithChartFamily(perfdataFamily("check_memory")),
+		metrix.WithUnit("bytes"),
+	).ObserveFields(fields, ls)
+	cc.CommitCycleSuccess()
+
+	plan, err := prepareCommittedPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+
+	var found bool
+	for _, action := range plan.Actions {
+		create, ok := action.(chartengine.CreateChartAction)
+		if !ok || !strings.Contains(create.ChartID, "perfdata.check_memory") {
+			continue
+		}
+		found = true
+		assert.Equal(t, "nagios.perfdata.check_memory.bytes_used", create.Meta.Context,
+			"autogen perfdata context must be single-namespaced via context_namespace")
+		assert.NotContains(t, create.Meta.Context, "nagios.nagios.",
+			"autogen context must not double-prefix the namespace")
+		assert.Falsef(t, strings.HasPrefix(create.ChartID, "nagios."),
+			"autogen chart ID should drop the redundant nagios. prefix, got %q", create.ChartID)
+	}
+	require.True(t, found, "expected an autogen create-chart action for the perfdata measureset")
 }
 
 func countActions[T any](actions []chartengine.EngineAction) int {


### PR DESCRIPTION
##### Summary

Part of #22635

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Autogen chart contexts now honor the spec’s top-level `context_namespace`, so unmatched metrics share the same namespace as template charts. The Nagios collector now relies on the template namespace (no local `nagios` meter prefix) to avoid doubled or missing prefixes.

- **New Features**
  - `chartengine`: prefix autogen chart contexts with the top-level `context_namespace` (joined with `.`; group-level does not apply). Uses the full metric name (including any meter prefix), so prefer `SnapshotMeter("")` when `context_namespace` is set; empty namespace leaves the metric name unchanged.

- **Refactors**
  - Nagios: remove the `nagios` meter prefix; `charts.yaml` `context_namespace: nagios` provides the namespace.
  - Nagios templates: selectors now use `job.*` and `perfdata.*`; contexts remain `nagios.job.*` and `nagios.perfdata.*`. Only internal metric names and autogen perfdata chart IDs changed.

<sup>Written for commit ba637287cf4f892766b4f1f1c74b36e93670dee4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

