### PR TITLE
Validate data loaded from SQLite to prevent crashes on corrupted databases

### DIFF
--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -441,7 +441,8 @@ static cmd_status_t cmd_remove_stale_node_internal(char *args, char **message, b
         int cnt = 0;
         while (sqlite3_step_monitored(res) == SQLITE_ROW) {
             char guid[UUID_STR_LEN];
-            uuid_unparse_lower(*(nd_uuid_t *)sqlite3_column_blob(res, 0), guid);
+            if (!sqlite3_column_uuid_unparse_lower(res, 0, guid))
+                continue;
             host = rrdhost_find_by_guid(guid);
             if (host) {
                 int rc = remove_ephemeral_host(wb, host, report_error, unregister);

--- a/src/database/contexts/rrdcontext-loading.c
+++ b/src/database/contexts/rrdcontext-loading.c
@@ -135,6 +135,12 @@ static void rrdcontext_load_context_callback(VERSIONED_CONTEXT_DATA *ctx_data, v
     RRDHOST *host = data;
     (void)host;
 
+    // the insert callback replaces the SQLite-owned hub string pointers with
+    // owned copies only when hub.version is set - a versionless row would
+    // keep dangling pointers, so skip it
+    if(unlikely(!ctx_data->version))
+        return;
+
     RRDCONTEXT trc = {
         .id = string_strdupz(ctx_data->id),
         .flags = RRD_FLAG_ARCHIVED | RRD_FLAG_UPDATE_REASON_LOAD_SQL, // no need for atomics

--- a/src/database/rrdhost-system-info.c
+++ b/src/database/rrdhost-system-info.c
@@ -19,6 +19,9 @@ void rrdhost_system_info_swap(struct rrdhost_system_info *a, struct rrdhost_syst
 int rrdhost_system_info_set_by_name(struct rrdhost_system_info *system_info, char *name, char *value) {
     int res = 0;
 
+    if (unlikely(!name || !value))
+        return 1;
+
     if (!strcmp(name, "NETDATA_PROTOCOL_VERSION"))
         return res;
 

--- a/src/database/rrdset-type.c
+++ b/src/database/rrdset-type.c
@@ -3,6 +3,9 @@
 #include "rrdset-type.h"
 
 RRDSET_TYPE rrdset_type_id(const char *name) {
+    if(unlikely(!name))
+        return RRDSET_TYPE_LINE;
+
     if(unlikely(strcmp(name, RRDSET_TYPE_AREA_NAME) == 0))
         return RRDSET_TYPE_AREA;
 

--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -402,8 +402,8 @@ void health_alarm_log_populate(
     char *source = (char *) sqlite3_column_text(res, SOURCE);
     alarm_log->command = source ? health_edit_command_from_source(source) : strdupz("UNKNOWN=0=UNKNOWN");
 
-    alarm_log->chart = strdupz((char *) sqlite3_column_text(res, CHART));
-    alarm_log->name = strdupz((char *) sqlite3_column_text(res, NAME));
+    alarm_log->chart = sqlite3_text_strdupz_empty(res, CHART);
+    alarm_log->name = sqlite3_text_strdupz_empty(res, NAME);
 
     alarm_log->when = sqlite3_column_int64(res, WHEN_KEY);
 

--- a/src/database/sqlite/sqlite_db_migration.c
+++ b/src/database/sqlite/sqlite_db_migration.c
@@ -186,34 +186,46 @@ static int do_migration_v2_v3(sqlite3 *database)
     return 0;
 }
 
-static int do_migration_v3_v4(sqlite3 *database)
+// For every table whose name matches 'like_pattern' and is missing 'column',
+// run each statement in 'stmts_fmt' (one '%s' placeholder for the table name).
+static int add_column_to_matching_tables(
+    sqlite3 *database, const char *like_pattern, const char *column,
+    const char *const *stmts_fmt, size_t stmt_count, const char *err_context)
 {
     char sql[256];
 
-    int rc;
+    snprintfz(sql, sizeof(sql) - 1,
+              "SELECT name FROM sqlite_schema WHERE type ='table' AND name LIKE '%s'", like_pattern);
+
     sqlite3_stmt *res = NULL;
-    snprintfz(sql, sizeof(sql) - 1, "SELECT name FROM sqlite_schema WHERE type ='table' AND name LIKE 'health_log_%%'");
-    rc = sqlite3_prepare_v2(database, sql, -1, &res, 0);
-    if (rc != SQLITE_OK) {
-        error_report("Failed to prepare statement to alter health_log tables");
+    if (sqlite3_prepare_v2(database, sql, -1, &res, 0) != SQLITE_OK) {
+        error_report("Failed to prepare statement to alter %s tables", err_context);
         return 1;
     }
 
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-         const char *name = (const char *) sqlite3_column_text(res, 0);
-         if (unlikely(!name))
-             continue;
-         char *table = strdupz(name);
-         if (!column_exists_in_table(database, table, "chart_context")) {
-             snprintfz(sql, sizeof(sql) - 1, "ALTER TABLE %s ADD chart_context text", table);
-             sqlite3_exec_monitored(database, sql, 0, 0, NULL);
-         }
-         freez(table);
+        const char *name = (const char *) sqlite3_column_text(res, 0);
+        if (unlikely(!name))
+            continue;
+        char *table = strdupz(name);
+        if (!column_exists_in_table(database, table, column)) {
+            for (size_t i = 0; i < stmt_count; i++) {
+                snprintfz(sql, sizeof(sql) - 1, stmts_fmt[i], table);
+                sqlite3_exec_monitored(database, sql, 0, 0, NULL);
+            }
+        }
+        freez(table);
     }
 
     SQLITE_FINALIZE(res);
 
     return 0;
+}
+
+static int do_migration_v3_v4(sqlite3 *database)
+{
+    const char *stmts[] = { "ALTER TABLE %s ADD chart_context text" };
+    return add_column_to_matching_tables(database, "health_log_%", "chart_context", stmts, 1, "health_log");
 }
 
 static int do_migration_v4_v5(sqlite3 *database)
@@ -228,64 +240,17 @@ static int do_migration_v5_v6(sqlite3 *database)
 
 static int do_migration_v6_v7(sqlite3 *database)
 {
-    char sql[256];
-
-    int rc;
-    sqlite3_stmt *res = NULL;
-    snprintfz(sql, sizeof(sql) - 1, "SELECT name FROM sqlite_schema WHERE type ='table' AND name LIKE 'aclk_alert_%%'");
-    rc = sqlite3_prepare_v2(database, sql, -1, &res, 0);
-    if (rc != SQLITE_OK) {
-        error_report("Failed to prepare statement to alter aclk_alert tables");
-        return 1;
-    }
-
-    while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-         const char *name = (const char *) sqlite3_column_text(res, 0);
-         if (unlikely(!name))
-             continue;
-         char *table = strdupz(name);
-         if (!column_exists_in_table(database, table, "filtered_alert_unique_id")) {
-             snprintfz(sql, sizeof(sql) - 1, "ALTER TABLE %s ADD filtered_alert_unique_id", table);
-             sqlite3_exec_monitored(database, sql, 0, 0, NULL);
-             snprintfz(sql, sizeof(sql) - 1, "UPDATE %s SET filtered_alert_unique_id = alert_unique_id", table);
-             sqlite3_exec_monitored(database, sql, 0, 0, NULL);
-         }
-         freez(table);
-    }
-
-    SQLITE_FINALIZE(res);
-
-    return 0;
+    const char *stmts[] = {
+        "ALTER TABLE %s ADD filtered_alert_unique_id",
+        "UPDATE %s SET filtered_alert_unique_id = alert_unique_id",
+    };
+    return add_column_to_matching_tables(database, "aclk_alert_%", "filtered_alert_unique_id", stmts, 2, "aclk_alert");
 }
 
 static int do_migration_v7_v8(sqlite3 *database)
 {
-    char sql[256];
-
-    int rc;
-    sqlite3_stmt *res = NULL;
-    snprintfz(sql, sizeof(sql) - 1, "SELECT name FROM sqlite_schema WHERE type ='table' AND name LIKE 'health_log_%%'");
-    rc = sqlite3_prepare_v2(database, sql, -1, &res, 0);
-    if (rc != SQLITE_OK) {
-        error_report("Failed to prepare statement to alter health_log tables");
-        return 1;
-    }
-
-    while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-         const char *name = (const char *) sqlite3_column_text(res, 0);
-         if (unlikely(!name))
-             continue;
-         char *table = strdupz(name);
-         if (!column_exists_in_table(database, table, "transition_id")) {
-             snprintfz(sql, sizeof(sql) - 1, "ALTER TABLE %s ADD transition_id blob", table);
-             sqlite3_exec_monitored(database, sql, 0, 0, NULL);
-         }
-         freez(table);
-    }
-
-    SQLITE_FINALIZE(res);
-
-    return 0;
+    const char *stmts[] = { "ALTER TABLE %s ADD transition_id blob" };
+    return add_column_to_matching_tables(database, "health_log_%", "transition_id", stmts, 1, "health_log");
 }
 
 static int do_migration_v8_v9(sqlite3 *database)
@@ -391,16 +356,14 @@ static int do_migration_v11_v12(sqlite3 *database)
     return rc;
 }
 
-static int do_migration_v14_v15(sqlite3 *database)
+// Run 'stmt_fmt' (one '%s' placeholder for the object name) against every name
+// returned by 'select_sql', batched into a single execution.
+static int execute_on_matching_names(
+    sqlite3 *database, const char *select_sql, const char *stmt_fmt, const char *err_context)
 {
-    char sql[256];
-
-    int rc;
     sqlite3_stmt *res = NULL;
-    snprintfz(sql, sizeof(sql) - 1, "SELECT name FROM sqlite_schema WHERE type = \"index\" AND name LIKE \"aclk_alert_index@_%%\" ESCAPE \"@\"");
-    rc = sqlite3_prepare_v2(database, sql, -1, &res, 0);
-    if (rc != SQLITE_OK) {
-        error_report("Failed to prepare statement to drop unused indices");
+    if (sqlite3_prepare_v2(database, select_sql, -1, &res, 0) != SQLITE_OK) {
+        error_report("Failed to prepare statement to %s", err_context);
         return 1;
     }
 
@@ -410,7 +373,7 @@ static int do_migration_v14_v15(sqlite3 *database)
         const char *name = (const char *) sqlite3_column_text(res, 0);
         if (unlikely(!name))
             continue;
-        buffer_sprintf(wb, "DROP INDEX IF EXISTS %s; ", name);
+        buffer_sprintf(wb, stmt_fmt, name);
         count++;
     }
 
@@ -423,36 +386,22 @@ static int do_migration_v14_v15(sqlite3 *database)
     return 0;
 }
 
+static int do_migration_v14_v15(sqlite3 *database)
+{
+    return execute_on_matching_names(
+        database,
+        "SELECT name FROM sqlite_schema WHERE type = \"index\" AND name LIKE \"aclk_alert_index@_%\" ESCAPE \"@\"",
+        "DROP INDEX IF EXISTS %s; ",
+        "drop unused indices");
+}
+
 static int do_migration_v15_v16(sqlite3 *database)
 {
-    char sql[256];
-
-    int rc;
-    sqlite3_stmt *res = NULL;
-    snprintfz(sql, sizeof(sql) - 1, "SELECT name FROM sqlite_schema WHERE type = \"table\" AND name LIKE \"aclk_alert_%%\"");
-    rc = sqlite3_prepare_v2(database, sql, -1, &res, 0);
-    if (rc != SQLITE_OK) {
-        error_report("Failed to prepare statement to drop unused indices");
-        return 1;
-    }
-
-    BUFFER *wb = buffer_create(128, NULL);
-    size_t count = 0;
-    while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-        const char *name = (const char *) sqlite3_column_text(res, 0);
-        if (unlikely(!name))
-            continue;
-        buffer_sprintf(wb, "ANALYZE %s ; ", name);
-        count++;
-    }
-
-    SQLITE_FINALIZE(res);
-
-    if (count)
-        (void)db_execute(database, buffer_tostring(wb), NULL);
-
-    buffer_free(wb);
-    return 0;
+    return execute_on_matching_names(
+        database,
+        "SELECT name FROM sqlite_schema WHERE type = \"table\" AND name LIKE \"aclk_alert_%\"",
+        "ANALYZE %s ; ",
+        "analyze aclk_alert tables");
 }
 
 static int do_migration_v16_v17(sqlite3 *database)

--- a/src/database/sqlite/sqlite_db_migration.c
+++ b/src/database/sqlite/sqlite_db_migration.c
@@ -200,7 +200,10 @@ static int do_migration_v3_v4(sqlite3 *database)
     }
 
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-         char *table = strdupz((char *) sqlite3_column_text(res, 0));
+         const char *name = (const char *) sqlite3_column_text(res, 0);
+         if (unlikely(!name))
+             continue;
+         char *table = strdupz(name);
          if (!column_exists_in_table(database, table, "chart_context")) {
              snprintfz(sql, sizeof(sql) - 1, "ALTER TABLE %s ADD chart_context text", table);
              sqlite3_exec_monitored(database, sql, 0, 0, NULL);
@@ -237,7 +240,10 @@ static int do_migration_v6_v7(sqlite3 *database)
     }
 
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-         char *table = strdupz((char *) sqlite3_column_text(res, 0));
+         const char *name = (const char *) sqlite3_column_text(res, 0);
+         if (unlikely(!name))
+             continue;
+         char *table = strdupz(name);
          if (!column_exists_in_table(database, table, "filtered_alert_unique_id")) {
              snprintfz(sql, sizeof(sql) - 1, "ALTER TABLE %s ADD filtered_alert_unique_id", table);
              sqlite3_exec_monitored(database, sql, 0, 0, NULL);
@@ -266,7 +272,10 @@ static int do_migration_v7_v8(sqlite3 *database)
     }
 
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-         char *table = strdupz((char *) sqlite3_column_text(res, 0));
+         const char *name = (const char *) sqlite3_column_text(res, 0);
+         if (unlikely(!name))
+             continue;
+         char *table = strdupz(name);
          if (!column_exists_in_table(database, table, "transition_id")) {
              snprintfz(sql, sizeof(sql) - 1, "ALTER TABLE %s ADD transition_id blob", table);
              sqlite3_exec_monitored(database, sql, 0, 0, NULL);
@@ -327,7 +336,10 @@ static int do_migration_v8_v9(sqlite3 *database)
     DICTIONARY *dict_tables = dictionary_create(DICT_OPTION_NONE);
 
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-        char *table = strdupz((char *) sqlite3_column_text(res, 0));
+        const char *name = (const char *) sqlite3_column_text(res, 0);
+        if (unlikely(!name))
+            continue;
+        char *table = strdupz(name);
         if (health_migrate_old_health_log_table(table)) {
             dictionary_set(dict_tables, table, NULL, 0);
         }
@@ -395,7 +407,10 @@ static int do_migration_v14_v15(sqlite3 *database)
     BUFFER *wb = buffer_create(128, NULL);
     size_t count = 0;
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-        buffer_sprintf(wb, "DROP INDEX IF EXISTS %s; ", (char *)sqlite3_column_text(res, 0));
+        const char *name = (const char *) sqlite3_column_text(res, 0);
+        if (unlikely(!name))
+            continue;
+        buffer_sprintf(wb, "DROP INDEX IF EXISTS %s; ", name);
         count++;
     }
 
@@ -424,7 +439,10 @@ static int do_migration_v15_v16(sqlite3 *database)
     BUFFER *wb = buffer_create(128, NULL);
     size_t count = 0;
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-        buffer_sprintf(wb, "ANALYZE %s ; ", (char *)sqlite3_column_text(res, 0));
+        const char *name = (const char *) sqlite3_column_text(res, 0);
+        if (unlikely(!name))
+            continue;
+        buffer_sprintf(wb, "ANALYZE %s ; ", name);
         count++;
     }
 

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -601,22 +601,6 @@ done:
     SQLITE_FINALIZE(res);
 }
 
-static int clean_host_alerts(void *data, int argc, char **argv, char **column)
-{
-    UNUSED(argc);
-    UNUSED(data);
-    UNUSED(column);
-
-    char guid[UUID_STR_LEN];
-    uuid_unparse_lower(*(nd_uuid_t *)argv[0], guid);
-
-    netdata_log_info("Checking host %s (%s)", guid, (const char *) argv[1]);
-    sql_remove_alerts_from_deleted_charts(NULL, (nd_uuid_t *)argv[0]);
-
-    return 0;
-}
-
-
 #define SQL_HEALTH_CHECK_ALL_HOSTS "SELECT host_id, hostname FROM host"
 
 void sql_alert_cleanup(bool cli)
@@ -629,12 +613,30 @@ void sql_alert_cleanup(bool cli)
         return;
     }
     netdata_log_info("Alert cleanup running ...");
