### PR TITLE
Force updater to actually update in CI checks.

### DIFF
--- a/.github/scripts/run-updater-check.sh
+++ b/.github/scripts/run-updater-check.sh
@@ -14,7 +14,7 @@ echo "::endgroup::"
 echo ">>> Updating Netdata..."
 export NETDATA_BASE_URL="http://localhost:8080" # Pull the tarball from the local web server.
 echo 'NETDATA_ACCEPT_MAJOR_VERSIONS="1 9999"' > /etc/netdata/netdata-updater.conf
-timeout 3600 sh -x packaging/installer/netdata-updater.sh --not-running-from-cron --no-updater-self-update
+timeout 3600 sh -x packaging/installer/netdata-updater.sh --force-update --not-running-from-cron --no-updater-self-update
 
 case "$?" in
     124) echo "!!! Updater timed out." ; exit 1 ;;

--- a/.github/scripts/run-updater-check.sh
+++ b/.github/scripts/run-updater-check.sh
@@ -1,22 +1,26 @@
 #!/bin/sh
 
-echo ">>> Installing CI support packages..."
+echo "::group::>>> Installing CI support packages..."
 sh -x .github/scripts/ci-support-pkgs.sh
+echo "::endgroup::"
 mkdir -p /etc/cron.daily # Needed to make auto-update checking work correctly on some platforms.
-echo ">>> Installing Netdata..."
+echo "::group::>>> Installing Netdata..."
 sh -x packaging/installer/kickstart.sh --dont-wait --build-only --dont-start-it --disable-telemetry "${EXTRA_INSTALL_FLAGS:+--local-build-options "${EXTRA_INSTALL_FLAGS}"}" || exit 1
+echo "::endgroup::"
 echo "::group::>>> Pre-Update Environment File Contents"
 cat /etc/netdata/.environment
 echo "::endgroup::"
 echo "::group::>>> Pre-Update Netdata Build Info"
 netdata -W buildinfo
 echo "::endgroup::"
-echo ">>> Updating Netdata..."
+echo "::group::>>> Updating Netdata..."
 export NETDATA_BASE_URL="http://localhost:8080" # Pull the tarball from the local web server.
 echo 'NETDATA_ACCEPT_MAJOR_VERSIONS="1 9999"' > /etc/netdata/netdata-updater.conf
 timeout 3600 sh -x packaging/installer/netdata-updater.sh --force-update --not-running-from-cron --no-updater-self-update
+ret="$?"
+echo "::endgroup::"
 
-case "$?" in
+case "${ret}" in
     124) echo "!!! Updater timed out." ; exit 1 ;;
     0) ;;
     *) echo "!!! Updater failed." ; exit 1 ;;

--- a/.github/scripts/run-updater-check.sh
+++ b/.github/scripts/run-updater-check.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 echo "::group::>>> Installing CI support packages..."
-sh -x .github/scripts/ci-support-pkgs.sh
+sh -x .github/scripts/ci-support-pkgs.sh || exit 1
 echo "::endgroup::"
 mkdir -p /etc/cron.daily # Needed to make auto-update checking work correctly on some platforms.
 echo "::group::>>> Installing Netdata..."
-sh -x packaging/installer/kickstart.sh --dont-wait --build-only --dont-start-it --disable-telemetry "${EXTRA_INSTALL_FLAGS:+--local-build-options "${EXTRA_INSTALL_FLAGS}"}" || exit 1
+sh -x packaging/installer/kickstart.sh --dont-wait --build-only --dont-start-it --disable-telemetry ${EXTRA_INSTALL_FLAGS:+--local-build-options "${EXTRA_INSTALL_FLAGS}"} || exit 1
 echo "::endgroup::"
 echo "::group::>>> Pre-Update Environment File Contents"
 cat /etc/netdata/.environment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -649,10 +649,10 @@ jobs:
         id: prepare
         if: needs.file-check.outputs.run == 'true'
         run: |
-          mkdir -p download/latest latest "download/$(cat artifacts/latest-version.txt)"
+          mkdir -p download/latest latest "download/$(cat packaging/version)"
           mv artifacts/* download/latest
           cp -a download/latest/* latest
-          cp -a download/latest/* "download/$(cat artifacts/latest-version.txt)"
+          cp -a download/latest/* "download/$(cat packaging/version)"
           ls -al download/latest
       - name: Verify that artifacts work with installer
         id: verify
@@ -720,10 +720,10 @@ jobs:
         id: prepare
         if: needs.file-check.outputs.run == 'true'
         run: |
-          mkdir -p download/latest latest "download/$(cat artifacts/latest-version.txt)"
+          mkdir -p download/latest latest "download/$(cat packaging/version)"
           mv artifacts/* download/latest
           cp -a download/latest/* latest
-          cp -a download/latest/* "download/$(cat artifacts/latest-version.txt)"
+          cp -a download/latest/* "download/$(cat packaging/version)"
           ls -al download/latest
       - name: Verify that artifacts work with installer
         id: verify
@@ -791,10 +791,10 @@ jobs:
         id: prepare
         if: needs.file-check.outputs.run == 'true'
         run: |
-          mkdir -p download/latest latest "download/$(cat artifacts/latest-version.txt)"
+          mkdir -p download/latest latest "download/$(cat packaging/version)"
           mv artifacts/* download/latest
           cp -a download/latest/* latest
-          cp -a download/latest/* "download/$(cat artifacts/latest-version.txt)"
+          cp -a download/latest/* "download/$(cat packaging/version)"
           ls -al download/latest
       - name: Run Updater Check
         id: check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -649,9 +649,10 @@ jobs:
         id: prepare
         if: needs.file-check.outputs.run == 'true'
         run: |
-          mkdir -p download/latest latest
+          mkdir -p download/latest latest "download/$(cat artifacts/latest-version.txt)"
           mv artifacts/* download/latest
           cp -a download/latest/* latest
+          cp -a download/latest/* "download/$(cat artifacts/latest-version.txt)"
           ls -al download/latest
       - name: Verify that artifacts work with installer
         id: verify
@@ -719,9 +720,10 @@ jobs:
         id: prepare
         if: needs.file-check.outputs.run == 'true'
         run: |
-          mkdir -p download/latest latest
+          mkdir -p download/latest latest "download/$(cat artifacts/latest-version.txt)"
           mv artifacts/* download/latest
           cp -a download/latest/* latest
+          cp -a download/latest/* "download/$(cat artifacts/latest-version.txt)"
           ls -al download/latest
       - name: Verify that artifacts work with installer
         id: verify
@@ -789,9 +791,10 @@ jobs:
         id: prepare
         if: needs.file-check.outputs.run == 'true'
         run: |
-          mkdir -p download/latest latest
+          mkdir -p download/latest latest "download/$(cat artifacts/latest-version.txt)"
           mv artifacts/* download/latest
           cp -a download/latest/* latest
+          cp -a download/latest/* "download/$(cat artifacts/latest-version.txt)"
           ls -al download/latest
       - name: Run Updater Check
         id: check


### PR DESCRIPTION
##### Summary

This avoids the case of the updater not actually updating things due to the latest nightly version being newer than the PR itself.

##### Test Plan

n/a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force CI updater checks to always perform a real upgrade by running `packaging/installer/netdata-updater.sh` with `--force-update`. Use `NETDATA_BASE_URL=http://localhost:8080`, populate versioned artifact dirs, group CI logs, and fail fast on setup errors.

<sup>Written for commit 456e403d74b835adbe02d6fed3252e4baac234ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

