### PR TITLE
Fix SNMP trap counter chart algorithms

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -74,8 +74,15 @@ source files for evidence.
   one-active-state values.
 - Metric names MUST be stable and selected by `charts.yaml`.
 - In `charts.yaml`: use `version: v1`, `context_namespace`, `instances.by_labels`,
-  `label_promotion`, `algorithm: incremental` for counters, and `absolute` for
-  gauges.
+  `label_promotion`, and an explicit `algorithm` on every chart:
+  `incremental` for counters and `absolute` for gauges.
+- `Counter.ObserveTotal()` only records monotonic values in `metrix`; it does
+  NOT set the chart `DIMENSION` algorithm by itself. Every chart that presents
+  a counter as a rate MUST explicitly set `algorithm: incremental`, including
+  dynamically built `charttpl.Chart` values.
+- Do NOT rely on chartengine's metric-name suffix inference for generated
+  Netdata metrics. Suffix inference is only a fallback and MUST NOT be used as
+  the correctness mechanism for V2 collector charts.
 - Put multipliers, divisors, hidden flags, and float formatting in the chart
   template, not ad hoc chart-emission code.
 - `metrix` registers a descriptor per metric NAME permanently (no unregister), so

--- a/src/go/plugin/go.d/collector/snmp_traps/charts.yaml
+++ b/src/go/plugin/go.d/collector/snmp_traps/charts.yaml
@@ -41,6 +41,7 @@ groups:
         title: SNMP trap events
         context: events
         units: events/s
+        algorithm: incremental
         type: stacked
         instances:
           by_labels: [job_name]
@@ -65,6 +66,7 @@ groups:
         title: SNMP trap events by severity
         context: severity
         units: events/s
+        algorithm: incremental
         type: stacked
         instances:
           by_labels: [job_name]
@@ -89,6 +91,7 @@ groups:
         title: SNMP trap processing errors
         context: errors
         units: errors/s
+        algorithm: incremental
         type: stacked
         instances:
           by_labels: [job_name]
@@ -127,6 +130,7 @@ groups:
         title: SNMP trap dedup suppressed events
         context: dedup_suppressed
         units: events/s
+        algorithm: incremental
         type: line
         instances:
           by_labels: [job_name]

--- a/src/go/plugin/go.d/collector/snmp_traps/init_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/init_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
 	"github.com/stretchr/testify/assert"
@@ -21,10 +22,58 @@ func TestCollectorChartTemplateYAML(t *testing.T) {
 	collecttest.AssertChartTemplateSchema(t, New().ChartTemplateYAML())
 }
 
