### PR TITLE
feat(go.d/snmp_topology): add l3 subnet adjacency

### DIFF
--- a/.agents/skills/project-create-topology/SKILL.md
+++ b/.agents/skills/project-create-topology/SKILL.md
@@ -100,7 +100,8 @@ developer-facing and must stay in this project skill, not under
 4. Pick evidence rows.
    - Evidence is the lossless relationship proof.
    - For sockets, preserve the exact matching tuple.
-   - For SNMP/L2, preserve LLDP/CDP/FDB/ARP/STP facts according to role.
+   - For SNMP, preserve LLDP/CDP/FDB/ARP/STP facts according to role and keep
+     logical L3 adjacency in distinct L3 link/evidence types.
    - For streaming, keep relationship facts separate from actor-owned path data.
    - For vSphere, preserve inventory/relationship facts using stable object IDs.
 
@@ -395,9 +396,9 @@ For `topology:streaming` actor modals:
   so Cloud aggregation can preserve multiple retaining parents and a future
   explicitly named `Retained by` section can be added without changing facts.
 
-## SNMP/L2 Modal Rules
+## SNMP Topology Modal Rules
 
-For SNMP/L2 managed device actor modals:
+For SNMP managed device actor modals:
 
 - Treat the device as a collection of ports. The primary section is `Ports`
   over `actor_ports`.
@@ -418,6 +419,13 @@ For SNMP/L2 managed device actor modals:
   confidence, inference, attachment mode, or timestamps.
 - `actor_port_links` may carry compact side-specific refs and scalar facts, but
   must not duplicate raw LLDP/CDP/FDB/ARP/STP evidence JSON.
+- Keep logical L3 adjacency out of `actor_port_links`. `l3_subnet` is not a
+  physical or L2 port-neighbor relationship.
+- Expose logical L3 adjacency through typed `l3_subnet` relationship evidence
+  and an evidence-backed device modal section such as `L3 Adjacencies`.
+- `l3_subnet` links represent shared-subnet logical L3 adjacency between
+  resolved managed SNMP device actors. They must use explicit L3 link/evidence
+  types and must not be presented as discovery, physical, or L2 links.
 - Keep generic graph-link `Links` sections only for endpoint, segment, or
   custom actors that do not own port inventory.
 - Build link endpoint port labels only from real port fields: `port_name`,

--- a/.agents/sow/specs/topology-function-schema.md
+++ b/.agents/sow/specs/topology-function-schema.md
@@ -16,7 +16,7 @@ The production schema is defined by:
 - `src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md`
 
 The schema is generic across topology domains. It applies to network
-connections, streaming, SNMP/L2, vSphere, and future topology producers.
+connections, streaming, SNMP, vSphere, and future topology producers.
 
 ## Planes
 
@@ -587,15 +587,29 @@ deduplicated actor-label values when available.
 
 `topology:snmp` now emits `netdata.topology.v1` from the Function handler
 through an adapter over the existing SNMP topology engine output. The adapter
-preserves actors, links, L2 observation evidence, actor metadata, and actor
-custom detail tables. Remaining SNMP refinement is to promote interface metric
-lookup fragments into first-class overlay templates/refs.
+preserves actors, links, L2 observation evidence, bounded L3 adjacency
+evidence, actor metadata, and actor custom detail tables. Remaining SNMP
+refinement is to promote interface metric lookup fragments into first-class
+overlay templates/refs.
+
+SNMP `l3_subnet` links are logical L3 adjacency, not physical or L2 adjacency.
+They use `orientation: observed_bidirectional`, `direction_role: observation`,
+and `semantic_role: normal`. The producer emits them only between resolved
+managed SNMP device actors; unresolved or ambiguous L3 endpoints remain
+diagnostic/suppression state and must not create IP-only graph actors.
+
+SNMP `l3_subnet` evidence must preserve the relationship facts needed for
+drilldown and aggregation, including a `link_ref`, source/destination actors,
+source/destination interface IPs, subnet, network, netmask, prefix, source, and
+logical inference/attachment metadata. The evidence is an actor-modal source
+for L3 adjacency drilldowns.
 
 SNMP modal composition must be port-centric for managed device actors. A managed
 device modal uses actor-label identification for important device facts, a
 primary `Ports` section over `actor_ports`, and a `Port Neighbors` section over
-`actor_port_links`. Generic graph-link `Links` sections are reserved for
-endpoint, segment, or custom actors that do not own port inventory.
+`actor_port_links`. It may also expose an `L3 Adjacencies` section sourced from
+`l3_subnet` relationship evidence. Generic graph-link `Links` sections are
+reserved for endpoint, segment, or custom actors that do not own port inventory.
 
 SNMP `actor_ports` exposes real port identity and status as typed columns:
 SNMP `if_index` as the visible numeric port ID when known, source `port_id`,
@@ -615,6 +629,10 @@ links and evidence. It has one row per incident actor side and carries the local
 state, evidence count, confidence, inference, attachment mode, and timestamps.
 It exists so device modals can align neighbor rows with the same port identity
 shown in `actor_ports`; it is not a second copy of raw evidence.
+
+SNMP `actor_port_links` must remain port-neighbor oriented. It must not include
+`l3_subnet` links, because shared-subnet L3 adjacency does not prove a physical
+or L2 port neighbor.
 
 SNMP polished UI must not depend on raw `actor_metadata` and endpoint JSON.
 Important scalar/count summary values live in typed actor or actor-detail

--- a/.agents/sow/specs/topology-modes-correlation-aggregation.md
+++ b/.agents/sow/specs/topology-modes-correlation-aggregation.md
@@ -29,7 +29,7 @@ rules, table merge policies, and presentation recipes in the payload.
 ## Terms
 
 - **Producer**: the Agent Function that emits one `netdata.topology.v1`
-  payload, for example network-connections, SNMP/L2, streaming, or vSphere.
+  payload, for example network-connections, SNMP, streaming, or vSphere.
 - **Aggregator**: Cloud service that fans out to many producers, decodes their
   payloads, correlates them, optionally aggregates detail, and returns a normal
   `netdata.topology.v1` payload.
@@ -88,7 +88,7 @@ aggregator returns either detailed or aggregated output according to the
 original user request.
 
 If a producer does not expose `__topology_mode`, the aggregator must not invent
-that parameter for it. SNMP/L2 and streaming are expected to be mode-invariant
+that parameter for it. SNMP and streaming are expected to be mode-invariant
 unless a future producer change defines a real mode difference.
 
 ### Final Output
@@ -497,20 +497,32 @@ Aggregator detailed:
 - Show exact socket evidence with resolved actors where possible.
 - Unresolved rows retain their loose-side facts.
 
-## SNMP/L2
+## SNMP
 
 ### Domain Model
 
-SNMP/L2 topology observations are device, interface, neighbor, forwarding,
-ARP, bridge, VLAN, and protocol facts. A graph link represents an observed or
-inferred L2 relationship between two actors.
+SNMP topology observations are device, interface, neighbor, forwarding, ARP,
+bridge, VLAN, protocol, and bounded L3 adjacency facts.
 
-SNMP is not a loose-side topology. Every link should have two actors in both
-Agent and aggregator views.
+Most graph links represent observed or inferred L2 relationships between two
+actors. SNMP may also emit logical L3 relationships with their own link and
+evidence types. These links MUST NOT be presented as physical or L2 adjacency.
+
+`l3_subnet` represents an observed shared-subnet relationship between two
+managed SNMP device actors. It is currently derived from interface IP/netmask
+state collected from IP-MIB `ipAddrTable`, limited to IPv4 point-to-point
+`/30` and `/31` subnets. It means both devices have managed interfaces in the
+same point-to-point subnet; it does not prove that the devices are physically
+connected.
+
+SNMP is not a loose-side topology. Every graph link should have two actors in
+both Agent and aggregator views. `l3_subnet` follows the same rule: unmatched
+or ambiguous L3 endpoints are diagnostic/suppression state, not materialized
+IP-only graph actors.
 
 ### Mode Behavior
 
-SNMP/L2 detailed and aggregated modes are currently a no-op. The producer should
+SNMP detailed and aggregated modes are currently a no-op. The producer should
 not expose `__topology_mode` until it has a real lower/higher-grain distinction.
 
 If a global Cloud topology request asks for aggregated output, the aggregator
@@ -546,9 +558,14 @@ switch-a port 10 -> managed-switch-b
 The weaker LLDP remote actor is removed from the aggregated output and its
 incident links/tables are rewired to the managed device actor.
 
-### UI SNMP/L2
+For `l3_subnet`, aggregation MUST preserve the explicit `l3_subnet` link and
+evidence type. Replacement may rewire endpoint actors to stronger managed
+device actors, but it MUST NOT reinterpret `l3_subnet` as discovery protocol
+evidence or port-neighbor evidence.
 
-The UI should not expose a detailed/aggregated toggle for SNMP/L2 unless the
+### UI SNMP
+
+The UI should not expose a detailed/aggregated toggle for SNMP unless the
 payload declares supported modes.
 
 Device modals should remain port-centric:
@@ -562,6 +579,8 @@ Device modals should remain port-centric:
   when graph-link facts can align the port to a remote actor;
 - links/neighbor information: derived from the same port rows or aligned
   relationship rows so local port identity never contradicts the port table.
+- L3 adjacency information: derived from typed `l3_subnet` relationship
+  evidence, not from `actor_port_links`.
 
 ## Streaming
 

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_test.go
@@ -594,6 +594,32 @@ func TestSNMPTopologyToV1_PreservesL3SubnetPresentationAndEvidence(t *testing.T)
 	}
 }
 
