### PR TITLE
Fix MSI issues

### DIFF
--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -250,7 +250,20 @@
             </InstallExecuteSequence>
 
             <!-- Add new files (stream.conf and netdata.conf) -->
-            <CustomAction Id="NDCreateNewFiles" Directory="USRLIBEXECNETDATADIR" ExeCommand='&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -NoProfile -ExecutionPolicy Bypass -NonInteractive -File &quot;[USRLIBEXECNETDATADIR]\copy_files.ps1&quot;' Execute="deferred" Return="ignore" Impersonate="no"/>
+            <SetProperty
+                Id="NDCreateNewFiles"
+                Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -NoProfile -ExecutionPolicy Bypass -NonInteractive -File &quot;[USRLIBEXECNETDATADIR]\copy_files.ps1&quot;"
+                Before="NDCreateNewFiles"
+                Sequence="execute"
+            />
+            <CustomAction
+                Id="NDCreateNewFiles"
+                BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)"
+                DllEntry="WixQuietExec"
+                Execute="deferred"
+                Return="ignore"
+                Impersonate="no"
+            />
             <InstallExecuteSequence>
                 <Custom Action="NDCreateNewFiles" Before="InstallFinalize" />
             </InstallExecuteSequence>
@@ -272,12 +285,38 @@
                 </File>
             </FeatureGroup>
 
-            <CustomAction Id="DllPermission" Directory="System64Folder" ExeCommand='[System64Folder]icacls.exe &quot;[System64Folder]wevt_netdata.dll&quot; /grant &quot;NT SERVICE\EventLog&quot;:R' Execute="deferred" Return="ignore" Impersonate="no"/>
+            <SetProperty
+                Id="DllPermission"
+                Value="&quot;[System64Folder]icacls.exe&quot; &quot;[System64Folder]wevt_netdata.dll&quot; /grant &quot;NT SERVICE\EventLog&quot;:R"
+                Before="DllPermission"
+                Sequence="execute"
+            />
+            <CustomAction
+                Id="DllPermission"
+                BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)"
+                DllEntry="WixQuietExec"
+                Execute="deferred"
+                Return="ignore"
+                Impersonate="no"
+            />
             <InstallExecuteSequence>
                 <Custom Action="DllPermission" After="InstallFiles" />
             </InstallExecuteSequence>
 
-            <CustomAction Id="InstallManifest" Directory="System64Folder" ExeCommand='[System64Folder]wevtutil.exe im &quot;[System64Folder]wevt_netdata_manifest.xml&quot; &quot;/mf:[System64Folder]\wevt_netdata.dll&quot; &quot;/rf:[System64Folder]\wevt_netdata.dll&quot;' Execute="deferred" Return="ignore" Impersonate="no"/>
+            <SetProperty
+                Id="InstallManifest"
+                Value="&quot;[System64Folder]wevtutil.exe&quot; im &quot;[System64Folder]wevt_netdata_manifest.xml&quot; &quot;/mf:[System64Folder]\wevt_netdata.dll&quot; &quot;/rf:[System64Folder]\wevt_netdata.dll&quot;"
+                Before="InstallManifest"
+                Sequence="execute"
+            />
+            <CustomAction
+                Id="InstallManifest"
+                BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)"
+                DllEntry="WixQuietExec"
+                Execute="deferred"
+                Return="ignore"
+                Impersonate="no"
+            />
             <InstallExecuteSequence>
                 <Custom Action="InstallManifest" After="InstallFiles" />
             </InstallExecuteSequence>

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -305,7 +305,7 @@
 
             <SetProperty
                 Id="InstallManifest"
-                Value="&quot;[System64Folder]wevtutil.exe&quot; im &quot;[System64Folder]wevt_netdata_manifest.xml&quot; &quot;/mf:[System64Folder]\wevt_netdata.dll&quot; &quot;/rf:[System64Folder]\wevt_netdata.dll&quot;"
+                Value="&quot;[System64Folder]wevtutil.exe&quot; im &quot;[System64Folder]wevt_netdata_manifest.xml&quot; &quot;/mf:[System64Folder]wevt_netdata.dll&quot; &quot;/rf:[System64Folder]wevt_netdata.dll&quot;"
                 Before="InstallManifest"
                 Sequence="execute"
             />

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -250,7 +250,7 @@
             </InstallExecuteSequence>
 
             <!-- Add new files (stream.conf and netdata.conf) -->
-            <CustomAction Id="NDCreateNewFiles" Directory="USRLIBEXECNETDATADIR" ExeCommand='powershell.exe -NoProfile -ExecutionPolicy Bypass -NonInteractive -File &quot;[USRLIBEXECNETDATADIR]\copy_files.ps1&quot;' Execute="deferred" Return="ignore" Impersonate="no"/>
+            <CustomAction Id="NDCreateNewFiles" Directory="USRLIBEXECNETDATADIR" ExeCommand='&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -NoProfile -ExecutionPolicy Bypass -NonInteractive -File &quot;[USRLIBEXECNETDATADIR]\copy_files.ps1&quot;' Execute="deferred" Return="ignore" Impersonate="no"/>
             <InstallExecuteSequence>
                 <Custom Action="NDCreateNewFiles" Before="InstallFinalize" />
             </InstallExecuteSequence>


### PR DESCRIPTION
##### Summary
This PR fixes:
- https://github.com/netdata/netdata/security/advisories/GHSA-jmv4-pq25-crvv
- https://github.com/netdata/netdata/security/advisories/GHSA-8hxv-2mg6-ggw5

##### Test Plan

1. Check CI

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Windows MSI by running custom actions through `WixQuietExec` with explicit `[System64Folder]` binaries, addressing GHSA-jmv4-pq25-crvv and GHSA-8hxv-2mg6-ggw5. Ensures safer execution of `powershell.exe`, `wevtutil.exe`, and `icacls.exe` during install.

- **Bug Fixes**
  - Replaced direct `ExeCommand` actions with `SetProperty` + `WixQuietExec` for `NDCreateNewFiles`, `DllPermission`, and `InstallManifest`.
  - Enforced `[System64Folder]` paths and strict quoting; corrected `wevtutil` `/mf` and `/rf` argument handling.

<sup>Written for commit 60e1fea56d00c7e9c3732390a9d4edd3befb4152. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

