### PR TITLE
NetFlow: journal backend on systemd-journal-sdk, compact format, optional fsync

### DIFF
--- a/docs/network-flows/configuration.md
+++ b/docs/network-flows/configuration.md
@@ -72,15 +72,14 @@ listener:
 
 ### UDP buffer tuning is not in this file
 
-If you receive a high flow rate, the kernel UDP receive buffer matters more than `max_packet_size`. Tune at the kernel level:
+If you receive a high flow rate, the kernel UDP receive buffer matters more than `max_packet_size`. The plugin requests a large buffer (64 MiB) at startup via `setsockopt(SO_RCVBUF)`, but the kernel silently caps unprivileged requests at `net.core.rmem_max`, and distribution defaults are tiny (~208 KiB). Raise the cap at the kernel level:
 
 ```bash
-sudo sysctl -w net.core.rmem_max=33554432
-sudo sysctl -w net.core.rmem_default=8388608
+sudo sysctl -w net.core.rmem_max=67108864
 sudo sysctl -w net.core.netdev_max_backlog=250000
 ```
 
-Persist these in `/etc/sysctl.d/99-netflow.conf`. The plugin does not call `setsockopt(SO_RCVBUF)` itself; whatever the kernel default is, that's what the listener gets.
+Persist these in `/etc/sysctl.d/99-netflow.conf`. The plugin logs the effective buffer size at startup; `net.core.rmem_default` does not affect it — only `rmem_max` does.
 
 ## `protocols`
 

--- a/docs/network-flows/configuration.md
+++ b/docs/network-flows/configuration.md
@@ -59,7 +59,7 @@ Controls the UDP socket and the journal write cadence.
 listener:
   listen: "0.0.0.0:2055"
   max_packet_size: 9216
-  sync_every_entries: 1024
+  sync_every_entries: 0
   sync_interval: "1s"
 ```
 
@@ -67,8 +67,8 @@ listener:
 |---|---|---|---|
 | `listen` | `--netflow-listen` | `0.0.0.0:2055` | Address and port for the UDP socket. Same socket handles NetFlow v5/v7/v9, IPFIX, and sFlow. |
 | `max_packet_size` | `--netflow-max-packet-size` | `9216` | Maximum UDP datagram in bytes. Increase for jumbo sFlow datagrams or routers that send oversized IPFIX. |
-| `sync_every_entries` | `--netflow-sync-every-entries` | `1024` | Flush the raw journal to disk after this many records, regardless of `sync_interval`. |
-| `sync_interval` | `--netflow-sync-interval` | `1s` | Maximum time between forced flushes. |
+| `sync_every_entries` | `--netflow-sync-every-entries` | `0` | Periodic fsync of the active raw journal. `0` (default) disables it: data reaches disk via kernel writeback, and every journal file is fully synced when rotated and at shutdown. Values > 0 fsync after that many records (and at least once per `sync_interval`); at high flow rates the fsync stalls the receive path and can cause UDP drops. |
+| `sync_interval` | `--netflow-sync-interval` | `1s` | Maximum time between forced fsyncs when `sync_every_entries` > 0. Also the cadence for facet-state persistence and tier maintenance. |
 
 ### UDP buffer tuning is not in this file
 

--- a/docs/network-flows/sizing-capacity.md
+++ b/docs/network-flows/sizing-capacity.md
@@ -31,7 +31,7 @@ Practical guidance:
 
 - Plan with **~30 000 flows/s as the conservative floor** for a well-provisioned agent — it holds even for high-cardinality traffic on fast NVMe, and includes UDP receive, protocol decode, all four storage tiers, and the typical enrichment stack without BMP / BioRIS. Treat rates toward 100 000 flows/s as achievable when your traffic is low-cardinality and the raw tier sits on dedicated NVMe.
 - Enabling periodic fsync (`sync_every_entries` > 0) trades throughput for a tighter crash-durability window: each fsync stalls the receive path, and on slow disks this causes `RcvbufErrors` (kernel-level UDP drops) well below the envelope.
-- Bursts above your sustainable rate cost UDP queue backpressure and eventually `RcvbufErrors`. Tune the kernel UDP receive buffer (`net.core.rmem_max`, `net.core.rmem_default`, `net.core.netdev_max_backlog`) for headroom.
+- Bursts above your sustainable rate cost UDP queue backpressure and eventually `RcvbufErrors`. The plugin requests a 64 MiB receive buffer at startup, capped by `net.core.rmem_max` — raise that sysctl (and `net.core.netdev_max_backlog`) for burst headroom.
 - The hot path is single-threaded. Adding cores does not raise the per-agent ceiling. The way to go past it is to add agents (next section).
 
 ## Distributed deployment is the scaling answer

--- a/docs/network-flows/sizing-capacity.md
+++ b/docs/network-flows/sizing-capacity.md
@@ -16,18 +16,22 @@ A practical guide to choosing the host, the storage, and the deployment shape fo
 
 The netflow plugin is designed to receive, decode, and store flow records (NetFlow / IPFIX / sFlow) from one network — typically the routers and switches at one site — directly on a Netdata Agent.
 
-Sustained ingestion of about **25 000 flows per second** on a single agent already approaches **ISP-level traffic capacities** for most enterprise / branch / data-centre profiles. Past that point you are at the scale of a regional service provider, and you should be running multiple agents (see "Distributed deployment" below), not pushing harder on one box.
+A single agent sustains **30 000 to 100 000 flows per second, depending on traffic cardinality and disk I/O** — which already approaches **ISP-level traffic capacities** for most enterprise / branch / data-centre profiles. Past that point you are at the scale of a regional service provider, and you should be running multiple agents (see "Distributed deployment" below), not pushing harder on one box.
 
-If your worst-case sustained flow rate stays at or below **~25 000 flows/s**, you have headroom on a single agent. If it does not, plan distributed before you plan harder iron.
+If your worst-case sustained flow rate stays at or below **~30 000 flows/s**, you have headroom on a single agent regardless of traffic profile. If it does not, check your cardinality and storage against the envelope below — or plan distributed before you plan harder iron.
 
 ## Plugin throughput cap
 
-The post-decode ingest path has a single-thread hot path. For planning, treat **~25 000 flows/s sustained** as the comfortable ceiling for a well-provisioned single agent running the full pipeline (raw + 1m + 5m + 1h tiers). High-cardinality traffic reaches the ceiling sooner; low-cardinality traffic has more headroom.
+The post-decode ingest path has a single-thread hot path. For planning, treat **30 000–100 000 flows/s sustained** as the per-agent envelope for the full pipeline (raw + 1m + 5m + 1h tiers). Where a given deployment lands inside that envelope depends on two factors:
+
+- **Traffic cardinality** — the per-flow CPU cost grows with how many *unique* flows the traffic contains (unique flows defeat journal deduplication and inflate index work). Low-cardinality traffic (typical real-world mixes, many repeated flows) sustains ~100 000 flows/s on one core; pathological all-unique traffic lands near the ~30 000–45 000 flows/s end.
+- **Disk I/O** — the raw tier is an indexed write stream (~400 bytes/flow). By default the plugin does not fsync on the hot path (see `sync_every_entries` in [Configuration](/docs/network-flows/configuration.md)); data reaches disk via kernel writeback and every file is fully synced when rotated. Fast NVMe absorbs this easily; slow or contended storage (SATA SSD, HDD, busy shared volumes) backpressures the receive loop and pushes the achievable rate toward the bottom of the envelope or below it.
 
 Practical guidance:
 
-- Plan for ~25 000 flows/s sustained on a well-provisioned agent. That is the comfortable steady-state ceiling and includes UDP receive, protocol decode, all four storage tiers, and the typical enrichment stack without BMP / BioRIS.
-- Bursts above the ceiling cost UDP queue backpressure and eventually `RcvbufErrors` (kernel-level drops). Tune the kernel UDP receive buffer (`net.core.rmem_max`, `net.core.rmem_default`, `net.core.netdev_max_backlog`) for headroom.
+- Plan with **~30 000 flows/s as the conservative floor** for a well-provisioned agent — it holds even for high-cardinality traffic on fast NVMe, and includes UDP receive, protocol decode, all four storage tiers, and the typical enrichment stack without BMP / BioRIS. Treat rates toward 100 000 flows/s as achievable when your traffic is low-cardinality and the raw tier sits on dedicated NVMe.
+- Enabling periodic fsync (`sync_every_entries` > 0) trades throughput for a tighter crash-durability window: each fsync stalls the receive path, and on slow disks this causes `RcvbufErrors` (kernel-level UDP drops) well below the envelope.
+- Bursts above your sustainable rate cost UDP queue backpressure and eventually `RcvbufErrors`. Tune the kernel UDP receive buffer (`net.core.rmem_max`, `net.core.rmem_default`, `net.core.netdev_max_backlog`) for headroom.
 - The hot path is single-threaded. Adding cores does not raise the per-agent ceiling. The way to go past it is to add agents (next section).
 
 ## Distributed deployment is the scaling answer
@@ -49,18 +53,20 @@ Storage cost scales linearly with **sustained flows per second** and the **reten
 
 ### How ingestion rate maps to disk
 
-Use **~800 bytes on disk per flow** as the journal sizing estimate for the raw tier. For sustained ingestion this gives you:
+Use **~400 bytes on disk per flow** as the journal sizing estimate for the raw tier. The journal uses the compact on-disk format, which roughly halves the per-flow footprint versus the legacy format (measured ~340 bytes/flow on low-cardinality traffic, ~490 bytes/flow on high-cardinality). For sustained ingestion this gives you:
 
 | Sustained flows/s | Disk used per day, raw tier |
 |---|---|
-| 1 000 | ~70 GB |
-| 5 000 | ~350 GB |
-| 10 000 | ~700 GB |
-| 25 000 | ~1.7 TB |
+| 1 000 | ~35 GB |
+| 5 000 | ~175 GB |
+| 10 000 | ~350 GB |
+| 30 000 | ~1.0 TB |
+| 50 000 | ~1.7 TB |
+| 100 000 | ~3.5 TB |
 
 These numbers are dominated by raw-tier writes; rollup tiers (1m, 5m, 1h) add a small constant on top because each rollup row aggregates many raw rows.
 
-The number is sensitive to traffic cardinality (how unique the 5-tuples are). Real-world traffic with many repeated flows trends a bit lower; pathological all-unique traffic trends a bit higher.
+The number is sensitive to traffic cardinality (how unique the 5-tuples are). Real-world traffic with many repeated flows trends toward the low end (~350 bytes/flow); pathological all-unique traffic trends toward the high end (~490 bytes/flow).
 
 ### Raw tier dominates — keep it bounded
 
@@ -68,24 +74,24 @@ The raw tier carries every individual flow record. **Rollup tiers (1m, 5m, 1h) a
 
 Set raw-tier retention to match your forensic window — typically **24 hours**. Rollup tiers can keep weeks to a year of history at a small fraction of raw-tier cost.
 
-The example below is sized for an agent at the **upper end of the per-host scaling envelope (25 000 flows/s sustained)** — the raw tier needs about 1.7 TB / day at that rate (see the table above), so the 2 TB raw budget gives a small safety margin to keep the duration limit (24 h) the one that fires first:
+The example below is sized for a busy agent sustaining **30 000 flows/s** — the raw tier needs about 1.0 TB / day at that rate (see the table above), so the 1.5 TB raw budget gives a safety margin to keep the duration limit (24 h) the one that fires first. Scale the raw budget with the table above if your agent runs higher inside the envelope:
 
 ```yaml
 journal:
   tiers:
