### PR TITLE
chore(go.d/framework): render non-finite summary quantile values as a gap

### DIFF
--- a/src/go/pkg/metrix/README.md
+++ b/src/go/pkg/metrix/README.md
@@ -94,10 +94,10 @@
 
 ### Writers
 
-| Mode     | Gauge-like family                                                                                                               | Counter-like family                                                                                           |
-|----------|---------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
-| Snapshot | `MeasureSetGauge(...).ObservePoint(...)` or preferred `ObserveFields(...)`                                                      | `MeasureSetCounter(...).ObserveTotalPoint(...)` or preferred `ObserveTotalFields(...)`                       |
-| Stateful | `MeasureSetGauge(...).SetPoint(...)`, `AddPoint(...)`, `SetFields(...)`, `AddFields(...)`, `SetField(...)`, `AddField(...)`    | `MeasureSetCounter(...).AddPoint(...)`, `AddFields(...)`, `AddField(...)`                                    |
+| Mode     | Gauge-like family                                                                                                           | Counter-like family                                                                    |
+|----------|-----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| Snapshot | `MeasureSetGauge(...).ObservePoint(...)` or preferred `ObserveFields(...)`                                                  | `MeasureSetCounter(...).ObserveTotalPoint(...)` or preferred `ObserveTotalFields(...)` |
+| Stateful | `MeasureSetGauge(...).SetPoint(...)`, `AddPoint(...)`, `SetFields(...)`, `AddFields(...)`, `SetField(...)`, `AddField(...)` | `MeasureSetCounter(...).AddPoint(...)`, `AddFields(...)`, `AddField(...)`              |
 
 ### Phase-1 write contract
 
@@ -243,6 +243,7 @@ see [how-to-write-a-collector.md](/src/go/plugin/go.d/docs/how-to-write-a-collec
 - **Schema stability** — Re-registering an existing metric name with different kind/mode/schema returns an error (or panics in strict runtime paths).
 - **MeasureSet flatten naming** — Flattened `MeasureSet` series use per-field metric names like `<name>_<field>` and also carry a synthetic `measure_field=<field>` label.
 - **MeasureSet counter semantics** — Stateful counter-like `MeasureSet` families reject negative `AddPoint(...)` deltas, just like scalar counters.
+- **Summary NaN quantiles** — a summary point may carry NaN quantile *values* (e.g. an empty observation window); they are stored (only Inf is rejected) and render as a chart gap downstream (chartengine emits `SETEMPTY`). Count and Sum must still be finite.
 - **Collector retention** — `CollectorStore` evicts series not seen for 10 successful cycles by default.
 
 ## Internal Architecture Notes

--- a/src/go/pkg/metrix/summary.go
+++ b/src/go/pkg/metrix/summary.go
@@ -219,7 +219,11 @@ func normalizeSummaryPoint(point SummaryPoint, schema *summarySchema) (SampleVal
 		if idx == -1 {
 			panic(fmt.Errorf("%w: quantile %v is not declared", errSummaryPoint, q.Quantile))
 		}
-		mustFiniteSample(q.Value)
+		// A summary may report a NaN quantile value (e.g. an empty observation window). Store it;
+		// chartengine renders a non-finite dimension value as a gap (SETEMPTY). Reject only Inf.
+		if math.IsInf(float64(q.Value), 0) {
+			panic(fmt.Errorf("%w: infinite quantile value %v", errSummaryPoint, q.Value))
+		}
 		values[idx] = q.Value
 	}
 

--- a/src/go/pkg/metrix/summary_store_test.go
+++ b/src/go/pkg/metrix/summary_store_test.go
@@ -13,6 +13,34 @@ func TestSummaryStoreScenarios(t *testing.T) {
 	tests := map[string]struct {
 		run func(t *testing.T)
 	}{
+		"snapshot summary stores NaN quantile values (sparse window -> gap downstream)": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				sum := s.Write().SnapshotMeter("svc").Summary("latency", WithSummaryQuantiles(0.5, 0.9))
+
+				cc.BeginCycle()
+				require.NotPanics(t, func() {
+					sum.ObservePoint(SummaryPoint{
+						Count: 0,
+						Sum:   0,
+						Quantiles: []QuantilePoint{
+							{Quantile: 0.5, Value: SampleValue(math.NaN())},
+							{Quantile: 0.9, Value: SampleValue(math.NaN())},
+						},
+					})
+				})
+				cc.CommitCycleSuccess()
+
+				point, ok := s.Read().Summary("svc.latency", nil)
+				require.True(t, ok)
+				require.Len(t, point.Quantiles, 2)
+				for _, q := range point.Quantiles {
+					require.Truef(t, math.IsNaN(float64(q.Value)),
+						"quantile %v value must be stored as NaN, got %v", q.Quantile, q.Value)
+				}
+			},
+		},
 		"snapshot summary count sum read and flatten": {
 			run: func(t *testing.T) {
 				s := NewCollectorStore()

--- a/src/go/pkg/metrix/value_validation_test.go
+++ b/src/go/pkg/metrix/value_validation_test.go
@@ -71,7 +71,9 @@ func TestValueValidationScenarios(t *testing.T) {
 						Count: 1,
 						Sum:   1,
 						Quantiles: []QuantilePoint{
-							{Quantile: 0.5, Value: math.NaN()},
+							// A NaN quantile value is accepted (stored, then rendered
+							// downstream as a gap), so only an Inf value panics here.
+							{Quantile: 0.5, Value: math.Inf(1)},
 						},
 					})
 				})

