### PR TITLE
chore(go.d/snmp_topology): table-drive topology tests

### DIFF
--- a/src/go/plugin/go.d/collector/snmp_topology/charts_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/charts_test.go
@@ -22,11 +22,27 @@ func TestCollector_ChartTemplateYAML(t *testing.T) {
 	require.NoError(t, err)
 
 	contexts := chartTemplateContexts(spec.Groups)
-	assert.Contains(t, contexts, "netdata.go.plugin.collector.snmp_topology.devices")
-	assert.Contains(t, contexts, "netdata.go.plugin.collector.snmp_topology.last_refresh")
-	assert.Contains(t, contexts, "netdata.go.plugin.collector.snmp_topology.refreshes")
-	assert.NotContains(t, contexts, "snmp_topology.devices")
-	assert.NotContains(t, contexts, "snmp_topology.links")
+	for name, tc := range map[string]struct {
+		context string
+	}{
+		"devices":      {context: "netdata.go.plugin.collector.snmp_topology.devices"},
+		"last-refresh": {context: "netdata.go.plugin.collector.snmp_topology.last_refresh"},
+		"refreshes":    {context: "netdata.go.plugin.collector.snmp_topology.refreshes"},
+	} {
+		t.Run("contains/"+name, func(t *testing.T) {
+			assert.Contains(t, contexts, tc.context)
+		})
+	}
+	for name, tc := range map[string]struct {
+		context string
+	}{
+		"legacy-devices": {context: "snmp_topology.devices"},
+		"legacy-links":   {context: "snmp_topology.links"},
+	} {
+		t.Run("not-contains/"+name, func(t *testing.T) {
+			assert.NotContains(t, contexts, tc.context)
+		})
+	}
 }
 
 func chartTemplateContexts(groups []charttpl.Group) map[string]struct{} {

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_presentation_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_presentation_test.go
@@ -36,21 +36,57 @@ func TestSNMPTopologyCreatorOwnsTopologyFunction(t *testing.T) {
 }
 
 func TestSNMPTopologyCreatorRequiresSharedDependencies(t *testing.T) {
-	require.PanicsWithValue(t, "snmp_topology Register requires a non-nil device store", func() {
-		_ = newCreator(nil, NewTrapEnrichmentHandle())
-	})
-	require.PanicsWithValue(t, "snmp_topology Register requires a non-nil trap enrichment handle", func() {
-		_ = newCreator(ddsnmp.NewDeviceStore(), nil)
-	})
+	tests := map[string]struct {
+		store     *ddsnmp.DeviceStore
+		traps     *TrapEnrichmentHandle
+		wantPanic string
+	}{
+		"nil-device-store": {
+			store:     nil,
+			traps:     NewTrapEnrichmentHandle(),
+			wantPanic: "snmp_topology Register requires a non-nil device store",
+		},
+		"nil-trap-handle": {
+			store:     ddsnmp.NewDeviceStore(),
+			traps:     nil,
+			wantPanic: "snmp_topology Register requires a non-nil trap enrichment handle",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.PanicsWithValue(t, tc.wantPanic, func() {
+				_ = newCreator(tc.store, tc.traps)
+			})
+		})
+	}
 }
 
 func TestSNMPTopologyNewRequiresSharedDependencies(t *testing.T) {
-	require.PanicsWithValue(t, "snmp_topology New requires a non-nil device store", func() {
-		_ = New(nil, NewTrapEnrichmentHandle())
-	})
-	require.PanicsWithValue(t, "snmp_topology New requires a non-nil trap enrichment handle", func() {
-		_ = New(ddsnmp.NewDeviceStore(), nil)
-	})
+	tests := map[string]struct {
+		store     *ddsnmp.DeviceStore
+		traps     *TrapEnrichmentHandle
+		wantPanic string
+	}{
+		"nil-device-store": {
+			store:     nil,
+			traps:     NewTrapEnrichmentHandle(),
+			wantPanic: "snmp_topology New requires a non-nil device store",
+		},
+		"nil-trap-handle": {
+			store:     ddsnmp.NewDeviceStore(),
+			traps:     nil,
+			wantPanic: "snmp_topology New requires a non-nil trap enrichment handle",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.PanicsWithValue(t, tc.wantPanic, func() {
+				_ = New(tc.store, tc.traps)
+			})
+		})
+	}
 }
 
 type topologyRuntimeJobForTest struct {

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_test.go
@@ -829,45 +829,48 @@ func TestSNMPTopologyToV1_PreservesLinkPresentationTypes(t *testing.T) {
 }
 
 func TestNormalizeTopologyInferenceStrategy(t *testing.T) {
-	assert.Equal(t, topologyInferenceStrategyFDBMinimumKnowledge, normalizeTopologyInferenceStrategy(""))
-	assert.Equal(t, topologyInferenceStrategyFDBMinimumKnowledge, normalizeTopologyInferenceStrategy(topologyInferenceStrategyFDBMinimumKnowledge))
-	assert.Equal(t, topologyInferenceStrategySTPParentTree, normalizeTopologyInferenceStrategy(topologyInferenceStrategySTPParentTree))
-	assert.Equal(t, topologyInferenceStrategyFDBPairwise, normalizeTopologyInferenceStrategy(topologyInferenceStrategyFDBPairwise))
-	assert.Equal(t, topologyInferenceStrategySTPFDBCorrelated, normalizeTopologyInferenceStrategy(topologyInferenceStrategySTPFDBCorrelated))
-	assert.Equal(t, topologyInferenceStrategyCDPFDBHybrid, normalizeTopologyInferenceStrategy(topologyInferenceStrategyCDPFDBHybrid))
-	assert.Equal(t, "", normalizeTopologyInferenceStrategy("invalid"))
+	tests := map[string]struct {
+		in   string
+		want string
+	}{
+		"default-empty":         {in: "", want: topologyInferenceStrategyFDBMinimumKnowledge},
+		"fdb-minimum-knowledge": {in: topologyInferenceStrategyFDBMinimumKnowledge, want: topologyInferenceStrategyFDBMinimumKnowledge},
+		"stp-parent-tree":       {in: topologyInferenceStrategySTPParentTree, want: topologyInferenceStrategySTPParentTree},
+		"fdb-pairwise":          {in: topologyInferenceStrategyFDBPairwise, want: topologyInferenceStrategyFDBPairwise},
+		"stp-fdb-correlated":    {in: topologyInferenceStrategySTPFDBCorrelated, want: topologyInferenceStrategySTPFDBCorrelated},
+		"cdp-fdb-hybrid":        {in: topologyInferenceStrategyCDPFDBHybrid, want: topologyInferenceStrategyCDPFDBHybrid},
+		"invalid":               {in: "invalid", want: ""},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeTopologyInferenceStrategy(tc.in))
+		})
+	}
 }
 
 func TestNormalizeTopologyManagedFocuses(t *testing.T) {
-	assert.Equal(t, []string{topologyManagedFocusAllDevices}, normalizeTopologyManagedFocuses(nil))
-	assert.Equal(t, []string{topologyManagedFocusAllDevices}, normalizeTopologyManagedFocuses([]string{}))
-	assert.Equal(t, []string{topologyManagedFocusAllDevices}, normalizeTopologyManagedFocuses([]string{""}))
-	assert.Equal(t, []string{topologyManagedFocusAllDevices}, normalizeTopologyManagedFocuses([]string{" , , "}))
-	assert.Equal(
-		t,
-		[]string{topologyManagedFocusAllDevices},
-		normalizeTopologyManagedFocuses([]string{"invalid"}),
-	)
-	assert.Equal(
-		t,
-		[]string{"ip:10.0.0.1", "ip:10.0.0.2"},
-		normalizeTopologyManagedFocuses([]string{"ip:10.0.0.2", "ip:10.0.0.1", "ip:10.0.0.2"}),
-	)
-	assert.Equal(
-		t,
-		[]string{"ip:10.0.0.1", "ip:10.0.0.2"},
-		normalizeTopologyManagedFocuses([]string{" ip:10.0.0.2 , ip:10.0.0.1 "}),
-	)
-	assert.Equal(
-		t,
-		[]string{topologyManagedFocusAllDevices},
-		normalizeTopologyManagedFocuses([]string{"ip:10.0.0.1", topologyManagedFocusAllDevices}),
-	)
-	assert.Equal(
-		t,
-		[]string{topologyManagedFocusAllDevices},
-		normalizeTopologyManagedFocuses([]string{"ip:10.0.0.1,all_devices"}),
-	)
+	tests := map[string]struct {
+		in   []string
+		want []string
+	}{
+		"nil":                 {in: nil, want: []string{topologyManagedFocusAllDevices}},
+		"empty":               {in: []string{}, want: []string{topologyManagedFocusAllDevices}},
+		"blank":               {in: []string{""}, want: []string{topologyManagedFocusAllDevices}},
+		"comma-blanks":        {in: []string{" , , "}, want: []string{topologyManagedFocusAllDevices}},
+		"invalid":             {in: []string{"invalid"}, want: []string{topologyManagedFocusAllDevices}},
+		"deduplicated-ips":    {in: []string{"ip:10.0.0.2", "ip:10.0.0.1", "ip:10.0.0.2"}, want: []string{"ip:10.0.0.1", "ip:10.0.0.2"}},
+		"comma-separated-ips": {in: []string{" ip:10.0.0.2 , ip:10.0.0.1 "}, want: []string{"ip:10.0.0.1", "ip:10.0.0.2"}},
+		"all-devices-token":   {in: []string{"ip:10.0.0.1", topologyManagedFocusAllDevices}, want: []string{topologyManagedFocusAllDevices}},
+		"all-devices-comma":   {in: []string{"ip:10.0.0.1,all_devices"}, want: []string{topologyManagedFocusAllDevices}},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeTopologyManagedFocuses(tc.in))
+		})
+	}
+
 	assert.Equal(
 		t,
 		"ip:10.0.0.1,ip:10.0.0.2",

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_helpers_test.go
@@ -10,48 +10,66 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildSNMPTopologyV1DynamicTable_TrimsColumnKeysBeforeLookup(t *testing.T) {
-	dict := topologyv1.NewStringDictionary("")
-
-	table, err := buildSNMPTopologyV1DynamicTable([]topologyV1DynamicRow{
-		{
-			actorRef: 0,
+func TestBuildSNMPTopologyV1DynamicTable_KeyNormalization(t *testing.T) {
+	tests := map[string]struct {
+		values map[string]any
+		want   []any
+	}{
+		"trimmed-key-lookup": {
 			values: map[string]any{
 				" speed ": uint64(1000),
 			},
+			want: []any{uint64(1000)},
 		},
-	}, dict)
-
-	require.NoError(t, err)
-	assert.Equal(t, []any{uint64(1000)}, topologyV1TestColumnValues(t, table, "speed"))
-}
-
-func TestBuildSNMPTopologyV1DynamicTable_PrefersExactKeyOnTrimCollision(t *testing.T) {
-	dict := topologyv1.NewStringDictionary("")
-
-	table, err := buildSNMPTopologyV1DynamicTable([]topologyV1DynamicRow{
-		{
-			actorRef: 0,
+		"exact-key-on-trim-collision": {
 			values: map[string]any{
 				" speed ": uint64(1000),
 				"speed":   uint64(2000),
 			},
+			want: []any{uint64(2000)},
 		},
-	}, dict)
+	}
 
-	require.NoError(t, err)
-	assert.Equal(t, []any{uint64(2000)}, topologyV1TestColumnValues(t, table, "speed"))
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			table, err := buildSNMPTopologyV1DynamicTable([]topologyV1DynamicRow{
+				{
+					actorRef: 0,
+					values:   tc.values,
+				},
+			}, topologyv1.NewStringDictionary(""))
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, topologyV1TestColumnValues(t, table, "speed"))
+		})
+	}
 }
 
 func TestAnyStringSlice_DropsNilAndNonScalarItems(t *testing.T) {
-	require.Nil(t, anyStringSlice(nil))
-	assert.Equal(t, []string{"up", "42", "false"}, anyStringSlice([]any{
-		nil,
-		" up ",
-		42,
-		false,
-		map[string]any{"not": "scalar"},
-	}))
+	tests := map[string]struct {
+		in   any
+		want []string
+	}{
+		"nil": {
+			in: nil,
+		},
+		"mixed-values": {
+			in: []any{
+				nil,
+				" up ",
+				42,
+				false,
+				map[string]any{"not": "scalar"},
+			},
+			want: []string{"up", "42", "false"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, anyStringSlice(tc.in))
+		})
+	}
 }
 
 func TestBuildSNMPTopologyV1Actors_UsesStableFallbackActorID(t *testing.T) {
@@ -88,64 +106,54 @@ func TestBuildSNMPTopologyV1Actors_FallbackDoesNotCollideWithExplicitActorID(t *
 	}, actorIndex)
 }
 
