### PR TITLE
chore(go/chartengine): template dims inherit float from the series metric meta

### DIFF
--- a/src/go/plugin/framework/chartengine/matcher.go
+++ b/src/go/plugin/framework/chartengine/matcher.go
@@ -82,6 +82,7 @@ func (e *Engine) resolveSeriesRoutes(
 	name string,
 	labels metrix.LabelView,
 	meta metrix.SeriesMeta,
+	reader metrix.Reader,
 	index matchIndex,
 	revision uint64,
 	buildSeq uint64,
@@ -97,6 +98,16 @@ func (e *Engine) resolveSeriesRoutes(
 	candidates := make([]routeCandidate, 0, len(index.byMetricName[name])+len(index.wildcardMatchers))
 	candidates = append(candidates, index.byMetricName[name]...)
 	candidates = append(candidates, index.wildcardMatchers...)
+
+	// Inherit the family-level float hint (the same source autogen uses) so float-native
+	// metrics render at full precision in template charts; the authored options.float only adds to it.
+	// Skip the lookup when there are no template candidates (the common autogen-only series).
+	metricFloat := false
+	if len(candidates) > 0 {
+		if mm, ok := reader.MetricMeta(name); ok {
+			metricFloat = mm.Float
+		}
+	}
 
 	routes := make([]routeBinding, 0)
 	for _, candidate := range candidates {
@@ -131,7 +142,7 @@ func (e *Engine) resolveSeriesRoutes(
 			Hidden:            candidate.dimension.Hidden,
 			Multiplier:        candidate.dimension.Multiplier,
 			Divisor:           candidate.dimension.Divisor,
-			Float:             candidate.dimension.Float,
+			Float:             candidate.dimension.Float || metricFloat,
 			Static:            !candidate.dimension.Dynamic,
 			Inferred:          candidate.dimension.InferNameFromSeriesMeta,
 			Autogen:           false,

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -370,6 +370,7 @@ func (e *Engine) scanPlanSeries(ctx *planBuildContext) error {
 			name,
 			labels,
 			meta,
+			ctx.reader,
 			ctx.index,
 			ctx.prog.Revision(),
 			buildSeq,

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -1426,6 +1426,8 @@ groups:
 	for _, v := range update.Values {
 		gotFloat[v.Name] = v.IsFloat
 	}
+	require.Contains(t, gotFloat, "floaty")
+	require.Contains(t, gotFloat, "inty")
 	assert.True(t, gotFloat["floaty"], "WithFloat metric should render float via meta inheritance")
 	assert.False(t, gotFloat["inty"], "plain metric with no options.float should stay int")
 }

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -1367,12 +1367,67 @@ groups:
 		break
 	}
 	require.NotNil(t, createdDim)
-	assert.False(t, createdDim.Float)
+	// The series is registered WithFloat, and template dims now inherit that float
+	// hint from the metric meta (as autogen does), so the dim renders at full precision.
+	assert.True(t, createdDim.Float)
 	update := findUpdateAction(plan)
 	require.NotNil(t, update)
 	require.Len(t, update.Values, 1)
-	assert.False(t, update.Values[0].IsFloat)
-	assert.Equal(t, int64(10), update.Values[0].Int64)
+	assert.True(t, update.Values[0].IsFloat)
+	assert.Equal(t, float64(10), update.Values[0].Float64)
+}
+
+// TestBuildPlanTemplateDimFloatFromMetricMeta pins the additive float contract for
+// template dimensions: a dim binding a metric the collector marked float (WithFloat)
+// renders float via meta inheritance, while a dim binding a plain metric (no WithFloat,
+// no options.float) stays int.
+func TestBuildPlanTemplateDimFloatFromMetricMeta(t *testing.T) {
+	e, err := New(WithEnginePolicy(EnginePolicy{Autogen: &AutogenPolicy{Enabled: true}}))
+	require.NoError(t, err)
+
+	yaml := `
+version: v1
+groups:
+  - family: svc
+    metrics:
+      - svc.floaty_total
+      - svc.inty_total
+    charts:
+      - id: svc_mixed
+        title: Mixed
+        context: mixed
+        units: units
+        dimensions:
+          - selector: svc.floaty_total
+            name: floaty
+          - selector: svc.inty_total
+            name: inty
+`
+	require.NoError(t, e.LoadYAML([]byte(yaml), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := mustCycleController(t, store)
+	sm := store.Write().SnapshotMeter("svc")
+	floaty := sm.Counter("floaty_total", metrix.WithFloat(true))
+	inty := sm.Counter("inty_total")
+	ls := sm.LabelSet(metrix.Label{Key: "id", Value: "a"})
+
+	cc.BeginCycle()
+	floaty.ObserveTotal(3, ls)
+	inty.ObserveTotal(7, ls)
+	cc.CommitCycleSuccess()
+
+	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+
+	update := findUpdateAction(plan)
+	require.NotNil(t, update)
+	gotFloat := map[string]bool{}
+	for _, v := range update.Values {
+		gotFloat[v.Name] = v.IsFloat
+	}
+	assert.True(t, gotFloat["floaty"], "WithFloat metric should render float via meta inheritance")
+	assert.False(t, gotFloat["inty"], "plain metric with no options.float should stay int")
 }
 
 func runTestBuildPlanAutogenStrictOverflowDrop(t *testing.T) {

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -658,7 +658,7 @@ dimensions:
 | `options.multiplier` | int    | no       | `1`     | Multiply the raw value by this factor.                           |
 | `options.divisor`    | int    | no       | `1`     | Divide the raw value by this factor.                             |
 | `options.hidden`     | bool   | no       | `false` | Hide this dimension in the chart (still collected).              |
-| `options.float`      | bool   | no       | `false` | Use floating-point precision for this dimension.                 |
+| `options.float`      | bool   | no       | `false` | Force floating-point precision. A dimension also inherits the metric's float flag from the collector, so this is redundant (and harmless) when the metric is already marked float. |
 
 > [!IMPORTANT]
 > There are three ways to name a dimension — pick **exactly one**:
@@ -725,7 +725,7 @@ dimensions:
       divisor: 1000
 ```
 
-**Float precision** — for ratios or small decimal values:
+**Float precision** — for ratios or small decimal values. A dimension also inherits the metric's float flag from the collector (collectors mark float-valued metrics), so `options.float` is redundant (harmless) for those and only needed to force float on a metric the collector did not mark float:
 
 ```yaml
 dimensions:


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Template chart dimensions now inherit the metric’s float flag from collector metadata. This matches autogen and prevents truncation when `options.float` isn’t set.

- **Bug Fixes**
  - In `chartengine`, `resolveSeriesRoutes` reads the metric’s float hint via the reader and merges it: `Float = dimension.Float || metricFloat` (lookup only when template candidates exist).
  - Planner now passes the reader to `resolveSeriesRoutes`; tests updated and a new test pins the additive float contract across mixed metrics.
  - `charttpl/README.md` clarifies that `options.float` is redundant when the metric is already marked float.

<sup>Written for commit 6ad1ff426d3360bb023b98b7e1d3d398b0ae9c56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

