### PR TITLE
feat(go.d/mssql): add SQL Agent job execution metrics

### DIFF
--- a/integrations/taxonomy/icons.yaml
+++ b/integrations/taxonomy/icons.yaml
@@ -8,6 +8,7 @@ icons:
   - hardware
   - k8s
   - mysql
+  - mssql
   - netdata
   - none
   - otel

--- a/integrations/taxonomy/sections.yaml
+++ b/integrations/taxonomy/sections.yaml
@@ -68,6 +68,13 @@ sections:
     section_order: 110
     status: active
 
+  - id: applications.mssql
+    parent_id: applications
+    title: Microsoft SQL Server
+    icon: mssql
+    section_order: 115
+    status: active
+
   - id: applications.postgres
     parent_id: applications
     title: PostgreSQL

--- a/src/go/plugin/go.d/collector/mssql/charts.go
+++ b/src/go/plugin/go.d/collector/mssql/charts.go
@@ -69,6 +69,10 @@ const (
 	prioWaitCount
 
 	prioJobStatus
+	prioJobLastExecutionStatus
+	prioJobLastExecutionDuration
+	prioJobLastExecutionAge
+	prioJobCurrentExecutionTime
 
 	prioReplicationStatus
 	prioReplicationLatency
@@ -716,19 +720,69 @@ var (
 	}
 )
 
-// Job status chart template
-var jobStatusChartTmpl = collectorapi.Chart{
-	ID:       "job_%s_status",
-	Title:    "Job status",
-	Units:    "status",
-	Fam:      "jobs",
-	Ctx:      "mssql.job_status",
-	Priority: prioJobStatus,
-	Dims: collectorapi.Dims{
-		{ID: "job_%s_enabled", Name: "enabled"},
-		{ID: "job_%s_disabled", Name: "disabled"},
-	},
-}
+// Job chart templates
+var (
+	jobStatusChartTmpl = collectorapi.Chart{
+		ID:       "job_%s_status",
+		Title:    "Job status",
+		Units:    "status",
+		Fam:      "jobs",
+		Ctx:      "mssql.job_status",
+		Priority: prioJobStatus,
+		Dims: collectorapi.Dims{
+			{ID: "job_%s_enabled", Name: "enabled"},
+			{ID: "job_%s_disabled", Name: "disabled"},
+		},
+	}
+	jobLastExecutionStatusChartTmpl = collectorapi.Chart{
+		ID:       "job_%s_last_execution_status",
+		Title:    "Job last execution status",
+		Units:    "status",
+		Fam:      "jobs",
+		Ctx:      "mssql.job_last_execution_status",
+		Priority: prioJobLastExecutionStatus,
+		Dims: collectorapi.Dims{
+			{ID: "job_%s_last_execution_status_unknown", Name: "unknown"},
+			{ID: "job_%s_last_execution_status_ok", Name: "ok"},
+			{ID: "job_%s_last_execution_status_warning", Name: "warning"},
+			{ID: "job_%s_last_execution_status_error", Name: "error"},
+			{ID: "job_%s_last_execution_status_canceled", Name: "canceled"},
+		},
+	}
+	jobLastExecutionDurationChartTmpl = collectorapi.Chart{
+		ID:       "job_%s_last_execution_duration",
+		Title:    "Job last execution duration",
+		Units:    "seconds",
+		Fam:      "jobs",
+		Ctx:      "mssql.job_last_execution_duration",
+		Priority: prioJobLastExecutionDuration,
+		Dims: collectorapi.Dims{
+			{ID: "job_%s_last_execution_duration", Name: "duration"},
+		},
+	}
+	jobLastExecutionAgeChartTmpl = collectorapi.Chart{
+		ID:       "job_%s_last_execution_age",
+		Title:    "Job last execution age",
+		Units:    "seconds",
+		Fam:      "jobs",
+		Ctx:      "mssql.job_last_execution_age",
+		Priority: prioJobLastExecutionAge,
+		Dims: collectorapi.Dims{
+			{ID: "job_%s_last_execution_age", Name: "age"},
+		},
+	}
+	jobCurrentExecutionTimeChartTmpl = collectorapi.Chart{
+		ID:       "job_%s_current_execution_time",
+		Title:    "Job current execution time",
+		Units:    "seconds",
+		Fam:      "jobs",
+		Ctx:      "mssql.job_current_execution_time",
+		Priority: prioJobCurrentExecutionTime,
+		Dims: collectorapi.Dims{
+			{ID: "job_%s_current_execution_time", Name: "duration"},
+		},
+	}
+)
 
 // Replication chart templates
 var (
@@ -924,22 +978,90 @@ func (c *Collector) addLockStatsCharts(resourceType string) {
 	}
 }
 