-func TestBuildSNMPTopologyV1PortNeighborSummaries_NormalizesRemotePortName(t *testing.T) {
-	summaries := buildSNMPTopologyV1PortNeighborSummaries([]topologyLink{
-		{
-			SrcActorID: "device-a",
-			DstActorID: "device-b",
-			Src: topologyLinkEndpoint{Attributes: map[string]any{
-				"if_index":  uint64(1),
-				"port_name": "Gi0/1",
-			}},
-			Dst: topologyLinkEndpoint{Attributes: map[string]any{
-				"port_name": " Gi0/2 ",
-			}},
+func TestBuildSNMPTopologyV1PortNeighborSummaries_RemotePortName(t *testing.T) {
+	tests := map[string]struct {
+		links              []topologyLink
+		wantRemotePortName string
+	}{
+		"normalizes-before-ambiguity-check": {
+			links: []topologyLink{
+				topologyV1PortNeighborSummaryLinkForTest(" Gi0/2 "),
+				topologyV1PortNeighborSummaryLinkForTest("gi0/2"),
+			},
+			wantRemotePortName: "Gi0/2",
 		},
-		{
-			SrcActorID: "device-a",
-			DstActorID: "device-b",
-			Src: topologyLinkEndpoint{Attributes: map[string]any{
-				"if_index":  uint64(1),
-				"port_name": "Gi0/1",
-			}},
-			Dst: topologyLinkEndpoint{Attributes: map[string]any{
-				"port_name": "gi0/2",
-			}},
+		"fills-missing-remote-port-name": {
+			links: []topologyLink{
+				topologyV1PortNeighborSummaryLinkForTest(""),
+				topologyV1PortNeighborSummaryLinkForTest("Gi0/2"),
+			},
+			wantRemotePortName: "Gi0/2",
 		},
-	}, map[string]int{"device-a": 0, "device-b": 1})
+	}
 
-	summary, ok := summaries[snmpTopologyV1PortNeighborKey{actorRef: 0, ifIndex: 1}]
-	require.True(t, ok)
-	assert.False(t, summary.ambiguous)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			summaries := buildSNMPTopologyV1PortNeighborSummaries(tc.links, map[string]int{"device-a": 0, "device-b": 1})
+
+			summary, ok := summaries[snmpTopologyV1PortNeighborKey{actorRef: 0, ifIndex: 1}]
+			require.True(t, ok)
+			assert.False(t, summary.ambiguous)
+			assert.Equal(t, tc.wantRemotePortName, summary.remotePortName)
+		})
+	}
 }
 
