### PR TITLE
refactor(go.d): bind single-instance functions to runtime job

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -67,6 +67,13 @@ source files for evidence.
 - If Functions exist, isolate them in a `<name>func/` subpackage with a narrow
   `Deps` interface declared there. The Function package MUST NOT import the
   collector package or hold `*Collector`.
+- If a single-instance collector exposes `AgentWide` module `Methods`, its
+  `MethodHandler(job)` receives the running canonical runtime job. Use
+  `job.Collector()` to bind the Function handler to collector-owned state; do
+  not add a `__job` parameter or introduce a package-global registry to bridge
+  Function dispatch. During method execution, when the singleton job is not
+  running, the framework returns an unavailable response before calling
+  `MethodHandler`.
 - `collectorapi.Creator.InstancePolicy` defaults to
   `InstancePolicyPerJob`. Use `InstancePolicySingle` only for collectors that
   are intentionally one canonical job per agent. Single-instance configs MUST

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -938,6 +938,188 @@ func TestControllerRawAgentWideModuleMethodDoesNotRequireRunningJob(t *testing.T
 	assert.Nil(t, gotJob)
 }
 
+func TestControllerRawSingleInstanceAgentWideModuleMethodUsesRunningJob(t *testing.T) {
+	var gotCode int
+	var gotResp map[string]any
+	var gotJob collectorapi.RuntimeJob
+	reg := newTestFunctionRegistry()
+	controller := New(Options{
+		FnReg: reg,
+		JSONWriter: func(data []byte, code int) {
+			gotCode = code
+			require.NoError(t, json.Unmarshal(data, &gotResp))
+		},
+	})
+	controller.RegisterModules(collectorapi.Registry{
+		"mod": collectorapi.Creator{
+			InstancePolicy: collectorapi.InstancePolicySingle,
+			Methods: func() []funcapi.MethodConfig {
+				return []funcapi.MethodConfig{{
+					ID:         "logs",
+					RawRequest: true,
+					AgentWide:  true,
+				}}
+			},
+			MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
+				gotJob = job
+				return &rawTestHandler{
+					raw: func(_ context.Context, req funcapi.RawMethodRequest) *funcapi.FunctionResponse {
+						assert.Equal(t, "logs", req.Method)
+						return funcapi.RawResponse(map[string]any{
+							"status": 200,
+							"type":   "table",
+						})
+					},
+				}
+			},
+		},
+	})
+	job := newTestRuntimeJob("mod", "mod", true)
+	controller.OnJobStart(job)
+
+	reg.call("mod:logs", context.Background(), functions.Function{
+		UID:     "raw-single-agent-wide",
+		Timeout: time.Second,
+	})
+
+	assert.Equal(t, 200, gotCode)
+	assert.Equal(t, float64(200), gotResp["status"])
+	assert.Same(t, job, gotJob)
+}
+
+func TestControllerSingleInstanceAgentWideModuleMethodUsesRunningJob(t *testing.T) {
+	var gotCode int
+	var gotResp map[string]any
+	var gotJob collectorapi.RuntimeJob
+	reg := newTestFunctionRegistry()
+	controller := New(Options{
+		FnReg: reg,
+		JSONWriter: func(data []byte, code int) {
+			gotCode = code
+			require.NoError(t, json.Unmarshal(data, &gotResp))
+		},
+	})
+	controller.RegisterModules(collectorapi.Registry{
+		"mod": collectorapi.Creator{
+			InstancePolicy: collectorapi.InstancePolicySingle,
+			Methods: func() []funcapi.MethodConfig {
+				return []funcapi.MethodConfig{{
+					ID:        "status",
+					AgentWide: true,
+				}}
+			},
+			MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
+				gotJob = job
+				return &rawTestHandler{
+					params: func(context.Context, string) ([]funcapi.ParamConfig, error) {
+						return []funcapi.ParamConfig{{
+							ID:        "scope",
+							Name:      "Scope",
+							Selection: funcapi.ParamSelect,
+							Options: []funcapi.ParamOption{{
+								ID:      "all",
+								Name:    "All",
+								Default: true,
+							}},
+						}}, nil
+					},
+					handle: func(_ context.Context, method string, params funcapi.ResolvedParams) *funcapi.FunctionResponse {
+						assert.Equal(t, "status", method)
+						assert.Equal(t, "all", params.GetOne("scope"))
+						return &funcapi.FunctionResponse{
+							Status:       200,
+							ResponseType: "table",
+							Help:         "status",
+						}
+					},
+				}
+			},
+		},
+	})
+	job := newTestRuntimeJob("mod", "mod", true)
+	controller.OnJobStart(job)
+
+	reg.call("mod:status", context.Background(), functions.Function{
+		UID:     "single-agent-wide",
+		Timeout: time.Second,
+		Payload: []byte(`{"scope":"all"}`),
+	})
+
+	assert.Equal(t, 200, gotCode)
+	assert.Equal(t, float64(200), gotResp["status"])
+	assert.Same(t, job, gotJob)
+	assert.Equal(t, []any{"scope"}, gotResp["accepted_params"])
+}
+
+func TestControllerSingleInstanceAgentWideModuleMethodRequiresRunningJob(t *testing.T) {
+	tests := map[string]struct {
+		setup   func(*Controller)
+		message string
+	}{
+		"before start": {
+			message: "module 'mod' is not running",
+		},
+		"after stop": {
+			setup: func(controller *Controller) {
+				job := newTestRuntimeJob("mod", "mod", true)
+				controller.OnJobStart(job)
+				controller.OnJobStop(job)
+			},
+			message: "module 'mod' is not running",
+		},
+		"registered but not running": {
+			setup: func(controller *Controller) {
+				controller.OnJobStart(newTestRuntimeJob("mod", "mod", false))
+			},
+			message: "job 'mod' is no longer running",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var gotCode int
+			var gotResp map[string]any
+			var gotHandler bool
+			reg := newTestFunctionRegistry()
+			controller := New(Options{
+				FnReg: reg,
+				JSONWriter: func(data []byte, code int) {
+					gotCode = code
+					require.NoError(t, json.Unmarshal(data, &gotResp))
+				},
+			})
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					InstancePolicy: collectorapi.InstancePolicySingle,
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{
+							ID:        "status",
+							AgentWide: true,
+						}}
+					},
+					MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
+						gotHandler = true
+						return &tableTestHandler{}
+					},
+				},
+			})
+			if tc.setup != nil {
+				tc.setup(controller)
+			}
+
+			reg.call("mod:status", context.Background(), functions.Function{
+				UID:     "single-agent-wide-missing-job",
+				Timeout: time.Second,
+			})
+
+			assert.Equal(t, 503, gotCode)
+			assert.Equal(t, float64(503), gotResp["status"])
+			assert.Equal(t, tc.message, gotResp["errorMessage"])
+			assert.False(t, gotHandler)
+		})
+	}
+}
+
 func TestControllerModuleMethodRequestContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -1119,13 +1301,17 @@ func (j *testRuntimeJob) IsRunning() bool    { return j.running }
 func (j *testRuntimeJob) Collector() any     { return nil }
 
 type rawTestHandler struct {
+	params func(context.Context, string) ([]funcapi.ParamConfig, error)
 	handle func(context.Context, string, funcapi.ResolvedParams) *funcapi.FunctionResponse
 	raw    func(context.Context, funcapi.RawMethodRequest) *funcapi.FunctionResponse
 }
 
 var _ funcapi.RawMethodHandler = (*rawTestHandler)(nil)
 
