### PR TITLE
Update vendored NetIPC SDK

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -1099,6 +1099,8 @@ void ebpf_stop_threads(int sig)
     }
     netdata_mutex_unlock(&ebpf_exit_cleanup);
 
+    ebpf_cgroup_cache_abort();
+
     for (i = 0; ebpf_modules[i].info.thread_name != NULL; i++) {
         enum ebpf_threads_status enabled = ebpf_module_enabled_get(&ebpf_modules[i]);
 

--- a/src/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/src/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -10,8 +10,20 @@ ebpf_cgroup_target_t *ebpf_cgroup_pids = NULL;
 _Atomic int send_cgroup_chart = 0;
 
 #ifdef OS_LINUX
+#define EBPF_CGROUP_NETIPC_CALL_TIMEOUT_MS 5000u
+
 static nipc_cgroups_cache_t ebpf_cgroup_cache;
 static bool ebpf_cgroup_cache_initialized = false;
+
+static bool ebpf_cgroup_cache_is_initialized(void)
+{
+    return __atomic_load_n(&ebpf_cgroup_cache_initialized, __ATOMIC_ACQUIRE);
+}
+
+static void ebpf_cgroup_cache_set_initialized(bool initialized)
+{
+    __atomic_store_n(&ebpf_cgroup_cache_initialized, initialized, __ATOMIC_RELEASE);
+}
 
 static const char *ebpf_netipc_client_state_name(nipc_client_state_t state)
 {
@@ -283,7 +295,7 @@ void ebpf_reset_updated_var()
 static void ebpf_cgroup_cache_init(void)
 {
 #ifdef OS_LINUX
-    if (ebpf_cgroup_cache_initialized)
+    if (ebpf_cgroup_cache_is_initialized())
         return;
 
     uint64_t auth = netipc_auth_token();
@@ -292,6 +304,7 @@ static void ebpf_cgroup_cache_init(void)
         .supported_profiles = NIPC_PROFILE_BASELINE | NIPC_PROFILE_SHM_HYBRID | NIPC_PROFILE_SHM_FUTEX,
         .preferred_profiles = NIPC_PROFILE_SHM_FUTEX,
         .auth_token = auth,
+        .call_timeout_ms = EBPF_CGROUP_NETIPC_CALL_TIMEOUT_MS,
     };
 
     nipc_cgroups_cache_init(&ebpf_cgroup_cache,
@@ -299,7 +312,15 @@ static void ebpf_cgroup_cache_init(void)
                              "cgroups-snapshot",
                              &config);
 
-    ebpf_cgroup_cache_initialized = true;
+    ebpf_cgroup_cache_set_initialized(true);
+#endif
+}
+
+void ebpf_cgroup_cache_abort(void)
+{
+#ifdef OS_LINUX
+    if (ebpf_cgroup_cache_is_initialized())
+        nipc_client_abort(&ebpf_cgroup_cache.client);
 #endif
 }
 
@@ -309,9 +330,10 @@ static void ebpf_cgroup_cache_init(void)
 void ebpf_cgroup_cache_cleanup(void)
 {
 #ifdef OS_LINUX
-    if (ebpf_cgroup_cache_initialized) {
+    if (ebpf_cgroup_cache_is_initialized()) {
+        nipc_client_abort(&ebpf_cgroup_cache.client);
         nipc_cgroups_cache_close(&ebpf_cgroup_cache);
-        ebpf_cgroup_cache_initialized = false;
+        ebpf_cgroup_cache_set_initialized(false);
     }
 #endif
 }
@@ -331,7 +353,7 @@ static void ebpf_parse_cgroup_netipc_data(void)
     static int previous_integration_active = -1;
     static int previous_systemd_enabled = -1;
 
-    if (!ebpf_cgroup_cache_initialized)
+    if (!ebpf_cgroup_cache_is_initialized())
         return;
 
     static int refresh_fail_count = 0;
@@ -532,8 +554,11 @@ void ebpf_cgroup_integration(void *ptr __maybe_unused)
         // refresh every NETDATA_EBPF_CGROUP_UPDATE seconds
         if (++counter >= NETDATA_EBPF_CGROUP_UPDATE) {
             counter = 0;
-            if (!ebpf_cgroup_cache_initialized)
+            if (!ebpf_cgroup_cache_is_initialized())
                 ebpf_cgroup_cache_init();
+
+            if (ebpf_plugin_stop())
+                break;
 
             ebpf_parse_cgroup_netipc_data();
         }

--- a/src/collectors/ebpf.plugin/ebpf_cgroup.h
+++ b/src/collectors/ebpf.plugin/ebpf_cgroup.h
@@ -78,6 +78,7 @@ typedef struct ebpf_systemd_args {
 
 void ebpf_create_charts_on_systemd(ebpf_systemd_args_t *chart);
 void ebpf_cgroup_integration(void *ptr);
+void ebpf_cgroup_cache_abort(void);
 void ebpf_cgroup_cache_cleanup(void);
 extern _Atomic int send_cgroup_chart;
 

--- a/src/crates/netipc/src/protocol/mod.rs
+++ b/src/crates/netipc/src/protocol/mod.rs
@@ -103,6 +103,10 @@ pub enum NipcError {
     BadItemCount,
     /// Builder ran out of space.
     Overflow,
+    /// Synchronous call timed out before a complete response arrived.
+    Timeout,
+    /// Synchronous call was aborted by the caller.
+    Aborted,
 }
 
 impl core::fmt::Display for NipcError {
@@ -119,6 +123,8 @@ impl core::fmt::Display for NipcError {
             NipcError::BadAlignment => write!(f, "item not 8-byte aligned"),
             NipcError::BadItemCount => write!(f, "item count inconsistent"),
             NipcError::Overflow => write!(f, "builder out of space"),
+            NipcError::Timeout => write!(f, "synchronous call timed out"),
+            NipcError::Aborted => write!(f, "synchronous call aborted"),
         }
     }
 }

--- a/src/crates/netipc/src/service/apps_lookup.rs
+++ b/src/crates/netipc/src/service/apps_lookup.rs
@@ -16,7 +16,7 @@ use crate::transport::windows::{
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-pub use raw::{AppsLookupHandler, ClientState, ClientStatus};
+pub use raw::{AppsLookupHandler, ClientAbortHandle, ClientState, ClientStatus};
 
 #[derive(Debug, Clone)]
 pub struct ClientConfig {
@@ -109,8 +109,32 @@ impl AppsLookupClient {
         self.inner.status()
     }
 
+    pub fn set_call_timeout(&mut self, timeout_ms: u32) {
+        self.inner.set_call_timeout(timeout_ms);
+    }
+
+    pub fn abort_handle(&self) -> ClientAbortHandle {
+        self.inner.abort_handle()
+    }
+
+    pub fn abort(&self) {
+        self.inner.abort();
+    }
+
+    pub fn clear_abort(&self) {
+        self.inner.clear_abort();
+    }
+
     pub fn call(&mut self, pids: &[u32]) -> Result<AppsLookupResponseView<'_>, NipcError> {
-        self.inner.call_apps_lookup(pids)
+        self.call_with_timeout(pids, 0)
+    }
+
+    pub fn call_with_timeout(
+        &mut self,
+        pids: &[u32],
+        timeout_ms: u32,
+    ) -> Result<AppsLookupResponseView<'_>, NipcError> {
+        self.inner.call_apps_lookup_with_timeout(pids, timeout_ms)
     }
 
     pub fn close(&mut self) {

--- a/src/crates/netipc/src/service/cgroups_lookup.rs
+++ b/src/crates/netipc/src/service/cgroups_lookup.rs
@@ -18,7 +18,7 @@ use crate::transport::windows::{
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-pub use raw::{CgroupsLookupHandler, ClientState, ClientStatus};
+pub use raw::{CgroupsLookupHandler, ClientAbortHandle, ClientState, ClientStatus};
 
 #[derive(Debug, Clone)]
 pub struct ClientConfig {
@@ -115,8 +115,33 @@ impl CgroupsLookupClient {
         self.inner.status()
     }
 
+    pub fn set_call_timeout(&mut self, timeout_ms: u32) {
+        self.inner.set_call_timeout(timeout_ms);
+    }
+
+    pub fn abort_handle(&self) -> ClientAbortHandle {
+        self.inner.abort_handle()
+    }
+
+    pub fn abort(&self) {
+        self.inner.abort();
+    }
+
+    pub fn clear_abort(&self) {
+        self.inner.clear_abort();
+    }
+
     pub fn call(&mut self, paths: &[&[u8]]) -> Result<CgroupsLookupResponseView<'_>, NipcError> {
-        self.inner.call_cgroups_lookup(paths)
+        self.call_with_timeout(paths, 0)
+    }
+
+    pub fn call_with_timeout(
+        &mut self,
+        paths: &[&[u8]],
+        timeout_ms: u32,
+    ) -> Result<CgroupsLookupResponseView<'_>, NipcError> {
+        self.inner
+            .call_cgroups_lookup_with_timeout(paths, timeout_ms)
     }
 
     pub fn close(&mut self) {

--- a/src/crates/netipc/src/service/cgroups_snapshot.rs
+++ b/src/crates/netipc/src/service/cgroups_snapshot.rs
@@ -20,7 +20,10 @@ use crate::transport::windows::{
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-pub use raw::{CgroupsCacheItem, CgroupsCacheStatus, ClientState, ClientStatus, SnapshotHandler};
+pub use raw::{
+    CgroupsCacheItem, CgroupsCacheStatus, ClientAbortHandle, ClientState, ClientStatus,
+    SnapshotHandler,
+};
 
 /// Public L2/L3 client configuration for the cgroups-snapshot service.
 ///
@@ -129,9 +132,39 @@ impl CgroupsClient {
         self.inner.status()
     }
 
+    /// Set the context-level default timeout for blocking calls.
+    pub fn set_call_timeout(&mut self, timeout_ms: u32) {
+        self.inner.set_call_timeout(timeout_ms);
+    }
+
+    /// Return a cloneable handle that can abort calls from another thread.
+    pub fn abort_handle(&self) -> ClientAbortHandle {
+        self.inner.abort_handle()
+    }
+
+    /// Request abort of an in-flight or future synchronous call.
+    pub fn abort(&self) {
+        self.inner.abort();
+    }
+
+    /// Clear a previous abort request so the client can be reused.
+    pub fn clear_abort(&self) {
+        self.inner.clear_abort();
+    }
+
     /// Blocking typed call for the cgroups-snapshot service.
     pub fn call_snapshot(&mut self) -> Result<CgroupsResponseView<'_>, NipcError> {
-        self.inner.call_snapshot()
+        self.call_snapshot_with_timeout(0)
+    }
+
+    /// Blocking typed call with an explicit timeout in milliseconds.
+    ///
+    /// A zero timeout uses the client's context-level default.
+    pub fn call_snapshot_with_timeout(
+        &mut self,
+        timeout_ms: u32,
+    ) -> Result<CgroupsResponseView<'_>, NipcError> {
+        self.inner.call_snapshot_with_timeout(timeout_ms)
     }
 
     /// Tear down connection and release resources.
@@ -241,6 +274,26 @@ impl CgroupsCache {
     /// Fill a status snapshot for diagnostics.
     pub fn status(&self) -> CgroupsCacheStatus {
         self.inner.status()
+    }
+
+    /// Set the context-level default timeout for blocking refresh calls.
+    pub fn set_call_timeout(&mut self, timeout_ms: u32) {
+        self.inner.set_call_timeout(timeout_ms);
+    }
+
+    /// Return a cloneable handle that can abort refresh calls from another thread.
+    pub fn abort_handle(&self) -> ClientAbortHandle {
+        self.inner.abort_handle()
+    }
+
+    /// Request abort of an in-flight or future refresh call.
+    pub fn abort(&self) {
+        self.inner.abort();
+    }
+
+    /// Clear a previous abort request so the cache client can be reused.
+    pub fn clear_abort(&self) {
+        self.inner.clear_abort();
     }
 
     /// Close the cache and underlying L2 client.

--- a/src/crates/netipc/src/service/raw.rs
+++ b/src/crates/netipc/src/service/raw.rs
@@ -32,7 +32,7 @@ pub use apps_lookup::{apps_lookup_dispatch, AppsLookupHandler};
 pub use cgroups_cache::{CgroupsCache, CgroupsCacheItem, CgroupsCacheStatus};
 pub use cgroups_lookup::{cgroups_lookup_dispatch, CgroupsLookupHandler};
 pub use cgroups_snapshot::{snapshot_dispatch, snapshot_max_items, SnapshotHandler};
-pub use client::{ClientState, ClientStatus, RawClient};
+pub use client::{ClientAbortHandle, ClientState, ClientStatus, RawClient};
 pub use dispatch::{DispatchError, DispatchHandler};
 pub use increment::{increment_dispatch, IncrementHandler};
 pub use server::ManagedServer;

--- a/src/crates/netipc/src/service/raw/apps_lookup.rs
+++ b/src/crates/netipc/src/service/raw/apps_lookup.rs
@@ -23,6 +23,17 @@ impl RawClient {
         &mut self,
         pids: &[u32],
     ) -> Result<AppsLookupResponseView<'_>, NipcError> {
+        self.call_apps_lookup_with_timeout(pids, 0)
+    }
+
+    /// Blocking typed call with an explicit timeout in milliseconds.
+    ///
+    /// A zero timeout uses the client's context-level default.
+    pub fn call_apps_lookup_with_timeout(
+        &mut self,
+        pids: &[u32],
+        timeout_ms: u32,
+    ) -> Result<AppsLookupResponseView<'_>, NipcError> {
         self.validate_method(METHOD_APPS_LOOKUP)?;
 
         let dir_size = pids
@@ -41,8 +52,12 @@ impl RawClient {
             let req_buf = self.request_scratch(req_size);
             protocol::encode_apps_lookup_request(pids, req_buf)?
         };
-        let response =
-            self.raw_call_with_retry(METHOD_APPS_LOOKUP, req_len, RawCallKind::single())?;
+        let response = self.raw_call_with_retry_timeout(
+            METHOD_APPS_LOOKUP,
+            req_len,
+            RawCallKind::single(),
+            timeout_ms,
+        )?;
         let view = AppsLookupResponseView::decode(self.response_payload(response)?)?;
         if view.item_count != pids.len() as u32 {
             return Err(NipcError::BadItemCount);

--- a/src/crates/netipc/src/service/raw/cgroups_cache.rs
+++ b/src/crates/netipc/src/service/raw/cgroups_cache.rs
@@ -1,4 +1,4 @@
-use super::client::{ClientConfig, ClientState, RawClient};
+use super::client::{ClientAbortHandle, ClientConfig, ClientState, RawClient};
 use super::common::next_power_of_2_u32;
 
 /// Cached copy of a single cgroup item. Owns its strings.
@@ -197,6 +197,26 @@ impl CgroupsCache {
             connection_state: self.client.status().state,
             last_refresh_ts: self.last_refresh_ts,
         }
+    }
+
+    /// Set the context-level default timeout for blocking refresh calls.
+    pub fn set_call_timeout(&mut self, timeout_ms: u32) {
+        self.client.set_call_timeout(timeout_ms);
+    }
+
+    /// Return a cloneable handle that can abort refresh calls from another thread.
+    pub fn abort_handle(&self) -> ClientAbortHandle {
+        self.client.abort_handle()
+    }
+
+    /// Request abort of an in-flight or future refresh call.
+    pub fn abort(&self) {
+        self.client.abort();
+    }
+
+    /// Clear a previous abort request so the cache client can be reused.
+    pub fn clear_abort(&self) {
+        self.client.clear_abort();
     }
 
     /// Close the cache: free all cached items, close the L2 client.

--- a/src/crates/netipc/src/service/raw/cgroups_lookup.rs
+++ b/src/crates/netipc/src/service/raw/cgroups_lookup.rs
@@ -24,6 +24,17 @@ impl RawClient {
         &mut self,
         paths: &[&[u8]],
     ) -> Result<CgroupsLookupResponseView<'_>, NipcError> {
+        self.call_cgroups_lookup_with_timeout(paths, 0)
+    }
+
+    /// Blocking typed call with an explicit timeout in milliseconds.
+    ///
+    /// A zero timeout uses the client's context-level default.
+    pub fn call_cgroups_lookup_with_timeout(
+        &mut self,
+        paths: &[&[u8]],
+        timeout_ms: u32,
+    ) -> Result<CgroupsLookupResponseView<'_>, NipcError> {
         self.validate_method(METHOD_CGROUPS_LOOKUP)?;
 
         let dir_size = paths
@@ -50,8 +61,12 @@ impl RawClient {
             let req_buf = self.request_scratch(req_size);
             protocol::encode_cgroups_lookup_request(paths, req_buf)?
         };
-        let response =
-            self.raw_call_with_retry(METHOD_CGROUPS_LOOKUP, req_len, RawCallKind::single())?;
+        let response = self.raw_call_with_retry_timeout(
+            METHOD_CGROUPS_LOOKUP,
+            req_len,
+            RawCallKind::single(),
+            timeout_ms,
+        )?;
         let view = CgroupsLookupResponseView::decode(self.response_payload(response)?)?;
         if view.item_count != paths.len() as u32 {
             return Err(NipcError::BadItemCount);

--- a/src/crates/netipc/src/service/raw/cgroups_snapshot.rs
+++ b/src/crates/netipc/src/service/raw/cgroups_snapshot.rs
@@ -20,6 +20,16 @@ impl RawClient {
     ///
     /// The returned view is valid until the next typed call on this client.
     pub fn call_snapshot(&mut self) -> Result<CgroupsResponseView<'_>, NipcError> {
+        self.call_snapshot_with_timeout(0)
+    }
+
+    /// Blocking typed call with an explicit timeout in milliseconds.
+    ///
+    /// A zero timeout uses the client's context-level default.
+    pub fn call_snapshot_with_timeout(
+        &mut self,
+        timeout_ms: u32,
+    ) -> Result<CgroupsResponseView<'_>, NipcError> {
         self.validate_method(METHOD_CGROUPS_SNAPSHOT)?;
         let req = CgroupsRequest {
             layout_version: 1,
@@ -34,8 +44,12 @@ impl RawClient {
             req_len
         };
 
-        let response =
-            self.raw_call_with_retry(METHOD_CGROUPS_SNAPSHOT, req_len, RawCallKind::single())?;
+        let response = self.raw_call_with_retry_timeout(
+            METHOD_CGROUPS_SNAPSHOT,
+            req_len,
+            RawCallKind::single(),
+            timeout_ms,
+        )?;
         CgroupsResponseView::decode(self.response_payload(response)?)
     }
 }

--- a/src/crates/netipc/src/service/raw/client.rs
+++ b/src/crates/netipc/src/service/raw/client.rs
@@ -1,5 +1,7 @@
 use super::common::{ensure_client_scratch, next_power_of_2_u32};
 use crate::protocol::{self, NipcError, MAX_PAYLOAD_CAP};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 #[cfg(unix)]
 pub(super) use crate::transport::posix::ClientConfig;
@@ -18,6 +20,11 @@ use crate::transport::windows::NpSession;
 
 #[cfg(windows)]
 use crate::transport::win_shm::WinShmContext;
+
+/// Default timeout for synchronous client calls.
+pub const CLIENT_CALL_TIMEOUT_DEFAULT_MS: u32 = 30_000;
+
+pub(super) const CLIENT_ABORT_POLL_MS: u32 = 100;
 
 /// Client connection state machine.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,6 +78,30 @@ pub struct RawClient {
     pub(super) reconnect_count: u32,
     pub(super) call_count: u32,
     pub(super) error_count: u32,
+
+    pub(super) call_timeout_ms: u32,
+    pub(super) abort_requested: Arc<AtomicBool>,
+}
+
+/// Cloneable handle that can abort a blocking client call from another thread.
+///
+/// Abort is sticky until `clear()` is called on either the handle or the
+/// owning client.
+#[derive(Clone, Debug)]
+pub struct ClientAbortHandle {
+    requested: Arc<AtomicBool>,
+}
+
+impl ClientAbortHandle {
+    /// Request abort of an in-flight or future synchronous call.
+    pub fn abort(&self) {
+        self.requested.store(true, Ordering::Release);
+    }
+
+    /// Clear a previous abort request.
+    pub fn clear(&self) {
+        self.requested.store(false, Ordering::Release);
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -123,7 +154,49 @@ impl RawClient {
             reconnect_count: 0,
             call_count: 0,
             error_count: 0,
+            call_timeout_ms: CLIENT_CALL_TIMEOUT_DEFAULT_MS,
+            abort_requested: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    pub(super) fn resolved_call_timeout(&self, timeout_ms: u32) -> u32 {
+        if timeout_ms != 0 {
+            return timeout_ms;
+        }
+        if self.call_timeout_ms != 0 {
+            return self.call_timeout_ms;
+        }
+        CLIENT_CALL_TIMEOUT_DEFAULT_MS
+    }
+
+    pub(super) fn abort_requested(&self) -> bool {
+        self.abort_requested.load(Ordering::Acquire)
+    }
+
+    /// Set the context-level default timeout for blocking calls.
+    pub fn set_call_timeout(&mut self, timeout_ms: u32) {
+        self.call_timeout_ms = if timeout_ms == 0 {
+            CLIENT_CALL_TIMEOUT_DEFAULT_MS
+        } else {
+            timeout_ms
+        };
+    }
+
+    /// Return a cloneable handle that can abort calls from another thread.
+    pub fn abort_handle(&self) -> ClientAbortHandle {
+        ClientAbortHandle {
+            requested: self.abort_requested.clone(),
+        }
+    }
+
+    /// Request abort of an in-flight or future synchronous call.
+    pub fn abort(&self) {
+        self.abort_requested.store(true, Ordering::Release);
+    }
+
+    /// Clear a previous abort request so the client can be refreshed/reused.
+    pub fn clear_abort(&self) {
+        self.abort_requested.store(false, Ordering::Release);
     }
 
     /// Attempt connect if DISCONNECTED/NOT_FOUND, reconnect if BROKEN.
@@ -231,6 +304,7 @@ impl RawClient {
     pub fn close(&mut self) {
         self.disconnect();
         self.state = ClientState::Disconnected;
+        self.clear_abort();
     }
 
     /// Tear down the current connection.

--- a/src/crates/netipc/src/service/raw/client_call.rs
+++ b/src/crates/netipc/src/service/raw/client_call.rs
@@ -1,25 +1,35 @@
-use super::client::{ClientResponseRef, ClientResponseSource, ClientState, RawCallKind, RawClient};
+use super::client::{
+    ClientResponseRef, ClientResponseSource, ClientState, RawCallKind, RawClient,
+    CLIENT_ABORT_POLL_MS,
+};
 use super::common::{ensure_client_scratch, CACHE_RESPONSE_BUF_SIZE};
 use crate::protocol::{
     self, Header, NipcError, HEADER_SIZE, KIND_REQUEST, KIND_RESPONSE, MAGIC_MSG,
     STATUS_LIMIT_EXCEEDED, STATUS_OK, VERSION,
 };
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 
 impl RawClient {
-    /// Reconnect-driven recovery for raw calls.
-    ///
-    /// Ordinary failures retry once. Overflow-driven resize recovery may
-    /// reconnect more than once while negotiated capacities grow.
-    pub(super) fn raw_call_with_retry(
+    pub(super) fn raw_call_with_retry_timeout(
         &mut self,
         method_code: u16,
         req_len: usize,
         call: RawCallKind,
+        timeout_ms: u32,
     ) -> Result<ClientResponseRef, NipcError> {
         if self.state != ClientState::Ready {
             self.error_count += 1;
             return Err(NipcError::BadLayout);
         }
+        if self.abort_requested() {
+            self.disconnect();
+            self.state = ClientState::Broken;
+            self.error_count += 1;
+            return Err(NipcError::Aborted);
+        }
+
+        let timeout_ms = self.resolved_call_timeout(timeout_ms);
 
         let mut overflow_retries = 0u32;
         loop {
@@ -28,12 +38,19 @@ impl RawClient {
             let prev_cfg_req = self.transport_config.max_request_payload_bytes;
             let prev_cfg_resp = self.transport_config.max_response_payload_bytes;
 
-            match self.do_raw_call(method_code, req_len, call) {
+            match self.do_raw_call(method_code, req_len, call, timeout_ms) {
                 Ok(payload) => {
                     self.call_count += 1;
                     return Ok(payload);
                 }
                 Err(first_err) => {
+                    if first_err == NipcError::Timeout || first_err == NipcError::Aborted {
+                        self.disconnect();
+                        self.state = ClientState::Broken;
+                        self.error_count += 1;
+                        return Err(first_err);
+                    }
+
                     if first_err != NipcError::Overflow {
                         self.disconnect();
                         self.state = ClientState::Broken;
@@ -44,7 +61,7 @@ impl RawClient {
                         }
                         self.reconnect_count += 1;
 
-                        match self.do_raw_call(method_code, req_len, call) {
+                        match self.do_raw_call(method_code, req_len, call, timeout_ms) {
                             Ok(payload) => {
                                 self.call_count += 1;
                                 return Ok(payload);
@@ -96,7 +113,12 @@ impl RawClient {
         method_code: u16,
         req_len: usize,
         call: RawCallKind,
+        timeout_ms: u32,
     ) -> Result<ClientResponseRef, NipcError> {
+        if self.abort_requested() {
+            return Err(NipcError::Aborted);
+        }
+
         let mut hdr = Header {
             kind: KIND_REQUEST,
             code: method_code,
@@ -108,7 +130,7 @@ impl RawClient {
         };
 
         self.transport_send_request_buf(&mut hdr, req_len)?;
-        let (resp_hdr, response) = self.transport_receive()?;
+        let (resp_hdr, response) = self.transport_receive(timeout_ms)?;
 
         if resp_hdr.kind != KIND_RESPONSE {
             return Err(NipcError::BadKind);
@@ -250,16 +272,18 @@ impl RawClient {
     }
 
     /// Receive via the active transport. Returns (header, payload view).
-    pub(super) fn transport_receive(&mut self) -> Result<(Header, ClientResponseRef), NipcError> {
+    pub(super) fn transport_receive(
+        &mut self,
+        timeout_ms: u32,
+    ) -> Result<(Header, ClientResponseRef), NipcError> {
         let needed = self.max_receive_message_bytes();
+        let abort = self.abort_requested.clone();
         let scratch = ensure_client_scratch(&mut self.transport_buf, needed);
 
         #[cfg(target_os = "linux")]
         {
             if let Some(ref mut shm) = self.shm {
-                let mlen = shm
-                    .receive(scratch, 30000)
-                    .map_err(|_| NipcError::Truncated)?;
+                let mlen = receive_posix_shm_with_control(shm, scratch, timeout_ms, &abort)?;
 
                 if mlen < HEADER_SIZE {
                     return Err(NipcError::Truncated);
@@ -279,9 +303,7 @@ impl RawClient {
         #[cfg(windows)]
         {
             if let Some(ref mut shm) = self.shm {
-                let mlen = shm
-                    .receive(scratch, 30000)
-                    .map_err(|_| NipcError::Truncated)?;
+                let mlen = receive_win_shm_with_control(shm, scratch, timeout_ms, &abort)?;
 
                 if mlen < HEADER_SIZE {
                     return Err(NipcError::Truncated);
@@ -303,7 +325,9 @@ impl RawClient {
         #[cfg(unix)]
         {
             let scratch_payload_ptr = unsafe { scratch.as_ptr().add(HEADER_SIZE) };
-            let (hdr, payload) = session.receive(scratch).map_err(|_| NipcError::Truncated)?;
+            let (hdr, payload) = session
+                .receive_with_control(scratch, timeout_ms, Some(&abort))
+                .map_err(map_uds_receive_error)?;
             let source = if payload.as_ptr() == scratch_payload_ptr {
                 ClientResponseSource::TransportBuf
             } else {
@@ -321,7 +345,9 @@ impl RawClient {
         #[cfg(windows)]
         {
             let scratch_payload_ptr = unsafe { scratch.as_ptr().add(HEADER_SIZE) };
-            let (hdr, payload) = session.receive(scratch).map_err(|_| NipcError::Truncated)?;
+            let (hdr, payload) = session
+                .receive_with_control(scratch, timeout_ms, Some(&abort))
+                .map_err(map_np_receive_error)?;
             let source = if payload.as_ptr() == scratch_payload_ptr {
                 ClientResponseSource::TransportBuf
             } else {
@@ -382,5 +408,93 @@ impl RawClient {
             max_payload = CACHE_RESPONSE_BUF_SIZE;
         }
         HEADER_SIZE + max_payload
+    }
+}
+
+fn receive_deadline(timeout_ms: u32) -> Option<Instant> {
+    (timeout_ms != 0).then(|| Instant::now() + Duration::from_millis(timeout_ms as u64))
+}
+
+fn receive_wait_slice_ms(deadline: Option<Instant>, abort: &AtomicBool) -> Result<u32, NipcError> {
+    if abort.load(Ordering::Acquire) {
+        return Err(NipcError::Aborted);
+    }
+
+    let mut wait_ms: Option<u128> = if let Some(deadline) = deadline {
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(NipcError::Timeout);
+        }
+        Some(deadline.duration_since(now).as_millis().max(1))
+    } else {
+        None
+    };
+
+    wait_ms = Some(wait_ms.map_or(CLIENT_ABORT_POLL_MS as u128, |ms| {
+        ms.min(CLIENT_ABORT_POLL_MS as u128)
+    }));
+
+    Ok(wait_ms.unwrap().min(u32::MAX as u128) as u32)
+}
+
+#[cfg(target_os = "linux")]
+fn receive_posix_shm_with_control(
+    shm: &mut crate::transport::shm::ShmContext,
+    scratch: &mut [u8],
+    timeout_ms: u32,
+    abort: &AtomicBool,
+) -> Result<usize, NipcError> {
+    use crate::transport::shm::ShmError;
+
+    let deadline = receive_deadline(timeout_ms);
+    loop {
+        let wait_ms = receive_wait_slice_ms(deadline, abort)?;
+        match shm.receive(scratch, wait_ms) {
+            Ok(mlen) => return Ok(mlen),
+            Err(ShmError::Timeout) => continue,
+            Err(ShmError::MsgTooLarge) => return Err(NipcError::Overflow),
+            Err(_) => return Err(NipcError::Truncated),
+        }
+    }
+}
+
+#[cfg(windows)]
+fn receive_win_shm_with_control(
+    shm: &mut crate::transport::win_shm::WinShmContext,
+    scratch: &mut [u8],
+    timeout_ms: u32,
+    abort: &AtomicBool,
+) -> Result<usize, NipcError> {
+    use crate::transport::win_shm::WinShmError;
+
+    let deadline = receive_deadline(timeout_ms);
+    loop {
+        let wait_ms = receive_wait_slice_ms(deadline, abort)?;
+        match shm.receive(scratch, wait_ms) {
+            Ok(mlen) => return Ok(mlen),
+            Err(WinShmError::Timeout) => continue,
+            Err(WinShmError::MsgTooLarge) => return Err(NipcError::Overflow),
+            Err(_) => return Err(NipcError::Truncated),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn map_uds_receive_error(err: crate::transport::posix::UdsError) -> NipcError {
+    match err {
+        crate::transport::posix::UdsError::Timeout => NipcError::Timeout,
+        crate::transport::posix::UdsError::Aborted => NipcError::Aborted,
+        crate::transport::posix::UdsError::LimitExceeded => NipcError::Overflow,
+        _ => NipcError::Truncated,
+    }
+}
+
+#[cfg(windows)]
+fn map_np_receive_error(err: crate::transport::windows::NpError) -> NipcError {
+    match err {
+        crate::transport::windows::NpError::Timeout => NipcError::Timeout,
+        crate::transport::windows::NpError::Aborted => NipcError::Aborted,
+        crate::transport::windows::NpError::LimitExceeded => NipcError::Overflow,
+        _ => NipcError::Truncated,
     }
 }

--- a/src/crates/netipc/src/service/raw/client_unix.rs
+++ b/src/crates/netipc/src/service/raw/client_unix.rs
@@ -1,5 +1,3 @@
-#![cfg(unix)]
-
 use super::client::{ClientState, RawClient};
 use super::common::{CLIENT_SHM_ATTACH_RETRY_INTERVAL_MS, CLIENT_SHM_ATTACH_RETRY_TIMEOUT_MS};
 #[cfg(target_os = "linux")]

--- a/src/crates/netipc/src/service/raw/increment.rs
+++ b/src/crates/netipc/src/service/raw/increment.rs
@@ -18,6 +18,17 @@ impl RawClient {
     /// Blocking typed call: INCREMENT method.
     /// Sends a u64 value, receives the incremented u64 back.
     pub fn call_increment(&mut self, value: u64) -> Result<u64, NipcError> {
+        self.call_increment_with_timeout(value, 0)
+    }
+
+    /// Blocking typed call with an explicit timeout in milliseconds.
+    ///
+    /// A zero timeout uses the client's context-level default.
+    pub fn call_increment_with_timeout(
+        &mut self,
+        value: u64,
+        timeout_ms: u32,
+    ) -> Result<u64, NipcError> {
         self.validate_method(METHOD_INCREMENT)?;
         let req_len = {
             let req_buf = self.request_scratch(INCREMENT_PAYLOAD_SIZE);
@@ -28,21 +39,36 @@ impl RawClient {
             req_len
         };
 
-        let response =
-            self.raw_call_with_retry(METHOD_INCREMENT, req_len, RawCallKind::single())?;
+        let response = self.raw_call_with_retry_timeout(
+            METHOD_INCREMENT,
+            req_len,
+            RawCallKind::single(),
+            timeout_ms,
+        )?;
         increment_decode(self.response_payload(response)?)
     }
 
     /// Blocking typed batch call: INCREMENT method.
     /// Sends multiple u64 values, receives the incremented u64s back.
     pub fn call_increment_batch(&mut self, values: &[u64]) -> Result<Vec<u64>, NipcError> {
+        self.call_increment_batch_with_timeout(values, 0)
+    }
+
+    /// Blocking typed batch call with an explicit timeout in milliseconds.
+    ///
+    /// A zero timeout uses the client's context-level default.
+    pub fn call_increment_batch_with_timeout(
+        &mut self,
+        values: &[u64],
+        timeout_ms: u32,
+    ) -> Result<Vec<u64>, NipcError> {
         self.validate_method(METHOD_INCREMENT)?;
         if values.is_empty() {
             return Ok(Vec::new());
         }
 
         if values.len() == 1 {
-            let r = self.call_increment(values[0])?;
+            let r = self.call_increment_with_timeout(values[0], timeout_ms)?;
             return Ok(vec![r]);
         }
 
@@ -64,8 +90,12 @@ impl RawClient {
             req_len
         };
 
-        let response =
-            self.raw_call_with_retry(METHOD_INCREMENT, req_len, RawCallKind::batch(count))?;
+        let response = self.raw_call_with_retry_timeout(
+            METHOD_INCREMENT,
+            req_len,
+            RawCallKind::batch(count),
+            timeout_ms,
+        )?;
         let resp_payload = self.response_payload(response)?;
         let mut results = Vec::with_capacity(values.len());
         for i in 0..count {

--- a/src/crates/netipc/src/service/raw/server_unix.rs
+++ b/src/crates/netipc/src/service/raw/server_unix.rs
@@ -1,5 +1,3 @@
-#![cfg(unix)]
-
 use super::common::SERVER_POLL_TIMEOUT_MS;
 use super::server::{ManagedServer, ServerConfig};
 use super::server_session_unix::{handle_session_threaded, poll_fd};

--- a/src/crates/netipc/src/service/raw/string_reverse.rs
+++ b/src/crates/netipc/src/service/raw/string_reverse.rs
@@ -23,6 +23,17 @@ impl RawClient {
         &mut self,
         s: &str,
     ) -> Result<protocol::StringReverseView<'_>, NipcError> {
+        self.call_string_reverse_with_timeout(s, 0)
+    }
+
+    /// Blocking typed call with an explicit timeout in milliseconds.
+    ///
+    /// A zero timeout uses the client's context-level default.
+    pub fn call_string_reverse_with_timeout(
+        &mut self,
+        s: &str,
+        timeout_ms: u32,
+    ) -> Result<protocol::StringReverseView<'_>, NipcError> {
         self.validate_method(METHOD_STRING_REVERSE)?;
         let req_size = STRING_REVERSE_HDR_SIZE
             .checked_add(s.len())
@@ -37,8 +48,12 @@ impl RawClient {
             req_len
         };
 
-        let response =
-            self.raw_call_with_retry(METHOD_STRING_REVERSE, req_len, RawCallKind::single())?;
+        let response = self.raw_call_with_retry_timeout(
+            METHOD_STRING_REVERSE,
+            req_len,
+            RawCallKind::single(),
+            timeout_ms,
+        )?;
         string_reverse_decode(self.response_payload(response)?)
     }
 }

--- a/src/crates/netipc/src/service/raw_unix_tests.rs
+++ b/src/crates/netipc/src/service/raw_unix_tests.rs
@@ -11,8 +11,9 @@ use crate::protocol::{
 use std::os::fd::RawFd;
 use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
+use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const TEST_RUN_DIR: &str = "/tmp/nipc_svc_rust_test";
 const AUTH_TOKEN: u64 = 0xDEADBEEFCAFEBABE;
@@ -163,6 +164,75 @@ fn connect_ready(client: &mut RawClient) {
     }
 
     panic!("client did not reach READY state");
+}
+
+#[test]
+fn test_client_call_timeout_on_wedged_peer() {
+    let svc = unique_service("rs_call_timeout");
+    let mut server =
+        start_raw_session_server(&svc, server_config(), move |_session, _hdr, _payload| {
+            thread::sleep(Duration::from_millis(150));
+            Ok(())
+        });
+
+    let mut client = increment_client(&svc, client_config());
+    connect_ready(&mut client);
+
+    let start = Instant::now();
+    let err = client
+        .call_increment_with_timeout(41, 30)
+        .expect_err("wedged peer should time out");
+    assert_eq!(err, NipcError::Timeout);
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "timeout took too long: {:?}",
+        start.elapsed()
+    );
+
+    client.close();
+    server.wait();
+    cleanup_all(&svc);
+}
+
+#[test]
+fn test_client_abort_unblocks_call() {
+    let svc = unique_service("rs_call_abort");
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let mut server =
+        start_raw_session_server(&svc, server_config(), move |_session, _hdr, _payload| {
+            let _ = entered_tx.send(());
+            let _ = release_rx.recv_timeout(Duration::from_secs(5));
+            Ok(())
+        });
+
+    let mut client = increment_client(&svc, client_config());
+    connect_ready(&mut client);
+    let abort = client.abort_handle();
+
+    let call_thread = thread::spawn(move || {
+        client
+            .call_increment_with_timeout(41, 5_000)
+            .expect_err("aborted call should fail")
+    });
+
+    entered_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("server handler should receive request");
+
+    let start = Instant::now();
+    abort.abort();
+    let err = call_thread.join().expect("call thread should not panic");
+    assert_eq!(err, NipcError::Aborted);
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "abort took too long: {:?}",
+        start.elapsed()
+    );
+
+    release_tx.send(()).expect("release handler");
+    server.wait();
+    cleanup_all(&svc);
 }
 
 fn fill_test_cgroups_snapshot(builder: &mut CgroupsBuilder<'_>) -> bool {
@@ -1156,7 +1226,10 @@ fn test_server_falls_back_to_baseline_when_linux_shm_prepare_fails() {
 
     let shm_path = format!("{TEST_RUN_DIR}/{svc}-{:016x}.ipcshm", 1u64);
     let _ = std::fs::remove_dir_all(&shm_path);
+    // A non-empty directory cannot be reclaimed by stale recovery, so SHM
+    // prepare keeps failing and the server must fall back to baseline.
     std::fs::create_dir(&shm_path).expect("create SHM obstruction directory");
+    std::fs::write(format!("{shm_path}/keep"), b"x").expect("populate obstruction");
 
     let mut server = TestServer::start_with(
         svc,
@@ -4342,7 +4415,7 @@ fn test_shm_batch_request_item_decode_failure_returns_bad_envelope() {
         .send(&msg)
         .expect("send malformed batch request");
 
-    let (resp_hdr, response) = client.transport_receive().expect("receive response");
+    let (resp_hdr, response) = client.transport_receive(0).expect("receive response");
     assert_eq!(resp_hdr.kind, KIND_RESPONSE);
     assert_eq!(resp_hdr.code, METHOD_INCREMENT);
     assert_eq!(resp_hdr.transport_status, STATUS_BAD_ENVELOPE);

--- a/src/crates/netipc/src/service/raw_windows_tests.rs
+++ b/src/crates/netipc/src/service/raw_windows_tests.rs
@@ -12,9 +12,10 @@ use crate::protocol::{
 use crate::transport::windows::build_pipe_name;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const TEST_RUN_DIR: &str = r"C:\Temp\nipc_svc_rust_test";
 const AUTH_TOKEN: u64 = 0xDEADBEEFCAFEBABE;
@@ -285,6 +286,75 @@ fn wait_for_state(client: &mut RawClient, want: ClientState) {
     }
 
     panic!("client did not reach state {:?}", want);
+}
+
+#[test]
+fn test_client_call_timeout_on_wedged_peer() {
+    let svc = unique_service("rs_win_call_timeout");
+    let mut server =
+        start_raw_session_server(&svc, server_config(), move |_session, _hdr, _payload| {
+            thread::sleep(Duration::from_millis(150));
+            Ok(())
+        });
+
+    let mut client = increment_client(&svc, client_config());
+    connect_ready(&mut client);
+
+    let start = Instant::now();
+    let err = client
+        .call_increment_with_timeout(41, 30)
+        .expect_err("wedged peer should time out");
+    assert_eq!(err, NipcError::Timeout);
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "timeout took too long: {:?}",
+        start.elapsed()
+    );
+
+    client.close();
+    server.wait();
+    cleanup_all(&svc);
+}
+
+#[test]
+fn test_client_abort_unblocks_call() {
+    let svc = unique_service("rs_win_call_abort");
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let mut server =
+        start_raw_session_server(&svc, server_config(), move |_session, _hdr, _payload| {
+            let _ = entered_tx.send(());
+            let _ = release_rx.recv_timeout(Duration::from_secs(5));
+            Ok(())
+        });
+
+    let mut client = increment_client(&svc, client_config());
+    connect_ready(&mut client);
+    let abort = client.abort_handle();
+
+    let call_thread = thread::spawn(move || {
+        client
+            .call_increment_with_timeout(41, 5_000)
+            .expect_err("aborted call should fail")
+    });
+
+    entered_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("server handler should receive request");
+
+    let start = Instant::now();
+    abort.abort();
+    let err = call_thread.join().expect("call thread should not panic");
+    assert_eq!(err, NipcError::Aborted);
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "abort took too long: {:?}",
+        start.elapsed()
+    );
+
+    release_tx.send(()).expect("release handler");
+    server.wait();
+    cleanup_all(&svc);
 }
 
 struct TestServer {

--- a/src/crates/netipc/src/transport/posix.rs
+++ b/src/crates/netipc/src/transport/posix.rs
@@ -12,10 +12,10 @@ use crate::protocol::{
 use std::collections::HashSet;
 use std::ffi::CString;
 use std::io;
-use std::os::unix::fs::MetadataExt;
 use std::os::unix::io::RawFd;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 // ---------------------------------------------------------------------------
 //  Constants
@@ -46,6 +46,10 @@ pub enum UdsError {
     Send(i32),
     /// recv() failed or peer disconnected.
     Recv(i32),
+    /// Receive timed out before a complete message arrived.
+    Timeout,
+    /// Receive was aborted by the caller.
+    Aborted,
     /// Handshake protocol error.
     Handshake(String),
     /// Authentication token rejected.
@@ -81,6 +85,8 @@ impl std::fmt::Display for UdsError {
             UdsError::Accept(e) => write!(f, "accept failed: errno {e}"),
             UdsError::Send(e) => write!(f, "send failed: errno {e}"),
             UdsError::Recv(e) => write!(f, "recv failed: errno {e}"),
+            UdsError::Timeout => write!(f, "receive timed out"),
+            UdsError::Aborted => write!(f, "receive aborted"),
             UdsError::Handshake(s) => write!(f, "handshake error: {s}"),
             UdsError::AuthFailed => write!(f, "authentication token rejected"),
             UdsError::NoProfile => write!(f, "no common transport profile"),
@@ -337,6 +343,13 @@ impl UdsSession {
     /// Inner send logic, separated so the caller can rollback on failure.
     fn send_inner(&mut self, hdr: &mut Header, payload: &[u8]) -> Result<(), UdsError> {
         let total_msg = HEADER_SIZE + payload.len();
+        // total_message_len is a u32 wire field; larger totals are
+        // unrepresentable (parity with the C nipc_uds_header_payload_len).
+        if total_msg > u32::MAX as usize {
+            return Err(UdsError::BadParam(
+                "total message length exceeds protocol limit".into(),
+            ));
+        }
 
         // Single packet?
         if total_msg <= self.packet_size as usize {
@@ -398,12 +411,28 @@ impl UdsSession {
     /// On success, returns (header, payload_view). The payload view is valid
     /// until the next receive call on this session.
     pub fn receive<'a>(&'a mut self, buf: &'a mut [u8]) -> Result<(Header, &'a [u8]), UdsError> {
+        self.receive_with_control(buf, 0, None)
+    }
+
+    /// Receive one logical message with an optional deadline and abort flag.
+    ///
+    /// `timeout_ms == 0` waits indefinitely. When `abort` is set before a
+    /// complete message arrives, the call returns `UdsError::Aborted`.
+    pub fn receive_with_control<'a>(
+        &'a mut self,
+        buf: &'a mut [u8],
+        timeout_ms: u32,
+        abort: Option<&AtomicBool>,
+    ) -> Result<(Header, &'a [u8]), UdsError> {
         if self.fd < 0 {
             return Err(UdsError::BadParam("session closed".into()));
         }
 
+        let controlled = timeout_ms != 0 || abort.is_some();
+        let mut wait = ReceiveWait::new(timeout_ms, abort);
+
         // Read first packet
-        let n = match raw_recv(self.fd, buf) {
+        let n = match raw_recv_control(self.fd, buf, controlled, &mut wait) {
             Ok(n) => n,
             Err(err) => {
                 self.fail_all_inflight();
@@ -447,6 +476,14 @@ impl UdsSession {
         }
 
         let total_msg = HEADER_SIZE + hdr.payload_len as usize;
+        // total_message_len is a u32 wire field; reject unrepresentable totals
+        // so the chunk-header comparison below cannot truncate-match (parity
+        // with the C nipc_uds_header_payload_len).
+        if total_msg > u32::MAX as usize {
+            return Err(UdsError::Protocol(
+                "total message length exceeds protocol limit".into(),
+            ));
+        }
 
         if n > total_msg {
             return Err(UdsError::Protocol(
@@ -508,7 +545,7 @@ impl UdsSession {
 
         let mut ci = 1u32;
         while assembled < hdr.payload_len as usize {
-            let cn = match raw_recv(self.fd, &mut self.pkt_buf) {
+            let cn = match raw_recv_control(self.fd, &mut self.pkt_buf, controlled, &mut wait) {
                 Ok(n) => n,
                 Err(err) => {
                     self.fail_all_inflight();
@@ -602,7 +639,7 @@ impl UdsListener {
         let path = build_socket_path(run_dir, service_name)?;
 
         // Stale recovery
-        match check_and_recover_stale(&path, run_dir_allows_stale_unlink(run_dir)) {
+        match check_and_recover_stale(&path) {
             StaleResult::LiveServer => return Err(UdsError::AddrInUse),
             StaleResult::Stale | StaleResult::NotExist => { /* proceed */ }
         }
@@ -853,6 +890,105 @@ fn raw_recv(fd: RawFd, buf: &mut [u8]) -> Result<usize, UdsError> {
     Ok(n as usize)
 }
 
+struct ReceiveWait<'a> {
+    deadline: Option<Instant>,
+    abort: Option<&'a AtomicBool>,
+}
+
+impl<'a> ReceiveWait<'a> {
+    fn new(timeout_ms: u32, abort: Option<&'a AtomicBool>) -> Self {
+        Self {
+            deadline: (timeout_ms != 0)
+                .then(|| Instant::now() + Duration::from_millis(timeout_ms as u64)),
+            abort,
+        }
+    }
+
+    fn aborted(&self) -> bool {
+        self.abort
+            .map(|flag| flag.load(Ordering::Acquire))
+            .unwrap_or(false)
+    }
+
+    fn poll_timeout_ms(&self) -> Result<i32, UdsError> {
+        if self.aborted() {
+            return Err(UdsError::Aborted);
+        }
+
+        let mut wait_ms: Option<u64> = if let Some(deadline) = self.deadline {
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(UdsError::Timeout);
+            }
+            Some(
+                deadline
+                    .duration_since(now)
+                    .as_millis()
+                    .min(i32::MAX as u128) as u64,
+            )
+        } else {
+            None
+        };
+
+        if self.abort.is_some() {
+            wait_ms = Some(wait_ms.map_or(100, |ms| ms.min(100)));
+        }
+
+        Ok(wait_ms.map_or(-1, |ms| ms as i32))
+    }
+}
+
+fn wait_fd_readable(fd: RawFd, wait: &ReceiveWait<'_>) -> Result<(), UdsError> {
+    loop {
+        let timeout = wait.poll_timeout_ms()?;
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let rc = unsafe { libc::poll(&mut pfd, 1, timeout) };
+        if rc < 0 {
+            let err = errno();
+            if err == libc::EINTR {
+                continue;
+            }
+            return Err(UdsError::Recv(err));
+        }
+        if rc == 0 {
+            if wait.aborted() {
+                return Err(UdsError::Aborted);
+            }
+            return Err(UdsError::Timeout);
+        }
+        if wait.aborted() {
+            return Err(UdsError::Aborted);
+        }
+        return Ok(());
+    }
+}
+
+fn raw_recv_with_wait(
+    fd: RawFd,
+    buf: &mut [u8],
+    wait: &mut ReceiveWait<'_>,
+) -> Result<usize, UdsError> {
+    wait_fd_readable(fd, wait)?;
+    raw_recv(fd, buf)
+}
+
+fn raw_recv_control(
+    fd: RawFd,
+    buf: &mut [u8],
+    controlled: bool,
+    wait: &mut ReceiveWait<'_>,
+) -> Result<usize, UdsError> {
+    if controlled {
+        raw_recv_with_wait(fd, buf, wait)
+    } else {
+        raw_recv(fd, buf)
+    }
+}
+
 // ---------------------------------------------------------------------------
 //  Socket helpers
 // ---------------------------------------------------------------------------
@@ -919,17 +1055,7 @@ enum StaleResult {
     LiveServer,
 }
 
-fn run_dir_allows_stale_unlink(run_dir: &str) -> bool {
-    let metadata = match std::fs::metadata(run_dir) {
-        Ok(m) => m,
-        Err(_) => return false,
-    };
-    metadata.is_dir()
-        && metadata.uid() == unsafe { libc::geteuid() }
-        && metadata.mode() & 0o022 == 0
-}
-
-fn check_and_recover_stale(path: &str, allow_stale_unlink: bool) -> StaleResult {
+fn check_and_recover_stale(path: &str) -> StaleResult {
     if !Path::new(path).exists() {
         return StaleResult::NotExist;
     }
@@ -937,7 +1063,9 @@ fn check_and_recover_stale(path: &str, allow_stale_unlink: bool) -> StaleResult 
     // Try connecting to see if a live server is there
     let probe = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_SEQPACKET, 0) };
     if probe < 0 {
-        return StaleResult::NotExist;
+        // Cannot probe liveness (fd exhaustion) — keep the endpoint; the
+        // subsequent bind() fails instead of risking a live socket.
+        return StaleResult::LiveServer;
     }
 
     let result = match connect_unix(probe, path) {
@@ -946,22 +1074,20 @@ fn check_and_recover_stale(path: &str, allow_stale_unlink: bool) -> StaleResult 
             StaleResult::LiveServer
         }
         Err(UdsError::Connect(e)) if e == libc::ENOENT => StaleResult::NotExist,
-        Err(UdsError::Connect(e)) if e == libc::ECONNREFUSED => {
-            if !allow_stale_unlink {
-                StaleResult::LiveServer
-            } else {
-                // Connection refused means stale; unlink only in a private run dir.
-                match std::fs::remove_file(path) {
-                    Ok(()) => StaleResult::Stale,
-                    Err(err) if err.kind() == io::ErrorKind::NotFound => StaleResult::NotExist,
-                    Err(_) => StaleResult::LiveServer,
-                }
-            }
-        }
         Err(_) => {
-            // Other errors (EACCES, etc.) — can't determine ownership,
-            // treat as live to prevent overwriting
-            StaleResult::LiveServer
+            // Nothing accepted the connection: a dead server's socket, or a
+            // foreign file squatting on the endpoint path. Reclaim it.
+            match std::fs::remove_file(path) {
+                Ok(()) => StaleResult::Stale,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => StaleResult::NotExist,
+                Err(err) if err.raw_os_error() == Some(libc::EISDIR) => {
+                    match std::fs::remove_dir(path) {
+                        Ok(()) => StaleResult::Stale,
+                        Err(_) => StaleResult::LiveServer,
+                    }
+                }
+                Err(_) => StaleResult::LiveServer,
+            }
         }
     };
 

--- a/src/crates/netipc/src/transport/posix_tests.rs
+++ b/src/crates/netipc/src/transport/posix_tests.rs
@@ -473,20 +473,14 @@ fn test_request_payload_over_cap() {
 //  Test 7: Stale socket recovery
 // -----------------------------------------------------------------------
 
-#[test]
-fn test_stale_recovery() {
-    ensure_run_dir();
-    let svc = unique_service("rs_stale");
-    cleanup_socket(&svc);
-
-    let path = format!("{TEST_RUN_DIR}/{svc}.sock");
-
-    // Create a stale socket file (bound but not listening)
+/// Create a socket file that is bound but not listening — what a crashed
+/// server leaves behind.
+fn create_stale_socket_file(path: &str) {
     unsafe {
         let sock = libc::socket(libc::AF_UNIX, libc::SOCK_SEQPACKET, 0);
         assert!(sock >= 0);
 
-        let c_path = CString::new(path.as_str()).unwrap();
+        let c_path = CString::new(path).unwrap();
         let mut addr: libc::sockaddr_un = std::mem::zeroed();
         addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
         let path_bytes = c_path.as_bytes_with_nul();
@@ -501,12 +495,56 @@ fn test_stale_recovery() {
         // Close without unlink => stale
         libc::close(sock);
     }
+}
 
+#[test]
+fn test_stale_recovery() {
+    ensure_run_dir();
+    let svc = unique_service("rs_stale");
+    cleanup_socket(&svc);
+
+    let path = format!("{TEST_RUN_DIR}/{svc}.sock");
+    create_stale_socket_file(&path);
     assert!(Path::new(&path).exists(), "stale socket should exist");
 
     // listen should recover it
     let listener = UdsListener::bind(TEST_RUN_DIR, &svc, default_server_config())
         .expect("listen should recover stale socket");
+    drop(listener);
+    cleanup_socket(&svc);
+}
+
+#[test]
+fn test_stale_recovery_in_group_writable_run_dir() {
+    use std::os::unix::fs::PermissionsExt;
+    // Crash recovery must work regardless of run-dir permissions
+    // (netdata's systemd unit ships RuntimeDirectoryMode=0775).
+    let dir = format!("{TEST_RUN_DIR}_0775");
+    let _ = std::fs::create_dir_all(&dir);
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o775)).expect("chmod 0775");
+
+    let svc = unique_service("rs_stale_gw");
+    let path = format!("{dir}/{svc}.sock");
+    let _ = std::fs::remove_file(&path);
+    create_stale_socket_file(&path);
+
+    let listener = UdsListener::bind(&dir, &svc, default_server_config())
+        .expect("stale recovery must work in a group-writable run dir");
+    drop(listener);
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn test_foreign_file_at_socket_path_is_reclaimed() {
+    ensure_run_dir();
+    let svc = unique_service("rs_foreign");
+    cleanup_socket(&svc);
+
+    let path = format!("{TEST_RUN_DIR}/{svc}.sock");
+    std::fs::write(&path, b"accidentally copied file").expect("write foreign file");
+
+    let listener = UdsListener::bind(TEST_RUN_DIR, &svc, default_server_config())
+        .expect("listen should silently replace a foreign file at the socket path");
     drop(listener);
     cleanup_socket(&svc);
 }

--- a/src/crates/netipc/src/transport/shm.rs
+++ b/src/crates/netipc/src/transport/shm.rs
@@ -7,7 +7,6 @@
 //! Wire-compatible with the C implementation in netipc_shm.c.
 
 use std::ffi::CString;
-use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::ptr;
 
@@ -247,7 +246,7 @@ impl ShmContext {
 
         // If O_EXCL failed (file exists), do stale recovery and retry.
         if fd < 0 && unsafe { *libc::__errno_location() } == libc::EEXIST {
-            let stale = check_shm_stale(&path, run_dir_allows_stale_unlink(run_dir));
+            let stale = check_shm_stale(&path);
             if stale == StaleResult::LiveServer {
                 return Err(ShmError::AddrInUse);
             }
@@ -742,7 +741,6 @@ pub fn cleanup_stale(run_dir: &str, service_name: &str) {
         Ok(e) => e,
         Err(_) => return,
     };
-    let allow_stale_unlink = run_dir_allows_stale_unlink(run_dir);
 
     for entry in entries.flatten() {
         let name = match entry.file_name().into_string() {
@@ -763,11 +761,11 @@ pub fn cleanup_stale(run_dir: &str, service_name: &str) {
         // Open read-only to inspect the header
         let fd = unsafe { libc::open(c_path.as_ptr(), libc::O_RDONLY) };
         if fd < 0 {
-            // The entry vanished after readdir() (for example, a dangling symlink
-            // target disappeared) — remove the stale directory entry. Any other
-            // open failure is ambiguous, so leave the entry alone.
-            if should_unlink_cleanup_open_failure(errno()) {
-                let _ = unlink_stale_path(&c_path, allow_stale_unlink);
+            // Entries that cannot be opened are junk (vanished, unreadable,
+            // dangling symlink) — remove them. Keep the entry only when fd
+            // exhaustion prevented the liveness check from running at all.
+            if !stale_check_unavailable(errno()) {
+                let _ = unlink_stale_path(&c_path);
             }
             continue;
         }
@@ -777,7 +775,7 @@ pub fn cleanup_stale(run_dir: &str, service_name: &str) {
             unsafe {
                 libc::close(fd);
             }
-            let _ = unlink_stale_path(&c_path, allow_stale_unlink);
+            let _ = unlink_stale_path(&c_path);
             continue;
         }
 
@@ -794,7 +792,7 @@ pub fn cleanup_stale(run_dir: &str, service_name: &str) {
         unsafe { libc::close(fd) };
 
         if map == libc::MAP_FAILED {
-            let _ = unlink_stale_path(&c_path, allow_stale_unlink);
+            let _ = unlink_stale_path(&c_path);
             continue;
         }
 
@@ -804,7 +802,7 @@ pub fn cleanup_stale(run_dir: &str, service_name: &str) {
             unsafe {
                 libc::munmap(map, HEADER_LEN as usize);
             }
-            let _ = unlink_stale_path(&c_path, allow_stale_unlink);
+            let _ = unlink_stale_path(&c_path);
             continue;
         }
 
@@ -814,7 +812,7 @@ pub fn cleanup_stale(run_dir: &str, service_name: &str) {
 
         // If owner is dead (or generation is zero / legacy), unlink
         if !pid_alive(owner) || gen == 0 {
-            let _ = unlink_stale_path(&c_path, allow_stale_unlink);
+            let _ = unlink_stale_path(&c_path);
         }
     }
 }
@@ -969,34 +967,23 @@ enum StaleResult {
     Invalid,
 }
 
-fn should_unlink_cleanup_open_failure(err: i32) -> bool {
-    err == libc::ENOENT
+/// Open failures that mean the liveness check itself could not run (fd
+/// exhaustion). Deleting on these could remove a live endpoint, so the
+/// entry is kept and reported as in-use.
+fn stale_check_unavailable(err: i32) -> bool {
+    err == libc::EMFILE || err == libc::ENFILE
 }
 
-fn run_dir_allows_stale_unlink(run_dir: &str) -> bool {
-    let metadata = match std::fs::metadata(run_dir) {
-        Ok(m) => m,
-        Err(_) => return false,
-    };
-    metadata.is_dir()
-        && metadata.uid() == unsafe { libc::geteuid() }
-        && metadata.mode() & 0o022 == 0
-}
-
-fn unlink_stale_path(c_path: &CString, allow_stale_unlink: bool) -> bool {
-    allow_stale_unlink && (unsafe { libc::unlink(c_path.as_ptr()) } == 0 || errno() == libc::ENOENT)
-}
-
-fn classify_stale_open_failure(err: i32) -> StaleResult {
-    if err == libc::ENOENT {
-        StaleResult::NotExist
-    } else {
-        StaleResult::Invalid
+fn unlink_stale_path(c_path: &CString) -> bool {
+    if unsafe { libc::unlink(c_path.as_ptr()) } == 0 || errno() == libc::ENOENT {
+        return true;
     }
+    // A directory squatting on the region path is junk too.
+    errno() == libc::EISDIR && unsafe { libc::rmdir(c_path.as_ptr()) } == 0
 }
 
 #[allow(dead_code)]
-fn check_shm_stale(path: &Path, allow_stale_unlink: bool) -> StaleResult {
+fn check_shm_stale(path: &Path) -> StaleResult {
     let c_path = match path_to_cstring(path) {
         Ok(c) => c,
         Err(_) => return StaleResult::NotExist,
@@ -1008,7 +995,7 @@ fn check_shm_stale(path: &Path, allow_stale_unlink: bool) -> StaleResult {
     }
 
     if (st.st_size as usize) < HEADER_LEN as usize {
-        if !unlink_stale_path(&c_path, allow_stale_unlink) {
+        if !unlink_stale_path(&c_path) {
             return StaleResult::LiveServer;
         }
         return StaleResult::Invalid;
@@ -1016,7 +1003,14 @@ fn check_shm_stale(path: &Path, allow_stale_unlink: bool) -> StaleResult {
 
     let fd = unsafe { libc::open(c_path.as_ptr(), libc::O_RDONLY) };
     if fd < 0 {
-        return classify_stale_open_failure(errno());
+        let e = errno();
+        if e == libc::ENOENT {
+            return StaleResult::NotExist;
+        }
+        if stale_check_unavailable(e) || !unlink_stale_path(&c_path) {
+            return StaleResult::LiveServer;
+        }
+        return StaleResult::Invalid;
     }
 
     let map = unsafe {
@@ -1032,7 +1026,7 @@ fn check_shm_stale(path: &Path, allow_stale_unlink: bool) -> StaleResult {
     unsafe { libc::close(fd) };
 
     if map == libc::MAP_FAILED {
-        if !unlink_stale_path(&c_path, allow_stale_unlink) {
+        if !unlink_stale_path(&c_path) {
             return StaleResult::LiveServer;
         }
         return StaleResult::Invalid;
@@ -1044,7 +1038,7 @@ fn check_shm_stale(path: &Path, allow_stale_unlink: bool) -> StaleResult {
         unsafe {
             libc::munmap(map, HEADER_LEN as usize);
         }
-        if !unlink_stale_path(&c_path, allow_stale_unlink) {
+        if !unlink_stale_path(&c_path) {
             return StaleResult::LiveServer;
         }
         return StaleResult::Invalid;
@@ -1059,7 +1053,7 @@ fn check_shm_stale(path: &Path, allow_stale_unlink: bool) -> StaleResult {
     }
 
     // Dead owner or zero generation (PID reuse / legacy) — stale
-    if !unlink_stale_path(&c_path, allow_stale_unlink) {
+    if !unlink_stale_path(&c_path) {
         return StaleResult::LiveServer;
     }
     StaleResult::Recovered

--- a/src/crates/netipc/src/transport/shm_tests.rs
+++ b/src/crates/netipc/src/transport/shm_tests.rs
@@ -175,6 +175,32 @@ fn test_stale_recovery() {
 }
 
 #[test]
+fn test_stale_recovery_in_group_writable_run_dir() {
+    use std::os::unix::fs::PermissionsExt;
+    // Crash recovery must work regardless of run-dir permissions
+    // (netdata's systemd unit ships RuntimeDirectoryMode=0775).
+    let dir = format!("{TEST_RUN_DIR}_0775");
+    let _ = std::fs::create_dir_all(&dir);
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o775)).expect("chmod 0775");
+
+    let svc = "rs_shm_stale_gw";
+    let sid: u64 = 7060;
+    let path = format!("{dir}/{svc}-{sid:016x}.ipcshm");
+    let _ = std::fs::remove_file(&path);
+
+    let mut first = ShmContext::server_create(&dir, svc, sid, 1024, 1024).expect("first create");
+    let hdr = first.base as *mut RegionHeader;
+    unsafe { (*hdr).owner_pid = 99999 }; // very unlikely alive
+    first.close(); // close without unlink
+
+    // server_create must reclaim the dead-owner region through its EEXIST path
+    let mut second = ShmContext::server_create(&dir, svc, sid, 1024, 1024)
+        .expect("crash recovery must work in a group-writable run dir");
+    second.destroy();
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
 fn test_large_message() {
     ensure_run_dir();
     let svc = "rs_shm_large";
@@ -1125,10 +1151,7 @@ fn test_check_shm_stale_nonexistent_returns_not_exist() {
     cleanup_shm(svc, sid);
 
     let path = build_shm_path(TEST_RUN_DIR, svc, sid).expect("path");
-    assert!(matches!(
-        check_shm_stale(&path, true),
-        StaleResult::NotExist
-    ));
+    assert!(matches!(check_shm_stale(&path), StaleResult::NotExist));
 }
 
 #[test]
@@ -1136,37 +1159,19 @@ fn test_check_shm_stale_invalid_cstring_returns_not_exist() {
     let bad_path = PathBuf::from(OsString::from_vec(vec![
         b'/', b't', b'm', b'p', b'/', b'n', b'i', b'p', b'c', 0, b'b',
     ]));
-    assert!(matches!(
-        check_shm_stale(&bad_path, true),
-        StaleResult::NotExist
-    ));
+    assert!(matches!(check_shm_stale(&bad_path), StaleResult::NotExist));
 }
 
 #[test]
-fn test_stale_open_failure_policies_are_conservative() {
-    assert!(should_unlink_cleanup_open_failure(libc::ENOENT));
-    assert!(!should_unlink_cleanup_open_failure(libc::EACCES));
-    assert!(!should_unlink_cleanup_open_failure(libc::EPERM));
-    assert!(!should_unlink_cleanup_open_failure(libc::EMFILE));
-    assert!(!should_unlink_cleanup_open_failure(libc::ENFILE));
-    assert!(!should_unlink_cleanup_open_failure(libc::ELOOP));
-
-    assert!(matches!(
-        classify_stale_open_failure(libc::ENOENT),
-        StaleResult::NotExist
-    ));
-    assert!(matches!(
-        classify_stale_open_failure(libc::EACCES),
-        StaleResult::Invalid
-    ));
-    assert!(matches!(
-        classify_stale_open_failure(libc::EMFILE),
-        StaleResult::Invalid
-    ));
-    assert!(matches!(
-        classify_stale_open_failure(libc::ELOOP),
-        StaleResult::Invalid
-    ));
+fn test_stale_check_unavailable_only_for_fd_exhaustion() {
+    // Only fd exhaustion keeps an entry alive without a liveness check;
+    // every other open failure marks the entry as junk to reclaim.
+    assert!(stale_check_unavailable(libc::EMFILE));
+    assert!(stale_check_unavailable(libc::ENFILE));
+    assert!(!stale_check_unavailable(libc::ENOENT));
+    assert!(!stale_check_unavailable(libc::EACCES));
+    assert!(!stale_check_unavailable(libc::EPERM));
+    assert!(!stale_check_unavailable(libc::ELOOP));
 }
 
 #[test]
@@ -1241,17 +1246,13 @@ fn test_cleanup_stale_invalid_entries() {
     assert!(!build_shm_path(TEST_RUN_DIR, svc, magic_sid)
         .unwrap()
         .exists());
-    // Under non-root: unreadable file is preserved (EACCES skip).
-    // Under root: chmod 000 has no effect, so the file gets opened,
-    // inspected, and removed normally.
-    if unsafe { libc::geteuid() } != 0 {
-        assert!(
-            unreadable_path.exists(),
-            "unreadable entry should be preserved (EACCES skip)"
-        );
-    }
-    // Clean up
-    unsafe { libc::chmod(unreadable_c.as_ptr(), 0o600) };
+    // An unreadable entry at a matching name is junk: it cannot be a live
+    // endpoint we can verify, so cleanup reclaims it (under root chmod 000
+    // has no effect and the file is opened, inspected, and removed instead).
+    assert!(
+        !unreadable_path.exists(),
+        "unreadable entry should be reclaimed"
+    );
     std::fs::remove_file(&unreadable_path).ok();
 }
 
@@ -1265,7 +1266,7 @@ fn test_check_shm_stale_short_file_invalid() {
     let path = build_shm_path(TEST_RUN_DIR, svc, sid).expect("path");
     std::fs::write(&path, [0u8; 8]).expect("write short file");
 
-    assert!(matches!(check_shm_stale(&path, true), StaleResult::Invalid));
+    assert!(matches!(check_shm_stale(&path), StaleResult::Invalid));
     assert!(!path.exists(), "short stale file should be removed");
 }
 
@@ -1283,7 +1284,7 @@ fn test_check_shm_stale_bad_magic_invalid() {
     server.close();
 
     let path = build_shm_path(TEST_RUN_DIR, svc, sid).expect("path");
-    assert!(matches!(check_shm_stale(&path, true), StaleResult::Invalid));
+    assert!(matches!(check_shm_stale(&path), StaleResult::Invalid));
     assert!(!path.exists(), "bad magic stale file should be removed");
 }
 
@@ -1301,10 +1302,7 @@ fn test_check_shm_stale_zero_generation_recovers() {
     server.close();
 
     let path = build_shm_path(TEST_RUN_DIR, svc, sid).expect("path");
-    assert!(matches!(
-        check_shm_stale(&path, true),
-        StaleResult::Recovered
-    ));
+    assert!(matches!(check_shm_stale(&path), StaleResult::Recovered));
     assert!(
         !path.exists(),
         "zero-generation stale file should be removed"
@@ -1342,16 +1340,14 @@ fn test_check_shm_stale_open_failure_invalid() {
         errno()
     );
 
-    assert!(matches!(check_shm_stale(&path, true), StaleResult::Invalid));
-    // Under non-root: file preserved (EACCES). Under root: chmod 000
-    // has no effect, so the file is opened, inspected, and removed.
-    if unsafe { libc::geteuid() } != 0 {
-        assert!(
-            path.exists(),
-            "unopenable file should be preserved (EACCES skip)"
-        );
-    }
-    unsafe { libc::chmod(c_path.as_ptr(), 0o600) };
+    assert!(matches!(check_shm_stale(&path), StaleResult::Invalid));
+    // An unopenable file at the region path is junk: it cannot be a live
+    // endpoint we can verify, so it is reclaimed (under root chmod 000 has
+    // no effect and the file is opened, inspected, and removed instead).
+    assert!(
+        !path.exists(),
+        "unopenable file at the region path should be reclaimed"
+    );
     std::fs::remove_file(&path).ok();
 }
 
@@ -1368,7 +1364,7 @@ fn test_check_shm_stale_directory_symlink_invalid() {
     std::fs::create_dir_all(&target).expect("create target dir");
     std::os::unix::fs::symlink(&target, &path).expect("create symlink");
 
-    assert!(matches!(check_shm_stale(&path, true), StaleResult::Invalid));
+    assert!(matches!(check_shm_stale(&path), StaleResult::Invalid));
     assert!(
         !path.exists(),
         "directory symlink stale entry should be removed"
@@ -1405,7 +1401,7 @@ fn test_cleanup_stale_unlinks_dangling_symlink() {
 }
 
 #[test]
-fn test_cleanup_stale_preserves_self_referential_symlink_open_failure() {
+fn test_cleanup_stale_unlinks_self_referential_symlink() {
     ensure_run_dir();
     let svc = "rs_shm_cleanup_self_symlink";
     let sid: u64 = 7061;
@@ -1423,14 +1419,12 @@ fn test_cleanup_stale_preserves_self_referential_symlink_open_failure() {
 
     cleanup_stale(TEST_RUN_DIR, svc);
 
+    // A symlink at an endpoint name (ELOOP on open) cannot be a live
+    // endpoint — it is junk and is reclaimed.
     assert!(
-        std::fs::symlink_metadata(&path)
-            .map(|meta| meta.file_type().is_symlink())
-            .unwrap_or(false),
-        "ambiguous open failures must not delete the entry"
+        std::fs::symlink_metadata(&path).is_err(),
+        "self-referential symlink entry should be removed"
     );
-
-    std::fs::remove_file(&path).expect("remove self symlink");
 }
 
 #[test]

--- a/src/crates/netipc/src/transport/windows.rs
+++ b/src/crates/netipc/src/transport/windows.rs
@@ -11,7 +11,8 @@ use crate::protocol::{
 };
 use std::collections::HashSet;
 use std::ptr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 // ---------------------------------------------------------------------------
 //  Win32 FFI — using windows-sys when available, raw bindings as fallback
@@ -148,6 +149,10 @@ pub enum NpError {
     Send(u32),
     /// ReadFile failed or peer disconnected.
     Recv(u32),
+    /// Receive timed out before a complete message arrived.
+    Timeout,
+    /// Receive was aborted by the caller.
+    Aborted,
     /// Handshake protocol error.
     Handshake(String),
     /// Authentication token rejected.
@@ -185,6 +190,8 @@ impl std::fmt::Display for NpError {
             NpError::Accept(e) => write!(f, "accept failed: {e}"),
             NpError::Send(e) => write!(f, "send failed: {e}"),
             NpError::Recv(e) => write!(f, "recv failed: {e}"),
+            NpError::Timeout => write!(f, "receive timed out"),
+            NpError::Aborted => write!(f, "receive aborted"),
             NpError::Handshake(s) => write!(f, "handshake error: {s}"),
             NpError::AuthFailed => write!(f, "authentication token rejected"),
             NpError::NoProfile => write!(f, "no common transport profile"),
@@ -496,6 +503,164 @@ fn raw_recv(handle: ffi::HANDLE, buf: &mut [u8]) -> Result<usize, NpError> {
 }
 
 #[cfg(windows)]
+struct ReceiveWait<'a> {
+    deadline: Option<Instant>,
+    abort: Option<&'a AtomicBool>,
+}
+
+#[cfg(windows)]
+impl<'a> ReceiveWait<'a> {
+    fn new(timeout_ms: u32, abort: Option<&'a AtomicBool>) -> Self {
+        Self {
+            deadline: (timeout_ms != 0)
+                .then(|| Instant::now() + Duration::from_millis(timeout_ms as u64)),
+            abort,
+        }
+    }
+
+    fn aborted(&self) -> bool {
+        self.abort
+            .map(|flag| flag.load(Ordering::Acquire))
+            .unwrap_or(false)
+    }
+
+    fn wait_slice_ms(&self) -> Result<u32, NpError> {
+        if self.aborted() {
+            return Err(NpError::Aborted);
+        }
+
+        let mut wait_ms: Option<u128> = if let Some(deadline) = self.deadline {
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(NpError::Timeout);
+            }
+            Some(deadline.duration_since(now).as_millis())
+        } else {
+            None
+        };
+
+        if self.abort.is_some() {
+            wait_ms = Some(wait_ms.map_or(100, |ms| ms.min(100)));
+        }
+
+        Ok(wait_ms.unwrap_or(u32::MAX as u128).min(u32::MAX as u128) as u32)
+    }
+}
+
+#[cfg(windows)]
+fn wait_pipe_readable(handle: ffi::HANDLE, timeout_ms: u32) -> Result<bool, NpError> {
+    if handle == ffi::INVALID_HANDLE_VALUE || handle == 0 {
+        return Err(NpError::BadParam("session closed".into()));
+    }
+
+    let deadline = unsafe { ffi::GetTickCount64() }.saturating_add(timeout_ms as u64);
+    let mut yielded = false;
+    loop {
+        let mut available: u32 = 0;
+        let ok = unsafe {
+            ffi::PeekNamedPipe(
+                handle,
+                ptr::null_mut(),
+                0,
+                ptr::null_mut(),
+                &mut available,
+                ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            let err = last_error();
+            if is_disconnect_error(err) {
+                return Err(NpError::Disconnected);
+            }
+            return Err(NpError::Recv(err));
+        }
+        if available > 0 {
+            return Ok(true);
+        }
+
+        if unsafe { ffi::GetTickCount64() } >= deadline {
+            return Ok(false);
+        }
+
+        if !yielded {
+            yielded = true;
+            for _ in 0..256 {
+                unsafe {
+                    ffi::SwitchToThread();
+                }
+
+                let mut yielded_available: u32 = 0;
+                let yielded_ok = unsafe {
+                    ffi::PeekNamedPipe(
+                        handle,
+                        ptr::null_mut(),
+                        0,
+                        ptr::null_mut(),
+                        &mut yielded_available,
+                        ptr::null_mut(),
+                    )
+                };
+                if yielded_ok == 0 {
+                    let err = last_error();
+                    if is_disconnect_error(err) {
+                        return Err(NpError::Disconnected);
+                    }
+                    return Err(NpError::Recv(err));
+                }
+                if yielded_available > 0 {
+                    return Ok(true);
+                }
+
+                if unsafe { ffi::GetTickCount64() } >= deadline {
+                    return Ok(false);
+                }
+            }
+            continue;
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+}
+
+#[cfg(windows)]
+fn raw_recv_with_wait(
+    handle: ffi::HANDLE,
+    buf: &mut [u8],
+    wait: &mut ReceiveWait<'_>,
+) -> Result<usize, NpError> {
+    loop {
+        let wait_ms = wait.wait_slice_ms()?;
+        if !wait_pipe_readable(handle, wait_ms)? {
+            if wait.aborted() {
+                return Err(NpError::Aborted);
+            }
+            if wait.deadline.is_some() {
+                return Err(NpError::Timeout);
+            }
+            continue;
+        }
+        if wait.aborted() {
+            return Err(NpError::Aborted);
+        }
+        return raw_recv(handle, buf);
+    }
+}
+
+#[cfg(windows)]
+fn raw_recv_control(
+    handle: ffi::HANDLE,
+    buf: &mut [u8],
+    controlled: bool,
+    wait: &mut ReceiveWait<'_>,
+) -> Result<usize, NpError> {
+    if controlled {
+        raw_recv_with_wait(handle, buf, wait)
+    } else {
+        raw_recv(handle, buf)
+    }
+}
+
+#[cfg(windows)]
 fn close_handle(handle: ffi::HANDLE) {
     if handle != ffi::INVALID_HANDLE_VALUE && handle != 0 {
         unsafe {
@@ -552,77 +717,7 @@ impl NpSession {
 
     /// Wait until the pipe becomes readable or the timeout expires.
     pub fn wait_readable(&self, timeout_ms: u32) -> Result<bool, NpError> {
-        if self.handle == ffi::INVALID_HANDLE_VALUE || self.handle == 0 {
-            return Err(NpError::BadParam("session closed".into()));
-        }
-
-        let deadline = unsafe { ffi::GetTickCount64() }.saturating_add(timeout_ms as u64);
-        let mut yielded = false;
-        loop {
-            let mut available: u32 = 0;
-            let ok = unsafe {
-                ffi::PeekNamedPipe(
-                    self.handle,
-                    ptr::null_mut(),
-                    0,
-                    ptr::null_mut(),
-                    &mut available,
-                    ptr::null_mut(),
-                )
-            };
-            if ok == 0 {
-                let err = last_error();
-                if is_disconnect_error(err) {
-                    return Err(NpError::Disconnected);
-                }
-                return Err(NpError::Recv(err));
-            }
-            if available > 0 {
-                return Ok(true);
-            }
-
-            if unsafe { ffi::GetTickCount64() } >= deadline {
-                return Ok(false);
-            }
-
-            if !yielded {
-                yielded = true;
-                for _ in 0..256 {
-                    unsafe {
-                        ffi::SwitchToThread();
-                    }
-
-                    let mut yielded_available: u32 = 0;
-                    let yielded_ok = unsafe {
-                        ffi::PeekNamedPipe(
-                            self.handle,
-                            ptr::null_mut(),
-                            0,
-                            ptr::null_mut(),
-                            &mut yielded_available,
-                            ptr::null_mut(),
-                        )
-                    };
-                    if yielded_ok == 0 {
-                        let err = last_error();
-                        if is_disconnect_error(err) {
-                            return Err(NpError::Disconnected);
-                        }
-                        return Err(NpError::Recv(err));
-                    }
-                    if yielded_available > 0 {
-                        return Ok(true);
-                    }
-
-                    if unsafe { ffi::GetTickCount64() } >= deadline {
-                        return Ok(false);
-                    }
-                }
-                continue;
-            }
-
-            std::thread::sleep(std::time::Duration::from_millis(1));
-        }
+        wait_pipe_readable(self.handle, timeout_ms)
     }
 
     /// Return the most recently reassembled payload stored in the internal
@@ -801,11 +896,24 @@ impl NpSession {
     /// Receive one logical message. buf is a scratch buffer for the first read.
     /// The payload view is valid until the next receive call on this session.
     pub fn receive<'a>(&'a mut self, buf: &'a mut [u8]) -> Result<(Header, &'a [u8]), NpError> {
+        self.receive_with_control(buf, 0, None)
+    }
+
+    /// Receive one logical message with an optional deadline and abort flag.
+    pub fn receive_with_control<'a>(
+        &'a mut self,
+        buf: &'a mut [u8],
+        timeout_ms: u32,
+        abort: Option<&AtomicBool>,
+    ) -> Result<(Header, &'a [u8]), NpError> {
         if self.handle == ffi::INVALID_HANDLE_VALUE {
             return Err(NpError::BadParam("session closed".into()));
         }
 
-        let n = match raw_recv(self.handle, buf) {
+        let controlled = timeout_ms != 0 || abort.is_some();
+        let mut wait = ReceiveWait::new(timeout_ms, abort);
+
+        let n = match raw_recv_control(self.handle, buf, controlled, &mut wait) {
             Ok(n) => n,
             Err(err) => {
                 self.fail_all_inflight();
@@ -905,7 +1013,7 @@ impl NpSession {
 
         let mut ci: u32 = 1;
         while assembled < hdr.payload_len as usize {
-            let cn = match raw_recv(self.handle, &mut self.pkt_buf) {
+            let cn = match raw_recv_control(self.handle, &mut self.pkt_buf, controlled, &mut wait) {
                 Ok(n) => n,
                 Err(err) => {
                     self.fail_all_inflight();

--- a/src/go/pkg/netipc/protocol/frame.go
+++ b/src/go/pkg/netipc/protocol/frame.go
@@ -90,6 +90,8 @@ var (
 	ErrBadAlignment = errors.New("item not 8-byte aligned")
 	ErrBadItemCount = errors.New("item count inconsistent")
 	ErrOverflow     = errors.New("builder out of space")
+	ErrTimeout      = errors.New("synchronous call deadline expired")
+	ErrAborted      = errors.New("synchronous call aborted")
 )
 
 // ---------------------------------------------------------------------------

--- a/src/go/pkg/netipc/service/apps_lookup/client_common.go
+++ b/src/go/pkg/netipc/service/apps_lookup/client_common.go
@@ -2,6 +2,7 @@ package apps_lookup
 
 import (
 	"github.com/netdata/netdata/go/plugins/pkg/netipc/protocol"
+	"github.com/netdata/netdata/go/plugins/pkg/netipc/service/internal/transportconfig"
 	raw "github.com/netdata/netdata/go/plugins/pkg/netipc/service/raw"
 )
 
@@ -10,7 +11,9 @@ type Client struct {
 }
 
 func NewClient(runDir, serviceName string, config ClientConfig) *Client {
-	return &Client{inner: raw.NewAppsLookupClient(runDir, serviceName, clientConfigToTransport(config))}
+	inner := raw.NewAppsLookupClient(runDir, serviceName, clientConfigToTransport(config))
+	inner.SetCallTimeout(transportconfig.TypedConfig(config).CallTimeoutMs)
+	return &Client{inner: inner}
 }
 
 func (c *Client) Refresh() bool { return c.inner.Refresh() }
@@ -18,8 +21,14 @@ func (c *Client) Ready() bool   { return c.inner.Ready() }
 func (c *Client) Status() ClientStatus {
 	return c.inner.Status()
 }
+func (c *Client) SetCallTimeout(timeoutMs uint32) { c.inner.SetCallTimeout(timeoutMs) }
+func (c *Client) Abort()                          { c.inner.Abort() }
+func (c *Client) ClearAbort()                     { c.inner.ClearAbort() }
 func (c *Client) Call(pids []uint32) (*protocol.AppsLookupResponseView, error) {
-	return c.inner.CallAppsLookup(pids)
+	return c.CallWithTimeout(pids, 0)
+}
+func (c *Client) CallWithTimeout(pids []uint32, timeoutMs uint32) (*protocol.AppsLookupResponseView, error) {
+	return c.inner.CallAppsLookupWithTimeout(pids, timeoutMs)
 }
 func (c *Client) Close() { c.inner.Close() }
 

--- a/src/go/pkg/netipc/service/cgroups_lookup/client_common.go
+++ b/src/go/pkg/netipc/service/cgroups_lookup/client_common.go
@@ -2,6 +2,7 @@ package cgroups_lookup
 
 import (
 	"github.com/netdata/netdata/go/plugins/pkg/netipc/protocol"
+	"github.com/netdata/netdata/go/plugins/pkg/netipc/service/internal/transportconfig"
 	raw "github.com/netdata/netdata/go/plugins/pkg/netipc/service/raw"
 )
 
@@ -10,7 +11,9 @@ type Client struct {
 }
 
 func NewClient(runDir, serviceName string, config ClientConfig) *Client {
-	return &Client{inner: raw.NewCgroupsLookupClient(runDir, serviceName, clientConfigToTransport(config))}
+	inner := raw.NewCgroupsLookupClient(runDir, serviceName, clientConfigToTransport(config))
+	inner.SetCallTimeout(transportconfig.TypedConfig(config).CallTimeoutMs)
+	return &Client{inner: inner}
 }
 
 func (c *Client) Refresh() bool { return c.inner.Refresh() }
@@ -18,8 +21,14 @@ func (c *Client) Ready() bool   { return c.inner.Ready() }
 func (c *Client) Status() ClientStatus {
 	return c.inner.Status()
 }
+func (c *Client) SetCallTimeout(timeoutMs uint32) { c.inner.SetCallTimeout(timeoutMs) }
+func (c *Client) Abort()                          { c.inner.Abort() }
+func (c *Client) ClearAbort()                     { c.inner.ClearAbort() }
 func (c *Client) Call(paths [][]byte) (*protocol.CgroupsLookupResponseView, error) {
-	return c.inner.CallCgroupsLookup(paths)
+	return c.CallWithTimeout(paths, 0)
+}
+func (c *Client) CallWithTimeout(paths [][]byte, timeoutMs uint32) (*protocol.CgroupsLookupResponseView, error) {
+	return c.inner.CallCgroupsLookupWithTimeout(paths, timeoutMs)
 }
 func (c *Client) Close() { c.inner.Close() }
 

--- a/src/go/pkg/netipc/service/cgroups_snapshot/cache.go
+++ b/src/go/pkg/netipc/service/cgroups_snapshot/cache.go
@@ -3,10 +3,13 @@
 package cgroups_snapshot
 
 import (
+	"github.com/netdata/netdata/go/plugins/pkg/netipc/service/internal/transportconfig"
 	raw "github.com/netdata/netdata/go/plugins/pkg/netipc/service/raw"
 )
 
 // NewCache creates a new L3 cache. Does NOT connect.
 func NewCache(runDir, serviceName string, config ClientConfig) *Cache {
-	return &Cache{inner: raw.NewCache(runDir, serviceName, clientConfigToTransport(config))}
+	inner := raw.NewCache(runDir, serviceName, clientConfigToTransport(config))
+	inner.SetCallTimeout(transportconfig.TypedConfig(config).CallTimeoutMs)
+	return &Cache{inner: inner}
 }

--- a/src/go/pkg/netipc/service/cgroups_snapshot/cache_common.go
+++ b/src/go/pkg/netipc/service/cgroups_snapshot/cache_common.go
@@ -29,6 +29,21 @@ func (c *Cache) Status() CacheStatus {
 	return c.inner.Status()
 }
 
+// SetCallTimeout sets the context-level default timeout for refresh calls.
+func (c *Cache) SetCallTimeout(timeoutMs uint32) {
+	c.inner.SetCallTimeout(timeoutMs)
+}
+
+// Abort unblocks an in-flight refresh call.
+func (c *Cache) Abort() {
+	c.inner.Abort()
+}
+
+// ClearAbort clears a previous abort request so the cache can be reused.
+func (c *Cache) ClearAbort() {
+	c.inner.ClearAbort()
+}
+
 // Close frees all cached items and closes the L2 client.
 func (c *Cache) Close() {
 	c.inner.Close()

--- a/src/go/pkg/netipc/service/cgroups_snapshot/cache_windows.go
+++ b/src/go/pkg/netipc/service/cgroups_snapshot/cache_windows.go
@@ -3,10 +3,13 @@
 package cgroups_snapshot
 
 import (
+	"github.com/netdata/netdata/go/plugins/pkg/netipc/service/internal/transportconfig"
 	raw "github.com/netdata/netdata/go/plugins/pkg/netipc/service/raw"
 )
 
 // NewCache creates a new L3 cache. Does NOT connect.
 func NewCache(runDir, serviceName string, config ClientConfig) *Cache {
-	return &Cache{inner: raw.NewCache(runDir, serviceName, clientConfigToTransport(config))}
+	inner := raw.NewCache(runDir, serviceName, clientConfigToTransport(config))
+	inner.SetCallTimeout(transportconfig.TypedConfig(config).CallTimeoutMs)
+	return &Cache{inner: inner}
 }

--- a/src/go/pkg/netipc/service/cgroups_snapshot/client_common.go
+++ b/src/go/pkg/netipc/service/cgroups_snapshot/client_common.go
@@ -2,6 +2,7 @@ package cgroups_snapshot
 
 import (
 	"github.com/netdata/netdata/go/plugins/pkg/netipc/protocol"
+	"github.com/netdata/netdata/go/plugins/pkg/netipc/service/internal/transportconfig"
 	raw "github.com/netdata/netdata/go/plugins/pkg/netipc/service/raw"
 )
 
@@ -16,7 +17,9 @@ type Client struct {
 
 // NewClient creates a new client context. Does NOT connect.
 func NewClient(runDir, serviceName string, config ClientConfig) *Client {
-	return &Client{inner: raw.NewSnapshotClient(runDir, serviceName, clientConfigToTransport(config))}
+	inner := raw.NewSnapshotClient(runDir, serviceName, clientConfigToTransport(config))
+	inner.SetCallTimeout(transportconfig.TypedConfig(config).CallTimeoutMs)
+	return &Client{inner: inner}
 }
 
 // Refresh attempts connect if DISCONNECTED/NOT_FOUND, reconnect if BROKEN.
@@ -34,9 +37,30 @@ func (c *Client) Status() ClientStatus {
 	return c.inner.Status()
 }
 
+// SetCallTimeout sets the context-level default timeout for blocking calls.
+func (c *Client) SetCallTimeout(timeoutMs uint32) {
+	c.inner.SetCallTimeout(timeoutMs)
+}
+
+// Abort unblocks an in-flight synchronous call.
+func (c *Client) Abort() {
+	c.inner.Abort()
+}
+
+// ClearAbort clears a previous abort request so the client can be reused.
+func (c *Client) ClearAbort() {
+	c.inner.ClearAbort()
+}
+
 // CallSnapshot performs a blocking typed cgroups snapshot call.
 func (c *Client) CallSnapshot() (*protocol.CgroupsResponseView, error) {
-	return c.inner.CallSnapshot()
+	return c.CallSnapshotWithTimeout(0)
+}
+
+// CallSnapshotWithTimeout performs a blocking typed call with an explicit
+// timeout. A zero timeout uses the client's context-level default.
+func (c *Client) CallSnapshotWithTimeout(timeoutMs uint32) (*protocol.CgroupsResponseView, error) {
+	return c.inner.CallSnapshotWithTimeout(timeoutMs)
 }
 
 // Close tears down the connection and releases resources.

--- a/src/go/pkg/netipc/service/internal/transportconfig/types.go
+++ b/src/go/pkg/netipc/service/internal/transportconfig/types.go
@@ -5,6 +5,7 @@ type TypedConfig struct {
 	PreferredProfiles       uint32
 	MaxRequestBatchItems    uint32
 	MaxResponsePayloadBytes uint32
+	CallTimeoutMs           uint32
 	AuthToken               uint64
 }
 

--- a/src/go/pkg/netipc/service/raw/apps_lookup.go
+++ b/src/go/pkg/netipc/service/raw/apps_lookup.go
@@ -24,6 +24,10 @@ func appsLookupRequestSize(pids []uint32) (int, error) {
 // CallAppsLookup performs a blocking typed APPS_LOOKUP call.
 // The returned view is valid until the next typed call on this client.
 func (c *Client) CallAppsLookup(pids []uint32) (*protocol.AppsLookupResponseView, error) {
+	return c.CallAppsLookupWithTimeout(pids, 0)
+}
+
+func (c *Client) CallAppsLookupWithTimeout(pids []uint32, timeoutMs uint32) (*protocol.AppsLookupResponseView, error) {
 	if err := c.validateMethod(protocol.MethodAppsLookup); err != nil {
 		return nil, err
 	}
@@ -40,7 +44,7 @@ func (c *Client) CallAppsLookup(pids []uint32) (*protocol.AppsLookupResponseView
 			return err
 		}
 
-		_, payload, rerr := c.doRawCall(protocol.MethodAppsLookup, reqBuf[:reqLen])
+		_, payload, rerr := c.doRawCallWithTimeout(protocol.MethodAppsLookup, reqBuf[:reqLen], timeoutMs)
 		if rerr != nil {
 			return rerr
 		}

--- a/src/go/pkg/netipc/service/raw/cgroups_cache.go
+++ b/src/go/pkg/netipc/service/raw/cgroups_cache.go
@@ -198,6 +198,21 @@ func (c *Cache) Status() CacheStatus {
 	}
 }
 
+// SetCallTimeout sets the context-level default timeout for refresh calls.
+func (c *Cache) SetCallTimeout(timeoutMs uint32) {
+	c.client.SetCallTimeout(timeoutMs)
+}
+
+// Abort unblocks an in-flight refresh call.
+func (c *Cache) Abort() {
+	c.client.Abort()
+}
+
+// ClearAbort clears a previous abort request so the cache can be reused.
+func (c *Cache) ClearAbort() {
+	c.client.ClearAbort()
+}
+
 // Close frees all cached items and closes the L2 client.
 func (c *Cache) Close() {
 	c.items = nil

--- a/src/go/pkg/netipc/service/raw/cgroups_lookup.go
+++ b/src/go/pkg/netipc/service/raw/cgroups_lookup.go
@@ -39,6 +39,10 @@ func cgroupsLookupRequestSize(paths [][]byte) (int, error) {
 // CallCgroupsLookup performs a blocking typed CGROUPS_LOOKUP call.
 // The returned view is valid until the next typed call on this client.
 func (c *Client) CallCgroupsLookup(paths [][]byte) (*protocol.CgroupsLookupResponseView, error) {
+	return c.CallCgroupsLookupWithTimeout(paths, 0)
+}
+
+func (c *Client) CallCgroupsLookupWithTimeout(paths [][]byte, timeoutMs uint32) (*protocol.CgroupsLookupResponseView, error) {
 	if err := c.validateMethod(protocol.MethodCgroupsLookup); err != nil {
 		return nil, err
 	}
@@ -55,7 +59,7 @@ func (c *Client) CallCgroupsLookup(paths [][]byte) (*protocol.CgroupsLookupRespo
 			return err
 		}
 
-		_, payload, rerr := c.doRawCall(protocol.MethodCgroupsLookup, reqBuf[:reqLen])
+		_, payload, rerr := c.doRawCallWithTimeout(protocol.MethodCgroupsLookup, reqBuf[:reqLen], timeoutMs)
 		if rerr != nil {
 			return rerr
 		}

--- a/src/go/pkg/netipc/service/raw/cgroups_snapshot.go
+++ b/src/go/pkg/netipc/service/raw/cgroups_snapshot.go
@@ -16,6 +16,10 @@ func SnapshotMaxItems(responseBufSize int, override uint32) uint32 {
 // CallSnapshot performs a blocking typed cgroups snapshot call.
 // The returned view is valid until the next typed call on this client.
 func (c *Client) CallSnapshot() (*protocol.CgroupsResponseView, error) {
+	return c.CallSnapshotWithTimeout(0)
+}
+
+func (c *Client) CallSnapshotWithTimeout(timeoutMs uint32) (*protocol.CgroupsResponseView, error) {
 	if err := c.validateMethod(protocol.MethodCgroupsSnapshot); err != nil {
 		return nil, err
 	}
@@ -29,7 +33,7 @@ func (c *Client) CallSnapshot() (*protocol.CgroupsResponseView, error) {
 			return protocol.ErrTruncated
 		}
 
-		_, payload, rerr := c.doRawCall(protocol.MethodCgroupsSnapshot, reqBuf[:])
+		_, payload, rerr := c.doRawCallWithTimeout(protocol.MethodCgroupsSnapshot, reqBuf[:], timeoutMs)
 		if rerr != nil {
 			return rerr
 		}

--- a/src/go/pkg/netipc/service/raw/client.go
+++ b/src/go/pkg/netipc/service/raw/client.go
@@ -30,6 +30,55 @@ func (c *Client) validateMethod(methodCode uint16) error {
 	return nil
 }
 
+func (c *Client) resolvedCallTimeout(timeoutMs uint32) uint32 {
+	if timeoutMs != 0 {
+		return timeoutMs
+	}
+	if c.callTimeoutMs != 0 {
+		return c.callTimeoutMs
+	}
+	return ClientCallTimeoutDefaultMs
+}
+
+func (c *Client) abortSignal() <-chan struct{} {
+	c.abortMu.Lock()
+	ch := c.abortCh
+	c.abortMu.Unlock()
+	return ch
+}
+
+// SetCallTimeout sets the context-level default timeout for typed calls.
+// Passing zero restores the library default.
+func (c *Client) SetCallTimeout(timeoutMs uint32) {
+	if timeoutMs == 0 {
+		timeoutMs = ClientCallTimeoutDefaultMs
+	}
+	c.callTimeoutMs = timeoutMs
+}
+
+// Abort unblocks an in-flight synchronous call. Abort is sticky until ClearAbort
+// or Close is called.
+func (c *Client) Abort() {
+	c.abortMu.Lock()
+	defer c.abortMu.Unlock()
+	if c.abortRequested.Load() {
+		return
+	}
+	c.abortRequested.Store(true)
+	close(c.abortCh)
+}
+
+// ClearAbort clears a previous Abort so the client can be refreshed/reused.
+func (c *Client) ClearAbort() {
+	c.abortMu.Lock()
+	defer c.abortMu.Unlock()
+	if !c.abortRequested.Load() {
+		return
+	}
+	c.abortCh = make(chan struct{})
+	c.abortRequested.Store(false)
+}
+
 // Refresh attempts connect if DISCONNECTED/NOT_FOUND, reconnect if BROKEN.
 // Returns true if the state changed.
 func (c *Client) Refresh() bool {
@@ -112,6 +161,10 @@ func (c *Client) callWithRetry(attempt func() error) error {
 		c.errorCount++
 		return protocol.ErrBadLayout
 	}
+	if c.abortRequested.Load() {
+		c.errorCount++
+		return protocol.ErrAborted
+	}
 
 	// Cap overflow-driven retries: payloads grow by powers of 2, so 8
 	// retries allows ~256x growth from the initial negotiated size.
@@ -126,6 +179,13 @@ func (c *Client) callWithRetry(attempt func() error) error {
 		if firstErr == nil {
 			c.callCount++
 			return nil
+		}
+
+		if errors.Is(firstErr, protocol.ErrTimeout) || errors.Is(firstErr, protocol.ErrAborted) {
+			c.disconnect()
+			c.state = StateBroken
+			c.errorCount++
+			return firstErr
 		}
 
 		if !errors.Is(firstErr, protocol.ErrOverflow) {
@@ -184,6 +244,10 @@ func (c *Client) callWithRetry(attempt func() error) error {
 // doRawCall sends a request and receives/validates the response envelope.
 // Returns the validated response header and a borrowed payload view.
 func (c *Client) doRawCall(methodCode uint16, reqPayload []byte) (protocol.Header, []byte, error) {
+	return c.doRawCallWithTimeout(methodCode, reqPayload, 0)
+}
+
+func (c *Client) doRawCallWithTimeout(methodCode uint16, reqPayload []byte, timeoutMs uint32) (protocol.Header, []byte, error) {
 	hdr := protocol.Header{
 		Kind:            protocol.KindRequest,
 		Code:            methodCode,
@@ -197,7 +261,7 @@ func (c *Client) doRawCall(methodCode uint16, reqPayload []byte) (protocol.Heade
 		return protocol.Header{}, nil, err
 	}
 
-	respHdr, payload, err := c.transportReceive()
+	respHdr, payload, err := c.transportReceiveWithControl(c.resolvedCallTimeout(timeoutMs), c.abortSignal())
 	if err != nil {
 		return protocol.Header{}, nil, err
 	}
@@ -232,5 +296,6 @@ func (c *Client) doRawCall(methodCode uint16, reqPayload []byte) (protocol.Heade
 // Close tears down the connection and releases resources.
 func (c *Client) Close() {
 	c.disconnect()
+	c.ClearAbort()
 	c.state = StateDisconnected
 }

--- a/src/go/pkg/netipc/service/raw/client_unix.go
+++ b/src/go/pkg/netipc/service/raw/client_unix.go
@@ -4,6 +4,8 @@ package raw
 
 import (
 	"errors"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/netipc/protocol"
@@ -34,6 +36,11 @@ type Client struct {
 	reconnectCount uint32
 	callCount      uint32
 	errorCount     uint32
+
+	callTimeoutMs  uint32
+	abortRequested atomic.Bool
+	abortMu        sync.Mutex
+	abortCh        chan struct{}
 }
 
 func newClient(runDir, serviceName string, config posix.ClientConfig, expectedMethodCode uint16) *Client {
@@ -43,6 +50,8 @@ func newClient(runDir, serviceName string, config posix.ClientConfig, expectedMe
 		serviceName:        serviceName,
 		expectedMethodCode: expectedMethodCode,
 		config:             config,
+		callTimeoutMs:      ClientCallTimeoutDefaultMs,
+		abortCh:            make(chan struct{}),
 	}
 }
 
@@ -160,22 +169,51 @@ func (c *Client) transportSend(hdr *protocol.Header, payload []byte) error {
 }
 
 func (c *Client) transportReceive() (protocol.Header, []byte, error) {
+	return c.transportReceiveWithControl(c.resolvedCallTimeout(0), c.abortSignal())
+}
+
+func (c *Client) transportReceiveWithControl(timeoutMs uint32, abortCh <-chan struct{}) (protocol.Header, []byte, error) {
 	scratch := ensureClientScratch(&c.transportBuf, c.maxReceiveMessageBytes())
 
 	if c.shm != nil {
-		mlen, err := c.shm.ShmReceive(scratch, 30000)
-		if err != nil {
-			return protocol.Header{}, nil, protocol.ErrTruncated
-		}
-		if mlen < protocol.HeaderSize {
-			return protocol.Header{}, nil, protocol.ErrTruncated
-		}
+		deadline := time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
+		for {
+			select {
+			case <-abortCh:
+				return protocol.Header{}, nil, protocol.ErrAborted
+			default:
+			}
 
-		hdr, err := protocol.DecodeHeader(scratch[:mlen])
-		if err != nil {
-			return protocol.Header{}, nil, err
+			if timeoutMs != 0 && !time.Now().Before(deadline) {
+				return protocol.Header{}, nil, protocol.ErrTimeout
+			}
+
+			waitMs := clientAbortPollMs
+			if timeoutMs != 0 {
+				remaining := time.Until(deadline)
+				if remaining <= 0 {
+					return protocol.Header{}, nil, protocol.ErrTimeout
+				}
+				waitMs = boundedClientWaitMs(remaining, waitMs)
+			}
+
+			mlen, err := c.shm.ShmReceive(scratch, waitMs)
+			if err != nil {
+				if errors.Is(err, posix.ErrShmTimeout) {
+					continue
+				}
+				return protocol.Header{}, nil, protocol.ErrTruncated
+			}
+			if mlen < protocol.HeaderSize {
+				return protocol.Header{}, nil, protocol.ErrTruncated
+			}
+
+			hdr, err := protocol.DecodeHeader(scratch[:mlen])
+			if err != nil {
+				return protocol.Header{}, nil, err
+			}
+			return hdr, scratch[protocol.HeaderSize:mlen], nil
 		}
-		return hdr, scratch[protocol.HeaderSize:mlen], nil
 	}
 
 	// UDS path: receive returns (Header, payload, error)
@@ -183,8 +221,14 @@ func (c *Client) transportReceive() (protocol.Header, []byte, error) {
 		return protocol.Header{}, nil, protocol.ErrTruncated
 	}
 
-	hdr, payload, err := c.session.Receive(scratch)
+	hdr, payload, err := c.session.ReceiveTimeout(scratch, timeoutMs, abortCh)
 	if err != nil {
+		if errors.Is(err, posix.ErrTimeout) {
+			return protocol.Header{}, nil, protocol.ErrTimeout
+		}
+		if errors.Is(err, posix.ErrAborted) {
+			return protocol.Header{}, nil, protocol.ErrAborted
+		}
 		return protocol.Header{}, nil, protocol.ErrTruncated
 	}
 	return hdr, payload, nil

--- a/src/go/pkg/netipc/service/raw/client_windows.go
+++ b/src/go/pkg/netipc/service/raw/client_windows.go
@@ -4,6 +4,8 @@ package raw
 
 import (
 	"errors"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/netipc/protocol"
@@ -29,6 +31,11 @@ type Client struct {
 	reconnectCount uint32
 	callCount      uint32
 	errorCount     uint32
+
+	callTimeoutMs  uint32
+	abortRequested atomic.Bool
+	abortMu        sync.Mutex
+	abortCh        chan struct{}
 }
 
 func newClient(runDir, serviceName string, config windows.ClientConfig, expectedMethodCode uint16) *Client {
@@ -38,6 +45,8 @@ func newClient(runDir, serviceName string, config windows.ClientConfig, expected
 		serviceName:        serviceName,
 		expectedMethodCode: expectedMethodCode,
 		config:             config,
+		callTimeoutMs:      ClientCallTimeoutDefaultMs,
+		abortCh:            make(chan struct{}),
 	}
 }
 
@@ -148,30 +157,65 @@ func (c *Client) transportSend(hdr *protocol.Header, payload []byte) error {
 }
 
 func (c *Client) transportReceive() (protocol.Header, []byte, error) {
+	return c.transportReceiveWithControl(c.resolvedCallTimeout(0), c.abortSignal())
+}
+
+func (c *Client) transportReceiveWithControl(timeoutMs uint32, abortCh <-chan struct{}) (protocol.Header, []byte, error) {
 	scratch := ensureClientScratch(&c.transportBuf, c.maxReceiveMessageBytes())
 
 	if c.shm != nil {
-		mlen, err := c.shm.WinShmReceive(scratch, 30000)
-		if err != nil {
-			return protocol.Header{}, nil, protocol.ErrTruncated
-		}
-		if mlen < protocol.HeaderSize {
-			return protocol.Header{}, nil, protocol.ErrTruncated
-		}
+		deadline := time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
+		for {
+			select {
+			case <-abortCh:
+				return protocol.Header{}, nil, protocol.ErrAborted
+			default:
+			}
 
-		hdr, err := protocol.DecodeHeader(scratch[:mlen])
-		if err != nil {
-			return protocol.Header{}, nil, err
+			if timeoutMs != 0 && !time.Now().Before(deadline) {
+				return protocol.Header{}, nil, protocol.ErrTimeout
+			}
+
+			waitMs := clientAbortPollMs
+			if timeoutMs != 0 {
+				remaining := time.Until(deadline)
+				if remaining <= 0 {
+					return protocol.Header{}, nil, protocol.ErrTimeout
+				}
+				waitMs = boundedClientWaitMs(remaining, waitMs)
+			}
+
+			mlen, err := c.shm.WinShmReceive(scratch, waitMs)
+			if err != nil {
+				if errors.Is(err, windows.ErrWinShmTimeout) {
+					continue
+				}
+				return protocol.Header{}, nil, protocol.ErrTruncated
+			}
+			if mlen < protocol.HeaderSize {
+				return protocol.Header{}, nil, protocol.ErrTruncated
+			}
+
+			hdr, err := protocol.DecodeHeader(scratch[:mlen])
+			if err != nil {
+				return protocol.Header{}, nil, err
+			}
+			return hdr, scratch[protocol.HeaderSize:mlen], nil
 		}
-		return hdr, scratch[protocol.HeaderSize:mlen], nil
 	}
 
 	if c.session == nil {
 		return protocol.Header{}, nil, protocol.ErrTruncated
 	}
 
-	hdr, payload, err := c.session.Receive(scratch)
+	hdr, payload, err := c.session.ReceiveTimeout(scratch, timeoutMs, abortCh)
 	if err != nil {
+		if errors.Is(err, windows.ErrTimeout) {
+			return protocol.Header{}, nil, protocol.ErrTimeout
+		}
+		if errors.Is(err, windows.ErrAborted) {
+			return protocol.Header{}, nil, protocol.ErrAborted
+		}
 		return protocol.Header{}, nil, protocol.ErrTruncated
 	}
 	return hdr, payload, nil

--- a/src/go/pkg/netipc/service/raw/increment.go
+++ b/src/go/pkg/netipc/service/raw/increment.go
@@ -8,6 +8,10 @@ type IncrementHandler func(uint64) (uint64, bool)
 // CallIncrement performs a blocking INCREMENT call.
 // Sends requestValue, returns the server's response value.
 func (c *Client) CallIncrement(requestValue uint64) (uint64, error) {
+	return c.CallIncrementWithTimeout(requestValue, 0)
+}
+
+func (c *Client) CallIncrementWithTimeout(requestValue uint64, timeoutMs uint32) (uint64, error) {
 	if err := c.validateMethod(protocol.MethodIncrement); err != nil {
 		return 0, err
 	}
@@ -20,7 +24,7 @@ func (c *Client) CallIncrement(requestValue uint64) (uint64, error) {
 			return protocol.ErrTruncated
 		}
 
-		_, payload, rerr := c.doRawCall(protocol.MethodIncrement, reqBuf[:])
+		_, payload, rerr := c.doRawCallWithTimeout(protocol.MethodIncrement, reqBuf[:], timeoutMs)
 		if rerr != nil {
 			return rerr
 		}
@@ -38,6 +42,10 @@ func (c *Client) CallIncrement(requestValue uint64) (uint64, error) {
 // CallIncrementBatch performs a blocking batch INCREMENT call.
 // Sends multiple values, returns the server's response values.
 func (c *Client) CallIncrementBatch(values []uint64) ([]uint64, error) {
+	return c.CallIncrementBatchWithTimeout(values, 0)
+}
+
+func (c *Client) CallIncrementBatchWithTimeout(values []uint64, timeoutMs uint32) ([]uint64, error) {
 	if err := c.validateMethod(protocol.MethodIncrement); err != nil {
 		return nil, err
 	}
@@ -106,7 +114,8 @@ func (c *Client) CallIncrementBatch(values []uint64) ([]uint64, error) {
 			return err
 		}
 
-		respHdr, respPayload, err := c.transportReceive()
+		respHdr, respPayload, err := c.transportReceiveWithControl(
+			c.resolvedCallTimeout(timeoutMs), c.abortSignal())
 		if err != nil {
 			return err
 		}

--- a/src/go/pkg/netipc/service/raw/more_unix_test.go
+++ b/src/go/pkg/netipc/service/raw/more_unix_test.go
@@ -211,6 +211,87 @@ func refreshUnixClientReady(t *testing.T, client *Client) {
 	t.Fatalf("client not ready, state=%d", client.state)
 }
 
+func TestUnixClientCallTimeoutOnWedgedPeer(t *testing.T) {
+	cfg := testServerConfig()
+	svc := uniqueUnixService("go_unix_call_timeout")
+	srv := startRawPosixSessionServer(t, svc, cfg,
+		func(session *posix.Session, hdr protocol.Header, payload []byte) error {
+			_ = session
+			_ = hdr
+			_ = payload
+			time.Sleep(150 * time.Millisecond)
+			return nil
+		})
+
+	client := NewIncrementClient(testRunDir, svc, testClientConfig())
+	defer client.Close()
+	refreshUnixClientReady(t, client)
+
+	start := time.Now()
+	_, err := client.CallIncrementWithTimeout(41, 30)
+	elapsed := time.Since(start)
+	if !errors.Is(err, protocol.ErrTimeout) {
+		t.Fatalf("CallIncrementWithTimeout error = %v, want %v", err, protocol.ErrTimeout)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("timeout took too long: %s", elapsed)
+	}
+
+	srv.wait(t)
+	cleanupAll(svc)
+}
+
+func TestUnixClientAbortUnblocksCall(t *testing.T) {
+	cfg := testServerConfig()
+	svc := uniqueUnixService("go_unix_call_abort")
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	srv := startRawPosixSessionServer(t, svc, cfg,
+		func(session *posix.Session, hdr protocol.Header, payload []byte) error {
+			_ = session
+			_ = hdr
+			_ = payload
+			close(entered)
+			<-release
+			return nil
+		})
+
+	client := NewIncrementClient(testRunDir, svc, testClientConfig())
+	defer client.Close()
+	refreshUnixClientReady(t, client)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.CallIncrementWithTimeout(41, 5000)
+		errCh <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server handler did not receive request")
+	}
+
+	start := time.Now()
+	client.Abort()
+	var err error
+	select {
+	case err = <-errCh:
+	case <-time.After(time.Second):
+		t.Fatal("Abort did not unblock the call within one second")
+	}
+	if !errors.Is(err, protocol.ErrAborted) {
+		t.Fatalf("aborted call error = %v, want %v", err, protocol.ErrAborted)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("abort took too long: %s", elapsed)
+	}
+
+	close(release)
+	srv.wait(t)
+	cleanupAll(svc)
+}
+
 func newRawPosixShmClient(t *testing.T) (*Client, *posix.ShmContext) {
 	t.Helper()
 

--- a/src/go/pkg/netipc/service/raw/more_windows_test.go
+++ b/src/go/pkg/netipc/service/raw/more_windows_test.go
@@ -98,6 +98,83 @@ func TestWinClientRefreshFromReadyNoop(t *testing.T) {
 	}
 }
 
+func TestWinClientCallTimeoutOnWedgedPeer(t *testing.T) {
+	svc := uniqueWinService("go_win_call_timeout")
+	srv := startRawWinSessionServer(t, svc, testWinServerConfig(),
+		func(session *windows.Session, hdr protocol.Header, payload []byte) error {
+			_ = session
+			_ = hdr
+			_ = payload
+			time.Sleep(150 * time.Millisecond)
+			return nil
+		})
+
+	client := NewIncrementClient(winTestRunDir, svc, testWinClientConfig())
+	defer client.Close()
+	waitWinClientReady(t, client)
+
+	start := time.Now()
+	_, err := client.CallIncrementWithTimeout(41, 30)
+	elapsed := time.Since(start)
+	if !errors.Is(err, protocol.ErrTimeout) {
+		t.Fatalf("CallIncrementWithTimeout error = %v, want %v", err, protocol.ErrTimeout)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("timeout took too long: %s", elapsed)
+	}
+
+	srv.wait(t)
+}
+
+func TestWinClientAbortUnblocksCall(t *testing.T) {
+	svc := uniqueWinService("go_win_call_abort")
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	srv := startRawWinSessionServer(t, svc, testWinServerConfig(),
+		func(session *windows.Session, hdr protocol.Header, payload []byte) error {
+			_ = session
+			_ = hdr
+			_ = payload
+			close(entered)
+			<-release
+			return nil
+		})
+
+	client := NewIncrementClient(winTestRunDir, svc, testWinClientConfig())
+	defer client.Close()
+	waitWinClientReady(t, client)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.CallIncrementWithTimeout(41, 5000)
+		errCh <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server handler did not receive request")
+	}
+
+	start := time.Now()
+	client.Abort()
+	var err error
+	select {
+	case err = <-errCh:
+	case <-time.After(time.Second):
+		t.Fatal("Abort did not unblock the call within one second")
+	}
+	if !errors.Is(err, protocol.ErrAborted) {
+		t.Fatalf("aborted call error = %v, want %v", err, protocol.ErrAborted)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("abort took too long: %s", elapsed)
+	}
+
+	close(release)
+	srv.wait(t)
+}
+
 func TestWinServerStopWhileIdle(t *testing.T) {
 	svc := uniqueWinService("go_win_stop_idle")
 	server := NewServer(

--- a/src/go/pkg/netipc/service/raw/string_reverse.go
+++ b/src/go/pkg/netipc/service/raw/string_reverse.go
@@ -8,6 +8,10 @@ type StringReverseHandler func(string) (string, bool)
 // CallStringReverse performs a blocking STRING_REVERSE call.
 // The returned view is valid until the next typed call on this client.
 func (c *Client) CallStringReverse(requestStr string) (*protocol.StringReverseView, error) {
+	return c.CallStringReverseWithTimeout(requestStr, 0)
+}
+
+func (c *Client) CallStringReverseWithTimeout(requestStr string, timeoutMs uint32) (*protocol.StringReverseView, error) {
 	if err := c.validateMethod(protocol.MethodStringReverse); err != nil {
 		return nil, err
 	}
@@ -20,7 +24,7 @@ func (c *Client) CallStringReverse(requestStr string) (*protocol.StringReverseVi
 			return protocol.ErrTruncated
 		}
 
-		_, payload, rerr := c.doRawCall(protocol.MethodStringReverse, reqBuf)
+		_, payload, rerr := c.doRawCallWithTimeout(protocol.MethodStringReverse, reqBuf, timeoutMs)
 		if rerr != nil {
 			return rerr
 		}

--- a/src/go/pkg/netipc/service/raw/types.go
+++ b/src/go/pkg/netipc/service/raw/types.go
@@ -8,8 +8,29 @@
 // Pure Go — no cgo. Works with CGO_ENABLED=0.
 package raw
 
+import "time"
+
 // Poll/receive timeout for server loops (ms). Controls shutdown detection latency.
 const serverPollTimeoutMs = 100
+
+// ClientCallTimeoutDefaultMs is the default synchronous client call timeout.
+const ClientCallTimeoutDefaultMs uint32 = 30000
+
+const clientAbortPollMs uint32 = 100
+
+func boundedClientWaitMs(remaining time.Duration, pollCapMs uint32) uint32 {
+	if remaining <= 0 {
+		return 0
+	}
+	if remaining >= time.Duration(pollCapMs)*time.Millisecond {
+		return pollCapMs
+	}
+	waitMs := uint32((remaining + time.Millisecond - 1) / time.Millisecond) // #nosec G115 -- remaining is positive and below pollCapMs here.
+	if waitMs == 0 {
+		return 1
+	}
+	return waitMs
+}
 
 // ---------------------------------------------------------------------------
 //  Client state (shared across platforms)

--- a/src/go/pkg/netipc/transport/internal/framing/receive.go
+++ b/src/go/pkg/netipc/transport/internal/framing/receive.go
@@ -23,6 +23,7 @@ type Receiver struct {
 	Recv                func([]byte) (int, error)
 	EnsurePacketScratch func(*[]byte, int) []byte
 	OnRecvError         func(error)
+	PropagateRecvError  func(error) bool
 
 	ErrLimitExceeded func(string) error
 	ErrProtocol      func(string) error
@@ -47,6 +48,7 @@ type SessionReceiveConfig struct {
 	Recv                func([]byte) (int, error)
 	EnsurePacketScratch func(*[]byte, int) []byte
 	IsRecvDisconnect    func(error) bool
+	PropagateRecvError  func(error) bool
 	FailAllInflight     func()
 
 	ErrLimitExceeded func(string) error
@@ -74,6 +76,7 @@ func SessionReceive(config SessionReceiveConfig, buf []byte) (protocol.Header, [
 		PacketBuf:           config.PacketBuf,
 		Recv:                config.Recv,
 		EnsurePacketScratch: config.EnsurePacketScratch,
+		PropagateRecvError:  config.PropagateRecvError,
 		OnRecvError: func(err error) {
 			if config.IsRecvDisconnect(err) {
 				config.FailAllInflight()
@@ -133,8 +136,10 @@ func (r Receiver) Receive(buf []byte) (protocol.Header, []byte, error) {
 func (r Receiver) totalMessageLen(hdr protocol.Header) (int, error) {
 	maxInt := uint64(int(^uint(0) >> 1))
 	totalMsg := uint64(protocol.HeaderSize) + uint64(hdr.PayloadLen)
-	if totalMsg > maxInt {
-		return 0, r.ErrLimitExceeded("total message length exceeds platform limit")
+	// The u32 bound mirrors the C implementation (nipc_uds_header_payload_len):
+	// total_message_len is a u32 wire field, so larger totals are unrepresentable.
+	if totalMsg > uint64(^uint32(0)) || totalMsg > maxInt {
+		return 0, r.ErrLimitExceeded("total message length exceeds protocol limit")
 	}
 	return int(totalMsg), nil
 }
@@ -185,7 +190,10 @@ func (r Receiver) validateBatchPayload(hdr protocol.Header, payload []byte) erro
 	if len(payload) < dirAligned {
 		return r.ErrProtocol("batch dir exceeds payload")
 	}
-	packedAreaLen := uint32(len(payload) - dirAligned)
+	packedAreaLen, ok := checkedU32(len(payload) - dirAligned)
+	if !ok {
+		return r.ErrProtocol("packed area exceeds protocol limit")
+	}
 	if err := protocol.BatchDirValidate(payload[:dirBytes], hdr.ItemCount, packedAreaLen); err != nil {
 		return r.ErrProtocol("batch dir: " + err.Error())
 	}
@@ -209,8 +217,11 @@ func (r Receiver) receiveChunked(
 
 	assembled := firstPayloadBytes
 	chunkPayloadBudget := int(r.PacketSize) - protocol.HeaderSize
-	expectedChunkCount := expectedReceiveChunkCount(
+	expectedChunkCount, ok := expectedReceiveChunkCount(
 		int(hdr.PayloadLen), firstPayloadBytes, chunkPayloadBudget)
+	if !ok {
+		return protocol.Header{}, nil, r.ErrProtocol("chunk count exceeds protocol limit")
+	}
 
 	pktBuf := r.EnsurePacketScratch(r.PacketBuf, int(r.PacketSize))
 	for ci := uint32(1); assembled < int(hdr.PayloadLen); ci++ {
@@ -228,13 +239,13 @@ func (r Receiver) receiveChunked(
 	return hdr, payload, nil
 }
 
-func expectedReceiveChunkCount(payloadLen, firstPayloadBytes, chunkPayloadBudget int) uint32 {
+func expectedReceiveChunkCount(payloadLen, firstPayloadBytes, chunkPayloadBudget int) (uint32, bool) {
 	remainingAfterFirst := payloadLen - firstPayloadBytes
-	expectedContinuations := uint32(0)
+	expectedContinuations := 0
 	if remainingAfterFirst > 0 && chunkPayloadBudget > 0 {
-		expectedContinuations = uint32(1 + ((remainingAfterFirst - 1) / chunkPayloadBudget))
+		expectedContinuations = 1 + ((remainingAfterFirst - 1) / chunkPayloadBudget)
 	}
-	return 1 + expectedContinuations
+	return checkedU32(1 + expectedContinuations)
 }
 
 func (r Receiver) receiveOneChunk(
@@ -248,6 +259,9 @@ func (r Receiver) receiveOneChunk(
 	cn, err := r.Recv(pktBuf)
 	if err != nil {
 		r.noteRecvError(err)
+		if r.PropagateRecvError != nil && r.PropagateRecvError(err) {
+			return err
+		}
 		return r.ErrRecv("continuation recv: " + err.Error())
 	}
 	if cn < protocol.HeaderSize {
@@ -293,7 +307,10 @@ func (r Receiver) validateReceiveChunk(
 	if chk.ChunkCount != expectedChunkCount {
 		return r.ErrChunk("chunk_count mismatch")
 	}
-	if chk.TotalMessageLen != uint32(totalMsg) {
+	// checkedU32 prevents a truncated comparison from falsely matching a
+	// crafted total_message_len when totalMsg exceeds the u32 wire range.
+	totalMsgU32, ok := checkedU32(totalMsg)
+	if !ok || chk.TotalMessageLen != totalMsgU32 {
 		return r.ErrChunk("total_message_len mismatch")
 	}
 	return nil

--- a/src/go/pkg/netipc/transport/internal/framing/send.go
+++ b/src/go/pkg/netipc/transport/internal/framing/send.go
@@ -16,7 +16,11 @@ func HeaderPayloadLen(payloadLen int) (int, uint32, bool) {
 	if totalMsg > uint64(^uint32(0)) || totalMsg > uint64(int(^uint(0)>>1)) {
 		return 0, 0, false
 	}
-	return int(totalMsg), uint32(payloadLen), true
+	payloadU32, ok := checkedU32(payloadLen)
+	if !ok {
+		return 0, 0, false
+	}
+	return int(totalMsg), payloadU32, true
 }
 
 // FillMessageHeader applies the common NetIPC message header fields.
@@ -115,11 +119,18 @@ func (s Sender) Send(hdr *protocol.Header, payload []byte, totalMsg int) error {
 
 	firstChunkPayload := minInt(len(payload), chunkPayloadBudget)
 	remainingAfterFirst := len(payload) - firstChunkPayload
-	continuationChunks := uint32(0)
+	continuationChunks := 0
 	if remainingAfterFirst > 0 {
-		continuationChunks = uint32(1 + ((remainingAfterFirst - 1) / chunkPayloadBudget))
+		continuationChunks = 1 + ((remainingAfterFirst - 1) / chunkPayloadBudget)
 	}
-	chunkCount := 1 + continuationChunks
+	chunkCount, ok := checkedU32(1 + continuationChunks)
+	if !ok {
+		return s.ErrBadParam("chunk count exceeds protocol limit")
+	}
+	totalMsgU32, ok := checkedU32(totalMsg)
+	if !ok {
+		return s.ErrBadParam("total message length exceeds protocol limit")
+	}
 
 	if err := s.SendFirstPacket(hdr, payload[:firstChunkPayload],
 		protocol.HeaderSize+firstChunkPayload); err != nil {
@@ -140,7 +151,7 @@ func (s Sender) Send(hdr *protocol.Header, payload []byte, totalMsg int) error {
 			Version:         protocol.Version,
 			Flags:           0,
 			MessageID:       hdr.MessageID,
-			TotalMessageLen: uint32(totalMsg),
+			TotalMessageLen: totalMsgU32,
 			ChunkIndex:      ci,
 			ChunkCount:      chunkCount,
 			ChunkPayloadLen: chunkLen,

--- a/src/go/pkg/netipc/transport/posix/shm_linux.go
+++ b/src/go/pkg/netipc/transport/posix/shm_linux.go
@@ -159,7 +159,7 @@ func ShmServerCreate(runDir, serviceName string, sessionID uint64, reqCapacity, 
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600) // #nosec G304 -- path is built from runDir, validated service name, and hex session ID.
 	if err != nil && os.IsExist(err) {
 		// File exists — do stale recovery and retry.
-		stale := checkShmStale(path, runDirAllowsStaleUnlink(runDir))
+		stale := checkShmStale(path)
 		if stale == shmStaleLive {
 			return nil, fmt.Errorf("%w: live server owns SHM region", ErrShmOpen)
 		}
@@ -742,14 +742,10 @@ func ShmCleanupStale(runDir, serviceName string) {
 	if err != nil {
 		return
 	}
-	allowStaleUnlink := runDirAllowsStaleUnlink(runDir)
 	prefix := serviceName + "-"
 	suffix := ".ipcshm"
 	for _, e := range entries {
 		name := e.Name()
-		if !e.Type().IsRegular() {
-			continue
-		}
 		if len(name) < len(prefix)+len(suffix) {
 			continue
 		}
@@ -757,7 +753,7 @@ func ShmCleanupStale(runDir, serviceName string) {
 			continue
 		}
 		path := filepath.Join(runDir, name)
-		result := checkShmStale(path, allowStaleUnlink)
+		result := checkShmStale(path)
 		_ = result // checkShmStale already unlinks stale/invalid files
 	}
 }
@@ -775,22 +771,20 @@ const (
 	shmStaleInvalid
 )
 
-func removeStalePath(path string, allowStaleUnlink bool) bool {
-	if !allowStaleUnlink {
-		return false
-	}
+func removeStalePath(path string) bool {
+	// os.Remove also reclaims a directory squatting on the endpoint path.
 	err := os.Remove(path)
 	return err == nil || os.IsNotExist(err)
 }
 
-func checkShmStale(path string, allowStaleUnlink bool) shmStaleResult {
+func checkShmStale(path string) shmStaleResult {
 	info, err := os.Stat(path)
 	if err != nil {
 		return shmStaleNotExist
 	}
 
 	if info.Size() < int64(shmHeaderLen) {
-		if !removeStalePath(path, allowStaleUnlink) {
+		if !removeStalePath(path) {
 			return shmStaleLive
 		}
 		return shmStaleInvalid
@@ -798,7 +792,12 @@ func checkShmStale(path string, allowStaleUnlink bool) shmStaleResult {
 
 	f, err := os.Open(path) // #nosec G304 -- path comes from the validated SHM cleanup scan or buildShmPath.
 	if err != nil {
-		if !removeStalePath(path, allowStaleUnlink) {
+		if errors.Is(err, syscall.EMFILE) || errors.Is(err, syscall.ENFILE) {
+			// Cannot probe liveness (fd exhaustion) — keep the endpoint
+			// rather than risk deleting a live region.
+			return shmStaleLive
+		}
+		if !removeStalePath(path) {
 			return shmStaleLive
 		}
 		return shmStaleInvalid
@@ -808,7 +807,7 @@ func checkShmStale(path string, allowStaleUnlink bool) shmStaleResult {
 		syscall.PROT_READ, syscall.MAP_SHARED)
 	_ = f.Close()
 	if err != nil {
-		if !removeStalePath(path, allowStaleUnlink) {
+		if !removeStalePath(path) {
 			return shmStaleLive
 		}
 		return shmStaleInvalid
@@ -817,7 +816,7 @@ func checkShmStale(path string, allowStaleUnlink bool) shmStaleResult {
 	magic := binary.NativeEndian.Uint32(data[shmHeaderMagicOff : shmHeaderMagicOff+4])
 	if magic != shmRegionMagic {
 		_ = syscall.Munmap(data)
-		if !removeStalePath(path, allowStaleUnlink) {
+		if !removeStalePath(path) {
 			return shmStaleLive
 		}
 		return shmStaleInvalid
@@ -832,7 +831,7 @@ func checkShmStale(path string, allowStaleUnlink bool) shmStaleResult {
 	}
 
 	// Dead owner or zero generation (PID reuse / legacy) — stale
-	if !removeStalePath(path, allowStaleUnlink) {
+	if !removeStalePath(path) {
 		return shmStaleLive
 	}
 	return shmStaleRecovered

--- a/src/go/pkg/netipc/transport/posix/shm_linux_test.go
+++ b/src/go/pkg/netipc/transport/posix/shm_linux_test.go
@@ -276,6 +276,30 @@ func TestShmStaleRecovery(t *testing.T) {
 	second.ShmDestroy()
 }
 
+func TestShmStaleRecoveryInGroupWritableRunDir(t *testing.T) {
+	// Crash recovery must work regardless of run-dir permissions
+	// (netdata's systemd unit ships RuntimeDirectoryMode=0775).
+	runDir := t.TempDir()
+	if err := os.Chmod(runDir, 0o775); err != nil {
+		t.Fatalf("chmod run dir: %v", err)
+	}
+	svc := uniqueShmService(t, "go_shm_stale_gw")
+
+	first, err := ShmServerCreate(runDir, svc, 3, 1024, 1024)
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	binary.NativeEndian.PutUint32(first.data[8:12], 99999) // very unlikely alive
+	first.ShmClose()                                       // close without unlink
+
+	// ServerCreate must reclaim the dead-owner region through its EEXIST path
+	second, err := ShmServerCreate(runDir, svc, 3, 1024, 1024)
+	if err != nil {
+		t.Fatalf("crash recovery must work in a group-writable run dir: %v", err)
+	}
+	second.ShmDestroy()
+}
+
 func TestShmClientAttachPartialHeaderNotReady(t *testing.T) {
 	ensureShmRunDir(t)
 	svc := uniqueShmService(t, "go_shm_partial")

--- a/src/go/pkg/netipc/transport/posix/shm_more_edge_test.go
+++ b/src/go/pkg/netipc/transport/posix/shm_more_edge_test.go
@@ -347,12 +347,12 @@ func TestCheckShmStaleVariants(t *testing.T) {
 	validSize := int(respOff + respCap)
 
 	missingPath := filepath.Join(runDir, "missing.ipcshm")
-	if got := checkShmStale(missingPath, true); got != shmStaleNotExist {
+	if got := checkShmStale(missingPath); got != shmStaleNotExist {
 		t.Fatalf("missing path result = %v, want %v", got, shmStaleNotExist)
 	}
 
 	tinyPath := writeRawShmRegionFile(t, runDir, "go_shm_check_tiny", 1, 8, nil)
-	if got := checkShmStale(tinyPath, true); got != shmStaleInvalid {
+	if got := checkShmStale(tinyPath); got != shmStaleInvalid {
 		t.Fatalf("tiny file result = %v, want %v", got, shmStaleInvalid)
 	}
 	if _, err := os.Stat(tinyPath); !errors.Is(err, os.ErrNotExist) {
@@ -363,14 +363,14 @@ func TestCheckShmStaleVariants(t *testing.T) {
 		fillShmHeader(data, int32(os.Getpid()), 1, reqOff, reqCap, respOff, respCap)
 		binary.NativeEndian.PutUint32(data[shmHeaderMagicOff:shmHeaderMagicOff+4], 0)
 	})
-	if got := checkShmStale(badMagicPath, true); got != shmStaleInvalid {
+	if got := checkShmStale(badMagicPath); got != shmStaleInvalid {
 		t.Fatalf("bad magic result = %v, want %v", got, shmStaleInvalid)
 	}
 
 	livePath := writeRawShmRegionFile(t, runDir, "go_shm_check_live", 3, validSize, func(data []byte) {
 		fillShmHeader(data, int32(os.Getpid()), 7, reqOff, reqCap, respOff, respCap)
 	})
-	if got := checkShmStale(livePath, true); got != shmStaleLive {
+	if got := checkShmStale(livePath); got != shmStaleLive {
 		t.Fatalf("live path result = %v, want %v", got, shmStaleLive)
 	}
 	if _, err := os.Stat(livePath); err != nil {
@@ -380,7 +380,7 @@ func TestCheckShmStaleVariants(t *testing.T) {
 	legacyPath := writeRawShmRegionFile(t, runDir, "go_shm_check_legacy", 4, validSize, func(data []byte) {
 		fillShmHeader(data, int32(os.Getpid()), 0, reqOff, reqCap, respOff, respCap)
 	})
-	if got := checkShmStale(legacyPath, true); got != shmStaleRecovered {
+	if got := checkShmStale(legacyPath); got != shmStaleRecovered {
 		t.Fatalf("legacy path result = %v, want %v", got, shmStaleRecovered)
 	}
 	if _, err := os.Stat(legacyPath); !errors.Is(err, os.ErrNotExist) {
@@ -393,7 +393,7 @@ func TestCheckShmStaleVariants(t *testing.T) {
 	if err := os.Chmod(unreadablePath, 0); err != nil {
 		t.Fatalf("chmod unreadable stale file: %v", err)
 	}
-	if got := checkShmStale(unreadablePath, true); got != shmStaleInvalid {
+	if got := checkShmStale(unreadablePath); got != shmStaleInvalid {
 		t.Fatalf("unreadable path result = %v, want %v", got, shmStaleInvalid)
 	}
 	if _, err := os.Stat(unreadablePath); !errors.Is(err, os.ErrNotExist) {
@@ -407,7 +407,7 @@ func TestCheckShmStaleVariants(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dirPath, "keep"), 0700); err != nil {
 		t.Fatalf("mkdir stale dir: %v", err)
 	}
-	if got := checkShmStale(dirPath, true); got != shmStaleLive {
+	if got := checkShmStale(dirPath); got != shmStaleLive {
 		t.Fatalf("directory path result = %v, want %v", got, shmStaleLive)
 	}
 	if info, err := os.Stat(dirPath); err != nil || !info.IsDir() {
@@ -474,8 +474,10 @@ func TestShmCleanupStaleMixedEntries(t *testing.T) {
 	if _, err := os.Stat(unrelatedPath); err != nil {
 		t.Fatalf("unrelated file should remain, stat err = %v", err)
 	}
-	if info, err := os.Stat(matchingDir); err != nil || !info.IsDir() {
-		t.Fatalf("matching directory should remain, stat err = %v", err)
+	// An empty directory squatting on a matching SHM name is junk and is
+	// reclaimed; non-empty directories survive (see TestCheckShmStaleVariants).
+	if _, err := os.Stat(matchingDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("matching empty directory should be removed, stat err = %v", err)
 	}
 }
 

--- a/src/go/pkg/netipc/transport/posix/uds.go
+++ b/src/go/pkg/netipc/transport/posix/uds.go
@@ -55,6 +55,8 @@ var (
 	ErrBadParam       = errors.New("invalid argument")
 	ErrDuplicateMsgID = errors.New("duplicate message_id")
 	ErrUnknownMsgID   = errors.New("unknown response message_id")
+	ErrTimeout        = errors.New("receive deadline expired")
+	ErrAborted        = errors.New("receive aborted")
 )
 
 // wrapErr creates a descriptive error wrapping a sentinel.

--- a/src/go/pkg/netipc/transport/posix/uds_handshake.go
+++ b/src/go/pkg/netipc/transport/posix/uds_handshake.go
@@ -138,10 +138,6 @@ func serverHandshake(fd int, config *ServerConfig, sessionID uint64) (*Session, 
 	}, nil
 }
 
-func sendRejection(fd int, status uint16) {
-	_ = sendHelloAck(fd, status, protocol.HelloAck{LayoutVersion: 1})
-}
-
 func sendHelloAck(fd int, status uint16, ack protocol.HelloAck) error {
 	pkt := framing.BuildHelloAckPacket(status, ack)
 

--- a/src/go/pkg/netipc/transport/posix/uds_listener.go
+++ b/src/go/pkg/netipc/transport/posix/uds_listener.go
@@ -24,7 +24,7 @@ func Listen(runDir, serviceName string, config ServerConfig) (*Listener, error) 
 		return nil, err
 	}
 
-	stale := checkAndRecoverStale(path, runDirAllowsStaleUnlink(runDir))
+	stale := checkAndRecoverStale(path)
 	if stale == staleLiveServer {
 		return nil, ErrAddrInUse
 	}

--- a/src/go/pkg/netipc/transport/posix/uds_receive.go
+++ b/src/go/pkg/netipc/transport/posix/uds_receive.go
@@ -4,18 +4,138 @@ package posix
 
 import (
 	"errors"
+	"syscall"
+	"time"
+	"unsafe"
 
 	"github.com/netdata/netdata/go/plugins/pkg/netipc/protocol"
 	"github.com/netdata/netdata/go/plugins/pkg/netipc/transport/internal/framing"
 )
+
+const receiveAbortPollMs = 100
+
+const (
+	_pollIn   = 0x0001
+	_pollErr  = 0x0008
+	_pollHup  = 0x0010
+	_pollNval = 0x0020
+)
+
+type receiveWait struct {
+	infinite bool
+	deadline time.Time
+	abortCh  <-chan struct{}
+}
+
+type receivePollFd struct {
+	fd      int32
+	events  int16
+	revents int16
+}
+
+func newReceiveWait(timeoutMs uint32, abortCh <-chan struct{}) receiveWait {
+	w := receiveWait{
+		infinite: timeoutMs == 0,
+		abortCh:  abortCh,
+	}
+	if !w.infinite {
+		w.deadline = time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
+	}
+	return w
+}
+
+func (w receiveWait) waitMs() (int, error) {
+	if w.abortCh != nil {
+		select {
+		case <-w.abortCh:
+			return 0, ErrAborted
+		default:
+		}
+	}
+
+	waitMs := receiveAbortPollMs
+	if w.infinite {
+		return waitMs, nil
+	}
+
+	remaining := time.Until(w.deadline)
+	if remaining <= 0 {
+		return 0, ErrTimeout
+	}
+	if remaining < time.Duration(waitMs)*time.Millisecond {
+		waitMs = int((remaining + time.Millisecond - 1) / time.Millisecond)
+		if waitMs == 0 {
+			waitMs = 1
+		}
+	}
+	return waitMs, nil
+}
+
+func pollReadableForReceive(fd int, wait receiveWait) error {
+	const maxInt32 = 1<<31 - 1
+	if fd < 0 || fd > maxInt32 {
+		return wrapErr(ErrBadParam, "fd out of range")
+	}
+
+	for {
+		waitMs, err := wait.waitMs()
+		if err != nil {
+			return err
+		}
+
+		pfd := receivePollFd{
+			fd:     int32(fd), // #nosec G115 -- fd is checked against int32 range above.
+			events: _pollIn,
+		}
+		r, _, errno := syscall.Syscall(
+			syscall.SYS_POLL,
+			uintptr(unsafe.Pointer(&pfd)), // #nosec G103 -- raw poll syscall requires a pollfd pointer.
+			1,
+			uintptr(waitMs),
+		)
+		n := int(r)
+		if n < 0 {
+			if errno == syscall.EINTR {
+				continue
+			}
+			return wrapErr(ErrRecv, errno.Error())
+		}
+		if n == 0 {
+			continue
+		}
+		if pfd.revents&_pollIn != 0 {
+			return nil
+		}
+		if pfd.revents&(_pollErr|_pollHup|_pollNval) != 0 {
+			return nil
+		}
+	}
+}
+
+func rawRecvWithTimeout(fd int, buf []byte, wait receiveWait) (int, error) {
+	if err := pollReadableForReceive(fd, wait); err != nil {
+		return 0, err
+	}
+	return rawRecv(fd, buf)
+}
 
 // Receive reads one logical message. Blocks until a complete message
 // arrives. buf is a caller-provided scratch buffer for the first packet.
 // On success, returns the header and a payload view valid until the next
 // Receive call on this session.
 func (s *Session) Receive(buf []byte) (protocol.Header, []byte, error) {
+	return s.ReceiveTimeout(buf, 0, nil)
+}
+
+func (s *Session) ReceiveTimeout(buf []byte, timeoutMs uint32, abortCh <-chan struct{}) (protocol.Header, []byte, error) {
 	if s.fd < 0 {
 		return protocol.Header{}, nil, wrapErr(ErrBadParam, "session closed")
+	}
+
+	recv := func(dst []byte) (int, error) { return rawRecv(s.fd, dst) }
+	if timeoutMs != 0 || abortCh != nil {
+		wait := newReceiveWait(timeoutMs, abortCh)
+		recv = func(dst []byte) (int, error) { return rawRecvWithTimeout(s.fd, dst, wait) }
 	}
 
 	return framing.SessionReceive(framing.SessionReceiveConfig{
@@ -28,14 +148,17 @@ func (s *Session) Receive(buf []byte) (protocol.Header, []byte, error) {
 		InflightIDs:             s.inflightIDs,
 		RecvBuf:                 &s.recvBuf,
 		PacketBuf:               &s.pktBuf,
-		Recv:                    func(dst []byte) (int, error) { return rawRecv(s.fd, dst) },
+		Recv:                    recv,
 		EnsurePacketScratch:     ensureScratchBuf,
 		IsRecvDisconnect:        func(err error) bool { return errors.Is(err, ErrRecv) },
-		FailAllInflight:         s.failAllInflight,
-		ErrLimitExceeded:        func(msg string) error { return wrapErr(ErrLimitExceeded, msg) },
-		ErrProtocol:             func(msg string) error { return wrapErr(ErrProtocol, msg) },
-		ErrChunk:                func(msg string) error { return wrapErr(ErrChunk, msg) },
-		ErrUnknownMsgID:         func(msg string) error { return wrapErr(ErrUnknownMsgID, msg) },
-		ErrRecv:                 func(msg string) error { return wrapErr(ErrRecv, msg) },
+		PropagateRecvError: func(err error) bool {
+			return errors.Is(err, ErrTimeout) || errors.Is(err, ErrAborted)
+		},
+		FailAllInflight:  s.failAllInflight,
+		ErrLimitExceeded: func(msg string) error { return wrapErr(ErrLimitExceeded, msg) },
+		ErrProtocol:      func(msg string) error { return wrapErr(ErrProtocol, msg) },
+		ErrChunk:         func(msg string) error { return wrapErr(ErrChunk, msg) },
+		ErrUnknownMsgID:  func(msg string) error { return wrapErr(ErrUnknownMsgID, msg) },
+		ErrRecv:          func(msg string) error { return wrapErr(ErrRecv, msg) },
 	}, buf)
 }

--- a/src/go/pkg/netipc/transport/posix/uds_stale.go
+++ b/src/go/pkg/netipc/transport/posix/uds_stale.go
@@ -24,19 +24,6 @@ const (
 	staleDialTimeout    = 1 * time.Second
 )
 
-func runDirAllowsStaleUnlink(runDir string) bool {
-	euid := uint32(os.Geteuid())
-	info, err := os.Stat(runDir)
-	if err != nil || !info.IsDir() {
-		return false
-	}
-	st, ok := info.Sys().(*syscall.Stat_t)
-	if !ok || st.Uid != euid {
-		return false
-	}
-	return info.Mode().Perm()&0022 == 0
-}
-
 func dialStaleCandidate(path string) error {
 	var err error
 	for attempt := range staleDialAttempts {
@@ -56,7 +43,7 @@ func dialStaleCandidate(path string) error {
 	return err
 }
 
-func checkAndRecoverStale(path string, allowStaleUnlink bool) staleResult {
+func checkAndRecoverStale(path string) staleResult {
 	_, err := os.Stat(path)
 	if err != nil {
 		return staleNotExist
@@ -70,17 +57,19 @@ func checkAndRecoverStale(path string, allowStaleUnlink bool) staleResult {
 	if errors.Is(err, syscall.ENOENT) {
 		return staleNotExist
 	}
-	if errors.Is(err, syscall.ECONNREFUSED) {
-		if !allowStaleUnlink {
-			return staleLiveServer
-		}
-		if removeErr := os.Remove(path); removeErr != nil {
-			if os.IsNotExist(removeErr) {
-				return staleNotExist
-			}
-			return staleLiveServer
-		}
-		return staleRecovered
+	if errors.Is(err, syscall.EMFILE) || errors.Is(err, syscall.ENFILE) {
+		// Cannot probe liveness (fd exhaustion) — keep the endpoint rather
+		// than risk deleting a live socket.
+		return staleLiveServer
 	}
-	return staleLiveServer
+	// Nothing accepted the connection: a dead server's socket, or a foreign
+	// file squatting on the endpoint path. Reclaim it (os.Remove also
+	// handles a directory at the path).
+	if removeErr := os.Remove(path); removeErr != nil {
+		if os.IsNotExist(removeErr) {
+			return staleNotExist
+		}
+		return staleLiveServer
+	}
+	return staleRecovered
 }

--- a/src/go/pkg/netipc/transport/posix/uds_test.go
+++ b/src/go/pkg/netipc/transport/posix/uds_test.go
@@ -635,6 +635,28 @@ func TestStaleRecovery(t *testing.T) {
 	}
 }
 
+func TestStaleRecoveryInGroupWritableRunDir(t *testing.T) {
+	// Crash recovery must work regardless of run-dir permissions
+	// (netdata's systemd unit ships RuntimeDirectoryMode=0775).
+	runDir := t.TempDir()
+	if err := os.Chmod(runDir, 0o775); err != nil {
+		t.Fatalf("chmod run dir: %v", err)
+	}
+	service := uniqueService(t)
+	sockPath := filepath.Join(runDir, service+".sock")
+
+	// A foreign regular file squatting on the socket path
+	if err := os.WriteFile(sockPath, []byte("accidentally copied file"), 0o644); err != nil {
+		t.Fatalf("cannot create foreign file: %v", err)
+	}
+
+	listener, err := Listen(runDir, service, defaultServerConfig())
+	if err != nil {
+		t.Fatalf("Listen must reclaim the endpoint in a group-writable run dir: %v", err)
+	}
+	listener.Close()
+}
+
 // ---------------------------------------------------------------------------
 //  Test: Disconnect detection
 // ---------------------------------------------------------------------------

--- a/src/go/pkg/netipc/transport/windows/pipe.go
+++ b/src/go/pkg/netipc/transport/windows/pipe.go
@@ -77,6 +77,8 @@ var (
 	ErrDuplicateMsgID = errors.New("duplicate message_id")
 	ErrUnknownMsgID   = errors.New("unknown response message_id")
 	ErrDisconnected   = errors.New("peer disconnected")
+	ErrTimeout        = errors.New("receive deadline expired")
+	ErrAborted        = errors.New("receive aborted")
 )
 
 func wrapErr(sentinel error, detail string) error {

--- a/src/go/pkg/netipc/transport/windows/pipe_receive.go
+++ b/src/go/pkg/netipc/transport/windows/pipe_receive.go
@@ -5,15 +5,28 @@ package windows
 import (
 	"errors"
 	"syscall"
+	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/netipc/protocol"
 	"github.com/netdata/netdata/go/plugins/pkg/netipc/transport/internal/framing"
 )
 
+const receiveAbortPollMs uint32 = 100
+
 // Receive reads one logical message. buf is a scratch buffer.
 func (s *Session) Receive(buf []byte) (protocol.Header, []byte, error) {
+	return s.ReceiveTimeout(buf, 0, nil)
+}
+
+func (s *Session) ReceiveTimeout(buf []byte, timeoutMs uint32, abortCh <-chan struct{}) (protocol.Header, []byte, error) {
 	if s.handle == syscall.InvalidHandle {
 		return protocol.Header{}, nil, wrapErr(ErrBadParam, "session closed")
+	}
+
+	recv := func(dst []byte) (int, error) { return rawRecv(s.handle, dst) }
+	if timeoutMs != 0 || abortCh != nil {
+		wait := newReceiveWait(timeoutMs, abortCh)
+		recv = func(dst []byte) (int, error) { return s.rawRecvWithTimeout(dst, wait) }
 	}
 
 	return framing.SessionReceive(framing.SessionReceiveConfig{
@@ -26,14 +39,87 @@ func (s *Session) Receive(buf []byte) (protocol.Header, []byte, error) {
 		InflightIDs:             s.inflightIDs,
 		RecvBuf:                 &s.recvBuf,
 		PacketBuf:               &s.pktBuf,
-		Recv:                    func(dst []byte) (int, error) { return rawRecv(s.handle, dst) },
+		Recv:                    recv,
 		EnsurePacketScratch:     ensurePipeScratchBuf,
 		IsRecvDisconnect:        func(err error) bool { return errors.Is(err, ErrDisconnected) },
-		FailAllInflight:         s.failAllInflight,
-		ErrLimitExceeded:        func(msg string) error { return wrapErr(ErrLimitExceeded, msg) },
-		ErrProtocol:             func(msg string) error { return wrapErr(ErrProtocol, msg) },
-		ErrChunk:                func(msg string) error { return wrapErr(ErrChunk, msg) },
-		ErrUnknownMsgID:         func(msg string) error { return wrapErr(ErrUnknownMsgID, msg) },
-		ErrRecv:                 func(msg string) error { return wrapErr(ErrRecv, msg) },
+		PropagateRecvError: func(err error) bool {
+			return errors.Is(err, ErrTimeout) || errors.Is(err, ErrAborted)
+		},
+		FailAllInflight:  s.failAllInflight,
+		ErrLimitExceeded: func(msg string) error { return wrapErr(ErrLimitExceeded, msg) },
+		ErrProtocol:      func(msg string) error { return wrapErr(ErrProtocol, msg) },
+		ErrChunk:         func(msg string) error { return wrapErr(ErrChunk, msg) },
+		ErrUnknownMsgID:  func(msg string) error { return wrapErr(ErrUnknownMsgID, msg) },
+		ErrRecv:          func(msg string) error { return wrapErr(ErrRecv, msg) },
 	}, buf)
+}
+
+type receiveWait struct {
+	infinite bool
+	deadline time.Time
+	abortCh  <-chan struct{}
+}
+
+func newReceiveWait(timeoutMs uint32, abortCh <-chan struct{}) receiveWait {
+	w := receiveWait{
+		infinite: timeoutMs == 0,
+		abortCh:  abortCh,
+	}
+	if !w.infinite {
+		w.deadline = time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
+	}
+	return w
+}
+
+func (w receiveWait) waitMs() (uint32, error) {
+	if w.abortCh != nil {
+		select {
+		case <-w.abortCh:
+			return 0, ErrAborted
+		default:
+		}
+	}
+
+	waitMs := receiveAbortPollMs
+	if w.infinite {
+		return waitMs, nil
+	}
+
+	remaining := time.Until(w.deadline)
+	if remaining <= 0 {
+		return 0, ErrTimeout
+	}
+	return boundedReceiveWaitMs(remaining, waitMs), nil
+}
+
+func boundedReceiveWaitMs(remaining time.Duration, pollCapMs uint32) uint32 {
+	if remaining <= 0 {
+		return 0
+	}
+	if remaining >= time.Duration(pollCapMs)*time.Millisecond {
+		return pollCapMs
+	}
+	waitMs := uint32((remaining + time.Millisecond - 1) / time.Millisecond) // #nosec G115 -- remaining is positive and below pollCapMs here.
+	if waitMs == 0 {
+		return 1
+	}
+	return waitMs
+}
+
+func (s *Session) rawRecvWithTimeout(buf []byte, wait receiveWait) (int, error) {
+	for {
+		waitMs, err := wait.waitMs()
+		if err != nil {
+			return 0, err
+		}
+
+		ready, err := s.WaitReadable(waitMs)
+		if err != nil {
+			return 0, err
+		}
+		if !ready {
+			continue
+		}
+		return rawRecv(s.handle, buf)
+	}
 }

--- a/src/libnetdata/netipc/include/netipc/netipc_named_pipe.h
+++ b/src/libnetdata/netipc/include/netipc/netipc_named_pipe.h
@@ -68,6 +68,8 @@ typedef enum {
     NIPC_NP_ERR_DUPLICATE_MSG_ID,   /* message_id already in-flight */
     NIPC_NP_ERR_UNKNOWN_MSG_ID,     /* response message_id not in-flight */
     NIPC_NP_ERR_DISCONNECTED,       /* peer disconnected (graceful) */
+    NIPC_NP_ERR_TIMEOUT,            /* receive deadline expired */
+    NIPC_NP_ERR_ABORTED,            /* receive aborted by caller */
 } nipc_np_error_t;
 
 /* ------------------------------------------------------------------ */
@@ -243,6 +245,21 @@ nipc_np_error_t nipc_np_receive(nipc_np_session_t *session,
                                  nipc_header_t *hdr_out,
                                  const void **payload_out,
                                  size_t *payload_len_out);
+
+/*
+ * Receive one logical message with an optional deadline and abort event.
+ *
+ * timeout_ms == 0 waits indefinitely. abort_event == NULL disables abort
+ * waiting. If abort_event is signaled before a complete message arrives,
+ * returns NIPC_NP_ERR_ABORTED.
+ */
+nipc_np_error_t nipc_np_receive_timeout(nipc_np_session_t *session,
+                                         void *buf, size_t buf_size,
+                                         nipc_header_t *hdr_out,
+                                         const void **payload_out,
+                                         size_t *payload_len_out,
+                                         uint32_t timeout_ms,
+                                         HANDLE abort_event);
 
 /*
  * Poll until a session becomes readable or the timeout expires.

--- a/src/libnetdata/netipc/include/netipc/netipc_protocol.h
+++ b/src/libnetdata/netipc/include/netipc/netipc_protocol.h
@@ -97,6 +97,8 @@ typedef enum {
     NIPC_ERR_OVERFLOW,        /* builder ran out of space */
     NIPC_ERR_HANDLER_FAILED,  /* typed handler rejected an otherwise valid request */
     NIPC_ERR_NOT_READY,       /* client not connected / service unavailable */
+    NIPC_ERR_TIMEOUT,         /* synchronous call deadline expired */
+    NIPC_ERR_ABORTED,         /* synchronous call aborted by caller */
 } nipc_error_t;
 
 /* ------------------------------------------------------------------ */

--- a/src/libnetdata/netipc/include/netipc/netipc_service.h
+++ b/src/libnetdata/netipc/include/netipc/netipc_service.h
@@ -38,6 +38,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define NIPC_CLIENT_CALL_TIMEOUT_DEFAULT_MS 30000u
+#define NIPC_CLIENT_ABORT_POLL_MS 100u
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -86,6 +89,7 @@ typedef struct {
     uint32_t max_request_batch_items;
     uint32_t max_response_payload_bytes;
     uint64_t auth_token;
+    uint32_t call_timeout_ms;          /* 0 = use default (30000 ms) */
 } nipc_client_config_t;
 
 /*
@@ -123,6 +127,7 @@ typedef struct {
     nipc_np_session_t session;
     bool session_valid;
     nipc_win_shm_ctx_t *shm;  /* non-NULL if SHM profile negotiated */
+    HANDLE abort_event;
 #else
     nipc_uds_client_config_t transport_config;
 
@@ -130,7 +135,12 @@ typedef struct {
     nipc_uds_session_t session;
     bool session_valid;
     nipc_shm_ctx_t *shm;  /* non-NULL if SHM profile negotiated */
+    int abort_pipe[2];
+    bool abort_pipe_valid;
 #endif
+
+    uint32_t call_timeout_ms;
+    uint32_t abort_requested;
 
     /* Stats */
     uint32_t connect_count;
@@ -182,6 +192,24 @@ void nipc_client_status(const nipc_client_ctx_t *ctx,
                         nipc_client_status_t *out);
 
 /*
+ * Set the context-level default timeout used by typed calls when their
+ * per-call timeout argument is zero. Passing zero restores the library default.
+ */
+void nipc_client_set_call_timeout(nipc_client_ctx_t *ctx, uint32_t timeout_ms);
+
+/*
+ * Abort an in-flight synchronous client call from another thread. Abort is
+ * sticky: future calls fail with NIPC_ERR_ABORTED until nipc_client_clear_abort()
+ * or nipc_client_close() is called.
+ */
+void nipc_client_abort(nipc_client_ctx_t *ctx);
+
+/*
+ * Clear a previously requested abort so the context can be refreshed/reused.
+ */
+void nipc_client_clear_abort(nipc_client_ctx_t *ctx);
+
+/*
  * Tear down connection and release resources. Safe on a zero-init ctx.
  */
 void nipc_client_close(nipc_client_ctx_t *ctx);
@@ -211,17 +239,36 @@ nipc_error_t nipc_client_call_cgroups_snapshot(
     nipc_client_ctx_t *ctx,
     nipc_cgroups_resp_view_t *view_out);
 
+nipc_error_t nipc_client_call_cgroups_snapshot_timeout(
+    nipc_client_ctx_t *ctx,
+    nipc_cgroups_resp_view_t *view_out,
+    uint32_t timeout_ms);
+
 nipc_error_t nipc_client_call_cgroups_lookup(
     nipc_client_ctx_t *ctx,
     const nipc_str_view_t *paths,
     uint32_t path_count,
     nipc_cgroups_lookup_resp_view_t *view_out);
 
+nipc_error_t nipc_client_call_cgroups_lookup_timeout(
+    nipc_client_ctx_t *ctx,
+    const nipc_str_view_t *paths,
+    uint32_t path_count,
+    nipc_cgroups_lookup_resp_view_t *view_out,
+    uint32_t timeout_ms);
+
 nipc_error_t nipc_client_call_apps_lookup(
     nipc_client_ctx_t *ctx,
     const uint32_t *pids,
     uint32_t pid_count,
     nipc_apps_lookup_resp_view_t *view_out);
+
+nipc_error_t nipc_client_call_apps_lookup_timeout(
+    nipc_client_ctx_t *ctx,
+    const uint32_t *pids,
+    uint32_t pid_count,
+    nipc_apps_lookup_resp_view_t *view_out,
+    uint32_t timeout_ms);
 
 /* ------------------------------------------------------------------ */
 /*  Managed server                                                     */

--- a/src/libnetdata/netipc/include/netipc/netipc_uds.h
+++ b/src/libnetdata/netipc/include/netipc/netipc_uds.h
@@ -41,6 +41,8 @@ typedef enum {
     NIPC_UDS_ERR_BAD_PARAM,         /* invalid argument */
     NIPC_UDS_ERR_DUPLICATE_MSG_ID,  /* message_id already in-flight */
     NIPC_UDS_ERR_UNKNOWN_MSG_ID,    /* response message_id not in-flight */
+    NIPC_UDS_ERR_TIMEOUT,           /* receive deadline expired */
+    NIPC_UDS_ERR_ABORTED,           /* receive aborted by caller */
 } nipc_uds_error_t;
 
 /* ------------------------------------------------------------------ */
@@ -204,6 +206,21 @@ nipc_uds_error_t nipc_uds_receive(nipc_uds_session_t *session,
                                    nipc_header_t *hdr_out,
                                    const void **payload_out,
                                    size_t *payload_len_out);
+
+/*
+ * Receive one logical message with an optional deadline and abort fd.
+ *
+ * timeout_ms == 0 waits indefinitely. abort_fd < 0 disables abort waiting.
+ * If abort_fd becomes readable before a complete message arrives, returns
+ * NIPC_UDS_ERR_ABORTED.
+ */
+nipc_uds_error_t nipc_uds_receive_timeout(nipc_uds_session_t *session,
+                                           void *buf, size_t buf_size,
+                                           nipc_header_t *hdr_out,
+                                           const void **payload_out,
+                                           size_t *payload_len_out,
+                                           uint32_t timeout_ms,
+                                           int abort_fd);
 
 /* ------------------------------------------------------------------ */
 /*  Utility                                                            */

--- a/src/libnetdata/netipc/src/service/netipc_service_apps_lookup.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_apps_lookup.c
@@ -46,6 +46,7 @@ typedef struct {
     const uint32_t *pids;
     uint32_t pid_count;
     nipc_apps_lookup_resp_view_t *view_out;
+    uint32_t timeout_ms;
 } apps_lookup_call_state_t;
 
 static nipc_error_t do_apps_lookup_attempt(nipc_client_ctx_t *ctx, void *state)
@@ -74,7 +75,7 @@ static nipc_error_t do_apps_lookup_attempt(nipc_client_ctx_t *ctx, void *state)
     size_t payload_len;
     nipc_error_t err = nipc_service_platform_do_raw_call(
         ctx, NIPC_METHOD_APPS_LOOKUP, ctx->send_buf, req_len,
-        &payload, &payload_len);
+        &payload, &payload_len, s->timeout_ms);
     if (err != NIPC_OK)
         return err;
 
@@ -100,10 +101,21 @@ nipc_error_t nipc_client_call_apps_lookup(
     uint32_t pid_count,
     nipc_apps_lookup_resp_view_t *view_out)
 {
+    return nipc_client_call_apps_lookup_timeout(ctx, pids, pid_count, view_out, 0);
+}
+
+nipc_error_t nipc_client_call_apps_lookup_timeout(
+    nipc_client_ctx_t *ctx,
+    const uint32_t *pids,
+    uint32_t pid_count,
+    nipc_apps_lookup_resp_view_t *view_out,
+    uint32_t timeout_ms)
+{
     apps_lookup_call_state_t state = {
         .pids = pids,
         .pid_count = pid_count,
         .view_out = view_out,
+        .timeout_ms = timeout_ms,
     };
     return nipc_service_platform_call_with_retry(
         ctx, do_apps_lookup_attempt, &state);

--- a/src/libnetdata/netipc/src/service/netipc_service_cgroups_lookup.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_cgroups_lookup.c
@@ -51,6 +51,7 @@ typedef struct {
     const nipc_str_view_t *paths;
     uint32_t path_count;
     nipc_cgroups_lookup_resp_view_t *view_out;
+    uint32_t timeout_ms;
 } cgroups_lookup_call_state_t;
 
 static nipc_error_t do_cgroups_lookup_attempt(nipc_client_ctx_t *ctx,
@@ -80,7 +81,7 @@ static nipc_error_t do_cgroups_lookup_attempt(nipc_client_ctx_t *ctx,
     size_t payload_len;
     nipc_error_t err = nipc_service_platform_do_raw_call(
         ctx, NIPC_METHOD_CGROUPS_LOOKUP, ctx->send_buf, req_len,
-        &payload, &payload_len);
+        &payload, &payload_len, s->timeout_ms);
     if (err != NIPC_OK)
         return err;
 
@@ -107,10 +108,22 @@ nipc_error_t nipc_client_call_cgroups_lookup(
     uint32_t path_count,
     nipc_cgroups_lookup_resp_view_t *view_out)
 {
+    return nipc_client_call_cgroups_lookup_timeout(
+        ctx, paths, path_count, view_out, 0);
+}
+
+nipc_error_t nipc_client_call_cgroups_lookup_timeout(
+    nipc_client_ctx_t *ctx,
+    const nipc_str_view_t *paths,
+    uint32_t path_count,
+    nipc_cgroups_lookup_resp_view_t *view_out,
+    uint32_t timeout_ms)
+{
     cgroups_lookup_call_state_t state = {
         .paths = paths,
         .path_count = path_count,
         .view_out = view_out,
+        .timeout_ms = timeout_ms,
     };
     return nipc_service_platform_call_with_retry(
         ctx, do_cgroups_lookup_attempt, &state);

--- a/src/libnetdata/netipc/src/service/netipc_service_cgroups_snapshot.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_cgroups_snapshot.c
@@ -35,6 +35,7 @@ static nipc_error_t cgroups_snapshot_dispatch(void *user,
 
 typedef struct {
     nipc_cgroups_resp_view_t *view_out;
+    uint32_t timeout_ms;
 } cgroups_snapshot_call_state_t;
 
 static nipc_error_t do_cgroups_snapshot_attempt(nipc_client_ctx_t *ctx,
@@ -52,7 +53,7 @@ static nipc_error_t do_cgroups_snapshot_attempt(nipc_client_ctx_t *ctx,
     size_t payload_len;
     nipc_error_t err = nipc_service_platform_do_raw_call(
         ctx, NIPC_METHOD_CGROUPS_SNAPSHOT, req_buf, req_len,
-        &payload, &payload_len);
+        &payload, &payload_len, s->timeout_ms);
     if (err != NIPC_OK)
         return err;
 
@@ -63,8 +64,17 @@ nipc_error_t nipc_client_call_cgroups_snapshot(
     nipc_client_ctx_t *ctx,
     nipc_cgroups_resp_view_t *view_out)
 {
+    return nipc_client_call_cgroups_snapshot_timeout(ctx, view_out, 0);
+}
+
+nipc_error_t nipc_client_call_cgroups_snapshot_timeout(
+    nipc_client_ctx_t *ctx,
+    nipc_cgroups_resp_view_t *view_out,
+    uint32_t timeout_ms)
+{
     cgroups_snapshot_call_state_t state = {
         .view_out = view_out,
+        .timeout_ms = timeout_ms,
     };
     return nipc_service_platform_call_with_retry(
         ctx, do_cgroups_snapshot_attempt, &state);

--- a/src/libnetdata/netipc/src/service/netipc_service_common.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_common.c
@@ -125,6 +125,7 @@ void nipc_service_common_client_init(nipc_client_ctx_t *ctx,
     ctx->state = NIPC_CLIENT_DISCONNECTED;
     ctx->session_valid = false;
     ctx->shm = NULL;
+    ctx->call_timeout_ms = NIPC_CLIENT_CALL_TIMEOUT_DEFAULT_MS;
     nipc_service_common_copy_cstr_field(ctx->run_dir, sizeof(ctx->run_dir), run_dir);
     nipc_service_common_copy_cstr_field(ctx->service_name, sizeof(ctx->service_name), service_name);
 }
@@ -148,6 +149,21 @@ void nipc_service_common_client_close_buffers(nipc_client_ctx_t *ctx)
     ctx->response_buf_size = 0;
     ctx->send_buf_size = 0;
     ctx->state = NIPC_CLIENT_DISCONNECTED;
+}
+
+uint32_t nipc_service_common_client_call_timeout_ms(const nipc_client_ctx_t *ctx,
+                                                    uint32_t timeout_ms)
+{
+    if (timeout_ms != 0)
+        return timeout_ms;
+    if (ctx->call_timeout_ms != 0)
+        return ctx->call_timeout_ms;
+    return NIPC_CLIENT_CALL_TIMEOUT_DEFAULT_MS;
+}
+
+bool nipc_service_common_client_abort_requested(const nipc_client_ctx_t *ctx)
+{
+    return __atomic_load_n(&ctx->abort_requested, __ATOMIC_ACQUIRE) != 0;
 }
 
 bool nipc_service_common_client_refresh(nipc_client_ctx_t *ctx,
@@ -290,9 +306,13 @@ nipc_error_t nipc_service_common_do_raw_call(
     size_t request_len,
     const void **response_payload_out,
     size_t *response_len_out,
+    uint32_t timeout_ms,
     nipc_service_common_transport_send_fn send_fn,
     nipc_service_common_transport_receive_fn receive_fn)
 {
+    if (nipc_service_common_client_abort_requested(ctx))
+        return NIPC_ERR_ABORTED;
+
     nipc_header_t hdr = {0};
     hdr.kind             = NIPC_KIND_REQUEST;
     hdr.code             = method_code;
@@ -307,7 +327,8 @@ nipc_error_t nipc_service_common_do_raw_call(
 
     nipc_header_t resp_hdr;
     err = receive_fn(ctx, ctx->response_buf, ctx->response_buf_size,
-                     &resp_hdr, response_payload_out, response_len_out);
+                     &resp_hdr, response_payload_out, response_len_out,
+                     timeout_ms);
     if (err != NIPC_OK)
         return err;
 
@@ -342,6 +363,13 @@ nipc_error_t nipc_service_common_call_with_retry(
         if (err == NIPC_OK) {
             ctx->call_count++;
             return NIPC_OK;
+        }
+
+        if (err == NIPC_ERR_TIMEOUT || err == NIPC_ERR_ABORTED) {
+            ops->disconnect(ctx);
+            ctx->state = NIPC_CLIENT_BROKEN;
+            ctx->error_count++;
+            return err;
         }
 
         if (err != NIPC_ERR_OVERFLOW) {

--- a/src/libnetdata/netipc/src/service/netipc_service_common.h
+++ b/src/libnetdata/netipc/src/service/netipc_service_common.h
@@ -34,7 +34,8 @@ typedef nipc_error_t (*nipc_service_common_transport_receive_fn)(
     size_t buf_size,
     nipc_header_t *hdr_out,
     const void **payload_out,
-    size_t *payload_len_out);
+    size_t *payload_len_out,
+    uint32_t timeout_ms);
 
 typedef struct {
     void (*disconnect)(nipc_client_ctx_t *ctx);
@@ -90,6 +91,9 @@ void nipc_service_common_client_init(nipc_client_ctx_t *ctx,
 void nipc_service_common_client_status(const nipc_client_ctx_t *ctx,
                                        nipc_client_status_t *out);
 void nipc_service_common_client_close_buffers(nipc_client_ctx_t *ctx);
+uint32_t nipc_service_common_client_call_timeout_ms(const nipc_client_ctx_t *ctx,
+                                                    uint32_t timeout_ms);
+bool nipc_service_common_client_abort_requested(const nipc_client_ctx_t *ctx);
 bool nipc_service_common_client_refresh(nipc_client_ctx_t *ctx,
                                         const nipc_service_common_client_ops_t *ops);
 void nipc_service_common_client_note_request_capacity(nipc_client_ctx_t *ctx,
@@ -118,6 +122,7 @@ nipc_error_t nipc_service_common_do_raw_call(
     size_t request_len,
     const void **response_payload_out,
     size_t *response_len_out,
+    uint32_t timeout_ms,
     nipc_service_common_transport_send_fn send_fn,
     nipc_service_common_transport_receive_fn receive_fn);
 nipc_error_t nipc_service_common_call_with_retry(

--- a/src/libnetdata/netipc/src/service/netipc_service_platform.h
+++ b/src/libnetdata/netipc/src/service/netipc_service_platform.h
@@ -35,7 +35,8 @@ nipc_error_t nipc_service_platform_do_raw_call(
     const void *request_payload,
     size_t request_len,
     const void **response_payload_out,
-    size_t *response_len_out);
+    size_t *response_len_out,
+    uint32_t timeout_ms);
 
 nipc_error_t nipc_service_platform_call_with_retry(
     nipc_client_ctx_t *ctx,

--- a/src/libnetdata/netipc/src/service/netipc_service_posix_client.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_posix_client.c
@@ -13,6 +13,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 static nipc_uds_client_config_t service_client_config_to_transport(
     const nipc_client_config_t *config)
@@ -30,6 +33,59 @@ static nipc_uds_client_config_t service_client_config_to_transport(
 static void client_sleep_ms(uint32_t ms)
 {
     nipc_service_posix_sleep_us(ms * 1000u);
+}
+
+static void close_abort_pipe(nipc_client_ctx_t *ctx)
+{
+    if (!ctx->abort_pipe_valid)
+        return;
+
+    if (ctx->abort_pipe[0] >= 0) {
+        close(ctx->abort_pipe[0]);
+        ctx->abort_pipe[0] = -1;
+    }
+    if (ctx->abort_pipe[1] >= 0) {
+        close(ctx->abort_pipe[1]);
+        ctx->abort_pipe[1] = -1;
+    }
+    ctx->abort_pipe_valid = false;
+}
+
+static void drain_abort_pipe(nipc_client_ctx_t *ctx)
+{
+    if (!ctx->abort_pipe_valid || ctx->abort_pipe[0] < 0)
+        return;
+
+    char buf[64];
+    for (;;) {
+        ssize_t n = read(ctx->abort_pipe[0], buf, sizeof(buf));
+        if (n > 0)
+            continue;
+        if (n < 0 && errno == EINTR)
+            continue;
+        break;
+    }
+}
+
+static void init_abort_pipe(nipc_client_ctx_t *ctx)
+{
+    ctx->abort_pipe[0] = -1;
+    ctx->abort_pipe[1] = -1;
+    ctx->abort_pipe_valid = false;
+
+    int fds[2];
+    if (pipe(fds) != 0)
+        return;
+
+    for (int i = 0; i < 2; i++) {
+        int flags = fcntl(fds[i], F_GETFL, 0);
+        if (flags >= 0)
+            (void)fcntl(fds[i], F_SETFL, flags | O_NONBLOCK);
+    }
+
+    ctx->abort_pipe[0] = fds[0];
+    ctx->abort_pipe[1] = fds[1];
+    ctx->abort_pipe_valid = true;
 }
 
 const nipc_service_common_client_ops_t *nipc_service_posix_client_ops(void)
@@ -69,8 +125,12 @@ void nipc_client_init(nipc_client_ctx_t *ctx,
 {
     nipc_service_common_client_init(ctx, run_dir, service_name);
     ctx->session.fd = -1;
+    init_abort_pipe(ctx);
 
     ctx->transport_config = service_client_config_to_transport(config);
+    ctx->call_timeout_ms = (config && config->call_timeout_ms != 0)
+        ? config->call_timeout_ms
+        : NIPC_CLIENT_CALL_TIMEOUT_DEFAULT_MS;
     if (ctx->transport_config.max_request_payload_bytes == 0)
         ctx->transport_config.max_request_payload_bytes =
             nipc_service_common_request_payload_default();
@@ -90,8 +150,43 @@ void nipc_client_status(const nipc_client_ctx_t *ctx,
     nipc_service_common_client_status(ctx, out);
 }
 
+void nipc_client_set_call_timeout(nipc_client_ctx_t *ctx, uint32_t timeout_ms)
+{
+    if (!ctx)
+        return;
+    ctx->call_timeout_ms = (timeout_ms != 0)
+        ? timeout_ms
+        : NIPC_CLIENT_CALL_TIMEOUT_DEFAULT_MS;
+}
+
+void nipc_client_abort(nipc_client_ctx_t *ctx)
+{
+    if (!ctx)
+        return;
+
+    __atomic_store_n(&ctx->abort_requested, 1u, __ATOMIC_RELEASE);
+    if (ctx->abort_pipe_valid && ctx->abort_pipe[1] >= 0) {
+        const char b = 1;
+        ssize_t n;
+        do {
+            n = write(ctx->abort_pipe[1], &b, 1);
+        } while (n < 0 && errno == EINTR);
+    }
+}
+
+void nipc_client_clear_abort(nipc_client_ctx_t *ctx)
+{
+    if (!ctx)
+        return;
+
+    drain_abort_pipe(ctx);
+    __atomic_store_n(&ctx->abort_requested, 0u, __ATOMIC_RELEASE);
+}
+
 void nipc_client_close(nipc_client_ctx_t *ctx)
 {
     nipc_service_posix_client_disconnect(ctx);
+    close_abort_pipe(ctx);
+    __atomic_store_n(&ctx->abort_requested, 0u, __ATOMIC_RELEASE);
     nipc_service_common_client_close_buffers(ctx);
 }

--- a/src/libnetdata/netipc/src/service/netipc_service_posix_client_call.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_posix_client_call.c
@@ -69,24 +69,63 @@ static nipc_error_t transport_receive(nipc_client_ctx_t *ctx,
                                        void *buf, size_t buf_size,
                                        nipc_header_t *hdr_out,
                                        const void **payload_out,
-                                       size_t *payload_len_out)
+                                       size_t *payload_len_out,
+                                       uint32_t timeout_ms)
 {
     if (ctx->shm) {
         size_t msg_len;
-        nipc_shm_error_t serr = nipc_shm_receive(ctx->shm, buf, buf_size,
-                                                    &msg_len, 30000);
-        if (serr != NIPC_SHM_OK)
+        uint64_t deadline = nipc_service_platform_monotonic_ms() + timeout_ms;
+
+        for (;;) {
+            if (nipc_service_common_client_abort_requested(ctx))
+                return NIPC_ERR_ABORTED;
+
+            uint64_t now = nipc_service_platform_monotonic_ms();
+            if (timeout_ms != 0 && now >= deadline)
+                return NIPC_ERR_TIMEOUT;
+
+            uint32_t wait_ms = NIPC_CLIENT_ABORT_POLL_MS;
+            if (timeout_ms != 0) {
+                uint64_t remaining = deadline - now;
+                if (remaining < wait_ms)
+                    wait_ms = (uint32_t)remaining;
+                if (wait_ms == 0)
+                    wait_ms = 1;
+            }
+
+            nipc_shm_error_t serr = nipc_shm_receive(ctx->shm, buf, buf_size,
+                                                     &msg_len, wait_ms);
+            if (serr == NIPC_SHM_OK)
+                break;
+            if (serr == NIPC_SHM_ERR_TIMEOUT)
+                continue;
             return NIPC_ERR_TRUNCATED;
+        }
 
         return nipc_service_common_client_parse_shm_response(
             buf, msg_len, hdr_out, payload_out, payload_len_out);
     }
 
     /* UDS path */
-    nipc_uds_error_t uerr = nipc_uds_receive(&ctx->session, buf, buf_size,
-                                               hdr_out, payload_out,
-                                               payload_len_out);
-    return (uerr == NIPC_UDS_OK) ? NIPC_OK : NIPC_ERR_TRUNCATED;
+    if (nipc_service_common_client_abort_requested(ctx))
+        return NIPC_ERR_ABORTED;
+
+    int abort_fd = ctx->abort_pipe_valid ? ctx->abort_pipe[0] : -1;
+    nipc_uds_error_t uerr = nipc_uds_receive_timeout(
+        &ctx->session, buf, buf_size, hdr_out, payload_out, payload_len_out,
+        timeout_ms, abort_fd);
+    switch (uerr) {
+    case NIPC_UDS_OK:
+        return NIPC_OK;
+    case NIPC_UDS_ERR_TIMEOUT:
+        return NIPC_ERR_TIMEOUT;
+    case NIPC_UDS_ERR_ABORTED:
+        return NIPC_ERR_ABORTED;
+    case NIPC_UDS_ERR_LIMIT_EXCEEDED:
+        return NIPC_ERR_OVERFLOW;
+    default:
+        return NIPC_ERR_TRUNCATED;
+    }
 }
 
 /* ------------------------------------------------------------------ */
@@ -105,11 +144,13 @@ nipc_error_t nipc_service_platform_do_raw_call(nipc_client_ctx_t *ctx,
                                                const void *request_payload,
                                                size_t request_len,
                                                const void **response_payload_out,
-                                               size_t *response_len_out)
+                                               size_t *response_len_out,
+                                               uint32_t timeout_ms)
 {
     return nipc_service_common_do_raw_call(
         ctx, method_code, request_payload, request_len,
         response_payload_out, response_len_out,
+        nipc_service_common_client_call_timeout_ms(ctx, timeout_ms),
         transport_send, transport_receive);
 }
 

--- a/src/libnetdata/netipc/src/service/netipc_service_win_client.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_win_client.c
@@ -35,6 +35,14 @@ static void client_sleep_ms(uint32_t ms)
     Sleep(ms);
 }
 
+static void close_abort_event(nipc_client_ctx_t *ctx)
+{
+    if (ctx->abort_event) {
+        CloseHandle(ctx->abort_event);
+        ctx->abort_event = NULL;
+    }
+}
+
 const nipc_service_common_client_ops_t *nipc_service_win_client_ops(void)
 {
     static const nipc_service_common_client_ops_t ops = {
@@ -72,8 +80,12 @@ void nipc_client_init(nipc_client_ctx_t *ctx,
 {
     nipc_service_common_client_init(ctx, run_dir, service_name);
     ctx->session.pipe = INVALID_HANDLE_VALUE;
+    ctx->abort_event = CreateEventW(NULL, TRUE, FALSE, NULL);
 
     ctx->transport_config = service_client_config_to_transport(config);
+    ctx->call_timeout_ms = (config && config->call_timeout_ms != 0)
+        ? config->call_timeout_ms
+        : NIPC_CLIENT_CALL_TIMEOUT_DEFAULT_MS;
     if (ctx->transport_config.max_request_payload_bytes == 0)
         ctx->transport_config.max_request_payload_bytes =
             nipc_service_common_request_payload_default();
@@ -93,9 +105,40 @@ void nipc_client_status(const nipc_client_ctx_t *ctx,
     nipc_service_common_client_status(ctx, out);
 }
 
+void nipc_client_set_call_timeout(nipc_client_ctx_t *ctx, uint32_t timeout_ms)
+{
+    if (!ctx)
+        return;
+    ctx->call_timeout_ms = (timeout_ms != 0)
+        ? timeout_ms
+        : NIPC_CLIENT_CALL_TIMEOUT_DEFAULT_MS;
+}
+
+void nipc_client_abort(nipc_client_ctx_t *ctx)
+{
+    if (!ctx)
+        return;
+
+    __atomic_store_n(&ctx->abort_requested, 1u, __ATOMIC_RELEASE);
+    if (ctx->abort_event)
+        SetEvent(ctx->abort_event);
+}
+
+void nipc_client_clear_abort(nipc_client_ctx_t *ctx)
+{
+    if (!ctx)
+        return;
+
+    if (ctx->abort_event)
+        ResetEvent(ctx->abort_event);
+    __atomic_store_n(&ctx->abort_requested, 0u, __ATOMIC_RELEASE);
+}
+
 void nipc_client_close(nipc_client_ctx_t *ctx)
 {
     nipc_service_win_client_disconnect(ctx);
+    close_abort_event(ctx);
+    __atomic_store_n(&ctx->abort_requested, 0u, __ATOMIC_RELEASE);
     nipc_service_common_client_close_buffers(ctx);
 }
 

--- a/src/libnetdata/netipc/src/service/netipc_service_win_client_call.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_win_client_call.c
@@ -61,24 +61,62 @@ static nipc_error_t transport_receive(nipc_client_ctx_t *ctx,
                                        void *buf, size_t buf_size,
                                        nipc_header_t *hdr_out,
                                        const void **payload_out,
-                                       size_t *payload_len_out)
+                                       size_t *payload_len_out,
+                                       uint32_t timeout_ms)
 {
     if (ctx->shm) {
         size_t msg_len;
-        nipc_win_shm_error_t serr = nipc_win_shm_receive(ctx->shm, buf, buf_size,
-                                                            &msg_len, 30000);
-        if (serr != NIPC_WIN_SHM_OK)
+        uint64_t deadline = nipc_service_platform_monotonic_ms() + timeout_ms;
+
+        for (;;) {
+            if (nipc_service_common_client_abort_requested(ctx))
+                return NIPC_ERR_ABORTED;
+
+            uint64_t now = nipc_service_platform_monotonic_ms();
+            if (timeout_ms != 0 && now >= deadline)
+                return NIPC_ERR_TIMEOUT;
+
+            uint32_t wait_ms = NIPC_CLIENT_ABORT_POLL_MS;
+            if (timeout_ms != 0) {
+                uint64_t remaining = deadline - now;
+                if (remaining < wait_ms)
+                    wait_ms = (uint32_t)remaining;
+                if (wait_ms == 0)
+                    wait_ms = 1;
+            }
+
+            nipc_win_shm_error_t serr = nipc_win_shm_receive(
+                ctx->shm, buf, buf_size, &msg_len, wait_ms);
+            if (serr == NIPC_WIN_SHM_OK)
+                break;
+            if (serr == NIPC_WIN_SHM_ERR_TIMEOUT)
+                continue;
             return NIPC_ERR_TRUNCATED;
+        }
 
         return nipc_service_common_client_parse_shm_response(
             buf, msg_len, hdr_out, payload_out, payload_len_out);
     }
 
     /* Named Pipe path */
-    nipc_np_error_t uerr = nipc_np_receive(&ctx->session, buf, buf_size,
-                                             hdr_out, payload_out,
-                                             payload_len_out);
-    return (uerr == NIPC_NP_OK) ? NIPC_OK : NIPC_ERR_TRUNCATED;
+    if (nipc_service_common_client_abort_requested(ctx))
+        return NIPC_ERR_ABORTED;
+
+    nipc_np_error_t uerr = nipc_np_receive_timeout(
+        &ctx->session, buf, buf_size, hdr_out, payload_out, payload_len_out,
+        timeout_ms, ctx->abort_event);
+    switch (uerr) {
+    case NIPC_NP_OK:
+        return NIPC_OK;
+    case NIPC_NP_ERR_TIMEOUT:
+        return NIPC_ERR_TIMEOUT;
+    case NIPC_NP_ERR_ABORTED:
+        return NIPC_ERR_ABORTED;
+    case NIPC_NP_ERR_LIMIT_EXCEEDED:
+        return NIPC_ERR_OVERFLOW;
+    default:
+        return NIPC_ERR_TRUNCATED;
+    }
 }
 
 /* ------------------------------------------------------------------ */
@@ -97,11 +135,13 @@ nipc_error_t nipc_service_platform_do_raw_call(nipc_client_ctx_t *ctx,
                                                const void *request_payload,
                                                size_t request_len,
                                                const void **response_payload_out,
-                                               size_t *response_len_out)
+                                               size_t *response_len_out,
+                                               uint32_t timeout_ms)
 {
     return nipc_service_common_do_raw_call(
         ctx, method_code, request_payload, request_len,
         response_payload_out, response_len_out,
+        nipc_service_common_client_call_timeout_ms(ctx, timeout_ms),
         transport_send, transport_receive);
 }
 

--- a/src/libnetdata/netipc/src/transport/posix/netipc_shm.c
+++ b/src/libnetdata/netipc/src/transport/posix/netipc_shm.c
@@ -101,16 +101,24 @@ static int build_shm_path(char *dst, size_t dst_len,
     return 0;
 }
 
-static bool dir_fd_allows_stale_unlink(int dir_fd)
+/*
+ * Open failures that mean the liveness check itself could not run (fd
+ * exhaustion). Deleting on these could remove a live endpoint, so the
+ * entry is kept and reported as in-use.
+ */
+static bool stale_check_unavailable(int err)
 {
-    struct stat st;
-    if (dir_fd < 0 || fstat(dir_fd, &st) != 0)
-        return false;
-    if (!S_ISDIR(st.st_mode))
-        return false;
-    if (st.st_uid != geteuid())
-        return false;
-    return (st.st_mode & (S_IWGRP | S_IWOTH)) == 0;
+    return err == EMFILE || err == ENFILE;
+}
+
+/* Remove a junk entry at an endpoint name; directories are junk too. */
+static int unlink_stale_name(int dir_fd, const char *name)
+{
+    if (unlinkat(dir_fd, name, 0) == 0 || errno == ENOENT)
+        return 0;
+    if (errno == EISDIR && unlinkat(dir_fd, name, AT_REMOVEDIR) == 0)
+        return 0;
+    return -1;
 }
 
 static int open_run_dir_fd(const char *run_dir)
@@ -196,12 +204,8 @@ static inline uint32_t *shm_u32_ptr(void *base, int offset)
  *  -1  = doesn't exist
  *  -2  = exists but undersized / invalid (treated as stale, unlinked)
  */
-static int unlink_same_file(int dir_fd, const char *name, const struct stat *expected,
-                            bool allow_stale_unlink)
+static int unlink_same_file(int dir_fd, const char *name, const struct stat *expected)
 {
-    if (!allow_stale_unlink)
-        return -1;
-
     struct stat current;
     if (fstatat(dir_fd, name, &current, AT_SYMLINK_NOFOLLOW) != 0)
         return (errno == ENOENT) ? 0 : -1;
@@ -209,15 +213,10 @@ static int unlink_same_file(int dir_fd, const char *name, const struct stat *exp
     if (current.st_dev != expected->st_dev || current.st_ino != expected->st_ino)
         return -1;
 
-    /* Stale recovery only unlinks same-inode entries in a private run directory. */
-    if (unlinkat(dir_fd, name, 0) == 0 || errno == ENOENT)
-        return 0;
-
-    return -1;
+    return unlink_stale_name(dir_fd, name);
 }
 
-static int check_shm_stale(int dir_fd, const char *name,
-                           bool allow_stale_unlink)
+static int check_shm_stale(int dir_fd, const char *name)
 {
 #ifdef O_NOFOLLOW
     int fd = openat(dir_fd, name, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
@@ -227,9 +226,12 @@ static int check_shm_stale(int dir_fd, const char *name,
     if (fd < 0) {
         if (errno == ENOENT)
             return -1;
-        /* Symlinks, permission failures, and other ambiguous path states are
-         * treated as live so stale recovery cannot remove an unsafe path. */
-        return 1;
+        if (stale_check_unavailable(errno))
+            return 1;
+        /* Unopenable entries (symlinks, unreadable files) cannot be live
+         * endpoints we can verify — they are junk squatting on the endpoint
+         * name. Reclaim them. */
+        return (unlink_stale_name(dir_fd, name) == 0) ? -2 : 1;
     }
 
     struct stat st;
@@ -240,19 +242,19 @@ static int check_shm_stale(int dir_fd, const char *name,
 
     if (!S_ISREG(st.st_mode)) {
         close(fd);
-        return 1;
+        return (unlink_same_file(dir_fd, name, &st) == 0) ? -2 : 1;
     }
 
     /* Must be at least header-sized to inspect. */
     if (st.st_size < (off_t)NIPC_SHM_HEADER_LEN) {
         close(fd);
-        return (unlink_same_file(dir_fd, name, &st, allow_stale_unlink) == 0) ? -2 : 1;
+        return (unlink_same_file(dir_fd, name, &st) == 0) ? -2 : 1;
     }
 
     void *map = mmap(NULL, NIPC_SHM_HEADER_LEN, PROT_READ, MAP_SHARED, fd, 0);
     close(fd);
     if (map == MAP_FAILED) {
-        return (unlink_same_file(dir_fd, name, &st, allow_stale_unlink) == 0) ? -2 : 1;
+        return (unlink_same_file(dir_fd, name, &st) == 0) ? -2 : 1;
     }
 
     const nipc_shm_region_header_t *hdr = (const nipc_shm_region_header_t *)map;
@@ -260,7 +262,7 @@ static int check_shm_stale(int dir_fd, const char *name,
     /* Validate magic first. */
     if (hdr->magic != NIPC_SHM_REGION_MAGIC) {
         munmap(map, NIPC_SHM_HEADER_LEN);
-        return (unlink_same_file(dir_fd, name, &st, allow_stale_unlink) == 0) ? -2 : 1;
+        return (unlink_same_file(dir_fd, name, &st) == 0) ? -2 : 1;
     }
 
     int32_t owner = hdr->owner_pid;
@@ -272,7 +274,7 @@ static int check_shm_stale(int dir_fd, const char *name,
     }
 
     /* Dead owner or zero generation (uninitialized/legacy) — stale */
-    return (unlink_same_file(dir_fd, name, &st, allow_stale_unlink) == 0) ? 0 : 1;
+    return (unlink_same_file(dir_fd, name, &st) == 0) ? 0 : 1;
 }
 
 /* ------------------------------------------------------------------ */
@@ -336,9 +338,7 @@ nipc_shm_error_t nipc_shm_server_create(const char *run_dir,
 
     /* If O_EXCL failed because file exists, do stale recovery and retry. */
     if (fd < 0 && errno == EEXIST) {
-        bool allow_stale_unlink = dir_fd_allows_stale_unlink(dir_fd);
-
-        int stale = check_shm_stale(dir_fd, shm_name, allow_stale_unlink);
+        int stale = check_shm_stale(dir_fd, shm_name);
         if (stale == 1) {
             close(dir_fd);
             return NIPC_SHM_ERR_ADDR_IN_USE;
@@ -896,8 +896,6 @@ void nipc_shm_cleanup_stale(const char *run_dir, const char *service_name)
         return;
     }
 
-    bool allow_stale_unlink = dir_fd_allows_stale_unlink(dir_fd);
-
     struct dirent *ent;
     while ((ent = readdir(dir)) != NULL) {
         size_t nlen = strlen(ent->d_name);
@@ -912,7 +910,7 @@ void nipc_shm_cleanup_stale(const char *run_dir, const char *service_name)
 
         /* check_shm_stale unlinks stale files and returns:
          *   0 = stale (unlinked), +1 = live, -1 = gone, -2 = invalid (unlinked) */
-        check_shm_stale(dir_fd, ent->d_name, allow_stale_unlink);
+        check_shm_stale(dir_fd, ent->d_name);
     }
 
     closedir(dir);

--- a/src/libnetdata/netipc/src/transport/posix/netipc_uds_internal.h
+++ b/src/libnetdata/netipc/src/transport/posix/netipc_uds_internal.h
@@ -25,11 +25,9 @@ int nipc_uds_build_socket_name(char *dst, size_t dst_len,
 int nipc_uds_build_socket_path(char *dst, size_t dst_len,
                                const char *run_dir,
                                const char *service_name);
-bool nipc_uds_run_dir_allows_stale_unlink(const char *run_dir);
 int nipc_uds_check_and_recover_stale(const char *run_dir,
                                      const char *socket_name,
-                                     const char *path,
-                                     bool allow_stale_unlink);
+                                     const char *path);
 
 nipc_uds_error_t nipc_uds_client_handshake(int fd,
                                            const nipc_uds_client_config_t *cfg,

--- a/src/libnetdata/netipc/src/transport/posix/netipc_uds_lifecycle.c
+++ b/src/libnetdata/netipc/src/transport/posix/netipc_uds_lifecycle.c
@@ -81,25 +81,9 @@ int nipc_uds_build_socket_path(char *dst, size_t dst_len,
     return 0;
 }
 
-bool nipc_uds_run_dir_allows_stale_unlink(const char *run_dir)
-{
-    struct stat st;
-    if (stat(run_dir, &st) != 0)
-        return false;
-    if (!S_ISDIR(st.st_mode))
-        return false;
-    if (st.st_uid != geteuid())
-        return false;
-    return (st.st_mode & (S_IWGRP | S_IWOTH)) == 0;
-}
-
 static int unlink_stale_socket_path(const char *run_dir,
-                                    const char *socket_name,
-                                    bool allow_stale_unlink)
+                                    const char *socket_name)
 {
-    if (!allow_stale_unlink)
-        return -1;
-
     DIR *dir = opendir(run_dir);
     if (!dir)
         return -1;
@@ -110,20 +94,13 @@ static int unlink_stale_socket_path(const char *run_dir,
         return -1;
     }
 
-    struct stat st;
-    if (fstatat(dir_fd, socket_name, &st, AT_SYMLINK_NOFOLLOW) != 0) {
-        int ret = (errno == ENOENT) ? 0 : -1;
-        closedir(dir);
-        return ret;
-    }
-
-    if (!S_ISSOCK(st.st_mode)) {
-        closedir(dir);
-        return -1;
-    }
-
+    /* Whatever sits at the endpoint name is not a live server (the connect
+     * probe already failed): a dead server's socket or a foreign file.
+     * Reclaim the name; directories are junk too. */
     int ret = -1;
     if (unlinkat(dir_fd, socket_name, 0) == 0 || errno == ENOENT)
+        ret = 0;
+    else if (errno == EISDIR && unlinkat(dir_fd, socket_name, AT_REMOVEDIR) == 0)
         ret = 0;
 
     closedir(dir);
@@ -132,12 +109,14 @@ static int unlink_stale_socket_path(const char *run_dir,
 
 int nipc_uds_check_and_recover_stale(const char *run_dir,
                                      const char *socket_name,
-                                     const char *path,
-                                     bool allow_stale_unlink)
+                                     const char *path)
 {
     int probe = socket(AF_UNIX, SOCK_SEQPACKET, 0);
-    if (probe < 0)
-        return -1;
+    if (probe < 0) {
+        /* Cannot probe liveness (fd exhaustion) — keep the endpoint and
+         * report it in use rather than risk deleting a live socket. */
+        return 1;
+    }
 
     struct sockaddr_un addr;
     if (fill_sockaddr_path(&addr, path) != 0) {
@@ -154,11 +133,8 @@ int nipc_uds_check_and_recover_stale(const char *run_dir,
         close(probe);
         if (saved_errno == ENOENT) {
             ret = -1;
-        } else if (saved_errno == ECONNREFUSED) {
-            ret = (unlink_stale_socket_path(run_dir, socket_name,
-                                            allow_stale_unlink) == 0) ? 0 : 1;
         } else {
-            ret = 1;
+            ret = (unlink_stale_socket_path(run_dir, socket_name) == 0) ? 0 : 1;
         }
     }
     return ret;
@@ -188,9 +164,7 @@ nipc_uds_error_t nipc_uds_listen(const char *run_dir,
     if (name_rc < 0)
         return NIPC_UDS_ERR_PATH_TOO_LONG;
 
-    bool allow_stale_unlink = nipc_uds_run_dir_allows_stale_unlink(run_dir);
-    int stale = nipc_uds_check_and_recover_stale(run_dir, socket_name, path,
-                                                allow_stale_unlink);
+    int stale = nipc_uds_check_and_recover_stale(run_dir, socket_name, path);
     if (stale == 1)
         return NIPC_UDS_ERR_ADDR_IN_USE;
 

--- a/src/libnetdata/netipc/src/transport/posix/netipc_uds_receive.c
+++ b/src/libnetdata/netipc/src/transport/posix/netipc_uds_receive.c
@@ -1,7 +1,89 @@
 #include "netipc_uds_internal.h"
 
+#include <errno.h>
+#include <limits.h>
+#include <poll.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
+
+typedef struct {
+    bool infinite;
+    uint64_t deadline_ms;
+    int abort_fd;
+} receive_wait_t;
+
+static uint64_t monotonic_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000ull + (uint64_t)ts.tv_nsec / 1000000ull;
+}
+
+static receive_wait_t receive_wait_init(uint32_t timeout_ms, int abort_fd)
+{
+    receive_wait_t wait = {
+        .infinite = (timeout_ms == 0),
+        .deadline_ms = 0,
+        .abort_fd = abort_fd,
+    };
+    if (!wait.infinite)
+        wait.deadline_ms = monotonic_ms() + timeout_ms;
+    return wait;
+}
+
+static int receive_wait_timeout(const receive_wait_t *wait)
+{
+    if (wait->infinite)
+        return -1;
+
+    uint64_t now = monotonic_ms();
+    if (now >= wait->deadline_ms)
+        return 0;
+
+    uint64_t remaining = wait->deadline_ms - now;
+    return remaining > (uint64_t)INT_MAX ? INT_MAX : (int)remaining;
+}
+
+static nipc_uds_error_t wait_for_readable(int fd, const receive_wait_t *wait)
+{
+    for (;;) {
+        struct pollfd fds[2];
+        nfds_t nfds = 1;
+
+        fds[0].fd = fd;
+        fds[0].events = POLLIN;
+        fds[0].revents = 0;
+
+        if (wait->abort_fd >= 0) {
+            fds[1].fd = wait->abort_fd;
+            fds[1].events = POLLIN;
+            fds[1].revents = 0;
+            nfds = 2;
+        }
+
+        int timeout = receive_wait_timeout(wait);
+        if (timeout == 0)
+            return NIPC_UDS_ERR_TIMEOUT;
+
+        int rc = poll(fds, nfds, timeout);
+        if (rc < 0) {
+            if (errno == EINTR)
+                continue;
+            return NIPC_UDS_ERR_RECV;
+        }
+        if (rc == 0)
+            return NIPC_UDS_ERR_TIMEOUT;
+
+        if (nfds == 2 && (fds[1].revents & (POLLIN | POLLHUP | POLLERR)))
+            return NIPC_UDS_ERR_ABORTED;
+
+        if (fds[0].revents & POLLIN)
+            return NIPC_UDS_OK;
+        if (fds[0].revents & (POLLHUP | POLLERR | POLLNVAL))
+            return NIPC_UDS_OK;
+    }
+}
 
 static nipc_uds_error_t ensure_recv_buf(nipc_uds_session_t *session,
                                         size_t needed)
@@ -72,8 +154,13 @@ static nipc_uds_error_t receive_first_packet(nipc_uds_session_t *session,
                                              void *buf,
                                              size_t buf_size,
                                              nipc_header_t *hdr_out,
-                                             ssize_t *received_out)
+                                             ssize_t *received_out,
+                                             const receive_wait_t *wait)
 {
+    nipc_uds_error_t werr = wait_for_readable(session->fd, wait);
+    if (werr != NIPC_UDS_OK)
+        return werr;
+
     ssize_t n = nipc_uds_raw_recv(session->fd, buf, buf_size);
     if (n <= 0) {
         nipc_uds_inflight_fail_all(session);
@@ -135,8 +222,13 @@ static nipc_uds_error_t receive_one_chunk(nipc_uds_session_t *session,
                                           uint32_t chunk_index,
                                           uint32_t chunk_count,
                                           size_t total_msg,
-                                          size_t *assembled)
+                                          size_t *assembled,
+                                          const receive_wait_t *wait)
 {
+    nipc_uds_error_t werr = wait_for_readable(session->fd, wait);
+    if (werr != NIPC_UDS_OK)
+        return werr;
+
     ssize_t cn = nipc_uds_raw_recv(session->fd, pkt_buf, pkt_buf_size);
     if (cn <= 0) {
         nipc_uds_inflight_fail_all(session);
@@ -178,7 +270,8 @@ static nipc_uds_error_t receive_chunked_payload(nipc_uds_session_t *session,
                                                 const nipc_header_t *hdr,
                                                 size_t total_msg,
                                                 const void **payload_out,
-                                                size_t *payload_len_out)
+                                                size_t *payload_len_out,
+                                                const receive_wait_t *wait)
 {
 	size_t first_payload_bytes = (size_t)first_packet_len - NIPC_HEADER_LEN;
     if (first_payload_bytes > hdr->payload_len)
@@ -203,7 +296,7 @@ static nipc_uds_error_t receive_chunked_payload(nipc_uds_session_t *session,
 
     for (uint32_t ci = 1; assembled < hdr->payload_len; ci++) {
         err = receive_one_chunk(session, pkt_buf, pkt_buf_size, hdr, ci,
-                                chunk_count, total_msg, &assembled);
+                                chunk_count, total_msg, &assembled, wait);
         if (err != NIPC_UDS_OK) {
             free(pkt_buf);
             return err;
@@ -223,12 +316,26 @@ nipc_uds_error_t nipc_uds_receive(nipc_uds_session_t *session,
                                    const void **payload_out,
                                    size_t *payload_len_out)
 {
+    return nipc_uds_receive_timeout(session, buf, buf_size, hdr_out,
+                                    payload_out, payload_len_out, 0, -1);
+}
+
+nipc_uds_error_t nipc_uds_receive_timeout(nipc_uds_session_t *session,
+                                           void *buf, size_t buf_size,
+                                           nipc_header_t *hdr_out,
+                                           const void **payload_out,
+                                           size_t *payload_len_out,
+                                           uint32_t timeout_ms,
+                                           int abort_fd)
+{
     if (!session || session->fd < 0)
         return NIPC_UDS_ERR_BAD_PARAM;
 
+    receive_wait_t wait = receive_wait_init(timeout_ms, abort_fd);
+
     ssize_t n;
     nipc_uds_error_t err = receive_first_packet(session, buf, buf_size,
-                                                hdr_out, &n);
+                                                hdr_out, &n, &wait);
     if (err != NIPC_UDS_OK)
         return err;
 
@@ -253,5 +360,5 @@ nipc_uds_error_t nipc_uds_receive(nipc_uds_session_t *session,
     }
 
     return receive_chunked_payload(session, buf, n, hdr_out, total_msg,
-                                   payload_out, payload_len_out);
+                                   payload_out, payload_len_out, &wait);
 }

--- a/src/libnetdata/netipc/src/transport/windows/netipc_named_pipe.c
+++ b/src/libnetdata/netipc/src/transport/windows/netipc_named_pipe.c
@@ -389,6 +389,137 @@ static nipc_np_error_t wait_readable(HANDLE pipe,
     }
 }
 
+typedef struct {
+    bool infinite;
+    ULONGLONG deadline;
+    HANDLE abort_event;
+} receive_wait_t;
+
+static void inflight_fail_all(nipc_np_session_t *s);
+
+static receive_wait_t receive_wait_init(uint32_t timeout_ms,
+                                        HANDLE abort_event)
+{
+    receive_wait_t wait = {
+        .infinite = (timeout_ms == 0),
+        .deadline = 0,
+        .abort_event = abort_event,
+    };
+    if (!wait.infinite)
+        wait.deadline = GetTickCount64() + timeout_ms;
+    return wait;
+}
+
+static bool receive_wait_expired(const receive_wait_t *wait)
+{
+    return !wait->infinite && GetTickCount64() >= wait->deadline;
+}
+
+static bool receive_wait_aborted(const receive_wait_t *wait)
+{
+    return wait->abort_event &&
+           WaitForSingleObject(wait->abort_event, 0) == WAIT_OBJECT_0;
+}
+
+static nipc_np_error_t wait_readable_for_receive(HANDLE pipe,
+                                                  const receive_wait_t *wait,
+                                                  bool *readable_out)
+{
+    int yielded = 0;
+
+    if (readable_out)
+        *readable_out = false;
+
+    for (;;) {
+        if (receive_wait_aborted(wait))
+            return NIPC_NP_ERR_ABORTED;
+
+        DWORD available = 0;
+        BOOL ok = PeekNamedPipe(pipe, NULL, 0, NULL, &available, NULL);
+        if (!ok) {
+            DWORD err = GetLastError();
+            if (is_disconnect_error(err))
+                return NIPC_NP_ERR_DISCONNECTED;
+            return NIPC_NP_ERR_RECV;
+        }
+
+        if (available > 0) {
+            if (readable_out)
+                *readable_out = true;
+            return NIPC_NP_OK;
+        }
+
+        if (receive_wait_expired(wait))
+            return NIPC_NP_ERR_TIMEOUT;
+
+        if (!yielded) {
+            yielded = 1;
+            for (int i = 0; i < 256; i++) {
+                if (receive_wait_aborted(wait))
+                    return NIPC_NP_ERR_ABORTED;
+
+                SwitchToThread();
+
+                available = 0;
+                ok = PeekNamedPipe(pipe, NULL, 0, NULL, &available, NULL);
+                if (!ok) {
+                    DWORD err = GetLastError();
+                    if (is_disconnect_error(err))
+                        return NIPC_NP_ERR_DISCONNECTED;
+                    return NIPC_NP_ERR_RECV;
+                }
+
+                if (available > 0) {
+                    if (readable_out)
+                        *readable_out = true;
+                    return NIPC_NP_OK;
+                }
+
+                if (receive_wait_expired(wait))
+                    return NIPC_NP_ERR_TIMEOUT;
+            }
+            continue;
+        }
+
+        Sleep(1);
+    }
+}
+
+static nipc_np_error_t raw_recv_with_wait(nipc_np_session_t *session,
+                                           void *buf,
+                                           size_t buf_size,
+                                           const receive_wait_t *wait,
+                                           DWORD *bytes_read)
+{
+    bool readable = false;
+    nipc_np_error_t werr = wait_readable_for_receive(
+        session->pipe, wait, &readable);
+    if (werr != NIPC_NP_OK)
+        return werr;
+    if (!readable)
+        return NIPC_NP_ERR_TIMEOUT;
+
+    int rc = raw_recv(session->pipe, buf, buf_size, bytes_read);
+    if (rc <= 0) {
+        inflight_fail_all(session);
+        return NIPC_NP_ERR_RECV;
+    }
+    return NIPC_NP_OK;
+}
+
+static nipc_np_error_t raw_recv_blocking(nipc_np_session_t *session,
+                                          void *buf,
+                                          size_t buf_size,
+                                          DWORD *bytes_read)
+{
+    int rc = raw_recv(session->pipe, buf, buf_size, bytes_read);
+    if (rc <= 0) {
+        inflight_fail_all(session);
+        return NIPC_NP_ERR_RECV;
+    }
+    return NIPC_NP_OK;
+}
+
 /* ------------------------------------------------------------------ */
 /*  In-flight message_id tracking (client side)                        */
 /* ------------------------------------------------------------------ */
@@ -1092,16 +1223,31 @@ nipc_np_error_t nipc_np_receive(nipc_np_session_t *session,
                                  const void **payload_out,
                                  size_t *payload_len_out)
 {
+    return nipc_np_receive_timeout(session, buf, buf_size, hdr_out,
+                                    payload_out, payload_len_out, 0, NULL);
+}
+
+nipc_np_error_t nipc_np_receive_timeout(nipc_np_session_t *session,
+                                         void *buf, size_t buf_size,
+                                         nipc_header_t *hdr_out,
+                                         const void **payload_out,
+                                         size_t *payload_len_out,
+                                         uint32_t timeout_ms,
+                                         HANDLE abort_event)
+{
     if (!session || session->pipe == INVALID_HANDLE_VALUE)
         return NIPC_NP_ERR_BAD_PARAM;
 
+    receive_wait_t wait = receive_wait_init(timeout_ms, abort_event);
+    bool controlled_receive = timeout_ms != 0 || abort_event != NULL;
+
     /* Read first message */
     DWORD bytes_read = 0;
-    int rc = raw_recv(session->pipe, buf, buf_size, &bytes_read);
-    if (rc <= 0) {
-        inflight_fail_all(session);
-        return NIPC_NP_ERR_RECV;
-    }
+    nipc_np_error_t rerr = controlled_receive
+        ? raw_recv_with_wait(session, buf, buf_size, &wait, &bytes_read)
+        : raw_recv_blocking(session, buf, buf_size, &bytes_read);
+    if (rerr != NIPC_NP_OK)
+        return rerr;
 
     size_t n = (size_t)bytes_read;
     if (n < NIPC_HEADER_LEN)
@@ -1182,11 +1328,12 @@ nipc_np_error_t nipc_np_receive(nipc_np_session_t *session,
 
     for (uint32_t ci = 1; assembled < hdr_out->payload_len; ci++) {
         DWORD cn = 0;
-        int crc = raw_recv(session->pipe, pkt_buf, pkt_buf_size, &cn);
-        if (crc <= 0) {
+        rerr = controlled_receive
+            ? raw_recv_with_wait(session, pkt_buf, pkt_buf_size, &wait, &cn)
+            : raw_recv_blocking(session, pkt_buf, pkt_buf_size, &cn);
+        if (rerr != NIPC_NP_OK) {
             free(pkt_buf);
-            inflight_fail_all(session);
-            return NIPC_NP_ERR_RECV;
+            return rerr;
         }
 
         if ((size_t)cn < NIPC_HEADER_LEN) {


### PR DESCRIPTION
## Summary
- Vendor plugin-ipc commit d7cccb2889b8a74fd5889b5cd59ee136ccc4ccad into Netdata's C, Go, and Rust NetIPC copies.
- Keep the vendored trees drift-free after Netdata wrapper, workspace, and Go import-path normalization.
- Adapt the eBPF cgroup cache consumer to use an explicit 5s NetIPC call timeout and abort blocked refreshes during shutdown.

## Validation
- bash diff-netdata-vendor.sh /home/costa/src/netdata-ktsaou.git: no C, Rust, or Go source drift after expected normalization.
- rg "github.com/netdata/plugin-ipc/go" src/go/pkg/netipc src/crates/netipc src/libnetdata/netipc src/collectors: no matches.
- CMake source-list completeness check: no vendored NetIPC .c file missing from CMakeLists.txt.
- git diff --check.
- cd src/go && go test -count=1 ./pkg/netipc/...
- cd src/go && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -run '^$' ./pkg/netipc/transport/windows ./pkg/netipc/service/raw ./pkg/netipc/service/cgroups_snapshot ./pkg/netipc/service/cgroups_lookup ./pkg/netipc/service/apps_lookup
- cargo test --manifest-path src/crates/netipc/Cargo.toml -- --test-threads=1
- cmake -S . -B /tmp/netdata-netipc-vendor-d7cccb2-build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_PLUGIN_EBPF=ON -DENABLE_PLUGIN_CGROUPS=ON -DENABLE_PLUGIN_XENSTAT=OFF
- cmake --build /tmp/netdata-netipc-vendor-d7cccb2-build --target netipc -j 8
- cmake --build /tmp/netdata-netipc-vendor-d7cccb2-build --target ebpf.plugin -j 8
- ninja -C /tmp/netdata-netipc-vendor-d7cccb2-build CMakeFiles/netdata.dir/src/collectors/cgroups.plugin/cgroup-netipc.c.o

Note: ENABLE_PLUGIN_XENSTAT was disabled only for local validation because this workstation lacks the optional xenstat development package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the vendored NetIPC SDK and adds bounded synchronous call timeouts and abort support across C, Go, and Rust. eBPF cgroup cache now uses a 5s NetIPC call timeout and aborts blocked refreshes during shutdown.

- **New Features**
  - Added per-call timeouts and abort handles to C (`netipc_service_*`), Go (`netipc/service/raw` and typed clients), and Rust (`crates/netipc`) clients with a 30s default.
  - New error surfaces: `Timeout` and `Aborted` in all languages; APIs expose `SetCallTimeout`/`Abort`/`ClearAbort` (Go) and `set_call_timeout`/`abort_handle` (Rust); C accepts `call_timeout_ms` in `nipc_client_config_t`.
  - eBPF: cgroup cache uses a 5s timeout and calls `ebpf_cgroup_cache_abort()` during shutdown to avoid hangs.

- **Bug Fixes**
  - Stale endpoint recovery for UDS and SHM works even in group-writable run dirs (e.g., systemd `RuntimeDirectoryMode=0775`).
  - Safer framing and transport: improved overflow checks and deadline/abort-aware receive on POSIX and Windows.

<sup>Written for commit 27a1e06a986e343a2293927225d7e6d64283f358. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

