### PR TITLE
streaming: add receiver disconnect diagnostics and per-child join keys

### DIFF
--- a/src/streaming/stream-receiver-internals.h
+++ b/src/streaming/stream-receiver-internals.h
@@ -74,6 +74,7 @@ struct receiver_state {
 
         nd_poll_event_t wanted;
         usec_t last_traffic_ut;
+        size_t bytes_received;          // raw socket bytes received on this connection (diagnostics)
         struct pollfd_meta meta;
     } thread;
 

--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -153,6 +153,7 @@ static ssize_t receiver_read_uncompressed(struct receiver_state *r) {
 
         r->thread.uncompressed.read_len += bytes;
         r->thread.uncompressed.read_buffer[r->thread.uncompressed.read_len] = '\0';
+        r->thread.bytes_received += bytes;
         pulse_stream_received_bytes(bytes);
     }
 
@@ -271,6 +272,7 @@ static ssize_t receiver_read_compressed(struct receiver_state *r) {
 
     if(bytes > 0) {
         r->thread.compressed.used += bytes;
+        r->thread.bytes_received += bytes;
         worker_set_metric(WORKER_RECEIVER_JOB_BYTES_READ, (NETDATA_DOUBLE)bytes);
         pulse_stream_received_bytes(bytes);
     }
@@ -423,6 +425,11 @@ void stream_receiver_move_to_running_unsafe(struct stream_thread *sth, struct re
     rpt->thread.compressed.enabled = stream_decompression_initialize(rpt);
     buffered_reader_init(&rpt->thread.uncompressed);
 
+    // start fresh at admission: the no-traffic timeout must be measured from when we start
+    // reading (now), not from when the connection was accepted and queued.
+    rpt->thread.bytes_received = 0;
+    rpt->thread.last_traffic_ut = now_monotonic_usec();
+
     rpt->thread.line_buffer = buffer_create(sizeof(rpt->thread.uncompressed.read_buffer), NULL);
 
     // help preferred_sender_buffer() select the right buffer
@@ -516,16 +523,39 @@ static void stream_receiver_remove_internal(struct stream_thread *sth, struct re
     if(parser)
         count = parser->user.data_collections_count;
 
+    // gather diagnostics for a single, uniform disconnect line (same fields for every reason):
+    // bytes_in distinguishes "the child sent nothing" (network/silent) from "sent but unparsed";
+    // iface exposes the child's connection type (e.g. ppp0 cellular vs eth0) for log-side pivots.
+    size_t bytes_out = 0;
+    spinlock_lock(&rpt->thread.send_to_child.spinlock);
+    if(rpt->thread.send_to_child.scb)
+        bytes_out = stream_circular_buffer_stats_unsafe(rpt->thread.send_to_child.scb)->bytes_sent;
+    spinlock_unlock(&rpt->thread.send_to_child.spinlock);
+
+    char iface[64] = "";
+    if(rpt->host && rpt->host->rrdlabels)
+        rrdlabels_get_value_strcpyz(rpt->host->rrdlabels, iface, sizeof(iface), "_net_default_iface");
+
+    time_t connected_s = rpt->connected_since_s ? (now_realtime_sec() - rpt->connected_since_s) : 0;
+    long long idle_s = (long long)((now_monotonic_usec() - rpt->thread.last_traffic_ut) / USEC_PER_SEC);
+    double repl_pct = rpt->host ? rpt->host->stream.rcv.status.replication.percent : 0.0;
+
     errno_clear();
     nd_log(NDLS_DAEMON, NDLP_ERR,
-           "STREAM RCV[%zu] '%s' [from [%s]:%s]: "
-           "receiver disconnected (after %zu received messages): %s"
+           "STREAM RCV[%zu] '%s' [from [%s]:%s]: receiver disconnected: "
+           "reason=\"%s\" msgs=%zu bytes_in=%zu bytes_out=%zu connected=%llds idle=%llds repl=%.0f%% iface=%s"
            , sth->id
            , rpt->hostname ? rpt->hostname : "-"
            , rpt->remote_ip ? rpt->remote_ip : "-"
            , rpt->remote_port ? rpt->remote_port : "-"
+           , stream_handshake_error_to_string(reason)
            , count
-           , stream_handshake_error_to_string(reason));
+           , rpt->thread.bytes_received
+           , bytes_out
+           , (long long)connected_s
+           , idle_s
+           , repl_pct
+           , iface[0] ? iface : "-");
 
     internal_fatal(META_GET(&sth->run.meta, (Word_t)&rpt->thread.meta) == NULL,
                    "Receiver to be removed is not found in the list of receivers");

--- a/src/web/api/functions/function-netdata-streaming.c
+++ b/src/web/api/functions/function-netdata-streaming.c
@@ -309,6 +309,16 @@ int function_netdata_streaming(BUFFER *wb, const char *function __maybe_unused, 
                 buffer_json_add_array_item_string(wb, NULL); // MlSilenced
             }
 
+            // MachineGUID + NodeID — hidden columns, to join streaming rows to the node inventory
+            buffer_json_add_array_item_string(wb, host->machine_guid); // MachineGUID
+            if(!UUIDiszero(host->node_id)) {
+                char node_id_str[UUID_STR_LEN];
+                uuid_unparse_lower(host->node_id.uuid, node_id_str);
+                buffer_json_add_array_item_string(wb, node_id_str); // NodeID
+            }
+            else
+                buffer_json_add_array_item_string(wb, NULL); // NodeID
+
             // close
             buffer_json_array_close(wb);
         }
@@ -878,6 +888,19 @@ int function_netdata_streaming(BUFFER *wb, const char *function __maybe_unused, 
                                     (double)max_ml_silenced,
                                     RRDF_FIELD_SORT_DESCENDING, NULL,
                                     RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_RANGE,
+                                    RRDF_FIELD_OPTS_NONE, NULL);
+
+        // MachineGUID + NodeID — hidden, used to join streaming rows to the node inventory
+        buffer_rrdf_table_add_field(wb, field_id++, "MachineGUID", "Machine GUID",
+                                    RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                                    RRDF_FIELD_OPTS_NONE, NULL);
+
+        buffer_rrdf_table_add_field(wb, field_id++, "NodeID", "Cloud Node ID",
+                                    RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
                                     RRDF_FIELD_OPTS_NONE, NULL);
     }
     buffer_json_object_close(wb); // columns


