### PR TITLE
chore(go.d/snmp_topology): make collection cache explicit

### DIFF
--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -80,7 +80,6 @@ type (
 
 		deviceCaches        map[string]*topologyCache // one cache per SNMP device
 		deviceLastCollected map[string]time.Time      // last collection time per device
-		topologyCache       *topologyCache            // current device cache (set during refreshDeviceTopology)
 		topologyRegistry    *topologyRegistry
 		deviceSource        deviceSource
 		trapEnrichment      *TrapEnrichmentHandle
@@ -321,17 +320,15 @@ func (c *Collector) refreshDeviceTopology(ctx context.Context, key string, dev d
 	// Build the next snapshot off-registry. Function readers keep seeing the
 	// previous complete snapshot until this collection is fully ingested.
 	next := c.newDeviceCollectionCache(dev)
-	c.topologyCache = next
-	defer func() { c.topologyCache = nil }()
 
-	c.updateTopologySysUptime(sysUptime)
-	c.updateTopologyProfileTags(pms)
-	c.ingestTopologyProfileMetrics(pms)
-	c.collectTopologyVTPVLANContexts(ctx, dev)
+	next.updateTopologySysUptime(sysUptime)
+	next.updateTopologyProfileTags(pms)
+	next.ingestTopologyProfileMetrics(pms)
+	c.collectTopologyVTPVLANContexts(ctx, next, dev)
 	if ctx.Err() != nil {
 		return false
 	}
-	c.finalizeTopologyCache()
+	c.finalizeTopologyCache(next)
 
 	cache := c.getOrCreateDeviceCache(key)
 	cache.mu.Lock()
@@ -395,18 +392,6 @@ func (c *Collector) getTopologyProfiles(dev ddsnmp.DeviceConnectionInfo) []*ddsn
 		return c.topologyProfiles(dev)
 	}
 	return c.findTopologyProfiles(dev)
-}
-
-func (c *Collector) ingestTopologyProfileMetrics(pms []*ddsnmp.ProfileMetrics) {
-	for _, pm := range pms {
-		c.ingestTopologyMetricSet(pm.TopologyMetrics)
-	}
-}
-
-func (c *Collector) ingestTopologyMetricSet(metrics []ddsnmp.Metric) {
-	for _, metric := range metrics {
-		c.updateTopologyCacheEntry(metric)
-	}
 }
 
 func newSNMPClientFromDeviceInfo(newClient func() gosnmp.Handler, dev ddsnmp.DeviceConnectionInfo) (gosnmp.Handler, error) {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -4,6 +4,7 @@ package snmptopology
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -359,6 +360,42 @@ func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T
 	<-done
 }
 
+func TestCollector_RefreshFailureKeepsPublishedSnapshot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dev := ddsnmp.DeviceConnectionInfo{
+		Hostname:    "10.0.0.10",
+		Port:        161,
+		SysObjectID: "1.3.6.1.4.1.9.1.1",
+	}
+	mockHandler := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClientConnect(mockHandler, dev)
+	mockHandler.EXPECT().Close().Return(nil)
+
+	key := "10.0.0.10:161"
+	published := newTopologyCache()
+	seedPublishedEndpointSnapshot(published)
+
+	coll := newTestSNMPTopologyCollector()
+	coll.deviceCaches[key] = published
+	coll.topologyRegistry.register(published)
+	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
+	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+		return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) {
+			return nil, errors.New("collection failed")
+		})
+	}
+
+	require.False(t, coll.refreshDeviceTopology(context.Background(), key, dev))
+
+	snapshot, ok := published.snapshotEngineObservations()
+	require.True(t, ok)
+	require.Len(t, snapshot.l2Observations, 1)
+	require.Len(t, snapshot.l2Observations[0].FDBEntries, 1)
+	require.Len(t, snapshot.l2Observations[0].ARPNDEntries, 1)
+}
+
 type blockingTopologyCollector struct {
 	started chan<- struct{}
 	release <-chan struct{}
@@ -376,15 +413,7 @@ func (c *blockingTopologyCollector) Collect() ([]*ddsnmp.ProfileMetrics, error) 
 }
 
 func expectTopologyRefreshSNMPClient(mockHandler *snmpmock.MockHandler, dev ddsnmp.DeviceConnectionInfo) {
-	mockHandler.EXPECT().SetTarget(dev.Hostname)
-	mockHandler.EXPECT().SetPort(uint16(dev.Port))
-	mockHandler.EXPECT().SetRetries(dev.Retries)
-	mockHandler.EXPECT().SetTimeout(time.Duration(dev.Timeout) * time.Second)
-	mockHandler.EXPECT().SetMaxOids(dev.MaxOIDs)
-	mockHandler.EXPECT().SetMaxRepetitions(uint32(dev.MaxRepetitions))
-	mockHandler.EXPECT().SetCommunity(dev.Community)
-	mockHandler.EXPECT().SetVersion(gosnmp.Version2c)
-	mockHandler.EXPECT().Connect().Return(nil)
+	expectTopologyRefreshSNMPClientConnect(mockHandler, dev)
 	mockHandler.EXPECT().Get(gomock.InAnyOrder([]string{
 		snmputils.OidSnmpEngineTime,
 		snmputils.OidHrSystemUptime,
@@ -395,6 +424,18 @@ func expectTopologyRefreshSNMPClient(mockHandler *snmpmock.MockHandler, dev ddsn
 		},
 	}, nil)
 	mockHandler.EXPECT().Close().Return(nil)
+}
+
+func expectTopologyRefreshSNMPClientConnect(mockHandler *snmpmock.MockHandler, dev ddsnmp.DeviceConnectionInfo) {
+	mockHandler.EXPECT().SetTarget(dev.Hostname)
+	mockHandler.EXPECT().SetPort(uint16(dev.Port))
+	mockHandler.EXPECT().SetRetries(dev.Retries)
+	mockHandler.EXPECT().SetTimeout(time.Duration(dev.Timeout) * time.Second)
+	mockHandler.EXPECT().SetMaxOids(dev.MaxOIDs)
+	mockHandler.EXPECT().SetMaxRepetitions(uint32(dev.MaxRepetitions))
+	mockHandler.EXPECT().SetCommunity(dev.Community)
+	mockHandler.EXPECT().SetVersion(gosnmp.Version2c)
+	mockHandler.EXPECT().Connect().Return(nil)
 }
 
 func seedPublishedEndpointSnapshot(cache *topologyCache) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_ingest.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_ingest.go
@@ -8,13 +8,13 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 )
 
