### PR TITLE
Bump aclk-schemas and adapt to Buf v2 proto layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2671,7 +2671,11 @@ endif()
 #
 # proto definitions
 #
-netdata_protoc_generate_cpp("${CMAKE_SOURCE_DIR}/src/aclk/aclk-schemas"
+# aclk-schemas moved to Buf v2 (PR netdata/aclk-schemas#57): the module root is
+# now "proto/" and internal imports are relative to it (e.g. "aclk/v1/lib.proto"),
+# so protoc's include root must be the proto/ directory. Generated headers are
+# therefore included without the "proto/" prefix (e.g. "aclk/v1/lib.pb.h").
+netdata_protoc_generate_cpp("${CMAKE_SOURCE_DIR}/src/aclk/aclk-schemas/proto"
                             "${CMAKE_BINARY_DIR}/src/aclk/aclk-schemas"
                             ACLK_PROTO_BUILT_SRCS
                             ACLK_PROTO_BUILT_HDRS

--- a/src/aclk/schema-wrappers/agent_cmds.cc
+++ b/src/aclk/schema-wrappers/agent_cmds.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "proto/agent/v1/cmds.pb.h"
+#include "agent/v1/cmds.pb.h"
 
 #include "agent_cmds.h"
 

--- a/src/aclk/schema-wrappers/alarm_config.cc
+++ b/src/aclk/schema-wrappers/alarm_config.cc
@@ -2,7 +2,7 @@
 
 #include "alarm_config.h"
 
-#include "proto/alarm/v1/config.pb.h"
+#include "alarm/v1/config.pb.h"
 
 #include "libnetdata/libnetdata.h"
 

--- a/src/aclk/schema-wrappers/alarm_stream.cc
+++ b/src/aclk/schema-wrappers/alarm_stream.cc
@@ -2,7 +2,7 @@
 
 #include "alarm_stream.h"
 
-#include "proto/alarm/v1/stream.pb.h"
+#include "alarm/v1/stream.pb.h"
 
 #include "libnetdata/libnetdata.h"
 

--- a/src/aclk/schema-wrappers/capability.cc
+++ b/src/aclk/schema-wrappers/capability.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "proto/aclk/v1/lib.pb.h"
+#include "aclk/v1/lib.pb.h"
 
 #include "capability.h"
 

--- a/src/aclk/schema-wrappers/capability.h
+++ b/src/aclk/schema-wrappers/capability.h
@@ -16,7 +16,7 @@ struct capability {
 #ifdef __cplusplus
 }
 
-#include "proto/aclk/v1/lib.pb.h"
+#include "aclk/v1/lib.pb.h"
 
 void capability_set(aclk_lib::v1::Capability *proto_capa, const struct capability *c_capa);
 #endif

--- a/src/aclk/schema-wrappers/connection.cc
+++ b/src/aclk/schema-wrappers/connection.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "src/aclk/aclk-schemas/proto/agent/v1/connection.pb.h"
-#include "src/aclk/aclk-schemas/proto/agent/v1/disconnect.pb.h"
+#include "agent/v1/connection.pb.h"
+#include "agent/v1/disconnect.pb.h"
 #include "connection.h"
 
 #include "schema_wrapper_utils.h"

--- a/src/aclk/schema-wrappers/context.cc
+++ b/src/aclk/schema-wrappers/context.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "proto/context/v1/context.pb.h"
+#include "context/v1/context.pb.h"
 
 #include "libnetdata/libnetdata.h"
 

--- a/src/aclk/schema-wrappers/context_stream.cc
+++ b/src/aclk/schema-wrappers/context_stream.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "proto/context/v1/stream.pb.h"
+#include "context/v1/stream.pb.h"
 
 #include "context_stream.h"
 

--- a/src/aclk/schema-wrappers/node_connection.cc
+++ b/src/aclk/schema-wrappers/node_connection.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "proto/nodeinstance/connection/v1/connection.pb.h"
+#include "nodeinstance/connection/v1/connection.pb.h"
 #include "node_connection.h"
 
 #include "schema_wrapper_utils.h"

--- a/src/aclk/schema-wrappers/node_creation.cc
+++ b/src/aclk/schema-wrappers/node_creation.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "proto/nodeinstance/create/v1/creation.pb.h"
+#include "nodeinstance/create/v1/creation.pb.h"
 #include "node_creation.h"
 
 #include "schema_wrapper_utils.h"

--- a/src/aclk/schema-wrappers/node_info.cc
+++ b/src/aclk/schema-wrappers/node_info.cc
@@ -1,6 +1,6 @@
 #include "node_info.h"
 
-#include "proto/nodeinstance/info/v1/info.pb.h"
+#include "nodeinstance/info/v1/info.pb.h"
 
 #include "schema_wrapper_utils.h"
 

--- a/src/aclk/schema-wrappers/proto_2_json.cc
+++ b/src/aclk/schema-wrappers/proto_2_json.cc
@@ -1,17 +1,17 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/util/json_util.h>
 
-#include "proto/alarm/v1/config.pb.h"
-#include "proto/alarm/v1/stream.pb.h"
-#include "proto/aclk/v1/lib.pb.h"
-#include "proto/agent/v1/connection.pb.h"
-#include "proto/agent/v1/disconnect.pb.h"
-#include "proto/nodeinstance/connection/v1/connection.pb.h"
-#include "proto/nodeinstance/create/v1/creation.pb.h"
-#include "proto/nodeinstance/info/v1/info.pb.h"
-#include "proto/context/v1/stream.pb.h"
-#include "proto/context/v1/context.pb.h"
-#include "proto/agent/v1/cmds.pb.h"
+#include "alarm/v1/config.pb.h"
+#include "alarm/v1/stream.pb.h"
+#include "aclk/v1/lib.pb.h"
+#include "agent/v1/connection.pb.h"
+#include "agent/v1/disconnect.pb.h"
+#include "nodeinstance/connection/v1/connection.pb.h"
+#include "nodeinstance/create/v1/creation.pb.h"
+#include "nodeinstance/info/v1/info.pb.h"
+#include "context/v1/stream.pb.h"
+#include "context/v1/context.pb.h"
+#include "agent/v1/cmds.pb.h"
 
 #include "libnetdata/libnetdata.h"
 


### PR DESCRIPTION
##### Summary
Bumps the aclk-schemas submodule (ec319a14 → db1f9d8534), which migrated to Buf v2. That change made `proto/` the module root and rewrote every internal  import to be module-root relative (e.g. `import "aclk/v1/lib.proto"` instead of `proto/aclk/v1/lib.proto`).
  
Adapts the agent build accordingly:
- point protoc's include root at `src/aclk/aclk-schemas/proto`
- drop the now-wrong `proto/` prefix from the generated-header includes in the schema-wrappers
    
No behavioral change: existing messages are wire-identical and all topics are unchanged. 
The bump also drops four unused alarm-log messages, which the agent does not reference.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `aclk-schemas` to the Buf v2 proto layout and update our build/imports to match. No behavior change; wire formats and topics are unchanged.

- **Dependencies**
  - Bump `aclk-schemas` to the Buf v2 module layout (root is `proto/`).
  - Upstream dropped four unused alarm-log messages; the agent didn’t use them.

- **Refactors**
  - Point protoc include root to `src/aclk/aclk-schemas/proto` in CMake.
  - Remove the `proto/` prefix from protobuf header includes in schema wrappers.

<sup>Written for commit 1d99150ce4631e9be6ed3f0893de79abc04e0e9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

