### PR TITLE
Update map.yaml

### DIFF
--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -569,7 +569,6 @@ sidebar:
           description: Understand stock trap coverage, custom profiles, overrides, MIB conversion, and profile-defined metrics.
       - meta:
           label: SNMP Trap Profile Format
-          path: snmp-trap-profile-format
           edit_url: https://github.com/netdata/netdata/edit/master/src/go/plugin/go.d/config/go.d/snmp.trap-profiles/profile-format.md
           description: Reference for SNMP trap profile YAML, trap definitions, varbind metadata, rendering, and profile metric rules.
       - meta:


### PR DESCRIPTION
##### Summary

https://github.com/netdata/learn/pull/2885 the deploy has the path as a folder and looks off.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the path entry for “SNMP Trap Profile Format” in docs/.map/map.yaml to fix the sidebar link. This stops the deploy from treating the page as a folder and renders the link correctly.

<sup>Written for commit 78a8db160dde9aaf588a77b391fec960928d738c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

