### PR TITLE
Check privilege escalation in ndsudo and JSON conversion status in proto_2_json

### DIFF
--- a/src/aclk/schema-wrappers/proto_2_json.cc
+++ b/src/aclk/schema-wrappers/proto_2_json.cc
@@ -1,6 +1,8 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/util/json_util.h>
 
+#include <memory>
+
 #include "alarm/v1/config.pb.h"
 #include "alarm/v1/stream.pb.h"
 #include "aclk/v1/lib.pb.h"
@@ -72,14 +74,14 @@ static google::protobuf::Message *msg_name_to_protomsg(const char *msgname)
 
 char *protomsg_to_json(const void *protobin, size_t len, const char *msgname)
 {
-    google::protobuf::Message *msg = msg_name_to_protomsg(msgname);
-    if (msg == NULL)
+    // unique_ptr owns the message and frees it on every return path, so no
+    // manual delete is needed (and no path can leak it).
+    std::unique_ptr<google::protobuf::Message> msg(msg_name_to_protomsg(msgname));
+    if (msg == nullptr)
         return strdupz("Don't know this message type by name.");
 
-    if (!msg->ParseFromArray(protobin, len)) {
-        delete msg;
+    if (!msg->ParseFromArray(protobin, len))
         return strdupz("Can't parse this message. Malformed or wrong parser used.");
-    }
 
     JsonPrintOptions options;
 
@@ -89,7 +91,6 @@ char *protomsg_to_json(const void *protobin, size_t len, const char *msgname)
     // 'output' is empty/partial, so check it instead of returning a silent
     // truncated result. .ok() is available on both Status types.
     auto status = google::protobuf::util::MessageToJsonString(*msg, &output, options);
-    delete msg;
     if (!status.ok())
         return strdupz("Failed to convert this message to JSON.");
     return strdupz(output.c_str());

--- a/src/aclk/schema-wrappers/proto_2_json.cc
+++ b/src/aclk/schema-wrappers/proto_2_json.cc
@@ -76,13 +76,21 @@ char *protomsg_to_json(const void *protobin, size_t len, const char *msgname)
     if (msg == NULL)
         return strdupz("Don't know this message type by name.");
 
-    if (!msg->ParseFromArray(protobin, len))
+    if (!msg->ParseFromArray(protobin, len)) {
+        delete msg;
         return strdupz("Can't parse this message. Malformed or wrong parser used.");
+    }
 
     JsonPrintOptions options;
 
     std::string output;
-    google::protobuf::util::MessageToJsonString(*msg, &output, options);
+    // MessageToJsonString returns a nodiscard Status (absl::Status or the
+    // protobuf util Status depending on the linked version). On failure
+    // 'output' is empty/partial, so check it instead of returning a silent
+    // truncated result. .ok() is available on both Status types.
+    auto status = google::protobuf::util::MessageToJsonString(*msg, &output, options);
     delete msg;
+    if (!status.ok())
+        return strdupz("Failed to convert this message to JSON.");
     return strdupz(output.c_str());
 }

--- a/src/collectors/utils/ndsudo.c
+++ b/src/collectors/utils/ndsudo.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <errno.h>
 
 #define MAX_SEARCH 3
 #define MAX_PARAMETERS 128
@@ -456,9 +457,23 @@ int main(int argc, char *argv[]) {
     char new_path[] = "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin";
     putenv(new_path);
 
-    setuid(0);
-    setgid(0);
-    setegid(0);
+    // Escalate to root before searching PATH and running the whitelisted
+    // command. This binary is installed setuid-root; if escalation fails
+    // (e.g. the setuid bit was lost, or a restrictive seccomp/no_new_privs
+    // policy is in effect) a real execution would run the command without
+    // the privileges it needs and misbehave, so we refuse to continue.
+    // --test never runs the privileged command (it only prints the command
+    // line), so a failed escalation is tolerated there -- e.g. inspecting a
+    // non-setuid build -- but it is reported so the output makes clear that a
+    // real run would fail. The escalation is still attempted pre-search in
+    // both modes to preserve the behaviour of installed setuid executions.
+    bool privileges_ok = (setuid(0) == 0 && setgid(0) == 0 && setegid(0) == 0);
+    int privileges_errno = privileges_ok ? 0 : errno; // capture before later syscalls clobber errno
+    if (!privileges_ok && !test) {
+        fprintf(stderr, "ndsudo: failed to acquire root privileges (is the binary setuid-root?): %s\n",
+                strerror(privileges_errno));
+        return 7;
+    }
 
     bool found = false;
     char filename[FILENAME_MAX];
@@ -493,6 +508,11 @@ int main(int argc, char *argv[]) {
             fprintf(stderr, "'%s' ", params[i]);
 
         fprintf(stderr, "\n");
+
+        if(!privileges_ok)
+            fprintf(stderr,
+                    "WARNING: a real run would FAIL before executing this: could not acquire root "
+                    "privileges (is the binary setuid-root?): %s\n", strerror(privileges_errno));
 
         exit(0);
     }


### PR DESCRIPTION
##### Summary
- In `ndsudo.c`, introduced checks to ensure successful privilege escalation (`setuid`, `setgid`, and `setegid`). Added error reporting for failed escalation and warnings in test mode to clarify potential runtime issues.
- In `proto_2_json.cc`, added comprehensive status checks for `MessageToJsonString`. Ensured proper cleanup of allocated resources and added error handling for failed JSON conversions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit privilege escalation checks in `ndsudo` and safer, status-checked JSON conversion in `proto_2_json` to prevent silent failures and memory leaks.

- **Bug Fixes**
  - `ndsudo`: Check `setuid(0)`, `setgid(0)`, and `setegid(0)`; on failure, exit with a clear error. In `--test`, continue but print a warning.
  - `proto_2_json`: Use `std::unique_ptr` for `Message` ownership to avoid leaks; check `MessageToJsonString` status and return an error on failure.

<sup>Written for commit 2b083cf29942be00f49b60c7555b98b461a22d39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

