### PR TITLE
docs(go.d): add V1-to-V2 parity-manifest recipe and V2-collector patterns

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -78,6 +78,19 @@ source files for evidence.
   gauges.
 - Put multipliers, divisors, hidden flags, and float formatting in the chart
   template, not ad hoc chart-emission code.
+- `metrix` registers a descriptor per metric NAME permanently (no unregister), so
+  re-registering a name with a changed kind, summary quantile set, or histogram
+  bounds PANICS. When a name's contract can drift across cycles, keep the per-name
+  handle for the job lifetime and SKIP a drifted series instead of re-registering.
+- To reproduce a V1 chart context in a migration, inject `context_namespace` (the
+  fixed prefix, or `prefix.<app>` per job) so autogen rebuilds `prefix.<metric>` /
+  `prefix.<app>.<metric>` without hand-built chart IDs.
+- Skip empty distributions -- e.g. a summary whose every quantile is NaN -- so a
+  chart waits for real data, matching how scalar NaN values are already skipped.
+- For dynamic surfaces whose label sets churn, `metrix`'s `Vec` handle cache is
+  unbounded; cache per-series instruments yourself and evict handles unseen for N
+  cycles to stay bounded. Prefer a framework fix if the need is general
+  (Decision Discipline).
 
 ## Compatibility Rules
 

--- a/src/go/plugin/go.d/docs/migrate-v1-to-v2.md
+++ b/src/go/plugin/go.d/docs/migrate-v1-to-v2.md
@@ -351,6 +351,37 @@ variable-equivalent design, or approved alert change.
 Prefer table-driven tests using `map[string]struct{}` keyed by case name when
 cases share setup and assertion shape.
 
+### Parity manifest recipe
+
+When chart-identity parity needs the compiled fields above and no shared helper
+observes them, this is a concrete form of that "manual comparison recipe": prove
+context/dimension/value parity by rendering BOTH collectors into one manifest
+shape, without depending on chart-ID string equality.
+
+1. Freeze the V1 output as a golden manifest. For representative fixtures, run
+   the V1 `Collect()` + `Charts()` and serialize, per chart: context, type,
+   family, units, priority, and per dimension the name, algorithm, and de-scaled
+   value (the V1 `map[string]int64` value divided by the dimension `Div`). Commit
+   the goldens under `testdata/`.
+2. Render the V2 path into the same shape. Load the collector's LIVE
+   `ChartTemplateYAML()` into a real `chartengine`, run a cycle through the real
+   `Collect()` and `metrix` store, plan against the store, and read the plan's
+   create/update actions into the same per-chart structure.
+3. Compare structurally with a float tolerance. V1 truncates `value*Div` to
+   `int64` while V2 stores the true float, so compare values within a tolerance
+   (for example `1e-3`), not for exact equality. Assert that context, family,
+   units, dimension names, and dimension algorithms match.
+
+Compare chart IDs too when the migration preserves them (the default). Omit only
+chart-ID equality when the user approved a breaking chart-ID change -- then the
+preserved contract is the context, and chart-ID-keyed alert examples in
+`src/health/REFERENCE.md` must be updated. A gap (NaN or absent value) MUST fail
+the comparison loudly; never silently map it to 0.
+
+The render MUST go through the collector's LIVE `ChartTemplateYAML()` and store,
+not a separately rebuilt template -- a test that rebuilds the template can pass
+even when the shipped `ChartTemplateYAML()` is wrong.
+
 ## Validation
 
 Run the narrowest commands that prove the changed contract. Typical migration


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a V1→V2 parity-manifest test recipe and V2 collector patterns to the migration docs. This helps verify chart/context/dimension/value parity and avoid `metrix` pitfalls during migrations.

- **Migration**
  - Parity recipe: freeze V1 golden manifest; render V2 via live `ChartTemplateYAML()` + store + `chartengine`; compare structures with a small float tolerance; gaps fail loudly.
  - Compare chart IDs when preserved; if a breaking ID change is approved, compare by context and update alert examples.
  - `metrix` guidance: descriptors are permanent; keep per-name handles and skip drifted series instead of re-registering.
  - Tips: inject `context_namespace` for V1 context parity; skip all-NaN distributions; bound per-series caches for churning label sets.

<sup>Written for commit 7f6b1314b6f7abaec8342b135963f07cb3bfd164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