-func (c *Collector) updateTopologyProfileTags(pms []*ddsnmp.ProfileMetrics) {
-	if c.topologyCache == nil {
+func (c *topologyCache) updateTopologyProfileTags(pms []*ddsnmp.ProfileMetrics) {
+	if c == nil {
 		return
 	}
 
-	c.topologyCache.mu.Lock()
-	defer c.topologyCache.mu.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	for _, pm := range pms {
 		tags := topologyMetadataValues(pm.DeviceMetadata)
@@ -30,41 +30,53 @@ func (c *Collector) updateTopologyProfileTags(pms []*ddsnmp.ProfileMetrics) {
 		}
 
 		if len(tags) > 0 {
-			c.topologyCache.applyLLDPLocalDeviceProfileTags(tags)
-			c.topologyCache.updateLocalBridgeIdentityFromTags(tags)
-			c.topologyCache.applySTPProfileTags(tags)
-			c.topologyCache.applyVTPProfileTags(tags)
+			c.applyLLDPLocalDeviceProfileTags(tags)
+			c.updateLocalBridgeIdentityFromTags(tags)
+			c.applySTPProfileTags(tags)
+			c.applyVTPProfileTags(tags)
 		}
 	}
 }
 
-func (c *Collector) updateTopologyCacheEntry(m ddsnmp.Metric) {
-	if c.topologyCache == nil {
+func (c *topologyCache) updateTopologyCacheEntry(m ddsnmp.Metric) {
+	if c == nil {
 		return
 	}
 
-	c.topologyCache.mu.Lock()
-	defer c.topologyCache.mu.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	c.topologyCache.ingestMetric(m.TopologyKind, m.Tags)
+	c.ingestMetric(m.TopologyKind, m.Tags)
 }
 
-func (c *Collector) updateTopologySysUptime(value int64) {
-	if c == nil || c.topologyCache == nil {
+func (c *topologyCache) updateTopologySysUptime(value int64) {
+	if c == nil {
 		return
 	}
 	if value <= 0 {
 		return
 	}
 
-	c.topologyCache.mu.Lock()
-	defer c.topologyCache.mu.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	local := c.topologyCache.localDevice
+	local := c.localDevice
 	local.SysUptime = value
 	local.Labels = ensureLabels(local.Labels)
 	setTopologyMetadataLabelIfMissing(local.Labels, "sys_uptime", strconv.FormatInt(value, 10))
-	c.topologyCache.localDevice = local
+	c.localDevice = local
+}
+
+func (c *topologyCache) ingestTopologyProfileMetrics(pms []*ddsnmp.ProfileMetrics) {
+	for _, pm := range pms {
+		c.ingestTopologyMetricSet(pm.TopologyMetrics)
+	}
+}
+
+func (c *topologyCache) ingestTopologyMetricSet(metrics []ddsnmp.Metric) {
+	for _, metric := range metrics {
+		c.updateTopologyCacheEntry(metric)
+	}
 }
 
 func topologyMetadataValues(meta map[string]ddsnmp.MetaTag) map[string]string {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
@@ -65,26 +65,43 @@ func (c *topologyCache) hasFreshSnapshotAt(now time.Time) bool {
 	return true
 }
 
-func (c *Collector) finalizeTopologyCache() {
-	cache := c.topologyCache
+func (c *Collector) finalizeTopologyCache(cache *topologyCache) {
 	if cache == nil {
 		return
 	}
 
-	cache.mu.Lock()
-	cache.updateFDBDiagnostics()
-	droppedNoMAC := cache.fdbRowsDroppedNoMAC
-	unmappedPort := cache.fdbRowsUnmappedPort
-	agentID := cache.agentID
-	cache.lastUpdate = cache.updateTime
-	cache.mu.Unlock()
+	stats := cache.finalizeTopologyCache()
 
-	if droppedNoMAC > 0 {
-		c.Warningf("device '%s': dropped %d topology FDB row(s) with empty MAC", agentID, droppedNoMAC)
+	if stats.droppedNoMAC > 0 {
+		c.Warningf("device '%s': dropped %d topology FDB row(s) with empty MAC", stats.agentID, stats.droppedNoMAC)
 	}
-	if unmappedPort > 0 {
-		c.Warningf("device '%s': observed %d topology FDB row(s) with bridge ports missing ifIndex mapping", agentID, unmappedPort)
+	if stats.unmappedPort > 0 {
+		c.Warningf("device '%s': observed %d topology FDB row(s) with bridge ports missing ifIndex mapping", stats.agentID, stats.unmappedPort)
 	}
+}
+
+type topologyCacheFinalizeStats struct {
+	agentID      string
+	droppedNoMAC int
+	unmappedPort int
+}
+
+func (c *topologyCache) finalizeTopologyCache() topologyCacheFinalizeStats {
+	if c == nil {
+		return topologyCacheFinalizeStats{}
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.updateFDBDiagnostics()
+	stats := topologyCacheFinalizeStats{
+		agentID:      c.agentID,
+		droppedNoMAC: c.fdbRowsDroppedNoMAC,
+		unmappedPort: c.fdbRowsUnmappedPort,
+	}
+	c.lastUpdate = c.updateTime
+	return stats
 }
 
 func (c *topologyCache) updateFDBDiagnostics() {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
@@ -15,15 +15,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestCollector(dev ddsnmp.DeviceConnectionInfo) *Collector {
+func newTestTopologyCache(dev ddsnmp.DeviceConnectionInfo) *topologyCache {
 	cache := newTopologyCache()
 	cache.localDevice = buildLocalTopologyDevice(dev)
 	cache.agentID = dev.Hostname
 	cache.updateTime = time.Now()
-	return &Collector{
-		topologyCache: cache,
-		deviceCaches:  map[string]*topologyCache{dev.Hostname: cache},
-	}
+	return cache
 }
 
 func TestTopologyMetricHandlersRegisteredForRowKinds(t *testing.T) {
@@ -58,7 +55,7 @@ func TestTopologyMetricHandlersRegisteredForRowKinds(t *testing.T) {
 }
 
 func TestTopologyCache_LldpSnapshot(t *testing.T) {
-	coll := newTestCollector(ddsnmp.DeviceConnectionInfo{
+	cache := newTestTopologyCache(ddsnmp.DeviceConnectionInfo{
 		Hostname: "10.0.0.1", SysObjectID: "1.3.6.1.4.1.9.1.1", SysName: "sw1", SysDescr: "Switch 1", SysLocation: "dc1",
 	})
 
@@ -68,9 +65,9 @@ func TestTopologyCache_LldpSnapshot(t *testing.T) {
 			tagLldpLocChassisIDSubtype: {Value: "4"},
 		},
 	}}
-	coll.updateTopologyProfileTags(pms)
+	cache.updateTopologyProfileTags(pms)
 
-	coll.updateTopologyCacheEntry(ddsnmp.Metric{
+	cache.updateTopologyCacheEntry(ddsnmp.Metric{
 		TopologyKind: ddsnmp.KindLldpLocPort,
 		Tags: map[string]string{
 			tagLldpLocPortNum:       "1",
@@ -79,7 +76,7 @@ func TestTopologyCache_LldpSnapshot(t *testing.T) {
 			tagLldpLocPortDesc:      "uplink",
 		},
 	})
-	coll.updateTopologyCacheEntry(ddsnmp.Metric{
+	cache.updateTopologyCacheEntry(ddsnmp.Metric{
 		TopologyKind: ddsnmp.KindLldpRem,
 		Tags: map[string]string{
 			tagLldpLocPortNum:          "1",
@@ -94,9 +91,9 @@ func TestTopologyCache_LldpSnapshot(t *testing.T) {
 		},
 	})
 
-	coll.finalizeTopologyCache()
+	cache.finalizeTopologyCache()
 
-	data, ok := snapshotTopologyCacheForTest(coll.topologyCache)
+	data, ok := snapshotTopologyCacheForTest(cache)
 
 	require.True(t, ok)
 	require.Len(t, data.Actors, 2)
@@ -141,19 +138,19 @@ func TestTopologyCache_CdpSnapshot(t *testing.T) {
 }
 
 func TestTopologyCache_UpdateTopologyProfileTags_STPBridgeAddressSetsSNMPIdentity(t *testing.T) {
-	coll := newTestCollector(ddsnmp.DeviceConnectionInfo{Hostname: "10.20.4.2"})
-	coll.topologyCache.localDevice.ChassisID = "10.20.4.2"
-	coll.topologyCache.localDevice.ChassisIDType = "management_ip"
+	cache := newTestTopologyCache(ddsnmp.DeviceConnectionInfo{Hostname: "10.20.4.2"})
+	cache.localDevice.ChassisID = "10.20.4.2"
+	cache.localDevice.ChassisIDType = "management_ip"
 
-	coll.updateTopologyProfileTags([]*ddsnmp.ProfileMetrics{{
+	cache.updateTopologyProfileTags([]*ddsnmp.ProfileMetrics{{
 		DeviceMetadata: map[string]ddsnmp.MetaTag{
 			tagBridgeBaseAddress: {Value: "\"18 FD 74 33 1A 9C \""},
 		},
 	}})
 
-	require.Equal(t, "18:fd:74:33:1a:9c", coll.topologyCache.stpBaseBridgeAddress)
-	require.Equal(t, "18:fd:74:33:1a:9c", coll.topologyCache.localDevice.ChassisID)
-	require.Equal(t, "macAddress", coll.topologyCache.localDevice.ChassisIDType)
+	require.Equal(t, "18:fd:74:33:1a:9c", cache.stpBaseBridgeAddress)
+	require.Equal(t, "18:fd:74:33:1a:9c", cache.localDevice.ChassisID)
+	require.Equal(t, "macAddress", cache.localDevice.ChassisIDType)
 }
 
 func TestTopologyCache_UpdateFdbEntry_STPBridgeAddressTagSetsSNMPIdentity(t *testing.T) {
@@ -249,12 +246,12 @@ func TestTopologyCache_UpdateIfIndexByIP_CollectsAllSNMPDeviceIPs(t *testing.T) 
 }
 
 func TestTopologyCache_UpdateTopologyProfileTags_LLDPDoesNotOverrideExistingSNMPIdentity(t *testing.T) {
-	coll := newTestCollector(ddsnmp.DeviceConnectionInfo{Hostname: "10.20.4.2"})
-	coll.topologyCache.localDevice.ChassisID = "18:fd:74:33:1a:9c"
-	coll.topologyCache.localDevice.ChassisIDType = "macAddress"
-	coll.topologyCache.localDevice.SysName = "MikroTik-Switch"
+	cache := newTestTopologyCache(ddsnmp.DeviceConnectionInfo{Hostname: "10.20.4.2"})
+	cache.localDevice.ChassisID = "18:fd:74:33:1a:9c"
+	cache.localDevice.ChassisIDType = "macAddress"
+	cache.localDevice.SysName = "MikroTik-Switch"
 
-	coll.updateTopologyProfileTags([]*ddsnmp.ProfileMetrics{{
+	cache.updateTopologyProfileTags([]*ddsnmp.ProfileMetrics{{
 		DeviceMetadata: map[string]ddsnmp.MetaTag{
 			tagLldpLocChassisID:        {Value: "00:11:22:33:44:55"},
 			tagLldpLocChassisIDSubtype: {Value: "4"},
@@ -262,9 +259,9 @@ func TestTopologyCache_UpdateTopologyProfileTags_LLDPDoesNotOverrideExistingSNMP
 		},
 	}})
 
-	require.Equal(t, "18:fd:74:33:1a:9c", coll.topologyCache.localDevice.ChassisID)
-	require.Equal(t, "macAddress", coll.topologyCache.localDevice.ChassisIDType)
-	require.Equal(t, "MikroTik-Switch", coll.topologyCache.localDevice.SysName)
+	require.Equal(t, "18:fd:74:33:1a:9c", cache.localDevice.ChassisID)
+	require.Equal(t, "macAddress", cache.localDevice.ChassisIDType)
+	require.Equal(t, "MikroTik-Switch", cache.localDevice.SysName)
 }
 
 func TestTopologyCache_CdpSnapshotHexAddress(t *testing.T) {
@@ -473,10 +470,10 @@ func TestTopologyCache_SnapshotMergesRemoteIdentityAcrossProtocols(t *testing.T)
 }
 
 func TestTopologyCache_LLDPManagementAddressesAndCaps(t *testing.T) {
-	coll := newTestCollector(ddsnmp.DeviceConnectionInfo{
+	cache := newTestTopologyCache(ddsnmp.DeviceConnectionInfo{
 		Hostname: "10.0.0.1", SysObjectID: "1.3.6.1.4.1.9.1.1", SysName: "sw1", SysDescr: "Switch 1",
 	})
-	coll.updateTopologyProfileTags([]*ddsnmp.ProfileMetrics{{
+	cache.updateTopologyProfileTags([]*ddsnmp.ProfileMetrics{{
 		DeviceMetadata: map[string]ddsnmp.MetaTag{
 			tagLldpLocChassisID:        {Value: "00:11:22:33:44:55"},
 			tagLldpLocChassisIDSubtype: {Value: "4"},
@@ -485,7 +482,7 @@ func TestTopologyCache_LLDPManagementAddressesAndCaps(t *testing.T) {
 		},
 	}})
 
-	coll.updateTopologyCacheEntry(ddsnmp.Metric{
+	cache.updateTopologyCacheEntry(ddsnmp.Metric{
 		TopologyKind: ddsnmp.KindLldpLocManAddr,
 		Tags: map[string]string{
 			tagLldpLocMgmtAddrSubtype: "2",
@@ -493,7 +490,7 @@ func TestTopologyCache_LLDPManagementAddressesAndCaps(t *testing.T) {
 			tagLldpLocMgmtAddrIfID:    "1",
 		},
 	})
-	coll.updateTopologyCacheEntry(ddsnmp.Metric{
+	cache.updateTopologyCacheEntry(ddsnmp.Metric{
 		TopologyKind: ddsnmp.KindLldpRemManAddr,
 		Tags: map[string]string{
 			tagLldpLocPortNum:         "1",
@@ -502,7 +499,7 @@ func TestTopologyCache_LLDPManagementAddressesAndCaps(t *testing.T) {
 			tagLldpRemMgmtAddr:        "0a000002",
 		},
 	})
-	coll.updateTopologyCacheEntry(ddsnmp.Metric{
+	cache.updateTopologyCacheEntry(ddsnmp.Metric{
 		TopologyKind: ddsnmp.KindLldpRemManAddr,
 		Tags: map[string]string{
 			tagLldpLocPortNum:         "1",
@@ -511,7 +508,7 @@ func TestTopologyCache_LLDPManagementAddressesAndCaps(t *testing.T) {
 			tagLldpRemMgmtAddr:        "31302e32302e342e3834", // "10.20.4.84" ASCII-hex
 		},
 	})
-	coll.updateTopologyCacheEntry(ddsnmp.Metric{
+	cache.updateTopologyCacheEntry(ddsnmp.Metric{
 		TopologyKind: ddsnmp.KindLldpRemManAddr,
 		Tags: map[string]string{
 			tagLldpLocPortNum:         "1",
@@ -520,7 +517,7 @@ func TestTopologyCache_LLDPManagementAddressesAndCaps(t *testing.T) {
 			tagLldpRemMgmtAddr:        "666330303a663835333a6363643a653739333a3a31", // "fc00:f853:ccd:e793::1" ASCII-hex
 		},
 	})
-	coll.updateTopologyCacheEntry(ddsnmp.Metric{
+	cache.updateTopologyCacheEntry(ddsnmp.Metric{
 		TopologyKind: ddsnmp.KindLldpRemManAddr,
 		Tags: map[string]string{
 			tagLldpLocPortNum:                 "1",
@@ -533,7 +530,7 @@ func TestTopologyCache_LLDPManagementAddressesAndCaps(t *testing.T) {
 			tagLldpRemMgmtAddrOctetPref + "4": "21",
 		},
 	})
-	coll.updateTopologyCacheEntry(ddsnmp.Metric{
+	cache.updateTopologyCacheEntry(ddsnmp.Metric{
 		TopologyKind: ddsnmp.KindLldpRem,
 		Tags: map[string]string{
 			tagLldpLocPortNum:          "1",
@@ -545,9 +542,9 @@ func TestTopologyCache_LLDPManagementAddressesAndCaps(t *testing.T) {
 		},
 	})
 
-	coll.finalizeTopologyCache()
+	cache.finalizeTopologyCache()
 
-	data, ok := snapshotTopologyCacheForTest(coll.topologyCache)
+	data, ok := snapshotTopologyCacheForTest(cache)
 
 	require.True(t, ok)
 	require.Greater(t, len(data.Actors), 1)
@@ -1289,24 +1286,20 @@ func TestBuildLocalTopologyDevice_IncludesSysContactVendorAndModel(t *testing.T)
 	require.Equal(t, topologyProfileChartContextPrefix, device.ChartContextPrefix)
 }
 
-func TestCollector_UpdateTopologySysUptime_StoresSysUptime(t *testing.T) {
-	coll := &Collector{
-		topologyCache: newTopologyCache(),
-	}
-	coll.topologyCache.localDevice = topologyDevice{}
+func TestTopologyCache_UpdateTopologySysUptime_StoresSysUptime(t *testing.T) {
+	cache := newTopologyCache()
+	cache.localDevice = topologyDevice{}
 
-	coll.updateTopologySysUptime(4321)
+	cache.updateTopologySysUptime(4321)
 
-	require.EqualValues(t, 4321, coll.topologyCache.localDevice.SysUptime)
-	require.Equal(t, "4321", coll.topologyCache.localDevice.Labels["sys_uptime"])
+	require.EqualValues(t, 4321, cache.localDevice.SysUptime)
+	require.Equal(t, "4321", cache.localDevice.Labels["sys_uptime"])
 }
 
-func TestCollector_IngestTopologyProfileMetrics_IncludesTopologyMetrics(t *testing.T) {
-	coll := &Collector{
-		topologyCache: newTopologyCache(),
-	}
+func TestTopologyCache_IngestTopologyProfileMetrics_IncludesTopologyMetrics(t *testing.T) {
+	cache := newTopologyCache()
 
-	coll.ingestTopologyProfileMetrics([]*ddsnmp.ProfileMetrics{
+	cache.ingestTopologyProfileMetrics([]*ddsnmp.ProfileMetrics{
 		{
 			TopologyMetrics: []ddsnmp.Metric{
 				{
@@ -1337,10 +1330,10 @@ func TestCollector_IngestTopologyProfileMetrics_IncludesTopologyMetrics(t *testi
 		},
 	})
 
-	require.Contains(t, coll.topologyCache.lldpLocPorts, "7")
-	require.Contains(t, coll.topologyCache.lldpRemotes, "7:1")
-	require.Zero(t, coll.topologyCache.localDevice.SysUptime)
-	require.Empty(t, coll.topologyCache.localDevice.Labels["sys_uptime"])
+	require.Contains(t, cache.lldpLocPorts, "7")
+	require.Contains(t, cache.lldpRemotes, "7:1")
+	require.Zero(t, cache.localDevice.SysUptime)
+	require.Empty(t, cache.localDevice.Labels["sys_uptime"])
 }
 
 func TestBuildLocalTopologyDevice_MapsVersionToSoftwareOnly(t *testing.T) {
@@ -1445,73 +1438,6 @@ func TestAugmentLocalActorFromCache_InjectsIdentityFields(t *testing.T) {
 	require.Equal(t, "swp07", statuses[0]["chart_id_suffix"])
 	require.Equal(t, []string{"ifErrors", "ifTraffic"}, statuses[0]["available_metrics"])
 }
-
-/* Chart cross-linking test removed — feature dropped during split.
-func TestCollector_SyncTopologyChartReferences(t *testing.T) {
-	charts := &collectorapi.Charts{}
-	require.NoError(t, charts.Add(
-		&collectorapi.Chart{
-			ID:    "snmp_device_prof_sysUpTime",
-			Title: "System Uptime",
-			Units: "1",
-			Fam:   "sys",
-			Ctx:   "snmp.device_prof_sysUpTime",
-			Dims: collectorapi.Dims{
-				{ID: "snmp_device_prof_sysUpTime", Name: "sysUpTime"},
-			},
-		},
-		&collectorapi.Chart{
-			ID:    "snmp_device_prof_ifTraffic_swp07",
-			Title: "Traffic swp07",
-			Units: "bit/s",
-			Fam:   "ifTraffic",
-			Ctx:   "snmp.device_prof_ifTraffic",
-			Dims: collectorapi.Dims{
-				{ID: "snmp_device_prof_ifTraffic_swp07_in", Name: "in"},
-			},
-		},
-		&collectorapi.Chart{
-			ID:    "ping_rtt",
-			Title: "Ping round-trip time",
-			Units: "milliseconds",
-			Fam:   "Ping/RTT",
-			Ctx:   "snmp.device_ping_rtt",
-			Dims: collectorapi.Dims{
-				{ID: "ping_rtt_avg", Name: "avg"},
-			},
-		},
-	))
-
-	coll := &Collector{
-		charts:            charts,
-		seenScalarMetrics: map[string]bool{"sysUpTime": true},
-		ifaceCache:        newIfaceCache(),
-		topologyCache:     newTopologyCache(),
-		vnode:             &vnodes.VirtualNode{GUID: "11111111-1111-1111-1111-111111111111"},
-	}
-
-	coll.ifaceCache.interfaces["swp07"] = &ifaceEntry{
-		name: "swp07",
-		availableMetrics: map[string]struct{}{
-			"ifTraffic": {},
-			"ifErrors":  {},
-		},
-		updated: true,
-	}
-
-	coll.syncTopologyChartReferences()
-
-	local := coll.topologyCache.localDevice
-	require.Equal(t, "11111111-1111-1111-1111-111111111111", local.NetdataHostID)
-	require.Equal(t, topologyProfileChartIDPrefix, local.ChartIDPrefix)
-	require.Equal(t, topologyProfileChartContextPrefix, local.ChartContextPrefix)
-	require.Equal(t, "snmp_device_prof_sysUpTime", local.DeviceCharts["sysUpTime"])
-	require.Equal(t, "ping_rtt", local.DeviceCharts["ping_rtt"])
-	require.Contains(t, local.InterfaceCharts, "swp07")
-	require.Equal(t, "swp07", local.InterfaceCharts["swp07"].ChartIDSuffix)
-	require.Equal(t, []string{"ifTraffic"}, local.InterfaceCharts["swp07"].AvailableMetrics)
-}
-*/
 
 func actorHasAttributeList(snapshot topologyData, key string) bool {
 	for _, actor := range snapshot.Actors {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snmprec_forwarding_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snmprec_forwarding_test.go
@@ -73,8 +73,8 @@ func TestTopologyCache_RealSnmprecForwardingFixtures(t *testing.T) {
 			require.NotEmpty(t, data.bridgePorts, "fixture %q should expose bridge port mappings", tt.fixture)
 			require.True(t, len(data.fdbEntries) > 0 || len(data.qBridgeFdb) > 0, "fixture %q should expose FDB data", tt.fixture)
 
-			coll := replaySnmprecForwardingFixture(t, tt.fixture, data)
-			obs := coll.topologyCache.buildEngineObservation(coll.topologyCache.localDevice)
+			cache := replaySnmprecForwardingFixture(t, tt.fixture, data)
+			obs := cache.buildEngineObservation(cache.localDevice)
 
 			require.NotEmpty(t, obs.Interfaces, "expected observed interfaces from fixture %q", tt.fixture)
 			require.NotEmpty(t, obs.BridgePorts, "expected observed bridge ports from fixture %q", tt.fixture)
@@ -93,56 +93,56 @@ func TestTopologyCache_RealSnmprecForwardingFixtures(t *testing.T) {
 			}
 			if tt.wantVTPVLANMap {
 				require.NotEmpty(t, data.vtpVLANs, "fixture %q should expose VTP VLAN data", tt.fixture)
-				require.True(t, cacheContainsAnyVLANName(coll.topologyCache.vlanIDToName, data.vtpVLANNames), "expected VTP VLAN names from fixture %q", tt.fixture)
+				require.True(t, cacheContainsAnyVLANName(cache.vlanIDToName, data.vtpVLANNames), "expected VTP VLAN names from fixture %q", tt.fixture)
 			}
 		})
 	}
 }
 
-func replaySnmprecForwardingFixture(t *testing.T, fixture string, data snmprecForwardingFixture) *Collector {
+func replaySnmprecForwardingFixture(t *testing.T, fixture string, data snmprecForwardingFixture) *topologyCache {
 	t.Helper()
 
-	coll := newTestCollector(ddsnmp.DeviceConnectionInfo{
+	cache := newTestTopologyCache(ddsnmp.DeviceConnectionInfo{
 		Hostname:    "192.0.2.10",
 		SysObjectID: "1.3.6.1.4.1.9.1.1",
 		SysName:     fixture,
 	})
 
 	if len(data.bridgeMetadata) > 0 {
-		coll.updateTopologyProfileTags([]*ddsnmp.ProfileMetrics{{DeviceMetadata: data.bridgeMetadata}})
+		cache.updateTopologyProfileTags([]*ddsnmp.ProfileMetrics{{DeviceMetadata: data.bridgeMetadata}})
 	}
 	for _, tags := range data.ifNameEntries {
-		coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindIfName, Tags: tags})
+		cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindIfName, Tags: tags})
 	}
 	for _, tags := range data.ifStatusEntries {
-		coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindIfStatus, Tags: tags})
+		cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindIfStatus, Tags: tags})
 	}
 	for _, tags := range data.ipIfEntries {
-		coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindIpIfIndex, Tags: tags})
+		cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindIpIfIndex, Tags: tags})
 	}
 	for _, tags := range data.bridgePorts {
-		coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindBridgePortIfIndex, Tags: tags})
+		cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindBridgePortIfIndex, Tags: tags})
 	}
 	for _, tags := range data.qBridgeVLANs {
-		coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindQbridgeVlanEntry, Tags: tags})
+		cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindQbridgeVlanEntry, Tags: tags})
 	}
 	for _, tags := range data.vtpVLANs {
-		coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindVtpVlan, Tags: tags})
+		cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindVtpVlan, Tags: tags})
 	}
 	for _, tags := range data.fdbEntries {
-		coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindFdbEntry, Tags: tags})
+		cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindFdbEntry, Tags: tags})
 	}
 	for _, tags := range data.qBridgeFdb {
-		coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindQbridgeFdbEntry, Tags: tags})
+		cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindQbridgeFdbEntry, Tags: tags})
 	}
 	for _, tags := range data.stpPorts {
-		coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindStpPort, Tags: tags})
+		cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindStpPort, Tags: tags})
 	}
 	for _, tags := range data.arpEntries {
-		coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindArpEntry, Tags: tags})
+		cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindArpEntry, Tags: tags})
 	}
 
-	return coll
+	return cache
 }
 
 func parseSnmprecForwardingFixture(t *testing.T, path string) snmprecForwardingFixture {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snmprec_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snmprec_test.go
@@ -43,34 +43,34 @@ func TestTopologyCache_RealSnmprecFixtures(t *testing.T) {
 				t.Skip("no LLDP/CDP data detected")
 			}
 
-			coll := newTestCollector(ddsnmp.DeviceConnectionInfo{
+			cache := newTestTopologyCache(ddsnmp.DeviceConnectionInfo{
 				Hostname: "192.0.2.10", SysObjectID: "1.3.6.1.4.1.9.1.1", SysName: filepath.Base(path),
 			})
 
 			if len(data.lldpLocalMeta) > 0 {
-				coll.updateTopologyProfileTags([]*ddsnmp.ProfileMetrics{{DeviceMetadata: data.lldpLocalMeta}})
+				cache.updateTopologyProfileTags([]*ddsnmp.ProfileMetrics{{DeviceMetadata: data.lldpLocalMeta}})
 			}
 			for _, tags := range data.lldpLocPorts {
-				coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindLldpLocPort, Tags: tags})
+				cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindLldpLocPort, Tags: tags})
 			}
 			for _, tags := range data.lldpLocManAddrs {
-				coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindLldpLocManAddr, Tags: tags})
+				cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindLldpLocManAddr, Tags: tags})
 			}
 			for _, tags := range data.lldpRemotes {
-				coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindLldpRem, Tags: tags})
+				cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindLldpRem, Tags: tags})
 			}
 			for _, tags := range data.lldpRemManAddrs {
-				coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindLldpRemManAddr, Tags: tags})
+				cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindLldpRemManAddr, Tags: tags})
 			}
 			for _, tags := range data.cdpRemotes {
-				coll.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindCdpCache, Tags: tags})
+				cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindCdpCache, Tags: tags})
 			}
-			coll.finalizeTopologyCache()
+			cache.finalizeTopologyCache()
 
 			options := defaultTopologyQueryOptionsForTest()
 			options.CollapseActorsByIP = false
 			options.EliminateNonIPInferred = false
-			snapshot, ok := snapshotTopologyCacheForTestWithOptions(coll.topologyCache, options)
+			snapshot, ok := snapshotTopologyCacheForTestWithOptions(cache, options)
 
 			require.True(t, ok)
 			require.GreaterOrEqual(t, len(snapshot.Actors), 1)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context.go
@@ -8,15 +8,15 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 )
 
-func (c *Collector) collectTopologyVTPVLANContexts(ctx context.Context, dev ddsnmp.DeviceConnectionInfo) {
-	if c.topologyCache == nil {
+func (c *Collector) collectTopologyVTPVLANContexts(ctx context.Context, cache *topologyCache, dev ddsnmp.DeviceConnectionInfo) {
+	if cache == nil {
 		return
 	}
 	if ctx.Err() != nil {
 		return
 	}
 
-	contexts := c.topologyCache.vtpVLANContexts()
+	contexts := cache.vtpVLANContexts()
 	if len(contexts) == 0 {
 		return
 	}
@@ -40,6 +40,6 @@ func (c *Collector) collectTopologyVTPVLANContexts(ctx context.Context, dev ddsn
 			c.Warningf("device '%s': topology vlan-context polling failed for vlan %s: %v", dev.Hostname, context.vlanID, err)
 			continue
 		}
-		c.ingestTopologyVLANContextMetrics(context.vlanID, context.vlanName, pms)
+		cache.ingestTopologyVLANContextMetrics(context.vlanID, context.vlanName, pms)
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context_ingest.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context_ingest.go
@@ -9,7 +9,11 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 )
 
-func (c *Collector) ingestTopologyVLANContextMetrics(vlanID, vlanName string, pms []*ddsnmp.ProfileMetrics) {
+func (c *topologyCache) ingestTopologyVLANContextMetrics(vlanID, vlanName string, pms []*ddsnmp.ProfileMetrics) {
+	if c == nil {
+		return
+	}
+
 	c.updateTopologyProfileTags(pms)
 
 	for _, pm := range pms {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored SNMP topology collection to use an explicit `*topologyCache` during refresh. This removes implicit shared state on `Collector`, improves snapshot isolation, and keeps the published snapshot stable on errors.

- **Refactors**
  - Build and pass an explicit `*topologyCache` in `refreshDeviceTopology`; removed `Collector.topologyCache`.
  - Moved cache update helpers to `topologyCache` methods (`updateTopologyProfileTags`, `updateTopologyCacheEntry`, `ingestTopologyProfileMetrics`, `updateTopologySysUptime`, `ingestTopologyVLANContextMetrics`).
  - Updated `collectTopologyVTPVLANContexts` to accept the cache.
  - `finalizeTopologyCache` now works on a given cache and returns stats used for warning logs.

- **Bug Fixes**
  - Published snapshot remains unchanged if collection fails (added `TestCollector_RefreshFailureKeepsPublishedSnapshot`).
  - More accurate FDB diagnostics logging via finalize stats.

<sup>Written for commit d0be8e0e6a405d691a610cd6df36696f1caf5563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

