### PR TITLE
feat(go.d/prometheus): add promprofiles catalog package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4378,6 +4378,17 @@ if(ENABLE_PLUGIN_GO)
             COMPONENT plugin-go
             DESTINATION usr/lib/netdata/conf.d/go.d/azure_monitor.profiles/default)
 
+    install(DIRECTORY
+            COMPONENT plugin-go
+            DESTINATION usr/lib/netdata/conf.d/go.d/prometheus.profiles)
+    install(DIRECTORY
+            COMPONENT plugin-go
+            DESTINATION usr/lib/netdata/conf.d/go.d/prometheus.profiles/default)
+    file(GLOB GO_PROMETHEUS_PROFILE_FILES src/go/plugin/go.d/config/go.d/prometheus.profiles/default/*.yaml)
+    install(FILES ${GO_PROMETHEUS_PROFILE_FILES}
+            COMPONENT plugin-go
+            DESTINATION usr/lib/netdata/conf.d/go.d/prometheus.profiles/default)
+
     if(BUILD_FOR_PACKAGING)
         install(FILES
                 ${PKG_FILES_PATH}/copyright

--- a/src/go/plugin/go.d/collector/prometheus/chart_template.go
+++ b/src/go/plugin/go.d/collector/prometheus/chart_template.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/promprofiles"
 	"gopkg.in/yaml.v2"
 )
 
@@ -14,19 +15,19 @@ import (
 // which its series is not seen.
 const chartExpireAfterCycles = 10
 
-// buildChartTemplate returns the per-job chart template (charttpl YAML) for the prometheus collector.
-// It is a pure-autogen template: a stub group satisfies the schema, and chartengine autogen builds
-// one chart per scraped metric, prefixing the context with context_namespace. The namespace is
-// "prometheus" or "prometheus.<app>" so contexts match V1 (prometheus.<metric> /
-// prometheus.<app>.<metric>); autogen joins namespace + "." + metric, so the app's separating dot is
-// part of the namespace itself.
-func buildChartTemplate(app string) (string, error) {
+// newAutogenSpec is the base per-job chart-template spec: the per-app context
+// namespace ("prometheus" / "prometheus.<app>") with autogen enabled and
+// V1-matching expiry. A stub group satisfies the schema; chartengine autogen
+// builds one chart per scraped metric, prefixing the context with the namespace
+// (autogen joins namespace + "." + metric, so the app's separating dot is part
+// of the namespace itself), so contexts match V1 (prometheus[.app].<metric>).
+func newAutogenSpec(app string) charttpl.Spec {
 	namespace := "prometheus"
 	if app != "" {
 		namespace = "prometheus." + app
 	}
 
-	spec := charttpl.Spec{
+	return charttpl.Spec{
 		Version:          charttpl.VersionV1,
 		ContextNamespace: namespace,
 		Engine: &charttpl.Engine{
@@ -37,7 +38,26 @@ func buildChartTemplate(app string) (string, error) {
 		},
 		Groups: []charttpl.Group{{Family: "prometheus"}},
 	}
+}
 
+// buildChartTemplate returns the pure-autogen per-job chart template (no profiles).
+func buildChartTemplate(app string) (string, error) {
+	return marshalChartSpec(newAutogenSpec(app))
+}
+
+// buildMergedChartTemplate returns the per-job chart template: the autogen base
+// plus the selected profiles' curated groups appended read-only (autogen stays
+// the fallback for families no profile charts). With no profiles it is identical
+// to buildChartTemplate.
+func buildMergedChartTemplate(app string, profiles []promprofiles.Profile) (string, error) {
+	spec := newAutogenSpec(app)
+	for _, p := range profiles {
+		spec.Groups = append(spec.Groups, p.Template)
+	}
+	return marshalChartSpec(spec)
+}
+
+func marshalChartSpec(spec charttpl.Spec) (string, error) {
 	if err := spec.Validate(); err != nil {
 		return "", fmt.Errorf("build prometheus chart template: %w", err)
 	}

--- a/src/go/plugin/go.d/collector/prometheus/collect.go
+++ b/src/go/plugin/go.d/collector/prometheus/collect.go
@@ -41,6 +41,9 @@ func (c *Collector) check(ctx context.Context) error {
 	if c.writer.countWritable(mfs) == 0 {
 		return fmt.Errorf("endpoint '%s' exposes no usable metrics", c.URL)
 	}
+	if err := c.ensureChartTemplate(mfs); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/src/go/plugin/go.d/collector/prometheus/collector.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector.go
@@ -39,6 +39,7 @@ func New() *Collector {
 			},
 			MaxTS:          2000,
 			MaxTSPerMetric: 200,
+			Profiles:       ProfilesConfig{Mode: profilesModeAuto},
 		},
 		store: metrix.NewCollectorStore(),
 	}

--- a/src/go/plugin/go.d/collector/prometheus/collector.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector.go
@@ -13,6 +13,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/prometheus"
 	"github.com/netdata/netdata/go/plugins/pkg/web"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/promprofiles"
 )
 
 //go:embed "config_schema.json"
@@ -41,7 +42,8 @@ func New() *Collector {
 			MaxTSPerMetric: 200,
 			Profiles:       ProfilesConfig{Mode: profilesModeAuto},
 		},
-		store: metrix.NewCollectorStore(),
+		store:              metrix.NewCollectorStore(),
+		loadProfileCatalog: promprofiles.DefaultCatalog,
 	}
 }
 
@@ -53,7 +55,10 @@ type Collector struct {
 	relabelBlocks []relabelBlock
 	store         metrix.CollectorStore
 	writer        *metricFamilyWriter
-	chartTemplate string
+	runtime       *promRuntime
+
+	// loadProfileCatalog resolves the profile catalog; a field so tests inject a fake.
+	loadProfileCatalog func() (promprofiles.Catalog, error)
 }
 
 func (c *Collector) Configuration() any {
@@ -94,12 +99,6 @@ func (c *Collector) Init(context.Context) error {
 		isFallbackTypeCounter: counterFallback,
 	}, c.Logger)
 
-	tmpl, err := buildChartTemplate(c.application())
-	if err != nil {
-		return fmt.Errorf("build chart template: %v", err)
-	}
-	c.chartTemplate = tmpl
-
 	return nil
 }
 
@@ -112,6 +111,7 @@ func (c *Collector) Collect(ctx context.Context) error {
 }
 
 func (c *Collector) Cleanup(context.Context) {
+	c.runtime = nil
 	if c.prom != nil && c.prom.HTTPClient() != nil {
 		c.prom.HTTPClient().CloseIdleConnections()
 	}
@@ -122,5 +122,8 @@ func (c *Collector) MetricStore() metrix.CollectorStore {
 }
 
 func (c *Collector) ChartTemplateYAML() string {
-	return c.chartTemplate
+	if c.runtime == nil {
+		return ""
+	}
+	return c.runtime.chartTemplate
 }

--- a/src/go/plugin/go.d/collector/prometheus/collector.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector.go
@@ -11,10 +11,8 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/confopt"
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	"github.com/netdata/netdata/go/plugins/pkg/prometheus"
-	"github.com/netdata/netdata/go/plugins/pkg/prometheus/selector"
 	"github.com/netdata/netdata/go/plugins/pkg/web"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
-	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
 )
 
 //go:embed "config_schema.json"
@@ -44,33 +42,6 @@ func New() *Collector {
 		},
 		store: metrix.NewCollectorStore(),
 	}
-}
-
-type Config struct {
-	Vnode              string `yaml:"vnode,omitempty" json:"vnode"`
-	UpdateEvery        int    `yaml:"update_every,omitempty" json:"update_every"`
-	AutoDetectionRetry int    `yaml:"autodetection_retry,omitempty" json:"autodetection_retry"`
-	web.HTTPConfig     `yaml:",inline" json:""`
-	Name               string         `yaml:"name,omitempty" json:"name"`
-	Application        string         `yaml:"app,omitempty" json:"app"`
-	Selector           selector.Expr  `yaml:"selector,omitempty" json:"selector"`
-	Relabeling         []RelabelBlock `yaml:"relabeling,omitempty" json:"relabeling,omitempty"`
-	ExpectedPrefix     string         `yaml:"expected_prefix,omitempty" json:"expected_prefix"`
-	MaxTS              int            `yaml:"max_time_series" json:"max_time_series"`
-	MaxTSPerMetric     int            `yaml:"max_time_series_per_metric" json:"max_time_series_per_metric"`
-	FallbackType       struct {
-		Gauge   []string `yaml:"gauge,omitempty" json:"gauge"`
-		Counter []string `yaml:"counter,omitempty" json:"counter"`
-	} `yaml:"fallback_type,omitempty" json:"fallback_type"`
-}
-
-// RelabelBlock is one job-level metric-relabeling block: a required metric-name
-// match that scopes a list of Prometheus relabel rules to a metric-name subset.
-// Use match "*" to target every metric. Rules run pre-assembly on the sample
-// stream, in block order.
-type RelabelBlock struct {
-	Match                string           `yaml:"match" json:"match"`
-	MetricRelabelConfigs []relabel.Config `yaml:"metric_relabel_configs" json:"metric_relabel_configs"`
 }
 
 type Collector struct {

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -98,6 +98,69 @@ func TestCollector_Init(t *testing.T) {
 				Relabeling: []RelabelBlock{{Match: "app_*"}},
 			},
 		},
+		"profiles mode none": {
+			wantFail: false,
+			config: Config{
+				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
+				Profiles:   ProfilesConfig{Mode: "none"},
+			},
+		},
+		"profiles mode exact with entries": {
+			wantFail: false,
+			config: Config{
+				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
+				Profiles:   ProfilesConfig{Mode: "exact", ModeExact: &ProfilesModeConfig{Entries: []ProfileEntryConfig{{Name: "haproxy"}}}},
+			},
+		},
+		"profiles mode exact without entries": {
+			wantFail: true,
+			config: Config{
+				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
+				Profiles:   ProfilesConfig{Mode: "exact"},
+			},
+		},
+		"profiles mode combined with entries": {
+			wantFail: false,
+			config: Config{
+				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
+				Profiles:   ProfilesConfig{Mode: "combined", ModeCombined: &ProfilesModeConfig{Entries: []ProfileEntryConfig{{Name: "haproxy"}}}},
+			},
+		},
+		"profiles mode combined without entries": {
+			wantFail: true,
+			config: Config{
+				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
+				Profiles:   ProfilesConfig{Mode: "combined"},
+			},
+		},
+		"profiles unknown mode": {
+			wantFail: true,
+			config: Config{
+				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
+				Profiles:   ProfilesConfig{Mode: "bogus"},
+			},
+		},
+		"profiles duplicate entries": {
+			wantFail: true,
+			config: Config{
+				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
+				Profiles:   ProfilesConfig{Mode: "exact", ModeExact: &ProfilesModeConfig{Entries: []ProfileEntryConfig{{Name: "haproxy"}, {Name: "haproxy"}}}},
+			},
+		},
+		"profiles invalid entry name": {
+			wantFail: true,
+			config: Config{
+				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
+				Profiles:   ProfilesConfig{Mode: "exact", ModeExact: &ProfilesModeConfig{Entries: []ProfileEntryConfig{{Name: "HAProxy"}}}},
+			},
+		},
+		"profiles entry empty name": {
+			wantFail: true,
+			config: Config{
+				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
+				Profiles:   ProfilesConfig{Mode: "exact", ModeExact: &ProfilesModeConfig{Entries: []ProfileEntryConfig{{Name: "  "}}}},
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	"github.com/netdata/netdata/go/plugins/pkg/prometheus/selector"
 	"github.com/netdata/netdata/go/plugins/pkg/web"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
 )
@@ -537,7 +539,7 @@ test_requests_total{method="get"} 5
 }
 
 // TestCollector_ChartCoverage verifies the collector's own ChartTemplateYAML() (the per-job
-// autogen template built in Init from the configured app) plus the collected store materialize
+// autogen template built at Check from the configured app) plus the collected store materialize
 // the expected chart contexts and dimensions. Unlike the manifest parity test (which builds the
 // template directly), this exercises the real CollectorV2.ChartTemplateYAML() method and the
 // "prometheus" / "prometheus.<app>" context namespace end-to-end via chartengine autogen.
@@ -589,6 +591,7 @@ test_gauge_metric{label1="value1"} 11
 			collr := tc.prepare()
 			collr.URL = srv.URL
 			require.NoError(t, collr.Init(context.Background()))
+			require.NoError(t, collr.Check(context.Background()))
 
 			cc := cycle(t, collr.MetricStore())
 			cc.BeginCycle()
@@ -596,6 +599,206 @@ test_gauge_metric{label1="value1"} 11
 			require.NoError(t, cc.CommitCycleSuccess())
 
 			collecttest.AssertChartCoverage(t, collr, collecttest.ChartCoverageExpectation{RequiredContexts: tc.want})
+		})
+	}
+}
+
+// TestCollector_HAProxyProfile exercises the full profile path against the stock
+// haproxy profile: selection (auto/exact/combined select it; none falls back to
+// autogen) and the curated charts rendering under the per-app namespace, including
+// the label-split charts (status by `state`, http responses by `code`).
+func TestCollector_HAProxyProfile(t *testing.T) {
+	const input = `
+# TYPE haproxy_frontend_status gauge
+haproxy_frontend_status{proxy="http",state="UP"} 1
+# TYPE haproxy_frontend_current_sessions gauge
+haproxy_frontend_current_sessions{proxy="http"} 5
+haproxy_frontend_current_sessions{proxy="https"} 12
+# TYPE haproxy_frontend_sessions_total counter
+haproxy_frontend_sessions_total{proxy="http"} 100
+# TYPE haproxy_frontend_bytes_in_total counter
+haproxy_frontend_bytes_in_total{proxy="http"} 1000
+# TYPE haproxy_frontend_bytes_out_total counter
+haproxy_frontend_bytes_out_total{proxy="http"} 2000
+# TYPE haproxy_frontend_http_requests_total counter
+haproxy_frontend_http_requests_total{proxy="http"} 50
+# TYPE haproxy_frontend_http_responses_total counter
+haproxy_frontend_http_responses_total{proxy="http",code="2xx"} 40
+haproxy_frontend_http_responses_total{proxy="http",code="5xx"} 2
+# TYPE haproxy_backend_current_sessions gauge
+haproxy_backend_current_sessions{proxy="app"} 3
+# TYPE haproxy_backend_sessions_total counter
+haproxy_backend_sessions_total{proxy="app"} 70
+# TYPE haproxy_backend_current_queue gauge
+haproxy_backend_current_queue{proxy="app"} 1
+# TYPE haproxy_backend_bytes_in_total counter
+haproxy_backend_bytes_in_total{proxy="app"} 500
+# TYPE haproxy_backend_bytes_out_total counter
+haproxy_backend_bytes_out_total{proxy="app"} 800
+# TYPE haproxy_backend_response_time_average_seconds gauge
+haproxy_backend_response_time_average_seconds{proxy="app"} 0.05
+`
+	curated := map[string][]string{
+		"prometheus.haproxy.frontend_status":           {"UP"},
+		"prometheus.haproxy.frontend_current_sessions": {"current"},
+		"prometheus.haproxy.frontend_sessions":         {"sessions"},
+		"prometheus.haproxy.frontend_traffic":          {"received", "sent"},
+		"prometheus.haproxy.frontend_http_requests":    {"requests"},
+		"prometheus.haproxy.frontend_http_responses":   {"2xx", "5xx"},
+		"prometheus.haproxy.backend_current_sessions":  {"current"},
+		"prometheus.haproxy.backend_sessions":          {"sessions"},
+		"prometheus.haproxy.backend_queue":             {"queued"},
+		"prometheus.haproxy.backend_traffic":           {"received", "sent"},
+		"prometheus.haproxy.backend_response_time":     {"response"},
+	}
+
+	tests := map[string]struct {
+		profiles ProfilesConfig
+		want     map[string][]string
+	}{
+		"auto mode selects haproxy": {
+			profiles: ProfilesConfig{Mode: "auto"},
+			want:     curated,
+		},
+		"exact mode selects haproxy": {
+			profiles: ProfilesConfig{Mode: "exact", ModeExact: &ProfilesModeConfig{Entries: []ProfileEntryConfig{{Name: "haproxy"}}}},
+			want:     curated,
+		},
+		"combined mode selects haproxy": {
+			profiles: ProfilesConfig{Mode: "combined", ModeCombined: &ProfilesModeConfig{Entries: []ProfileEntryConfig{{Name: "haproxy"}}}},
+			want:     curated,
+		},
+		"none mode falls back to autogen": {
+			profiles: ProfilesConfig{Mode: "none"},
+			want: map[string][]string{
+				"prometheus.haproxy_frontend_current_sessions": {"haproxy_frontend_current_sessions"},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(input)) }))
+			defer srv.Close()
+
+			collr := New()
+			collr.URL = srv.URL
+			collr.Profiles = tc.profiles
+			require.NoError(t, collr.Init(context.Background()))
+			require.NoError(t, collr.Check(context.Background()))
+
+			cc := cycle(t, collr.MetricStore())
+			cc.BeginCycle()
+			require.NoError(t, collr.Collect(context.Background()))
+			require.NoError(t, cc.CommitCycleSuccess())
+
+			collecttest.AssertChartCoverage(t, collr, collecttest.ChartCoverageExpectation{RequiredContexts: tc.want})
+		})
+	}
+}
+
+// TestCollector_HAProxyProfileAllMetrics feeds the synthetic full HAProxy scrape
+// (every source-derived family, incl. ?extra-counters) through the haproxy profile
+// in auto mode and proves the merged template (autogen + profile groups) accepts the
+// whole set: it compiles and plans with no error and produces no chart-ID collision.
+// It also checks that a representative curated context from every scope materializes
+// (process/frontend/listener/backend/server/resolver/sticktable + the state/code
+// label-split charts). Synthetic placeholder values are not asserted.
+func TestCollector_HAProxyProfileAllMetrics(t *testing.T) {
+	input, err := os.ReadFile(filepath.Join("testdata", "haproxy_all_metrics.prom"))
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(input) }))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: "auto"}
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+
+	cc := cycle(t, collr.MetricStore())
+	cc.BeginCycle()
+	require.NoError(t, collr.Collect(context.Background()))
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	// The merged template (autogen base + haproxy profile groups) must compile and
+	// plan over the whole scraped set without error, and every materialized chart ID
+	// must be unique (curated and autogen contexts share no derived chart ID).
+	eng, err := chartengine.New()
+	require.NoError(t, err)
+	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
+
+	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
+	require.NoError(t, err)
+	defer attempt.Abort()
+	plan := attempt.Plan()
+	require.NoError(t, attempt.Commit())
+
+	seenChartIDs := make(map[string]string)
+	for _, a := range plan.Actions {
+		create, ok := a.(chartengine.CreateChartAction)
+		if !ok {
+			continue
+		}
+		if prev, dup := seenChartIDs[create.ChartID]; dup {
+			t.Fatalf("chart-ID collision %q: contexts %q and %q", create.ChartID, prev, create.Meta.Context)
+		}
+		seenChartIDs[create.ChartID] = create.Meta.Context
+	}
+	assert.NotEmpty(t, seenChartIDs, "the merged template must materialize charts")
+
+	// One representative curated context per scope, including the label-split charts.
+	curated := map[string][]string{
+		"prometheus.haproxy.process_connections":       {"connections"},
+		"prometheus.haproxy.frontend_status":           {"UP", "DOWN"},
+		"prometheus.haproxy.frontend_http_responses":   {"1xx", "2xx", "3xx", "4xx", "5xx", "other"},
+		"prometheus.haproxy.listener_current_sessions": {"current"},
+		"prometheus.haproxy.backend_status":            {"UP", "DOWN"},
+		"prometheus.haproxy.server_current_sessions":   {"current"},
+		"prometheus.haproxy.resolver_events":           {"sent", "valid"},
+		"prometheus.haproxy.sticktable_entries":        {"used", "size"},
+	}
+	collecttest.AssertChartCoverage(t, collr, collecttest.ChartCoverageExpectation{RequiredContexts: curated})
+}
+
+// TestCollector_ProfileSelectionErrors covers the exact/combined contract: a named
+// profile that does not exist, or that matches no scraped metric, fails Check.
+func TestCollector_ProfileSelectionErrors(t *testing.T) {
+	// No haproxy_* metrics, so the haproxy profile resolves but matches nothing.
+	const nonHAProxyInput = "# TYPE up gauge\nup 1\n"
+
+	tests := map[string]struct {
+		input    string
+		profiles ProfilesConfig
+	}{
+		"exact names an unknown profile": {
+			input:    nonHAProxyInput,
+			profiles: ProfilesConfig{Mode: "exact", ModeExact: &ProfilesModeConfig{Entries: []ProfileEntryConfig{{Name: "does_not_exist"}}}},
+		},
+		"exact profile matches no scraped metric": {
+			input:    nonHAProxyInput,
+			profiles: ProfilesConfig{Mode: "exact", ModeExact: &ProfilesModeConfig{Entries: []ProfileEntryConfig{{Name: "haproxy"}}}},
+		},
+		"combined names an unknown profile": {
+			input:    nonHAProxyInput,
+			profiles: ProfilesConfig{Mode: "combined", ModeCombined: &ProfilesModeConfig{Entries: []ProfileEntryConfig{{Name: "does_not_exist"}}}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(tc.input)) }))
+			defer srv.Close()
+
+			collr := New()
+			collr.URL = srv.URL
+			collr.Profiles = tc.profiles
+			require.NoError(t, collr.Init(context.Background()))
+			assert.Error(t, collr.Check(context.Background()))
 		})
 	}
 }

--- a/src/go/plugin/go.d/collector/prometheus/config.go
+++ b/src/go/plugin/go.d/collector/prometheus/config.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package prometheus
+
+import (
+	"github.com/netdata/netdata/go/plugins/pkg/prometheus/selector"
+	"github.com/netdata/netdata/go/plugins/pkg/web"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
+)
+
+type Config struct {
+	Vnode              string `yaml:"vnode,omitempty" json:"vnode"`
+	UpdateEvery        int    `yaml:"update_every,omitempty" json:"update_every"`
+	AutoDetectionRetry int    `yaml:"autodetection_retry,omitempty" json:"autodetection_retry"`
+	web.HTTPConfig     `yaml:",inline" json:""`
+	Name               string         `yaml:"name,omitempty" json:"name"`
+	Application        string         `yaml:"app,omitempty" json:"app"`
+	Selector           selector.Expr  `yaml:"selector,omitempty" json:"selector"`
+	Relabeling         []RelabelBlock `yaml:"relabeling,omitempty" json:"relabeling,omitempty"`
+	ExpectedPrefix     string         `yaml:"expected_prefix,omitempty" json:"expected_prefix"`
+	MaxTS              int            `yaml:"max_time_series" json:"max_time_series"`
+	MaxTSPerMetric     int            `yaml:"max_time_series_per_metric" json:"max_time_series_per_metric"`
+	FallbackType       struct {
+		Gauge   []string `yaml:"gauge,omitempty" json:"gauge"`
+		Counter []string `yaml:"counter,omitempty" json:"counter"`
+	} `yaml:"fallback_type,omitempty" json:"fallback_type"`
+}
+
+// RelabelBlock is one job-level metric-relabeling block: a required metric-name
+// match that scopes a list of Prometheus relabel rules to a metric-name subset.
+// Use match "*" to target every metric. Rules run pre-assembly on the sample
+// stream, in block order.
+type RelabelBlock struct {
+	Match                string           `yaml:"match" json:"match"`
+	MetricRelabelConfigs []relabel.Config `yaml:"metric_relabel_configs" json:"metric_relabel_configs"`
+}

--- a/src/go/plugin/go.d/collector/prometheus/config.go
+++ b/src/go/plugin/go.d/collector/prometheus/config.go
@@ -3,8 +3,13 @@
 package prometheus
 
 import (
+	"errors"
+	"fmt"
+	"strings"
+
 	"github.com/netdata/netdata/go/plugins/pkg/prometheus/selector"
 	"github.com/netdata/netdata/go/plugins/pkg/web"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/promprofiles"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
 )
 
@@ -17,6 +22,7 @@ type Config struct {
 	Application        string         `yaml:"app,omitempty" json:"app"`
 	Selector           selector.Expr  `yaml:"selector,omitempty" json:"selector"`
 	Relabeling         []RelabelBlock `yaml:"relabeling,omitempty" json:"relabeling,omitempty"`
+	Profiles           ProfilesConfig `yaml:"profiles" json:"profiles"`
 	ExpectedPrefix     string         `yaml:"expected_prefix,omitempty" json:"expected_prefix"`
 	MaxTS              int            `yaml:"max_time_series" json:"max_time_series"`
 	MaxTSPerMetric     int            `yaml:"max_time_series_per_metric" json:"max_time_series_per_metric"`
@@ -33,4 +39,94 @@ type Config struct {
 type RelabelBlock struct {
 	Match                string           `yaml:"match" json:"match"`
 	MetricRelabelConfigs []relabel.Config `yaml:"metric_relabel_configs" json:"metric_relabel_configs"`
+}
+
+const (
+	profilesModeNone     = "none"
+	profilesModeAuto     = "auto"
+	profilesModeExact    = "exact"
+	profilesModeCombined = "combined"
+)
+
+// ProfilesConfig selects which curated profiles apply to the job:
+//   - "auto" (default): every profile whose match hits at least one scraped metric family;
+//   - "exact": only the named profiles, each of which must match or Check fails;
+//   - "combined": "auto" plus the named profiles, deduplicated;
+//   - "none": no profiles (pure autogen, the pre-profile behavior).
+//
+// Only "exact" and "combined" carry entries; "auto" and "none" take none.
+type ProfilesConfig struct {
+	Mode         string              `yaml:"mode,omitempty" json:"mode"`
+	ModeExact    *ProfilesModeConfig `yaml:"mode_exact,omitempty" json:"mode_exact,omitempty"`
+	ModeCombined *ProfilesModeConfig `yaml:"mode_combined,omitempty" json:"mode_combined,omitempty"`
+}
+
+type ProfilesModeConfig struct {
+	Entries []ProfileEntryConfig `yaml:"entries,omitempty" json:"entries,omitempty"`
+}
+
+// ProfileEntryConfig names a profile by its catalog identity (the profile file's
+// basename), matched case-insensitively.
+type ProfileEntryConfig struct {
+	Name string `yaml:"name" json:"name"`
+}
+
+// effectiveMode normalizes an empty mode to the default ("auto").
+func (p ProfilesConfig) effectiveMode() string {
+	if m := strings.ToLower(strings.TrimSpace(p.Mode)); m != "" {
+		return m
+	}
+	return profilesModeAuto
+}
+
+func (p ProfilesConfig) validate() error {
+	switch p.effectiveMode() {
+	case profilesModeNone, profilesModeAuto:
+		return nil
+	case profilesModeExact:
+		return validateProfileEntries("profiles.mode_exact.entries", modeEntries(p.ModeExact))
+	case profilesModeCombined:
+		return validateProfileEntries("profiles.mode_combined.entries", modeEntries(p.ModeCombined))
+	default:
+		return fmt.Errorf("'profiles.mode' must be one of: %s, %s, %s, %s",
+			profilesModeNone, profilesModeAuto, profilesModeExact, profilesModeCombined)
+	}
+}
+
+func modeEntries(m *ProfilesModeConfig) []ProfileEntryConfig {
+	if m == nil {
+		return nil
+	}
+	return m.Entries
+}
+
+// validateProfileEntries enforces a non-empty entry list with non-empty,
+// case-insensitively-unique names. Names are matched against the catalog the
+// same (case-insensitive) way, so duplicates that differ only in case would
+// select the same profile twice and collide during the template merge.
+func validateProfileEntries(path string, entries []ProfileEntryConfig) error {
+	if len(entries) == 0 {
+		return fmt.Errorf("'%s' must not be empty for the selected profiles mode", path)
+	}
+
+	var errs []error
+	seen := make(map[string]struct{}, len(entries))
+	for i, e := range entries {
+		name := strings.TrimSpace(e.Name)
+		if name == "" {
+			errs = append(errs, fmt.Errorf("'%s[%d].name' must not be empty", path, i))
+			continue
+		}
+		if !promprofiles.IsValidProfileName(name) {
+			errs = append(errs, fmt.Errorf("'%s[%d].name' (%q) must be lowercase letters, digits, or underscores and start with a letter", path, i, name))
+			continue
+		}
+		key := promprofiles.NormalizeProfileKey(name)
+		if _, ok := seen[key]; ok {
+			errs = append(errs, fmt.Errorf("'%s' contains duplicate profile name %q", path, name))
+			continue
+		}
+		seen[key] = struct{}{}
+	}
+	return errors.Join(errs...)
 }

--- a/src/go/plugin/go.d/collector/prometheus/config.go
+++ b/src/go/plugin/go.d/collector/prometheus/config.go
@@ -66,7 +66,7 @@ type ProfilesModeConfig struct {
 }
 
 // ProfileEntryConfig names a profile by its catalog identity (the profile file's
-// basename), matched case-insensitively.
+// basename; must match promprofiles.IsValidProfileName).
 type ProfileEntryConfig struct {
 	Name string `yaml:"name" json:"name"`
 }
@@ -101,9 +101,9 @@ func modeEntries(m *ProfilesModeConfig) []ProfileEntryConfig {
 }
 
 // validateProfileEntries enforces a non-empty entry list with non-empty,
-// case-insensitively-unique names. Names are matched against the catalog the
-// same (case-insensitive) way, so duplicates that differ only in case would
-// select the same profile twice and collide during the template merge.
+// unique, valid profile basenames (see promprofiles.IsValidProfileName).
+// Duplicate names are rejected to avoid selecting the same profile more than once
+// and colliding during the template merge.
 func validateProfileEntries(path string, entries []ProfileEntryConfig) error {
 	if len(entries) == 0 {
 		return fmt.Errorf("'%s' must not be empty for the selected profiles mode", path)

--- a/src/go/plugin/go.d/collector/prometheus/config_schema.json
+++ b/src/go/plugin/go.d/collector/prometheus/config_schema.json
@@ -38,12 +38,12 @@
       },
       "expected_prefix": {
         "title": "Expected prefix",
-        "description": "If an endpoint does not return at least one metric with the specified prefix, the data is not processed.",
+        "description": "If set, the job's check passes only when at least one scraped metric name starts with this prefix. Guards against scraping an unexpected endpoint.",
         "type": "string"
       },
       "app": {
         "title": "Application",
-        "description": "If set, this value will be used in the chart context as 'prometheus.{app}.{metric_name}'.",
+        "description": "Application name used as the app segment of chart contexts ('prometheus.{app}.{metric}'). When unset, the segment falls back to the job name.",
         "type": "string"
       },
       "vnode": {
@@ -178,6 +178,123 @@
             "match",
             "metric_relabel_configs"
           ]
+        }
+      },
+      "profiles": {
+        "title": "Profiles",
+        "description": "Curated, exporter-specific chart profiles. `auto` (default) selects every profile whose match hits a scraped metric; `exact` selects only the named profiles (each must match); `combined` is auto plus the named profiles; `none` disables profiles (generic autogen charts only).",
+        "type": "object",
+        "properties": {
+          "mode": {
+            "title": "Profiles mode",
+            "description": "How chart profiles are selected.",
+            "type": "string",
+            "enum": [
+              "none",
+              "auto",
+              "exact",
+              "combined"
+            ],
+            "default": "auto"
+          }
+        },
+        "dependencies": {
+          "mode": {
+            "oneOf": [
+              {
+                "properties": {
+                  "mode": {
+                    "const": "none"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "mode": {
+                    "const": "auto"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "mode": {
+                    "const": "exact"
+                  },
+                  "mode_exact": {
+                    "title": "Exact profiles",
+                    "type": "object",
+                    "properties": {
+                      "entries": {
+                        "title": "Profile entries",
+                        "description": "Profiles to select. Each must match at least one scraped metric or the job fails its check.",
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "title": "Profile basename",
+                              "description": "Profile file basename: lowercase letters, digits, or underscores, starting with a letter.",
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_]*$"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ]
+                        }
+                      }
+                    },
+                    "required": [
+                      "entries"
+                    ]
+                  }
+                },
+                "required": [
+                  "mode_exact"
+                ]
+              },
+              {
+                "properties": {
+                  "mode": {
+                    "const": "combined"
+                  },
+                  "mode_combined": {
+                    "title": "Combined profiles",
+                    "type": "object",
+                    "properties": {
+                      "entries": {
+                        "title": "Profile entries",
+                        "description": "Profiles to select in addition to the auto-selected ones.",
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "title": "Profile basename",
+                              "description": "Profile file basename: lowercase letters, digits, or underscores, starting with a letter.",
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_]*$"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ]
+                        }
+                      }
+                    },
+                    "required": [
+                      "entries"
+                    ]
+                  }
+                },
+                "required": [
+                  "mode_combined"
+                ]
+              }
+            ]
+          }
         }
       },
       "max_time_series": {
@@ -346,6 +463,12 @@
           "title": "Relabeling",
           "fields": [
             "relabeling"
+          ]
+        },
+        {
+          "title": "Profiles",
+          "fields": [
+            "profiles"
           ]
         },
         {

--- a/src/go/plugin/go.d/collector/prometheus/init.go
+++ b/src/go/plugin/go.d/collector/prometheus/init.go
@@ -17,6 +17,9 @@ func (c *Collector) validateConfig() error {
 	if c.URL == "" {
 		return errors.New("'url' can not be empty")
 	}
+	if err := c.Profiles.validate(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/src/go/plugin/go.d/collector/prometheus/manifest_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/manifest_test.go
@@ -271,7 +271,7 @@ func manifestLabels(m map[string]string) map[string]string {
 // renderManifestV2 renders the V2 path into the manifestChart shape: it loads the given chart
 // template (the collector's ChartTemplateYAML output) into chartengine, plans it against a store
 // that already holds exactly one freshly-committed cycle of the collector's output, and reads the
-// plan. Taking the live template (rather than rebuilding it) keeps the Init -> ChartTemplateYAML()
+// plan. Taking the live template (rather than rebuilding it) keeps the Init -> Check -> ChartTemplateYAML()
 // wiring, including the app/Name context namespace, on the tested path. The create actions
 // (context, labels, dim name+algo, soft fields) are emitted only on the first cycle, so a single
 // cycle MUST be committed before calling this.
@@ -338,7 +338,7 @@ func renderManifestV2(t *testing.T, store metrix.CollectorStore, templateYAML st
 	return out
 }
 
-// TestCollector_compatManifestV2 drives the real V2 collector (Init then a framework-style
+// TestCollector_compatManifestV2 drives the real V2 collector (Init, Check, then a framework-style
 // store cycle around Collect) and proves its rendered chart manifest reproduces the V1
 // contract captured in the goldens: identical chart contexts, labels, and dimensions
 // (name, algorithm, value), plus units and family. Only chart type is logged rather than
@@ -353,6 +353,7 @@ func TestCollector_compatManifestV2(t *testing.T) {
 			collr := tc.prepare()
 			collr.URL = srv.URL
 			require.NoError(t, collr.Init(context.Background()))
+			require.NoError(t, collr.Check(context.Background()))
 
 			// Drive Collect exactly as the framework does: one store cycle around it.
 			cc := cycle(t, collr.MetricStore())

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -73,6 +73,17 @@ modules:
               default_value: 10
               required: false
               group: Target
+            - name: expected_prefix
+              description: If set, the job's check passes only when at least one scraped metric name starts with this prefix. Guards against scraping an unexpected endpoint.
+              default_value: ""
+              required: false
+              group: Target
+
+            - name: app
+              description: Application name used as the app segment of chart contexts (`prometheus.<app>.<metric>`). When unset, the segment falls back to the job name.
+              default_value: ""
+              required: false
+              group: Customization
 
             - name: selector
               description: Time series selector (filter).
@@ -159,6 +170,29 @@ modules:
                         regex: '(\d)\d\d'
                         target_label: code_class
                         replacement: '${1}xx'
+                ```
+
+            - name: profiles
+              description: Curated, exporter-specific chart profiles. Disable with mode `none`.
+              default_value: auto
+              required: false
+              group: Customization
+              detailed_description: |
+                Profiles ship curated charts for recognized exporters. `profiles.mode` selects them:
+
+                - `auto` (default): every profile whose `match` hits at least one scraped metric.
+                - `exact`: only the profiles named in `mode_exact.entries` (each must match, or the job fails its check).
+                - `combined`: `auto` plus the profiles named in `mode_combined.entries`.
+                - `none`: no profiles — generic autogen charts only (the pre-profile behavior).
+
+                Only the block matching the selected mode (`mode_exact` or `mode_combined`) is read; entries under the other block are ignored. Metrics not covered by a selected profile keep their generic autogen charts.
+
+                ```yaml
+                profiles:
+                  mode: exact
+                  mode_exact:
+                    entries:
+                      - name: haproxy
                 ```
 
             - name: username

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog.go
@@ -26,6 +26,14 @@ var log = logger.New().With("component", "prometheus/promprofiles")
 // validProfileName constrains a profile's identity, which is its file basename.
 var validProfileName = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
+// IsValidProfileName reports whether name satisfies the profile-identity
+// constraint (the same pattern applied to profile file basenames). Callers that
+// reference a profile by name — config entries, for example — use it to reject
+// names no catalog profile can ever have.
+func IsValidProfileName(name string) bool {
+	return validProfileName.MatchString(name)
+}
+
 // Catalog holds the resolved set of profiles, keyed by normalized name and kept
 // in discovery order so OrderedProfiles is deterministic.
 type Catalog struct {
@@ -241,7 +249,9 @@ func profilesDirFromThisFile() string {
 	}
 
 	base := filepath.Dir(thisFile)
-	candidate := filepath.Join(base, "..", "..", "..", "..", "config", "go.d", profilesDirName, "default")
+	// This file sits at plugin/go.d/collector/prometheus/promprofiles; three levels
+	// up is plugin/go.d, under which config/go.d/<profilesDirName>/default lives.
+	candidate := filepath.Join(base, "..", "..", "..", "config", "go.d", profilesDirName, "default")
 	if !isDirExists(candidate) {
 		return ""
 	}

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package promprofiles
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/pkg/executable"
+	"github.com/netdata/netdata/go/plugins/pkg/pluginconfig"
+)
+
+const profilesDirName = "prometheus.profiles"
+
+var log = logger.New().With("component", "prometheus/promprofiles")
+
+// validProfileName constrains a profile's identity, which is its file basename.
+var validProfileName = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// Catalog holds the resolved set of profiles, keyed by normalized name and kept
+// in discovery order so OrderedProfiles is deterministic.
+type Catalog struct {
+	byName      map[string]Profile
+	orderedKeys []string
+}
+
+type catalogEntry struct {
+	config  Profile
+	path    string
+	isStock bool
+}
+
+// DirSpec is one profile search directory. Stock directories are authoritative:
+// an invalid stock profile is fatal, while an invalid user profile is skipped.
+type DirSpec struct {
+	Path    string
+	IsStock bool
+}
+
+func loadFromDefaultDirs() (Catalog, error) {
+	return LoadFromDirs(defaultDirSpecs())
+}
+
+// LoadFromDirs builds a Catalog from the given directories. A profile's identity
+// is its file basename. User profiles override stock profiles of the same name.
+// Invalid or duplicate user profiles are skipped with a warning; invalid or
+// duplicate stock profiles are fatal.
+func LoadFromDirs(specs []DirSpec) (Catalog, error) {
+	catalog := Catalog{
+		byName: make(map[string]Profile),
+	}
+	if len(specs) == 0 {
+		return catalog, nil
+	}
+
+	seen := make(map[string]catalogEntry)
+	for _, spec := range specs {
+		if strings.TrimSpace(spec.Path) == "" {
+			continue
+		}
+		if !isDirExists(spec.Path) {
+			if spec.IsStock {
+				return Catalog{}, fmt.Errorf("stock profiles directory does not exist: %s", spec.Path)
+			}
+			continue
+		}
+
+		err := filepath.WalkDir(spec.Path, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return handleProfileLoadError(spec, path, err)
+			}
+			if d.IsDir() {
+				return nil
+			}
+
+			name := d.Name()
+			ext := strings.ToLower(filepath.Ext(name))
+			if ext != ".yaml" && ext != ".yml" {
+				return nil
+			}
+			if strings.HasPrefix(name, "_") {
+				return nil
+			}
+
+			baseName := strings.TrimSuffix(name, filepath.Ext(name))
+			if !validProfileName.MatchString(baseName) {
+				return handleProfileLoadError(spec, path, fmt.Errorf("profile file %q: basename %q must match %s", path, baseName, validProfileName.String()))
+			}
+
+			cfg, err := loadProfileFile(path, baseName)
+			if err != nil {
+				return handleProfileLoadError(spec, path, err)
+			}
+
+			key := normalizeKey(baseName)
+
+			prev, exists := seen[key]
+			if !exists {
+				seen[key] = catalogEntry{config: cfg, path: path, isStock: spec.IsStock}
+				catalog.orderedKeys = append(catalog.orderedKeys, key)
+				return nil
+			}
+
+			switch {
+			case prev.isStock == spec.IsStock:
+				if !spec.IsStock {
+					log.Warningf("ignoring duplicate user profile %q in %q; already loaded from %q", cfg.Name, path, prev.path)
+					return nil
+				}
+				return fmt.Errorf("duplicate stock profile name %q in %q and %q", cfg.Name, prev.path, path)
+			case prev.isStock && !spec.IsStock:
+				// User profile overrides the stock one.
+				seen[key] = catalogEntry{config: cfg, path: path, isStock: false}
+			case !prev.isStock && spec.IsStock:
+				// User profile already loaded; stock does not override it.
+			}
+
+			return nil
+		})
+		if err != nil {
+			return Catalog{}, err
+		}
+	}
+
+	for _, key := range catalog.orderedKeys {
+		catalog.byName[key] = seen[key].config
+	}
+
+	return catalog, nil
+}
+
+// Empty reports whether the catalog holds no profiles.
+func (c Catalog) Empty() bool { return len(c.byName) == 0 }
+
+// OrderedProfiles returns all profiles in deterministic discovery order.
+func (c Catalog) OrderedProfiles() []Profile {
+	if len(c.orderedKeys) == 0 {
+		return nil
+	}
+
+	profiles := make([]Profile, 0, len(c.orderedKeys))
+	for _, key := range c.orderedKeys {
+		profiles = append(profiles, c.byName[key])
+	}
+	return profiles
+}
+
+// Resolve returns the profiles for the given names, in the requested order.
+// Names are matched case-insensitively. An unknown name is an error.
+func (c Catalog) Resolve(profileNames []string) ([]Profile, error) {
+	if len(profileNames) == 0 {
+		return nil, fmt.Errorf("no Prometheus profiles selected")
+	}
+
+	profiles := make([]Profile, 0, len(profileNames))
+	for _, name := range profileNames {
+		prof, ok := c.byName[normalizeKey(name)]
+		if !ok {
+			return nil, fmt.Errorf("unknown profile %q", name)
+		}
+		profiles = append(profiles, prof)
+	}
+	return profiles, nil
+}
+
+func loadProfileFile(path, baseName string) (Profile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Profile{}, err
+	}
+
+	var cfg Profile
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil {
+		return Profile{}, fmt.Errorf("unmarshal profile %q: %w", path, err)
+	}
+	cfg.Name = baseName
+
+	if err := cfg.validate(fmt.Sprintf("profile %q", path)); err != nil {
+		return Profile{}, err
+	}
+
+	return cfg, nil
+}
+
+// handleProfileLoadError makes a stock-profile error fatal while downgrading a
+// user-profile error to a skip-with-warning, so one bad user file cannot stop
+// the agent from loading the rest of the catalog.
+func handleProfileLoadError(spec DirSpec, path string, err error) error {
+	if spec.IsStock {
+		return err
+	}
+
+	log.Warningf("ignoring invalid user profile %q: %v", path, err)
+	return nil
+}
+
+func defaultDirSpecs() []DirSpec {
+	if executable.Name == "test" {
+		if dir := profilesDirFromThisFile(); dir != "" {
+			return []DirSpec{{Path: dir, IsStock: true}}
+		}
+		return nil
+	}
+
+	if dir := filepath.Join(executable.Directory, "../config/go.d", profilesDirName, "default"); isDirExists(dir) {
+		return []DirSpec{{Path: dir, IsStock: true}}
+	}
+
+	specs := make([]DirSpec, 0, len(pluginconfig.CollectorsUserDirs())+1)
+	for _, dir := range pluginconfig.CollectorsUserDirs() {
+		specs = append(specs, DirSpec{
+			Path:    filepath.Join(dir, profilesDirName),
+			IsStock: false,
+		})
+	}
+	if dir := filepath.Join(pluginconfig.CollectorsStockDir(), profilesDirName, "default"); isDirExists(dir) {
+		specs = append(specs, DirSpec{
+			Path:    dir,
+			IsStock: true,
+		})
+	}
+
+	return specs
+}
+
+func profilesDirFromThisFile() string {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return ""
+	}
+
+	base := filepath.Dir(thisFile)
+	candidate := filepath.Join(base, "..", "..", "..", "..", "config", "go.d", profilesDirName, "default")
+	if !isDirExists(candidate) {
+		return ""
+	}
+
+	abs, _ := filepath.Abs(candidate)
+	return abs
+}
+
+func isDirExists(dir string) bool {
+	fi, err := os.Stat(dir)
+	if err != nil {
+		return false
+	}
+	return fi.Mode().IsDir()
+}
+
+// NormalizeProfileKey is the canonical-name transform shared with callers that
+// need to compare profile names against the catalog (case-insensitive).
+func NormalizeProfileKey(v string) string { return strings.ToLower(strings.TrimSpace(v)) }
+
+func normalizeKey(v string) string { return NormalizeProfileKey(v) }

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog_test.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package promprofiles
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fileSpec struct {
+	stock   bool
+	name    string
+	content string
+}
+
+// profileYAML is a valid profile body: no name (identity is the filename) and an
+// explicit metrics: list, exactly like any v2 chart template.
+func profileYAML(match string) string {
+	return fmt.Sprintf(`match: "%s"
+template:
+  family: test
+  metrics:
+    - test_metric_total
+  charts:
+    - title: Test Metric
+      context: test_metric
+      units: count
+      dimensions:
+        - selector: test_metric_total
+          name: total
+`, match)
+}
+
+func loadCatalog(t *testing.T, files ...fileSpec) (Catalog, error) {
+	t.Helper()
+
+	userDir := t.TempDir()
+	stockDir := t.TempDir()
+	for _, f := range files {
+		dir := userDir
+		if f.stock {
+			dir = stockDir
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(dir, f.name), []byte(f.content), 0o600))
+	}
+	// User dir first mirrors defaultDirSpecs ordering.
+	return LoadFromDirs([]DirSpec{{Path: userDir, IsStock: false}, {Path: stockDir, IsStock: true}})
+}
+
+func TestLoadFromDirs(t *testing.T) {
+	tests := map[string]struct {
+		files     []fileSpec
+		wantErr   bool
+		wantNames []string
+	}{
+		"single stock profile": {
+			files:     []fileSpec{{stock: true, name: "app.yaml", content: profileYAML("app_*")}},
+			wantNames: []string{"app"},
+		},
+		"ignores non-yaml and underscore-prefixed files": {
+			files: []fileSpec{
+				{stock: true, name: "app.yaml", content: profileYAML("app_*")},
+				{stock: true, name: "_partial.yaml", content: profileYAML("p_*")},
+				{stock: true, name: "notes.txt", content: "ignored"},
+			},
+			wantNames: []string{"app"},
+		},
+		"strict yaml rejects unknown field in stock profile": {
+			files:   []fileSpec{{stock: true, name: "app.yaml", content: profileYAML("app_*") + "bogus: 1\n"}},
+			wantErr: true,
+		},
+		"stray name field is rejected in stock profile": {
+			files:   []fileSpec{{stock: true, name: "app.yaml", content: "name: app\n" + profileYAML("app_*")}},
+			wantErr: true,
+		},
+		"empty match in stock profile is fatal": {
+			files:   []fileSpec{{stock: true, name: "app.yaml", content: profileYAML("")}},
+			wantErr: true,
+		},
+		"invalid basename in stock profile is fatal": {
+			files:   []fileSpec{{stock: true, name: "App.yaml", content: profileYAML("app_*")}},
+			wantErr: true,
+		},
+		"invalid profile in user dir is skipped": {
+			files: []fileSpec{
+				{stock: true, name: "good.yaml", content: profileYAML("g_*")},
+				{stock: false, name: "bad.yaml", content: profileYAML("")},
+			},
+			wantNames: []string{"good"},
+		},
+		"invalid basename in user dir is skipped": {
+			files: []fileSpec{
+				{stock: true, name: "good.yaml", content: profileYAML("g_*")},
+				{stock: false, name: "Bad.yaml", content: profileYAML("b_*")},
+			},
+			wantNames: []string{"good"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cat, err := loadCatalog(t, tc.files...)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			var got []string
+			for _, p := range cat.OrderedProfiles() {
+				got = append(got, p.Name)
+			}
+			assert.ElementsMatch(t, tc.wantNames, got)
+		})
+	}
+}
+
+func TestLoadFromDirs_userOverridesStock(t *testing.T) {
+	cat, err := loadCatalog(t,
+		fileSpec{stock: true, name: "app.yaml", content: profileYAML("stock_*")},
+		fileSpec{stock: false, name: "app.yaml", content: profileYAML("user_*")},
+	)
+	require.NoError(t, err)
+
+	got, err := cat.Resolve([]string{"app"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "user_*", got[0].Match)
+}
+
+func TestLoadFromDirs_userOverridesStockWhenStockSeenFirst(t *testing.T) {
+	userDir := t.TempDir()
+	stockDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(stockDir, "app.yaml"), []byte(profileYAML("stock_*")), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(userDir, "app.yaml"), []byte(profileYAML("user_*")), 0o600))
+
+	cat, err := LoadFromDirs([]DirSpec{{Path: stockDir, IsStock: true}, {Path: userDir, IsStock: false}})
+	require.NoError(t, err)
+
+	got, err := cat.Resolve([]string{"app"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "user_*", got[0].Match)
+}
+
+func TestLoadFromDirs_duplicateStockAcrossDirsIsFatal(t *testing.T) {
+	d1 := t.TempDir()
+	d2 := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(d1, "app.yaml"), []byte(profileYAML("a_*")), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(d2, "app.yaml"), []byte(profileYAML("b_*")), 0o600))
+
+	_, err := LoadFromDirs([]DirSpec{{Path: d1, IsStock: true}, {Path: d2, IsStock: true}})
+	assert.Error(t, err)
+}
+
+func TestLoadFromDirs_duplicateUserAcrossDirsKeepsFirst(t *testing.T) {
+	d1 := t.TempDir()
+	d2 := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(d1, "app.yaml"), []byte(profileYAML("first_*")), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(d2, "app.yaml"), []byte(profileYAML("second_*")), 0o600))
+
+	cat, err := LoadFromDirs([]DirSpec{{Path: d1, IsStock: false}, {Path: d2, IsStock: false}})
+	require.NoError(t, err)
+	require.Len(t, cat.OrderedProfiles(), 1)
+	assert.Equal(t, "first_*", cat.OrderedProfiles()[0].Match)
+}
+
+func TestLoadFromDirs_missingStockDirIsFatal(t *testing.T) {
+	_, err := LoadFromDirs([]DirSpec{{Path: filepath.Join(t.TempDir(), "nope"), IsStock: true}})
+	assert.Error(t, err)
+}
+
+func TestLoadFromDirs_missingUserDirIsSkipped(t *testing.T) {
+	cat, err := LoadFromDirs([]DirSpec{{Path: filepath.Join(t.TempDir(), "nope"), IsStock: false}})
+	require.NoError(t, err)
+	assert.True(t, cat.Empty())
+}
+
+func TestLoadFromDirs_emptySpecs(t *testing.T) {
+	cat, err := LoadFromDirs(nil)
+	require.NoError(t, err)
+	assert.True(t, cat.Empty())
+}
+
+func TestCatalog_Resolve(t *testing.T) {
+	cat, err := loadCatalog(t, fileSpec{stock: true, name: "app.yaml", content: profileYAML("a_*")})
+	require.NoError(t, err)
+
+	t.Run("matches case-insensitively", func(t *testing.T) {
+		got, err := cat.Resolve([]string{"App"})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "app", got[0].Name)
+	})
+	t.Run("unknown name errors", func(t *testing.T) {
+		_, err := cat.Resolve([]string{"nope"})
+		assert.Error(t, err)
+	})
+	t.Run("empty selection errors", func(t *testing.T) {
+		_, err := cat.Resolve(nil)
+		assert.Error(t, err)
+	})
+}

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/default_catalog.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/default_catalog.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package promprofiles
+
+import (
+	"sync"
+
+	"github.com/netdata/netdata/go/plugins/pkg/executable"
+)
+
+var (
+	defaultCatalogMu           sync.Mutex
+	defaultCatalog             Catalog
+	defaultCatalogLoaded       bool
+	defaultCatalogLoader       = loadFromDefaultDirs
+	defaultCatalogCacheEnabled = func() bool { return executable.Name != "test" }
+)
+
+// DefaultCatalog returns the process-wide profile catalog loaded from the stock
+// and user directories. The result is cached for the agent process; tests load
+// fresh each call so fixtures are not shared across cases.
+func DefaultCatalog() (Catalog, error) {
+	if !defaultCatalogCacheEnabled() {
+		return defaultCatalogLoader()
+	}
+
+	defaultCatalogMu.Lock()
+	defer defaultCatalogMu.Unlock()
+
+	if defaultCatalogLoaded {
+		return defaultCatalog, nil
+	}
+
+	catalog, err := defaultCatalogLoader()
+	if err != nil {
+		return Catalog{}, err
+	}
+
+	defaultCatalog = catalog
+	defaultCatalogLoaded = true
+
+	return defaultCatalog, nil
+}

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/default_catalog_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/default_catalog_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package promprofiles
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultCatalog_CachesSuccessfulLoads(t *testing.T) {
+	calls := 0
+	restore := stubDefaultCatalog(t, func() bool { return true }, func() (Catalog, error) {
+		calls++
+		return testCatalog("haproxy"), nil
+	})
+	defer restore()
+
+	first, err := DefaultCatalog()
+	require.NoError(t, err)
+
+	second, err := DefaultCatalog()
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, []string{"haproxy"}, profileNames(first.OrderedProfiles()))
+	assert.Equal(t, []string{"haproxy"}, profileNames(second.OrderedProfiles()))
+}
+
+func TestDefaultCatalog_RetriesAfterFailure(t *testing.T) {
+	calls := 0
+	restore := stubDefaultCatalog(t, func() bool { return true }, func() (Catalog, error) {
+		calls++
+		if calls == 1 {
+			return Catalog{}, errors.New("boom")
+		}
+		return testCatalog("nginx"), nil
+	})
+	defer restore()
+
+	_, err := DefaultCatalog()
+	require.Error(t, err)
+
+	catalog, err := DefaultCatalog()
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, calls)
+	assert.Equal(t, []string{"nginx"}, profileNames(catalog.OrderedProfiles()))
+}
+
+func TestDefaultCatalog_DoesNotCacheWhenDisabled(t *testing.T) {
+	calls := 0
+	restore := stubDefaultCatalog(t, func() bool { return false }, func() (Catalog, error) {
+		calls++
+		return testCatalog("haproxy"), nil
+	})
+	defer restore()
+
+	_, err := DefaultCatalog()
+	require.NoError(t, err)
+	_, err = DefaultCatalog()
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, calls)
+}
+
+// stubDefaultCatalog swaps the package-level loader and cache-enabled gate for the
+// duration of a test, restoring them (and the cached state) afterwards.
+func stubDefaultCatalog(t *testing.T, cacheEnabled func() bool, loader func() (Catalog, error)) func() {
+	t.Helper()
+
+	defaultCatalogMu.Lock()
+	prevCatalog := defaultCatalog
+	prevLoaded := defaultCatalogLoaded
+	prevLoader := defaultCatalogLoader
+	prevEnabled := defaultCatalogCacheEnabled
+
+	defaultCatalog = Catalog{}
+	defaultCatalogLoaded = false
+	defaultCatalogLoader = loader
+	defaultCatalogCacheEnabled = cacheEnabled
+	defaultCatalogMu.Unlock()
+
+	return func() {
+		defaultCatalogMu.Lock()
+		defaultCatalog = prevCatalog
+		defaultCatalogLoaded = prevLoaded
+		defaultCatalogLoader = prevLoader
+		defaultCatalogCacheEnabled = prevEnabled
+		defaultCatalogMu.Unlock()
+	}
+}
+
+func testCatalog(name string) Catalog {
+	key := normalizeKey(name)
+	return Catalog{
+		byName:      map[string]Profile{key: {Name: name}},
+		orderedKeys: []string{key},
+	}
+}
+
+func profileNames(profiles []Profile) []string {
+	names := make([]string, 0, len(profiles))
+	for _, p := range profiles {
+		names = append(names, p.Name)
+	}
+	return names
+}

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/profile.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/profile.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package promprofiles
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/matcher"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
+)
+
+// Profile is a curated, exporter-specific chart profile. Match selects the
+// profile by scraped metric names; Template is a standard v2 charttpl group
+// rendered for the matched metrics. Identity is the profile file's basename
+// (set by the loader), so the file itself carries no name field. The Template
+// is validated exactly like any other v2 chart template, including its
+// author-written metrics: visibility list.
+type Profile struct {
+	Name     string         `yaml:"-" json:"name"`
+	Match    string         `yaml:"match" json:"match"`
+	Template charttpl.Group `yaml:"template" json:"template"`
+}
+
+func (p *Profile) validate(path string) error {
+	if strings.TrimSpace(p.Match) == "" {
+		return fmt.Errorf("%s: 'match' must not be empty", path)
+	}
+	if _, err := matcher.NewSimplePatternsMatcher(p.Match); err != nil {
+		return fmt.Errorf("%s: 'match': %w", path, err)
+	}
+
+	if !groupHasChart(p.Template) {
+		return fmt.Errorf("%s: 'template' must contain at least one chart", path)
+	}
+
+	spec := charttpl.Spec{
+		Version: charttpl.VersionV1,
+		Groups:  []charttpl.Group{p.Template},
+	}
+	if err := spec.Validate(); err != nil {
+		return fmt.Errorf("%s: 'template': %w", path, err)
+	}
+
+	return nil
+}
+
+func groupHasChart(group charttpl.Group) bool {
+	if len(group.Charts) > 0 {
+		return true
+	}
+	for _, child := range group.Groups {
+		if groupHasChart(child) {
+			return true
+		}
+	}
+	return false
+}

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/profile.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/profile.go
@@ -4,6 +4,7 @@ package promprofiles
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/netdata/netdata/go/plugins/pkg/matcher"
@@ -49,10 +50,5 @@ func groupHasChart(group charttpl.Group) bool {
 	if len(group.Charts) > 0 {
 		return true
 	}
-	for _, child := range group.Groups {
-		if groupHasChart(child) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(group.Groups, groupHasChart)
 }

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/profile.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/profile.go
@@ -12,10 +12,10 @@ import (
 )
 
 // Profile is a curated, exporter-specific chart profile. Match selects the
-// profile by scraped metric names; Template is a standard v2 charttpl group
+// profile by scraped metric names; Template is a standard charttpl group
 // rendered for the matched metrics. Identity is the profile file's basename
 // (set by the loader), so the file itself carries no name field. The Template
-// is validated exactly like any other v2 chart template, including its
+// is validated exactly like any other chart template, including its
 // author-written metrics: visibility list.
 type Profile struct {
 	Name     string         `yaml:"-" json:"name"`

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/profile_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/profile_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package promprofiles
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
+	"github.com/stretchr/testify/assert"
+)
+
+// chartGroup builds a minimal valid charttpl group with an explicit metrics:
+// visibility list (declared as a real v2 template would), matching the
+// dimension selectors.
+func chartGroup(family, context string, selectors ...string) charttpl.Group {
+	dims := make([]charttpl.Dimension, len(selectors))
+	for i, sel := range selectors {
+		dims[i] = charttpl.Dimension{Selector: sel, Name: fmt.Sprintf("dim%d", i)}
+	}
+	return charttpl.Group{
+		Family:  family,
+		Metrics: append([]string(nil), selectors...),
+		Charts:  []charttpl.Chart{{Title: "Title", Context: context, Units: "count", Dimensions: dims}},
+	}
+}
+
+func TestProfile_validate(t *testing.T) {
+	tests := map[string]struct {
+		profile Profile
+		wantErr bool
+	}{
+		"valid": {
+			profile: Profile{Match: "a_*", Template: chartGroup("fam", "ctx", "a_total", "a_count")},
+		},
+		"empty match": {
+			profile: Profile{Match: "", Template: chartGroup("fam", "ctx", "a_total")},
+			wantErr: true,
+		},
+		"template with no chart": {
+			profile: Profile{Match: "a_*", Template: charttpl.Group{Family: "fam"}},
+			wantErr: true,
+		},
+		"dimension metric not declared in metrics": {
+			profile: Profile{Match: "a_*", Template: charttpl.Group{
+				Family:  "fam",
+				Metrics: []string{"declared_total"},
+				Charts: []charttpl.Chart{{Title: "T", Context: "ctx", Units: "count",
+					Dimensions: []charttpl.Dimension{{Selector: "undeclared_total", Name: "d"}}}},
+			}},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := tc.profile
+			err := p.validate("test")
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/prometheus/runtime.go
+++ b/src/go/plugin/go.d/collector/prometheus/runtime.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package prometheus
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/matcher"
+	"github.com/netdata/netdata/go/plugins/pkg/prometheus"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/promprofiles"
+)
+
+// promRuntime is the per-job state built once at Check and reused afterwards:
+// the selected profiles and the chart template served via ChartTemplateYAML
+// (autogen, or autogen merged with the selected profiles' curated groups).
+type promRuntime struct {
+	profiles      []promprofiles.Profile
+	chartTemplate string
+}
+
+// ensureChartTemplate selects the profiles that apply to this job against the
+// scraped families and builds the per-job chart template, caching both on the
+// runtime on the first Check. Later cycles reuse it; Cleanup (job restart)
+// clears it so the next Check rebuilds. Building at Check (not Init) is what
+// lets selection depend on what the endpoint actually exposes.
+func (c *Collector) ensureChartTemplate(mfs prometheus.MetricFamilies) error {
+	if c.runtime != nil {
+		return nil
+	}
+
+	profiles, err := c.selectProfiles(mfs)
+	if err != nil {
+		return err
+	}
+
+	tmpl, err := buildMergedChartTemplate(c.application(), profiles)
+	if err != nil {
+		return err
+	}
+
+	c.runtime = &promRuntime{profiles: profiles, chartTemplate: tmpl}
+	return nil
+}
+
+// selectProfiles resolves the profiles for this job per profiles.mode, matching
+// each profile's pattern against the scraped family base names (the metric's
+// declared "# TYPE" name; the 2B selection surface). mode "none" selects nothing
+// and skips the catalog entirely so a broken stock profile cannot break a job
+// that opted out of profiles.
+func (c *Collector) selectProfiles(mfs prometheus.MetricFamilies) ([]promprofiles.Profile, error) {
+	mode := c.Profiles.effectiveMode()
+	if mode == profilesModeNone {
+		return nil, nil
+	}
+
+	catalog, err := c.loadProfileCatalog()
+	if err != nil {
+		return nil, fmt.Errorf("loading profiles catalog: %w", err)
+	}
+
+	var selected []promprofiles.Profile
+	switch mode {
+	case profilesModeAuto:
+		selected, err = autoSelectProfiles(catalog.OrderedProfiles(), mfs)
+	case profilesModeExact:
+		selected, err = namedSelectProfiles(catalog, entryNames(c.Profiles.ModeExact), mfs)
+	case profilesModeCombined:
+		selected, err = combinedSelectProfiles(catalog, entryNames(c.Profiles.ModeCombined), mfs)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if len(selected) == 0 {
+		c.Infof("profiles: mode %q selected no profiles; using generic autogen charts", mode)
+	} else {
+		c.Infof("profiles: mode %q selected %d profile(s): %s", mode, len(selected), profileNamesList(selected))
+	}
+	return selected, nil
+}
+
+// autoSelectProfiles returns every catalog profile whose match hits at least one
+// scraped family.
+func autoSelectProfiles(profiles []promprofiles.Profile, mfs prometheus.MetricFamilies) ([]promprofiles.Profile, error) {
+	var out []promprofiles.Profile
+	for _, p := range profiles {
+		ok, err := profileMatchesFamilies(p, mfs)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+// namedSelectProfiles resolves the named profiles (each must exist) and requires
+// each to match at least one scraped family, else the job fails its check.
+func namedSelectProfiles(catalog promprofiles.Catalog, names []string, mfs prometheus.MetricFamilies) ([]promprofiles.Profile, error) {
+	profiles, err := catalog.Resolve(names)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range profiles {
+		ok, err := profileMatchesFamilies(p, mfs)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fmt.Errorf("profile %q matches no scraped metric (pattern %q)", p.Name, p.Match)
+		}
+	}
+	return profiles, nil
+}
+
+// combinedSelectProfiles selects the auto-matched profiles plus the named ones
+// (each named must match), deduplicated by name so a profile picked by both
+// parts is merged once.
+func combinedSelectProfiles(catalog promprofiles.Catalog, names []string, mfs prometheus.MetricFamilies) ([]promprofiles.Profile, error) {
+	auto, err := autoSelectProfiles(catalog.OrderedProfiles(), mfs)
+	if err != nil {
+		return nil, err
+	}
+	named, err := namedSelectProfiles(catalog, names, mfs)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(auto)+len(named))
+	out := make([]promprofiles.Profile, 0, len(auto)+len(named))
+	for _, p := range auto {
+		seen[promprofiles.NormalizeProfileKey(p.Name)] = struct{}{}
+		out = append(out, p)
+	}
+	for _, p := range named {
+		if _, ok := seen[promprofiles.NormalizeProfileKey(p.Name)]; ok {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// profileMatchesFamilies reports whether the profile's match pattern hits at
+// least one scraped family base name.
+func profileMatchesFamilies(p promprofiles.Profile, mfs prometheus.MetricFamilies) (bool, error) {
+	m, err := matcher.NewSimplePatternsMatcher(p.Match)
+	if err != nil {
+		return false, fmt.Errorf("profile %q: invalid match %q: %w", p.Name, p.Match, err)
+	}
+	for name := range mfs {
+		if m.MatchString(name) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// entryNames extracts the non-empty profile names from a mode block.
+func entryNames(m *ProfilesModeConfig) []string {
+	if m == nil {
+		return nil
+	}
+	names := make([]string, 0, len(m.Entries))
+	for _, e := range m.Entries {
+		if n := strings.TrimSpace(e.Name); n != "" {
+			names = append(names, n)
+		}
+	}
+	return names
+}
+
+func profileNamesList(profiles []promprofiles.Profile) string {
+	names := make([]string, 0, len(profiles))
+	for _, p := range profiles {
+		names = append(names, p.Name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}

--- a/src/go/plugin/go.d/collector/prometheus/runtime_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/runtime_test.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package prometheus
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/pkg/prometheus"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/promprofiles"
+)
+
+func Test_profileMatchesFamilies(t *testing.T) {
+	mfs := testMetricFamilies("haproxy_up", "haproxy_frontend_status")
+
+	tests := map[string]struct {
+		match string
+		want  bool
+	}{
+		"match hits a family":       {match: "haproxy_*", want: true},
+		"match misses every family": {match: "nginx_*", want: false},
+		"exact-name match":          {match: "haproxy_up", want: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ok, err := profileMatchesFamilies(promprofiles.Profile{Name: "p", Match: tc.match}, mfs)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, ok)
+		})
+	}
+}
+
+func Test_autoSelectProfiles(t *testing.T) {
+	profiles := []promprofiles.Profile{
+		{Name: "haproxy", Match: "haproxy_*"},
+		{Name: "nginx", Match: "nginx_*"},
+	}
+
+	tests := map[string]struct {
+		mfs  prometheus.MetricFamilies
+		want []string
+	}{
+		"keeps only profiles whose match hits a scraped family": {
+			mfs:  testMetricFamilies("haproxy_up"),
+			want: []string{"haproxy"},
+		},
+		"keeps every matching profile in catalog order": {
+			mfs:  testMetricFamilies("haproxy_up", "nginx_connections"),
+			want: []string{"haproxy", "nginx"},
+		},
+		"selects nothing when no family matches": {
+			mfs:  testMetricFamilies("redis_up"),
+			want: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := autoSelectProfiles(profiles, tc.mfs)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, profileNames(got))
+		})
+	}
+}
+
+func Test_namedSelectProfiles(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"haproxy": testProfileYAML("haproxy_*"),
+		"nginx":   testProfileYAML("nginx_*"),
+	})
+	mfs := testMetricFamilies("haproxy_up")
+
+	tests := map[string]struct {
+		names   []string
+		want    []string
+		wantErr bool
+	}{
+		"resolves and returns the named profile": {
+			names: []string{"haproxy"},
+			want:  []string{"haproxy"},
+		},
+		"errors when a named profile matches nothing": {
+			names:   []string{"nginx"},
+			wantErr: true,
+		},
+		"errors on an unknown name": {
+			names:   []string{"does_not_exist"},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := namedSelectProfiles(catalog, tc.names, mfs)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, profileNames(got))
+		})
+	}
+}
+
+func Test_combinedSelectProfiles(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"haproxy": testProfileYAML("haproxy_*"),
+		"nginx":   testProfileYAML("nginx_*"),
+	})
+	mfs := testMetricFamilies("haproxy_up")
+
+	tests := map[string]struct {
+		names   []string
+		want    []string
+		wantErr bool
+	}{
+		"dedups a profile selected by both auto and name": {
+			names: []string{"haproxy"},
+			want:  []string{"haproxy"},
+		},
+		"dedups case-insensitively": {
+			names: []string{"HAPROXY"},
+			want:  []string{"haproxy"},
+		},
+		"propagates a named no-match error": {
+			names:   []string{"nginx"},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := combinedSelectProfiles(catalog, tc.names, mfs)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, profileNames(got))
+		})
+	}
+}
+
+// testMetricFamilies builds a MetricFamilies whose only meaningful content is the
+// set of family names (selection matches on the keys).
+func testMetricFamilies(names ...string) prometheus.MetricFamilies {
+	mfs := make(prometheus.MetricFamilies, len(names))
+	for _, n := range names {
+		mfs[n] = nil
+	}
+	return mfs
+}
+
+func profileNames(profiles []promprofiles.Profile) []string {
+	if len(profiles) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(profiles))
+	for _, p := range profiles {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+// loadTestCatalog writes the given <name>.yaml profiles to a temp stock dir and
+// loads them, so named/combined selection can be tested without the on-disk
+// stock catalog.
+func loadTestCatalog(t *testing.T, profiles map[string]string) promprofiles.Catalog {
+	t.Helper()
+
+	dir := t.TempDir()
+	for name, data := range profiles {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name+".yaml"), []byte(data), 0o600))
+	}
+
+	catalog, err := promprofiles.LoadFromDirs([]promprofiles.DirSpec{{Path: dir, IsStock: true}})
+	require.NoError(t, err)
+	return catalog
+}
+
+// testProfileYAML is a minimal valid profile body with the given match pattern.
+func testProfileYAML(match string) string {
+	return strings.Join([]string{
+		"match: '" + match + "'",
+		"template:",
+		"  family: Test",
+		"  context_namespace: test",
+		"  metrics:",
+		"    - test_up",
+		"  charts:",
+		"    - title: Up",
+		"      context: up",
+		"      units: status",
+		"      algorithm: absolute",
+		"      dimensions:",
+		"        - selector: test_up",
+		"          name: up",
+	}, "\n") + "\n"
+}

--- a/src/go/plugin/go.d/collector/prometheus/testdata/config.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/config.json
@@ -49,6 +49,23 @@
       ]
     }
   ],
+  "profiles": {
+    "mode": "ok",
+    "mode_exact": {
+      "entries": [
+        {
+          "name": "ok"
+        }
+      ]
+    },
+    "mode_combined": {
+      "entries": [
+        {
+          "name": "ok"
+        }
+      ]
+    }
+  },
   "expected_prefix": "ok",
   "max_time_series": 123,
   "max_time_series_per_metric": 123,

--- a/src/go/plugin/go.d/collector/prometheus/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/config.yaml
@@ -37,6 +37,14 @@ relabeling:
         target_label: "ok"
         replacement: "ok"
         action: "replace"
+profiles:
+  mode: "ok"
+  mode_exact:
+    entries:
+      - name: "ok"
+  mode_combined:
+    entries:
+      - name: "ok"
 expected_prefix: "ok"
 max_time_series: 123
 max_time_series_per_metric: 123

--- a/src/go/plugin/go.d/collector/prometheus/testdata/haproxy_all_metrics.prom
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/haproxy_all_metrics.prom
@@ -1,0 +1,960 @@
+# Synthetic full HAProxy PromEx scrape: every source-derived family (449) from the
+# HAProxy source inventory at commit d2c9bf70e5c481658a7d561b58ce94de8b76a212.
+# Values are placeholder 0 (structural fixture only; do not assert specific values).
+# Includes the ?extra-counters H1/H2/SSL/QUIC/H3 (mod) families, which a real scrape
+# emits only with ?extra-counters. TYPE is taken from the inventory type column
+# (some *_total names are gauges; resolver/sticktable families are gauges).
+
+# ── process ──────────────────────────────────────────────────────────────────
+# TYPE haproxy_process_nbthread gauge
+haproxy_process_nbthread 0
+# TYPE haproxy_process_nbproc gauge
+haproxy_process_nbproc 0
+# TYPE haproxy_process_relative_process_id gauge
+haproxy_process_relative_process_id 0
+# TYPE haproxy_process_uptime_seconds gauge
+haproxy_process_uptime_seconds 0
+# TYPE haproxy_process_start_time_seconds gauge
+haproxy_process_start_time_seconds 0
+# TYPE haproxy_process_max_memory_bytes gauge
+haproxy_process_max_memory_bytes 0
+# TYPE haproxy_process_pool_allocated_bytes gauge
+haproxy_process_pool_allocated_bytes 0
+# TYPE haproxy_process_pool_used_bytes gauge
+haproxy_process_pool_used_bytes 0
+# TYPE haproxy_process_pool_failures_total counter
+haproxy_process_pool_failures_total 0
+# TYPE haproxy_process_max_fds gauge
+haproxy_process_max_fds 0
+# TYPE haproxy_process_max_sockets gauge
+haproxy_process_max_sockets 0
+# TYPE haproxy_process_max_connections gauge
+haproxy_process_max_connections 0
+# TYPE haproxy_process_hard_max_connections gauge
+haproxy_process_hard_max_connections 0
+# TYPE haproxy_process_current_connections gauge
+haproxy_process_current_connections 0
+# TYPE haproxy_process_connections_total counter
+haproxy_process_connections_total 0
+# TYPE haproxy_process_requests_total counter
+haproxy_process_requests_total 0
+# TYPE haproxy_process_max_ssl_connections gauge
+haproxy_process_max_ssl_connections 0
+# TYPE haproxy_process_current_ssl_connections gauge
+haproxy_process_current_ssl_connections 0
+# TYPE haproxy_process_ssl_connections_total counter
+haproxy_process_ssl_connections_total 0
+# TYPE haproxy_process_max_pipes gauge
+haproxy_process_max_pipes 0
+# TYPE haproxy_process_pipes_used_total counter
+haproxy_process_pipes_used_total 0
+# TYPE haproxy_process_pipes_free_total counter
+haproxy_process_pipes_free_total 0
+# TYPE haproxy_process_current_connection_rate gauge
+haproxy_process_current_connection_rate 0
+# TYPE haproxy_process_limit_connection_rate gauge
+haproxy_process_limit_connection_rate 0
+# TYPE haproxy_process_max_connection_rate gauge
+haproxy_process_max_connection_rate 0
+# TYPE haproxy_process_current_session_rate gauge
+haproxy_process_current_session_rate 0
+# TYPE haproxy_process_limit_session_rate gauge
+haproxy_process_limit_session_rate 0
+# TYPE haproxy_process_max_session_rate gauge
+haproxy_process_max_session_rate 0
+# TYPE haproxy_process_current_ssl_rate gauge
+haproxy_process_current_ssl_rate 0
+# TYPE haproxy_process_limit_ssl_rate gauge
+haproxy_process_limit_ssl_rate 0
+# TYPE haproxy_process_max_ssl_rate gauge
+haproxy_process_max_ssl_rate 0
+# TYPE haproxy_process_current_frontend_ssl_key_rate gauge
+haproxy_process_current_frontend_ssl_key_rate 0
+# TYPE haproxy_process_max_frontend_ssl_key_rate gauge
+haproxy_process_max_frontend_ssl_key_rate 0
+# TYPE haproxy_process_frontend_ssl_reuse gauge
+haproxy_process_frontend_ssl_reuse 0
+# TYPE haproxy_process_current_backend_ssl_key_rate gauge
+haproxy_process_current_backend_ssl_key_rate 0
+# TYPE haproxy_process_max_backend_ssl_key_rate gauge
+haproxy_process_max_backend_ssl_key_rate 0
+# TYPE haproxy_process_ssl_cache_lookups_total counter
+haproxy_process_ssl_cache_lookups_total 0
+# TYPE haproxy_process_ssl_cache_misses_total counter
+haproxy_process_ssl_cache_misses_total 0
+# TYPE haproxy_process_http_comp_bytes_in_total counter
+haproxy_process_http_comp_bytes_in_total 0
+# TYPE haproxy_process_http_comp_bytes_out_total counter
+haproxy_process_http_comp_bytes_out_total 0
+# TYPE haproxy_process_limit_http_comp gauge
+haproxy_process_limit_http_comp 0
+# TYPE haproxy_process_current_zlib_memory gauge
+haproxy_process_current_zlib_memory 0
+# TYPE haproxy_process_max_zlib_memory gauge
+haproxy_process_max_zlib_memory 0
+# TYPE haproxy_process_current_tasks gauge
+haproxy_process_current_tasks 0
+# TYPE haproxy_process_current_run_queue gauge
+haproxy_process_current_run_queue 0
+# TYPE haproxy_process_idle_time_percent gauge
+haproxy_process_idle_time_percent 0
+# TYPE haproxy_process_node gauge
+haproxy_process_node{node="node1"} 0
+# TYPE haproxy_process_description gauge
+haproxy_process_description{desc="description"} 0
+# TYPE haproxy_process_stopping gauge
+haproxy_process_stopping 0
+# TYPE haproxy_process_jobs gauge
+haproxy_process_jobs 0
+# TYPE haproxy_process_unstoppable_jobs gauge
+haproxy_process_unstoppable_jobs 0
+# TYPE haproxy_process_listeners gauge
+haproxy_process_listeners 0
+# TYPE haproxy_process_active_peers gauge
+haproxy_process_active_peers 0
+# TYPE haproxy_process_connected_peers gauge
+haproxy_process_connected_peers 0
+# TYPE haproxy_process_dropped_logs_total counter
+haproxy_process_dropped_logs_total 0
+# TYPE haproxy_process_busy_polling_enabled gauge
+haproxy_process_busy_polling_enabled 0
+# TYPE haproxy_process_failed_resolutions counter
+haproxy_process_failed_resolutions 0
+# TYPE haproxy_process_bytes_out_total counter
+haproxy_process_bytes_out_total 0
+# TYPE haproxy_process_spliced_bytes_out_total counter
+haproxy_process_spliced_bytes_out_total 0
+# TYPE haproxy_process_bytes_out_rate gauge
+haproxy_process_bytes_out_rate 0
+# TYPE haproxy_process_recv_logs_total counter
+haproxy_process_recv_logs_total 0
+# TYPE haproxy_process_build_info gauge
+haproxy_process_build_info{version="0.0.0-source"} 0
+# TYPE haproxy_process_total_warnings counter
+haproxy_process_total_warnings 0
+# TYPE haproxy_process_patterns_added_total gauge
+haproxy_process_patterns_added_total 0
+# TYPE haproxy_process_patterns_freed_total gauge
+haproxy_process_patterns_freed_total 0
+# TYPE haproxy_process_nb_thread_groups gauge
+haproxy_process_nb_thread_groups 0
+
+# ── frontend (proxy) ───────────────────────────────────────────────────────────
+# TYPE haproxy_frontend_current_sessions gauge
+haproxy_frontend_current_sessions{proxy="px"} 0
+# TYPE haproxy_frontend_max_sessions gauge
+haproxy_frontend_max_sessions{proxy="px"} 0
+# TYPE haproxy_frontend_limit_sessions gauge
+haproxy_frontend_limit_sessions{proxy="px"} 0
+# TYPE haproxy_frontend_sessions_total counter
+haproxy_frontend_sessions_total{proxy="px"} 0
+# TYPE haproxy_frontend_current_session_rate gauge
+haproxy_frontend_current_session_rate{proxy="px"} 0
+# TYPE haproxy_frontend_limit_session_rate gauge
+haproxy_frontend_limit_session_rate{proxy="px"} 0
+# TYPE haproxy_frontend_max_session_rate gauge
+haproxy_frontend_max_session_rate{proxy="px"} 0
+# TYPE haproxy_frontend_bytes_in_total counter
+haproxy_frontend_bytes_in_total{proxy="px"} 0
+# TYPE haproxy_frontend_bytes_out_total counter
+haproxy_frontend_bytes_out_total{proxy="px"} 0
+# TYPE haproxy_frontend_req_bytes_in_total counter
+haproxy_frontend_req_bytes_in_total{proxy="px"} 0
+# TYPE haproxy_frontend_req_bytes_out_total counter
+haproxy_frontend_req_bytes_out_total{proxy="px"} 0
+# TYPE haproxy_frontend_res_bytes_in_total counter
+haproxy_frontend_res_bytes_in_total{proxy="px"} 0
+# TYPE haproxy_frontend_res_bytes_out_total counter
+haproxy_frontend_res_bytes_out_total{proxy="px"} 0
+# TYPE haproxy_frontend_requests_denied_total counter
+haproxy_frontend_requests_denied_total{proxy="px"} 0
+# TYPE haproxy_frontend_responses_denied_total counter
+haproxy_frontend_responses_denied_total{proxy="px"} 0
+# TYPE haproxy_frontend_request_errors_total counter
+haproxy_frontend_request_errors_total{proxy="px"} 0
+# TYPE haproxy_frontend_status gauge
+haproxy_frontend_status{proxy="px",state="DOWN"} 0
+haproxy_frontend_status{proxy="px",state="UP"} 0
+# TYPE haproxy_frontend_http_requests_rate_max gauge
+haproxy_frontend_http_requests_rate_max{proxy="px"} 0
+# TYPE haproxy_frontend_http_requests_total counter
+haproxy_frontend_http_requests_total{proxy="px"} 0
+# TYPE haproxy_frontend_http_responses_total counter
+haproxy_frontend_http_responses_total{proxy="px",code="1xx"} 0
+haproxy_frontend_http_responses_total{proxy="px",code="2xx"} 0
+haproxy_frontend_http_responses_total{proxy="px",code="3xx"} 0
+haproxy_frontend_http_responses_total{proxy="px",code="4xx"} 0
+haproxy_frontend_http_responses_total{proxy="px",code="5xx"} 0
+haproxy_frontend_http_responses_total{proxy="px",code="other"} 0
+# TYPE haproxy_frontend_http_comp_bytes_in_total counter
+haproxy_frontend_http_comp_bytes_in_total{proxy="px"} 0
+# TYPE haproxy_frontend_http_comp_bytes_out_total counter
+haproxy_frontend_http_comp_bytes_out_total{proxy="px"} 0
+# TYPE haproxy_frontend_http_comp_bytes_bypassed_total counter
+haproxy_frontend_http_comp_bytes_bypassed_total{proxy="px"} 0
+# TYPE haproxy_frontend_http_comp_responses_total counter
+haproxy_frontend_http_comp_responses_total{proxy="px"} 0
+# TYPE haproxy_frontend_connections_rate_max gauge
+haproxy_frontend_connections_rate_max{proxy="px"} 0
+# TYPE haproxy_frontend_connections_total counter
+haproxy_frontend_connections_total{proxy="px"} 0
+# TYPE haproxy_frontend_intercepted_requests_total counter
+haproxy_frontend_intercepted_requests_total{proxy="px"} 0
+# TYPE haproxy_frontend_denied_connections_total counter
+haproxy_frontend_denied_connections_total{proxy="px"} 0
+# TYPE haproxy_frontend_denied_sessions_total counter
+haproxy_frontend_denied_sessions_total{proxy="px"} 0
+# TYPE haproxy_frontend_failed_header_rewriting_total counter
+haproxy_frontend_failed_header_rewriting_total{proxy="px"} 0
+# TYPE haproxy_frontend_http_cache_lookups_total counter
+haproxy_frontend_http_cache_lookups_total{proxy="px"} 0
+# TYPE haproxy_frontend_http_cache_hits_total counter
+haproxy_frontend_http_cache_hits_total{proxy="px"} 0
+# TYPE haproxy_frontend_internal_errors_total counter
+haproxy_frontend_internal_errors_total{proxy="px"} 0
+
+# ── backend (proxy) ──────────────────────────────────────────────────────────
+# TYPE haproxy_backend_current_queue gauge
+haproxy_backend_current_queue{proxy="px"} 0
+# TYPE haproxy_backend_max_queue gauge
+haproxy_backend_max_queue{proxy="px"} 0
+# TYPE haproxy_backend_current_sessions gauge
+haproxy_backend_current_sessions{proxy="px"} 0
+# TYPE haproxy_backend_max_sessions gauge
+haproxy_backend_max_sessions{proxy="px"} 0
+# TYPE haproxy_backend_limit_sessions gauge
+haproxy_backend_limit_sessions{proxy="px"} 0
+# TYPE haproxy_backend_sessions_total counter
+haproxy_backend_sessions_total{proxy="px"} 0
+# TYPE haproxy_backend_current_session_rate gauge
+haproxy_backend_current_session_rate{proxy="px"} 0
+# TYPE haproxy_backend_max_session_rate gauge
+haproxy_backend_max_session_rate{proxy="px"} 0
+# TYPE haproxy_backend_bytes_in_total counter
+haproxy_backend_bytes_in_total{proxy="px"} 0
+# TYPE haproxy_backend_bytes_out_total counter
+haproxy_backend_bytes_out_total{proxy="px"} 0
+# TYPE haproxy_backend_req_bytes_in_total counter
+haproxy_backend_req_bytes_in_total{proxy="px"} 0
+# TYPE haproxy_backend_req_bytes_out_total counter
+haproxy_backend_req_bytes_out_total{proxy="px"} 0
+# TYPE haproxy_backend_res_bytes_in_total counter
+haproxy_backend_res_bytes_in_total{proxy="px"} 0
+# TYPE haproxy_backend_res_bytes_out_total counter
+haproxy_backend_res_bytes_out_total{proxy="px"} 0
+# TYPE haproxy_backend_requests_denied_total counter
+haproxy_backend_requests_denied_total{proxy="px"} 0
+# TYPE haproxy_backend_responses_denied_total counter
+haproxy_backend_responses_denied_total{proxy="px"} 0
+# TYPE haproxy_backend_connection_errors_total counter
+haproxy_backend_connection_errors_total{proxy="px"} 0
+# TYPE haproxy_backend_response_errors_total counter
+haproxy_backend_response_errors_total{proxy="px"} 0
+# TYPE haproxy_backend_retry_warnings_total counter
+haproxy_backend_retry_warnings_total{proxy="px"} 0
+# TYPE haproxy_backend_redispatch_warnings_total counter
+haproxy_backend_redispatch_warnings_total{proxy="px"} 0
+# TYPE haproxy_backend_status gauge
+haproxy_backend_status{proxy="px",state="DOWN"} 0
+haproxy_backend_status{proxy="px",state="UP"} 0
+# TYPE haproxy_backend_weight gauge
+haproxy_backend_weight{proxy="px"} 0
+# TYPE haproxy_backend_active_servers gauge
+haproxy_backend_active_servers{proxy="px"} 0
+# TYPE haproxy_backend_backup_servers gauge
+haproxy_backend_backup_servers{proxy="px"} 0
+# TYPE haproxy_backend_check_up_down_total counter
+haproxy_backend_check_up_down_total{proxy="px"} 0
+# TYPE haproxy_backend_check_last_change_seconds gauge
+haproxy_backend_check_last_change_seconds{proxy="px"} 0
+# TYPE haproxy_backend_downtime_seconds_total counter
+haproxy_backend_downtime_seconds_total{proxy="px"} 0
+# TYPE haproxy_backend_loadbalanced_total counter
+haproxy_backend_loadbalanced_total{proxy="px"} 0
+# TYPE haproxy_backend_http_requests_total counter
+haproxy_backend_http_requests_total{proxy="px"} 0
+# TYPE haproxy_backend_http_responses_total counter
+haproxy_backend_http_responses_total{proxy="px",code="1xx"} 0
+haproxy_backend_http_responses_total{proxy="px",code="2xx"} 0
+haproxy_backend_http_responses_total{proxy="px",code="3xx"} 0
+haproxy_backend_http_responses_total{proxy="px",code="4xx"} 0
+haproxy_backend_http_responses_total{proxy="px",code="5xx"} 0
+haproxy_backend_http_responses_total{proxy="px",code="other"} 0
+# TYPE haproxy_backend_client_aborts_total counter
+haproxy_backend_client_aborts_total{proxy="px"} 0
+# TYPE haproxy_backend_server_aborts_total counter
+haproxy_backend_server_aborts_total{proxy="px"} 0
+# TYPE haproxy_backend_http_comp_bytes_in_total counter
+haproxy_backend_http_comp_bytes_in_total{proxy="px"} 0
+# TYPE haproxy_backend_http_comp_bytes_out_total counter
+haproxy_backend_http_comp_bytes_out_total{proxy="px"} 0
+# TYPE haproxy_backend_http_comp_bytes_bypassed_total counter
+haproxy_backend_http_comp_bytes_bypassed_total{proxy="px"} 0
+# TYPE haproxy_backend_http_comp_responses_total counter
+haproxy_backend_http_comp_responses_total{proxy="px"} 0
+# TYPE haproxy_backend_last_session_seconds gauge
+haproxy_backend_last_session_seconds{proxy="px"} 0
+# TYPE haproxy_backend_queue_time_average_seconds gauge
+haproxy_backend_queue_time_average_seconds{proxy="px"} 0
+# TYPE haproxy_backend_connect_time_average_seconds gauge
+haproxy_backend_connect_time_average_seconds{proxy="px"} 0
+# TYPE haproxy_backend_response_time_average_seconds gauge
+haproxy_backend_response_time_average_seconds{proxy="px"} 0
+# TYPE haproxy_backend_total_time_average_seconds gauge
+haproxy_backend_total_time_average_seconds{proxy="px"} 0
+# TYPE haproxy_backend_failed_header_rewriting_total counter
+haproxy_backend_failed_header_rewriting_total{proxy="px"} 0
+# TYPE haproxy_backend_connection_attempts_total counter
+haproxy_backend_connection_attempts_total{proxy="px"} 0
+# TYPE haproxy_backend_connection_reuses_total counter
+haproxy_backend_connection_reuses_total{proxy="px"} 0
+# TYPE haproxy_backend_http_cache_lookups_total counter
+haproxy_backend_http_cache_lookups_total{proxy="px"} 0
+# TYPE haproxy_backend_http_cache_hits_total counter
+haproxy_backend_http_cache_hits_total{proxy="px"} 0
+# TYPE haproxy_backend_max_queue_time_seconds gauge
+haproxy_backend_max_queue_time_seconds{proxy="px"} 0
+# TYPE haproxy_backend_max_connect_time_seconds gauge
+haproxy_backend_max_connect_time_seconds{proxy="px"} 0
+# TYPE haproxy_backend_max_response_time_seconds gauge
+haproxy_backend_max_response_time_seconds{proxy="px"} 0
+# TYPE haproxy_backend_max_total_time_seconds gauge
+haproxy_backend_max_total_time_seconds{proxy="px"} 0
+# TYPE haproxy_backend_internal_errors_total counter
+haproxy_backend_internal_errors_total{proxy="px"} 0
+# TYPE haproxy_backend_uweight gauge
+haproxy_backend_uweight{proxy="px"} 0
+# TYPE haproxy_backend_agg_server_check_status gauge
+haproxy_backend_agg_server_check_status{proxy="px",state="DOWN"} 0
+haproxy_backend_agg_server_check_status{proxy="px",state="UP"} 0
+haproxy_backend_agg_server_check_status{proxy="px",state="MAINT"} 0
+haproxy_backend_agg_server_check_status{proxy="px",state="DRAIN"} 0
+haproxy_backend_agg_server_check_status{proxy="px",state="NOLB"} 0
+# TYPE haproxy_backend_agg_check_status gauge
+haproxy_backend_agg_check_status{proxy="px",state="HANA"} 0
+haproxy_backend_agg_check_status{proxy="px",state="L7OK"} 0
+haproxy_backend_agg_check_status{proxy="px",state="L7STS"} 0
+
+# ── server (proxy, server) ─────────────────────────────────────────────────────
+# TYPE haproxy_server_current_queue gauge
+haproxy_server_current_queue{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_max_queue gauge
+haproxy_server_max_queue{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_current_sessions gauge
+haproxy_server_current_sessions{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_max_sessions gauge
+haproxy_server_max_sessions{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_limit_sessions gauge
+haproxy_server_limit_sessions{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_sessions_total counter
+haproxy_server_sessions_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_current_session_rate gauge
+haproxy_server_current_session_rate{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_max_session_rate gauge
+haproxy_server_max_session_rate{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_bytes_in_total counter
+haproxy_server_bytes_in_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_bytes_out_total counter
+haproxy_server_bytes_out_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_req_bytes_in_total counter
+haproxy_server_req_bytes_in_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_req_bytes_out_total counter
+haproxy_server_req_bytes_out_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_res_bytes_in_total counter
+haproxy_server_res_bytes_in_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_res_bytes_out_total counter
+haproxy_server_res_bytes_out_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_responses_denied_total counter
+haproxy_server_responses_denied_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_connection_errors_total counter
+haproxy_server_connection_errors_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_response_errors_total counter
+haproxy_server_response_errors_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_retry_warnings_total counter
+haproxy_server_retry_warnings_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_redispatch_warnings_total counter
+haproxy_server_redispatch_warnings_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_status gauge
+haproxy_server_status{proxy="px",server="srv1",state="DOWN"} 0
+haproxy_server_status{proxy="px",server="srv1",state="UP"} 0
+haproxy_server_status{proxy="px",server="srv1",state="MAINT"} 0
+haproxy_server_status{proxy="px",server="srv1",state="DRAIN"} 0
+haproxy_server_status{proxy="px",server="srv1",state="NOLB"} 0
+# TYPE haproxy_server_weight gauge
+haproxy_server_weight{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_active gauge
+haproxy_server_active{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_backup gauge
+haproxy_server_backup{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_check_failures_total counter
+haproxy_server_check_failures_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_check_up_down_total counter
+haproxy_server_check_up_down_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_check_last_change_seconds gauge
+haproxy_server_check_last_change_seconds{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_downtime_seconds_total counter
+haproxy_server_downtime_seconds_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_queue_limit gauge
+haproxy_server_queue_limit{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_current_throttle gauge
+haproxy_server_current_throttle{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_loadbalanced_total counter
+haproxy_server_loadbalanced_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_check_status gauge
+haproxy_server_check_status{proxy="px",server="srv1",state="HANA"} 0
+haproxy_server_check_status{proxy="px",server="srv1",state="L4CON"} 0
+haproxy_server_check_status{proxy="px",server="srv1",state="L7OK"} 0
+# TYPE haproxy_server_check_code gauge
+haproxy_server_check_code{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_check_duration_seconds gauge
+haproxy_server_check_duration_seconds{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_http_requests_total counter
+haproxy_server_http_requests_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_http_responses_total counter
+haproxy_server_http_responses_total{proxy="px",server="srv1",code="1xx"} 0
+haproxy_server_http_responses_total{proxy="px",server="srv1",code="2xx"} 0
+haproxy_server_http_responses_total{proxy="px",server="srv1",code="3xx"} 0
+haproxy_server_http_responses_total{proxy="px",server="srv1",code="4xx"} 0
+haproxy_server_http_responses_total{proxy="px",server="srv1",code="5xx"} 0
+haproxy_server_http_responses_total{proxy="px",server="srv1",code="other"} 0
+# TYPE haproxy_server_client_aborts_total counter
+haproxy_server_client_aborts_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_server_aborts_total counter
+haproxy_server_server_aborts_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_last_session_seconds gauge
+haproxy_server_last_session_seconds{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_queue_time_average_seconds gauge
+haproxy_server_queue_time_average_seconds{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_connect_time_average_seconds gauge
+haproxy_server_connect_time_average_seconds{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_response_time_average_seconds gauge
+haproxy_server_response_time_average_seconds{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_total_time_average_seconds gauge
+haproxy_server_total_time_average_seconds{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_agent_status gauge
+haproxy_server_agent_status{proxy="px",server="srv1",state="HANA"} 0
+haproxy_server_agent_status{proxy="px",server="srv1",state="L7OK"} 0
+# TYPE haproxy_server_agent_code gauge
+haproxy_server_agent_code{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_agent_duration_seconds gauge
+haproxy_server_agent_duration_seconds{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_failed_header_rewriting_total counter
+haproxy_server_failed_header_rewriting_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_connection_attempts_total counter
+haproxy_server_connection_attempts_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_connection_reuses_total counter
+haproxy_server_connection_reuses_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_idle_connections_current gauge
+haproxy_server_idle_connections_current{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_idle_connections_limit gauge
+haproxy_server_idle_connections_limit{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_max_queue_time_seconds gauge
+haproxy_server_max_queue_time_seconds{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_max_connect_time_seconds gauge
+haproxy_server_max_connect_time_seconds{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_max_response_time_seconds gauge
+haproxy_server_max_response_time_seconds{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_max_total_time_seconds gauge
+haproxy_server_max_total_time_seconds{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_internal_errors_total counter
+haproxy_server_internal_errors_total{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_unsafe_idle_connections_current gauge
+haproxy_server_unsafe_idle_connections_current{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_safe_idle_connections_current gauge
+haproxy_server_safe_idle_connections_current{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_used_connections_current gauge
+haproxy_server_used_connections_current{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_need_connections_current gauge
+haproxy_server_need_connections_current{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_uweight gauge
+haproxy_server_uweight{proxy="px",server="srv1"} 0
+# TYPE haproxy_server_private_idle_connections_current gauge
+haproxy_server_private_idle_connections_current{proxy="px",server="srv1"} 0
+
+# ── listener (proxy, listener) ─────────────────────────────────────────────────
+# TYPE haproxy_listener_current_sessions gauge
+haproxy_listener_current_sessions{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_max_sessions gauge
+haproxy_listener_max_sessions{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_limit_sessions gauge
+haproxy_listener_limit_sessions{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_sessions_total counter
+haproxy_listener_sessions_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_bytes_in_total counter
+haproxy_listener_bytes_in_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_bytes_out_total counter
+haproxy_listener_bytes_out_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_req_bytes_in_total counter
+haproxy_listener_req_bytes_in_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_req_bytes_out_total counter
+haproxy_listener_req_bytes_out_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_res_bytes_in_total counter
+haproxy_listener_res_bytes_in_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_res_bytes_out_total counter
+haproxy_listener_res_bytes_out_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_requests_denied_total counter
+haproxy_listener_requests_denied_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_responses_denied_total counter
+haproxy_listener_responses_denied_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_request_errors_total counter
+haproxy_listener_request_errors_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_status gauge
+haproxy_listener_status{proxy="px",listener="listener1",state="WAITING"} 0
+haproxy_listener_status{proxy="px",listener="listener1",state="OPEN"} 0
+haproxy_listener_status{proxy="px",listener="listener1",state="FULL"} 0
+# TYPE haproxy_listener_connections_total counter
+haproxy_listener_connections_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_denied_connections_total counter
+haproxy_listener_denied_connections_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_denied_sessions_total counter
+haproxy_listener_denied_sessions_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_failed_header_rewriting_total counter
+haproxy_listener_failed_header_rewriting_total{proxy="px",listener="listener1"} 0
+# TYPE haproxy_listener_internal_errors_total counter
+haproxy_listener_internal_errors_total{proxy="px",listener="listener1"} 0
+
+# ── resolver (resolver, nameserver) — all gauges in source ─────────────────────
+# TYPE haproxy_resolver_sent gauge
+haproxy_resolver_sent{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_send_error gauge
+haproxy_resolver_send_error{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_valid gauge
+haproxy_resolver_valid{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_update gauge
+haproxy_resolver_update{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_cname gauge
+haproxy_resolver_cname{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_cname_error gauge
+haproxy_resolver_cname_error{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_any_err gauge
+haproxy_resolver_any_err{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_nx gauge
+haproxy_resolver_nx{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_timeout gauge
+haproxy_resolver_timeout{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_refused gauge
+haproxy_resolver_refused{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_other gauge
+haproxy_resolver_other{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_invalid gauge
+haproxy_resolver_invalid{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_too_big gauge
+haproxy_resolver_too_big{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_truncated gauge
+haproxy_resolver_truncated{resolver="resolvers1",nameserver="ns1"} 0
+# TYPE haproxy_resolver_outdated gauge
+haproxy_resolver_outdated{resolver="resolvers1",nameserver="ns1"} 0
+
+# ── sticktable (name, type) — all gauges in source ─────────────────────────────
+# TYPE haproxy_sticktable_size gauge
+haproxy_sticktable_size{name="table1",type="ip"} 0
+# TYPE haproxy_sticktable_used gauge
+haproxy_sticktable_used{name="table1",type="ip"} 0
+# TYPE haproxy_sticktable_local_updates gauge
+haproxy_sticktable_local_updates{name="table1",type="ip"} 0
+
+# ── extra-counters: H1 (mod="h1") ───────────────────────────────────────────────
+# TYPE haproxy_frontend_h1_open_connections gauge
+haproxy_frontend_h1_open_connections{proxy="px",mod="h1"} 0
+# TYPE haproxy_backend_h1_open_connections gauge
+haproxy_backend_h1_open_connections{proxy="px",mod="h1"} 0
+# TYPE haproxy_frontend_h1_open_streams gauge
+haproxy_frontend_h1_open_streams{proxy="px",mod="h1"} 0
+# TYPE haproxy_backend_h1_open_streams gauge
+haproxy_backend_h1_open_streams{proxy="px",mod="h1"} 0
+# TYPE haproxy_frontend_h1_total_connections counter
+haproxy_frontend_h1_total_connections{proxy="px",mod="h1"} 0
+# TYPE haproxy_backend_h1_total_connections counter
+haproxy_backend_h1_total_connections{proxy="px",mod="h1"} 0
+# TYPE haproxy_frontend_h1_total_streams counter
+haproxy_frontend_h1_total_streams{proxy="px",mod="h1"} 0
+# TYPE haproxy_backend_h1_total_streams counter
+haproxy_backend_h1_total_streams{proxy="px",mod="h1"} 0
+# TYPE haproxy_frontend_h1_bytes_in counter
+haproxy_frontend_h1_bytes_in{proxy="px",mod="h1"} 0
+# TYPE haproxy_backend_h1_bytes_in counter
+haproxy_backend_h1_bytes_in{proxy="px",mod="h1"} 0
+# TYPE haproxy_frontend_h1_bytes_out counter
+haproxy_frontend_h1_bytes_out{proxy="px",mod="h1"} 0
+# TYPE haproxy_backend_h1_bytes_out counter
+haproxy_backend_h1_bytes_out{proxy="px",mod="h1"} 0
+# TYPE haproxy_frontend_h1_spliced_bytes_in counter
+haproxy_frontend_h1_spliced_bytes_in{proxy="px",mod="h1"} 0
+# TYPE haproxy_backend_h1_spliced_bytes_in counter
+haproxy_backend_h1_spliced_bytes_in{proxy="px",mod="h1"} 0
+# TYPE haproxy_frontend_h1_spliced_bytes_out counter
+haproxy_frontend_h1_spliced_bytes_out{proxy="px",mod="h1"} 0
+# TYPE haproxy_backend_h1_spliced_bytes_out counter
+haproxy_backend_h1_spliced_bytes_out{proxy="px",mod="h1"} 0
+
+# ── extra-counters: H2 (mod="h2") ───────────────────────────────────────────────
+# TYPE haproxy_frontend_h2_headers_rcvd counter
+haproxy_frontend_h2_headers_rcvd{proxy="px",mod="h2"} 0
+# TYPE haproxy_backend_h2_headers_rcvd counter
+haproxy_backend_h2_headers_rcvd{proxy="px",mod="h2"} 0
+# TYPE haproxy_frontend_h2_data_rcvd counter
+haproxy_frontend_h2_data_rcvd{proxy="px",mod="h2"} 0
+# TYPE haproxy_backend_h2_data_rcvd counter
+haproxy_backend_h2_data_rcvd{proxy="px",mod="h2"} 0
+# TYPE haproxy_frontend_h2_settings_rcvd counter
+haproxy_frontend_h2_settings_rcvd{proxy="px",mod="h2"} 0
+# TYPE haproxy_backend_h2_settings_rcvd counter
+haproxy_backend_h2_settings_rcvd{proxy="px",mod="h2"} 0
+# TYPE haproxy_frontend_h2_rst_stream_rcvd counter
+haproxy_frontend_h2_rst_stream_rcvd{proxy="px",mod="h2"} 0
+# TYPE haproxy_backend_h2_rst_stream_rcvd counter
+haproxy_backend_h2_rst_stream_rcvd{proxy="px",mod="h2"} 0
+# TYPE haproxy_frontend_h2_goaway_rcvd counter
+haproxy_frontend_h2_goaway_rcvd{proxy="px",mod="h2"} 0
+# TYPE haproxy_backend_h2_goaway_rcvd counter
+haproxy_backend_h2_goaway_rcvd{proxy="px",mod="h2"} 0
+# TYPE haproxy_frontend_h2_detected_conn_protocol_errors counter
+haproxy_frontend_h2_detected_conn_protocol_errors{proxy="px",mod="h2"} 0
+# TYPE haproxy_backend_h2_detected_conn_protocol_errors counter
+haproxy_backend_h2_detected_conn_protocol_errors{proxy="px",mod="h2"} 0
+# TYPE haproxy_frontend_h2_detected_strm_protocol_errors counter
+haproxy_frontend_h2_detected_strm_protocol_errors{proxy="px",mod="h2"} 0
+# TYPE haproxy_backend_h2_detected_strm_protocol_errors counter
+haproxy_backend_h2_detected_strm_protocol_errors{proxy="px",mod="h2"} 0
+# TYPE haproxy_frontend_h2_rst_stream_resp counter
+haproxy_frontend_h2_rst_stream_resp{proxy="px",mod="h2"} 0
+# TYPE haproxy_backend_h2_rst_stream_resp counter
+haproxy_backend_h2_rst_stream_resp{proxy="px",mod="h2"} 0
+# TYPE haproxy_frontend_h2_goaway_resp counter
+haproxy_frontend_h2_goaway_resp{proxy="px",mod="h2"} 0
+# TYPE haproxy_backend_h2_goaway_resp counter
+haproxy_backend_h2_goaway_resp{proxy="px",mod="h2"} 0
+# TYPE haproxy_frontend_h2_open_connections gauge
+haproxy_frontend_h2_open_connections{proxy="px",mod="h2"} 0
+# TYPE haproxy_backend_h2_open_connections gauge
+haproxy_backend_h2_open_connections{proxy="px",mod="h2"} 0
+# TYPE haproxy_frontend_h2_backend_open_streams gauge
+haproxy_frontend_h2_backend_open_streams{proxy="px",mod="h2"} 0
+# TYPE haproxy_backend_h2_backend_open_streams gauge
+haproxy_backend_h2_backend_open_streams{proxy="px",mod="h2"} 0
+# TYPE haproxy_frontend_h2_total_connections counter
+haproxy_frontend_h2_total_connections{proxy="px",mod="h2"} 0
+# TYPE haproxy_backend_h2_total_connections counter
+haproxy_backend_h2_total_connections{proxy="px",mod="h2"} 0
+# TYPE haproxy_frontend_h2_backend_total_streams counter
+haproxy_frontend_h2_backend_total_streams{proxy="px",mod="h2"} 0
+# TYPE haproxy_backend_h2_backend_total_streams counter
+haproxy_backend_h2_backend_total_streams{proxy="px",mod="h2"} 0
+
+# ── extra-counters: SSL (mod="ssl") ─────────────────────────────────────────────
+# TYPE haproxy_frontend_ssl_sess counter
+haproxy_frontend_ssl_sess{proxy="px",mod="ssl"} 0
+# TYPE haproxy_listener_ssl_sess counter
+haproxy_listener_ssl_sess{proxy="px",listener="listener1",mod="ssl"} 0
+# TYPE haproxy_backend_ssl_sess counter
+haproxy_backend_ssl_sess{proxy="px",mod="ssl"} 0
+# TYPE haproxy_server_ssl_sess counter
+haproxy_server_ssl_sess{proxy="px",server="srv1",mod="ssl"} 0
+# TYPE haproxy_frontend_ssl_reused_sess counter
+haproxy_frontend_ssl_reused_sess{proxy="px",mod="ssl"} 0
+# TYPE haproxy_listener_ssl_reused_sess counter
+haproxy_listener_ssl_reused_sess{proxy="px",listener="listener1",mod="ssl"} 0
+# TYPE haproxy_backend_ssl_reused_sess counter
+haproxy_backend_ssl_reused_sess{proxy="px",mod="ssl"} 0
+# TYPE haproxy_server_ssl_reused_sess counter
+haproxy_server_ssl_reused_sess{proxy="px",server="srv1",mod="ssl"} 0
+# TYPE haproxy_frontend_ssl_failed_handshake counter
+haproxy_frontend_ssl_failed_handshake{proxy="px",mod="ssl"} 0
+# TYPE haproxy_listener_ssl_failed_handshake counter
+haproxy_listener_ssl_failed_handshake{proxy="px",listener="listener1",mod="ssl"} 0
+# TYPE haproxy_backend_ssl_failed_handshake counter
+haproxy_backend_ssl_failed_handshake{proxy="px",mod="ssl"} 0
+# TYPE haproxy_server_ssl_failed_handshake counter
+haproxy_server_ssl_failed_handshake{proxy="px",server="srv1",mod="ssl"} 0
+# TYPE haproxy_frontend_ssl_ocsp_staple counter
+haproxy_frontend_ssl_ocsp_staple{proxy="px",mod="ssl"} 0
+# TYPE haproxy_listener_ssl_ocsp_staple counter
+haproxy_listener_ssl_ocsp_staple{proxy="px",listener="listener1",mod="ssl"} 0
+# TYPE haproxy_backend_ssl_ocsp_staple counter
+haproxy_backend_ssl_ocsp_staple{proxy="px",mod="ssl"} 0
+# TYPE haproxy_server_ssl_ocsp_staple counter
+haproxy_server_ssl_ocsp_staple{proxy="px",server="srv1",mod="ssl"} 0
+# TYPE haproxy_frontend_ssl_failed_ocsp_staple counter
+haproxy_frontend_ssl_failed_ocsp_staple{proxy="px",mod="ssl"} 0
+# TYPE haproxy_listener_ssl_failed_ocsp_staple counter
+haproxy_listener_ssl_failed_ocsp_staple{proxy="px",listener="listener1",mod="ssl"} 0
+# TYPE haproxy_backend_ssl_failed_ocsp_staple counter
+haproxy_backend_ssl_failed_ocsp_staple{proxy="px",mod="ssl"} 0
+# TYPE haproxy_server_ssl_failed_ocsp_staple counter
+haproxy_server_ssl_failed_ocsp_staple{proxy="px",server="srv1",mod="ssl"} 0
+
+# ── extra-counters: QUIC (mod="quic") ───────────────────────────────────────────
+# TYPE haproxy_frontend_quic_rxbuf_full counter
+haproxy_frontend_quic_rxbuf_full{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_rxbuf_full counter
+haproxy_backend_quic_rxbuf_full{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_dropped_pkt counter
+haproxy_frontend_quic_dropped_pkt{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_dropped_pkt counter
+haproxy_backend_quic_dropped_pkt{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_dropped_pkt_bufoverrun counter
+haproxy_frontend_quic_dropped_pkt_bufoverrun{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_dropped_pkt_bufoverrun counter
+haproxy_backend_quic_dropped_pkt_bufoverrun{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_dropped_parsing_pkt counter
+haproxy_frontend_quic_dropped_parsing_pkt{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_dropped_parsing_pkt counter
+haproxy_backend_quic_dropped_parsing_pkt{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_socket_full counter
+haproxy_frontend_quic_socket_full{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_socket_full counter
+haproxy_backend_quic_socket_full{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_sendto_err counter
+haproxy_frontend_quic_sendto_err{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_sendto_err counter
+haproxy_backend_quic_sendto_err{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_sendto_err_unknwn counter
+haproxy_frontend_quic_sendto_err_unknwn{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_sendto_err_unknwn counter
+haproxy_backend_quic_sendto_err_unknwn{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_sent_pkt counter
+haproxy_frontend_quic_sent_pkt{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_sent_pkt counter
+haproxy_backend_quic_sent_pkt{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_lost_pkt counter
+haproxy_frontend_quic_lost_pkt{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_lost_pkt counter
+haproxy_backend_quic_lost_pkt{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_too_short_dgram counter
+haproxy_frontend_quic_too_short_dgram{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_too_short_dgram counter
+haproxy_backend_quic_too_short_dgram{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_retry_sent counter
+haproxy_frontend_quic_retry_sent{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_retry_sent counter
+haproxy_backend_quic_retry_sent{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_retry_validated counter
+haproxy_frontend_quic_retry_validated{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_retry_validated counter
+haproxy_backend_quic_retry_validated{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_retry_error counter
+haproxy_frontend_quic_retry_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_retry_error counter
+haproxy_backend_quic_retry_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_half_open_conn counter
+haproxy_frontend_quic_half_open_conn{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_half_open_conn counter
+haproxy_backend_quic_half_open_conn{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_hdshk_fail counter
+haproxy_frontend_quic_hdshk_fail{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_hdshk_fail counter
+haproxy_backend_quic_hdshk_fail{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_stless_rst_sent counter
+haproxy_frontend_quic_stless_rst_sent{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_stless_rst_sent counter
+haproxy_backend_quic_stless_rst_sent{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_conn_migration_done counter
+haproxy_frontend_quic_conn_migration_done{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_conn_migration_done counter
+haproxy_backend_quic_conn_migration_done{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_no_error counter
+haproxy_frontend_quic_transp_err_no_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_no_error counter
+haproxy_backend_quic_transp_err_no_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_internal_error counter
+haproxy_frontend_quic_transp_err_internal_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_internal_error counter
+haproxy_backend_quic_transp_err_internal_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_connection_refused counter
+haproxy_frontend_quic_transp_err_connection_refused{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_connection_refused counter
+haproxy_backend_quic_transp_err_connection_refused{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_flow_control_error counter
+haproxy_frontend_quic_transp_err_flow_control_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_flow_control_error counter
+haproxy_backend_quic_transp_err_flow_control_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_stream_limit_error counter
+haproxy_frontend_quic_transp_err_stream_limit_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_stream_limit_error counter
+haproxy_backend_quic_transp_err_stream_limit_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_stream_state_error counter
+haproxy_frontend_quic_transp_err_stream_state_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_stream_state_error counter
+haproxy_backend_quic_transp_err_stream_state_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_final_size_error counter
+haproxy_frontend_quic_transp_err_final_size_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_final_size_error counter
+haproxy_backend_quic_transp_err_final_size_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_frame_encoding_error counter
+haproxy_frontend_quic_transp_err_frame_encoding_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_frame_encoding_error counter
+haproxy_backend_quic_transp_err_frame_encoding_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_transport_parameter_error counter
+haproxy_frontend_quic_transp_err_transport_parameter_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_transport_parameter_error counter
+haproxy_backend_quic_transp_err_transport_parameter_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_connection_id_limit counter
+haproxy_frontend_quic_transp_err_connection_id_limit{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_connection_id_limit counter
+haproxy_backend_quic_transp_err_connection_id_limit{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_protocol_violation_error counter
+haproxy_frontend_quic_transp_err_protocol_violation_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_protocol_violation_error counter
+haproxy_backend_quic_transp_err_protocol_violation_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_invalid_token counter
+haproxy_frontend_quic_transp_err_invalid_token{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_invalid_token counter
+haproxy_backend_quic_transp_err_invalid_token{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_application_error counter
+haproxy_frontend_quic_transp_err_application_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_application_error counter
+haproxy_backend_quic_transp_err_application_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_crypto_buffer_exceeded counter
+haproxy_frontend_quic_transp_err_crypto_buffer_exceeded{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_crypto_buffer_exceeded counter
+haproxy_backend_quic_transp_err_crypto_buffer_exceeded{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_key_update_error counter
+haproxy_frontend_quic_transp_err_key_update_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_key_update_error counter
+haproxy_backend_quic_transp_err_key_update_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_aead_limit_reached counter
+haproxy_frontend_quic_transp_err_aead_limit_reached{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_aead_limit_reached counter
+haproxy_backend_quic_transp_err_aead_limit_reached{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_no_viable_path counter
+haproxy_frontend_quic_transp_err_no_viable_path{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_no_viable_path counter
+haproxy_backend_quic_transp_err_no_viable_path{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_crypto_error counter
+haproxy_frontend_quic_transp_err_crypto_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_crypto_error counter
+haproxy_backend_quic_transp_err_crypto_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_transp_err_unknown_error counter
+haproxy_frontend_quic_transp_err_unknown_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_transp_err_unknown_error counter
+haproxy_backend_quic_transp_err_unknown_error{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_data_blocked counter
+haproxy_frontend_quic_data_blocked{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_data_blocked counter
+haproxy_backend_quic_data_blocked{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_stream_data_blocked counter
+haproxy_frontend_quic_stream_data_blocked{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_stream_data_blocked counter
+haproxy_backend_quic_stream_data_blocked{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_streams_blocked_bidi counter
+haproxy_frontend_quic_streams_blocked_bidi{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_streams_blocked_bidi counter
+haproxy_backend_quic_streams_blocked_bidi{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_streams_blocked_uni counter
+haproxy_frontend_quic_streams_blocked_uni{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_streams_blocked_uni counter
+haproxy_backend_quic_streams_blocked_uni{proxy="px",mod="quic"} 0
+# TYPE haproxy_frontend_quic_ncbuf_gap_limit counter
+haproxy_frontend_quic_ncbuf_gap_limit{proxy="px",mod="quic"} 0
+# TYPE haproxy_backend_quic_ncbuf_gap_limit counter
+haproxy_backend_quic_ncbuf_gap_limit{proxy="px",mod="quic"} 0
+
+# ── extra-counters: H3/QPACK (mod="h3") ─────────────────────────────────────────
+# TYPE haproxy_frontend_h3_data counter
+haproxy_frontend_h3_data{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_data counter
+haproxy_backend_h3_data{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_headers counter
+haproxy_frontend_h3_headers{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_headers counter
+haproxy_backend_h3_headers{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_cancel_push counter
+haproxy_frontend_h3_cancel_push{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_cancel_push counter
+haproxy_backend_h3_cancel_push{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_push_promise counter
+haproxy_frontend_h3_push_promise{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_push_promise counter
+haproxy_backend_h3_push_promise{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_max_push_id counter
+haproxy_frontend_h3_max_push_id{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_max_push_id counter
+haproxy_backend_h3_max_push_id{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_goaway counter
+haproxy_frontend_h3_goaway{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_goaway counter
+haproxy_backend_h3_goaway{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_settings counter
+haproxy_frontend_h3_settings{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_settings counter
+haproxy_backend_h3_settings{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_no_error counter
+haproxy_frontend_h3_no_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_no_error counter
+haproxy_backend_h3_no_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_general_protocol_error counter
+haproxy_frontend_h3_general_protocol_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_general_protocol_error counter
+haproxy_backend_h3_general_protocol_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_internal_error counter
+haproxy_frontend_h3_internal_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_internal_error counter
+haproxy_backend_h3_internal_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_stream_creation_error counter
+haproxy_frontend_h3_stream_creation_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_stream_creation_error counter
+haproxy_backend_h3_stream_creation_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_closed_critical_stream counter
+haproxy_frontend_h3_closed_critical_stream{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_closed_critical_stream counter
+haproxy_backend_h3_closed_critical_stream{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_frame_unexpected counter
+haproxy_frontend_h3_frame_unexpected{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_frame_unexpected counter
+haproxy_backend_h3_frame_unexpected{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_frame_error counter
+haproxy_frontend_h3_frame_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_frame_error counter
+haproxy_backend_h3_frame_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_excessive_load counter
+haproxy_frontend_h3_excessive_load{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_excessive_load counter
+haproxy_backend_h3_excessive_load{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_id_error counter
+haproxy_frontend_h3_id_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_id_error counter
+haproxy_backend_h3_id_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_settings_error counter
+haproxy_frontend_h3_settings_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_settings_error counter
+haproxy_backend_h3_settings_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_missing_settings counter
+haproxy_frontend_h3_missing_settings{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_missing_settings counter
+haproxy_backend_h3_missing_settings{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_request_rejected counter
+haproxy_frontend_h3_request_rejected{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_request_rejected counter
+haproxy_backend_h3_request_rejected{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_request_cancelled counter
+haproxy_frontend_h3_request_cancelled{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_request_cancelled counter
+haproxy_backend_h3_request_cancelled{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_request_incomplete counter
+haproxy_frontend_h3_request_incomplete{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_request_incomplete counter
+haproxy_backend_h3_request_incomplete{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_message_error counter
+haproxy_frontend_h3_message_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_message_error counter
+haproxy_backend_h3_message_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_connect_error counter
+haproxy_frontend_h3_connect_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_connect_error counter
+haproxy_backend_h3_connect_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_h3_version_fallback counter
+haproxy_frontend_h3_version_fallback{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_h3_version_fallback counter
+haproxy_backend_h3_version_fallback{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_pack_decompression_failed counter
+haproxy_frontend_pack_decompression_failed{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_pack_decompression_failed counter
+haproxy_backend_pack_decompression_failed{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_qpack_encoder_stream_error counter
+haproxy_frontend_qpack_encoder_stream_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_qpack_encoder_stream_error counter
+haproxy_backend_qpack_encoder_stream_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_frontend_qpack_decoder_stream_error counter
+haproxy_frontend_qpack_decoder_stream_error{proxy="px",mod="h3"} 0
+# TYPE haproxy_backend_qpack_decoder_stream_error counter
+haproxy_backend_qpack_decoder_stream_error{proxy="px",mod="h3"} 0

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/haproxy.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/haproxy.yaml
@@ -1,0 +1,1110 @@
+# HAProxy PromEx exporter (USE_PROMEX=1) chart profile.
+#
+# Template-only: groups/charts shape the default scrape (no ?extra-counters) into an
+# operator-oriented menu. Multi-value labels (state/code) become dimensions via
+# name_from_label. Instance identity per scope is set with instances.by_labels.
+# Chart contexts are scope-prefixed so derived chart IDs stay globally unique
+# (chartengine derives the ID from context; same context across scopes would collide).
+# The ?extra-counters H1/H2/SSL/QUIC/H3 families (mod label) are intentionally left to
+# the collector's autogen fallback so the common no-extra-counters menu stays focused.
+match: 'haproxy_*'
+template:
+  family: HAProxy
+  context_namespace: haproxy
+  groups:
+    # ── Process / global ───────────────────────────────────────────────────────
+    - family: Process
+      groups:
+        - family: Connections
+          metrics:
+            - haproxy_process_current_connections
+            - haproxy_process_connections_total
+            - haproxy_process_requests_total
+            - haproxy_process_current_connection_rate
+            - haproxy_process_pipes_used_total
+            - haproxy_process_pipes_free_total
+          charts:
+            - title: Current Connections
+              context: process_current_connections
+              units: connections
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_process_current_connections
+                  name: connections
+            - title: Connections
+              context: process_connections
+              units: connections/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_process_connections_total
+                  name: connections
+            - title: Requests
+              context: process_requests
+              units: requests/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_process_requests_total
+                  name: requests
+            - title: Connection Rate
+              context: process_connection_rate
+              units: connections/s
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_process_current_connection_rate
+                  name: connections
+            - title: Pipes
+              context: process_pipes
+              units: pipes/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_process_pipes_used_total
+                  name: used
+                - selector: haproxy_process_pipes_free_total
+                  name: free
+        - family: Sessions
+          metrics:
+            - haproxy_process_current_session_rate
+          charts:
+            - title: Session Rate
+              context: process_session_rate
+              units: sessions/s
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_process_current_session_rate
+                  name: sessions
+        - family: Traffic
+          metrics:
+            - haproxy_process_bytes_out_total
+            - haproxy_process_spliced_bytes_out_total
+          charts:
+            - title: Traffic
+              context: process_traffic
+              units: bytes/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_process_bytes_out_total
+                  name: out
+                - selector: haproxy_process_spliced_bytes_out_total
+                  name: spliced_out
+        - family: SSL
+          metrics:
+            - haproxy_process_current_ssl_connections
+            - haproxy_process_ssl_connections_total
+            - haproxy_process_current_ssl_rate
+            - haproxy_process_ssl_cache_lookups_total
+            - haproxy_process_ssl_cache_misses_total
+          charts:
+            - title: SSL Connections
+              context: process_ssl_connections
+              units: connections/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_process_ssl_connections_total
+                  name: connections
+            - title: Current SSL Connections
+              context: process_current_ssl_connections
+              units: connections
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_process_current_ssl_connections
+                  name: connections
+            - title: SSL Rate
+              context: process_ssl_rate
+              units: connections/s
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_process_current_ssl_rate
+                  name: ssl
+            - title: SSL Cache
+              context: process_ssl_cache
+              units: lookups/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_process_ssl_cache_lookups_total
+                  name: lookups
+                - selector: haproxy_process_ssl_cache_misses_total
+                  name: misses
+        - family: Compression
+          metrics:
+            - haproxy_process_http_comp_bytes_in_total
+            - haproxy_process_http_comp_bytes_out_total
+          charts:
+            - title: HTTP Compression
+              context: process_http_comp
+              units: bytes/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_process_http_comp_bytes_in_total
+                  name: in
+                - selector: haproxy_process_http_comp_bytes_out_total
+                  name: out
+        - family: Scheduler
+          metrics:
+            - haproxy_process_current_tasks
+            - haproxy_process_current_run_queue
+            - haproxy_process_idle_time_percent
+            - haproxy_process_jobs
+            - haproxy_process_listeners
+            - haproxy_process_active_peers
+            - haproxy_process_connected_peers
+            - haproxy_process_dropped_logs_total
+            - haproxy_process_recv_logs_total
+            - haproxy_process_total_warnings
+          charts:
+            - title: Tasks
+              context: process_tasks
+              units: tasks
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_process_current_tasks
+                  name: tasks
+                - selector: haproxy_process_current_run_queue
+                  name: run_queue
+            - title: Idle Time
+              context: process_idle_time
+              units: percentage
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_process_idle_time_percent
+                  name: idle
+            - title: Jobs
+              context: process_jobs
+              units: jobs
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_process_jobs
+                  name: jobs
+                - selector: haproxy_process_listeners
+                  name: listeners
+            - title: Peers
+              context: process_peers
+              units: peers
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_process_active_peers
+                  name: active
+                - selector: haproxy_process_connected_peers
+                  name: connected
+            - title: Logs
+              context: process_logs
+              units: logs/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_process_recv_logs_total
+                  name: received
+                - selector: haproxy_process_dropped_logs_total
+                  name: dropped
+            - title: Warnings
+              context: process_warnings
+              units: warnings/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_process_total_warnings
+                  name: warnings
+
+    # ── Frontends ────────────────────────────────────────────────────────────────
+    - family: Frontends
+      chart_defaults:
+        instances:
+          by_labels:
+            - proxy
+      groups:
+        - family: Status
+          metrics:
+            - haproxy_frontend_status
+          charts:
+            - title: Frontend Status
+              context: frontend_status
+              units: status
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_frontend_status
+                  name_from_label: state
+        - family: Sessions
+          metrics:
+            - haproxy_frontend_current_sessions
+            - haproxy_frontend_sessions_total
+            - haproxy_frontend_current_session_rate
+          charts:
+            - title: Frontend Current Sessions
+              context: frontend_current_sessions
+              units: sessions
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_frontend_current_sessions
+                  name: current
+            - title: Frontend Session Rate
+              context: frontend_sessions
+              units: sessions/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_frontend_sessions_total
+                  name: sessions
+            - title: Frontend Current Session Rate
+              context: frontend_current_session_rate
+              units: sessions/s
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_frontend_current_session_rate
+                  name: sessions
+        - family: Connections
+          metrics:
+            - haproxy_frontend_connections_total
+            - haproxy_frontend_denied_connections_total
+            - haproxy_frontend_denied_sessions_total
+          charts:
+            - title: Frontend Connections
+              context: frontend_connections
+              units: connections/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_frontend_connections_total
+                  name: connections
+            - title: Frontend Denied
+              context: frontend_denied
+              units: events/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_frontend_denied_connections_total
+                  name: connections
+                - selector: haproxy_frontend_denied_sessions_total
+                  name: sessions
+        - family: Traffic
+          metrics:
+            - haproxy_frontend_bytes_in_total
+            - haproxy_frontend_bytes_out_total
+            - haproxy_frontend_req_bytes_in_total
+            - haproxy_frontend_req_bytes_out_total
+            - haproxy_frontend_res_bytes_in_total
+            - haproxy_frontend_res_bytes_out_total
+          charts:
+            - title: Frontend Traffic
+              context: frontend_traffic
+              units: bytes/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_frontend_bytes_in_total
+                  name: received
+                - selector: haproxy_frontend_bytes_out_total
+                  name: sent
+            - title: Frontend Request Traffic
+              context: frontend_req_traffic
+              units: bytes/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_frontend_req_bytes_in_total
+                  name: received
+                - selector: haproxy_frontend_req_bytes_out_total
+                  name: sent
+            - title: Frontend Response Traffic
+              context: frontend_res_traffic
+              units: bytes/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_frontend_res_bytes_in_total
+                  name: received
+                - selector: haproxy_frontend_res_bytes_out_total
+                  name: sent
+        - family: HTTP
+          metrics:
+            - haproxy_frontend_http_requests_total
+            - haproxy_frontend_intercepted_requests_total
+            - haproxy_frontend_http_cache_lookups_total
+            - haproxy_frontend_http_cache_hits_total
+          charts:
+            - title: Frontend HTTP Requests
+              context: frontend_http_requests
+              units: requests/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_frontend_http_requests_total
+                  name: requests
+                - selector: haproxy_frontend_intercepted_requests_total
+                  name: intercepted
+            - title: Frontend HTTP Cache
+              context: frontend_http_cache
+              units: lookups/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_frontend_http_cache_lookups_total
+                  name: lookups
+                - selector: haproxy_frontend_http_cache_hits_total
+                  name: hits
+        - family: HTTP Responses
+          metrics:
+            - haproxy_frontend_http_responses_total
+          charts:
+            - title: Frontend HTTP Responses
+              context: frontend_http_responses
+              units: responses/s
+              type: stacked
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_frontend_http_responses_total
+                  name_from_label: code
+        - family: Errors
+          metrics:
+            - haproxy_frontend_request_errors_total
+            - haproxy_frontend_requests_denied_total
+            - haproxy_frontend_responses_denied_total
+            - haproxy_frontend_failed_header_rewriting_total
+            - haproxy_frontend_internal_errors_total
+          charts:
+            - title: Frontend Errors
+              context: frontend_errors
+              units: errors/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_frontend_request_errors_total
+                  name: request
+                - selector: haproxy_frontend_failed_header_rewriting_total
+                  name: header_rewriting
+                - selector: haproxy_frontend_internal_errors_total
+                  name: internal
+            - title: Frontend Denied
+              context: frontend_denied_requests
+              units: events/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_frontend_requests_denied_total
+                  name: requests
+                - selector: haproxy_frontend_responses_denied_total
+                  name: responses
+
+    # ── Listeners ──────────────────────────────────────────────────────────────
+    - family: Listeners
+      chart_defaults:
+        instances:
+          by_labels:
+            - proxy
+            - listener
+      groups:
+        - family: Status
+          metrics:
+            - haproxy_listener_status
+          charts:
+            - title: Listener Status
+              context: listener_status
+              units: status
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_listener_status
+                  name_from_label: state
+        - family: Sessions
+          metrics:
+            - haproxy_listener_current_sessions
+            - haproxy_listener_sessions_total
+          charts:
+            - title: Listener Current Sessions
+              context: listener_current_sessions
+              units: sessions
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_listener_current_sessions
+                  name: current
+            - title: Listener Session Rate
+              context: listener_sessions
+              units: sessions/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_listener_sessions_total
+                  name: sessions
+        - family: Traffic
+          metrics:
+            - haproxy_listener_bytes_in_total
+            - haproxy_listener_bytes_out_total
+            - haproxy_listener_connections_total
+          charts:
+            - title: Listener Traffic
+              context: listener_traffic
+              units: bytes/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_listener_bytes_in_total
+                  name: received
+                - selector: haproxy_listener_bytes_out_total
+                  name: sent
+            - title: Listener Connections
+              context: listener_connections
+              units: connections/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_listener_connections_total
+                  name: connections
+        - family: Errors
+          metrics:
+            - haproxy_listener_request_errors_total
+            - haproxy_listener_requests_denied_total
+            - haproxy_listener_responses_denied_total
+            - haproxy_listener_denied_connections_total
+            - haproxy_listener_denied_sessions_total
+            - haproxy_listener_failed_header_rewriting_total
+            - haproxy_listener_internal_errors_total
+          charts:
+            - title: Listener Errors
+              context: listener_errors
+              units: errors/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_listener_request_errors_total
+                  name: request
+                - selector: haproxy_listener_failed_header_rewriting_total
+                  name: header_rewriting
+                - selector: haproxy_listener_internal_errors_total
+                  name: internal
+            - title: Listener Denied
+              context: listener_denied
+              units: events/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_listener_requests_denied_total
+                  name: requests
+                - selector: haproxy_listener_responses_denied_total
+                  name: responses
+                - selector: haproxy_listener_denied_connections_total
+                  name: connections
+                - selector: haproxy_listener_denied_sessions_total
+                  name: sessions
+
+    # ── Backends ───────────────────────────────────────────────────────────────
+    - family: Backends
+      chart_defaults:
+        instances:
+          by_labels:
+            - proxy
+      groups:
+        - family: Status
+          metrics:
+            - haproxy_backend_status
+            - haproxy_backend_agg_check_status
+            - haproxy_backend_agg_server_check_status
+          charts:
+            - title: Backend Status
+              context: backend_status
+              units: status
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_backend_status
+                  name_from_label: state
+            - title: Backend Aggregated Check Status
+              context: backend_agg_check_status
+              units: servers
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_backend_agg_check_status
+                  name_from_label: state
+            - title: Backend Aggregated Server Check Status
+              context: backend_agg_server_check_status
+              units: servers
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_backend_agg_server_check_status
+                  name_from_label: state
+        - family: Sessions
+          metrics:
+            - haproxy_backend_current_sessions
+            - haproxy_backend_sessions_total
+            - haproxy_backend_current_session_rate
+          charts:
+            - title: Backend Current Sessions
+              context: backend_current_sessions
+              units: sessions
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_backend_current_sessions
+                  name: current
+            - title: Backend Session Rate
+              context: backend_sessions
+              units: sessions/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_sessions_total
+                  name: sessions
+            - title: Backend Current Session Rate
+              context: backend_current_session_rate
+              units: sessions/s
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_backend_current_session_rate
+                  name: sessions
+        - family: Connections
+          metrics:
+            - haproxy_backend_connection_attempts_total
+            - haproxy_backend_connection_reuses_total
+            - haproxy_backend_client_aborts_total
+            - haproxy_backend_server_aborts_total
+          charts:
+            - title: Backend Connections
+              context: backend_connections
+              units: connections/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_connection_attempts_total
+                  name: attempts
+                - selector: haproxy_backend_connection_reuses_total
+                  name: reuses
+            - title: Backend Aborts
+              context: backend_aborts
+              units: aborts/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_client_aborts_total
+                  name: client
+                - selector: haproxy_backend_server_aborts_total
+                  name: server
+        - family: Traffic
+          metrics:
+            - haproxy_backend_bytes_in_total
+            - haproxy_backend_bytes_out_total
+            - haproxy_backend_req_bytes_in_total
+            - haproxy_backend_req_bytes_out_total
+            - haproxy_backend_res_bytes_in_total
+            - haproxy_backend_res_bytes_out_total
+          charts:
+            - title: Backend Traffic
+              context: backend_traffic
+              units: bytes/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_bytes_in_total
+                  name: received
+                - selector: haproxy_backend_bytes_out_total
+                  name: sent
+            - title: Backend Request Traffic
+              context: backend_req_traffic
+              units: bytes/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_req_bytes_in_total
+                  name: received
+                - selector: haproxy_backend_req_bytes_out_total
+                  name: sent
+            - title: Backend Response Traffic
+              context: backend_res_traffic
+              units: bytes/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_res_bytes_in_total
+                  name: received
+                - selector: haproxy_backend_res_bytes_out_total
+                  name: sent
+        - family: HTTP
+          metrics:
+            - haproxy_backend_http_requests_total
+            - haproxy_backend_http_cache_lookups_total
+            - haproxy_backend_http_cache_hits_total
+          charts:
+            - title: Backend HTTP Requests
+              context: backend_http_requests
+              units: requests/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_http_requests_total
+                  name: requests
+            - title: Backend HTTP Cache
+              context: backend_http_cache
+              units: lookups/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_http_cache_lookups_total
+                  name: lookups
+                - selector: haproxy_backend_http_cache_hits_total
+                  name: hits
+        - family: HTTP Responses
+          metrics:
+            - haproxy_backend_http_responses_total
+          charts:
+            - title: Backend HTTP Responses
+              context: backend_http_responses
+              units: responses/s
+              type: stacked
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_http_responses_total
+                  name_from_label: code
+        - family: Queue
+          metrics:
+            - haproxy_backend_current_queue
+          charts:
+            - title: Backend Queue
+              context: backend_queue
+              units: requests
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_backend_current_queue
+                  name: queued
+        - family: Timings
+          metrics:
+            - haproxy_backend_queue_time_average_seconds
+            - haproxy_backend_connect_time_average_seconds
+            - haproxy_backend_response_time_average_seconds
+            - haproxy_backend_total_time_average_seconds
+          charts:
+            - title: Backend Average Response Time
+              context: backend_response_time
+              units: seconds
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_backend_response_time_average_seconds
+                  name: response
+            - title: Backend Average Timings
+              context: backend_timings
+              units: seconds
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_backend_queue_time_average_seconds
+                  name: queue
+                - selector: haproxy_backend_connect_time_average_seconds
+                  name: connect
+                - selector: haproxy_backend_total_time_average_seconds
+                  name: total
+        - family: Health
+          metrics:
+            - haproxy_backend_active_servers
+            - haproxy_backend_backup_servers
+            - haproxy_backend_weight
+            - haproxy_backend_check_up_down_total
+            - haproxy_backend_downtime_seconds_total
+            - haproxy_backend_loadbalanced_total
+          charts:
+            - title: Backend Servers
+              context: backend_servers
+              units: servers
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_backend_active_servers
+                  name: active
+                - selector: haproxy_backend_backup_servers
+                  name: backup
+            - title: Backend Weight
+              context: backend_weight
+              units: weight
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_backend_weight
+                  name: weight
+            - title: Backend Check Transitions
+              context: backend_check_up_down
+              units: events/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_check_up_down_total
+                  name: up_down
+            - title: Backend Downtime
+              context: backend_downtime
+              units: seconds
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_downtime_seconds_total
+                  name: downtime
+            - title: Backend Load Balanced Requests
+              context: backend_loadbalanced
+              units: requests/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_loadbalanced_total
+                  name: requests
+        - family: Errors
+          metrics:
+            - haproxy_backend_response_errors_total
+            - haproxy_backend_connection_errors_total
+            - haproxy_backend_requests_denied_total
+            - haproxy_backend_responses_denied_total
+            - haproxy_backend_retry_warnings_total
+            - haproxy_backend_redispatch_warnings_total
+            - haproxy_backend_failed_header_rewriting_total
+            - haproxy_backend_internal_errors_total
+          charts:
+            - title: Backend Errors
+              context: backend_errors
+              units: errors/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_response_errors_total
+                  name: response
+                - selector: haproxy_backend_connection_errors_total
+                  name: connection
+                - selector: haproxy_backend_failed_header_rewriting_total
+                  name: header_rewriting
+                - selector: haproxy_backend_internal_errors_total
+                  name: internal
+            - title: Backend Warnings
+              context: backend_warnings
+              units: warnings/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_retry_warnings_total
+                  name: retry
+                - selector: haproxy_backend_redispatch_warnings_total
+                  name: redispatch
+            - title: Backend Denied
+              context: backend_denied
+              units: events/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_backend_requests_denied_total
+                  name: requests
+                - selector: haproxy_backend_responses_denied_total
+                  name: responses
+
+    # ── Servers ────────────────────────────────────────────────────────────────
+    - family: Servers
+      chart_defaults:
+        instances:
+          by_labels:
+            - proxy
+            - server
+      groups:
+        - family: Status
+          metrics:
+            - haproxy_server_status
+            - haproxy_server_check_status
+            - haproxy_server_agent_status
+          charts:
+            - title: Server Status
+              context: server_status
+              units: status
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_server_status
+                  name_from_label: state
+            - title: Server Check Status
+              context: server_check_status
+              units: status
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_server_check_status
+                  name_from_label: state
+            - title: Server Agent Status
+              context: server_agent_status
+              units: status
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_server_agent_status
+                  name_from_label: state
+        - family: Sessions
+          metrics:
+            - haproxy_server_current_sessions
+            - haproxy_server_sessions_total
+            - haproxy_server_current_session_rate
+          charts:
+            - title: Server Current Sessions
+              context: server_current_sessions
+              units: sessions
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_server_current_sessions
+                  name: current
+            - title: Server Session Rate
+              context: server_sessions
+              units: sessions/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_server_sessions_total
+                  name: sessions
+            - title: Server Current Session Rate
+              context: server_current_session_rate
+              units: sessions/s
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_server_current_session_rate
+                  name: sessions
+        - family: Connections
+          metrics:
+            - haproxy_server_connection_attempts_total
+            - haproxy_server_connection_reuses_total
+            - haproxy_server_client_aborts_total
+            - haproxy_server_server_aborts_total
+            - haproxy_server_idle_connections_current
+          charts:
+            - title: Server Connections
+              context: server_connections
+              units: connections/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_server_connection_attempts_total
+                  name: attempts
+                - selector: haproxy_server_connection_reuses_total
+                  name: reuses
+            - title: Server Aborts
+              context: server_aborts
+              units: aborts/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_server_client_aborts_total
+                  name: client
+                - selector: haproxy_server_server_aborts_total
+                  name: server
+            - title: Server Idle Connections
+              context: server_idle_connections
+              units: connections
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_server_idle_connections_current
+                  name: idle
+        - family: Traffic
+          metrics:
+            - haproxy_server_bytes_in_total
+            - haproxy_server_bytes_out_total
+            - haproxy_server_req_bytes_in_total
+            - haproxy_server_req_bytes_out_total
+            - haproxy_server_res_bytes_in_total
+            - haproxy_server_res_bytes_out_total
+          charts:
+            - title: Server Traffic
+              context: server_traffic
+              units: bytes/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_server_bytes_in_total
+                  name: received
+                - selector: haproxy_server_bytes_out_total
+                  name: sent
+            - title: Server Request Traffic
+              context: server_req_traffic
+              units: bytes/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_server_req_bytes_in_total
+                  name: received
+                - selector: haproxy_server_req_bytes_out_total
+                  name: sent
+            - title: Server Response Traffic
+              context: server_res_traffic
+              units: bytes/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_server_res_bytes_in_total
+                  name: received
+                - selector: haproxy_server_res_bytes_out_total
+                  name: sent
+        - family: Queue
+          metrics:
+            - haproxy_server_current_queue
+          charts:
+            - title: Server Queue
+              context: server_queue
+              units: requests
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_server_current_queue
+                  name: queued
+        - family: Timings
+          metrics:
+            - haproxy_server_queue_time_average_seconds
+            - haproxy_server_connect_time_average_seconds
+            - haproxy_server_response_time_average_seconds
+            - haproxy_server_total_time_average_seconds
+          charts:
+            - title: Server Average Response Time
+              context: server_response_time
+              units: seconds
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_server_response_time_average_seconds
+                  name: response
+            - title: Server Average Timings
+              context: server_timings
+              units: seconds
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_server_queue_time_average_seconds
+                  name: queue
+                - selector: haproxy_server_connect_time_average_seconds
+                  name: connect
+                - selector: haproxy_server_total_time_average_seconds
+                  name: total
+        - family: Health
+          metrics:
+            - haproxy_server_weight
+            - haproxy_server_check_failures_total
+            - haproxy_server_check_up_down_total
+            - haproxy_server_downtime_seconds_total
+            - haproxy_server_check_duration_seconds
+            - haproxy_server_agent_duration_seconds
+            - haproxy_server_loadbalanced_total
+          charts:
+            - title: Server Weight
+              context: server_weight
+              units: weight
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_server_weight
+                  name: weight
+            - title: Server Check Failures
+              context: server_check_failures
+              units: failures/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_server_check_failures_total
+                  name: failures
+            - title: Server Check Transitions
+              context: server_check_up_down
+              units: events/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_server_check_up_down_total
+                  name: up_down
+            - title: Server Downtime
+              context: server_downtime
+              units: seconds
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_server_downtime_seconds_total
+                  name: downtime
+            - title: Server Check Duration
+              context: server_check_duration
+              units: seconds
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_server_check_duration_seconds
+                  name: check
+                - selector: haproxy_server_agent_duration_seconds
+                  name: agent
+            - title: Server Load Balanced Requests
+              context: server_loadbalanced
+              units: requests/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_server_loadbalanced_total
+                  name: requests
+        - family: Errors
+          metrics:
+            - haproxy_server_response_errors_total
+            - haproxy_server_connection_errors_total
+            - haproxy_server_responses_denied_total
+            - haproxy_server_retry_warnings_total
+            - haproxy_server_redispatch_warnings_total
+            - haproxy_server_failed_header_rewriting_total
+            - haproxy_server_internal_errors_total
+          charts:
+            - title: Server Errors
+              context: server_errors
+              units: errors/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_server_response_errors_total
+                  name: response
+                - selector: haproxy_server_connection_errors_total
+                  name: connection
+                - selector: haproxy_server_failed_header_rewriting_total
+                  name: header_rewriting
+                - selector: haproxy_server_internal_errors_total
+                  name: internal
+            - title: Server Warnings
+              context: server_warnings
+              units: warnings/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_server_retry_warnings_total
+                  name: retry
+                - selector: haproxy_server_redispatch_warnings_total
+                  name: redispatch
+            - title: Server Denied
+              context: server_denied
+              units: events/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_server_responses_denied_total
+                  name: responses
+
+    # ── Resolvers ────────────────────────────────────────────────────────────────
+    # All resolver families are gauges in source (algorithm: absolute) though semantically
+    # cumulative; type taken from inventory.
+    - family: Resolvers
+      chart_defaults:
+        instances:
+          by_labels:
+            - resolver
+            - nameserver
+      groups:
+        - family: DNS
+          metrics:
+            - haproxy_resolver_sent
+            - haproxy_resolver_valid
+            - haproxy_resolver_update
+            - haproxy_resolver_cname
+            - haproxy_resolver_nx
+            - haproxy_resolver_other
+            - haproxy_resolver_truncated
+            - haproxy_resolver_outdated
+            - haproxy_resolver_send_error
+            - haproxy_resolver_cname_error
+            - haproxy_resolver_any_err
+            - haproxy_resolver_timeout
+            - haproxy_resolver_refused
+            - haproxy_resolver_invalid
+            - haproxy_resolver_too_big
+          charts:
+            - title: Resolver Events
+              context: resolver_events
+              units: events
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_resolver_sent
+                  name: sent
+                - selector: haproxy_resolver_valid
+                  name: valid
+                - selector: haproxy_resolver_update
+                  name: update
+                - selector: haproxy_resolver_cname
+                  name: cname
+                - selector: haproxy_resolver_nx
+                  name: nx
+                - selector: haproxy_resolver_other
+                  name: other
+                - selector: haproxy_resolver_truncated
+                  name: truncated
+                - selector: haproxy_resolver_outdated
+                  name: outdated
+            - title: Resolver Errors
+              context: resolver_errors
+              units: errors
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_resolver_send_error
+                  name: send
+                - selector: haproxy_resolver_cname_error
+                  name: cname
+                - selector: haproxy_resolver_any_err
+                  name: any
+                - selector: haproxy_resolver_timeout
+                  name: timeout
+                - selector: haproxy_resolver_refused
+                  name: refused
+                - selector: haproxy_resolver_invalid
+                  name: invalid
+                - selector: haproxy_resolver_too_big
+                  name: too_big
+
+    # ── Stick Tables ─────────────────────────────────────────────────────────────
+    # local_updates is cumulative but exposed as a gauge by source (algorithm: absolute).
+    - family: Stick Tables
+      chart_defaults:
+        instances:
+          by_labels:
+            - name
+            - type
+      groups:
+        - family: Entries
+          metrics:
+            - haproxy_sticktable_size
+            - haproxy_sticktable_used
+            - haproxy_sticktable_local_updates
+          charts:
+            - title: Stick Table Entries
+              context: sticktable_entries
+              units: entries
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_sticktable_used
+                  name: used
+                - selector: haproxy_sticktable_size
+                  name: size
+            - title: Stick Table Local Updates
+              context: sticktable_local_updates
+              units: updates
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_sticktable_local_updates
+                  name: local_updates


### PR DESCRIPTION
Fixes: #22637

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds curated chart profiles to the `prometheus` collector via the new `promprofiles` catalog. Profiles are selected at Check from scraped metric names and merged into the per-app autogen template; a default HAProxy profile is included and installed.

- **New Features**
  - `promprofiles` catalog (user + stock dirs) with a process-wide default; profiles are filename-identified and include `match` + `charttpl` group.
  - `profiles` config with modes none|auto|exact|combined (default auto), entry validation, and schema/UI updates; `metadata.yaml` clarifies `app` and `expected_prefix`.
  - Profile selection at Check; matched groups merge into autogen (autogen remains fallback). HAProxy PromEx profile installed to `usr/lib/netdata/conf.d/go.d/prometheus.profiles/default`.

- **Refactors**
  - Moved `Config` and `RelabelBlock` to `config.go` (no behavior change).
  - Chart template now built at Check via runtime state (`ensureChartTemplate`); minor template and test updates.

<sup>Written for commit a5d983b778e0287a99d5bf7534d7a18eb14da5fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