-func TestBuildSNMPTopologyV1PortNeighborSummaries_FillsMissingRemotePortName(t *testing.T) {
-	summaries := buildSNMPTopologyV1PortNeighborSummaries([]topologyLink{
-		{
-			SrcActorID: "device-a",
-			DstActorID: "device-b",
-			Src: topologyLinkEndpoint{Attributes: map[string]any{
-				"if_index":  uint64(1),
-				"port_name": "Gi0/1",
-			}},
-		},
-		{
-			SrcActorID: "device-a",
-			DstActorID: "device-b",
-			Src: topologyLinkEndpoint{Attributes: map[string]any{
-				"if_index":  uint64(1),
-				"port_name": "Gi0/1",
-			}},
-			Dst: topologyLinkEndpoint{Attributes: map[string]any{
-				"port_name": "Gi0/2",
-			}},
-		},
-	}, map[string]int{"device-a": 0, "device-b": 1})
-
-	summary, ok := summaries[snmpTopologyV1PortNeighborKey{actorRef: 0, ifIndex: 1}]
-	require.True(t, ok)
-	assert.False(t, summary.ambiguous)
-	assert.Equal(t, "Gi0/2", summary.remotePortName)
+func topologyV1PortNeighborSummaryLinkForTest(remotePortName string) topologyLink {
+	link := topologyLink{
+		SrcActorID: "device-a",
+		DstActorID: "device-b",
+		Src: topologyLinkEndpoint{Attributes: map[string]any{
+			"if_index":  uint64(1),
+			"port_name": "Gi0/1",
+		}},
+	}
+	if remotePortName != "" {
+		link.Dst = topologyLinkEndpoint{Attributes: map[string]any{
+			"port_name": remotePortName,
+		}}
+	}
+	return link
 }
 
 func topologyV1TestColumnValues(t *testing.T, table topologyv1.Table, columnID string) []any {

--- a/src/go/plugin/go.d/collector/snmp_topology/profile_filter_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/profile_filter_test.go
@@ -46,11 +46,27 @@ func TestFindTopologyProfiles_UsesDeclarativeProfileExtensions(t *testing.T) {
 		}
 	}
 
-	assert.Contains(t, metricNames, "lldp_rem")
-	assert.Contains(t, metricNames, "cdp_cache")
-	assert.Contains(t, metricNames, "fdb_entry")
-	assert.Contains(t, metricNames, "stp_port")
-	assert.Contains(t, metricNames, "vtp_vlan")
-	assert.Contains(t, metadataFields, "lldp_loc_sys_name")
-	assert.Contains(t, metadataFields, "vtp_version")
+	for name, tc := range map[string]struct {
+		metric string
+	}{
+		"lldp": {metric: "lldp_rem"},
+		"cdp":  {metric: "cdp_cache"},
+		"fdb":  {metric: "fdb_entry"},
+		"stp":  {metric: "stp_port"},
+		"vtp":  {metric: "vtp_vlan"},
+	} {
+		t.Run("metric/"+name, func(t *testing.T) {
+			assert.Contains(t, metricNames, tc.metric)
+		})
+	}
+	for name, tc := range map[string]struct {
+		field string
+	}{
+		"lldp-system-name": {field: "lldp_loc_sys_name"},
+		"vtp-version":      {field: "vtp_version"},
+	} {
+		t.Run("metadata/"+name, func(t *testing.T) {
+			assert.Contains(t, metadataFields, tc.field)
+		})
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/snmptopologyfunc/topology_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/snmptopologyfunc/topology_test.go
@@ -182,32 +182,46 @@ func TestTopologyHandlerHandleUnknownSelectorsFallbackToDefaults(t *testing.T) {
 }
 
 func TestTopologyHandlerUnavailableAndErrors(t *testing.T) {
-	t.Run("unknown method", func(t *testing.T) {
-		resp := NewHandler(&fakeDeps{}).Handle(context.Background(), "unknown", nil)
-		require.NotNil(t, resp)
-		assert.Equal(t, 404, resp.Status)
-	})
+	tests := map[string]struct {
+		deps        Deps
+		method      string
+		wantStatus  int
+		wantMessage string
+	}{
+		"unknown-method": {
+			deps:       &fakeDeps{},
+			method:     "unknown",
+			wantStatus: 404,
+		},
+		"nil-deps": {
+			method:      MethodID,
+			wantStatus:  503,
+			wantMessage: "topology data not available",
+		},
+		"snapshot-unavailable": {
+			deps:        &fakeDeps{},
+			method:      MethodID,
+			wantStatus:  503,
+			wantMessage: "topology data not available",
+		},
+		"snapshot-error": {
+			deps:        &fakeDeps{err: errors.New("boom")},
+			method:      MethodID,
+			wantStatus:  500,
+			wantMessage: "failed to build topology response",
+		},
+	}
 
-	t.Run("nil deps", func(t *testing.T) {
-		resp := NewHandler(nil).Handle(context.Background(), MethodID, nil)
-		require.NotNil(t, resp)
-		assert.Equal(t, 503, resp.Status)
-		assert.Contains(t, resp.Message, "topology data not available")
-	})
-
-	t.Run("snapshot unavailable", func(t *testing.T) {
-		resp := NewHandler(&fakeDeps{}).Handle(context.Background(), MethodID, nil)
-		require.NotNil(t, resp)
-		assert.Equal(t, 503, resp.Status)
-		assert.Contains(t, resp.Message, "topology data not available")
-	})
-
-	t.Run("snapshot error", func(t *testing.T) {
-		resp := NewHandler(&fakeDeps{err: errors.New("boom")}).Handle(context.Background(), MethodID, nil)
-		require.NotNil(t, resp)
-		assert.Equal(t, 500, resp.Status)
-		assert.Contains(t, resp.Message, "failed to build topology response")
-	})
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			resp := NewHandler(tc.deps).Handle(context.Background(), tc.method, nil)
+			require.NotNil(t, resp)
+			assert.Equal(t, tc.wantStatus, resp.Status)
+			if tc.wantMessage != "" {
+				assert.Contains(t, resp.Message, tc.wantMessage)
+			}
+		})
+	}
 }
 
 type fakeDeps struct {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
@@ -889,58 +889,50 @@ func TestTopologyCache_InterfaceStatusObservation_FallsBackToIfIndexWhenIfNameMi
 }
 
 func TestStpBridgeAddressToMAC_ParsesAndRejectsSentinels(t *testing.T) {
-	tests := []struct {
-		name   string
+	tests := map[string]struct {
 		in     string
 		status stpBridgeIDStatus
 		mac    string
 	}{
-		{
-			name:   "bridge-id-hex",
+		"bridge-id-hex": {
 			in:     "800066778899aabb",
 			status: stpBridgeIDValid,
 			mac:    "66:77:88:99:aa:bb",
 		},
-		{
-			name:   "priority-bridge-id",
+		"priority-bridge-id": {
 			in:     "32768-66.77.88.99.aa.bb",
 			status: stpBridgeIDValid,
 			mac:    "66:77:88:99:aa:bb",
 		},
-		{
-			name:   "quoted-hex-string",
+		"quoted-hex-string": {
 			in:     "\"18 FD 74 33 1A 9C \"",
 			status: stpBridgeIDValid,
 			mac:    "18:fd:74:33:1a:9c",
 		},
-		{
-			name:   "hex-string-prefix",
+		"hex-string-prefix": {
 			in:     "Hex-STRING: 18 FD 74 33 1A 9C",
 			status: stpBridgeIDValid,
 			mac:    "18:fd:74:33:1a:9c",
 		},
-		{
-			name:   "sentinel-text-empty",
+		"sentinel-text-empty": {
 			in:     "0-00.00.00.00.00.00",
 			status: stpBridgeIDEmpty,
 			mac:    "",
 		},
-		{
-			name:   "sentinel-hex-empty",
+		"sentinel-hex-empty": {
 			in:     "302d30302e30302e30302e30302e30302e3030",
 			status: stpBridgeIDEmpty,
 			mac:    "",
 		},
-		{
-			name:   "invalid",
+		"invalid": {
 			in:     "not-a-bridge-id",
 			status: stpBridgeIDInvalid,
 			mac:    "",
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
 			mac, status := parseSTPBridgeID(tt.in, 0)
 			require.Equal(t, tt.status, status)
 			require.Equal(t, tt.mac, mac)
@@ -1166,58 +1158,64 @@ func TestDecodePrintableASCII_HexValueIsNotNumeric(t *testing.T) {
 }
 
 func TestNormalizeInterfaceAdminStatusAcceptsEnumStrings(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		in   string
 		want string
 	}{
-		{in: "up(1)", want: "up"},
-		{in: "down(2)", want: "down"},
-		{in: "testing(3)", want: "testing"},
-		{in: "UP (1)", want: "up"},
-		{in: "invalid(9)", want: ""},
+		"up":      {in: "up(1)", want: "up"},
+		"down":    {in: "down(2)", want: "down"},
+		"testing": {in: "testing(3)", want: "testing"},
+		"case":    {in: "UP (1)", want: "up"},
+		"invalid": {in: "invalid(9)", want: ""},
 	}
 
-	for _, tc := range tests {
-		assert.Equal(t, tc.want, normalizeInterfaceAdminStatus(tc.in), tc.in)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeInterfaceAdminStatus(tc.in), tc.in)
+		})
 	}
 }
 
 func TestNormalizeInterfaceOperStatusAcceptsEnumStrings(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		in   string
 		want string
 	}{
-		{in: "up(1)", want: "up"},
-		{in: "down(2)", want: "down"},
-		{in: "testing(3)", want: "testing"},
-		{in: "unknown(4)", want: "unknown"},
-		{in: "dormant(5)", want: "dormant"},
-		{in: "notPresent(6)", want: "notPresent"},
-		{in: "lowerLayerDown(7)", want: "lowerLayerDown"},
-		{in: "LOWERLAYERDOWN (7)", want: "lowerLayerDown"},
-		{in: "invalid(9)", want: ""},
+		"up":                 {in: "up(1)", want: "up"},
+		"down":               {in: "down(2)", want: "down"},
+		"testing":            {in: "testing(3)", want: "testing"},
+		"unknown":            {in: "unknown(4)", want: "unknown"},
+		"dormant":            {in: "dormant(5)", want: "dormant"},
+		"not-present":        {in: "notPresent(6)", want: "notPresent"},
+		"lower-layer-down":   {in: "lowerLayerDown(7)", want: "lowerLayerDown"},
+		"case-normalization": {in: "LOWERLAYERDOWN (7)", want: "lowerLayerDown"},
+		"invalid":            {in: "invalid(9)", want: ""},
 	}
 
-	for _, tc := range tests {
-		assert.Equal(t, tc.want, normalizeInterfaceOperStatus(tc.in), tc.in)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeInterfaceOperStatus(tc.in), tc.in)
+		})
 	}
 }
 
 func TestNormalizeInterfaceTypeAcceptsEnumStrings(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		in   string
 		want string
 	}{
-		{in: "ethernetCsmacd(6)", want: "ethernetcsmacd"},
-		{in: "6", want: "ethernetcsmacd"},
-		{in: "ieee8023adLag(161)", want: "ieee8023adlag"},
-		{in: "161", want: "ieee8023adlag"},
-		{in: "l2vlan(135)", want: "l2vlan"},
-		{in: "", want: ""},
+		"ethernet-enum": {in: "ethernetCsmacd(6)", want: "ethernetcsmacd"},
+		"ethernet-id":   {in: "6", want: "ethernetcsmacd"},
+		"lag-enum":      {in: "ieee8023adLag(161)", want: "ieee8023adlag"},
+		"lag-id":        {in: "161", want: "ieee8023adlag"},
+		"vlan-enum":     {in: "l2vlan(135)", want: "l2vlan"},
+		"empty":         {in: "", want: ""},
 	}
 
-	for _, tc := range tests {
-		assert.Equal(t, tc.want, normalizeInterfaceType(tc.in), tc.in)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeInterfaceType(tc.in), tc.in)
+		})
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links_test.go
@@ -25,86 +25,99 @@ func TestTopologyL3ActorResolverSuppressesAmbiguousIP(t *testing.T) {
 	require.False(t, ok)
 }
 
-func TestApplyTopologyL3SubnetEnrichmentSuppressesUnresolvedActor(t *testing.T) {
-	data := topologyData{
-		Actors: []topologyActor{
-			topologyL3ManagedActorForTest("device-a", nil, "198.51.100.1"),
+func TestApplyTopologyL3SubnetEnrichmentSuppressions(t *testing.T) {
+	tests := map[string]struct {
+		data                     topologyData
+		aggregate                topologyObservationAggregate
+		wantLinks                []topologyLink
+		wantUnresolvedActor      int
+		wantSelfActor            int
+		wantDuplicateLink        int
+		wantVisibleLinks         int
+		wantSuppressedMetricName string
+	}{
+		"unresolved-actor": {
+			data: topologyData{
+				Actors: []topologyActor{
+					topologyL3ManagedActorForTest("device-a", nil, "198.51.100.1"),
+				},
+			},
+			aggregate: topologyObservationAggregate{
+				l3Interfaces: []topologyL3Interface{
+					l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+					l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
+				},
+			},
+			wantUnresolvedActor:      1,
+			wantSuppressedMetricName: "l3_subnet_suppressed_unresolved_actor",
 		},
-	}
-	aggregate := topologyObservationAggregate{
-		l3Interfaces: []topologyL3Interface{
-			l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
-			l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
+		"self-actor": {
+			data: topologyData{
+				Actors: []topologyActor{
+					topologyL3ManagedActorForTest("router-a", nil, "198.51.100.1", "198.51.100.2"),
+				},
+			},
+			aggregate: topologyObservationAggregate{
+				l3Interfaces: []topologyL3Interface{
+					l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+					l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
+				},
+			},
+			wantSelfActor:            1,
+			wantSuppressedMetricName: "l3_subnet_suppressed_self_actor",
+		},
+		"duplicate-link": {
+			data: topologyData{
+				Actors: []topologyActor{
+					topologyL3ManagedActorForTest("router-a", nil, "198.51.100.1"),
+					topologyL3ManagedActorForTest("router-b", nil, "198.51.100.2"),
+				},
+				Links: []topologyLink{topologyL3SubnetLinkForTest("router-a", "router-b", "198.51.100.0/30", uint64(30))},
+			},
+			aggregate: topologyObservationAggregate{
+				l3Interfaces: []topologyL3Interface{
+					l3InterfaceForTest("router-a", "198.51.100.1", "255.255.255.252", "2"),
+					l3InterfaceForTest("router-b", "198.51.100.2", "255.255.255.252", "3"),
+				},
+			},
+			wantLinks:                []topologyLink{topologyL3SubnetLinkForTest("router-a", "router-b", "198.51.100.0/30", uint64(30))},
+			wantDuplicateLink:        1,
+			wantVisibleLinks:         1,
+			wantSuppressedMetricName: "l3_subnet_suppressed_duplicate_link",
 		},
 	}
 
-	stats := applyTopologyL3SubnetEnrichment(&data, aggregate)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			stats := applyTopologyL3SubnetEnrichment(&tc.data, tc.aggregate)
 
-	require.Empty(t, data.Links)
-	require.Equal(t, 1, stats.suppressedUnresolvedActor)
-	require.Equal(t, 1, data.Stats["l3_subnet_candidate_links"])
-	require.Equal(t, 0, data.Stats["l3_subnet_emitted_links"])
-	require.Equal(t, 0, data.Stats["l3_subnet_visible_links"])
-	require.Equal(t, 1, data.Stats["l3_subnet_suppressed_unresolved_actor"])
+			if tc.wantLinks == nil {
+				require.Empty(t, tc.data.Links)
+			} else {
+				require.Equal(t, tc.wantLinks, tc.data.Links)
+			}
+			require.Equal(t, tc.wantUnresolvedActor, stats.suppressedUnresolvedActor)
+			require.Equal(t, tc.wantSelfActor, stats.suppressedSelfActor)
+			require.Equal(t, tc.wantDuplicateLink, stats.suppressedDuplicateLink)
+			require.Equal(t, 1, tc.data.Stats["l3_subnet_candidate_links"])
+			require.Equal(t, 0, tc.data.Stats["l3_subnet_emitted_links"])
+			require.Equal(t, tc.wantVisibleLinks, tc.data.Stats["l3_subnet_visible_links"])
+			require.Equal(t, 1, tc.data.Stats[tc.wantSuppressedMetricName])
+		})
+	}
 }
 
-func TestApplyTopologyL3SubnetEnrichmentSuppressesSelfActor(t *testing.T) {
-	data := topologyData{
-		Actors: []topologyActor{
-			topologyL3ManagedActorForTest("router-a", nil, "198.51.100.1", "198.51.100.2"),
-		},
-	}
-	aggregate := topologyObservationAggregate{
-		l3Interfaces: []topologyL3Interface{
-			l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
-			l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
-		},
-	}
-
-	stats := applyTopologyL3SubnetEnrichment(&data, aggregate)
-
-	require.Empty(t, data.Links)
-	require.Equal(t, 1, stats.suppressedSelfActor)
-	require.Equal(t, 1, data.Stats["l3_subnet_candidate_links"])
-	require.Equal(t, 0, data.Stats["l3_subnet_emitted_links"])
-	require.Equal(t, 0, data.Stats["l3_subnet_visible_links"])
-	require.Equal(t, 1, data.Stats["l3_subnet_suppressed_self_actor"])
-}
-
-func TestApplyTopologyL3SubnetEnrichmentSuppressesDuplicateLink(t *testing.T) {
-	existing := topologyLink{
+func topologyL3SubnetLinkForTest(srcActorID, dstActorID, subnet string, prefix any) topologyLink {
+	return topologyLink{
 		Protocol:   topologyL3SubnetLinkType,
 		LinkType:   topologyL3SubnetLinkType,
-		SrcActorID: "router-a",
-		DstActorID: "router-b",
+		SrcActorID: srcActorID,
+		DstActorID: dstActorID,
 		Metrics: map[string]any{
-			"subnet": "198.51.100.0/30",
-			"prefix": uint64(30),
+			"subnet": subnet,
+			"prefix": prefix,
 		},
 	}
-	data := topologyData{
-		Actors: []topologyActor{
-			topologyL3ManagedActorForTest("router-a", nil, "198.51.100.1"),
-			topologyL3ManagedActorForTest("router-b", nil, "198.51.100.2"),
-		},
-		Links: []topologyLink{existing},
-	}
-	aggregate := topologyObservationAggregate{
-		l3Interfaces: []topologyL3Interface{
-			l3InterfaceForTest("router-a", "198.51.100.1", "255.255.255.252", "2"),
-			l3InterfaceForTest("router-b", "198.51.100.2", "255.255.255.252", "3"),
-		},
-	}
-
-	stats := applyTopologyL3SubnetEnrichment(&data, aggregate)
-
-	require.Len(t, data.Links, 1)
-	require.Equal(t, existing, data.Links[0])
-	require.Equal(t, 1, stats.suppressedDuplicateLink)
-	require.Equal(t, 1, data.Stats["l3_subnet_candidate_links"])
-	require.Equal(t, 0, data.Stats["l3_subnet_emitted_links"])
-	require.Equal(t, 1, data.Stats["l3_subnet_visible_links"])
-	require.Equal(t, 1, data.Stats["l3_subnet_suppressed_duplicate_link"])
 }
 
 func TestTopologyL3SubnetLinkKeySeparatesDelimitedFields(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_subnets_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_subnets_test.go
@@ -9,116 +9,126 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildTopologyL3SubnetAdjacenciesIPv4PointToPoint(t *testing.T) {
-	rows := []topologyL3Interface{
-		l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
-		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+func TestBuildTopologyL3SubnetAdjacencies(t *testing.T) {
+	tests := map[string]struct {
+		rows      []topologyL3Interface
+		wantLinks []topologyL3SubnetAdjacency
+		wantStats topologyL3SubnetBuildStats
+	}{
+		"ipv4-point-to-point": {
+			rows: []topologyL3Interface{
+				l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
+				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+			},
+			wantLinks: []topologyL3SubnetAdjacency{
+				{
+					Subnet:  "198.51.100.0/30",
+					Network: "198.51.100.0",
+					Netmask: "255.255.255.252",
+					Prefix:  30,
+					A:       l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+					B:       l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
+				},
+			},
+			wantStats: topologyL3SubnetBuildStats{
+				candidateSubnets: 1,
+				candidateLinks:   1,
+			},
+		},
+		"ipv4-thirty-one": {
+			rows: []topologyL3Interface{
+				l3InterfaceForTest("device-a", "198.51.100.0", "255.255.255.254", "2"),
+				l3InterfaceForTest("device-b", "198.51.100.1", "255.255.255.254", "3"),
+			},
+			wantLinks: []topologyL3SubnetAdjacency{
+				{
+					Subnet:  "198.51.100.0/31",
+					Network: "198.51.100.0",
+					Netmask: "255.255.255.254",
+					Prefix:  31,
+					A:       l3InterfaceForTest("device-a", "198.51.100.0", "255.255.255.254", "2"),
+					B:       l3InterfaceForTest("device-b", "198.51.100.1", "255.255.255.254", "3"),
+				},
+			},
+			wantStats: topologyL3SubnetBuildStats{
+				candidateSubnets: 1,
+				candidateLinks:   1,
+			},
+		},
+		"unsupported-prefix": {
+			rows: []topologyL3Interface{
+				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.0", "2"),
+				l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.0", "3"),
+			},
+			wantStats: topologyL3SubnetBuildStats{
+				suppressedUnsupportedPrefix: 2,
+			},
+		},
+		"duplicate-ip-ownership": {
+			rows: []topologyL3Interface{
+				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+				l3InterfaceForTest("device-b", "198.51.100.1", "255.255.255.252", "3"),
+			},
+			wantStats: topologyL3SubnetBuildStats{
+				candidateSubnets:      1,
+				suppressedDuplicateIP: 1,
+			},
+		},
+		"same-device-self-link": {
+			rows: []topologyL3Interface{
+				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+				l3InterfaceForTest("device-a", "198.51.100.2", "255.255.255.252", "3"),
+			},
+			wantStats: topologyL3SubnetBuildStats{
+				candidateSubnets:   1,
+				suppressedSelfLink: 1,
+			},
+		},
+		"unmatched-subnet": {
+			rows: []topologyL3Interface{
+				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+			},
+			wantStats: topologyL3SubnetBuildStats{
+				candidateSubnets:    1,
+				suppressedUnmatched: 1,
+			},
+		},
+		"multi-access-rows": {
+			rows: []topologyL3Interface{
+				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
+				l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
+				l3InterfaceForTest("device-c", "198.51.100.3", "255.255.255.252", "4"),
+			},
+			wantStats: topologyL3SubnetBuildStats{
+				candidateSubnets:      1,
+				suppressedMultiAccess: 1,
+			},
+		},
+		"invalid-rows": {
+			rows: []topologyL3Interface{
+				l3InterfaceForTest("", "198.51.100.1", "255.255.255.252", "2"),
+				l3InterfaceForTest("device-a", "not-an-ip", "255.255.255.252", "2"),
+				l3InterfaceForTest("device-a", "2001:db8::1", "ffff:ffff:ffff:ffff::", "2"),
+				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", ""),
+			},
+			wantStats: topologyL3SubnetBuildStats{
+				suppressedInvalid: 4,
+			},
+		},
 	}
 
-	links, stats := buildTopologyL3SubnetAdjacencies(rows)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			links, stats := buildTopologyL3SubnetAdjacencies(tc.rows)
 
-	require.Len(t, links, 1)
-	require.Equal(t, "198.51.100.0/30", links[0].Subnet)
-	require.Equal(t, "198.51.100.0", links[0].Network)
-	require.Equal(t, "255.255.255.252", links[0].Netmask)
-	require.Equal(t, 30, links[0].Prefix)
-	require.Equal(t, "device-a", links[0].A.DeviceID)
-	require.Equal(t, "device-b", links[0].B.DeviceID)
-	require.Equal(t, topologyL3SubnetBuildStats{
-		candidateSubnets: 1,
-		candidateLinks:   1,
-	}, stats)
-}
-
-func TestBuildTopologyL3SubnetAdjacenciesSupportsIPv4ThirtyOne(t *testing.T) {
-	rows := []topologyL3Interface{
-		l3InterfaceForTest("device-a", "198.51.100.0", "255.255.255.254", "2"),
-		l3InterfaceForTest("device-b", "198.51.100.1", "255.255.255.254", "3"),
+			if len(tc.wantLinks) == 0 {
+				require.Empty(t, links)
+			} else {
+				require.Equal(t, tc.wantLinks, links)
+			}
+			require.Equal(t, tc.wantStats, stats)
+		})
 	}
-
-	links, stats := buildTopologyL3SubnetAdjacencies(rows)
-
-	require.Len(t, links, 1)
-	require.Equal(t, "198.51.100.0/31", links[0].Subnet)
-	require.Equal(t, 31, links[0].Prefix)
-	require.Equal(t, topologyL3SubnetBuildStats{
-		candidateSubnets: 1,
-		candidateLinks:   1,
-	}, stats)
-}
-
-func TestBuildTopologyL3SubnetAdjacenciesSuppressesUnsupportedPrefix(t *testing.T) {
-	rows := []topologyL3Interface{
-		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.0", "2"),
-		l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.0", "3"),
-	}
-
-	links, stats := buildTopologyL3SubnetAdjacencies(rows)
-
-	require.Empty(t, links)
-	require.Equal(t, topologyL3SubnetBuildStats{
-		suppressedUnsupportedPrefix: 2,
-	}, stats)
-}
-
-func TestBuildTopologyL3SubnetAdjacenciesSuppressesDuplicateIPOwnership(t *testing.T) {
-	rows := []topologyL3Interface{
-		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
-		l3InterfaceForTest("device-b", "198.51.100.1", "255.255.255.252", "3"),
-	}
-
-	links, stats := buildTopologyL3SubnetAdjacencies(rows)
-
-	require.Empty(t, links)
-	require.Equal(t, topologyL3SubnetBuildStats{
-		candidateSubnets:      1,
-		suppressedDuplicateIP: 1,
-	}, stats)
-}
-
-func TestBuildTopologyL3SubnetAdjacenciesSuppressesSameDeviceSelfLink(t *testing.T) {
-	rows := []topologyL3Interface{
-		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
-		l3InterfaceForTest("device-a", "198.51.100.2", "255.255.255.252", "3"),
-	}
-
-	links, stats := buildTopologyL3SubnetAdjacencies(rows)
-
-	require.Empty(t, links)
-	require.Equal(t, topologyL3SubnetBuildStats{
-		candidateSubnets:   1,
-		suppressedSelfLink: 1,
-	}, stats)
-}
-
-func TestBuildTopologyL3SubnetAdjacenciesSuppressesUnmatchedSubnet(t *testing.T) {
-	rows := []topologyL3Interface{
-		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
-	}
-
-	links, stats := buildTopologyL3SubnetAdjacencies(rows)
-
-	require.Empty(t, links)
-	require.Equal(t, topologyL3SubnetBuildStats{
-		candidateSubnets:    1,
-		suppressedUnmatched: 1,
-	}, stats)
-}
-
-func TestBuildTopologyL3SubnetAdjacenciesSuppressesMultiAccessRows(t *testing.T) {
-	rows := []topologyL3Interface{
-		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
-		l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
-		l3InterfaceForTest("device-c", "198.51.100.3", "255.255.255.252", "4"),
-	}
-
-	links, stats := buildTopologyL3SubnetAdjacencies(rows)
-
-	require.Empty(t, links)
-	require.Equal(t, topologyL3SubnetBuildStats{
-		candidateSubnets:      1,
-		suppressedMultiAccess: 1,
-	}, stats)
 }
 
 func TestBuildTopologyL3SubnetAdjacenciesDeterministic(t *testing.T) {
@@ -139,22 +149,6 @@ func TestBuildTopologyL3SubnetAdjacenciesDeterministic(t *testing.T) {
 	require.Len(t, links, 2)
 	require.Equal(t, "198.51.100.0/30", links[0].Subnet)
 	require.Equal(t, "198.51.100.4/30", links[1].Subnet)
-}
-
-func TestBuildTopologyL3SubnetAdjacenciesSuppressesInvalidRows(t *testing.T) {
-	rows := []topologyL3Interface{
-		l3InterfaceForTest("", "198.51.100.1", "255.255.255.252", "2"),
-		l3InterfaceForTest("device-a", "not-an-ip", "255.255.255.252", "2"),
-		l3InterfaceForTest("device-a", "2001:db8::1", "ffff:ffff:ffff:ffff::", "2"),
-		l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", ""),
-	}
-
-	links, stats := buildTopologyL3SubnetAdjacencies(rows)
-
-	require.Empty(t, links)
-	require.Equal(t, topologyL3SubnetBuildStats{
-		suppressedInvalid: 4,
-	}, stats)
 }
 
 func l3InterfaceForTest(deviceID, ip, netmask, ifIndex string) topologyL3Interface {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_local_actor_charts_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_local_actor_charts_test.go
@@ -36,13 +36,24 @@ func TestEnrichLocalActorChartReferencesAddsStatusAndPortRows(t *testing.T) {
 
 	statuses, ok := actor.Attributes["if_statuses"].([]map[string]any)
 	require.True(t, ok)
-	require.Equal(t, "gi0_1", statuses[0]["chart_id_suffix"])
-	require.Equal(t, []string{"errors", "traffic"}, statuses[0]["available_metrics"])
-	require.Equal(t, "gi0/2", statuses[1]["chart_id_suffix"])
-	require.Equal(t, []string{"drops"}, statuses[1]["available_metrics"])
 
-	require.Equal(t, "gi0_1", actor.Tables["ports"][0]["chart_id_suffix"])
-	require.Equal(t, []string{"errors", "traffic"}, actor.Tables["ports"][0]["available_metrics"])
+	tests := map[string]struct {
+		row         map[string]any
+		wantSuffix  string
+		wantMetrics []string
+	}{
+		"port-exact":        {row: actor.Tables["ports"][0], wantSuffix: "gi0_1", wantMetrics: []string{"errors", "traffic"}},
+		"status-exact":      {row: statuses[0], wantSuffix: "gi0_1", wantMetrics: []string{"errors", "traffic"}},
+		"status-normalized": {row: statuses[1], wantSuffix: "gi0/2", wantMetrics: []string{"drops"}},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.wantSuffix, tc.row["chart_id_suffix"])
+			require.Equal(t, tc.wantMetrics, tc.row["available_metrics"])
+		})
+	}
+
 	require.NotContains(t, actor.Tables["ports"][1], "chart_id_suffix")
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_management_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_management_helpers_test.go
@@ -9,20 +9,42 @@ import (
 )
 
 func TestNormalizeManagementAddress_DecodesHexAndASCIIIPs(t *testing.T) {
-	addr, addrType := normalizeManagementAddress("0A14043C", "1")
-	require.Equal(t, "10.20.4.60", addr)
-	require.Equal(t, "ipv4", addrType)
+	tests := map[string]struct {
+		addr     string
+		addrType string
+		wantAddr string
+		wantType string
+	}{
+		"hex-ipv4":   {addr: "0A14043C", addrType: "1", wantAddr: "10.20.4.60", wantType: "ipv4"},
+		"ascii-ipv4": {addr: "31302E32302E342E323035", wantAddr: "10.20.4.205", wantType: "ipv4"},
+	}
 
-	addr, addrType = normalizeManagementAddress("31302E32302E342E323035", "")
-	require.Equal(t, "10.20.4.205", addr)
-	require.Equal(t, "ipv4", addrType)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			addr, addrType := normalizeManagementAddress(tc.addr, tc.addrType)
+			require.Equal(t, tc.wantAddr, addr)
+			require.Equal(t, tc.wantType, addrType)
+		})
+	}
 }
 
 func TestNormalizeHexHelpers_ClassifyTokensDeterministically(t *testing.T) {
-	require.Equal(t, "00:11:22:33:44:55", normalizeMAC("hex-string: 00 11 22 33 44 55"))
-	require.Equal(t, "10.20.4.60", normalizeIPAddress("0A14043C"))
-	require.Equal(t, "10.20.4.205", normalizeHexToken("31302E32302E342E323035"))
-	require.Equal(t, "001122334455", normalizeHexIdentifier("00:11:22:33:44:55"))
+	tests := map[string]struct {
+		normalize func(string) string
+		in        string
+		want      string
+	}{
+		"mac":            {normalize: normalizeMAC, in: "hex-string: 00 11 22 33 44 55", want: "00:11:22:33:44:55"},
+		"ip-address":     {normalize: normalizeIPAddress, in: "0A14043C", want: "10.20.4.60"},
+		"hex-token":      {normalize: normalizeHexToken, in: "31302E32302E342E323035", want: "10.20.4.205"},
+		"hex-identifier": {normalize: normalizeHexIdentifier, in: "00:11:22:33:44:55", want: "001122334455"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.normalize(tc.in))
+		})
+	}
 }
 
 func TestReconstructLldpRemMgmtAddrHex_FromOctets(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_match_keys_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_match_keys_test.go
@@ -9,16 +9,31 @@ import (
 )
 
 func TestCanonicalKeyHelpers_DeduplicateAndNormalizeDeterministically(t *testing.T) {
-	require.Equal(t,
-		"10.20.4.60,alpha",
-		canonicalIPListKey([]string{"alpha", "10.20.4.60", "0A14043C", "ALPHA"}),
-	)
-	require.Equal(t,
-		"00:11:22:33:44:55,10.20.4.60,chassis-a",
-		canonicalHardwareListKey([]string{"chassis-a", "00:11:22:33:44:55", "0A14043C", "001122334455"}),
-	)
-	require.Equal(t,
-		"edge-a,edge-b",
-		canonicalStringListKey([]string{"edge-b", " Edge-A ", "edge-a"}),
-	)
+	tests := map[string]struct {
+		canonical func([]string) string
+		values    []string
+		want      string
+	}{
+		"ip-list": {
+			canonical: canonicalIPListKey,
+			values:    []string{"alpha", "10.20.4.60", "0A14043C", "ALPHA"},
+			want:      "10.20.4.60,alpha",
+		},
+		"hardware-list": {
+			canonical: canonicalHardwareListKey,
+			values:    []string{"chassis-a", "00:11:22:33:44:55", "0A14043C", "001122334455"},
+			want:      "00:11:22:33:44:55,10.20.4.60,chassis-a",
+		},
+		"string-list": {
+			canonical: canonicalStringListKey,
+			values:    []string{"edge-b", " Edge-A ", "edge-a"},
+			want:      "edge-a,edge-b",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.canonical(tc.values))
+		})
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_metadata_values_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_metadata_values_test.go
@@ -15,9 +15,20 @@ func TestTopologyMetadataValue_CanonicalizesAliasKeys(t *testing.T) {
 		"sys-location":     "dc1",
 	}
 
-	require.Equal(t, "SN-123", topologyMetadataValue(labels, []string{"serial_number"}))
-	require.Equal(t, "17.9.4", topologyMetadataValue(labels, []string{"software_version"}))
-	require.Equal(t, "dc1", topologyMetadataValue(labels, []string{"sys_location"}))
+	tests := map[string]struct {
+		keys []string
+		want string
+	}{
+		"serial-number":    {keys: []string{"serial_number"}, want: "SN-123"},
+		"software-version": {keys: []string{"software_version"}, want: "17.9.4"},
+		"sys-location":     {keys: []string{"sys_location"}, want: "dc1"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, topologyMetadataValue(labels, tc.keys))
+		})
+	}
 }
 
 func TestSetTopologyMetadataLabelIfMissing_PreservesExistingValue(t *testing.T) {
@@ -31,15 +42,26 @@ func TestSetTopologyMetadataLabelIfMissing_PreservesExistingValue(t *testing.T) 
 }
 
 func TestTopologyMetadataValue_DeterministicAcrossCanonicalKeyCollisions(t *testing.T) {
-	first := map[string]string{
-		"serial_number": "SN-200",
-		"serial-number": "SN-100",
-	}
-	second := map[string]string{
-		"serial-number": "SN-100",
-		"serial_number": "SN-200",
+	tests := map[string]struct {
+		labels map[string]string
+	}{
+		"underscore-first": {
+			labels: map[string]string{
+				"serial_number": "SN-200",
+				"serial-number": "SN-100",
+			},
+		},
+		"dash-first": {
+			labels: map[string]string{
+				"serial-number": "SN-100",
+				"serial_number": "SN-200",
+			},
+		},
 	}
 
-	require.Equal(t, "SN-100", topologyMetadataValue(first, []string{"serial_number"}))
-	require.Equal(t, "SN-100", topologyMetadataValue(second, []string{"serial_number"}))
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, "SN-100", topologyMetadataValue(tc.labels, []string{"serial_number"}))
+		})
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_observation_device_identity_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_observation_device_identity_test.go
@@ -9,11 +9,27 @@ import (
 )
 
 func TestEnsureTopologyObservationDeviceID_PrefersAgentScopedFallbacks(t *testing.T) {
-	require.Equal(t, "agent_job:job-1", ensureTopologyObservationDeviceID(topologyDevice{AgentJobID: "Job-1"}, ""))
-	require.Equal(t, "agent:11111111-1111-1111-1111-111111111111", ensureTopologyObservationDeviceID(topologyDevice{
-		NetdataHostID: "11111111-1111-1111-1111-111111111111",
-	}, ""))
-	require.Equal(t, "agent:22222222-2222-2222-2222-222222222222", ensureTopologyObservationDeviceID(topologyDevice{
-		AgentID: "22222222-2222-2222-2222-222222222222",
-	}, ""))
+	tests := map[string]struct {
+		device topologyDevice
+		want   string
+	}{
+		"agent-job-id": {
+			device: topologyDevice{AgentJobID: "Job-1"},
+			want:   "agent_job:job-1",
+		},
+		"netdata-host-id": {
+			device: topologyDevice{NetdataHostID: "11111111-1111-1111-1111-111111111111"},
+			want:   "agent:11111111-1111-1111-1111-111111111111",
+		},
+		"agent-id": {
+			device: topologyDevice{AgentID: "22222222-2222-2222-2222-222222222222"},
+			want:   "agent:22222222-2222-2222-2222-222222222222",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, ensureTopologyObservationDeviceID(tc.device, ""))
+		})
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_observation_identity_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_observation_identity_test.go
@@ -10,12 +10,24 @@ import (
 )
 
 func TestTopologyObservationIdentityCanonicalHelpers(t *testing.T) {
-	require.Equal(t, "edge-a", canonicalObservationHost(" Edge-A "))
-	require.Equal(t, "00:11:22:33:44:55", canonicalObservationChassis("001122334455"))
-	require.Equal(t, "chassis-a", canonicalObservationChassis("Chassis-A"))
-	require.Equal(t, "00:11:22:33:44:55", canonicalObservationMAC("00-11-22-33-44-55"))
-	require.Equal(t, "10.20.4.60", canonicalObservationIP("0A14043C"))
-	require.Equal(t, "", canonicalObservationIP(""))
+	tests := map[string]struct {
+		normalize func(string) string
+		in        string
+		want      string
+	}{
+		"host":              {normalize: canonicalObservationHost, in: " Edge-A ", want: "edge-a"},
+		"chassis-mac":       {normalize: canonicalObservationChassis, in: "001122334455", want: "00:11:22:33:44:55"},
+		"chassis-text":      {normalize: canonicalObservationChassis, in: "Chassis-A", want: "chassis-a"},
+		"mac":               {normalize: canonicalObservationMAC, in: "00-11-22-33-44-55", want: "00:11:22:33:44:55"},
+		"ip-hex":            {normalize: canonicalObservationIP, in: "0A14043C", want: "10.20.4.60"},
+		"ip-empty-rejected": {normalize: canonicalObservationIP, in: "", want: ""},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.normalize(tc.in))
+		})
+	}
 }
 
 func TestTopologyObservationIdentityResolver_AssignsDeterministicFallbackIDs(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_links_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_links_test.go
@@ -38,92 +38,105 @@ func TestApplyTopologyOSPFAdjacencyEnrichmentEmitsFullManagedLink(t *testing.T) 
 	require.Equal(t, "router-b", data.Actors[0].Tables["ospf_neighbors"][0]["remote_actor_id"])
 }
 
