### PR TITLE
Fix namespace-relative cgroup lookup for topology

### DIFF
--- a/.agents/sow/specs/topology-containers-ipc-contract.md
+++ b/.agents/sow/specs/topology-containers-ipc-contract.md
@@ -1,7 +1,7 @@
 # Topology Containers IPC Contract
 
 Status: current
-Last updated: 2026-06-13
+Last updated: 2026-06-15
 
 ## Purpose
 
@@ -62,6 +62,16 @@ Consumers must not periodically refresh known entries only because time passed, 
 - `KNOWN`: all returned item fields are valid and cacheable.
 - `UNKNOWN_RETRY_LATER`: the producer may know later; cache the incomplete status with its generation so the consumer can throttle re-asks. Query again only if the key remains in the consumer's working set and the producer generation has advanced or the key identity changes.
 - `UNKNOWN_PERMANENT`: the producer will not know this key until the key identity or reachability changes; cache the negative status so the consumer does not re-query the same unreachable key every scan.
+
+Namespace-relative cgroup paths:
+
+- `/proc/<pid>/cgroup` may expose paths whose first real component is `..` when the reader is in a different cgroup namespace than the target process.
+- `apps.plugin` forwards these paths exactly as read and uses the raw path as its cache key.
+- `cgroups.plugin` may resolve a namespace-relative request internally against its canonical cgroup snapshot and return `KNOWN` metadata while echoing the original request path in the response.
+- If no snapshot generation exists yet, namespace-relative paths return `UNKNOWN_RETRY_LATER` without raw-path discovery signalling.
+- If a namespace-relative path cannot be resolved uniquely in the current snapshot generation, it remains `UNKNOWN_RETRY_LATER` and must not fall through to raw path reachability or permanent negative status.
+- Duplicate suffix matches fail closed as `UNKNOWN_RETRY_LATER`; cgroups.plugin must not guess between multiple canonical candidates.
+- Consumers must not normalize namespace-relative cgroup paths locally unless a future multi-reader design keys caches by the reader cgroup namespace identity.
 
 `APPS_LOOKUP` has two layers:
 
@@ -132,6 +142,7 @@ Role-specific telemetry covers request outcomes, cache outcomes, peer lifecycle,
 - container grouping is available when APPS_LOOKUP returns known container metadata;
 - orchestrator grouping is available from the `CGROUPS_LOOKUP` orchestrator value propagated through apps.plugin;
 - host/root and unknown cases remain explicit fallback states rather than fabricated container identities;