-    int rc = sqlite3_exec_monitored(db_meta, SQL_HEALTH_CHECK_ALL_HOSTS, clean_host_alerts, NULL, NULL);
-    if (rc != SQLITE_OK)
-        netdata_log_error("Failed to check host alerts");
-    else
-        netdata_log_info("Alert cleanup done");
 
+    sqlite3_stmt *res = NULL;
+    if (!PREPARE_STATEMENT(db_meta, SQL_HEALTH_CHECK_ALL_HOSTS, &res)) {
+        netdata_log_error("Failed to check host alerts");
+        return;
+    }
+
+    while (sqlite3_step_monitored(res) == SQLITE_ROW) {
+        nd_uuid_t host_uuid;
+        if (!sqlite3_column_uuid_copy(res, 0, host_uuid)) {
+            error_report("Alert cleanup: skipping host with invalid host_id");
+            continue;
+        }
+
+        char guid[UUID_STR_LEN];
+        uuid_unparse_lower(host_uuid, guid);
+
+        const char *hostname = (const char *) sqlite3_column_text(res, 1);
+        netdata_log_info("Checking host %s (%s)", guid, hostname ? hostname : "unknown");
+        sql_remove_alerts_from_deleted_charts(NULL, &host_uuid);
+    }
+
+    SQLITE_FINALIZE(res);
+    netdata_log_info("Alert cleanup done");
 }
 /* Health related SQL queries
    Load from the health log table

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -620,7 +620,8 @@ void sql_alert_cleanup(bool cli)
         return;
     }
 
-    while (sqlite3_step_monitored(res) == SQLITE_ROW) {
+    int rc;
+    while ((rc = sqlite3_step_monitored(res)) == SQLITE_ROW) {
         nd_uuid_t host_uuid;
         if (!sqlite3_column_uuid_copy(res, 0, host_uuid)) {
             error_report("Alert cleanup: skipping host with invalid host_id");
@@ -636,7 +637,11 @@ void sql_alert_cleanup(bool cli)
     }
 
     SQLITE_FINALIZE(res);
-    netdata_log_info("Alert cleanup done");
+
+    if (rc != SQLITE_DONE)
+        netdata_log_error("Failed to check host alerts");
+    else
+        netdata_log_info("Alert cleanup done");
 }
 /* Health related SQL queries
    Load from the health log table

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -511,7 +511,8 @@ done:
     SQLITE_FINALIZE(res);
 }
 
-#define SELECT_HOST_INFO "SELECT system_key, system_value FROM host_info WHERE host_id = @host_id"
+#define SELECT_HOST_INFO "SELECT system_key, system_value FROM host_info WHERE host_id = @host_id " \
+    "AND system_key IS NOT NULL AND system_value IS NOT NULL"
 
 void sql_build_host_system_info(nd_uuid_t *host_id, struct rrdhost_system_info *system_info)
 {


### PR DESCRIPTION
##### Summary
 SQLite enforces schema constraints (`NOT NULL`, types, lengths) only at write time. When reading a database damaged by storage failures or modified outside the agent, any column can return SQL NULL, an unexpected type, or a blob of any length. 

An audit of every `sqlite3_column_*` read site found seven places that dereference such values unvalidated, crashing the agent — three of them during startup, turning one bad row into a permanent boot loop.

All fixes route through validation helpers that already exist in the codebase. 
Behavior for valid data is unchanged; malformed rows are skipped instead of crashing.

- **Host system info** — a single bad row in the `host_info` table crashed the agent on every startup. Bad rows are now ignored.
- **Chart type** — a context entry with a missing chart type crashed startup; it now falls back to the default (`line`).
- **Alert push to Cloud** — alert log entries with a missing chart or alert name crashed the agent each time it tried to send them to Netdata Cloud; they are now sent with empty values instead.
- **`remove-stale-node` CLI command** — a host entry with a missing or truncated host ID crashed the command; such entries are now skipped.
- **`sqlite-alert-cleanup` CLI command** — same problem; the lookup was also reworked so the host ID can be fully validated before use.
- **Database schema upgrades** — corrupted table names in the database catalog crashed the upgrade that runs at startup; they are now skipped.
- **Context loading** — context entries saved without a version could leave the agent reading freed memory later; they are now ignored at load.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate and sanitize SQLite reads to prevent crashes on corrupted or externally modified databases. Invalid rows are skipped or defaulted, fixing startup loops and runtime failures without changing behavior for valid data; also simplifies migration code for safer upgrades.

- **Bug Fixes**
  - Host system info: ignore rows with null key/value; fix startup crash.
  - Chart type: default to `line` when missing; fix startup crash.
  - Context loading: skip entries without a version to avoid dangling pointers.
  - Alert push to Cloud: allow missing chart/name by sending empty strings.
  - remove-stale-node CLI: skip invalid/truncated `host_id` UUIDs.
  - sqlite-alert-cleanup CLI: skip hosts with invalid `host_id`; log and continue.
  - Migrations: skip null/invalid table and index names during schema upgrades.

- **Refactors**
  - Replaced `sqlite3_exec` callback in alert cleanup with prepared statements for clearer control flow and errors.
  - Centralized use of validation helpers for SQLite reads (e.g., safe UUID/text extraction).
  - Alert cleanup: log non-SQLITE_DONE results for clearer failures.
  - Migrations: extracted reusable helpers to alter/analyze/drop across matching tables/indexes, reducing duplication and improving safety.

<sup>Written for commit 6f613546ce377f272ddfb1a414fc9a4c4e024748. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

