### PR TITLE
feat(go.d/prometheus): add profile-driven app detection for chart contexts

### DIFF
--- a/.agents/sow/specs/README.md
+++ b/.agents/sow/specs/README.md
@@ -11,6 +11,7 @@ this index in the same change that adds, renames, or removes a spec.
 | Spec | Scope | Main consumers |
 |---|---|---|
 | [go-v2-host-scope.md](go-v2-host-scope.md) | Go framework V2 host-scope and vnode metric routing contract. | Go V2 collector work, `metrix`, `jobruntime`, `chartengine`, go.d collector docs and skills. |
+| [prometheus-profiles.md](prometheus-profiles.md) | go.d prometheus chart-profile format, selection modes, app-segment resolution, and chart-context assembly. | prometheus collector profile work, chart-context/UI app-section contract, profile authoring. |
 | [query-planner-tier-selection.md](query-planner-tier-selection.md) | Automatic storage-tier selection for metric query planning. | Query planner code, API data paths, MCP metric query behavior. |
 | [sensitive-data-discipline.md](sensitive-data-discipline.md) | Sensitive-data rules for committed artifacts, scripts, skills, specs, SOWs, commit messages, and PR text. | All repository work, SOW audits, private/public skills, token-safe scripts. |
 | [snmp-profile-projection.md](snmp-profile-projection.md) | SNMP profile projection contract across metrics, topology, licensing, and BGP consumers. | SNMP profile authoring, ddsnmp loader/projection code, SNMP project skill. |

--- a/.agents/sow/specs/prometheus-profiles.md
+++ b/.agents/sow/specs/prometheus-profiles.md
@@ -1,0 +1,101 @@
+# Prometheus Chart Profiles And App Resolution
+
+## Scope
+
+This spec records the contract for the go.d `prometheus` collector's chart
+profiles: the profile file format, how profiles are selected for a scraped
+target, how a job's `<app>` context segment is resolved, and how a chart context
+is assembled. It applies to `plugin/go.d/collector/prometheus` (runtime,
+`chart_template`, `promprofiles`) and the stock profiles under
+`config/go.d/prometheus.profiles/`.
+
+## Chart Context Contract
+
+- A prometheus chart context is `prometheus.<app>.<context_namespace>.<context>`.
+  The framework skips empty segments, so an absent `<app>` or
+  `<context_namespace>` collapses out.
+- `<app>` is the per-job deployment/instance identity (the "where" axis). The
+  Netdata UI parses this second segment and renders it as a section under the
+  "Applications" menu, so distinct apps do not collapse into one section. This is
+  an external UI contract; the segment value MUST remain a stable identity.
+- `<context_namespace>` is the exporter-type axis (the "what" axis), e.g.
+  `haproxy`. It is orthogonal to `<app>`.
+- `<context>` is the leaf chart context (curated chart context, or, for autogen,
+  the full scraped metric name).
+- Menu hierarchy beneath `<app>` is driven by chart `family`, not by
+  `<context_namespace>`.
+
+## Profile File Format
+
+- A profile is a YAML file under a profiles directory. Its identity (`Name`) is
+  the file basename; the file carries no name field.
+- Fields:
+  - `match` (REQUIRED): a `pkg/matcher` simple-patterns expression matched
+    against scraped metric family base names (the `# TYPE` names).
+  - `app` (OPTIONAL): the application identity contributed to `<app>` resolution
+    (see below). MUST match `^[a-z][a-z0-9_]*$` when set.
+  - `template` (REQUIRED): a standard `charttpl.Group`, validated like any chart
+    template (including its author-written `metrics:` visibility list).
+- The file basename MUST also match `^[a-z][a-z0-9_]*$`.
+- Exporter profiles (e.g. `haproxy`) SHOULD declare both `app:` and a root
+  `context_namespace`. Shared/runtime profiles (e.g. `go_*`, `http_*`,
+  `process_*`) SHOULD omit `app:` so they render under the job's resolved app.
+
+## Catalog
+
+- Stock profiles live under `config/go.d/prometheus.profiles/default/`. Operator
+  profiles extend the stock set; they do not overwrite stock files.
+- Profiles are loaded from the configured directories into a catalog keyed by
+  profile name (case-insensitive selection).
+
+## Profile Selection
+
+Selection is driven by `profiles.mode`:
+
+- `auto`: keep every profile whose `match` hits at least one scraped family.
+- `exact`: resolve the explicitly named profiles only. A named profile that is
+  unknown, or that matches no scraped family, fails `Check`.
+- `combined`: union of `auto` and the named profiles, de-duplicated.
+- `none`: select nothing; the job renders with pure autogen.
+
+Unselected families always fall through to the autogen base, so a profile never
+suppresses metrics it does not chart.
+
+## App Resolution
+
+`<app>` for a job is resolved in this precedence:
+
+1. the job's `app` config option (`Application`), when non-empty;
+2. otherwise, the first selected profile (in selection order) that declares a
+   non-empty `app:`;
+3. otherwise, the job name.
+
+- When two or more selected profiles declare different non-empty apps, the first
+  wins and each differing one is logged once (operator hint to set the job
+  `app`). The conflict check is skipped when the job `app` config already
+  decides the result.
+- The job `app` config and job name are used verbatim; only the profile `app:`
+  field is format-validated.
+
+## Context Assembly And Namespace Deduplication
+
+- The autogen base spec sets its context namespace to `prometheus` (no app) or
+  `prometheus.<app>` (resolved app non-empty). Autogen emits one chart per
+  scraped metric at `prometheus[.<app>].<metric>`.
+- Selected profile groups are appended to that base. A profile group's root
+  `context_namespace` becomes the `<context_namespace>` sub-segment, yielding
+  `prometheus.<app>.<context_namespace>.<context>`.
+- When the resolved app EQUALS a profile group's root `context_namespace` (the
+  common case where the app fell back to that profile's own `app:`), the merge
+  clears the group's `context_namespace` on a local copy so the context stays
+  `prometheus.<app>.<context>` and does not double to
+  `prometheus.<app>.<app>.<context>`. The shared catalog profile MUST NOT be
+  mutated.
+
+## Consistency
+
+- The job `app` config option is documented in `config_schema.json` and
+  `metadata.yaml`; its description MUST reflect the resolution precedence above.
+- Profile-mode chart contexts differ from `none`-mode autogen contexts only by
+  the `<app>`/`<context_namespace>` segments; the leaf identity and dimensions
+  are unchanged.

