### PR TITLE
fix(claim): avoid SIGSEGV when the random session id file cannot be created

### DIFF
--- a/src/web/api/v2/api_v2_claim.c
+++ b/src/web/api/v2/api_v2_claim.c
@@ -105,6 +105,21 @@ typedef enum {
 
 static void claim_add_user_info_command(BUFFER *wb) {
     const char *filename = netdata_random_session_id_get_filename();
+
+    if(!filename) {
+        // netdata_random_session_id_get_filename() returns NULL when the random
+        // session id file could not be created (e.g. netdata_configured_varlib_dir
+        // is not writable by the agent). Without this guard the code below
+        // dereferences NULL (strchr) and the agent crashes with SIGSEGV on every
+        // /api/v2/claim and /api/v3/claim request, which the web UI issues on load.
+        buffer_json_member_add_string(wb, "key_filename", "");
+        buffer_json_member_add_string(wb, "cmd", "");
+        buffer_json_member_add_string(wb, "help",
+            "Netdata could not create its claiming verification file. "
+            "Make sure the Netdata library directory is writable by the Netdata user.");
+        return;
+    }
+
     CLEAN_BUFFER *os_cmd = buffer_create(0, NULL);
 
     const char *os_filename;


### PR DESCRIPTION
## Summary

Fixes #22786.

`claim_add_user_info_command()` dereferenced the result of `netdata_random_session_id_get_filename()` without a NULL check:

```c
const char *filename = netdata_random_session_id_get_filename(); // can be NULL
...
os_filename = filename;
...
if(strchr(os_filename, ' '))   // strchr(NULL) -> SIGSEGV
```

`netdata_random_session_id_get_filename()` returns `NULL` when `netdata_random_session_id_generate()` failed to create the file in `netdata_configured_varlib_dir` (its `open(O_WRONLY|O_CREAT...)` returned `-1`, leaving `netdata_random_session_id_filename == NULL`).

Because the web UI requests `/api/v2/claim` / `/api/v3/claim` on load, **any** agent whose lib dir is not writable (read-only sandbox, full disk, wrong ownership, …) crashes with SIGSEGV on every dashboard load and then restart-loops via `Restart=on-failure`.

### Backtrace (v2.10.3, official Debian .deb)

```
#0  __strchr_avx2 ()
#1  claim_add_user_info_command (wb=...) at src/web/api/v2/api_v2_claim.c:131
#2  claim_json_response (..., response=CLAIM_RESP_INFO, ...) at src/web/api/v2/api_v2_claim.c:158
#3  api_claim (...) at src/web/api/v2/api_v2_claim.c:230
#4  web_client_api_request_v3 (...) at src/web/api/web_api_v3.c:269
...  (request = "/api/v3/claim")
```

## The change

Add a NULL guard in `claim_add_user_info_command()`. When the session-id filename is unavailable, emit a graceful JSON response (empty `cmd`/`key_filename` + a `help` string telling the operator the lib dir must be writable) instead of dereferencing NULL. No behaviour change on the normal path.

## Testing

On the affected host (v2.10.3 Debian .deb, agent acting as an unclaimed streaming parent), before the fix:

```
$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:19999/api/v3/claim
000          # empty reply; journal: netdata.service: Main process exited, code=killed, status=11/SEGV
```

After making the lib dir writable (`ReadWritePaths=/var/lib/netdata` drop-in) **and** with this guard in place, `/api/v3/claim` returns `200` and the agent no longer crashes. The guard additionally ensures the agent stays up even when the lib dir genuinely cannot be made writable.

## Note (packaging — separate from this code fix)

The trigger on the official `.deb` is that the shipped systemd unit (`system/systemd/netdata.service.in`: `ProtectSystem=full`, `ProtectHome=read-only`, `ReadWriteDirectories=/run/netdata`) leaves `/var/lib/netdata` read-only for the agent process, so `netdata_random_session_id` can never be created. Adding the lib dir to the unit's writable paths (e.g. `ReadWritePaths=/var/lib/netdata`) is worth considering as a complementary fix so claiming verification actually works — but this PR focuses on the universal crash-hardening, which is needed regardless of why the lib dir is non-writable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents agent crashes on dashboard load by guarding NULL session-id filenames in the claim API. Returns a safe JSON response when the random session ID file cannot be created instead of segfaulting.

- Bug Fixes
  - Added a NULL check before using netdata_random_session_id_get_filename() in claim_add_user_info_command().
  - When the filename is unavailable, respond with empty cmd/key_filename and a help message; normal path unchanged.
  - Stops crash loops when the lib dir is not writable (read-only, full disk, wrong ownership, etc.).

<sup>Written for commit 874d31e9e685f1b55704822c3560fd5b2183b9bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