+func TestSNMPTopologyToV1_ReturnsErrorForL3SubnetWithoutSubnet(t *testing.T) {
+	data := topologyData{
+		AgentID: "agent-test",
+		Actors: []topologyActor{
+			{ActorID: "router-a", ActorType: "router"},
+			{ActorID: "router-b", ActorType: "router"},
+		},
+		Links: []topologyLink{
+			{
+				Protocol:   topologyL3SubnetLinkType,
+				LinkType:   topologyL3SubnetLinkType,
+				SrcActorID: "router-a",
+				DstActorID: "router-b",
+				Metrics: map[string]any{
+					"prefix": uint64(30),
+				},
+			},
+		},
+	}
+
+	_, err := snmpTopologyToV1(data)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "l3_subnet link 0 is missing subnet")
+}
+
 func TestSNMPTopologyToV1_PreservesLinkPresentationTypes(t *testing.T) {
 	ts := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
 	data := topologyData{

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_test.go
@@ -341,7 +341,7 @@ func TestSNMPTopologyToV1_PreservesActorCustomTables(t *testing.T) {
 	require.NotNil(t, deviceType.Presentation.Modal.Labels)
 	require.NotNil(t, deviceType.Presentation.Modal.Labels.Identification)
 	assert.Equal(t, "management_ip", deviceType.Presentation.Modal.Labels.Identification.Fields[1].Key)
-	require.Len(t, deviceType.Presentation.Modal.Sections, 2)
+	require.Len(t, deviceType.Presentation.Modal.Sections, 3)
 	assert.Equal(t, "ports", deviceType.Presentation.Modal.Sections[0].ID)
 	assert.Equal(t, "if_index", deviceType.Presentation.Modal.Sections[0].Columns[0].ID)
 	assert.Equal(t, "Port ID", deviceType.Presentation.Modal.Sections[0].Columns[0].Label)
@@ -351,6 +351,9 @@ func TestSNMPTopologyToV1_PreservesActorCustomTables(t *testing.T) {
 	assert.Equal(t, "port_neighbors", deviceType.Presentation.Modal.Sections[1].ID)
 	assert.Equal(t, "actor_table", deviceType.Presentation.Modal.Sections[1].Source.Kind)
 	assert.Equal(t, "actor_port_links", deviceType.Presentation.Modal.Sections[1].Source.Table)
+	assert.Equal(t, "l3_adjacencies", deviceType.Presentation.Modal.Sections[2].ID)
+	assert.Equal(t, "evidence", deviceType.Presentation.Modal.Sections[2].Source.Kind)
+	assert.Equal(t, snmpTopologyV1LinkL3Subnet, deviceType.Presentation.Modal.Sections[2].Source.Evidence)
 
 	endpointType := payload.Types.ActorTypes["endpoint"]
 	require.NotNil(t, endpointType.Presentation)
@@ -468,6 +471,127 @@ func TestSNMPTopologyToV1_PortNamesOnlyUsePortFields(t *testing.T) {
 	portLinksTable := payload.Tables.Actor["actor_port_links"].Table
 	assert.Equal(t, []any{nil, nil}, topologyV1ColumnValues(t, portLinksTable, "port_name"))
 	assert.Equal(t, []any{nil, nil}, topologyV1ColumnValues(t, portLinksTable, "remote_port_name"))
+}
+
+func TestSNMPTopologyToV1_PreservesL3SubnetPresentationAndEvidence(t *testing.T) {
+	data := topologyData{
+		AgentID: "agent-test",
+		View:    "summary",
+		Actors: []topologyActor{
+			{
+				ActorID:   "router-a",
+				ActorType: "router",
+				Match: topologyMatch{
+					IPAddresses: []string{"192.0.2.1"},
+					SysName:     "router-a",
+				},
+			},
+			{
+				ActorID:   "router-b",
+				ActorType: "router",
+				Match: topologyMatch{
+					IPAddresses: []string{"192.0.2.2"},
+					SysName:     "router-b",
+				},
+			},
+		},
+		Links: []topologyLink{
+			{
+				Protocol:   topologyL3SubnetLinkType,
+				LinkType:   topologyL3SubnetLinkType,
+				Direction:  "observed",
+				SrcActorID: "router-a",
+				DstActorID: "router-b",
+				Src: topologyLinkEndpoint{
+					Attributes: map[string]any{
+						"if_index": uint64(10),
+						"if_name":  "xe-0/0/0",
+						"ip":       "192.0.2.1",
+						"subnet":   "192.0.2.0/30",
+					},
+				},
+				Dst: topologyLinkEndpoint{
+					Attributes: map[string]any{
+						"if_index": uint64(20),
+						"if_name":  "xe-0/0/1",
+						"ip":       "192.0.2.2",
+						"subnet":   "192.0.2.0/30",
+					},
+				},
+				Metrics: map[string]any{
+					"source":          "ip_mib",
+					"inference":       "shared_subnet",
+					"attachment_mode": "logical_l3_subnet",
+					"subnet":          "192.0.2.0/30",
+					"network":         "192.0.2.0",
+					"netmask":         "255.255.255.252",
+					"prefix":          uint64(30),
+				},
+			},
+		},
+	}
+
+	payload, err := snmpTopologyToV1(data)
+	require.NoError(t, err)
+	require.NoError(t, validateTopologyV1Data(payload))
+
+	assert.Contains(t, payload.Producer.Capabilities, "l3_subnet")
+	require.NotNil(t, payload.Presentation)
+	assert.Equal(t, "snmp-l2.v2", payload.Presentation.ProfileVersion)
+	assert.Contains(t, topologyV1LegendLinkTypes(payload), snmpTopologyV1LinkL3Subnet)
+
+	require.Contains(t, payload.Types.LinkTypes, snmpTopologyV1LinkL3Subnet)
+	linkType := payload.Types.LinkTypes[snmpTopologyV1LinkL3Subnet]
+	assert.Equal(t, "observed_bidirectional", linkType.Orientation)
+	assert.Equal(t, "observation", linkType.DirectionRole)
+	assert.Equal(t, "normal", linkType.SemanticRole)
+	require.NotNil(t, linkType.Presentation)
+	assert.Equal(t, "L3 subnet", linkType.Presentation.Label)
+	assert.Equal(t, "info", linkType.Presentation.ColorSlot)
+	assert.Equal(t, "dashed", linkType.Presentation.LineStyle)
+	assert.Equal(t, "normal", linkType.Presentation.Width)
+
+	require.Contains(t, payload.Types.EvidenceTypes, snmpTopologyV1LinkL3Subnet)
+	evidenceType := payload.Types.EvidenceTypes[snmpTopologyV1LinkL3Subnet]
+	assert.Equal(t, snmpTopologyV1LinkL3Subnet, evidenceType.LinkType)
+	assert.Equal(t, []string{"src_actor", "dst_actor", "subnet", "src_ip", "dst_ip"}, evidenceType.MatchColumns)
+
+	require.Contains(t, payload.Evidence, snmpTopologyV1LinkL3Subnet)
+	evidenceTable := payload.Evidence[snmpTopologyV1LinkL3Subnet].Table
+	assert.Equal(t, 1, evidenceTable.Rows)
+	assert.Equal(t, "link_ref", topologyV1ColumnType(evidenceTable, "link"))
+	assert.Equal(t, "string_ref", topologyV1ColumnType(evidenceTable, "src_ip"))
+	assert.Equal(t, "string_ref", topologyV1ColumnType(evidenceTable, "dst_ip"))
+	assert.Equal(t, "string_ref", topologyV1ColumnType(evidenceTable, "subnet"))
+	assert.Equal(t, "uint", topologyV1ColumnType(evidenceTable, "prefix"))
+	assert.Equal(t, []any{0}, topologyV1ColumnValues(t, evidenceTable, "link"))
+	assert.Equal(t, []string{"192.0.2.1"}, topologyV1StringColumnValues(t, payload, evidenceTable, "src_ip"))
+	assert.Equal(t, []string{"192.0.2.2"}, topologyV1StringColumnValues(t, payload, evidenceTable, "dst_ip"))
+	assert.Equal(t, []string{"192.0.2.0/30"}, topologyV1StringColumnValues(t, payload, evidenceTable, "subnet"))
+	assert.Equal(t, []any{uint64(30)}, topologyV1ColumnValues(t, evidenceTable, "prefix"))
+	assert.Equal(t, []string{"ip_mib"}, topologyV1StringColumnValues(t, payload, evidenceTable, "source"))
+
+	assert.Equal(t, []string{snmpTopologyV1LinkL3Subnet}, topologyV1StringColumnValues(t, payload, payload.Links, "type"))
+	assert.Equal(t, []string{snmpTopologyV1LinkL3Subnet}, topologyV1StringColumnValues(t, payload, payload.Links, "protocol"))
+
+	deviceType := payload.Types.ActorTypes["router"]
+	require.NotNil(t, deviceType.Presentation)
+	require.NotNil(t, deviceType.Presentation.Modal)
+	l3Section := requireTopologyV1ModalSection(t, deviceType.Presentation.Modal.Sections, "l3_adjacencies")
+	assert.Equal(t, "evidence", l3Section.Source.Kind)
+	assert.Equal(t, snmpTopologyV1LinkL3Subnet, l3Section.Source.Evidence)
+	require.NotNil(t, l3Section.OwnerFilter)
+	assert.Equal(t, "incident_evidence", l3Section.OwnerFilter.Mode)
+	assert.Equal(t, "link", l3Section.OwnerFilter.LinkColumn)
+	assert.Equal(t, "src_actor", l3Section.OwnerFilter.SrcActorColumn)
+	assert.Equal(t, "dst_actor", l3Section.OwnerFilter.DstActorColumn)
+	assert.Equal(t, "subnet", l3Section.Sort.Column)
+	assert.Equal(t, "selected_side_endpoint", l3Section.Columns[1].Projection.Kind)
+	assert.Equal(t, "endpoint", l3Section.Columns[1].Cell)
+
+	if payload.Tables != nil {
+		assert.NotContains(t, payload.Tables.Actor, "actor_port_links")
+	}
 }
 
 func TestSNMPTopologyToV1_PreservesLinkPresentationTypes(t *testing.T) {
@@ -785,4 +909,16 @@ func topologyV1LegendLinkTypes(data topologyv1.Data) []string {
 		out = append(out, entry.Type)
 	}
 	return out
+}
+
+func requireTopologyV1ModalSection(t *testing.T, sections []topologyv1.ModalSection, id string) topologyv1.ModalSection {
+	t.Helper()
+
+	for _, section := range sections {
+		if section.ID == id {
+			return section
+		}
+	}
+	require.Failf(t, "missing modal section", "section %q not found", id)
+	return topologyv1.ModalSection{}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1.go
@@ -24,6 +24,7 @@ const (
 	snmpTopologyV1LinkARP         = "arp"
 	snmpTopologyV1LinkSNMP        = "snmp"
 	snmpTopologyV1LinkProbable    = "probable"
+	snmpTopologyV1LinkL3Subnet    = topologyL3SubnetLinkType
 )
 
 func snmpTopologyToV1(data topologyData) (topologyv1.Data, error) {
@@ -105,6 +106,7 @@ func snmpTopologyToV1(data topologyData) (topologyv1.Data, error) {
 				"cdp",
 				"fdb",
 				"stp",
+				"l3_subnet",
 			},
 		},
 		CollectedAt: data.CollectedAt,

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_actor_ports.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_actor_ports.go
@@ -68,6 +68,9 @@ func buildSNMPTopologyV1PortNeighborSummaries(
 	}
 
 	for _, link := range links {
+		if snmpTopologyV1LinkIsL3Subnet(link) {
+			continue
+		}
 		appendSide(link.SrcActorID, link.DstActorID, link.Src, link.Dst)
 		appendSide(link.DstActorID, link.SrcActorID, link.Dst, link.Src)
 	}
@@ -291,6 +294,9 @@ func buildSNMPTopologyV1ActorPortLinksTable(
 	}
 
 	for i, link := range links {
+		if snmpTopologyV1LinkIsL3Subnet(link) {
+			continue
+		}
 		if err := appendSide(i, link, link.SrcActorID, link.DstActorID, link.Src, link.Dst); err != nil {
 			return topologyv1.Table{}, err
 		}

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_links.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_links.go
@@ -72,6 +72,13 @@ func buildSNMPTopologyV1Links(
 		evidenceRows.confidences = append(evidenceRows.confidences, nullableStringRef(stringsDict, topologyMetricValueString(link.Metrics, "confidence")))
 		evidenceRows.inferences = append(evidenceRows.inferences, nullableStringRef(stringsDict, topologyMetricValueString(link.Metrics, "inference")))
 		evidenceRows.attachmentModes = append(evidenceRows.attachmentModes, nullableStringRef(stringsDict, topologyMetricValueString(link.Metrics, "attachment_mode")))
+		evidenceRows.srcIPs = append(evidenceRows.srcIPs, nullableStringRef(stringsDict, topologyV1EndpointString(link.Src, "ip")))
+		evidenceRows.dstIPs = append(evidenceRows.dstIPs, nullableStringRef(stringsDict, topologyV1EndpointString(link.Dst, "ip")))
+		evidenceRows.subnets = append(evidenceRows.subnets, nullableStringRef(stringsDict, topologyMetricValueString(link.Metrics, "subnet")))
+		evidenceRows.networks = append(evidenceRows.networks, nullableStringRef(stringsDict, topologyMetricValueString(link.Metrics, "network")))
+		evidenceRows.netmasks = append(evidenceRows.netmasks, nullableStringRef(stringsDict, topologyMetricValueString(link.Metrics, "netmask")))
+		evidenceRows.prefixes = append(evidenceRows.prefixes, nullableUintValue(link.Metrics["prefix"]))
+		evidenceRows.sources = append(evidenceRows.sources, nullableStringRef(stringsDict, topologyMetricValueString(link.Metrics, "source")))
 		evidenceRows.srcEndpoints = append(evidenceRows.srcEndpoints, srcEndpoint)
 		evidenceRows.dstEndpoints = append(evidenceRows.dstEndpoints, dstEndpoint)
 		evidenceRows.metrics = append(evidenceRows.metrics, metrics)
@@ -110,7 +117,7 @@ func buildSNMPTopologyV1Links(
 	for linkType, rows := range evidenceRowsByType {
 		evidenceSections[linkType] = topologyv1.EvidenceSection{
 			Type:  linkType,
-			Table: rows.table(),
+			Table: rows.table(linkType),
 		}
 	}
 
@@ -133,35 +140,82 @@ type snmpTopologyV1EvidenceRows struct {
 	confidences      []any
 	inferences       []any
 	attachmentModes  []any
+	srcIPs           []any
+	dstIPs           []any
+	subnets          []any
+	networks         []any
+	netmasks         []any
+	prefixes         []any
+	sources          []any
 	srcEndpoints     []any
 	dstEndpoints     []any
 	metrics          []any
 }
 
-func (rows *snmpTopologyV1EvidenceRows) table() topologyv1.Table {
+func (rows *snmpTopologyV1EvidenceRows) table(linkType string) topologyv1.Table {
 	return topologyv1.MustTable(len(rows.linkRefs),
-		snmpTopologyV1EvidenceColumns(),
-		[]topologyv1.ColumnEncoding{
-			topologyv1.Values(rows.linkRefs...),
-			topologyv1.Values(rows.srcActors...),
-			topologyv1.Values(rows.dstActors...),
-			topologyv1.Values(rows.protocols...),
-			topologyv1.Values(rows.directions...),
-			topologyv1.Values(rows.states...),
-			topologyv1.Values(rows.srcPortNames...),
-			topologyv1.Values(rows.dstPortNames...),
-			topologyv1.Values(rows.srcIfIndexes...),
-			topologyv1.Values(rows.dstIfIndexes...),
-			topologyv1.Values(rows.srcManagementIPs...),
-			topologyv1.Values(rows.dstManagementIPs...),
-			topologyv1.Values(rows.confidences...),
-			topologyv1.Values(rows.inferences...),
-			topologyv1.Values(rows.attachmentModes...),
-			topologyv1.Values(rows.srcEndpoints...),
-			topologyv1.Values(rows.dstEndpoints...),
-			topologyv1.Values(rows.metrics...),
-		},
+		snmpTopologyV1EvidenceColumnsForType(linkType),
+		rows.columnEncodingsForType(linkType),
 	)
+}
+
+func (rows *snmpTopologyV1EvidenceRows) columnEncodingsForType(linkType string) []topologyv1.ColumnEncoding {
+	encodings := []topologyv1.ColumnEncoding{
+		topologyv1.Values(rows.linkRefs...),
+		topologyv1.Values(rows.srcActors...),
+		topologyv1.Values(rows.dstActors...),
+		topologyv1.Values(rows.protocols...),
+		topologyv1.Values(rows.directions...),
+		topologyv1.Values(rows.states...),
+		topologyv1.Values(rows.srcPortNames...),
+		topologyv1.Values(rows.dstPortNames...),
+		topologyv1.Values(rows.srcIfIndexes...),
+		topologyv1.Values(rows.dstIfIndexes...),
+		topologyv1.Values(rows.srcManagementIPs...),
+		topologyv1.Values(rows.dstManagementIPs...),
+		topologyv1.Values(rows.confidences...),
+		topologyv1.Values(rows.inferences...),
+		topologyv1.Values(rows.attachmentModes...),
+	}
+	if linkType == snmpTopologyV1LinkL3Subnet {
+		encodings = append(encodings,
+			topologyv1.Values(rows.srcIPs...),
+			topologyv1.Values(rows.dstIPs...),
+			topologyv1.Values(rows.subnets...),
+			topologyv1.Values(rows.networks...),
+			topologyv1.Values(rows.netmasks...),
+			topologyv1.Values(rows.prefixes...),
+			topologyv1.Values(rows.sources...),
+		)
+	}
+	encodings = append(encodings,
+		topologyv1.Values(rows.srcEndpoints...),
+		topologyv1.Values(rows.dstEndpoints...),
+		topologyv1.Values(rows.metrics...),
+	)
+	return encodings
+}
+
+func snmpTopologyV1EvidenceColumnsForType(linkType string) []topologyv1.Column {
+	columns := snmpTopologyV1EvidenceColumns()
+	if linkType != snmpTopologyV1LinkL3Subnet {
+		return columns
+	}
+	extras := []topologyv1.Column{
+		topologyv1.NewColumn("src_ip", "string_ref", topologyv1.WithDictionary("strings"), topologyv1.WithNullable()),
+		topologyv1.NewColumn("dst_ip", "string_ref", topologyv1.WithDictionary("strings"), topologyv1.WithNullable()),
+		topologyv1.NewColumn("subnet", "string_ref", topologyv1.WithDictionary("strings"), topologyv1.WithRole("group_key")),
+		topologyv1.NewColumn("network", "string_ref", topologyv1.WithDictionary("strings"), topologyv1.WithNullable()),
+		topologyv1.NewColumn("netmask", "string_ref", topologyv1.WithDictionary("strings"), topologyv1.WithNullable()),
+		topologyv1.NewColumn("prefix", "uint", topologyv1.WithNullable()),
+		topologyv1.NewColumn("source", "string_ref", topologyv1.WithDictionary("strings"), topologyv1.WithNullable()),
+	}
+	insertAt := len(columns) - 3
+	out := make([]topologyv1.Column, 0, len(columns)+len(extras))
+	out = append(out, columns[:insertAt]...)
+	out = append(out, extras...)
+	out = append(out, columns[insertAt:]...)
+	return out
 }
 
 func snmpTopologyV1EvidenceColumns() []topologyv1.Column {
@@ -207,9 +261,15 @@ func snmpTopologyV1LinkType(link topologyLink) string {
 		return snmpTopologyV1LinkARP
 	case snmpTopologyV1LinkSNMP:
 		return snmpTopologyV1LinkSNMP
+	case snmpTopologyV1LinkL3Subnet:
+		return snmpTopologyV1LinkL3Subnet
 	default:
 		return snmpTopologyV1LinkObservation
 	}
+}
+
+func snmpTopologyV1LinkIsL3Subnet(link topologyLink) bool {
+	return snmpTopologyV1LinkType(link) == snmpTopologyV1LinkL3Subnet
 }
 
 func snmpTopologyV1LinkIsProbable(link topologyLink) bool {

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_links.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_links.go
@@ -48,6 +48,10 @@ func buildSNMPTopologyV1Links(
 		evidenceCounts[i] = 1
 		discoveredAt[i] = nullableTime(link.DiscoveredAt)
 		lastSeen[i] = nullableTime(link.LastSeen)
+		subnet := topologyMetricValueString(link.Metrics, "subnet")
+		if linkType == snmpTopologyV1LinkL3Subnet && subnet == "" {
+			return topologyv1.Table{}, nil, fmt.Errorf("l3_subnet link %d is missing subnet", i)
+		}
 		srcEndpoint := nullableJSON(link.Src.Attributes)
 		dstEndpoint := nullableJSON(link.Dst.Attributes)
 		metrics := nullableJSON(link.Metrics)
@@ -74,7 +78,7 @@ func buildSNMPTopologyV1Links(
 		evidenceRows.attachmentModes = append(evidenceRows.attachmentModes, nullableStringRef(stringsDict, topologyMetricValueString(link.Metrics, "attachment_mode")))
 		evidenceRows.srcIPs = append(evidenceRows.srcIPs, nullableStringRef(stringsDict, topologyV1EndpointString(link.Src, "ip")))
 		evidenceRows.dstIPs = append(evidenceRows.dstIPs, nullableStringRef(stringsDict, topologyV1EndpointString(link.Dst, "ip")))
-		evidenceRows.subnets = append(evidenceRows.subnets, nullableStringRef(stringsDict, topologyMetricValueString(link.Metrics, "subnet")))
+		evidenceRows.subnets = append(evidenceRows.subnets, nullableStringRef(stringsDict, subnet))
 		evidenceRows.networks = append(evidenceRows.networks, nullableStringRef(stringsDict, topologyMetricValueString(link.Metrics, "network")))
 		evidenceRows.netmasks = append(evidenceRows.netmasks, nullableStringRef(stringsDict, topologyMetricValueString(link.Metrics, "netmask")))
 		evidenceRows.prefixes = append(evidenceRows.prefixes, nullableUintValue(link.Metrics["prefix"]))

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_presentation.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_presentation.go
@@ -153,6 +153,7 @@ func snmpTopologyV1DeviceModal() *topologyv1.ModalPresentation {
 				Sort:    &topologyv1.ModalSort{Column: "if_index", Direction: "asc"},
 			},
 			snmpTopologyV1PortLinksSection(2),
+			snmpTopologyV1L3SubnetSection(3),
 		},
 	}
 }
@@ -249,6 +250,47 @@ func snmpTopologyV1PortLinksSection(order int) topologyv1.ModalSection {
 	}
 }
 
+func snmpTopologyV1L3SubnetSection(order int) topologyv1.ModalSection {
+	return topologyv1.ModalSection{
+		ID:    "l3_adjacencies",
+		Label: "L3 Adjacencies",
+		Order: order,
+		Source: topologyv1.ModalSource{
+			Kind:     "evidence",
+			Evidence: snmpTopologyV1LinkL3Subnet,
+		},
+		OwnerFilter: &topologyv1.ModalOwnerFilter{
+			Mode:           "incident_evidence",
+			LinkColumn:     "link",
+			SrcActorColumn: "src_actor",
+			DstActorColumn: "dst_actor",
+		},
+		Columns: []topologyv1.ModalColumn{
+			{
+				ID:    "remote",
+				Label: "Remote Actor",
+				Projection: topologyv1.ModalProjection{
+					Kind:           "opposite_actor",
+					SrcActorColumn: "src_actor",
+					DstActorColumn: "dst_actor",
+				},
+				Cell: "actor_link",
+			},
+			modalSelectedSideEndpointColumn("local_endpoint", "Local Endpoint", "src_ip", "src_port_name", "dst_ip", "dst_port_name"),
+			modalSelectedSideEndpointColumn("remote_endpoint", "Remote Endpoint", "dst_ip", "dst_port_name", "src_ip", "src_port_name"),
+			modalDirectColumn("subnet", "Subnet", "subnet", "text"),
+			modalDirectColumn("prefix", "Prefix", "prefix", "number"),
+			modalDirectColumnWithVisibility("network", "Network", "network", "text", "expanded"),
+			modalDirectColumnWithVisibility("netmask", "Netmask", "netmask", "text", "expanded"),
+			modalDirectColumnWithVisibility("source", "Source", "source", "badge", "expanded"),
+			modalDirectColumnWithVisibility("inference", "Inference", "inference", "badge", "expanded"),
+			modalDirectColumnWithVisibility("attachment_mode", "Attachment", "attachment_mode", "badge", "expanded"),
+		},
+		Sort:       &topologyv1.ModalSort{Column: "subnet", Direction: "asc"},
+		EmptyLabel: "No L3 adjacencies",
+	}
+}
+
 func modalSelectedSidePortColumn(id, label, selectedSrcPortColumn, selectedDstPortColumn string) topologyv1.ModalColumn {
 	return topologyv1.ModalColumn{
 		ID:    id,
@@ -261,6 +303,23 @@ func modalSelectedSidePortColumn(id, label, selectedSrcPortColumn, selectedDstPo
 			RemotePortColumn: selectedDstPortColumn,
 		},
 		Cell: "text",
+	}
+}
+
+func modalSelectedSideEndpointColumn(id, label, selectedSrcIPColumn, selectedSrcPortColumn, selectedDstIPColumn, selectedDstPortColumn string) topologyv1.ModalColumn {
+	return topologyv1.ModalColumn{
+		ID:    id,
+		Label: label,
+		Projection: topologyv1.ModalProjection{
+			Kind:             "selected_side_endpoint",
+			SrcActorColumn:   "src_actor",
+			DstActorColumn:   "dst_actor",
+			LocalIPColumn:    selectedSrcIPColumn,
+			LocalPortColumn:  selectedSrcPortColumn,
+			RemoteIPColumn:   selectedDstIPColumn,
+			RemotePortColumn: selectedDstPortColumn,
+		},
+		Cell: "endpoint",
 	}
 }
 
@@ -328,6 +387,7 @@ func snmpTopologyV1LinkTypeSpecs() []snmpTopologyV1LinkTypeSpec {
 		{id: snmpTopologyV1LinkFDB, label: "FDB", colorSlot: "neutral", lineStyle: "solid", width: "normal", semanticRole: "normal"},
 		{id: snmpTopologyV1LinkSTP, label: "STP", colorSlot: "muted", lineStyle: "solid", width: "normal", semanticRole: "normal"},
 		{id: snmpTopologyV1LinkARP, label: "ARP", colorSlot: "muted", lineStyle: "solid", width: "normal", semanticRole: "normal"},
+		{id: snmpTopologyV1LinkL3Subnet, label: "L3 subnet", colorSlot: "info", lineStyle: "dashed", width: "normal", semanticRole: "normal"},
 		{id: snmpTopologyV1LinkSNMP, label: "SNMP", colorSlot: "primary", lineStyle: "solid", width: "normal", semanticRole: "normal"},
 		{id: snmpTopologyV1LinkProbable, label: "Probable", colorSlot: "dim", lineStyle: "solid", width: "normal", semanticRole: "normal"},
 		{id: snmpTopologyV1LinkObservation, label: "L2 observation", colorSlot: "neutral", lineStyle: "solid", width: "normal", semanticRole: "normal"},
@@ -368,22 +428,37 @@ func snmpTopologyV1EvidenceTypes() map[string]topologyv1.EvidenceType {
 		types[spec.id] = topologyv1.EvidenceType{
 			LinkType: spec.id,
 			Role:     "observation_evidence",
-			Columns:  snmpTopologyV1EvidenceColumns(),
-			MatchColumns: []string{
-				"src_actor",
-				"dst_actor",
-				"protocol",
-				"src_endpoint",
-				"dst_endpoint",
-			},
+			Columns:  snmpTopologyV1EvidenceColumnsForType(spec.id),
+			MatchColumns: snmpTopologyV1EvidenceMatchColumnsForType(
+				spec.id,
+			),
 		}
 	}
 	return types
 }
 
+func snmpTopologyV1EvidenceMatchColumnsForType(linkType string) []string {
+	if linkType == snmpTopologyV1LinkL3Subnet {
+		return []string{
+			"src_actor",
+			"dst_actor",
+			"subnet",
+			"src_ip",
+			"dst_ip",
+		}
+	}
+	return []string{
+		"src_actor",
+		"dst_actor",
+		"protocol",
+		"src_endpoint",
+		"dst_endpoint",
+	}
+}
+
 func snmpTopologyV1Presentation() *topologyv1.Presentation {
 	return &topologyv1.Presentation{
-		ProfileVersion: "snmp-l2.v1",
+		ProfileVersion: "snmp-l2.v2",
 		Selection: &topologyv1.SelectionPresentation{
 			ActorClick: &topologyv1.ActorClickPresentation{Mode: "highlight_connections"},
 		},
@@ -410,6 +485,7 @@ func snmpTopologyV1Presentation() *topologyv1.Presentation {
 				{Type: snmpTopologyV1LinkCDP, Label: "CDP"},
 				{Type: snmpTopologyV1LinkSNMP, Label: "SNMP"},
 				{Type: snmpTopologyV1LinkBridge, Label: "Bridge"},
+				{Type: snmpTopologyV1LinkL3Subnet, Label: "L3 subnet"},
 				{Type: snmpTopologyV1LinkProbable, Label: "Probable"},
 			},
 			Ports: []topologyv1.LegendEntry{

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache.go
@@ -24,6 +24,7 @@ type topologyCache struct {
 	ifStatusByIndex      map[string]ifStatus
 	ifIndexByIP          map[string]string
 	ifNetmaskByIP        map[string]string
+	l3InterfacesByIP     map[string]topologyL3Interface
 	bridgePortToIf       map[string]string
 	fdbEntries           map[string]*fdbEntry
 	fdbIDToVlanID        map[string]string

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_interfaces.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_interfaces.go
@@ -94,6 +94,11 @@ func (c *topologyCache) updateIfIndexByIP(tags map[string]string) {
 	})
 	if mask := normalizeIPAddress(tags[tagTopoIPMask]); mask != "" {
 		c.ifNetmaskByIP[ip] = mask
+		c.l3InterfacesByIP[ip] = topologyL3Interface{
+			IP:      ip,
+			Netmask: mask,
+			IfIndex: ifIndex,
+		}
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
@@ -9,19 +9,20 @@ import (
 
 func newTopologyCache() *topologyCache {
 	return &topologyCache{
-		lldpLocPorts:    make(map[string]*lldpLocPort),
-		lldpRemotes:     make(map[string]*lldpRemote),
-		cdpRemotes:      make(map[string]*cdpRemote),
-		ifNamesByIndex:  make(map[string]string),
-		ifStatusByIndex: make(map[string]ifStatus),
-		ifIndexByIP:     make(map[string]string),
-		ifNetmaskByIP:   make(map[string]string),
-		bridgePortToIf:  make(map[string]string),
-		fdbEntries:      make(map[string]*fdbEntry),
-		fdbIDToVlanID:   make(map[string]string),
-		vlanIDToName:    make(map[string]string),
-		stpPorts:        make(map[string]*stpPortEntry),
-		arpEntries:      make(map[string]*arpEntry),
+		lldpLocPorts:     make(map[string]*lldpLocPort),
+		lldpRemotes:      make(map[string]*lldpRemote),
+		cdpRemotes:       make(map[string]*cdpRemote),
+		ifNamesByIndex:   make(map[string]string),
+		ifStatusByIndex:  make(map[string]ifStatus),
+		ifIndexByIP:      make(map[string]string),
+		ifNetmaskByIP:    make(map[string]string),
+		l3InterfacesByIP: make(map[string]topologyL3Interface),
+		bridgePortToIf:   make(map[string]string),
+		fdbEntries:       make(map[string]*fdbEntry),
+		fdbIDToVlanID:    make(map[string]string),
+		vlanIDToName:     make(map[string]string),
+		stpPorts:         make(map[string]*stpPortEntry),
+		arpEntries:       make(map[string]*arpEntry),
 	}
 }
 
@@ -42,6 +43,7 @@ func (c *topologyCache) replaceWith(src *topologyCache) {
 	c.ifStatusByIndex = src.ifStatusByIndex
 	c.ifIndexByIP = src.ifIndexByIP
 	c.ifNetmaskByIP = src.ifNetmaskByIP
+	c.l3InterfacesByIP = src.l3InterfacesByIP
 	c.bridgePortToIf = src.bridgePortToIf
 	c.fdbEntries = src.fdbEntries
 	c.fdbIDToVlanID = src.fdbIDToVlanID

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
@@ -225,6 +225,20 @@ func TestTopologyCache_UpdateIfIndexByIP_CollectsAllSNMPDeviceIPs(t *testing.T) 
 	require.Equal(t, "1", cache.ifIndexByIP["10.20.4.1"])
 	require.Equal(t, "2", cache.ifIndexByIP["10.20.4.2"])
 	require.Equal(t, "3", cache.ifIndexByIP["2001:db8::1"])
+	require.Equal(t, "255.255.255.0", cache.ifNetmaskByIP["10.20.4.1"])
+	require.Equal(t, "255.255.255.0", cache.ifNetmaskByIP["10.20.4.2"])
+	require.Empty(t, cache.ifNetmaskByIP["2001:db8::1"])
+	require.Equal(t, topologyL3Interface{
+		IP:      "10.20.4.1",
+		Netmask: "255.255.255.0",
+		IfIndex: "1",
+	}, cache.l3InterfacesByIP["10.20.4.1"])
+	require.Equal(t, topologyL3Interface{
+		IP:      "10.20.4.2",
+		Netmask: "255.255.255.0",
+		IfIndex: "2",
+	}, cache.l3InterfacesByIP["10.20.4.2"])
+	require.NotContains(t, cache.l3InterfacesByIP, "2001:db8::1")
 
 	addrs := cache.localDevice.ManagementAddresses
 	require.Len(t, addrs, 3)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_actor_resolver.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_actor_resolver.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"strings"
+)
+
+type topologyL3ActorRef struct {
+	actorID string
+	match   topologyMatch
+}
+
+type topologyL3ActorResolver struct {
+	byActorID  map[string]topologyL3ActorRef
+	byDeviceID map[string]topologyL3ActorRef
+	byIP       map[string]topologyL3ActorRef
+}
+
+func newTopologyL3ActorResolver(data *topologyData, snapshots []topologyObservationSnapshot) topologyL3ActorResolver {
+	resolver := topologyL3ActorResolver{
+		byActorID:  make(map[string]topologyL3ActorRef),
+		byDeviceID: make(map[string]topologyL3ActorRef),
+		byIP:       make(map[string]topologyL3ActorRef),
+	}
+	if data == nil || len(data.Actors) == 0 {
+		return resolver
+	}
+
+	managedActors := make([]topologyActor, 0, len(data.Actors))
+	for _, actor := range data.Actors {
+		if !isManagedSNMPDeviceActor(actor) {
+			continue
+		}
+		managedActors = append(managedActors, actor)
+		ref := topologyL3ActorRef{
+			actorID: strings.TrimSpace(actor.ActorID),
+			match:   actor.Match,
+		}
+		if ref.actorID != "" {
+			resolver.byActorID[ref.actorID] = ref
+		}
+		if deviceID := topologyMetricValueString(actor.Attributes, "device_id"); deviceID != "" {
+			resolver.addUniqueDeviceID(deviceID, ref)
+		}
+		for _, ip := range normalizedMatchIPs(actor.Match) {
+			resolver.addUniqueIP(ip, ref)
+		}
+	}
+
+	for _, snapshot := range snapshots {
+		deviceID := strings.TrimSpace(snapshot.localDeviceID)
+		if deviceID == "" {
+			continue
+		}
+		for _, actor := range managedActors {
+			if !matchLocalTopologyActor(actor.Match, snapshot.localDevice) {
+				continue
+			}
+			resolver.addUniqueDeviceID(deviceID, topologyL3ActorRef{
+				actorID: strings.TrimSpace(actor.ActorID),
+				match:   actor.Match,
+			})
+		}
+	}
+
+	return resolver
+}
+
+func (r topologyL3ActorResolver) resolve(row topologyL3Interface) (topologyL3ActorRef, bool) {
+	if ref, ok := r.byDeviceID[strings.TrimSpace(row.DeviceID)]; ok && ref.actorID != "" {
+		return ref, true
+	}
+	if ref, ok := r.byActorID[strings.TrimSpace(row.DeviceID)]; ok && ref.actorID != "" {
+		return ref, true
+	}
+	if ref, ok := r.byIP[normalizeIPAddress(row.IP)]; ok && ref.actorID != "" {
+		return ref, true
+	}
+	return topologyL3ActorRef{}, false
+}
+
+func (r topologyL3ActorResolver) addUniqueDeviceID(deviceID string, ref topologyL3ActorRef) {
+	deviceID = strings.TrimSpace(deviceID)
+	if deviceID == "" || ref.actorID == "" {
+		return
+	}
+	existing, ok := r.byDeviceID[deviceID]
+	if !ok {
+		r.byDeviceID[deviceID] = ref
+		return
+	}
+	if existing.actorID != "" && existing.actorID != ref.actorID {
+		r.byDeviceID[deviceID] = topologyL3ActorRef{}
+	}
+}
+
+func (r topologyL3ActorResolver) addUniqueIP(ip string, ref topologyL3ActorRef) {
+	ip = normalizeIPAddress(ip)
+	if ip == "" || ref.actorID == "" {
+		return
+	}
+	existing, ok := r.byIP[ip]
+	if !ok {
+		r.byIP[ip] = ref
+		return
+	}
+	if existing.actorID != "" && existing.actorID != ref.actorID {
+		r.byIP[ip] = topologyL3ActorRef{}
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_interfaces.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_interfaces.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"sort"
+	"strings"
+)
+
+type topologyL3Interface struct {
+	DeviceID string
+	AgentID  string
+	IP       string
+	Netmask  string
+	IfIndex  string
+	IfName   string
+	IfDescr  string
+}
+
+func (c *topologyCache) snapshotL3Interfaces(localDeviceID, agentID string) []topologyL3Interface {
+	if c == nil || len(c.l3InterfacesByIP) == 0 {
+		return nil
+	}
+
+	ips := make([]string, 0, len(c.l3InterfacesByIP))
+	for ip := range c.l3InterfacesByIP {
+		ips = append(ips, ip)
+	}
+	sort.Strings(ips)
+
+	rows := make([]topologyL3Interface, 0, len(ips))
+	for _, ip := range ips {
+		row := c.l3InterfacesByIP[ip]
+		row.DeviceID = strings.TrimSpace(localDeviceID)
+		row.AgentID = strings.TrimSpace(agentID)
+		row.IfIndex = strings.TrimSpace(row.IfIndex)
+		row.IP = normalizeIPAddress(row.IP)
+		row.Netmask = normalizeIPAddress(row.Netmask)
+		if row.IP == "" || row.Netmask == "" || row.IfIndex == "" {
+			continue
+		}
+		row.IfName = strings.TrimSpace(c.ifNamesByIndex[row.IfIndex])
+		status := c.ifStatusByIndex[row.IfIndex]
+		row.IfDescr = strings.TrimSpace(status.ifDescr)
+		if row.IfDescr == "" {
+			row.IfDescr = row.IfName
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_interfaces.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_interfaces.go
@@ -9,7 +9,6 @@ import (
 
 type topologyL3Interface struct {
 	DeviceID string
-	AgentID  string
 	IP       string
 	Netmask  string
 	IfIndex  string
@@ -17,7 +16,7 @@ type topologyL3Interface struct {
 	IfDescr  string
 }
 
-func (c *topologyCache) snapshotL3Interfaces(localDeviceID, agentID string) []topologyL3Interface {
+func (c *topologyCache) snapshotL3Interfaces(localDeviceID string) []topologyL3Interface {
 	if c == nil || len(c.l3InterfacesByIP) == 0 {
 		return nil
 	}
@@ -32,7 +31,6 @@ func (c *topologyCache) snapshotL3Interfaces(localDeviceID, agentID string) []to
 	for _, ip := range ips {
 		row := c.l3InterfacesByIP[ip]
 		row.DeviceID = strings.TrimSpace(localDeviceID)
-		row.AgentID = strings.TrimSpace(agentID)
 		row.IfIndex = strings.TrimSpace(row.IfIndex)
 		row.IP = normalizeIPAddress(row.IP)
 		row.Netmask = normalizeIPAddress(row.Netmask)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const topologyL3SubnetLinkType = "l3_subnet"
+
+type topologyL3EnrichmentStats struct {
+	subnetStats               topologyL3SubnetBuildStats
+	emittedLinks              int
+	suppressedUnresolvedActor int
+	suppressedSelfActor       int
+	suppressedDuplicateLink   int
+}
+
+func applyTopologyL3SubnetEnrichment(data *topologyData, aggregate topologyObservationAggregate) topologyL3EnrichmentStats {
+	var stats topologyL3EnrichmentStats
+	if data == nil || len(aggregate.l3Interfaces) == 0 {
+		recordTopologyL3EnrichmentStats(data, stats)
+		return stats
+	}
+
+	adjacencies, subnetStats := buildTopologyL3SubnetAdjacencies(aggregate.l3Interfaces)
+	stats.subnetStats = subnetStats
+	if len(adjacencies) == 0 {
+		recordTopologyL3EnrichmentStats(data, stats)
+		return stats
+	}
+
+	resolver := newTopologyL3ActorResolver(data, aggregate.snapshots)
+	seen := existingTopologyL3LinkKeys(data.Links)
+	for _, adjacency := range adjacencies {
+		srcRef, ok := resolver.resolve(adjacency.A)
+		if !ok {
+			stats.suppressedUnresolvedActor++
+			continue
+		}
+		dstRef, ok := resolver.resolve(adjacency.B)
+		if !ok {
+			stats.suppressedUnresolvedActor++
+			continue
+		}
+		if srcRef.actorID == dstRef.actorID {
+			stats.suppressedSelfActor++
+			continue
+		}
+		link := topologyL3SubnetLink(adjacency, srcRef, dstRef)
+		key := topologyL3SubnetLinkKey(link)
+		if _, exists := seen[key]; exists {
+			stats.suppressedDuplicateLink++
+			continue
+		}
+		seen[key] = struct{}{}
+		data.Links = append(data.Links, link)
+		stats.emittedLinks++
+	}
+
+	sort.Slice(data.Links, func(i, j int) bool {
+		return topologyLinkSortKey(data.Links[i]) < topologyLinkSortKey(data.Links[j])
+	})
+	recordTopologyL3EnrichmentStats(data, stats)
+	recomputeTopologyLinkStats(data)
+	return stats
+}
+
+func topologyL3SubnetLink(adjacency topologyL3SubnetAdjacency, srcRef, dstRef topologyL3ActorRef) topologyLink {
+	return topologyLink{
+		Layer:      "3",
+		Protocol:   topologyL3SubnetLinkType,
+		LinkType:   topologyL3SubnetLinkType,
+		Direction:  "observed",
+		SrcActorID: srcRef.actorID,
+		DstActorID: dstRef.actorID,
+		Src: topologyLinkEndpoint{
+			Match:      srcRef.match,
+			Attributes: topologyL3EndpointAttributes(adjacency.A, adjacency),
+		},
+		Dst: topologyLinkEndpoint{
+			Match:      dstRef.match,
+			Attributes: topologyL3EndpointAttributes(adjacency.B, adjacency),
+		},
+		Metrics: map[string]any{
+			"source":          "ip_mib",
+			"inference":       "shared_subnet",
+			"attachment_mode": "logical_l3_subnet",
+			"subnet":          adjacency.Subnet,
+			"network":         adjacency.Network,
+			"netmask":         adjacency.Netmask,
+			"prefix":          adjacency.Prefix,
+		},
+	}
+}
+
+func topologyL3EndpointAttributes(row topologyL3Interface, adjacency topologyL3SubnetAdjacency) map[string]any {
+	attrs := map[string]any{
+		"ip":      normalizeIPAddress(row.IP),
+		"subnet":  adjacency.Subnet,
+		"network": adjacency.Network,
+		"netmask": adjacency.Netmask,
+		"prefix":  adjacency.Prefix,
+		"source":  "ip_mib",
+	}
+	if ifIndex := parseIndex(row.IfIndex); ifIndex > 0 {
+		attrs["if_index"] = ifIndex
+	}
+	if ifName := strings.TrimSpace(row.IfName); ifName != "" {
+		attrs["if_name"] = ifName
+	}
+	if ifDescr := strings.TrimSpace(row.IfDescr); ifDescr != "" {
+		attrs["if_descr"] = ifDescr
+	}
+	return attrs
+}
+
+func existingTopologyL3LinkKeys(links []topologyLink) map[string]struct{} {
+	seen := make(map[string]struct{})
+	for _, link := range links {
+		if strings.EqualFold(strings.TrimSpace(firstNonEmptyString(link.LinkType, link.Protocol)), topologyL3SubnetLinkType) {
+			seen[topologyL3SubnetLinkKey(link)] = struct{}{}
+		}
+	}
+	return seen
+}
+
+func topologyL3SubnetLinkKey(link topologyLink) string {
+	src := strings.TrimSpace(link.SrcActorID)
+	dst := strings.TrimSpace(link.DstActorID)
+	if src > dst {
+		src, dst = dst, src
+	}
+	return strings.Join([]string{
+		src,
+		dst,
+		topologyMetricValueString(link.Metrics, "subnet"),
+		strconv.Itoa(intStatValue(link.Metrics["prefix"])),
+	}, "|")
+}
+
+func recordTopologyL3EnrichmentStats(data *topologyData, stats topologyL3EnrichmentStats) {
+	if data == nil {
+		return
+	}
+	if data.Stats == nil {
+		data.Stats = make(map[string]any)
+	}
+	data.Stats["l3_subnet_candidate_subnets"] = stats.subnetStats.candidateSubnets
+	data.Stats["l3_subnet_candidate_links"] = stats.subnetStats.candidateLinks
+	data.Stats["l3_subnet_emitted_links"] = stats.emittedLinks
+	data.Stats["l3_subnet_suppressed_invalid"] = stats.subnetStats.suppressedInvalid
+	data.Stats["l3_subnet_suppressed_unsupported_prefix"] = stats.subnetStats.suppressedUnsupportedPrefix
+	data.Stats["l3_subnet_suppressed_duplicate_ip"] = stats.subnetStats.suppressedDuplicateIP
+	data.Stats["l3_subnet_suppressed_self_link"] = stats.subnetStats.suppressedSelfLink
+	data.Stats["l3_subnet_suppressed_unmatched"] = stats.subnetStats.suppressedUnmatched
+	data.Stats["l3_subnet_suppressed_multi_access"] = stats.subnetStats.suppressedMultiAccess
+	data.Stats["l3_subnet_suppressed_unresolved_actor"] = stats.suppressedUnresolvedActor
+	data.Stats["l3_subnet_suppressed_self_actor"] = stats.suppressedSelfActor
+	data.Stats["l3_subnet_suppressed_duplicate_link"] = stats.suppressedDuplicateLink
+	recomputeTopologyL3VisibleLinkStats(data)
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links.go
@@ -133,12 +133,22 @@ func topologyL3SubnetLinkKey(link topologyLink) string {
 	if src > dst {
 		src, dst = dst, src
 	}
-	return strings.Join([]string{
+	return topologyL3SubnetLinkKeyParts(
 		src,
 		dst,
 		topologyMetricValueString(link.Metrics, "subnet"),
 		strconv.Itoa(intStatValue(link.Metrics["prefix"])),
-	}, "|")
+	)
+}
+
+func topologyL3SubnetLinkKeyParts(parts ...string) string {
+	var b strings.Builder
+	for _, part := range parts {
+		b.WriteString(strconv.Itoa(len(part)))
+		b.WriteByte(':')
+		b.WriteString(part)
+	}
+	return b.String()
 }
 
 func recordTopologyL3EnrichmentStats(data *topologyData, stats topologyL3EnrichmentStats) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links_test.go
@@ -79,7 +79,7 @@ func TestApplyTopologyL3SubnetEnrichmentSuppressesDuplicateLink(t *testing.T) {
 		DstActorID: "router-b",
 		Metrics: map[string]any{
 			"subnet": "198.51.100.0/30",
-			"prefix": 30,
+			"prefix": uint64(30),
 		},
 	}
 	data := topologyData{

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links_test.go
@@ -107,6 +107,27 @@ func TestApplyTopologyL3SubnetEnrichmentSuppressesDuplicateLink(t *testing.T) {
 	require.Equal(t, 1, data.Stats["l3_subnet_suppressed_duplicate_link"])
 }
 
+func TestTopologyL3SubnetLinkKeySeparatesDelimitedFields(t *testing.T) {
+	left := topologyLink{
+		SrcActorID: "a|b",
+		DstActorID: "c",
+		Metrics: map[string]any{
+			"subnet": "198.51.100.0/30",
+			"prefix": 30,
+		},
+	}
+	right := topologyLink{
+		SrcActorID: "a",
+		DstActorID: "b|c",
+		Metrics: map[string]any{
+			"subnet": "198.51.100.0/30",
+			"prefix": 30,
+		},
+	}
+
+	require.NotEqual(t, topologyL3SubnetLinkKey(left), topologyL3SubnetLinkKey(right))
+}
+
 func TestApplyTopologyDepthFocusFilterKeepsIncidentL3SubnetLink(t *testing.T) {
 	data := topologyData{
 		Stats: map[string]any{

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopologyL3ActorResolverSuppressesAmbiguousIP(t *testing.T) {
+	data := topologyData{
+		Actors: []topologyActor{
+			topologyL3ManagedActorForTest("router-a", nil, "198.51.100.1"),
+			topologyL3ManagedActorForTest("router-b", nil, "198.51.100.1"),
+		},
+	}
+
+	resolver := newTopologyL3ActorResolver(&data, nil)
+	_, ok := resolver.resolve(topologyL3Interface{
+		DeviceID: "unknown-device",
+		IP:       "198.51.100.1",
+	})
+
+	require.False(t, ok)
+}
+
+func TestApplyTopologyL3SubnetEnrichmentSuppressesUnresolvedActor(t *testing.T) {
+	data := topologyData{
+		Actors: []topologyActor{
+			topologyL3ManagedActorForTest("device-a", nil, "198.51.100.1"),
+		},
+	}
+	aggregate := topologyObservationAggregate{
+		l3Interfaces: []topologyL3Interface{
+			l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+			l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
+		},
+	}
+
+	stats := applyTopologyL3SubnetEnrichment(&data, aggregate)
+
+	require.Empty(t, data.Links)
+	require.Equal(t, 1, stats.suppressedUnresolvedActor)
+	require.Equal(t, 1, data.Stats["l3_subnet_candidate_links"])
+	require.Equal(t, 0, data.Stats["l3_subnet_emitted_links"])
+	require.Equal(t, 0, data.Stats["l3_subnet_visible_links"])
+	require.Equal(t, 1, data.Stats["l3_subnet_suppressed_unresolved_actor"])
+}
+
+func TestApplyTopologyL3SubnetEnrichmentSuppressesSelfActor(t *testing.T) {
+	data := topologyData{
+		Actors: []topologyActor{
+			topologyL3ManagedActorForTest("router-a", nil, "198.51.100.1", "198.51.100.2"),
+		},
+	}
+	aggregate := topologyObservationAggregate{
+		l3Interfaces: []topologyL3Interface{
+			l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+			l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
+		},
+	}
+
+	stats := applyTopologyL3SubnetEnrichment(&data, aggregate)
+
+	require.Empty(t, data.Links)
+	require.Equal(t, 1, stats.suppressedSelfActor)
+	require.Equal(t, 1, data.Stats["l3_subnet_candidate_links"])
+	require.Equal(t, 0, data.Stats["l3_subnet_emitted_links"])
+	require.Equal(t, 0, data.Stats["l3_subnet_visible_links"])
+	require.Equal(t, 1, data.Stats["l3_subnet_suppressed_self_actor"])
+}
+
+func TestApplyTopologyL3SubnetEnrichmentSuppressesDuplicateLink(t *testing.T) {
+	existing := topologyLink{
+		Protocol:   topologyL3SubnetLinkType,
+		LinkType:   topologyL3SubnetLinkType,
+		SrcActorID: "router-a",
+		DstActorID: "router-b",
+		Metrics: map[string]any{
+			"subnet": "198.51.100.0/30",
+			"prefix": 30,
+		},
+	}
+	data := topologyData{
+		Actors: []topologyActor{
+			topologyL3ManagedActorForTest("router-a", nil, "198.51.100.1"),
+			topologyL3ManagedActorForTest("router-b", nil, "198.51.100.2"),
+		},
+		Links: []topologyLink{existing},
+	}
+	aggregate := topologyObservationAggregate{
+		l3Interfaces: []topologyL3Interface{
+			l3InterfaceForTest("router-a", "198.51.100.1", "255.255.255.252", "2"),
+			l3InterfaceForTest("router-b", "198.51.100.2", "255.255.255.252", "3"),
+		},
+	}
+
+	stats := applyTopologyL3SubnetEnrichment(&data, aggregate)
+
+	require.Len(t, data.Links, 1)
+	require.Equal(t, existing, data.Links[0])
+	require.Equal(t, 1, stats.suppressedDuplicateLink)
+	require.Equal(t, 1, data.Stats["l3_subnet_candidate_links"])
+	require.Equal(t, 0, data.Stats["l3_subnet_emitted_links"])
+	require.Equal(t, 1, data.Stats["l3_subnet_visible_links"])
+	require.Equal(t, 1, data.Stats["l3_subnet_suppressed_duplicate_link"])
+}
+
+func TestApplyTopologyDepthFocusFilterKeepsIncidentL3SubnetLink(t *testing.T) {
+	data := topologyData{
+		Stats: map[string]any{
+			"l3_subnet_emitted_links": 1,
+		},
+		Actors: []topologyActor{
+			topologyL3ManagedActorForTest("router-a", nil, "198.51.100.1"),
+			topologyL3ManagedActorForTest("router-b", nil, "198.51.100.2"),
+		},
+		Links: []topologyLink{
+			{
+				Protocol:   topologyL3SubnetLinkType,
+				LinkType:   topologyL3SubnetLinkType,
+				SrcActorID: "router-a",
+				DstActorID: "router-b",
+				Metrics: map[string]any{
+					"subnet": "198.51.100.0/30",
+					"prefix": 30,
+				},
+			},
+		},
+	}
+
+	applyTopologyDepthFocusFilter(&data, topologyQueryOptions{
+		ManagedDeviceFocus:     "ip:198.51.100.1",
+		Depth:                  1,
+		InferenceStrategy:      topologyInferenceStrategyFDBMinimumKnowledge,
+		MapType:                topologyMapTypeHighConfidenceInferred,
+		EliminateNonIPInferred: true,
+	})
+
+	require.Len(t, data.Actors, 2)
+	require.Len(t, data.Links, 1)
+	require.Equal(t, topologyL3SubnetLinkType, data.Links[0].LinkType)
+	require.Equal(t, 1, data.Stats["l3_subnet_emitted_links"])
+	require.Equal(t, 1, data.Stats["l3_subnet_visible_links"])
+}
+
+func topologyL3ManagedActorForTest(actorID string, attrs map[string]any, ips ...string) topologyActor {
+	return topologyActor{
+		ActorID:    actorID,
+		ActorType:  "router",
+		Layer:      "network",
+		Source:     "snmp",
+		Match:      topologyMatch{IPAddresses: ips},
+		Attributes: attrs,
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_subnets.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_subnets.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"net/netip"
+	"sort"
+	"strconv"
+	"strings"
+
+	topologyengine "github.com/netdata/netdata/go/plugins/pkg/l2topology"
+)
+
+type topologyL3SubnetAdjacency struct {
+	Subnet  string
+	Network string
+	Netmask string
+	Prefix  int
+	A       topologyL3Interface
+	B       topologyL3Interface
+}
+
+type topologyL3SubnetBuildStats struct {
+	candidateSubnets            int
+	candidateLinks              int
+	suppressedInvalid           int
+	suppressedUnsupportedPrefix int
+	suppressedDuplicateIP       int
+	suppressedSelfLink          int
+	suppressedUnmatched         int
+	suppressedMultiAccess       int
+}
+
+type topologyL3SubnetGroup struct {
+	network netip.Addr
+	netmask netip.Addr
+	prefix  int
+	rows    []topologyL3Interface
+}
+
+func buildTopologyL3SubnetAdjacencies(rows []topologyL3Interface) ([]topologyL3SubnetAdjacency, topologyL3SubnetBuildStats) {
+	var stats topologyL3SubnetBuildStats
+	if len(rows) == 0 {
+		return nil, stats
+	}
+
+	groups := make(map[string]*topologyL3SubnetGroup)
+	for _, row := range rows {
+		group, ok := topologyL3SubnetGroupForInterface(row)
+		if !ok {
+			stats.suppressedInvalid++
+			continue
+		}
+		if !topologyL3SubnetPrefixSupported(group.prefix) {
+			stats.suppressedUnsupportedPrefix++
+			continue
+		}
+		key := topologyL3SubnetKey(group.network, group.prefix)
+		existing := groups[key]
+		if existing == nil {
+			existing = group
+			groups[key] = existing
+		}
+		existing.rows = append(existing.rows, row)
+	}
+
+	keys := make([]string, 0, len(groups))
+	for key := range groups {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	adjacencies := make([]topologyL3SubnetAdjacency, 0, len(keys))
+	for _, key := range keys {
+		group := groups[key]
+		stats.candidateSubnets++
+		sortTopologyL3Interfaces(group.rows)
+		if topologyL3SubnetHasDuplicateIP(group.rows) {
+			stats.suppressedDuplicateIP++
+			continue
+		}
+		if len(group.rows) < 2 {
+			stats.suppressedUnmatched++
+			continue
+		}
+		if len(group.rows) > 2 {
+			stats.suppressedMultiAccess++
+			continue
+		}
+		if strings.TrimSpace(group.rows[0].DeviceID) == strings.TrimSpace(group.rows[1].DeviceID) {
+			stats.suppressedSelfLink++
+			continue
+		}
+		adjacencies = append(adjacencies, topologyL3SubnetAdjacency{
+			Subnet:  group.network.String() + "/" + strconv.Itoa(group.prefix),
+			Network: group.network.String(),
+			Netmask: group.netmask.String(),
+			Prefix:  group.prefix,
+			A:       group.rows[0],
+			B:       group.rows[1],
+		})
+		stats.candidateLinks++
+	}
+
+	return adjacencies, stats
+}
+
+func topologyL3SubnetGroupForInterface(row topologyL3Interface) (*topologyL3SubnetGroup, bool) {
+	deviceID := strings.TrimSpace(row.DeviceID)
+	if deviceID == "" || strings.TrimSpace(row.IfIndex) == "" {
+		return nil, false
+	}
+	ip, err := netip.ParseAddr(normalizeIPAddress(row.IP))
+	if err != nil || !ip.Is4() {
+		return nil, false
+	}
+	netmask, err := netip.ParseAddr(normalizeIPAddress(row.Netmask))
+	if err != nil || !netmask.Is4() {
+		return nil, false
+	}
+	network, ok := topologyengine.NetworkAddress(ip, netmask)
+	if !ok {
+		return nil, false
+	}
+	prefix, err := topologyengine.MaskToCIDRPrefix(netmask)
+	if err != nil {
+		return nil, false
+	}
+	return &topologyL3SubnetGroup{
+		network: network,
+		netmask: netmask,
+		prefix:  prefix,
+	}, true
+}
+
+func topologyL3SubnetPrefixSupported(prefix int) bool {
+	return prefix == 30 || prefix == 31
+}
+
+func topologyL3SubnetKey(network netip.Addr, prefix int) string {
+	return network.String() + "/" + strconv.Itoa(prefix)
+}
+
+func sortTopologyL3Interfaces(rows []topologyL3Interface) {
+	sort.Slice(rows, func(i, j int) bool {
+		return topologyL3InterfaceSortKey(rows[i]) < topologyL3InterfaceSortKey(rows[j])
+	})
+}
+
+func topologyL3InterfaceSortKey(row topologyL3Interface) string {
+	return strings.Join([]string{
+		strings.TrimSpace(row.DeviceID),
+		normalizeIPAddress(row.IP),
+		strings.TrimSpace(row.IfIndex),
+	}, "\x00")
+}
+
+func topologyL3SubnetHasDuplicateIP(rows []topologyL3Interface) bool {
+	seen := make(map[string]string, len(rows))
+	for _, row := range rows {
+		ip := normalizeIPAddress(row.IP)
+		if ip == "" {
+			continue
+		}
+		deviceID := strings.TrimSpace(row.DeviceID)
+		if owner, ok := seen[ip]; ok && owner != deviceID {
+			return true
+		}
+		seen[ip] = deviceID
+	}
+	return false
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_subnets_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_subnets_test.go
@@ -160,7 +160,6 @@ func TestBuildTopologyL3SubnetAdjacenciesSuppressesInvalidRows(t *testing.T) {
 func l3InterfaceForTest(deviceID, ip, netmask, ifIndex string) topologyL3Interface {
 	return topologyL3Interface{
 		DeviceID: deviceID,
-		AgentID:  "agent-test",
 		IP:       ip,
 		Netmask:  netmask,
 		IfIndex:  ifIndex,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_subnets_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_subnets_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildTopologyL3SubnetAdjacenciesIPv4PointToPoint(t *testing.T) {
+	rows := []topologyL3Interface{
+		l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
+		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+	}
+
+	links, stats := buildTopologyL3SubnetAdjacencies(rows)
+
+	require.Len(t, links, 1)
+	require.Equal(t, "198.51.100.0/30", links[0].Subnet)
+	require.Equal(t, "198.51.100.0", links[0].Network)
+	require.Equal(t, "255.255.255.252", links[0].Netmask)
+	require.Equal(t, 30, links[0].Prefix)
+	require.Equal(t, "device-a", links[0].A.DeviceID)
+	require.Equal(t, "device-b", links[0].B.DeviceID)
+	require.Equal(t, topologyL3SubnetBuildStats{
+		candidateSubnets: 1,
+		candidateLinks:   1,
+	}, stats)
+}
+
+func TestBuildTopologyL3SubnetAdjacenciesSupportsIPv4ThirtyOne(t *testing.T) {
+	rows := []topologyL3Interface{
+		l3InterfaceForTest("device-a", "198.51.100.0", "255.255.255.254", "2"),
+		l3InterfaceForTest("device-b", "198.51.100.1", "255.255.255.254", "3"),
+	}
+
+	links, stats := buildTopologyL3SubnetAdjacencies(rows)
+
+	require.Len(t, links, 1)
+	require.Equal(t, "198.51.100.0/31", links[0].Subnet)
+	require.Equal(t, 31, links[0].Prefix)
+	require.Equal(t, topologyL3SubnetBuildStats{
+		candidateSubnets: 1,
+		candidateLinks:   1,
+	}, stats)
+}
+
+func TestBuildTopologyL3SubnetAdjacenciesSuppressesUnsupportedPrefix(t *testing.T) {
+	rows := []topologyL3Interface{
+		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.0", "2"),
+		l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.0", "3"),
+	}
+
+	links, stats := buildTopologyL3SubnetAdjacencies(rows)
+
+	require.Empty(t, links)
+	require.Equal(t, topologyL3SubnetBuildStats{
+		suppressedUnsupportedPrefix: 2,
+	}, stats)
+}
+
+func TestBuildTopologyL3SubnetAdjacenciesSuppressesDuplicateIPOwnership(t *testing.T) {
+	rows := []topologyL3Interface{
+		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+		l3InterfaceForTest("device-b", "198.51.100.1", "255.255.255.252", "3"),
+	}
+
+	links, stats := buildTopologyL3SubnetAdjacencies(rows)
+
+	require.Empty(t, links)
+	require.Equal(t, topologyL3SubnetBuildStats{
+		candidateSubnets:      1,
+		suppressedDuplicateIP: 1,
+	}, stats)
+}
+
+func TestBuildTopologyL3SubnetAdjacenciesSuppressesSameDeviceSelfLink(t *testing.T) {
+	rows := []topologyL3Interface{
+		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+		l3InterfaceForTest("device-a", "198.51.100.2", "255.255.255.252", "3"),
+	}
+
+	links, stats := buildTopologyL3SubnetAdjacencies(rows)
+
+	require.Empty(t, links)
+	require.Equal(t, topologyL3SubnetBuildStats{
+		candidateSubnets:   1,
+		suppressedSelfLink: 1,
+	}, stats)
+}
+
+func TestBuildTopologyL3SubnetAdjacenciesSuppressesUnmatchedSubnet(t *testing.T) {
+	rows := []topologyL3Interface{
+		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+	}
+
+	links, stats := buildTopologyL3SubnetAdjacencies(rows)
+
+	require.Empty(t, links)
+	require.Equal(t, topologyL3SubnetBuildStats{
+		candidateSubnets:    1,
+		suppressedUnmatched: 1,
+	}, stats)
+}
+
+func TestBuildTopologyL3SubnetAdjacenciesSuppressesMultiAccessRows(t *testing.T) {
+	rows := []topologyL3Interface{
+		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+		l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
+		l3InterfaceForTest("device-c", "198.51.100.3", "255.255.255.252", "4"),
+	}
+
+	links, stats := buildTopologyL3SubnetAdjacencies(rows)
+
+	require.Empty(t, links)
+	require.Equal(t, topologyL3SubnetBuildStats{
+		candidateSubnets:      1,
+		suppressedMultiAccess: 1,
+	}, stats)
+}
+
+func TestBuildTopologyL3SubnetAdjacenciesDeterministic(t *testing.T) {
+	rows := []topologyL3Interface{
+		l3InterfaceForTest("device-d", "198.51.100.6", "255.255.255.252", "6"),
+		l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
+		l3InterfaceForTest("device-c", "198.51.100.5", "255.255.255.252", "5"),
+		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+	}
+	reversed := slices.Clone(rows)
+	slices.Reverse(reversed)
+
+	links, stats := buildTopologyL3SubnetAdjacencies(rows)
+	reversedLinks, reversedStats := buildTopologyL3SubnetAdjacencies(reversed)
+
+	require.Equal(t, links, reversedLinks)
+	require.Equal(t, stats, reversedStats)
+	require.Len(t, links, 2)
+	require.Equal(t, "198.51.100.0/30", links[0].Subnet)
+	require.Equal(t, "198.51.100.4/30", links[1].Subnet)
+}
+
+func TestBuildTopologyL3SubnetAdjacenciesSuppressesInvalidRows(t *testing.T) {
+	rows := []topologyL3Interface{
+		l3InterfaceForTest("", "198.51.100.1", "255.255.255.252", "2"),
+		l3InterfaceForTest("device-a", "not-an-ip", "255.255.255.252", "2"),
+		l3InterfaceForTest("device-a", "2001:db8::1", "ffff:ffff:ffff:ffff::", "2"),
+		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", ""),
+	}
+
+	links, stats := buildTopologyL3SubnetAdjacencies(rows)
+
+	require.Empty(t, links)
+	require.Equal(t, topologyL3SubnetBuildStats{
+		suppressedInvalid: 4,
+	}, stats)
+}
+
+func l3InterfaceForTest(deviceID, ip, netmask, ifIndex string) topologyL3Interface {
+	return topologyL3Interface{
+		DeviceID: deviceID,
+		AgentID:  "agent-test",
+		IP:       ip,
+		Netmask:  netmask,
+		IfIndex:  ifIndex,
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_build.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_build.go
@@ -33,6 +33,7 @@ func buildSingleMapTopologySnapshot(aggregate topologyObservationAggregate, opti
 	}
 	augmentTopologySnapshotLocals(&data, aggregate.snapshots)
 	applySNMPTopologyShapePolicies(&data, options)
+	applyTopologyL3SubnetEnrichment(&data, aggregate)
 	applyTopologyDepthFocusFilter(&data, options)
 	return data, true
 }
@@ -68,6 +69,7 @@ func buildProbableTopologySnapshot(aggregate topologyObservationAggregate, optio
 	augmentTopologySnapshotLocals(&probableData, aggregate.snapshots)
 	applySNMPTopologyShapePolicies(&probableData, probableOptions)
 	markProbableDeltaLinks(&strictData, &probableData)
+	applyTopologyL3SubnetEnrichment(&probableData, aggregate)
 	applyTopologyDepthFocusFilter(&probableData, options)
 	return probableData, true
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_observations.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_observations.go
@@ -74,16 +74,20 @@ func aggregateTopologyObservationSnapshots(snapshots []topologyObservationSnapsh
 	}
 
 	totalObservations := 0
+	totalL3Interfaces := 0
 	for _, snapshot := range snapshots {
 		totalObservations += len(snapshot.l2Observations)
+		totalL3Interfaces += len(snapshot.l3Interfaces)
 	}
 
 	aggregate := topologyObservationAggregate{
 		snapshots:      snapshots,
 		l2Observations: make([]topologyengine.L2Observation, 0, totalObservations),
+		l3Interfaces:   make([]topologyL3Interface, 0, totalL3Interfaces),
 	}
 	for _, snapshot := range snapshots {
 		aggregate.l2Observations = append(aggregate.l2Observations, snapshot.l2Observations...)
+		aggregate.l3Interfaces = append(aggregate.l3Interfaces, snapshot.l3Interfaces...)
 		if aggregate.localDeviceID == "" {
 			aggregate.localDeviceID = snapshot.localDeviceID
 		}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_snapshot.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_snapshot.go
@@ -54,7 +54,7 @@ func (c *topologyCache) snapshotEngineObservations() (topologyObservationSnapsho
 
 	return topologyObservationSnapshot{
 		l2Observations: []topologyengine.L2Observation{localObservation},
-		l3Interfaces:   c.snapshotL3Interfaces(localObservation.DeviceID, c.agentID),
+		l3Interfaces:   c.snapshotL3Interfaces(localObservation.DeviceID),
 		localDevice:    local,
 		localDeviceID:  localObservation.DeviceID,
 		agentID:        strings.TrimSpace(c.agentID),

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_snapshot.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_snapshot.go
@@ -11,6 +11,7 @@ import (
 
 type topologyObservationSnapshot struct {
 	l2Observations []topologyengine.L2Observation
+	l3Interfaces   []topologyL3Interface
 	localDevice    topologyDevice
 	localDeviceID  string
 	agentID        string
@@ -20,6 +21,7 @@ type topologyObservationSnapshot struct {
 type topologyObservationAggregate struct {
 	snapshots      []topologyObservationSnapshot
 	l2Observations []topologyengine.L2Observation
+	l3Interfaces   []topologyL3Interface
 	localDeviceID  string
 	agentID        string
 	collectedAt    time.Time
@@ -52,6 +54,7 @@ func (c *topologyCache) snapshotEngineObservations() (topologyObservationSnapsho
 
 	return topologyObservationSnapshot{
 		l2Observations: []topologyengine.L2Observation{localObservation},
+		l3Interfaces:   c.snapshotL3Interfaces(localObservation.DeviceID, c.agentID),
 		localDevice:    local,
 		localDeviceID:  localObservation.DeviceID,
 		agentID:        strings.TrimSpace(c.agentID),

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -392,7 +392,6 @@ func TestTopologyCache_SnapshotEngineObservationsIncludesL3Interfaces(t *testing
 	require.Len(t, snapshot.l3Interfaces, 1)
 	require.Equal(t, topologyL3Interface{
 		DeviceID: snapshot.localDeviceID,
-		AgentID:  "agent-test",
 		IP:       "198.51.100.1",
 		Netmask:  "255.255.255.252",
 		IfIndex:  "2",
@@ -413,7 +412,6 @@ func TestAggregateTopologyObservationSnapshotsIncludesL3Interfaces(t *testing.T)
 			}},
 			l3Interfaces: []topologyL3Interface{{
 				DeviceID: "device-a",
-				AgentID:  "agent-a",
 				IP:       "198.51.100.1",
 				Netmask:  "255.255.255.252",
 				IfIndex:  "2",

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	topologyengine "github.com/netdata/netdata/go/plugins/pkg/l2topology"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -119,6 +120,72 @@ func TestTopologyRegistry_SnapshotSingleCacheKeepsLLDPUnidirectional(t *testing.
 	require.False(t, hasPairConsistency)
 	require.Equal(t, 1, data.Stats["links_unidirectional"].(int))
 	require.Equal(t, 0, data.Stats["links_bidirectional"].(int))
+}
+
+func TestTopologyRegistry_DefaultMapEmitsL3SubnetForManagedRoutersWithoutLLDP(t *testing.T) {
+	registry := newTopologyRegistry()
+
+	cacheA := newTopologyCache()
+	cacheA.updateTime = time.Now()
+	cacheA.lastUpdate = cacheA.updateTime
+	cacheA.agentID = "agent-test"
+	cacheA.localDevice = topologyDevice{
+		ChassisID:     "00:11:22:33:44:55",
+		ChassisIDType: "macAddress",
+		SysName:       "router-a",
+		ManagementIP:  "10.0.0.1",
+	}
+	cacheA.updateIfIndexByIP(map[string]string{
+		tagTopoIfIndex: "2",
+		tagTopoIPAddr:  "198.51.100.1",
+		tagTopoIPMask:  "255.255.255.252",
+	})
+	cacheA.updateIfNameByIndex(map[string]string{
+		tagTopoIfIndex: "2",
+		tagTopoIfName:  "wan0",
+	})
+
+	cacheB := newTopologyCache()
+	cacheB.updateTime = time.Now().Add(time.Second)
+	cacheB.lastUpdate = cacheB.updateTime
+	cacheB.agentID = "agent-test"
+	cacheB.localDevice = topologyDevice{
+		ChassisID:     "aa:bb:cc:dd:ee:ff",
+		ChassisIDType: "macAddress",
+		SysName:       "router-b",
+		ManagementIP:  "10.0.0.2",
+	}
+	cacheB.updateIfIndexByIP(map[string]string{
+		tagTopoIfIndex: "7",
+		tagTopoIPAddr:  "198.51.100.2",
+		tagTopoIPMask:  "255.255.255.252",
+	})
+	cacheB.updateIfNameByIndex(map[string]string{
+		tagTopoIfIndex: "7",
+		tagTopoIfName:  "wan7",
+	})
+
+	registry.register(cacheA)
+	registry.register(cacheB)
+
+	data, ok := snapshotTopologyRegistryForTest(registry)
+
+	require.True(t, ok)
+	require.Len(t, data.Actors, 2)
+	require.Len(t, data.Links, 1)
+	link := data.Links[0]
+	require.Equal(t, "3", link.Layer)
+	require.Equal(t, topologyL3SubnetLinkType, link.Protocol)
+	require.Equal(t, topologyL3SubnetLinkType, link.LinkType)
+	require.Equal(t, "observed", link.Direction)
+	require.Equal(t, "198.51.100.0/30", link.Metrics["subnet"])
+	require.Equal(t, "shared_subnet", link.Metrics["inference"])
+	require.Equal(t, "logical_l3_subnet", link.Metrics["attachment_mode"])
+	require.Equal(t, "198.51.100.1", link.Src.Attributes["ip"])
+	require.Equal(t, "198.51.100.2", link.Dst.Attributes["ip"])
+	require.Equal(t, 1, data.Stats["l3_subnet_emitted_links"])
+	require.Equal(t, 1, data.Stats["l3_subnet_visible_links"])
+	require.Equal(t, 1, data.Stats["links_total"])
 }
 
 func TestCompareCollapseActorPriorityPrefersNonEmptyActorID(t *testing.T) {
@@ -291,6 +358,74 @@ func TestTopologyCache_SnapshotEngineObservationsUsesDirectLocalObservation(t *t
 	require.Equal(t, snapshot.localDeviceID, snapshot.l2Observations[0].DeviceID)
 	require.Len(t, snapshot.l2Observations[0].LLDPRemotes, 1)
 	require.Len(t, snapshot.l2Observations[0].CDPRemotes, 1)
+}
+
+func TestTopologyCache_SnapshotEngineObservationsIncludesL3Interfaces(t *testing.T) {
+	cache := newTopologyCache()
+	cache.updateTime = time.Now()
+	cache.lastUpdate = cache.updateTime
+	cache.agentID = "agent-test"
+	cache.localDevice = topologyDevice{
+		ChassisID:     "00:11:22:33:44:55",
+		ChassisIDType: "macAddress",
+		SysName:       "router-a",
+		ManagementIP:  "10.0.0.1",
+	}
+	cache.updateIfIndexByIP(map[string]string{
+		tagTopoIfIndex: "2",
+		tagTopoIPAddr:  "198.51.100.1",
+		tagTopoIPMask:  "255.255.255.252",
+	})
+	cache.updateIfNameByIndex(map[string]string{
+		tagTopoIfIndex: "2",
+		tagTopoIfName:  "Gi0/2",
+		tagTopoIfDescr: "Uplink",
+	})
+	cache.updateIfIndexByIP(map[string]string{
+		tagTopoIfIndex: "3",
+		tagTopoIPAddr:  "2001:db8::1",
+	})
+
+	snapshot, ok := cache.snapshotEngineObservations()
+
+	require.True(t, ok)
+	require.Len(t, snapshot.l3Interfaces, 1)
+	require.Equal(t, topologyL3Interface{
+		DeviceID: snapshot.localDeviceID,
+		AgentID:  "agent-test",
+		IP:       "198.51.100.1",
+		Netmask:  "255.255.255.252",
+		IfIndex:  "2",
+		IfName:   "Gi0/2",
+		IfDescr:  "Uplink",
+	}, snapshot.l3Interfaces[0])
+}
+
+func TestAggregateTopologyObservationSnapshotsIncludesL3Interfaces(t *testing.T) {
+	collectedAt := time.Now()
+	snapshots := []topologyObservationSnapshot{
+		{
+			localDeviceID: "device-a",
+			agentID:       "agent-a",
+			collectedAt:   collectedAt,
+			l2Observations: []topologyengine.L2Observation{{
+				DeviceID: "device-a",
+			}},
+			l3Interfaces: []topologyL3Interface{{
+				DeviceID: "device-a",
+				AgentID:  "agent-a",
+				IP:       "198.51.100.1",
+				Netmask:  "255.255.255.252",
+				IfIndex:  "2",
+			}},
+		},
+	}
+
+	aggregate, ok := aggregateTopologyObservationSnapshots(snapshots)
+
+	require.True(t, ok)
+	require.Len(t, aggregate.l3Interfaces, 1)
+	require.Equal(t, snapshots[0].l3Interfaces[0], aggregate.l3Interfaces[0])
 }
 
 func TestTopologyRegistry_SnapshotReturnsFalseWithoutCollectedCaches(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_shape_stats.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_shape_stats.go
@@ -26,4 +26,21 @@ func recomputeTopologyLinkStats(data *topologyData) {
 		}
 	}
 	data.Stats["links_probable"] = probable
+	recomputeTopologyL3VisibleLinkStats(data)
+}
+
+func recomputeTopologyL3VisibleLinkStats(data *topologyData) {
+	if data == nil || data.Stats == nil {
+		return
+	}
+	if _, ok := data.Stats["l3_subnet_emitted_links"]; !ok {
+		return
+	}
+	count := 0
+	for _, link := range data.Links {
+		if strings.EqualFold(strings.TrimSpace(firstNonEmptyString(link.LinkType, link.Protocol)), topologyL3SubnetLinkType) {
+			count++
+		}
+	}
+	data.Stats["l3_subnet_visible_links"] = count
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_shape_stats_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_shape_stats_test.go
@@ -51,3 +51,21 @@ func TestApplySNMPTopologyShapePolicies_EmitsStatsContractKeys(t *testing.T) {
 	require.Equal(t, topologyMapTypeHighConfidenceInferred, data.Stats["map_type"])
 	require.Equal(t, topologyInferenceStrategySTPParentTree, data.Stats["inference_strategy"])
 }
+
+func TestRecomputeTopologyLinkStatsRefreshesExistingL3VisibleCount(t *testing.T) {
+	data := &topologyData{
+		Stats: map[string]any{
+			"l3_subnet_emitted_links": 2,
+		},
+		Links: []topologyLink{
+			{Protocol: topologyL3SubnetLinkType, LinkType: topologyL3SubnetLinkType},
+			{Protocol: "lldp", LinkType: "lldp"},
+		},
+	}
+
+	recomputeTopologyLinkStats(data)
+
+	require.Equal(t, 2, data.Stats["links_total"])
+	require.Equal(t, 2, data.Stats["l3_subnet_emitted_links"])
+	require.Equal(t, 1, data.Stats["l3_subnet_visible_links"])
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_shape_values.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_shape_values.go
@@ -72,7 +72,25 @@ func intStatValue(value any) int {
 	switch typed := value.(type) {
 	case int:
 		return typed
+	case int8:
+		return int(typed)
+	case int16:
+		return int(typed)
+	case int32:
+		return int(typed)
 	case int64:
+		return int(typed)
+	case uint:
+		return uintStatValue(uint64(typed))
+	case uint8:
+		return int(typed)
+	case uint16:
+		return int(typed)
+	case uint32:
+		return int(typed)
+	case uint64:
+		return uintStatValue(typed)
+	case float32:
 		return int(typed)
 	case float64:
 		return int(typed)
@@ -83,6 +101,13 @@ func intStatValue(value any) int {
 		}
 	}
 	return 0
+}
+
+func uintStatValue(value uint64) int {
+	if value > uint64(^uint(0)>>1) {
+		return 0
+	}
+	return int(value)
 }
 
 func topologyMetricValueString(metrics map[string]any, key string) string {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_shape_values_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_shape_values_test.go
@@ -19,7 +19,9 @@ func TestTopologyShapeValues_ClassifyActorsAndValues(t *testing.T) {
 	require.False(t, boolStatValue("0"))
 
 	require.Equal(t, 7, intStatValue("7"))
+	require.Equal(t, 6, intStatValue(uint(6)))
 	require.Equal(t, 5, intStatValue(int64(5)))
+	require.Equal(t, 30, intStatValue(uint64(30)))
 	require.Equal(t, 0, intStatValue("nan"))
 
 	require.Equal(t, "value", topologyMetricValueString(map[string]any{"key": " value "}, "key"))


### PR DESCRIPTION
##### Summary

**Problem**: SNMP topology was L2-only, so router-to-router adjacencies with no LLDP/CDP/FDB/STP evidence were invisible.

**Solution**: Add logical L3 subnet adjacency from existing IP-MIB interface data. The producer detects managed devices sharing IPv4 `/30` or `/31` subnets, emits l3_subnet graph links/evidence, exposes L3 stats, and adds an L3 Adjacencies device modal section.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add L3 subnet adjacency to SNMP topology so router-to-router links without LLDP/CDP/FDB/STP are visible. Emits logical `l3_subnet` links with evidence and a new device modal section.

- New Features
  - Infer bidirectional `l3_subnet` links for routers sharing IPv4 /30 or /31 subnets from IP-MIB; treat as logical L3 (not L2/physical), with a dashed legend and observed/observation semantics.
  - Add evidence table (src/dst IP, subnet, network, netmask, prefix, source) and an “L3 Adjacencies” modal section per device; keep L3 links out of port-neighbor tables.
  - Cache/snapshots include L3 interfaces (IP, netmask, ifIndex/name/descr) and aggregate them; dedupe/filter self-links, multi-access subnets, unsupported prefixes, duplicate IP ownership, unresolved/ambiguous actors; deterministic ordering.
  - Expose L3 stats (candidates, emitted/visible, suppression counts); producer capabilities include `l3_subnet`; presentation profile bumped to `snmp-l2.v2`.

- Bug Fixes
  - Correctly handle unsigned L3 prefix values in evidence and stats.
  - Harden `l3_subnet` evidence validation in V1 conversion by requiring a subnet and rejecting invalid entries.

<sup>Written for commit 0589be019b839424c56efaa4be7c42b0ff346ca7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

