### PR TITLE
docs: escape `labels:<pattern>` placeholder in network-viewer metadata

### DIFF
--- a/src/collectors/network-viewer.plugin/integrations/network_connections.md
+++ b/src/collectors/network-viewer.plugin/integrations/network_connections.md
@@ -244,7 +244,7 @@ displayed as raw `cri-containerd-*.scope` systemd scope names.
 Fields that can vary across grouped processes, such as PID, UID, network namespace, command line,
 cgroup path, and detailed container metadata, are scalar columns in group_by:pid and merged actor
 labels in grouped views. Free-form labels are hidden by default and can be allowed per request with
-labels:<pattern>, where patterns are pipe-separated. Actor modals also expose producer-declared
+`labels:<pattern>`, where patterns are pipe-separated. Actor modals also expose producer-declared
 Processes and CGroups tables for the selected actor.
 
 

--- a/src/collectors/network-viewer.plugin/metadata.yaml
+++ b/src/collectors/network-viewer.plugin/metadata.yaml
@@ -208,7 +208,7 @@ modules:
             Fields that can vary across grouped processes, such as PID, UID, network namespace, command line,
             cgroup path, and detailed container metadata, are scalar columns in group_by:pid and merged actor
             labels in grouped views. Free-form labels are hidden by default and can be allowed per request with
-            labels:<pattern>, where patterns are pipe-separated. Actor modals also expose producer-declared
+            `labels:<pattern>`, where patterns are pipe-separated. Actor modals also expose producer-declared
             Processes and CGroups tables for the selected actor.
           parameters:
             - id: group_by


### PR DESCRIPTION
## Problem

The Network Connections collector overview (`network-viewer.plugin/metadata.yaml`) contains the raw text `labels:<pattern>`.

When this text is ingested into [learn.netdata.cloud](https://learn.netdata.cloud) (Docusaurus 3 / MDX v3), `<pattern>` is parsed as a JSX opening tag with no matching close, which fails MDX compilation and breaks the **Netlify deploy preview** of the docs ingest PR:

```
Error: MDX compilation failed for file ".../Network Connections.mdx"
Cause: Expected a closing tag for `<pattern>` (254:8) before the end of `paragraph`
```

## Fix

Wrap the placeholder in backticks → `` `labels:<pattern>` `` so it renders as inline code and is no longer interpreted as JSX. This matches the existing convention in the same overview (e.g. `` `cri-containerd-*.scope` `` is already backticked) and elsewhere in the docs (e.g. `` `prometheus.<app>.<metric>` ``).

The same one-line change is applied to the generated `integrations/network_connections.md` to keep it in sync with the source metadata (the generator passes this overview text through verbatim).

## Verification

Rebuilt the full Docusaurus site locally with the fix applied to the ingested `.mdx` — the build completes successfully (`Generated static files in "build"`) with no remaining MDX errors. A scan of the affected docs confirmed this was the only raw, non-code-span placeholder tag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escaped the placeholder `labels:<pattern>` in the Network Connections docs so MDX stops parsing `<pattern>` as JSX, fixing the docs build and Netlify preview. Also updated the generated integration doc to match.

- **Bug Fixes**
  - Backticked `labels:<pattern>` in `src/collectors/network-viewer.plugin/metadata.yaml` to prevent MDX parse errors.
  - Mirrored the change in `src/collectors/network-viewer.plugin/integrations/network_connections.md` for consistency.

<sup>Written for commit bd1aaeba1b830db410854fe24ff4866bfd16964a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