-func TestApplyTopologyOSPFAdjacencyEnrichmentKeepsNonFullNeighborAsDetailOnly(t *testing.T) {
-	data := topologyData{
-		Actors: []topologyActor{
-			topologyOSPFManagedActorForTest("router-a", "device-a", "1.1.1.1", "198.51.100.1"),
-			topologyOSPFManagedActorForTest("router-b", "device-b", "2.2.2.2", "198.51.100.2"),
+func TestApplyTopologyOSPFAdjacencyEnrichmentKeepsSuppressedNeighborsAsDetailOnly(t *testing.T) {
+	tests := map[string]struct {
+		data                       topologyData
+		aggregate                  topologyObservationAggregate
+		wantNonFullState           int
+		wantUnresolvedNeighbor     int
+		wantSelfActor              int
+		wantDetailState            string
+		wantRemoteActorID          string
+		wantRemoteActorIDAbsent    bool
+		wantSuppressedStatsCounter string
+	}{
+		"non-full-neighbor": {
+			data: topologyData{
+				Actors: []topologyActor{
+					topologyOSPFManagedActorForTest("router-a", "device-a", "1.1.1.1", "198.51.100.1"),
+					topologyOSPFManagedActorForTest("router-b", "device-b", "2.2.2.2", "198.51.100.2"),
+				},
+			},
+			aggregate: topologyObservationAggregate{
+				ospfNeighbors: []topologyOSPFNeighbor{
+					ospfNeighborForTest("device-a", "1.1.1.1", "2.2.2.2", "198.51.100.2", "twoWay"),
+				},
+			},
+			wantNonFullState: 1,
+			wantDetailState:  "twoWay",
 		},
-	}
-	aggregate := topologyObservationAggregate{
-		ospfNeighbors: []topologyOSPFNeighbor{
-			ospfNeighborForTest("device-a", "1.1.1.1", "2.2.2.2", "198.51.100.2", "twoWay"),
+		"unresolved-neighbor": {
+			data: topologyData{
+				Actors: []topologyActor{
+					topologyOSPFManagedActorForTest("router-a", "device-a", "1.1.1.1", "198.51.100.1"),
+				},
+			},
+			aggregate: topologyObservationAggregate{
+				ospfNeighbors: []topologyOSPFNeighbor{
+					ospfNeighborForTest("device-a", "1.1.1.1", "2.2.2.2", "198.51.100.2", "full"),
+				},
+			},
+			wantUnresolvedNeighbor:  1,
+			wantRemoteActorIDAbsent: true,
 		},
-	}
-
-	stats := applyTopologyOSPFAdjacencyEnrichment(&data, aggregate)
-
-	require.Zero(t, stats.emittedLinks)
-	require.Equal(t, 1, stats.suppressedNonFullState)
-	require.Empty(t, data.Links)
-	require.Len(t, data.Actors[0].Tables["ospf_neighbors"], 1)
-	require.Equal(t, "twoWay", data.Actors[0].Tables["ospf_neighbors"][0]["state"])
-}
-
-func TestApplyTopologyOSPFAdjacencyEnrichmentKeepsUnresolvedNeighborAsDetailOnly(t *testing.T) {
-	data := topologyData{
-		Actors: []topologyActor{
-			topologyOSPFManagedActorForTest("router-a", "device-a", "1.1.1.1", "198.51.100.1"),
+		"ambiguous-router-id-neighbor": {
+			data: topologyData{
+				Actors: []topologyActor{
+					topologyOSPFManagedActorForTest("router-a", "device-a", "1.1.1.1", "198.51.100.1"),
+					topologyOSPFManagedActorForTest("router-b", "device-b", "2.2.2.2", "198.51.100.2"),
+					topologyOSPFManagedActorForTest("router-c", "device-c", "2.2.2.2", "198.51.100.3"),
+				},
+			},
+			aggregate: topologyObservationAggregate{
+				ospfNeighbors: []topologyOSPFNeighbor{
+					ospfNeighborForTest("device-a", "1.1.1.1", "2.2.2.2", "0.0.0.0", "full"),
+				},
+			},
+			wantUnresolvedNeighbor:  1,
+			wantRemoteActorIDAbsent: true,
 		},
-	}
-	aggregate := topologyObservationAggregate{
-		ospfNeighbors: []topologyOSPFNeighbor{
-			ospfNeighborForTest("device-a", "1.1.1.1", "2.2.2.2", "198.51.100.2", "full"),
-		},
-	}
-
-	stats := applyTopologyOSPFAdjacencyEnrichment(&data, aggregate)
-
-	require.Zero(t, stats.emittedLinks)
-	require.Equal(t, 1, stats.suppressedUnresolvedNeighbor)
-	require.Empty(t, data.Links)
-	require.Len(t, data.Actors[0].Tables["ospf_neighbors"], 1)
-	require.NotContains(t, data.Actors[0].Tables["ospf_neighbors"][0], "remote_actor_id")
-}
-
-func TestApplyTopologyOSPFAdjacencyEnrichmentKeepsAmbiguousRouterIDNeighborAsDetailOnly(t *testing.T) {
-	data := topologyData{
-		Actors: []topologyActor{
-			topologyOSPFManagedActorForTest("router-a", "device-a", "1.1.1.1", "198.51.100.1"),
-			topologyOSPFManagedActorForTest("router-b", "device-b", "2.2.2.2", "198.51.100.2"),
-			topologyOSPFManagedActorForTest("router-c", "device-c", "2.2.2.2", "198.51.100.3"),
-		},
-	}
-	aggregate := topologyObservationAggregate{
-		ospfNeighbors: []topologyOSPFNeighbor{
-			ospfNeighborForTest("device-a", "1.1.1.1", "2.2.2.2", "0.0.0.0", "full"),
-		},
-	}
-
-	stats := applyTopologyOSPFAdjacencyEnrichment(&data, aggregate)
-
-	require.Zero(t, stats.emittedLinks)
-	require.Equal(t, 1, stats.suppressedUnresolvedNeighbor)
-	require.Empty(t, data.Links)
-	require.Len(t, data.Actors[0].Tables["ospf_neighbors"], 1)
-	require.NotContains(t, data.Actors[0].Tables["ospf_neighbors"][0], "remote_actor_id")
-}
-
-func TestApplyTopologyOSPFAdjacencyEnrichmentSuppressesSelfActor(t *testing.T) {
-	data := topologyData{
-		Actors: []topologyActor{
-			topologyOSPFManagedActorForTest("router-a", "device-a", "1.1.1.1", "198.51.100.1"),
-		},
-	}
-	aggregate := topologyObservationAggregate{
-		ospfNeighbors: []topologyOSPFNeighbor{
-			ospfNeighborForTest("device-a", "1.1.1.1", "1.1.1.1", "198.51.100.1", "full"),
+		"self-actor": {
+			data: topologyData{
+				Actors: []topologyActor{
+					topologyOSPFManagedActorForTest("router-a", "device-a", "1.1.1.1", "198.51.100.1"),
+				},
+			},
+			aggregate: topologyObservationAggregate{
+				ospfNeighbors: []topologyOSPFNeighbor{
+					ospfNeighborForTest("device-a", "1.1.1.1", "1.1.1.1", "198.51.100.1", "full"),
+				},
+			},
+			wantSelfActor:              1,
+			wantRemoteActorID:          "router-a",
+			wantSuppressedStatsCounter: "ospf_adjacency_suppressed_self_actor",
 		},
 	}
 
-	stats := applyTopologyOSPFAdjacencyEnrichment(&data, aggregate)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			stats := applyTopologyOSPFAdjacencyEnrichment(&tc.data, tc.aggregate)
 
-	require.Zero(t, stats.emittedLinks)
-	require.Equal(t, 1, stats.suppressedSelfActor)
-	require.Empty(t, data.Links)
-	require.Len(t, data.Actors[0].Tables["ospf_neighbors"], 1)
-	require.Equal(t, "router-a", data.Actors[0].Tables["ospf_neighbors"][0]["remote_actor_id"])
-	require.Equal(t, 1, data.Stats["ospf_adjacency_suppressed_self_actor"])
+			require.Zero(t, stats.emittedLinks)
+			require.Equal(t, tc.wantNonFullState, stats.suppressedNonFullState)
+			require.Equal(t, tc.wantUnresolvedNeighbor, stats.suppressedUnresolvedNeighbor)
+			require.Equal(t, tc.wantSelfActor, stats.suppressedSelfActor)
+			require.Empty(t, tc.data.Links)
+			require.Len(t, tc.data.Actors[0].Tables["ospf_neighbors"], 1)
+			row := tc.data.Actors[0].Tables["ospf_neighbors"][0]
+			if tc.wantDetailState != "" {
+				require.Equal(t, tc.wantDetailState, row["state"])
+			}
+			if tc.wantRemoteActorID != "" {
+				require.Equal(t, tc.wantRemoteActorID, row["remote_actor_id"])
+			}
+			if tc.wantRemoteActorIDAbsent {
+				require.NotContains(t, row, "remote_actor_id")
+			}
+			if tc.wantSuppressedStatsCounter != "" {
+				require.Equal(t, 1, tc.data.Stats[tc.wantSuppressedStatsCounter])
+			}
+		})
+	}
 }
 
 func TestApplyTopologyOSPFAdjacencyEnrichmentDeduplicatesBidirectionalObservations(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
@@ -9,10 +9,21 @@ import (
 )
 
 func TestNormalizeOSPFRouterIDDropsUnspecifiedAddresses(t *testing.T) {
-	require.Empty(t, normalizeOSPFRouterID("0.0.0.0"))
-	require.Empty(t, normalizeOSPFRouterID("::"))
-	require.Empty(t, normalizeOSPFRouterID("00000000"))
-	require.Equal(t, "1.2.3.4", normalizeOSPFRouterID(" 1.2.3.4 "))
+	tests := map[string]struct {
+		in   string
+		want string
+	}{
+		"ipv4-unspecified": {in: "0.0.0.0"},
+		"ipv6-unspecified": {in: "::"},
+		"hex-unspecified":  {in: "00000000"},
+		"valid-router-id":  {in: " 1.2.3.4 ", want: "1.2.3.4"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, normalizeOSPFRouterID(tc.in))
+		})
+	}
 }
 
 func TestTopologyOSPFNeighborLinkKeyIgnoresUnspecifiedIPs(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_shape_focus_graph_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_shape_focus_graph_test.go
@@ -139,11 +139,22 @@ func TestTopologyActorHasIPMatchesMatchAndManagementAddresses(t *testing.T) {
 		},
 	}
 
-	require.True(t, topologyActorHasIP(actor, "10.0.0.1"))
-	require.True(t, topologyActorHasIP(actor, "10.0.0.2"))
-	require.True(t, topologyActorHasIP(actor, "10.0.0.3"))
-	require.False(t, topologyActorHasIP(actor, "10.0.0.9"))
-	require.False(t, topologyActorHasIP(actor, "not-an-ip"))
+	tests := map[string]struct {
+		ip   string
+		want bool
+	}{
+		"match-ip":            {ip: "10.0.0.1", want: true},
+		"management-ip":       {ip: "10.0.0.2", want: true},
+		"management-address":  {ip: "10.0.0.3", want: true},
+		"missing-ip":          {ip: "10.0.0.9"},
+		"invalid-ip-rejected": {ip: "not-an-ip"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, topologyActorHasIP(actor, tc.ip))
+		})
+	}
 }
 
 func TestRecordTopologyFocusStatsNormalizesDepthAndFilteredCounts(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_shape_stats_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_shape_stats_test.go
@@ -43,13 +43,24 @@ func TestApplySNMPTopologyShapePolicies_EmitsStatsContractKeys(t *testing.T) {
 		"segments_sparse_suppressed",
 		"segments_suppressed",
 	}, keys)
