### PR TITLE
Record spinlock holder identity for datafile/journal deadlock fatals

### DIFF
--- a/src/database/engine/datafile.c
+++ b/src/database/engine/datafile.c
@@ -49,7 +49,7 @@ static struct rrdengine_datafile *datafile_alloc_and_init(struct rrdengine_insta
     datafile->users.available = true;
     datafile->users.pending_deletion = false;
 
-    spinlock_init(&datafile->users.spinlock);
+    spinlock_tracked_init(&datafile->users.spinlock);
     spinlock_init(&datafile->writers.spinlock);
     rw_spinlock_init(&datafile->extent_epdl.spinlock);
 
@@ -60,7 +60,7 @@ ALWAYS_INLINE bool datafile_acquire(struct rrdengine_datafile *df, DATAFILE_ACQU
 {
     bool ret = false;
 
-    spinlock_lock(&df->users.spinlock);
+    spinlock_tracked_lock(&df->users.spinlock);
 
     if(df->users.available && reason < DATAFILE_ACQUIRE_MAX) {
         bool allow = true;
@@ -87,20 +87,20 @@ ALWAYS_INLINE bool datafile_acquire(struct rrdengine_datafile *df, DATAFILE_ACQU
         }
     }
 
-    spinlock_unlock(&df->users.spinlock);
+    spinlock_tracked_unlock(&df->users.spinlock);
 
     return ret;
 }
 
 void datafile_release_with_trace(struct rrdengine_datafile *df, DATAFILE_ACQUIRE_REASONS reason, const char *func) {
-    spinlock_lock(&df->users.spinlock);
+    spinlock_tracked_lock(&df->users.spinlock);
     if(!df->users.lockers)
         fatal("DBENGINE DATAFILE: cannot release datafile %u of tier %u - it is not acquired, called from %s() with reason %u",
               df->fileno, df->tier, func, reason);
 
     df->users.lockers--;
     df->users.lockers_by_reason[reason]--;
-    spinlock_unlock(&df->users.spinlock);
+    spinlock_tracked_unlock(&df->users.spinlock);
 }
 
 bool datafile_acquire_for_deletion(struct rrdengine_datafile *df, bool is_shutdown)
@@ -109,7 +109,7 @@ bool datafile_acquire_for_deletion(struct rrdengine_datafile *df, bool is_shutdo
     bool marked_pending = false;
     bool should_evict_open_pages = false;
 
-    spinlock_lock(&df->users.spinlock);
+    spinlock_tracked_lock(&df->users.spinlock);
 
     if(!df->users.pending_deletion) {
         df->users.pending_deletion = true;
@@ -131,7 +131,7 @@ bool datafile_acquire_for_deletion(struct rrdengine_datafile *df, bool is_shutdo
     }
     else if(df->users.lockers)
         should_evict_open_pages = true;
-    spinlock_unlock(&df->users.spinlock);
+    spinlock_tracked_unlock(&df->users.spinlock);
 
     if(marked_pending)
         netdata_log_info("DBENGINE: tier %d: " DATAFILE_PREFIX RRDENG_FILE_NUMBER_PRINT_TMPL " is pending deletion (%s)",
@@ -148,7 +148,7 @@ bool datafile_acquire_for_deletion(struct rrdengine_datafile *df, bool is_shutdo
     size_t hot_pages_in_open_cache = pgc_count_hot_pages_having_data_ptr(open_cache, (Word_t)datafile_ctx(df), df);
     time_to_scan_ut = now_monotonic_usec() - time_to_scan_ut;
 
-    spinlock_lock(&df->users.spinlock);
+    spinlock_tracked_lock(&df->users.spinlock);
 
     spinlock_lock(&df->writers.spinlock);
     writers_running = df->writers.running;
@@ -221,7 +221,7 @@ bool datafile_acquire_for_deletion(struct rrdengine_datafile *df, bool is_shutdo
                        hot_pages_in_open_cache,
                        time_to_scan_ut);
 
-    spinlock_unlock(&df->users.spinlock);
+    spinlock_tracked_unlock(&df->users.spinlock);
 
     return can_be_deleted;
 }

--- a/src/database/engine/datafile.h
+++ b/src/database/engine/datafile.h
@@ -75,7 +75,7 @@ struct rrdengine_datafile {
     } writers;
 
     struct {
-        SPINLOCK spinlock;
+        SPINLOCK_TRACKED spinlock;  // tracked: 3600s deadlock fatals here are un-triagable without holder identity
         unsigned lockers;
         unsigned lockers_by_reason[DATAFILE_ACQUIRE_MAX];
         bool available;

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -216,7 +216,7 @@ static void njfv2idx_remove(struct rrdengine_datafile *datafile) {
 static struct journal_v2_header *journalfile_v2_mounted_data_get(struct rrdengine_journalfile *journalfile, size_t *data_size) {
     struct journal_v2_header *j2_header = NULL;
 
-    spinlock_lock(&journalfile->data_spinlock);
+    spinlock_tracked_lock(&journalfile->data_spinlock);
 
     if(!journalfile->mmap.data) {
         journalfile->mmap.data = nd_mmap(NULL, journalfile->mmap.size, PROT_READ, MAP_SHARED, journalfile->mmap.fd, 0);
@@ -259,7 +259,7 @@ static struct journal_v2_header *journalfile_v2_mounted_data_get(struct rrdengin
             *data_size = journalfile->mmap.size;
     }
 
-    spinlock_unlock(&journalfile->data_spinlock);
+    spinlock_tracked_unlock(&journalfile->data_spinlock);
 
     return j2_header;
 }
@@ -269,11 +269,11 @@ static bool journalfile_v2_mounted_data_unmount(struct rrdengine_journalfile *jo
 
     if(!have_locks) {
         if(!wait) {
-            if (!spinlock_trylock(&journalfile->data_spinlock))
+            if (!spinlock_tracked_trylock(&journalfile->data_spinlock))
                 return false;
         }
         else
-            spinlock_lock(&journalfile->data_spinlock);
+            spinlock_tracked_lock(&journalfile->data_spinlock);
     }
 
     if(!journalfile->v2.refcount) {
@@ -296,7 +296,7 @@ static bool journalfile_v2_mounted_data_unmount(struct rrdengine_journalfile *jo
     }
 
     if(!have_locks) {
-        spinlock_unlock(&journalfile->data_spinlock);
+        spinlock_tracked_unlock(&journalfile->data_spinlock);
     }
 
     return unmounted;
@@ -325,7 +325,7 @@ void journalfile_v2_data_unmount_cleanup(time_t now_s) {
 
             struct rrdengine_journalfile *journalfile = datafile->journalfile;
 
-            if(!spinlock_trylock(&journalfile->data_spinlock))
+            if(!spinlock_tracked_trylock(&journalfile->data_spinlock))
                 continue;
 
             bool unmount = false;
@@ -340,7 +340,7 @@ void journalfile_v2_data_unmount_cleanup(time_t now_s) {
                     // enough time has passed since we last needed this journal
                     unmount = true;
             }
-            spinlock_unlock(&journalfile->data_spinlock);
+            spinlock_tracked_unlock(&journalfile->data_spinlock);
 
             if (unmount)
                 journalfile_v2_mounted_data_unmount(journalfile, false, false);
@@ -352,7 +352,7 @@ void journalfile_v2_data_unmount_cleanup(time_t now_s) {
 ALWAYS_INLINE struct journal_v2_header *journalfile_v2_data_acquire_with_hint(struct rrdengine_journalfile *journalfile,
     size_t *data_size, time_t wanted_first_time_s, time_t wanted_last_time_s, JOURNALFILE_V2_ACCESS_HINT hint)
 {
-    spinlock_lock(&journalfile->data_spinlock);
+    spinlock_tracked_lock(&journalfile->data_spinlock);
 
     bool has_data = (journalfile->v2.flags & JOURNALFILE_FLAG_IS_AVAILABLE);
     bool is_mounted = (journalfile->v2.flags & JOURNALFILE_FLAG_IS_MOUNTED);
@@ -390,7 +390,7 @@ ALWAYS_INLINE struct journal_v2_header *journalfile_v2_data_acquire_with_hint(st
 
         }
     }
-    spinlock_unlock(&journalfile->data_spinlock);
+    spinlock_tracked_unlock(&journalfile->data_spinlock);
 
     if(do_we_need_it)
         return journalfile_v2_mounted_data_get(journalfile, data_size);
@@ -403,7 +403,7 @@ ALWAYS_INLINE struct journal_v2_header *journalfile_v2_data_acquire(struct rrden
 }
 
 ALWAYS_INLINE void journalfile_v2_data_release(struct rrdengine_journalfile *journalfile) {
-    spinlock_lock(&journalfile->data_spinlock);
+    spinlock_tracked_lock(&journalfile->data_spinlock);
 
     internal_fatal(!journalfile->mmap.data, "trying to release a journalfile without data");
     internal_fatal(journalfile->v2.refcount < 1, "trying to release a non-acquired journalfile");
@@ -418,7 +418,7 @@ ALWAYS_INLINE void journalfile_v2_data_release(struct rrdengine_journalfile *jou
         if(journalfile->v2.flags & JOURNALFILE_FLAG_MOUNTED_FOR_RETENTION)
             unmount = true;
     }
-    spinlock_unlock(&journalfile->data_spinlock);
+    spinlock_tracked_unlock(&journalfile->data_spinlock);
 
     if(unmount)
         journalfile_v2_mounted_data_unmount(journalfile, false, true);
@@ -426,18 +426,18 @@ ALWAYS_INLINE void journalfile_v2_data_release(struct rrdengine_journalfile *jou
 
 bool journalfile_v2_data_available(struct rrdengine_journalfile *journalfile) {
 
-    spinlock_lock(&journalfile->data_spinlock);
+    spinlock_tracked_lock(&journalfile->data_spinlock);
     bool has_data = (journalfile->v2.flags & JOURNALFILE_FLAG_IS_AVAILABLE);
-    spinlock_unlock(&journalfile->data_spinlock);
+    spinlock_tracked_unlock(&journalfile->data_spinlock);
 
     return has_data;
 }
 
 size_t journalfile_v2_data_size_get(struct rrdengine_journalfile *journalfile) {
 
-    spinlock_lock(&journalfile->data_spinlock);
+    spinlock_tracked_lock(&journalfile->data_spinlock);
     size_t data_size = journalfile->mmap.size;
-    spinlock_unlock(&journalfile->data_spinlock);
+    spinlock_tracked_unlock(&journalfile->data_spinlock);
 
     return data_size;
 }
@@ -449,7 +449,7 @@ void journalfile_v2_data_set(struct rrdengine_journalfile *journalfile, int fd, 
     if(unlikely(!journalfile->datafile))
         fatal("DBENGINE: JOURNALFILE: trying to set journal data without a datafile");
 
-    spinlock_lock(&journalfile->data_spinlock);
+    spinlock_tracked_lock(&journalfile->data_spinlock);
 
     internal_fatal(journalfile->mmap.fd != -1, "DBENGINE JOURNALFILE: trying to re-set journal fd");
     internal_fatal(journalfile->mmap.data, "DBENGINE JOURNALFILE: trying to re-set journal_data");
@@ -468,7 +468,7 @@ void journalfile_v2_data_set(struct rrdengine_journalfile *journalfile, int fd, 
 
     journalfile_v2_mounted_data_unmount(journalfile, true, true);
 
-    spinlock_unlock(&journalfile->data_spinlock);
+    spinlock_tracked_unlock(&journalfile->data_spinlock);
 
     njfv2idx_add(journalfile->datafile);
 }
@@ -485,7 +485,7 @@ static void journalfile_v2_data_unmap_permanently(struct rrdengine_journalfile *
         if (has_references)
             sleep_usec(10 * USEC_PER_MS);
 
-        spinlock_lock(&journalfile->data_spinlock);
+        spinlock_tracked_lock(&journalfile->data_spinlock);
 
         if(journalfile_v2_mounted_data_unmount(journalfile, true, true)) {
             if(journalfile->mmap.fd != -1)
@@ -505,7 +505,7 @@ static void journalfile_v2_data_unmap_permanently(struct rrdengine_journalfile *
             nd_log_limit(&journalfile_erl, NDLS_DAEMON, NDLP_WARNING, "DBENGINE: journalfile \"%s\" is not available for unmap", path_v2);
         }
 
-        spinlock_unlock(&journalfile->data_spinlock);
+        spinlock_tracked_unlock(&journalfile->data_spinlock);
 
     } while(has_references);
 }
@@ -514,7 +514,7 @@ struct rrdengine_journalfile *journalfile_alloc_and_init(struct rrdengine_datafi
 {
     struct rrdengine_journalfile *journalfile = callocz(1, sizeof(struct rrdengine_journalfile));
     journalfile->datafile = datafile;
-    spinlock_init(&journalfile->data_spinlock);
+    spinlock_tracked_init(&journalfile->data_spinlock);
     spinlock_init(&journalfile->unsafe.spinlock);
     journalfile->mmap.fd = -1;
     datafile->journalfile = journalfile;
@@ -1195,9 +1195,9 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
         // IS_AVAILABLE and skip journalfile_v2_data_unmap_permanently(),
         // leaving a dangling njfv2idx entry, an unclosed fd, and an unmapped
         // region.
-        spinlock_lock(&journalfile->data_spinlock);
+        spinlock_tracked_lock(&journalfile->data_spinlock);
         journalfile->v2.flags &= ~JOURNALFILE_FLAG_IS_AVAILABLE;
-        spinlock_unlock(&journalfile->data_spinlock);
+        spinlock_tracked_unlock(&journalfile->data_spinlock);
     }
 
     journalfile_v2_data_release(journalfile);

--- a/src/database/engine/journalfile.h
+++ b/src/database/engine/journalfile.h
@@ -30,7 +30,7 @@ typedef enum __attribute__ ((__packed__)) {
 } JOURNALFILE_V2_ACCESS_HINT;
 
 struct rrdengine_journalfile {
-    SPINLOCK data_spinlock;
+    SPINLOCK_TRACKED data_spinlock;  // tracked: journalfile_v2_data_acquire 3600s deadlocks need holder identity
     struct {
         void *data;                    // MMAPed file of journal v2
         uint32_t size;                 // Total file size mapped

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -724,10 +724,10 @@ extent_flush_to_open(struct rrdengine_instance *ctx, struct extent_io_descriptor
             time_t new_last_time_s = (time_t)(max_end_time_ut / USEC_PER_SEC);
 
             // Atomically update to keep the maximum
-            spinlock_lock(&datafile->journalfile->data_spinlock);
+            spinlock_tracked_lock(&datafile->journalfile->data_spinlock);
             if (new_last_time_s > datafile->journalfile->v2.last_time_s)
                 datafile->journalfile->v2.last_time_s = new_last_time_s;
-            spinlock_unlock(&datafile->journalfile->data_spinlock);
+            spinlock_tracked_unlock(&datafile->journalfile->data_spinlock);
         }
     }
 

--- a/src/libnetdata/locks/spinlock.c
+++ b/src/libnetdata/locks/spinlock.c
@@ -150,14 +150,58 @@ ALWAYS_INLINE void spinlock_tracked_lock_with_trace(SPINLOCK_TRACKED *spinlock, 
     spinlock_lock_core(&spinlock->spinlock, func, spinlock);
 }
 
-ALWAYS_INLINE void spinlock_tracked_unlock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func __maybe_unused) {
-    // clear the holder while still holding the lock, then release
-    __atomic_store_n(&spinlock->holder_tid, 0, __ATOMIC_RELAXED);
+ALWAYS_INLINE void spinlock_tracked_unlock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func) {
+    // Intentionally do NOT clear the holder fields here. They are advisory and
+    // read by the deadlock detector ONLY while the lock is held (it reads them
+    // from inside the spin loop, i.e. when locked == true). Clearing holder_tid
+    // before releasing would let a waiter observe holder_tid == 0 with the lock
+    // still held and falsely report "[holder: NONE - possible corruption]";
+    // clearing after releasing would race a new acquirer and wipe its identity.
+    // Leaving the previous holder in place is harmless: a free lock is never
+    // reported, and the next acquirer overwrites these fields via
+    // spinlock_tracked_record_holder().
     spinlock_unlock_with_trace(&spinlock->spinlock, func);
 }
 
 ALWAYS_INLINE bool spinlock_tracked_trylock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func) {
     if (spinlock_trylock_with_trace(&spinlock->spinlock, func)) {
+        spinlock_tracked_record_holder(spinlock, func);
+        return true;
+    }
+
+    return false;
+}
+
+#else // SPINLOCK_IMPL_WITH_MUTEX
+
+// ----------------------------------------------------------------------------
+// SPINLOCK_TRACKED on top of the mutex-backed SPINLOCK. This implementation
+// does not spin, so it has no holder-aware deadlock detector; it only records
+// the holder fields so the type and API match the spinning implementation.
+
+void spinlock_tracked_init_with_trace(SPINLOCK_TRACKED *spinlock, const char *func __maybe_unused) {
+    memset(spinlock, 0, sizeof(SPINLOCK_TRACKED));
+    spinlock_init(&spinlock->spinlock);
+}
+
+static ALWAYS_INLINE void spinlock_tracked_record_holder(SPINLOCK_TRACKED *spinlock, const char *func) {
+    __atomic_store_n(&spinlock->holder_tid, gettid_cached(), __ATOMIC_RELAXED);
+    __atomic_store_n(&spinlock->holder_func, func, __ATOMIC_RELAXED);
+    __atomic_store_n(&spinlock->holder_since_ut, now_monotonic_usec(), __ATOMIC_RELAXED);
+}
+
+void spinlock_tracked_lock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func) {
+    spinlock_lock(&spinlock->spinlock);
+    spinlock_tracked_record_holder(spinlock, func);
+}
+
+void spinlock_tracked_unlock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func __maybe_unused) {
+    // Holder fields are intentionally left in place; see the spinning impl.
+    spinlock_unlock(&spinlock->spinlock);
+}
+
+bool spinlock_tracked_trylock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func) {
+    if(spinlock_trylock(&spinlock->spinlock)) {
         spinlock_tracked_record_holder(spinlock, func);
         return true;
     }

--- a/src/libnetdata/locks/spinlock.c
+++ b/src/libnetdata/locks/spinlock.c
@@ -32,7 +32,50 @@ ALWAYS_INLINE void spinlock_init_with_trace(SPINLOCK *spinlock, const char *func
     memset(spinlock, 0, sizeof(SPINLOCK));
 }
 
-ALWAYS_INLINE void spinlock_lock_with_trace(SPINLOCK *spinlock, const char *func) {
+// Holder-aware deadlock detector, used only by SPINLOCK_TRACKED. Identical to
+// spinlock_deadlock_detect() but, on timeout, names the current holder (tid,
+// acquire-site function, and how long it has held the lock) in the fatal
+// message so the event identifies WHO holds the lock, not just the waiter.
+static void spinlock_tracked_deadlock_detect(usec_t *timestamp, const char *func, SPINLOCK_TRACKED *spinlock) {
+    if (!*timestamp) {
+        *timestamp = now_monotonic_usec();
+        return;
+    }
+
+    usec_t now = now_monotonic_usec();
+    if (now - *timestamp >= SPINLOCK_DEADLOCK_TIMEOUT_SEC * USEC_PER_SEC) {
+        pid_t holder = __atomic_load_n(&spinlock->holder_tid, __ATOMIC_RELAXED);
+        const char *holder_func = __atomic_load_n(&spinlock->holder_func, __ATOMIC_RELAXED);
+        usec_t since = __atomic_load_n(&spinlock->holder_since_ut, __ATOMIC_RELAXED);
+        int64_t waited_s = (int64_t)((now - *timestamp) / USEC_PER_SEC);
+
+        if (holder)
+            fatal("DEADLOCK DETECTED: spinlock in function '%s' could not be acquired for %"PRIi64" seconds "
+                  "[holder: tid=%d func='%s' held_for=%"PRIi64"s]",
+                  func, waited_s, holder, holder_func ? holder_func : "(unknown)",
+                  since ? (int64_t)((now - since) / USEC_PER_SEC) : (int64_t)-1);
+        else
+            fatal("DEADLOCK DETECTED: spinlock in function '%s' could not be acquired for %"PRIi64" seconds "
+                  "[holder: NONE - lock shows unlocked, possible corruption/stuck byte]",
+                  func, waited_s);
+    }
+}
+
+// Record the calling thread as the current holder of a tracked spinlock.
+// Called immediately after the lock is acquired (lock and trylock paths).
+static ALWAYS_INLINE void spinlock_tracked_record_holder(SPINLOCK_TRACKED *spinlock, const char *func) {
+    __atomic_store_n(&spinlock->holder_tid, gettid_cached(), __ATOMIC_RELAXED);
+    __atomic_store_n(&spinlock->holder_func, func, __ATOMIC_RELAXED);
+    __atomic_store_n(&spinlock->holder_since_ut, now_monotonic_usec(), __ATOMIC_RELAXED);
+}
+
+// Shared spin-acquire core for both plain SPINLOCK and SPINLOCK_TRACKED. When
+// `tracked` is non-NULL the holder fields are recorded on acquire and the
+// holder-aware detector is used on contention. Being static + ALWAYS_INLINE,
+// the NULL passed by spinlock_lock_with_trace() constant-folds away, so the
+// plain spinlock path compiles to exactly the same code as before (no added
+// branch, no holder stores).
+static ALWAYS_INLINE void spinlock_lock_core(SPINLOCK *spinlock, const char *func, SPINLOCK_TRACKED *tracked) {
     size_t spins = 0;
     usec_t usec = 1;
     usec_t deadlock_timestamp = 0;
@@ -46,12 +89,15 @@ ALWAYS_INLINE void spinlock_lock_with_trace(SPINLOCK *spinlock, const char *func
 
         // Backoff strategy with exponential growth
         spins++;
-        
+
         // Check for deadlock every SPINS_BEFORE_DEADLOCK_CHECK iterations
         if ((spins % SPINS_BEFORE_DEADLOCK_CHECK) == 0) {
-            spinlock_deadlock_detect(&deadlock_timestamp, "spinlock", func);
+            if (tracked)
+                spinlock_tracked_deadlock_detect(&deadlock_timestamp, func, tracked);
+            else
+                spinlock_deadlock_detect(&deadlock_timestamp, "spinlock", func);
         }
-        
+
         microsleep(usec);
         usec = usec >= MAX_USEC ? MAX_USEC : usec * 2;
     }
@@ -61,8 +107,15 @@ ALWAYS_INLINE void spinlock_lock_with_trace(SPINLOCK *spinlock, const char *func
     spinlock->locker_pid = gettid_cached();
 #endif
 
+    if (tracked)
+        spinlock_tracked_record_holder(tracked, func);
+
     nd_thread_spinlock_locked();
     worker_spinlock_contention(func, spins);
+}
+
+ALWAYS_INLINE void spinlock_lock_with_trace(SPINLOCK *spinlock, const char *func) {
+    spinlock_lock_core(spinlock, func, NULL);
 }
 
 ALWAYS_INLINE void spinlock_unlock_with_trace(SPINLOCK *spinlock, const char *func __maybe_unused) {
@@ -80,6 +133,32 @@ ALWAYS_INLINE bool spinlock_trylock_with_trace(SPINLOCK *spinlock, const char *f
         !__atomic_test_and_set(&spinlock->locked, __ATOMIC_ACQUIRE)) {
         // Acquired the lock
         nd_thread_spinlock_locked();
+        return true;
+    }
+
+    return false;
+}
+
+// ----------------------------------------------------------------------------
+// SPINLOCK_TRACKED: holder-recording spinlock (see spinlock.h).
+
+ALWAYS_INLINE void spinlock_tracked_init_with_trace(SPINLOCK_TRACKED *spinlock, const char *func __maybe_unused) {
+    memset(spinlock, 0, sizeof(SPINLOCK_TRACKED));
+}
+
+ALWAYS_INLINE void spinlock_tracked_lock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func) {
+    spinlock_lock_core(&spinlock->spinlock, func, spinlock);
+}
+
+ALWAYS_INLINE void spinlock_tracked_unlock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func __maybe_unused) {
+    // clear the holder while still holding the lock, then release
+    __atomic_store_n(&spinlock->holder_tid, 0, __ATOMIC_RELAXED);
+    spinlock_unlock_with_trace(&spinlock->spinlock, func);
+}
+
+ALWAYS_INLINE bool spinlock_tracked_trylock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func) {
+    if (spinlock_trylock_with_trace(&spinlock->spinlock, func)) {
+        spinlock_tracked_record_holder(spinlock, func);
         return true;
     }
 

--- a/src/libnetdata/locks/spinlock.h
+++ b/src/libnetdata/locks/spinlock.h
@@ -53,6 +53,36 @@ void spinlock_unlock_with_trace(SPINLOCK *spinlock, const char *func __maybe_unu
 bool spinlock_trylock_with_trace(SPINLOCK *spinlock, const char *func __maybe_unused);
 #define spinlock_trylock(spinlock) spinlock_trylock_with_trace(spinlock, __FUNCTION__)
 
+// ----------------------------------------------------------------------------
+// SPINLOCK_TRACKED: a spinlock that records its current holder (thread id,
+// acquire-site function, and acquire time) so the deadlock detector can name
+// the holder, not just the waiter, in its fatal message.
+//
+// Unlike SPINLOCK's locker_pid (NETDATA_INTERNAL_CHECKS-only), the holder is
+// recorded in PRODUCTION. The cost (a cached gettid, a monotonic clock read,
+// and a few relaxed stores per acquire) is paid ONLY by the few known-
+// contended locks that opt in to this type; every plain SPINLOCK is untouched
+// and pays nothing. Use it on locks whose 3600s deadlock fatals are
+// un-triagable without holder identity.
+typedef struct netdata_spinlock_tracked {
+    SPINLOCK spinlock;
+    pid_t holder_tid;           // gettid_cached() of the current holder; 0 when free
+    const char *holder_func;    // acquire-site function (rodata literal); NULL when free
+    usec_t holder_since_ut;     // monotonic time the current holder acquired the lock
+} SPINLOCK_TRACKED;
+
+void spinlock_tracked_init_with_trace(SPINLOCK_TRACKED *spinlock, const char *func);
+#define spinlock_tracked_init(spinlock) spinlock_tracked_init_with_trace(spinlock, __FUNCTION__)
+
+void spinlock_tracked_lock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func);
+#define spinlock_tracked_lock(spinlock) spinlock_tracked_lock_with_trace(spinlock, __FUNCTION__)
+
+void spinlock_tracked_unlock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func __maybe_unused);
+#define spinlock_tracked_unlock(spinlock) spinlock_tracked_unlock_with_trace(spinlock, __FUNCTION__)
+
+bool spinlock_tracked_trylock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func);
+#define spinlock_tracked_trylock(spinlock) spinlock_tracked_trylock_with_trace(spinlock, __FUNCTION__)
+
 #endif
 
 #endif //NETDATA_SPINLOCK_H

--- a/src/libnetdata/locks/spinlock.h
+++ b/src/libnetdata/locks/spinlock.h
@@ -27,7 +27,7 @@ typedef struct netdata_spinlock
 #define spinlock_lock(spinlock) netdata_mutex_lock(&((spinlock)->inner))
 #define spinlock_unlock(spinlock) netdata_mutex_unlock(&((spinlock)->inner))
 #define spinlock_trylock(spinlock) (netdata_mutex_trylock(&((spinlock)->inner)) == 0)
-#define spinlock_init(spinlock) netdata_mutex_init(&((spinlock)->inner)
+#define spinlock_init(spinlock) netdata_mutex_init(&((spinlock)->inner))
 #else
 #ifdef NETDATA_INTERNAL_CHECKS
 #define SPINLOCK_INITIALIZER { .locked = false, .locker_pid = 0, .spins = 0 }
@@ -53,6 +53,8 @@ void spinlock_unlock_with_trace(SPINLOCK *spinlock, const char *func __maybe_unu
 bool spinlock_trylock_with_trace(SPINLOCK *spinlock, const char *func __maybe_unused);
 #define spinlock_trylock(spinlock) spinlock_trylock_with_trace(spinlock, __FUNCTION__)
 
+#endif
+
 // ----------------------------------------------------------------------------
 // SPINLOCK_TRACKED: a spinlock that records its current holder (thread id,
 // acquire-site function, and acquire time) so the deadlock detector can name
@@ -64,11 +66,19 @@ bool spinlock_trylock_with_trace(SPINLOCK *spinlock, const char *func __maybe_un
 // contended locks that opt in to this type; every plain SPINLOCK is untouched
 // and pays nothing. Use it on locks whose 3600s deadlock fatals are
 // un-triagable without holder identity.
+//
+// Available under both spinlock implementations. The spinning implementation
+// integrates a holder-aware deadlock detector into the spin loop; the
+// mutex-backed implementation (SPINLOCK_IMPL_WITH_MUTEX) only records the
+// holder fields, since it does not spin and cannot self-detect deadlocks.
 typedef struct netdata_spinlock_tracked {
     SPINLOCK spinlock;
-    pid_t holder_tid;           // gettid_cached() of the current holder; 0 when free
-    const char *holder_func;    // acquire-site function (rodata literal); NULL when free
-    usec_t holder_since_ut;     // monotonic time the current holder acquired the lock
+    // The holder fields are NOT cleared on unlock; they describe the most
+    // recent holder and are overwritten by the next acquirer. The detector
+    // reads them only while the lock is held, so a free lock is never reported.
+    pid_t holder_tid;           // gettid_cached() of the most recent holder; 0 before first acquire
+    const char *holder_func;    // acquire-site function (rodata literal); NULL before first acquire
+    usec_t holder_since_ut;     // monotonic time the most recent holder acquired the lock
 } SPINLOCK_TRACKED;
 
 void spinlock_tracked_init_with_trace(SPINLOCK_TRACKED *spinlock, const char *func);
@@ -77,12 +87,10 @@ void spinlock_tracked_init_with_trace(SPINLOCK_TRACKED *spinlock, const char *fu
 void spinlock_tracked_lock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func);
 #define spinlock_tracked_lock(spinlock) spinlock_tracked_lock_with_trace(spinlock, __FUNCTION__)
 
-void spinlock_tracked_unlock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func __maybe_unused);
+void spinlock_tracked_unlock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func);
 #define spinlock_tracked_unlock(spinlock) spinlock_tracked_unlock_with_trace(spinlock, __FUNCTION__)
 
 bool spinlock_tracked_trylock_with_trace(SPINLOCK_TRACKED *spinlock, const char *func);
 #define spinlock_tracked_trylock(spinlock) spinlock_tracked_trylock_with_trace(spinlock, __FUNCTION__)
-
-#endif
 
 #endif //NETDATA_SPINLOCK_H


### PR DESCRIPTION
##### Summary
- Record additional information to better track deadlock detection and holder identification. 
- Updated accompanying locking logic and introduced tracked spinlock helpers in `spinlock.h`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add holder-aware spinlocks to improve deadlock diagnostics in the DB engine. Datafile and journal locks now report the blocking thread (tid, function, held-for), and tracked info persists across unlock; works under the mutex-backed build too.

- New Features
  - Added `SPINLOCK_TRACKED` with holder tracking and `spinlock_tracked_*` APIs; holder fields persist after unlock for accurate reporting.
  - Deadlock detector now names the holder and hold duration; shared lock core keeps plain `SPINLOCK` cost unchanged.
  - Added a mutex-backed `SPINLOCK_TRACKED` so holder recording works when `SPINLOCK_IMPL_WITH_MUTEX` is enabled.

- Refactors
  - Switched datafile `users.spinlock` and journal `data_spinlock` to `SPINLOCK_TRACKED`, updated call sites in `datafile.c`, `journalfile.c`, and `rrdengine.c`, and fixed the `spinlock_init` macro typo in `spinlock.h`.
  - No change to normal behavior; only clearer diagnostics for long waits.

<sup>Written for commit 59055de70490667813353839b64ca1e77d031c08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