### PR DESCRIPTION
## Summary

Improves parent-side observability for streaming reception, so it is possible to diagnose why some children complete the streaming handshake but then never deliver metric data.

## Changes

- **`netdata-streaming` function:** add two hidden columns, `MachineGUID` and `NodeID`. They are appended at the end of each row and the column list (no existing column index shifts) and are not visible by default. They provide a stable, unique join key for the per-child rows — until now the function exposed only the hostname, which is not unique across nodes.

- **Receiver disconnect log:** `stream_receiver_remove_internal` now emits a single uniform line for every disconnect reason:

  ```
  receiver disconnected: reason="..." msgs=N bytes_in=N bytes_out=N connected=Ns idle=Ns repl=N% iface=...
  ```

  - `bytes_in` is a new per-receiver counter of raw bytes received on the connection. It distinguishes "the child sent nothing" from "the child sent data that did not parse" — previously only the parsed-message count was logged, which is `0` in both cases.
  - `iface` is the child's default network interface (host label `_net_default_iface`), so failures can be grouped by connectivity (for example cellular vs ethernet) from the logs alone.

- **No-traffic timeout origin:** the receiver no-traffic timeout is now measured from admission (when the parent starts reading the socket) instead of from connection accept, so the time a receiver spends waiting in the admission queue is not counted against the child.

## Notes

- The added function columns are appended and hidden, so existing consumers that key by column name (or rely on existing indices) are unaffected.
- The new `bytes_received` counter is owned by the receiver's dispatcher thread, so no locking is required. `bytes_out` and the replication percentage are read using the same patterns already used elsewhere in this file.
- The disconnect log replaces one line with one richer line; it does not add log lines per disconnect.

## Testing

- Both changed translation units compile cleanly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds receiver disconnect diagnostics and stable per-child join keys to make it easier to debug children that connect but never send metrics. Also starts the no-traffic timeout at admission to avoid penalizing queued connections.

- **New Features**
  - `netdata-streaming`: add hidden `MachineGUID` and `NodeID` columns (appended, not visible) to provide unique join keys; existing consumers remain unaffected.
  - Emit a single, uniform receiver disconnect log with reason, msgs, bytes_in, bytes_out, connected, idle, repl%, and default iface to distinguish silent vs unparsed data and group issues by connectivity.

- **Bug Fixes**
  - Measure the receiver no-traffic timeout from admission (when reading starts) instead of accept, excluding time spent in the admission queue.

<sup>Written for commit dfef8599315524258ba779c8eb9cb085cfd98d78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

