### PR TITLE
Adjust ML model deletion query

### DIFF
--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -346,7 +346,7 @@ const char *db_models_delete =
 
 const char *db_models_prune =
     "DELETE FROM models "
-    "WHERE after < @after LIMIT @n;";
+    "WHERE rowid IN (SELECT rowid FROM models WHERE after < @after LIMIT @n);";
 
 static int
 ml_dimension_add_model(const nd_uuid_t *metric_uuid, const ml_kmeans_inlined_t *inlined_km)


### PR DESCRIPTION
##### Summary
- Do not relay on the delete / limit add-on behavior of sqlite 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ML model pruning to reliably delete only up to `@n` older records without relying on SQLite’s `DELETE ... LIMIT` extension. This makes pruning portable across SQLite builds and prevents accidental over-deletion.

- **Bug Fixes**
  - Replaced `DELETE ... LIMIT` with `DELETE WHERE rowid IN (SELECT rowid ... LIMIT @n)` for models where `after < @after`.

<sup>Written for commit 6b9aa850d9f5f852eef19695fdb0deddb09c7e01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