+func TestCollectorChartTemplateYAMLChartsDeclareAlgorithms(t *testing.T) {
+	charts := chartTemplatesByIDFromYAML(t, New().ChartTemplateYAML())
+	assertAllChartTemplatesDeclareAlgorithm(t, charts)
+
+	for _, id := range []string{
+		"events",
+		"severity",
+		"errors",
+		"dedup_suppressed",
+	} {
+		chart, ok := charts[id]
+		require.Truef(t, ok, "missing chart %q", id)
+		assert.Equalf(t, "incremental", chart.Algorithm, "chart %q algorithm", id)
+	}
+}
+
 func TestCollectorRegistrationAvailableByDefault(t *testing.T) {
 	creator, ok := collectorapi.DefaultRegistry.Lookup("snmp_traps")
 	require.True(t, ok)
 	assert.False(t, creator.Defaults.Disabled)
+}
+
+func chartTemplatesByIDFromYAML(t *testing.T, raw string) map[string]charttpl.Chart {
+	t.Helper()
+
+	spec, err := charttpl.DecodeYAML([]byte(raw))
+	require.NoError(t, err)
+
+	charts := make(map[string]charttpl.Chart)
+	collectChartTemplatesByID(t, charts, spec.Groups)
+	return charts
+}
+
+func assertAllChartTemplatesDeclareAlgorithm(t *testing.T, charts map[string]charttpl.Chart) {
+	t.Helper()
+
+	for id, chart := range charts {
+		assert.NotEmptyf(t, chart.Algorithm, "chart %q must not rely on algorithm inference", id)
+	}
+}
+
+func collectChartTemplatesByID(t *testing.T, charts map[string]charttpl.Chart, groups []charttpl.Group) {
+	t.Helper()
+
+	for _, group := range groups {
+		for _, chart := range group.Charts {
+			require.NotEmpty(t, chart.ID)
+			require.NotContainsf(t, charts, chart.ID, "duplicate chart id %q", chart.ID)
+			charts[chart.ID] = chart
+		}
+		collectChartTemplatesByID(t, charts, group.Groups)
+	}
 }
 
 func TestConfigSchemaDynCfgListFieldsHaveSafeDefaults(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_traps/operator_metric.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/operator_metric.go
@@ -410,11 +410,12 @@ func buildOperatorMetricChartTemplate(metrics []MetricConfig) (charttplMetrics [
 
 		suffix := metricContextSuffix(m.Context)
 		chart := charttpl.Chart{
-			ID:      metricChartID(m.Context),
-			Title:   fmt.Sprintf("SNMP trap metric: %s", suffix),
-			Context: suffix,
-			Units:   "events/s",
-			Type:    "line",
+			ID:        metricChartID(m.Context),
+			Title:     fmt.Sprintf("SNMP trap metric: %s", suffix),
+			Context:   suffix,
+			Units:     "events/s",
+			Algorithm: "incremental",
+			Type:      "line",
 			Instances: &charttpl.Instances{
 				ByLabels: []string{"job_name"},
 			},

--- a/src/go/plugin/go.d/collector/snmp_traps/operator_metric_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/operator_metric_test.go
@@ -400,6 +400,30 @@ func TestBuildChartTemplateYAMLMultipleMetrics(t *testing.T) {
 	collecttest.AssertChartTemplateSchema(t, yaml)
 }
 
+func TestBuildChartTemplateYAMLOperatorMetricChartsDeclareIncremental(t *testing.T) {
+	cfg := []MetricConfig{
+		{OID: "1.3.6.1.4.1.9.9.43.2.0.1", Context: "snmp.trap.cisco_config"},
+		{OID: "1.3.6.1.4.1.9.9.43.2.0.1", Context: "snmp.trap.cisco_config.terminal_type", DimensionFromVarbind: "ccmHistoryEventTerminalType"},
+	}
+	yaml, err := buildChartTemplateYAML(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	charts := chartTemplatesByIDFromYAML(t, yaml)
+	assertAllChartTemplatesDeclareAlgorithm(t, charts)
+
+	for _, m := range cfg {
+		id := metricChartID(m.Context)
+		chart, ok := charts[id]
+		if !ok {
+			t.Fatalf("missing operator metric chart %q", id)
+		}
+		if chart.Algorithm != "incremental" {
+			t.Fatalf("operator metric chart %q algorithm = %q, want incremental", id, chart.Algorithm)
+		}
+	}
+}
+
 func TestOperatorMetricsIncSingleDimension(t *testing.T) {
 	cfg := []MetricConfig{
 		{OID: "1.3.6.1.4.1.9.9.43.2.0.1", Context: "snmp.trap.cisco_config"},


### PR DESCRIPTION
## Summary

Fixes SNMP trap counter charts so Netdata receives monotonic trap totals as incremental dimensions instead of relying on chartengine metric-name suffix inference.

Changes:
- set `algorithm: incremental` on all static SNMP trap counter charts
- set `Algorithm: "incremental"` on operator-created per-OID trap metric charts
- add tests that fail if any SNMP trap chart omits an explicit algorithm
- update V2 collector authoring guidance to require explicit chart algorithms

## Root cause

SNMP traps writes monotonic counters with `Counter(...).ObserveTotal(...)`, but the chart templates did not declare an explicit algorithm. The chartengine fallback infers algorithms from metric-name suffixes, and SNMP trap metric names do not end in `_total`, `_count`, `_sum`, or `_bucket`, so the charts were treated as `absolute`.

## Validation

- `cd src/go && go test ./plugin/go.d/collector/snmp_traps/...`
- `python3 integrations/gen_taxonomy.py --check-only`
- `git diff --cached --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SNMP trap counter charts by explicitly setting the incremental algorithm so monotonic trap totals show as rates. This removes reliance on suffix inference and restores correct events/s reporting.

- **Bug Fixes**
  - Set `algorithm: incremental` on static charts: `events`, `severity`, `errors`, `dedup_suppressed`.
  - Set `Algorithm: "incremental"` on operator-created per-OID metric charts.
  - Added tests to require an explicit algorithm on all SNMP trap charts and verify operator metrics are incremental.
  - Updated V2 collector guidance to mandate explicit chart algorithms and avoid suffix-based inference.

<sup>Written for commit a8405b7f63d588dcc7a1bf7cccb925e195d790b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