-    raw:      { size_of_journal_files: 2TB,  duration_of_journal_files: 24h }
-    minute_1: { size_of_journal_files: 20GB, duration_of_journal_files: 14d }
-    minute_5: { size_of_journal_files: 20GB, duration_of_journal_files: 30d }
-    hour_1:   { size_of_journal_files: 20GB, duration_of_journal_files: 365d }
+    raw:      { size_of_journal_files: 1.5TB, duration_of_journal_files: 24h }
+    minute_1: { size_of_journal_files: 20GB,  duration_of_journal_files: 14d }
+    minute_5: { size_of_journal_files: 20GB,  duration_of_journal_files: 30d }
+    hour_1:   { size_of_journal_files: 20GB,  duration_of_journal_files: 365d }
 ```
 
-For lighter loads, scale `size_of_journal_files` on the raw tier down proportionally — at 10 000 flows/s ~700 GB / 24 h is enough; at 1 000 flows/s ~70 GB / 24 h is enough. Whichever limit (size or duration) is hit first triggers rotation; size your raw tier so the **duration limit fires first** under normal load and the size cap is a safety net for traffic surges.
+For lighter loads, scale `size_of_journal_files` on the raw tier down proportionally — at 10 000 flows/s ~350 GB / 24 h is enough; at 1 000 flows/s ~35 GB / 24 h is enough. Whichever limit (size or duration) is hit first triggers rotation; size your raw tier so the **duration limit fires first** under normal load and the size cap is a safety net for traffic surges.
 
 ### Use fast NVMe for the raw tier
 
-The raw tier is queried directly for any IP-level investigation, full-text search, city / latitude / longitude maps, and anything that filters on a raw-only field (see [Field Reference](/docs/network-flows/field-reference.md) for which fields survive into rollups). At 25 000 flows/s sustained, the raw tier produces 1.7 TB / day of indexed writes that you may also be reading back in real time.
+The raw tier is queried directly for any IP-level investigation, full-text search, city / latitude / longitude maps, and anything that filters on a raw-only field (see [Field Reference](/docs/network-flows/field-reference.md) for which fields survive into rollups). At 30 000 flows/s sustained, the raw tier produces ~1.0 TB / day of indexed writes that you may also be reading back in real time.
 
-This is **fast-NVMe territory**. 1.7 TB/day of write throughput is well within a modern PCIe Gen4 / Gen5 NVMe drive but punishes SATA SSDs (queue-depth and write-endurance) and HDDs (IOPS) once concurrent queries land on the same device. A modern PCIe Gen4 / Gen5 NVMe is what you want for the raw-tier directory. Rollup tiers (1m / 5m / 1h) are far less I/O-intensive and can live on slower storage if needed, but in practice it's easier to put the whole journal directory on one fast device.
+This is **fast-NVMe territory** — and it is also half of what positions you inside the throughput envelope, because the receive loop's writes must keep flowing to this device. ~1.0 TB/day of write throughput is well within a modern PCIe Gen4 / Gen5 NVMe drive but punishes SATA SSDs (queue-depth and write-endurance) and HDDs (IOPS) once concurrent queries land on the same device — on slower devices write backpressure drops UDP packets well below the envelope. A modern PCIe Gen4 / Gen5 NVMe is what you want for the raw-tier directory. Rollup tiers (1m / 5m / 1h) are far less I/O-intensive and can live on slower storage if needed, but in practice it's easier to put the whole journal directory on one fast device.
 
 If the raw tier exceeds the device capacity for your retention target, **shorten raw-tier retention** before you switch to slower storage. A 12-hour raw tier on fast NVMe queries cleanly; a 7-day raw tier on slow storage will time out queries.
 
@@ -95,8 +101,8 @@ The journal backend uses **free system memory as page cache** — the bigger the
 
 Concrete guidance:
 
-- For the agent process itself, expect **a few hundred MB to ~1 GB of RSS** at typical 5-25k flows/s loads. Enrichment, classifiers, accumulators, and routing tries add to the base process footprint. BMP / BioRIS full-table feeds can add a few hundred MB per peer, depending on table count and prefix mix.
-- For the kernel page cache, aim to **leave at least the size of the recently-queried working set free** — practically, plan a few GB of free RAM on a 25k flows/s agent so query I/O lands in cache instead of hitting NVMe each time.
+- For the agent process itself, expect **a few hundred MB to ~1 GB of RSS** at typical loads across the envelope. Enrichment, classifiers, accumulators, and routing tries add to the base process footprint. BMP / BioRIS full-table feeds can add a few hundred MB per peer, depending on table count and prefix mix.
+- For the kernel page cache, aim to **leave at least the size of the recently-queried working set free** — practically, plan a few GB of free RAM on a busy agent so query I/O lands in cache instead of hitting NVMe each time.
 - Watch `netflow.memory_resident_bytes`, `netflow.memory_resident_mapping_bytes`, and `netflow.memory_accounted_bytes` for the agent's own footprint. Watch the system's overall free memory for the page-cache headroom.
 
 The plugin does **not** preload the journal into RAM. Memory consumption is driven by active accumulators (during ingestion) and routing tries (when configured). Storage growth pressures memory only via the page cache, which the kernel manages.
@@ -107,13 +113,13 @@ The journal is **fully indexed**: every field is indexed, exact-match selections
 
 The exception is the **full-text search box** in the dashboard. FTS runs as a regex against the raw journal payload bytes — it is a **full scan** of the matching tier. Any non-empty FTS query also forces the query to the raw tier (FTS is meaningless on aggregated rollup rows). That means:
 
-- A full-text search over a 24-hour raw tier with 25k flows/s sustained scans hundreds of GB. It runs but it is not fast.
+- A full-text search over a 24-hour raw tier with 30k flows/s sustained scans on the order of a terabyte. It runs but it is not fast.
 - For fast queries, use **filters on indexed fields** (the filter ribbon, exact selections). Reserve full-text for the cases where you don't have an indexed handle.
 - The 30-second hard query timeout is a real ceiling for FTS over wide windows. Narrow the time range, add an indexed filter, or switch to a rollup tier (which means dropping the FTS).
 
 ## Practical checklist before you deploy
 
-1. **Estimate sustained flows/s** for the worst-case router or site. If it exceeds ~25k/s, plan distributed before iron.
+1. **Estimate sustained flows/s** for the worst-case router or site. If it exceeds the per-agent envelope (30k–100k depending on cardinality and disk I/O — use 30k as the safe floor), plan distributed before iron.
 2. **Pick raw-tier retention** that matches your forensic window — typically 24 hours.
 3. **Compute storage** for that retention from the table above; size the raw-tier directory with a realistic safety margin, usually **1.2× to 1.5×** depending on burstiness and available disk.
 4. **Use NVMe** for the raw tier. Slower storage shortens raw-tier retention until queries are responsive.

--- a/docs/network-flows/troubleshooting.md
+++ b/docs/network-flows/troubleshooting.md
@@ -101,15 +101,14 @@ grep ^Udp: /proc/net/snmp          # RcvbufErrors counter (system-wide)
 
 `/proc/net/udp` lists open sockets and includes per-socket `drops`; the kernel-wide UDP `RcvbufErrors` total lives under the `Udp:` line of `/proc/net/snmp` (this is what Netdata's own `ipv4.udperrors` chart and the `1m_ipv4_udp_receive_buffer_errors` alert read).
 
-If drops are occurring, the kernel UDP receive buffer is too small for the burst rate. Tune:
+If drops are occurring, the kernel UDP receive buffer is too small for the burst rate. The plugin requests a 64 MiB receive buffer at startup, but the kernel silently caps unprivileged requests at `net.core.rmem_max` — and distribution defaults are tiny (~208 KiB, a few tens of datagrams). Raise the cap:
 
 ```bash
