### PR TITLE
simple_pattern: fix inverted empty-buffer guard in matches_buffer_extract

### DIFF
--- a/src/libnetdata/simple_pattern/simple_pattern.c
+++ b/src/libnetdata/simple_pattern/simple_pattern.c
@@ -300,7 +300,7 @@ static SIMPLE_PATTERN_RESULT simple_pattern_matches_extract_with_length(SIMPLE_P
 }
 
 SIMPLE_PATTERN_RESULT simple_pattern_matches_buffer_extract(SIMPLE_PATTERN *list, BUFFER *str, char *wildcarded, size_t wildcarded_size) {
-    if(!list || !str || buffer_strlen(str)) return SP_NOT_MATCHED;
+    if(!list || !str || !buffer_strlen(str)) return SP_NOT_MATCHED;
     return simple_pattern_matches_extract_with_length(list, buffer_tostring(str), buffer_strlen(str), wildcarded, wildcarded_size);
 }
 


### PR DESCRIPTION
## Summary

One-line fix for an inverted guard in `simple_pattern_matches_buffer_extract()` (`src/libnetdata/simple_pattern/simple_pattern.c`).

## The bug

```c
SIMPLE_PATTERN_RESULT simple_pattern_matches_buffer_extract(SIMPLE_PATTERN *list, BUFFER *str, char *wildcarded, size_t wildcarded_size) {
    if(!list || !str || buffer_strlen(str)) return SP_NOT_MATCHED;   // <-- inverted
    return simple_pattern_matches_extract_with_length(list, buffer_tostring(str), buffer_strlen(str), wildcarded, wildcarded_size);
}
```

`buffer_strlen(str)` is used directly as the reject condition, so the function:

- returns `SP_NOT_MATCHED` for every **non-empty** buffer (the normal case), *before* any matching runs;
- only proceeds when the buffer is **empty**, where a zero-length string matches nothing meaningful.

Net effect: the function can never return a genuine match.

The intended guard rejects the **empty** buffer, consistent with the sibling functions in the same file:

- `simple_pattern_matches_extract` → `if(!list || !str || !*str)`
- `simple_pattern_matches_length_extract` → `if(!list || !str || !*str || !len)`

The fix adds the missing negation:

```c
    if(!list || !str || !buffer_strlen(str)) return SP_NOT_MATCHED;
```

## Impact

Single reachable caller: `query_target_match_alert_pattern()` (`src/database/contexts/query_target.c:695`), driven by the `alerts=` query parameter on `/api/v2/data` and `/api/v2/weights` (and v3 equivalents).

Per the API docs (`netdata-swagger.yaml`), the `alerts` pattern matches against both the alert `name` and the `name:status` combination (`CLEAR`, `WARNING`, `CRITICAL`, `REMOVED`, `UNDEFINED`, `UNINITIALIZED`). The `name:status` form runs through this function, so it was silently dead — never matching, never excluding — while plain-`name` matching (a separate call) worked.

Restoring the guard re-enables the documented status-based filtering, including negative patterns (`!name:status`).

## Blast radius

- The convenience macro `simple_pattern_matches_buffer` (simple_pattern.h) wraps the same function but has no callers.
- Behavior change is limited to the `alerts=` status-form filtering on the data/weights endpoints; plain-name filtering is unaffected.
- Callers passing `name:status` patterns today receive empty/under-filtered results; after this fix they receive the documented result set.

## Notes

- Draft: no test added yet. The function had no unit coverage, which is why the inverted guard went unnoticed. A targeted unit test for `simple_pattern_matches_buffer_extract` is a reasonable follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix inverted empty-buffer guard in `simple_pattern_matches_buffer_extract()` so non-empty buffers are actually matched. Restores `alerts=` name:status filtering in `/api/v2/data` and `/api/v2/weights` (and v3).

- **Bug Fixes**
  - Changed guard to `!buffer_strlen(str)` to reject empty buffers.
  - Re-enables documented status-based filtering (including negative patterns); plain name filtering is unchanged.

<sup>Written for commit 7a3bc89dad6add8b6af26ec600f9bd223abd5fa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

