### PR TITLE
Fix search for VS tooling to check for multiple versions.

### DIFF
--- a/packaging/windows/find-sdk-path.sh
+++ b/packaging/windows/find-sdk-path.sh
@@ -73,7 +73,24 @@ find_sdk_tools() {
 
 # Function to find tools in Visual Studio
 find_visual_studio_tools() {
-  studio_base_path="/c/Program Files/Microsoft Visual Studio/2022"
+  versions=("2026" "2022")
+  found=0
+
+  for version in "${versions[@]}"; do
+    if check_visual_studio_version "${version}"; then
+      found=1
+      break
+    fi
+  done
+
+  if [ "${found}" -ne 1 ]; then
+    echo "ERROR: Failed to find a usable version of Visual Studio"
+    return 1
+  fi
+}
+
+check_visual_studio_version() {
+  studio_base_path="/c/Program Files/Microsoft Visual Studio/${1}"
   echo "Checking for Visual Studio installations in: \"$studio_base_path\"" >&2
 
   if [ ! -d "$studio_base_path" ]; then
@@ -210,7 +227,6 @@ if [ "$tool_path" != "$system_root" ]; then
     echo "$tool_path"
   fi
 else
-  echo "$system_root"
   exit 1
 fi
 

--- a/packaging/windows/find-sdk-path.sh
+++ b/packaging/windows/find-sdk-path.sh
@@ -73,10 +73,68 @@ find_sdk_tools() {
 
 # Function to find tools in Visual Studio
 find_visual_studio_tools() {
-  versions=("2026" "2022")
-  found=0
+  # vswhere.exe is the Microsoft-recommended way to locate VS installations,
+  # guaranteed present on any machine with VS or VS Build Tools installed.
+  local vswhere_path="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
 
-  for version in "${versions[@]}"; do
+  if [ -f "$vswhere_path" ]; then
+    echo "Checking for Visual Studio via vswhere.exe..." >&2
+    local vs_install_path
+    vs_install_path=$("$vswhere_path" -latest -products '*' \
+      -requires 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64' \
+      -property installationPath 2>/dev/null | tr -d '\r\n')
+
+    if [ -z "$vs_install_path" ]; then
+      # Retry without component filter for stripped installs or Build Tools
+      vs_install_path=$("$vswhere_path" -latest -products '*' \
+        -property installationPath 2>/dev/null | tr -d '\r\n')
+    fi
+
+    if [ -n "$vs_install_path" ]; then
+      local vs_unix_path msvc_tools_dir latest_msvc tool_path
+      vs_unix_path=$(cygpath -u "$vs_install_path")
+      msvc_tools_dir="$vs_unix_path/VC/Tools/MSVC"
+
+      if [ -d "$msvc_tools_dir" ]; then
+        latest_msvc=$(ls "$msvc_tools_dir" | grep -E "^[0-9]+\." | sort -V | tail -n 1)
+        if [ -n "$latest_msvc" ]; then
+          tool_path="$msvc_tools_dir/$latest_msvc/bin/Hostx64/x64"
+          if [ -f "$tool_path/link.exe" ]; then
+            echo "Found VS tools via vswhere in: \"$tool_path\"" >&2
+            echo "$tool_path"
+            return 0
+          fi
+        fi
+      fi
+      echo "WARNING: vswhere found VS at \"$vs_install_path\" but VC tools not available there." >&2
+    else
+      echo "WARNING: vswhere.exe found no VS installations with VC tools." >&2
+    fi
+  else
+    echo "WARNING: vswhere.exe not found at \"$vswhere_path\", falling back to directory scan." >&2
+  fi
+
+  # Fall back: scan available year directories instead of using a fixed list
+  local vs_base_path="/c/Program Files/Microsoft Visual Studio"
+  if [ ! -d "$vs_base_path" ]; then
+    echo "ERROR: Visual Studio base path \"$vs_base_path\" does not exist." >&2
+    echo "$system_root"
+    return 1
+  fi
+
+  local available_versions
+  available_versions=$(ls "$vs_base_path" | grep -E "^[0-9]{4}$" | sort -V -r)
+  if [ -z "$available_versions" ]; then
+    echo "ERROR: No Visual Studio year directories found in \"$vs_base_path\"." >&2
+    echo "$system_root"
+    return 1
+  fi
+
+  echo "Found VS year directories: $(echo "$available_versions" | tr '\n' ' ')" >&2
+
+  local found=0
+  local tool_path_candidate
+  for version in $available_versions; do
     if tool_path_candidate="$(check_visual_studio_version "${version}")"; then
       echo "${tool_path_candidate}"
       found=1
@@ -85,7 +143,8 @@ find_visual_studio_tools() {
   done
 
   if [ "${found}" -ne 1 ]; then
-    echo "ERROR: Failed to find a usable version of Visual Studio"
+    echo "ERROR: Failed to find a usable version of Visual Studio" >&2
+    echo "$system_root"
     return 1
   fi
 }
@@ -214,21 +273,21 @@ fi
 
 # Determine which function to call based on the search mode
 if [ "$search_mode" = "sdk" ]; then
-  tool_path=$(find_sdk_tools)
-else
-  tool_path=$(find_visual_studio_tools)
-fi
-
-# If a valid path is found, output it
-if [ "$tool_path" != "$system_root" ]; then
-  if [ "$windows_format" -eq 1 ]; then
-    windows_tool_path=$(convert_to_windows_format "$tool_path")
-    echo "$windows_tool_path"
-  else
-    echo "$tool_path"
+  if ! tool_path=$(find_sdk_tools); then
+    exit 1
   fi
 else
-  exit 1
+  if ! tool_path=$(find_visual_studio_tools); then
+    exit 1
+  fi
+fi
+
+# Output the discovered path
+if [ "$windows_format" -eq 1 ]; then
+  windows_tool_path=$(convert_to_windows_format "$tool_path")
+  echo "$windows_tool_path"
+else
+  echo "$tool_path"
 fi
 
 exit 0

--- a/packaging/windows/find-sdk-path.sh
+++ b/packaging/windows/find-sdk-path.sh
@@ -77,7 +77,8 @@ find_visual_studio_tools() {
   found=0
 
   for version in "${versions[@]}"; do
-    if check_visual_studio_version "${version}"; then
+    if tool_path_candidate="$(check_visual_studio_version "${version}")"; then
+      echo "${tool_path_candidate}"
       found=1
       break
     fi

--- a/src/libnetdata/log/wevt_netdata_compile.bat
+++ b/src/libnetdata/log/wevt_netdata_compile.bat
@@ -18,8 +18,6 @@ set "BIN_DIR=%~2"
 set "MC_FILE=%BIN_DIR%\wevt_netdata.mc"
 set "MAN_FILE=%BIN_DIR%\wevt_netdata_manifest.xml"
 set "BASE_NAME=wevt_netdata"
-set "SDK_PATH=C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-set "VS_PATH=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\bin\Hostx64\x64"
 
 if not exist "%SRC_DIR%" (
     echo Error: Source directory does not exist.
@@ -40,9 +38,6 @@ if not exist "%MAN_FILE%" (
     echo Error: %MAN_FILE% not found.
     exit /b 1
 )
-
-REM Add SDK paths to PATH
-set "PATH=C:\Windows\System32;%SDK_PATH%;%VS_PATH%;%PATH%"
 
 REM Check if commands are available
 where mc >nul 2>nul

--- a/src/libnetdata/log/wevt_netdata_compile.sh
+++ b/src/libnetdata/log/wevt_netdata_compile.sh
@@ -20,11 +20,11 @@ SCRIPT_DIR="$(dirname "$0")"
 temp_bat=$(mktemp --suffix=.bat)
 
 # Determine paths for SDKs
-if win_sdk_path="$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --sdk -w)"; then
+if ! win_sdk_path="$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --sdk -w)"; then
     echo "ERROR: Failed to find Windows SDK"
     exit 1
 fi
-if vs_sdk_path="$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --visualstudio -w)"; then
+if ! vs_sdk_path="$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --visualstudio -w)"; then
     echo "ERROR: Failed to find Visual Studio SDK"
     exit 1
 fi

--- a/src/libnetdata/log/wevt_netdata_compile.sh
+++ b/src/libnetdata/log/wevt_netdata_compile.sh
@@ -20,10 +20,12 @@ SCRIPT_DIR="$(dirname "$0")"
 temp_bat=$(mktemp --suffix=.bat)
 
 # Determine paths for SDKs
-win_sdk_path="$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --sdk -w)"
-vs_sdk_path="$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --visualstudio -w)"
-if [ -z "${win_sdk_path}" ] || [ -z "${vs_sdk_path}" ]; then
-    echo "ERROR: Failed to find required SDKs."
+if win_sdk_path="$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --sdk -w)"; then
+    echo "ERROR: Failed to find Windows SDK"
+    exit 1
+fi
+if vs_sdk_path="$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --visualstudio -w)"; then
+    echo "ERROR: Failed to find Visual Studio SDK"
     exit 1
 fi
 # Write the contents to the temporary batch file

--- a/src/libnetdata/log/wevt_netdata_compile.sh
+++ b/src/libnetdata/log/wevt_netdata_compile.sh
@@ -4,8 +4,8 @@ mylocation=$(dirname "${0}")
 
 # Check if both parameters are provided
 if [ $# -ne 2 ]; then
-    echo "Error: Incorrect number of parameters."
-    echo "Usage: $0 <source_directory> <destination_directory>"
+    echo "Error: Incorrect number of parameters." >&2
+    echo "Usage: $0 <source_directory> <destination_directory>" >&2
     exit 1
 fi
 
@@ -21,11 +21,11 @@ temp_bat=$(mktemp --suffix=.bat)
 
 # Determine paths for SDKs
 if ! win_sdk_path="$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --sdk -w)"; then
-    echo "ERROR: Failed to find Windows SDK"
+    echo "ERROR: Failed to find Windows SDK" >&2
     exit 1
 fi
 if ! vs_sdk_path="$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --visualstudio -w)"; then
-    echo "ERROR: Failed to find Visual Studio SDK"
+    echo "ERROR: Failed to find Visual Studio SDK" >&2
     exit 1
 fi
 # Write the contents to the temporary batch file
@@ -51,7 +51,7 @@ rm "$temp_bat"
 if [ $exit_status -eq 0 ]; then
     echo "nd_wevents_compile.bat executed successfully."
 else
-    echo "nd_wevents_compile.bat failed with exit status $exit_status."
+    echo "nd_wevents_compile.bat failed with exit status $exit_status." >&2
 fi
 
 exit $exit_status

--- a/src/libnetdata/log/wevt_netdata_compile.sh
+++ b/src/libnetdata/log/wevt_netdata_compile.sh
@@ -32,7 +32,7 @@ fi
 # Use cygpath directly within the heredoc
 cat << EOF > "$temp_bat"
 @echo off
-set "PATH=%SYSTEMROOT%;${win_sdk_path};${vs_sdk_path}"
+set "PATH=%SystemRoot%\System32;${win_sdk_path};${vs_sdk_path}"
 call "$(cygpath -w -a "$SCRIPT_DIR/wevt_netdata_compile.bat")" "$(cygpath -w -a "$src_dir")" "$(cygpath -w -a "$dest_dir")"
 EOF
 

--- a/src/libnetdata/log/wevt_netdata_compile.sh
+++ b/src/libnetdata/log/wevt_netdata_compile.sh
@@ -19,11 +19,18 @@ SCRIPT_DIR="$(dirname "$0")"
 # Create a temporary batch file
 temp_bat=$(mktemp --suffix=.bat)
 
+# Determine paths for SDKs
+win_sdk_path="$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --sdk -w)"
+vs_sdk_path="$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --visualstudio -w)"
+if [ -z "${win_sdk_path}" ] || [ -z "${vs_sdk_path}" ]; then
+    echo "ERROR: Failed to find required SDKs."
+    exit 1
+fi
 # Write the contents to the temporary batch file
 # Use cygpath directly within the heredoc
 cat << EOF > "$temp_bat"
 @echo off
-set "PATH=%SYSTEMROOT%;$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --sdk -w);$("${mylocation}/../../../packaging/windows/find-sdk-path.sh" --visualstudio -w)"
+set "PATH=%SYSTEMROOT%;${win_sdk_path};${vs_sdk_path}"
 call "$(cygpath -w -a "$SCRIPT_DIR/wevt_netdata_compile.bat")" "$(cygpath -w -a "$src_dir")" "$(cygpath -w -a "$dest_dir")"
 EOF
 


### PR DESCRIPTION
##### Summary

Instead of relying specifically on VS 2022, also check for and use VS 2026.

##### Test Plan

Windows build CI job passes on this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved Windows tool detection using `vswhere` with a safe fallback, and made the event log build fail fast with clean, machine-readable output. Removed hard-coded SDK/VS paths and routed diagnostics to stderr to keep stdout consumable and satisfy Sonar.

- **Bug Fixes**
  - `packaging/windows/find-sdk-path.sh`: Prefer `vswhere`, then scan year directories via `check_visual_studio_version`; emit only the discovered path (respect `-w`); send diagnostics to stderr; exit non-zero on failure.
  - `src/libnetdata/log/wevt_netdata_compile.sh` + `.bat`: Resolve and validate Windows SDK and VS tool paths before running; set PATH once with `%SystemRoot%\System32` + resolved paths; emit errors to stderr; `.bat` no longer hard-codes or modifies PATH.

<sup>Written for commit 13df5c21a5c98e25a3632a9d1069a21cdda61ce3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

