### PR TITLE
Bump rand to 0.9.4 in Cargo.lock

### DIFF
--- a/src/crates/Cargo.lock
+++ b/src/crates/Cargo.lock
@@ -4313,7 +4313,7 @@ dependencies = [
  "notify",
  "num-bigint",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "rustc-hash",
  "ruzstd",


### PR DESCRIPTION
SSIA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `rand` from 0.9.2 to 0.9.4 in `Cargo.lock` to pull in patch fixes and keep dependencies current. No source changes.

<sup>Written for commit 24a15aaa665e96db6969636ec35fe07684261b25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