-func (c *Collector) addJobCharts(jobName string) {
-	chart := jobStatusChartTmpl.Copy()
+func (c *Collector) addJobCharts(job sqlAgentJob) {
+	c.removeObsoleteJobCharts(job.chartID)
 
-	jobID := cleanJobName(jobName)
-
-	chart.ID = fmt.Sprintf(chart.ID, jobID)
-	chart.Labels = []collectorapi.Label{
-		{Key: "job_name", Value: jobName},
-	}
-	for _, dim := range chart.Dims {
-		dim.ID = fmt.Sprintf(dim.ID, jobID)
+	charts := &collectorapi.Charts{
+		jobStatusChartTmpl.Copy(),
+		jobLastExecutionStatusChartTmpl.Copy(),
+		jobLastExecutionDurationChartTmpl.Copy(),
+		jobLastExecutionAgeChartTmpl.Copy(),
+		jobCurrentExecutionTimeChartTmpl.Copy(),
 	}
 
-	if err := c.Charts().Add(chart); err != nil {
+	labels := []collectorapi.Label{
+		{Key: "job_name", Value: job.name},
+	}
+	for _, chart := range *charts {
+		chart.ID = fmt.Sprintf(chart.ID, job.chartID)
+		chart.Labels = labels
+		for _, dim := range chart.Dims {
+			dim.ID = fmt.Sprintf(dim.ID, job.chartID)
+		}
+	}
+
+	if err := c.Charts().Add(*charts...); err != nil {
 		c.Warning(err)
 	}
+}
+
+func (c *Collector) removeObsoleteJobCharts(chartID string) {
+	for _, id := range jobChartIDs(chartID) {
+		chart := c.Charts().Get(id)
+		if chart == nil || !chart.IsRemoved() {
+			continue
+		}
+		if err := c.Charts().Remove(id); err != nil {
+			c.Warningf("remove obsolete job chart '%s': %v", id, err)
+		}
+	}
+}
+
+func (c *Collector) updateJobChartsLabels(job sqlAgentJob) {
+	labels := []collectorapi.Label{
+		{Key: "job_name", Value: job.name},
+	}
+	for _, chartID := range jobChartIDs(job.chartID) {
+		chart := c.Charts().Get(chartID)
+		if chart == nil || chart.IsRemoved() {
+			continue
+		}
+		if hasJobNameLabel(chart, job.name) {
+			continue
+		}
+		chart.Labels = labels
+		chart.MarkNotCreated()
+	}
+}
+
+func (c *Collector) removeJobCharts(chartID string) {
+	for _, id := range jobChartIDs(chartID) {
+		chart := c.Charts().Get(id)
+		if chart == nil {
+			continue
+		}
+		chart.MarkRemove()
+		chart.MarkNotCreated()
+	}
+}
+
+func jobChartIDs(chartID string) []string {
+	return []string{
+		fmt.Sprintf(jobStatusChartTmpl.ID, chartID),
+		fmt.Sprintf(jobLastExecutionStatusChartTmpl.ID, chartID),
+		fmt.Sprintf(jobLastExecutionDurationChartTmpl.ID, chartID),
+		fmt.Sprintf(jobLastExecutionAgeChartTmpl.ID, chartID),
+		fmt.Sprintf(jobCurrentExecutionTimeChartTmpl.ID, chartID),
+	}
+}
+
+func hasJobNameLabel(chart *collectorapi.Chart, jobName string) bool {
+	for _, label := range chart.Labels {
+		if label.Key == "job_name" {
+			return label.Value == jobName
+		}
+	}
+	return false
 }
 
 func (c *Collector) addReplicationCharts(pubDB, publication string) {
@@ -983,6 +1105,11 @@ func cleanResourceTypeName(name string) string {
 func cleanJobName(name string) string {
 	r := strings.NewReplacer(" ", "_", ".", "_", "-", "_")
 	return strings.ToLower(r.Replace(name))
+}
+
+func cleanJobID(id string) string {
+	r := strings.NewReplacer("-", "_", "{", "", "}", "")
+	return strings.ToLower(r.Replace(id))
 }
 
 func cleanPublicationName(pubDB, publication string) string {

--- a/src/go/plugin/go.d/collector/mssql/collect.go
+++ b/src/go/plugin/go.d/collector/mssql/collect.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -20,6 +21,46 @@ const (
 	maxKBToBytes        = int64(1<<63-1) / 1024
 	maxKBToCentiPercent = int64(1<<63-1) / 10000
 )
+
+const (
+	logKeySQLAgentJobsQueryFailed = "mssql:sql-agent-jobs-query-failed"
+)
+
+const (
+	sqlAgentJobRunStatusFailed    = 0
+	sqlAgentJobRunStatusSucceeded = 1
+	sqlAgentJobRunStatusCanceled  = 3
+)
+
+const (
+	jobLastExecutionStatusUnknown  = "unknown"
+	jobLastExecutionStatusOK       = "ok"
+	jobLastExecutionStatusWarning  = "warning"
+	jobLastExecutionStatusError    = "error"
+	jobLastExecutionStatusCanceled = "canceled"
+)
+
+var jobLastExecutionStatusNames = []string{
+	jobLastExecutionStatusUnknown,
+	jobLastExecutionStatusOK,
+	jobLastExecutionStatusWarning,
+	jobLastExecutionStatusError,
+	jobLastExecutionStatusCanceled,
+}
+
+type sqlAgentJob struct {
+	id      string
+	name    string
+	chartID string
+	enabled bool
+}
+
+type sqlAgentJobLastExecution struct {
+	runStatus       int64
+	durationSeconds int64
+	ageSeconds      sql.NullInt64
+	hasFailedStep   bool
+}
 
 func (c *Collector) collect() (map[string]int64, error) {
 	if c.db == nil {
@@ -61,9 +102,7 @@ func (c *Collector) collect() (map[string]int64, error) {
 	if err := c.collectWaitStats(mx); err != nil {
 		return nil, err
 	}
-	if err := c.collectJobStatus(mx); err != nil {
-		return nil, err
-	}
+	c.collectJobStatus(mx)
 	if err := c.collectReplicationStatus(mx); err != nil {
 		return nil, err
 	}
@@ -659,41 +698,263 @@ func (c *Collector) collectWaitStats(mx map[string]int64) error {
 	return rows.Err()
 }
 
-func (c *Collector) collectJobStatus(mx map[string]int64) error {
+func (c *Collector) collectJobStatus(mx map[string]int64) {
+	jobs, complete, err := c.querySQLAgentJobs()
+	if err != nil {
+		c.Limit(logKeySQLAgentJobsQueryFailed, 1, 0).
+			Warningf("SQL Server Agent jobs query failed; job metrics will be unavailable: %v", err)
+		return
+	}
+
+	assignJobChartIDs(jobs, c.seenJobs)
+	c.updateJobCharts(jobs, complete)
+
+	for _, job := range jobs {
+		px := fmt.Sprintf("job_%s_", job.chartID)
+		mx[px+"enabled"] = boolToInt64(job.enabled)
+		mx[px+"disabled"] = boolToInt64(!job.enabled)
+	}
+
+	if lastExecutions, ok := c.querySQLAgentJobLastExecutions(); ok {
+		for _, job := range jobs {
+			if lastExec, ok := lastExecutions[job.id]; ok {
+				collectJobLastExecution(mx, job, &lastExec)
+			} else {
+				collectJobLastExecution(mx, job, nil)
+			}
+		}
+	}
+
+	if currentExecutions, ok := c.querySQLAgentJobCurrentExecutions(); ok {
+		for _, job := range jobs {
+			mx[fmt.Sprintf("job_%s_current_execution_time", job.chartID)] = currentExecutions[job.id]
+		}
+	}
+}
+
+func (c *Collector) querySQLAgentJobs() ([]sqlAgentJob, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout.Duration())
 	defer cancel()
 
 	rows, err := c.db.QueryContext(ctx, queryJobs)
 	if err != nil {
-		return fmt.Errorf("jobs query failed: %v", err)
+		return nil, false, err
 	}
 	defer rows.Close()
 
+	var jobs []sqlAgentJob
+	var scanFailed bool
 	for rows.Next() {
-		var jobName string
+		var jobID, jobName string
 		var enabled int64
-		if err := rows.Scan(&jobName, &enabled); err != nil {
+		if err := rows.Scan(&jobID, &jobName, &enabled); err != nil {
+			c.Debugf("jobs row scan failed: %v", err)
+			scanFailed = true
 			continue
 		}
 
+		jobID = strings.TrimSpace(jobID)
 		jobName = strings.TrimSpace(jobName)
-
-		if !c.seenJobs[jobName] {
-			c.seenJobs[jobName] = true
-			c.addJobCharts(jobName)
+		if jobID == "" || jobName == "" {
+			continue
 		}
 
-		jobID := cleanJobName(jobName)
-		if enabled == 1 {
-			mx[fmt.Sprintf("job_%s_enabled", jobID)] = 1
-			mx[fmt.Sprintf("job_%s_disabled", jobID)] = 0
-		} else {
-			mx[fmt.Sprintf("job_%s_enabled", jobID)] = 0
-			mx[fmt.Sprintf("job_%s_disabled", jobID)] = 1
+		jobs = append(jobs, sqlAgentJob{
+			id:      strings.ToLower(jobID),
+			name:    jobName,
+			enabled: enabled == 1,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+
+	return jobs, !scanFailed, nil
+}
+
+func assignJobChartIDs(jobs []sqlAgentJob, previous map[string]string) {
+	sort.SliceStable(jobs, func(i, j int) bool {
+		if jobs[i].name != jobs[j].name {
+			return jobs[i].name < jobs[j].name
+		}
+		return jobs[i].id < jobs[j].id
+	})
+
+	used := make(map[string]bool, len(jobs))
+	for i := range jobs {
+		if chartID := previous[jobs[i].id]; chartID != "" && !used[chartID] {
+			jobs[i].chartID = chartID
+			used[chartID] = true
 		}
 	}
 
-	return rows.Err()
+	for i := range jobs {
+		if jobs[i].chartID != "" {
+			continue
+		}
+
+		base := cleanJobName(jobs[i].name)
+		chartID := base
+		for n := 0; used[chartID]; n++ {
+			chartID = fmt.Sprintf("%s_%s", base, cleanJobID(jobs[i].id))
+			if n > 0 {
+				chartID = fmt.Sprintf("%s_%d", chartID, n)
+			}
+		}
+		jobs[i].chartID = chartID
+		used[chartID] = true
+	}
+}
+
+func (c *Collector) updateJobCharts(jobs []sqlAgentJob, removeMissing bool) {
+	seen := make(map[string]bool, len(jobs))
+	currentChartIDs := make(map[string]bool, len(jobs))
+	for _, job := range jobs {
+		currentChartIDs[job.chartID] = true
+	}
+
+	for _, job := range jobs {
+		seen[job.id] = true
+
+		if chartID, ok := c.seenJobs[job.id]; ok {
+			if chartID != job.chartID {
+				if !currentChartIDs[chartID] {
+					c.removeJobCharts(chartID)
+				}
+				c.addJobCharts(job)
+			} else {
+				c.updateJobChartsLabels(job)
+			}
+		} else {
+			c.addJobCharts(job)
+		}
+		c.seenJobs[job.id] = job.chartID
+	}
+
+	if !removeMissing {
+		return
+	}
+	for jobID, chartID := range c.seenJobs {
+		if seen[jobID] {
+			continue
+		}
+		c.removeJobCharts(chartID)
+		delete(c.seenJobs, jobID)
+	}
+}
+
+func (c *Collector) querySQLAgentJobLastExecutions() (map[string]sqlAgentJobLastExecution, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout.Duration())
+	defer cancel()
+
+	rows, err := c.db.QueryContext(ctx, queryJobLastExecutions)
+	if err != nil {
+		c.Debugf("job last executions query failed: %v", err)
+		return nil, false
+	}
+	defer rows.Close()
+
+	executions := make(map[string]sqlAgentJobLastExecution)
+	for rows.Next() {
+		var jobID string
+		var runStatus, durationSeconds int64
+		var ageSeconds sql.NullInt64
+		var hasFailedStep int64
+		if err := rows.Scan(&jobID, &runStatus, &durationSeconds, &ageSeconds, &hasFailedStep); err != nil {
+			c.Debugf("job last executions row scan failed: %v", err)
+			continue
+		}
+
+		jobID = strings.ToLower(strings.TrimSpace(jobID))
+		if jobID == "" {
+			continue
+		}
+		executions[jobID] = sqlAgentJobLastExecution{
+			runStatus:       runStatus,
+			durationSeconds: durationSeconds,
+			ageSeconds:      ageSeconds,
+			hasFailedStep:   hasFailedStep != 0,
+		}
+	}
+	if err := rows.Err(); err != nil {
+		c.Debugf("job last executions rows failed: %v", err)
+		return nil, false
+	}
+
+	return executions, true
+}
+
+func collectJobLastExecution(mx map[string]int64, job sqlAgentJob, exec *sqlAgentJobLastExecution) {
+	status := jobLastExecutionStatusUnknown
+	if exec != nil {
+		switch exec.runStatus {
+		case sqlAgentJobRunStatusFailed:
+			status = jobLastExecutionStatusError
+		case sqlAgentJobRunStatusSucceeded:
+			if exec.hasFailedStep {
+				status = jobLastExecutionStatusWarning
+			} else {
+				status = jobLastExecutionStatusOK
+			}
+		case sqlAgentJobRunStatusCanceled:
+			status = jobLastExecutionStatusCanceled
+		}
+	}
+
+	px := fmt.Sprintf("job_%s_last_execution_status_", job.chartID)
+	for _, name := range jobLastExecutionStatusNames {
+		mx[px+name] = boolToInt64(name == status)
+	}
+
+	if exec == nil {
+		return
+	}
+
+	mx[fmt.Sprintf("job_%s_last_execution_duration", job.chartID)] = exec.durationSeconds
+	if exec.ageSeconds.Valid {
+		mx[fmt.Sprintf("job_%s_last_execution_age", job.chartID)] = exec.ageSeconds.Int64
+	}
+}
+
+func (c *Collector) querySQLAgentJobCurrentExecutions() (map[string]int64, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout.Duration())
+	defer cancel()
+
+	rows, err := c.db.QueryContext(ctx, queryJobCurrentExecutions)
+	if err != nil {
+		c.Debugf("job current executions query failed: %v", err)
+		return nil, false
+	}
+	defer rows.Close()
+
+	executions := make(map[string]int64)
+	for rows.Next() {
+		var jobID string
+		var seconds int64
+		if err := rows.Scan(&jobID, &seconds); err != nil {
+			c.Debugf("job current executions row scan failed: %v", err)
+			continue
+		}
+
+		jobID = strings.ToLower(strings.TrimSpace(jobID))
+		if jobID == "" {
+			continue
+		}
+		executions[jobID] = seconds
+	}
+	if err := rows.Err(); err != nil {
+		c.Debugf("job current executions rows failed: %v", err)
+		return nil, false
+	}
+
+	return executions, true
+}
+
+func boolToInt64(v bool) int64 {
+	if v {
+		return 1
+	}
+	return 0
 }
 
 func (c *Collector) collectSQLErrors(mx map[string]int64) error {

--- a/src/go/plugin/go.d/collector/mssql/collector.go
+++ b/src/go/plugin/go.d/collector/mssql/collector.go
@@ -55,7 +55,7 @@ func New() *Collector {
 		seenWaitTypes:        make(map[string]bool),
 		seenLockTypes:        make(map[string]bool),
 		seenLockStatsTypes:   make(map[string]bool),
-		seenJobs:             make(map[string]bool),
+		seenJobs:             make(map[string]string),
 		seenReplications:     make(map[string]bool),
 
 		seenAGs:                make(map[string]bool),
@@ -161,7 +161,7 @@ type Collector struct {
 	seenWaitTypes        map[string]bool
 	seenLockTypes        map[string]bool
 	seenLockStatsTypes   map[string]bool
-	seenJobs             map[string]bool
+	seenJobs             map[string]string
 	seenReplications     map[string]bool
 
 	hadrEnabled  bool // true if Always On AG is enabled on this instance

--- a/src/go/plugin/go.d/collector/mssql/integrations/microsoft_sql_server.md
+++ b/src/go/plugin/go.d/collector/mssql/integrations/microsoft_sql_server.md
@@ -58,19 +58,18 @@ This collector is supported on all platforms.
 This collector supports collecting metrics from multiple instances of this integration, including remote instances.
 
 The monitoring user requires the VIEW SERVER STATE permission to access DMVs.
+
 SQL Agent job metrics require access to `msdb.dbo.sysjobs`.
-SQL Agent job execution metrics additionally require access to
-`msdb.dbo.sysjobhistory` and `msdb.dbo.sysjobactivity`.
-If those optional `msdb` grants are missing, the collector continues
-collecting other SQL Server metrics and omits only the affected SQL Agent job metrics.
-Current job execution time is based on the latest visible SQL Server Agent
-activity session. If SQL Server Agent stops or crashes while a job is recorded
-as running, `sysjobactivity` can report that job as running until Agent creates
-a newer session or activity/history state changes.
-Last execution warning detection checks failed step history between the previous
-and latest completed job summary rows. If SQL Server Agent step history is
-suppressed or purged before collection, a job that completed successfully with
-failed intermediate steps can be reported as `ok` instead of `warning`.
+
+SQL Agent job execution metrics additionally require access to `msdb.dbo.sysjobhistory` and `msdb.dbo.sysjobactivity`.
+If those optional `msdb` grants are missing, the collector continues collecting other SQL Server metrics and omits only the affected SQL Agent job metrics.
+
+Current job execution time is based on the latest visible SQL Server Agent activity session.
+If SQL Server Agent stops or crashes while a job is recorded as running, `sysjobactivity` can report that job as running until Agent creates a newer session or activity/history state changes.
+
+Last execution warning detection checks failed step history between the previous and latest completed job summary rows.
+If SQL Server Agent step history is suppressed or purged before collection, a job that completed successfully with failed intermediate steps can be reported as `ok` instead of `warning`.
+
 Always On AG monitoring requires VIEW ANY DEFINITION for access to availability group catalog views.
 On SQL Server 2022+, HADR DMVs may additionally require VIEW SERVER PERFORMANCE STATE.
 
@@ -472,7 +471,7 @@ This scope has no labels.
 
 Metrics:
 
-| Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
+| Metric | Dimensions | Unit | SQL Server | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
 | mssql.user_connections | user | connections | • | • |
 | mssql.session_connections | user, internal | connections | • | • |
@@ -512,7 +511,7 @@ Labels:
 
 Metrics:
 
-| Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
+| Metric | Dimensions | Unit | SQL Server | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
 | mssql.database_active_transactions | active | transactions | • | • |
 | mssql.database_transactions | transactions | transactions/s | • | • |
@@ -541,7 +540,7 @@ Labels:
 
 Metrics:
 
-| Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
+| Metric | Dimensions | Unit | SQL Server | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
 | mssql.lock_stats_deadlocks | deadlocks | deadlocks/s | • | • |
 | mssql.lock_stats_waits | waits | waits/s | • | • |
@@ -560,7 +559,7 @@ Labels:
 
 Metrics:
 
-| Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
+| Metric | Dimensions | Unit | SQL Server | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
 | mssql.locks_by_resource | locks | locks | • | • |
 
@@ -577,7 +576,7 @@ Labels:
 
 Metrics:
 
-| Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
+| Metric | Dimensions | Unit | SQL Server | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
 | mssql.wait_total_time | duration | ms | • | • |
 | mssql.wait_resource_time | duration | ms | • | • |
@@ -597,7 +596,7 @@ Labels:
 
 Metrics:
 
-| Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
+| Metric | Dimensions | Unit | SQL Server | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
 | mssql.job_status | enabled, disabled | status | • |   |
 | mssql.job_last_execution_status | unknown, ok, warning, error, canceled | status | • |   |
@@ -618,7 +617,7 @@ Labels:
 
 Metrics:
 
-| Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
+| Metric | Dimensions | Unit | SQL Server | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
 | mssql.replication_status | started, succeeded, in_progress, idle, retrying, failed | status | • | • |
 | mssql.replication_warning | expiration, latency, merge_expiration, merge_slow_duration, merge_fast_duration, merge_fast_speed, merge_slow_speed | flags | • | • |
@@ -637,7 +636,7 @@ Labels:
 
 Metrics:
 
-| Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
+| Metric | Dimensions | Unit | SQL Server | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
 | mssql.ag_sync_health | not_healthy, partially_healthy, healthy | state | • | • |
 | mssql.ag_recovery_health | primary_online, primary_in_progress, secondary_online, secondary_in_progress | state | • | • |
@@ -658,7 +657,7 @@ Labels:
 
 Metrics:
 
-| Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
+| Metric | Dimensions | Unit | SQL Server | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
 | mssql.ag_replica_role | primary, secondary, resolving, unknown | state | • | • |
 | mssql.ag_replica_connected_state | connected, disconnected, unknown | state | • | • |
@@ -678,7 +677,7 @@ Labels:
 
 Metrics:
 
-| Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
+| Metric | Dimensions | Unit | SQL Server | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
 | mssql.ag_db_sync_state | not_synchronizing, synchronizing, synchronized, reverting, initializing | state | • | • |
 | mssql.ag_db_log_send_queue | queue_size | bytes | • | • |
@@ -699,7 +698,7 @@ This scope has no labels.
 
 Metrics:
 
-| Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
+| Metric | Dimensions | Unit | SQL Server | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
 | mssql.ag_cluster_quorum_state | normal, forced, unknown | state | • | • |
 
@@ -715,7 +714,7 @@ Labels:
 
 Metrics:
 
-| Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
+| Metric | Dimensions | Unit | SQL Server | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
 | mssql.ag_cluster_member_state | up, down | state | • | • |
 | mssql.ag_cluster_member_quorum_votes | votes | votes | • | • |
@@ -732,7 +731,7 @@ Labels:
 
 Metrics:
 
-| Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
+| Metric | Dimensions | Unit | SQL Server | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
 | mssql.ag_page_repair | successful, failed | repairs | • | • |
 

--- a/src/go/plugin/go.d/collector/mssql/integrations/microsoft_sql_server.md
+++ b/src/go/plugin/go.d/collector/mssql/integrations/microsoft_sql_server.md
@@ -27,7 +27,7 @@ It collects metrics from:
 - Performance counters (buffer manager, memory manager, SQL statistics)
 - Dynamic management views (DMVs) for wait statistics, locks, and sessions
 - Per-database transaction and lock statistics
-- SQL Server Agent job status
+- SQL Server Agent job status and execution history
 - Always On Availability Group health, replica states, and per-database synchronization metrics
 
 
@@ -42,6 +42,8 @@ It connects to the SQL Server instance via TCP using the go-mssqldb driver and e
 - `sys.dm_os_sys_memory` - OS physical memory and page file
 - `sys.master_files` - Database file sizes
 - `msdb.dbo.sysjobs` - SQL Agent job status
+- `msdb.dbo.sysjobhistory` - SQL Agent completed job execution history
+- `msdb.dbo.sysjobactivity` - SQL Agent current job activity
 - `sys.dm_hadr_availability_group_states` - AG health rollup
 - `sys.dm_hadr_availability_replica_states` - Replica operational state
 - `sys.dm_hadr_database_replica_states` - Database sync queues and rates
@@ -56,8 +58,19 @@ This collector is supported on all platforms.
 This collector supports collecting metrics from multiple instances of this integration, including remote instances.
 
 The monitoring user requires the VIEW SERVER STATE permission to access DMVs.
-SQL Agent job monitoring is part of collector startup, so access to
-`msdb.dbo.sysjobs` is required.
+SQL Agent job metrics require access to `msdb.dbo.sysjobs`.
+SQL Agent job execution metrics additionally require access to
+`msdb.dbo.sysjobhistory` and `msdb.dbo.sysjobactivity`.
+If those optional `msdb` grants are missing, the collector continues
+collecting other SQL Server metrics and omits only the affected SQL Agent job metrics.
+Current job execution time is based on the latest visible SQL Server Agent
+activity session. If SQL Server Agent stops or crashes while a job is recorded
+as running, `sysjobactivity` can report that job as running until Agent creates
+a newer session or activity/history state changes.
+Last execution warning detection checks failed step history between the previous
+and latest completed job summary rows. If SQL Server Agent step history is
+suppressed or purged before collection, a job that completed successfully with
+failed intermediate steps can be reported as `ok` instead of `warning`.
 Always On AG monitoring requires VIEW ANY DEFINITION for access to availability group catalog views.
 On SQL Server 2022+, HADR DMVs may additionally require VIEW SERVER PERFORMANCE STATE.
 
@@ -121,10 +134,12 @@ GRANT VIEW ANY DEFINITION TO netdata_user;
 -- Grant VIEW SERVER PERFORMANCE STATE (required for HADR DMVs on SQL Server 2022+)
 -- GRANT VIEW SERVER PERFORMANCE STATE TO netdata_user;
 
--- Grant access to msdb for SQL Agent job monitoring (required)
+-- Grant access to msdb for SQL Agent job monitoring
 USE msdb;
 CREATE USER netdata_user FOR LOGIN netdata_user;
 GRANT SELECT ON dbo.sysjobs TO netdata_user;
+GRANT SELECT ON dbo.sysjobhistory TO netdata_user;
+GRANT SELECT ON dbo.sysjobactivity TO netdata_user;
 
 -- Optional: Grant access to distribution database for replication monitoring
 -- (only if replication is configured)
@@ -137,9 +152,11 @@ GRANT SELECT ON dbo.MSsubscriptions TO netdata_user;
 
 **Required permissions:**
 - `VIEW SERVER STATE` - Access to dynamic management views
-- `SELECT on msdb.dbo.sysjobs` - SQL Agent job status monitoring
 
 **Optional permissions:**
+- `SELECT on msdb.dbo.sysjobs` - SQL Agent job status monitoring
+- `SELECT on msdb.dbo.sysjobhistory` - SQL Agent completed job execution history
+- `SELECT on msdb.dbo.sysjobactivity` - SQL Agent current job activity
 - `VIEW ANY DEFINITION` - Always On Availability Group monitoring
 - `VIEW SERVER PERFORMANCE STATE` - HADR DMVs on SQL Server 2022+
 - `SELECT on distribution.dbo.MSreplication_monitordata` - Replication monitoring
@@ -167,6 +184,8 @@ GRANT VIEW ANY DEFINITION TO [NT AUTHORITY\SYSTEM];
 USE msdb;
 CREATE USER [NT AUTHORITY\SYSTEM] FOR LOGIN [NT AUTHORITY\SYSTEM];
 GRANT SELECT ON dbo.sysjobs TO [NT AUTHORITY\SYSTEM];
+GRANT SELECT ON dbo.sysjobhistory TO [NT AUTHORITY\SYSTEM];
+GRANT SELECT ON dbo.sysjobactivity TO [NT AUTHORITY\SYSTEM];
 ```
 
 **Remote connection (Netdata connects to SQL Server on another machine):**
@@ -182,6 +201,8 @@ GRANT VIEW ANY DEFINITION TO [DOMAIN\COMPUTERNAME$];
 USE msdb;
 CREATE USER [DOMAIN\COMPUTERNAME$] FOR LOGIN [DOMAIN\COMPUTERNAME$];
 GRANT SELECT ON dbo.sysjobs TO [DOMAIN\COMPUTERNAME$];
+GRANT SELECT ON dbo.sysjobhistory TO [DOMAIN\COMPUTERNAME$];
+GRANT SELECT ON dbo.sysjobactivity TO [DOMAIN\COMPUTERNAME$];
 ```
 
 For the default `Local System` service account, remote Windows Authentication works
@@ -431,6 +452,8 @@ The following alerts are available:
 | Alert name  | On metric | Description |
 |:------------|:----------|:------------|
 | [ mssql_database_log_percent_used ](https://github.com/netdata/netdata/blob/master/src/health/health.d/mssql.conf) | mssql.database_log_percent_used | SQL Server transaction log percent used has been above 90% for the last 15 minutes |
+| [ mssql_sql_agent_job_last_execution_warning ](https://github.com/netdata/netdata/blob/master/src/health/health.d/mssql.conf) | mssql.job_last_execution_status | SQL Server Agent job succeeded but at least one step failed in the last completed execution |
+| [ mssql_sql_agent_job_last_execution_failed ](https://github.com/netdata/netdata/blob/master/src/health/health.d/mssql.conf) | mssql.job_last_execution_status | SQL Server Agent job failed in the last completed execution |
 
 
 ## Metrics
@@ -576,7 +599,11 @@ Metrics:
 
 | Metric | Dimensions | Unit | SQL Server 2016+ | Azure SQL Database |
 |:------|:----------|:----|:---:|:---:|
-| mssql.job_status | enabled, disabled | status | • | • |
+| mssql.job_status | enabled, disabled | status | • |   |
+| mssql.job_last_execution_status | unknown, ok, warning, error, canceled | status | • |   |
+| mssql.job_last_execution_duration | duration | seconds | • |   |
+| mssql.job_last_execution_age | age | seconds | • |   |
+| mssql.job_current_execution_time | duration | seconds | • |   |
 
 ### Per replication
 

--- a/src/go/plugin/go.d/collector/mssql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mssql/metadata.yaml
@@ -74,19 +74,18 @@ modules:
       additional_permissions:
         description: |
           The monitoring user requires the VIEW SERVER STATE permission to access DMVs.
+
           SQL Agent job metrics require access to `msdb.dbo.sysjobs`.
-          SQL Agent job execution metrics additionally require access to
-          `msdb.dbo.sysjobhistory` and `msdb.dbo.sysjobactivity`.
-          If those optional `msdb` grants are missing, the collector continues
-          collecting other SQL Server metrics and omits only the affected SQL Agent job metrics.
-          Current job execution time is based on the latest visible SQL Server Agent
-          activity session. If SQL Server Agent stops or crashes while a job is recorded
-          as running, `sysjobactivity` can report that job as running until Agent creates
-          a newer session or activity/history state changes.
-          Last execution warning detection checks failed step history between the previous
-          and latest completed job summary rows. If SQL Server Agent step history is
-          suppressed or purged before collection, a job that completed successfully with
-          failed intermediate steps can be reported as `ok` instead of `warning`.
+
+          SQL Agent job execution metrics additionally require access to `msdb.dbo.sysjobhistory` and `msdb.dbo.sysjobactivity`.
+          If those optional `msdb` grants are missing, the collector continues collecting other SQL Server metrics and omits only the affected SQL Agent job metrics.
+
+          Current job execution time is based on the latest visible SQL Server Agent activity session.
+          If SQL Server Agent stops or crashes while a job is recorded as running, `sysjobactivity` can report that job as running until Agent creates a newer session or activity/history state changes.
+
+          Last execution warning detection checks failed step history between the previous and latest completed job summary rows.
+          If SQL Server Agent step history is suppressed or purged before collection, a job that completed successfully with failed intermediate steps can be reported as `ok` instead of `warning`.
+
           Always On AG monitoring requires VIEW ANY DEFINITION for access to availability group catalog views.
           On SQL Server 2022+, HADR DMVs may additionally require VIEW SERVER PERFORMANCE STATE.
       supported_platforms:
@@ -983,7 +982,7 @@ modules:
         enabled: false
       description: ""
       availability:
-        - SQL Server 2016+
+        - SQL Server
         - Azure SQL Database
       scopes:
         - name: global
@@ -1335,7 +1334,7 @@ modules:
             - name: mssql.job_status
               description: Job Status
               availability:
-                - SQL Server 2016+
+                - SQL Server
               unit: status
               chart_type: line
               dimensions:
@@ -1344,7 +1343,7 @@ modules:
             - name: mssql.job_last_execution_status
               description: Job Last Execution Status
               availability:
-                - SQL Server 2016+
+                - SQL Server
               unit: status
               chart_type: line
               dimensions:
@@ -1356,7 +1355,7 @@ modules:
             - name: mssql.job_last_execution_duration
               description: Job Last Execution Duration
               availability:
-                - SQL Server 2016+
+                - SQL Server
               unit: seconds
               chart_type: line
               dimensions:
@@ -1364,7 +1363,7 @@ modules:
             - name: mssql.job_last_execution_age
               description: Job Last Execution Age
               availability:
-                - SQL Server 2016+
+                - SQL Server
               unit: seconds
               chart_type: line
               dimensions:
@@ -1372,7 +1371,7 @@ modules:
             - name: mssql.job_current_execution_time
               description: Job Current Execution Time
               availability:
-                - SQL Server 2016+
+                - SQL Server
               unit: seconds
               chart_type: line
               dimensions:

--- a/src/go/plugin/go.d/collector/mssql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mssql/metadata.yaml
@@ -37,7 +37,7 @@ modules:
           - Performance counters (buffer manager, memory manager, SQL statistics)
           - Dynamic management views (DMVs) for wait statistics, locks, and sessions
           - Per-database transaction and lock statistics
-          - SQL Server Agent job status
+          - SQL Server Agent job status and execution history
           - Always On Availability Group health, replica states, and per-database synchronization metrics
         method_description: |
           It connects to the SQL Server instance via TCP using the go-mssqldb driver and executes queries against:
@@ -51,6 +51,8 @@ modules:
           - `sys.dm_os_sys_memory` - OS physical memory and page file
           - `sys.master_files` - Database file sizes
           - `msdb.dbo.sysjobs` - SQL Agent job status
+          - `msdb.dbo.sysjobhistory` - SQL Agent completed job execution history
+          - `msdb.dbo.sysjobactivity` - SQL Agent current job activity
           - `sys.dm_hadr_availability_group_states` - AG health rollup
           - `sys.dm_hadr_availability_replica_states` - Replica operational state
           - `sys.dm_hadr_database_replica_states` - Database sync queues and rates
@@ -72,8 +74,19 @@ modules:
       additional_permissions:
         description: |
           The monitoring user requires the VIEW SERVER STATE permission to access DMVs.
-          SQL Agent job monitoring is part of collector startup, so access to
-          `msdb.dbo.sysjobs` is required.
+          SQL Agent job metrics require access to `msdb.dbo.sysjobs`.
+          SQL Agent job execution metrics additionally require access to
+          `msdb.dbo.sysjobhistory` and `msdb.dbo.sysjobactivity`.
+          If those optional `msdb` grants are missing, the collector continues
+          collecting other SQL Server metrics and omits only the affected SQL Agent job metrics.
+          Current job execution time is based on the latest visible SQL Server Agent
+          activity session. If SQL Server Agent stops or crashes while a job is recorded
+          as running, `sysjobactivity` can report that job as running until Agent creates
+          a newer session or activity/history state changes.
+          Last execution warning detection checks failed step history between the previous
+          and latest completed job summary rows. If SQL Server Agent step history is
+          suppressed or purged before collection, a job that completed successfully with
+          failed intermediate steps can be reported as `ok` instead of `warning`.
           Always On AG monitoring requires VIEW ANY DEFINITION for access to availability group catalog views.
           On SQL Server 2022+, HADR DMVs may additionally require VIEW SERVER PERFORMANCE STATE.
       supported_platforms:
@@ -99,10 +112,12 @@ modules:
               -- Grant VIEW SERVER PERFORMANCE STATE (required for HADR DMVs on SQL Server 2022+)
               -- GRANT VIEW SERVER PERFORMANCE STATE TO netdata_user;
 
-              -- Grant access to msdb for SQL Agent job monitoring (required)
+              -- Grant access to msdb for SQL Agent job monitoring
               USE msdb;
               CREATE USER netdata_user FOR LOGIN netdata_user;
               GRANT SELECT ON dbo.sysjobs TO netdata_user;
+              GRANT SELECT ON dbo.sysjobhistory TO netdata_user;
+              GRANT SELECT ON dbo.sysjobactivity TO netdata_user;
 
               -- Optional: Grant access to distribution database for replication monitoring
               -- (only if replication is configured)
@@ -115,9 +130,11 @@ modules:
 
               **Required permissions:**
               - `VIEW SERVER STATE` - Access to dynamic management views
-              - `SELECT on msdb.dbo.sysjobs` - SQL Agent job status monitoring
 
               **Optional permissions:**
+              - `SELECT on msdb.dbo.sysjobs` - SQL Agent job status monitoring
+              - `SELECT on msdb.dbo.sysjobhistory` - SQL Agent completed job execution history
+              - `SELECT on msdb.dbo.sysjobactivity` - SQL Agent current job activity
               - `VIEW ANY DEFINITION` - Always On Availability Group monitoring
               - `VIEW SERVER PERFORMANCE STATE` - HADR DMVs on SQL Server 2022+
               - `SELECT on distribution.dbo.MSreplication_monitordata` - Replication monitoring
@@ -143,6 +160,8 @@ modules:
               USE msdb;
               CREATE USER [NT AUTHORITY\SYSTEM] FOR LOGIN [NT AUTHORITY\SYSTEM];
               GRANT SELECT ON dbo.sysjobs TO [NT AUTHORITY\SYSTEM];
+              GRANT SELECT ON dbo.sysjobhistory TO [NT AUTHORITY\SYSTEM];
+              GRANT SELECT ON dbo.sysjobactivity TO [NT AUTHORITY\SYSTEM];
               ```
 
               **Remote connection (Netdata connects to SQL Server on another machine):**
@@ -158,6 +177,8 @@ modules:
               USE msdb;
               CREATE USER [DOMAIN\COMPUTERNAME$] FOR LOGIN [DOMAIN\COMPUTERNAME$];
               GRANT SELECT ON dbo.sysjobs TO [DOMAIN\COMPUTERNAME$];
+              GRANT SELECT ON dbo.sysjobhistory TO [DOMAIN\COMPUTERNAME$];
+              GRANT SELECT ON dbo.sysjobactivity TO [DOMAIN\COMPUTERNAME$];
               ```
 
               For the default `Local System` service account, remote Windows Authentication works
@@ -404,6 +425,14 @@ modules:
       - name: mssql_database_log_percent_used
         metric: mssql.database_log_percent_used
         info: SQL Server transaction log percent used has been above 90% for the last 15 minutes
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/mssql.conf
+      - name: mssql_sql_agent_job_last_execution_warning
+        metric: mssql.job_last_execution_status
+        info: SQL Server Agent job succeeded but at least one step failed in the last completed execution
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/mssql.conf
+      - name: mssql_sql_agent_job_last_execution_failed
+        metric: mssql.job_last_execution_status
+        info: SQL Server Agent job failed in the last completed execution
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/mssql.conf
     functions:
       description: |
@@ -1305,11 +1334,49 @@ modules:
           metrics:
             - name: mssql.job_status
               description: Job Status
+              availability:
+                - SQL Server 2016+
               unit: status
               chart_type: line
               dimensions:
                 - name: enabled
                 - name: disabled
+            - name: mssql.job_last_execution_status
+              description: Job Last Execution Status
+              availability:
+                - SQL Server 2016+
+              unit: status
+              chart_type: line
+              dimensions:
+                - name: unknown
+                - name: ok
+                - name: warning
+                - name: error
+                - name: canceled
+            - name: mssql.job_last_execution_duration
+              description: Job Last Execution Duration
+              availability:
+                - SQL Server 2016+
+              unit: seconds
+              chart_type: line
+              dimensions:
+                - name: duration
+            - name: mssql.job_last_execution_age
+              description: Job Last Execution Age
+              availability:
+                - SQL Server 2016+
+              unit: seconds
+              chart_type: line
+              dimensions:
+                - name: age
+            - name: mssql.job_current_execution_time
+              description: Job Current Execution Time
+              availability:
+                - SQL Server 2016+
+              unit: seconds
+              chart_type: line
+              dimensions:
+                - name: duration
         - name: replication
           description: These metrics refer to SQL Server replication publications.
           labels:

--- a/src/go/plugin/go.d/collector/mssql/mssql_test.go
+++ b/src/go/plugin/go.d/collector/mssql/mssql_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -142,6 +143,13 @@ func TestAGDatabaseReplicaQuery(t *testing.T) {
 	assert.Equal(t, queryAGDatabaseReplicas16, agDatabaseReplicaQuery(14))
 	assert.Equal(t, queryAGDatabaseReplicas16, agDatabaseReplicaQuery(15))
 	assert.Equal(t, queryAGDatabaseReplicas16, agDatabaseReplicaQuery(16))
+}
+
+func TestQueryJobLastExecutionsAvoidsSQLServer2012OnlyFunctions(t *testing.T) {
+	query := strings.ToUpper(queryJobLastExecutions)
+
+	assert.NotContains(t, query, "TRY_CONVERT")
+	assert.NotContains(t, query, "LEAD(")
 }
 
 func TestCollectJobLastExecution(t *testing.T) {

--- a/src/go/plugin/go.d/collector/mssql/mssql_test.go
+++ b/src/go/plugin/go.d/collector/mssql/mssql_test.go
@@ -4,10 +4,12 @@ package mssql
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/cloudauth"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/cloudauth/sqladapter"
 	"github.com/stretchr/testify/assert"
@@ -140,6 +142,437 @@ func TestAGDatabaseReplicaQuery(t *testing.T) {
 	assert.Equal(t, queryAGDatabaseReplicas16, agDatabaseReplicaQuery(14))
 	assert.Equal(t, queryAGDatabaseReplicas16, agDatabaseReplicaQuery(15))
 	assert.Equal(t, queryAGDatabaseReplicas16, agDatabaseReplicaQuery(16))
+}
+
+func TestCollectJobLastExecution(t *testing.T) {
+	job := sqlAgentJob{id: "job-id", name: "Job", chartID: "job"}
+
+	tests := map[string]struct {
+		exec           *sqlAgentJobLastExecution
+		wantStatus     string
+		wantDuration   *int64
+		wantAge        *int64
+		notWantMetrics []string
+	}{
+		"no history": {
+			wantStatus: jobLastExecutionStatusUnknown,
+			notWantMetrics: []string{
+				"job_job_last_execution_duration",
+				"job_job_last_execution_age",
+			},
+		},
+		"succeeded": {
+			exec: &sqlAgentJobLastExecution{
+				runStatus:       sqlAgentJobRunStatusSucceeded,
+				durationSeconds: 90,
+				ageSeconds:      sql.NullInt64{Int64: 30, Valid: true},
+			},
+			wantStatus:   jobLastExecutionStatusOK,
+			wantDuration: ptrInt64(90),
+			wantAge:      ptrInt64(30),
+		},
+		"succeeded with failed step": {
+			exec: &sqlAgentJobLastExecution{
+				runStatus:       sqlAgentJobRunStatusSucceeded,
+				durationSeconds: 120,
+				ageSeconds:      sql.NullInt64{Int64: 60, Valid: true},
+				hasFailedStep:   true,
+			},
+			wantStatus:   jobLastExecutionStatusWarning,
+			wantDuration: ptrInt64(120),
+			wantAge:      ptrInt64(60),
+		},
+		"failed": {
+			exec: &sqlAgentJobLastExecution{
+				runStatus:       sqlAgentJobRunStatusFailed,
+				durationSeconds: 8,
+				ageSeconds:      sql.NullInt64{Int64: 10, Valid: true},
+			},
+			wantStatus:   jobLastExecutionStatusError,
+			wantDuration: ptrInt64(8),
+			wantAge:      ptrInt64(10),
+		},
+		"canceled": {
+			exec: &sqlAgentJobLastExecution{
+				runStatus:       sqlAgentJobRunStatusCanceled,
+				durationSeconds: 15,
+				ageSeconds:      sql.NullInt64{Int64: 20, Valid: true},
+			},
+			wantStatus:   jobLastExecutionStatusCanceled,
+			wantDuration: ptrInt64(15),
+			wantAge:      ptrInt64(20),
+		},
+		"unknown status with invalid age": {
+			exec: &sqlAgentJobLastExecution{
+				runStatus:       9,
+				durationSeconds: 42,
+				ageSeconds:      sql.NullInt64{},
+			},
+			wantStatus:   jobLastExecutionStatusUnknown,
+			wantDuration: ptrInt64(42),
+			notWantMetrics: []string{
+				"job_job_last_execution_age",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mx := make(map[string]int64)
+			collectJobLastExecution(mx, job, tc.exec)
+
+			for _, status := range jobLastExecutionStatusNames {
+				want := int64(0)
+				if status == tc.wantStatus {
+					want = 1
+				}
+				assert.Equalf(t, want, mx["job_job_last_execution_status_"+status], "status %s", status)
+			}
+			if tc.wantDuration != nil {
+				assert.Equal(t, *tc.wantDuration, mx["job_job_last_execution_duration"])
+			}
+			if tc.wantAge != nil {
+				assert.Equal(t, *tc.wantAge, mx["job_job_last_execution_age"])
+			}
+			for _, key := range tc.notWantMetrics {
+				_, ok := mx[key]
+				assert.Falsef(t, ok, "metric %s should not be present", key)
+			}
+		})
+	}
+}
+
+func TestAssignJobChartIDs(t *testing.T) {
+	jobs := []sqlAgentJob{
+		{id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", name: "A-B"},
+		{id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", name: "A.B"},
+		{id: "cccccccc-cccc-cccc-cccc-cccccccccccc", name: "Plain"},
+	}
+
+	assignJobChartIDs(jobs, nil)
+
+	assert.Equal(t, "a_b", jobs[0].chartID)
+	assert.Equal(t, "a_b_aaaaaaaa_aaaa_aaaa_aaaa_aaaaaaaaaaaa", jobs[1].chartID)
+	assert.Equal(t, "plain", jobs[2].chartID)
+}
+
+func TestAssignJobChartIDsPreservesPreviousAssignments(t *testing.T) {
+	jobs := []sqlAgentJob{
+		{id: "11111111-1111-1111-1111-111111111111", name: "A-B"},
+		{id: "22222222-2222-2222-2222-222222222222", name: "A.B"},
+	}
+	previous := map[string]string{
+		"22222222-2222-2222-2222-222222222222": "a_b",
+	}
+
+	assignJobChartIDs(jobs, previous)
+
+	assert.Equal(t, "a_b_11111111_1111_1111_1111_111111111111", jobs[0].chartID)
+	assert.Equal(t, "a_b", jobs[1].chartID)
+}
+
+func TestCollector_CollectJobStatus(t *testing.T) {
+	const (
+		jobID1 = "11111111-1111-1111-1111-111111111111"
+		jobID2 = "22222222-2222-2222-2222-222222222222"
+	)
+
+	tests := map[string]struct {
+		prepareMock    func(mock sqlmock.Sqlmock)
+		wantMetrics    map[string]int64
+		notWantMetrics []string
+		checkCollector func(t *testing.T, c *Collector)
+	}{
+		"complete collection": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "Clean Job", int64(1)).
+						AddRow(jobID2, "Warning.Job", int64(0)).
+						AddRow("33333333-3333-3333-3333-333333333333", "Never Job", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "run_status", "duration_seconds", "age_seconds", "has_failed_step"}).
+						AddRow(jobID1, int64(sqlAgentJobRunStatusSucceeded), int64(90), int64(30), int64(0)).
+						AddRow(jobID2, int64(sqlAgentJobRunStatusSucceeded), int64(3723), nil, int64(1)),
+				)
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "current_execution_time_seconds"}).
+						AddRow(jobID1, int64(0)).
+						AddRow(jobID2, int64(3600)),
+				)
+			},
+			wantMetrics: map[string]int64{
+				"job_clean_job_enabled":                         1,
+				"job_clean_job_disabled":                        0,
+				"job_clean_job_last_execution_status_ok":        1,
+				"job_clean_job_last_execution_status_warning":   0,
+				"job_clean_job_last_execution_duration":         90,
+				"job_clean_job_last_execution_age":              30,
+				"job_clean_job_current_execution_time":          0,
+				"job_warning_job_enabled":                       0,
+				"job_warning_job_disabled":                      1,
+				"job_warning_job_last_execution_status_ok":      0,
+				"job_warning_job_last_execution_status_warning": 1,
+				"job_warning_job_last_execution_duration":       3723,
+				"job_warning_job_current_execution_time":        3600,
+				"job_never_job_last_execution_status_unknown":   1,
+				"job_never_job_current_execution_time":          0,
+			},
+			notWantMetrics: []string{
+				"job_warning_job_last_execution_age",
+				"job_never_job_last_execution_duration",
+				"job_never_job_last_execution_age",
+			},
+		},
+		"history query failure keeps base and activity metrics": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "Clean Job", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "current_execution_time_seconds"}),
+				)
+			},
+			wantMetrics: map[string]int64{
+				"job_clean_job_enabled":                1,
+				"job_clean_job_disabled":               0,
+				"job_clean_job_current_execution_time": 0,
+			},
+			notWantMetrics: []string{
+				"job_clean_job_last_execution_status_unknown",
+				"job_clean_job_last_execution_duration",
+				"job_clean_job_last_execution_age",
+			},
+		},
+		"activity query failure omits current runtime": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "Clean Job", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "run_status", "duration_seconds", "age_seconds", "has_failed_step"}),
+				)
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+			},
+			wantMetrics: map[string]int64{
+				"job_clean_job_enabled":                       1,
+				"job_clean_job_last_execution_status_unknown": 1,
+			},
+			notWantMetrics: []string{
+				"job_clean_job_current_execution_time",
+			},
+		},
+		"base query failure is non fatal": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnError(fmt.Errorf("permission denied"))
+			},
+			wantMetrics: map[string]int64{},
+		},
+		"disappeared job removes exact charts only": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "abc", int64(1)).
+						AddRow(jobID2, "abc.def", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID2, "abc.def", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+			},
+			checkCollector: func(t *testing.T, c *Collector) {
+				mx := make(map[string]int64)
+				c.collectJobStatus(mx)
+
+				removed := c.Charts().Get("job_abc_status")
+				require.NotNil(t, removed)
+				assert.True(t, removed.IsRemoved())
+
+				survived := c.Charts().Get("job_abc_def_status")
+				require.NotNil(t, survived)
+				assert.False(t, survived.IsRemoved())
+			},
+		},
+		"disappeared job can reappear without duplicate stale charts": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "abc", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+
+				mock.ExpectQuery(queryJobs).WillReturnRows(sqlmock.NewRows([]string{"job_id", "name", "enabled"}))
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "abc", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+
+				mock.ExpectQuery(queryJobs).WillReturnRows(sqlmock.NewRows([]string{"job_id", "name", "enabled"}))
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+			},
+			checkCollector: func(t *testing.T, c *Collector) {
+				mx := make(map[string]int64)
+				c.collectJobStatus(mx)
+
+				removed := c.Charts().Get("job_abc_status")
+				require.NotNil(t, removed)
+				assert.True(t, removed.IsRemoved())
+				assert.Equal(t, 1, countCollectorChartsByID(c, "job_abc_status"))
+
+				mx = make(map[string]int64)
+				c.collectJobStatus(mx)
+
+				reappeared := c.Charts().Get("job_abc_status")
+				require.NotNil(t, reappeared)
+				assert.False(t, reappeared.IsRemoved())
+				assert.Equal(t, 1, countCollectorChartsByID(c, "job_abc_status"))
+
+				mx = make(map[string]int64)
+				c.collectJobStatus(mx)
+
+				removedAgain := c.Charts().Get("job_abc_status")
+				require.NotNil(t, removedAgain)
+				assert.True(t, removedAgain.IsRemoved())
+				assert.Equal(t, 1, countCollectorChartsByID(c, "job_abc_status"))
+			},
+		},
+		"new colliding job keeps existing owner charts": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID2, "A.B", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "A-B", int64(1)).
+						AddRow(jobID2, "A.B", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+			},
+			checkCollector: func(t *testing.T, c *Collector) {
+				require.Equal(t, "a_b", c.seenJobs[jobID2])
+
+				mx := make(map[string]int64)
+				c.collectJobStatus(mx)
+
+				suffix := "a_b_" + cleanJobID(jobID1)
+				assert.Equal(t, "a_b", c.seenJobs[jobID2])
+				assert.Equal(t, suffix, c.seenJobs[jobID1])
+				assert.Equal(t, int64(1), mx["job_a_b_enabled"])
+				assert.Equal(t, int64(1), mx["job_"+suffix+"_enabled"])
+
+				baseChart := c.Charts().Get("job_a_b_status")
+				require.NotNil(t, baseChart)
+				assert.False(t, baseChart.IsRemoved())
+				assert.Equal(t, []collectorapi.Label{{Key: "job_name", Value: "A.B"}}, baseChart.Labels)
+
+				suffixChart := c.Charts().Get("job_" + suffix + "_status")
+				require.NotNil(t, suffixChart)
+				assert.False(t, suffixChart.IsRemoved())
+				assert.Equal(t, []collectorapi.Label{{Key: "job_name", Value: "A-B"}}, suffixChart.Labels)
+			},
+		},
+		"surviving colliding job keeps suffix when base owner disappears": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "A-B", int64(1)).
+						AddRow(jobID2, "A.B", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID2, "A.B", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+			},
+			checkCollector: func(t *testing.T, c *Collector) {
+				suffix := "a_b_" + cleanJobID(jobID2)
+				require.Equal(t, "a_b", c.seenJobs[jobID1])
+				require.Equal(t, suffix, c.seenJobs[jobID2])
+
+				mx := make(map[string]int64)
+				c.collectJobStatus(mx)
+
+				assert.Equal(t, suffix, c.seenJobs[jobID2])
+				assert.NotContains(t, c.seenJobs, jobID1)
+				assert.Equal(t, int64(1), mx["job_"+suffix+"_enabled"])
+
+				removedBase := c.Charts().Get("job_a_b_status")
+				require.NotNil(t, removedBase)
+				assert.True(t, removedBase.IsRemoved())
+
+				survived := c.Charts().Get("job_" + suffix + "_status")
+				require.NotNil(t, survived)
+				assert.False(t, survived.IsRemoved())
+				assert.Equal(t, []collectorapi.Label{{Key: "job_name", Value: "A.B"}}, survived.Labels)
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			require.NoError(t, err)
+			defer func() { _ = db.Close() }()
+
+			c := New()
+			c.db = db
+			tc.prepareMock(mock)
+
+			mx := make(map[string]int64)
+			c.collectJobStatus(mx)
+
+			for key, want := range tc.wantMetrics {
+				assert.Equalf(t, want, mx[key], "metric %s", key)
+			}
+			for _, key := range tc.notWantMetrics {
+				_, ok := mx[key]
+				assert.Falsef(t, ok, "metric %s should not be present", key)
+			}
+			if tc.checkCollector != nil {
+				tc.checkCollector(t, c)
+			}
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func ptrInt64(v int64) *int64 {
+	return &v
+}
+
+func countCollectorChartsByID(c *Collector, id string) int {
+	var count int
+	for _, chart := range *c.Charts() {
+		if chart.ID == id {
+			count++
+		}
+	}
+	return count
 }
 
 func TestCollector_Collect(t *testing.T) {

--- a/src/go/plugin/go.d/collector/mssql/mssql_test.go
+++ b/src/go/plugin/go.d/collector/mssql/mssql_test.go
@@ -176,8 +176,8 @@ func TestCollectJobLastExecution(t *testing.T) {
 				ageSeconds:      sql.NullInt64{Int64: 30, Valid: true},
 			},
 			wantStatus:   jobLastExecutionStatusOK,
-			wantDuration: ptrInt64(90),
-			wantAge:      ptrInt64(30),
+			wantDuration: new(int64(90)),
+			wantAge:      new(int64(30)),
 		},
 		"succeeded with failed step": {
 			exec: &sqlAgentJobLastExecution{
@@ -187,8 +187,8 @@ func TestCollectJobLastExecution(t *testing.T) {
 				hasFailedStep:   true,
 			},
 			wantStatus:   jobLastExecutionStatusWarning,
-			wantDuration: ptrInt64(120),
-			wantAge:      ptrInt64(60),
+			wantDuration: new(int64(120)),
+			wantAge:      new(int64(60)),
 		},
 		"failed": {
 			exec: &sqlAgentJobLastExecution{
@@ -197,8 +197,8 @@ func TestCollectJobLastExecution(t *testing.T) {
 				ageSeconds:      sql.NullInt64{Int64: 10, Valid: true},
 			},
 			wantStatus:   jobLastExecutionStatusError,
-			wantDuration: ptrInt64(8),
-			wantAge:      ptrInt64(10),
+			wantDuration: new(int64(8)),
+			wantAge:      new(int64(10)),
 		},
 		"canceled": {
 			exec: &sqlAgentJobLastExecution{
@@ -207,8 +207,8 @@ func TestCollectJobLastExecution(t *testing.T) {
 				ageSeconds:      sql.NullInt64{Int64: 20, Valid: true},
 			},
 			wantStatus:   jobLastExecutionStatusCanceled,
-			wantDuration: ptrInt64(15),
-			wantAge:      ptrInt64(20),
+			wantDuration: new(int64(15)),
+			wantAge:      new(int64(20)),
 		},
 		"unknown status with invalid age": {
 			exec: &sqlAgentJobLastExecution{
@@ -217,7 +217,7 @@ func TestCollectJobLastExecution(t *testing.T) {
 				ageSeconds:      sql.NullInt64{},
 			},
 			wantStatus:   jobLastExecutionStatusUnknown,
-			wantDuration: ptrInt64(42),
+			wantDuration: new(int64(42)),
 			notWantMetrics: []string{
 				"job_job_last_execution_age",
 			},
@@ -567,10 +567,6 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 			assert.NoError(t, mock.ExpectationsWereMet())
 		})
 	}
-}
-
-func ptrInt64(v int64) *int64 {
-	return &v
 }
 
 func countCollectorChartsByID(c *Collector, id string) int {

--- a/src/go/plugin/go.d/collector/mssql/queries.go
+++ b/src/go/plugin/go.d/collector/mssql/queries.go
@@ -226,10 +226,6 @@ WITH final_summary_rows AS (
     run_date,
     run_time,
     run_duration,
-    LEAD(instance_id) OVER (
-      PARTITION BY job_id
-      ORDER BY instance_id DESC
-    ) AS previous_summary_instance_id,
     ROW_NUMBER() OVER (
       PARTITION BY job_id
       ORDER BY instance_id DESC
@@ -240,25 +236,34 @@ WITH final_summary_rows AS (
 ),
 latest_final_summary AS (
   SELECT
-    job_id,
-    instance_id,
-    previous_summary_instance_id,
-    run_status,
-    ((CAST(run_duration AS bigint) / 10000) * 3600)
-      + (((CAST(run_duration AS bigint) % 10000) / 100) * 60)
-      + (CAST(run_duration AS bigint) % 100) AS duration_seconds,
+    fs.job_id,
+    fs.instance_id,
+    (
+      SELECT MAX(prev.instance_id)
+      FROM final_summary_rows AS prev
+      WHERE prev.job_id = fs.job_id
+        AND prev.instance_id < fs.instance_id
+    ) AS previous_summary_instance_id,
+    fs.run_status,
+    ((CAST(fs.run_duration AS bigint) / 10000) * 3600)
+      + (((CAST(fs.run_duration AS bigint) % 10000) / 100) * 60)
+      + (CAST(fs.run_duration AS bigint) % 100) AS duration_seconds,
     DATEADD(
       second,
-      ((run_time / 10000) * 3600)
-        + (((run_time % 10000) / 100) * 60)
-        + (run_time % 100),
-      TRY_CONVERT(
+      ((fs.run_time / 10000) * 3600)
+        + (((fs.run_time % 10000) / 100) * 60)
+        + (fs.run_time % 100),
+      CONVERT(
         datetime,
-        RIGHT('00000000' + CONVERT(varchar(8), NULLIF(run_date, 0)), 8),
+        CASE
+          WHEN ISDATE(CONVERT(char(8), NULLIF(fs.run_date, 0))) = 1
+            THEN CONVERT(char(8), fs.run_date)
+          ELSE NULL
+        END,
         112
       )
     ) AS started_at
-  FROM final_summary_rows
+  FROM final_summary_rows AS fs
   WHERE row_num = 1
 ),
 failed_steps AS (

--- a/src/go/plugin/go.d/collector/mssql/queries.go
+++ b/src/go/plugin/go.d/collector/mssql/queries.go
@@ -206,10 +206,117 @@ WHERE ws.[waiting_tasks_count] > 0
 ORDER BY ws.[wait_time_ms] DESC;
 `
 
-// queryJobs gets SQL Agent job status
+// queryJobs gets SQL Agent job configuration status.
 const queryJobs = `
-SELECT name, enabled
-FROM msdb.dbo.sysjobs;
+SELECT
+  CONVERT(varchar(36), job_id) AS job_id,
+  name,
+  enabled
+FROM msdb.dbo.sysjobs
+ORDER BY name, job_id;
+`
+
+// queryJobLastExecutions gets the latest completed SQL Agent job execution.
+const queryJobLastExecutions = `
+WITH final_summary_rows AS (
+  SELECT
+    job_id,
+    instance_id,
+    run_status,
+    run_date,
+    run_time,
+    run_duration,
+    LEAD(instance_id) OVER (
+      PARTITION BY job_id
+      ORDER BY instance_id DESC
+    ) AS previous_summary_instance_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY job_id
+      ORDER BY instance_id DESC
+    ) AS row_num
+  FROM msdb.dbo.sysjobhistory
+  WHERE step_id = 0
+    AND run_status IN (0, 1, 3)
+),
+latest_final_summary AS (
+  SELECT
+    job_id,
+    instance_id,
+    previous_summary_instance_id,
+    run_status,
+    ((CAST(run_duration AS bigint) / 10000) * 3600)
+      + (((CAST(run_duration AS bigint) % 10000) / 100) * 60)
+      + (CAST(run_duration AS bigint) % 100) AS duration_seconds,
+    DATEADD(
+      second,
+      ((run_time / 10000) * 3600)
+        + (((run_time % 10000) / 100) * 60)
+        + (run_time % 100),
+      TRY_CONVERT(
+        datetime,
+        RIGHT('00000000' + CONVERT(varchar(8), NULLIF(run_date, 0)), 8),
+        112
+      )
+    ) AS started_at
+  FROM final_summary_rows
+  WHERE row_num = 1
+),
+failed_steps AS (
+  SELECT
+    ls.job_id,
+    COUNT_BIG(*) AS failed_step_count
+  FROM latest_final_summary AS ls
+  JOIN msdb.dbo.sysjobhistory AS sh
+    ON sh.job_id = ls.job_id
+   AND sh.step_id > 0
+   AND sh.run_status = 0
+   AND sh.instance_id < ls.instance_id
+   AND (
+        ls.previous_summary_instance_id IS NULL
+        OR sh.instance_id > ls.previous_summary_instance_id
+   )
+  GROUP BY ls.job_id
+)
+SELECT
+  CONVERT(varchar(36), ls.job_id) AS job_id,
+  ls.run_status,
+  ls.duration_seconds,
+  CASE
+    WHEN ls.started_at IS NULL THEN NULL
+    WHEN DATEDIFF(
+      second,
+      DATEADD(second, CAST(ls.duration_seconds AS int), ls.started_at),
+      GETDATE()
+    ) < 0 THEN 0
+    ELSE DATEDIFF(
+      second,
+      DATEADD(second, CAST(ls.duration_seconds AS int), ls.started_at),
+      GETDATE()
+    )
+  END AS age_seconds,
+  CASE WHEN COALESCE(fs.failed_step_count, 0) > 0 THEN 1 ELSE 0 END AS has_failed_step
+FROM latest_final_summary AS ls
+LEFT JOIN failed_steps AS fs
+  ON fs.job_id = ls.job_id;
+`
+
+// queryJobCurrentExecutions gets current SQL Agent job execution runtime.
+const queryJobCurrentExecutions = `
+WITH latest_session AS (
+  SELECT MAX(session_id) AS session_id
+  FROM msdb.dbo.sysjobactivity
+)
+SELECT
+  CONVERT(varchar(36), job_id) AS job_id,
+  CASE
+    WHEN start_execution_date IS NOT NULL
+     AND stop_execution_date IS NULL
+     AND DATEDIFF(second, start_execution_date, GETDATE()) > 0
+      THEN DATEDIFF(second, start_execution_date, GETDATE())
+    ELSE 0
+  END AS current_execution_time_seconds
+FROM msdb.dbo.sysjobactivity
+WHERE session_id = (SELECT session_id FROM latest_session);
 `
 
 // querySQLErrors gets SQL error counts from performance counters

--- a/src/go/plugin/go.d/collector/mssql/taxonomy.yaml
+++ b/src/go/plugin/go.d/collector/mssql/taxonomy.yaml
@@ -1,0 +1,116 @@
+taxonomy_version: 1
+plugin_name: go.d.plugin
+module_name: mssql
+placements:
+  - id: mssql
+    section_id: applications.mssql
+    title: Microsoft SQL Server
+    icon: mssql
+    families: true
+    items:
+      - type: group
+        id: instance
+        title: Instance
+        items:
+          - mssql.user_connections
+          - mssql.session_connections
+          - mssql.blocked_processes
+          - mssql.batch_requests
+          - mssql.compilations
+          - mssql.recompilations
+          - mssql.auto_param_attempts
+          - mssql.sql_errors
+          - mssql.buffer_cache_hit_ratio
+          - mssql.buffer_page_life_expectancy
+          - mssql.buffer_page_iops
+          - mssql.buffer_checkpoint_pages
+          - mssql.buffer_page_lookups
+          - mssql.buffer_lazy_writes
+          - mssql.memory_total
+          - mssql.memory_connection
+          - mssql.memory_pending_grants
+          - mssql.memory_external_benefit
+          - mssql.page_splits
+          - mssql.process_memory_resident
+          - mssql.process_memory_virtual
+          - mssql.process_memory_utilization
+          - mssql.process_page_faults
+          - mssql.os_memory
+          - mssql.os_pagefile
+      - type: group
+        id: databases
+        title: Databases
+        items:
+          - mssql.database_active_transactions
+          - mssql.database_transactions
+          - mssql.database_write_transactions
+          - mssql.database_log_flushes
+          - mssql.database_log_flushed
+          - mssql.database_log_growths
+          - mssql.database_log_file_size
+          - mssql.database_log_percent_used
+          - mssql.database_log_truncations_shrinks
+          - mssql.database_io_stall
+          - mssql.database_data_file_size
+          - mssql.database_backup_restore_throughput
+          - mssql.database_state
+          - mssql.database_read_only
+      - type: group
+        id: locks
+        title: Locks
+        items:
+          - mssql.lock_stats_deadlocks
+          - mssql.lock_stats_waits
+          - mssql.lock_stats_timeouts
+          - mssql.lock_stats_requests
+          - mssql.locks_by_resource
+      - type: group
+        id: waits
+        title: Waits
+        items:
+          - mssql.wait_total_time
+          - mssql.wait_resource_time
+          - mssql.wait_signal_time
+          - mssql.wait_max_time
+          - mssql.wait_count
+      - type: group
+        id: sql-agent
+        title: SQL Server Agent
+        items:
+          - mssql.job_status
+          - mssql.job_last_execution_status
+          - mssql.job_last_execution_duration
+          - mssql.job_last_execution_age
+          - mssql.job_current_execution_time
+      - type: group
+        id: replication
+        title: Replication
+        items:
+          - mssql.replication_status
+          - mssql.replication_warning
+          - mssql.replication_latency
+          - mssql.replication_subscriptions
+      - type: group
+        id: availability-groups
+        title: Availability Groups
+        items:
+          - mssql.ag_sync_health
+          - mssql.ag_recovery_health
+          - mssql.ag_threads
+          - mssql.ag_replica_role
+          - mssql.ag_replica_connected_state
+          - mssql.ag_replica_sync_health
+          - mssql.ag_db_sync_state
+          - mssql.ag_db_log_send_queue
+          - mssql.ag_db_log_send_rate
+          - mssql.ag_db_redo_queue
+          - mssql.ag_db_redo_rate
+          - mssql.ag_db_filestream_send_rate
+          - mssql.ag_db_secondary_lag
+          - mssql.ag_db_suspended
+          - mssql.ag_db_failover_readiness
+          - mssql.ag_db_joined_state
+          - mssql.ag_cluster_quorum_state
+          - mssql.ag_cluster_member_state
+          - mssql.ag_cluster_member_quorum_votes
+          - mssql.ag_page_repair

--- a/src/health/health.d/mssql.conf
+++ b/src/health/health.d/mssql.conf
@@ -14,3 +14,33 @@ component: Microsoft SQL Server
   summary: SQL Server database ${label:database} transaction log utilization
      info: SQL Server transaction log percent used has been above 90% for the last 15 minutes
        to: dba
+
+# SQL Server Agent job execution status
+
+ template: mssql_sql_agent_job_last_execution_warning
+       on: mssql.job_last_execution_status
+    class: Errors
+     type: Database
+component: Microsoft SQL Server
+   lookup: average -1m unaligned of warning
+    units: status
+    every: 1m
+     warn: $this > 0
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Server Agent job ${label:job_name} completed with failed steps
+     info: SQL Server Agent job succeeded, but at least one step failed in the last completed execution
+       to: dba
+
+ template: mssql_sql_agent_job_last_execution_failed
+       on: mssql.job_last_execution_status
+    class: Errors
+     type: Database
+component: Microsoft SQL Server
+   lookup: average -1m unaligned of error
+    units: status
+    every: 1m
+     crit: $this > 0
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SQL Server Agent job ${label:job_name} failed
+     info: SQL Server Agent job failed in the last completed execution
+       to: dba


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SQL Server Agent job execution metrics to `go.d/mssql` with per‑job charts for last execution status, duration, age, and current runtime. Stabilizes per‑job chart IDs, cleans up stale charts, and corrects metric availability to be SQL Server‑only (not Azure SQL Database).

- New Features
  - Collects per‑job last execution status (unknown/ok/warning/error/canceled), duration, age, and current execution time.
  - Adds charts: `mssql.job_last_execution_status`, `mssql.job_last_execution_duration`, `mssql.job_last_execution_age`, `mssql.job_current_execution_time` (keeps `mssql.job_status`).
  - Adds health alerts: `mssql_sql_agent_job_last_execution_warning` and `mssql_sql_agent_job_last_execution_failed`.
  - Stabilizes per‑job chart IDs across runs, resolves name collisions with job GUID suffixes, updates labels, and removes stale charts when jobs change or disappear.
  - Makes job execution collection best‑effort: if job history/activity queries fail, other MSSQL metrics continue.
  - Updates docs/taxonomy: adds Microsoft SQL Server icon/section and marks job metrics as SQL Server‑only.

- Migration
  - For job status: grant SELECT on `msdb.dbo.sysjobs`.
  - For execution metrics: also grant SELECT on `msdb.dbo.sysjobhistory` and `msdb.dbo.sysjobactivity`.
  - If these grants are missing, other MSSQL metrics continue; only the affected job metrics are omitted.

<sup>Written for commit e39526ba62a23cf6c7815ad3f033116068ff64cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