-	require.Equal(t, 1, data.Stats["actors_total"])
-	require.Equal(t, 0, data.Stats["links_total"])
-	require.Equal(t, 1, data.Stats["actors_non_ip_inferred_suppressed"])
-	require.Equal(t, 1, data.Stats["segments_sparse_suppressed"])
-	require.Equal(t, 1, data.Stats["segments_suppressed"])
-	require.Equal(t, topologyMapTypeHighConfidenceInferred, data.Stats["map_type"])
-	require.Equal(t, topologyInferenceStrategySTPParentTree, data.Stats["inference_strategy"])
+
+	expectedStats := map[string]struct {
+		key  string
+		want any
+	}{
+		"actors-total":                      {key: "actors_total", want: 1},
+		"inference-strategy":                {key: "inference_strategy", want: topologyInferenceStrategySTPParentTree},
+		"links-total":                       {key: "links_total", want: 0},
+		"map-type":                          {key: "map_type", want: topologyMapTypeHighConfidenceInferred},
+		"non-ip-inferred-actors-suppressed": {key: "actors_non_ip_inferred_suppressed", want: 1},
+		"sparse-segments-suppressed":        {key: "segments_sparse_suppressed", want: 1},
+		"suppressed-segments-after-cleanup": {key: "segments_suppressed", want: 1},
+	}
+	for name, tc := range expectedStats {
+		t.Run("stat/"+name, func(t *testing.T) {
+			require.Equal(t, tc.want, data.Stats[tc.key])
+		})
+	}
 }
 
 func TestRecomputeTopologyLinkStatsRefreshesExistingL3VisibleCount(t *testing.T) {
@@ -65,7 +76,17 @@ func TestRecomputeTopologyLinkStatsRefreshesExistingL3VisibleCount(t *testing.T)
 
 	recomputeTopologyLinkStats(data)
 
-	require.Equal(t, 2, data.Stats["links_total"])
-	require.Equal(t, 2, data.Stats["l3_subnet_emitted_links"])
-	require.Equal(t, 1, data.Stats["l3_subnet_visible_links"])
+	expectedStats := map[string]struct {
+		key  string
+		want any
+	}{
+		"emitted-l3-subnet-links": {key: "l3_subnet_emitted_links", want: 2},
+		"links-total":             {key: "links_total", want: 2},
+		"visible-l3-subnet-links": {key: "l3_subnet_visible_links", want: 1},
+	}
+	for name, tc := range expectedStats {
+		t.Run("stat/"+name, func(t *testing.T) {
+			require.Equal(t, tc.want, data.Stats[tc.key])
+		})
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_shape_values_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_shape_values_test.go
@@ -8,21 +8,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTopologyShapeValues_ClassifyActorsAndValues(t *testing.T) {
-	require.True(t, topologyActorIsInferred(topologyActor{ActorType: "endpoint"}))
-	require.True(t, topologyActorIsInferred(topologyActor{Labels: map[string]string{"inferred": "yes"}}))
-	require.True(t, topologyActorIsInferred(topologyActor{Attributes: map[string]any{"inferred": true}}))
-	require.False(t, topologyActorIsInferred(topologyActor{ActorType: "device"}))
+func TestTopologyActorIsInferred(t *testing.T) {
+	tests := map[string]struct {
+		actor topologyActor
+		want  bool
+	}{
+		"endpoint-type":      {actor: topologyActor{ActorType: "endpoint"}, want: true},
+		"inferred-label":     {actor: topologyActor{Labels: map[string]string{"inferred": "yes"}}, want: true},
+		"inferred-attribute": {actor: topologyActor{Attributes: map[string]any{"inferred": true}}, want: true},
+		"device-type":        {actor: topologyActor{ActorType: "device"}},
+	}
 
-	require.True(t, boolStatValue("true"))
-	require.True(t, boolStatValue(" yes "))
-	require.False(t, boolStatValue("0"))
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, topologyActorIsInferred(tc.actor))
+		})
+	}
+}
 
