### PR TITLE
Add prepopulation index for MRG to optimize journal replay

### DIFF
--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1091,6 +1091,12 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
     // Calculate number of samples here and update once the file is loaded
     uint64_t journal_samples = 0;
 
+    // The prepopulation index holds the pinned metrics of the multidb tiers
+    // only (see mrg_load()); other instances (tests) take the fallback path.
+    size_t tier = (size_t)ctx->config.tier;
+    bool use_index = tier < (size_t)nd_profile.storage_tiers && multidb_ctx[tier] == ctx;
+    size_t index_hits = 0, index_misses = 0;
+
     // Protect the whole walk -- both the optional CRC check and the mrg update
     // read into the mmap'd v2 journal. If a backing page cannot be paged in
     // (file truncated, sparse hole, transient I/O error) the kernel raises
@@ -1165,15 +1171,32 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
                 time_t end_time_s = header_start_time_s + metric->delta_end_s;
                 uint32_t update_every_s = metric->update_every_s;
 
-                mrg_update_metric_retention_and_granularity_by_uuid(
-                    main_mrg,
-                    (Word_t)ctx,
-                    &local_uuid,
-                    start_time_s,
-                    end_time_s,
-                    update_every_s,
-                    now_s,
-                    &journal_samples);
+                // fast path: the metric was prepopulated from the metadata
+                // database and is pinned - a lock-free probe replaces the
+                // uuidmap + MRG lookups, and the retention is expanded
+                // directly on it
+                METRIC *m = use_index ? mrg_prepopulation_index_get(local_uuid, tier) : NULL;
+                if(likely(m)) {
+                    index_hits++;
+                    mrg_metric_update_retention_and_granularity(
+                        main_mrg, m, start_time_s, end_time_s, update_every_s, now_s, &journal_samples);
+                }
+                else {
+                    // uuid not in the metadata database (e.g. deleted
+                    // metrics still present in journal files), or no index
+                    if(use_index)
+                        index_misses++;
+
+                    mrg_update_metric_retention_and_granularity_by_uuid(
+                        main_mrg,
+                        (Word_t)ctx,
+                        &local_uuid,
+                        start_time_s,
+                        end_time_s,
+                        update_every_s,
+                        now_s,
+                        &journal_samples);
+                }
 
                 metric++;
             }
@@ -1201,6 +1224,9 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
     }
 
     journalfile_v2_data_release(journalfile);
