### PR TITLE
refactor(go.d/snmp): inject shared SNMP state

### DIFF
--- a/.agents/sow/specs/snmp-traps/netdata.md
+++ b/.agents/sow/specs/snmp-traps/netdata.md
@@ -784,7 +784,7 @@ _HOSTNAME=<the source device hostname from enrichment, or source IP when enrichm
 
 `_HOSTNAME` is normally a systemd "trusted field" set by journald; the trap plugin's journal writer writes directly to journal files through the Go-compatible backend selected in SOW-0035 M1 (bypassing journald) and controls every field, including `_HOSTNAME`. The hostname resolution priority is:
 
-1. **Vnode hostname** — when the SNMP polling job has an explicit `vnode.hostname` configured for the source device (available in the in-process `DeviceRegistry` as `VnodeHostname`).
+1. **Vnode hostname** — when the SNMP polling job has an explicit `vnode.hostname` configured for the source device (available from the injected SNMP device store as `VnodeHostname`).
 2. **SNMP sysName** — the device's self-reported `sysName` from polling state, unless empty or equal to literal `"unknown"` (case-insensitive).
 3. **SNMP/topology sysName** — the source device `sysName` from the topology cache when the trap source IP matches topology-managed IP state and the direct SNMP registry lookup missed, for example when the SNMP collector target was configured by DNS name but traps arrive from an IP.
 4. **Source IP** — the string form of the validated trap source IP. `_HOSTNAME` is always emitted; the source IP is the mandatory fallback when no enrichment identity exists.

