### PR TITLE
fix(go.d/snmp_topology): clone device labels to fix snapshot data race

### DIFF
--- a/src/go/plugin/go.d/collector/snmp_topology/topology_management_helpers.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_management_helpers.go
@@ -3,10 +3,17 @@
 package snmptopology
 
 import (
+	"maps"
 	"strings"
 )
 
 func normalizeTopologyDevice(dev topologyDevice) topologyDevice {
+	// dev is a shallow copy of the caller's value, so dev.Labels still aliases
+	// the caller's map (e.g. a live topologyCache.localDevice read under RLock).
+	// Clone it before the mutations below so concurrent snapshot readers never
+	// write a shared map (fatal "concurrent map writes").
+	dev.Labels = maps.Clone(dev.Labels)
+
 	if dev.ChartIDPrefix == "" {
 		dev.ChartIDPrefix = topologyProfileChartIDPrefix
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snapshot_race_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snapshot_race_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestTopologyRegistry_ConcurrentSnapshotsDoNotRaceOnDeviceLabels reproduces the
+// concurrent-map-write crash where the snapshot read path mutated a cache-shared
+// map. snapshotEngineObservations holds only an RLock and passes c.localDevice
+// (by value, so Labels still aliases the cache map) to normalizeTopologyDevice,
+// which writes Labels. Two concurrent readers (Collect's snapshot() and a
+// Function's snapshotWithOptions()) then write the same map.
+//
+// Run with -race. Before the fix this reports a data race / fatal concurrent map
+// writes; after the fix (normalizeTopologyDevice clones Labels) it passes.
+func TestTopologyRegistry_ConcurrentSnapshotsDoNotRaceOnDeviceLabels(t *testing.T) {
+	registry := newTopologyRegistry()
+
+	cache := newTopologyCache()
+	cache.lastUpdate = time.Now()
+	cache.localDevice = topologyDevice{
+		ManagementIP:  "192.0.2.1",
+		ChassisID:     "aa:bb:cc:dd:ee:ff",
+		ChassisIDType: "macAddress",
+		// Capabilities + a non-nil Labels map make normalizeTopologyDevice write
+		// Labels["type"], which is the mutation that raced on the shared map.
+		Capabilities: []string{"bridge"},
+		Labels:       map[string]string{"seed": "value"},
+	}
+	cache.lldpLocPorts["1"] = &lldpLocPort{
+		portNum:       "1",
+		portID:        "Gi0/1",
+		portIDSubtype: "interfaceName",
+	}
+	cache.lldpRemotes["1:1"] = &lldpRemote{
+		localPortNum:     "1",
+		remIndex:         "1",
+		chassisID:        "11:22:33:44:55:66",
+		chassisIDSubtype: "macAddress",
+		portID:           "Gi0/2",
+		portIDSubtype:    "interfaceName",
+	}
+	registry.register(cache)
+
+	const goroutines = 64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		// Alternate the two production read paths: Collect (snapshot) and the
+		// Function handler (snapshotWithOptions).
+		collectPath := i%2 == 0
+		go func() {
+			defer wg.Done()
+			if collectPath {
+				_, _ = registry.snapshot()
+			} else {
+				_, _ = registry.snapshotWithOptions(topologyQueryOptions{})
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snapshot_race_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snapshot_race_test.go
@@ -49,7 +49,7 @@ func TestTopologyRegistry_ConcurrentSnapshotsDoNotRaceOnDeviceLabels(t *testing.
 	const goroutines = 64
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for i := range goroutines {
 		// Alternate the two production read paths: Collect (snapshot) and the
 		// Function handler (snapshotWithOptions).
 		collectPath := i%2 == 0


### PR DESCRIPTION
##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clone `topologyDevice.Labels` during normalization to prevent concurrent map writes in `go.d/snmp_topology` snapshots. Adds a `-race` regression test covering concurrent snapshot paths.

- **Bug Fixes**
  - Clone labels in `normalizeTopologyDevice` using `maps.Clone` before mutations so snapshot readers never write shared cache maps.
  - Add `topology_snapshot_race_test.go` to run concurrent `snapshot()` and `snapshotWithOptions()` and verify no race under `-race`.

<sup>Written for commit 7f12a24f23dbc7b327a61aeab8a60e7d25986786. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

