### PR TITLE
bound v2 journal header offsets before crc reads in list checks

### DIFF
--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -902,11 +902,26 @@ skip_file:
 // Checks that the extent list checksum is valid
 static int journalfile_check_v2_extent_list (void *data_start, size_t file_size)
 {
-    UNUSED(file_size);
     uLong crc;
 
     struct journal_v2_header *j2_header = (void *) data_start;
     struct journal_v2_block_trailer *journal_v2_trailer;
+
+    // Bound the header-controlled offsets against the trusted file size before
+    // reading through them. Check extent_offset first so the subtraction cannot
+    // underflow, then bound extent_count via division instead of multiplying
+    // extent_count * sizeof(...), which would wrap size_t on 32-bit builds. The
+    // on-disk layout (journalfile_migrate_to_v2_callback) places the extent
+    // trailer immediately after the extent list. Same pattern as the walk in
+    // journalfile_v2_populate_retention_to_mrg().
+    if ((size_t)j2_header->extent_offset > file_size ||
+        (size_t)j2_header->extent_count > (file_size - (size_t)j2_header->extent_offset) / sizeof(struct journal_extent_list) ||
+        (size_t)j2_header->extent_trailer_offset > file_size ||
+        file_size - (size_t)j2_header->extent_trailer_offset < sizeof(struct journal_v2_block_trailer) ||
+        (size_t)j2_header->extent_trailer_offset != (size_t)j2_header->extent_offset + (size_t)j2_header->extent_count * sizeof(struct journal_extent_list)) {
+        netdata_log_error("DBENGINE: extent list header offsets out of range");
+        return 1;
+    }
 
     journal_v2_trailer = (struct journal_v2_block_trailer *) ((uint8_t *) data_start + j2_header->extent_trailer_offset);
     crc = crc32(0L, Z_NULL, 0);
@@ -922,11 +937,26 @@ static int journalfile_check_v2_extent_list (void *data_start, size_t file_size)
 // Checks that the metric list (UUIDs) checksum is valid
 static int journalfile_check_v2_metric_list(void *data_start, size_t file_size)
 {
-    UNUSED(file_size);
     uLong crc;
 
     struct journal_v2_header *j2_header = (void *) data_start;
     struct journal_v2_block_trailer *journal_v2_trailer;
+
+    // Bound the header-controlled offsets against the trusted file size before
+    // reading through them. Check metric_offset first so the subtraction cannot
+    // underflow, then bound metric_count via division instead of multiplying
+    // metric_count * sizeof(...), which would wrap size_t on 32-bit builds. The
+    // on-disk layout (journalfile_migrate_to_v2_callback) places the metric
+    // trailer immediately after the metric list. Same pattern as the walk in
+    // journalfile_v2_populate_retention_to_mrg().
+    if ((size_t)j2_header->metric_offset > file_size ||
+        (size_t)j2_header->metric_count > (file_size - (size_t)j2_header->metric_offset) / sizeof(struct journal_metric_list) ||
+        (size_t)j2_header->metric_trailer_offset > file_size ||
+        file_size - (size_t)j2_header->metric_trailer_offset < sizeof(struct journal_v2_block_trailer) ||
+        (size_t)j2_header->metric_trailer_offset != (size_t)j2_header->metric_offset + (size_t)j2_header->metric_count * sizeof(struct journal_metric_list)) {
+        netdata_log_error("DBENGINE: metric list header offsets out of range");
+        return 1;
+    }
 
     journal_v2_trailer = (struct journal_v2_block_trailer *) ((uint8_t *) data_start + j2_header->metric_trailer_offset);
     crc = crc32(0L, Z_NULL, 0);


### PR DESCRIPTION
##### Summary

`journalfile_check_v2_extent_list()` runs on every v2 journal load (before the `db_engine_journal_check` gate) and reads `extent_count * sizeof(struct journal_extent_list)` bytes from `extent_offset`, plus the trailer at `extent_trailer_offset`, all taken straight from the on-disk header with no bound against the mapping. The file-trailer crc only covers the header bytes and is not a MAC, so a crafted or corrupted header passes it; the read then walks past the mmap, and since `PROTECTED_ACCESS_SETUP` only covers `[data_start, data_start + file_size)`, an offset past that range faults outside the protected region and aborts with SIGBUS. On 32-bit the `count * sizeof` length also wraps. The `file_size` argument was already threaded into both helpers but ignored (`UNUSED`).

Wire `file_size` into `journalfile_check_v2_extent_list()` and `journalfile_check_v2_metric_list()`: bound the offset first so the subtraction can't underflow, bound the count by division instead of multiplying it out, and require the trailer to sit immediately after the list per the on-disk layout. Out-of-range headers return 1 and are treated as invalid (rebuild), same as a crc mismatch. Same shape as the inline checks added to the populate walk in #22514.

##### Test Plan

Reproduced with a standalone harness that places a v2 journal mapping in front of a `PROT_NONE` guard page and sets `extent_count = 0x08000000`: the current read spans bytes `[64 .. 2147483712)` against a one-page mapping and faults with SIGBUS; the bounded version returns 1 before any read. CI covers the existing dbengine journal load and migration paths.

##### Additional Information

The two helpers are reached from `journalfile_v2_validate()` (extent check always, metric check under `db_engine_journal_check`) and from `journalfile_v2_populate_retention_to_mrg()` where the metric check already has an inline guard. The added checks make the helpers safe on their own regardless of caller.

<details> <summary>For users: How does this change affect me?</summary>
Affects the dbengine at agent startup. No visible change for healthy databases. A truncated or corrupted v2 journal that could previously crash the agent during load is now rejected and rebuilt.
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds checks v2 journal extent and metric list offsets and counts before CRC reads to avoid out‑of‑mapping access. Corrupted or truncated headers now fail validation and trigger a safe rebuild instead of crashing on startup.

- **Bug Fixes**
  - Use `file_size` in `journalfile_check_v2_extent_list()` and `journalfile_check_v2_metric_list()` to bound header-controlled reads.
  - Validate `*_offset`, `*_count`, and trailer placement: check against file size, bound counts via division, require trailer immediately after the list; log and return invalid when out of range.

<sup>Written for commit cfa6b6e8c385e52e2a00425f0f3a48dc9383c6c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

