### PR TITLE
Update systemd journal SDK to v0.7.0

### DIFF
--- a/src/crates/Cargo.lock
+++ b/src/crates/Cargo.lock
@@ -4283,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-common"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0cdf326f361fda6cf51242a2a3f60819b70e8e843b10666718a43a9b19305e"
+checksum = "f1840de1963100b920cfe33724c77d350a63f1967ebc67711022099f08226275"
 dependencies = [
  "libc",
  "rustc-hash",
@@ -4296,9 +4296,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-core"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8a0cfb1a1e4646c74b247bd522ba1ab20171393c132ade00a6e06871c20d34"
+checksum = "c277c0acd0800c0678fe38a15bc7e4786eb772e01052ab1e628023a8453076ae"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4337,9 +4337,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-engine"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ba9e6117ac55131071ef4446b5d678a3b4980a963faffefe5679f4a8987cfa2"
+checksum = "beb46ca836ac762f9bee6b0a1f68a7ce0932a2af696911b365830622bac15704"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4363,9 +4363,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-index"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1a430a6edd804410abc132549fbf6b9b03a9b478c4b9bda5a69fbd43a21955"
+checksum = "4121207d6d8c0756338fd8a9b76416f17e2f93ba2af81696b0f780c77b2bc877"
 dependencies = [
  "regex",
  "roaring 0.11.4",
@@ -4380,9 +4380,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-log-writer"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6e14e481ab3f340c819b51b07a98a587e5f6d44394bc54a3914db2e7a642d4"
+checksum = "88ef67ce2874b5ddeec41e0232b79758f1a371eb676b61a0f7edf7c8fe7c47e4"
 dependencies = [
  "itoa",
  "systemd-journal-sdk-common",
@@ -4395,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-registry"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e089e4ba868df7623d4c02a72e7ce5cbb46561d8c29dfcc5d896314e937e27cf"
+checksum = "480f7f6d6044b85e0b7b9949ff8a689c10fdd65a3c148098583e6d5c8a1a440a"
 dependencies = [
  "notify",
  "parking_lot",

--- a/src/crates/netflow-plugin/Cargo.toml
+++ b/src/crates/netflow-plugin/Cargo.toml
@@ -24,12 +24,12 @@ clap = { workspace = true, features = ["derive"] }
 # crates). Aliased to the historical names so call sites keep `use journal_*`.
 # Scope: netflow-plugin only; log-viewer/otel still use the vendored workspace
 # crates (tracked as a follow-up). One source of journal-core in this binary.
-journal-common = { package = "systemd-journal-sdk-common", version = "0.6.4" }
-journal-core = { package = "systemd-journal-sdk-core", version = "0.6.4" }
-journal-engine = { package = "systemd-journal-sdk-engine", version = "0.6.4" }
-journal-index = { package = "systemd-journal-sdk-index", version = "0.6.4" }
-journal-log-writer = { package = "systemd-journal-sdk-log-writer", version = "0.6.4" }
-journal-registry = { package = "systemd-journal-sdk-registry", version = "0.6.4" }
+journal-common = { package = "systemd-journal-sdk-common", version = "0.7.0" }
+journal-core = { package = "systemd-journal-sdk-core", version = "0.7.0" }
+journal-engine = { package = "systemd-journal-sdk-engine", version = "0.7.0" }
+journal-index = { package = "systemd-journal-sdk-index", version = "0.7.0" }
+journal-log-writer = { package = "systemd-journal-sdk-log-writer", version = "0.7.0" }
+journal-registry = { package = "systemd-journal-sdk-registry", version = "0.7.0" }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 hashbrown = { workspace = true }

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/klauspost/compress v1.18.6
 	github.com/maxmind/mmdbwriter v1.2.0
 	github.com/microsoft/go-mssqldb v1.10.0
-	github.com/netdata/systemd-journal-sdk/go v0.6.4
+	github.com/netdata/systemd-journal-sdk/go v0.7.0
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	golang.org/x/sys v0.46.0

--- a/src/go/go.sum
+++ b/src/go/go.sum
@@ -338,8 +338,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/netdata/systemd-journal-sdk/go v0.6.4 h1:LGrHRfjImN+QgUQeDT2Z3Wcq4xTtGeyskhx/7hDHTbA=
-github.com/netdata/systemd-journal-sdk/go v0.6.4/go.mod h1:2n1eOsdTJ6v5xszIOH/xsvmtZXlMnNhWCSEaW4liGNk=
+github.com/netdata/systemd-journal-sdk/go v0.7.0 h1:Fvhi+Q5IDMJK4lrcb6M8fTQlbyogl1JFGv3aYfJWhBw=
+github.com/netdata/systemd-journal-sdk/go v0.7.0/go.mod h1:2n1eOsdTJ6v5xszIOH/xsvmtZXlMnNhWCSEaW4liGNk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=


### PR DESCRIPTION
## Summary

- Update Rust `systemd-journal-sdk-*` dependencies used by `netflow-plugin` from `0.6.4` to `0.7.0`.
- Update the Go `github.com/netdata/systemd-journal-sdk/go` module from `v0.6.4` to `v0.7.0`.
- Refresh the Rust lockfile and Go checksum file without unrelated dependency drift.

## Impact

This keeps the existing Rust NetFlow journal I/O and Go SNMP trap journal SDK consumers on the current published SDK release. No source-level API adaptation was required.

## Validation

- `timeout 1800 cargo check -p netflow-plugin`
- `timeout 1800 cargo check --locked -p netflow-plugin`
- `timeout 1800 go test ./plugin/go.d/collector/snmp_traps/...`
- `git diff --check -- src/crates/netflow-plugin/Cargo.toml src/crates/Cargo.lock src/go/go.mod src/go/go.sum`
- stale SDK v0.6.4 dependency scan returned no matches

Note: the Rust checks emitted an existing dead-code warning in `netflow-plugin/src/tiering/model.rs`, unrelated to this dependency update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `systemd-journal-sdk` to v0.7.0 across Rust `netflow-plugin` and Go SNMP traps to stay on the latest release. No code changes; refreshed `Cargo.lock` and `go.sum`.

- **Dependencies**
  - Rust: `systemd-journal-sdk-{common,core,engine,index,log-writer,registry}` from 0.6.4 → 0.7.0 in `netflow-plugin`.
  - Go: `github.com/netdata/systemd-journal-sdk/go` from v0.6.4 → v0.7.0.

<sup>Written for commit b457d584f2516105de2cf15b0602debeca7d8cf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

