### PR TITLE
Increase UUIDMAP_PARTITIONS to 32

### DIFF
--- a/src/database/engine/mrg-internals.h
+++ b/src/database/engine/mrg-internals.h
@@ -52,6 +52,8 @@ struct metric {
 extern struct aral_statistics mrg_aral_statistics;
 
 struct mrg {
+    // each partition 64-aligned so the contended rw_spinlock words of
+    // adjacent partitions do not false-share a cache line
     struct mrg_partition {
         ARAL *aral;                 // not protected by our spinlock - it has its own
 
@@ -59,7 +61,7 @@ struct mrg {
         Pvoid_t uuid_judy;          // JudyL: each UUID has a JudyL of sections (tiers)
 
         struct mrg_statistics stats;
-    } index[UUIDMAP_PARTITIONS];
+    } __attribute__((aligned(64))) index[UUIDMAP_PARTITIONS];
 };
 
 static inline void MRG_STATS_DUPLICATE_ADD(MRG *mrg, size_t partition) {

--- a/src/libnetdata/uuid/uuidmap.c
+++ b/src/libnetdata/uuid/uuidmap.c
@@ -67,6 +67,17 @@ static UUIDMAP_ID get_next_id_unsafe(struct uuidmap_partition *partition) {
         fatal("UUIDMAP: Maximum ID limit reached for partition %u. UUIDs exhausted.",
               (unsigned int)(partition - uuid_map.p));
 
+    // IDs are never reused, so the sequence space is lifetime capacity.
+    // next_id is monotonic and only changes under the partition write lock,
+    // so the equality check fires exactly once per partition.
+    if (unlikely(partition->next_id == (UUIDMAP_ID_SEQ_MASK / 10) * 9))
+        nd_log(NDLS_DAEMON, NDLP_WARNING,
+               "UUIDMAP: partition %u has used 90%% of its lifetime ID space (%u of %u). "
+               "When it is exhausted, netdata will exit. Restarting netdata resets it.",
+               (unsigned int)(partition - uuid_map.p),
+               (unsigned int)partition->next_id,
+               (unsigned int)UUIDMAP_ID_SEQ_MASK);
+
     // Simply increment and return the next ID
     return uuidmap_make_id(partition - uuid_map.p, ++partition->next_id);
 }

--- a/src/libnetdata/uuid/uuidmap.c
+++ b/src/libnetdata/uuid/uuidmap.c
@@ -7,6 +7,8 @@ struct uuidmap_entry {
     REFCOUNT refcount;
 };
 
+// each partition on its own cache line(s), so the heavily contended lock
+// words of adjacent partitions do not false-share
 struct uuidmap_partition {
     Pvoid_t uuid_to_id;         // JudyL: UUID string -> ID
     Pvoid_t id_to_uuid;         // JudyL: ID -> UUID binary
@@ -15,7 +17,7 @@ struct uuidmap_partition {
 
     int64_t memory;
     int32_t entries;
-};
+} __attribute__((aligned(64)));
 
 static struct {
     struct uuidmap_partition p[UUIDMAP_PARTITIONS];
@@ -61,7 +63,7 @@ static void uuidmap_init_aral(void) {
 
 static UUIDMAP_ID get_next_id_unsafe(struct uuidmap_partition *partition) {
     // Check if we've reached the maximum ID value
-    if (unlikely(partition->next_id >= 0x1FFFFFFF))
+    if (unlikely(partition->next_id >= UUIDMAP_ID_SEQ_MASK))
         fatal("UUIDMAP: Maximum ID limit reached for partition %u. UUIDs exhausted.",
               (unsigned int)(partition - uuid_map.p));
 

--- a/src/libnetdata/uuid/uuidmap.h
+++ b/src/libnetdata/uuid/uuidmap.h
@@ -18,8 +18,8 @@ typedef uint32_t UUIDMAP_ID;
 #define UUIDMAP_ID_SEQ_BITS (32 - UUIDMAP_PARTITION_BITS)
 #define UUIDMAP_ID_SEQ_MASK ((1u << UUIDMAP_ID_SEQ_BITS) - 1)
 
-#if UUIDMAP_PARTITION_BITS > 8
-#error "UUIDMAP_PARTITION_BITS must be <= 8: the partition is derived from one uuid byte and stored in uint8_t"
+#if UUIDMAP_PARTITION_BITS < 1 || UUIDMAP_PARTITION_BITS > 8
+#error "UUIDMAP_PARTITION_BITS must be 1..8: the partition is derived from one uuid byte, is stored in uint8_t, and 0 bits would make the ID packing shifts undefined (shift by 32)"
 #endif
 
 static inline uint8_t uuid_to_uuidmap_partition(const nd_uuid_t uuid) {

--- a/src/libnetdata/uuid/uuidmap.h
+++ b/src/libnetdata/uuid/uuidmap.h
@@ -13,7 +13,7 @@ typedef uint32_t UUIDMAP_ID;
 // capacity - total lifetime capacity stays at 2^32 and random UUIDs
 // distribute evenly across partitions. The partition is also reused by MRG
 // to index its own partitions, so this knob spreads the lock words of both.
-#define UUIDMAP_PARTITION_BITS 8
+#define UUIDMAP_PARTITION_BITS 5
 #define UUIDMAP_PARTITIONS (1u << UUIDMAP_PARTITION_BITS)
 #define UUIDMAP_ID_SEQ_BITS (32 - UUIDMAP_PARTITION_BITS)
 #define UUIDMAP_ID_SEQ_MASK ((1u << UUIDMAP_ID_SEQ_BITS) - 1)

--- a/src/libnetdata/uuid/uuidmap.h
+++ b/src/libnetdata/uuid/uuidmap.h
@@ -7,18 +7,31 @@
 
 typedef uint32_t UUIDMAP_ID;
 
-#define UUIDMAP_PARTITIONS 8
+// 2^UUIDMAP_PARTITION_BITS partitions; the remaining bits of UUIDMAP_ID are
+// the per-partition ID sequence space. IDs are never reused, so raising the
+// partition count proportionally lowers the per-partition lifetime ID
+// capacity - total lifetime capacity stays at 2^32 and random UUIDs
+// distribute evenly across partitions. The partition is also reused by MRG
+// to index its own partitions, so this knob spreads the lock words of both.
+#define UUIDMAP_PARTITION_BITS 8
+#define UUIDMAP_PARTITIONS (1u << UUIDMAP_PARTITION_BITS)
+#define UUIDMAP_ID_SEQ_BITS (32 - UUIDMAP_PARTITION_BITS)
+#define UUIDMAP_ID_SEQ_MASK ((1u << UUIDMAP_ID_SEQ_BITS) - 1)
+
+#if UUIDMAP_PARTITION_BITS > 8
+#error "UUIDMAP_PARTITION_BITS must be <= 8: the partition is derived from one uuid byte and stored in uint8_t"
+#endif
 
 static inline uint8_t uuid_to_uuidmap_partition(const nd_uuid_t uuid) {
-    return uuid[15] & 0x07;  // Mask for 8 partitions (0b111)
+    return uuid[15] & (UUIDMAP_PARTITIONS - 1);
 }
 
 static inline uint8_t uuidmap_id_to_partition(UUIDMAP_ID id) {
-    return (uint8_t)(id >> 29);  // Use top 3 bits for partition
+    return (uint8_t)(id >> UUIDMAP_ID_SEQ_BITS);
 }
 
 static inline UUIDMAP_ID uuidmap_make_id(uint8_t partition, uint32_t id) {
-    return ((UUIDMAP_ID)partition << 29) | (id & 0x1FFFFFFF);  // Use bottom 29 bits for sequence
+    return ((UUIDMAP_ID)partition << UUIDMAP_ID_SEQ_BITS) | (id & UUIDMAP_ID_SEQ_MASK);
 }
 
 // returns ID, or zero on error


### PR DESCRIPTION
##### Summary
- Increased `UUIDMAP_PARTITIONS` from 8 to 32 for improved partitioning range.
- Applied 64-byte alignment to UUID and MRG structures to minimize cache line contention across partitions.
- Refactored ID partition mapping logic for flexibility with configurable partition sizes.
- Improved documentation and introduced safeguards for partition bit definitions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase UUID map partitions from 8 to 32 and 64-byte align partition structures to reduce lock contention and improve parallel writes. Refactor ID encoding/decoding to use configurable partition bits with safety checks, clearer errors, and a 90% capacity warning.

- **Refactors**
  - Introduced `UUIDMAP_PARTITION_BITS` (default 5) with derived `UUIDMAP_PARTITIONS`, `UUIDMAP_ID_SEQ_BITS`, and `UUIDMAP_ID_SEQ_MASK`.
  - Partition selection and ID layout now use configurable bits; top bits = partition, lower bits = sequence; removed magic numbers.
  - Added `__attribute__((aligned(64)))` to `uuidmap_partition` and MRG partitions to avoid cache-line false sharing.
  - Compile-time guard for `UUIDMAP_PARTITION_BITS` (1..8) and safer max-ID checks using `UUIDMAP_ID_SEQ_MASK`.
  - Warn at 90% per-partition ID space.

<sup>Written for commit c471216c0b94f7106dccccbf6707391589e89435. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

