### PR TITLE
fix(go.d/fail2ban): move fail2ban socket path into ndsudo

### DIFF
--- a/src/collectors/utils/ndsudo.c
+++ b/src/collectors/utils/ndsudo.c
@@ -7,6 +7,7 @@
 #define MAX_SEARCH 3
 #define MAX_PARAMETERS 128
 #define ERROR_BUFFER_SIZE 1024
+#define FAIL2BAN_SOCKET_PATH_IN_DOCKER "/host/var/run/fail2ban/fail2ban.sock"
 
 struct command {
     const char *name;
@@ -133,7 +134,7 @@ struct command {
     },
     {
         .name = "fail2ban-client-status-socket",
-        .params = "-s {{socket_path}} status",
+        .params = "-s " FAIL2BAN_SOCKET_PATH_IN_DOCKER " status",
         .search = {
             [0] = "fail2ban-client",
             [1] = NULL,
@@ -149,7 +150,7 @@ struct command {
     },
     {
         .name = "fail2ban-client-status-jail-socket",
-        .params = "-s {{socket_path}} status {{jail}}",
+        .params = "-s " FAIL2BAN_SOCKET_PATH_IN_DOCKER " status {{jail}}",
         .search = {
             [0] = "fail2ban-client",
             [1] = NULL,

--- a/src/go/plugin/go.d/collector/fail2ban/exec.go
+++ b/src/go/plugin/go.d/collector/fail2ban/exec.go
@@ -16,8 +16,6 @@ import (
 
 var errJailNotExist = errors.New("jail not exist")
 
-const socketPathInDocker = "/host/var/run/fail2ban/fail2ban.sock"
-
 type fail2banClientCli interface {
 	status() ([]byte, error)
 	jailStatus(s string) ([]byte, error)
@@ -42,9 +40,7 @@ type fail2banClientCliExec struct {
 
 func (e *fail2banClientCliExec) status() ([]byte, error) {
 	if e.isInsideDocker {
-		return e.execute("fail2ban-client-status-socket",
-			"--socket_path", socketPathInDocker,
-		)
+		return e.execute("fail2ban-client-status-socket")
 	}
 	return e.execute("fail2ban-client-status")
 }
@@ -53,7 +49,6 @@ func (e *fail2banClientCliExec) jailStatus(jail string) ([]byte, error) {
 	if e.isInsideDocker {
 		return e.execute("fail2ban-client-status-jail-socket",
 			"--jail", jail,
-			"--socket_path", socketPathInDocker,
 		)
 	}
 	return e.execute("fail2ban-client-status-jail",

--- a/src/go/plugin/go.d/collector/fail2ban/exec_test.go
+++ b/src/go/plugin/go.d/collector/fail2ban/exec_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build linux
+
+package fail2ban
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/pkg/buildinfo"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFail2banClientCliExec_NDSudoArgs(t *testing.T) {
+	ndsudoPath := prepareNDSudoArgEcho(t)
+	ndexec.SetRunnerPathsForTests("", ndsudoPath)
+	t.Cleanup(func() {
+		ndexec.SetRunnerPathsForTests("", filepath.Join(buildinfo.PluginsDir, "ndsudo"))
+	})
+
+	tests := map[string]struct {
+		isInsideDocker bool
+		call           func(*fail2banClientCliExec) ([]byte, error)
+		wantArgs       []string
+	}{
+		"host status": {
+			call: func(exec *fail2banClientCliExec) ([]byte, error) {
+				return exec.status()
+			},
+			wantArgs: []string{"fail2ban-client-status"},
+		},
+		"docker status": {
+			isInsideDocker: true,
+			call: func(exec *fail2banClientCliExec) ([]byte, error) {
+				return exec.status()
+			},
+			wantArgs: []string{"fail2ban-client-status-socket"},
+		},
+		"host jail status": {
+			call: func(exec *fail2banClientCliExec) ([]byte, error) {
+				return exec.jailStatus("sshd")
+			},
+			wantArgs: []string{"fail2ban-client-status-jail", "--jail", "sshd"},
+		},
+		"docker jail status": {
+			isInsideDocker: true,
+			call: func(exec *fail2banClientCliExec) ([]byte, error) {
+				return exec.jailStatus("sshd")
+			},
+			wantArgs: []string{"fail2ban-client-status-jail-socket", "--jail", "sshd"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			exec := &fail2banClientCliExec{
+				Logger:         logger.NewWithWriter(io.Discard),
+				timeout:        time.Second,
+				isInsideDocker: test.isInsideDocker,
+			}
+
+			bs, err := test.call(exec)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.wantArgs, splitLines(bs))
+		})
+	}
+}
+
+func prepareNDSudoArgEcho(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "ndsudo")
+	require.NoError(t, os.WriteFile(path, []byte(`#!/bin/sh
+for arg do
+  printf '%s\n' "$arg"
+done
+`), 0o755))
+
+	return path
+}
+
+func splitLines(bs []byte) []string {
+	s := strings.TrimSuffix(string(bs), "\n")
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the Fail2ban Docker socket path into `ndsudo` and stop passing it from the go.d collector. This centralizes configuration, reduces duplication, and avoids mismatches in containers.

- **Refactors**
  - `ndsudo`: hardcodes Fail2ban socket path `/host/var/run/fail2ban/fail2ban.sock` for `fail2ban-client-status-socket` and `fail2ban-client-status-jail-socket`.
  - `go.d` Fail2ban exec: removes `--socket_path` usage and constant; calls the socket variants only when running in Docker.
  - Adds tests to verify `ndsudo` receives the expected arguments for host and Docker calls (status and jail status).

<sup>Written for commit b5a0ed588ca27fb566d3e7964144c9f902935917. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

