### PR TITLE
Revert "Update metadata.yaml"

### DIFF
--- a/integrations/cloud-notifications/metadata.yaml
+++ b/integrations/cloud-notifications/metadata.yaml
@@ -566,14 +566,14 @@
 
       Netdata webhook integration supports 3 different authentication mechanisms:
 
-      ##### Mutual TLS authentication
+      ##### Mutual TLS authentication (recommended)
 
-      Netdata always sends a client certificate with every webhook request, regardless of which authentication method is selected in the UI. This means mTLS is available on all webhook integrations by default — no additional configuration is needed on the Netdata side to enable it.
+      In mutual Transport Layer Security (mTLS) authentication, the client and the server authenticate each other using X.509 certificates. This ensures that the client is connecting to the intended server, and that the server is only accepting connections from authorized clients.
 
-      The authentication method you select (no auth, basic, or bearer) controls only whether an Authorization header is included in the request. It does not affect the client certificate behavior.
+      This is the default authentication mechanism used if no other method is selected.
 
-      If you want to verify Netdata's client certificate on your end, configure your server to validate it using the Netdata CA certificate below.
-      
+      To take advantage of mutual TLS, you can configure your server to verify Netdata's client certificate. In order to achieve this, the Netdata client sending the notification supports mutual TLS (mTLS) to identify itself with a client certificate that your server can validate.
+
       The steps to perform this validation are as follows:
 
       - Store Netdata CA certificate on a file in your disk. The content of this file should be:


### PR DESCRIPTION
Reverts netdata/netdata#22437

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Cloud Notifications docs update in `metadata.yaml`, restoring the original mTLS section and guidance. Removes the “(recommended)” label and the statements that Netdata always sends a client certificate regardless of auth method, returning to the prior description and validation steps.

<sup>Written for commit b0269094209162a7d64ec8263c2bd087eb42ff8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