--- a/src/go/plugin/framework/chartemit/apply.go
+++ b/src/go/plugin/framework/chartemit/apply.go
@@ -4,6 +4,7 @@ package chartemit
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -212,6 +213,12 @@ func emitUpdatePhase(api *netdataapi.API, env EmitEnv, updates []UpdateChartActi
 				continue
 			}
 			if dim.IsFloat {
+				// Defensive: a non-finite float renders as 0 on the wire (the C parser accepts
+				// only lowercase "nan"); emit a gap. The planner already maps these to IsEmpty.
+				if math.IsNaN(dim.Float64) || math.IsInf(dim.Float64, 0) {
+					api.SETEMPTY(sanitizeWireID(dim.Name))
+					continue
+				}
 				api.SETFLOAT(sanitizeWireID(dim.Name), dim.Float64)
 				continue
 			}

--- a/src/go/plugin/framework/chartemit/apply_test.go
+++ b/src/go/plugin/framework/chartemit/apply_test.go
@@ -4,6 +4,7 @@ package chartemit
 
 import (
 	"bytes"
+	"math"
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine"
@@ -240,6 +241,47 @@ END
 
 `, out)
 	assert.NotContains(t, out, "SET 'total' = 7.9")
+}
+
+func TestApplyPlanGapsNonFiniteFloatUpdate(t *testing.T) {
+	var buf bytes.Buffer
+	api := netdataapi.New(&buf)
+
+	meta := chartengine.ChartMeta{
+		Title:     "Latency",
+		Family:    "Latency",
+		Context:   "svc.latency",
+		Units:     "ms",
+		Algorithm: chartengine.AlgorithmAbsolute,
+		Type:      chartengine.ChartTypeLine,
+	}
+
+	plan := Plan{
+		Actions: []EngineAction{
+			chartengine.CreateChartAction{ChartTemplateID: "g0c0", ChartID: "svc_latency", Meta: meta},
+			chartengine.CreateDimensionAction{
+				ChartID: "svc_latency", ChartMeta: meta, Name: "value",
+				Float: true, Algorithm: chartengine.AlgorithmAbsolute, Multiplier: 1, Divisor: 1,
+			},
+			chartengine.UpdateChartAction{
+				ChartID: "svc_latency",
+				Values: []chartengine.UpdateDimensionValue{
+					{Name: "value", IsFloat: true, Float64: math.NaN()},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, ApplyPlan(api, plan, EmitEnv{
+		TypeID: "collector.job", UpdateEvery: 1, Plugin: "go.d.plugin", Module: "prometheus",
+		JobName: "job01", MSSinceLast: 1,
+	}))
+
+	out := buf.String()
+	// A non-finite float dimension is emitted as a gap (empty SET), never "SET = NaN" (which the C
+	// agent would render as 0).
+	assert.NotContains(t, out, "NaN")
+	assert.Contains(t, out, "SET 'value' = \n")
 }
 
 func TestApplyPlanDimensionOnlyCreateEmitsLabelsAndCommit(t *testing.T) {

--- a/src/go/plugin/framework/chartengine/README.md
+++ b/src/go/plugin/framework/chartengine/README.md
@@ -83,11 +83,11 @@ plan := attempt.Plan()
 defer attempt.Abort()
 
 err = chartemit.ApplyPlan(api, plan, chartemit.EmitEnv{
-TypeID:      "plugin.job",
-UpdateEvery: 1,
-Plugin:      "example",
-Module:      "example",
-JobName:     "example",
+	TypeID:      "plugin.job",
+	UpdateEvery: 1,
+	Plugin:      "example",
+	Module:      "example",
+	JobName:     "example",
 })
 // handle err
 err = attempt.Commit()
@@ -124,13 +124,13 @@ If inferred dimensions are present without flattened reader metadata, `PreparePl
 
 ## Action Semantics
 
-| Action                  | Meaning                                                                |
-|-------------------------|------------------------------------------------------------------------|
-| `CreateChartAction`     | Materialize chart instance (with chart metadata and labels)            |
-| `CreateDimensionAction` | Materialize dimension for a chart                                      |
-| `UpdateChartAction`     | Emit chart values for current cycle; unseen dims become `IsEmpty=true` |
-| `RemoveDimensionAction` | Obsolete one dimension                                                 |
-| `RemoveChartAction`     | Obsolete one chart                                                     |
+| Action                  | Meaning                                                                                                                              |
+|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `CreateChartAction`     | Materialize chart instance (with chart metadata and labels)                                                                          |
+| `CreateDimensionAction` | Materialize dimension for a chart                                                                                                    |
+| `UpdateChartAction`     | Emit chart values for current cycle; unseen dims, and dims whose value is non-finite (NaN/Inf), become `IsEmpty=true` (gap, never 0) |
+| `RemoveDimensionAction` | Obsolete one dimension                                                                                                               |
+| `RemoveChartAction`     | Obsolete one chart                                                                                                                   |
 
 `chartemit` normalizes emitted action order by phase:
 

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -4,6 +4,7 @@ package chartengine
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -598,6 +599,12 @@ func (e *Engine) materializePlanCharts(ctx *planBuildContext) error {
 		for _, name := range updateNames {
 			entry, ok := cs.entries[name]
 			if ok && entry != nil && entry.seenSeq == cs.currentBuildSeq {
+				if math.IsNaN(entry.value) || math.IsInf(entry.value, 0) {
+					// A non-finite value (e.g. a summary quantile with no observations this
+					// cycle) must render as a gap, not 0: emit SETEMPTY rather than carry NaN.
+					values = append(values, UpdateDimensionValue{Name: name, IsEmpty: true})
+					continue
+				}
 				values = append(values, UpdateDimensionValue{
 					Name:    name,
 					IsFloat: entry.float,

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -3,6 +3,7 @@
 package chartengine
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -235,6 +236,8 @@ func TestBuildPlanLegacySingleScenarioCases(t *testing.T) {
 		"BuildPlanEmptyEmissionAndScratchReusePruneAcrossCycles":       {run: runTestBuildPlanEmptyEmissionAndScratchReusePruneAcrossCycles},
 		"BuildPlanAutogenContextNamespacePrefixesContext":              {run: runTestBuildPlanAutogenContextNamespacePrefixesContext},
 		"BuildPlanAutogenContextNamespaceStubGroupOnly":                {run: runTestBuildPlanAutogenContextNamespaceStubGroupOnly},
+		"BuildPlanSummaryNaNQuantileGaps":                              {run: runTestBuildPlanSummaryNaNQuantileGaps},
+		"BuildPlanSummaryMixedFiniteNaNQuantileGaps":                   {run: runTestBuildPlanSummaryMixedFiniteNaNQuantileGaps},
 	}
 
 	for name, tc := range tests {
@@ -2382,6 +2385,109 @@ func actionKinds(actions []EngineAction) []ActionKind {
 		out = append(out, action.Kind())
 	}
 	return out
+}
+
+// A summary scraped with NaN quantile values is still an OBSERVED point, so its quantile chart is
+// created (not skipped by the observedCount==0 path) and each NaN quantile dim renders as a gap
+// (IsEmpty → SETEMPTY), never a 0 value.
+func runTestBuildPlanSummaryNaNQuantileGaps(t *testing.T) {
+	e, err := New(WithEnginePolicy(EnginePolicy{Autogen: &AutogenPolicy{Enabled: true}}))
+	require.NoError(t, err)
+	require.NoError(t, e.LoadYAML([]byte(`
+version: v1
+groups:
+  - family: Service
+`), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := mustCycleController(t, store)
+	sum := store.Write().SnapshotMeter("svc").Summary("latency", metrix.WithSummaryQuantiles(0.5, 0.9))
+
+	cc.BeginCycle()
+	sum.ObservePoint(metrix.SummaryPoint{
+		Count: 0,
+		Sum:   0,
+		Quantiles: []metrix.QuantilePoint{
+			{Quantile: 0.5, Value: metrix.SampleValue(math.NaN())},
+			{Quantile: 0.9, Value: metrix.SampleValue(math.NaN())},
+		},
+	})
+	cc.CommitCycleSuccess()
+
+	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+
+	require.NotNil(t, findCreateChartActionByID(plan, "svc.latency"),
+		"summary quantile chart should be created from an observed all-NaN point")
+
+	var quantileUpdate *UpdateChartAction
+	for i := range plan.Actions {
+		if u, ok := plan.Actions[i].(UpdateChartAction); ok && u.ChartID == "svc.latency" {
+			cp := u
+			quantileUpdate = &cp
+			break
+		}
+	}
+	require.NotNil(t, quantileUpdate, "expected an update action for the quantile chart")
+	require.NotEmpty(t, quantileUpdate.Values)
+	for _, v := range quantileUpdate.Values {
+		assert.Truef(t, v.IsEmpty, "NaN quantile dim %q must gap (IsEmpty), got %+v", v.Name, v)
+	}
+}
+
+func runTestBuildPlanSummaryMixedFiniteNaNQuantileGaps(t *testing.T) {
+	e, err := New(WithEnginePolicy(EnginePolicy{Autogen: &AutogenPolicy{Enabled: true}}))
+	require.NoError(t, err)
+	require.NoError(t, e.LoadYAML([]byte(`
+version: v1
+groups:
+  - family: Service
+`), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := mustCycleController(t, store)
+	sum := store.Write().SnapshotMeter("svc").Summary("latency", metrix.WithSummaryQuantiles(0.5, 0.9))
+
+	// One quantile carries a finite value, the other is NaN: the planner must gap
+	// only the NaN dimension and keep the finite one (per-dimension, same chart).
+	cc.BeginCycle()
+	sum.ObservePoint(metrix.SummaryPoint{
+		Count: 1,
+		Sum:   0.4,
+		Quantiles: []metrix.QuantilePoint{
+			{Quantile: 0.5, Value: 0.4},
+			{Quantile: 0.9, Value: metrix.SampleValue(math.NaN())},
+		},
+	})
+	cc.CommitCycleSuccess()
+
+	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+
+	require.NotNil(t, findCreateChartActionByID(plan, "svc.latency"),
+		"summary quantile chart should be created")
+
+	var quantileUpdate *UpdateChartAction
+	for i := range plan.Actions {
+		if u, ok := plan.Actions[i].(UpdateChartAction); ok && u.ChartID == "svc.latency" {
+			cp := u
+			quantileUpdate = &cp
+			break
+		}
+	}
+	require.NotNil(t, quantileUpdate, "expected an update action for the quantile chart")
+	require.Len(t, quantileUpdate.Values, 2, "expected both quantile dimensions")
+
+	var empty, finite int
+	for _, v := range quantileUpdate.Values {
+		if v.IsEmpty {
+			empty++
+		} else {
+			finite++
+		}
+	}
+	assert.Equalf(t, 1, empty, "exactly the NaN quantile dim must gap, got %+v", quantileUpdate.Values)
+	assert.Equalf(t, 1, finite, "exactly the finite quantile dim must carry a value, got %+v", quantileUpdate.Values)
 }
 
 func findUpdateAction(plan Plan) *UpdateChartAction {


### PR DESCRIPTION
##### Summary

Part of #22635

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render non-finite summary quantile values as gaps instead of 0. `metrix` now stores NaN quantiles (rejects Inf), and the engine emits `SETEMPTY` so charts show gaps for empty windows and invalid values.

- **Bug Fixes**
  - `metrix`: allow NaN quantile values; reject Inf; `Count` and `Sum` must be finite.
  - `chartengine` and `chartemit`: map non-finite dimension values to gaps (`IsEmpty` → `SETEMPTY`) before conversion; works for snapshot and stateful summaries; only NaN dims gap in mixed finite/NaN cases.
  - Docs/tests: updated README notes; added planner/emitter tests (including no "NaN" on the wire).

<sup>Written for commit 99e9fc968562e0cb1262fcd4bf7b0c16b0bafe74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

