### PR TITLE
Switch log level from `NOTICE` to `DEBUG` for active context checkpoint logs

### DIFF
--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -324,7 +324,7 @@ static void rrdcontext_checkpoint_execute(RRDHOST *host, const char *claim_id, c
         return;
 
     if(rrdhost_flag_check(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS)) {
-        nd_log(NDLS_DAEMON, NDLP_NOTICE,
+        nd_log(NDLS_DAEMON, NDLP_DEBUG,
                "RRDCONTEXT: checkpoint for claim id '%s', node id '%s', "
                "while node '%s' has an active context streaming.",
                claim_id, node_id, rrdhost_hostname(host));


### PR DESCRIPTION
##### Summary
- Reduce messages on busy parents


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the RRDCONTEXT checkpoint message from NOTICE to DEBUG when context streaming is active. This reduces log noise on busy parents while keeping the message available for troubleshooting.

<sup>Written for commit a66c459e94b699d9d30b168d2d5e886fd5776b93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