-sudo sysctl -w net.core.rmem_max=33554432
-sudo sysctl -w net.core.rmem_default=8388608
+sudo sysctl -w net.core.rmem_max=67108864
 sudo sysctl -w net.core.netdev_max_backlog=250000
 ```
 
-Persist in `/etc/sysctl.d/99-netflow.conf`.
+Persist in `/etc/sysctl.d/99-netflow.conf` and restart the plugin (it logs the effective buffer size at startup). `net.core.rmem_default` does not matter for the plugin's socket — only `rmem_max` does.
 
 **Per-protocol switch off:**
 

--- a/src/crates/Cargo.lock
+++ b/src/crates/Cargo.lock
@@ -394,6 +394,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bridge"
 version = "0.1.3"
 dependencies = [
@@ -635,10 +644,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -672,6 +687,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -745,6 +769,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,8 +839,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1376,6 +1421,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,6 +1488,15 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -1925,8 +1988,8 @@ dependencies = [
  "journal-common",
  "journal-registry",
  "libc",
- "lz4_flex",
- "lzma-rust2",
+ "lz4_flex 0.12.1",
+ "lzma-rust2 0.15.7",
  "md5",
  "memmap2",
  "nix 0.30.1",
@@ -2019,7 +2082,7 @@ dependencies = [
  "journal-core",
  "journal-registry",
  "regex",
- "roaring",
+ "roaring 0.11.2",
  "serde",
  "static_assertions",
  "tempfile",
@@ -2187,13 +2250,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
 
 [[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+
+[[package]]
 name = "lzma-rust2"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 dependencies = [
  "crc",
- "sha2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02"
+dependencies = [
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2469,12 +2547,6 @@ dependencies = [
  "jaq-core",
  "jaq-json",
  "jaq-std",
- "journal-common",
- "journal-core",
- "journal-engine",
- "journal-index",
- "journal-log-writer",
- "journal-registry",
  "libc",
  "maxminddb",
  "memchr",
@@ -2492,7 +2564,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.2",
  "rmp-serde",
- "roaring",
+ "roaring 0.11.2",
  "rt",
  "rustc-hash",
  "schemars",
@@ -2501,6 +2573,12 @@ dependencies = [
  "serde_yaml",
  "sflow-parser",
  "socket2 0.6.3",
+ "systemd-journal-sdk-common",
+ "systemd-journal-sdk-core",
+ "systemd-journal-sdk-engine",
+ "systemd-journal-sdk-index",
+ "systemd-journal-sdk-log-writer",
+ "systemd-journal-sdk-registry",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3660,6 +3738,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "serde",
+]
+
+[[package]]
 name = "rt"
 version = "0.1.3"
 dependencies = [
@@ -3800,9 +3889,9 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 dependencies = [
  "twox-hash",
 ]
@@ -4009,8 +4098,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4179,6 +4279,135 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "systemd-journal-sdk-common"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42bca248a360b6413eb7f622b386adb2a97fa1f329158ba367922471ba998093"
+dependencies = [
+ "libc",
+ "rustc-hash",
+ "serde",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "systemd-journal-sdk-core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569428bdc1bce7b69842321c0bb582bb9b0f991d1f986364ce7d1f21c1783bc"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "crossbeam-channel",
+ "hashers",
+ "hmac",
+ "libc",
+ "lz4_flex 0.13.1",
+ "lzma-rust2 0.16.4",
+ "md5",
+ "memmap2",
+ "notify",
+ "num-bigint",
+ "parking_lot",
+ "rand 0.9.2",
+ "regex",
+ "rustc-hash",
+ "ruzstd",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "siphasher",
+ "static_assertions",
+ "systemd-journal-sdk-common",
+ "systemd-journal-sdk-registry",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "twox-hash",
+ "uuid",
+ "walkdir",
+ "windows-sys 0.61.2",
+ "zerocopy 0.9.0-alpha.0",
+ "zstd",
+]
+
+[[package]]
+name = "systemd-journal-sdk-engine"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40cb0e14e49e670953611ca4ba9f150396d5f35c41c9dc219cf80a94d729f948"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "chrono",
+ "foyer",
+ "futures",
+ "lru",
+ "parking_lot",
+ "rayon",
+ "serde",
+ "serde_json",
+ "static_assertions",
+ "systemd-journal-sdk-core",
+ "systemd-journal-sdk-index",
+ "systemd-journal-sdk-registry",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "systemd-journal-sdk-index"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde0f4f59b8d3235be5014452b7cd807f4fac75d2afa5f267ace4f3f50a649ea"
+dependencies = [
+ "regex",
+ "roaring 0.11.4",
+ "serde",
+ "static_assertions",
+ "systemd-journal-sdk-common",
+ "systemd-journal-sdk-core",
+ "systemd-journal-sdk-registry",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "systemd-journal-sdk-log-writer"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47f5b48d0fb433bedec0a5ca4c3cc5dfe23016b3efd99ac26fd4b48e35485b3"
+dependencies = [
+ "itoa",
+ "systemd-journal-sdk-common",
+ "systemd-journal-sdk-core",
+ "systemd-journal-sdk-registry",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "systemd-journal-sdk-registry"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8131b7929615e2dc2710199c6798424aef70007f0406a273bb1fbaed511b2007"
+dependencies = [
+ "notify",
+ "parking_lot",
+ "serde",
+ "systemd-journal-sdk-common",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "walkdir",
 ]
 
 [[package]]
@@ -4664,9 +4893,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"

--- a/src/crates/netflow-plugin/Cargo.toml
+++ b/src/crates/netflow-plugin/Cargo.toml
@@ -20,12 +20,16 @@ bitvec = { workspace = true }
 bytesize = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-journal-common = { workspace = true }
-journal-core = { workspace = true }
-journal-engine = { workspace = true }
-journal-index = { workspace = true }
-journal-log-writer = { workspace = true }
-journal-registry = { workspace = true }
+# Journal I/O migrated to the published systemd-journal-sdk (was vendored path
+# crates). Aliased to the historical names so call sites keep `use journal_*`.
+# Scope: netflow-plugin only; log-viewer/otel still use the vendored workspace
+# crates (tracked as a follow-up). One source of journal-core in this binary.
+journal-common = { package = "systemd-journal-sdk-common", version = "0.6.2" }
+journal-core = { package = "systemd-journal-sdk-core", version = "0.6.2" }
+journal-engine = { package = "systemd-journal-sdk-engine", version = "0.6.2" }
+journal-index = { package = "systemd-journal-sdk-index", version = "0.6.2" }
+journal-log-writer = { package = "systemd-journal-sdk-log-writer", version = "0.6.2" }
+journal-registry = { package = "systemd-journal-sdk-registry", version = "0.6.2" }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 hashbrown = { workspace = true }

--- a/src/crates/netflow-plugin/README.md
+++ b/src/crates/netflow-plugin/README.md
@@ -369,6 +369,15 @@ of the test process during the measurement window, divided by wall time, as a
 percent of one core. 100% means one core's worth of CPU was consumed; values
 above 100% are normal for multi-threaded saturation.
 
+> **Note (2026-06):** the recorded tables below predate the migration of the
+> journal backend to `systemd-journal-sdk` (compact file format, no
+> compression, periodic fsync disabled by default). Spot re-runs after the
+> migration show roughly 20-40% higher throughput at every point (e.g.
+> high-cardinality post-decode saturation moved from ~37k to ~43-46k flows/s,
+> low-cardinality full ingest from ~85-95k to ~110-120k flows/s) and about
+> half the physical disk write per flow (~400 bytes/flow). Re-run the
+> commands above for current numbers on your host.
+
 Reference measurements:
 
 - CPU: `12th Gen Intel(R) Core(TM) i9-12900K`
@@ -458,14 +467,16 @@ Single-threaded peak throughput at native fixture cardinality:
 - The post-decode ingest hot path is currently single-threaded. CPU pins at
   ~98-99% of one core at saturation; it does not scale further with more cores.
 - Low-cardinality saturation is above 60 000 flows/s for NetFlow v9 and IPFIX,
-  and around 70 000 flows/s for sFlow on this host. The matrix above does not
-  reach those ceilings on purpose; extrapolate from the CPU% column.
+  and around 70 000 flows/s for sFlow on this host (above 100 000 flows/s
+  post-decode after the systemd-journal-sdk migration). The matrix above does
+  not reach those ceilings on purpose; extrapolate from the CPU% column.
 - High-cardinality saturation is around 30 000 flows/s post-decode for all
-  three protocols. Above the knee, achieved rate stays at the plateau while
-  offered rate grows.
+  three protocols (~43-46 000 flows/s after the migration). Above the knee,
+  achieved rate stays at the plateau while offered rate grows.
 - Adding decode (~10 µs/flow) on top of post-decode ingest brings the practical
   full-path ceiling to roughly 22-25 000 flows/s at high cardinality on this
-  host, with the four-tier pipeline running and no enrichment. UDP socket
+  host (~40 000 flows/s after the migration), with the four-tier pipeline
+  running and no enrichment. UDP socket
   receive is not measured; at these flow rates packet rate (1-5k pps) is well
   below typical socket limits.
 - Disk reads stay near zero because the benchmark isolates the ingest path

--- a/src/crates/netflow-plugin/configs/netflow.yaml
+++ b/src/crates/netflow-plugin/configs/netflow.yaml
@@ -17,7 +17,12 @@ listener:
   # UDP socket for NetFlow/IPFIX/sFlow exporters.
   listen: "0.0.0.0:2055"
   max_packet_size: 9216
-  sync_every_entries: 1024
+  # Periodic fsync of the active raw journal. 0 (default) disables it: data
+  # reaches disk via kernel writeback, and every journal file is fully synced
+  # when rotated and at shutdown. Values > 0 fsync after that many records
+  # (and at least once per sync_interval); at high flow rates this stalls the
+  # receive path and can cause UDP drops.
+  sync_every_entries: 0
   sync_interval: 1s
 
 protocols:

--- a/src/crates/netflow-plugin/integrations/ipfix.md
+++ b/src/crates/netflow-plugin/integrations/ipfix.md
@@ -53,7 +53,7 @@ The plugin starts when enabled in netflow.yaml and listens on the configured UDP
 
 #### Limits
 
-Operational limits are driven by sustained flows/s, template churn, cardinality, retention, storage speed, and enrichment. Plan around 25k sustained flows/s per well-provisioned agent for the full raw + rollup pipeline; use distributed agents for larger deployments.
+Operational limits are driven by sustained flows/s, template churn, cardinality, retention, storage speed, and enrichment. Plan around 30k-100k sustained flows/s per well-provisioned agent for the full raw + rollup pipeline, depending on flow cardinality and disk I/O; use distributed agents for larger deployments.
 
 #### Performance Impact
 

--- a/src/crates/netflow-plugin/integrations/netflow.md
+++ b/src/crates/netflow-plugin/integrations/netflow.md
@@ -53,7 +53,7 @@ The plugin starts when enabled in netflow.yaml and listens on the configured UDP
 
 #### Limits
 
-Operational limits are driven by sustained flows/s, cardinality, retention, storage speed, and enrichment. Plan around 25k sustained flows/s per well-provisioned agent for the full raw + rollup pipeline; use distributed agents for larger deployments.
+Operational limits are driven by sustained flows/s, cardinality, retention, storage speed, and enrichment. Plan around 30k-100k sustained flows/s per well-provisioned agent for the full raw + rollup pipeline, depending on flow cardinality and disk I/O; use distributed agents for larger deployments.
 
 #### Performance Impact
 

--- a/src/crates/netflow-plugin/metadata.yaml
+++ b/src/crates/netflow-plugin/metadata.yaml
@@ -53,7 +53,7 @@ modules:
         auto_detection:
           description: "The plugin starts when enabled in netflow.yaml and listens on the configured UDP port."
         limits:
-          description: "Operational limits are driven by sustained flows/s, cardinality, retention, storage speed, and enrichment. Plan around 25k sustained flows/s per well-provisioned agent for the full raw + rollup pipeline; use distributed agents for larger deployments."
+          description: "Operational limits are driven by sustained flows/s, cardinality, retention, storage speed, and enrichment. Plan around 30k-100k sustained flows/s per well-provisioned agent for the full raw + rollup pipeline, depending on flow cardinality and disk I/O; use distributed agents for larger deployments."
         performance_impact:
           description: "Disabled until exporters send traffic. Once active, CPU and disk I/O scale with flow rate and cardinality; size retention and storage from observed flows/s."
     setup:
@@ -213,7 +213,7 @@ modules:
         auto_detection:
           description: "The plugin starts when enabled in netflow.yaml and listens on the configured UDP port."
         limits:
-          description: "Operational limits are driven by sustained flows/s, template churn, cardinality, retention, storage speed, and enrichment. Plan around 25k sustained flows/s per well-provisioned agent for the full raw + rollup pipeline; use distributed agents for larger deployments."
+          description: "Operational limits are driven by sustained flows/s, template churn, cardinality, retention, storage speed, and enrichment. Plan around 30k-100k sustained flows/s per well-provisioned agent for the full raw + rollup pipeline, depending on flow cardinality and disk I/O; use distributed agents for larger deployments."
         performance_impact:
           description: "Disabled until exporters send traffic. Once active, CPU and disk I/O scale with flow rate, template volume, and cardinality; size retention and storage from observed flows/s."
     setup:

--- a/src/crates/netflow-plugin/src/ingest.rs
+++ b/src/crates/netflow-plugin/src/ingest.rs
@@ -21,7 +21,7 @@ use journal_engine::{
     batch_compute_file_indexes,
 };
 use journal_index::{Anchor, Direction, FieldName, Seconds};
-use journal_log_writer::{Config, EntryTimestamps, Log, RetentionPolicy, RotationPolicy};
+use journal_log_writer::{Compression, Config, EntryTimestamps, Log, RetentionPolicy, RotationPolicy};
 use journal_registry::{Monitor, Origin, Registry, Source};
 use std::collections::HashMap;
 use std::fs;

--- a/src/crates/netflow-plugin/src/ingest/service.rs
+++ b/src/crates/netflow-plugin/src/ingest/service.rs
@@ -19,6 +19,10 @@ struct FacetLifecycleObserver {
 impl LogLifecycleObserver for FacetLifecycleObserver {
     fn on_event(&self, event: &LogLifecycleEvent) {
         match event {
+            // A newly created active file carries no entries the facet runtime
+            // must reconcile: active files are discovered at query time and
+            // rotation is handled below. Nothing to do (matches pre-SDK behavior).
+            LogLifecycleEvent::Created { .. } => {}
             LogLifecycleEvent::Rotated { archived, active } => {
                 let archived_path = Path::new(archived.path());
                 let active_path = Path::new(active.path());

--- a/src/crates/netflow-plugin/src/ingest/service/init.rs
+++ b/src/crates/netflow-plugin/src/ingest/service/init.rs
@@ -46,7 +46,15 @@ impl IngestService {
                 retention_policy =
                     retention_policy.with_duration_of_journal_files(duration_of_journal_files);
             }
+            // Fastest-storage profile for the netflow flow store: compact
+            // on-disk layout, no DATA compression, no FSS sealing (not enabled),
+            // and live publication disabled (0) — the plugin reads its own files
+            // by opening them, not via journalctl --follow, so the per-entry
+            // inotify/set_len publication is pure overhead here.
             Config::new(origin, rotation_policy, retention_policy)
+                .with_compact(true)
+                .with_compression(Compression::None)
+                .with_live_publish_every_entries(0)
         };
         let raw_journal =
             Self::build_raw_journal(&cfg, &build_journal_cfg, Arc::clone(&lifecycle_observer))?;

--- a/src/crates/netflow-plugin/src/ingest/service/runtime.rs
+++ b/src/crates/netflow-plugin/src/ingest/service/runtime.rs
@@ -9,6 +9,7 @@ impl IngestService {
         let socket = UdpSocket::bind(&listen)
             .await
             .with_context(|| format!("failed to bind {}", listen))?;
+        Self::expand_receive_buffer(&socket, &listen);
         let mut buffer = vec![0_u8; self.cfg.listener.max_packet_size];
         let mut entries_since_sync = 0_usize;
         let mut sync_tick = tokio::time::interval(self.cfg.listener.sync_interval);
@@ -67,6 +68,32 @@ impl IngestService {
 
     fn periodic_sync_enabled(&self) -> bool {
         self.cfg.listener.sync_every_entries > 0
+    }
+
+    /// Request the largest UDP receive buffer the kernel allows. The
+    /// single-threaded receive loop is periodically stalled by inline disk
+    /// work (journal rotation sync, tier flushes), and the socket buffer is
+    /// what absorbs those stalls; the OS default (typically ~208 KiB, only a
+    /// few tens of datagrams) overflows after a few milliseconds at high flow
+    /// rates. The kernel caps unprivileged requests at net.core.rmem_max.
+    fn expand_receive_buffer(socket: &UdpSocket, listen: &str) {
+        const REQUESTED_RECV_BUFFER_BYTES: usize = 64 * 1024 * 1024;
+        let sock_ref = socket2::SockRef::from(socket);
+        if let Err(err) = sock_ref.set_recv_buffer_size(REQUESTED_RECV_BUFFER_BYTES) {
+            tracing::warn!("failed to expand UDP receive buffer for {}: {}", listen, err);
+            return;
+        }
+        match sock_ref.recv_buffer_size() {
+            Ok(actual) => tracing::info!(
+                "UDP receive buffer for {}: {} bytes (requested {}; capped by net.core.rmem_max)",
+                listen,
+                actual,
+                REQUESTED_RECV_BUFFER_BYTES
+            ),
+            Err(err) => {
+                tracing::warn!("failed to read back UDP receive buffer for {}: {}", listen, err);
+            }
+        }
     }
 
     fn handle_received_packet(

--- a/src/crates/netflow-plugin/src/ingest/service/runtime.rs
+++ b/src/crates/netflow-plugin/src/ingest/service/runtime.rs
@@ -48,9 +48,25 @@ impl IngestService {
         let now = now_usec();
         self.decoders.refresh_enrichment_state();
         self.run_tier_maintenance(now);
-        let entries_since_sync = self.sync_if_needed(entries_since_sync);
+        let entries_since_sync = if self.periodic_sync_enabled() {
+            self.sync_if_needed(entries_since_sync)
+        } else {
+            // Periodic fsync is disabled (sync_every_entries = 0): the raw
+            // journal reaches disk via kernel writeback and is fully synced on
+            // rotation and at shutdown. Facet state still persists on the tick
+            // cadence, and the entry counter keeps accumulating so shutdown
+            // performs one final sync.
+            if let Err(err) = self.facet_runtime.persist_if_dirty() {
+                tracing::warn!("facet runtime persist failed: {}", err);
+            }
+            entries_since_sync
+        };
         self.persist_decoder_state_if_due(now);
         entries_since_sync
+    }
+
+    fn periodic_sync_enabled(&self) -> bool {
+        self.cfg.listener.sync_every_entries > 0
     }
 
     fn handle_received_packet(
@@ -181,7 +197,8 @@ impl IngestService {
     }
 
     fn sync_if_threshold_reached(&mut self, entries_since_sync: usize) -> usize {
-        if entries_since_sync >= self.cfg.listener.sync_every_entries {
+        let sync_every_entries = self.cfg.listener.sync_every_entries;
+        if sync_every_entries > 0 && entries_since_sync >= sync_every_entries {
             return self.sync_if_needed(entries_since_sync);
         }
 

--- a/src/crates/netflow-plugin/src/ingest_test_support.rs
+++ b/src/crates/netflow-plugin/src/ingest_test_support.rs
@@ -97,9 +97,14 @@ pub(super) fn new_disk_benchmark_raw_log() -> (TempDir, Log) {
             retention_policy.with_duration_of_journal_files(duration_of_journal_files);
     }
 
+    // Match the production fastest-storage profile so benchmarks measure the
+    // same on-disk format the plugin ships: compact, no compression, no live.
     let log = Log::new(
         &raw_dir,
-        Config::new(origin, rotation_policy, retention_policy),
+        Config::new(origin, rotation_policy, retention_policy)
+            .with_compact(true)
+            .with_compression(Compression::None)
+            .with_live_publish_every_entries(0),
     )
     .unwrap_or_else(|e| panic!("create raw benchmark log in {}: {e}", raw_dir.display()));
 

--- a/src/crates/netflow-plugin/src/main_tests.rs
+++ b/src/crates/netflow-plugin/src/main_tests.rs
@@ -1847,17 +1847,23 @@ async fn bench_udp_loss_ceiling() {
         sock.connect(&sender_listen).expect("connect sender");
         let total = target_pps.saturating_mul(duration_secs);
         let start = Instant::now();
+        let mut attempted = 0_u64;
         let mut sent = 0_u64;
         let mut idx = 0_usize;
-        while sent < total {
+        while attempted < total {
             let due = (start.elapsed().as_secs_f64() * target_pps as f64) as u64;
             let upto = due.min(total);
-            while sent < upto {
-                let _ = sock.send(&payloads[idx % payloads.len()]);
-                sent += 1;
+            while attempted < upto {
+                // Count only datagrams the local stack accepted; a failed
+                // send (e.g. ENOBUFS) never reached the receiver and must not
+                // inflate the reported loss.
+                if sock.send(&payloads[idx % payloads.len()]).is_ok() {
+                    sent += 1;
+                }
+                attempted += 1;
                 idx += 1;
             }
-            if sent < total {
+            if attempted < total {
                 std::thread::sleep(Duration::from_micros(150));
             }
         }
@@ -1873,7 +1879,10 @@ async fn bench_udp_loss_ceiling() {
     let entries = metrics.journal_entries_written.load(Ordering::Relaxed) - entries_before;
 
     shutdown.cancel();
-    let _ = ingest_task.await;
+    ingest_task
+        .await
+        .expect("join ingestion task")
+        .expect("ingestion run");
 
     let secs = duration_secs as f64;
     let flows_per_pkt = if recv > 0 {

--- a/src/crates/netflow-plugin/src/main_tests.rs
+++ b/src/crates/netflow-plugin/src/main_tests.rs
@@ -1617,6 +1617,26 @@ async fn ingest_fixture_with_timestamp_source(
     ingest_fixture_with_config(fixture_name, timestamp_source, |_| {}).await
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_disabled_periodic_sync_syncs_raw_journal_only_at_shutdown() {
+    let (_cfg, metrics, _open_tiers, _tier_flow_indexes, _tmp) = ingest_fixture_with_config(
+        "nfv5.pcap",
+        plugin_config::TimestampSource::Input,
+        |cfg| cfg.listener.sync_every_entries = 0,
+    )
+    .await;
+
+    assert!(
+        metrics.journal_entries_written.load(Ordering::Relaxed) > 0,
+        "expected raw entries to be written"
+    );
+    assert_eq!(
+        metrics.raw_journal_syncs.load(Ordering::Relaxed),
+        1,
+        "with sync_every_entries=0 the raw journal must fsync exactly once, at shutdown"
+    );
+}
+
 async fn ingest_fixture_with_config(
     fixture_name: &str,
     timestamp_source: plugin_config::TimestampSource,
@@ -1731,6 +1751,148 @@ fn reserve_udp_listen_addr() -> String {
     let sock = StdUdpSocket::bind("127.0.0.1:0").expect("reserve udp listen socket");
     let addr = sock.local_addr().expect("read local addr");
     addr.to_string()
+}
+
+/// Sum the kernel UDP receive-buffer drop counter for the socket bound to
+/// `port` (the last column of /proc/net/udp[6]). This is the authoritative
+/// packet-loss signal: it increments when the kernel discards a datagram
+/// because the socket receive buffer was full.
+fn read_udp_socket_drops(port: u16) -> u64 {
+    let want = format!(":{port:04X}");
+    let mut total = 0_u64;
+    for path in ["/proc/net/udp", "/proc/net/udp6"] {
+        let Ok(content) = fs::read_to_string(path) else {
+            continue;
+        };
+        for line in content.lines().skip(1) {
+            let cols: Vec<&str> = line.split_whitespace().collect();
+            // 0:sl 1:local_addr 2:rem 3:st 4:tx:rx 5:tr:when 6:retr 7:uid
+            // 8:timeout 9:inode 10:ref 11:pointer 12:drops
+            if cols.len() < 13 {
+                continue;
+            }
+            if cols[1].to_uppercase().ends_with(&want) {
+                total += cols[12].parse::<u64>().unwrap_or(0);
+            }
+        }
+    }
+    total
+}
+
+/// Live UDP loss-ceiling load test. Drives the REAL socket receive path of a
+/// running `IngestService` at a fixed target datagrams/s and reports kernel UDP
+/// drops plus achieved flows/s. Ramp `NETFLOW_UDP_BENCH_PPS` across runs to find
+/// the sustained rate before the kernel starts dropping datagrams (the true
+/// per-agent ingestion ceiling, end-to-end through the socket).
+///
+/// Env: NETFLOW_UDP_BENCH_PPS (target datagrams/s, default 5000),
+///      NETFLOW_UDP_BENCH_SECS (measurement duration, default 10),
+///      NETFLOW_UDP_BENCH_FIXTURE (pcap fixture, default "nfv5.pcap").
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "manual live UDP loss-ceiling load test"]
+async fn bench_udp_loss_ceiling() {
+    let target_pps: u64 = std::env::var("NETFLOW_UDP_BENCH_PPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(5_000);
+    let duration_secs: u64 = std::env::var("NETFLOW_UDP_BENCH_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(10);
+    let fixture =
+        std::env::var("NETFLOW_UDP_BENCH_FIXTURE").unwrap_or_else(|_| "nfv5.pcap".to_string());
+
+    let payloads = fixture_udp_payloads(&fixture);
+    assert!(!payloads.is_empty(), "fixture {fixture} has no udp payloads");
+
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let listen = reserve_udp_listen_addr();
+    let port: u16 = listen
+        .rsplit(':')
+        .next()
+        .and_then(|p| p.parse().ok())
+        .expect("listen port");
+
+    let mut cfg = plugin_config::PluginConfig::default();
+    cfg.journal.journal_dir = tmp.path().join("flows").to_string_lossy().to_string();
+    cfg.listener.listen = listen.clone();
+    // Production-realistic sync behavior is the default (periodic fsync
+    // disabled; files sync on rotation and shutdown). Do NOT force per-entry
+    // sync, which would not reflect the real ceiling.
+
+    let metrics = Arc::new(ingest::IngestMetrics::default());
+    let open_tiers = Arc::new(RwLock::new(tiering::OpenTierState::default()));
+    let tier_flow_indexes = Arc::new(RwLock::new(tiering::TierFlowIndexStore::default()));
+    let service = ingest::IngestService::new(
+        cfg.clone(),
+        Arc::clone(&metrics),
+        Arc::clone(&open_tiers),
+        Arc::clone(&tier_flow_indexes),
+    )
+    .expect("create ingest service");
+    let shutdown = CancellationToken::new();
+    let run_shutdown = shutdown.clone();
+    let ingest_task = tokio::spawn(async move { service.run(run_shutdown).await });
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let drops_before = read_udp_socket_drops(port);
+    let recv_before = metrics.udp_packets_received.load(Ordering::Relaxed);
+    let entries_before = metrics.journal_entries_written.load(Ordering::Relaxed);
+
+    // Sender on a dedicated OS thread with a blocking socket, deadline-paced to
+    // the target rate so it does not steal the listener's tokio workers.
+    let sender_listen = listen.clone();
+    let sender = std::thread::spawn(move || -> u64 {
+        let sock = StdUdpSocket::bind("127.0.0.1:0").expect("bind sender");
+        sock.connect(&sender_listen).expect("connect sender");
+        let total = target_pps.saturating_mul(duration_secs);
+        let start = Instant::now();
+        let mut sent = 0_u64;
+        let mut idx = 0_usize;
+        while sent < total {
+            let due = (start.elapsed().as_secs_f64() * target_pps as f64) as u64;
+            let upto = due.min(total);
+            while sent < upto {
+                let _ = sock.send(&payloads[idx % payloads.len()]);
+                sent += 1;
+                idx += 1;
+            }
+            if sent < total {
+                std::thread::sleep(Duration::from_micros(150));
+            }
+        }
+        sent
+    });
+
+    let sent = sender.join().expect("join sender");
+    // Let the listener drain any datagrams still buffered in the socket.
+    tokio::time::sleep(Duration::from_millis(750)).await;
+
+    let drops = read_udp_socket_drops(port).saturating_sub(drops_before);
+    let recv = metrics.udp_packets_received.load(Ordering::Relaxed) - recv_before;
+    let entries = metrics.journal_entries_written.load(Ordering::Relaxed) - entries_before;
+
+    shutdown.cancel();
+    let _ = ingest_task.await;
+
+    let secs = duration_secs as f64;
+    let flows_per_pkt = if recv > 0 {
+        entries as f64 / recv as f64
+    } else {
+        0.0
+    };
+    let loss_pct = if sent > 0 {
+        100.0 * sent.saturating_sub(recv) as f64 / sent as f64
+    } else {
+        0.0
+    };
+    println!(
+        "UDP_LOSS_RESULT fixture={fixture} target_pps={target_pps} dur={duration_secs}s \
+         sent_pkts={sent} recv_pkts={recv} kernel_drops={drops} flows={entries} \
+         achieved_pps={:.0} achieved_fps={:.0} flows_per_pkt={flows_per_pkt:.1} loss_pct={loss_pct:.2}",
+        recv as f64 / secs,
+        entries as f64 / secs,
+    );
 }
 
 fn assert_tier_has_files(path: &Path, tier_name: &str) {

--- a/src/crates/netflow-plugin/src/plugin_config/types/listener.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/types/listener.rs
@@ -9,7 +9,13 @@ pub(crate) struct ListenerConfig {
     #[arg(long = "netflow-max-packet-size", default_value_t = 9216)]
     pub(crate) max_packet_size: usize,
 
-    #[arg(long = "netflow-sync-every-entries", default_value_t = 1024)]
+    /// Fsync the active raw journal after this many entries. 0 (default)
+    /// disables periodic fsync: entries reach disk via kernel writeback, and
+    /// every journal file is still fully synced when it is rotated/archived
+    /// and once at shutdown. Values > 0 also fsync at least once per
+    /// `sync_interval`; at high flow rates this stalls the receive path and
+    /// can cause UDP drops.
+    #[arg(long = "netflow-sync-every-entries", default_value_t = 0)]
     pub(crate) sync_every_entries: usize,
 
     #[arg(
@@ -26,7 +32,7 @@ impl Default for ListenerConfig {
         Self {
             listen: "0.0.0.0:2055".to_string(),
             max_packet_size: 9216,
-            sync_every_entries: 1024,
+            sync_every_entries: 0,
             sync_interval: Duration::from_secs(1),
         }
     }

--- a/src/crates/netflow-plugin/src/plugin_config/validation/listener.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/validation/listener.rs
@@ -6,9 +6,6 @@ pub(super) fn validate_listener_and_protocols(cfg: &PluginConfig) -> Result<()> 
     if cfg.listener.max_packet_size == 0 {
         anyhow::bail!("listener.max_packet_size must be greater than 0");
     }
-    if cfg.listener.sync_every_entries == 0 {
-        anyhow::bail!("listener.sync_every_entries must be greater than 0");
-    }
 
     cfg.listener
         .listen


### PR DESCRIPTION
##### Summary

Migrates the netflow plugin's journal storage from the vendored in-tree journal crates to the published [systemd-journal-sdk](https://crates.io/crates/systemd-journal-sdk) 0.6.2, and tunes the on-disk profile for the flow store:

- **Dependencies**: the six `journal-*` crates are now `systemd-journal-sdk-*` 0.6.2 from crates.io, aliased to the historical names (call sites unchanged). Scope is the netflow plugin only — `netdata-log-viewer` and the OTEL plugins intentionally remain on the vendored crates; consolidating them is a tracked follow-up.
- **On-disk format**: compact journal layout, no compression, no FSS sealing, per-entry live publication disabled (the plugin reads its own files; it is not followed by `journalctl -f`). Existing journals written in the old format remain readable; readers handle mixed directories.
- **Periodic fsync is now configurable and disabled by default** (`sync_every_entries: 0`, previously `1024` and `0` was rejected). Live UDP load testing showed the per-1024-entries `fdatasync` stalls the single receive thread and causes kernel UDP drops. Every journal file is still fully synced when rotated/archived and once at shutdown, and facet state still persists on the sync tick — the change narrows nothing except the (~seconds) power-loss window of the active file's tail, which rotation already bounds.

Measured on the same host with the plugin's own benchmarks:

| metric | before | after |
|---|---|---|
| full ingest, low cardinality | 85–95k flows/s | 110–120k flows/s |
| post-decode, high cardinality (50k unique) | ~37k flows/s | ~43–46k flows/s |
| all-tiers CPU @30k flows/s (high card.) | 75% of one core | 62% |
| raw tier on disk | ~800 bytes/flow | ~400 bytes/flow |
| live UDP on ext4 @29k flows/s offered | 24k achieved, 17% loss | 28.8k achieved, 0.6% loss |
| live UDP on ext4 @58k flows/s offered | 25k achieved, 57% loss | 56.6k achieved, 2.5% loss |

Documentation is updated accordingly: the sizing guide now states a **30k–100k flows/s per-agent envelope depending on flow cardinality and disk I/O** (30k as the conservative planning floor), the storage table uses ~400 bytes/flow, and the `sync_every_entries` semantics are documented in the configuration reference. The plugin README's recorded benchmark tables are annotated as pre-migration with the re-measured deltas.

##### Test Plan

- `cargo test --release -p netflow-plugin` — 479 passed, 0 failed (includes ingest/query round-trip on the compact format, facets, rebuild).
- New e2e test `e2e_disabled_periodic_sync_syncs_raw_journal_only_at_shutdown` verifies the default performs exactly one raw fsync, at shutdown.
- New manual bench `tests::bench_udp_loss_ceiling` drives the real UDP socket at a target rate and reads per-socket kernel drop counters from `/proc/net/udp` — this is the tool behind the live numbers above (`NETFLOW_UDP_BENCH_PPS=... cargo test --release -p netflow-plugin tests::bench_udp_loss_ceiling -- --exact --ignored --nocapture`).
- Existing protocol/cardinality/resource-envelope benchmarks re-run before and after; numbers above.

##### Additional Information

The live load testing also identified the next bottleneck (not addressed here): all four tier writes plus their flush bursts run inline on the single receive thread, and the epoch-aligned 1m/5m/1h buckets all close simultaneously at the top of each hour. A design that offloads tier commits to per-tier worker threads (keeping the receive thread allocation- and lock-free) is written up and pending review; it targets the remaining gap to the ~113k flows/s CPU ceiling measured on tmpfs.

<details> <summary>For users: How does this change affect me?</summary>

Network Flows (NetFlow/IPFIX/sFlow) ingestion gets a higher sustained throughput ceiling and roughly half the disk usage for the raw flow tier. The sizing guidance on Learn is updated: plan around 30k–100k flows/s per agent depending on traffic cardinality and storage speed, at ~400 bytes per flow on disk. A new `listener.sync_every_entries` setting controls periodic fsync of the active flow journal; the default (0) favors throughput — set it to a positive value only if you need a sub-rotation crash-durability window and your storage can absorb the fsync stalls. Existing flow journals remain readable; new files are written in the compact journal format (readable by systemd 252+ tooling).

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the NetFlow plugin to `systemd-journal-sdk` 0.6.2, switches the raw flow store to the compact format, disables periodic fsync by default, and requests a 64 MiB UDP receive buffer at startup. This raises throughput (+20–40%), cuts disk to ~400 B/flow, reduces UDP drops (zero kernel drops through ~87k flows/s on ext4 with higher `net.core.rmem_max`), and tightens the UDP loss bench to surface ingest failures and count only successful sends.

- **Migration**
  - No action required. Existing journals remain readable; old and new files can coexist.
  - `listener.sync_every_entries` now defaults to `0` (periodic fsync off). Files still fsync on rotation and at shutdown. Set > 0 only if you need tighter crash durability and your storage can handle the stalls.
  - The listener now requests a 64 MiB UDP receive buffer via SO_RCVBUF and logs the effective size; the kernel caps it at `net.core.rmem_max`. Raise `net.core.rmem_max` for burst headroom (`rmem_default` does not affect this socket).

- **Dependencies**
  - Replaced vendored `journal-*` crates with `systemd-journal-sdk-*` 0.6.2 from crates.io, aliased to the historical names. Scope is the NetFlow plugin only; other components stay on the vendored crates for now.

<sup>Written for commit b4c53d5e62a283e52fa590c29b90a058e6359153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