--- a/src/go/plugin/go.d/collector/init.go
+++ b/src/go/plugin/go.d/collector/init.go
@@ -3,6 +3,11 @@
 package collector
 
 import (
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
+	snmptraps "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps"
+
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/activemq"
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/adaptecraid"
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/ap"
@@ -108,9 +113,6 @@ import (
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/scaleio"
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/sensors"
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/smartctl"
-	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp"
-	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
-	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps"
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/spigotmc"
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/sql"
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/squid"
@@ -140,3 +142,14 @@ import (
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/zfspool"
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/zookeeper"
 )
+
+func init() {
+	// These collectors share SNMP state; wire them together here instead of
+	// exposing package-global registries from the individual collector packages.
+	deviceStore := ddsnmp.NewDeviceStore()
+	trapEnrichment := snmptopology.NewTrapEnrichmentHandle()
+
+	snmp.Register(deviceStore)
+	snmptopology.Register(deviceStore, trapEnrichment)
+	snmptraps.Register(deviceStore, trapEnrichment)
+}

--- a/src/go/plugin/go.d/collector/init_test.go
+++ b/src/go/plugin/go.d/collector/init_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package collector
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp"
+	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
+	snmptraps "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSNMPFamilyRegistrationUsesSharedDependencies(t *testing.T) {
+	snmpCreator := requireCreator(t, "snmp")
+	topologyCreator := requireCreator(t, "snmp_topology")
+	trapsCreator := requireCreator(t, "snmp_traps")
+
+	assert.NotNil(t, snmpCreator.Create)
+	assert.Nil(t, snmpCreator.CreateV2)
+	assert.NotNil(t, snmpCreator.Config)
+	assert.NotNil(t, snmpCreator.Methods)
+	assert.NotNil(t, snmpCreator.MethodHandler)
+	assert.Equal(t, 10, snmpCreator.Defaults.UpdateEvery)
+
+	assert.Nil(t, topologyCreator.Create)
+	assert.NotNil(t, topologyCreator.CreateV2)
+	assert.Equal(t, collectorapi.InstancePolicySingle, topologyCreator.InstancePolicy)
+	assert.False(t, topologyCreator.FunctionOnly)
+	assert.NotNil(t, topologyCreator.Methods)
+	assert.NotNil(t, topologyCreator.MethodHandler)
+	assert.Equal(t, 60, topologyCreator.Defaults.UpdateEvery)
+
+	assert.Nil(t, trapsCreator.Create)
+	assert.NotNil(t, trapsCreator.CreateV2)
+	assert.NotNil(t, trapsCreator.Methods)
+	assert.NotNil(t, trapsCreator.MethodHandler)
+	assert.Equal(t, 1, trapsCreator.Defaults.UpdateEvery)
+
+	snmpCollector, ok := snmpCreator.Create().(*snmp.Collector)
+	require.True(t, ok)
+	topologyCollector, ok := topologyCreator.CreateV2().(*snmptopology.Collector)
+	require.True(t, ok)
+	trapsCollector, ok := trapsCreator.CreateV2().(*snmptraps.Collector)
+	require.True(t, ok)
+
+	deviceStore := pointerField(t, snmpCollector, "deviceStore")
+	require.NotZero(t, deviceStore)
+	assert.Equal(t, deviceStore, interfacePointerField(t, topologyCollector, "deviceSource"))
+	assert.Equal(t, deviceStore, interfacePointerField(t, trapsCollector, "deviceLookup"))
+
+	trapEnrichment := pointerField(t, topologyCollector, "trapEnrichment")
+	require.NotZero(t, trapEnrichment)
+	assert.Equal(t, trapEnrichment, interfacePointerField(t, trapsCollector, "topologyEnricher"))
+}
+
+func requireCreator(t *testing.T, module string) collectorapi.Creator {
+	t.Helper()
+	creator, ok := collectorapi.DefaultRegistry.Lookup(module)
+	require.True(t, ok, "collector %q is not registered", module)
+	return creator
+}
+
+func pointerField(t *testing.T, obj any, name string) uintptr {
+	t.Helper()
+	field := reflect.ValueOf(obj).Elem().FieldByName(name)
+	require.True(t, field.IsValid(), "field %q not found", name)
+	require.Equal(t, reflect.Pointer, field.Kind(), "field %q", name)
+	require.False(t, field.IsNil(), "field %q is nil", name)
+	return field.Pointer()
+}
+
+func interfacePointerField(t *testing.T, obj any, name string) uintptr {
+	t.Helper()
+	field := reflect.ValueOf(obj).Elem().FieldByName(name)
+	require.True(t, field.IsValid(), "field %q not found", name)
+	require.Equal(t, reflect.Interface, field.Kind(), "field %q", name)
+	require.False(t, field.IsNil(), "field %q is nil", name)
+
+	elem := field.Elem()
+	require.Equal(t, reflect.Pointer, elem.Kind(), "field %q concrete value", name)
+	require.False(t, elem.IsNil(), "field %q concrete value is nil", name)
+	return elem.Pointer()
+}

--- a/src/go/plugin/go.d/collector/snmp/bgp_typed_metrics_test.go
+++ b/src/go/plugin/go.d/collector/snmp/bgp_typed_metrics_test.go
@@ -291,7 +291,7 @@ func TestBGPIntegration_PreservesFunctionCacheOnProfileBGPError(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			collr := New()
+			collr := newTestSNMPCollector()
 			collr.sysInfo = &snmputils.SysInfo{}
 			collr.enableBGPIntegration()
 			collr.ddSnmpColl = &mockDdSnmpCollector{pms: tc.initial}
@@ -339,7 +339,7 @@ func TestBGPIntegration_RecoveryClearsStaleFunctionRows(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			collr := New()
+			collr := newTestSNMPCollector()
 			collr.sysInfo = &snmputils.SysInfo{}
 			collr.enableBGPIntegration()
 
@@ -401,7 +401,7 @@ func TestBGPIntegration_MixedProfileBGPErrorRefreshesSuccessfulProfiles(t *testi
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			collr := New()
+			collr := newTestSNMPCollector()
 			collr.sysInfo = &snmputils.SysInfo{}
 			collr.enableBGPIntegration()
 			collr.ddSnmpColl = &mockDdSnmpCollector{pms: tc.initial}
@@ -457,7 +457,7 @@ func TestBGPIntegration_ExpiredFailedProfileDoesNotKeepStaleRowsWithFreshProfile
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			collr := New()
+			collr := newTestSNMPCollector()
 			collr.sysInfo = &snmputils.SysInfo{}
 			collr.enableBGPIntegration()
 			collr.bgp.setStaleAfter(time.Minute)

--- a/src/go/plugin/go.d/collector/snmp/charts_test.go
+++ b/src/go/plugin/go.d/collector/snmp/charts_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCollector_AddProfileScalarMetricChart_LabelsIncludeMetricTags(t *testing.T) {
-	collr := New()
+	collr := newTestSNMPCollector()
 	collr.Hostname = "192.0.2.1"
 	collr.sysInfo = &snmputils.SysInfo{
 		Name:   "test-device",
@@ -132,7 +132,7 @@ func TestCollector_AddLicenseCharts_LazyBySignalClass(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			collr := New()
+			collr := newTestSNMPCollector()
 			collr.sysInfo = &snmputils.SysInfo{}
 			collr.addLicenseCharts(tc.agg)
 			collr.addLicenseCharts(tc.agg)

--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -140,7 +140,7 @@ func (c *Collector) ensureInitialized() error {
 		c.addPingCharts()
 	}
 
-	c.registerDeviceForTopology(si)
+	c.registerDeviceState(si)
 
 	return nil
 }

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -23,20 +23,32 @@ import (
 //go:embed "config_schema.json"
 var configSchema string
 
-func init() {
-	collectorapi.Register("snmp", collectorapi.Creator{
+// Register registers the SNMP collector with its shared SNMP-family device store.
+func Register(store *ddsnmp.DeviceStore) {
+	collectorapi.Register("snmp", newCreator(store))
+}
+
+func newCreator(store *ddsnmp.DeviceStore) collectorapi.Creator {
+	if store == nil {
+		panic("snmp Register requires a non-nil device store")
+	}
+	return collectorapi.Creator{
 		JobConfigSchema: configSchema,
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 10,
 		},
-		Create:        func() collectorapi.CollectorV1 { return New() },
+		Create:        func() collectorapi.CollectorV1 { return New(store) },
 		Config:        func() any { return &Config{} },
 		Methods:       snmpMethods,
 		MethodHandler: snmpFunctionHandler,
-	})
+	}
 }
 
-func New() *Collector {
+// New returns an SNMP collector. A nil store creates an isolated store for direct use.
+func New(store *ddsnmp.DeviceStore) *Collector {
+	if store == nil {
+		store = ddsnmp.NewDeviceStore()
+	}
 	c := &Collector{
 		Config: Config{
 			CreateVnode:              true,
@@ -70,6 +82,7 @@ func New() *Collector {
 		seenScalarMetrics: make(map[string]bool),
 		seenTableMetrics:  make(map[string]bool),
 		seenProfiles:      make(map[string]bool),
+		deviceStore:       store,
 
 		ifaceCache: newIfaceCache(),
 		licensing:  newLicensingIntegration(),
@@ -98,6 +111,7 @@ type (
 		seenScalarMetrics map[string]bool
 		seenTableMetrics  map[string]bool
 		seenProfiles      map[string]bool
+		deviceStore       *ddsnmp.DeviceStore
 
 		ifaceCache *ifaceCache // interface metrics cache for functions
 		licensing  *licensingIntegration
@@ -193,7 +207,9 @@ func (c *Collector) Cleanup(ctx context.Context) {
 	if c.funcRouter != nil {
 		c.funcRouter.Cleanup(ctx)
 	}
-	ddsnmp.DeviceRegistry.Unregister(c.deviceRegistryKey())
+	if c.deviceStore != nil {
+		c.deviceStore.Unregister(c.deviceStoreKey())
+	}
 	if c.snmpClient != nil {
 		_ = c.snmpClient.Close()
 	}

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -44,10 +44,10 @@ func newCreator(store *ddsnmp.DeviceStore) collectorapi.Creator {
 	}
 }
 
-// New returns an SNMP collector. A nil store creates an isolated store for direct use.
+// New returns an SNMP collector using the provided SNMP-family device store.
 func New(store *ddsnmp.DeviceStore) *Collector {
 	if store == nil {
-		store = ddsnmp.NewDeviceStore()
+		panic("snmp New requires a non-nil device store")
 	}
 	c := &Collector{
 		Config: Config{

--- a/src/go/plugin/go.d/collector/snmp/collector_licensing_edge_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_licensing_edge_test.go
@@ -70,7 +70,7 @@ func TestCollector_Collect_LicensingAggregation_ReadsTypedRowsAndIgnoresPrivateM
 			setMockClientInitExpect(mockSNMP)
 			setMockClientSysInfoExpect(mockSNMP)
 
-			collr := New()
+			collr := newTestSNMPCollector()
 			collr.Config = prepareV2Config()
 			collr.CreateVnode = false
 			collr.Ping.Enabled = false

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -52,6 +52,12 @@ func TestCollectorCreatorRequiresDeviceStore(t *testing.T) {
 	})
 }
 
+func TestCollectorNewRequiresDeviceStore(t *testing.T) {
+	require.PanicsWithValue(t, "snmp New requires a non-nil device store", func() {
+		_ = New(nil)
+	})
+}
+
 func TestCollector_Init(t *testing.T) {
 	tests := map[string]struct {
 		prepareSNMP func() *Collector

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -46,6 +46,12 @@ func TestCollector_ConfigurationSerialize(t *testing.T) {
 	collecttest.TestConfigurationSerialize(t, &Collector{}, dataConfigJSON, dataConfigYAML)
 }
 
+func TestCollectorCreatorRequiresDeviceStore(t *testing.T) {
+	require.PanicsWithValue(t, "snmp Register requires a non-nil device store", func() {
+		_ = newCreator(nil)
+	})
+}
+
 func TestCollector_Init(t *testing.T) {
 	tests := map[string]struct {
 		prepareSNMP func() *Collector
@@ -54,13 +60,13 @@ func TestCollector_Init(t *testing.T) {
 		"fail with default config": {
 			wantFail: true,
 			prepareSNMP: func() *Collector {
-				return New()
+				return newTestSNMPCollector()
 			},
 		},
 		"fail when using SNMPv3 but 'user.name' not set": {
 			wantFail: true,
 			prepareSNMP: func() *Collector {
-				collr := New()
+				collr := newTestSNMPCollector()
 				collr.Config = prepareV3Config()
 				collr.User.Name = ""
 				return collr
@@ -69,7 +75,7 @@ func TestCollector_Init(t *testing.T) {
 		"success when using SNMPv1 with valid config": {
 			wantFail: false,
 			prepareSNMP: func() *Collector {
-				collr := New()
+				collr := newTestSNMPCollector()
 				collr.Config = prepareV1Config()
 				return collr
 			},
@@ -77,7 +83,7 @@ func TestCollector_Init(t *testing.T) {
 		"success when using SNMPv2 with valid config": {
 			wantFail: false,
 			prepareSNMP: func() *Collector {
-				collr := New()
+				collr := newTestSNMPCollector()
 				collr.Config = prepareV2Config()
 				return collr
 			},
@@ -85,7 +91,7 @@ func TestCollector_Init(t *testing.T) {
 		"success when using SNMPv3 with valid config": {
 			wantFail: false,
 			prepareSNMP: func() *Collector {
-				collr := New()
+				collr := newTestSNMPCollector()
 				collr.Config = prepareV3Config()
 				return collr
 			},
@@ -108,7 +114,7 @@ func TestCollector_Init(t *testing.T) {
 func TestCollector_InitPassesSharedPingerConfig(t *testing.T) {
 	var gotCfg pinger.Config
 
-	collr := New()
+	collr := newTestSNMPCollector()
 	collr.Config = prepareV2Config()
 	collr.PingOnly = true
 	collr.Ping.Network = "ip6"
@@ -139,9 +145,14 @@ func TestCollector_Cleanup(t *testing.T) {
 	tests := map[string]struct {
 		prepareSNMP func(t *testing.T, m *snmpmock.MockHandler) *Collector
 	}{
+		"cleanup call does not panic on zero value collector": {
+			prepareSNMP: func(t *testing.T, m *snmpmock.MockHandler) *Collector {
+				return &Collector{}
+			},
+		},
 		"cleanup call does not panic if snmpClient not initialized": {
 			prepareSNMP: func(t *testing.T, m *snmpmock.MockHandler) *Collector {
-				collr := New()
+				collr := newTestSNMPCollector()
 				collr.Config = prepareV2Config()
 				collr.newSnmpClient = func() gosnmp.Handler { return m }
 				setMockClientInitExpect(m)
@@ -167,6 +178,46 @@ func TestCollector_Cleanup(t *testing.T) {
 	}
 }
 
+func TestCollector_CollectRegistersAndCleanupUnregistersDevice(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSNMP := snmpmock.NewMockHandler(ctrl)
+	setMockClientInitExpect(mockSNMP)
+	setMockClientSysInfoExpect(mockSNMP)
+	mockSNMP.EXPECT().Close().Return(nil).AnyTimes()
+
+	deviceStore := ddsnmp.NewDeviceStore()
+	collr := New(deviceStore)
+	collr.Config = prepareV2Config()
+	collr.CreateVnode = false
+	collr.Ping.Enabled = false
+	collr.snmpProfiles = []*ddsnmp.Profile{{}}
+	collr.newSnmpClient = func() gosnmp.Handler { return mockSNMP }
+	collr.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+		return &mockDdSnmpCollector{}
+	}
+
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+	require.Empty(t, deviceStore.Devices())
+
+	_ = collr.Collect(context.Background())
+
+	devices := deviceStore.Devices()
+	require.Len(t, devices, 1)
+	assert.Equal(t, "192.0.2.1", devices[0].Hostname)
+	assert.Equal(t, 161, devices[0].Port)
+	assert.Equal(t, gosnmp.Version2c.String(), devices[0].SNMPVersion)
+	assert.Equal(t, "mock sysName", devices[0].SysName)
+	assert.Equal(t, "mock sysDescr", devices[0].SysDescr)
+	assert.Equal(t, "mock sysContact", devices[0].SysContact)
+	assert.Equal(t, "mock sysLocation", devices[0].SysLocation)
+
+	collr.Cleanup(context.Background())
+	require.Empty(t, deviceStore.Devices())
+}
+
 func TestCollector_Check(t *testing.T) {
 	tests := map[string]struct {
 		prepare func(m *snmpmock.MockHandler) *Collector
@@ -178,7 +229,7 @@ func TestCollector_Check(t *testing.T) {
 				setMockClientInitExpect(m)
 				setMockClientSysInfoExpect(m)
 
-				c := New()
+				c := newTestSNMPCollector()
 				c.Config = prepareV2Config()
 				c.CreateVnode = false
 				c.Ping.Enabled = false
@@ -193,7 +244,7 @@ func TestCollector_Check(t *testing.T) {
 				setMockClientSetterExpect(m)
 				m.EXPECT().Connect().Return(errors.New("connect failed")).AnyTimes()
 
-				c := New()
+				c := newTestSNMPCollector()
 				c.Config = prepareV2Config()
 				c.CreateVnode = false
 				c.Ping.Enabled = false
@@ -214,7 +265,7 @@ func TestCollector_Check(t *testing.T) {
 					WalkAll(gomock.Any()).
 					Return(nil, errors.New("walk failed"))
 
-				c := New()
+				c := newTestSNMPCollector()
 				c.Config = prepareV2Config()
 				c.CreateVnode = false
 				c.Ping.Enabled = false
@@ -229,7 +280,7 @@ func TestCollector_Check(t *testing.T) {
 				setMockClientInitExpect(m)
 				setMockClientSysInfoExpect(m)
 
-				c := New()
+				c := newTestSNMPCollector()
 				c.Config = prepareV2Config()
 				c.PingOnly = true
 				c.CreateVnode = false
@@ -247,7 +298,7 @@ func TestCollector_Check(t *testing.T) {
 				setMockClientInitExpect(m)
 				setMockClientSysInfoExpect(m)
 
-				c := New()
+				c := newTestSNMPCollector()
 				c.Config = prepareV2Config()
 				c.PingOnly = true
 				c.CreateVnode = false
@@ -265,7 +316,7 @@ func TestCollector_Check(t *testing.T) {
 				setMockClientInitExpect(m)
 				setMockClientSysInfoExpect(m)
 
-				c := New()
+				c := newTestSNMPCollector()
 				c.Config = prepareV2Config()
 				c.PingOnly = true
 				c.CreateVnode = false
@@ -310,7 +361,7 @@ func TestCollector_CheckPingOnlyUsesReadOnlyProbing(t *testing.T) {
 
 	pingClient := &mockPingClient{sample: pingSuccessSample("192.0.2.1")}
 
-	collr := New()
+	collr := newTestSNMPCollector()
 	collr.Config = prepareV2Config()
 	collr.PingOnly = true
 	collr.CreateVnode = false
@@ -340,7 +391,7 @@ func TestCollector_Collect(t *testing.T) {
 				setMockClientInitExpect(m)
 				setMockClientSysInfoExpect(m)
 
-				collr := New()
+				collr := newTestSNMPCollector()
 				collr.Config = prepareV2Config()
 				collr.CreateVnode = false
 				collr.Ping.Enabled = false
@@ -400,7 +451,7 @@ func TestCollector_Collect(t *testing.T) {
 				setMockClientInitExpect(m)
 				setMockClientSysInfoExpect(m)
 
-				collr := New()
+				collr := newTestSNMPCollector()
 				collr.Config = prepareV2Config()
 				collr.CreateVnode = false
 				collr.Ping.Enabled = false
@@ -469,7 +520,7 @@ func TestCollector_Collect(t *testing.T) {
 			setMockClientInitExpect(m)
 			setMockClientSysInfoExpect(m)
 
-			collr := New()
+			collr := newTestSNMPCollector()
 			collr.Config = prepareV2Config()
 			collr.PingOnly = true
 			collr.CreateVnode = false
@@ -495,7 +546,7 @@ func TestCollector_Collect(t *testing.T) {
 			setMockClientInitExpect(m)
 			setMockClientSysInfoExpect(m)
 
-			collr := New()
+			collr := newTestSNMPCollector()
 			collr.Config = prepareV2Config()
 			collr.PingOnly = true
 			collr.CreateVnode = false
@@ -537,7 +588,7 @@ func TestCollector_CollectPingOnlyUsesTrackingProbing(t *testing.T) {
 
 	pingClient := &mockPingClient{sample: pingSuccessSample("192.0.2.1")}
 
-	collr := New()
+	collr := newTestSNMPCollector()
 	collr.Config = prepareV2Config()
 	collr.PingOnly = true
 	collr.CreateVnode = false
@@ -579,7 +630,7 @@ func TestCollector_CollectMixedModeCollectsSNMPAndPingMetrics(t *testing.T) {
 
 	pingClient := &mockPingClient{sample: pingSuccessSample("192.0.2.1")}
 
-	collr := New()
+	collr := newTestSNMPCollector()
 	collr.Config = prepareV2Config()
 	collr.CreateVnode = false
 	collr.Ping.Enabled = true
@@ -896,7 +947,7 @@ func TestCollector_Collect_LicensingAggregation(t *testing.T) {
 			setMockClientSysInfoExpect(mockSNMP)
 
 			now := time.Now().UTC()
-			collr := New()
+			collr := newTestSNMPCollector()
 			collr.Config = prepareV2Config()
 			collr.CreateVnode = false
 			collr.Ping.Enabled = false

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
@@ -11,7 +11,7 @@ import (
 )
 
 // DeviceConnectionInfo holds SNMP connection parameters for a device.
-// Registered by SNMP collector jobs, consumed by the topology collector.
+// Registered by SNMP collector jobs, consumed by SNMP-family modules.
 type DeviceConnectionInfo struct {
 	Hostname        string
 	Port            int
@@ -45,79 +45,70 @@ type DeviceConnectionInfo struct {
 	VnodeLabels   map[string]string
 }
 
-// DeviceRegistry is a global registry where SNMP jobs register their connection
-// info so the topology collector can discover which devices to poll.
-var DeviceRegistry = &deviceRegistry{
-	devices:    make(map[string]DeviceConnectionInfo),
-	byHostname: make(map[string]map[string]struct{}),
+// NewDeviceStore returns an empty SNMP device connection-state store.
+func NewDeviceStore() *DeviceStore {
+	return &DeviceStore{
+		devices:    make(map[string]DeviceConnectionInfo),
+		byHostname: make(map[string]map[string]struct{}),
+	}
 }
 
-type deviceRegistry struct {
+// DeviceStore holds SNMP device connection state shared between SNMP-family modules.
+type DeviceStore struct {
 	mu         sync.RWMutex
 	devices    map[string]DeviceConnectionInfo
 	byHostname map[string]map[string]struct{}
 }
 
-// Register adds or updates a device in the registry.
+// Register adds or updates a device in the store.
 // Reference types are deep-copied to prevent data races with the caller.
-func (r *deviceRegistry) Register(key string, info DeviceConnectionInfo) {
-	r.mu.Lock()
-	r.ensureMapsLocked()
-	if old, ok := r.devices[key]; ok {
-		r.removeHostnameIndexLocked(key, old.Hostname)
+func (s *DeviceStore) Register(key string, info DeviceConnectionInfo) {
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	if old, ok := s.devices[key]; ok {
+		s.removeHostnameIndexLocked(key, old.Hostname)
 	}
-	r.devices[key] = cloneDeviceConnectionInfo(info)
-	r.addHostnameIndexLocked(key, info.Hostname)
-	r.mu.Unlock()
+	s.devices[key] = cloneDeviceConnectionInfo(info)
+	s.addHostnameIndexLocked(key, info.Hostname)
+	s.mu.Unlock()
 }
 
-// Unregister removes a device from the registry.
-func (r *deviceRegistry) Unregister(key string) {
-	r.mu.Lock()
-	if old, ok := r.devices[key]; ok {
-		r.removeHostnameIndexLocked(key, old.Hostname)
+// Unregister removes a device from the store.
+func (s *DeviceStore) Unregister(key string) {
+	s.mu.Lock()
+	if old, ok := s.devices[key]; ok {
+		s.removeHostnameIndexLocked(key, old.Hostname)
 	}
-	delete(r.devices, key)
-	r.mu.Unlock()
+	delete(s.devices, key)
+	s.mu.Unlock()
 }
 
 // Devices returns a deep-copied snapshot of all registered devices.
-func (r *deviceRegistry) Devices() []DeviceConnectionInfo {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+func (s *DeviceStore) Devices() []DeviceConnectionInfo {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	devices := make([]DeviceConnectionInfo, 0, len(r.devices))
-	for _, info := range r.devices {
+	devices := make([]DeviceConnectionInfo, 0, len(s.devices))
+	for _, info := range s.devices {
 		devices = append(devices, cloneDeviceConnectionInfo(info))
 	}
 	return devices
 }
 
-// DeviceByHostname returns a deep-copied registered device whose configured
-// hostname matches the provided value. IP literals are normalized before
-// comparison; DNS names are matched case-insensitively.
-func (r *deviceRegistry) DeviceByHostname(hostname string) (DeviceConnectionInfo, bool) {
-	devices := r.DevicesByHostname(hostname)
-	if len(devices) == 0 {
-		return DeviceConnectionInfo{}, false
-	}
-	return devices[0], true
-}
-
 // DevicesByHostname returns all deep-copied registered devices whose configured
 // hostname matches the provided value. IP literals are normalized before
 // comparison; DNS names are matched case-insensitively.
-func (r *deviceRegistry) DevicesByHostname(hostname string) []DeviceConnectionInfo {
+func (s *DeviceStore) DevicesByHostname(hostname string) []DeviceConnectionInfo {
 	hostnameKey := deviceHostnameIndexKey(hostname)
 	if hostnameKey == "" {
 		return nil
 	}
 
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	if r.byHostname != nil {
-		keySet := r.byHostname[hostnameKey]
+	if s.byHostname != nil {
+		keySet := s.byHostname[hostnameKey]
 		if len(keySet) == 0 {
 			return nil
 		}
@@ -129,7 +120,7 @@ func (r *deviceRegistry) DevicesByHostname(hostname string) []DeviceConnectionIn
 
 		devices := make([]DeviceConnectionInfo, 0, len(keys))
 		for _, key := range keys {
-			info, ok := r.devices[key]
+			info, ok := s.devices[key]
 			if ok {
 				devices = append(devices, cloneDeviceConnectionInfo(info))
 			}
@@ -138,19 +129,12 @@ func (r *deviceRegistry) DevicesByHostname(hostname string) []DeviceConnectionIn
 	}
 
 	devices := make([]DeviceConnectionInfo, 0, 1)
-	for _, info := range r.devices {
+	for _, info := range s.devices {
 		if deviceHostnameIndexKey(info.Hostname) == hostnameKey {
 			devices = append(devices, cloneDeviceConnectionInfo(info))
 		}
 	}
 	return devices
-}
-
-// Len returns the number of registered devices.
-func (r *deviceRegistry) Len() int {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return len(r.devices)
 }
 
 func cloneDeviceConnectionInfo(info DeviceConnectionInfo) DeviceConnectionInfo {
@@ -166,46 +150,46 @@ func cloneDeviceConnectionInfo(info DeviceConnectionInfo) DeviceConnectionInfo {
 	return dev
 }
 
-func (r *deviceRegistry) ensureMapsLocked() {
-	if r.devices == nil {
-		r.devices = make(map[string]DeviceConnectionInfo)
+func (s *DeviceStore) ensureMapsLocked() {
+	if s.devices == nil {
+		s.devices = make(map[string]DeviceConnectionInfo)
 	}
-	if r.byHostname == nil {
-		r.byHostname = make(map[string]map[string]struct{})
-		for key, info := range r.devices {
-			r.addHostnameIndexLocked(key, info.Hostname)
+	if s.byHostname == nil {
+		s.byHostname = make(map[string]map[string]struct{})
+		for key, info := range s.devices {
+			s.addHostnameIndexLocked(key, info.Hostname)
 		}
 	}
 }
 
-func (r *deviceRegistry) addHostnameIndexLocked(key, hostname string) {
+func (s *DeviceStore) addHostnameIndexLocked(key, hostname string) {
 	hostnameKey := deviceHostnameIndexKey(hostname)
 	if hostnameKey == "" {
 		return
 	}
-	if r.byHostname == nil {
-		r.byHostname = make(map[string]map[string]struct{})
+	if s.byHostname == nil {
+		s.byHostname = make(map[string]map[string]struct{})
 	}
-	keySet := r.byHostname[hostnameKey]
+	keySet := s.byHostname[hostnameKey]
 	if keySet == nil {
 		keySet = make(map[string]struct{})
-		r.byHostname[hostnameKey] = keySet
+		s.byHostname[hostnameKey] = keySet
 	}
 	keySet[key] = struct{}{}
 }
 
-func (r *deviceRegistry) removeHostnameIndexLocked(key, hostname string) {
+func (s *DeviceStore) removeHostnameIndexLocked(key, hostname string) {
 	hostnameKey := deviceHostnameIndexKey(hostname)
-	if hostnameKey == "" || r.byHostname == nil {
+	if hostnameKey == "" || s.byHostname == nil {
 		return
 	}
-	keySet := r.byHostname[hostnameKey]
+	keySet := s.byHostname[hostnameKey]
 	if keySet == nil {
 		return
 	}
 	delete(keySet, key)
 	if len(keySet) == 0 {
-		delete(r.byHostname, hostnameKey)
+		delete(s.byHostname, hostnameKey)
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeviceRegistryDeviceByHostname(t *testing.T) {
-	reg := &deviceRegistry{devices: make(map[string]DeviceConnectionInfo)}
+func TestDeviceStoreDevicesByHostname(t *testing.T) {
+	reg := NewDeviceStore()
 	reg.Register("switch-a", DeviceConnectionInfo{
 		Hostname:       "192.0.2.10",
 		SysName:        "switch-a",
@@ -17,58 +17,57 @@ func TestDeviceRegistryDeviceByHostname(t *testing.T) {
 		VnodeLabels:    map[string]string{"site": "lab"},
 	})
 
-	dev, ok := reg.DeviceByHostname("::ffff:192.0.2.10")
-	require.True(t, ok)
+	devices := reg.DevicesByHostname("::ffff:192.0.2.10")
+	require.Len(t, devices, 1)
+	dev := devices[0]
 	require.Equal(t, "switch-a", dev.SysName)
 
 	dev.ManualProfiles[0] = "changed"
 	dev.VnodeLabels["site"] = "changed"
 
-	again, ok := reg.DeviceByHostname("192.0.2.10")
-	require.True(t, ok)
-	require.Equal(t, []string{"profile-a"}, again.ManualProfiles)
-	require.Equal(t, "lab", again.VnodeLabels["site"])
+	again := reg.DevicesByHostname("192.0.2.10")
+	require.Len(t, again, 1)
+	require.Equal(t, []string{"profile-a"}, again[0].ManualProfiles)
+	require.Equal(t, "lab", again[0].VnodeLabels["site"])
 }
 
-func TestDeviceRegistryDeviceByHostnameNoMatch(t *testing.T) {
-	reg := &deviceRegistry{devices: make(map[string]DeviceConnectionInfo)}
+func TestDeviceStoreDevicesByHostnameNoMatch(t *testing.T) {
+	reg := NewDeviceStore()
 	reg.Register("switch-a", DeviceConnectionInfo{Hostname: "switch-a.example.com"})
 
-	_, ok := reg.DeviceByHostname("switch-b.example.com")
-	require.False(t, ok)
+	require.Empty(t, reg.DevicesByHostname("switch-b.example.com"))
 }
 
-func TestDeviceRegistryDeviceByHostnameMatchesDNSCaseInsensitive(t *testing.T) {
-	reg := &deviceRegistry{devices: make(map[string]DeviceConnectionInfo)}
+func TestDeviceStoreDevicesByHostnameMatchesDNSCaseInsensitive(t *testing.T) {
+	reg := NewDeviceStore()
 	reg.Register("switch-a", DeviceConnectionInfo{Hostname: "Switch-A.Example.COM"})
 
-	_, ok := reg.DeviceByHostname("switch-a.example.com")
-	require.True(t, ok)
+	require.Len(t, reg.DevicesByHostname("switch-a.example.com"), 1)
 }
 
-func TestDeviceRegistryDeviceByHostnameIndexUpdatesOnRegisterAndUnregister(t *testing.T) {
-	reg := &deviceRegistry{devices: make(map[string]DeviceConnectionInfo)}
+func TestDeviceStoreDevicesByHostnameIndexUpdatesOnRegisterAndUnregister(t *testing.T) {
+	reg := NewDeviceStore()
 	reg.Register("switch-a", DeviceConnectionInfo{Hostname: "192.0.2.10", SysName: "switch-a"})
 
-	dev, ok := reg.DeviceByHostname("192.0.2.10")
-	require.True(t, ok)
+	devices := reg.DevicesByHostname("192.0.2.10")
+	require.Len(t, devices, 1)
+	dev := devices[0]
 	require.Equal(t, "switch-a", dev.SysName)
 
 	reg.Register("switch-a", DeviceConnectionInfo{Hostname: "192.0.2.11", SysName: "switch-a-renumbered"})
 
-	_, ok = reg.DeviceByHostname("192.0.2.10")
-	require.False(t, ok)
-	dev, ok = reg.DeviceByHostname("192.0.2.11")
-	require.True(t, ok)
+	require.Empty(t, reg.DevicesByHostname("192.0.2.10"))
+	devices = reg.DevicesByHostname("192.0.2.11")
+	require.Len(t, devices, 1)
+	dev = devices[0]
 	require.Equal(t, "switch-a-renumbered", dev.SysName)
 
 	reg.Unregister("switch-a")
-	_, ok = reg.DeviceByHostname("192.0.2.11")
-	require.False(t, ok)
+	require.Empty(t, reg.DevicesByHostname("192.0.2.11"))
 }
 
-func TestDeviceRegistryDevicesByHostnameReturnsAllMatches(t *testing.T) {
-	reg := &deviceRegistry{devices: make(map[string]DeviceConnectionInfo)}
+func TestDeviceStoreDevicesByHostnameReturnsAllMatches(t *testing.T) {
+	reg := NewDeviceStore()
 	reg.Register("switch-b", DeviceConnectionInfo{Hostname: "192.0.2.10", SysName: "switch-b"})
 	reg.Register("switch-a", DeviceConnectionInfo{Hostname: "::ffff:192.0.2.10", SysName: "switch-a"})
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
@@ -9,15 +9,15 @@ import (
 )
 
 func TestDeviceStoreDevicesByHostname(t *testing.T) {
-	reg := NewDeviceStore()
-	reg.Register("switch-a", DeviceConnectionInfo{
+	store := NewDeviceStore()
+	store.Register("switch-a", DeviceConnectionInfo{
 		Hostname:       "192.0.2.10",
 		SysName:        "switch-a",
 		ManualProfiles: []string{"profile-a"},
 		VnodeLabels:    map[string]string{"site": "lab"},
 	})
 
-	devices := reg.DevicesByHostname("::ffff:192.0.2.10")
+	devices := store.DevicesByHostname("::ffff:192.0.2.10")
 	require.Len(t, devices, 1)
 	dev := devices[0]
 	require.Equal(t, "switch-a", dev.SysName)
@@ -25,58 +25,76 @@ func TestDeviceStoreDevicesByHostname(t *testing.T) {
 	dev.ManualProfiles[0] = "changed"
 	dev.VnodeLabels["site"] = "changed"
 
-	again := reg.DevicesByHostname("192.0.2.10")
+	again := store.DevicesByHostname("192.0.2.10")
 	require.Len(t, again, 1)
 	require.Equal(t, []string{"profile-a"}, again[0].ManualProfiles)
 	require.Equal(t, "lab", again[0].VnodeLabels["site"])
 }
 
 func TestDeviceStoreDevicesByHostnameNoMatch(t *testing.T) {
-	reg := NewDeviceStore()
-	reg.Register("switch-a", DeviceConnectionInfo{Hostname: "switch-a.example.com"})
+	store := NewDeviceStore()
+	store.Register("switch-a", DeviceConnectionInfo{Hostname: "switch-a.example.com"})
 
-	require.Empty(t, reg.DevicesByHostname("switch-b.example.com"))
+	require.Empty(t, store.DevicesByHostname("switch-b.example.com"))
 }
 
 func TestDeviceStoreDevicesByHostnameMatchesDNSCaseInsensitive(t *testing.T) {
-	reg := NewDeviceStore()
-	reg.Register("switch-a", DeviceConnectionInfo{Hostname: "Switch-A.Example.COM"})
+	store := NewDeviceStore()
+	store.Register("switch-a", DeviceConnectionInfo{Hostname: "Switch-A.Example.COM"})
 
-	require.Len(t, reg.DevicesByHostname("switch-a.example.com"), 1)
+	require.Len(t, store.DevicesByHostname("switch-a.example.com"), 1)
 }
 
 func TestDeviceStoreDevicesByHostnameIndexUpdatesOnRegisterAndUnregister(t *testing.T) {
-	reg := NewDeviceStore()
-	reg.Register("switch-a", DeviceConnectionInfo{Hostname: "192.0.2.10", SysName: "switch-a"})
+	store := NewDeviceStore()
+	store.Register("switch-a", DeviceConnectionInfo{Hostname: "192.0.2.10", SysName: "switch-a"})
 
-	devices := reg.DevicesByHostname("192.0.2.10")
+	devices := store.DevicesByHostname("192.0.2.10")
 	require.Len(t, devices, 1)
 	dev := devices[0]
 	require.Equal(t, "switch-a", dev.SysName)
 
-	reg.Register("switch-a", DeviceConnectionInfo{Hostname: "192.0.2.11", SysName: "switch-a-renumbered"})
+	store.Register("switch-a", DeviceConnectionInfo{Hostname: "192.0.2.11", SysName: "switch-a-renumbered"})
 
-	require.Empty(t, reg.DevicesByHostname("192.0.2.10"))
-	devices = reg.DevicesByHostname("192.0.2.11")
+	require.Empty(t, store.DevicesByHostname("192.0.2.10"))
+	devices = store.DevicesByHostname("192.0.2.11")
 	require.Len(t, devices, 1)
 	dev = devices[0]
 	require.Equal(t, "switch-a-renumbered", dev.SysName)
 
-	reg.Unregister("switch-a")
-	require.Empty(t, reg.DevicesByHostname("192.0.2.11"))
+	store.Unregister("switch-a")
+	require.Empty(t, store.DevicesByHostname("192.0.2.11"))
 }
 
 func TestDeviceStoreDevicesByHostnameReturnsAllMatches(t *testing.T) {
-	reg := NewDeviceStore()
-	reg.Register("switch-b", DeviceConnectionInfo{Hostname: "192.0.2.10", SysName: "switch-b"})
-	reg.Register("switch-a", DeviceConnectionInfo{Hostname: "::ffff:192.0.2.10", SysName: "switch-a"})
+	store := NewDeviceStore()
+	store.Register("switch-b", DeviceConnectionInfo{Hostname: "192.0.2.10", SysName: "switch-b"})
+	store.Register("switch-a", DeviceConnectionInfo{Hostname: "::ffff:192.0.2.10", SysName: "switch-a"})
 
-	devices := reg.DevicesByHostname("192.0.2.10")
+	devices := store.DevicesByHostname("192.0.2.10")
 	require.Len(t, devices, 2)
 	require.Equal(t, "switch-a", devices[0].SysName)
 	require.Equal(t, "switch-b", devices[1].SysName)
 
 	devices[0].SysName = "changed"
-	again := reg.DevicesByHostname("192.0.2.10")
+	again := store.DevicesByHostname("192.0.2.10")
 	require.Equal(t, "switch-a", again[0].SysName)
+}
+
+func TestDeviceStoreRegisterClonesReferenceFields(t *testing.T) {
+	store := NewDeviceStore()
+	info := DeviceConnectionInfo{
+		Hostname:       "192.0.2.10",
+		ManualProfiles: []string{"profile-a"},
+		VnodeLabels:    map[string]string{"site": "lab"},
+	}
+
+	store.Register("switch-a", info)
+	info.ManualProfiles[0] = "changed"
+	info.VnodeLabels["site"] = "changed"
+
+	devices := store.Devices()
+	require.Len(t, devices, 1)
+	require.Equal(t, []string{"profile-a"}, devices[0].ManualProfiles)
+	require.Equal(t, "lab", devices[0].VnodeLabels["site"])
 }

--- a/src/go/plugin/go.d/collector/snmp/device_state.go
+++ b/src/go/plugin/go.d/collector/snmp/device_state.go
@@ -42,14 +42,17 @@ func (c *Collector) vnodeLabels() map[string]string {
 	return nil
 }
 
-func (c *Collector) deviceRegistryKey() string {
+func (c *Collector) deviceStoreKey() string {
 	return fmt.Sprintf("%p:%s:%d", c, c.Hostname, c.Options.Port)
 }
 
-// registerDeviceForTopology exposes the already-configured SNMP job to the
-// snmp_topology collector without duplicating job configuration.
-func (c *Collector) registerDeviceForTopology(si *snmputils.SysInfo) {
-	ddsnmp.DeviceRegistry.Register(c.deviceRegistryKey(), ddsnmp.DeviceConnectionInfo{
+// registerDeviceState exposes the already-configured SNMP job to SNMP-family
+// consumers without duplicating job configuration.
+func (c *Collector) registerDeviceState(si *snmputils.SysInfo) {
+	if c.deviceStore == nil {
+		return
+	}
+	c.deviceStore.Register(c.deviceStoreKey(), ddsnmp.DeviceConnectionInfo{
 		Hostname:        c.Hostname,
 		Port:            c.Options.Port,
 		SNMPVersion:     c.Options.Version,

--- a/src/go/plugin/go.d/collector/snmp/func_bgp_peers_test.go
+++ b/src/go/plugin/go.d/collector/snmp/func_bgp_peers_test.go
@@ -428,7 +428,7 @@ func TestCollector_BGPFunctionHandlerIsAlwaysRegistered(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			collr := New()
+			collr := newTestSNMPCollector()
 			if tc.prepare != nil {
 				tc.prepare(collr)
 			}
@@ -453,7 +453,7 @@ func TestCollectSNMP_HidesBGPDiagnosticsButKeepsFunctionCache(t *testing.T) {
 	setMockClientInitExpect(mockSNMP)
 	setMockClientSysInfoExpect(mockSNMP)
 
-	collr := New()
+	collr := newTestSNMPCollector()
 	collr.Config = prepareV2Config()
 	collr.CreateVnode = false
 	collr.Ping.Enabled = false

--- a/src/go/plugin/go.d/collector/snmp/test_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp/test_helpers_test.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmp
+
+import "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+
+func newTestSNMPCollector() *Collector {
+	return New(ddsnmp.NewDeviceStore())
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/charts_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/charts_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestCollector_ChartTemplateYAML(t *testing.T) {
-	raw := New().ChartTemplateYAML()
+	raw := newTestSNMPTopologyCollector().ChartTemplateYAML()
 	collecttest.AssertChartTemplateSchema(t, raw)
 
 	spec, err := charttpl.DecodeYAML([]byte(raw))

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -25,33 +25,52 @@ import (
 //go:embed "config_schema.json"
 var configSchema string
 
-func init() {
-	collectorapi.Register("snmp_topology", collectorapi.Creator{
+// Register registers the SNMP topology collector with shared SNMP-family state.
+func Register(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmentHandle) {
+	collectorapi.Register("snmp_topology", newCreator(deviceStore, trapEnrichment))
+}
+
+func newCreator(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmentHandle) collectorapi.Creator {
+	if deviceStore == nil {
+		panic("snmp_topology Register requires a non-nil device store")
+	}
+	if trapEnrichment == nil {
+		panic("snmp_topology Register requires a non-nil trap enrichment handle")
+	}
+	return collectorapi.Creator{
 		JobConfigSchema: configSchema,
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 60,
 		},
-		CreateV2:       func() collectorapi.CollectorV2 { return New() },
+		CreateV2:       func() collectorapi.CollectorV2 { return New(deviceStore, trapEnrichment) },
 		Config:         func() any { return &Config{} },
 		InstancePolicy: collectorapi.InstancePolicySingle,
 		Methods:        topologyMethods,
 		MethodHandler:  topologyFunctionHandler,
-	})
+	}
 }
 
-func New() *Collector {
-	store := metrix.NewCollectorStore()
+// New returns an SNMP topology collector. Nil dependencies create isolated state for direct use.
+func New(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmentHandle) *Collector {
+	if deviceStore == nil {
+		deviceStore = ddsnmp.NewDeviceStore()
+	}
+	if trapEnrichment == nil {
+		trapEnrichment = NewTrapEnrichmentHandle()
+	}
+	metricStore := metrix.NewCollectorStore()
 	return &Collector{
 		deviceCaches:        make(map[string]*topologyCache),
 		deviceLastCollected: make(map[string]time.Time),
 		topologyRegistry:    newTopologyRegistry(),
-		registeredDevices:   ddsnmp.DeviceRegistry.Devices,
+		deviceSource:        deviceStore,
+		trapEnrichment:      trapEnrichment,
 		newSnmpClient:       gosnmp.NewHandler,
 		newDdSnmpColl: func(cfg ddsnmpcollector.Config) ddCollector {
 			return ddsnmpcollector.New(cfg)
 		},
-		store:   store,
-		metrics: newCollectorMetrics(store),
+		store:   metricStore,
+		metrics: newCollectorMetrics(metricStore),
 	}
 }
 
@@ -64,6 +83,8 @@ type (
 		deviceLastCollected map[string]time.Time      // last collection time per device
 		topologyCache       *topologyCache            // current device cache (set during refreshDeviceTopology)
 		topologyRegistry    *topologyRegistry
+		deviceSource        deviceSource
+		trapEnrichment      *TrapEnrichmentHandle
 
 		refreshMu sync.Mutex
 		statsMu   sync.RWMutex
@@ -72,10 +93,12 @@ type (
 		store   metrix.CollectorStore
 		metrics *collectorMetrics
 
-		registeredDevices func() []ddsnmp.DeviceConnectionInfo
-		topologyProfiles  func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile
-		newSnmpClient     func() gosnmp.Handler
-		newDdSnmpColl     func(ddsnmpcollector.Config) ddCollector
+		topologyProfiles func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile
+		newSnmpClient    func() gosnmp.Handler
+		newDdSnmpColl    func(ddsnmpcollector.Config) ddCollector
+	}
+	deviceSource interface {
+		Devices() []ddsnmp.DeviceConnectionInfo
 	}
 	ddCollector interface {
 		Collect() ([]*ddsnmp.ProfileMetrics, error)
@@ -203,10 +226,10 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 }
 
 func (c *Collector) getRegisteredDevices() []ddsnmp.DeviceConnectionInfo {
-	if c.registeredDevices == nil {
+	if c.deviceSource == nil {
 		return nil
 	}
-	return c.registeredDevices()
+	return c.deviceSource.Devices()
 }
 
 func (c *Collector) refreshTopologyRecovering(ctx context.Context) {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -50,13 +50,13 @@ func newCreator(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmentH
 	}
 }
 
-// New returns an SNMP topology collector. Nil dependencies create isolated state for direct use.
+// New returns an SNMP topology collector using the provided SNMP-family state.
 func New(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmentHandle) *Collector {
 	if deviceStore == nil {
-		deviceStore = ddsnmp.NewDeviceStore()
+		panic("snmp_topology New requires a non-nil device store")
 	}
 	if trapEnrichment == nil {
-		trapEnrichment = NewTrapEnrichmentHandle()
+		panic("snmp_topology New requires a non-nil trap enrichment handle")
 	}
 	metricStore := metrix.NewCollectorStore()
 	return &Collector{

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -18,15 +18,35 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
 )
 
+func TestCollectorGetRegisteredDevicesUsesInjectedDeviceStore(t *testing.T) {
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	registerTestDeviceState(store, ddsnmp.DeviceConnectionInfo{
+		Hostname:       "192.0.2.10",
+		Port:           161,
+		ManualProfiles: []string{"profile-a"},
+		VnodeLabels:    map[string]string{"site": "lab"},
+	})
+
+	devices := coll.getRegisteredDevices()
+	require.Len(t, devices, 1)
+	require.Equal(t, "192.0.2.10", devices[0].Hostname)
+
+	devices[0].ManualProfiles[0] = "changed"
+	devices[0].VnodeLabels["site"] = "changed"
+
+	again := coll.getRegisteredDevices()
+	require.Len(t, again, 1)
+	require.Equal(t, []string{"profile-a"}, again[0].ManualProfiles)
+	require.Equal(t, "lab", again[0].VnodeLabels["site"])
+}
+
 func TestCollectorValidationLifecycleDoesNotStartPolling(t *testing.T) {
-	coll := New()
+	coll, store := newTestSNMPTopologyCollectorWithStore()
 	coll.UpdateEvery = 3600
-	coll.registeredDevices = func() []ddsnmp.DeviceConnectionInfo {
-		return []ddsnmp.DeviceConnectionInfo{{
-			Hostname: "192.0.2.10",
-			Port:     161,
-		}}
-	}
+	registerTestDeviceState(store, ddsnmp.DeviceConnectionInfo{
+		Hostname: "192.0.2.10",
+		Port:     161,
+	})
 	coll.newSnmpClient = func() gosnmp.Handler {
 		t.Fatal("validation lifecycle must not start topology polling")
 		return nil
@@ -39,14 +59,12 @@ func TestCollectorValidationLifecycleDoesNotStartPolling(t *testing.T) {
 }
 
 func TestCollectorRunRefreshesImmediatelyBeforeUpdateEvery(t *testing.T) {
-	coll := New()
+	coll, store := newTestSNMPTopologyCollectorWithStore()
 	coll.UpdateEvery = 3600
-	coll.registeredDevices = func() []ddsnmp.DeviceConnectionInfo {
-		return []ddsnmp.DeviceConnectionInfo{{
-			Hostname: "192.0.2.10",
-			Port:     161,
-		}}
-	}
+	registerTestDeviceState(store, ddsnmp.DeviceConnectionInfo{
+		Hostname: "192.0.2.10",
+		Port:     161,
+	})
 
 	refreshed := make(chan struct{}, 1)
 	coll.newSnmpClient = func() gosnmp.Handler {
@@ -87,7 +105,7 @@ func TestCollectorRunRefreshesImmediatelyBeforeUpdateEvery(t *testing.T) {
 }
 
 func TestCollectorRunStopsOnContextCancel(t *testing.T) {
-	coll := New()
+	coll := newTestSNMPTopologyCollector()
 	coll.UpdateEvery = 3600
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -106,13 +124,11 @@ func TestCollectorRunStopsOnContextCancel(t *testing.T) {
 }
 
 func TestCollectorRunDoesNotPollWhenContextAlreadyCanceled(t *testing.T) {
-	coll := New()
-	coll.registeredDevices = func() []ddsnmp.DeviceConnectionInfo {
-		return []ddsnmp.DeviceConnectionInfo{{
-			Hostname: "192.0.2.10",
-			Port:     161,
-		}}
-	}
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	registerTestDeviceState(store, ddsnmp.DeviceConnectionInfo{
+		Hostname: "192.0.2.10",
+		Port:     161,
+	})
 	coll.newSnmpClient = func() gosnmp.Handler {
 		t.Fatal("Run must not poll with an already canceled context")
 		return nil
@@ -125,13 +141,12 @@ func TestCollectorRunDoesNotPollWhenContextAlreadyCanceled(t *testing.T) {
 }
 
 func TestCollectorPruneStaleDeviceCachesRemovesLastDeviceCache(t *testing.T) {
-	coll := New()
+	coll := newTestSNMPTopologyCollector()
 	cache := newTopologyCache()
 	coll.deviceCaches["gone:161"] = cache
 	coll.deviceLastCollected["gone:161"] = time.Now()
 	coll.topologyRegistry.register(cache)
 
-	coll.registeredDevices = func() []ddsnmp.DeviceConnectionInfo { return nil }
 	coll.refreshTopology(context.Background())
 
 	require.Empty(t, coll.deviceCaches)
@@ -140,13 +155,11 @@ func TestCollectorPruneStaleDeviceCachesRemovesLastDeviceCache(t *testing.T) {
 }
 
 func TestCollectorRefreshTopologyRecoveringHandlesPanic(t *testing.T) {
-	coll := New()
-	coll.registeredDevices = func() []ddsnmp.DeviceConnectionInfo {
-		return []ddsnmp.DeviceConnectionInfo{{
-			Hostname: "192.0.2.10",
-			Port:     161,
-		}}
-	}
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	registerTestDeviceState(store, ddsnmp.DeviceConnectionInfo{
+		Hostname: "192.0.2.10",
+		Port:     161,
+	})
 	coll.newSnmpClient = func() gosnmp.Handler {
 		panic("boom")
 	}
@@ -192,11 +205,9 @@ func TestCollectorRunCancelsInFlightRefresh(t *testing.T) {
 		return nil
 	}).AnyTimes()
 
-	coll := New()
+	coll, store := newTestSNMPTopologyCollectorWithStore()
 	coll.UpdateEvery = 3600
-	coll.registeredDevices = func() []ddsnmp.DeviceConnectionInfo {
-		return []ddsnmp.DeviceConnectionInfo{dev}
-	}
+	registerTestDeviceState(store, dev)
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
 	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile {
 		return []*ddsnmp.Profile{{}}
@@ -258,7 +269,7 @@ func TestCollectorCancelsInFlightVLANContextRefresh(t *testing.T) {
 		return nil
 	}).AnyTimes()
 
-	coll := New()
+	coll := newTestSNMPTopologyCollector()
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
 	collectStarted := make(chan struct{})
 	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
@@ -292,7 +303,7 @@ func TestCollectorCancelsInFlightVLANContextRefresh(t *testing.T) {
 }
 
 func TestCollectorNewDeviceCollectionCacheUsesEffectiveDeviceCheckEvery(t *testing.T) {
-	coll := New()
+	coll := newTestSNMPTopologyCollector()
 
 	cache := coll.newDeviceCollectionCache(ddsnmp.DeviceConnectionInfo{Hostname: "switch-a"})
 
@@ -319,7 +330,7 @@ func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T
 	release := make(chan struct{})
 	done := make(chan struct{})
 
-	coll := New()
+	coll := newTestSNMPTopologyCollector()
 	coll.deviceCaches[key] = published
 	coll.topologyRegistry.register(published)
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }

--- a/src/go/plugin/go.d/collector/snmp_topology/config.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/config.go
@@ -5,7 +5,7 @@ package snmptopology
 import "github.com/netdata/netdata/go/plugins/pkg/confopt"
 
 // Config for the snmp_topology module.
-// This module has a single global collector instance; devices come from the SNMP device registry.
+// This module has a single process-level collector instance; devices come from the injected SNMP device store.
 type Config struct {
 	UpdateEvery  int                  `yaml:"update_every,omitempty" json:"update_every"`
 	RefreshEvery confopt.LongDuration `yaml:"refresh_every,omitempty" json:"refresh_every,omitempty"`

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_presentation_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_presentation_test.go
@@ -52,6 +52,15 @@ func TestSNMPTopologyCreatorRequiresSharedDependencies(t *testing.T) {
 	})
 }
 
+func TestSNMPTopologyNewRequiresSharedDependencies(t *testing.T) {
+	require.PanicsWithValue(t, "snmp_topology New requires a non-nil device store", func() {
+		_ = New(nil, NewTrapEnrichmentHandle())
+	})
+	require.PanicsWithValue(t, "snmp_topology New requires a non-nil trap enrichment handle", func() {
+		_ = New(ddsnmp.NewDeviceStore(), nil)
+	})
+}
+
 type topologyRuntimeJobForTest struct {
 	collector *Collector
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_presentation_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_presentation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,8 +21,7 @@ func TestSNMPTopologyMethodConfigDoesNotUseLegacyPresentation(t *testing.T) {
 }
 
 func TestSNMPTopologyCreatorOwnsTopologyFunction(t *testing.T) {
-	creator, ok := collectorapi.DefaultRegistry.Lookup("snmp_topology")
-	require.True(t, ok)
+	creator := newCreator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle())
 	require.Nil(t, creator.Create)
 	require.NotNil(t, creator.CreateV2)
 	require.Equal(t, collectorapi.InstancePolicySingle, creator.InstancePolicy)
@@ -36,11 +36,20 @@ func TestSNMPTopologyCreatorOwnsTopologyFunction(t *testing.T) {
 	require.Equal(t, topologyFunctionName, methods[0].FunctionName)
 	require.True(t, methods[0].AgentWide)
 
-	coll := New()
+	coll := newTestSNMPTopologyCollector()
 	handler := creator.MethodHandler(&topologyRuntimeJobForTest{collector: coll})
 	require.IsType(t, &funcTopology{}, handler)
 	require.Same(t, coll.topologyRegistry, handler.(*funcTopology).registry)
 	require.Nil(t, creator.MethodHandler(nil))
+}
+
+func TestSNMPTopologyCreatorRequiresSharedDependencies(t *testing.T) {
+	require.PanicsWithValue(t, "snmp_topology Register requires a non-nil device store", func() {
+		_ = newCreator(nil, NewTrapEnrichmentHandle())
+	})
+	require.PanicsWithValue(t, "snmp_topology Register requires a non-nil trap enrichment handle", func() {
+		_ = newCreator(ddsnmp.NewDeviceStore(), nil)
+	})
 }
 
 type topologyRuntimeJobForTest struct {

--- a/src/go/plugin/go.d/collector/snmp_topology/metrix_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/metrix_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestCollector_WriteInternalMetrics(t *testing.T) {
-	coll := New()
+	coll := newTestSNMPTopologyCollector()
 	now := time.Unix(100, 0)
 	coll.recordRefreshStats(refreshStats{
 		hasDeviceCounts:   true,
@@ -42,11 +42,8 @@ func TestCollector_WriteInternalMetrics(t *testing.T) {
 }
 
 func TestCollectorCollectWritesInternalMetrics(t *testing.T) {
-	coll := New()
-	coll.registeredDevices = func() []ddsnmp.DeviceConnectionInfo {
-		t.Fatal("Collect must not poll SNMP devices")
-		return nil
-	}
+	coll := newTestSNMPTopologyCollector()
+	coll.deviceSource = fatalDeviceSource{t: t}
 	coll.recordRefreshStats(refreshStats{
 		hasDeviceCounts:   true,
 		registeredDevices: 1,
@@ -78,4 +75,14 @@ func requireMetricValue(t *testing.T, reader metrix.Reader, name string, want me
 	got, ok := reader.Value(name, nil)
 	require.True(t, ok, "metric %s not found", name)
 	require.Equal(t, want, got)
+}
+
+type fatalDeviceSource struct {
+	t *testing.T
+}
+
+func (s fatalDeviceSource) Devices() []ddsnmp.DeviceConnectionInfo {
+	s.t.Helper()
+	s.t.Fatal("Collect must not poll SNMP devices")
+	return nil
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_integration_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_integration_test.go
@@ -92,11 +92,11 @@ func TestTopologyIntegrationWithSnmpsimV3(t *testing.T) {
 func collectTopologySnapshotFromDevice(t *testing.T, dev ddsnmp.DeviceConnectionInfo) topologyData {
 	t.Helper()
 
+	deviceStore := ddsnmp.NewDeviceStore()
 	deviceKey := "integration:" + dev.SNMPVersion + ":" + dev.SysName
-	ddsnmp.DeviceRegistry.Register(deviceKey, dev)
-	defer ddsnmp.DeviceRegistry.Unregister(deviceKey)
+	deviceStore.Register(deviceKey, dev)
 
-	coll := New()
+	coll := New(deviceStore, NewTrapEnrichmentHandle())
 	coll.Config = Config{UpdateEvery: 3600}
 	require.NoError(t, coll.Init(context.Background()))
 	defer coll.Cleanup(context.Background())

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
@@ -2,6 +2,28 @@
 
 package snmptopology
 
+import (
+	"fmt"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+)
+
+func newTestSNMPTopologyCollector() *Collector {
+	coll, _ := newTestSNMPTopologyCollectorWithStore()
+	return coll
+}
+
+func newTestSNMPTopologyCollectorWithStore() (*Collector, *ddsnmp.DeviceStore) {
+	store := ddsnmp.NewDeviceStore()
+	return New(store, NewTrapEnrichmentHandle()), store
+}
+
+func registerTestDeviceState(store *ddsnmp.DeviceStore, devices ...ddsnmp.DeviceConnectionInfo) {
+	for i, dev := range devices {
+		store.Register(fmt.Sprintf("test:%s:%d:%d", dev.Hostname, dev.Port, i), dev)
+	}
+}
+
 func snapshotTopologyRegistryForTest(registry *topologyRegistry) (topologyData, bool) {
 	return registry.snapshotWithOptions(topologyQueryOptions{
 		CollapseActorsByIP:     true,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich.go
@@ -23,26 +23,37 @@ type TrapTopologyEnrichment struct {
 	Neighbors       []string
 }
 
-var activeTrapTopologyRegistry atomic.Pointer[topologyRegistry]
+// TrapEnrichmentHandle exposes the currently running topology registry to trap enrichment consumers.
+type TrapEnrichmentHandle struct {
+	registry atomic.Pointer[topologyRegistry]
+}
+
+// NewTrapEnrichmentHandle returns an empty process-local trap enrichment handle.
+func NewTrapEnrichmentHandle() *TrapEnrichmentHandle {
+	return &TrapEnrichmentHandle{}
+}
 
 func (c *Collector) publishTrapTopologyEnrichment() {
-	if c.topologyRegistry != nil {
-		activeTrapTopologyRegistry.Store(c.topologyRegistry)
+	if c.trapEnrichment != nil && c.topologyRegistry != nil {
+		c.trapEnrichment.registry.Store(c.topologyRegistry)
 	}
 }
 
 func (c *Collector) unpublishTrapTopologyEnrichment() {
-	if c.topologyRegistry != nil {
-		activeTrapTopologyRegistry.CompareAndSwap(c.topologyRegistry, nil)
+	if c.trapEnrichment != nil && c.topologyRegistry != nil {
+		c.trapEnrichment.registry.CompareAndSwap(c.topologyRegistry, nil)
 	}
 }
 
-// TrapEnrichmentForSource returns topology enrichment data for a trap received
+// EnrichmentForSource returns topology enrichment data for a trap received
 // from the given source IP and, when available, the trap subject ifIndex.
 // Interface and neighbor enrichment only use the trap ifIndex after the source
 // IP matches exactly one local topology cache.
-func TrapEnrichmentForSource(ip, trapIfIndex string) *TrapTopologyEnrichment {
-	registry := activeTrapTopologyRegistry.Load()
+func (h *TrapEnrichmentHandle) EnrichmentForSource(ip, trapIfIndex string) *TrapTopologyEnrichment {
+	if h == nil {
+		return nil
+	}
+	registry := h.registry.Load()
 	if registry == nil {
 		return nil
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTopologyCacheTrapEnrichmentForSourceUsesTrapIfIndex(t *testing.T) {
+func TestTopologyCacheTrapEnrichmentUsesTrapIfIndex(t *testing.T) {
 	cache := newTopologyCache()
 	cache.localDevice.ManagementIP = "192.0.2.30"
 	cache.ifIndexByIP["192.0.2.10"] = "99"
@@ -32,7 +32,7 @@ func TestTopologyCacheTrapEnrichmentForSourceUsesTrapIfIndex(t *testing.T) {
 	require.Equal(t, []string{"dist-a", "dist-b"}, enrich.Neighbors)
 }
 
-func TestTopologyCacheTrapEnrichmentForSourceFallsBackToRemoteMapKeys(t *testing.T) {
+func TestTopologyCacheTrapEnrichmentFallsBackToRemoteMapKeys(t *testing.T) {
 	cache := newTopologyCache()
 	cache.localDevice.ManagementIP = "192.0.2.30"
 	cache.lldpRemotes["7:2"] = &lldpRemote{sysName: "dist-b"}
@@ -45,7 +45,7 @@ func TestTopologyCacheTrapEnrichmentForSourceFallsBackToRemoteMapKeys(t *testing
 	require.Equal(t, []string{"dist-a", "dist-b"}, enrich.Neighbors)
 }
 
-func TestTopologyCacheTrapEnrichmentForSourceDoesNotInferInterfaceFromSourceIP(t *testing.T) {
+func TestTopologyCacheTrapEnrichmentDoesNotInferInterfaceFromSourceIP(t *testing.T) {
 	cache := newTopologyCache()
 	cache.ifIndexByIP["192.0.2.10"] = "7"
 	cache.ifNamesByIndex["7"] = "Gi0/7"
@@ -61,7 +61,7 @@ func TestTopologyCacheTrapEnrichmentForSourceDoesNotInferInterfaceFromSourceIP(t
 	require.Equal(t, "skipped", enrich.NeighborStatus)
 }
 
-func TestTopologyCacheTrapEnrichmentForSourceNoInterfaceMatch(t *testing.T) {
+func TestTopologyCacheTrapEnrichmentNoInterfaceMatch(t *testing.T) {
 	cache := newTopologyCache()
 	cache.localDevice.ManagementIP = "192.0.2.30"
 	cache.lldpRemotes["7:1"] = &lldpRemote{sysName: "dist-a"}
@@ -74,7 +74,7 @@ func TestTopologyCacheTrapEnrichmentForSourceNoInterfaceMatch(t *testing.T) {
 	require.Empty(t, enrich.Neighbors)
 }
 
-func TestTopologyCacheTrapEnrichmentForSourceIncludesLocalDeviceIdentity(t *testing.T) {
+func TestTopologyCacheTrapEnrichmentIncludesLocalDeviceIdentity(t *testing.T) {
 	cache := newTopologyCache()
 	cache.localDevice.ManagementIP = "192.0.2.30"
 	cache.localDevice.SysName = "core-sw-01"
@@ -89,9 +89,9 @@ func TestTopologyCacheTrapEnrichmentForSourceIncludesLocalDeviceIdentity(t *test
 	require.Equal(t, "vnode-node-id", enrich.SourceVnodeID)
 }
 
-func TestTrapEnrichmentForSourceUsesActiveRegistry(t *testing.T) {
+func TestTrapEnrichmentHandleForSourceUsesPublishedRegistry(t *testing.T) {
 	registry := newTopologyRegistry()
-	publishTrapTopologyRegistryForTest(t, registry)
+	handle := publishTrapTopologyRegistryForTest(registry)
 
 	cache := newTopologyCache()
 	cache.localDevice.ManagementIP = "192.0.2.20"
@@ -100,20 +100,20 @@ func TestTrapEnrichmentForSourceUsesActiveRegistry(t *testing.T) {
 
 	registry.register(cache)
 
-	enrich := TrapEnrichmentForSource("192.0.2.20", "11")
+	enrich := handle.EnrichmentForSource("192.0.2.20", "11")
 	require.NotNil(t, enrich)
 	require.Equal(t, "matched", enrich.DeviceStatus)
 	require.Equal(t, "Gi0/11", enrich.Interface)
 	require.Equal(t, []string{"dist-c"}, enrich.Neighbors)
 
-	mapped := TrapEnrichmentForSource("::ffff:192.0.2.20", "11")
+	mapped := handle.EnrichmentForSource("::ffff:192.0.2.20", "11")
 	require.NotNil(t, mapped)
 	require.Equal(t, "Gi0/11", mapped.Interface)
 }
 
-func TestTrapEnrichmentForSourceAmbiguousActiveRegistryMatchDoesNotEnrich(t *testing.T) {
+func TestTrapEnrichmentHandleForSourceAmbiguousRegistryMatchDoesNotEnrich(t *testing.T) {
 	registry := newTopologyRegistry()
-	publishTrapTopologyRegistryForTest(t, registry)
+	handle := publishTrapTopologyRegistryForTest(registry)
 
 	cacheA := newTopologyCache()
 	cacheA.localDevice.ManagementIP = "192.0.2.20"
@@ -125,7 +125,7 @@ func TestTrapEnrichmentForSourceAmbiguousActiveRegistryMatchDoesNotEnrich(t *tes
 	registry.register(cacheA)
 	registry.register(cacheB)
 
-	enrich := TrapEnrichmentForSource("192.0.2.20", "11")
+	enrich := handle.EnrichmentForSource("192.0.2.20", "11")
 	require.NotNil(t, enrich)
 	require.Equal(t, "ambiguous", enrich.DeviceStatus)
 	require.Equal(t, 2, enrich.DeviceMatches)
@@ -134,12 +134,8 @@ func TestTrapEnrichmentForSourceAmbiguousActiveRegistryMatchDoesNotEnrich(t *tes
 }
 
 func TestCollectorRunPublishesAndClearsTrapTopologyRegistry(t *testing.T) {
-	previous := activeTrapTopologyRegistry.Swap(nil)
-	t.Cleanup(func() { activeTrapTopologyRegistry.Store(previous) })
-
-	coll := New()
+	coll := newTestSNMPTopologyCollector()
 	coll.UpdateEvery = 3600
-	coll.registeredDevices = nil
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
@@ -166,31 +162,28 @@ func TestCollectorRunPublishesAndClearsTrapTopologyRegistry(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return activeTrapTopologyRegistry.Load() == coll.topologyRegistry
+		return coll.trapEnrichment.registry.Load() == coll.topologyRegistry
 	}, time.Second, 10*time.Millisecond)
 
 	require.NoError(t, stopRunner())
-	require.Nil(t, activeTrapTopologyRegistry.Load())
+	require.Nil(t, coll.trapEnrichment.registry.Load())
 }
 
 func TestCollectorCleanupDoesNotClearNewerTrapTopologyRegistry(t *testing.T) {
-	previous := activeTrapTopologyRegistry.Swap(nil)
-	t.Cleanup(func() { activeTrapTopologyRegistry.Store(previous) })
-
-	oldColl := New()
-	newColl := New()
-	activeTrapTopologyRegistry.Store(newColl.topologyRegistry)
+	trapEnrichment := NewTrapEnrichmentHandle()
+	oldColl := newTestSNMPTopologyCollector()
+	newColl := newTestSNMPTopologyCollector()
+	oldColl.trapEnrichment = trapEnrichment
+	newColl.trapEnrichment = trapEnrichment
+	trapEnrichment.registry.Store(newColl.topologyRegistry)
 
 	oldColl.Cleanup(context.Background())
 
-	require.Same(t, newColl.topologyRegistry, activeTrapTopologyRegistry.Load())
+	require.Same(t, newColl.topologyRegistry, trapEnrichment.registry.Load())
 }
 
-func publishTrapTopologyRegistryForTest(t *testing.T, registry *topologyRegistry) {
-	t.Helper()
-
-	previous := activeTrapTopologyRegistry.Swap(registry)
-	t.Cleanup(func() {
-		activeTrapTopologyRegistry.CompareAndSwap(registry, previous)
-	})
+func publishTrapTopologyRegistryForTest(registry *topologyRegistry) *TrapEnrichmentHandle {
+	handle := NewTrapEnrichmentHandle()
+	handle.registry.Store(registry)
+	return handle
 }

--- a/src/go/plugin/go.d/collector/snmp_traps/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/collector.go
@@ -18,6 +18,8 @@ import (
 	"github.com/gosnmp/gosnmp"
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
 )
 
 //go:embed "config_schema.json"
@@ -40,20 +42,38 @@ func directJournalLogsAvailable() bool {
 	return activeDirectJournalJobs.Load() > 0
 }
 
-func init() {
-	collectorapi.Register("snmp_traps", collectorapi.Creator{
+// Register registers the SNMP traps collector with shared SNMP-family enrichment state.
+func Register(deviceStore *ddsnmp.DeviceStore, topologyEnricher *snmptopology.TrapEnrichmentHandle) {
+	collectorapi.Register("snmp_traps", newCreator(deviceStore, topologyEnricher))
+}
+
+func newCreator(deviceStore *ddsnmp.DeviceStore, topologyEnricher *snmptopology.TrapEnrichmentHandle) collectorapi.Creator {
+	if deviceStore == nil {
+		panic("snmp_traps Register requires a non-nil device store")
+	}
+	if topologyEnricher == nil {
+		panic("snmp_traps Register requires a non-nil trap enrichment handle")
+	}
+	return collectorapi.Creator{
 		JobConfigSchema: configSchema,
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 1,
 		},
-		CreateV2:      func() collectorapi.CollectorV2 { return New() },
+		CreateV2:      func() collectorapi.CollectorV2 { return New(deviceStore, topologyEnricher) },
 		Config:        func() any { return &Config{} },
 		Methods:       snmpTrapsMethods,
 		MethodHandler: snmpTrapsMethodHandler,
-	})
+	}
 }
 
-func New() *Collector {
+// New returns an SNMP traps collector. Nil dependencies create isolated state for direct use.
+func New(deviceStore *ddsnmp.DeviceStore, topologyEnricher *snmptopology.TrapEnrichmentHandle) *Collector {
+	if deviceStore == nil {
+		deviceStore = ddsnmp.NewDeviceStore()
+	}
+	if topologyEnricher == nil {
+		topologyEnricher = snmptopology.NewTrapEnrichmentHandle()
+	}
 	store := metrix.NewCollectorStore()
 
 	return &Collector{
@@ -63,7 +83,9 @@ func New() *Collector {
 				ReceiveBuffer: defaultListenerReceiveBuffer,
 			},
 		},
-		store: store,
+		store:            store,
+		deviceLookup:     deviceStore,
+		topologyEnricher: topologyEnricher,
 	}
 }
 
@@ -75,6 +97,8 @@ type Collector struct {
 	trapWriter         TrapWriter
 	journalDir         string
 	store              metrix.CollectorStore
+	deviceLookup       deviceLookup
+	topologyEnricher   trapTopologyEnricher
 	jobName            string
 	vnode              string
 	versions           map[SnmpVersion]struct{}
@@ -636,7 +660,7 @@ func (c *Collector) handlePacket(data []byte, peerIP net.IP, conn *net.UDPConn, 
 
 	entry := trapEntryFromPDU(c.jobName, pdu, td, time.Now().UnixMicro(), monotonicUsec())
 	entry.PacketSequence = packetSequence
-	enrichTrapEntry(entry, c.reverseDNSEnabled, c.reverseDNS)
+	c.enrichTrapEntry(entry, c.reverseDNSEnabled, c.reverseDNS)
 	renderTrapEntryTemplates(entry, td)
 	if unknownOID {
 		c.incTrapError("unknown_oid")

--- a/src/go/plugin/go.d/collector/snmp_traps/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/collector.go
@@ -66,13 +66,13 @@ func newCreator(deviceStore *ddsnmp.DeviceStore, topologyEnricher *snmptopology.
 	}
 }
 
-// New returns an SNMP traps collector. Nil dependencies create isolated state for direct use.
+// New returns an SNMP traps collector using the provided SNMP-family enrichment state.
 func New(deviceStore *ddsnmp.DeviceStore, topologyEnricher *snmptopology.TrapEnrichmentHandle) *Collector {
 	if deviceStore == nil {
-		deviceStore = ddsnmp.NewDeviceStore()
+		panic("snmp_traps New requires a non-nil device store")
 	}
 	if topologyEnricher == nil {
-		topologyEnricher = snmptopology.NewTrapEnrichmentHandle()
+		panic("snmp_traps New requires a non-nil trap enrichment handle")
 	}
 	store := metrix.NewCollectorStore()
 

--- a/src/go/plugin/go.d/collector/snmp_traps/collector_e2e_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/collector_e2e_test.go
@@ -17,7 +17,7 @@ func TestCollectorReplayPcapThroughListenerToJournal(t *testing.T) {
 	withTestCacheDir(t)
 
 	port := freeUDPPort(t)
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("e2e")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port}}
 	c.Versions = []string{"v2c"}

--- a/src/go/plugin/go.d/collector/snmp_traps/enrich.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/enrich.go
@@ -278,10 +278,19 @@ type deviceEnrichment struct {
 	matches        int
 }
 
-var trapTopologyEnrichmentForSource = snmptopology.TrapEnrichmentForSource
+type deviceLookup interface {
+	DevicesByHostname(hostname string) []ddsnmp.DeviceConnectionInfo
+}
 
-func resolveDeviceEnrichment(sourceIP string) deviceEnrichment {
-	devices := ddsnmp.DeviceRegistry.DevicesByHostname(sourceIP)
+type trapTopologyEnricher interface {
+	EnrichmentForSource(ip, trapIfIndex string) *snmptopology.TrapTopologyEnrichment
+}
+
+func (c *Collector) resolveDeviceEnrichment(sourceIP string) deviceEnrichment {
+	if c == nil || c.deviceLookup == nil {
+		return deviceEnrichment{}
+	}
+	devices := c.deviceLookup.DevicesByHostname(sourceIP)
 	enrich := deviceEnrichment{matches: len(devices)}
 	if len(devices) != 1 {
 		return enrich
@@ -305,7 +314,7 @@ func resolveDeviceEnrichment(sourceIP string) deviceEnrichment {
 	return enrich
 }
 
-func enrichTrapEntry(entry *TrapEntry, useReverseDNS bool, dns *reverseDNSResolver) {
+func (c *Collector) enrichTrapEntry(entry *TrapEntry, useReverseDNS bool, dns *reverseDNSResolver) {
 	if entry == nil {
 		return
 	}
@@ -324,7 +333,7 @@ func enrichTrapEntry(entry *TrapEntry, useReverseDNS bool, dns *reverseDNSResolv
 		audit.Source = &TrapSourceAudit{Selected: sourceIP, Method: "entry_source"}
 	}
 
-	enrich := resolveDeviceEnrichment(sourceIP)
+	enrich := c.resolveDeviceEnrichment(sourceIP)
 	audit.Registry = &TrapEnrichmentLookup{
 		Key:     sourceIP,
 		Status:  lookupStatus(enrich.matches),
@@ -364,7 +373,10 @@ func enrichTrapEntry(entry *TrapEntry, useReverseDNS bool, dns *reverseDNSResolv
 		addTrapEnrichmentApplied(audit, "TRAP_INTERFACE", iface)
 	}
 
-	topo := trapTopologyEnrichmentForSource(sourceIP, trapIfIndex)
+	var topo *snmptopology.TrapTopologyEnrichment
+	if c != nil && c.topologyEnricher != nil {
+		topo = c.topologyEnricher.EnrichmentForSource(sourceIP, trapIfIndex)
+	}
 	topologyTrusted := topo != nil && topo.DeviceStatus == "matched"
 	if topo != nil {
 		audit.Topology = &TrapEnrichmentLookup{

--- a/src/go/plugin/go.d/collector/snmp_traps/enrich_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/enrich_test.go
@@ -12,15 +12,15 @@ import (
 )
 
 func TestEnrichTrapEntryHostnamePriority(t *testing.T) {
+	c, store := newTestTrapEnrichmentCollector(nil)
 	regKey := "key:10.1.2.3:162"
-	ddsnmp.DeviceRegistry.Register(regKey, ddsnmp.DeviceConnectionInfo{
+	store.Register(regKey, ddsnmp.DeviceConnectionInfo{
 		Hostname:      "10.1.2.3",
 		SysName:       "core-sw-01",
 		VnodeHostname: "core-sw.mydc.example.com",
 		Vendor:        "cisco",
 		VnodeGUID:     "8f72c1e2-3a4b-5c6d-7e8f-9a0b1c2d3e4f",
 	})
-	defer ddsnmp.DeviceRegistry.Unregister(regKey)
 
 	dns := newReverseDNSResolver()
 
@@ -49,7 +49,7 @@ func TestEnrichTrapEntryHostnamePriority(t *testing.T) {
 			entry := &TrapEntry{
 				SourceIP: tc.sourceIP,
 			}
-			enrichTrapEntry(entry, tc.useReverseDNS, dns)
+			c.enrichTrapEntry(entry, tc.useReverseDNS, dns)
 
 			if entry.DeviceHostname != tc.wantHostname {
 				t.Errorf("DeviceHostname = %q, want %q", entry.DeviceHostname, tc.wantHostname)
@@ -101,8 +101,7 @@ func TestEnrichTrapEntryRegistryHostnameWinsOverTopologyAndReverseDNS(t *testing
 		},
 	}
 
-	prev := trapTopologyEnrichmentForSource
-	trapTopologyEnrichmentForSource = func(ip, ifIndex string) *snmptopology.TrapTopologyEnrichment {
+	topologyEnricher := testTrapTopologyEnricher(func(ip, ifIndex string) *snmptopology.TrapTopologyEnrichment {
 		vnodeID := "topology-vnode-id"
 		if ip == "10.1.2.6" {
 			vnodeID = "registry-vnode-id"
@@ -120,14 +119,13 @@ func TestEnrichTrapEntryRegistryHostnameWinsOverTopologyAndReverseDNS(t *testing
 			NeighborStatus:  "matched",
 			Neighbors:       []string{"topo-neighbor"},
 		}
-	}
-	t.Cleanup(func() { trapTopologyEnrichmentForSource = prev })
+	})
 
 	for tcName, tc := range tests {
 		t.Run(tcName, func(t *testing.T) {
+			c, store := newTestTrapEnrichmentCollector(topologyEnricher)
 			regKey := "key:" + tc.info.Hostname + ":162"
-			ddsnmp.DeviceRegistry.Register(regKey, tc.info)
-			defer ddsnmp.DeviceRegistry.Unregister(regKey)
+			store.Register(regKey, tc.info)
 
 			dns := newReverseDNSResolver()
 			dns.cache[tc.info.Hostname] = reverseDNSCacheEntry{
@@ -142,7 +140,7 @@ func TestEnrichTrapEntryRegistryHostnameWinsOverTopologyAndReverseDNS(t *testing
 					{Name: "ifIndex", OID: ifIndexOIDPrefix + ".1", Type: "InterfaceIndex", Value: int64(1)},
 				},
 			}
-			enrichTrapEntry(entry, true, dns)
+			c.enrichTrapEntry(entry, true, dns)
 
 			if entry.DeviceHostname != tc.wantHost {
 				t.Errorf("DeviceHostname = %q, want %q", entry.DeviceHostname, tc.wantHost)
@@ -164,16 +162,16 @@ func TestEnrichTrapEntryRegistryHostnameWinsOverTopologyAndReverseDNS(t *testing
 }
 
 func TestEnrichTrapEntrySysNameOverVnodeUnknown(t *testing.T) {
+	c, store := newTestTrapEnrichmentCollector(nil)
 	regKey := "key:10.1.2.4:162"
-	ddsnmp.DeviceRegistry.Register(regKey, ddsnmp.DeviceConnectionInfo{
+	store.Register(regKey, ddsnmp.DeviceConnectionInfo{
 		Hostname:      "10.1.2.4",
 		SysName:       "real-switch",
 		VnodeHostname: "unknown",
 	})
-	defer ddsnmp.DeviceRegistry.Unregister(regKey)
 
 	entry := &TrapEntry{SourceIP: "10.1.2.4"}
-	enrichTrapEntry(entry, false, nil)
+	c.enrichTrapEntry(entry, false, nil)
 
 	if entry.DeviceHostname != "real-switch" {
 		t.Errorf("DeviceHostname = %q, want real-switch (unknown vnode hostname treated as unresolved)", entry.DeviceHostname)
@@ -181,24 +179,25 @@ func TestEnrichTrapEntrySysNameOverVnodeUnknown(t *testing.T) {
 }
 
 func TestEnrichTrapEntryEmptySysNameSkipped(t *testing.T) {
+	c, store := newTestTrapEnrichmentCollector(nil)
 	regKey := "key:10.1.2.5:162"
-	ddsnmp.DeviceRegistry.Register(regKey, ddsnmp.DeviceConnectionInfo{
+	store.Register(regKey, ddsnmp.DeviceConnectionInfo{
 		Hostname: "10.1.2.5",
 		SysName:  "",
 	})
-	defer ddsnmp.DeviceRegistry.Unregister(regKey)
 
 	entry := &TrapEntry{SourceIP: "10.1.2.5"}
-	enrichTrapEntry(entry, false, nil)
+	c.enrichTrapEntry(entry, false, nil)
 
 	if entry.DeviceHostname != "" {
 		t.Errorf("DeviceHostname = %q, want empty (empty sysName treated as unresolved)", entry.DeviceHostname)
 	}
 }
 
-func TestEnrichTrapEntryNoDeviceRegistryMatch(t *testing.T) {
+func TestEnrichTrapEntryNoDeviceStoreMatch(t *testing.T) {
+	c, _ := newTestTrapEnrichmentCollector(nil)
 	entry := &TrapEntry{SourceIP: "172.16.0.99"}
-	enrichTrapEntry(entry, false, nil)
+	c.enrichTrapEntry(entry, false, nil)
 
 	if entry.DeviceHostname != "" {
 		t.Errorf("DeviceHostname = %q, want empty for unknown device", entry.DeviceHostname)
@@ -211,22 +210,21 @@ func TestEnrichTrapEntryNoDeviceRegistryMatch(t *testing.T) {
 	}
 }
 
-func TestEnrichTrapEntryAmbiguousDeviceRegistryMatchDoesNotEnrich(t *testing.T) {
-	ddsnmp.DeviceRegistry.Register("job-a:10.9.9.1:162", ddsnmp.DeviceConnectionInfo{
+func TestEnrichTrapEntryAmbiguousDeviceStoreMatchDoesNotEnrich(t *testing.T) {
+	c, store := newTestTrapEnrichmentCollector(nil)
+	store.Register("job-a:10.9.9.1:162", ddsnmp.DeviceConnectionInfo{
 		Hostname: "10.9.9.1",
 		SysName:  "switch-a",
 		Vendor:   "vendor-a",
 	})
-	defer ddsnmp.DeviceRegistry.Unregister("job-a:10.9.9.1:162")
-	ddsnmp.DeviceRegistry.Register("job-b:10.9.9.1:162", ddsnmp.DeviceConnectionInfo{
+	store.Register("job-b:10.9.9.1:162", ddsnmp.DeviceConnectionInfo{
 		Hostname: "10.9.9.1",
 		SysName:  "switch-b",
 		Vendor:   "vendor-b",
 	})
-	defer ddsnmp.DeviceRegistry.Unregister("job-b:10.9.9.1:162")
 
 	entry := &TrapEntry{SourceIP: "10.9.9.1"}
-	enrichTrapEntry(entry, false, nil)
+	c.enrichTrapEntry(entry, false, nil)
 
 	if entry.DeviceHostname != "" {
 		t.Errorf("DeviceHostname = %q, want empty for ambiguous registry source", entry.DeviceHostname)
@@ -243,8 +241,7 @@ func TestEnrichTrapEntryAmbiguousDeviceRegistryMatchDoesNotEnrich(t *testing.T) 
 }
 
 func TestEnrichTrapEntryDoesNotUseTopologyOnVnodeConflict(t *testing.T) {
-	prev := trapTopologyEnrichmentForSource
-	trapTopologyEnrichmentForSource = func(_, ifIndex string) *snmptopology.TrapTopologyEnrichment {
+	topologyEnricher := testTrapTopologyEnricher(func(_, ifIndex string) *snmptopology.TrapTopologyEnrichment {
 		return &snmptopology.TrapTopologyEnrichment{
 			DeviceStatus:    "matched",
 			DeviceMethod:    "management_ip",
@@ -258,15 +255,14 @@ func TestEnrichTrapEntryDoesNotUseTopologyOnVnodeConflict(t *testing.T) {
 			NeighborStatus:  "matched",
 			Neighbors:       []string{"dist-a"},
 		}
-	}
-	t.Cleanup(func() { trapTopologyEnrichmentForSource = prev })
+	})
 
-	ddsnmp.DeviceRegistry.Register("job-a:10.9.9.2:162", ddsnmp.DeviceConnectionInfo{
+	c, store := newTestTrapEnrichmentCollector(topologyEnricher)
+	store.Register("job-a:10.9.9.2:162", ddsnmp.DeviceConnectionInfo{
 		Hostname:  "10.9.9.2",
 		SysName:   "registry-switch",
 		VnodeGUID: "registry-vnode-id",
 	})
-	defer ddsnmp.DeviceRegistry.Unregister("job-a:10.9.9.2:162")
 
 	entry := &TrapEntry{
 		SourceIP: "10.9.9.2",
@@ -274,7 +270,7 @@ func TestEnrichTrapEntryDoesNotUseTopologyOnVnodeConflict(t *testing.T) {
 			{Name: "ifIndex", OID: ifIndexOIDPrefix + ".1", Type: "InterfaceIndex", Value: int64(1)},
 		},
 	}
-	enrichTrapEntry(entry, false, nil)
+	c.enrichTrapEntry(entry, false, nil)
 
 	if entry.DeviceHostname != "registry-switch" {
 		t.Errorf("DeviceHostname = %q, want registry-switch", entry.DeviceHostname)
@@ -294,11 +290,10 @@ func TestEnrichTrapEntryDoesNotUseTopologyOnVnodeConflict(t *testing.T) {
 }
 
 func TestEnrichTrapEntryUsesTrapVarbindInterfaceWithoutTopology(t *testing.T) {
-	prev := trapTopologyEnrichmentForSource
-	trapTopologyEnrichmentForSource = func(_, _ string) *snmptopology.TrapTopologyEnrichment {
+	topologyEnricher := testTrapTopologyEnricher(func(_, _ string) *snmptopology.TrapTopologyEnrichment {
 		return nil
-	}
-	t.Cleanup(func() { trapTopologyEnrichmentForSource = prev })
+	})
+	c, _ := newTestTrapEnrichmentCollector(topologyEnricher)
 
 	entry := &TrapEntry{
 		SourceIP: "10.9.9.3",
@@ -307,7 +302,7 @@ func TestEnrichTrapEntryUsesTrapVarbindInterfaceWithoutTopology(t *testing.T) {
 			{Name: "ifName", OID: ifNameOIDPrefix + ".29", Type: "OctetString", Value: "uplink-29"},
 		},
 	}
-	enrichTrapEntry(entry, false, nil)
+	c.enrichTrapEntry(entry, false, nil)
 
 	if entry.TopologyInterface != "uplink-29" {
 		t.Errorf("TopologyInterface = %q, want uplink-29", entry.TopologyInterface)
@@ -327,8 +322,9 @@ func TestEnrichTrapEntryUsesTrapVarbindInterfaceWithoutTopology(t *testing.T) {
 }
 
 func TestEnrichTrapEntrySourceUDPPeerFallback(t *testing.T) {
+	c, _ := newTestTrapEnrichmentCollector(nil)
 	entry := &TrapEntry{SourceUDPPeer: "192.168.1.1"}
-	enrichTrapEntry(entry, false, nil)
+	c.enrichTrapEntry(entry, false, nil)
 
 	if entry.DeviceHostname != "" {
 		t.Errorf("DeviceHostname = %q, want empty (no device match)", entry.DeviceHostname)
@@ -336,12 +332,14 @@ func TestEnrichTrapEntrySourceUDPPeerFallback(t *testing.T) {
 }
 
 func TestEnrichTrapEntryNilEntry(t *testing.T) {
-	enrichTrapEntry(nil, false, nil)
+	c, _ := newTestTrapEnrichmentCollector(nil)
+	c.enrichTrapEntry(nil, false, nil)
 }
 
 func TestEnrichTrapEntryNoSource(t *testing.T) {
+	c, _ := newTestTrapEnrichmentCollector(nil)
 	entry := &TrapEntry{}
-	enrichTrapEntry(entry, false, nil)
+	c.enrichTrapEntry(entry, false, nil)
 
 	if entry.DeviceHostname != "" {
 		t.Errorf("DeviceHostname = %q, want empty", entry.DeviceHostname)
@@ -349,11 +347,11 @@ func TestEnrichTrapEntryNoSource(t *testing.T) {
 }
 
 func TestEnrichTrapEntryReverseDNSDefaultOff(t *testing.T) {
+	c, store := newTestTrapEnrichmentCollector(nil)
 	regKey := "key:10.5.5.1:162"
-	ddsnmp.DeviceRegistry.Register(regKey, ddsnmp.DeviceConnectionInfo{
+	store.Register(regKey, ddsnmp.DeviceConnectionInfo{
 		Hostname: "10.5.5.1",
 	})
-	defer ddsnmp.DeviceRegistry.Unregister(regKey)
 
 	dns := newReverseDNSResolver()
 	dns.cache["10.5.5.1"] = reverseDNSCacheEntry{
@@ -362,7 +360,7 @@ func TestEnrichTrapEntryReverseDNSDefaultOff(t *testing.T) {
 	}
 
 	entry := &TrapEntry{SourceIP: "10.5.5.1"}
-	enrichTrapEntry(entry, false, dns)
+	c.enrichTrapEntry(entry, false, dns)
 
 	if entry.DeviceHostname != "" {
 		t.Errorf("DeviceHostname = %q, want empty (reverse DNS disabled, no vnode/sysName)", entry.DeviceHostname)
@@ -370,6 +368,7 @@ func TestEnrichTrapEntryReverseDNSDefaultOff(t *testing.T) {
 }
 
 func TestEnrichTrapEntryReverseDNSEnabledNoSNMPState(t *testing.T) {
+	c, _ := newTestTrapEnrichmentCollector(nil)
 	dns := newReverseDNSResolver()
 	dns.cache["10.6.6.1"] = reverseDNSCacheEntry{
 		name:      "peer.mydc.example.com",
@@ -377,7 +376,7 @@ func TestEnrichTrapEntryReverseDNSEnabledNoSNMPState(t *testing.T) {
 	}
 
 	entry := &TrapEntry{SourceIP: "10.6.6.1"}
-	enrichTrapEntry(entry, true, dns)
+	c.enrichTrapEntry(entry, true, dns)
 
 	if entry.DeviceHostname != "" {
 		t.Errorf("DeviceHostname = %q, want empty because reverse DNS is not authoritative identity", entry.DeviceHostname)
@@ -394,11 +393,11 @@ func TestEnrichTrapEntryReverseDNSEnabledNoSNMPState(t *testing.T) {
 }
 
 func TestEnrichTrapEntryReverseDNSDisabledNoCacheUse(t *testing.T) {
+	c, store := newTestTrapEnrichmentCollector(nil)
 	regKey := "key:10.7.7.1:162"
-	ddsnmp.DeviceRegistry.Register(regKey, ddsnmp.DeviceConnectionInfo{
+	store.Register(regKey, ddsnmp.DeviceConnectionInfo{
 		Hostname: "10.7.7.1",
 	})
-	defer ddsnmp.DeviceRegistry.Unregister(regKey)
 
 	dns := newReverseDNSResolver()
 	dns.cache["10.7.7.1"] = reverseDNSCacheEntry{
@@ -407,7 +406,7 @@ func TestEnrichTrapEntryReverseDNSDisabledNoCacheUse(t *testing.T) {
 	}
 
 	entry := &TrapEntry{SourceIP: "10.7.7.1"}
-	enrichTrapEntry(entry, false, dns)
+	c.enrichTrapEntry(entry, false, dns)
 
 	if entry.DeviceHostname != "" {
 		t.Errorf("DeviceHostname = %q, want empty (reverse DNS disabled, no SNMP state)", entry.DeviceHostname)
@@ -415,12 +414,12 @@ func TestEnrichTrapEntryReverseDNSDisabledNoCacheUse(t *testing.T) {
 }
 
 func TestEnrichTrapEntryReverseDNSDoesNotReplaceKnownHostname(t *testing.T) {
+	c, store := newTestTrapEnrichmentCollector(nil)
 	regKey := "key:10.7.7.2:162"
-	ddsnmp.DeviceRegistry.Register(regKey, ddsnmp.DeviceConnectionInfo{
+	store.Register(regKey, ddsnmp.DeviceConnectionInfo{
 		Hostname: "10.7.7.2",
 		SysName:  "known-switch",
 	})
-	defer ddsnmp.DeviceRegistry.Unregister(regKey)
 
 	dns := newReverseDNSResolver()
 	dns.cache["10.7.7.2"] = reverseDNSCacheEntry{
@@ -428,7 +427,7 @@ func TestEnrichTrapEntryReverseDNSDoesNotReplaceKnownHostname(t *testing.T) {
 		expiresAt: farFuture(),
 	}
 	entry := &TrapEntry{SourceIP: "10.7.7.2"}
-	enrichTrapEntry(entry, true, dns)
+	c.enrichTrapEntry(entry, true, dns)
 
 	if entry.DeviceHostname != "known-switch" {
 		t.Errorf("DeviceHostname = %q, want known-switch", entry.DeviceHostname)
@@ -439,6 +438,7 @@ func TestEnrichTrapEntryReverseDNSDoesNotReplaceKnownHostname(t *testing.T) {
 }
 
 func TestEnrichTrapEntryReverseDNSEnabledSchedulesAsyncLookup(t *testing.T) {
+	c, _ := newTestTrapEnrichmentCollector(nil)
 	dns := newReverseDNSResolver()
 	defer dns.Close()
 
@@ -455,7 +455,7 @@ func TestEnrichTrapEntryReverseDNSEnabledSchedulesAsyncLookup(t *testing.T) {
 	}
 
 	entry := &TrapEntry{SourceIP: "203.0.113.10"}
-	enrichTrapEntry(entry, true, dns)
+	c.enrichTrapEntry(entry, true, dns)
 
 	select {
 	case <-started:
@@ -515,17 +515,17 @@ func TestEnrichTrapEntryVendorAndVnodeEnrichment(t *testing.T) {
 
 	for tcName, tc := range tests {
 		t.Run(tcName, func(t *testing.T) {
+			c, store := newTestTrapEnrichmentCollector(nil)
 			regKey := "key:" + tc.hostname + ":162"
-			ddsnmp.DeviceRegistry.Register(regKey, ddsnmp.DeviceConnectionInfo{
+			store.Register(regKey, ddsnmp.DeviceConnectionInfo{
 				Hostname:  tc.hostname,
 				SysName:   tc.sysName,
 				Vendor:    tc.vendor,
 				VnodeGUID: tc.vnodeGUID,
 			})
-			defer ddsnmp.DeviceRegistry.Unregister(regKey)
 
 			entry := &TrapEntry{SourceIP: tc.hostname}
-			enrichTrapEntry(entry, false, nil)
+			c.enrichTrapEntry(entry, false, nil)
 
 			if entry.DeviceVendor != tc.wantVendor {
 				t.Errorf("DeviceVendor = %q, want %q", entry.DeviceVendor, tc.wantVendor)

--- a/src/go/plugin/go.d/collector/snmp_traps/func_logs_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/func_logs_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/funcctl"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/snmptrapsfunc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -147,8 +149,7 @@ func TestSNMPTrapsLogsDispatchDoesNotRequireRunningJob(t *testing.T) {
 	t.Cleanup(func() { activeDirectJournalJobs.Store(startJournalJobs) })
 	t.Setenv(netdataLogDirEnv, filepath.Join(t.TempDir(), "logs"))
 
-	creator, ok := collectorapi.DefaultRegistry.Lookup("snmp_traps")
-	require.True(t, ok)
+	creator := newCreator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle())
 
 	reg := newSNMPTrapsTestFunctionRegistry()
 	var gotCode int

--- a/src/go/plugin/go.d/collector/snmp_traps/init_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/init_test.go
@@ -13,18 +13,19 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
-	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCollectorChartTemplateYAML(t *testing.T) {
-	collecttest.AssertChartTemplateSchema(t, New().ChartTemplateYAML())
+	collecttest.AssertChartTemplateSchema(t, newTestSNMPTrapsCollector().ChartTemplateYAML())
 }
 
 func TestCollectorChartTemplateYAMLChartsDeclareAlgorithms(t *testing.T) {
-	charts := chartTemplatesByIDFromYAML(t, New().ChartTemplateYAML())
+	charts := chartTemplatesByIDFromYAML(t, newTestSNMPTrapsCollector().ChartTemplateYAML())
 	assertAllChartTemplatesDeclareAlgorithm(t, charts)
 
 	for _, id := range []string{
@@ -68,7 +69,7 @@ func TestCollectorChartTemplateYAMLIncludesProfileMetricCharts(t *testing.T) {
 	require.NotNil(t, rt)
 	require.NotEmpty(t, tmpl)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.profileMetrics = rt
 	c.dynamicChartYAML = tmpl
 
@@ -90,10 +91,18 @@ func TestCollectorChartTemplateYAMLIncludesProfileMetricCharts(t *testing.T) {
 	assert.Contains(t, contexts, "snmp.trap.cisco.config.changes")
 }
 
-func TestCollectorRegistrationAvailableByDefault(t *testing.T) {
-	creator, ok := collectorapi.DefaultRegistry.Lookup("snmp_traps")
-	require.True(t, ok)
+func TestCollectorCreatorDefaults(t *testing.T) {
+	creator := newCreator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle())
 	assert.False(t, creator.Defaults.Disabled)
+}
+
+func TestCollectorCreatorRequiresSharedDependencies(t *testing.T) {
+	require.PanicsWithValue(t, "snmp_traps Register requires a non-nil device store", func() {
+		_ = newCreator(nil, snmptopology.NewTrapEnrichmentHandle())
+	})
+	require.PanicsWithValue(t, "snmp_traps Register requires a non-nil trap enrichment handle", func() {
+		_ = newCreator(ddsnmp.NewDeviceStore(), nil)
+	})
 }
 
 func chartTemplatesByIDFromYAML(t *testing.T, raw string) map[string]charttpl.Chart {
@@ -215,7 +224,7 @@ func TestConfigSchemaDynCfgRetentionDefaultDisablesTimeRotation(t *testing.T) {
 }
 
 func TestCollectorDefaultListenReceiveBuffer(t *testing.T) {
-	assert.Equal(t, defaultListenerReceiveBuffer, New().Listen.ReceiveBuffer)
+	assert.Equal(t, defaultListenerReceiveBuffer, newTestSNMPTrapsCollector().Listen.ReceiveBuffer)
 }
 
 func TestConfigSchemaDynCfgTabsRenderAllTopLevelFieldsOnce(t *testing.T) {
@@ -469,7 +478,7 @@ func TestCollectorInit_BindsEndpointsAndCheckIsNoop(t *testing.T) {
 	withTestCacheDir(t)
 	port := freeUDPPort(t)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port}}
 
@@ -493,7 +502,7 @@ func TestCollectorInit_IdempotentDoubleInit(t *testing.T) {
 	withTestCacheDir(t)
 	port := freeUDPPort(t)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port}}
 
@@ -510,7 +519,7 @@ func TestCollectorInit_IdempotentDoubleInit(t *testing.T) {
 func TestCollectorInit_InvalidJobNameIsCodedError(t *testing.T) {
 	withTestCacheDir(t)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("../bad")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: 162}}
 
@@ -528,7 +537,7 @@ func TestCollectorInit_InvalidJobNameIsCodedError(t *testing.T) {
 func TestCollectorInit_InvalidEndpointsIsCodedError(t *testing.T) {
 	withTestCacheDir(t)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "tcp", Address: "127.0.0.1", Port: 162}}
 
@@ -543,7 +552,7 @@ func TestCollectorInit_InvalidEndpointsIsCodedError(t *testing.T) {
 func TestCollectorInit_InvalidReceiveBufferIsCodedError(t *testing.T) {
 	withTestCacheDir(t)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Listen.ReceiveBuffer = -1
@@ -560,7 +569,7 @@ func TestCollectorInit_InvalidReceiveBufferIsCodedError(t *testing.T) {
 func TestCollectorInit_TooLargeReceiveBufferIsCodedError(t *testing.T) {
 	withTestCacheDir(t)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Listen.ReceiveBuffer = maxListenerReceiveBuffer + 1
@@ -576,7 +585,7 @@ func TestCollectorInit_TooLargeReceiveBufferIsCodedError(t *testing.T) {
 
 func TestCollectorInit_NoOutputBackendIsCodedError(t *testing.T) {
 	disabled := false
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Journal.Enabled = &disabled
@@ -595,7 +604,7 @@ func TestCollectorInit_MissingNetdataLogRootIsRetryableCodedError(t *testing.T) 
 	root := filepath.Join(t.TempDir(), "missing")
 	withNetdataLogDir(t, root)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 
@@ -623,7 +632,7 @@ func TestCollectorInit_OTELOnlySkipsJournalCreation(t *testing.T) {
 	srv := startOTLPFixture(t, nil)
 
 	const jobName = "otel-only"
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName(jobName)
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Journal.Enabled = &disabled
@@ -657,7 +666,7 @@ func TestCollectorInit_OTLPPreflightFailureIsRetryableCodedError(t *testing.T) {
 	endpoint := "http://" + ln.Addr().String()
 	require.NoError(t, ln.Close())
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("otlp-preflight")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Journal.Enabled = &disabled
@@ -685,7 +694,7 @@ func TestCollectorInit_BindsMultipleEndpoints(t *testing.T) {
 	firstPort := freeUDPPort(t)
 	secondPort := freeUDPPort(t)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{
 		{Protocol: "udp", Address: "127.0.0.1", Port: firstPort},
@@ -717,7 +726,7 @@ func TestCollectorInit_BindFailureIsRetryableCodedError(t *testing.T) {
 
 	port := conn.LocalAddr().(*net.UDPAddr).Port
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port}}
 
@@ -742,7 +751,7 @@ func TestCollectorInit_ReceiveBufferFailureIsRetryableCodedError(t *testing.T) {
 		return errors.New("set buffer failed")
 	}
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 
@@ -761,7 +770,7 @@ func TestCollectorInit_ReceiveBufferFailureIsRetryableCodedError(t *testing.T) {
 func TestCollectorInit_InvalidVersionIsCodedError(t *testing.T) {
 	withTestCacheDir(t)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: 162}}
 	c.Versions = []string{"v5"}
@@ -779,7 +788,7 @@ func TestCollectorInit_ProfileLoadFailureIsCodedError(t *testing.T) {
 	resetProfileCacheForTest()
 	withTestCacheDir(t)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Versions = []string{" V1 ", "V2C"}
@@ -802,7 +811,7 @@ func TestCollectorInit_PartialBindFailureClosesPriorSockets(t *testing.T) {
 	defer secondConn.Close()
 	secondPort := secondConn.LocalAddr().(*net.UDPAddr).Port
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{
 		{Protocol: "udp", Address: "127.0.0.1", Port: firstPort},
@@ -836,7 +845,7 @@ func TestCollectorInit_EngineStateStatErrorIsRetryableCodedError(t *testing.T) {
 	const jobName = "engine-state-stat-error"
 	require.NoError(t, os.WriteFile(engineBootsDir(jobName), []byte("not a directory"), 0644))
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName(jobName)
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Versions = []string{"v3"}
@@ -870,7 +879,7 @@ func TestCollectorInit_CleansCreatedV3StateOnEngineBootsFailure(t *testing.T) {
 	const jobName = "cleanup-v3-state"
 	require.NoError(t, os.MkdirAll(engineBootsPath(jobName), 0750))
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName(jobName)
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Versions = []string{"v3"}
@@ -896,7 +905,7 @@ func TestCollectorCleanupIsIdempotent(t *testing.T) {
 	withTestCacheDir(t)
 	port := freeUDPPort(t)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port}}
 
@@ -909,7 +918,7 @@ func TestCollectorCleanupIsIdempotent(t *testing.T) {
 }
 
 func TestCollectorCollectRequiresStartedListener(t *testing.T) {
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	err := c.Collect(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "listener not started")

--- a/src/go/plugin/go.d/collector/snmp_traps/init_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/init_test.go
@@ -105,6 +105,15 @@ func TestCollectorCreatorRequiresSharedDependencies(t *testing.T) {
 	})
 }
 
+func TestCollectorNewRequiresSharedDependencies(t *testing.T) {
+	require.PanicsWithValue(t, "snmp_traps New requires a non-nil device store", func() {
+		_ = New(nil, snmptopology.NewTrapEnrichmentHandle())
+	})
+	require.PanicsWithValue(t, "snmp_traps New requires a non-nil trap enrichment handle", func() {
+		_ = New(ddsnmp.NewDeviceStore(), nil)
+	})
+}
+
 func chartTemplatesByIDFromYAML(t *testing.T, raw string) map[string]charttpl.Chart {
 	t.Helper()
 

--- a/src/go/plugin/go.d/collector/snmp_traps/listener_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/listener_test.go
@@ -81,7 +81,7 @@ func TestListenerReadLoopDoesNotReportReadErrorDuringClose(t *testing.T) {
 
 func TestCollectorLogListenerReadErrorIsRateLimited(t *testing.T) {
 	var buf bytes.Buffer
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.Logger = logger.NewWithWriter(&buf)
 	ep := EndpointConfig{
 		Protocol: "udp4",

--- a/src/go/plugin/go.d/collector/snmp_traps/pipeline_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/pipeline_test.go
@@ -119,18 +119,19 @@ func TestCollectorHandlePacketRecoversFromPanic(t *testing.T) {
 
 func TestCollectorHandlePacketRendersTemplatesAfterEnrichment(t *testing.T) {
 	packet := readColdStartUDPPacket(t)
+	deviceStore := ddsnmp.NewDeviceStore()
 	regKey := "test:198.51.100.10:162"
-	ddsnmp.DeviceRegistry.Register(regKey, ddsnmp.DeviceConnectionInfo{
+	deviceStore.Register(regKey, ddsnmp.DeviceConnectionInfo{
 		Hostname: "198.51.100.10",
 		SysName:  "core-sw-01",
 		Vendor:   "cisco",
 	})
-	defer ddsnmp.DeviceRegistry.Unregister(regKey)
 
 	trap := testColdStartTrap("security", "warning", "security coldStart on {_HOSTNAME} from {TRAP_DEVICE_VENDOR}")
 	setSingleTestTrap(t, trap)
 	writer := &mockTrapWriter{}
 	c := newDefaultTestV2Collector(writer)
+	c.deviceLookup = deviceStore
 
 	c.handlePacket(packet.payload, packet.peer, nil, nil)
 
@@ -162,8 +163,7 @@ func TestCollectorHandlePacketDoesNotUseListenerVnodeAsSourceNode(t *testing.T) 
 
 func TestCollectorHandlePacketRendersTopologyEnrichmentBeforeReverseDNS(t *testing.T) {
 	packet := readColdStartUDPPacket(t)
-	prev := trapTopologyEnrichmentForSource
-	trapTopologyEnrichmentForSource = func(ip, ifIndex string) *snmptopology.TrapTopologyEnrichment {
+	topologyEnricher := testTrapTopologyEnricher(func(ip, ifIndex string) *snmptopology.TrapTopologyEnrichment {
 		if ip != "198.51.100.10" {
 			t.Fatalf("topology enrichment looked up IP %q, want 198.51.100.10", ip)
 		}
@@ -180,8 +180,7 @@ func TestCollectorHandlePacketRendersTopologyEnrichmentBeforeReverseDNS(t *testi
 			InterfaceStatus: "skipped",
 			NeighborStatus:  "skipped",
 		}
-	}
-	t.Cleanup(func() { trapTopologyEnrichmentForSource = prev })
+	})
 
 	dns := newReverseDNSResolver()
 	dns.cache["198.51.100.10"] = reverseDNSCacheEntry{
@@ -198,6 +197,7 @@ func TestCollectorHandlePacketRendersTopologyEnrichmentBeforeReverseDNS(t *testi
 	setSingleTestTrap(t, trap)
 	writer := &mockTrapWriter{}
 	c := newDefaultTestV2Collector(writer)
+	c.topologyEnricher = topologyEnricher
 	c.reverseDNSEnabled = true
 	c.reverseDNS = dns
 

--- a/src/go/plugin/go.d/collector/snmp_traps/profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/profile_test.go
@@ -90,7 +90,7 @@ func TestCollectorInitAcquiresProfileCache(t *testing.T) {
 
 	port := freeUDPPort(t)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port}}
 
@@ -109,11 +109,11 @@ func TestMultipleCollectorsShareSameCache(t *testing.T) {
 	port1 := freeUDPPort(t)
 	port2 := freeUDPPort(t)
 
-	c1 := New()
+	c1 := newTestSNMPTrapsCollector()
 	c1.SetJobName("job1")
 	c1.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port1}}
 
-	c2 := New()
+	c2 := newTestSNMPTrapsCollector()
 	c2.SetJobName("job2")
 	c2.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port2}}
 
@@ -142,7 +142,7 @@ func TestInitBindFailureReleasesProfileRef(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.SetJobName("local")
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: conn.LocalAddr().(*net.UDPAddr).Port}}
 
@@ -444,7 +444,7 @@ traps:
 	require.Equal(t, "diagnostic", td.Category)
 	require.Equal(t, "warning", td.Severity)
 
-	c := New()
+	c := newTestSNMPTrapsCollector()
 	c.overrides = buildOverrideMap([]OverrideConfig{
 		{
 			OID:      oid,

--- a/src/go/plugin/go.d/collector/snmp_traps/test_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/test_helpers_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
 )
 
 func readSinglePcapUDPPacket(t *testing.T, fixture string) pcapUDPPacket {
@@ -53,6 +55,24 @@ func newTestV2Collector(jobName string, writer TrapWriter, prefixes []netip.Pref
 
 func newDefaultTestV2Collector(writer TrapWriter) *Collector {
 	return newTestV2Collector("test", writer, nil, []string{"public"})
+}
+
+func newTestSNMPTrapsCollector() *Collector {
+	return New(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle())
+}
+
+type testTrapTopologyEnricher func(ip, trapIfIndex string) *snmptopology.TrapTopologyEnrichment
+
+func (f testTrapTopologyEnricher) EnrichmentForSource(ip, trapIfIndex string) *snmptopology.TrapTopologyEnrichment {
+	return f(ip, trapIfIndex)
+}
+
+func newTestTrapEnrichmentCollector(topologyEnricher trapTopologyEnricher) (*Collector, *ddsnmp.DeviceStore) {
+	store := ddsnmp.NewDeviceStore()
+	return &Collector{
+		deviceLookup:     store,
+		topologyEnricher: topologyEnricher,
+	}, store
 }
 
 func withCleanJobMetrics(t *testing.T, jobName string) *perJobMetrics {


### PR DESCRIPTION
##### Summary

**Problem**: SNMP, SNMP topology, and SNMP traps shared runtime state through package-level mutable globals (`ddsnmp.DeviceRegistry` and topology trap enrichment state). That made ownership and lifecycle implicit, kept cross-collector coupling hidden, and made it harder to reason about cleanup, replacement, and future singleton-service work.

**Solution**: Replace the globals with explicit composition-owned dependencies: `ddsnmp.DeviceStore` and `snmptopology.TrapEnrichmentHandle`. The go.d collector package wires one shared store/handle in `collector/init.go`, and the SNMP-family collectors receive them through their registered creator closures while preserving existing registration, cleanup, trap enrichment, topology refresh, and public behavior.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects a shared SNMP `ddsnmp.DeviceStore` and `snmp_topology.TrapEnrichmentHandle` across `snmp`, `snmp_topology`, and `snmp_traps`, and tightens constructors to require non-nil shared state. One shared store/handle is wired in `collector/init.go`; behavior is preserved and globals are removed.

- **Refactors**
  - Replaced global `ddsnmp.DeviceRegistry` with `ddsnmp.DeviceStore`; `snmp` registers/unregisters via the injected store.
  - Replaced global trap topology pointer with `snmp_topology.TrapEnrichmentHandle`; `snmp_topology` publishes to it; `snmp_traps` reads from it.
  - Added `Register(...)` and dependency-aware constructors; wired once in `collector/init.go`:
    - `snmp.Register(store)` → `snmp.New(store)`
    - `snmp_topology.Register(store, handle)` → `snmp_topology.New(store, handle)`
    - `snmp_traps.Register(store, handle)` → `snmp_traps.New(store, handle)`
  - Made trap enrichment and device lookup in `snmp_traps` instance-based (`c.enrichTrapEntry`, `c.resolveDeviceEnrichment`).
  - Hardened constructors: `Register(...)`/`New(...)` now panic on nil `store`/`handle`.
  - Updated SOW docs to reference the injected device store.

- **Migration**
  - Pass shared deps when constructing collectors:
    - `snmp.New(store)`
    - `snmp_topology.New(store, handle)`
    - `snmp_traps.New(store, handle)`
  - Replace `snmp_topology.TrapEnrichmentForSource(...)` with `handle.EnrichmentForSource(...)`.
  - `New(nil, ...)` is no longer allowed; create a shared `ddsnmp.NewDeviceStore()` and `snmp_topology.NewTrapEnrichmentHandle()` for tests or manual wiring.

<sup>Written for commit f081efcaa485db9c9eb1a5d2710abf113f2bfdda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