+- unresolved namespace-relative cgroup paths remain pending or process fallback identities and must not be displayed as `cri-containerd-*.scope` systemd actors;
 - `group_by:pid` exposes per-PID enrichment as scalar actor fields and actor labels;
 - grouped `process_name` and `container` views merge per-PID enrichment through deduplicated actor labels and schema-declared `set` aggregation metadata, not by replacing variable values with whichever PID happened to be processed first;
 - the tabular `network-connections` Function and apps.plugin `processes` Function expose the same per-PID cgroup/container/service enrichment fields where the PID context is available.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2060,10 +2060,14 @@ set(CGROUPS_PLUGIN_FILES
         src/collectors/cgroups.plugin/cgroup-internals.h
         src/collectors/cgroups.plugin/cgroup-discovery.c
         src/collectors/cgroups.plugin/cgroup-orchestrator.c
+        src/collectors/common-cgroups/cgroup-path.c
+        src/collectors/common-cgroups/cgroup-path.h
         src/collectors/cgroups.plugin/cgroup-charts.c
         src/collectors/cgroups.plugin/cgroup-top.c
         src/collectors/cgroups.plugin/cgroup-netipc.c
         "$<$<BOOL:${ENABLE_CGROUPS_LOOKUP_SERVER}>:src/collectors/cgroups.plugin/cgroup-lookup-netipc.c>"
+        "$<$<BOOL:${ENABLE_CGROUPS_LOOKUP_SERVER}>:src/collectors/cgroups.plugin/cgroup-lookup-resolver.c>"
+        "$<$<BOOL:${ENABLE_CGROUPS_LOOKUP_SERVER}>:src/collectors/cgroups.plugin/cgroup-lookup-resolver.h>"
         src/collectors/cgroups.plugin/cgroup-netipc.h
         src/collectors/cgroups.plugin/cgroup-snapshot-store.c
         src/collectors/cgroups.plugin/cgroup-snapshot-store.h
@@ -2827,6 +2831,8 @@ if(ENABLE_PLUGIN_APPS)
                 src/collectors/collectors-ipc/ebpfgo_shared_memory.h
                 src/collectors/collectors-ipc/ebpfgo_shared_memory.c
                 src/collectors/apps.plugin/apps_ebpf_shared_memory.c
+                src/collectors/common-cgroups/cgroup-path.c
+                src/collectors/common-cgroups/cgroup-path.h
                 src/collectors/common-cgroups/cgroup-topology-rules.c
                 src/collectors/common-cgroups/cgroup-topology-rules.h
                 src/collectors/apps.plugin/apps-cgroups-path.c
@@ -3048,13 +3054,21 @@ if(OS_LINUX)
 
     add_executable(apps-cgroups-path-test EXCLUDE_FROM_ALL
             src/collectors/apps.plugin/tests/test_apps_cgroups_path.c
+            src/collectors/common-cgroups/cgroup-path.c
             src/collectors/apps.plugin/apps-cgroups-path.c)
     target_link_libraries(apps-cgroups-path-test libnetdata)
 
     add_executable(apps-cgroups-enrichment-test EXCLUDE_FROM_ALL
             src/collectors/apps.plugin/tests/test_apps_cgroups_enrichment.c
+            src/collectors/common-cgroups/cgroup-path.c
             src/collectors/common-cgroups/cgroup-topology-rules.c)
     target_link_libraries(apps-cgroups-enrichment-test libnetdata)
+
+    add_executable(cgroup-topology-rules-test EXCLUDE_FROM_ALL
+            src/collectors/common-cgroups/tests/test_cgroup_topology_rules.c
+            src/collectors/common-cgroups/cgroup-path.c
+            src/collectors/common-cgroups/cgroup-topology-rules.c)
+    target_link_libraries(cgroup-topology-rules-test libnetdata)
 
     add_executable(apps-lookup-protocol-test EXCLUDE_FROM_ALL
             src/collectors/apps.plugin/tests/test_apps_lookup_protocol.c)
@@ -3073,7 +3087,9 @@ if(ENABLE_CGROUPS_LOOKUP_SERVER)
     add_executable(cgroup-lookup-netipc-test EXCLUDE_FROM_ALL
             src/collectors/cgroups.plugin/tests/test_cgroup_lookup_netipc.c
             src/collectors/cgroups.plugin/cgroup-lookup-netipc.c
+            src/collectors/cgroups.plugin/cgroup-lookup-resolver.c
             src/collectors/cgroups.plugin/cgroup-snapshot-store.c
+            src/collectors/common-cgroups/cgroup-path.c
             src/collectors/cgroups.plugin/cgroup-orchestrator.c)
     target_compile_definitions(cgroup-lookup-netipc-test PRIVATE NETDATA_INTERNAL_CHECKS=1)
     target_link_libraries(cgroup-lookup-netipc-test libnetdata)
@@ -3345,6 +3361,8 @@ if(ENABLE_PLUGIN_NETWORK_VIEWER)
         if(OS_LINUX)
                 list(APPEND NETWORK_VIEWER_FILES
                         src/libnetdata/local-sockets/local-sockets.h
+                        src/collectors/common-cgroups/cgroup-path.c
+                        src/collectors/common-cgroups/cgroup-path.h
                         src/collectors/common-cgroups/cgroup-topology-rules.c
                         src/collectors/common-cgroups/cgroup-topology-rules.h
                         src/collectors/network-viewer.plugin/network-viewer-apps-lookup-client.c
@@ -3362,6 +3380,8 @@ if(ENABLE_PLUGIN_NETWORK_VIEWER)
         if(OS_FREEBSD)
                 list(APPEND NETWORK_VIEWER_FILES
                         src/libnetdata/local-sockets/local-sockets-freebsd.h
+                        src/collectors/common-cgroups/cgroup-path.c
+                        src/collectors/common-cgroups/cgroup-path.h
                         src/collectors/common-cgroups/cgroup-topology-rules.c
                         src/collectors/common-cgroups/cgroup-topology-rules.h
                         src/collectors/network-viewer.plugin/network-viewer-apps-lookup-client.h
@@ -3395,6 +3415,7 @@ if(ENABLE_PLUGIN_NETWORK_VIEWER)
 
                 add_executable(network-viewer-topology-containers-test EXCLUDE_FROM_ALL
                         src/collectors/network-viewer.plugin/tests/test_network_viewer_topology_containers.c
+                        src/collectors/common-cgroups/cgroup-path.c
                         src/collectors/common-cgroups/cgroup-topology-rules.c
                         src/collectors/network-viewer.plugin/network-viewer-topology-containers.c)
                 target_link_libraries(network-viewer-topology-containers-test libnetdata)

--- a/src/collectors/apps.plugin/apps-cgroups-lookup-client.c
+++ b/src/collectors/apps.plugin/apps-cgroups-lookup-client.c
@@ -369,6 +369,9 @@ static void cgroups_lookup_commit_staged(
     struct cgroups_lookup_staged_item *staged,
     uint64_t generation)
 {
+    // CGROUPS_LOOKUP may resolve a namespace-relative cgroup internally, but the
+    // response path remains the original request key so this cache can commit
+    // without normalizing paths in apps.plugin.
     struct cgroup_lookup_entry *entry =
         dictionary_get_advanced(cgroups_lookup_cache, item->path.ptr, item->path.len);
     if (!entry)

--- a/src/collectors/apps.plugin/apps-cgroups-path.c
+++ b/src/collectors/apps.plugin/apps-cgroups-path.c
@@ -1,118 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "apps-cgroups-path.h"
+#include "collectors/common-cgroups/cgroup-path.h"
 
 #ifdef OS_LINUX
 
-static bool cgroup_controller_token_matches(const char *controllers, size_t len, const char *needle)
-{
-    size_t needle_len = strlen(needle);
-    const char *p = controllers;
-    const char *end = controllers + len;
-
-    while (p < end) {
-        const char *comma = memchr(p, ',', (size_t)(end - p));
-        const char *token_end = comma ? comma : end;
-        size_t token_len = (size_t)(token_end - p);
-
-        if (token_len == needle_len && memcmp(p, needle, needle_len) == 0)
-            return true;
-
-        if (!comma)
-            break;
-
-        p = comma + 1;
-    }
-
-    return false;
-}
-
-static unsigned cgroup_v1_precedence(const char *controllers, size_t len)
-{
-    if (cgroup_controller_token_matches(controllers, len, "cpuacct"))
-        return 1;
-
-    if (cgroup_controller_token_matches(controllers, len, "blkio"))
-        return 2;
-
-    if (cgroup_controller_token_matches(controllers, len, "memory"))
-        return 3;
-
-    if (len == strlen("name=systemd") && memcmp(controllers, "name=systemd", len) == 0)
-        return 4;
-
-    return 5;
-}
-
-static bool cgroup_copy_path(const char *path, size_t len, char *dst, size_t dst_size)
-{
-    if (!path || len == 0 || path[0] != '/' || !dst || dst_size == 0 || len >= dst_size)
-        return false;
-
-    memcpy(dst, path, len);
-    dst[len] = '\0';
-    return true;
-}
-
 bool apps_cgroup_parse_proc_pid_cgroup_content(const char *content, char *dst, size_t dst_size)
 {
-    if (!content || !dst || dst_size == 0)
-        return false;
-
-    dst[0] = '\0';
-
-    const char *best_path = NULL;
-    size_t best_path_len = 0;
-    unsigned best_score = UINT_MAX;
-
-    const char *line = content;
-    while (*line) {
-        const char *line_end = strchr(line, '\n');
-        if (!line_end)
-            line_end = line + strlen(line);
-
-        const char *next_line = (*line_end == '\n') ? line_end + 1 : line_end;
-        const char *field_end = line_end;
-        if (field_end > line && field_end[-1] == '\r')
-            field_end--;
-
-        const char *first_colon = memchr(line, ':', (size_t)(field_end - line));
-        if (!first_colon) {
-            line = next_line;
-            continue;
-        }
-
-        const char *second_colon = memchr(first_colon + 1, ':', (size_t)(field_end - first_colon - 1));
-        if (!second_colon) {
-            line = next_line;
-            continue;
-        }
-
-        const char *path = second_colon + 1;
-        size_t path_len = (size_t)(field_end - path);
-        if (path_len == 0 || path[0] != '/') {
-            line = next_line;
-            continue;
-        }
-
-        bool is_v2 = (first_colon == line + 1 && line[0] == '0' && second_colon == first_colon + 1);
-        if (is_v2)
-            return cgroup_copy_path(path, path_len, dst, dst_size);
-
-        const char *controllers = first_colon + 1;
-        size_t controllers_len = (size_t)(second_colon - controllers);
-        unsigned score = cgroup_v1_precedence(controllers, controllers_len);
-
-        if (score < best_score) {
-            best_score = score;
-            best_path = path;
-            best_path_len = path_len;
-        }
-
-        line = next_line;
-    }
-
-    return cgroup_copy_path(best_path, best_path_len, dst, dst_size);
+    return cgroup_path_parse_proc_pid_cgroup_content(content, dst, dst_size);
 }
 
 #endif /* OS_LINUX */

--- a/src/collectors/apps.plugin/tests/test_apps_cgroups_enrichment.c
+++ b/src/collectors/apps.plugin/tests/test_apps_cgroups_enrichment.c
@@ -116,6 +116,30 @@ static bool test_pending_container_path_without_cache(void)
     return ok;
 }
 
+static bool test_namespace_relative_container_scope_without_cache(void)
+{
+    struct pid_stat p = {
+        .pid = 1008,
+        .uid = 1001,
+        .comm = string_strdupz("worker"),
+        .cgroup_path = string_strdupz(
+            "/../../kubepods.slice/kubepods-besteffort.slice/podabc/"
+            "cri-containerd-0123456789abcdef.scope"),
+    };
+    APPS_PROCESS_ENRICHMENT out;
+
+    apps_process_enrichment_fill(&p, &out);
+
+    bool ok =
+        expect_str_eq(out.container_name, "[pending]", "namespace-relative pending container name mismatch") &&
+        expect_str_eq(out.actor_type, "container", "namespace-relative pending actor type mismatch") &&
+        expect_str_eq(out.actor_kind, "pending", "namespace-relative pending actor kind mismatch") &&
+        expect_str_eq(out.cgroup_status, "retry_later", "namespace-relative pending cgroup status mismatch");
+
+    pid_fixture_clear(&p);
+    return ok;
+}
+
 static bool test_known_k8s_labels(void)
 {
     struct cgroup_lookup_label labels[5] = {
@@ -165,6 +189,7 @@ int main(void)
         test_process_without_cgroup_path() &&
         test_systemd_user_scope_without_cache() &&
         test_pending_container_path_without_cache() &&
+        test_namespace_relative_container_scope_without_cache() &&
         test_known_k8s_labels();
 
     return ok ? 0 : 1;

--- a/src/collectors/apps.plugin/tests/test_apps_cgroups_lookup_client_abort.c
+++ b/src/collectors/apps.plugin/tests/test_apps_cgroups_lookup_client_abort.c
@@ -116,6 +116,67 @@ static bool test_retry_later_generation_reset(void)
     return ok;
 }
 
+static bool test_retry_later_same_generation_not_requeued(void)
+{
+    bool ok = true;
+    bool queue_mutex_initialized = false;
+    bool queue_cond_initialized = false;
+
+    cgroups_lookup_cache_create();
+    cgroups_lookup_latest_generation = 7;
+
+    if (!expect_ok(netdata_mutex_init(&cgroups_lookup_queue_mutex) == 0, "queue mutex init failed"))
+        goto cleanup;
+    queue_mutex_initialized = true;
+
+    if (!expect_ok(netdata_cond_init(&cgroups_lookup_queue_cond) == 0, "queue cond init failed"))
+        goto cleanup;
+    queue_cond_initialized = true;
+
+    cgroups_lookup_queue_initialized = true;
+    cgroups_lookup_worker_thread = (ND_THREAD *)0x1;
+
+    test_pid = (struct pid_stat){ 0 };
+    test_pid.pid = 22345;
+    test_pid.cgroup_path = string_strdupz(
+        "/../../kubepods.slice/pod-a/cri-containerd-0123456789abcdef.scope");
+    test_pid.cgroup_cache = cgroups_lookup_cache_get_or_create(test_pid.cgroup_path);
+    test_pid.cgroup_cache->refcount = 1;
+    test_pid.cgroup_cache->cgroup_status = NIPC_CGROUP_LOOKUP_UNKNOWN_RETRY_LATER;
+    test_pid.cgroup_cache->generation = 7;
+    test_pid.cgroup_cache->pending = false;
+
+    apps_cgroups_lookup_scan_pids();
+    ok =
+        expect_ok(cgroups_lookup_queue_count == 0, "same-generation retry-later path was requeued") &&
+        expect_ok(!test_pid.cgroup_cache->pending, "same-generation retry-later entry was marked pending") &&
+        ok;
+
+    cgroups_lookup_latest_generation = 8;
+    apps_cgroups_lookup_scan_pids();
+    ok =
+        expect_ok(cgroups_lookup_queue_count == 1, "new-generation retry-later path was not requeued") &&
+        expect_ok(test_pid.cgroup_cache->pending, "new-generation retry-later entry was not marked pending") &&
+        ok;
+
+cleanup:
+    if (cgroups_lookup_queue_initialized)
+        cgroups_lookup_queue_drain();
+    cgroups_lookup_queue_initialized = false;
+    cgroups_lookup_worker_thread = NULL;
+    if (queue_cond_initialized)
+        netdata_cond_destroy(&cgroups_lookup_queue_cond);
+    if (queue_mutex_initialized)
+        netdata_mutex_destroy(&cgroups_lookup_queue_mutex);
+
+    test_pid.cgroup_cache = NULL;
+    string_freez(test_pid.cgroup_path);
+    test_pid.cgroup_path = NULL;
+    cgroups_lookup_latest_generation = 0;
+    cgroups_lookup_cache_destroy();
+    return ok;
+}
+
 static bool blocking_cgroups_lookup_handler(
     void *user __maybe_unused,
     const nipc_cgroups_lookup_req_view_t *request,
@@ -182,6 +243,10 @@ int main(void)
     if (!expect_ok(test_cache_allows_more_than_legacy_fixed_cap(), "active cgroup cache cardinality test failed"))
         goto cleanup_fixture;
     if (!expect_ok(test_retry_later_generation_reset(), "retry-later generation reset test failed"))
+        goto cleanup_fixture;
+    if (!expect_ok(
+            test_retry_later_same_generation_not_requeued(),
+            "retry-later same-generation requeue test failed"))
         goto cleanup_fixture;
 
     test_pid.pid = 12345;

--- a/src/collectors/apps.plugin/tests/test_apps_cgroups_path.c
+++ b/src/collectors/apps.plugin/tests/test_apps_cgroups_path.c
@@ -61,6 +61,12 @@ int main(void)
         return 1;
 
     if (!expect_path(
+            "v1 namespace-relative cpuacct precedence",
+            "3:memory:/memory-path\n1:cpu,cpuacct:/../../../kubepods.slice/pod-a/cri-containerd-abc.scope\n",
+            "/../../../kubepods.slice/pod-a/cri-containerd-abc.scope"))
+        return 1;
+
+    if (!expect_path(
             "v1 blkio precedence",
             "3:memory:/memory-path\n2:blkio:/blkio-path\n4:name=systemd:/init.scope\n",
             "/blkio-path"))

--- a/src/collectors/apps.plugin/tests/test_apps_cgroups_path.c
+++ b/src/collectors/apps.plugin/tests/test_apps_cgroups_path.c
@@ -43,6 +43,12 @@ int main(void)
         return 1;
 
     if (!expect_path(
+            "v2 namespace-relative",
+            "0::/../../../kubepods-besteffort.slice/pod-a/cri-containerd-abc.scope\n",
+            "/../../../kubepods-besteffort.slice/pod-a/cri-containerd-abc.scope"))
+        return 1;
+
+    if (!expect_path(
             "crlf malformed line advances",
             "malformed\r\n0::/unified\r\n",
             "/unified"))

--- a/src/collectors/cgroups.plugin/cgroup-lookup-netipc.c
+++ b/src/collectors/cgroups.plugin/cgroup-lookup-netipc.c
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "cgroup-internals.h"
+#include "cgroup-lookup-resolver.h"
 #include "cgroup-netipc.h"
 #include "cgroup-snapshot-store.h"
+#include "collectors/common-cgroups/cgroup-path.h"
 #include "libnetdata/netipc/netipc_netdata.h"
 
 #if defined(OS_LINUX) && defined(ENABLE_CGROUPS_LOOKUP_SERVER)
@@ -195,11 +197,21 @@ static bool cgroups_lookup_handler(
         uint32_t name_len = 0;
         uint16_t label_count = 0;
 
-        if (generation == 0) {
+        char *pathz = mallocz((size_t)path_len + 1);
+        memcpy(pathz, path, path_len);
+        pathz[path_len] = '\0';
+        bool is_namespace_relative = cgroup_path_is_namespace_relative(pathz);
+
+        if (generation == 0 && is_namespace_relative) {
+            // no snapshot exists yet; do not signal discovery for a raw namespace-relative path
+        } else if (generation == 0) {
             // discovery has not published a snapshot yet
             should_signal_lookup_miss = true;
         } else {
             const CGROUP_SNAPSHOT_ENTRY *e = cgroup_snapshot_store_find(store, path, path_len);
+            if (!e && is_namespace_relative)
+                e = cgroup_lookup_resolver_resolve(store, generation, path, path_len);
+
             if (e) {
                 if (e->known) {
                     status = NIPC_CGROUP_LOOKUP_KNOWN;
@@ -221,6 +233,8 @@ static bool cgroups_lookup_handler(
                 }
                 // else: discovery knows the cgroup but has not resolved its name
                 // yet -- transient, retry without waking discovery (it is aware)
+            } else if (is_namespace_relative) {
+                // namespace-relative misses stay retry-later and never fall through to raw reachability
             } else if (cgroup_lookup_path_reachable(path, path_len)) {
                 // discovery could enumerate this path but has not seen it yet
                 should_signal_lookup_miss = true;
@@ -238,8 +252,11 @@ static bool cgroups_lookup_handler(
 
         if (err != NIPC_OK) {
             builder->error = err;
+            freez(pathz);
             break;
         }
+
+        freez(pathz);
     }
 
     cgroup_snapshot_store_release();
@@ -264,6 +281,8 @@ static void cgroup_netipc_lookup_server_thread(void *arg)
 
 static void cgroup_netipc_lookup_init_at(const char *run_dir, const char *service_name)
 {
+    cgroup_lookup_resolver_init();
+
     uint64_t auth = netipc_auth_token();
 
     nipc_server_config_t config = {
@@ -287,6 +306,7 @@ static void cgroup_netipc_lookup_init_at(const char *run_dir, const char *servic
 
     if (err != NIPC_OK) {
         collector_error("CGROUP: netipc lookup server init failed (error %u), lookup IPC disabled", (unsigned int)err);
+        cgroup_lookup_resolver_cleanup();
         return;
     }
 
@@ -299,6 +319,7 @@ static void cgroup_netipc_lookup_init_at(const char *run_dir, const char *servic
         collector_error("CGROUP: failed to create netipc lookup server thread");
         nipc_server_destroy(&cgroup_netipc_lookup_server);
         cgroup_netipc_lookup_server_initialized = false;
+        cgroup_lookup_resolver_cleanup();
         return;
     }
 
@@ -334,6 +355,8 @@ void cgroup_netipc_lookup_cleanup(void)
         errno_clear();
         collector_info("CGROUP: netipc lookup server stopped");
     }
+
+    cgroup_lookup_resolver_cleanup();
 }
 
 void cgroup_netipc_lookup_update_charts(int update_every)

--- a/src/collectors/cgroups.plugin/cgroup-lookup-resolver.c
+++ b/src/collectors/cgroups.plugin/cgroup-lookup-resolver.c
@@ -313,51 +313,6 @@ static bool cgroup_lookup_clean_join(const char *base, const char *relative, cha
     return ok;
 }
 
-static bool cgroup_lookup_prefix_has_parent_component(const char *path)
-{
-    if(!path)
-        return true;
-
-    const char *p = path;
-    while(*p) {
-        while(*p == '/')
-            p++;
-
-        const char *start = p;
-        while(*p && *p != '/')
-            p++;
-
-        size_t len = (size_t)(p - start);
-        if(len == 2 && start[0] == '.' && start[1] == '.')
-            return true;
-    }
-
-    return false;
-}
-
-static bool cgroup_lookup_build_host_proc_self_cgroup_path(char *dst, size_t dst_size)
-{
-    static const char proc_self_cgroup[] = "/proc/self/cgroup";
-
-    if(!dst || dst_size == 0 || !netdata_configured_host_prefix || !*netdata_configured_host_prefix)
-        return false;
-
-    const char *prefix = netdata_configured_host_prefix;
-    if(prefix[0] != '/' || cgroup_lookup_prefix_has_parent_component(prefix))
-        return false;
-
-    size_t prefix_len = strlen(prefix);
-    size_t child_len = sizeof(proc_self_cgroup) - 1;
-    bool prefix_has_trailing_slash = prefix[prefix_len - 1] == '/';
-    size_t child_offset = prefix_has_trailing_slash ? 1 : 0;
-    if(prefix_len + child_len - child_offset >= dst_size)
-        return false;
-
-    memcpy(dst, prefix, prefix_len);
-    memcpy(dst + prefix_len, proc_self_cgroup + child_offset, child_len + 1 - child_offset);
-    return true;
-}
-
 static bool cgroup_lookup_stat_under_base(const char *base, const char *cgroup_id, struct stat *st)
 {
     if(!base || !*base || !cgroup_id || !st)
@@ -523,21 +478,12 @@ static const CGROUP_SNAPSHOT_ENTRY *cgroup_lookup_resolve_with_self_views(
     const CGROUP_SNAPSHOT_STORE *store,
     const char *path)
 {
-    char proc_path[FILENAME_MAX + 1];
     char self_cgroup[FILENAME_MAX + 1];
 
     if(cgroup_lookup_read_proc_self_cgroup("/proc/self/cgroup", self_cgroup, sizeof(self_cgroup))) {
         const CGROUP_SNAPSHOT_ENTRY *entry = cgroup_lookup_resolve_with_self_path(store, self_cgroup, path);
         if(entry)
             return entry;
-    }
-
-    if(cgroup_lookup_build_host_proc_self_cgroup_path(proc_path, sizeof(proc_path))) {
-        if(cgroup_lookup_read_proc_self_cgroup(proc_path, self_cgroup, sizeof(self_cgroup))) {
-            const CGROUP_SNAPSHOT_ENTRY *entry = cgroup_lookup_resolve_with_self_path(store, self_cgroup, path);
-            if(entry)
-                return entry;
-        }
     }
 
     return NULL;

--- a/src/collectors/cgroups.plugin/cgroup-lookup-resolver.c
+++ b/src/collectors/cgroups.plugin/cgroup-lookup-resolver.c
@@ -313,6 +313,51 @@ static bool cgroup_lookup_clean_join(const char *base, const char *relative, cha
     return ok;
 }
 
+static bool cgroup_lookup_prefix_has_parent_component(const char *path)
+{
+    if(!path)
+        return true;
+
+    const char *p = path;
+    while(*p) {
+        while(*p == '/')
+            p++;
+
+        const char *start = p;
+        while(*p && *p != '/')
+            p++;
+
+        size_t len = (size_t)(p - start);
+        if(len == 2 && start[0] == '.' && start[1] == '.')
+            return true;
+    }
+
+    return false;
+}
+
+static bool cgroup_lookup_build_host_proc_self_cgroup_path(char *dst, size_t dst_size)
+{
+    static const char proc_self_cgroup[] = "/proc/self/cgroup";
+
+    if(!dst || dst_size == 0 || !netdata_configured_host_prefix || !*netdata_configured_host_prefix)
+        return false;
+
+    const char *prefix = netdata_configured_host_prefix;
+    if(prefix[0] != '/' || cgroup_lookup_prefix_has_parent_component(prefix))
+        return false;
+
+    size_t prefix_len = strlen(prefix);
+    size_t child_len = sizeof(proc_self_cgroup) - 1;
+    bool prefix_has_trailing_slash = prefix[prefix_len - 1] == '/';
+    size_t child_offset = prefix_has_trailing_slash ? 1 : 0;
+    if(prefix_len + child_len - child_offset >= dst_size)
+        return false;
+
+    memcpy(dst, prefix, prefix_len);
+    memcpy(dst + prefix_len, proc_self_cgroup + child_offset, child_len + 1 - child_offset);
+    return true;
+}
+
 static bool cgroup_lookup_stat_under_base(const char *base, const char *cgroup_id, struct stat *st)
 {
     if(!base || !*base || !cgroup_id || !st)
@@ -478,9 +523,17 @@ static const CGROUP_SNAPSHOT_ENTRY *cgroup_lookup_resolve_with_self_views(
     const CGROUP_SNAPSHOT_STORE *store,
     const char *path)
 {
+    char proc_path[FILENAME_MAX + 1];
     char self_cgroup[FILENAME_MAX + 1];
 
-    if(cgroup_lookup_read_proc_self_cgroup("/proc/self/cgroup", self_cgroup, sizeof(self_cgroup))) {
+    if(netdata_configured_host_prefix && *netdata_configured_host_prefix) {
+        if(!cgroup_lookup_build_host_proc_self_cgroup_path(proc_path, sizeof(proc_path)))
+            return NULL;
+    }
+    else
+        strncpyz(proc_path, "/proc/self/cgroup", sizeof(proc_path) - 1);
+
+    if(cgroup_lookup_read_proc_self_cgroup(proc_path, self_cgroup, sizeof(self_cgroup))) {
         const CGROUP_SNAPSHOT_ENTRY *entry = cgroup_lookup_resolve_with_self_path(store, self_cgroup, path);
         if(entry)
             return entry;

--- a/src/collectors/cgroups.plugin/cgroup-lookup-resolver.c
+++ b/src/collectors/cgroups.plugin/cgroup-lookup-resolver.c
@@ -313,28 +313,6 @@ static bool cgroup_lookup_clean_join(const char *base, const char *relative, cha
     return ok;
 }
 
-static bool cgroup_lookup_prefix_has_parent_component(const char *path)
-{
-    if(!path)
-        return true;
-
-    const char *p = path;
-    while(*p) {
-        while(*p == '/')
-            p++;
-
-        const char *start = p;
-        while(*p && *p != '/')
-            p++;
-
-        size_t len = (size_t)(p - start);
-        if(len == 2 && start[0] == '.' && start[1] == '.')
-            return true;
-    }
-
-    return false;
-}
-
 static bool cgroup_lookup_build_host_proc_self_cgroup_path(char *dst, size_t dst_size)
 {
     static const char proc_self_cgroup[] = "/proc/self/cgroup";
@@ -343,7 +321,7 @@ static bool cgroup_lookup_build_host_proc_self_cgroup_path(char *dst, size_t dst
         return false;
 
     const char *prefix = netdata_configured_host_prefix;
-    if(prefix[0] != '/' || cgroup_lookup_prefix_has_parent_component(prefix))
+    if(prefix[0] != '/' || cgroup_lookup_path_has_parent_component(prefix))
         return false;
 
     size_t prefix_len = strlen(prefix);

--- a/src/collectors/cgroups.plugin/cgroup-lookup-resolver.c
+++ b/src/collectors/cgroups.plugin/cgroup-lookup-resolver.c
@@ -1,0 +1,617 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "cgroup-internals.h"
+#include "cgroup-lookup-resolver.h"
+#include "collectors/common-cgroups/cgroup-path.h"
+
+#if defined(OS_LINUX) && defined(ENABLE_CGROUPS_LOOKUP_SERVER)
+
+typedef struct cgroup_lookup_resolver_prefix_cache {
+    char *raw_prefix;
+    char *canonical_prefix;
+} CGROUP_LOOKUP_RESOLVER_PREFIX_CACHE;
+
+typedef struct cgroup_lookup_resolver_state {
+    netdata_mutex_t mutex;
+    bool initialized;
+    uint64_t generation;
+    CGROUP_LOOKUP_RESOLVER_PREFIX_CACHE *positive;
+    size_t positive_count;
+    size_t positive_capacity;
+    char **negative;
+    size_t negative_count;
+    size_t negative_capacity;
+#ifdef NETDATA_INTERNAL_CHECKS
+    size_t suffix_scans;
+#endif
+} CGROUP_LOOKUP_RESOLVER_STATE;
+
+static CGROUP_LOOKUP_RESOLVER_STATE resolver_state;
+
+static void cgroup_lookup_resolver_clear_locked(void)
+{
+    for(size_t i = 0; i < resolver_state.positive_count; i++) {
+        freez(resolver_state.positive[i].raw_prefix);
+        freez(resolver_state.positive[i].canonical_prefix);
+    }
+    freez(resolver_state.positive);
+    resolver_state.positive = NULL;
+    resolver_state.positive_count = 0;
+    resolver_state.positive_capacity = 0;
+
+    for(size_t i = 0; i < resolver_state.negative_count; i++)
+        freez(resolver_state.negative[i]);
+    freez(resolver_state.negative);
+    resolver_state.negative = NULL;
+    resolver_state.negative_count = 0;
+    resolver_state.negative_capacity = 0;
+#ifdef NETDATA_INTERNAL_CHECKS
+    resolver_state.suffix_scans = 0;
+#endif
+}
+
+void cgroup_lookup_resolver_init(void)
+{
+    if(resolver_state.initialized)
+        return;
+
+    netdata_mutex_init(&resolver_state.mutex);
+    resolver_state.initialized = true;
+}
+
+void cgroup_lookup_resolver_cleanup(void)
+{
+    if(!resolver_state.initialized)
+        return;
+
+    netdata_mutex_lock(&resolver_state.mutex);
+    cgroup_lookup_resolver_clear_locked();
+    netdata_mutex_unlock(&resolver_state.mutex);
+
+    netdata_mutex_destroy(&resolver_state.mutex);
+    resolver_state = (CGROUP_LOOKUP_RESOLVER_STATE){ 0 };
+}
+
+#ifdef NETDATA_INTERNAL_CHECKS
+size_t cgroup_lookup_resolver_suffix_scans_for_testing(void)
+{
+    if(!resolver_state.initialized)
+        return 0;
+
+    netdata_mutex_lock(&resolver_state.mutex);
+    size_t scans = resolver_state.suffix_scans;
+    netdata_mutex_unlock(&resolver_state.mutex);
+    return scans;
+}
+#endif
+
+static bool cgroup_lookup_path_has_parent_component(const char *path)
+{
+    if(!path)
+        return false;
+
+    const char *p = path;
+    while(*p) {
+        while(*p == '/')
+            p++;
+
+        const char *start = p;
+        while(*p && *p != '/')
+            p++;
+
+        size_t len = (size_t)(p - start);
+        if(len == 2 && start[0] == '.' && start[1] == '.')
+            return true;
+    }
+
+    return false;
+}
+
+static bool cgroup_lookup_resolver_parse(
+    const char *path,
+    char **raw_prefix,
+    char **suffix,
+    size_t *prefix_len)
+{
+    if(raw_prefix)
+        *raw_prefix = NULL;
+    if(suffix)
+        *suffix = NULL;
+    if(prefix_len)
+        *prefix_len = 0;
+
+    if(!cgroup_path_is_namespace_relative(path))
+        return false;
+
+    size_t i = 0;
+    while(path[i] == '/')
+        i++;
+
+    size_t first_component_start = 0;
+    size_t first_component_end = 0;
+    bool found = false;
+
+    while(path[i]) {
+        size_t start = i;
+        while(path[i] && path[i] != '/')
+            i++;
+        size_t end = i;
+
+        if(end - start == 2 && path[start] == '.' && path[start + 1] == '.') {
+            while(path[i] == '/')
+                i++;
+            continue;
+        }
+
+        first_component_start = start;
+        first_component_end = end;
+        found = true;
+        break;
+    }
+
+    if(!found || first_component_end == first_component_start)
+        return false;
+
+    size_t pfx_len = first_component_end;
+    char *pfx = mallocz(pfx_len + 1);
+    memcpy(pfx, path, pfx_len);
+    pfx[pfx_len] = '\0';
+
+    char *sfx = strdupz(path + first_component_start);
+    if(cgroup_lookup_path_has_parent_component(sfx)) {
+        freez(pfx);
+        freez(sfx);
+        return false;
+    }
+
+    if(raw_prefix)
+        *raw_prefix = pfx;
+    else
+        freez(pfx);
+
+    if(suffix)
+        *suffix = sfx;
+    else
+        freez(sfx);
+
+    if(prefix_len)
+        *prefix_len = pfx_len;
+
+    return true;
+}
+
+static const CGROUP_LOOKUP_RESOLVER_PREFIX_CACHE *cgroup_lookup_resolver_positive_get_locked(const char *raw_prefix)
+{
+    for(size_t i = 0; i < resolver_state.positive_count; i++) {
+        if(strcmp(resolver_state.positive[i].raw_prefix, raw_prefix) == 0)
+            return &resolver_state.positive[i];
+    }
+
+    return NULL;
+}
+
+static bool cgroup_lookup_resolver_negative_has_locked(const char *path)
+{
+    for(size_t i = 0; i < resolver_state.negative_count; i++) {
+        if(strcmp(resolver_state.negative[i], path) == 0)
+            return true;
+    }
+
+    return false;
+}
+
+static void cgroup_lookup_resolver_positive_add_locked(const char *raw_prefix, const char *canonical_prefix)
+{
+    if(cgroup_lookup_resolver_positive_get_locked(raw_prefix))
+        return;
+
+    if(resolver_state.positive_count == resolver_state.positive_capacity) {
+        resolver_state.positive_capacity = resolver_state.positive_capacity ? resolver_state.positive_capacity * 2 : 8;
+        resolver_state.positive = reallocz(
+            resolver_state.positive,
+            resolver_state.positive_capacity * sizeof(*resolver_state.positive));
+    }
+
+    CGROUP_LOOKUP_RESOLVER_PREFIX_CACHE *entry = &resolver_state.positive[resolver_state.positive_count++];
+    entry->raw_prefix = strdupz(raw_prefix);
+    entry->canonical_prefix = strdupz(canonical_prefix);
+}
+
+static void cgroup_lookup_resolver_negative_add_locked(const char *path)
+{
+    if(cgroup_lookup_resolver_negative_has_locked(path))
+        return;
+
+    if(resolver_state.negative_count == resolver_state.negative_capacity) {
+        resolver_state.negative_capacity = resolver_state.negative_capacity ? resolver_state.negative_capacity * 2 : 16;
+        resolver_state.negative = reallocz(
+            resolver_state.negative,
+            resolver_state.negative_capacity * sizeof(*resolver_state.negative));
+    }
+
+    resolver_state.negative[resolver_state.negative_count++] = strdupz(path);
+}
+
+static bool cgroup_lookup_clean_join(const char *base, const char *relative, char *dst, size_t dst_size)
+{
+    if(!base || !relative || !dst || dst_size == 0)
+        return false;
+
+    size_t base_len = strlen(base);
+    size_t relative_len = strlen(relative);
+    bool add_separator = base_len && relative_len && base[base_len - 1] != '/' && relative[0] != '/';
+    char *combined = mallocz(base_len + relative_len + (add_separator ? 2 : 1));
+    snprintfz(
+        combined,
+        base_len + relative_len + (add_separator ? 2 : 1),
+        "%s%s%s",
+        base,
+        add_separator ? "/" : "",
+        relative);
+
+    const char **components = callocz(base_len + relative_len + 2, sizeof(*components));
+    size_t *component_lens = callocz(base_len + relative_len + 2, sizeof(*component_lens));
+    size_t component_count = 0;
+
+    bool ok = true;
+    char *p = combined;
+    while(*p) {
+        while(*p == '/')
+            p++;
+
+        char *start = p;
+        while(*p && *p != '/')
+            p++;
+
+        size_t len = (size_t)(p - start);
+        if(len == 0 || (len == 1 && start[0] == '.'))
+            continue;
+
+        if(len == 2 && start[0] == '.' && start[1] == '.') {
+            if(component_count == 0) {
+                ok = false;
+                break;
+            }
+            component_count--;
+            continue;
+        }
+
+        components[component_count] = start;
+        component_lens[component_count] = len;
+        component_count++;
+    }
+
+    if(ok) {
+        size_t used = 0;
+        if(dst_size < 2)
+            ok = false;
+        else {
+            dst[used++] = '/';
+            for(size_t i = 0; i < component_count; i++) {
+                if(i) {
+                    if(used + 1 >= dst_size) {
+                        ok = false;
+                        break;
+                    }
+                    dst[used++] = '/';
+                }
+
+                if(used + component_lens[i] >= dst_size) {
+                    ok = false;
+                    break;
+                }
+                memcpy(&dst[used], components[i], component_lens[i]);
+                used += component_lens[i];
+            }
+            dst[used] = '\0';
+        }
+    }
+
+    freez(component_lens);
+    freez(components);
+    freez(combined);
+    return ok;
+}
+
+static bool cgroup_lookup_stat_under_base(const char *base, const char *cgroup_id, struct stat *st)
+{
+    if(!base || !*base || !cgroup_id || !st)
+        return false;
+
+    char path[FILENAME_MAX + 1];
+    snprintfz(path, sizeof(path) - 1, "%s%s", base, cgroup_id);
+    return stat(path, st) == 0;
+}
+
+static bool cgroup_lookup_strip_host_prefix(const char *base, char *dst, size_t dst_size)
+{
+    if(!base || !dst || dst_size == 0 || !netdata_configured_host_prefix || !*netdata_configured_host_prefix)
+        return false;
+
+    size_t prefix_len = strlen(netdata_configured_host_prefix);
+    if(strncmp(base, netdata_configured_host_prefix, prefix_len) != 0)
+        return false;
+    if(base[prefix_len] && base[prefix_len] != '/')
+        return false;
+
+    const char *stripped = base + prefix_len;
+    if(!*stripped)
+        stripped = "/";
+
+    if(strlen(stripped) >= dst_size)
+        return false;
+
+    strncpyz(dst, stripped, dst_size - 1);
+    return true;
+}
+
+static bool cgroup_lookup_stat_plugin_visible_base(const char *canonical_base, const char *cgroup_id, struct stat *st)
+{
+    char plugin_base[FILENAME_MAX + 1];
+
+    if(cgroup_lookup_strip_host_prefix(canonical_base, plugin_base, sizeof(plugin_base)) &&
+       cgroup_lookup_stat_under_base(plugin_base, cgroup_id, st))
+        return true;
+
+    if(netdata_configured_host_prefix && *netdata_configured_host_prefix)
+        return false;
+
+    return cgroup_lookup_stat_under_base(canonical_base, cgroup_id, st);
+}
+
+static bool cgroup_lookup_stat_self_cgroup_dir(const char *cgroup_id, struct stat *st)
+{
+    if(cgroup_use_unified_cgroups && cgroup_unified_base) {
+        if(cgroup_lookup_stat_plugin_visible_base(cgroup_unified_base, cgroup_id, st))
+            return true;
+
+        return false;
+    }
+
+    if(cgroup_cpuset_base) {
+        if(cgroup_lookup_stat_plugin_visible_base(cgroup_cpuset_base, cgroup_id, st))
+            return true;
+    }
+
+    if(cgroup_blkio_base) {
+        if(cgroup_lookup_stat_plugin_visible_base(cgroup_blkio_base, cgroup_id, st))
+            return true;
+    }
+
+    if(cgroup_memory_base) {
+        if(cgroup_lookup_stat_plugin_visible_base(cgroup_memory_base, cgroup_id, st))
+            return true;
+    }
+
+    return false;
+}
+
+static bool cgroup_lookup_read_proc_self_cgroup(const char *proc_path, char *dst, size_t dst_size)
+{
+    char content[8192];
+
+    if(read_txt_file(proc_path, content, sizeof(content)) != 0)
+        return false;
+
+    bool ok = cgroup_path_parse_proc_pid_cgroup_content(content, dst, dst_size);
+    return ok;
+}
+
+static bool cgroup_lookup_path_has_suffix_component_boundary(const char *path, const char *suffix)
+{
+    if(!path || !suffix)
+        return false;
+
+    size_t path_len = strlen(path);
+    size_t suffix_len = strlen(suffix);
+    if(suffix_len == 1 && suffix[0] == '/')
+        return true;
+
+    if(path_len <= suffix_len)
+        return false;
+
+    const char *tail = path + path_len - suffix_len;
+    if(memcmp(tail, suffix, suffix_len) != 0)
+        return false;
+
+    return suffix[0] == '/' || tail[-1] == '/';
+}
+
+static bool cgroup_lookup_namespace_base_from_self_path(
+    const CGROUP_SNAPSHOT_STORE *store,
+    const char *self_cgroup,
+    char *base,
+    size_t base_size)
+{
+    if(!store || !self_cgroup || !base || base_size < 2)
+        return false;
+
+    if(strcmp(self_cgroup, "/") == 0)
+        return false;
+
+    struct stat st;
+    if(!cgroup_lookup_stat_self_cgroup_dir(self_cgroup, &st))
+        return false;
+
+    const CGROUP_SNAPSHOT_ENTRY *entry =
+        cgroup_snapshot_store_find_unique_identity(store, st.st_dev, st.st_ino);
+    if(!entry)
+        return false;
+
+    const char *canonical_self = string2str(entry->id);
+    if(!cgroup_lookup_path_has_suffix_component_boundary(canonical_self, self_cgroup))
+        return false;
+
+    size_t canonical_len = string_strlen(entry->id);
+    size_t self_len = strlen(self_cgroup);
+    size_t base_len = canonical_len - self_len;
+    if(base_len == 0 || base_len >= base_size)
+        return false;
+
+    memcpy(base, canonical_self, base_len);
+    base[base_len] = '\0';
+    return true;
+}
+
+static const CGROUP_SNAPSHOT_ENTRY *cgroup_lookup_resolve_with_self_path(
+    const CGROUP_SNAPSHOT_STORE *store,
+    const char *self_cgroup,
+    const char *path)
+{
+    char base[FILENAME_MAX + 1];
+    if(!cgroup_lookup_namespace_base_from_self_path(store, self_cgroup, base, sizeof(base)))
+        return NULL;
+
+    char candidate[FILENAME_MAX + 1];
+    if(!cgroup_lookup_clean_join(base, path, candidate, sizeof(candidate)))
+        return NULL;
+
+    return cgroup_snapshot_store_find(store, candidate, strlen(candidate));
+}
+
+static const CGROUP_SNAPSHOT_ENTRY *cgroup_lookup_resolve_with_self_views(
+    const CGROUP_SNAPSHOT_STORE *store,
+    const char *path)
+{
+    char proc_path[FILENAME_MAX + 1];
+    char self_cgroup[FILENAME_MAX + 1];
+
+    if(cgroup_lookup_read_proc_self_cgroup("/proc/self/cgroup", self_cgroup, sizeof(self_cgroup))) {
+        const CGROUP_SNAPSHOT_ENTRY *entry = cgroup_lookup_resolve_with_self_path(store, self_cgroup, path);
+        if(entry)
+            return entry;
+    }
+
+    if(netdata_configured_host_prefix && *netdata_configured_host_prefix) {
+        snprintfz(proc_path, sizeof(proc_path) - 1, "%s/proc/self/cgroup", netdata_configured_host_prefix);
+        if(cgroup_lookup_read_proc_self_cgroup(proc_path, self_cgroup, sizeof(self_cgroup))) {
+            const CGROUP_SNAPSHOT_ENTRY *entry = cgroup_lookup_resolve_with_self_path(store, self_cgroup, path);
+            if(entry)
+                return entry;
+        }
+    }
+
+    return NULL;
+}
+
+static bool cgroup_lookup_replacement_prefix(
+    const CGROUP_SNAPSHOT_ENTRY *entry,
+    const char *suffix,
+    char *dst,
+    size_t dst_size)
+{
+    if(!entry || !entry->id || !suffix || !dst || !dst_size)
+        return false;
+
+    const char *id = string2str(entry->id);
+    size_t id_len = string_strlen(entry->id);
+    size_t suffix_len = strlen(suffix);
+    if(id_len < suffix_len)
+        return false;
+
+    size_t suffix_offset = id_len - suffix_len;
+    const char *slash = strchr(suffix, '/');
+    size_t first_component_len = slash ? (size_t)(slash - suffix) : suffix_len;
+    size_t prefix_len = suffix_offset + first_component_len;
+    if(prefix_len >= dst_size)
+        return false;
+
+    memcpy(dst, id, prefix_len);
+    dst[prefix_len] = '\0';
+    return true;
+}
+
+static const CGROUP_SNAPSHOT_ENTRY *cgroup_lookup_resolver_apply_positive(
+    const CGROUP_SNAPSHOT_STORE *store,
+    const CGROUP_LOOKUP_RESOLVER_PREFIX_CACHE *cache,
+    const char *path,
+    size_t raw_prefix_len)
+{
+    char candidate[FILENAME_MAX + 1];
+    const char *remainder = path + raw_prefix_len;
+    size_t replacement_len = strlen(cache->canonical_prefix);
+    size_t remainder_len = strlen(remainder);
+
+    if(replacement_len + remainder_len >= sizeof(candidate))
+        return NULL;
+
+    memcpy(candidate, cache->canonical_prefix, replacement_len);
+    memcpy(candidate + replacement_len, remainder, remainder_len + 1);
+
+    if(cgroup_lookup_path_has_parent_component(candidate))
+        return NULL;
+
+    return cgroup_snapshot_store_find(store, candidate, strlen(candidate));
+}
+
+const CGROUP_SNAPSHOT_ENTRY *cgroup_lookup_resolver_resolve(
+    const CGROUP_SNAPSHOT_STORE *store,
+    uint64_t generation,
+    const char *path,
+    size_t path_len)
+{
+    if(!store || !generation || !path || !path_len || !resolver_state.initialized)
+        return NULL;
+
+    char *pathz = mallocz(path_len + 1);
+    memcpy(pathz, path, path_len);
+    pathz[path_len] = '\0';
+
+    char *raw_prefix = NULL;
+    char *suffix = NULL;
+    size_t raw_prefix_len = 0;
+    if(!cgroup_lookup_resolver_parse(pathz, &raw_prefix, &suffix, &raw_prefix_len)) {
+        freez(pathz);
+        return NULL;
+    }
+
+    const CGROUP_SNAPSHOT_ENTRY *resolved = NULL;
+
+    // Lock order is snapshot read lock first (held by caller), resolver mutex second.
+    netdata_mutex_lock(&resolver_state.mutex);
+    if(resolver_state.generation != generation) {
+        cgroup_lookup_resolver_clear_locked();
+        resolver_state.generation = generation;
+    }
+
+    if(cgroup_lookup_resolver_negative_has_locked(pathz))
+        goto done;
+
+    const CGROUP_LOOKUP_RESOLVER_PREFIX_CACHE *positive =
+        cgroup_lookup_resolver_positive_get_locked(raw_prefix);
+    if(positive) {
+        resolved = cgroup_lookup_resolver_apply_positive(store, positive, pathz, raw_prefix_len);
+        if(!resolved)
+            cgroup_lookup_resolver_negative_add_locked(pathz);
+        goto done;
+    }
+
+    resolved = cgroup_lookup_resolve_with_self_views(store, pathz);
+    if(!resolved) {
+#ifdef NETDATA_INTERNAL_CHECKS
+        resolver_state.suffix_scans++;
+#endif
+        bool duplicate = false;
+        resolved = cgroup_snapshot_store_find_unique_suffix(store, suffix, strlen(suffix), &duplicate);
+        if(duplicate)
+            resolved = NULL;
+    }
+
+    if(resolved) {
+        char canonical_prefix[FILENAME_MAX + 1];
+        if(cgroup_lookup_replacement_prefix(resolved, suffix, canonical_prefix, sizeof(canonical_prefix)))
+            cgroup_lookup_resolver_positive_add_locked(raw_prefix, canonical_prefix);
+    }
+    else
+        cgroup_lookup_resolver_negative_add_locked(pathz);
+
+done:
+    netdata_mutex_unlock(&resolver_state.mutex);
+
+    freez(suffix);
+    freez(raw_prefix);
+    freez(pathz);
+    return resolved;
+}
+
+#endif

--- a/src/collectors/cgroups.plugin/cgroup-lookup-resolver.c
+++ b/src/collectors/cgroups.plugin/cgroup-lookup-resolver.c
@@ -282,10 +282,10 @@ static bool cgroup_lookup_clean_join(const char *base, const char *relative, cha
     }
 
     if(ok) {
-        size_t used = 0;
         if(dst_size < 2)
             ok = false;
         else {
+            size_t used = 0;
             dst[used++] = '/';
             for(size_t i = 0; i < component_count; i++) {
                 if(i) {
@@ -311,6 +311,51 @@ static bool cgroup_lookup_clean_join(const char *base, const char *relative, cha
     freez(components);
     freez(combined);
     return ok;
+}
+
+static bool cgroup_lookup_prefix_has_parent_component(const char *path)
+{
+    if(!path)
+        return true;
+
+    const char *p = path;
+    while(*p) {
+        while(*p == '/')
+            p++;
+
+        const char *start = p;
+        while(*p && *p != '/')
+            p++;
+
+        size_t len = (size_t)(p - start);
+        if(len == 2 && start[0] == '.' && start[1] == '.')
+            return true;
+    }
+
+    return false;
+}
+
+static bool cgroup_lookup_build_host_proc_self_cgroup_path(char *dst, size_t dst_size)
+{
+    static const char proc_self_cgroup[] = "/proc/self/cgroup";
+
+    if(!dst || dst_size == 0 || !netdata_configured_host_prefix || !*netdata_configured_host_prefix)
+        return false;
+
+    const char *prefix = netdata_configured_host_prefix;
+    if(prefix[0] != '/' || cgroup_lookup_prefix_has_parent_component(prefix))
+        return false;
+
+    size_t prefix_len = strlen(prefix);
+    size_t child_len = sizeof(proc_self_cgroup) - 1;
+    bool prefix_has_trailing_slash = prefix[prefix_len - 1] == '/';
+    size_t child_offset = prefix_has_trailing_slash ? 1 : 0;
+    if(prefix_len + child_len - child_offset >= dst_size)
+        return false;
+
+    memcpy(dst, prefix, prefix_len);
+    memcpy(dst + prefix_len, proc_self_cgroup + child_offset, child_len + 1 - child_offset);
+    return true;
 }
 
 static bool cgroup_lookup_stat_under_base(const char *base, const char *cgroup_id, struct stat *st)
@@ -366,6 +411,11 @@ static bool cgroup_lookup_stat_self_cgroup_dir(const char *cgroup_id, struct sta
             return true;
 
         return false;
+    }
+
+    if(cgroup_cpuacct_base) {
+        if(cgroup_lookup_stat_plugin_visible_base(cgroup_cpuacct_base, cgroup_id, st))
+            return true;
     }
 
     if(cgroup_cpuset_base) {
@@ -482,8 +532,7 @@ static const CGROUP_SNAPSHOT_ENTRY *cgroup_lookup_resolve_with_self_views(
             return entry;
     }
 
-    if(netdata_configured_host_prefix && *netdata_configured_host_prefix) {
-        snprintfz(proc_path, sizeof(proc_path) - 1, "%s/proc/self/cgroup", netdata_configured_host_prefix);
+    if(cgroup_lookup_build_host_proc_self_cgroup_path(proc_path, sizeof(proc_path))) {
         if(cgroup_lookup_read_proc_self_cgroup(proc_path, self_cgroup, sizeof(self_cgroup))) {
             const CGROUP_SNAPSHOT_ENTRY *entry = cgroup_lookup_resolve_with_self_path(store, self_cgroup, path);
             if(entry)

--- a/src/collectors/cgroups.plugin/cgroup-lookup-resolver.h
+++ b/src/collectors/cgroups.plugin/cgroup-lookup-resolver.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_CGROUP_LOOKUP_RESOLVER_H
+#define NETDATA_CGROUP_LOOKUP_RESOLVER_H 1
+
+#include "cgroup-snapshot-store.h"
+
+void cgroup_lookup_resolver_init(void);
+void cgroup_lookup_resolver_cleanup(void);
+
+const CGROUP_SNAPSHOT_ENTRY *cgroup_lookup_resolver_resolve(
+    const CGROUP_SNAPSHOT_STORE *store,
+    uint64_t generation,
+    const char *path,
+    size_t path_len);
+
+#ifdef NETDATA_INTERNAL_CHECKS
+size_t cgroup_lookup_resolver_suffix_scans_for_testing(void);
+#endif
+
+#endif /* NETDATA_CGROUP_LOOKUP_RESOLVER_H */

--- a/src/collectors/cgroups.plugin/cgroup-netipc.c
+++ b/src/collectors/cgroups.plugin/cgroup-netipc.c
@@ -33,6 +33,24 @@ static bool cgroup_find_procs_path_v1(char *path_buf, size_t path_buf_size, cons
     return false;
 }
 
+static bool cgroup_stat_dir_v1(const char *cg_id, struct stat *st) {
+    char path_buf[FILENAME_MAX + 1];
+
+    snprintfz(path_buf, sizeof(path_buf) - 1, "%s%s", cgroup_cpuset_base, cg_id);
+    if (stat(path_buf, st) == 0)
+        return true;
+
+    snprintfz(path_buf, sizeof(path_buf) - 1, "%s%s", cgroup_blkio_base, cg_id);
+    if (stat(path_buf, st) == 0)
+        return true;
+
+    snprintfz(path_buf, sizeof(path_buf) - 1, "%s%s", cgroup_memory_base, cg_id);
+    if (stat(path_buf, st) == 0)
+        return true;
+
+    return false;
+}
+
 static int cgroup_snapshot_label_cb(
     const char *name, const char *value, RRDLABEL_SRC ls __maybe_unused, void *data) {
     cgroup_snapshot_entry_add_label((CGROUP_SNAPSHOT_ENTRY *)data, name, value);
@@ -77,6 +95,8 @@ void cgroup_snapshot_rebuild_and_publish(void) {
         snprintfz(name_buf, sizeof(name_buf) - 1, "%s%s", prefix, cg->chart_id);
 
         uint32_t enabled = cg->enabled;
+        struct stat dir_st;
+        bool has_dir_identity = false;
         if (cgroup_use_unified_cgroups) {
             struct stat st;
             snprintfz(path_buf, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_unified_base, cg->id);
@@ -84,8 +104,15 @@ void cgroup_snapshot_rebuild_and_publish(void) {
                 path_buf[0] = '\0';
                 enabled = 0;
             }
+
+            char dir_path[FILENAME_MAX + 1];
+            snprintfz(dir_path, sizeof(dir_path) - 1, "%s%s", cgroup_unified_base, cg->id);
+            has_dir_identity = (stat(dir_path, &dir_st) == 0);
         } else if (!cgroup_find_procs_path_v1(path_buf, sizeof(path_buf), cg->id)) {
             enabled = 0;
+            has_dir_identity = cgroup_stat_dir_v1(cg->id, &dir_st);
+        } else {
+            has_dir_identity = cgroup_stat_dir_v1(cg->id, &dir_st);
         }
 
         e->known = (cg->processed && cg->pending_renames == 0);
@@ -96,6 +123,8 @@ void cgroup_snapshot_rebuild_and_publish(void) {
         e->options = cg->options;
         e->enabled = enabled;
         e->procs_path = string_strdupz(path_buf);
+        if (has_dir_identity)
+            cgroup_snapshot_entry_set_dir_identity(e, &dir_st);
 
         if (cg->chart_labels)
             rrdlabels_walkthrough_read(cg->chart_labels, cgroup_snapshot_label_cb, e);

--- a/src/collectors/cgroups.plugin/cgroup-netipc.c
+++ b/src/collectors/cgroups.plugin/cgroup-netipc.c
@@ -33,19 +33,26 @@ static bool cgroup_find_procs_path_v1(char *path_buf, size_t path_buf_size, cons
     return false;
 }
 
-static bool cgroup_stat_dir_v1(const char *cg_id, struct stat *st) {
+static bool cgroup_stat_dir_under_base(const char *base, const char *cg_id, struct stat *st) {
+    if (!base || !*base)
+        return false;
+
     char path_buf[FILENAME_MAX + 1];
+    snprintfz(path_buf, sizeof(path_buf) - 1, "%s%s", base, cg_id);
+    return stat(path_buf, st) == 0;
+}
 
-    snprintfz(path_buf, sizeof(path_buf) - 1, "%s%s", cgroup_cpuset_base, cg_id);
-    if (stat(path_buf, st) == 0)
+static bool cgroup_stat_dir_v1(const char *cg_id, struct stat *st) {
+    if (cgroup_stat_dir_under_base(cgroup_cpuacct_base, cg_id, st))
         return true;
 
-    snprintfz(path_buf, sizeof(path_buf) - 1, "%s%s", cgroup_blkio_base, cg_id);
-    if (stat(path_buf, st) == 0)
+    if (cgroup_stat_dir_under_base(cgroup_cpuset_base, cg_id, st))
         return true;
 
-    snprintfz(path_buf, sizeof(path_buf) - 1, "%s%s", cgroup_memory_base, cg_id);
-    if (stat(path_buf, st) == 0)
+    if (cgroup_stat_dir_under_base(cgroup_blkio_base, cg_id, st))
+        return true;
+
+    if (cgroup_stat_dir_under_base(cgroup_memory_base, cg_id, st))
         return true;
 
     return false;

--- a/src/collectors/cgroups.plugin/cgroup-snapshot-store.c
+++ b/src/collectors/cgroups.plugin/cgroup-snapshot-store.c
@@ -99,6 +99,15 @@ void cgroup_snapshot_entry_add_label(CGROUP_SNAPSHOT_ENTRY *entry, const char *k
     entry->label_count++;
 }
 
+void cgroup_snapshot_entry_set_dir_identity(CGROUP_SNAPSHOT_ENTRY *entry, const struct stat *st) {
+    if (!entry || !st)
+        return;
+
+    entry->dir_identity_available = true;
+    entry->dir_dev = st->st_dev;
+    entry->dir_ino = st->st_ino;
+}
+
 CGROUP_SNAPSHOT_STORE *cgroup_snapshot_builder_finalize(CGROUP_SNAPSHOT_BUILDER *builder) {
     if (!builder)
         return NULL;
@@ -160,6 +169,68 @@ const CGROUP_SNAPSHOT_ENTRY *cgroup_snapshot_store_find(
     if (!store || !path)
         return NULL;
     return dictionary_get_advanced(store->by_path, path, (ssize_t)path_len);
+}
+
+const CGROUP_SNAPSHOT_ENTRY *cgroup_snapshot_store_find_unique_identity(
+    const CGROUP_SNAPSHOT_STORE *store, dev_t dev, ino_t ino) {
+    if (!store)
+        return NULL;
+
+    const CGROUP_SNAPSHOT_ENTRY *match = NULL;
+    for (size_t i = 0; i < store->count; i++) {
+        const CGROUP_SNAPSHOT_ENTRY *entry = &store->entries[i];
+        if (!entry->dir_identity_available || entry->dir_dev != dev || entry->dir_ino != ino)
+            continue;
+
+        if (match)
+            return NULL;
+
+        match = entry;
+    }
+
+    return match;
+}
+
+static bool cgroup_snapshot_entry_has_suffix(const CGROUP_SNAPSHOT_ENTRY *entry, const char *suffix, size_t suffix_len) {
+    if (!entry || !entry->id || !suffix || !suffix_len)
+        return false;
+
+    const char *id = string2str(entry->id);
+    size_t id_len = string_strlen(entry->id);
+    if (id_len < suffix_len)
+        return false;
+
+    const char *tail = id + id_len - suffix_len;
+    if (memcmp(tail, suffix, suffix_len) != 0)
+        return false;
+
+    return id_len == suffix_len || tail == id || tail[-1] == '/';
+}
+
+const CGROUP_SNAPSHOT_ENTRY *cgroup_snapshot_store_find_unique_suffix(
+    const CGROUP_SNAPSHOT_STORE *store, const char *suffix, size_t suffix_len, bool *duplicate) {
+    if (duplicate)
+        *duplicate = false;
+
+    if (!store || !suffix || !suffix_len)
+        return NULL;
+
+    const CGROUP_SNAPSHOT_ENTRY *match = NULL;
+    for (size_t i = 0; i < store->count; i++) {
+        const CGROUP_SNAPSHOT_ENTRY *entry = &store->entries[i];
+        if (!cgroup_snapshot_entry_has_suffix(entry, suffix, suffix_len))
+            continue;
+
+        if (match) {
+            if (duplicate)
+                *duplicate = true;
+            return NULL;
+        }
+
+        match = entry;
+    }
+
+    return match;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/collectors/cgroups.plugin/cgroup-snapshot-store.h
+++ b/src/collectors/cgroups.plugin/cgroup-snapshot-store.h
@@ -35,6 +35,9 @@ typedef struct cgroup_snapshot_entry {
     uint32_t options;
     uint32_t enabled;
     STRING *procs_path;     // precomputed cgroup.procs path; empty when missing
+    bool dir_identity_available;
+    dev_t dir_dev;
+    ino_t dir_ino;
 } CGROUP_SNAPSHOT_ENTRY;
 
 typedef struct cgroup_snapshot_store CGROUP_SNAPSHOT_STORE;
@@ -58,6 +61,7 @@ CGROUP_SNAPSHOT_ENTRY *cgroup_snapshot_builder_add_entry(CGROUP_SNAPSHOT_BUILDER
 
 // Appends a label to an entry returned by _add_entry(); copies key and value.
 void cgroup_snapshot_entry_add_label(CGROUP_SNAPSHOT_ENTRY *entry, const char *key, const char *value);
+void cgroup_snapshot_entry_set_dir_identity(CGROUP_SNAPSHOT_ENTRY *entry, const struct stat *st);
 
 // Finalizes into an immutable store. The builder is consumed.
 CGROUP_SNAPSHOT_STORE *cgroup_snapshot_builder_finalize(CGROUP_SNAPSHOT_BUILDER *builder);
@@ -81,5 +85,9 @@ size_t cgroup_snapshot_store_count(const CGROUP_SNAPSHOT_STORE *store);
 const CGROUP_SNAPSHOT_ENTRY *cgroup_snapshot_store_at(const CGROUP_SNAPSHOT_STORE *store, size_t index);
 const CGROUP_SNAPSHOT_ENTRY *cgroup_snapshot_store_find(
     const CGROUP_SNAPSHOT_STORE *store, const char *path, size_t path_len);
+const CGROUP_SNAPSHOT_ENTRY *cgroup_snapshot_store_find_unique_identity(
+    const CGROUP_SNAPSHOT_STORE *store, dev_t dev, ino_t ino);
+const CGROUP_SNAPSHOT_ENTRY *cgroup_snapshot_store_find_unique_suffix(
+    const CGROUP_SNAPSHOT_STORE *store, const char *suffix, size_t suffix_len, bool *duplicate);
 
 #endif // NETDATA_CGROUP_SNAPSHOT_STORE_H

--- a/src/collectors/cgroups.plugin/tests/test_cgroup_lookup_netipc.c
+++ b/src/collectors/cgroups.plugin/tests/test_cgroup_lookup_netipc.c
@@ -19,6 +19,7 @@ int cgroup_use_unified_cgroups = 0;
 char *cgroup_cpuset_base = NULL;
 char *cgroup_blkio_base = NULL;
 char *cgroup_memory_base = NULL;
+char *cgroup_cpuacct_base = NULL;
 char *cgroup_unified_base = NULL;
 
 int rrdlabels_walkthrough_read(
@@ -170,20 +171,50 @@ static bool expect_true(bool condition, const char *message)
 
 // Publish a snapshot store holding the known (resolved) and retry (discovered
 // but not yet resolved) cgroups, mirroring what discovery's rebuild would build.
-static void publish_test_store(const char *known_path, const char *retry_path)
+static void publish_test_store_with_generation(
+    uint64_t generation,
+    const char *known_path,
+    const char *retry_path,
+    const char *known_name)
 {
-    CGROUP_SNAPSHOT_BUILDER *builder = cgroup_snapshot_builder_create(1, 2);
+    size_t entries = (known_path ? 1 : 0) + (retry_path ? 1 : 0);
+    CGROUP_SNAPSHOT_BUILDER *builder = cgroup_snapshot_builder_create(generation, entries);
 
-    CGROUP_SNAPSHOT_ENTRY *known = cgroup_snapshot_builder_add_entry(builder, known_path);
-    struct stat known_st = { .st_dev = 1, .st_ino = 10 };
-    cgroup_snapshot_entry_set_dir_identity(known, &known_st);
-    known->known = true;
-    known->orchestrator = (uint16_t)CGROUPS_ORCHESTRATOR_DOCKER;
-    known->name = string_strdupz("known-container");
-    cgroup_snapshot_entry_add_label(known, "image", "netdata/test");
+    if (known_path) {
+        CGROUP_SNAPSHOT_ENTRY *known = cgroup_snapshot_builder_add_entry(builder, known_path);
+        struct stat known_st = { .st_dev = 1, .st_ino = (ino_t)(10 + generation) };
+        cgroup_snapshot_entry_set_dir_identity(known, &known_st);
+        known->known = true;
+        known->orchestrator = (uint16_t)CGROUPS_ORCHESTRATOR_DOCKER;
+        known->name = string_strdupz(known_name ? known_name : "known-container");
+        cgroup_snapshot_entry_add_label(known, "image", "netdata/test");
+    }
 
     // discovered but unresolved: known stays false -> RETRY_LATER without a name
-    (void)cgroup_snapshot_builder_add_entry(builder, retry_path);
+    if (retry_path)
+        (void)cgroup_snapshot_builder_add_entry(builder, retry_path);
+
+    cgroup_snapshot_store_publish(cgroup_snapshot_builder_finalize(builder));
+}
+
+static void publish_test_store(const char *known_path, const char *retry_path)
+{
+    publish_test_store_with_generation(1, known_path, retry_path, "known-container");
+}
+
+static void publish_duplicate_suffix_store(uint64_t generation)
+{
+    CGROUP_SNAPSHOT_BUILDER *builder = cgroup_snapshot_builder_create(generation, 2);
+
+    CGROUP_SNAPSHOT_ENTRY *first = cgroup_snapshot_builder_add_entry(builder, "/left.slice/pod-a/container.scope");
+    first->known = true;
+    first->orchestrator = (uint16_t)CGROUPS_ORCHESTRATOR_DOCKER;
+    first->name = string_strdupz("left-container");
+
+    CGROUP_SNAPSHOT_ENTRY *second = cgroup_snapshot_builder_add_entry(builder, "/right.slice/pod-a/container.scope");
+    second->known = true;
+    second->orchestrator = (uint16_t)CGROUPS_ORCHESTRATOR_DOCKER;
+    second->name = string_strdupz("right-container");
 
     cgroup_snapshot_store_publish(cgroup_snapshot_builder_finalize(builder));
 }
@@ -366,13 +397,37 @@ int main(void)
         goto cleanup_client;
     }
 
+    size_t scans_after_first_resolution = cgroup_lookup_resolver_suffix_scans_for_testing();
+    const char *namespace_relative_retry_same_prefix =
+        "/../../docker/aaaaaaaaaaaaaaaa";
+    nipc_str_view_t namespace_relative_retry_same_prefix_path = {
+        .ptr = namespace_relative_retry_same_prefix,
+        .len = (uint32_t)strlen(namespace_relative_retry_same_prefix),
+    };
+    err = nipc_client_call_cgroups_lookup(&client, &namespace_relative_retry_same_prefix_path, 1, &response);
+    if (err != NIPC_OK) {
+        fprintf(stderr, "namespace-relative positive-cache lookup failed: %u\n", (unsigned int)err);
+        goto cleanup_client;
+    }
+
+    if (!expect_item(
+            &response, 0, namespace_relative_retry_same_prefix,
+            NIPC_CGROUP_LOOKUP_UNKNOWN_RETRY_LATER, NIPC_ORCHESTRATOR_UNKNOWN, "", 0))
+        goto cleanup_client;
+
+    if (cgroup_lookup_resolver_suffix_scans_for_testing() != scans_after_first_resolution) {
+        fprintf(stderr, "namespace-relative positive cache did not avoid a second suffix scan\n");
+        goto cleanup_client;
+    }
+
     __atomic_store_n(&discovery_signal_pending, false, __ATOMIC_RELEASE);
     const char *namespace_relative_missing =
-        "/../../docker/not-present.scope";
+        "/../../missing/not-present.scope";
     nipc_str_view_t namespace_relative_missing_path = {
         .ptr = namespace_relative_missing,
         .len = (uint32_t)strlen(namespace_relative_missing),
     };
+    size_t scans_before_negative_miss = cgroup_lookup_resolver_suffix_scans_for_testing();
     err = nipc_client_call_cgroups_lookup(&client, &namespace_relative_missing_path, 1, &response);
     if (err != NIPC_OK) {
         fprintf(stderr, "namespace-relative missing lookup call failed: %u\n", (unsigned int)err);
@@ -384,11 +439,64 @@ int main(void)
             NIPC_CGROUP_LOOKUP_UNKNOWN_RETRY_LATER, NIPC_ORCHESTRATOR_UNKNOWN, "", 0))
         goto cleanup_client;
 
+    size_t scans_after_negative_miss = cgroup_lookup_resolver_suffix_scans_for_testing();
+    if (scans_after_negative_miss != scans_before_negative_miss + 1) {
+        fprintf(stderr, "namespace-relative negative lookup did not perform exactly one suffix scan\n");
+        goto cleanup_client;
+    }
+
+    err = nipc_client_call_cgroups_lookup(&client, &namespace_relative_missing_path, 1, &response);
+    if (err != NIPC_OK) {
+        fprintf(stderr, "namespace-relative negative-cache lookup call failed: %u\n", (unsigned int)err);
+        goto cleanup_client;
+    }
+
+    if (!expect_item(
+            &response, 0, namespace_relative_missing,
+            NIPC_CGROUP_LOOKUP_UNKNOWN_RETRY_LATER, NIPC_ORCHESTRATOR_UNKNOWN, "", 0))
+        goto cleanup_client;
+
+    if (cgroup_lookup_resolver_suffix_scans_for_testing() != scans_after_negative_miss) {
+        fprintf(stderr, "namespace-relative negative cache did not avoid a second suffix scan\n");
+        goto cleanup_client;
+    }
+
     if (__atomic_load_n(&discovery_signal_pending, __ATOMIC_ACQUIRE)) {
         fprintf(stderr, "namespace-relative miss incorrectly armed discovery signal flag\n");
         goto cleanup_client;
     }
 
+    publish_test_store_with_generation(2, "/missing/not-present.scope", retry_path, "late-container");
+    err = nipc_client_call_cgroups_lookup(&client, &namespace_relative_missing_path, 1, &response);
+    if (err != NIPC_OK) {
+        fprintf(stderr, "namespace-relative generation-invalidation lookup failed: %u\n", (unsigned int)err);
+        goto cleanup_client;
+    }
+
+    if (!expect_item(
+            &response, 0, namespace_relative_missing,
+            NIPC_CGROUP_LOOKUP_KNOWN, NIPC_ORCHESTRATOR_DOCKER, "late-container", 1))
+        goto cleanup_client;
+
+    publish_duplicate_suffix_store(3);
+    const char *namespace_relative_duplicate =
+        "/../../pod-a/container.scope";
+    nipc_str_view_t namespace_relative_duplicate_path = {
+        .ptr = namespace_relative_duplicate,
+        .len = (uint32_t)strlen(namespace_relative_duplicate),
+    };
+    err = nipc_client_call_cgroups_lookup(&client, &namespace_relative_duplicate_path, 1, &response);
+    if (err != NIPC_OK) {
+        fprintf(stderr, "namespace-relative duplicate-suffix lookup failed: %u\n", (unsigned int)err);
+        goto cleanup_client;
+    }
+
+    if (!expect_item(
+            &response, 0, namespace_relative_duplicate,
+            NIPC_CGROUP_LOOKUP_UNKNOWN_RETRY_LATER, NIPC_ORCHESTRATOR_UNKNOWN, "", 0))
+        goto cleanup_client;
+
+    publish_test_store(known_path, retry_path);
     err = nipc_client_call_cgroups_lookup(&client, paths, 4, &response);
     if (err != NIPC_OK) {
         fprintf(stderr, "second lookup call failed: %u\n", (unsigned int)err);

--- a/src/collectors/cgroups.plugin/tests/test_cgroup_lookup_netipc.c
+++ b/src/collectors/cgroups.plugin/tests/test_cgroup_lookup_netipc.c
@@ -2,6 +2,7 @@
 
 #include "../cgroup-internals.h"
 #include "../cgroup-netipc.h"
+#include "../cgroup-lookup-resolver.h"
 #include "../cgroup-snapshot-store.h"
 #include "libnetdata/netipc/netipc_netdata.h"
 
@@ -14,6 +15,11 @@ struct discovery_thread discovery_thread = { 0 };
 int cgroup_max_depth = 0;
 bool discovery_signal_pending = false;
 uint64_t cgroup_discovery_generation = 0;
+int cgroup_use_unified_cgroups = 0;
+char *cgroup_cpuset_base = NULL;
+char *cgroup_blkio_base = NULL;
+char *cgroup_memory_base = NULL;
+char *cgroup_unified_base = NULL;
 
 int rrdlabels_walkthrough_read(
     RRDLABELS *labels,
@@ -153,6 +159,15 @@ static bool expect_item(
     return true;
 }
 
+static bool expect_true(bool condition, const char *message)
+{
+    if (condition)
+        return true;
+
+    fprintf(stderr, "%s\n", message);
+    return false;
+}
+
 // Publish a snapshot store holding the known (resolved) and retry (discovered
 // but not yet resolved) cgroups, mirroring what discovery's rebuild would build.
 static void publish_test_store(const char *known_path, const char *retry_path)
@@ -160,6 +175,8 @@ static void publish_test_store(const char *known_path, const char *retry_path)
     CGROUP_SNAPSHOT_BUILDER *builder = cgroup_snapshot_builder_create(1, 2);
 
     CGROUP_SNAPSHOT_ENTRY *known = cgroup_snapshot_builder_add_entry(builder, known_path);
+    struct stat known_st = { .st_dev = 1, .st_ino = 10 };
+    cgroup_snapshot_entry_set_dir_identity(known, &known_st);
     known->known = true;
     known->orchestrator = (uint16_t)CGROUPS_ORCHESTRATOR_DOCKER;
     known->name = string_strdupz("known-container");
@@ -169,6 +186,44 @@ static void publish_test_store(const char *known_path, const char *retry_path)
     (void)cgroup_snapshot_builder_add_entry(builder, retry_path);
 
     cgroup_snapshot_store_publish(cgroup_snapshot_builder_finalize(builder));
+}
+
+static bool test_snapshot_lookup_helpers(void)
+{
+    CGROUP_SNAPSHOT_BUILDER *builder = cgroup_snapshot_builder_create(2, 3);
+
+    CGROUP_SNAPSHOT_ENTRY *first = cgroup_snapshot_builder_add_entry(builder, "/kubepods.slice/pod-a/container.scope");
+    struct stat first_st = { .st_dev = 2, .st_ino = 20 };
+    cgroup_snapshot_entry_set_dir_identity(first, &first_st);
+
+    CGROUP_SNAPSHOT_ENTRY *second = cgroup_snapshot_builder_add_entry(builder, "/other.slice/pod-a/container.scope");
+    struct stat second_st = { .st_dev = 2, .st_ino = 21 };
+    cgroup_snapshot_entry_set_dir_identity(second, &second_st);
+
+    cgroup_snapshot_store_publish(cgroup_snapshot_builder_finalize(builder));
+
+    const CGROUP_SNAPSHOT_STORE *store = cgroup_snapshot_store_acquire();
+    bool duplicate = false;
+    bool ok =
+        expect_true(
+            cgroup_snapshot_store_find_unique_identity(store, first_st.st_dev, first_st.st_ino) == first,
+            "unique identity helper did not find first entry") &&
+        expect_true(
+            cgroup_snapshot_store_find_unique_suffix(
+                store, "kubepods.slice/pod-a/container.scope",
+                strlen("kubepods.slice/pod-a/container.scope"), &duplicate) == first,
+            "unique suffix helper did not find first entry") &&
+        expect_true(!duplicate, "unique suffix helper reported a duplicate for unique suffix");
+
+    duplicate = false;
+    ok = expect_true(
+             cgroup_snapshot_store_find_unique_suffix(
+                 store, "pod-a/container.scope", strlen("pod-a/container.scope"), &duplicate) == NULL,
+             "duplicate suffix helper should not return an entry") && ok;
+    ok = expect_true(duplicate, "duplicate suffix helper did not report duplicate") && ok;
+
+    cgroup_snapshot_store_release();
+    return ok;
 }
 
 int main(void)
@@ -213,6 +268,9 @@ int main(void)
     }
 
     cgroup_snapshot_store_init();
+
+    if (!test_snapshot_lookup_helpers())
+        goto cleanup_snapshot_store;
 
     publish_test_store(known_path, retry_path);
 
@@ -286,6 +344,51 @@ int main(void)
         goto cleanup_client;
     }
 
+    const char *namespace_relative_known =
+        "/../../docker/0123456789abcdef";
+    nipc_str_view_t namespace_relative_path = {
+        .ptr = namespace_relative_known,
+        .len = (uint32_t)strlen(namespace_relative_known),
+    };
+    err = nipc_client_call_cgroups_lookup(&client, &namespace_relative_path, 1, &response);
+    if (err != NIPC_OK) {
+        fprintf(stderr, "namespace-relative lookup call failed: %u\n", (unsigned int)err);
+        goto cleanup_client;
+    }
+
+    if (!expect_item(
+            &response, 0, namespace_relative_known,
+            NIPC_CGROUP_LOOKUP_KNOWN, NIPC_ORCHESTRATOR_DOCKER, "known-container", 1))
+        goto cleanup_client;
+
+    if (cgroup_lookup_resolver_suffix_scans_for_testing() == 0) {
+        fprintf(stderr, "namespace-relative lookup did not use suffix resolver path\n");
+        goto cleanup_client;
+    }
+
+    __atomic_store_n(&discovery_signal_pending, false, __ATOMIC_RELEASE);
+    const char *namespace_relative_missing =
+        "/../../docker/not-present.scope";
+    nipc_str_view_t namespace_relative_missing_path = {
+        .ptr = namespace_relative_missing,
+        .len = (uint32_t)strlen(namespace_relative_missing),
+    };
+    err = nipc_client_call_cgroups_lookup(&client, &namespace_relative_missing_path, 1, &response);
+    if (err != NIPC_OK) {
+        fprintf(stderr, "namespace-relative missing lookup call failed: %u\n", (unsigned int)err);
+        goto cleanup_client;
+    }
+
+    if (!expect_item(
+            &response, 0, namespace_relative_missing,
+            NIPC_CGROUP_LOOKUP_UNKNOWN_RETRY_LATER, NIPC_ORCHESTRATOR_UNKNOWN, "", 0))
+        goto cleanup_client;
+
+    if (__atomic_load_n(&discovery_signal_pending, __ATOMIC_ACQUIRE)) {
+        fprintf(stderr, "namespace-relative miss incorrectly armed discovery signal flag\n");
+        goto cleanup_client;
+    }
+
     err = nipc_client_call_cgroups_lookup(&client, paths, 4, &response);
     if (err != NIPC_OK) {
         fprintf(stderr, "second lookup call failed: %u\n", (unsigned int)err);
@@ -303,6 +406,7 @@ cleanup_client:
     nipc_client_close(&client);
 cleanup_server:
     cgroup_netipc_lookup_cleanup();
+cleanup_snapshot_store:
     cgroup_snapshot_store_shutdown();
     netdata_cond_destroy(&discovery_thread.cond_var);
 cleanup_discovery_mutex:

--- a/src/collectors/common-cgroups/cgroup-path.c
+++ b/src/collectors/common-cgroups/cgroup-path.c
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "cgroup-path.h"
+
+static bool cgroup_controller_token_matches(const char *controllers, size_t len, const char *needle)
+{
+    size_t needle_len = strlen(needle);
+    const char *p = controllers;
+    const char *end = controllers + len;
+
+    while(p < end) {
+        const char *comma = memchr(p, ',', (size_t)(end - p));
+        const char *token_end = comma ? comma : end;
+        size_t token_len = (size_t)(token_end - p);
+
+        if(token_len == needle_len && memcmp(p, needle, needle_len) == 0)
+            return true;
+
+        if(!comma)
+            break;
+
+        p = comma + 1;
+    }
+
+    return false;
+}
+
+static unsigned cgroup_v1_precedence(const char *controllers, size_t len)
+{
+    if(cgroup_controller_token_matches(controllers, len, "cpuacct"))
+        return 1;
+
+    if(cgroup_controller_token_matches(controllers, len, "blkio"))
+        return 2;
+
+    if(cgroup_controller_token_matches(controllers, len, "memory"))
+        return 3;
+
+    if(len == strlen("name=systemd") && memcmp(controllers, "name=systemd", len) == 0)
+        return 4;
+
+    return 5;
+}
+
+static bool cgroup_copy_path(const char *path, size_t len, char *dst, size_t dst_size)
+{
+    if(!path || len == 0 || path[0] != '/' || !dst || dst_size == 0 || len >= dst_size)
+        return false;
+
+    memcpy(dst, path, len);
+    dst[len] = '\0';
+    return true;
+}
+
+bool cgroup_path_parse_proc_pid_cgroup_content(const char *content, char *dst, size_t dst_size)
+{
+    if(!content || !dst || dst_size == 0)
+        return false;
+
+    dst[0] = '\0';
+
+    const char *best_path = NULL;
+    size_t best_path_len = 0;
+    unsigned best_score = UINT_MAX;
+
+    const char *line = content;
+    while(*line) {
+        const char *line_end = strchr(line, '\n');
+        if(!line_end)
+            line_end = line + strlen(line);
+
+        const char *next_line = (*line_end == '\n') ? line_end + 1 : line_end;
+        const char *field_end = line_end;
+        if(field_end > line && field_end[-1] == '\r')
+            field_end--;
+
+        const char *first_colon = memchr(line, ':', (size_t)(field_end - line));
+        if(!first_colon) {
+            line = next_line;
+            continue;
+        }
+
+        const char *second_colon = memchr(first_colon + 1, ':', (size_t)(field_end - first_colon - 1));
+        if(!second_colon) {
+            line = next_line;
+            continue;
+        }
+
+        const char *path = second_colon + 1;
+        size_t path_len = (size_t)(field_end - path);
+        if(path_len == 0 || path[0] != '/') {
+            line = next_line;
+            continue;
+        }
+
+        bool is_v2 = (first_colon == line + 1 && line[0] == '0' && second_colon == first_colon + 1);
+        if(is_v2)
+            return cgroup_copy_path(path, path_len, dst, dst_size);
+
+        const char *controllers = first_colon + 1;
+        size_t controllers_len = (size_t)(second_colon - controllers);
+        unsigned score = cgroup_v1_precedence(controllers, controllers_len);
+
+        if(score < best_score) {
+            best_score = score;
+            best_path = path;
+            best_path_len = path_len;
+        }
+
+        line = next_line;
+    }
+
+    return cgroup_copy_path(best_path, best_path_len, dst, dst_size);
+}
+
+bool cgroup_path_is_namespace_relative(const char *path)
+{
+    if(!path || !*path)
+        return false;
+
+    const char *p = path;
+    while(*p == '/')
+        p++;
+
+    return p[0] == '.' && p[1] == '.' && (p[2] == '\0' || p[2] == '/');
+}

--- a/src/collectors/common-cgroups/cgroup-path.h
+++ b/src/collectors/common-cgroups/cgroup-path.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_CGROUP_PATH_H
+#define NETDATA_CGROUP_PATH_H 1
+
+#include "libnetdata/libnetdata.h"
+
+bool cgroup_path_parse_proc_pid_cgroup_content(const char *content, char *dst, size_t dst_size);
+bool cgroup_path_is_namespace_relative(const char *path);
+
+#endif /* NETDATA_CGROUP_PATH_H */

--- a/src/collectors/common-cgroups/cgroup-topology-rules.c
+++ b/src/collectors/common-cgroups/cgroup-topology-rules.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "cgroup-topology-rules.h"
+#include "cgroup-path.h"
 
 #include <ctype.h>
 
@@ -501,7 +502,8 @@ void cgroup_topology_classify(
         }
     }
 
-    if(has_systemd_unit) {
+    if(has_systemd_unit &&
+       !(cgroup_status != NIPC_APPS_CGROUP_KNOWN && cgroup_path_is_namespace_relative(cgroup_path))) {
         const CGROUP_TOPOLOGY_SYSTEMD_RULE *rule =
             cgroup_topology_systemd_rule_for_component(out->systemd_unit_name);
         cgroup_topology_set_classification(

--- a/src/collectors/common-cgroups/tests/test_cgroup_topology_rules.c
+++ b/src/collectors/common-cgroups/tests/test_cgroup_topology_rules.c
@@ -70,6 +70,10 @@ static bool test_proc_pid_cgroup_parser(void)
              "3:memory:/memory-path\n2:blkio:/blkio-path\n1:cpu,cpuacct:/cpuacct-path\n",
              "/cpuacct-path") && ok;
     ok = expect_path(
+             "v1 namespace-relative cpuacct precedence",
+             "3:memory:/memory-path\n1:cpu,cpuacct:/../../../kubepods.slice/pod-a/cri-containerd-abc.scope\n",
+             "/../../../kubepods.slice/pod-a/cri-containerd-abc.scope") && ok;
+    ok = expect_path(
              "v1 systemd fallback",
              "7:name=systemd:/init.scope\n9:freezer:/first-nonpreferred\n",
              "/init.scope") && ok;

--- a/src/collectors/common-cgroups/tests/test_cgroup_topology_rules.c
+++ b/src/collectors/common-cgroups/tests/test_cgroup_topology_rules.c
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../cgroup-path.h"
+#include "../cgroup-topology-rules.h"
+
+static bool expect_bool(bool actual, bool expected, const char *message)
+{
+    if(actual == expected)
+        return true;
+
+    fprintf(stderr, "%s: expected %s, got %s\n",
+            message,
+            expected ? "true" : "false",
+            actual ? "true" : "false");
+    return false;
+}
+
+static bool expect_string(const char *actual, const char *expected, const char *message)
+{
+    if(strcmp(actual ? actual : "", expected ? expected : "") == 0)
+        return true;
+
+    fprintf(stderr, "%s: expected '%s', got '%s'\n",
+            message,
+            expected ? expected : "",
+            actual ? actual : "");
+    return false;
+}
+
+static bool expect_path(const char *name, const char *content, const char *expected)
+{
+    char path[FILENAME_MAX + 1];
+
+    if(!cgroup_path_parse_proc_pid_cgroup_content(content, path, sizeof(path))) {
+        fprintf(stderr, "%s: parse failed\n", name);
+        return false;
+    }
+
+    return expect_string(path, expected, name);
+}
+
+static bool test_namespace_relative_helper(void)
+{
+    bool ok = true;
+
+    ok = expect_bool(cgroup_path_is_namespace_relative("/../foo"), true, "/../foo namespace-relative") && ok;
+    ok = expect_bool(cgroup_path_is_namespace_relative("/../../foo"), true, "/../../foo namespace-relative") && ok;
+    ok = expect_bool(cgroup_path_is_namespace_relative("../../../foo"), true, "../../../foo namespace-relative") && ok;
+    ok = expect_bool(cgroup_path_is_namespace_relative("/foo/../bar"), false, "/foo/../bar not namespace-relative") && ok;
+    ok = expect_bool(cgroup_path_is_namespace_relative(".../foo"), false, ".../foo not namespace-relative") && ok;
+    ok = expect_bool(cgroup_path_is_namespace_relative("/..../foo"), false, "/..../foo not namespace-relative") && ok;
+    ok = expect_bool(cgroup_path_is_namespace_relative("/foo/..bar"), false, "/foo/..bar not namespace-relative") && ok;
+    ok = expect_bool(cgroup_path_is_namespace_relative("/foo"), false, "/foo not namespace-relative") && ok;
+    ok = expect_bool(cgroup_path_is_namespace_relative("/"), false, "/ not namespace-relative") && ok;
+
+    return ok;
+}
+
+static bool test_proc_pid_cgroup_parser(void)
+{
+    bool ok = true;
+
+    ok = expect_path("v2 unified", "0::/kubepods.slice/pod-a\n", "/kubepods.slice/pod-a") && ok;
+    ok = expect_path(
+             "v2 namespace-relative",
+             "0::/../../../kubepods-besteffort.slice/pod-a/cri-containerd-abc.scope\n",
+             "/../../../kubepods-besteffort.slice/pod-a/cri-containerd-abc.scope") && ok;
+    ok = expect_path(
+             "v1 cpuacct precedence",
+             "3:memory:/memory-path\n2:blkio:/blkio-path\n1:cpu,cpuacct:/cpuacct-path\n",
+             "/cpuacct-path") && ok;
+    ok = expect_path(
+             "v1 systemd fallback",
+             "7:name=systemd:/init.scope\n9:freezer:/first-nonpreferred\n",
+             "/init.scope") && ok;
+
+    return ok;
+}
+
+static bool test_namespace_relative_classifier(void)
+{
+    CGROUP_TOPOLOGY_CLASSIFICATION classification;
+    const char *path =
+        "/../../kubepods.slice/kubepods-besteffort.slice/podabc/"
+        "cri-containerd-0123456789abcdef.scope";
+
+    cgroup_topology_classify(
+        NIPC_APPS_CGROUP_UNKNOWN_RETRY_LATER,
+        NIPC_ORCHESTRATOR_UNKNOWN,
+        path,
+        &classification);
+
+    bool ok =
+        expect_string(classification.actor_type, "container", "retry-later namespace-relative actor type") &&
+        expect_string(classification.actor_kind, "pending", "retry-later namespace-relative actor kind");
+
+    cgroup_topology_classify(
+        NIPC_APPS_CGROUP_UNKNOWN_PERMANENT,
+        NIPC_ORCHESTRATOR_UNKNOWN,
+        path,
+        &classification);
+
+    ok = expect_bool(
+             strcmp(classification.actor_type, "systemd_scope") != 0,
+             true,
+             "unknown-permanent namespace-relative must not become systemd scope") && ok;
+
+    cgroup_topology_classify(
+        NIPC_APPS_CGROUP_UNKNOWN_RETRY_LATER,
+        NIPC_ORCHESTRATOR_UNKNOWN,
+        "/user.slice/user-1001.slice/user@1001.service/app.slice/opencode.scope",
+        &classification);
+
+    ok = expect_string(classification.actor_type, "systemd_scope", "absolute systemd retry-later actor type") && ok;
+    ok = expect_string(classification.actor_kind, "scope", "absolute systemd retry-later actor kind") && ok;
+
+    cgroup_topology_classify(
+        NIPC_APPS_CGROUP_KNOWN,
+        NIPC_ORCHESTRATOR_UNKNOWN,
+        path,
+        &classification);
+
+    ok = expect_string(classification.actor_type, "systemd_scope", "known namespace-relative systemd actor type") && ok;
+
+    return ok;
+}
+
+int main(void)
+{
+    bool ok = true;
+
+    ok = test_namespace_relative_helper() && ok;
+    ok = test_proc_pid_cgroup_parser() && ok;
+    ok = test_namespace_relative_classifier() && ok;
+
+    return ok ? 0 : 1;
+}

--- a/src/collectors/network-viewer.plugin/integrations/network_connections.md
+++ b/src/collectors/network-viewer.plugin/integrations/network_connections.md
@@ -240,7 +240,9 @@ Shows active network connections as a topology graph with self, process or conta
 The group_by selector controls the actor level. process_name groups sockets by process name, pid shows
 one actor per PID with scalar per-PID information, and container groups sockets by canonical
 container_name. For systemd services, container_name is the service name. For non-container,
-non-service processes, container_name falls back to the process name.
+non-service processes, container_name falls back to the process name. Unresolved cgroup
+namespace-relative paths remain pending or process fallback identities instead of being
+displayed as raw `cri-containerd-*.scope` systemd scope names.
 
 Fields that can vary across grouped processes, such as PID, UID, network namespace, command line,
 cgroup path, and detailed container metadata, are scalar columns in group_by:pid and merged actor
@@ -255,7 +257,7 @@ Processes and CGroups tables for the selected actor.
 | Require Cloud | no |
 | Performance | group_by:container performs APPS_LOOKUP cache reads to derive canonical container_name; cache warming runs asynchronously. |
 | Security | Free-form labels are denied by default. Raw cgroup paths may expose operator-chosen path segments and are hidden in table views by default. |
-| Availability | container_name uses APPS_LOOKUP data when available, keeps retry-later lookups pending, and falls back to process name only for known host/root or permanently unknown cgroup cases. |
+| Availability | container_name uses APPS_LOOKUP data when available, keeps retry-later lookups pending, and falls back to process name for host/root, permanently unknown, and unresolved namespace-relative cgroup cases. |
 
 #### Prerequisites
 

--- a/src/collectors/network-viewer.plugin/metadata.yaml
+++ b/src/collectors/network-viewer.plugin/metadata.yaml
@@ -201,7 +201,9 @@ modules:
             The group_by selector controls the actor level. process_name groups sockets by process name, pid shows
             one actor per PID with scalar per-PID information, and container groups sockets by canonical
             container_name. For systemd services, container_name is the service name. For non-container,
-            non-service processes, container_name falls back to the process name.
+            non-service processes, container_name falls back to the process name. Unresolved cgroup
+            namespace-relative paths remain pending or process fallback identities instead of being
+            displayed as raw `cri-containerd-*.scope` systemd scope names.
 
             Fields that can vary across grouped processes, such as PID, UID, network namespace, command line,
             cgroup path, and detailed container metadata, are scalar columns in group_by:pid and merged actor
@@ -287,7 +289,7 @@ modules:
                 description: "Producer-derived actor kind used to classify containers, services, slices, scopes, VMs, and process fallbacks."
           performance: "group_by:container performs APPS_LOOKUP cache reads to derive canonical container_name; cache warming runs asynchronously."
           security: "Free-form labels are denied by default. Raw cgroup paths may expose operator-chosen path segments and are hidden in table views by default."
-          availability: "container_name uses APPS_LOOKUP data when available, keeps retry-later lookups pending, and falls back to process name only for known host/root or permanently unknown cgroup cases."
+          availability: "container_name uses APPS_LOOKUP data when available, keeps retry-later lookups pending, and falls back to process name for host/root, permanently unknown, and unresolved namespace-relative cgroup cases."
   - meta:
       plugin_name: network-viewer.plugin
       module_name: PerflibNetworkProtocols

--- a/src/collectors/network-viewer.plugin/tests/test_network_viewer_topology_containers.c
+++ b/src/collectors/network-viewer.plugin/tests/test_network_viewer_topology_containers.c
@@ -264,6 +264,54 @@ static bool test_retry_later_empty_path_fallback_gate(void)
     return ok;
 }
 
+static bool test_namespace_relative_non_known_container_scope(void)
+{
+    const char *path =
+        "/../../kubepods.slice/kubepods-besteffort.slice/podabc/"
+        "cri-containerd-0123456789abcdef.scope";
+    const char *fallback = "worker";
+    NV_TOPOLOGY_CONTAINER_FIELDS fields;
+
+    nv_container_fields_set_process_fallback(&fields, fallback);
+
+    CGROUP_TOPOLOGY_CLASSIFICATION classification;
+    cgroup_topology_classify(
+        NIPC_APPS_CGROUP_UNKNOWN_RETRY_LATER,
+        NIPC_ORCHESTRATOR_UNKNOWN,
+        path,
+        &classification);
+
+    strncpyz(fields.actor_type, classification.actor_type, sizeof(fields.actor_type) - 1);
+    strncpyz(fields.actor_kind, classification.actor_kind, sizeof(fields.actor_kind) - 1);
+    strncpyz(fields.systemd_unit_name, classification.systemd_unit_name, sizeof(fields.systemd_unit_name) - 1);
+
+    bool use_systemd_unit_name = strncmp(fields.actor_type, "systemd_", strlen("systemd_")) == 0;
+    bool ok =
+        expect_string(fields.actor_type, "container", "namespace-relative retry-later actor type") &&
+        expect_string(fields.actor_kind, "pending", "namespace-relative retry-later actor kind") &&
+        expect_true(!use_systemd_unit_name, "namespace-relative retry-later must not use systemd unit name") &&
+        expect_string(fields.container_name, fallback, "namespace-relative retry-later should keep process fallback");
+
+    nv_container_fields_set_process_fallback(&fields, fallback);
+    cgroup_topology_classify(
+        NIPC_APPS_CGROUP_UNKNOWN_PERMANENT,
+        NIPC_ORCHESTRATOR_UNKNOWN,
+        path,
+        &classification);
+    strncpyz(fields.actor_type, classification.actor_type, sizeof(fields.actor_type) - 1);
+    strncpyz(fields.actor_kind, classification.actor_kind, sizeof(fields.actor_kind) - 1);
+    strncpyz(fields.systemd_unit_name, classification.systemd_unit_name, sizeof(fields.systemd_unit_name) - 1);
+
+    use_systemd_unit_name = strncmp(fields.actor_type, "systemd_", strlen("systemd_")) == 0;
+    if(!use_systemd_unit_name)
+        strncpyz(fields.container_name, fallback, sizeof(fields.container_name) - 1);
+
+    ok = expect_true(!use_systemd_unit_name, "namespace-relative unknown-permanent must not use systemd unit name") && ok;
+    ok = expect_string(fields.container_name, fallback, "namespace-relative unknown-permanent should keep process fallback") && ok;
+
+    return ok;
+}
+
 static bool test_systemd_and_orchestrator(void)
 {
     char value[NV_TOPOLOGY_SYSTEMD_UNIT_MAX];
@@ -365,6 +413,7 @@ int main(void)
     ok = test_container_identity_gating() && ok;
     ok = test_process_fallback_container_fields() && ok;
     ok = test_retry_later_empty_path_fallback_gate() && ok;
+    ok = test_namespace_relative_non_known_container_scope() && ok;
     ok = test_systemd_and_orchestrator() && ok;
 
     return ok ? 0 : 1;


### PR DESCRIPTION
## Summary

Fixes namespace-relative cgroup handling for topology/network-connections container grouping.

- keep apps.plugin cgroup paths raw and cache-key stable
- resolve namespace-relative cgroup paths inside cgroups.plugin against the canonical snapshot
- prevent unresolved namespace-relative paths from being displayed as raw cri-containerd systemd scope names
- add focused parser, classifier, lookup, enrichment, and network-viewer tests
- document namespace-relative lookup behavior in the topology IPC contract and network-viewer metadata

## Validation

- cmake --build build-clion --target cgroup-lookup-netipc-test cgroup-topology-rules-test apps-cgroups-enrichment-test network-viewer-topology-containers-test apps.plugin network-viewer.plugin netdata
- cmake --build build-clion --target apps-cgroups-path-test
- ./build-clion/cgroup-topology-rules-test
- ./build-clion/apps-cgroups-path-test
- ./build-clion/apps-cgroups-enrichment-test
- ./build-clion/network-viewer-topology-containers-test
- ./build-clion/cgroup-lookup-netipc-test
- git diff --check

Live cgroup namespace validation was not run locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes namespace-relative cgroup resolution so topology and network-connections group containers correctly across cgroup namespaces. Honors host prefixes for self cgroup lookup while avoiding cross-namespace leakage, and keeps UI clean and `apps.plugin` cache keys stable.

- **Bug Fixes**
  - Resolve namespace-relative cgroup paths in `cgroups.plugin` via the canonical snapshot and a resolver; return KNOWN while echoing the original request path.
  - When no snapshot exists, namespace-relative requests return UNKNOWN_RETRY_LATER without discovery signalling; misses never fall through to raw reachability; duplicate suffixes fail closed as retry-later.
  - Keep `apps.plugin` cgroup paths raw and commit by the original key; do not requeue same-generation retry-later entries (only on generation advance).
  - Classifier avoids mapping pending namespace-relative paths to systemd scope; UI shows pending or process fallback instead of raw `cri-containerd-*.scope`.
  - Honor host prefix when reading `/proc/self/cgroup`, and match directory identity against plugin-visible cgroup bases to avoid cross-namespace leakage.
  - IPC contract and `network-viewer` docs updated to describe namespace-relative behavior and fallback rules.

- **Refactors**
  - Added `common-cgroups/cgroup-path` (shared `/proc/<pid>/cgroup` parser and namespace-relative helper) and wired it into `apps.plugin`, `cgroups.plugin`, and `network-viewer.plugin`.
  - Snapshot store now tracks directory identity (dev,inode) and provides unique identity/suffix lookups; added a resolver with positive/negative caches and integrated it into the lookup server.
  - Reused a common parent-component check to validate namespace-relative joins and host-prefixed self-cgroup paths.
  - Expanded tests: parser, topology rules, resolver positive/negative caches and duplicate-suffix handling, generation-sensitive requeue behavior, enrichment, and network-viewer container fields; added CMake targets.

<sup>Written for commit 77baaed0ddc736812a25e913f29c9c5c15a3107f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

