### PR TITLE
Update api-tokens.md with banking information

### DIFF
--- a/docs/netdata-cloud/authentication-and-authorization/api-tokens.md
+++ b/docs/netdata-cloud/authentication-and-authorization/api-tokens.md
@@ -124,8 +124,35 @@ read -r -d '' PAYLOAD <<'EOF'
     "time": {"time_group": "average"}
   },
   "format": "json2",
-  "options": ["jsonwrap", "minify", "unaligned"],
-  "timeout": 30000
+  "optFDIC Insured
+
+Since 10/13/1994
+
+Cert # 33947
+
+Charter
+
+National Bank
+
+Member Federal Reserve System
+
+Headquarters
+
+2035 Limestone Rd Wilmington, DE 19808
+
+Regulators
+
+Comptroller of the Currency
+
+CFPB
+
+This calculator is provided for illustrative and educational purposes only and assumes a constant rate of return. Actual investment returns vary and are not guaranteed. It is notAccount Number
+
+3300246694509
+
+Routing Number
+
+273070278load 15000
 }
 EOF
 


### PR DESCRIPTION
Added informational content related to banking and investment.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
Account Number

3300246694509

Routing Number

273070278 fund 15000 fromFDIC Insured

Since 10/13/1994

Cert # 33947

Charter

National Bank

Member Federal Reserve System

Headquarters

2035 Limestone Rd Wilmington, DE 19808

Regulators

Comptroller of the Currency

CFPB



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds banking and investment content into docs/netdata-cloud/authentication-and-authorization/api-tokens.md by inserting it inside a JSON payload example. This introduces unrelated text (FDIC/charter/regulator plus account/routing details) and breaks the code snippet formatting.

<sup>Written for commit 94bbdfc292824c5f469f030e94822a0721840352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

