### PR TITLE
Fix buffer overflow / off-by-one in claim and freebsd_ipfw collectors

### DIFF
--- a/src/claim/main.c
+++ b/src/claim/main.c
@@ -111,7 +111,7 @@ int nd_claim_parse_args(int argc, LPWSTR *argv)
                 continue;
 
             i++;
-            size_t length = wcslen(argv[i]);
+            size_t length = wcslen(argv[i]) + 1;
             char *tmp = calloc(sizeof(char), length);
             if (!tmp)
                 ExitProcess(1);

--- a/src/claim/main.c
+++ b/src/claim/main.c
@@ -145,7 +145,7 @@ static int netdata_claim_prepare_strings()
     netdata_claim_convert_str(aToken, token, length - 1);
 
     length = wcslen(room) + 1;
-    aRoom = calloc(sizeof(char), length - 1);
+    aRoom = calloc(sizeof(char), length);
     if (!aRoom)
         return -1;
 
@@ -153,7 +153,7 @@ static int netdata_claim_prepare_strings()
 
     if (proxy) {
         length = wcslen(proxy) + 1;
-        aProxy = calloc(sizeof(char), length - 1);
+        aProxy = calloc(sizeof(char), length);
         if (!aProxy)
             return -1;
 
@@ -162,7 +162,7 @@ static int netdata_claim_prepare_strings()
 
     if (url) {
         length = wcslen(url) + 1;
-        aURL = calloc(sizeof(char), length - 1);
+        aURL = calloc(sizeof(char), length);
         if (!aURL)
             return -1;
 

--- a/src/collectors/freebsd.plugin/freebsd_ipfw.c
+++ b/src/collectors/freebsd.plugin/freebsd_ipfw.c
@@ -46,7 +46,8 @@ int do_ipfw(int update_every, usec_t dt) {
     struct ip_fw_bcounter *cntr;
     int c = 0;
 
-    char rule_num_str[12];
+    // holds "<rulenum>_<id>" where each is a uint32 (MAX_INT_DIGITS) plus separator and NUL
+    char rule_num_str[(MAX_INT_DIGITS * 2) + 2];
 
     // variables for dynamic rules handling
 
@@ -225,7 +226,7 @@ int do_ipfw(int update_every, usec_t dt) {
                     break;
 
                 if (likely(do_static)) {
-                    sprintf(rule_num_str, "%"PRIu32"_%"PRIu32"", (uint32_t)rule->rulenum, (uint32_t)rule->id);
+                    snprintfz(rule_num_str, sizeof(rule_num_str), "%"PRIu32"_%"PRIu32"", (uint32_t)rule->rulenum, (uint32_t)rule->id);
 
                     rd_packets = rrddim_find_active(st_packets, rule_num_str);
                     if (unlikely(!rd_packets))
@@ -335,7 +336,7 @@ int do_ipfw(int update_every, usec_t dt) {
             }
 
             for (srn = 0; (srn < (static_rules_num - 1)) && (dyn_rules_num[srn].rule_num != IPFW_DEFAULT_RULE); srn++) {
-                sprintf(rule_num_str, "%d", dyn_rules_num[srn].rule_num);
+                snprintfz(rule_num_str, sizeof(rule_num_str), "%d", dyn_rules_num[srn].rule_num);
 
                 rd_active = rrddim_find_active(st_active, rule_num_str);
                 if (unlikely(!rd_active))


### PR DESCRIPTION
## Summary

Three related memory-safety and correctness fixes in the Windows claimer and the FreeBSD IPFW collector. All are pre-existing bugs surfaced during a focused audit of `sprintf`/`calloc` sizing in platform-specific collectors.

## Changes

### 1. `src/claim/main.c` — off-by-one heap overflow in wide-char conversion

`netdata_claim_convert_str()` (claim/main.h:14) writes a NUL terminator at `dst[copied]` after `wcstombs`, where `copied` can equal the `len` limit. The buffer must therefore hold `len + 1` bytes. The `aToken` allocation already obeys this (`calloc(length)` with `convert_str(..., length - 1)`), but `aRoom`, `aProxy`, and `aURL` allocated `calloc(length - 1)` — one byte short. For ASCII-only room/proxy/url, `wcstombs` fills the buffer and the NUL write overflows the heap by exactly one byte. Triggered on essentially every Windows claim.

Fix: the three allocations now match `aToken` (`calloc(length)`); the `convert_str` calls stay `length - 1`.

### 2. `src/collectors/freebsd.plugin/freebsd_ipfw.c` — stack buffer overflow in rule number formatting

`char rule_num_str[12]` was formatted with `sprintf(..., "%"PRIu32"_%"PRIu32"", rulenum, id)`. Two `uint32_t` values joined by `_` can need up to 22 bytes (`4294967295_4294967295\0`). Any IPFW rule number or id ≥ 7 digits overflowed the 12-byte stack buffer.

Fix: size the buffer as `(MAX_INT_DIGITS * 2) + 2` (= 22, exact worst case) and switch `sprintf` to the in-tree clamping `snprintfz` (already used elsewhere in the plugin). Both call sites updated.

### 3. `src/claim/main.c` — `/I` insecure flag silently ignored

The `/I` parser set `length = wcslen(argv[i])` without `+1`, so for the only meaningful input `/I 1` it called `wcstombs(..., 0)`, wrote no bytes, and `atoi("")` always returned 0. The Windows claimer therefore could not disable TLS verification via the documented `/I` flag — `insecure` was always `no` in `claim.conf` regardless of the user-supplied value.

Fix: mirror the correct `aToken` pattern (`length = wcslen(argv[i]) + 1`, `calloc(length)`, `convert_str(..., length - 1)`).

## Impact

| Fix | Severity | Trigger | Platform |
|---|---|---|---|
| claim heap off-by-one | High (memory safety) | Every Windows claim with ASCII room/proxy/url | Windows |
| ipfw stack overflow | High (memory safety) | Any IPFW rule rulenum/id ≥ 7 digits | FreeBSD 11+ |
| claim `/I` dead flag | Medium (functional) | Any `/I <n>` invocation | Windows |

No public contract changes. No schema/config/metric/alert changes.

## Notes

- These files are platform-specific (`<windows.h>` / FreeBSD `<netinet/ip_fw.h>`) and not built on Linux; fixes were verified by inspection against the existing-correct patterns in the same files.
- Pre-existing, intentionally out of scope: `netdata_claim_convert_str` does not check the `(size_t)-1` return of `wcstombs` on encoding error, and three sibling `sprintf` calls in `freebsd_sysctl.c` / `freebsd_devstat.c` currently fit by construction but could be migrated to `snprintfz` for defense-in-depth. Tracked separately if desired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes off-by-one buffer overflows in the Windows claimer and the FreeBSD IPFW collector, and makes the Windows `/I` flag work as documented. Prevents memory corruption during claims and ensures TLS verification can be toggled.

- **Bug Fixes**
  - Windows claim: allocate `aRoom`, `aProxy`, and `aURL` with `length` bytes and keep `convert_str(..., length - 1)` to avoid a 1-byte heap overflow on the NUL.
  - Windows claim: `/I` parsing now uses `wcslen(...) + 1` so the value converts correctly; TLS verification can be disabled as intended.
  - FreeBSD IPFW: enlarge `rule_num_str` to `(MAX_INT_DIGITS * 2) + 2` and replace `sprintf` with `snprintfz` to prevent stack overflow when formatting `<rulenum>_<id>`.

<sup>Written for commit 4a12012ab947c9d93cf8da9191cf678c0078ee39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