-func (h *rawTestHandler) MethodParams(context.Context, string) ([]funcapi.ParamConfig, error) {
+func (h *rawTestHandler) MethodParams(ctx context.Context, method string) ([]funcapi.ParamConfig, error) {
+	if h.params != nil {
+		return h.params(ctx, method)
+	}
 	return nil, nil
 }
 

--- a/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
@@ -164,12 +164,20 @@ func (c *Controller) makeMethodFuncHandler(moduleName, methodID string) function
 		includeJobParam := methodRequiresJobParam(methodCfg)
 
 		if !includeJobParam {
+			job, jobName, jobGen, ok := c.resolveAgentWideMethodJob(fn, moduleName)
+			if !ok {
+				return
+			}
+
 			c.executeMethodRequest(ctx, methodExecutionInput{
 				fn:         fn,
 				moduleName: moduleName,
+				jobName:    jobName,
 				jobLabel:   moduleName,
 				methodID:   methodID,
 				methodCfg:  methodCfg,
+				job:        job,
+				jobGen:     jobGen,
 				info:       info,
 				payload:    payload,
 				argValues:  argValues,
@@ -237,6 +245,22 @@ func (c *Controller) makeMethodFuncHandler(moduleName, methodID string) function
 			},
 		})
 	}
+}
+
+func (c *Controller) resolveAgentWideMethodJob(fn functions.Function, moduleName string) (collectorapi.RuntimeJob, string, uint64, bool) {
+	creator, ok := c.registry.getCreator(moduleName)
+	if !ok || creator.InstancePolicy != collectorapi.InstancePolicySingle {
+		return nil, "", 0, true
+	}
+
+	jobName := moduleName
+	job, jobGen := c.registry.getJobWithGeneration(moduleName, jobName)
+	if job == nil {
+		c.respondError(fn, 503, "module '%s' is not running", moduleName)
+		return nil, "", 0, false
+	}
+
+	return job, jobName, jobGen, true
 }
 
 func (c *Controller) handleMethodFuncInfo(moduleName, methodID string, fn functions.Function) {

--- a/src/go/plugin/framework/collectorapi/registry.go
+++ b/src/go/plugin/framework/collectorapi/registry.go
@@ -67,8 +67,12 @@ type (
 		Methods func() []funcapi.MethodConfig
 
 		// Optional: MethodHandler returns a handler for method requests.
-		// AgentWide module methods are dispatched with nil job. Job-bound module
-		// methods and JobMethods are dispatched with the selected running job.
+		// AgentWide module methods are dispatched with nil job, except that
+		// single-instance collectors receive their running canonical job.
+		// Job-bound module methods and JobMethods are dispatched with the
+		// selected running job.
+		// When the canonical single-instance job is not running, dispatch returns
+		// unavailable before calling MethodHandler.
 		// The handler implements funcapi.MethodHandler interface with:
 		// - MethodParams(ctx, method) for dynamic params
 		// - Handle(ctx, method, params) for request handling

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -44,6 +44,7 @@ func New() *Collector {
 	return &Collector{
 		deviceCaches:        make(map[string]*topologyCache),
 		deviceLastCollected: make(map[string]time.Time),
+		topologyRegistry:    newTopologyRegistry(),
 		registeredDevices:   ddsnmp.DeviceRegistry.Devices,
 		newSnmpClient:       gosnmp.NewHandler,
 		newDdSnmpColl: func(cfg ddsnmpcollector.Config) ddCollector {
@@ -62,6 +63,7 @@ type (
 		deviceCaches        map[string]*topologyCache // one cache per SNMP device
 		deviceLastCollected map[string]time.Time      // last collection time per device
 		topologyCache       *topologyCache            // current device cache (set during refreshDeviceTopology)
+		topologyRegistry    *topologyRegistry
 
 		refreshMu sync.Mutex
 		statsMu   sync.RWMutex
@@ -103,6 +105,9 @@ func (c *Collector) Run(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return nil
 	}
+	c.publishTrapTopologyEnrichment()
+	defer c.unpublishTrapTopologyEnrichment()
+
 	c.refreshTopologyRecovering(ctx)
 
 	ticker := time.NewTicker(c.deviceCheckEvery())
@@ -138,11 +143,13 @@ func (c *Collector) refreshEvery() time.Duration {
 }
 
 func (c *Collector) Cleanup(context.Context) {
+	c.unpublishTrapTopologyEnrichment()
+
 	c.refreshMu.Lock()
 	defer c.refreshMu.Unlock()
 
 	for key, cache := range c.deviceCaches {
-		snmpTopologyRegistry.unregister(cache)
+		c.topologyRegistry.unregister(cache)
 		delete(c.deviceCaches, key)
 		delete(c.deviceLastCollected, key)
 	}
@@ -328,7 +335,7 @@ func (c *Collector) getOrCreateDeviceCache(key string) *topologyCache {
 	if !ok {
 		cache = newTopologyCache()
 		c.deviceCaches[key] = cache
-		snmpTopologyRegistry.register(cache)
+		c.topologyRegistry.register(cache)
 	}
 	return cache
 }
@@ -345,7 +352,7 @@ func (c *Collector) newDeviceCollectionCache(dev ddsnmp.DeviceConnectionInfo) *t
 func (c *Collector) pruneStaleDeviceCaches(seen map[string]bool) {
 	for key, cache := range c.deviceCaches {
 		if !seen[key] {
-			snmpTopologyRegistry.unregister(cache)
+			c.topologyRegistry.unregister(cache)
 			delete(c.deviceCaches, key)
 			delete(c.deviceLastCollected, key)
 		}
@@ -428,5 +435,12 @@ func topologyMethods() []funcapi.MethodConfig {
 }
 
 func topologyFunctionHandler(job collectorapi.RuntimeJob) funcapi.MethodHandler {
-	return &funcTopology{}
+	if job == nil {
+		return nil
+	}
+	coll, ok := job.Collector().(*Collector)
+	if !ok || coll == nil {
+		return nil
+	}
+	return &funcTopology{registry: coll.topologyRegistry}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -125,23 +125,18 @@ func TestCollectorRunDoesNotPollWhenContextAlreadyCanceled(t *testing.T) {
 }
 
 func TestCollectorPruneStaleDeviceCachesRemovesLastDeviceCache(t *testing.T) {
-	previousRegistry := snmpTopologyRegistry
-	registry := newTopologyRegistry()
-	snmpTopologyRegistry = registry
-	t.Cleanup(func() { snmpTopologyRegistry = previousRegistry })
-
 	coll := New()
 	cache := newTopologyCache()
 	coll.deviceCaches["gone:161"] = cache
 	coll.deviceLastCollected["gone:161"] = time.Now()
-	registry.register(cache)
+	coll.topologyRegistry.register(cache)
 
 	coll.registeredDevices = func() []ddsnmp.DeviceConnectionInfo { return nil }
 	coll.refreshTopology(context.Background())
 
 	require.Empty(t, coll.deviceCaches)
 	require.Empty(t, coll.deviceLastCollected)
-	require.False(t, topologyRegistryHasCache(registry, cache))
+	require.False(t, topologyRegistryHasCache(coll.topologyRegistry, cache))
 }
 
 func TestCollectorRefreshTopologyRecoveringHandlesPanic(t *testing.T) {
@@ -305,11 +300,6 @@ func TestCollectorNewDeviceCollectionCacheUsesEffectiveDeviceCheckEvery(t *testi
 }
 
 func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T) {
-	previousRegistry := snmpTopologyRegistry
-	registry := newTopologyRegistry()
-	snmpTopologyRegistry = registry
-	t.Cleanup(func() { snmpTopologyRegistry = previousRegistry })
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -324,7 +314,6 @@ func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T
 	key := "10.0.0.10:161"
 	published := newTopologyCache()
 	seedPublishedEndpointSnapshot(published)
-	registry.register(published)
 
 	started := make(chan struct{})
 	release := make(chan struct{})
@@ -332,6 +321,7 @@ func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T
 
 	coll := New()
 	coll.deviceCaches[key] = published
+	coll.topologyRegistry.register(published)
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
 	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
 		return &blockingTopologyCollector{

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology.go
@@ -7,7 +7,9 @@ import "github.com/netdata/netdata/go/plugins/pkg/funcapi"
 // Compile-time interface check.
 var _ funcapi.MethodHandler = (*funcTopology)(nil)
 
-type funcTopology struct{}
+type funcTopology struct {
+	registry *topologyRegistry
+}
 
 const (
 	topologyFunctionName = "snmp:topology:snmp"

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_handler.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_handler.go
@@ -18,7 +18,7 @@ func (f *funcTopology) MethodParams(_ context.Context, method string) ([]funcapi
 		topologyNodesIdentityParamConfig(),
 		topologyMapTypeParamConfig(),
 		topologyInferenceStrategyParamConfig(),
-		topologyManagedFocusParamConfig(topologyManagedFocusParamOptions()),
+		topologyManagedFocusParamConfig(topologyManagedFocusParamOptions(f.registry)),
 		topologyDepthParamConfig(),
 	}, nil
 }
@@ -30,13 +30,13 @@ func (f *funcTopology) Handle(_ context.Context, method string, params funcapi.R
 		return funcapi.NotFoundResponse(method)
 	}
 
-	if snmpTopologyRegistry == nil {
+	if f.registry == nil {
 		return funcapi.UnavailableResponse("topology data not available yet, please retry after topology refresh")
 	}
 
 	options := resolveTopologyQueryOptions(params)
 	options.ResolveDNSName = resolveTopologyReverseDNSNameCached // never block on network I/O
-	data, ok := snmpTopologyRegistry.snapshotWithOptions(options)
+	data, ok := f.registry.snapshotWithOptions(options)
 	if !ok {
 		return funcapi.UnavailableResponse("topology data not available yet, please retry after topology refresh")
 	}
@@ -53,13 +53,13 @@ func (f *funcTopology) Handle(_ context.Context, method string, params funcapi.R
 	}
 }
 
-func topologyManagedFocusParamOptions() []funcapi.ParamOption {
-	if snmpTopologyRegistry == nil {
+func topologyManagedFocusParamOptions(registry *topologyRegistry) []funcapi.ParamOption {
+	if registry == nil {
 		return nil
 	}
 
 	options := make([]funcapi.ParamOption, 0)
-	for _, target := range snmpTopologyRegistry.managedDeviceFocusTargets() {
+	for _, target := range registry.managedDeviceFocusTargets() {
 		if strings.TrimSpace(target.Value) == "" {
 			continue
 		}

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_presentation_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_presentation_test.go
@@ -35,5 +35,20 @@ func TestSNMPTopologyCreatorOwnsTopologyFunction(t *testing.T) {
 	require.Equal(t, topologyMethodID, methods[0].ID)
 	require.Equal(t, topologyFunctionName, methods[0].FunctionName)
 	require.True(t, methods[0].AgentWide)
-	require.IsType(t, &funcTopology{}, creator.MethodHandler(nil))
+
+	coll := New()
+	handler := creator.MethodHandler(&topologyRuntimeJobForTest{collector: coll})
+	require.IsType(t, &funcTopology{}, handler)
+	require.Same(t, coll.topologyRegistry, handler.(*funcTopology).registry)
+	require.Nil(t, creator.MethodHandler(nil))
 }
+
+type topologyRuntimeJobForTest struct {
+	collector *Collector
+}
+
+func (j *topologyRuntimeJobForTest) FullName() string   { return "snmp_topology" }
+func (j *topologyRuntimeJobForTest) ModuleName() string { return "snmp_topology" }
+func (j *topologyRuntimeJobForTest) Name() string       { return "snmp_topology" }
+func (j *topologyRuntimeJobForTest) IsRunning() bool    { return true }
+func (j *topologyRuntimeJobForTest) Collector() any     { return j.collector }

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_test.go
@@ -70,13 +70,7 @@ func TestTopologyMethodConfigIncludesSelectors(t *testing.T) {
 }
 
 func TestFuncTopology_MethodParams(t *testing.T) {
-	prev := snmpTopologyRegistry
-	t.Cleanup(func() {
-		snmpTopologyRegistry = prev
-	})
-
 	registry := newTopologyRegistry()
-	snmpTopologyRegistry = registry
 	registry.register(newTestTopologyCacheLLDP(
 		"agent-test",
 		time.Now().UTC(),
@@ -90,7 +84,7 @@ func TestFuncTopology_MethodParams(t *testing.T) {
 		"Gi0/2",
 	))
 
-	f := &funcTopology{}
+	f := &funcTopology{registry: registry}
 
 	params, err := f.MethodParams(context.Background(), topologyMethodID)
 	require.NoError(t, err)
@@ -110,13 +104,7 @@ func TestFuncTopology_MethodParams(t *testing.T) {
 }
 
 func TestFuncTopology_Handle_DefaultStrictL2(t *testing.T) {
-	prev := snmpTopologyRegistry
-	t.Cleanup(func() {
-		snmpTopologyRegistry = prev
-	})
-
 	registry := newTopologyRegistry()
-	snmpTopologyRegistry = registry
 	registry.register(newTestTopologyCacheLLDP(
 		"agent-test",
 		time.Now().UTC(),
@@ -130,7 +118,7 @@ func TestFuncTopology_Handle_DefaultStrictL2(t *testing.T) {
 		"Gi0/2",
 	))
 
-	f := &funcTopology{}
+	f := &funcTopology{registry: registry}
 	resp := f.Handle(context.Background(), topologyMethodID, nil)
 	require.NotNil(t, resp)
 	assert.Equal(t, 200, resp.Status)
@@ -150,13 +138,7 @@ func TestFuncTopology_Handle_DefaultStrictL2(t *testing.T) {
 }
 
 func TestFuncTopology_Handle_AcceptsSelectorParams(t *testing.T) {
-	prev := snmpTopologyRegistry
-	t.Cleanup(func() {
-		snmpTopologyRegistry = prev
-	})
-
 	registry := newTopologyRegistry()
-	snmpTopologyRegistry = registry
 	registry.register(newTestTopologyCacheLLDP(
 		"agent-test",
 		time.Now().UTC(),
@@ -170,7 +152,7 @@ func TestFuncTopology_Handle_AcceptsSelectorParams(t *testing.T) {
 		"Gi0/2",
 	))
 
-	f := &funcTopology{}
+	f := &funcTopology{registry: registry}
 	cfg := []funcapi.ParamConfig{
 		topologyNodesIdentityParamConfig(),
 		topologyMapTypeParamConfig(),
@@ -197,13 +179,7 @@ func TestFuncTopology_Handle_AcceptsSelectorParams(t *testing.T) {
 }
 
 func TestFuncTopology_Handle_UnknownSelectorsFallbackToDefaults(t *testing.T) {
-	prev := snmpTopologyRegistry
-	t.Cleanup(func() {
-		snmpTopologyRegistry = prev
-	})
-
 	registry := newTopologyRegistry()
-	snmpTopologyRegistry = registry
 	registry.register(newTestTopologyCacheLLDP(
 		"agent-test",
 		time.Now().UTC(),
@@ -217,7 +193,7 @@ func TestFuncTopology_Handle_UnknownSelectorsFallbackToDefaults(t *testing.T) {
 		"Gi0/2",
 	))
 
-	f := &funcTopology{}
+	f := &funcTopology{registry: registry}
 	cfg := []funcapi.ParamConfig{
 		topologyNodesIdentityParamConfig(),
 		topologyMapTypeParamConfig(),

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
@@ -32,8 +32,6 @@ func newTopologyRegistry() *topologyRegistry {
 	}
 }
 
-var snmpTopologyRegistry = newTopologyRegistry()
-
 func (r *topologyRegistry) register(cache *topologyCache) {
 	if r == nil || cache == nil {
 		return

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich.go
@@ -5,6 +5,7 @@ package snmptopology
 import (
 	"sort"
 	"strings"
+	"sync/atomic"
 )
 
 type TrapTopologyEnrichment struct {
@@ -22,27 +23,45 @@ type TrapTopologyEnrichment struct {
 	Neighbors       []string
 }
 
-// TrapEnrichmentForIP returns source-device topology enrichment for a trap
-// received from the given source IP. It intentionally does not infer a trap
-// interface from the source IP.
-func TrapEnrichmentForIP(ip string) *TrapTopologyEnrichment {
-	return TrapEnrichmentForSource(ip, "")
+var activeTrapTopologyRegistry atomic.Pointer[topologyRegistry]
+
+func (c *Collector) publishTrapTopologyEnrichment() {
+	if c.topologyRegistry != nil {
+		activeTrapTopologyRegistry.Store(c.topologyRegistry)
+	}
+}
+
+func (c *Collector) unpublishTrapTopologyEnrichment() {
+	if c.topologyRegistry != nil {
+		activeTrapTopologyRegistry.CompareAndSwap(c.topologyRegistry, nil)
+	}
 }
 
 // TrapEnrichmentForSource returns topology enrichment data for a trap received
 // from the given source IP and, when available, the trap subject ifIndex.
 // Interface and neighbor enrichment only use the trap ifIndex after the source
 // IP matches exactly one local topology cache.
-//
-// It copies active cache pointers under the registry lock, reads each cache
-// under its own lock, and never blocks on I/O.
 func TrapEnrichmentForSource(ip, trapIfIndex string) *TrapTopologyEnrichment {
+	registry := activeTrapTopologyRegistry.Load()
+	if registry == nil {
+		return nil
+	}
+	return registry.trapEnrichmentForSource(ip, trapIfIndex)
+}
+
+// trapEnrichmentForSource copies active cache pointers under the registry lock,
+// reads each cache under its own lock, and never blocks on I/O.
+func (r *topologyRegistry) trapEnrichmentForSource(ip, trapIfIndex string) *TrapTopologyEnrichment {
+	if r == nil {
+		return nil
+	}
+
 	ip = normalizeIPAddress(ip)
 	if ip == "" {
 		return nil
 	}
 
-	caches := snmpTopologyRegistry.activeCaches()
+	caches := r.activeCaches()
 	if len(caches) == 0 {
 		return nil
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich_test.go
@@ -3,7 +3,10 @@
 package snmptopology
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -86,14 +89,16 @@ func TestTopologyCacheTrapEnrichmentForSourceIncludesLocalDeviceIdentity(t *test
 	require.Equal(t, "vnode-node-id", enrich.SourceVnodeID)
 }
 
-func TestTrapEnrichmentForSourceUsesGlobalRegistry(t *testing.T) {
+func TestTrapEnrichmentForSourceUsesActiveRegistry(t *testing.T) {
+	registry := newTopologyRegistry()
+	publishTrapTopologyRegistryForTest(t, registry)
+
 	cache := newTopologyCache()
 	cache.localDevice.ManagementIP = "192.0.2.20"
 	cache.ifNamesByIndex["11"] = "Gi0/11"
 	cache.lldpRemotes["11:1"] = &lldpRemote{sysName: "dist-c"}
 
-	snmpTopologyRegistry.register(cache)
-	defer snmpTopologyRegistry.unregister(cache)
+	registry.register(cache)
 
 	enrich := TrapEnrichmentForSource("192.0.2.20", "11")
 	require.NotNil(t, enrich)
@@ -106,7 +111,10 @@ func TestTrapEnrichmentForSourceUsesGlobalRegistry(t *testing.T) {
 	require.Equal(t, "Gi0/11", mapped.Interface)
 }
 
-func TestTrapEnrichmentForSourceAmbiguousGlobalRegistryMatchDoesNotEnrich(t *testing.T) {
+func TestTrapEnrichmentForSourceAmbiguousActiveRegistryMatchDoesNotEnrich(t *testing.T) {
+	registry := newTopologyRegistry()
+	publishTrapTopologyRegistryForTest(t, registry)
+
 	cacheA := newTopologyCache()
 	cacheA.localDevice.ManagementIP = "192.0.2.20"
 	cacheA.ifNamesByIndex["11"] = "Gi0/11"
@@ -114,10 +122,8 @@ func TestTrapEnrichmentForSourceAmbiguousGlobalRegistryMatchDoesNotEnrich(t *tes
 	cacheB.localDevice.ManagementIP = "192.0.2.20"
 	cacheB.ifNamesByIndex["11"] = "Gi0/11"
 
-	snmpTopologyRegistry.register(cacheA)
-	snmpTopologyRegistry.register(cacheB)
-	defer snmpTopologyRegistry.unregister(cacheA)
-	defer snmpTopologyRegistry.unregister(cacheB)
+	registry.register(cacheA)
+	registry.register(cacheB)
 
 	enrich := TrapEnrichmentForSource("192.0.2.20", "11")
 	require.NotNil(t, enrich)
@@ -125,4 +131,66 @@ func TestTrapEnrichmentForSourceAmbiguousGlobalRegistryMatchDoesNotEnrich(t *tes
 	require.Equal(t, 2, enrich.DeviceMatches)
 	require.Empty(t, enrich.Interface)
 	require.Empty(t, enrich.Neighbors)
+}
+
+func TestCollectorRunPublishesAndClearsTrapTopologyRegistry(t *testing.T) {
+	previous := activeTrapTopologyRegistry.Swap(nil)
+	t.Cleanup(func() { activeTrapTopologyRegistry.Store(previous) })
+
+	coll := New()
+	coll.UpdateEvery = 3600
+	coll.registeredDevices = nil
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- coll.Run(ctx)
+	}()
+
+	stopped := false
+	stopRunner := func() error {
+		if stopped {
+			return nil
+		}
+		stopped = true
+		cancel()
+		select {
+		case err := <-errCh:
+			return err
+		case <-time.After(time.Second):
+			return errors.New("runner did not stop")
+		}
+	}
+	defer func() {
+		require.NoError(t, stopRunner())
+	}()
+
+	require.Eventually(t, func() bool {
+		return activeTrapTopologyRegistry.Load() == coll.topologyRegistry
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, stopRunner())
+	require.Nil(t, activeTrapTopologyRegistry.Load())
+}
+
+func TestCollectorCleanupDoesNotClearNewerTrapTopologyRegistry(t *testing.T) {
+	previous := activeTrapTopologyRegistry.Swap(nil)
+	t.Cleanup(func() { activeTrapTopologyRegistry.Store(previous) })
+
+	oldColl := New()
+	newColl := New()
+	activeTrapTopologyRegistry.Store(newColl.topologyRegistry)
+
+	oldColl.Cleanup(context.Background())
+
+	require.Same(t, newColl.topologyRegistry, activeTrapTopologyRegistry.Load())
+}
+
+func publishTrapTopologyRegistryForTest(t *testing.T, registry *topologyRegistry) {
+	t.Helper()
+
+	previous := activeTrapTopologyRegistry.Swap(registry)
+	t.Cleanup(func() {
+		activeTrapTopologyRegistry.CompareAndSwap(registry, previous)
+	})
 }


### PR DESCRIPTION
##### Summary

Before this change, `snmp_topology` was already a single-instance collector, but its agent-wide Function could not reach the running collector instance.

As a workaround, the Function path read package-global topology state. Trap enrichment also depended on that same global output registry. This kept singleton behavior outside the framework and left SNMP topology with hidden shared state.

This change adds framework support for binding `InstancePolicySingle + AgentWide` module Functions to the running singleton job, without adding `__job` or changing public Function names/publication timing.

`snmp_topology` now serves Function data from collector-owned topology state, trap enrichment reads through the active singleton provider, and the old `snmpTopologyRegistry` global is removed.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind single-instance AgentWide Functions to the running job and move `snmp_topology` Function + trap enrichment to per-collector topology state, removing the global registry.

- **New Features**
  - `funcctl`: resolves the canonical job for `InstancePolicySingle` AgentWide methods (raw and non-raw) and passes it to `MethodHandler`; returns 503 if the module isn’t running; no `__job` param or Function name changes.
  - `collectorapi`: documents that single-instance AgentWide methods get the running canonical job or an unavailable response.

- **Refactors**
  - `snmp_topology`: adds a per-collector `topologyRegistry`; `topologyFunctionHandler(job)` binds `funcTopology` to `job.Collector()` and reads from that registry, including managed-focus options.
  - Trap enrichment uses an atomic “active registry” published on `Run` and cleared on stop/Cleanup, preventing stale or cross-run globals.
  - Tests added for controller dispatch (job passed/503 cases), topology Function params/handling, and trap enrichment lifecycle.

<sup>Written for commit 510091ebc557fdb887b77a946d351b1cb8c7e655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

