### PR TITLE
Update systemd journal SDK to v0.7.1

### DIFF
--- a/src/crates/Cargo.lock
+++ b/src/crates/Cargo.lock
@@ -4283,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-common"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1840de1963100b920cfe33724c77d350a63f1967ebc67711022099f08226275"
+checksum = "5ecdc4beeab0dd7985596d7b222dd556c185386d2ddcaa36ea5164af2548ea7c"
 dependencies = [
  "libc",
  "rustc-hash",
@@ -4296,9 +4296,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-core"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c277c0acd0800c0678fe38a15bc7e4786eb772e01052ab1e628023a8453076ae"
+checksum = "47b9069167be29a6c715299007f6a1cb2afd01d6404faeb7e6a93d2b4aeccda1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4337,9 +4337,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-engine"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb46ca836ac762f9bee6b0a1f68a7ce0932a2af696911b365830622bac15704"
+checksum = "79cf4d0351e864ad73c971c2254b15724c2fac3d3f2e8f64385b4806386def71"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4363,9 +4363,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-index"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4121207d6d8c0756338fd8a9b76416f17e2f93ba2af81696b0f780c77b2bc877"
+checksum = "f855d4288c74fbd23ae3e16cc575b29e27d264b14864f0f455662ce9f3af5ad5"
 dependencies = [
  "regex",
  "roaring 0.11.4",
@@ -4380,9 +4380,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-log-writer"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ef67ce2874b5ddeec41e0232b79758f1a371eb676b61a0f7edf7c8fe7c47e4"
+checksum = "839494dee363999ed04dc52826d8b8375010b6f46a06ef2657c22fed2deb1e78"
 dependencies = [
  "itoa",
  "systemd-journal-sdk-common",
@@ -4395,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-registry"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480f7f6d6044b85e0b7b9949ff8a689c10fdd65a3c148098583e6d5c8a1a440a"
+checksum = "42a576e018ce8d05240392f075e129327e9d4ccc42db152dcb76f633c9cf6cfe"
 dependencies = [
  "notify",
  "parking_lot",

--- a/src/crates/netflow-plugin/Cargo.toml
+++ b/src/crates/netflow-plugin/Cargo.toml
@@ -24,12 +24,12 @@ clap = { workspace = true, features = ["derive"] }
 # crates). Aliased to the historical names so call sites keep `use journal_*`.
 # Scope: netflow-plugin only; log-viewer/otel still use the vendored workspace
 # crates (tracked as a follow-up). One source of journal-core in this binary.
-journal-common = { package = "systemd-journal-sdk-common", version = "0.7.0" }
-journal-core = { package = "systemd-journal-sdk-core", version = "0.7.0" }
-journal-engine = { package = "systemd-journal-sdk-engine", version = "0.7.0" }
-journal-index = { package = "systemd-journal-sdk-index", version = "0.7.0" }
-journal-log-writer = { package = "systemd-journal-sdk-log-writer", version = "0.7.0" }
-journal-registry = { package = "systemd-journal-sdk-registry", version = "0.7.0" }
+journal-common = { package = "systemd-journal-sdk-common", version = "0.7.1" }
+journal-core = { package = "systemd-journal-sdk-core", version = "0.7.1" }
+journal-engine = { package = "systemd-journal-sdk-engine", version = "0.7.1" }
+journal-index = { package = "systemd-journal-sdk-index", version = "0.7.1" }
+journal-log-writer = { package = "systemd-journal-sdk-log-writer", version = "0.7.1" }
+journal-registry = { package = "systemd-journal-sdk-registry", version = "0.7.1" }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 hashbrown = { workspace = true }

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/klauspost/compress v1.18.6
 	github.com/maxmind/mmdbwriter v1.2.0
 	github.com/microsoft/go-mssqldb v1.10.0
-	github.com/netdata/systemd-journal-sdk/go v0.7.0
+	github.com/netdata/systemd-journal-sdk/go v0.7.1
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	golang.org/x/sys v0.46.0

--- a/src/go/go.sum
+++ b/src/go/go.sum
@@ -338,8 +338,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/netdata/systemd-journal-sdk/go v0.7.0 h1:Fvhi+Q5IDMJK4lrcb6M8fTQlbyogl1JFGv3aYfJWhBw=
-github.com/netdata/systemd-journal-sdk/go v0.7.0/go.mod h1:2n1eOsdTJ6v5xszIOH/xsvmtZXlMnNhWCSEaW4liGNk=
+github.com/netdata/systemd-journal-sdk/go v0.7.1 h1:pi2IYhtMWj5pwo+ceH78hq/YSQWWXA39uO3ssJL5/HA=
+github.com/netdata/systemd-journal-sdk/go v0.7.1/go.mod h1:2n1eOsdTJ6v5xszIOH/xsvmtZXlMnNhWCSEaW4liGNk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=


### PR DESCRIPTION
## Summary

Bumps the `systemd-journal-sdk` dependency from **v0.7.0 to v0.7.1** for the existing direct consumers. Follows #22713 (the v0.6.4 → v0.7.0 bump).

- **Rust** (`netflow-plugin`): the six `systemd-journal-sdk-*` packages in `src/crates/netflow-plugin/Cargo.toml` + `src/crates/Cargo.lock`.
- **Go** (`snmp_traps` collector journal writer and logs Function): `github.com/netdata/systemd-journal-sdk/go` in `src/go/go.mod` + `src/go/go.sum`.

## Why it's safe

The v0.7.0..v0.7.1 source diff is non-breaking for Netdata's call sites:

- **Go**: `reader.go` changes are purely additive (new doc comments + two new `ReaderOptions` helpers). Netdata uses the `NetdataJournalFunction` facade, not the low-level reader.
- **Rust**: the only breaking change (`ReaderOptions.mmap_strategy` privatized, `with_mmap_strategy` renamed) is in the aggregate `systemd-journal-sdk` crate, which Netdata does **not** depend on — it uses only the low-level crates. A symbol search across `src/crates` finds no references to the changed API.

The `Cargo.lock` diff is intentionally limited to the six SDK packages' version + checksum (no unrelated resolver churn).

## Validation

- `cargo check --locked -p netflow-plugin` — passes (one pre-existing unrelated dead-code warning).
- `go test ./plugin/go.d/collector/snmp_traps/...` — passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `systemd-journal-sdk` to v0.7.1 for Rust (`netflow-plugin`) and Go (`snmp_traps` and logs Function). Non-breaking for our call sites.

- **Dependencies**
  - Rust: bump `systemd-journal-sdk-{common,core,engine,index,log-writer,registry}` to `0.7.1` (`Cargo.toml`, `Cargo.lock`).
  - Go: bump `github.com/netdata/systemd-journal-sdk/go` to `v0.7.1` (`go.mod`, `go.sum`).

- **Validation**
  - `cargo check --locked -p netflow-plugin` passes.
  - `go test ./plugin/go.d/collector/snmp_traps/...` passes.

<sup>Written for commit a342026a4f52deb409d548d2a318fc62a564f66f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