-	require.Equal(t, 7, intStatValue("7"))
-	require.Equal(t, 6, intStatValue(uint(6)))
-	require.Equal(t, 5, intStatValue(int64(5)))
-	require.Equal(t, 30, intStatValue(uint64(30)))
-	require.Equal(t, 0, intStatValue("nan"))
+func TestBoolStatValue(t *testing.T) {
+	tests := map[string]struct {
+		in   any
+		want bool
+	}{
+		"true":        {in: "true", want: true},
+		"yes-trimmed": {in: " yes ", want: true},
+		"zero":        {in: "0"},
+	}
 
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, boolStatValue(tc.in))
+		})
+	}
+}
+
+func TestIntStatValue(t *testing.T) {
+	tests := map[string]struct {
+		in   any
+		want int
+	}{
+		"string": {in: "7", want: 7},
+		"uint":   {in: uint(6), want: 6},
+		"int64":  {in: int64(5), want: 5},
+		"uint64": {in: uint64(30), want: 30},
+		"nan":    {in: "nan"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, intStatValue(tc.in))
+		})
+	}
+}
+
+func TestTopologyMetricValueString(t *testing.T) {
 	require.Equal(t, "value", topologyMetricValueString(map[string]any{"key": " value "}, "key"))
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snmp_value_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snmp_value_helpers_test.go
@@ -9,16 +9,41 @@ import (
 )
 
 func TestNormalizeSNMPHexText_StripsPrefixesAndQuotes(t *testing.T) {
-	require.Equal(t, "00 11 22 33", normalizeSNMPHexText(`"hex-string: 00 11 22 33"`))
-	require.Equal(t, "0A14043C", normalizeSNMPHexText("octet string: 0A14043C"))
-	require.Equal(t, "abc", normalizeSNMPHexText(`'string: abc'`))
+	tests := map[string]struct {
+		in   string
+		want string
+	}{
+		"quoted-hex-string":   {in: `"hex-string: 00 11 22 33"`, want: "00 11 22 33"},
+		"octet-string-prefix": {in: "octet string: 0A14043C", want: "0A14043C"},
+		"quoted-string":       {in: `'string: abc'`, want: "abc"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, normalizeSNMPHexText(tc.in))
+		})
+	}
 }
 
