### PR TITLE
Add chart to monitor in-flight ACLK messages

### DIFF
--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -1128,8 +1128,9 @@ char *aclk_state(void)
     }
 
     if (aclk_is_online) {
-        buffer_sprintf(wb, "Received Cloud MQTT Messages: %d\nMQTT Messages Confirmed by Remote Broker (PUBACKs): %d\nPending PUBACKS: %d\n",
-                       aclk_rcvd_cloud_msgs, aclk_pubacks_per_conn, aclk_stats.mqtt.packets_waiting_puback);
+        buffer_sprintf(wb, "Received Cloud MQTT Messages: %d\nMQTT Messages Confirmed by Remote Broker (PUBACKs): %d\nPending PUBACKS: %d\nServer Receive Maximum: %u\n",
+                       aclk_rcvd_cloud_msgs, aclk_pubacks_per_conn, aclk_stats.mqtt.packets_waiting_puback,
+                       (unsigned)aclk_stats.mqtt.rx_maximum);
 
         RRDHOST *host;
         rrd_rdlock();
@@ -1268,6 +1269,9 @@ char *aclk_state_json(void)
 
     tmp = json_object_new_int((int32_t) aclk_stats.mqtt.packets_waiting_puback);
     json_object_object_add(msg, "pending-mqtt-pubacks", tmp);
+
+    tmp = json_object_new_int((int32_t) aclk_stats.mqtt.rx_maximum);
+    json_object_object_add(msg, "server-receive-maximum", tmp);
 
     tmp = json_object_new_int(aclk_connection_counter > 0 ? (aclk_connection_counter - 1) : 0);
     json_object_object_add(msg, "reconnect-count", tmp);

--- a/src/aclk/mqtt_websockets/common_public.h
+++ b/src/aclk/mqtt_websockets/common_public.h
@@ -27,6 +27,8 @@ struct mqtt_ng_stats {
     int tx_messages_sent;
     int rx_messages_rcvd;
     int packets_waiting_puback;
+    // MQTT 5.0 server Receive Maximum from CONNACK (max concurrent unacked QoS1/2); 65535 if unset
+    uint16_t rx_maximum;
     size_t tx_buffer_used;
     size_t tx_buffer_free;
     size_t tx_buffer_size;

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -634,7 +634,7 @@ struct mqtt_ng_client *mqtt_ng_init(struct mqtt_ng_init *settings)
     client->tx_topic_aliases.idx_max = UINT16_MAX;
 
     // MQTT 5.0 default Receive Maximum when the server omits the property [MQTT-3.2.2.3.3]
-    client->rx_maximum = UINT16_MAX;
+    __atomic_store_n(&client->rx_maximum, UINT16_MAX, __ATOMIC_RELAXED);
 
     // TODO just embed the struct into mqtt_ng_client
     client->parser.received_data = settings->data_in;
@@ -2152,7 +2152,7 @@ int handle_incoming_traffic(struct mqtt_ng_client *client)
 
             if ((prop = get_property_by_id(client->parser.properties_parser.head, MQTT_PROP_RECEIVE_MAX)) != NULL) {
                 nd_log(NDLS_DAEMON, NDLP_INFO, "ACLK: MQTT server receive maximum is %" PRIu16, prop->data.uint16);
-                client->rx_maximum = prop->data.uint16;
+                __atomic_store_n(&client->rx_maximum, prop->data.uint16, __ATOMIC_RELAXED);
             }
 
             if (client->connack_callback)
@@ -2311,7 +2311,7 @@ void mqtt_ng_get_stats(struct mqtt_ng_client *client, struct mqtt_ng_stats *stat
     stats->tx_messages_sent = __atomic_load_n(&client->stats.tx_messages_sent, __ATOMIC_RELAXED);
     stats->rx_messages_rcvd = __atomic_load_n(&client->stats.rx_messages_rcvd, __ATOMIC_RELAXED);
     stats->packets_waiting_puback = __atomic_load_n(&client->stats.packets_waiting_puback, __ATOMIC_RELAXED);
-    stats->rx_maximum = client->rx_maximum;
+    stats->rx_maximum = __atomic_load_n(&client->rx_maximum, __ATOMIC_RELAXED);
 
     stats->tx_bytes_queued = 0;
     stats->tx_buffer_reclaimable = 0;

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -250,6 +250,9 @@ struct mqtt_ng_client {
     c_rhash rx_aliases;
 
     size_t max_msg_size;
+
+    // MQTT 5.0 server Receive Maximum (CONNACK prop 0x21); absent => 65535 default [MQTT-3.2.2.3.3]
+    uint16_t rx_maximum;
 };
 
 usec_t publish_latency;
@@ -629,6 +632,9 @@ struct mqtt_ng_client *mqtt_ng_init(struct mqtt_ng_init *settings)
 
     client->tx_topic_aliases.stoi_dict = TX_ALIASES_INITIALIZE();
     client->tx_topic_aliases.idx_max = UINT16_MAX;
+
+    // MQTT 5.0 default Receive Maximum when the server omits the property [MQTT-3.2.2.3.3]
+    client->rx_maximum = UINT16_MAX;
 
     // TODO just embed the struct into mqtt_ng_client
     client->parser.received_data = settings->data_in;
@@ -2144,6 +2150,11 @@ int handle_incoming_traffic(struct mqtt_ng_client *client)
                 client->max_msg_size = prop->data.uint32;
             }
 
+            if ((prop = get_property_by_id(client->parser.properties_parser.head, MQTT_PROP_RECEIVE_MAX)) != NULL) {
+                nd_log(NDLS_DAEMON, NDLP_INFO, "ACLK: MQTT server receive maximum is %" PRIu16, prop->data.uint16);
+                client->rx_maximum = prop->data.uint16;
+            }
+
             if (client->connack_callback)
                 client->connack_callback(client->user_ctx, client->parser.mqtt_packet.connack.reason_code);
             if (!client->parser.mqtt_packet.connack.reason_code) {
@@ -2300,6 +2311,7 @@ void mqtt_ng_get_stats(struct mqtt_ng_client *client, struct mqtt_ng_stats *stat
     stats->tx_messages_sent = __atomic_load_n(&client->stats.tx_messages_sent, __ATOMIC_RELAXED);
     stats->rx_messages_rcvd = __atomic_load_n(&client->stats.rx_messages_rcvd, __ATOMIC_RELAXED);
     stats->packets_waiting_puback = __atomic_load_n(&client->stats.packets_waiting_puback, __ATOMIC_RELAXED);
+    stats->rx_maximum = client->rx_maximum;
 
     stats->tx_bytes_queued = 0;
     stats->tx_buffer_reclaimable = 0;

--- a/src/daemon/pulse/pulse-network.c
+++ b/src/daemon/pulse/pulse-network.c
@@ -335,6 +335,40 @@ void pulse_network_do(bool extended __maybe_unused) {
 
         pulse_aclk_time_heatmap();
 
+        {
+            // In-flight QoS1 messages vs the broker's MQTT 5.0 Receive Maximum.
+            // When "in flight" approaches "receive maximum" the agent is at the
+            // broker's window limit. Always available (not extended) since it is
+            // the primary signal for the MQTT 5.0 Receive Maximum behavior.
+            static RRDSET *st_aclk_inflight = NULL;
+            static RRDDIM *rd_in_flight = NULL, *rd_receive_max = NULL;
+
+            if (unlikely(!st_aclk_inflight)) {
+                st_aclk_inflight = rrdset_create_localhost(
+                    "netdata",
+                    "aclk_mqtt_inflight",
+                    NULL,
+                    PULSE_NETWORK_CHART_FAMILY,
+                    "netdata.aclk_mqtt_inflight",
+                    "Netdata ACLK MQTT In-Flight QoS1 Window",
+                    "messages",
+                    "netdata",
+                    "pulse",
+                    PULSE_NETWORK_CHART_PRIORITY + 2,
+                    localhost->rrd_update_every,
+                    RRDSET_TYPE_LINE);
+
+                rrdlabels_add(st_aclk_inflight->rrdlabels, "endpoint", "aclk", RRDLABEL_SRC_AUTO);
+
+                rd_in_flight = rrddim_add(st_aclk_inflight, "in flight", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+                rd_receive_max = rrddim_add(st_aclk_inflight, "receive maximum", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            }
+
+            rrddim_set_by_pointer(st_aclk_inflight, rd_in_flight, (collected_number)t.mqtt.packets_waiting_puback);
+            rrddim_set_by_pointer(st_aclk_inflight, rd_receive_max, (collected_number)t.mqtt.rx_maximum);
+            rrdset_done(st_aclk_inflight);
+        }
+
         if(extended) {
             static RRDSET *st_aclk_queue_size = NULL;
             static RRDDIM *rd_messages = NULL;


### PR DESCRIPTION
##### Summary
- Extract the broker's Receive Maximum from CONNACK, expose it in aclk state
- Add an always-onnetdata.aclk_mqtt_inflight pulse chart (in flight vs receive maximum)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds visibility into MQTT 5.0 backpressure by exposing the broker’s Receive Maximum and charting in-flight QoS1 messages vs that limit. Observation-only; no pacing changes.

- **New Features**
  - Parse MQTT 5.0 Receive Maximum from CONNACK (defaults to 65535 if absent) and expose as `server-receive-maximum` in `aclk_state` text and JSON.
  - Add always-on pulse chart `netdata.aclk_mqtt_inflight` with “in flight” and “receive maximum” series.

- **Bug Fixes**
  - Use atomic reads/writes for `rx_maximum` to prevent races between ACLK and pulse threads.

<sup>Written for commit 51815c459c5a24c6bdc8d1c28a8df56df2119eff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