+
+    // batched here so the per-entry loop never touches shared counters
+    mrg_prepopulation_index_account(index_hits, index_misses);
 
     if (unlikely(failed)) {
         journalfile_v2_data_unmap_permanently(journalfile);

--- a/src/database/engine/mrg-load.c
+++ b/src/database/engine/mrg-load.c
@@ -7,8 +7,164 @@ METRIC_JudyLSet acquired_metrics = { 0 };
 size_t acquired_metrics_counter = 0;
 size_t acquired_metrics_deleted = 0;
 
+// ----------------------------------------------------------------------------
+// prepopulation index
+//
+// While mrg_load() prepopulates MRG with every (uuid, tier) known to the
+// metadata database, it also builds this open-addressing hash
+// (uuid -> METRIC* per tier), so that startup journal replay can find the
+// prepopulated metrics with a single lock-free probe instead of paying the
+// uuidmap intern/free, the MRG partition locks, the Judy walks and the
+// refcount round-trips for every journal metric entry (billions of entries
+// on busy parents, with each unique uuid repeated across hundreds of
+// journal files).
+//
+// Lifecycle: built single-threaded inside mrg_load() BEFORE the tiers start
+// journal replay, strictly read-only while replay runs (probes need no
+// locks), and freed by mrg_metric_prepopulate_cleanup() right before the
+// prepopulated references are released - so every METRIC* in the index is
+// pinned by acquired_metrics for the whole life of the index.
+
+#define PREP_IDX_INITIAL_CAPACITY (1 << 16)         // must be a power of 2
+
+struct prepopulation_index {
+    uint8_t *slots;         // capacity slots of stride bytes:
+                            // 16 bytes raw uuid + tiers x METRIC*
+                            // a nil uuid marks an empty slot
+    size_t capacity;        // power of 2
+    size_t stride;
+    size_t tiers;
+    size_t used;            // unique uuids stored
+};
+
+static struct prepopulation_index prep_idx = { 0 };
+static size_t prep_idx_hits = 0;
+static size_t prep_idx_misses = 0;
+
+static inline uint8_t *prep_idx_slot(const struct prepopulation_index *idx, size_t i) {
+    return idx->slots + i * idx->stride;
+}
+
+static inline METRIC **prep_idx_slot_metrics(uint8_t *slot) {
+    return (METRIC **)(slot + sizeof(nd_uuid_t));
+}
+
+static inline size_t prep_idx_first_slot(const struct prepopulation_index *idx, const nd_uuid_t uuid) {
+    return XXH3_64bits(uuid, sizeof(nd_uuid_t)) & (idx->capacity - 1);
+}
+
+void mrg_prepopulation_index_init(size_t tiers) {
+    if(!tiers || prep_idx.slots)
+        return;
+
+    prep_idx.tiers = tiers;
+    prep_idx.stride = sizeof(nd_uuid_t) + tiers * sizeof(METRIC *);
+    prep_idx.capacity = PREP_IDX_INITIAL_CAPACITY;
+    prep_idx.used = 0;
+    prep_idx.slots = callocz(prep_idx.capacity, prep_idx.stride);
+    prep_idx_hits = 0;
+    prep_idx_misses = 0;
+}
+
+// find the slot of uuid, or the empty slot where it should be inserted;
+// the load factor is kept below 3/4 so the linear probe always terminates
+static uint8_t *prep_idx_find_slot(const struct prepopulation_index *idx, const nd_uuid_t uuid) {
+    size_t mask = idx->capacity - 1;
+    for(size_t i = prep_idx_first_slot(idx, uuid); ; i = (i + 1) & mask) {
+        uint8_t *slot = prep_idx_slot(idx, i);
+        if(uuid_is_null(*(const nd_uuid_t *)slot) || memcmp(slot, uuid, sizeof(nd_uuid_t)) == 0)
+            return slot;
+    }
+}
+
+static void prep_idx_grow(struct prepopulation_index *idx) {
+    struct prepopulation_index old = *idx;
+
+    idx->capacity = old.capacity << 1;
+    idx->slots = callocz(idx->capacity, idx->stride);
+
+    for(size_t i = 0; i < old.capacity ;i++) {
+        uint8_t *slot = prep_idx_slot(&old, i);
+        if(uuid_is_null(*(const nd_uuid_t *)slot))
+            continue;
+
+        uint8_t *new_slot = prep_idx_find_slot(idx, *(const nd_uuid_t *)slot);
+        memcpy(new_slot, slot, idx->stride);
+    }
+
+    freez(old.slots);
+}
+
+// single-threaded, during mrg_load() only - the index is immutable once
+// journal replay starts
+void mrg_prepopulation_index_insert(const nd_uuid_t uuid, size_t tier, METRIC *metric) {
+    struct prepopulation_index *idx = &prep_idx;
+
+    if(unlikely(!idx->slots || tier >= idx->tiers || uuid_is_null(uuid)))
+        return;
+
+    if(unlikely(idx->used >= idx->capacity / 4 * 3))
+        prep_idx_grow(idx);
+
+    uint8_t *slot = prep_idx_find_slot(idx, uuid);
+    if(uuid_is_null(*(const nd_uuid_t *)slot)) {
+        memcpy(slot, uuid, sizeof(nd_uuid_t));
+        idx->used++;
+    }
+
+    prep_idx_slot_metrics(slot)[tier] = metric;
+}
+
+// lock-free; safe at any time - returns NULL when there is no index, the
+// tier is out of range, or the uuid is not in the metadata database
+METRIC *mrg_prepopulation_index_get(const nd_uuid_t uuid, size_t tier) {
+    const struct prepopulation_index *idx = &prep_idx;
+
+    if(unlikely(!idx->slots || tier >= idx->tiers))
+        return NULL;
+
+    size_t mask = idx->capacity - 1;
+    for(size_t i = prep_idx_first_slot(idx, uuid); ; i = (i + 1) & mask) {
+        uint8_t *slot = prep_idx_slot(idx, i);
+
+        if(uuid_is_null(*(const nd_uuid_t *)slot))
+            return NULL;
+
+        if(memcmp(slot, uuid, sizeof(nd_uuid_t)) == 0)
+            return prep_idx_slot_metrics(slot)[tier];
+    }
+}
+
+// hit/miss accounting is batched per journal file by the callers, so the
+// hot per-entry path never touches these shared counters
+void mrg_prepopulation_index_account(size_t hits, size_t misses) {
+    if(hits)
+        __atomic_add_fetch(&prep_idx_hits, hits, __ATOMIC_RELAXED);
+    if(misses)
+        __atomic_add_fetch(&prep_idx_misses, misses, __ATOMIC_RELAXED);
+}
+
+void mrg_prepopulation_index_free(void) {
+    if(!prep_idx.slots)
+        return;
+
+    nd_log(NDLS_DAEMON, NDLP_INFO,
+           "MRG: prepopulation index released: %zu unique metrics, %zu slots, %.1f MiB, "
+           "journal replay used it for %zu entries and fell back for %zu",
+           prep_idx.used, prep_idx.capacity,
+           (double)(prep_idx.capacity * prep_idx.stride) / (1024.0 * 1024.0),
+           __atomic_load_n(&prep_idx_hits, __ATOMIC_RELAXED),
+           __atomic_load_n(&prep_idx_misses, __ATOMIC_RELAXED));
+
+    freez(prep_idx.slots);
+    memset(&prep_idx, 0, sizeof(prep_idx));
+}
+
+// ----------------------------------------------------------------------------
+
 ALWAYS_INLINE
-static void mrg_metric_prepopulate(MRG *mrg, Word_t section, nd_uuid_t *uuid) {
+static void mrg_metric_prepopulate(void *mrg_ptr, Word_t section, size_t tier, nd_uuid_t *uuid) {
+    MRG *mrg = mrg_ptr;
     MRG_ENTRY entry = {
         .uuid = uuid,
         .section = section,
@@ -18,6 +174,12 @@ static void mrg_metric_prepopulate(MRG *mrg, Word_t section, nd_uuid_t *uuid) {
     };
     bool added = false;
     METRIC *metric = metric_add_and_acquire(mrg, &entry, &added);
+
+    // whether added now or already there, the metric is pinned by
+    // acquired_metrics until mrg_metric_prepopulate_cleanup(), so the index
+    // can hold the raw pointer
+    mrg_prepopulation_index_insert(*uuid, tier, metric);
+
     if(likely(added)) {
         METRIC_SET(&acquired_metrics, acquired_metrics_counter++, metric);
         return;
@@ -32,6 +194,9 @@ static void mrg_release_cb(Word_t idx __maybe_unused, METRIC *m, void *data) {
 }
 
 void mrg_metric_prepopulate_cleanup(MRG *mrg) {
+    // free the index BEFORE releasing the references that pin its metrics
+    mrg_prepopulation_index_free();
+
     acquired_metrics_deleted = 0;
     METRIC_FREE(&acquired_metrics, mrg_release_cb, mrg);
 
@@ -44,6 +209,7 @@ void mrg_metric_prepopulate_cleanup(MRG *mrg) {
 
 // Main function to load metrics from the database
 bool mrg_load(MRG *mrg) {
-    size_t processed_metrics = populate_metrics_from_database(mrg, (void (*)(void *, Word_t, nd_uuid_t *))mrg_metric_prepopulate);
+    mrg_prepopulation_index_init(nd_profile.storage_tiers);
+    size_t processed_metrics = populate_metrics_from_database(mrg, mrg_metric_prepopulate);
     return processed_metrics > 0;
 }

--- a/src/database/engine/mrg-unittest.c
+++ b/src/database/engine/mrg-unittest.c
@@ -51,9 +51,160 @@ static void mrg_stress(void *ptr) {
     }
 }
 
+static void prep_expect_retention(MRG *mrg, Word_t section, nd_uuid_t *uuid,
+                                  time_t expected_first, time_t expected_last,
+                                  uint32_t expected_ue, const char *test, const char *path) {
+    METRIC *m = mrg_metric_get_and_acquire_by_uuid(mrg, uuid, section);
+    if(!m)
+        fatal("PREP-IDX: test '%s' (%s): metric not found in MRG", test, path);
+
+    time_t first, last;
+    uint32_t ue;
+    mrg_metric_get_retention(mrg, m, &first, &last, &ue);
+    mrg_metric_release(mrg, m);
+
+    if(first != expected_first || last != expected_last || ue != expected_ue)
+        fatal("PREP-IDX: test '%s' (%s): got %ld - %ld @ %u, expected %ld - %ld @ %u",
+              test, path, first, last, ue, expected_first, expected_last, expected_ue);
+}
+
+static void mrg_prepopulation_index_unittest(MRG *mrg) {
+    nd_uuid_t nil_uuid = { 0 }, unknown;
+    uuid_generate_random(unknown);
+
+    // probes must be NULL-safe before any index exists
+    if(mrg_prepopulation_index_get(unknown, 0))
+        fatal("PREP-IDX: probe without an index returned a metric");
+
+    // ---- build an index across 2 tiers, forcing several growth cycles
+    size_t n = 200000;
+    nd_uuid_t *uuids = callocz(n, sizeof(nd_uuid_t));
+    METRIC **metrics = callocz(n, sizeof(METRIC *));
+
+    mrg_prepopulation_index_init(2);
+
+    for(size_t i = 0; i < n ;i++) {
+        uuid_generate_random(uuids[i]);
+        MRG_ENTRY entry = {
+            .uuid = &uuids[i],
+            .section = (Word_t)&test_ctx_0,
+            .first_time_s = 0,
+            .last_time_s = 0,
+            .latest_update_every_s = 0,
+        };
+        bool added = false;
+        metrics[i] = mrg_metric_add_and_acquire(mrg, entry, &added);
+        if(!added)
+            fatal("PREP-IDX: failed to add test metric %zu", i);
+
+        mrg_prepopulation_index_insert(uuids[i], 0, metrics[i]);
+        if(i % 2 == 0)
+            mrg_prepopulation_index_insert(uuids[i], 1, metrics[i]);
+    }
+
+    // nil uuid marks empty slots, so inserting it must be ignored
+    mrg_prepopulation_index_insert(nil_uuid, 0, metrics[0]);
+
+    for(size_t i = 0; i < n ;i++) {
+        if(mrg_prepopulation_index_get(uuids[i], 0) != metrics[i])
+            fatal("PREP-IDX: tier 0 probe mismatch at %zu", i);
+
+        METRIC *t1 = mrg_prepopulation_index_get(uuids[i], 1);
+        if(i % 2 == 0 ? (t1 != metrics[i]) : (t1 != NULL))
+            fatal("PREP-IDX: tier 1 probe mismatch at %zu", i);
+
+        if(mrg_prepopulation_index_get(uuids[i], 2) != NULL)
+            fatal("PREP-IDX: out-of-range tier probe returned a metric");
+    }
+
+    if(mrg_prepopulation_index_get(unknown, 0))
+        fatal("PREP-IDX: unknown uuid probe returned a metric");
+
+    if(mrg_prepopulation_index_get(nil_uuid, 0))
+        fatal("PREP-IDX: nil uuid probe returned a metric");
+
+    mrg_prepopulation_index_account(123, 45);
+    mrg_prepopulation_index_free();
+
+    if(mrg_prepopulation_index_get(uuids[0], 0))
+        fatal("PREP-IDX: probe after free returned a metric");
+
+    for(size_t i = 0; i < n ;i++)
+        mrg_metric_release(mrg, metrics[i]);
+
+    freez(metrics);
+    freez(uuids);
+
+    // ---- equivalence: expanding a zero-retention prepopulated metric via
+    // mrg_metric_update_retention_and_granularity() must end with the same
+    // retention as feeding the same entries to the by_uuid path
+    time_t now_s = max_acceptable_collected_time();
+
+    struct prep_entry { time_t f, l; uint32_t ue; };
+    struct {
+        const char *name;
+        struct prep_entry e[3];
+        size_t entries;
+        struct prep_entry expected;
+    } cases[] = {
+        { "min/max merge",          {{100,200,1},{50,150,2},{150,300,3}}, 3, {50,300,3} },
+        { "ue follows newest last", {{100,200,5},{10,100,7}},             2, {10,200,5} },
+        { "zeros first",            {{0,0,4},{100,200,1}},                2, {100,200,1} },
+        { "zeros last",             {{100,200,1},{0,0,4}},                2, {100,200,1} },
+        { "future last clamped",    {{100,0,9}},                          1, {100,0,9} },
+        { "first > last fixed",     {{300,200,2}},                        1, {200,200,2} },
+    };
+
+    // runtime values for the future-last case
+    cases[4].e[0].l = now_s + 1000;
+    cases[4].expected.l = now_s;
+
+    for(size_t c = 0; c < _countof(cases) ;c++) {
+        nd_uuid_t u;
+        uuid_generate_random(u);
+
+        // path A: existing by_uuid path
+        for(size_t i = 0; i < cases[c].entries ;i++)
+            mrg_update_metric_retention_and_granularity_by_uuid(
+                mrg, (Word_t)&test_ctx_0, &u,
+                cases[c].e[i].f, cases[c].e[i].l, cases[c].e[i].ue, now_s, NULL);
+
+        // path B: prepopulated zero-retention metric, expanded directly
+        MRG_ENTRY entry = {
+            .uuid = &u,
+            .section = (Word_t)&test_ctx_1,
+            .first_time_s = 0,
+            .last_time_s = 0,
+            .latest_update_every_s = 0,
+        };
+        bool added = false;
+        METRIC *m = mrg_metric_add_and_acquire(mrg, entry, &added);
+        if(!added)
+            fatal("PREP-IDX: test '%s': failed to add metric", cases[c].name);
+
+        uint64_t samples = 0;
+        for(size_t i = 0; i < cases[c].entries ;i++)
+            mrg_metric_update_retention_and_granularity(
+                mrg, m, cases[c].e[i].f, cases[c].e[i].l, cases[c].e[i].ue, now_s, &samples);
+
+        mrg_metric_release(mrg, m);
+
+        prep_expect_retention(mrg, (Word_t)&test_ctx_0, &u,
+                              cases[c].expected.f, cases[c].expected.l, cases[c].expected.ue,
+                              cases[c].name, "by_uuid");
+        prep_expect_retention(mrg, (Word_t)&test_ctx_1, &u,
+                              cases[c].expected.f, cases[c].expected.l, cases[c].expected.ue,
+                              cases[c].name, "prepopulated");
+    }
+
+    fprintf(stderr, "DBENGINE METRIC: prepopulation index tests passed\n");
+}
+
 int mrg_unittest(void) {
     // Use mrg_create_for_unittest to avoid pre-loaded metrics that block deletion
     MRG *mrg = mrg_create_for_unittest();
+
+    mrg_prepopulation_index_unittest(mrg);
     METRIC *m1_t0, *m2_t0, *m3_t0, *m4_t0;
     METRIC *m1_t1, *m2_t1, *m3_t1, *m4_t1;
     bool ret;

--- a/src/database/engine/mrg.c
+++ b/src/database/engine/mrg.c
@@ -398,6 +398,76 @@ ALWAYS_INLINE bool mrg_metric_clear_writer(MRG *mrg, METRIC *metric) {
 }
 #endif
 
+// sanitize journal retention values before they reach MRG, warning about
+// on-disk anomalies (rate-limited)
+static inline void mrg_sanitize_journal_retention(time_t *first_time_s, time_t *last_time_s, time_t now_s) {
+    if(unlikely(*last_time_s > now_s)) {
+        nd_log_limit_static_global_var(erl, 1, 0);
+        nd_log_limit(&erl, NDLS_DAEMON, NDLP_WARNING,
+                     "DBENGINE JV2: wrong last time on-disk (%ld - %ld, now %ld), "
+                     "fixing last time to now",
+                     *first_time_s, *last_time_s, now_s);
+        *last_time_s = now_s;
+    }
+
+    if (unlikely(*first_time_s > *last_time_s)) {
+        nd_log_limit_static_global_var(erl, 1, 0);
+        nd_log_limit(&erl, NDLS_DAEMON, NDLP_WARNING,
+                     "DBENGINE JV2: wrong first time on-disk (%ld - %ld, now %ld), "
+                     "fixing first time to last time",
+                     *first_time_s, *last_time_s, now_s);
+
+        *first_time_s = *last_time_s;
+    }
+
+    if (unlikely(*first_time_s == 0 || *last_time_s == 0)) {
+        nd_log_limit_static_global_var(erl, 1, 0);
+        nd_log_limit(&erl, NDLS_DAEMON, NDLP_WARNING,
+                     "DBENGINE JV2: zero on-disk timestamps (%ld - %ld, now %ld), "
+                     "using them as-is",
+                     *first_time_s, *last_time_s, now_s);
+    }
+}
+
+// retention expansion + journal samples accounting on an existing metric;
+// values must already be sanitized; performs NO refcount operations
+static inline void mrg_metric_update_retention_and_granularity_sanitized(
+    MRG *mrg,
+    METRIC *metric,
+    time_t first_time_s,
+    time_t last_time_s,
+    uint32_t update_every_s,
+    uint64_t *journal_samples)
+{
+    uint64_t old_samples = 0;
+
+    if (update_every_s && metric->latest_update_every_s && metric->latest_time_s_clean)
+        old_samples = (metric->latest_time_s_clean - metric->first_time_s) / metric->latest_update_every_s;
+
+    mrg_metric_expand_retention(mrg, metric, first_time_s, last_time_s, update_every_s);
+
+    uint64_t new_samples = 0;
+    if (update_every_s && metric->latest_update_every_s && metric->latest_time_s_clean)
+        new_samples = (metric->latest_time_s_clean - metric->first_time_s) / metric->latest_update_every_s;
+
+    if (journal_samples)
+        *journal_samples += (new_samples - old_samples);
+}
+
+void mrg_metric_update_retention_and_granularity(
+    MRG *mrg,
+    METRIC *metric,
+    time_t first_time_s,
+    time_t last_time_s,
+    uint32_t update_every_s,
+    time_t now_s,
+    uint64_t *journal_samples)
+{
+    mrg_sanitize_journal_retention(&first_time_s, &last_time_s, now_s);
+    mrg_metric_update_retention_and_granularity_sanitized(
+        mrg, metric, first_time_s, last_time_s, update_every_s, journal_samples);
+}
+
 inline void mrg_update_metric_retention_and_granularity_by_uuid(
     MRG *mrg,
     Word_t section,
@@ -408,32 +478,7 @@ inline void mrg_update_metric_retention_and_granularity_by_uuid(
     time_t now_s,
     uint64_t *journal_samples)
 {
-    if(unlikely(last_time_s > now_s)) {
-        nd_log_limit_static_global_var(erl, 1, 0);
-        nd_log_limit(&erl, NDLS_DAEMON, NDLP_WARNING,
-                     "DBENGINE JV2: wrong last time on-disk (%ld - %ld, now %ld), "
-                     "fixing last time to now",
-                     first_time_s, last_time_s, now_s);
-        last_time_s = now_s;
-    }
-
-    if (unlikely(first_time_s > last_time_s)) {
-        nd_log_limit_static_global_var(erl, 1, 0);
-        nd_log_limit(&erl, NDLS_DAEMON, NDLP_WARNING,
-                     "DBENGINE JV2: wrong first time on-disk (%ld - %ld, now %ld), "
-                     "fixing first time to last time",
-                     first_time_s, last_time_s, now_s);
-
-        first_time_s = last_time_s;
-    }
-
-    if (unlikely(first_time_s == 0 || last_time_s == 0)) {
-        nd_log_limit_static_global_var(erl, 1, 0);
-        nd_log_limit(&erl, NDLS_DAEMON, NDLP_WARNING,
-                     "DBENGINE JV2: zero on-disk timestamps (%ld - %ld, now %ld), "
-                     "using them as-is",
-                     first_time_s, last_time_s, now_s);
-    }
+    mrg_sanitize_journal_retention(&first_time_s, &last_time_s, now_s);
 
     bool added = false;
     METRIC *metric = mrg_metric_get_and_acquire_by_uuid(mrg, uuid, section);
@@ -448,21 +493,9 @@ inline void mrg_update_metric_retention_and_granularity_by_uuid(
         metric = mrg_metric_add_and_acquire(mrg, entry, &added);
     }
 
-    if (likely(!added)) {
-        uint64_t old_samples = 0;
-
-        if (update_every_s && metric->latest_update_every_s && metric->latest_time_s_clean)
-            old_samples = (metric->latest_time_s_clean - metric->first_time_s) / metric->latest_update_every_s;
-
-        mrg_metric_expand_retention(mrg, metric, first_time_s, last_time_s, update_every_s);
-
-        uint64_t new_samples = 0;
-        if (update_every_s && metric->latest_update_every_s && metric->latest_time_s_clean)
-            new_samples = (metric->latest_time_s_clean - metric->first_time_s) / metric->latest_update_every_s;
-
-        if (journal_samples)
-            *journal_samples += (new_samples - old_samples);
-    }
+    if (likely(!added))
+        mrg_metric_update_retention_and_granularity_sanitized(
+            mrg, metric, first_time_s, last_time_s, update_every_s, journal_samples);
     else {
         // Newly added
         if (update_every_s) {

--- a/src/database/engine/mrg.h
+++ b/src/database/engine/mrg.h
@@ -95,6 +95,33 @@ void mrg_update_metric_retention_and_granularity_by_uuid(
     time_t now_s,
     uint64_t *journal_samples);
 
+// same retention/granularity update on a metric the caller has already
+// acquired (or that is pinned by the prepopulation references) - performs
+// NO refcount operations
+void mrg_metric_update_retention_and_granularity(
+    MRG *mrg,
+    METRIC *metric,
+    time_t first_time_s,
+    time_t last_time_s,
+    uint32_t update_every_s,
+    time_t now_s,
+    uint64_t *journal_samples);
+
+// --------------------------------------------------------------------------
+// prepopulation index
+//
+// Immutable open-addressing hash uuid -> METRIC* per tier, built while
+// mrg_load() prepopulates MRG from the metadata database, probed lock-free
+// by startup journal replay, and freed by mrg_metric_prepopulate_cleanup()
+// right before the prepopulated references are released - so every METRIC*
+// it returns is pinned for the whole life of the index.
+
+void mrg_prepopulation_index_init(size_t tiers);
+void mrg_prepopulation_index_insert(const nd_uuid_t uuid, size_t tier, METRIC *metric);
+METRIC *mrg_prepopulation_index_get(const nd_uuid_t uuid, size_t tier);
+void mrg_prepopulation_index_account(size_t hits, size_t misses);
+void mrg_prepopulation_index_free(void);
+
 bool mrg_save(MRG *mrg);
 bool mrg_load(MRG *mrg);
 void mrg_metric_prepopulate_cleanup(MRG *mrg);

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2072,7 +2072,7 @@ static void after_metadata_hosts(uv_work_t *req, int status __maybe_unused)
 
 #ifdef ENABLE_DBENGINE
 #define GET_UUID_LIST  "SELECT dim_id FROM dimension"
-size_t populate_metrics_from_database(void *mrg, void (*populate_cb)(void *mrg, Word_t section, nd_uuid_t *uuid))
+size_t populate_metrics_from_database(void *mrg, void (*populate_cb)(void *mrg, Word_t section, size_t tier, nd_uuid_t *uuid))
 {
     sqlite3_stmt *res = NULL;
     sqlite3 *local_meta_db = NULL;
@@ -2105,7 +2105,7 @@ size_t populate_metrics_from_database(void *mrg, void (*populate_cb)(void *mrg, 
             if (unlikely(!multidb_ctx[tier]))
                 continue;
 
-            populate_cb(mrg, (Word_t)multidb_ctx[tier], &uuid);
+            populate_cb(mrg, (Word_t)multidb_ctx[tier], tier, &uuid);
         }
         count++;
     }

--- a/src/database/sqlite/sqlite_metadata.h
+++ b/src/database/sqlite/sqlite_metadata.h
@@ -61,7 +61,7 @@ void commit_alert_transitions(RRDHOST *host);
 void metadata_queue_ctx_host_cleanup(nd_uuid_t *host_uuid, const char *context);
 void store_host_info_and_metadata(RRDHOST *host);
 void metadata_execute_store_statement(sqlite3_stmt *stmt);
-size_t populate_metrics_from_database(void *mrg, void (*populate_cb)(void *mrg, Word_t section, nd_uuid_t *uuid));
+size_t populate_metrics_from_database(void *mrg, void (*populate_cb)(void *mrg, Word_t section, size_t tier, nd_uuid_t *uuid));
 
 // UNIT TEST
 int metadata_unittest(void);


### PR DESCRIPTION
##### Summary
- Introduced a lock-free prepopulation index (uuid -> METRIC* per tier) to improve efficiency during journal replay by reducing refcount and lock overhead.
- Implemented lifecycle management for the prepopulation index, ensuring safe initialization, usage, and cleanup.
- Enhanced `mrg_load` to build the index while preloading metrics from the metadata database.
- Added unit tests for the prepopulation index to validate insertion, retrieval, and retention equivalence.
- Refactored retention update logic to support prepopulated and uuidmap paths consistently.
- Updated v2 journal handling to use the prepopulation index for faster retention updates, falling back to uuidmap on misses.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lock-free prepopulation index (uuid -> METRIC* per tier) built during load to speed up v2 journal replay by avoiding uuidmap lookups, locks, and refcount churn. Replay probes the index first and falls back to uuidmap, with batched hit/miss accounting and a final usage report.

- **New Features**
  - Prepopulation index with open addressing and lock-free probes, per tier.
  - Built in mrg_load while preloading metrics; pointers are pinned for the index lifetime.
  - v2 journal replay uses direct updates on indexed metrics; falls back on misses.
  - Unit tests cover insert/probe/grow, nil/unknown/out-of-range handling, probe without index, and retention equivalence vs by-uuid.

- **Refactors**
  - Added an update path that operates on an acquired metric; centralized journal timestamp sanitization.
  - by-uuid path reuses the sanitized update logic.
  - Metadata population callback now includes tier; updated callers.
  - Index lifecycle: init before replay, track hit/miss counts in batches, log final stats, and free right before releasing prepopulated references.

<sup>Written for commit e1de4be5c160561f08c7c0f1b8ada66734a8a7cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

