### PR TITLE
Sonar cleanup

### DIFF
--- a/src/claim/ui.c
+++ b/src/claim/ui.c
@@ -10,8 +10,6 @@
 static LPCTSTR szWindowClass = _T("DesktopApp");
 
 static HINSTANCE hInst;
-static HWND hToken;
-static HWND hRoom;
 
 LRESULT CALLBACK WndProc(HWND hNetdatawnd, UINT message, WPARAM wParam, LPARAM lParam)
 {

--- a/src/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/src/collectors/cgroups.plugin/cgroup-discovery.c
@@ -794,7 +794,7 @@ static inline void discovery_update_filenames_all_cgroups() {
 static inline void discovery_cleanup_all_cgroups() {
     struct cgroup *cg = discovered_cgroup_root, *last = NULL;
 
-    for(; cg ;) {
+    while(cg) {
         if(!cg->available) {
             // enable the first duplicate cgroup
             {

--- a/src/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/src/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -574,9 +574,6 @@ int do_hw_intcnt(int update_every, usec_t dt) {
             for (i = 0; i < nintr; i++)
                 totalintr += intrcnt[i];
 
-            static RRDSET *st_intr = NULL;
-            static RRDDIM *rd_intr = NULL;
-
             common_interrupts(totalintr, update_every, "hw.intrcnt");
 
             size_t size;

--- a/src/database/rrdhost-system-info.c
+++ b/src/database/rrdhost-system-info.c
@@ -6,7 +6,10 @@
 #include "daemon/win_system-info.h"
 
 // coverity[ +tainted_string_sanitize_content : arg-0 ]
-static inline void coverity_remove_taint(char *s __maybe_unused) { }
+static inline void coverity_remove_taint(char *s __maybe_unused) {
+    // intentionally empty: only a marker for the Coverity taint sanitizer
+    // (see the annotation above); it has no runtime effect.
+}
 
 void rrdhost_system_info_swap(struct rrdhost_system_info *a, struct rrdhost_system_info *b) {
     if(a && b)

--- a/src/libnetdata/c_rhash/tests.c
+++ b/src/libnetdata/c_rhash/tests.c
@@ -105,7 +105,6 @@ test_cleanup:
 #define UINT64_PTR_INC_ITERATION_COUNT 5000
 int test_uint64_ptr_incremental() {
     c_rhash hash = c_rhash_new(100);
-    void *val;
 
     TEST_START();
 

--- a/src/libnetdata/inlined.h
+++ b/src/libnetdata/inlined.h
@@ -108,9 +108,9 @@ static inline uint32_t murmur32(uint32_t k) {
 static uint64_t murmur64(uint64_t k) __attribute__((const));
 static inline uint64_t murmur64(uint64_t k) {
     k ^= k >> 33;
-    k *= 0xff51afd7ed558ccdUL;
+    k *= 0xff51afd7ed558ccdULL;
     k ^= k >> 33;
-    k *= 0xc4ceb9fe1a85ec53UL;
+    k *= 0xc4ceb9fe1a85ec53ULL;
     k ^= k >> 33;
 
     return k;

--- a/src/libnetdata/log/nd_log.h
+++ b/src/libnetdata/log/nd_log.h
@@ -117,7 +117,7 @@ extern int aclklog_enabled;
 #define LOG_DATE_LENGTH 26
 void log_date(char *buffer, size_t len, time_t now);
 
-static inline void debug_dummy(void) {}
+static inline void debug_dummy(void) { /* no-op: target for debug/timing macros when those are compiled out */ }
 
 void nd_log_limits_reset(void);
 void nd_log_limits_unlimited(void);

--- a/src/libnetdata/log/systemd-cat-native.c
+++ b/src/libnetdata/log/systemd-cat-native.c
@@ -84,7 +84,6 @@ static inline size_t copy_replacing_newlines(char *dst, size_t dst_len, const ch
 
         memcpy(current_dst, current_src, copy_len);
         current_dst += copy_len;
-        remaining_dst_len -= copy_len;
         bytes_copied += copy_len;
         break;
     }

--- a/src/libnetdata/netipc/src/transport/posix/netipc_uds_receive.c
+++ b/src/libnetdata/netipc/src/transport/posix/netipc_uds_receive.c
@@ -17,7 +17,7 @@ static uint64_t monotonic_ms(void)
 {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    return (uint64_t)ts.tv_sec * 1000ull + (uint64_t)ts.tv_nsec / 1000000ull;
+    return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)ts.tv_nsec / 1000000ULL;
 }
 
 static receive_wait_t receive_wait_init(uint32_t timeout_ms, int abort_fd)

--- a/src/streaming/stream-connector.c
+++ b/src/streaming/stream-connector.c
@@ -693,7 +693,7 @@ bool stream_connector_init(struct sender_state *s) {
         completion_init(&sc->completion);
 
         char tag[NETDATA_THREAD_TAG_MAX + 1];
-        snprintfz(tag, NETDATA_THREAD_TAG_MAX, THREAD_TAG_STREAM_SENDER "-CN" "[%d]",
+        snprintfz(tag, NETDATA_THREAD_TAG_MAX, THREAD_TAG_STREAM_SENDER "-CN[%d]",
             sc->id);
 
         sc->thread = nd_thread_create(tag, NETDATA_THREAD_OPTION_DEFAULT, stream_connector_thread, sc);

--- a/src/web/api/v2/api_v2_claim.c
+++ b/src/web/api/v2/api_v2_claim.c
@@ -219,7 +219,6 @@ static int api_claim(uint8_t version, struct web_client *w, char *url) {
 
         if(claim_agent(base_url, token, rooms, cloud_config_proxy_get(), cloud_config_insecure_get())) {
             msg = "ok";
-            can_be_claimed = false;
             claim_reload_and_wait_online();
             response = CLAIM_RESP_ACTION_OK;
         }

--- a/src/web/websocket/websocket-send.c
+++ b/src/web/websocket/websocket-send.c
@@ -78,7 +78,7 @@ static int websocket_protocol_send_frame(
     if(!wsc)
         return -1;
 
-    const char *disconnect_msg = "";
+    const char *disconnect_msg;
 
     if (wsc->sock.fd < 0) {
         disconnect_msg = "Client not connected";


### PR DESCRIPTION
##### Summary
- Code cleanup to address sonar findings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sonar-driven cleanup across the codebase to remove unused variables and dead stores, fix 64-bit literal suffixes for portability, and tidy minor loop/string patterns. No behavior changes expected; improves readability, portability (LLP64/Windows), and static analysis signal.

- **Refactors**
  - Removed unused vars and dead stores in `claim/ui`, FreeBSD sysctl, `c_rhash` tests, `api_v2_claim`, systemd journald, and websocket send.
  - Switched 64-bit constants to `ULL` in Murmur64 and UDS receive time math for cross-platform correctness.
  - Replaced `for(; cg ;)` with `while(cg)` in cgroup discovery for clarity.
  - Merged adjacent string literals in the stream connector thread tag.
  - Documented intentional no-ops in `coverity_remove_taint()` and `debug_dummy()` to satisfy static analysis.

<sup>Written for commit 778fc7a538cb6b4835907ab3da83f3a8b38518f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