--- a/.agents/sow/specs/prometheus-profiles.md
+++ b/.agents/sow/specs/prometheus-profiles.md
@@ -43,10 +43,8 @@ is assembled. It applies to `plugin/go.d/collector/prometheus` (runtime,
 
 ## Catalog
 
-- Stock profiles live under `config/go.d/prometheus.profiles/default/`. Operator
-  profiles extend the stock set; they do not overwrite stock files.
-- Profiles are loaded from the configured directories into a catalog keyed by
-  profile name (case-insensitive selection).
+- Stock profiles live under `config/go.d/prometheus.profiles/default/`. Operator profiles extend the stock set and can override a stock profile by providing a user profile with the same basename (user profile wins).
+- Profiles are loaded from the configured directories into a catalog keyed by profile name (case-insensitive selection).
 
 ## Profile Selection
 

--- a/src/go/plugin/go.d/collector/prometheus/chart_meta.go
+++ b/src/go/plugin/go.d/collector/prometheus/chart_meta.go
@@ -15,16 +15,6 @@ const (
 	prioGORuntime = prioDefault + 10
 )
 
-// application is the "app" segment of a chart context: the configured Application, else
-// the job Name. It selects the per-job chart-template namespace ("prometheus" when empty,
-// else "prometheus.<app>").
-func (c *Collector) application() string {
-	if c.Application != "" {
-		return c.Application
-	}
-	return c.Name
-}
-
 // getChartTitle derives a chart title (description) from the metric HELP, falling back to
 // the metric name when HELP is absent. It is fed into the metrix instrument meta so
 // chartengine autogen reproduces the V1 chart title.

--- a/src/go/plugin/go.d/collector/prometheus/chart_template.go
+++ b/src/go/plugin/go.d/collector/prometheus/chart_template.go
@@ -52,7 +52,18 @@ func buildChartTemplate(app string) (string, error) {
 func buildMergedChartTemplate(app string, profiles []promprofiles.Profile) (string, error) {
 	spec := newAutogenSpec(app)
 	for _, p := range profiles {
-		spec.Groups = append(spec.Groups, p.Template)
+		g := p.Template
+		// The profile's root context_namespace is the exporter-type segment
+		// (prometheus.<app>.<ns>.<context>). When the resolved app equals that namespace —
+		// e.g. app fell back to the profile's own app: because the job has no app set
+		// (by the user or service discovery) — drop the redundant segment so the
+		// context is prometheus.<app>.<context>, not prometheus.<app>.<app>.<context>. We
+		// overwrite only the scalar ContextNamespace on this local copy (g), so the shared
+		// catalog profile — including its slice fields — is not mutated.
+		if g.ContextNamespace == app {
+			g.ContextNamespace = ""
+		}
+		spec.Groups = append(spec.Groups, g)
 	}
 	return marshalChartSpec(spec)
 }

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -652,9 +653,23 @@ haproxy_backend_response_time_average_seconds{proxy="app"} 0.05
 		"prometheus.haproxy.backend_response_time":     {"response"},
 	}
 
+	// curatedUnder reprefixes the curated contexts with an explicit <app> segment: it models
+	// a job whose app is set (by config, or automatically by service discovery in k8s) to
+	// something other than the profile's own app:. The resolved app becomes the <app> segment
+	// and the profile's context_namespace (haproxy) is KEPT as the exporter-type sub-segment
+	// (prometheus.<app>.haproxy.<context>) — the dedup's keep branch.
+	curatedUnder := func(app string) map[string][]string {
+		out := make(map[string][]string, len(curated))
+		for ctx, dims := range curated {
+			out[strings.Replace(ctx, "prometheus.", "prometheus."+app+".", 1)] = dims
+		}
+		return out
+	}
+
 	tests := map[string]struct {
-		profiles ProfilesConfig
-		want     map[string][]string
+		configApp string
+		profiles  ProfilesConfig
+		want      map[string][]string
 	}{
 		"auto mode selects haproxy": {
 			profiles: ProfilesConfig{Mode: "auto"},
@@ -667,6 +682,11 @@ haproxy_backend_response_time_average_seconds{proxy="app"} 0.05
 		"combined mode selects haproxy": {
 			profiles: ProfilesConfig{Mode: "combined", ModeCombined: &ProfilesModeConfig{Entries: []ProfileEntryConfig{{Name: "haproxy"}}}},
 			want:     curated,
+		},
+		"a configured app keeps the profile namespace as a sub-segment": {
+			configApp: "myproxy",
+			profiles:  ProfilesConfig{Mode: "auto"},
+			want:      curatedUnder("myproxy"),
 		},
 		"none mode falls back to autogen": {
 			profiles: ProfilesConfig{Mode: "none"},
@@ -684,6 +704,7 @@ haproxy_backend_response_time_average_seconds{proxy="app"} 0.05
 
 			collr := New()
 			collr.URL = srv.URL
+			collr.Application = tc.configApp
 			collr.Profiles = tc.profiles
 			require.NoError(t, collr.Init(context.Background()))
 			require.NoError(t, collr.Check(context.Background()))
@@ -749,6 +770,15 @@ func TestCollector_HAProxyProfileAllMetrics(t *testing.T) {
 		seenChartIDs[create.ChartID] = create.Meta.Context
 	}
 	assert.NotEmpty(t, seenChartIDs, "the merged template must materialize charts")
+
+	// Every materialized context — curated and autogen-fallback alike — must carry the
+	// resolved app segment from the profile's app: (prometheus.haproxy.<leaf>). The trailing
+	// dot is load-bearing: if app: were ignored, autogen would emit prometheus.haproxy_<metric>
+	// (the metric name, no app segment), which this prefix check rejects.
+	for chartID, ctx := range seenChartIDs {
+		assert.Truef(t, strings.HasPrefix(ctx, "prometheus.haproxy."),
+			"context %q (chart %q) is missing the prometheus.haproxy. app segment", ctx, chartID)
+	}
 
 	// One representative curated context per scope, including the label-split charts.
 	curated := map[string][]string{

--- a/src/go/plugin/go.d/collector/prometheus/config_schema.json
+++ b/src/go/plugin/go.d/collector/prometheus/config_schema.json
@@ -43,7 +43,7 @@
       },
       "app": {
         "title": "Application",
-        "description": "Application name used as the app segment of chart contexts ('prometheus.{app}.{metric}'). When unset, the segment falls back to the job name.",
+        "description": "Application name used as the app segment of chart contexts ('prometheus.{app}.{metric}'). When unset, it is taken from a matched profile, otherwise it falls back to the job name.",
         "type": "string"
       },
       "vnode": {

--- a/src/go/plugin/go.d/collector/prometheus/manifest_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/manifest_test.go
@@ -148,7 +148,7 @@ test_gauge_metric{label1="value1"} 11
 `,
 		},
 		"app_job_name": {
-			// Application empty -> the app segment falls back to the job Name (see application()).
+			// Application empty and no profile declares an app -> the app segment falls back to the job Name (see resolveApp).
 			prepare: func() *Collector { c := New(); c.Name = "job_app"; return c },
 			input: `
 # TYPE test_gauge_metric gauge

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -80,7 +80,7 @@ modules:
               group: Target
 
             - name: app
-              description: Application name used as the app segment of chart contexts (`prometheus.<app>.<metric>`). When unset, the segment falls back to the job name.
+              description: Application name used as the app segment of chart contexts (`prometheus.<app>.<metric>`). When unset, it is taken from a matched profile, otherwise it falls back to the job name.
               default_value: ""
               required: false
               group: Customization

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/profile.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/profile.go
@@ -12,14 +12,17 @@ import (
 )
 
 // Profile is a curated, exporter-specific chart profile. Match selects the
-// profile by scraped metric names; Template is a standard charttpl group
-// rendered for the matched metrics. Identity is the profile file's basename
-// (set by the loader), so the file itself carries no name field. The Template
-// is validated exactly like any other chart template, including its
-// author-written metrics: visibility list.
+// profile by scraped metric names; App, when set, is the application identity
+// used as the chart-context "app" segment (prometheus.<app>.…) when a job has no
+// `app` set (by the user or service discovery); Template is a standard charttpl group rendered
+// for the matched metrics. Identity is the profile file's basename (set by the
+// loader), so the file itself carries no name field. The Template is validated
+// exactly like any other chart template, including its author-written metrics:
+// visibility list.
 type Profile struct {
 	Name     string         `yaml:"-" json:"name"`
 	Match    string         `yaml:"match" json:"match"`
+	App      string         `yaml:"app,omitempty" json:"app,omitempty"`
 	Template charttpl.Group `yaml:"template" json:"template"`
 }
 
@@ -29,6 +32,10 @@ func (p *Profile) validate(path string) error {
 	}
 	if _, err := matcher.NewSimplePatternsMatcher(p.Match); err != nil {
 		return fmt.Errorf("%s: 'match': %w", path, err)
+	}
+
+	if p.App != "" && !validProfileName.MatchString(p.App) {
+		return fmt.Errorf("%s: 'app' %q must match %s", path, p.App, validProfileName.String())
 	}
 
 	if !groupHasChart(p.Template) {

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/profile_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/profile_test.go
@@ -33,6 +33,13 @@ func TestProfile_validate(t *testing.T) {
 		"valid": {
 			profile: Profile{Match: "a_*", Template: chartGroup("fam", "ctx", "a_total", "a_count")},
 		},
+		"valid with app": {
+			profile: Profile{Match: "a_*", App: "my_app", Template: chartGroup("fam", "ctx", "a_total")},
+		},
+		"invalid app format": {
+			profile: Profile{Match: "a_*", App: "Bad App!", Template: chartGroup("fam", "ctx", "a_total")},
+			wantErr: true,
+		},
 		"empty match": {
 			profile: Profile{Match: "", Template: chartGroup("fam", "ctx", "a_total")},
 			wantErr: true,

--- a/src/go/plugin/go.d/collector/prometheus/runtime.go
+++ b/src/go/plugin/go.d/collector/prometheus/runtime.go
@@ -35,13 +35,39 @@ func (c *Collector) ensureChartTemplate(mfs prometheus.MetricFamilies) error {
 		return err
 	}
 
-	tmpl, err := buildMergedChartTemplate(c.application(), profiles)
+	tmpl, err := buildMergedChartTemplate(c.resolveApp(profiles), profiles)
 	if err != nil {
 		return err
 	}
 
 	c.runtime = &promRuntime{profiles: profiles, chartTemplate: tmpl}
 	return nil
+}
+
+// resolveApp is the chart-context "app" segment — the per-job identity the UI
+// turns into an Applications section. Precedence: the configured app, else the
+// first selected profile that declares one, else the job name. If selected
+// profiles declare different apps, the first (in selection order) wins and the
+// rest are logged (set the job's app to disambiguate).
+func (c *Collector) resolveApp(profiles []promprofiles.Profile) string {
+	if c.Application != "" {
+		return c.Application
+	}
+	app := ""
+	for _, p := range profiles {
+		switch {
+		case p.App == "":
+			continue
+		case app == "":
+			app = p.App
+		case p.App != app:
+			c.Warningf("profiles: selected profiles declare different apps; using %q, ignoring %q (set the job's 'app' to disambiguate)", app, p.App)
+		}
+	}
+	if app != "" {
+		return app
+	}
+	return c.Name
 }
 
 // selectProfiles resolves the profiles for this job per profiles.mode, matching

--- a/src/go/plugin/go.d/collector/prometheus/runtime_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/runtime_test.go
@@ -3,6 +3,7 @@
 package prometheus
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,9 +12,79 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/pkg/prometheus"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/promprofiles"
 )
+
+func Test_Collector_resolveApp(t *testing.T) {
+	const hap, ngx = "haproxy", "nginx"
+
+	tests := map[string]struct {
+		configApp string
+		jobName   string
+		profiles  []promprofiles.Profile
+		want      string
+		wantWarn  bool
+	}{
+		"config app wins over a profile app": {
+			configApp: "myapp", jobName: "job",
+			profiles: []promprofiles.Profile{{Name: hap, App: hap}},
+			want:     "myapp",
+		},
+		"config app silences a profile-app conflict": {
+			configApp: "myapp", jobName: "job",
+			profiles: []promprofiles.Profile{{Name: hap, App: hap}, {Name: ngx, App: ngx}},
+			want:     "myapp",
+		},
+		"profile app when no config app": {
+			jobName:  "job",
+			profiles: []promprofiles.Profile{{Name: hap, App: hap}},
+			want:     hap,
+		},
+		"first profile app wins on conflict": {
+			jobName:  "job",
+			profiles: []promprofiles.Profile{{Name: hap, App: hap}, {Name: ngx, App: ngx}},
+			want:     hap,
+			wantWarn: true,
+		},
+		"shared profiles (no app) fall through to job name": {
+			jobName:  "job",
+			profiles: []promprofiles.Profile{{Name: "go_runtime"}, {Name: "http"}},
+			want:     "job",
+		},
+		"a profile app is used even after shared profiles": {
+			jobName:  "job",
+			profiles: []promprofiles.Profile{{Name: "go_runtime"}, {Name: hap, App: hap}},
+			want:     hap,
+		},
+		"job name when no config app and no profile declares one": {
+			jobName:  "job",
+			profiles: nil,
+			want:     "job",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			c := New()
+			c.Logger = logger.NewWithWriter(&logBuf)
+			c.Application = tc.configApp
+			c.Name = tc.jobName
+
+			assert.Equal(t, tc.want, c.resolveApp(tc.profiles))
+
+			// Conflicting profile apps must emit exactly one operator warning; every other
+			// case (including config-app-wins, which short-circuits before the loop) stays silent.
+			if tc.wantWarn {
+				assert.Contains(t, logBuf.String(), "different apps")
+			} else {
+				assert.NotContains(t, logBuf.String(), "different apps")
+			}
+		})
+	}
+}
 
 func Test_profileMatchesFamilies(t *testing.T) {
 	mfs := testMetricFamilies("haproxy_up", "haproxy_frontend_status")

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/haproxy.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/haproxy.yaml
@@ -8,6 +8,10 @@
 # The ?extra-counters H1/H2/SSL/QUIC/H3 families (mod label) are intentionally left to
 # the collector's autogen fallback so the common no-extra-counters menu stays focused.
 match: 'haproxy_*'
+# app: the exporter's application identity — the prometheus.<app>.… Applications section —
+# used when the job's `app` config is not set (by the user, or automatically by service
+# discovery). A configured `app` wins; the job name is the last resort.
+app: haproxy
 template:
   family: HAProxy
   context_namespace: haproxy


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds profile-driven app detection to `go.d/prometheus` so chart contexts always get a stable Applications section without manual config. App resolution: job `app`, else first selected profile `app`, else job name; dedups the namespace to avoid `prometheus.<app>.<app>.<context>`.

- **New Features**
  - Profiles: add optional, validated `app`; set `app: haproxy` in `default/haproxy.yaml`.
  - Runtime: new `resolveApp` precedence; log one warning on conflicting profile apps; autogen and merged templates use the resolved app.
  - Template merge: drop a profile `context_namespace` when it equals the resolved app to prevent doubled segments.
  - Docs/spec: add `.agents/sow/specs/prometheus-profiles.md` and index entry; update `config_schema.json` and `metadata.yaml` to document precedence.
  - Tests: add unit tests for `resolveApp`, namespace dedup, configured-app behavior, and merged contexts; update existing tests.

<sup>Written for commit c4ab375f4ccb9f6e93ac5ae5669bb6b44bb52067. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

