### PR TITLE
fix(windows): exclude sockets from the pipe poll path so streaming receive works

### DIFF
--- a/src/libnetdata/socket/socket.c
+++ b/src/libnetdata/socket/socket.c
@@ -366,7 +366,12 @@ inline int wait_on_socket_or_cancel_with_timeout(
     // WSAPoll() (used internally by MinGW poll()) only works for sockets.
     // For pipe file descriptors (e.g. stdin when launched as a subprocess),
     // poll() fails and kills the reader thread. Use PeekNamedPipe instead.
-    if(poll_events & POLLIN) {
+    //
+    // Sockets must be excluded from the pipe path: GetFileType() reports
+    // FILE_TYPE_PIPE for Winsock sockets too (they sit on \Device\Afd), so
+    // relying on GetFileType() alone would route stream sockets through
+    // PeekNamedPipe(), which fails on a socket and breaks receiving.
+    if((poll_events & POLLIN) && !fd_is_socket(fd)) {
         HANDLE h = (HANDLE)_get_osfhandle(fd);
         if(h != INVALID_HANDLE_VALUE && GetFileType(h) == FILE_TYPE_PIPE) {
             bool forever = (timeout_ms <= 0);


### PR DESCRIPTION
##### Summary
On Windows, agents connected to a parent (TCP established) but never streamed — `stream_info` and all reads failed with "socket receive error".

  #22470 added a Windows `PeekNamedPipe()` branch in `wait_on_socket_or_cancel_with_timeout()` for subprocess stdin pipes, selected via `GetFileType() == FILE_TYPE_PIPE`. 

But Windows reports `FILE_TYPE_PIPE` for sockets too (Winsock on `\Device\Afd`), so stream sockets were run through `PeekNamedPipe()`, which fails on a socket.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows socket polling so stream sockets aren’t treated as pipes. Restores streaming receive and prevents “socket receive error” when agents connect.

- **Bug Fixes**
  - Exclude sockets from the `PeekNamedPipe()` path by checking `!fd_is_socket(fd)` before `GetFileType() == FILE_TYPE_PIPE`.
  - Keep `PeekNamedPipe()` only for real pipe handles; sockets use `poll`/`WSAPoll` as intended.

<sup>Written for commit aa04c162f6c3bdc8fd993971d7a642a1e6a50f06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

