### PR TITLE
fatal handler: don't let a concurrent fatal mask the first one

### DIFF
--- a/src/libnetdata/log/nd_log.c
+++ b/src/libnetdata/log/nd_log.c
@@ -504,16 +504,42 @@ static void fatal_abort_internal_checks(void) {
 
 NEVER_INLINE
 void netdata_logger_fatal(const char *file, const char *function, const unsigned long line, const char *fmt, ... ) {
-    static size_t already_in_fatal = 0;
+    // Per-thread re-entrancy flag and a process-wide "a fatal is in progress" counter. These detect two different
+    // situations that the previous single
+    // global counter could not tell apart:
+    //  1. Same-thread re-entrancy: this thread called fatal() while already
+    //     handling its own fatal (e.g. an allocation in the logging path below
+    //     failed and re-entered fatal). That is a real bug in the fatal path
+    //     itself; abort with the recursive marker so it is visible.
+    //  2. Concurrency: a DIFFERENT thread is already handling a fatal. This is
+    //     common when a deadlock makes several threads time out and call fatal()
+    //     at once. The first thread owns the fatal record; this one must not
+    //     interleave its output or re-run cleanup, and it must NOT abort via
+    //     recursive_fatal_abort() -- that would surface as a separate crash and
+    //     mask the first (real) fatal. It waits a bounded time for the first to
+    //     finish writing, then exits quietly.
+    static __thread bool this_thread_in_fatal = false;
+    static size_t threads_in_fatal = 0;
 
-    size_t recursion = __atomic_add_fetch(&already_in_fatal, 1, __ATOMIC_SEQ_CST);
-    if(recursion > 1) {
-        // exit immediately, nothing more to be done
-        sleep(2); // give the first fatal the chance to be written
+    if(this_thread_in_fatal) {
+        // (1) same thread re-entered fatal: the outer fatal is suspended below
+        // us on this stack and cannot make progress, so do not wait for it.
         fprintf(stderr, "\nRECURSIVE FATAL STATEMENTS, latest from %s() of %lu@%s, EXITING NOW! 23e93dfccbf64e11aac858b9410d8a82\n",
                 function, line, file);
         fflush(stderr);
         recursive_fatal_abort();
+    }
+    this_thread_in_fatal = true;
+
+    if(__atomic_add_fetch(&threads_in_fatal, 1, __ATOMIC_SEQ_CST) > 1) {
+        // (2) another thread is already writing a fatal. Give it a bounded
+        // chance to finish, then exit quietly (not via recursive_fatal_abort,
+        // which would mask the first fatal as a crash of its own).
+        fprintf(stderr, "\nCONCURRENT FATAL from %s() of %lu@%s, deferring to the first fatal and exiting.\n",
+                function, line, file);
+        fflush(stderr);
+        sleep(2); // give the first fatal the chance to be written
+        _exit(1);
     }
 
     // send this event to deamon_status_file

--- a/src/libnetdata/log/nd_log.c
+++ b/src/libnetdata/log/nd_log.c
@@ -534,7 +534,7 @@ void netdata_logger_fatal(const char *file, const char *function, const unsigned
         int n = snprintf(msg, sizeof(msg),
                 "\nRECURSIVE FATAL STATEMENTS, latest from %s() of %lu@%s, EXITING NOW! 23e93dfccbf64e11aac858b9410d8a82\n",
                 function, line, file);
-        if(n > 0 && write(STDERR_FILENO, msg, (size_t)((n < (int)sizeof(msg)) ? n : (int)sizeof(msg))) < 0) { /* best effort */ }
+        if(n > 0 && write(STDERR_FILENO, msg, (size_t)((n < (int)sizeof(msg)) ? n : (int)sizeof(msg) - 1)) < 0) { /* best effort */ }
         recursive_fatal_abort();
     }
     this_thread_in_fatal = true;
@@ -546,7 +546,7 @@ void netdata_logger_fatal(const char *file, const char *function, const unsigned
         int n = snprintf(msg, sizeof(msg),
                 "\nCONCURRENT FATAL from %s() of %lu@%s, deferring to the first fatal and exiting.\n",
                 function, line, file);
-        if(n > 0 && write(STDERR_FILENO, msg, (size_t)((n < (int)sizeof(msg)) ? n : (int)sizeof(msg))) < 0) { /* best effort */ }
+        if(n > 0 && write(STDERR_FILENO, msg, (size_t)((n < (int)sizeof(msg)) ? n : (int)sizeof(msg) - 1)) < 0) { /* best effort */ }
         sleep(2); // give the first fatal the chance to be written
         _exit(1);
     }

--- a/src/libnetdata/log/nd_log.c
+++ b/src/libnetdata/log/nd_log.c
@@ -521,12 +521,20 @@ void netdata_logger_fatal(const char *file, const char *function, const unsigned
     static __thread bool this_thread_in_fatal = false;
     static size_t threads_in_fatal = 0;
 
+    // NOTE: the two exit paths below must NOT use stdio (fprintf/fflush). The
+    // first fatal thread is likely holding stderr's stdio lock mid-write, and a
+    // second fprintf(stderr) would block on that lock indefinitely -- defeating
+    // the bounded exit these paths are meant to guarantee. Use a raw write(),
+    // which takes no lock.
+    char msg[512];
+
     if(this_thread_in_fatal) {
         // (1) same thread re-entered fatal: the outer fatal is suspended below
         // us on this stack and cannot make progress, so do not wait for it.
-        fprintf(stderr, "\nRECURSIVE FATAL STATEMENTS, latest from %s() of %lu@%s, EXITING NOW! 23e93dfccbf64e11aac858b9410d8a82\n",
+        int n = snprintf(msg, sizeof(msg),
+                "\nRECURSIVE FATAL STATEMENTS, latest from %s() of %lu@%s, EXITING NOW! 23e93dfccbf64e11aac858b9410d8a82\n",
                 function, line, file);
-        fflush(stderr);
+        if(n > 0 && write(STDERR_FILENO, msg, (size_t)((n < (int)sizeof(msg)) ? n : (int)sizeof(msg))) < 0) { /* best effort */ }
         recursive_fatal_abort();
     }
     this_thread_in_fatal = true;
@@ -535,9 +543,10 @@ void netdata_logger_fatal(const char *file, const char *function, const unsigned
         // (2) another thread is already writing a fatal. Give it a bounded
         // chance to finish, then exit quietly (not via recursive_fatal_abort,
         // which would mask the first fatal as a crash of its own).
-        fprintf(stderr, "\nCONCURRENT FATAL from %s() of %lu@%s, deferring to the first fatal and exiting.\n",
+        int n = snprintf(msg, sizeof(msg),
+                "\nCONCURRENT FATAL from %s() of %lu@%s, deferring to the first fatal and exiting.\n",
                 function, line, file);
-        fflush(stderr);
+        if(n > 0 && write(STDERR_FILENO, msg, (size_t)((n < (int)sizeof(msg)) ? n : (int)sizeof(msg))) < 0) { /* best effort */ }
         sleep(2); // give the first fatal the chance to be written
         _exit(1);
     }


### PR DESCRIPTION
##### Summary
netdata_logger_fatal()'s recursion guard used a single process-wide counter, so it couldn't tell apart two different situations:
  
- a thread re-entering fatal() while handling its own fatal (a real fatal-path bug), and 
- a different thread calling fatal() concurrently.

Make the guard thread-aware:
- per-thread flag → same-thread re-entrancy still recursive_fatal_abort() (unchanged; it's a genuine bug);
- process-wide counter → a concurrent second fatal waits briefly for the first to finish writing, then exits quietly via _exit(1) instead of aborting, so it no longer surfaces as a separate crash.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the fatal handler thread-aware so a concurrent fatal can't mask the first crash. Same-thread re-entry still aborts; other threads log once, wait briefly, then exit to avoid a second crash and stderr deadlocks.

- **Bug Fixes**
  - Add a per-thread re-entrancy flag and a process-wide counter in netdata_logger_fatal() to distinguish recursion vs concurrency.
  - On concurrent fatal, bypass stdio and write to stderr using write() with corrected size calculation; wait briefly for the first to finish, then exit via _exit(1) (not abort).

<sup>Written for commit b6d3d19359dc9592a39d55a025f37c6aeeed59c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

