### PR TITLE
chore(go.d/snmp_topology): extract neutral topology graph model

### DIFF
--- a/src/go/pkg/l2topology/mac_oui_lookup.go
+++ b/src/go/pkg/l2topology/mac_oui_lookup.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 //go:embed mac_oui_vendors.tsv
@@ -114,7 +116,7 @@ func lookupTopologyVendorByMACInIndex(index topologyOUIVendorIndex, mac string) 
 	return "", ""
 }
 
-func inferTopologyVendorFromMatch(match Match) (vendor string, prefix string) {
+func inferTopologyVendorFromMatch(match graph.Match) (vendor string, prefix string) {
 	candidates := make(map[string]struct{}, len(match.MacAddresses)+len(match.ChassisIDs))
 	for _, value := range match.MacAddresses {
 		if mac := normalizeMAC(value); mac != "" {

--- a/src/go/pkg/l2topology/mac_oui_lookup_test.go
+++ b/src/go/pkg/l2topology/mac_oui_lookup_test.go
@@ -3,9 +3,11 @@
 package l2topology
 
 import (
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildTopologyOUIVendorIndex_IgnoresInvalidLinesAndKeepsFirstDuplicate(t *testing.T) {
@@ -47,7 +49,7 @@ func TestLookupTopologyVendorByMACInIndex_PrefersLongestPrefixAndNormalizesMAC(t
 }
 
 func TestInferTopologyVendorFromMatch_UsesDeterministicCandidateOrder(t *testing.T) {
-	match := Match{
+	match := graph.Match{
 		MacAddresses: []string{
 			"28:6f:b9:00:00:22",
 			"08:ea:44:11:22:33",

--- a/src/go/pkg/l2topology/topology_adapter.go
+++ b/src/go/pkg/l2topology/topology_adapter.go
@@ -6,6 +6,8 @@ import (
 	"net/netip"
 	"strings"
 	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 // GraphOptions controls conversion from Result to the internal graph projection.
@@ -54,8 +56,8 @@ type endpointActorAccumulator struct {
 }
 
 type projectedSegments struct {
-	actors                        []Actor
-	links                         []Link
+	actors                        []graph.Actor
+	links                         []graph.Link
 	linksFdb                      int
 	bidirectionalCount            int
 	endpointLinksCandidates       int
@@ -220,7 +222,7 @@ func topologyInferenceStrategyConfigFor(strategy string) topologyInferenceStrate
 }
 
 // ToGraph converts an engine result to the internal graph projection.
-func ToGraph(result Result, opts GraphOptions) Graph {
+func ToGraph(result Result, opts GraphOptions) graph.Graph {
 	builder := newGraphBuilder(result, opts)
 	builder.prepareIndexes()
 	builder.collectBridgeTopologyInputs()

--- a/src/go/pkg/l2topology/topology_adapter_actor_collapse.go
+++ b/src/go/pkg/l2topology/topology_adapter_actor_collapse.go
@@ -5,9 +5,11 @@ package l2topology
 import (
 	"sort"
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
-func collapseActorsByIP(actors []Actor) []Actor {
+func collapseActorsByIP(actors []graph.Actor) []graph.Actor {
 	if len(actors) <= 1 {
 		return actors
 	}
@@ -96,7 +98,7 @@ func collapseActorsByIP(actors []Actor) []Actor {
 		actors[rep] = merged
 	}
 
-	out := make([]Actor, 0, len(actors))
+	out := make([]graph.Actor, 0, len(actors))
 	for idx, actor := range actors {
 		if !keep[idx] {
 			continue
@@ -106,12 +108,12 @@ func collapseActorsByIP(actors []Actor) []Actor {
 	return out
 }
 
-func eliminateNonIPInferredActors(actors []Actor, links []Link) ([]Actor, []Link) {
+func eliminateNonIPInferredActors(actors []graph.Actor, links []graph.Link) ([]graph.Actor, []graph.Link) {
 	if len(actors) == 0 {
 		return actors, links
 	}
 	removedIdentityKeys := make(map[string]struct{})
-	filteredActors := make([]Actor, 0, len(actors))
+	filteredActors := make([]graph.Actor, 0, len(actors))
 	for _, actor := range actors {
 		if topologyActorIsInferred(actor) && len(normalizedTopologyActorIPs(actor)) == 0 {
 			for _, key := range topologyMatchIdentityKeys(actor.Match) {
@@ -125,7 +127,7 @@ func eliminateNonIPInferredActors(actors []Actor, links []Link) ([]Actor, []Link
 		return actors, links
 	}
 
-	filteredLinks := make([]Link, 0, len(links))
+	filteredLinks := make([]graph.Link, 0, len(links))
 	for _, link := range links {
 		srcKeys := topologyMatchIdentityKeys(link.Src.Match)
 		dstKeys := topologyMatchIdentityKeys(link.Dst.Match)
@@ -152,7 +154,7 @@ func topologyIdentityKeysOverlap(keys []string, set map[string]struct{}) bool {
 	return false
 }
 
-func normalizedTopologyActorIPs(actor Actor) []string {
+func normalizedTopologyActorIPs(actor graph.Actor) []string {
 	if len(actor.Match.IPAddresses) == 0 {
 		return nil
 	}
@@ -173,7 +175,7 @@ func normalizedTopologyActorIPs(actor Actor) []string {
 	return out
 }
 
-func compareTopologyActorCollapsePriority(left, right Actor) int {
+func compareTopologyActorCollapsePriority(left, right graph.Actor) int {
 	leftDevice := IsDeviceActorType(left.ActorType)
 	rightDevice := IsDeviceActorType(right.ActorType)
 	if leftDevice != rightDevice {
@@ -195,7 +197,7 @@ func compareTopologyActorCollapsePriority(left, right Actor) int {
 	return strings.Compare(leftKey, rightKey)
 }
 
-func mergeTopologyActorMatch(base, other Match) Match {
+func mergeTopologyActorMatch(base, other graph.Match) graph.Match {
 	base.ChassisIDs = mergeTopologyStringLists(base.ChassisIDs, other.ChassisIDs)
 	base.MacAddresses = mergeTopologyStringLists(base.MacAddresses, other.MacAddresses)
 	base.IPAddresses = mergeTopologyStringLists(base.IPAddresses, other.IPAddresses)
@@ -272,7 +274,7 @@ func mergeTopologyActorAttributes(base, extra map[string]any) map[string]any {
 	return base
 }
 
-func topologyActorIsInferred(actor Actor) bool {
+func topologyActorIsInferred(actor graph.Actor) bool {
 	if strings.EqualFold(strings.TrimSpace(actor.ActorType), "endpoint") {
 		return true
 	}

--- a/src/go/pkg/l2topology/topology_adapter_builder.go
+++ b/src/go/pkg/l2topology/topology_adapter_builder.go
@@ -5,6 +5,8 @@ package l2topology
 import (
 	"strings"
 	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 type graphBuilder struct {
@@ -26,7 +28,7 @@ type graphBuilder struct {
 	reporterAliases      map[string][]string
 	ifaceSummaryByDevice map[string]topologyDeviceInterfaceSummary
 
-	actors        []Actor
+	actors        []graph.Actor
 	actorIndex    map[string]struct{}
 	actorMACIndex map[string]struct{}
 
@@ -34,7 +36,7 @@ type graphBuilder struct {
 	endpointActors       builtEndpointActors
 	segmentProjection    projectedSegments
 
-	links              []Link
+	links              []graph.Link
 	segmentSuppressed  int
 	unlinkedSuppressed int
 	linkCounts         topologyLinkCounts
@@ -130,7 +132,7 @@ func (b *graphBuilder) collectBridgeTopologyInputs() {
 }
 
 func (b *graphBuilder) buildDeviceActors() {
-	b.actors = make([]Actor, 0, len(b.result.Devices))
+	b.actors = make([]graph.Actor, 0, len(b.result.Devices))
 	b.actorIndex = make(map[string]struct{}, len(b.result.Devices)*2)
 	b.actorMACIndex = make(map[string]struct{}, len(b.result.Devices))
 
@@ -215,7 +217,7 @@ func (b *graphBuilder) buildSegmentTopology() {
 func (b *graphBuilder) finalizeGraph() {
 	sortTopologyActors(b.actors)
 
-	b.links = make([]Link, 0, len(b.projectedAdjacencies.links)+len(b.segmentProjection.links))
+	b.links = make([]graph.Link, 0, len(b.projectedAdjacencies.links)+len(b.segmentProjection.links))
 	b.links = append(b.links, b.projectedAdjacencies.links...)
 	b.links = append(b.links, b.segmentProjection.links...)
 	sortTopologyLinks(b.links)
@@ -283,8 +285,8 @@ func (b *graphBuilder) buildStats() {
 	b.stats["inference_strategy"] = b.strategyConfig.id
 }
 
-func (b *graphBuilder) graph() Graph {
-	return Graph{
+func (b *graphBuilder) graph() graph.Graph {
+	return graph.Graph{
 		SchemaVersion: b.schemaVersion,
 		Source:        b.source,
 		Layer:         b.layer,

--- a/src/go/pkg/l2topology/topology_adapter_device_actor.go
+++ b/src/go/pkg/l2topology/topology_adapter_device_actor.go
@@ -4,6 +4,8 @@ package l2topology
 
 import (
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 func topologyDeviceInferred(dev Device) bool {
@@ -18,8 +20,8 @@ func topologyDeviceInferred(dev Device) bool {
 	}
 }
 
-func buildDeviceActorMatch(dev Device, reporterAliases []string) Match {
-	match := Match{
+func buildDeviceActorMatch(dev Device, reporterAliases []string) graph.Match {
+	match := graph.Match{
 		SysObjectID: strings.TrimSpace(dev.SysObject),
 		SysName:     strings.TrimSpace(dev.Hostname),
 	}
@@ -69,7 +71,7 @@ func buildDeviceActorAttributes(
 	dev Device,
 	localDeviceID string,
 	ifaceSummary topologyDeviceInterfaceSummary,
-	match Match,
+	match graph.Match,
 ) map[string]any {
 	discovered := strings.TrimSpace(localDeviceID) == "" || dev.ID != localDeviceID
 

--- a/src/go/pkg/l2topology/topology_adapter_device_endpoint.go
+++ b/src/go/pkg/l2topology/topology_adapter_device_endpoint.go
@@ -5,9 +5,11 @@ package l2topology
 import (
 	"strconv"
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
-func adjacencySideToEndpoint(dev Device, port string, ifIndexByDeviceName map[string]int, ifaceByDeviceIndex map[string]Interface) LinkEndpoint {
+func adjacencySideToEndpoint(dev Device, port string, ifIndexByDeviceName map[string]int, ifaceByDeviceIndex map[string]Interface) graph.LinkEndpoint {
 	match := buildDeviceActorMatch(dev, nil)
 
 	port = strings.TrimSpace(port)
@@ -56,7 +58,7 @@ func adjacencySideToEndpoint(dev Device, port string, ifIndexByDeviceName map[st
 		}
 	}
 
-	return LinkEndpoint{
+	return graph.LinkEndpoint{
 		Match:      match,
 		Attributes: pruneTopologyAttributes(attrs),
 	}

--- a/src/go/pkg/l2topology/topology_adapter_devices.go
+++ b/src/go/pkg/l2topology/topology_adapter_devices.go
@@ -2,17 +2,19 @@
 
 package l2topology
 
+import "github.com/netdata/netdata/go/plugins/pkg/topology/graph"
+
 func deviceToTopologyActor(
 	dev Device,
 	source, layer, localDeviceID string,
 	ifaceSummary topologyDeviceInterfaceSummary,
 	reporterAliases []string,
-) Actor {
+) graph.Actor {
 	match := buildDeviceActorMatch(dev, reporterAliases)
 	attrs := buildDeviceActorAttributes(dev, localDeviceID, ifaceSummary, match)
 	tables := buildDeviceActorTables(ifaceSummary)
 
-	return Actor{
+	return graph.Actor{
 		ActorType:  resolveDeviceActorType(dev.Labels),
 		Layer:      layer,
 		Source:     source,

--- a/src/go/pkg/l2topology/topology_adapter_display.go
+++ b/src/go/pkg/l2topology/topology_adapter_display.go
@@ -4,6 +4,8 @@ package l2topology
 
 import (
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 type topologyDisplayNameResolver struct {
@@ -16,7 +18,7 @@ type topologyDisplayName struct {
 	source string
 }
 
-func applyTopologyDisplayNames(actors []Actor, links []Link, lookup func(ip string) string) {
+func applyTopologyDisplayNames(actors []graph.Actor, links []graph.Link, lookup func(ip string) string) {
 	resolver := topologyDisplayNameResolver{
 		lookup: lookup,
 		cache:  make(map[string]string),
@@ -83,7 +85,7 @@ func applyTopologyDisplayNames(actors []Actor, links []Link, lookup func(ip stri
 	}
 }
 
-func topologySetActorDisplay(actor *Actor, display topologyDisplayName) {
+func topologySetActorDisplay(actor *graph.Actor, display topologyDisplayName) {
 	if actor == nil {
 		return
 	}
@@ -108,7 +110,7 @@ func topologySetActorDisplay(actor *Actor, display topologyDisplayName) {
 	actor.Attributes = pruneTopologyAttributes(attrs)
 }
 
-func topologySetEndpointDisplayAndCanonicalPortName(endpoint *LinkEndpoint, display topologyDisplayName) string {
+func topologySetEndpointDisplayAndCanonicalPortName(endpoint *graph.LinkEndpoint, display topologyDisplayName) string {
 	if endpoint == nil {
 		return ""
 	}
@@ -126,7 +128,7 @@ func topologySetEndpointDisplayAndCanonicalPortName(endpoint *LinkEndpoint, disp
 	return name
 }
 
-func topologyEndpointDisplayName(endpoint LinkEndpoint, actorDisplayByMatch map[string]string, resolver *topologyDisplayNameResolver) topologyDisplayName {
+func topologyEndpointDisplayName(endpoint graph.LinkEndpoint, actorDisplayByMatch map[string]string, resolver *topologyDisplayNameResolver) topologyDisplayName {
 	if key := canonicalTopologyMatchKey(endpoint.Match); key != "" {
 		if name := strings.TrimSpace(actorDisplayByMatch[key]); name != "" {
 			return topologyDisplayName{name: name, source: "actor"}
@@ -135,7 +137,7 @@ func topologyEndpointDisplayName(endpoint LinkEndpoint, actorDisplayByMatch map[
 	return topologyDisplayNameFromMatch(endpoint.Match, resolver)
 }
 
-func topologyActorDisplayName(actor Actor, deviceDisplayByID map[string]string, resolver *topologyDisplayNameResolver) topologyDisplayName {
+func topologyActorDisplayName(actor graph.Actor, deviceDisplayByID map[string]string, resolver *topologyDisplayNameResolver) topologyDisplayName {
 	if actor.ActorType == "segment" {
 		if name := topologySegmentDisplayName(actor, deviceDisplayByID); name != "" {
 			return topologyDisplayName{name: name, source: "segment"}
@@ -153,7 +155,7 @@ func topologyActorDisplayName(actor Actor, deviceDisplayByID map[string]string, 
 	return topologyDisplayName{}
 }
 
-func topologyFallbackActorDisplayName(actor Actor) topologyDisplayName {
+func topologyFallbackActorDisplayName(actor graph.Actor) topologyDisplayName {
 	if matchKey := canonicalTopologyMatchKey(actor.Match); matchKey != "" {
 		return topologyDisplayName{name: matchKey, source: "fallback_match"}
 	}
@@ -167,11 +169,11 @@ func topologyFallbackActorDisplayName(actor Actor) topologyDisplayName {
 	return topologyDisplayName{name: actorType + ":[unset]", source: "fallback"}
 }
 
-func topologyActorDeviceID(actor Actor) string {
+func topologyActorDeviceID(actor graph.Actor) string {
 	return topologyAttrString(actor.Attributes, "device_id")
 }
 
-func topologyDisplayNameFromMatch(match Match, resolver *topologyDisplayNameResolver) topologyDisplayName {
+func topologyDisplayNameFromMatch(match graph.Match, resolver *topologyDisplayNameResolver) topologyDisplayName {
 	if dns := topologyMatchPreferredDNSName(match, resolver); dns != "" {
 		return topologyDisplayName{name: dns, source: "dns"}
 	}
@@ -190,7 +192,7 @@ func topologyDisplayNameFromMatch(match Match, resolver *topologyDisplayNameReso
 	return topologyDisplayName{}
 }
 
-func topologyMatchPreferredDNSName(match Match, resolver *topologyDisplayNameResolver) string {
+func topologyMatchPreferredDNSName(match graph.Match, resolver *topologyDisplayNameResolver) string {
 	candidates := make(map[string]struct{})
 	for _, value := range match.DNSNames {
 		if normalized := normalizeDNSName(value); normalized != "" {
@@ -214,11 +216,11 @@ func topologyMatchPreferredDNSName(match Match, resolver *topologyDisplayNameRes
 	return names[0]
 }
 
-func topologyMatchPreferredSysName(match Match) string {
+func topologyMatchPreferredSysName(match graph.Match) string {
 	return strings.TrimSpace(match.SysName)
 }
 
-func topologyMatchPreferredHostname(match Match) string {
+func topologyMatchPreferredHostname(match graph.Match) string {
 	hostnames := uniqueTopologyStrings(match.Hostnames)
 	if len(hostnames) == 0 {
 		return ""
@@ -226,7 +228,7 @@ func topologyMatchPreferredHostname(match Match) string {
 	return hostnames[0]
 }
 
-func topologyMatchPreferredIP(match Match) string {
+func topologyMatchPreferredIP(match graph.Match) string {
 	ips := make([]string, 0, len(match.IPAddresses))
 	for _, value := range match.IPAddresses {
 		if ip := normalizeTopologyIP(value); ip != "" {
@@ -240,7 +242,7 @@ func topologyMatchPreferredIP(match Match) string {
 	return ips[0]
 }
 
-func topologyMatchPreferredMAC(match Match) string {
+func topologyMatchPreferredMAC(match graph.Match) string {
 	macs := make([]string, 0, len(match.MacAddresses)+len(match.ChassisIDs))
 	for _, value := range match.MacAddresses {
 		if mac := normalizeMAC(value); mac != "" {

--- a/src/go/pkg/l2topology/topology_adapter_display_segment.go
+++ b/src/go/pkg/l2topology/topology_adapter_display_segment.go
@@ -4,6 +4,8 @@ package l2topology
 
 import (
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 type topologySegmentPortRef struct {
@@ -13,7 +15,7 @@ type topologySegmentPortRef struct {
 	bridgePort string
 }
 
-func topologySegmentDisplayName(actor Actor, deviceDisplayByID map[string]string) string {
+func topologySegmentDisplayName(actor graph.Actor, deviceDisplayByID map[string]string) string {
 	attrs := actor.Attributes
 	if len(attrs) == 0 {
 		return ""

--- a/src/go/pkg/l2topology/topology_adapter_endpoints.go
+++ b/src/go/pkg/l2topology/topology_adapter_endpoints.go
@@ -7,12 +7,14 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 type builtEndpointActors struct {
-	actors             []Actor
+	actors             []graph.Actor
 	count              int
-	matchByEndpointID  map[string]Match
+	matchByEndpointID  map[string]graph.Match
 	labelsByEndpointID map[string]map[string]string
 }
 
@@ -90,7 +92,7 @@ func buildEndpointActors(
 
 	if len(accumulators) == 0 {
 		return builtEndpointActors{
-			matchByEndpointID:  map[string]Match{},
+			matchByEndpointID:  map[string]graph.Match{},
 			labelsByEndpointID: map[string]map[string]string{},
 		}
 	}
@@ -101,9 +103,9 @@ func buildEndpointActors(
 	}
 	sort.Strings(keys)
 
-	actors := make([]Actor, 0, len(keys))
+	actors := make([]graph.Actor, 0, len(keys))
 	endpointCount := 0
-	matchByEndpointID := make(map[string]Match, len(keys))
+	matchByEndpointID := make(map[string]graph.Match, len(keys))
 	labelsByEndpointID := make(map[string]map[string]string, len(keys))
 	for _, endpointID := range keys {
 		acc := accumulators[endpointID]
@@ -111,7 +113,7 @@ func buildEndpointActors(
 			continue
 		}
 
-		match := Match{}
+		match := graph.Match{}
 		if acc.mac != "" {
 			match.ChassisIDs = []string{acc.mac}
 			match.MacAddresses = []string{acc.mac}
@@ -143,7 +145,7 @@ func buildEndpointActors(
 			attrs["vendor_derived_confidence"] = "low"
 			attrs["vendor_derived_match_prefix"] = derivedPrefix
 		}
-		actor := Actor{
+		actor := graph.Actor{
 			ActorType:  "endpoint",
 			Layer:      layer,
 			Source:     source,

--- a/src/go/pkg/l2topology/topology_adapter_identity.go
+++ b/src/go/pkg/l2topology/topology_adapter_identity.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 var interfaceNameLookupSanitizer = strings.NewReplacer(
@@ -171,7 +173,7 @@ func buildDeviceIdentityKeySetByID(
 	return out
 }
 
-func topologyMatchIdentityKeys(match Match) []string {
+func topologyMatchIdentityKeys(match graph.Match) []string {
 	seen := make(map[string]struct{}, 8)
 	add := func(kind, value string) {
 		value = strings.TrimSpace(value)
@@ -232,7 +234,7 @@ func topologyMatchIdentityKeys(match Match) []string {
 	return keys
 }
 
-func topologyMatchHardwareIdentityKeys(match Match) []string {
+func topologyMatchHardwareIdentityKeys(match graph.Match) []string {
 	seen := make(map[string]struct{}, len(match.MacAddresses)+len(match.ChassisIDs))
 	add := func(value string) {
 		if mac := normalizeMAC(value); mac != "" {
@@ -259,7 +261,7 @@ func topologyMatchHardwareIdentityKeys(match Match) []string {
 }
 
 func endpointMatchOverlappingKnownDeviceIDs(
-	endpointMatch Match,
+	endpointMatch graph.Match,
 	deviceIdentityByID map[string]topologyIdentityKeySet,
 ) []string {
 	if len(deviceIdentityByID) == 0 {

--- a/src/go/pkg/l2topology/topology_adapter_identity_assignment.go
+++ b/src/go/pkg/l2topology/topology_adapter_identity_assignment.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 type topologyMatchLookup struct {
@@ -14,16 +16,16 @@ type topologyMatchLookup struct {
 }
 
 type topologyActorSortEntry struct {
-	actor Actor
+	actor graph.Actor
 	key   string
 }
 
 type topologyLinkSortEntry struct {
-	link Link
+	link graph.Link
 	key  string
 }
 
-func canonicalTopologyMatchKey(match Match) string {
+func canonicalTopologyMatchKey(match graph.Match) string {
 	if key := canonicalTopologyPrimaryMACKey(match); key != "" {
 		return "mac:" + key
 	}
@@ -48,7 +50,7 @@ func canonicalTopologyMatchKey(match Match) string {
 	return ""
 }
 
-func assignTopologyActorIDsAndLinkEndpoints(actors []Actor, links []Link) {
+func assignTopologyActorIDsAndLinkEndpoints(actors []graph.Actor, links []graph.Link) {
 	if len(actors) == 0 {
 		return
 	}
@@ -93,7 +95,7 @@ func assignTopologyActorIDsAndLinkEndpoints(actors []Actor, links []Link) {
 	}
 }
 
-func newTopologyMatchLookup(match Match) topologyMatchLookup {
+func newTopologyMatchLookup(match graph.Match) topologyMatchLookup {
 	return topologyMatchLookup{
 		canonical:    canonicalTopologyMatchKey(match),
 		identityKeys: topologyMatchIdentityKeys(match),
@@ -129,7 +131,7 @@ func resolveTopologyEndpointActorID(lookup topologyMatchLookup, byCanonicalMatch
 	return ""
 }
 
-func enrichTopologyPortTablesWithLinkCounts(actors []Actor, links []Link) {
+func enrichTopologyPortTablesWithLinkCounts(actors []graph.Actor, links []graph.Link) {
 	type actorPort struct {
 		actorID  string
 		portName string
@@ -172,7 +174,7 @@ func enrichTopologyPortTablesWithLinkCounts(actors []Actor, links []Link) {
 	}
 }
 
-func canonicalTopologyPrimaryMACKey(match Match) string {
+func canonicalTopologyPrimaryMACKey(match graph.Match) string {
 	set := make(map[string]struct{}, len(match.MacAddresses)+len(match.ChassisIDs))
 	for _, value := range match.MacAddresses {
 		if mac := normalizeMAC(value); mac != "" {
@@ -266,7 +268,7 @@ func canonicalTopologyStringListKey(values []string) string {
 	return strings.Join(out, ",")
 }
 
-func topologyLinkSortKey(link Link) string {
+func topologyLinkSortKey(link graph.Link) string {
 	return strings.Join([]string{
 		link.Protocol,
 		link.Direction,
@@ -282,7 +284,7 @@ func topologyLinkSortKey(link Link) string {
 	}, keySep)
 }
 
-func topologyActorSortKey(actor Actor) string {
+func topologyActorSortKey(actor graph.Actor) string {
 	return strings.Join([]string{
 		actor.ActorType,
 		canonicalTopologyMatchKey(actor.Match),
@@ -302,7 +304,7 @@ func topologyAttrKey(attrs map[string]any, key string) string {
 	return fmt.Sprint(value)
 }
 
-func sortTopologyActors(actors []Actor) {
+func sortTopologyActors(actors []graph.Actor) {
 	if len(actors) < 2 {
 		return
 	}
@@ -324,7 +326,7 @@ func sortTopologyActors(actors []Actor) {
 	}
 }
 
-func sortTopologyLinks(links []Link) {
+func sortTopologyLinks(links []graph.Link) {
 	if len(links) < 2 {
 		return
 	}

--- a/src/go/pkg/l2topology/topology_adapter_identity_assignment_test.go
+++ b/src/go/pkg/l2topology/topology_adapter_identity_assignment_test.go
@@ -3,8 +3,10 @@
 package l2topology
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCanonicalTopologyKeyHelpers_NormalizeDeterministically(t *testing.T) {
@@ -19,12 +21,12 @@ func TestCanonicalTopologyKeyHelpers_NormalizeDeterministically(t *testing.T) {
 }
 
 func TestAssignTopologyActorIDsAndLinkEndpoints_IsDeterministic(t *testing.T) {
-	actors := []Actor{
+	actors := []graph.Actor{
 		{
 			ActorType: "device",
 			Layer:     "l2",
 			Source:    "snmp",
-			Match: Match{
+			Match: graph.Match{
 				MacAddresses: []string{"00:11:22:33:44:55"},
 				Hostnames:    []string{"switch-a"},
 			},
@@ -33,7 +35,7 @@ func TestAssignTopologyActorIDsAndLinkEndpoints_IsDeterministic(t *testing.T) {
 			ActorType: "device",
 			Layer:     "l2",
 			Source:    "snmp",
-			Match: Match{
+			Match: graph.Match{
 				MacAddresses: []string{"00-11-22-33-44-55"},
 				Hostnames:    []string{"switch-a-duplicate"},
 			},
@@ -42,7 +44,7 @@ func TestAssignTopologyActorIDsAndLinkEndpoints_IsDeterministic(t *testing.T) {
 			ActorType: "endpoint",
 			Layer:     "l2",
 			Source:    "derived",
-			Match: Match{
+			Match: graph.Match{
 				IPAddresses: []string{"10.0.0.2"},
 			},
 		},
@@ -50,22 +52,22 @@ func TestAssignTopologyActorIDsAndLinkEndpoints_IsDeterministic(t *testing.T) {
 			ActorType: "segment",
 			Layer:     "l2",
 			Source:    "derived",
-			Match:     Match{},
+			Match:     graph.Match{},
 		},
 	}
-	links := []Link{
+	links := []graph.Link{
 		{
 			Protocol:  "lldp",
 			Direction: "outbound",
 			State:     "up",
-			Src: LinkEndpoint{
-				Match: Match{MacAddresses: []string{"00:11:22:33:44:55"}},
+			Src: graph.LinkEndpoint{
+				Match: graph.Match{MacAddresses: []string{"00:11:22:33:44:55"}},
 				Attributes: map[string]any{
 					"if_name": "eth0",
 				},
 			},
-			Dst: LinkEndpoint{
-				Match: Match{IPAddresses: []string{"10.0.0.2"}},
+			Dst: graph.LinkEndpoint{
+				Match: graph.Match{IPAddresses: []string{"10.0.0.2"}},
 				Attributes: map[string]any{
 					"if_name": "eth9",
 				},
@@ -75,14 +77,14 @@ func TestAssignTopologyActorIDsAndLinkEndpoints_IsDeterministic(t *testing.T) {
 			Protocol:  "lldp",
 			Direction: "outbound",
 			State:     "up",
-			Src: LinkEndpoint{
-				Match: Match{IPAddresses: []string{"10.0.0.2"}},
+			Src: graph.LinkEndpoint{
+				Match: graph.Match{IPAddresses: []string{"10.0.0.2"}},
 				Attributes: map[string]any{
 					"if_name": "eth9",
 				},
 			},
-			Dst: LinkEndpoint{
-				Match: Match{MacAddresses: []string{"00:11:22:33:44:55"}},
+			Dst: graph.LinkEndpoint{
+				Match: graph.Match{MacAddresses: []string{"00:11:22:33:44:55"}},
 				Attributes: map[string]any{
 					"if_name": "eth0",
 				},
@@ -117,7 +119,7 @@ func TestAssignTopologyActorIDsAndLinkEndpoints_IsDeterministic(t *testing.T) {
 }
 
 func TestEnrichTopologyPortTablesWithLinkCounts_AddsCountsToMatchingPorts(t *testing.T) {
-	actors := []Actor{
+	actors := []graph.Actor{
 		{
 			ActorID: "device-a",
 			Tables: map[string][]map[string]any{
@@ -136,18 +138,18 @@ func TestEnrichTopologyPortTablesWithLinkCounts_AddsCountsToMatchingPorts(t *tes
 			},
 		},
 	}
-	links := []Link{
+	links := []graph.Link{
 		{
 			SrcActorID: "device-a",
 			DstActorID: "device-b",
-			Src:        LinkEndpoint{Attributes: map[string]any{"if_name": "eth0"}},
-			Dst:        LinkEndpoint{Attributes: map[string]any{"if_name": "xe-0/0/0"}},
+			Src:        graph.LinkEndpoint{Attributes: map[string]any{"if_name": "eth0"}},
+			Dst:        graph.LinkEndpoint{Attributes: map[string]any{"if_name": "xe-0/0/0"}},
 		},
 		{
 			SrcActorID: "device-a",
 			DstActorID: "device-b",
-			Src:        LinkEndpoint{Attributes: map[string]any{"if_name": "eth0"}},
-			Dst:        LinkEndpoint{Attributes: map[string]any{"if_name": "xe-0/0/0"}},
+			Src:        graph.LinkEndpoint{Attributes: map[string]any{"if_name": "eth0"}},
+			Dst:        graph.LinkEndpoint{Attributes: map[string]any{"if_name": "xe-0/0/0"}},
 		},
 	}
 

--- a/src/go/pkg/l2topology/topology_adapter_projection.go
+++ b/src/go/pkg/l2topology/topology_adapter_projection.go
@@ -2,10 +2,12 @@
 
 package l2topology
 
+import "github.com/netdata/netdata/go/plugins/pkg/topology/graph"
+
 type builtAdjacencyLink struct {
 	adj      Adjacency
 	protocol string
-	link     Link
+	link     graph.Link
 }
 
 type pairedLinkAccumulator struct {
@@ -13,7 +15,7 @@ type pairedLinkAccumulator struct {
 }
 
 type projectedLinks struct {
-	links               []Link
+	links               []graph.Link
 	lldp                int
 	cdp                 int
 	bidirectionalCount  int

--- a/src/go/pkg/l2topology/topology_adapter_projection_pairs.go
+++ b/src/go/pkg/l2topology/topology_adapter_projection_pairs.go
@@ -5,6 +5,8 @@ package l2topology
 import (
 	"strings"
 	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 func projectAdjacencyLinks(
@@ -16,7 +18,7 @@ func projectAdjacencyLinks(
 	ifaceByDeviceIndex map[string]Interface,
 ) projectedLinks {
 	out := projectedLinks{
-		links: make([]Link, 0, len(adjacencies)),
+		links: make([]graph.Link, 0, len(adjacencies)),
 	}
 	if len(adjacencies) == 0 {
 		return out
@@ -164,11 +166,11 @@ func backfillPairGroupMissingEndpointPorts(entries []*builtAdjacencyLink) {
 	}
 }
 
-func endpointHasKnownCanonicalPort(endpoint LinkEndpoint) bool {
+func endpointHasKnownCanonicalPort(endpoint graph.LinkEndpoint) bool {
 	return strings.TrimSpace(topologyCanonicalPortName(endpoint.Attributes)) != ""
 }
 
-func backfillEndpointPortFromPeer(endpoint LinkEndpoint, peer LinkEndpoint) LinkEndpoint {
+func backfillEndpointPortFromPeer(endpoint graph.LinkEndpoint, peer graph.LinkEndpoint) graph.LinkEndpoint {
 	if endpointHasKnownCanonicalPort(endpoint) || !endpointHasKnownCanonicalPort(peer) {
 		return endpoint
 	}
@@ -218,14 +220,14 @@ func adjacencyToTopologyLink(
 	deviceByID map[string]Device,
 	ifIndexByDeviceName map[string]int,
 	ifaceByDeviceIndex map[string]Interface,
-) Link {
+) graph.Link {
 	src := adjacencySideToEndpoint(deviceByID[adj.SourceID], adj.SourcePort, ifIndexByDeviceName, ifaceByDeviceIndex)
 	dst := adjacencySideToEndpoint(deviceByID[adj.TargetID], adj.TargetPort, ifIndexByDeviceName, ifaceByDeviceIndex)
 	if rawAddress := strings.TrimSpace(adj.Labels["remote_address_raw"]); rawAddress != "" {
 		dst.Match.IPAddresses = uniqueTopologyStrings(append(dst.Match.IPAddresses, rawAddress))
 	}
 
-	link := Link{
+	link := graph.Link{
 		Layer:        layer,
 		Protocol:     protocol,
 		LinkType:     protocol,
@@ -284,7 +286,7 @@ func buildPairedLinkMetrics(sourceLabels, targetLabels map[string]string) map[st
 	return metrics
 }
 
-func mergeEndpointIPHints(base, extra LinkEndpoint) LinkEndpoint {
+func mergeEndpointIPHints(base, extra graph.LinkEndpoint) graph.LinkEndpoint {
 	if len(extra.Match.IPAddresses) == 0 {
 		return base
 	}

--- a/src/go/pkg/l2topology/topology_adapter_pruning.go
+++ b/src/go/pkg/l2topology/topology_adapter_pruning.go
@@ -5,9 +5,11 @@ package l2topology
 import (
 	"sort"
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
-func pruneSegmentArtifacts(actors []Actor, links []Link) ([]Actor, []Link, int) {
+func pruneSegmentArtifacts(actors []graph.Actor, links []graph.Link) ([]graph.Actor, []graph.Link, int) {
 	if len(actors) == 0 || len(links) == 0 {
 		return actors, links, 0
 	}
@@ -130,7 +132,7 @@ func pruneSegmentArtifacts(actors []Actor, links []Link) ([]Actor, []Link, int) 
 		return actors, links, 0
 	}
 
-	filteredActors := make([]Actor, 0, len(actors))
+	filteredActors := make([]graph.Actor, 0, len(actors))
 	for _, actor := range actors {
 		key := canonicalTopologyMatchKey(actor.Match)
 		if key == "" {
@@ -143,7 +145,7 @@ func pruneSegmentArtifacts(actors []Actor, links []Link) ([]Actor, []Link, int) 
 		filteredActors = append(filteredActors, actor)
 	}
 
-	filteredLinks := make([]Link, 0, len(links))
+	filteredLinks := make([]graph.Link, 0, len(links))
 	for _, link := range links {
 		src := canonicalTopologyMatchKey(link.Src.Match)
 		dst := canonicalTopologyMatchKey(link.Dst.Match)
@@ -184,7 +186,7 @@ type topologyLinkCounts struct {
 	unidirectional int
 }
 
-func summarizeTopologyLinks(links []Link) topologyLinkCounts {
+func summarizeTopologyLinks(links []graph.Link) topologyLinkCounts {
 	var counts topologyLinkCounts
 	for _, link := range links {
 		switch strings.ToLower(strings.TrimSpace(link.Protocol)) {
@@ -209,10 +211,10 @@ func summarizeTopologyLinks(links []Link) topologyLinkCounts {
 }
 
 func pruneManagedOverlapUnlinkedEndpointActors(
-	actors []Actor,
-	links []Link,
+	actors []graph.Actor,
+	links []graph.Link,
 	suppressedEndpointIDs map[string]struct{},
-) ([]Actor, int) {
+) ([]graph.Actor, int) {
 	if len(actors) == 0 || len(suppressedEndpointIDs) == 0 {
 		return actors, 0
 	}
@@ -254,7 +256,7 @@ func pruneManagedOverlapUnlinkedEndpointActors(
 		}
 	}
 
-	filtered := make([]Actor, 0, len(actors))
+	filtered := make([]graph.Actor, 0, len(actors))
 	suppressedCount := 0
 	for _, actor := range actors {
 		if !strings.EqualFold(strings.TrimSpace(actor.ActorType), "endpoint") {

--- a/src/go/pkg/l2topology/topology_adapter_regression_test.go
+++ b/src/go/pkg/l2topology/topology_adapter_regression_test.go
@@ -3,8 +3,10 @@
 package l2topology
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBackfillPairGroupMissingEndpointPortsCopiesPeerInterfaceAttributes(t *testing.T) {
@@ -14,9 +16,9 @@ func TestBackfillPairGroupMissingEndpointPortsCopiesPeerInterfaceAttributes(t *t
 				SourceID: "device-a",
 				TargetID: "device-b",
 			},
-			link: Link{
-				Src: LinkEndpoint{Attributes: map[string]any{}},
-				Dst: LinkEndpoint{Attributes: map[string]any{}},
+			link: graph.Link{
+				Src: graph.LinkEndpoint{Attributes: map[string]any{}},
+				Dst: graph.LinkEndpoint{Attributes: map[string]any{}},
 			},
 		},
 		{
@@ -24,13 +26,13 @@ func TestBackfillPairGroupMissingEndpointPortsCopiesPeerInterfaceAttributes(t *t
 				SourceID: "device-b",
 				TargetID: "device-a",
 			},
-			link: Link{
-				Src: LinkEndpoint{Attributes: map[string]any{
+			link: graph.Link{
+				Src: graph.LinkEndpoint{Attributes: map[string]any{
 					"if_index": 2,
 					"if_name":  "Gi0/2",
 					"port_id":  "Gi0/2",
 				}},
-				Dst: LinkEndpoint{Attributes: map[string]any{
+				Dst: graph.LinkEndpoint{Attributes: map[string]any{
 					"if_index": 1,
 					"if_name":  "Gi0/1",
 					"port_id":  "Gi0/1",
@@ -56,9 +58,9 @@ func TestBackfillPairGroupMissingEndpointPortsSkipsAmbiguousReverseCandidates(t 
 				SourceID: "device-a",
 				TargetID: "device-b",
 			},
-			link: Link{
-				Src: LinkEndpoint{Attributes: map[string]any{}},
-				Dst: LinkEndpoint{Attributes: map[string]any{}},
+			link: graph.Link{
+				Src: graph.LinkEndpoint{Attributes: map[string]any{}},
+				Dst: graph.LinkEndpoint{Attributes: map[string]any{}},
 			},
 		},
 		{
@@ -66,11 +68,11 @@ func TestBackfillPairGroupMissingEndpointPortsSkipsAmbiguousReverseCandidates(t 
 				SourceID: "device-b",
 				TargetID: "device-a",
 			},
-			link: Link{
-				Src: LinkEndpoint{Attributes: map[string]any{
+			link: graph.Link{
+				Src: graph.LinkEndpoint{Attributes: map[string]any{
 					"if_name": "Gi0/2",
 				}},
-				Dst: LinkEndpoint{Attributes: map[string]any{
+				Dst: graph.LinkEndpoint{Attributes: map[string]any{
 					"if_name": "Gi0/1",
 				}},
 			},
@@ -80,11 +82,11 @@ func TestBackfillPairGroupMissingEndpointPortsSkipsAmbiguousReverseCandidates(t 
 				SourceID: "device-b",
 				TargetID: "device-a",
 			},
-			link: Link{
-				Src: LinkEndpoint{Attributes: map[string]any{
+			link: graph.Link{
+				Src: graph.LinkEndpoint{Attributes: map[string]any{
 					"if_name": "Gi0/22",
 				}},
-				Dst: LinkEndpoint{Attributes: map[string]any{
+				Dst: graph.LinkEndpoint{Attributes: map[string]any{
 					"if_name": "Gi0/11",
 				}},
 			},
@@ -98,12 +100,12 @@ func TestBackfillPairGroupMissingEndpointPortsSkipsAmbiguousReverseCandidates(t 
 }
 
 func TestBackfillEndpointPortFromPeerPreservesExistingCanonicalPort(t *testing.T) {
-	endpoint := LinkEndpoint{
+	endpoint := graph.LinkEndpoint{
 		Attributes: map[string]any{
 			"if_name": "Gi0/10",
 		},
 	}
-	peer := LinkEndpoint{
+	peer := graph.LinkEndpoint{
 		Attributes: map[string]any{
 			"if_index": 7,
 			"if_name":  "Gi0/7",
@@ -122,7 +124,7 @@ func TestSegmentProjectionBuilderPruneSegmentsWithoutLinksRemovesEmptySegments(t
 	builder := &segmentProjectionBuilder{
 		segmentIDs: []string{"segment-a", "segment-b"},
 		out: projectedSegments{
-			actors: []Actor{
+			actors: []graph.Actor{
 				{
 					ActorID:   "segment-a",
 					ActorType: "segment",
@@ -138,7 +140,7 @@ func TestSegmentProjectionBuilderPruneSegmentsWithoutLinksRemovesEmptySegments(t
 					},
 				},
 			},
-			links: []Link{
+			links: []graph.Link{
 				{
 					Protocol:  "fdb",
 					Direction: "bidirectional",

--- a/src/go/pkg/l2topology/topology_adapter_reporter_hints.go
+++ b/src/go/pkg/l2topology/topology_adapter_reporter_hints.go
@@ -6,10 +6,12 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 func collectTopologyEndpointIDs(
-	endpointMatchByID map[string]Match,
+	endpointMatchByID map[string]graph.Match,
 	endpointLabelsByID map[string]map[string]string,
 	endpointSegmentCandidates map[string][]string,
 	rawFDBObservations fdbReporterObservation,

--- a/src/go/pkg/l2topology/topology_adapter_segment_actor.go
+++ b/src/go/pkg/l2topology/topology_adapter_segment_actor.go
@@ -6,9 +6,11 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
-func buildBridgeSegmentActor(segmentID string, segment *bridgeDomainSegment, layer string, source string) (Match, Actor) {
+func buildBridgeSegmentActor(segmentID string, segment *bridgeDomainSegment, layer string, source string) (graph.Match, graph.Actor) {
 	parentDevices := make(map[string]struct{})
 	ifNames := make(map[string]struct{})
 	ifIndexes := make(map[string]struct{})
@@ -34,7 +36,7 @@ func buildBridgeSegmentActor(segmentID string, segment *bridgeDomainSegment, lay
 		}
 	}
 
-	match := Match{
+	match := graph.Match{
 		Hostnames: []string{"segment:" + segmentID},
 	}
 
@@ -58,7 +60,7 @@ func buildBridgeSegmentActor(segmentID string, segment *bridgeDomainSegment, lay
 		}
 	}
 
-	actor := Actor{
+	actor := graph.Actor{
 		ActorType:  "segment",
 		Layer:      layer,
 		Source:     source,
@@ -72,36 +74,36 @@ func buildBridgeSegmentActor(segmentID string, segment *bridgeDomainSegment, lay
 	return match, actor
 }
 
-func endpointMatchFromID(endpointID string) Match {
+func endpointMatchFromID(endpointID string) graph.Match {
 	kind, value, ok := strings.Cut(strings.TrimSpace(endpointID), ":")
 	if !ok {
-		return Match{}
+		return graph.Match{}
 	}
 	switch strings.ToLower(strings.TrimSpace(kind)) {
 	case "mac":
 		mac := normalizeMAC(value)
 		if mac == "" {
-			return Match{}
+			return graph.Match{}
 		}
-		return Match{
+		return graph.Match{
 			ChassisIDs:   []string{mac},
 			MacAddresses: []string{mac},
 		}
 	case "ip":
 		addr := normalizeTopologyIP(value)
 		if addr == "" {
-			return Match{}
+			return graph.Match{}
 		}
-		return Match{
+		return graph.Match{
 			IPAddresses: []string{addr},
 		}
 	}
-	return Match{}
+	return graph.Match{}
 }
 
 func annotateEndpointActorsWithDirectOwners(
-	actors []Actor,
-	endpointMatchByID map[string]Match,
+	actors []graph.Actor,
+	endpointMatchByID map[string]graph.Match,
 	owners map[string]fdbEndpointOwner,
 	deviceByID map[string]Device,
 ) {

--- a/src/go/pkg/l2topology/topology_adapter_segments.go
+++ b/src/go/pkg/l2topology/topology_adapter_segments.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 func projectSegmentTopology(
@@ -19,7 +21,7 @@ func projectSegmentTopology(
 	ifIndexByDeviceName map[string]int,
 	bridgeLinks []bridgeBridgeLinkRecord,
 	reporterAliases map[string][]string,
-	endpointMatchByID map[string]Match,
+	endpointMatchByID map[string]graph.Match,
 	endpointLabelsByID map[string]map[string]string,
 	actorIndex map[string]struct{},
 	probabilisticConnectivity bool,

--- a/src/go/pkg/l2topology/topology_adapter_segments_builder.go
+++ b/src/go/pkg/l2topology/topology_adapter_segments_builder.go
@@ -4,6 +4,8 @@ package l2topology
 
 import (
 	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 type segmentProjectionBuilder struct {
@@ -17,14 +19,14 @@ type segmentProjectionBuilder struct {
 	ifIndexByDeviceName       map[string]int
 	bridgeLinks               []bridgeBridgeLinkRecord
 	reporterAliases           map[string][]string
-	endpointMatchByID         map[string]Match
+	endpointMatchByID         map[string]graph.Match
 	endpointLabelsByID        map[string]map[string]string
 	actorIndex                map[string]struct{}
 	probabilisticConnectivity bool
 	strategyConfig            topologyInferenceStrategyConfig
 	out                       projectedSegments
 	segmentIDs                []string
-	segmentMatchByID          map[string]Match
+	segmentMatchByID          map[string]graph.Match
 	segmentByID               map[string]*bridgeDomainSegment
 	deviceSegmentEdgeSeen     map[string]struct{}
 	endpointSegmentEdgeSeen   map[string]struct{}
@@ -62,7 +64,7 @@ func newSegmentProjectionBuilder(
 	ifIndexByDeviceName map[string]int,
 	bridgeLinks []bridgeBridgeLinkRecord,
 	reporterAliases map[string][]string,
-	endpointMatchByID map[string]Match,
+	endpointMatchByID map[string]graph.Match,
 	endpointLabelsByID map[string]map[string]string,
 	actorIndex map[string]struct{},
 	probabilisticConnectivity bool,
@@ -85,8 +87,8 @@ func newSegmentProjectionBuilder(
 		probabilisticConnectivity: probabilisticConnectivity,
 		strategyConfig:            strategyConfig,
 		out: projectedSegments{
-			actors: make([]Actor, 0),
-			links:  make([]Link, 0),
+			actors: make([]graph.Actor, 0),
+			links:  make([]graph.Link, 0),
 		},
 	}
 }

--- a/src/go/pkg/l2topology/topology_adapter_segments_builder_emit.go
+++ b/src/go/pkg/l2topology/topology_adapter_segments_builder_emit.go
@@ -5,6 +5,8 @@ package l2topology
 import (
 	"sort"
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 func (b *segmentProjectionBuilder) emitLinks() {
@@ -17,7 +19,7 @@ func (b *segmentProjectionBuilder) emitLinks() {
 		if segment == nil {
 			continue
 		}
-		segmentEndpoint := LinkEndpoint{
+		segmentEndpoint := graph.LinkEndpoint{
 			Match: b.segmentMatchByID[segmentID],
 			Attributes: map[string]any{
 				"segment_id": segmentID,
@@ -55,7 +57,7 @@ func (b *segmentProjectionBuilder) emitLinks() {
 			if segment.portIdentityKey(port) == segment.portIdentityKey(segment.designatedPort) {
 				metrics["designated"] = true
 			}
-			b.out.links = append(b.out.links, Link{
+			b.out.links = append(b.out.links, graph.Link{
 				Layer:        b.layer,
 				Protocol:     "bridge",
 				LinkType:     "bridge",
@@ -118,7 +120,7 @@ func (b *segmentProjectionBuilder) emitLinks() {
 							edgeKey := segmentID + "|managed-device|" + matchedDeviceID
 							if _, seen := b.endpointSegmentEdgeSeen[edgeKey]; !seen {
 								b.endpointSegmentEdgeSeen[edgeKey] = struct{}{}
-								b.out.links = append(b.out.links, Link{
+								b.out.links = append(b.out.links, graph.Link{
 									Layer:        b.layer,
 									Protocol:     "fdb",
 									LinkType:     "fdb",
@@ -179,13 +181,13 @@ func (b *segmentProjectionBuilder) emitLinks() {
 									linkState = "probable"
 								}
 							}
-							b.out.links = append(b.out.links, Link{
+							b.out.links = append(b.out.links, graph.Link{
 								Layer:        b.layer,
 								Protocol:     "fdb",
 								LinkType:     "fdb",
 								Direction:    "bidirectional",
 								Src:          adjacencySideToEndpoint(device, localPort, b.ifIndexByDeviceName, b.ifaceByDeviceIndex),
-								Dst:          LinkEndpoint{Match: endpointMatch},
+								Dst:          graph.LinkEndpoint{Match: endpointMatch},
 								DiscoveredAt: topologyTimePtr(b.collectedAt),
 								LastSeen:     topologyTimePtr(b.collectedAt),
 								State:        linkState,
@@ -226,13 +228,13 @@ func (b *segmentProjectionBuilder) emitLinks() {
 				}
 			}
 
-			b.out.links = append(b.out.links, Link{
+			b.out.links = append(b.out.links, graph.Link{
 				Layer:        b.layer,
 				Protocol:     "fdb",
 				LinkType:     "fdb",
 				Direction:    "bidirectional",
 				Src:          segmentEndpoint,
-				Dst:          LinkEndpoint{Match: endpointMatch},
+				Dst:          graph.LinkEndpoint{Match: endpointMatch},
 				DiscoveredAt: topologyTimePtr(b.collectedAt),
 				LastSeen:     topologyTimePtr(b.collectedAt),
 				State:        linkState,
@@ -253,7 +255,7 @@ func (b *segmentProjectionBuilder) pruneSegmentsWithoutLinks(segmentsWithAnyLink
 		return
 	}
 
-	filteredActors := make([]Actor, 0, len(b.out.actors))
+	filteredActors := make([]graph.Actor, 0, len(b.out.actors))
 	for _, actor := range b.out.actors {
 		segmentID := topologyAttrString(actor.Attributes, "segment_id")
 		if segmentID == "" {
@@ -265,7 +267,7 @@ func (b *segmentProjectionBuilder) pruneSegmentsWithoutLinks(segmentsWithAnyLink
 	}
 	b.out.actors = filteredActors
 
-	filteredLinks := make([]Link, 0, len(b.out.links))
+	filteredLinks := make([]graph.Link, 0, len(b.out.links))
 	b.out.linksFdb = 0
 	b.out.bidirectionalCount = 0
 	b.out.endpointLinksEmitted = 0

--- a/src/go/pkg/l2topology/topology_adapter_segments_builder_init.go
+++ b/src/go/pkg/l2topology/topology_adapter_segments_builder_init.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 func (b *segmentProjectionBuilder) initializeSegments() bool {
@@ -25,7 +27,7 @@ func (b *segmentProjectionBuilder) initializeSegments() bool {
 		return false
 	}
 
-	b.segmentMatchByID = make(map[string]Match)
+	b.segmentMatchByID = make(map[string]graph.Match)
 	b.segmentByID = make(map[string]*bridgeDomainSegment)
 	for _, domain := range model.domains {
 		if domain == nil {

--- a/src/go/pkg/l2topology/topology_adapter_test.go
+++ b/src/go/pkg/l2topology/topology_adapter_test.go
@@ -3,12 +3,14 @@
 package l2topology
 
 import (
-	"github.com/stretchr/testify/require"
 	"net/netip"
 	"slices"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
+	"github.com/stretchr/testify/require"
 )
 
 func TestToGraph_ProjectsResult(t *testing.T) {
@@ -840,10 +842,10 @@ func TestToGraph_DeduplicatesEndpointActorOverlappingManagedDevice(t *testing.T)
 }
 
 func TestCanonicalTopologyMatchKey_NormalizesEquivalentMACRepresentations(t *testing.T) {
-	raw := Match{
+	raw := graph.Match{
 		ChassisIDs: []string{"7049a26572cd"},
 	}
-	colon := Match{
+	colon := graph.Match{
 		ChassisIDs: []string{"70:49:A2:65:72:CD"},
 	}
 
@@ -2191,7 +2193,7 @@ func TestToGraph_DisplayNamesPreferDNSThenIPThenMAC(t *testing.T) {
 }
 
 func TestTopologyDisplayNameFromMatch_PrefersSysNameBeforeIP(t *testing.T) {
-	display := topologyDisplayNameFromMatch(Match{
+	display := topologyDisplayNameFromMatch(graph.Match{
 		SysName:     "MikroTik-router",
 		IPAddresses: []string{"10.20.4.1"},
 	}, &topologyDisplayNameResolver{
@@ -2204,7 +2206,7 @@ func TestTopologyDisplayNameFromMatch_PrefersSysNameBeforeIP(t *testing.T) {
 }
 
 func TestTopologyDisplayNameFromMatch_PrefersHostnameBeforeIPWhenSysNameMissing(t *testing.T) {
-	display := topologyDisplayNameFromMatch(Match{
+	display := topologyDisplayNameFromMatch(graph.Match{
 		Hostnames:   []string{"nova"},
 		IPAddresses: []string{"10.20.4.22"},
 	}, &topologyDisplayNameResolver{
@@ -2518,36 +2520,36 @@ func TestToGraph_KeepsChassisPlaceholderDevicesAsDevices(t *testing.T) {
 }
 
 func TestPruneSegmentArtifacts_SuppressesLLDPDuplicateSegmentPath(t *testing.T) {
-	actors := []Actor{
+	actors := []graph.Actor{
 		{
 			ActorType: "device",
-			Match:     Match{IPAddresses: []string{"10.0.0.1"}, SysName: "switch-a"},
+			Match:     graph.Match{IPAddresses: []string{"10.0.0.1"}, SysName: "switch-a"},
 		},
 		{
 			ActorType: "device",
-			Match:     Match{IPAddresses: []string{"10.0.0.2"}, SysName: "switch-b"},
+			Match:     graph.Match{IPAddresses: []string{"10.0.0.2"}, SysName: "switch-b"},
 		},
 		{
 			ActorType: "segment",
-			Match:     Match{Hostnames: []string{"segment:dup"}},
+			Match:     graph.Match{Hostnames: []string{"segment:dup"}},
 		},
 	}
 
-	links := []Link{
+	links := []graph.Link{
 		{
 			Protocol: "lldp",
-			Src:      LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.0.1"}}},
-			Dst:      LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.0.2"}}},
+			Src:      graph.LinkEndpoint{Match: graph.Match{IPAddresses: []string{"10.0.0.1"}}},
+			Dst:      graph.LinkEndpoint{Match: graph.Match{IPAddresses: []string{"10.0.0.2"}}},
 		},
 		{
 			Protocol: "bridge",
-			Src:      LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.0.1"}}},
-			Dst:      LinkEndpoint{Match: Match{Hostnames: []string{"segment:dup"}}},
+			Src:      graph.LinkEndpoint{Match: graph.Match{IPAddresses: []string{"10.0.0.1"}}},
+			Dst:      graph.LinkEndpoint{Match: graph.Match{Hostnames: []string{"segment:dup"}}},
 		},
 		{
 			Protocol: "bridge",
-			Src:      LinkEndpoint{Match: Match{Hostnames: []string{"segment:dup"}}},
-			Dst:      LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.0.2"}}},
+			Src:      graph.LinkEndpoint{Match: graph.Match{Hostnames: []string{"segment:dup"}}},
+			Dst:      graph.LinkEndpoint{Match: graph.Match{IPAddresses: []string{"10.0.0.2"}}},
 		},
 	}
 
@@ -2559,36 +2561,36 @@ func TestPruneSegmentArtifacts_SuppressesLLDPDuplicateSegmentPath(t *testing.T) 
 }
 
 func TestPruneSegmentArtifacts_SuppressesCDPDuplicateSegmentPath(t *testing.T) {
-	actors := []Actor{
+	actors := []graph.Actor{
 		{
 			ActorType: "device",
-			Match:     Match{IPAddresses: []string{"10.0.1.1"}, SysName: "switch-a"},
+			Match:     graph.Match{IPAddresses: []string{"10.0.1.1"}, SysName: "switch-a"},
 		},
 		{
 			ActorType: "device",
-			Match:     Match{IPAddresses: []string{"10.0.1.2"}, SysName: "switch-b"},
+			Match:     graph.Match{IPAddresses: []string{"10.0.1.2"}, SysName: "switch-b"},
 		},
 		{
 			ActorType: "segment",
-			Match:     Match{Hostnames: []string{"segment:dup-cdp"}},
+			Match:     graph.Match{Hostnames: []string{"segment:dup-cdp"}},
 		},
 	}
 
-	links := []Link{
+	links := []graph.Link{
 		{
 			Protocol: "cdp",
-			Src:      LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.1.1"}}},
-			Dst:      LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.1.2"}}},
+			Src:      graph.LinkEndpoint{Match: graph.Match{IPAddresses: []string{"10.0.1.1"}}},
+			Dst:      graph.LinkEndpoint{Match: graph.Match{IPAddresses: []string{"10.0.1.2"}}},
 		},
 		{
 			Protocol: "bridge",
-			Src:      LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.1.1"}}},
-			Dst:      LinkEndpoint{Match: Match{Hostnames: []string{"segment:dup-cdp"}}},
+			Src:      graph.LinkEndpoint{Match: graph.Match{IPAddresses: []string{"10.0.1.1"}}},
+			Dst:      graph.LinkEndpoint{Match: graph.Match{Hostnames: []string{"segment:dup-cdp"}}},
 		},
 		{
 			Protocol: "bridge",
-			Src:      LinkEndpoint{Match: Match{Hostnames: []string{"segment:dup-cdp"}}},
-			Dst:      LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.1.2"}}},
+			Src:      graph.LinkEndpoint{Match: graph.Match{Hostnames: []string{"segment:dup-cdp"}}},
+			Dst:      graph.LinkEndpoint{Match: graph.Match{IPAddresses: []string{"10.0.1.2"}}},
 		},
 	}
 
@@ -2600,22 +2602,22 @@ func TestPruneSegmentArtifacts_SuppressesCDPDuplicateSegmentPath(t *testing.T) {
 }
 
 func TestPruneSegmentArtifacts_SuppressesSegmentsWithSingleNeighbor(t *testing.T) {
-	actors := []Actor{
+	actors := []graph.Actor{
 		{
 			ActorType: "device",
-			Match:     Match{IPAddresses: []string{"10.0.0.1"}, SysName: "router-a"},
+			Match:     graph.Match{IPAddresses: []string{"10.0.0.1"}, SysName: "router-a"},
 		},
 		{
 			ActorType: "segment",
-			Match:     Match{Hostnames: []string{"segment:orphan"}},
+			Match:     graph.Match{Hostnames: []string{"segment:orphan"}},
 		},
 	}
 
-	links := []Link{
+	links := []graph.Link{
 		{
 			Protocol: "bridge",
-			Src:      LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.0.1"}}},
-			Dst:      LinkEndpoint{Match: Match{Hostnames: []string{"segment:orphan"}}},
+			Src:      graph.LinkEndpoint{Match: graph.Match{IPAddresses: []string{"10.0.0.1"}}},
+			Dst:      graph.LinkEndpoint{Match: graph.Match{Hostnames: []string{"segment:orphan"}}},
 		},
 	}
 
@@ -2890,8 +2892,8 @@ func findNeighborByProtocol(neighbors []map[string]any, protocol string) map[str
 	return nil
 }
 
-func findFDBLinksByEndpointMAC(links []Link, mac string) []Link {
-	out := make([]Link, 0)
+func findFDBLinksByEndpointMAC(links []graph.Link, mac string) []graph.Link {
+	out := make([]graph.Link, 0)
 	for _, link := range links {
 		if link.Protocol != "fdb" {
 			continue
@@ -2903,8 +2905,8 @@ func findFDBLinksByEndpointMAC(links []Link, mac string) []Link {
 	return out
 }
 
-func findFDBLinksByEndpointIP(links []Link, ip string) []Link {
-	out := make([]Link, 0)
+func findFDBLinksByEndpointIP(links []graph.Link, ip string) []graph.Link {
+	out := make([]graph.Link, 0)
 	for _, link := range links {
 		if link.Protocol != "fdb" {
 			continue
@@ -2916,7 +2918,7 @@ func findFDBLinksByEndpointIP(links []Link, ip string) []Link {
 	return out
 }
 
-func topologyLinkSignatures(links []Link) map[string]struct{} {
+func topologyLinkSignatures(links []graph.Link) map[string]struct{} {
 	out := make(map[string]struct{}, len(links))
 	for _, link := range links {
 		srcKey := canonicalTopologyMatchKey(link.Src.Match)
@@ -2937,8 +2939,8 @@ func topologyLinkSignatures(links []Link) map[string]struct{} {
 	return out
 }
 
-func findFDBLinksByDstSysName(links []Link, sysName string) []Link {
-	out := make([]Link, 0)
+func findFDBLinksByDstSysName(links []graph.Link, sysName string) []graph.Link {
+	out := make([]graph.Link, 0)
 	for _, link := range links {
 		if link.Protocol != "fdb" {
 			continue
@@ -2951,7 +2953,7 @@ func findFDBLinksByDstSysName(links []Link, sysName string) []Link {
 	return out
 }
 
-func findActorByMatch(actors []Actor, match Match) *Actor {
+func findActorByMatch(actors []graph.Actor, match graph.Match) *graph.Actor {
 	target := canonicalTopologyMatchKey(match)
 	if target == "" {
 		return nil
@@ -2964,7 +2966,7 @@ func findActorByMatch(actors []Actor, match Match) *Actor {
 	return nil
 }
 
-func findActorBySysName(actors []Actor, sysName string) *Actor {
+func findActorBySysName(actors []graph.Actor, sysName string) *graph.Actor {
 	for i := range actors {
 		if actors[i].Match.SysName == sysName {
 			return &actors[i]
@@ -2973,7 +2975,7 @@ func findActorBySysName(actors []Actor, sysName string) *Actor {
 	return nil
 }
 
-func findActorByMAC(actors []Actor, mac string) *Actor {
+func findActorByMAC(actors []graph.Actor, mac string) *graph.Actor {
 	for i := range actors {
 		if slices.Contains(actors[i].Match.MacAddresses, mac) {
 			return &actors[i]
@@ -2982,7 +2984,7 @@ func findActorByMAC(actors []Actor, mac string) *Actor {
 	return nil
 }
 
-func findActorByIP(actors []Actor, ip string) *Actor {
+func findActorByIP(actors []graph.Actor, ip string) *graph.Actor {
 	for i := range actors {
 		if slices.Contains(actors[i].Match.IPAddresses, ip) {
 			return &actors[i]
@@ -2991,7 +2993,7 @@ func findActorByIP(actors []Actor, ip string) *Actor {
 	return nil
 }
 
-func findActorByType(actors []Actor, actorType string) *Actor {
+func findActorByType(actors []graph.Actor, actorType string) *graph.Actor {
 	for i := range actors {
 		if actors[i].ActorType == actorType {
 			return &actors[i]
@@ -3000,7 +3002,7 @@ func findActorByType(actors []Actor, actorType string) *Actor {
 	return nil
 }
 
-func findLinkByProtocol(links []Link, protocol string) *Link {
+func findLinkByProtocol(links []graph.Link, protocol string) *graph.Link {
 	for i := range links {
 		if links[i].Protocol == protocol {
 			return &links[i]

--- a/src/go/pkg/topology/graph/doc.go
+++ b/src/go/pkg/topology/graph/doc.go
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package graph defines neutral, multi-layer topology graph DTOs.
+package graph

--- a/src/go/pkg/topology/graph/graph_types.go
+++ b/src/go/pkg/topology/graph/graph_types.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package graph
 
 import "time"
 

--- a/src/go/pkg/topology/graph/graph_types_test.go
+++ b/src/go/pkg/topology/graph/graph_types_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package graph
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGraphJSONShape(t *testing.T) {
+	tm := time.Date(2026, time.June, 20, 8, 9, 10, 0, time.UTC)
+	payload := Graph{
+		SchemaVersion: "2.0",
+		Source:        "snmp",
+		Layer:         "3",
+		AgentID:       "agent-id",
+		CollectedAt:   tm,
+		View:          "summary",
+		IPPolicy: &IPPolicy{
+			PublicAllowlist: []string{"10.0.0.0/8"},
+			LiveTopN:        &LiveTopN{Enabled: true, Limit: 10, SortBy: "bytes"},
+		},
+		Actors: []Actor{{
+			ActorID:   "actor-a",
+			ActorType: "router",
+			Layer:     "3",
+			Source:    "snmp",
+			Match: Match{
+				ChassisIDs:         []string{"chassis-a"},
+				MacAddresses:       []string{"00:11:22:33:44:55"},
+				IPAddresses:        []string{"10.0.0.1"},
+				Hostnames:          []string{"router-a"},
+				DNSNames:           []string{"router-a.example.net"},
+				SysObjectID:        "1.3.6.1.4.1.8072.3.2.10",
+				SysName:            "router-a",
+				NetdataNodeID:      "node-id",
+				NetdataMachineGUID: "machine-guid",
+				CloudInstanceID:    "instance-id",
+				CloudAccountID:     "account-id",
+				ContainerIDs:       []string{"container-id"},
+				PodNames:           []string{"pod-a"},
+				NamespaceIDs:       []string{"namespace-a"},
+			},
+			ParentMatch: &Match{SysName: "parent"},
+			Attributes:  map[string]any{"role": "core"},
+			Derived:     map[string]any{"score": float64(1)},
+			Labels:      map[string]string{"site": "lab"},
+			Tables:      map[string][]map[string]any{"ports": {{"if_name": "eth0"}}},
+		}},
+		Links: []Link{{
+			Layer:        "3",
+			Protocol:     "ospf",
+			LinkType:     "ospf_adjacency",
+			Direction:    "bidirectional",
+			State:        "up",
+			SrcActorID:   "actor-a",
+			DstActorID:   "actor-b",
+			Src:          LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.0.1"}}, Attributes: map[string]any{"if_name": "eth0"}},
+			Dst:          LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.0.2"}}, Attributes: map[string]any{"if_name": "eth1"}},
+			DiscoveredAt: &tm,
+			LastSeen:     &tm,
+			Metrics:      map[string]any{"cost": float64(10)},
+		}},
+		Flows: []Flow{{
+			Timestamp:   tm,
+			DurationSec: 60,
+			Exporter:    &FlowExporter{IP: "10.0.0.1", Name: "router-a", SamplingRate: 1000, FlowVersion: "v9"},
+			Src:         LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.0.10"}}},
+			Dst:         LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.0.20"}}},
+			Key:         map[string]any{"protocol": "tcp"},
+			Metrics:     map[string]any{"bytes": float64(42)},
+		}},
+		Stats:   map[string]any{"links": float64(1)},
+		Metrics: map[string]any{"refresh": float64(1)},
+	}
+
+	bs, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	require.JSONEq(t, `{
+		"schema_version":"2.0",
+		"source":"snmp",
+		"layer":"3",
+		"agent_id":"agent-id",
+		"collected_at":"2026-06-20T08:09:10Z",
+		"view":"summary",
+		"ip_policy":{
+			"public_allowlist":["10.0.0.0/8"],
+			"live_top_n":{"enabled":true,"limit":10,"sort_by":"bytes"}
+		},
+		"actors":[{
+			"actor_id":"actor-a",
+			"actor_type":"router",
+			"layer":"3",
+			"source":"snmp",
+			"match":{
+				"chassis_ids":["chassis-a"],
+				"mac_addresses":["00:11:22:33:44:55"],
+				"ip_addresses":["10.0.0.1"],
+				"hostnames":["router-a"],
+				"dns_names":["router-a.example.net"],
+				"sys_object_id":"1.3.6.1.4.1.8072.3.2.10",
+				"sys_name":"router-a",
+				"netdata_node_id":"node-id",
+				"netdata_machine_guid":"machine-guid",
+				"cloud_instance_id":"instance-id",
+				"cloud_account_id":"account-id",
+				"container_ids":["container-id"],
+				"pod_names":["pod-a"],
+				"namespace_ids":["namespace-a"]
+			},
+			"parent_match":{"sys_name":"parent"},
+			"attributes":{"role":"core"},
+			"derived":{"score":1},
+			"labels":{"site":"lab"},
+			"tables":{"ports":[{"if_name":"eth0"}]}
+		}],
+		"links":[{
+			"layer":"3",
+			"protocol":"ospf",
+			"link_type":"ospf_adjacency",
+			"direction":"bidirectional",
+			"state":"up",
+			"src_actor_id":"actor-a",
+			"dst_actor_id":"actor-b",
+			"src":{"match":{"ip_addresses":["10.0.0.1"]},"attributes":{"if_name":"eth0"}},
+			"dst":{"match":{"ip_addresses":["10.0.0.2"]},"attributes":{"if_name":"eth1"}},
+			"discovered_at":"2026-06-20T08:09:10Z",
+			"last_seen":"2026-06-20T08:09:10Z",
+			"metrics":{"cost":10}
+		}],
+		"flows":[{
+			"timestamp":"2026-06-20T08:09:10Z",
+			"duration_sec":60,
+			"exporter":{"ip":"10.0.0.1","name":"router-a","sampling_rate":1000,"flow_version":"v9"},
+			"src":{"match":{"ip_addresses":["10.0.0.10"]}},
+			"dst":{"match":{"ip_addresses":["10.0.0.20"]}},
+			"key":{"protocol":"tcp"},
+			"metrics":{"bytes":42}
+		}],
+		"stats":{"links":1},
+		"metrics":{"refresh":1}
+	}`, string(bs))
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_types.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_types.go
@@ -2,17 +2,17 @@
 
 package snmptopology
 
-import topologyengine "github.com/netdata/netdata/go/plugins/pkg/l2topology"
+import "github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 
 const topologySchemaVersion = "2.0"
 
-type topologyData = topologyengine.Graph
-type topologyActor = topologyengine.Actor
-type topologyMatch = topologyengine.Match
-type topologyLink = topologyengine.Link
-type topologyLinkEndpoint = topologyengine.LinkEndpoint
-type topologyFlow = topologyengine.Flow
-type topologyIPPolicy = topologyengine.IPPolicy
+type topologyData = graph.Graph
+type topologyActor = graph.Actor
+type topologyMatch = graph.Match
+type topologyLink = graph.Link
+type topologyLinkEndpoint = graph.LinkEndpoint
+type topologyFlow = graph.Flow
+type topologyIPPolicy = graph.IPPolicy
 
 type topologyManagementAddress struct {
 	Address     string `json:"address"`


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a neutral topology graph model into `pkg/topology/graph` and updated the SNMP L2 topology code to use it. This decouples DTOs from the L2 engine for reuse across layers, with no behavior change.

- **Refactors**
  - Introduced `github.com/netdata/netdata/go/plugins/pkg/topology/graph` with `Graph`, `Actor`, `Link`, `Match`, `Flow`, `IPPolicy`.
  - Replaced all local types with `graph.*` equivalents; `ToGraph` now returns `graph.Graph`.
  - Updated tests and added a `graph` JSON shape test; schema version remains "2.0".
  - Switched `go.d/snmp_topology` plugin type aliases to `graph.*`.

- **Migration**
  - Import `github.com/netdata/netdata/go/plugins/pkg/topology/graph`.
  - Replace usages: `Actor`→`graph.Actor`, `Link`→`graph.Link`, `Match`→`graph.Match`, `Graph`→`graph.Graph`, `Flow`→`graph.Flow`, `IPPolicy`→`graph.IPPolicy`.

<sup>Written for commit 8f0169192ab703bf9799de6a33e829487ca4d01e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