-func TestDecodeLLDPCapabilities_AndInferCategory(t *testing.T) {
+func TestDecodeLLDPCapabilities(t *testing.T) {
 	require.Equal(t,
 		[]string{"bridge", "router"},
 		decodeLLDPCapabilities("28"),
 	)
-	require.Equal(t, "router", inferCategoryFromCapabilities([]string{"bridge", "router"}))
-	require.Equal(t, "access point", inferCategoryFromCapabilities([]string{"wlanAccessPoint"}))
+}
+
+func TestInferCategoryFromCapabilities(t *testing.T) {
+	tests := map[string]struct {
+		capabilities []string
+		want         string
+	}{
+		"access-point": {capabilities: []string{"wlanAccessPoint"}, want: "access point"},
+		"router":       {capabilities: []string{"bridge", "router"}, want: "router"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, inferCategoryFromCapabilities(tc.capabilities))
+		})
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snmprec_forwarding_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snmprec_forwarding_test.go
@@ -35,28 +35,24 @@ type snmprecForwardingFixture struct {
 }
 
 func TestTopologyCache_RealSnmprecForwardingFixtures(t *testing.T) {
-	tests := []struct {
-		name           string
+	tests := map[string]struct {
 		fixture        string
 		wantARP        bool
 		wantSTP        bool
 		wantDot1qFDB   bool
 		wantVTPVLANMap bool
 	}{
-		{
-			name:    "ArubaCX",
+		"ArubaCX": {
 			fixture: "arubaos-cx_10.10.snmprec",
 			wantARP: true,
 			wantSTP: true,
 		},
-		{
-			name:         "CiscoSmallBusiness",
+		"CiscoSmallBusiness": {
 			fixture:      "ciscosb_sg350x-24p.snmprec",
 			wantDot1qFDB: true,
 			wantSTP:      true,
 		},
-		{
-			name:           "IOSXE",
+		"IOSXE": {
 			fixture:        "iosxe_ie32008t2s-ios17-12.snmprec",
 			wantARP:        true,
 			wantSTP:        true,
@@ -64,9 +60,8 @@ func TestTopologyCache_RealSnmprecForwardingFixtures(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
 			data := parseSnmprecForwardingFixture(t, filepath.Join("../../../../testdata/snmp/snmprec", tt.fixture))
 
 			require.NotEmpty(t, data.ifNameEntries, "fixture %q should expose ifName data", tt.fixture)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich_test.go
@@ -11,67 +11,101 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTopologyCacheTrapEnrichmentUsesTrapIfIndex(t *testing.T) {
-	cache := newTopologyCache()
-	cache.localDevice.ManagementIP = "192.0.2.30"
-	cache.ifIndexByIP["192.0.2.10"] = "99"
-	cache.ifNamesByIndex["7"] = "Gi0/7"
-	cache.ifNamesByIndex["99"] = "Gi0/99"
-	cache.lldpRemotes["7:2"] = &lldpRemote{localPortNum: "7", sysName: "dist-b"}
-	cache.lldpRemotes["7:1"] = &lldpRemote{localPortNum: "7", sysName: "dist-a"}
-	cache.lldpRemotes["99:1"] = &lldpRemote{localPortNum: "99", sysName: "wrong-source-ip-interface"}
-	cache.cdpRemotes["7:1"] = &cdpRemote{ifIndex: "7", sysName: "dist-a"}
-	cache.cdpRemotes["9:1"] = &cdpRemote{ifIndex: "9", sysName: "dist-d"}
+func TestTopologyCacheTrapEnrichment(t *testing.T) {
+	tests := map[string]struct {
+		setup               func(*topologyCache)
+		source              string
+		ifIndex             string
+		wantDeviceStatus    string
+		wantDeviceMethod    string
+		wantInterface       string
+		wantInterfaceStatus string
+		wantNeighborStatus  string
+		wantNeighbors       []string
+	}{
+		"uses-trap-if-index": {
+			setup: func(cache *topologyCache) {
+				cache.localDevice.ManagementIP = "192.0.2.30"
+				cache.ifIndexByIP["192.0.2.10"] = "99"
+				cache.ifNamesByIndex["7"] = "Gi0/7"
+				cache.ifNamesByIndex["99"] = "Gi0/99"
+				cache.lldpRemotes["7:2"] = &lldpRemote{localPortNum: "7", sysName: "dist-b"}
+				cache.lldpRemotes["7:1"] = &lldpRemote{localPortNum: "7", sysName: "dist-a"}
+				cache.lldpRemotes["99:1"] = &lldpRemote{localPortNum: "99", sysName: "wrong-source-ip-interface"}
+				cache.cdpRemotes["7:1"] = &cdpRemote{ifIndex: "7", sysName: "dist-a"}
+				cache.cdpRemotes["9:1"] = &cdpRemote{ifIndex: "9", sysName: "dist-d"}
+			},
+			source:              "192.0.2.30",
+			ifIndex:             "7",
+			wantDeviceStatus:    "matched",
+			wantDeviceMethod:    "management_ip",
+			wantInterface:       "Gi0/7",
+			wantInterfaceStatus: "matched",
+			wantNeighbors:       []string{"dist-a", "dist-b"},
+		},
+		"remote-map-key-fallback": {
+			setup: func(cache *topologyCache) {
+				cache.localDevice.ManagementIP = "192.0.2.30"
+				cache.lldpRemotes["7:2"] = &lldpRemote{sysName: "dist-b"}
+				cache.lldpRemotes["8:1"] = &lldpRemote{sysName: "dist-c"}
+				cache.cdpRemotes["7:1"] = &cdpRemote{sysName: "dist-a"}
+				cache.cdpRemotes["9:1"] = &cdpRemote{sysName: "dist-d"}
+			},
+			source:        "192.0.2.30",
+			ifIndex:       "7",
+			wantNeighbors: []string{"dist-a", "dist-b"},
+		},
+		"does-not-infer-interface-from-source-ip": {
+			setup: func(cache *topologyCache) {
+				cache.ifIndexByIP["192.0.2.10"] = "7"
+				cache.ifNamesByIndex["7"] = "Gi0/7"
+				cache.lldpRemotes["7:1"] = &lldpRemote{sysName: "dist-a"}
+			},
+			source:              "192.0.2.10",
+			wantDeviceStatus:    "matched",
+			wantDeviceMethod:    "local_interface_ip",
+			wantInterfaceStatus: "skipped",
+			wantNeighborStatus:  "skipped",
+		},
+		"no-interface-match": {
+			setup: func(cache *topologyCache) {
+				cache.localDevice.ManagementIP = "192.0.2.30"
+				cache.lldpRemotes["7:1"] = &lldpRemote{sysName: "dist-a"}
+			},
+			source:              "192.0.2.30",
+			ifIndex:             "9",
+			wantInterfaceStatus: "no_match",
+			wantNeighborStatus:  "no_match",
+		},
+	}
 
-	enrich := cache.trapEnrichmentForSource("192.0.2.30", "7")
-	require.NotNil(t, enrich)
-	require.Equal(t, "matched", enrich.DeviceStatus)
-	require.Equal(t, "management_ip", enrich.DeviceMethod)
-	require.Equal(t, "Gi0/7", enrich.Interface)
-	require.Equal(t, "matched", enrich.InterfaceStatus)
-	require.Equal(t, []string{"dist-a", "dist-b"}, enrich.Neighbors)
-}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := newTopologyCache()
+			tc.setup(cache)
 
-func TestTopologyCacheTrapEnrichmentFallsBackToRemoteMapKeys(t *testing.T) {
-	cache := newTopologyCache()
-	cache.localDevice.ManagementIP = "192.0.2.30"
-	cache.lldpRemotes["7:2"] = &lldpRemote{sysName: "dist-b"}
-	cache.lldpRemotes["8:1"] = &lldpRemote{sysName: "dist-c"}
-	cache.cdpRemotes["7:1"] = &cdpRemote{sysName: "dist-a"}
-	cache.cdpRemotes["9:1"] = &cdpRemote{sysName: "dist-d"}
-
-	enrich := cache.trapEnrichmentForSource("192.0.2.30", "7")
-	require.NotNil(t, enrich)
-	require.Equal(t, []string{"dist-a", "dist-b"}, enrich.Neighbors)
-}
-
-func TestTopologyCacheTrapEnrichmentDoesNotInferInterfaceFromSourceIP(t *testing.T) {
-	cache := newTopologyCache()
-	cache.ifIndexByIP["192.0.2.10"] = "7"
-	cache.ifNamesByIndex["7"] = "Gi0/7"
-	cache.lldpRemotes["7:1"] = &lldpRemote{sysName: "dist-a"}
-
-	enrich := cache.trapEnrichmentForSource("192.0.2.10", "")
-	require.NotNil(t, enrich)
-	require.Equal(t, "matched", enrich.DeviceStatus)
-	require.Equal(t, "local_interface_ip", enrich.DeviceMethod)
-	require.Empty(t, enrich.Interface)
-	require.Empty(t, enrich.Neighbors)
-	require.Equal(t, "skipped", enrich.InterfaceStatus)
-	require.Equal(t, "skipped", enrich.NeighborStatus)
-}
-
-func TestTopologyCacheTrapEnrichmentNoInterfaceMatch(t *testing.T) {
-	cache := newTopologyCache()
-	cache.localDevice.ManagementIP = "192.0.2.30"
-	cache.lldpRemotes["7:1"] = &lldpRemote{sysName: "dist-a"}
-
-	enrich := cache.trapEnrichmentForSource("192.0.2.30", "9")
-	require.NotNil(t, enrich)
-	require.Equal(t, "no_match", enrich.InterfaceStatus)
-	require.Empty(t, enrich.Interface)
-	require.Equal(t, "no_match", enrich.NeighborStatus)
-	require.Empty(t, enrich.Neighbors)
+			enrich := cache.trapEnrichmentForSource(tc.source, tc.ifIndex)
+			require.NotNil(t, enrich)
+			if tc.wantDeviceStatus != "" {
+				require.Equal(t, tc.wantDeviceStatus, enrich.DeviceStatus)
+			}
+			if tc.wantDeviceMethod != "" {
+				require.Equal(t, tc.wantDeviceMethod, enrich.DeviceMethod)
+			}
+			require.Equal(t, tc.wantInterface, enrich.Interface)
+			if tc.wantInterfaceStatus != "" {
+				require.Equal(t, tc.wantInterfaceStatus, enrich.InterfaceStatus)
+			}
+			if tc.wantNeighborStatus != "" {
+				require.Equal(t, tc.wantNeighborStatus, enrich.NeighborStatus)
+			}
+			if tc.wantNeighbors == nil {
+				require.Empty(t, enrich.Neighbors)
+			} else {
+				require.Equal(t, tc.wantNeighbors, enrich.Neighbors)
+			}
+		})
+	}
 }
 
 func TestTopologyCacheTrapEnrichmentIncludesLocalDeviceIdentity(t *testing.T) {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `snmp_topology` tests to table-driven style for clearer, more maintainable, and deterministic coverage. No production code changes.

- **Refactors**
  - Converted many tests to map-based, subtest-driven cases to remove duplication.
  - Added small test helpers (e.g., building L3 subnet links and neighbor summaries).
  - Grouped related scenarios and added explicit negative cases for edge conditions.
  - Made expectations deterministic (stable ordering, consistent key checks) with clearer assertions.
  - Kept behavior and metrics intact; assertions now target precise stat keys and values.

<sup>Written for commit 4d81da3d55cb46950cb2630654294682250ec6b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

