### PR TITLE
chore(go.d/snmp_topology): align protocol enrichment

### DIFF
--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_ospf_neighbors.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_ospf_neighbors.go
@@ -27,8 +27,8 @@ func buildSNMPTopologyV1OSPFNeighborsTable(
 	for i, row := range rows {
 		actorRefs[i] = row.actorRef
 		remoteActors[i] = nullableActorRef(actorIndex, row.values["remote_actor_id"])
-		localRouterIDs[i] = nullableStringRef(stringsDict, normalizeOSPFRouterID(topologyV1ScalarLabelValue(row.values["local_router_id"])))
-		neighborRouterIDs[i] = nullableStringRef(stringsDict, normalizeOSPFRouterID(topologyV1ScalarLabelValue(row.values["neighbor_router_id"])))
+		localRouterIDs[i] = nullableStringRef(stringsDict, normalizeTopologyRouterID(topologyV1ScalarLabelValue(row.values["local_router_id"])))
+		neighborRouterIDs[i] = nullableStringRef(stringsDict, normalizeTopologyRouterID(topologyV1ScalarLabelValue(row.values["neighbor_router_id"])))
 		neighborIPs[i] = nullableStringRef(stringsDict, normalizeNonUnspecifiedIPAddress(topologyV1ScalarLabelValue(row.values["neighbor_ip"])))
 		states[i] = nullableStringRef(stringsDict, normalizeOSPFNeighborState(topologyV1ScalarLabelValue(row.values["state"])))
 		localIPs[i] = nullableStringRef(stringsDict, normalizeNonUnspecifiedIPAddress(topologyV1ScalarLabelValue(row.values["local_ip"])))

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_actor_tables.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_actor_tables.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import "strings"
+
+func attachTopologyActorTableRows(data *topologyData, tableName string, rowsByActor map[string][]map[string]any, sortRows func([]map[string]any)) {
+	if data == nil || tableName == "" || len(rowsByActor) == 0 {
+		return
+	}
+	for i := range data.Actors {
+		actor := &data.Actors[i]
+		rows := rowsByActor[strings.TrimSpace(actor.ActorID)]
+		if len(rows) == 0 {
+			continue
+		}
+		if sortRows != nil {
+			sortRows(rows)
+		}
+		if actor.Tables == nil {
+			actor.Tables = make(map[string][]map[string]any)
+		}
+		actor.Tables[tableName] = rows
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_bgp_links.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_bgp_links.go
@@ -23,8 +23,7 @@ type topologyBGPEnrichmentStats struct {
 func applyTopologyBGPAdjacencyEnrichment(data *topologyData, aggregate topologyObservationAggregate) topologyBGPEnrichmentStats {
 	var stats topologyBGPEnrichmentStats
 	if data == nil || len(aggregate.bgpPeers) == 0 {
-		recordTopologyBGPEnrichmentStats(data, stats)
-		return stats
+		return finishTopologyBGPAdjacencyEnrichment(data, stats)
 	}
 
 	resolver := newTopologyBGPActorResolver(data, aggregate)
@@ -71,10 +70,14 @@ func applyTopologyBGPAdjacencyEnrichment(data *topologyData, aggregate topologyO
 		stats.emittedLinks++
 	}
 
-	attachTopologyBGPPeerRows(data, peerRowsByActor)
+	attachTopologyActorTableRows(data, "bgp_peers", peerRowsByActor, sortTopologyBGPPeerRows)
 	sort.Slice(data.Links, func(i, j int) bool {
 		return topologyLinkSortKey(data.Links[i]) < topologyLinkSortKey(data.Links[j])
 	})
+	return finishTopologyBGPAdjacencyEnrichment(data, stats)
+}
+
+func finishTopologyBGPAdjacencyEnrichment(data *topologyData, stats topologyBGPEnrichmentStats) topologyBGPEnrichmentStats {
 	recordTopologyBGPEnrichmentStats(data, stats)
 	recomputeTopologyLinkStats(data)
 	return stats
@@ -93,7 +96,7 @@ func newTopologyBGPActorResolver(data *topologyData, aggregate topologyObservati
 	for _, row := range aggregate.l3Interfaces {
 		ref, ok := resolver.l3.resolveDeviceID(row.DeviceID)
 		if ok {
-			resolver.l3.addUniqueIP(row.IP, ref)
+			resolver.l3.addUniqueIPAddress(row.IP, ref)
 		}
 	}
 	for _, row := range aggregate.bgpPeers {
@@ -102,7 +105,7 @@ func newTopologyBGPActorResolver(data *topologyData, aggregate topologyObservati
 			continue
 		}
 		resolver.addUniqueIdentifier(row.LocalIdentifier, ref)
-		resolver.l3.addUniqueIP(row.LocalIP, ref)
+		resolver.l3.addUniqueIPAddress(row.LocalIP, ref)
 	}
 	return resolver
 }
@@ -115,13 +118,7 @@ func (r topologyBGPActorResolver) resolveBGPPeer(row topologyBGPPeer) (topologyL
 	if ref, ok := r.byIdentifier[normalizeBGPRouterID(row.PeerIdentifier)]; ok && ref.actorID != "" {
 		return ref, true
 	}
-	if ref, ok := r.l3.byRouterID[normalizeOSPFRouterID(row.PeerIdentifier)]; ok && ref.actorID != "" {
-		return ref, true
-	}
-	if ref, ok := r.l3.byIP[normalizeNonUnspecifiedIPAddress(row.NeighborIP)]; ok && ref.actorID != "" {
-		return ref, true
-	}
-	return topologyL3ActorRef{}, false
+	return r.l3.resolveRouterEndpoint(row.PeerIdentifier, row.NeighborIP)
 }
 
 func (r topologyBGPActorResolver) addUniqueIdentifier(identifier string, ref topologyL3ActorRef) {
@@ -251,24 +248,6 @@ func topologyBGPPeerActorRow(row topologyBGPPeer) map[string]any {
 	return out
 }
 
-func attachTopologyBGPPeerRows(data *topologyData, rowsByActor map[string][]map[string]any) {
-	if data == nil || len(rowsByActor) == 0 {
-		return
-	}
-	for i := range data.Actors {
-		actor := &data.Actors[i]
-		rows := rowsByActor[strings.TrimSpace(actor.ActorID)]
-		if len(rows) == 0 {
-			continue
-		}
-		sortTopologyBGPPeerRows(rows)
-		if actor.Tables == nil {
-			actor.Tables = make(map[string][]map[string]any)
-		}
-		actor.Tables["bgp_peers"] = rows
-	}
-}
-
 func existingTopologyBGPLinkKeys(links []topologyLink) map[string]struct{} {
 	seen := make(map[string]struct{})
 	for _, link := range links {
@@ -316,20 +295,4 @@ func recordTopologyBGPEnrichmentStats(data *topologyData, stats topologyBGPEnric
 	data.Stats["bgp_adjacency_suppressed_unresolved_neighbor"] = stats.suppressedUnresolvedNeighbor
 	data.Stats["bgp_adjacency_suppressed_self_actor"] = stats.suppressedSelfActor
 	data.Stats["bgp_adjacency_suppressed_duplicate_link"] = stats.suppressedDuplicateLink
-}
-
-func recomputeTopologyBGPVisibleLinkStats(data *topologyData) {
-	if data == nil || data.Stats == nil {
-		return
-	}
-	if _, ok := data.Stats["bgp_adjacency_emitted_links"]; !ok {
-		return
-	}
-	count := 0
-	for _, link := range data.Links {
-		if strings.EqualFold(strings.TrimSpace(firstNonEmptyString(link.LinkType, link.Protocol)), topologyBGPAdjacencyLinkType) {
-			count++
-		}
-	}
-	data.Stats["bgp_adjacency_visible_links"] = count
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_bgp_peers.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_bgp_peers.go
@@ -115,17 +115,6 @@ func (c *topologyCache) snapshotBGPPeers(localDeviceID string) []topologyBGPPeer
 	return rows
 }
 
-func normalizeBGPRouterID(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return ""
-	}
-	if ip := normalizeNonUnspecifiedIPAddress(value); ip != "" {
-		return ip
-	}
-	return value
-}
-
 func topologyBGPAdminStatus(row ddsnmp.BGPRow) string {
 	if !row.Admin.Enabled.Has {
 		return ""

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_profile_tags.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_profile_tags.go
@@ -64,7 +64,7 @@ func (c *topologyCache) applyOSPFProfileTags(tags map[string]string) {
 	if c == nil || len(tags) == 0 {
 		return
 	}
-	if v := normalizeOSPFRouterID(tags[tagOSPFRouterID]); v != "" {
+	if v := normalizeTopologyRouterID(tags[tagOSPFRouterID]); v != "" {
 		c.localDevice.OSPFRouterID = v
 		c.localDevice.Labels = ensureLabels(c.localDevice.Labels)
 		c.localDevice.Labels[tagOSPFRouterID] = v

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_actor_resolver.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_actor_resolver.go
@@ -46,7 +46,7 @@ func newTopologyL3ActorResolver(data *topologyData, snapshots []topologyObservat
 			resolver.addUniqueDeviceID(deviceID, ref)
 		}
 		for _, ip := range normalizedMatchIPs(actor.Match) {
-			resolver.addUniqueIP(ip, ref)
+			resolver.addUniqueIPAddress(ip, ref)
 		}
 		for _, routerID := range topologyL3ActorRouterIDs(actor) {
 			resolver.addUniqueRouterID(routerID, ref)
@@ -83,10 +83,7 @@ func (r topologyL3ActorResolver) resolve(row topologyL3Interface) (topologyL3Act
 	if ref, ok := r.byActorID[strings.TrimSpace(row.DeviceID)]; ok && ref.actorID != "" {
 		return ref, true
 	}
-	if ref, ok := r.byIP[normalizeIPAddress(row.IP)]; ok && ref.actorID != "" {
-		return ref, true
-	}
-	return topologyL3ActorRef{}, false
+	return r.resolveIPAddress(row.IP)
 }
 
 func (r topologyL3ActorResolver) resolveDeviceID(deviceID string) (topologyL3ActorRef, bool) {
@@ -99,11 +96,29 @@ func (r topologyL3ActorResolver) resolveDeviceID(deviceID string) (topologyL3Act
 	return topologyL3ActorRef{}, false
 }
 
-func (r topologyL3ActorResolver) resolveOSPFNeighbor(row topologyOSPFNeighbor) (topologyL3ActorRef, bool) {
-	if ref, ok := r.byRouterID[normalizeOSPFRouterID(row.NeighborRouterID)]; ok && ref.actorID != "" {
+func (r topologyL3ActorResolver) resolveRouterEndpoint(routerID, ip string) (topologyL3ActorRef, bool) {
+	if ref, ok := r.resolveRouterID(routerID); ok {
 		return ref, true
 	}
-	if ref, ok := r.byIP[normalizeNonUnspecifiedIPAddress(row.NeighborIP)]; ok && ref.actorID != "" {
+	return r.resolveNonUnspecifiedIPAddress(ip)
+}
+
+func (r topologyL3ActorResolver) resolveRouterID(routerID string) (topologyL3ActorRef, bool) {
+	if ref, ok := r.byRouterID[normalizeTopologyRouterID(routerID)]; ok && ref.actorID != "" {
+		return ref, true
+	}
+	return topologyL3ActorRef{}, false
+}
+
+func (r topologyL3ActorResolver) resolveIPAddress(ip string) (topologyL3ActorRef, bool) {
+	if ref, ok := r.byIP[normalizeIPAddress(ip)]; ok && ref.actorID != "" {
+		return ref, true
+	}
+	return topologyL3ActorRef{}, false
+}
+
+func (r topologyL3ActorResolver) resolveNonUnspecifiedIPAddress(ip string) (topologyL3ActorRef, bool) {
+	if ref, ok := r.byIP[normalizeNonUnspecifiedIPAddress(ip)]; ok && ref.actorID != "" {
 		return ref, true
 	}
 	return topologyL3ActorRef{}, false
@@ -124,7 +139,7 @@ func (r topologyL3ActorResolver) addUniqueDeviceID(deviceID string, ref topology
 	}
 }
 
-func (r topologyL3ActorResolver) addUniqueIP(ip string, ref topologyL3ActorRef) {
+func (r topologyL3ActorResolver) addUniqueIPAddress(ip string, ref topologyL3ActorRef) {
 	ip = normalizeIPAddress(ip)
 	if ip == "" || ref.actorID == "" {
 		return
@@ -140,7 +155,7 @@ func (r topologyL3ActorResolver) addUniqueIP(ip string, ref topologyL3ActorRef) 
 }
 
 func (r topologyL3ActorResolver) addUniqueRouterID(routerID string, ref topologyL3ActorRef) {
-	routerID = normalizeOSPFRouterID(routerID)
+	routerID = normalizeTopologyRouterID(routerID)
 	if routerID == "" || ref.actorID == "" {
 		return
 	}
@@ -156,10 +171,10 @@ func (r topologyL3ActorResolver) addUniqueRouterID(routerID string, ref topology
 
 func topologyL3ActorRouterIDs(actor topologyActor) []string {
 	values := make([]string, 0, 2)
-	if routerID := normalizeOSPFRouterID(anyStringValue(actor.Attributes[tagOSPFRouterID])); routerID != "" {
+	if routerID := normalizeTopologyRouterID(anyStringValue(actor.Attributes[tagOSPFRouterID])); routerID != "" {
 		values = append(values, routerID)
 	}
-	if routerID := normalizeOSPFRouterID(actor.Labels[tagOSPFRouterID]); routerID != "" {
+	if routerID := normalizeTopologyRouterID(actor.Labels[tagOSPFRouterID]); routerID != "" {
 		values = append(values, routerID)
 	}
 	return values

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_links.go
@@ -21,15 +21,13 @@ type topologyL3EnrichmentStats struct {
 func applyTopologyL3SubnetEnrichment(data *topologyData, aggregate topologyObservationAggregate) topologyL3EnrichmentStats {
 	var stats topologyL3EnrichmentStats
 	if data == nil || len(aggregate.l3Interfaces) == 0 {
-		recordTopologyL3EnrichmentStats(data, stats)
-		return stats
+		return finishTopologyL3SubnetEnrichment(data, stats)
 	}
 
 	adjacencies, subnetStats := buildTopologyL3SubnetAdjacencies(aggregate.l3Interfaces)
 	stats.subnetStats = subnetStats
 	if len(adjacencies) == 0 {
-		recordTopologyL3EnrichmentStats(data, stats)
-		return stats
+		return finishTopologyL3SubnetEnrichment(data, stats)
 	}
 
 	resolver := newTopologyL3ActorResolver(data, aggregate.snapshots)
@@ -63,6 +61,10 @@ func applyTopologyL3SubnetEnrichment(data *topologyData, aggregate topologyObser
 	sort.Slice(data.Links, func(i, j int) bool {
 		return topologyLinkSortKey(data.Links[i]) < topologyLinkSortKey(data.Links[j])
 	})
+	return finishTopologyL3SubnetEnrichment(data, stats)
+}
+
+func finishTopologyL3SubnetEnrichment(data *topologyData, stats topologyL3EnrichmentStats) topologyL3EnrichmentStats {
 	recordTopologyL3EnrichmentStats(data, stats)
 	recomputeTopologyLinkStats(data)
 	return stats
@@ -170,5 +172,4 @@ func recordTopologyL3EnrichmentStats(data *topologyData, stats topologyL3Enrichm
 	data.Stats["l3_subnet_suppressed_unresolved_actor"] = stats.suppressedUnresolvedActor
 	data.Stats["l3_subnet_suppressed_self_actor"] = stats.suppressedSelfActor
 	data.Stats["l3_subnet_suppressed_duplicate_link"] = stats.suppressedDuplicateLink
-	recomputeTopologyL3VisibleLinkStats(data)
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_local_actor_attrs.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_local_actor_attrs.go
@@ -40,7 +40,7 @@ func populateLocalActorAttributes(attrs map[string]any, local topologyDevice) ma
 	if model := strings.TrimSpace(local.Model); model != "" {
 		attrs["model"] = model
 	}
-	if routerID := normalizeOSPFRouterID(local.OSPFRouterID); routerID != "" {
+	if routerID := normalizeTopologyRouterID(local.OSPFRouterID); routerID != "" {
 		attrs[tagOSPFRouterID] = routerID
 	}
 	if serial := strings.TrimSpace(local.SerialNumber); serial != "" {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_management_helpers.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_management_helpers.go
@@ -60,10 +60,10 @@ func normalizeTopologyDevice(dev topologyDevice) topologyDevice {
 	if value := topologyMetadataValue(dev.Labels, topologyMetadataAliasModel); value != "" && dev.Model == "" {
 		dev.Model = value
 	}
-	if value := normalizeOSPFRouterID(dev.Labels[tagOSPFRouterID]); value != "" && dev.OSPFRouterID == "" {
+	if value := normalizeTopologyRouterID(dev.Labels[tagOSPFRouterID]); value != "" && dev.OSPFRouterID == "" {
 		dev.OSPFRouterID = value
 	}
-	if value := normalizeOSPFRouterID(dev.OSPFRouterID); value != "" {
+	if value := normalizeTopologyRouterID(dev.OSPFRouterID); value != "" {
 		dev.OSPFRouterID = value
 		setTopologyMetadataLabelIfMissing(dev.Labels, tagOSPFRouterID, value)
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_links.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_links.go
@@ -18,14 +18,12 @@ type topologyOSPFEnrichmentStats struct {
 	suppressedUnresolvedNeighbor int
 	suppressedSelfActor          int
 	suppressedDuplicateLink      int
-	suppressedL3SubnetOverlap    int
 }
 
 func applyTopologyOSPFAdjacencyEnrichment(data *topologyData, aggregate topologyObservationAggregate) topologyOSPFEnrichmentStats {
 	var stats topologyOSPFEnrichmentStats
 	if data == nil || len(aggregate.ospfNeighbors) == 0 {
-		recordTopologyOSPFEnrichmentStats(data, stats)
-		return stats
+		return finishTopologyOSPFAdjacencyEnrichment(data, stats)
 	}
 
 	resolver := newTopologyL3ActorResolver(data, aggregate.snapshots)
@@ -35,7 +33,7 @@ func applyTopologyOSPFAdjacencyEnrichment(data *topologyData, aggregate topology
 	for _, row := range aggregate.ospfNeighbors {
 		stats.observedRows++
 		localRef, localOK := resolver.resolveDeviceID(row.DeviceID)
-		remoteRef, remoteOK := resolver.resolveOSPFNeighbor(row)
+		remoteRef, remoteOK := resolver.resolveRouterEndpoint(row.NeighborRouterID, row.NeighborIP)
 		if localOK {
 			modalRow := topologyOSPFNeighborActorRow(row)
 			if remoteOK {
@@ -70,15 +68,18 @@ func applyTopologyOSPFAdjacencyEnrichment(data *topologyData, aggregate topology
 			continue
 		}
 		seen[key] = struct{}{}
-		stats.suppressedL3SubnetOverlap += suppressMatchingTopologyL3SubnetLinks(data, link)
 		data.Links = append(data.Links, link)
 		stats.emittedLinks++
 	}
 
-	attachTopologyOSPFNeighborRows(data, neighborRowsByActor)
+	attachTopologyActorTableRows(data, "ospf_neighbors", neighborRowsByActor, sortTopologyOSPFNeighborRows)
 	sort.Slice(data.Links, func(i, j int) bool {
 		return topologyLinkSortKey(data.Links[i]) < topologyLinkSortKey(data.Links[j])
 	})
+	return finishTopologyOSPFAdjacencyEnrichment(data, stats)
+}
+
+func finishTopologyOSPFAdjacencyEnrichment(data *topologyData, stats topologyOSPFEnrichmentStats) topologyOSPFEnrichmentStats {
 	recordTopologyOSPFEnrichmentStats(data, stats)
 	recomputeTopologyLinkStats(data)
 	return stats
@@ -109,7 +110,7 @@ func topologyOSPFEndpointAttributes(routerID, ip string, row topologyOSPFNeighbo
 	attrs := map[string]any{
 		"source": "ospf_mib",
 	}
-	if normalizedRouterID := normalizeOSPFRouterID(routerID); normalizedRouterID != "" {
+	if normalizedRouterID := normalizeTopologyRouterID(routerID); normalizedRouterID != "" {
 		attrs["router_id"] = normalizedRouterID
 	}
 	if normalizedIP := normalizeNonUnspecifiedIPAddress(ip); normalizedIP != "" {
@@ -129,10 +130,10 @@ func topologyOSPFLinkMetrics(row topologyOSPFNeighbor) map[string]any {
 		"attachment_mode": "logical_l3_ospf",
 		"state":           "full",
 	}
-	if routerID := normalizeOSPFRouterID(row.LocalRouterID); routerID != "" {
+	if routerID := normalizeTopologyRouterID(row.LocalRouterID); routerID != "" {
 		metrics["local_router_id"] = routerID
 	}
-	if routerID := normalizeOSPFRouterID(row.NeighborRouterID); routerID != "" {
+	if routerID := normalizeTopologyRouterID(row.NeighborRouterID); routerID != "" {
 		metrics["neighbor_router_id"] = routerID
 	}
 	if ip := normalizeNonUnspecifiedIPAddress(row.LocalIP); ip != "" {
@@ -158,10 +159,10 @@ func topologyOSPFNeighborActorRow(row topologyOSPFNeighbor) map[string]any {
 		"state":  normalizeOSPFNeighborState(row.State),
 		"source": "ospf_mib",
 	}
-	if routerID := normalizeOSPFRouterID(row.LocalRouterID); routerID != "" {
+	if routerID := normalizeTopologyRouterID(row.LocalRouterID); routerID != "" {
 		out["local_router_id"] = routerID
 	}
-	if routerID := normalizeOSPFRouterID(row.NeighborRouterID); routerID != "" {
+	if routerID := normalizeTopologyRouterID(row.NeighborRouterID); routerID != "" {
 		out["neighbor_router_id"] = routerID
 	}
 	if ip := normalizeNonUnspecifiedIPAddress(row.NeighborIP); ip != "" {
@@ -179,24 +180,10 @@ func topologyOSPFNeighborActorRow(row topologyOSPFNeighbor) map[string]any {
 	return out
 }
 
-func attachTopologyOSPFNeighborRows(data *topologyData, rowsByActor map[string][]map[string]any) {
-	if data == nil || len(rowsByActor) == 0 {
-		return
-	}
-	for i := range data.Actors {
-		actor := &data.Actors[i]
-		rows := rowsByActor[strings.TrimSpace(actor.ActorID)]
-		if len(rows) == 0 {
-			continue
-		}
-		sort.Slice(rows, func(i, j int) bool {
-			return topologyOSPFNeighborActorRowSortKey(rows[i]) < topologyOSPFNeighborActorRowSortKey(rows[j])
-		})
-		if actor.Tables == nil {
-			actor.Tables = make(map[string][]map[string]any)
-		}
-		actor.Tables["ospf_neighbors"] = rows
-	}
+func sortTopologyOSPFNeighborRows(rows []map[string]any) {
+	sort.Slice(rows, func(i, j int) bool {
+		return topologyOSPFNeighborActorRowSortKey(rows[i]) < topologyOSPFNeighborActorRowSortKey(rows[j])
+	})
 }
 
 func topologyOSPFNeighborActorRowSortKey(row map[string]any) string {
@@ -229,58 +216,6 @@ func existingTopologyOSPFLinkKeys(links []topologyLink) map[string]struct{} {
 	return seen
 }
 
-func suppressMatchingTopologyL3SubnetLinks(data *topologyData, ospfLink topologyLink) int {
-	if data == nil || len(data.Links) == 0 {
-		return 0
-	}
-
-	dst := data.Links[:0]
-	removed := 0
-	for _, link := range data.Links {
-		if topologyLinkMatchesOSPFAdjacencyL3Subnet(link, ospfLink) {
-			removed++
-			continue
-		}
-		dst = append(dst, link)
-	}
-	data.Links = dst
-	return removed
-}
-
-func topologyLinkMatchesOSPFAdjacencyL3Subnet(link, ospfLink topologyLink) bool {
-	if !strings.EqualFold(strings.TrimSpace(firstNonEmptyString(link.LinkType, link.Protocol)), topologyL3SubnetLinkType) {
-		return false
-	}
-	if !sameTopologyActorPair(link, ospfLink) {
-		return false
-	}
-	ospfSubnet := topologyMetricValueString(ospfLink.Metrics, "subnet")
-	if ospfSubnet != "" && ospfSubnet == topologyMetricValueString(link.Metrics, "subnet") {
-		return true
-	}
-	return sameTopologyEndpointIPPair(
-		topologyV1EndpointString(link.Src, "ip"),
-		topologyV1EndpointString(link.Dst, "ip"),
-		topologyV1EndpointString(ospfLink.Src, "ip"),
-		topologyV1EndpointString(ospfLink.Dst, "ip"),
-	)
-}
-
-func sameTopologyActorPair(a, b topologyLink) bool {
-	aSrc, aDst := strings.TrimSpace(a.SrcActorID), strings.TrimSpace(a.DstActorID)
-	bSrc, bDst := strings.TrimSpace(b.SrcActorID), strings.TrimSpace(b.DstActorID)
-	return (aSrc == bSrc && aDst == bDst) || (aSrc == bDst && aDst == bSrc)
-}
-
-func sameTopologyEndpointIPPair(aSrc, aDst, bSrc, bDst string) bool {
-	aSrc, aDst = normalizeNonUnspecifiedIPAddress(aSrc), normalizeNonUnspecifiedIPAddress(aDst)
-	bSrc, bDst = normalizeNonUnspecifiedIPAddress(bSrc), normalizeNonUnspecifiedIPAddress(bDst)
-	if aSrc == "" || aDst == "" || bSrc == "" || bDst == "" {
-		return false
-	}
-	return (aSrc == bSrc && aDst == bDst) || (aSrc == bDst && aDst == bSrc)
-}
-
 func recordTopologyOSPFEnrichmentStats(data *topologyData, stats topologyOSPFEnrichmentStats) {
 	if data == nil {
 		return
@@ -296,22 +231,4 @@ func recordTopologyOSPFEnrichmentStats(data *topologyData, stats topologyOSPFEnr
 	data.Stats["ospf_adjacency_suppressed_unresolved_neighbor"] = stats.suppressedUnresolvedNeighbor
 	data.Stats["ospf_adjacency_suppressed_self_actor"] = stats.suppressedSelfActor
 	data.Stats["ospf_adjacency_suppressed_duplicate_link"] = stats.suppressedDuplicateLink
-	data.Stats["ospf_adjacency_suppressed_l3_subnet_overlap"] = stats.suppressedL3SubnetOverlap
-	recomputeTopologyOSPFVisibleLinkStats(data)
-}
-
-func recomputeTopologyOSPFVisibleLinkStats(data *topologyData) {
-	if data == nil || data.Stats == nil {
-		return
-	}
-	if _, ok := data.Stats["ospf_adjacency_emitted_links"]; !ok {
-		return
-	}
-	count := 0
-	for _, link := range data.Links {
-		if strings.EqualFold(strings.TrimSpace(firstNonEmptyString(link.LinkType, link.Protocol)), topologyOSPFAdjacencyLinkType) {
-			count++
-		}
-	}
-	data.Stats["ospf_adjacency_visible_links"] = count
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_links_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_links_test.go
@@ -162,7 +162,7 @@ func TestApplyTopologyOSPFAdjacencyEnrichmentDeduplicatesBidirectionalObservatio
 	require.Len(t, data.Actors[1].Tables["ospf_neighbors"], 1)
 }
 
-func TestApplyTopologyOSPFAdjacencyEnrichmentSuppressesMatchingL3SubnetEdge(t *testing.T) {
+func TestApplyTopologyOSPFAdjacencyEnrichmentKeepsMatchingL3SubnetEdge(t *testing.T) {
 	l3Link := topologyLink{
 		Protocol:   topologyL3SubnetLinkType,
 		LinkType:   topologyL3SubnetLinkType,
@@ -198,10 +198,10 @@ func TestApplyTopologyOSPFAdjacencyEnrichmentSuppressesMatchingL3SubnetEdge(t *t
 	stats := applyTopologyOSPFAdjacencyEnrichment(&data, aggregate)
 
 	require.Equal(t, 1, stats.emittedLinks)
-	require.Equal(t, 1, stats.suppressedL3SubnetOverlap)
-	require.Len(t, data.Links, 1)
-	require.Equal(t, topologyOSPFAdjacencyLinkType, data.Links[0].LinkType)
-	require.Equal(t, 0, data.Stats["l3_subnet_visible_links"])
+	require.Len(t, data.Links, 2)
+	require.Equal(t, 1, countTopologyLinksByType(data.Links, topologyL3SubnetLinkType))
+	require.Equal(t, 1, countTopologyLinksByType(data.Links, topologyOSPFAdjacencyLinkType))
+	require.Equal(t, 1, data.Stats["l3_subnet_visible_links"])
 	require.Equal(t, 1, data.Stats["ospf_adjacency_visible_links"])
 }
 
@@ -244,7 +244,6 @@ func TestApplyTopologyOSPFAdjacencyEnrichmentKeepsUnrelatedL3SubnetEdge(t *testi
 	stats := applyTopologyOSPFAdjacencyEnrichment(&data, aggregate)
 
 	require.Equal(t, 1, stats.emittedLinks)
-	require.Zero(t, stats.suppressedL3SubnetOverlap)
 	require.Len(t, data.Links, 2)
 	require.Equal(t, 1, countTopologyLinksByType(data.Links, topologyL3SubnetLinkType))
 	require.Equal(t, 1, countTopologyLinksByType(data.Links, topologyOSPFAdjacencyLinkType))

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors.go
@@ -16,14 +16,14 @@ func init() {
 }
 
 func (c *topologyCache) updateOSPFNeighbor(tags map[string]string) {
-	neighborRouterID := normalizeOSPFRouterID(tags[tagOSPFNeighborRouterID])
+	neighborRouterID := normalizeTopologyRouterID(tags[tagOSPFNeighborRouterID])
 	neighborIP := normalizeNonUnspecifiedIPAddress(tags[tagOSPFNeighborIP])
 	if neighborRouterID == "" && neighborIP == "" {
 		return
 	}
 
 	row := topologyOSPFNeighbor{
-		LocalRouterID:    normalizeOSPFRouterID(c.localDevice.OSPFRouterID),
+		LocalRouterID:    normalizeTopologyRouterID(c.localDevice.OSPFRouterID),
 		NeighborRouterID: neighborRouterID,
 		NeighborIP:       neighborIP,
 		AddresslessIndex: strings.TrimSpace(tags[tagOSPFNeighborAddresslessIndex]),
@@ -50,7 +50,7 @@ func (c *topologyCache) snapshotOSPFNeighbors(localDeviceID string) []topologyOS
 		row := c.ospfNeighborsByKey[key]
 		row.DeviceID = strings.TrimSpace(localDeviceID)
 		if row.LocalRouterID == "" {
-			row.LocalRouterID = normalizeOSPFRouterID(c.localDevice.OSPFRouterID)
+			row.LocalRouterID = normalizeTopologyRouterID(c.localDevice.OSPFRouterID)
 		}
 		if iface, ok := c.matchOSPFNeighborLocalInterface(row.NeighborIP); ok {
 			row.LocalIP = iface.IP
@@ -121,21 +121,10 @@ func (c *topologyCache) matchOSPFNeighborLocalInterface(neighborIP string) (topo
 
 func topologyOSPFNeighborCacheKey(row topologyOSPFNeighbor) string {
 	return topologyL3SubnetLinkKeyParts(
-		normalizeOSPFRouterID(row.NeighborRouterID),
+		normalizeTopologyRouterID(row.NeighborRouterID),
 		normalizeNonUnspecifiedIPAddress(row.NeighborIP),
 		strings.TrimSpace(row.AddresslessIndex),
 	)
-}
-
-func normalizeOSPFRouterID(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return ""
-	}
-	if ip := normalizeIPAddress(value); ip != "" {
-		return normalizeNonUnspecifiedIPAddress(ip)
-	}
-	return value
 }
 
 func normalizeOSPFNeighborState(value string) string {
@@ -176,8 +165,8 @@ func topologyOSPFNeighborLinkKeyParts(row topologyOSPFNeighbor, srcActorID, dstA
 		srcActorID, dstActorID = dstActorID, srcActorID
 	}
 
-	localRouterID := normalizeOSPFRouterID(row.LocalRouterID)
-	neighborRouterID := normalizeOSPFRouterID(row.NeighborRouterID)
+	localRouterID := normalizeTopologyRouterID(row.LocalRouterID)
+	neighborRouterID := normalizeTopologyRouterID(row.NeighborRouterID)
 	if localRouterID > neighborRouterID {
 		localRouterID, neighborRouterID = neighborRouterID, localRouterID
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
@@ -8,24 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNormalizeOSPFRouterIDDropsUnspecifiedAddresses(t *testing.T) {
-	tests := map[string]struct {
-		in   string
-		want string
-	}{
-		"ipv4-unspecified": {in: "0.0.0.0"},
-		"ipv6-unspecified": {in: "::"},
-		"hex-unspecified":  {in: "00000000"},
-		"valid-router-id":  {in: " 1.2.3.4 ", want: "1.2.3.4"},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			require.Equal(t, tc.want, normalizeOSPFRouterID(tc.in))
-		})
-	}
-}
-
 func TestTopologyOSPFNeighborLinkKeyIgnoresUnspecifiedIPs(t *testing.T) {
 	base := topologyOSPFNeighbor{
 		LocalRouterID:    "1.1.1.1",

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -249,16 +249,12 @@ func TestTopologyRegistry_OSPFSnapshotEnrichesSubnetAfterNeighborIngest(t *testi
 	data, ok := snapshotTopologyRegistryForTest(registry)
 
 	require.True(t, ok)
-	require.Len(t, data.Links, 1)
-	link := data.Links[0]
-	require.Equal(t, topologyOSPFAdjacencyLinkType, link.LinkType)
-	require.Equal(t, "198.51.100.0/30", link.Metrics["subnet"])
-	require.Equal(t, "198.51.100.1", link.Src.Attributes["ip"])
-	require.Equal(t, "198.51.100.2", link.Dst.Attributes["ip"])
+	require.Len(t, data.Links, 2)
+	require.Equal(t, 1, countTopologyLinksByType(data.Links, topologyL3SubnetLinkType))
+	require.Equal(t, 1, countTopologyLinksByType(data.Links, topologyOSPFAdjacencyLinkType))
 	require.Equal(t, 1, data.Stats["l3_subnet_emitted_links"])
-	require.Equal(t, 0, data.Stats["l3_subnet_visible_links"])
+	require.Equal(t, 1, data.Stats["l3_subnet_visible_links"])
 	require.Equal(t, 1, data.Stats["ospf_adjacency_emitted_links"])
-	require.Equal(t, 1, data.Stats["ospf_adjacency_suppressed_l3_subnet_overlap"])
 	require.Equal(t, 1, data.Stats["ospf_adjacency_visible_links"])
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_router_id.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_router_id.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import "strings"
+
+func normalizeTopologyRouterID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if ip := normalizeIPAddress(value); ip != "" {
+		return normalizeNonUnspecifiedIPAddress(ip)
+	}
+	return value
+}
+
+func normalizeBGPRouterID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if ip := normalizeNonUnspecifiedIPAddress(value); ip != "" {
+		return ip
+	}
+	return value
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_router_id_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_router_id_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeTopologyRouterIDDropsUnspecifiedAddresses(t *testing.T) {
+	tests := map[string]struct {
+		in   string
+		want string
+	}{
+		"ipv4-unspecified": {in: "0.0.0.0"},
+		"ipv6-unspecified": {in: "::"},
+		"hex-unspecified":  {in: "00000000"},
+		"valid-router-id":  {in: " 1.2.3.4 ", want: "1.2.3.4"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, normalizeTopologyRouterID(tc.in))
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_shape_stats.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_shape_stats.go
@@ -46,3 +46,35 @@ func recomputeTopologyL3VisibleLinkStats(data *topologyData) {
 	}
 	data.Stats["l3_subnet_visible_links"] = count
 }
+
+func recomputeTopologyOSPFVisibleLinkStats(data *topologyData) {
+	if data == nil || data.Stats == nil {
+		return
+	}
+	if _, ok := data.Stats["ospf_adjacency_emitted_links"]; !ok {
+		return
+	}
+	count := 0
+	for _, link := range data.Links {
+		if strings.EqualFold(strings.TrimSpace(firstNonEmptyString(link.LinkType, link.Protocol)), topologyOSPFAdjacencyLinkType) {
+			count++
+		}
+	}
+	data.Stats["ospf_adjacency_visible_links"] = count
+}
+
+func recomputeTopologyBGPVisibleLinkStats(data *topologyData) {
+	if data == nil || data.Stats == nil {
+		return
+	}
+	if _, ok := data.Stats["bgp_adjacency_emitted_links"]; !ok {
+		return
+	}
+	count := 0
+	for _, link := range data.Links {
+		if strings.EqualFold(strings.TrimSpace(firstNonEmptyString(link.LinkType, link.Protocol)), topologyBGPAdjacencyLinkType) {
+			count++
+		}
+	}
+	data.Stats["bgp_adjacency_visible_links"] = count
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snapshot_builder.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snapshot_builder.go
@@ -42,7 +42,7 @@ func buildLocalTopologyDevice(dev ddsnmp.DeviceConnectionInfo) topologyDevice {
 	if value := topologyMetadataValue(device.Labels, topologyMetadataAliasModel); value != "" && device.Model == "" {
 		device.Model = value
 	}
-	if value := normalizeOSPFRouterID(device.Labels[tagOSPFRouterID]); value != "" {
+	if value := normalizeTopologyRouterID(device.Labels[tagOSPFRouterID]); value != "" {
 		device.OSPFRouterID = value
 		setTopologyMetadataLabelIfMissing(device.Labels, tagOSPFRouterID, value)
 	}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns protocol enrichment across OSPF, BGP, and L3 in the SNMP topology collector. Unifies router ID handling, centralizes stats/table attachment, and keeps both OSPF and L3 subnet links when they overlap.

- **Refactors**
  - Added `normalizeTopologyRouterID` (and `normalizeBGPRouterID`) and replaced prior OSPF/BGP router ID normalization.
  - Introduced `attachTopologyActorTableRows` and used it for `ospf_neighbors` and `bgp_peers` with compact sort helpers.
  - Centralized visible-link stats in `topology_shape_stats.go` and added finalize helpers for L3/BGP/OSPF enrichment.
  - Expanded L3 actor resolver with endpoint resolution methods; renamed `addUniqueIP` to `addUniqueIPAddress`.
  - Removed suppression of L3-subnet links on OSPF overlap; both link types are kept. Updated tests and metrics accordingly.
  - Small cleanups in snapshot builder and local actor attributes; consistent use of `normalizeTopologyRouterID` across code and V1 tables.

<sup>Written for commit 8825250e6e9014a114950cbf2200b46d5ca64ec6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

