### PR TITLE
Track and account memory allocation size in replication queries

### DIFF
--- a/src/streaming/stream-replication-sender.c
+++ b/src/streaming/stream-replication-sender.c
@@ -98,6 +98,7 @@ struct replication_query {
     STORAGE_ENGINE_BACKEND backend;
     struct replication_request *rq;
 
+    size_t alloc_size;              // bytes accounted in replication_buffers_allocated for this query
     size_t dimensions;
     struct replication_dimension data[];
 };
@@ -118,9 +119,11 @@ static struct replication_query *replication_query_prepare(
         bool synchronous
 ) {
     size_t dimensions = rrdset_number_of_dimensions(st);
-    struct replication_query *q = callocz(1, sizeof(struct replication_query) + dimensions * sizeof(struct replication_dimension));
-    __atomic_add_fetch(&replication_buffers_allocated, sizeof(struct replication_query) + dimensions * sizeof(struct replication_dimension), __ATOMIC_RELAXED);
+    size_t alloc_size = sizeof(struct replication_query) + dimensions * sizeof(struct replication_dimension);
+    struct replication_query *q = callocz(1, alloc_size);
+    __atomic_add_fetch(&replication_buffers_allocated, alloc_size, __ATOMIC_RELAXED);
 
+    q->alloc_size = alloc_size;
     q->dimensions = dimensions;
     q->st = st;
 
@@ -301,7 +304,7 @@ static void replication_query_finalize(BUFFER *wb, struct replication_query *q, 
         spinlock_unlock(&replication_queries.spinlock);
     }
 
-    __atomic_sub_fetch(&replication_buffers_allocated, sizeof(struct replication_query) + dimensions * sizeof(struct replication_dimension), __ATOMIC_RELAXED);
+    __atomic_sub_fetch(&replication_buffers_allocated, q->alloc_size, __ATOMIC_RELAXED);
     freez(q);
 }
 
@@ -1574,6 +1577,7 @@ static void replication_pipeline_cancel_and_cleanup(void) {
 
     internal_error(true, "REPLICATION: cancelled %zu inflight queries", cancelled);
 
+    __atomic_sub_fetch(&replication_buffers_allocated, rtp.max_requests_ahead * sizeof(struct replication_request), __ATOMIC_RELAXED);
     freez(rtp.rqs);
     rtp.rqs = NULL;
     rtp.max_requests_ahead = 0;


### PR DESCRIPTION
##### Summary
- Added `alloc_size` field to `struct replication_query` to store allocation size.
- Modified `replication_buffers_allocated` updates to use `alloc_size` for both increments and decrements.
- Introduced an additional buffer deallocation safeguard during request cancellation.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make memory accounting for replication queries exact by tracking per-query allocation size and correcting counter updates on free and cancellation. Prevents drift in `replication_buffers_allocated`.

- **Bug Fixes**
  - Store `alloc_size` in `struct replication_query` and use it for counter increments/decrements.
  - During pipeline cancellation, subtract request buffer bytes before freeing `rtp.rqs`.

<sup>Written for commit 75fffd1c97dad7e3523beee840c7a45cd3ce64c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

