### PR TITLE
test(snmp_topology): add topology v1 golden output test

### DIFF
--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_golden_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_v1_golden_test.go
@@ -1,0 +1,823 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	topologyv1 "github.com/netdata/netdata/go/plugins/pkg/topology/v1"
+	"github.com/stretchr/testify/require"
+)
+
+var updateSNMPTopologyV1Golden = flag.Bool(
+	"update-snmp-topology-v1-golden",
+	false,
+	"rewrite snmp_topology normalized topology.v1 golden testdata",
+)
+
+const snmpTopologyV1GoldenPayloadPath = "testdata/topology_v1_normalized_golden.json"
+
+// Refresh with:
+// go test -count=1 ./plugin/go.d/collector/snmp_topology -run TestSNMPTopologyToV1_NormalizedGolden -update-snmp-topology-v1-golden
+func TestSNMPTopologyToV1_NormalizedGolden(t *testing.T) {
+	data, err := snmpTopologyToV1(snmpTopologyV1GoldenInput())
+	require.NoError(t, err)
+	require.NoError(t, validateTopologyV1Data(data))
+
+	normalized := normalizeTopologyV1GoldenData(t, data)
+	actual := canonicalTopologyV1GoldenJSON(t, normalized)
+	if *updateSNMPTopologyV1Golden {
+		require.NoError(t, os.MkdirAll(filepath.Dir(snmpTopologyV1GoldenPayloadPath), 0o755))
+		require.NoError(t, os.WriteFile(snmpTopologyV1GoldenPayloadPath, []byte(actual), 0o644))
+	}
+
+	expected, err := os.ReadFile(snmpTopologyV1GoldenPayloadPath)
+	require.NoError(t, err)
+	if string(expected) != actual {
+		t.Fatalf("normalized golden changed; inspect the payload below and rerun with -update-snmp-topology-v1-golden if intentional:\n%s", actual)
+	}
+}
+
+func snmpTopologyV1GoldenInput() topologyData {
+	collectedAt := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	discoveredAt := time.Date(2026, time.January, 2, 2, 4, 5, 0, time.UTC)
+	lastSeen := time.Date(2026, time.January, 2, 3, 3, 5, 0, time.UTC)
+
+	return topologyData{
+		SchemaVersion: topologySchemaVersion,
+		Source:        "snmp_topology_test",
+		Layer:         "multi",
+		AgentID:       "golden-agent",
+		CollectedAt:   collectedAt,
+		View:          "summary",
+		Actors: []topologyActor{
+			{
+				ActorID:   "switch-a",
+				ActorType: "switch",
+				Layer:     "2",
+				Source:    "snmp",
+				Match: topologyMatch{
+					ChassisIDs:   []string{"aa:bb:cc:00:00:01"},
+					MacAddresses: []string{"aa:bb:cc:00:00:01"},
+					IPAddresses:  []string{"192.0.2.10"},
+					Hostnames:    []string{"switch-a.example.test"},
+					DNSNames:     []string{"switch-a.example.test"},
+					SysObjectID:  "1.3.6.1.4.1.9.1.1208",
+					SysName:      "switch-a",
+				},
+				Attributes: map[string]any{
+					"capabilities":         []string{"bridge", "router"},
+					"cdp_neighbor_count":   uint64(1),
+					"chart_id_prefix":      "snmp_switch_a",
+					"display_name":         "Switch A",
+					"endpoints_total":      uint64(12),
+					"fdb_total_macs":       uint64(42),
+					"lldp_neighbor_count":  uint64(1),
+					"management_ip":        "192.0.2.10",
+					"model":                "Catalyst 9300",
+					"netdata_host_id":      "host-switch-a",
+					"ports_total":          uint64(2),
+					"protocols":            []string{"lldp", "cdp", "snmp"},
+					"sys_contact":          "noc@example.test",
+					"sys_descr":            "Synthetic switch fixture",
+					"sys_location":         "lab-rack-1",
+					"vendor":               "Cisco",
+					"vlan_count":           uint64(3),
+					tagOSPFRouterID:        "10.255.0.1",
+					"chart_context_prefix": "snmp.switch_a",
+				},
+				Labels: map[string]string{
+					"role": "distribution",
+					"site": "lab",
+				},
+				Tables: map[string][]map[string]any{
+					"ports": {
+						{
+							"admin_status":         "up",
+							"duplex":               "full",
+							"fdb_mac_count":        uint64(12),
+							"if_alias":             "to router-a",
+							"if_descr":             "GigabitEthernet1/0/1",
+							"if_index":             uint64(101),
+							"if_name":              "Gi1/0/1",
+							"last_change":          "2026-01-02T01:02:03Z",
+							"link_count":           uint64(1),
+							"link_mode":            "trunk",
+							"link_mode_confidence": "high",
+							"link_mode_sources":    []string{"if_mib", "lldp"},
+							"mac":                  "aa:bb:cc:00:01:01",
+							"neighbor_count":       uint64(1),
+							"neighbors": []map[string]any{
+								{
+									"protocol":          "lldp",
+									"remote_chassis_id": "aa:bb:cc:00:00:02",
+									"remote_port":       "Gi0/0",
+								},
+							},
+							"oper_status":              "up",
+							"port_id":                  "Gi1/0/1",
+							"port_type":                "ethernet",
+							"speed":                    uint64(1000000000),
+							"stp_state":                "forwarding",
+							"topology_role":            "uplink",
+							"topology_role_confidence": "medium",
+							"topology_role_sources":    []string{"stp", "fdb"},
+							"vendor_note":              "kept in actor_ports.extra until typed ports replace it",
+							"vlan_ids":                 []string{"10", "20"},
+							"vlans": []map[string]any{
+								{"id": "10", "name": "users"},
+								{"id": "20", "name": "servers"},
+							},
+						},
+					},
+					"inventory": {
+						{
+							"enabled":       true,
+							"sensor_labels": []any{"ambient", "rack"},
+							"slot":          "1",
+							"temperature_c": 42.5,
+						},
+					},
+				},
+			},
+			{
+				ActorID:   "router-a",
+				ActorType: "router",
+				Layer:     "3",
+				Source:    "snmp",
+				Match: topologyMatch{
+					ChassisIDs: []string{"aa:bb:cc:00:00:02"},
+					IPAddresses: []string{
+						"198.51.100.1",
+						"203.0.113.1",
+					},
+					SysObjectID: "1.3.6.1.4.1.9.1.1745",
+					SysName:     "router-a",
+				},
+				Attributes: map[string]any{
+					"capabilities":        []string{"router"},
+					"display_name":        "Router A",
+					"management_ip":       "198.51.100.1",
+					"model":               "ASR 1001",
+					"ports_total":         uint64(4),
+					"protocols_collected": []string{"ip_mib", "ospf_mib", "bgp_mib"},
+					"sys_descr":           "Synthetic router A",
+					"vendor":              "Cisco",
+					tagOSPFRouterID:       "10.255.0.1",
+				},
+				Labels: map[string]string{
+					"role": "edge",
+				},
+				Tables: map[string][]map[string]any{
+					"bgp_peers": {
+						{
+							"admin_status":             "enabled",
+							"bgp_version":              "4",
+							"description":              "router-b transit",
+							"established_uptime":       uint64(7200),
+							"last_received_update_age": uint64(15),
+							"local_as":                 "64512",
+							"local_identifier":         "10.255.0.1",
+							"local_ip":                 "203.0.113.1",
+							"neighbor_ip":              "203.0.113.2",
+							"peer_identifier":          "10.255.0.2",
+							"peer_type":                "external",
+							"remote_actor_id":          "router-b",
+							"remote_as":                "64513",
+							"routing_instance":         "default",
+							"source":                   "bgp_mib",
+							"state":                    "established",
+						},
+					},
+					"ospf_neighbors": {
+						{
+							"addressless_index":  "0",
+							"local_ip":           "198.51.100.1",
+							"local_router_id":    "10.255.0.1",
+							"neighbor_ip":        "198.51.100.2",
+							"neighbor_router_id": "10.255.0.2",
+							"remote_actor_id":    "router-b",
+							"source":             "ospf_mib",
+							"state":              "full",
+							"subnet":             "198.51.100.0/30",
+						},
+					},
+					"ports": {
+						{
+							"if_alias":       "to switch-a",
+							"if_index":       uint64(201),
+							"if_name":        "Gi0/0",
+							"link_mode":      "trunk",
+							"oper_status":    "up",
+							"port_id":        "Gi0/0",
+							"topology_role":  "uplink",
+							"vendor_context": "router uplink debug field",
+						},
+					},
+				},
+			},
+			{
+				ActorID:   "router-b",
+				ActorType: "router",
+				Layer:     "3",
+				Source:    "snmp",
+				Match: topologyMatch{
+					ChassisIDs:  []string{"aa:bb:cc:00:00:03"},
+					IPAddresses: []string{"198.51.100.2", "203.0.113.2"},
+					SysObjectID: "1.3.6.1.4.1.2636.1.1.1.2.131",
+					SysName:     "router-b",
+				},
+				Attributes: map[string]any{
+					"display_name":  "Router B",
+					"management_ip": "198.51.100.2",
+					"model":         "MX204",
+					"sys_descr":     "Synthetic router B",
+					"vendor":        "Juniper",
+					tagOSPFRouterID: "10.255.0.2",
+				},
+				Tables: map[string][]map[string]any{
+					"bgp_peers": {
+						{
+							"admin_status":             "enabled",
+							"bgp_version":              "4",
+							"description":              "router-a transit",
+							"established_uptime":       uint64(7100),
+							"last_received_update_age": uint64(20),
+							"local_as":                 "64513",
+							"local_identifier":         "10.255.0.2",
+							"local_ip":                 "203.0.113.2",
+							"neighbor_ip":              "203.0.113.1",
+							"peer_identifier":          "10.255.0.1",
+							"peer_type":                "external",
+							"remote_actor_id":          "router-a",
+							"remote_as":                "64512",
+							"routing_instance":         "default",
+							"source":                   "bgp_mib",
+							"state":                    "established",
+						},
+					},
+					"ospf_neighbors": {
+						{
+							"addressless_index":  "0",
+							"local_ip":           "198.51.100.2",
+							"local_router_id":    "10.255.0.2",
+							"neighbor_ip":        "198.51.100.1",
+							"neighbor_router_id": "10.255.0.1",
+							"remote_actor_id":    "router-a",
+							"source":             "ospf_mib",
+							"state":              "full",
+							"subnet":             "198.51.100.0/30",
+						},
+					},
+				},
+			},
+			{
+				ActorID:   "server-a",
+				ActorType: "endpoint",
+				Layer:     "2",
+				Source:    "fdb",
+				Match: topologyMatch{
+					MacAddresses: []string{"00:11:22:33:44:55"},
+					IPAddresses:  []string{"192.0.2.50"},
+					Hostnames:    []string{"server-a"},
+				},
+				Attributes: map[string]any{
+					"display_name":    "Server A",
+					"learned_sources": []string{"fdb", "arp"},
+				},
+				Labels: map[string]string{
+					"role": "application",
+				},
+			},
+			{
+				ActorID:   "segment-198-51-100-0-30",
+				ActorType: "segment",
+				Layer:     "3",
+				Source:    "ip_mib",
+				Match: topologyMatch{
+					IPAddresses: []string{"198.51.100.0"},
+				},
+				Attributes: map[string]any{
+					"display_name": "198.51.100.0/30",
+				},
+			},
+		},
+		Links: []topologyLink{
+			{
+				Layer:      "2",
+				Protocol:   "lldp",
+				LinkType:   "lldp",
+				Direction:  "observed",
+				State:      "up",
+				SrcActorID: "switch-a",
+				DstActorID: "router-a",
+				Src: topologyLinkEndpoint{
+					Attributes: map[string]any{
+						"if_index":      uint64(101),
+						"if_name":       "Gi1/0/1",
+						"management_ip": "192.0.2.10",
+						"port_id":       "Gi1/0/1",
+					},
+				},
+				Dst: topologyLinkEndpoint{
+					Attributes: map[string]any{
+						"if_index":      uint64(201),
+						"if_name":       "Gi0/0",
+						"management_ip": "198.51.100.1",
+						"port_id":       "Gi0/0",
+					},
+				},
+				DiscoveredAt: &discoveredAt,
+				LastSeen:     &lastSeen,
+				Metrics: map[string]any{
+					"attachment_mode": "direct",
+					"confidence":      "high",
+					"inference":       "lldp",
+				},
+			},
+			{
+				Layer:      "2",
+				Protocol:   "fdb",
+				LinkType:   "bridge",
+				Direction:  "observed",
+				State:      "probable",
+				SrcActorID: "switch-a",
+				DstActorID: "server-a",
+				Src: topologyLinkEndpoint{
+					Attributes: map[string]any{
+						"if_index": uint64(102),
+						"if_name":  "Gi1/0/2",
+						"port_id":  "Gi1/0/2",
+					},
+				},
+				Dst: topologyLinkEndpoint{
+					Attributes: map[string]any{
+						"mac": "00:11:22:33:44:55",
+					},
+				},
+				Metrics: map[string]any{
+					"attachment_mode": "probable_host",
+					"confidence":      "low",
+					"inference":       "probable",
+				},
+			},
+			{
+				Layer:      "3",
+				Protocol:   topologyL3SubnetLinkType,
+				LinkType:   topologyL3SubnetLinkType,
+				Direction:  "observed",
+				SrcActorID: "router-a",
+				DstActorID: "router-b",
+				Src: topologyLinkEndpoint{
+					Attributes: map[string]any{
+						"if_index": uint64(301),
+						"if_name":  "xe-0/0/0",
+						"ip":       "198.51.100.1",
+						"netmask":  "255.255.255.252",
+						"network":  "198.51.100.0",
+						"prefix":   uint64(30),
+						"source":   "ip_mib",
+						"subnet":   "198.51.100.0/30",
+					},
+				},
+				Dst: topologyLinkEndpoint{
+					Attributes: map[string]any{
+						"if_index": uint64(401),
+						"if_name":  "xe-0/0/1",
+						"ip":       "198.51.100.2",
+						"netmask":  "255.255.255.252",
+						"network":  "198.51.100.0",
+						"prefix":   uint64(30),
+						"source":   "ip_mib",
+						"subnet":   "198.51.100.0/30",
+					},
+				},
+				Metrics: map[string]any{
+					"attachment_mode": "logical_l3_subnet",
+					"inference":       "shared_subnet",
+					"netmask":         "255.255.255.252",
+					"network":         "198.51.100.0",
+					"prefix":          uint64(30),
+					"source":          "ip_mib",
+					"subnet":          "198.51.100.0/30",
+				},
+			},
+			{
+				Layer:      "3",
+				Protocol:   topologyOSPFAdjacencyLinkType,
+				LinkType:   topologyOSPFAdjacencyLinkType,
+				Direction:  "observed",
+				State:      "full",
+				SrcActorID: "router-a",
+				DstActorID: "router-b",
+				Src: topologyLinkEndpoint{
+					Attributes: map[string]any{
+						"ip":        "198.51.100.1",
+						"router_id": "10.255.0.1",
+						"source":    "ospf_mib",
+						"subnet":    "198.51.100.0/30",
+					},
+				},
+				Dst: topologyLinkEndpoint{
+					Attributes: map[string]any{
+						"ip":        "198.51.100.2",
+						"router_id": "10.255.0.2",
+						"source":    "ospf_mib",
+						"subnet":    "198.51.100.0/30",
+					},
+				},
+				Metrics: map[string]any{
+					"attachment_mode": "logical_ospf_adjacency",
+					"inference":       "ospf_neighbor",
+					"netmask":         "255.255.255.252",
+					"network":         "198.51.100.0",
+					"prefix":          uint64(30),
+					"source":          "ospf_mib",
+					"subnet":          "198.51.100.0/30",
+				},
+			},
+			{
+				Layer:      "3",
+				Protocol:   topologyBGPAdjacencyLinkType,
+				LinkType:   topologyBGPAdjacencyLinkType,
+				Direction:  "observed",
+				State:      "established",
+				SrcActorID: "router-a",
+				DstActorID: "router-b",
+				Src: topologyLinkEndpoint{
+					Attributes: map[string]any{
+						"as":             "64512",
+						"bgp_identifier": "10.255.0.1",
+						"ip":             "203.0.113.1",
+						"source":         "bgp_mib",
+					},
+				},
+				Dst: topologyLinkEndpoint{
+					Attributes: map[string]any{
+						"as":             "64513",
+						"bgp_identifier": "10.255.0.2",
+						"ip":             "203.0.113.2",
+						"source":         "bgp_mib",
+					},
+				},
+				Metrics: map[string]any{
+					"attachment_mode":  "logical_bgp_adjacency",
+					"inference":        "bgp_peer",
+					"routing_instance": "default",
+					"source":           "bgp_mib",
+				},
+			},
+		},
+		Stats: map[string]any{
+			"actors_collapsed_by_ip":     uint64(1),
+			"actors_map_type_suppressed": uint64(2),
+			"actors_total":               uint64(5),
+			"bgp_adjacency_visible":      uint64(1),
+			"custom_debug_stat":          "kept",
+			"depth":                      topologyDepthAll,
+			"l3_subnet_visible_links":    uint64(1),
+			"links_total":                uint64(5),
+			"map_type":                   topologyMapTypeHighConfidenceInferred,
+			"ospf_adjacency_visible":     uint64(1),
+			"probable_visible_links":     uint64(1),
+			"renderer_stats_are_open":    true,
+			"suppressed_duplicate_link":  uint64(0),
+		},
+	}
+}
+
+type normalizedTopologyV1GoldenData struct {
+	SchemaVersion string                                   `json:"schema_version"`
+	Producer      topologyv1.Producer                      `json:"producer"`
+	CollectedAt   string                                   `json:"collected_at"`
+	ValidAfter    string                                   `json:"valid_after,omitempty"`
+	ValidUntil    string                                   `json:"valid_until,omitempty"`
+	View          *topologyv1.View                         `json:"view,omitempty"`
+	Types         topologyv1.TypeRegistry                  `json:"types"`
+	Presentation  *topologyv1.Presentation                 `json:"presentation,omitempty"`
+	Correlation   any                                      `json:"correlation,omitempty"`
+	Actors        normalizedTopologyV1GoldenTable          `json:"actors"`
+	Links         normalizedTopologyV1GoldenTable          `json:"links"`
+	Evidence      map[string]normalizedTopologyV1GoldenRef `json:"evidence,omitempty"`
+	Tables        *normalizedTopologyV1GoldenDetailTables  `json:"tables,omitempty"`
+	Overlays      any                                      `json:"overlays,omitempty"`
+	Stats         any                                      `json:"stats,omitempty"`
+	Extensions    any                                      `json:"extensions,omitempty"`
+}
+
+type normalizedTopologyV1GoldenDetailTables struct {
+	Actor map[string]normalizedTopologyV1GoldenRef `json:"actor,omitempty"`
+}
+
+type normalizedTopologyV1GoldenRef struct {
+	Type  string                          `json:"type"`
+	Table normalizedTopologyV1GoldenTable `json:"table"`
+}
+
+type normalizedTopologyV1GoldenTable struct {
+	Columns []string         `json:"columns"`
+	Rows    []map[string]any `json:"rows"`
+}
+
+type topologyV1GoldenRefs struct {
+	actors []string
+	links  []string
+}
+
+func normalizeTopologyV1GoldenData(t *testing.T, data topologyv1.Data) normalizedTopologyV1GoldenData {
+	t.Helper()
+
+	refs := topologyV1GoldenRefs{}
+	actorRows := topologyV1GoldenTableRows(t, data, data.Actors, refs)
+	refs.actors = topologyV1GoldenActorRefs(t, actorRows)
+	linkRows := topologyV1GoldenTableRows(t, data, data.Links, refs)
+	refs.links = topologyV1GoldenLinkRefs(t, linkRows)
+
+	normalized := normalizedTopologyV1GoldenData{
+		SchemaVersion: data.SchemaVersion,
+		Producer:      data.Producer,
+		CollectedAt:   data.CollectedAt.UTC().Format(time.RFC3339Nano),
+		ValidAfter:    topologyV1GoldenTimeString(data.ValidAfter),
+		ValidUntil:    topologyV1GoldenTimeString(data.ValidUntil),
+		View:          data.View,
+		Types:         data.Types,
+		Presentation:  data.Presentation,
+		Actors: normalizedTopologyV1GoldenTable{
+			Columns: topologyV1GoldenColumnSummaries(data.Actors.Columns),
+			Rows:    topologyV1GoldenSortedRows(actorRows),
+		},
+		Links: normalizedTopologyV1GoldenTable{
+			Columns: topologyV1GoldenColumnSummaries(data.Links.Columns),
+			Rows:    topologyV1GoldenSortedRows(linkRows),
+		},
+		Stats: topologyV1GoldenNormalizeValue(t, data.Stats),
+	}
+	if data.Correlation != nil {
+		normalized.Correlation = topologyV1GoldenNormalizeValue(t, data.Correlation)
+	}
+	if data.Overlays != nil {
+		normalized.Overlays = topologyV1GoldenNormalizeValue(t, data.Overlays)
+	}
+	if len(data.Extensions) > 0 {
+		normalized.Extensions = topologyV1GoldenNormalizeValue(t, data.Extensions)
+	}
+
+	if len(data.Evidence) > 0 {
+		normalized.Evidence = make(map[string]normalizedTopologyV1GoldenRef, len(data.Evidence))
+		for key, section := range data.Evidence {
+			normalized.Evidence[key] = normalizedTopologyV1GoldenRef{
+				Type:  section.Type,
+				Table: topologyV1GoldenNormalizeTable(t, data, section.Table, refs),
+			}
+		}
+	}
+
+	if data.Tables != nil && len(data.Tables.Actor) > 0 {
+		normalized.Tables = &normalizedTopologyV1GoldenDetailTables{
+			Actor: make(map[string]normalizedTopologyV1GoldenRef, len(data.Tables.Actor)),
+		}
+		for key, detail := range data.Tables.Actor {
+			normalized.Tables.Actor[key] = normalizedTopologyV1GoldenRef{
+				Type:  detail.Type,
+				Table: topologyV1GoldenNormalizeTable(t, data, detail.Table, refs),
+			}
+		}
+	}
+
+	return normalized
+}
+
+func topologyV1GoldenNormalizeTable(
+	t *testing.T,
+	data topologyv1.Data,
+	table topologyv1.Table,
+	refs topologyV1GoldenRefs,
+) normalizedTopologyV1GoldenTable {
+	t.Helper()
+
+	return normalizedTopologyV1GoldenTable{
+		Columns: topologyV1GoldenColumnSummaries(table.Columns),
+		Rows:    topologyV1GoldenSortedRows(topologyV1GoldenTableRows(t, data, table, refs)),
+	}
+}
+
+func topologyV1GoldenTableRows(
+	t *testing.T,
+	data topologyv1.Data,
+	table topologyv1.Table,
+	refs topologyV1GoldenRefs,
+) []map[string]any {
+	t.Helper()
+
+	rows := make([]map[string]any, table.Rows)
+	for row := range rows {
+		rows[row] = make(map[string]any, len(table.Columns))
+	}
+	for columnIndex, column := range table.Columns {
+		values := topologyV1DecodeColumnValues(t, table, columnIndex)
+		require.Len(t, values, table.Rows)
+		for rowIndex, value := range values {
+			decoded := topologyV1GoldenDecodeValue(t, data, column, value, refs)
+			if decoded != nil {
+				rows[rowIndex][column.ID] = decoded
+			}
+		}
+	}
+	return rows
+}
+
+func topologyV1GoldenColumnSummaries(columns []topologyv1.Column) []string {
+	out := make([]string, len(columns))
+	for i, column := range columns {
+		summary := column.ID + ":" + column.Type
+		if column.Dictionary != "" {
+			summary += ":dict=" + column.Dictionary
+		}
+		if column.Nullable {
+			summary += ":nullable"
+		}
+		if column.Role != "" {
+			summary += ":role=" + column.Role
+		}
+		if column.Aggregation != "" {
+			summary += ":aggregation=" + column.Aggregation
+		}
+		if column.Unit != "" {
+			summary += ":unit=" + column.Unit
+		}
+		out[i] = summary
+	}
+	return out
+}
+
+func topologyV1GoldenDecodeValue(
+	t *testing.T,
+	data topologyv1.Data,
+	column topologyv1.Column,
+	value any,
+	refs topologyV1GoldenRefs,
+) any {
+	t.Helper()
+
+	if value == nil {
+		return nil
+	}
+
+	switch column.Type {
+	case "string_ref", "ip_ref", "mac_ref":
+		return topologyV1GoldenDictionaryValue(t, data, column, value)
+	case "actor_ref":
+		return topologyV1GoldenRefValue(t, refs.actors, value, "actor")
+	case "link_ref":
+		return topologyV1GoldenRefValue(t, refs.links, value, "link")
+	default:
+		return topologyV1GoldenNormalizeValue(t, value)
+	}
+}
+
+func topologyV1GoldenDictionaryValue(t *testing.T, data topologyv1.Data, column topologyv1.Column, value any) any {
+	t.Helper()
+
+	ref := topologyV1GoldenIntValue(t, value)
+	dict := data.Dictionaries[column.Dictionary]
+	require.NotNilf(t, dict, "missing dictionary %q for column %q", column.Dictionary, column.ID)
+	require.GreaterOrEqual(t, ref, 0)
+	require.Less(t, ref, len(dict))
+	return topologyV1GoldenNormalizeValue(t, dict[ref])
+}
+
+func topologyV1GoldenRefValue(t *testing.T, values []string, value any, kind string) any {
+	t.Helper()
+
+	ref := topologyV1GoldenIntValue(t, value)
+	require.GreaterOrEqual(t, ref, 0)
+	require.Lessf(t, ref, len(values), "%s ref %d out of bounds", kind, ref)
+	return values[ref]
+}
+
+func topologyV1GoldenIntValue(t *testing.T, value any) int {
+	t.Helper()
+
+	switch v := value.(type) {
+	case int:
+		return v
+	case int8:
+		return int(v)
+	case int16:
+		return int(v)
+	case int32:
+		return int(v)
+	case int64:
+		return int(v)
+	case uint:
+		return int(v)
+	case uint8:
+		return int(v)
+	case uint16:
+		return int(v)
+	case uint32:
+		return int(v)
+	case uint64:
+		return int(v)
+	case float64:
+		return int(v)
+	default:
+		require.Failf(t, "invalid reference value", "got %T", value)
+		return 0
+	}
+}
+
+func topologyV1GoldenActorRefs(t *testing.T, rows []map[string]any) []string {
+	t.Helper()
+
+	refs := make([]string, len(rows))
+	for i, row := range rows {
+		id, ok := row["id"].(string)
+		require.Truef(t, ok && id != "", "actor row %d has invalid id %v", i, row["id"])
+		refs[i] = id
+	}
+	return refs
+}
+
+func topologyV1GoldenLinkRefs(t *testing.T, rows []map[string]any) []string {
+	t.Helper()
+
+	refs := make([]string, len(rows))
+	seen := make(map[string]int, len(rows))
+	for i, row := range rows {
+		key := fmt.Sprintf("%v -> %v | %v | %v | %v | %v | %v",
+			row["src_actor"],
+			row["dst_actor"],
+			row["type"],
+			row["protocol"],
+			row["state"],
+			row["src_port_name"],
+			row["dst_port_name"],
+		)
+		seen[key]++
+		if seen[key] > 1 {
+			key = fmt.Sprintf("%s #%d", key, seen[key])
+		}
+		refs[i] = key
+	}
+	return refs
+}
+
+func topologyV1GoldenSortedRows(rows []map[string]any) []map[string]any {
+	out := append([]map[string]any(nil), rows...)
+	sort.Slice(out, func(i, j int) bool {
+		return topologyV1GoldenSortKey(out[i]) < topologyV1GoldenSortKey(out[j])
+	})
+	return out
+}
+
+func topologyV1GoldenSortKey(row map[string]any) string {
+	bs, err := json.Marshal(row)
+	if err != nil {
+		panic(err)
+	}
+	return string(bs)
+}
+
+func topologyV1GoldenNormalizeValue(t *testing.T, value any) any {
+	t.Helper()
+
+	if value == nil {
+		return nil
+	}
+	bs, err := json.Marshal(value)
+	require.NoError(t, err)
+	var normalized any
+	require.NoError(t, json.Unmarshal(bs, &normalized))
+	return normalized
+}
+
+func canonicalTopologyV1GoldenJSON(t *testing.T, value any) string {
+	t.Helper()
+
+	bs, err := json.Marshal(value)
+	require.NoError(t, err)
+	var normalized any
+	require.NoError(t, json.Unmarshal(bs, &normalized))
+
+	var out bytes.Buffer
+	enc := json.NewEncoder(&out)
+	enc.SetIndent("", "  ")
+	require.NoError(t, enc.Encode(normalized))
+	return out.String()
+}
+
+func topologyV1GoldenTimeString(value *time.Time) string {
+	if value == nil {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/testdata/topology_v1_normalized_golden.json
+++ b/src/go/plugin/go.d/collector/snmp_topology/testdata/topology_v1_normalized_golden.json
@@ -1,0 +1,16788 @@
+{
+  "actors": {
+    "columns": [
+      "id:string_ref:dict=strings:role=identity",
+      "type:string_ref:dict=strings:role=group_key",
+      "layer:string_ref:dict=strings:role=group_key",
+      "source:string_ref:dict=strings",
+      "display_name:string_ref:dict=strings:nullable:role=attribute",
+      "chassis_ids:array:role=merge_identity",
+      "mac_addresses:array:role=merge_identity",
+      "ip_addresses:array:role=merge_identity",
+      "hostnames:array",
+      "dns_names:array",
+      "sys_object_id:string_ref:dict=strings:role=merge_identity",
+      "sys_name:string_ref:dict=strings:role=merge_identity",
+      "parent_devices:array:role=parent_identity",
+      "vendor:string_ref:dict=strings:nullable",
+      "model:string_ref:dict=strings:nullable",
+      "sys_descr:string_ref:dict=strings:nullable",
+      "sys_location:string_ref:dict=strings:nullable",
+      "sys_contact:string_ref:dict=strings:nullable",
+      "management_ip:string_ref:dict=strings:nullable",
+      "protocols:array:nullable",
+      "capabilities:array:nullable",
+      "ports_total:uint:nullable",
+      "vlan_count:uint:nullable",
+      "fdb_total_macs:uint:nullable",
+      "lldp_neighbor_count:uint:nullable",
+      "cdp_neighbor_count:uint:nullable",
+      "endpoints_total:uint:nullable",
+      "chart_id_prefix:string_ref:dict=strings:nullable",
+      "netdata_host_id:string_ref:dict=strings:nullable"
+    ],
+    "rows": [
+      {
+        "capabilities": [
+          "bridge",
+          "router"
+        ],
+        "cdp_neighbor_count": 1,
+        "chart_id_prefix": "snmp_switch_a",
+        "chassis_ids": [
+          "aa:bb:cc:00:00:01"
+        ],
+        "display_name": "Switch A",
+        "dns_names": [
+          "switch-a.example.test"
+        ],
+        "endpoints_total": 12,
+        "fdb_total_macs": 42,
+        "hostnames": [
+          "switch-a.example.test"
+        ],
+        "id": "switch-a",
+        "ip_addresses": [
+          "192.0.2.10"
+        ],
+        "layer": "network",
+        "lldp_neighbor_count": 1,
+        "mac_addresses": [
+          "aa:bb:cc:00:00:01"
+        ],
+        "management_ip": "192.0.2.10",
+        "model": "Catalyst 9300",
+        "netdata_host_id": "host-switch-a",
+        "parent_devices": [],
+        "ports_total": 2,
+        "protocols": [
+          "lldp",
+          "cdp",
+          "snmp"
+        ],
+        "source": "snmp",
+        "sys_contact": "noc@example.test",
+        "sys_descr": "Synthetic switch fixture",
+        "sys_location": "lab-rack-1",
+        "sys_name": "switch-a",
+        "sys_object_id": "1.3.6.1.4.1.9.1.1208",
+        "type": "switch",
+        "vendor": "Cisco",
+        "vlan_count": 3
+      },
+      {
+        "capabilities": [
+          "router"
+        ],
+        "chassis_ids": [
+          "aa:bb:cc:00:00:02"
+        ],
+        "display_name": "Router A",
+        "dns_names": [],
+        "hostnames": [],
+        "id": "router-a",
+        "ip_addresses": [
+          "198.51.100.1",
+          "203.0.113.1"
+        ],
+        "layer": "network",
+        "mac_addresses": [],
+        "management_ip": "198.51.100.1",
+        "model": "ASR 1001",
+        "parent_devices": [],
+        "ports_total": 4,
+        "source": "snmp",
+        "sys_descr": "Synthetic router A",
+        "sys_name": "router-a",
+        "sys_object_id": "1.3.6.1.4.1.9.1.1745",
+        "type": "router",
+        "vendor": "Cisco"
+      },
+      {
+        "chassis_ids": [
+          "aa:bb:cc:00:00:03"
+        ],
+        "display_name": "Router B",
+        "dns_names": [],
+        "hostnames": [],
+        "id": "router-b",
+        "ip_addresses": [
+          "198.51.100.2",
+          "203.0.113.2"
+        ],
+        "layer": "network",
+        "mac_addresses": [],
+        "management_ip": "198.51.100.2",
+        "model": "MX204",
+        "parent_devices": [],
+        "source": "snmp",
+        "sys_descr": "Synthetic router B",
+        "sys_name": "router-b",
+        "sys_object_id": "1.3.6.1.4.1.2636.1.1.1.2.131",
+        "type": "router",
+        "vendor": "Juniper"
+      },
+      {
+        "chassis_ids": [],
+        "display_name": "198.51.100.0/30",
+        "dns_names": [],
+        "hostnames": [],
+        "id": "segment-198-51-100-0-30",
+        "ip_addresses": [
+          "198.51.100.0"
+        ],
+        "layer": "network",
+        "mac_addresses": [],
+        "parent_devices": [],
+        "source": "ip_mib",
+        "sys_name": "",
+        "sys_object_id": "",
+        "type": "segment"
+      },
+      {
+        "chassis_ids": [],
+        "display_name": "Server A",
+        "dns_names": [],
+        "hostnames": [
+          "server-a"
+        ],
+        "id": "server-a",
+        "ip_addresses": [
+          "192.0.2.50"
+        ],
+        "layer": "network",
+        "mac_addresses": [
+          "00:11:22:33:44:55"
+        ],
+        "parent_devices": [],
+        "protocols": [
+          "fdb",
+          "arp"
+        ],
+        "source": "fdb",
+        "sys_name": "",
+        "sys_object_id": "",
+        "type": "endpoint"
+      }
+    ]
+  },
+  "collected_at": "2026-01-02T03:04:05Z",
+  "evidence": {
+    "bgp_adjacency": {
+      "table": {
+        "columns": [
+          "link:link_ref:role=reference",
+          "src_actor:actor_ref:role=reference",
+          "dst_actor:actor_ref:role=reference",
+          "protocol:string_ref:dict=strings:role=group_key",
+          "direction:string_ref:dict=strings:role=group_key",
+          "state:string_ref:dict=strings:nullable",
+          "src_port_name:string_ref:dict=strings:nullable",
+          "dst_port_name:string_ref:dict=strings:nullable",
+          "src_if_index:uint:nullable",
+          "dst_if_index:uint:nullable",
+          "src_management_ip:string_ref:dict=strings:nullable",
+          "dst_management_ip:string_ref:dict=strings:nullable",
+          "confidence:string_ref:dict=strings:nullable",
+          "inference:string_ref:dict=strings:nullable",
+          "attachment_mode:string_ref:dict=strings:nullable",
+          "routing_instance:string_ref:dict=strings:nullable",
+          "local_identifier:string_ref:dict=strings:nullable",
+          "peer_identifier:string_ref:dict=strings:nullable",
+          "local_ip:string_ref:dict=strings:nullable",
+          "neighbor_ip:string_ref:dict=strings:nullable",
+          "local_as:string_ref:dict=strings:nullable",
+          "remote_as:string_ref:dict=strings:nullable",
+          "source:string_ref:dict=strings:nullable",
+          "src_endpoint:json:nullable",
+          "dst_endpoint:json:nullable",
+          "metrics:json:nullable"
+        ],
+        "rows": [
+          {
+            "attachment_mode": "logical_bgp_adjacency",
+            "direction": "observed",
+            "dst_actor": "router-b",
+            "dst_endpoint": {
+              "as": "64513",
+              "bgp_identifier": "10.255.0.2",
+              "ip": "203.0.113.2",
+              "source": "bgp_mib"
+            },
+            "inference": "bgp_peer",
+            "link": "router-a -\u003e router-b | bgp_adjacency | bgp_adjacency | established | \u003cnil\u003e | \u003cnil\u003e",
+            "local_as": "64512",
+            "local_identifier": "10.255.0.1",
+            "local_ip": "203.0.113.1",
+            "metrics": {
+              "attachment_mode": "logical_bgp_adjacency",
+              "inference": "bgp_peer",
+              "routing_instance": "default",
+              "source": "bgp_mib"
+            },
+            "neighbor_ip": "203.0.113.2",
+            "peer_identifier": "10.255.0.2",
+            "protocol": "bgp_adjacency",
+            "remote_as": "64513",
+            "routing_instance": "default",
+            "source": "bgp_mib",
+            "src_actor": "router-a",
+            "src_endpoint": {
+              "as": "64512",
+              "bgp_identifier": "10.255.0.1",
+              "ip": "203.0.113.1",
+              "source": "bgp_mib"
+            },
+            "state": "established"
+          }
+        ]
+      },
+      "type": "bgp_adjacency"
+    },
+    "l3_subnet": {
+      "table": {
+        "columns": [
+          "link:link_ref:role=reference",
+          "src_actor:actor_ref:role=reference",
+          "dst_actor:actor_ref:role=reference",
+          "protocol:string_ref:dict=strings:role=group_key",
+          "direction:string_ref:dict=strings:role=group_key",
+          "state:string_ref:dict=strings:nullable",
+          "src_port_name:string_ref:dict=strings:nullable",
+          "dst_port_name:string_ref:dict=strings:nullable",
+          "src_if_index:uint:nullable",
+          "dst_if_index:uint:nullable",
+          "src_management_ip:string_ref:dict=strings:nullable",
+          "dst_management_ip:string_ref:dict=strings:nullable",
+          "confidence:string_ref:dict=strings:nullable",
+          "inference:string_ref:dict=strings:nullable",
+          "attachment_mode:string_ref:dict=strings:nullable",
+          "src_ip:string_ref:dict=strings:nullable",
+          "dst_ip:string_ref:dict=strings:nullable",
+          "subnet:string_ref:dict=strings:role=group_key",
+          "network:string_ref:dict=strings:nullable",
+          "netmask:string_ref:dict=strings:nullable",
+          "prefix:uint:nullable",
+          "source:string_ref:dict=strings:nullable",
+          "src_endpoint:json:nullable",
+          "dst_endpoint:json:nullable",
+          "metrics:json:nullable"
+        ],
+        "rows": [
+          {
+            "attachment_mode": "logical_l3_subnet",
+            "direction": "observed",
+            "dst_actor": "router-b",
+            "dst_endpoint": {
+              "if_index": 401,
+              "if_name": "xe-0/0/1",
+              "ip": "198.51.100.2",
+              "netmask": "255.255.255.252",
+              "network": "198.51.100.0",
+              "prefix": 30,
+              "source": "ip_mib",
+              "subnet": "198.51.100.0/30"
+            },
+            "dst_if_index": 401,
+            "dst_ip": "198.51.100.2",
+            "dst_port_name": "xe-0/0/1",
+            "inference": "shared_subnet",
+            "link": "router-a -\u003e router-b | l3_subnet | l3_subnet | \u003cnil\u003e | xe-0/0/0 | xe-0/0/1",
+            "metrics": {
+              "attachment_mode": "logical_l3_subnet",
+              "inference": "shared_subnet",
+              "netmask": "255.255.255.252",
+              "network": "198.51.100.0",
+              "prefix": 30,
+              "source": "ip_mib",
+              "subnet": "198.51.100.0/30"
+            },
+            "netmask": "255.255.255.252",
+            "network": "198.51.100.0",
+            "prefix": 30,
+            "protocol": "l3_subnet",
+            "source": "ip_mib",
+            "src_actor": "router-a",
+            "src_endpoint": {
+              "if_index": 301,
+              "if_name": "xe-0/0/0",
+              "ip": "198.51.100.1",
+              "netmask": "255.255.255.252",
+              "network": "198.51.100.0",
+              "prefix": 30,
+              "source": "ip_mib",
+              "subnet": "198.51.100.0/30"
+            },
+            "src_if_index": 301,
+            "src_ip": "198.51.100.1",
+            "src_port_name": "xe-0/0/0",
+            "subnet": "198.51.100.0/30"
+          }
+        ]
+      },
+      "type": "l3_subnet"
+    },
+    "lldp": {
+      "table": {
+        "columns": [
+          "link:link_ref:role=reference",
+          "src_actor:actor_ref:role=reference",
+          "dst_actor:actor_ref:role=reference",
+          "protocol:string_ref:dict=strings:role=group_key",
+          "direction:string_ref:dict=strings:role=group_key",
+          "state:string_ref:dict=strings:nullable",
+          "src_port_name:string_ref:dict=strings:nullable",
+          "dst_port_name:string_ref:dict=strings:nullable",
+          "src_if_index:uint:nullable",
+          "dst_if_index:uint:nullable",
+          "src_management_ip:string_ref:dict=strings:nullable",
+          "dst_management_ip:string_ref:dict=strings:nullable",
+          "confidence:string_ref:dict=strings:nullable",
+          "inference:string_ref:dict=strings:nullable",
+          "attachment_mode:string_ref:dict=strings:nullable",
+          "src_endpoint:json:nullable",
+          "dst_endpoint:json:nullable",
+          "metrics:json:nullable"
+        ],
+        "rows": [
+          {
+            "attachment_mode": "direct",
+            "confidence": "high",
+            "direction": "observed",
+            "dst_actor": "router-a",
+            "dst_endpoint": {
+              "if_index": 201,
+              "if_name": "Gi0/0",
+              "management_ip": "198.51.100.1",
+              "port_id": "Gi0/0"
+            },
+            "dst_if_index": 201,
+            "dst_management_ip": "198.51.100.1",
+            "dst_port_name": "Gi0/0",
+            "inference": "lldp",
+            "link": "switch-a -\u003e router-a | lldp | lldp | up | Gi1/0/1 | Gi0/0",
+            "metrics": {
+              "attachment_mode": "direct",
+              "confidence": "high",
+              "inference": "lldp"
+            },
+            "protocol": "lldp",
+            "src_actor": "switch-a",
+            "src_endpoint": {
+              "if_index": 101,
+              "if_name": "Gi1/0/1",
+              "management_ip": "192.0.2.10",
+              "port_id": "Gi1/0/1"
+            },
+            "src_if_index": 101,
+            "src_management_ip": "192.0.2.10",
+            "src_port_name": "Gi1/0/1",
+            "state": "up"
+          }
+        ]
+      },
+      "type": "lldp"
+    },
+    "ospf_adjacency": {
+      "table": {
+        "columns": [
+          "link:link_ref:role=reference",
+          "src_actor:actor_ref:role=reference",
+          "dst_actor:actor_ref:role=reference",
+          "protocol:string_ref:dict=strings:role=group_key",
+          "direction:string_ref:dict=strings:role=group_key",
+          "state:string_ref:dict=strings:nullable",
+          "src_port_name:string_ref:dict=strings:nullable",
+          "dst_port_name:string_ref:dict=strings:nullable",
+          "src_if_index:uint:nullable",
+          "dst_if_index:uint:nullable",
+          "src_management_ip:string_ref:dict=strings:nullable",
+          "dst_management_ip:string_ref:dict=strings:nullable",
+          "confidence:string_ref:dict=strings:nullable",
+          "inference:string_ref:dict=strings:nullable",
+          "attachment_mode:string_ref:dict=strings:nullable",
+          "src_router_id:string_ref:dict=strings:nullable",
+          "dst_router_id:string_ref:dict=strings:nullable",
+          "src_ip:string_ref:dict=strings:nullable",
+          "dst_ip:string_ref:dict=strings:nullable",
+          "subnet:string_ref:dict=strings:nullable",
+          "network:string_ref:dict=strings:nullable",
+          "netmask:string_ref:dict=strings:nullable",
+          "prefix:uint:nullable",
+          "source:string_ref:dict=strings:nullable",
+          "src_endpoint:json:nullable",
+          "dst_endpoint:json:nullable",
+          "metrics:json:nullable"
+        ],
+        "rows": [
+          {
+            "attachment_mode": "logical_ospf_adjacency",
+            "direction": "observed",
+            "dst_actor": "router-b",
+            "dst_endpoint": {
+              "ip": "198.51.100.2",
+              "router_id": "10.255.0.2",
+              "source": "ospf_mib",
+              "subnet": "198.51.100.0/30"
+            },
+            "dst_ip": "198.51.100.2",
+            "dst_router_id": "10.255.0.2",
+            "inference": "ospf_neighbor",
+            "link": "router-a -\u003e router-b | ospf_adjacency | ospf_adjacency | full | \u003cnil\u003e | \u003cnil\u003e",
+            "metrics": {
+              "attachment_mode": "logical_ospf_adjacency",
+              "inference": "ospf_neighbor",
+              "netmask": "255.255.255.252",
+              "network": "198.51.100.0",
+              "prefix": 30,
+              "source": "ospf_mib",
+              "subnet": "198.51.100.0/30"
+            },
+            "netmask": "255.255.255.252",
+            "network": "198.51.100.0",
+            "prefix": 30,
+            "protocol": "ospf_adjacency",
+            "source": "ospf_mib",
+            "src_actor": "router-a",
+            "src_endpoint": {
+              "ip": "198.51.100.1",
+              "router_id": "10.255.0.1",
+              "source": "ospf_mib",
+              "subnet": "198.51.100.0/30"
+            },
+            "src_ip": "198.51.100.1",
+            "src_router_id": "10.255.0.1",
+            "state": "full",
+            "subnet": "198.51.100.0/30"
+          }
+        ]
+      },
+      "type": "ospf_adjacency"
+    },
+    "probable": {
+      "table": {
+        "columns": [
+          "link:link_ref:role=reference",
+          "src_actor:actor_ref:role=reference",
+          "dst_actor:actor_ref:role=reference",
+          "protocol:string_ref:dict=strings:role=group_key",
+          "direction:string_ref:dict=strings:role=group_key",
+          "state:string_ref:dict=strings:nullable",
+          "src_port_name:string_ref:dict=strings:nullable",
+          "dst_port_name:string_ref:dict=strings:nullable",
+          "src_if_index:uint:nullable",
+          "dst_if_index:uint:nullable",
+          "src_management_ip:string_ref:dict=strings:nullable",
+          "dst_management_ip:string_ref:dict=strings:nullable",
+          "confidence:string_ref:dict=strings:nullable",
+          "inference:string_ref:dict=strings:nullable",
+          "attachment_mode:string_ref:dict=strings:nullable",
+          "src_endpoint:json:nullable",
+          "dst_endpoint:json:nullable",
+          "metrics:json:nullable"
+        ],
+        "rows": [
+          {
+            "attachment_mode": "probable_host",
+            "confidence": "low",
+            "direction": "observed",
+            "dst_actor": "server-a",
+            "dst_endpoint": {
+              "mac": "00:11:22:33:44:55"
+            },
+            "inference": "probable",
+            "link": "switch-a -\u003e server-a | probable | fdb | probable | Gi1/0/2 | \u003cnil\u003e",
+            "metrics": {
+              "attachment_mode": "probable_host",
+              "confidence": "low",
+              "inference": "probable"
+            },
+            "protocol": "fdb",
+            "src_actor": "switch-a",
+            "src_endpoint": {
+              "if_index": 102,
+              "if_name": "Gi1/0/2",
+              "port_id": "Gi1/0/2"
+            },
+            "src_if_index": 102,
+            "src_port_name": "Gi1/0/2",
+            "state": "probable"
+          }
+        ]
+      },
+      "type": "probable"
+    }
+  },
+  "links": {
+    "columns": [
+      "src_actor:actor_ref:role=reference",
+      "dst_actor:actor_ref:role=reference",
+      "type:string_ref:dict=strings:role=group_key",
+      "protocol:string_ref:dict=strings:role=group_key",
+      "direction:string_ref:dict=strings:role=group_key",
+      "state:string_ref:dict=strings:nullable",
+      "src_port_name:string_ref:dict=strings:nullable",
+      "dst_port_name:string_ref:dict=strings:nullable",
+      "evidence_count:uint:aggregation=sum",
+      "discovered_at:timestamp:nullable:role=timestamp",
+      "last_seen:timestamp:nullable:role=timestamp"
+    ],
+    "rows": [
+      {
+        "direction": "observed",
+        "discovered_at": "2026-01-02T02:04:05Z",
+        "dst_actor": "router-a",
+        "dst_port_name": "Gi0/0",
+        "evidence_count": 1,
+        "last_seen": "2026-01-02T03:03:05Z",
+        "protocol": "lldp",
+        "src_actor": "switch-a",
+        "src_port_name": "Gi1/0/1",
+        "state": "up",
+        "type": "lldp"
+      },
+      {
+        "direction": "observed",
+        "dst_actor": "router-b",
+        "dst_port_name": "xe-0/0/1",
+        "evidence_count": 1,
+        "protocol": "l3_subnet",
+        "src_actor": "router-a",
+        "src_port_name": "xe-0/0/0",
+        "type": "l3_subnet"
+      },
+      {
+        "direction": "observed",
+        "dst_actor": "router-b",
+        "evidence_count": 1,
+        "protocol": "bgp_adjacency",
+        "src_actor": "router-a",
+        "state": "established",
+        "type": "bgp_adjacency"
+      },
+      {
+        "direction": "observed",
+        "dst_actor": "router-b",
+        "evidence_count": 1,
+        "protocol": "ospf_adjacency",
+        "src_actor": "router-a",
+        "state": "full",
+        "type": "ospf_adjacency"
+      },
+      {
+        "direction": "observed",
+        "dst_actor": "server-a",
+        "evidence_count": 1,
+        "protocol": "fdb",
+        "src_actor": "switch-a",
+        "src_port_name": "Gi1/0/2",
+        "state": "probable",
+        "type": "probable"
+      }
+    ]
+  },
+  "presentation": {
+    "legend": {
+      "actors": [
+        {
+          "label": "Router",
+          "type": "router"
+        },
+        {
+          "label": "Switch",
+          "type": "switch"
+        },
+        {
+          "label": "Firewall",
+          "type": "firewall"
+        },
+        {
+          "label": "Access Point",
+          "type": "access_point"
+        },
+        {
+          "label": "Server",
+          "type": "server"
+        },
+        {
+          "label": "Storage",
+          "type": "storage"
+        },
+        {
+          "label": "Load Balancer",
+          "type": "load_balancer"
+        },
+        {
+          "label": "Printer",
+          "type": "printer"
+        },
+        {
+          "label": "IP Phone",
+          "type": "phone"
+        },
+        {
+          "label": "UPS / PDU",
+          "type": "ups"
+        },
+        {
+          "label": "Camera / Media",
+          "type": "camera"
+        },
+        {
+          "label": "Other device",
+          "type": "device"
+        },
+        {
+          "label": "Other",
+          "type": "custom"
+        },
+        {
+          "label": "Inferred endpoint",
+          "type": "endpoint"
+        },
+        {
+          "label": "Network segment",
+          "type": "segment"
+        }
+      ],
+      "links": [
+        {
+          "label": "LLDP",
+          "type": "lldp"
+        },
+        {
+          "label": "CDP",
+          "type": "cdp"
+        },
+        {
+          "label": "SNMP",
+          "type": "snmp"
+        },
+        {
+          "label": "Bridge",
+          "type": "bridge"
+        },
+        {
+          "label": "L3 subnet",
+          "type": "l3_subnet"
+        },
+        {
+          "label": "OSPF adjacency",
+          "type": "ospf_adjacency"
+        },
+        {
+          "label": "BGP adjacency",
+          "type": "bgp_adjacency"
+        },
+        {
+          "label": "Probable",
+          "type": "probable"
+        }
+      ],
+      "ports": [
+        {
+          "label": "lldp/cdp",
+          "type": "lldp"
+        },
+        {
+          "label": "switch-facing",
+          "type": "switch_facing"
+        },
+        {
+          "label": "host-facing",
+          "type": "host_facing"
+        },
+        {
+          "label": "host-candidate",
+          "type": "host_candidate"
+        },
+        {
+          "label": "trunk",
+          "type": "trunk"
+        },
+        {
+          "label": "access",
+          "type": "access"
+        },
+        {
+          "label": "unclassified",
+          "type": "topology"
+        },
+        {
+          "label": "idle",
+          "type": "idle"
+        },
+        {
+          "label": "unknown",
+          "type": "unknown"
+        }
+      ]
+    },
+    "port_fields": [
+      {
+        "key": "type",
+        "label": "Type"
+      },
+      {
+        "key": "role",
+        "label": "Role"
+      },
+      {
+        "key": "status",
+        "label": "Status"
+      },
+      {
+        "key": "mode",
+        "label": "Mode"
+      },
+      {
+        "key": "sources",
+        "label": "Sources"
+      }
+    ],
+    "profile_version": "snmp-l2.v2",
+    "selection": {
+      "actor_click": {
+        "mode": "highlight_connections"
+      }
+    }
+  },
+  "producer": {
+    "capabilities": [
+      "lldp",
+      "cdp",
+      "fdb",
+      "stp",
+      "l3_subnet",
+      "ospf",
+      "bgp"
+    ],
+    "instance": "golden-agent",
+    "plugin": "go.d/snmp_topology",
+    "source": "snmp-l2"
+  },
+  "schema_version": "netdata.topology.v1",
+  "stats": {
+    "actors_collapsed_by_ip": 1,
+    "actors_map_type_suppressed": 2,
+    "actors_total": 5,
+    "bgp_adjacency_visible": 1,
+    "custom_debug_stat": "kept",
+    "depth": "all",
+    "l3_subnet_visible_links": 1,
+    "links_total": 5,
+    "map_type": "high_confidence_inferred",
+    "ospf_adjacency_visible": 1,
+    "probable_visible_links": 1,
+    "renderer_stats_are_open": true,
+    "suppressed_duplicate_link": 0
+  },
+  "tables": {
+    "actor": {
+      "actor_bgp_peers": {
+        "table": {
+          "columns": [
+            "actor:actor_ref:role=reference",
+            "remote_actor:actor_ref:nullable:role=reference",
+            "routing_instance:string_ref:dict=strings:nullable",
+            "neighbor_ip:string_ref:dict=strings:nullable",
+            "remote_as:string_ref:dict=strings:nullable",
+            "state:string_ref:dict=strings:nullable",
+            "admin_status:string_ref:dict=strings:nullable",
+            "local_ip:string_ref:dict=strings:nullable",
+            "local_as:string_ref:dict=strings:nullable",
+            "local_identifier:string_ref:dict=strings:nullable",
+            "peer_identifier:string_ref:dict=strings:nullable",
+            "peer_type:string_ref:dict=strings:nullable",
+            "bgp_version:string_ref:dict=strings:nullable",
+            "description:string_ref:dict=strings:nullable",
+            "established_uptime:uint:nullable",
+            "last_received_update_age:uint:nullable",
+            "source:string_ref:dict=strings:nullable"
+          ],
+          "rows": [
+            {
+              "actor": "router-a",
+              "admin_status": "enabled",
+              "bgp_version": "4",
+              "description": "router-b transit",
+              "established_uptime": 7200,
+              "last_received_update_age": 15,
+              "local_as": "64512",
+              "local_identifier": "10.255.0.1",
+              "local_ip": "203.0.113.1",
+              "neighbor_ip": "203.0.113.2",
+              "peer_identifier": "10.255.0.2",
+              "peer_type": "external",
+              "remote_actor": "router-b",
+              "remote_as": "64513",
+              "routing_instance": "default",
+              "source": "bgp_mib",
+              "state": "established"
+            },
+            {
+              "actor": "router-b",
+              "admin_status": "enabled",
+              "bgp_version": "4",
+              "description": "router-a transit",
+              "established_uptime": 7100,
+              "last_received_update_age": 20,
+              "local_as": "64513",
+              "local_identifier": "10.255.0.2",
+              "local_ip": "203.0.113.2",
+              "neighbor_ip": "203.0.113.1",
+              "peer_identifier": "10.255.0.1",
+              "peer_type": "external",
+              "remote_actor": "router-a",
+              "remote_as": "64512",
+              "routing_instance": "default",
+              "source": "bgp_mib",
+              "state": "established"
+            }
+          ]
+        },
+        "type": "actor_bgp_peers"
+      },
+      "actor_inventory": {
+        "table": {
+          "columns": [
+            "actor:actor_ref:role=reference",
+            "enabled:bool:nullable",
+            "sensor_labels:array:nullable",
+            "slot:string_ref:dict=strings:nullable",
+            "temperature_c:float:nullable"
+          ],
+          "rows": [
+            {
+              "actor": "switch-a",
+              "enabled": true,
+              "sensor_labels": [
+                "ambient",
+                "rack"
+              ],
+              "slot": "1",
+              "temperature_c": 42.5
+            }
+          ]
+        },
+        "type": "actor_inventory"
+      },
+      "actor_labels": {
+        "table": {
+          "columns": [
+            "actor:actor_ref:role=reference",
+            "key:string_ref:dict=strings:role=attribute",
+            "value:string_ref:dict=strings:role=attribute",
+            "source:string_ref:dict=strings:nullable:role=attribute",
+            "kind:string_ref:dict=strings:nullable:role=attribute",
+            "value_index:uint:nullable:role=attribute"
+          ],
+          "rows": [
+            {
+              "actor": "router-a",
+              "key": "actor_type",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "router"
+            },
+            {
+              "actor": "router-a",
+              "key": "capabilities",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "router",
+              "value_index": 0
+            },
+            {
+              "actor": "router-a",
+              "key": "chassis_id",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "aa:bb:cc:00:00:02",
+              "value_index": 0
+            },
+            {
+              "actor": "router-a",
+              "key": "display_name",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Router A"
+            },
+            {
+              "actor": "router-a",
+              "key": "display_name",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Router A"
+            },
+            {
+              "actor": "router-a",
+              "key": "ip_address",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "198.51.100.1",
+              "value_index": 0
+            },
+            {
+              "actor": "router-a",
+              "key": "ip_address",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "203.0.113.1",
+              "value_index": 1
+            },
+            {
+              "actor": "router-a",
+              "key": "layer",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "network"
+            },
+            {
+              "actor": "router-a",
+              "key": "management_ip",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "198.51.100.1"
+            },
+            {
+              "actor": "router-a",
+              "key": "model",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "ASR 1001"
+            },
+            {
+              "actor": "router-a",
+              "key": "ospf_router_id",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "10.255.0.1"
+            },
+            {
+              "actor": "router-a",
+              "key": "ports_total",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "4"
+            },
+            {
+              "actor": "router-a",
+              "key": "protocols_collected",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "bgp_mib",
+              "value_index": 2
+            },
+            {
+              "actor": "router-a",
+              "key": "protocols_collected",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "ip_mib",
+              "value_index": 0
+            },
+            {
+              "actor": "router-a",
+              "key": "protocols_collected",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "ospf_mib",
+              "value_index": 1
+            },
+            {
+              "actor": "router-a",
+              "key": "role",
+              "kind": "label",
+              "source": "producer_label",
+              "value": "edge"
+            },
+            {
+              "actor": "router-a",
+              "key": "source",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "snmp"
+            },
+            {
+              "actor": "router-a",
+              "key": "sys_descr",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Synthetic router A"
+            },
+            {
+              "actor": "router-a",
+              "key": "sys_name",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "router-a"
+            },
+            {
+              "actor": "router-a",
+              "key": "sys_object_id",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "1.3.6.1.4.1.9.1.1745"
+            },
+            {
+              "actor": "router-a",
+              "key": "vendor",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Cisco"
+            },
+            {
+              "actor": "router-b",
+              "key": "actor_type",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "router"
+            },
+            {
+              "actor": "router-b",
+              "key": "chassis_id",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "aa:bb:cc:00:00:03",
+              "value_index": 0
+            },
+            {
+              "actor": "router-b",
+              "key": "display_name",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Router B"
+            },
+            {
+              "actor": "router-b",
+              "key": "display_name",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Router B"
+            },
+            {
+              "actor": "router-b",
+              "key": "ip_address",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "198.51.100.2",
+              "value_index": 0
+            },
+            {
+              "actor": "router-b",
+              "key": "ip_address",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "203.0.113.2",
+              "value_index": 1
+            },
+            {
+              "actor": "router-b",
+              "key": "layer",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "network"
+            },
+            {
+              "actor": "router-b",
+              "key": "management_ip",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "198.51.100.2"
+            },
+            {
+              "actor": "router-b",
+              "key": "model",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "MX204"
+            },
+            {
+              "actor": "router-b",
+              "key": "ospf_router_id",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "10.255.0.2"
+            },
+            {
+              "actor": "router-b",
+              "key": "source",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "snmp"
+            },
+            {
+              "actor": "router-b",
+              "key": "sys_descr",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Synthetic router B"
+            },
+            {
+              "actor": "router-b",
+              "key": "sys_name",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "router-b"
+            },
+            {
+              "actor": "router-b",
+              "key": "sys_object_id",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "1.3.6.1.4.1.2636.1.1.1.2.131"
+            },
+            {
+              "actor": "router-b",
+              "key": "vendor",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Juniper"
+            },
+            {
+              "actor": "segment-198-51-100-0-30",
+              "key": "actor_type",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "segment"
+            },
+            {
+              "actor": "segment-198-51-100-0-30",
+              "key": "display_name",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "198.51.100.0/30"
+            },
+            {
+              "actor": "segment-198-51-100-0-30",
+              "key": "display_name",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "198.51.100.0/30"
+            },
+            {
+              "actor": "segment-198-51-100-0-30",
+              "key": "ip_address",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "198.51.100.0",
+              "value_index": 0
+            },
+            {
+              "actor": "segment-198-51-100-0-30",
+              "key": "layer",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "network"
+            },
+            {
+              "actor": "segment-198-51-100-0-30",
+              "key": "source",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "ip_mib"
+            },
+            {
+              "actor": "server-a",
+              "key": "actor_type",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "endpoint"
+            },
+            {
+              "actor": "server-a",
+              "key": "display_name",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Server A"
+            },
+            {
+              "actor": "server-a",
+              "key": "display_name",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Server A"
+            },
+            {
+              "actor": "server-a",
+              "key": "hostname",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "server-a",
+              "value_index": 0
+            },
+            {
+              "actor": "server-a",
+              "key": "ip_address",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "192.0.2.50",
+              "value_index": 0
+            },
+            {
+              "actor": "server-a",
+              "key": "layer",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "network"
+            },
+            {
+              "actor": "server-a",
+              "key": "learned_sources",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "arp",
+              "value_index": 1
+            },
+            {
+              "actor": "server-a",
+              "key": "learned_sources",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "fdb",
+              "value_index": 0
+            },
+            {
+              "actor": "server-a",
+              "key": "mac_address",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "00:11:22:33:44:55",
+              "value_index": 0
+            },
+            {
+              "actor": "server-a",
+              "key": "role",
+              "kind": "label",
+              "source": "producer_label",
+              "value": "application"
+            },
+            {
+              "actor": "server-a",
+              "key": "source",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "fdb"
+            },
+            {
+              "actor": "switch-a",
+              "key": "actor_type",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "switch"
+            },
+            {
+              "actor": "switch-a",
+              "key": "capabilities",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "bridge",
+              "value_index": 0
+            },
+            {
+              "actor": "switch-a",
+              "key": "capabilities",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "router",
+              "value_index": 1
+            },
+            {
+              "actor": "switch-a",
+              "key": "cdp_neighbor_count",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "1"
+            },
+            {
+              "actor": "switch-a",
+              "key": "chart_context_prefix",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "snmp.switch_a"
+            },
+            {
+              "actor": "switch-a",
+              "key": "chart_id_prefix",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "snmp_switch_a"
+            },
+            {
+              "actor": "switch-a",
+              "key": "chassis_id",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "aa:bb:cc:00:00:01",
+              "value_index": 0
+            },
+            {
+              "actor": "switch-a",
+              "key": "display_name",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Switch A"
+            },
+            {
+              "actor": "switch-a",
+              "key": "display_name",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Switch A"
+            },
+            {
+              "actor": "switch-a",
+              "key": "dns_name",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "switch-a.example.test",
+              "value_index": 0
+            },
+            {
+              "actor": "switch-a",
+              "key": "endpoints_total",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "12"
+            },
+            {
+              "actor": "switch-a",
+              "key": "fdb_total_macs",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "42"
+            },
+            {
+              "actor": "switch-a",
+              "key": "hostname",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "switch-a.example.test",
+              "value_index": 0
+            },
+            {
+              "actor": "switch-a",
+              "key": "ip_address",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "192.0.2.10",
+              "value_index": 0
+            },
+            {
+              "actor": "switch-a",
+              "key": "layer",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "network"
+            },
+            {
+              "actor": "switch-a",
+              "key": "lldp_neighbor_count",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "1"
+            },
+            {
+              "actor": "switch-a",
+              "key": "mac_address",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "aa:bb:cc:00:00:01",
+              "value_index": 0
+            },
+            {
+              "actor": "switch-a",
+              "key": "management_ip",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "192.0.2.10"
+            },
+            {
+              "actor": "switch-a",
+              "key": "model",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Catalyst 9300"
+            },
+            {
+              "actor": "switch-a",
+              "key": "netdata_host_id",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "host-switch-a"
+            },
+            {
+              "actor": "switch-a",
+              "key": "ospf_router_id",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "10.255.0.1"
+            },
+            {
+              "actor": "switch-a",
+              "key": "ports_total",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "2"
+            },
+            {
+              "actor": "switch-a",
+              "key": "protocols",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "cdp",
+              "value_index": 1
+            },
+            {
+              "actor": "switch-a",
+              "key": "protocols",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "lldp",
+              "value_index": 0
+            },
+            {
+              "actor": "switch-a",
+              "key": "protocols",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "snmp",
+              "value_index": 2
+            },
+            {
+              "actor": "switch-a",
+              "key": "role",
+              "kind": "label",
+              "source": "producer_label",
+              "value": "distribution"
+            },
+            {
+              "actor": "switch-a",
+              "key": "site",
+              "kind": "label",
+              "source": "producer_label",
+              "value": "lab"
+            },
+            {
+              "actor": "switch-a",
+              "key": "source",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "snmp"
+            },
+            {
+              "actor": "switch-a",
+              "key": "sys_contact",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "noc@example.test"
+            },
+            {
+              "actor": "switch-a",
+              "key": "sys_descr",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Synthetic switch fixture"
+            },
+            {
+              "actor": "switch-a",
+              "key": "sys_location",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "lab-rack-1"
+            },
+            {
+              "actor": "switch-a",
+              "key": "sys_name",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "switch-a"
+            },
+            {
+              "actor": "switch-a",
+              "key": "sys_object_id",
+              "kind": "match",
+              "source": "snmp-l2",
+              "value": "1.3.6.1.4.1.9.1.1208"
+            },
+            {
+              "actor": "switch-a",
+              "key": "vendor",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "Cisco"
+            },
+            {
+              "actor": "switch-a",
+              "key": "vlan_count",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "3"
+            }
+          ]
+        },
+        "type": "actor_labels"
+      },
+      "actor_metadata": {
+        "table": {
+          "columns": [
+            "actor:actor_ref:role=reference",
+            "attributes:json:nullable",
+            "labels:json:nullable"
+          ],
+          "rows": [
+            {
+              "actor": "router-a",
+              "attributes": {
+                "capabilities": [
+                  "router"
+                ],
+                "display_name": "Router A",
+                "management_ip": "198.51.100.1",
+                "model": "ASR 1001",
+                "ospf_router_id": "10.255.0.1",
+                "ports_total": 4,
+                "protocols_collected": [
+                  "ip_mib",
+                  "ospf_mib",
+                  "bgp_mib"
+                ],
+                "sys_descr": "Synthetic router A",
+                "vendor": "Cisco"
+              },
+              "labels": {
+                "role": "edge"
+              }
+            },
+            {
+              "actor": "router-b",
+              "attributes": {
+                "display_name": "Router B",
+                "management_ip": "198.51.100.2",
+                "model": "MX204",
+                "ospf_router_id": "10.255.0.2",
+                "sys_descr": "Synthetic router B",
+                "vendor": "Juniper"
+              }
+            },
+            {
+              "actor": "segment-198-51-100-0-30",
+              "attributes": {
+                "display_name": "198.51.100.0/30"
+              }
+            },
+            {
+              "actor": "server-a",
+              "attributes": {
+                "display_name": "Server A",
+                "learned_sources": [
+                  "fdb",
+                  "arp"
+                ]
+              },
+              "labels": {
+                "role": "application"
+              }
+            },
+            {
+              "actor": "switch-a",
+              "attributes": {
+                "capabilities": [
+                  "bridge",
+                  "router"
+                ],
+                "cdp_neighbor_count": 1,
+                "chart_context_prefix": "snmp.switch_a",
+                "chart_id_prefix": "snmp_switch_a",
+                "display_name": "Switch A",
+                "endpoints_total": 12,
+                "fdb_total_macs": 42,
+                "lldp_neighbor_count": 1,
+                "management_ip": "192.0.2.10",
+                "model": "Catalyst 9300",
+                "netdata_host_id": "host-switch-a",
+                "ospf_router_id": "10.255.0.1",
+                "ports_total": 2,
+                "protocols": [
+                  "lldp",
+                  "cdp",
+                  "snmp"
+                ],
+                "sys_contact": "noc@example.test",
+                "sys_descr": "Synthetic switch fixture",
+                "sys_location": "lab-rack-1",
+                "vendor": "Cisco",
+                "vlan_count": 3
+              },
+              "labels": {
+                "role": "distribution",
+                "site": "lab"
+              }
+            }
+          ]
+        },
+        "type": "actor_metadata"
+      },
+      "actor_ospf_neighbors": {
+        "table": {
+          "columns": [
+            "actor:actor_ref:role=reference",
+            "remote_actor:actor_ref:nullable:role=reference",
+            "local_router_id:string_ref:dict=strings:nullable",
+            "neighbor_router_id:string_ref:dict=strings:nullable",
+            "neighbor_ip:string_ref:dict=strings:nullable",
+            "state:string_ref:dict=strings:nullable",
+            "local_ip:string_ref:dict=strings:nullable",
+            "subnet:string_ref:dict=strings:nullable",
+            "addressless_index:string_ref:dict=strings:nullable",
+            "source:string_ref:dict=strings:nullable"
+          ],
+          "rows": [
+            {
+              "actor": "router-a",
+              "addressless_index": "0",
+              "local_ip": "198.51.100.1",
+              "local_router_id": "10.255.0.1",
+              "neighbor_ip": "198.51.100.2",
+              "neighbor_router_id": "10.255.0.2",
+              "remote_actor": "router-b",
+              "source": "ospf_mib",
+              "state": "full",
+              "subnet": "198.51.100.0/30"
+            },
+            {
+              "actor": "router-b",
+              "addressless_index": "0",
+              "local_ip": "198.51.100.2",
+              "local_router_id": "10.255.0.2",
+              "neighbor_ip": "198.51.100.1",
+              "neighbor_router_id": "10.255.0.1",
+              "remote_actor": "router-a",
+              "source": "ospf_mib",
+              "state": "full",
+              "subnet": "198.51.100.0/30"
+            }
+          ]
+        },
+        "type": "actor_ospf_neighbors"
+      },
+      "actor_port_links": {
+        "table": {
+          "columns": [
+            "actor:actor_ref:role=reference",
+            "link:link_ref:role=reference",
+            "remote_actor:actor_ref:role=reference",
+            "if_index:uint:nullable",
+            "port_id:string_ref:dict=strings:nullable",
+            "port_name:string_ref:dict=strings:nullable",
+            "remote_if_index:uint:nullable",
+            "remote_port_id:string_ref:dict=strings:nullable",
+            "remote_port_name:string_ref:dict=strings:nullable",
+            "type:string_ref:dict=strings:role=group_key",
+            "protocol:string_ref:dict=strings:role=group_key",
+            "state:string_ref:dict=strings:nullable",
+            "evidence_count:uint:aggregation=sum",
+            "confidence:string_ref:dict=strings:nullable",
+            "inference:string_ref:dict=strings:nullable",
+            "attachment_mode:string_ref:dict=strings:nullable",
+            "discovered_at:timestamp:nullable:role=timestamp",
+            "last_seen:timestamp:nullable:role=timestamp"
+          ],
+          "rows": [
+            {
+              "actor": "router-a",
+              "attachment_mode": "direct",
+              "confidence": "high",
+              "discovered_at": "2026-01-02T02:04:05Z",
+              "evidence_count": 1,
+              "if_index": 201,
+              "inference": "lldp",
+              "last_seen": "2026-01-02T03:03:05Z",
+              "link": "switch-a -\u003e router-a | lldp | lldp | up | Gi1/0/1 | Gi0/0",
+              "port_id": "Gi0/0",
+              "port_name": "Gi0/0",
+              "protocol": "lldp",
+              "remote_actor": "switch-a",
+              "remote_if_index": 101,
+              "remote_port_id": "Gi1/0/1",
+              "remote_port_name": "Gi1/0/1",
+              "state": "up",
+              "type": "lldp"
+            },
+            {
+              "actor": "server-a",
+              "attachment_mode": "probable_host",
+              "confidence": "low",
+              "evidence_count": 1,
+              "inference": "probable",
+              "link": "switch-a -\u003e server-a | probable | fdb | probable | Gi1/0/2 | \u003cnil\u003e",
+              "protocol": "fdb",
+              "remote_actor": "switch-a",
+              "remote_if_index": 102,
+              "remote_port_id": "Gi1/0/2",
+              "remote_port_name": "Gi1/0/2",
+              "state": "probable",
+              "type": "probable"
+            },
+            {
+              "actor": "switch-a",
+              "attachment_mode": "direct",
+              "confidence": "high",
+              "discovered_at": "2026-01-02T02:04:05Z",
+              "evidence_count": 1,
+              "if_index": 101,
+              "inference": "lldp",
+              "last_seen": "2026-01-02T03:03:05Z",
+              "link": "switch-a -\u003e router-a | lldp | lldp | up | Gi1/0/1 | Gi0/0",
+              "port_id": "Gi1/0/1",
+              "port_name": "Gi1/0/1",
+              "protocol": "lldp",
+              "remote_actor": "router-a",
+              "remote_if_index": 201,
+              "remote_port_id": "Gi0/0",
+              "remote_port_name": "Gi0/0",
+              "state": "up",
+              "type": "lldp"
+            },
+            {
+              "actor": "switch-a",
+              "attachment_mode": "probable_host",
+              "confidence": "low",
+              "evidence_count": 1,
+              "if_index": 102,
+              "inference": "probable",
+              "link": "switch-a -\u003e server-a | probable | fdb | probable | Gi1/0/2 | \u003cnil\u003e",
+              "port_id": "Gi1/0/2",
+              "port_name": "Gi1/0/2",
+              "protocol": "fdb",
+              "remote_actor": "server-a",
+              "state": "probable",
+              "type": "probable"
+            }
+          ]
+        },
+        "type": "actor_port_links"
+      },
+      "actor_ports": {
+        "table": {
+          "columns": [
+            "actor:actor_ref:role=reference",
+            "if_index:uint:nullable",
+            "port_id:string_ref:dict=strings:nullable",
+            "name:string_ref:dict=strings:nullable",
+            "if_name:string_ref:dict=strings:nullable",
+            "if_descr:string_ref:dict=strings:nullable",
+            "if_alias:string_ref:dict=strings:nullable",
+            "mac:string_ref:dict=strings:nullable",
+            "speed:uint:nullable",
+            "topology_role:string_ref:dict=strings:nullable",
+            "oper_status:string_ref:dict=strings:nullable",
+            "admin_status:string_ref:dict=strings:nullable",
+            "port_type:string_ref:dict=strings:nullable",
+            "link_mode:string_ref:dict=strings:nullable",
+            "stp_state:string_ref:dict=strings:nullable",
+            "vlan_ids:array:nullable",
+            "fdb_mac_count:uint:nullable",
+            "link_count:uint:nullable",
+            "neighbor_count:uint:nullable",
+            "neighbor_actor:actor_ref:nullable:role=reference",
+            "neighbor_port_name:string_ref:dict=strings:nullable",
+            "neighbors:json:nullable",
+            "vlans:json:nullable",
+            "extra:json:nullable"
+          ],
+          "rows": [
+            {
+              "actor": "router-a",
+              "extra": {
+                "vendor_context": "router uplink debug field"
+              },
+              "if_alias": "to switch-a",
+              "if_index": 201,
+              "if_name": "Gi0/0",
+              "link_mode": "trunk",
+              "name": "Gi0/0",
+              "neighbor_actor": "switch-a",
+              "neighbor_port_name": "Gi1/0/1",
+              "oper_status": "up",
+              "port_id": "Gi0/0",
+              "topology_role": "uplink"
+            },
+            {
+              "actor": "switch-a",
+              "admin_status": "up",
+              "extra": {
+                "duplex": "full",
+                "last_change": "2026-01-02T01:02:03Z",
+                "link_mode_confidence": "high",
+                "link_mode_sources": [
+                  "if_mib",
+                  "lldp"
+                ],
+                "topology_role_confidence": "medium",
+                "topology_role_sources": [
+                  "stp",
+                  "fdb"
+                ],
+                "vendor_note": "kept in actor_ports.extra until typed ports replace it"
+              },
+              "fdb_mac_count": 12,
+              "if_alias": "to router-a",
+              "if_descr": "GigabitEthernet1/0/1",
+              "if_index": 101,
+              "if_name": "Gi1/0/1",
+              "link_count": 1,
+              "link_mode": "trunk",
+              "mac": "aa:bb:cc:00:01:01",
+              "name": "Gi1/0/1",
+              "neighbor_actor": "router-a",
+              "neighbor_count": 1,
+              "neighbor_port_name": "Gi0/0",
+              "neighbors": [
+                {
+                  "protocol": "lldp",
+                  "remote_chassis_id": "aa:bb:cc:00:00:02",
+                  "remote_port": "Gi0/0"
+                }
+              ],
+              "oper_status": "up",
+              "port_id": "Gi1/0/1",
+              "port_type": "ethernet",
+              "speed": 1000000000,
+              "stp_state": "forwarding",
+              "topology_role": "uplink",
+              "vlan_ids": [
+                "10",
+                "20"
+              ],
+              "vlans": [
+                {
+                  "id": "10",
+                  "name": "users"
+                },
+                {
+                  "id": "20",
+                  "name": "servers"
+                }
+              ]
+            }
+          ]
+        },
+        "type": "actor_ports"
+      }
+    }
+  },
+  "types": {
+    "actor_types": {
+      "access_point": {
+        "aggregation_scopes": [
+          "device",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "chassis_ids",
+          "mac_addresses",
+          "ip_addresses",
+          "sys_name"
+        ],
+        "presentation": {
+          "border": {
+            "enabled": true
+          },
+          "color_slot": "info",
+          "icon": "access_point",
+          "label": "Access Point",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name",
+              "sys_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "stronger"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "management_ip",
+                    "label": "Management IP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "vendor",
+                    "label": "Vendor",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "model",
+                    "label": "Model",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ospf_router_id",
+                    "label": "OSPF Router ID",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ports_total",
+                    "label": "Ports",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "lldp_neighbor_count",
+                    "label": "LLDP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "cdp_neighbor_count",
+                    "label": "CDP",
+                    "max_values": 1
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "oper_status",
+                    "label": "Status",
+                    "projection": {
+                      "column": "oper_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "port_type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "port_type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "link_mode",
+                    "label": "Mode",
+                    "projection": {
+                      "column": "link_mode",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "topology_role",
+                    "label": "Role",
+                    "projection": {
+                      "column": "topology_role",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "array_count",
+                    "id": "vlan_ids",
+                    "label": "VLANs",
+                    "projection": {
+                      "column": "vlan_ids",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "fdb_mac_count",
+                    "label": "FDB",
+                    "projection": {
+                      "column": "fdb_mac_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "link_count",
+                    "label": "Links",
+                    "projection": {
+                      "column": "link_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "neighbor_count",
+                    "label": "Neighbors",
+                    "projection": {
+                      "column": "neighbor_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "neighbor_actor",
+                    "label": "Neighbor",
+                    "projection": {
+                      "actor_column": "neighbor_actor",
+                      "kind": "actor_ref_label"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_port_name",
+                    "label": "Neighbor Port",
+                    "projection": {
+                      "column": "neighbor_port_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_name",
+                    "label": "ifName",
+                    "projection": {
+                      "column": "if_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_descr",
+                    "label": "ifDescr",
+                    "projection": {
+                      "column": "if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_alias",
+                    "label": "Alias",
+                    "projection": {
+                      "column": "if_alias",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "mac",
+                    "label": "MAC",
+                    "projection": {
+                      "column": "mac",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "speed",
+                    "label": "Speed",
+                    "projection": {
+                      "column": "speed",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "stp_state",
+                    "label": "STP",
+                    "projection": {
+                      "column": "stp_state",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "neighbors",
+                    "label": "Neighbor Data",
+                    "projection": {
+                      "column": "neighbors",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "vlans",
+                    "label": "VLAN Data",
+                    "projection": {
+                      "column": "vlans",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "extra",
+                    "label": "Extra",
+                    "projection": {
+                      "column": "extra",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  }
+                ],
+                "id": "ports",
+                "label": "Ports",
+                "order": 1,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ports"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_name",
+                    "label": "Remote Port",
+                    "projection": {
+                      "column": "remote_port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "remote_if_index",
+                    "label": "Remote Port ID",
+                    "projection": {
+                      "column": "remote_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_id",
+                    "label": "Remote Source Port ID",
+                    "projection": {
+                      "column": "remote_port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "confidence",
+                    "label": "Confidence",
+                    "projection": {
+                      "column": "confidence",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "discovered_at",
+                    "label": "Discovered",
+                    "projection": {
+                      "column": "discovered_at",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "last_seen",
+                    "label": "Last Seen",
+                    "projection": {
+                      "column": "last_seen",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No port neighbors",
+                "id": "port_neighbors",
+                "label": "Port Neighbors",
+                "order": 2,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_port_links"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "local_endpoint",
+                    "label": "Local Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "src_ip",
+                      "local_port_column": "src_port_name",
+                      "remote_ip_column": "dst_ip",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "remote_endpoint",
+                    "label": "Remote Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "dst_ip",
+                      "local_port_column": "dst_port_name",
+                      "remote_ip_column": "src_ip",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 adjacencies",
+                "id": "l3_adjacencies",
+                "label": "L3 Adjacencies",
+                "order": 3,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_router_id",
+                    "label": "Neighbor Router ID",
+                    "projection": {
+                      "column": "neighbor_router_id",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_router_id",
+                    "label": "Local Router ID",
+                    "projection": {
+                      "column": "local_router_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "addressless_index",
+                    "label": "Addressless Index",
+                    "projection": {
+                      "column": "addressless_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No OSPF neighbors",
+                "id": "ospf_neighbors",
+                "label": "OSPF Neighbors",
+                "order": 4,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_router_id",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ospf_neighbors"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_as",
+                    "label": "Remote AS",
+                    "projection": {
+                      "column": "remote_as",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "routing_instance",
+                    "label": "Routing Instance",
+                    "projection": {
+                      "column": "routing_instance",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_as",
+                    "label": "Local AS",
+                    "projection": {
+                      "column": "local_as",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_identifier",
+                    "label": "Local Identifier",
+                    "projection": {
+                      "column": "local_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "peer_identifier",
+                    "label": "Peer Identifier",
+                    "projection": {
+                      "column": "peer_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "peer_type",
+                    "label": "Peer Type",
+                    "projection": {
+                      "column": "peer_type",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "bgp_version",
+                    "label": "BGP Version",
+                    "projection": {
+                      "column": "bgp_version",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "established_uptime",
+                    "label": "Established Uptime",
+                    "projection": {
+                      "column": "established_uptime",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "last_received_update_age",
+                    "label": "Last Update Age",
+                    "projection": {
+                      "column": "last_received_update_age",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "description",
+                    "label": "Description",
+                    "projection": {
+                      "column": "description",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No BGP peers",
+                "id": "bgp_peers",
+                "label": "BGP Peers",
+                "order": 5,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_ip",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_bgp_peers"
+                }
+              }
+            ]
+          },
+          "ports": {
+            "show_bullets": true,
+            "sources": [
+              {
+                "actor_column": "actor",
+                "default_type": "topology",
+                "mode_column": "link_mode",
+                "name_column": "name",
+                "role_column": "topology_role",
+                "source": "actor_table",
+                "status_column": "oper_status",
+                "table": "actor_ports",
+                "type_column": "topology_role"
+              }
+            ]
+          },
+          "role": "actor",
+          "size": {
+            "mode": "link_count",
+            "scale": "emphasized"
+          }
+        },
+        "search": {
+          "columns": [
+            "display_name",
+            "sys_name",
+            "management_ip",
+            "vendor",
+            "model"
+          ],
+          "label_keys": [
+            "ospf_router_id"
+          ]
+        }
+      },
+      "camera": {
+        "aggregation_scopes": [
+          "device",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "chassis_ids",
+          "mac_addresses",
+          "ip_addresses",
+          "sys_name"
+        ],
+        "presentation": {
+          "border": {
+            "enabled": true
+          },
+          "color_slot": "neutral",
+          "icon": "camera",
+          "label": "Camera",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name",
+              "sys_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "stronger"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "management_ip",
+                    "label": "Management IP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "vendor",
+                    "label": "Vendor",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "model",
+                    "label": "Model",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ospf_router_id",
+                    "label": "OSPF Router ID",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ports_total",
+                    "label": "Ports",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "lldp_neighbor_count",
+                    "label": "LLDP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "cdp_neighbor_count",
+                    "label": "CDP",
+                    "max_values": 1
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "oper_status",
+                    "label": "Status",
+                    "projection": {
+                      "column": "oper_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "port_type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "port_type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "link_mode",
+                    "label": "Mode",
+                    "projection": {
+                      "column": "link_mode",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "topology_role",
+                    "label": "Role",
+                    "projection": {
+                      "column": "topology_role",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "array_count",
+                    "id": "vlan_ids",
+                    "label": "VLANs",
+                    "projection": {
+                      "column": "vlan_ids",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "fdb_mac_count",
+                    "label": "FDB",
+                    "projection": {
+                      "column": "fdb_mac_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "link_count",
+                    "label": "Links",
+                    "projection": {
+                      "column": "link_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "neighbor_count",
+                    "label": "Neighbors",
+                    "projection": {
+                      "column": "neighbor_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "neighbor_actor",
+                    "label": "Neighbor",
+                    "projection": {
+                      "actor_column": "neighbor_actor",
+                      "kind": "actor_ref_label"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_port_name",
+                    "label": "Neighbor Port",
+                    "projection": {
+                      "column": "neighbor_port_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_name",
+                    "label": "ifName",
+                    "projection": {
+                      "column": "if_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_descr",
+                    "label": "ifDescr",
+                    "projection": {
+                      "column": "if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_alias",
+                    "label": "Alias",
+                    "projection": {
+                      "column": "if_alias",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "mac",
+                    "label": "MAC",
+                    "projection": {
+                      "column": "mac",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "speed",
+                    "label": "Speed",
+                    "projection": {
+                      "column": "speed",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "stp_state",
+                    "label": "STP",
+                    "projection": {
+                      "column": "stp_state",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "neighbors",
+                    "label": "Neighbor Data",
+                    "projection": {
+                      "column": "neighbors",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "vlans",
+                    "label": "VLAN Data",
+                    "projection": {
+                      "column": "vlans",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "extra",
+                    "label": "Extra",
+                    "projection": {
+                      "column": "extra",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  }
+                ],
+                "id": "ports",
+                "label": "Ports",
+                "order": 1,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ports"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_name",
+                    "label": "Remote Port",
+                    "projection": {
+                      "column": "remote_port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "remote_if_index",
+                    "label": "Remote Port ID",
+                    "projection": {
+                      "column": "remote_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_id",
+                    "label": "Remote Source Port ID",
+                    "projection": {
+                      "column": "remote_port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "confidence",
+                    "label": "Confidence",
+                    "projection": {
+                      "column": "confidence",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "discovered_at",
+                    "label": "Discovered",
+                    "projection": {
+                      "column": "discovered_at",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "last_seen",
+                    "label": "Last Seen",
+                    "projection": {
+                      "column": "last_seen",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No port neighbors",
+                "id": "port_neighbors",
+                "label": "Port Neighbors",
+                "order": 2,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_port_links"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "local_endpoint",
+                    "label": "Local Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "src_ip",
+                      "local_port_column": "src_port_name",
+                      "remote_ip_column": "dst_ip",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "remote_endpoint",
+                    "label": "Remote Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "dst_ip",
+                      "local_port_column": "dst_port_name",
+                      "remote_ip_column": "src_ip",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 adjacencies",
+                "id": "l3_adjacencies",
+                "label": "L3 Adjacencies",
+                "order": 3,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_router_id",
+                    "label": "Neighbor Router ID",
+                    "projection": {
+                      "column": "neighbor_router_id",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_router_id",
+                    "label": "Local Router ID",
+                    "projection": {
+                      "column": "local_router_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "addressless_index",
+                    "label": "Addressless Index",
+                    "projection": {
+                      "column": "addressless_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No OSPF neighbors",
+                "id": "ospf_neighbors",
+                "label": "OSPF Neighbors",
+                "order": 4,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_router_id",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ospf_neighbors"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_as",
+                    "label": "Remote AS",
+                    "projection": {
+                      "column": "remote_as",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "routing_instance",
+                    "label": "Routing Instance",
+                    "projection": {
+                      "column": "routing_instance",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_as",
+                    "label": "Local AS",
+                    "projection": {
+                      "column": "local_as",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_identifier",
+                    "label": "Local Identifier",
+                    "projection": {
+                      "column": "local_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "peer_identifier",
+                    "label": "Peer Identifier",
+                    "projection": {
+                      "column": "peer_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "peer_type",
+                    "label": "Peer Type",
+                    "projection": {
+                      "column": "peer_type",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "bgp_version",
+                    "label": "BGP Version",
+                    "projection": {
+                      "column": "bgp_version",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "established_uptime",
+                    "label": "Established Uptime",
+                    "projection": {
+                      "column": "established_uptime",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "last_received_update_age",
+                    "label": "Last Update Age",
+                    "projection": {
+                      "column": "last_received_update_age",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "description",
+                    "label": "Description",
+                    "projection": {
+                      "column": "description",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No BGP peers",
+                "id": "bgp_peers",
+                "label": "BGP Peers",
+                "order": 5,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_ip",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_bgp_peers"
+                }
+              }
+            ]
+          },
+          "ports": {
+            "show_bullets": true,
+            "sources": [
+              {
+                "actor_column": "actor",
+                "default_type": "topology",
+                "mode_column": "link_mode",
+                "name_column": "name",
+                "role_column": "topology_role",
+                "source": "actor_table",
+                "status_column": "oper_status",
+                "table": "actor_ports",
+                "type_column": "topology_role"
+              }
+            ]
+          },
+          "role": "actor",
+          "size": {
+            "mode": "link_count",
+            "scale": "emphasized"
+          }
+        },
+        "search": {
+          "columns": [
+            "display_name",
+            "sys_name",
+            "management_ip",
+            "vendor",
+            "model"
+          ],
+          "label_keys": [
+            "ospf_router_id"
+          ]
+        }
+      },
+      "custom": {
+        "aggregation_scopes": [
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "custom",
+        "merge_identity": [
+          "id"
+        ],
+        "presentation": {
+          "color_slot": "neutral",
+          "icon": "service",
+          "label": "Custom",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ip_address",
+                    "label": "IP",
+                    "max_values": 2
+                  },
+                  {
+                    "key": "mac_address",
+                    "label": "MAC",
+                    "max_values": 2
+                  },
+                  {
+                    "key": "hostname",
+                    "label": "Hostname",
+                    "max_values": 2
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_port",
+                    "label": "Local Port",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_port_column": "src_port_name",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port",
+                    "label": "Remote Port",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_port_column": "dst_port_name",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "direction",
+                    "label": "Direction",
+                    "projection": {
+                      "column": "direction",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  }
+                ],
+                "id": "links",
+                "label": "Links",
+                "order": 1,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "mode": "incident_link",
+                  "src_actor_column": "src_actor"
+                },
+                "source": {
+                  "kind": "links"
+                }
+              }
+            ]
+          },
+          "role": "actor"
+        },
+        "search": {
+          "columns": [
+            "display_name"
+          ]
+        }
+      },
+      "device": {
+        "aggregation_scopes": [
+          "device",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "chassis_ids",
+          "mac_addresses",
+          "ip_addresses",
+          "sys_name"
+        ],
+        "presentation": {
+          "border": {
+            "enabled": true
+          },
+          "color_slot": "primary",
+          "icon": "server",
+          "label": "Device",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name",
+              "sys_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "stronger"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "management_ip",
+                    "label": "Management IP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "vendor",
+                    "label": "Vendor",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "model",
+                    "label": "Model",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ospf_router_id",
+                    "label": "OSPF Router ID",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ports_total",
+                    "label": "Ports",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "lldp_neighbor_count",
+                    "label": "LLDP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "cdp_neighbor_count",
+                    "label": "CDP",
+                    "max_values": 1
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "oper_status",
+                    "label": "Status",
+                    "projection": {
+                      "column": "oper_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "port_type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "port_type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "link_mode",
+                    "label": "Mode",
+                    "projection": {
+                      "column": "link_mode",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "topology_role",
+                    "label": "Role",
+                    "projection": {
+                      "column": "topology_role",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "array_count",
+                    "id": "vlan_ids",
+                    "label": "VLANs",
+                    "projection": {
+                      "column": "vlan_ids",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "fdb_mac_count",
+                    "label": "FDB",
+                    "projection": {
+                      "column": "fdb_mac_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "link_count",
+                    "label": "Links",
+                    "projection": {
+                      "column": "link_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "neighbor_count",
+                    "label": "Neighbors",
+                    "projection": {
+                      "column": "neighbor_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "neighbor_actor",
+                    "label": "Neighbor",
+                    "projection": {
+                      "actor_column": "neighbor_actor",
+                      "kind": "actor_ref_label"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_port_name",
+                    "label": "Neighbor Port",
+                    "projection": {
+                      "column": "neighbor_port_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_name",
+                    "label": "ifName",
+                    "projection": {
+                      "column": "if_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_descr",
+                    "label": "ifDescr",
+                    "projection": {
+                      "column": "if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_alias",
+                    "label": "Alias",
+                    "projection": {
+                      "column": "if_alias",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "mac",
+                    "label": "MAC",
+                    "projection": {
+                      "column": "mac",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "speed",
+                    "label": "Speed",
+                    "projection": {
+                      "column": "speed",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "stp_state",
+                    "label": "STP",
+                    "projection": {
+                      "column": "stp_state",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "neighbors",
+                    "label": "Neighbor Data",
+                    "projection": {
+                      "column": "neighbors",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "vlans",
+                    "label": "VLAN Data",
+                    "projection": {
+                      "column": "vlans",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "extra",
+                    "label": "Extra",
+                    "projection": {
+                      "column": "extra",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  }
+                ],
+                "id": "ports",
+                "label": "Ports",
+                "order": 1,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ports"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_name",
+                    "label": "Remote Port",
+                    "projection": {
+                      "column": "remote_port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "remote_if_index",
+                    "label": "Remote Port ID",
+                    "projection": {
+                      "column": "remote_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_id",
+                    "label": "Remote Source Port ID",
+                    "projection": {
+                      "column": "remote_port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "confidence",
+                    "label": "Confidence",
+                    "projection": {
+                      "column": "confidence",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "discovered_at",
+                    "label": "Discovered",
+                    "projection": {
+                      "column": "discovered_at",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "last_seen",
+                    "label": "Last Seen",
+                    "projection": {
+                      "column": "last_seen",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No port neighbors",
+                "id": "port_neighbors",
+                "label": "Port Neighbors",
+                "order": 2,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_port_links"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "local_endpoint",
+                    "label": "Local Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "src_ip",
+                      "local_port_column": "src_port_name",
+                      "remote_ip_column": "dst_ip",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "remote_endpoint",
+                    "label": "Remote Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "dst_ip",
+                      "local_port_column": "dst_port_name",
+                      "remote_ip_column": "src_ip",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 adjacencies",
+                "id": "l3_adjacencies",
+                "label": "L3 Adjacencies",
+                "order": 3,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_router_id",
+                    "label": "Neighbor Router ID",
+                    "projection": {
+                      "column": "neighbor_router_id",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_router_id",
+                    "label": "Local Router ID",
+                    "projection": {
+                      "column": "local_router_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "addressless_index",
+                    "label": "Addressless Index",
+                    "projection": {
+                      "column": "addressless_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No OSPF neighbors",
+                "id": "ospf_neighbors",
+                "label": "OSPF Neighbors",
+                "order": 4,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_router_id",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ospf_neighbors"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_as",
+                    "label": "Remote AS",
+                    "projection": {
+                      "column": "remote_as",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "routing_instance",
+                    "label": "Routing Instance",
+                    "projection": {
+                      "column": "routing_instance",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_as",
+                    "label": "Local AS",
+                    "projection": {
+                      "column": "local_as",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_identifier",
+                    "label": "Local Identifier",
+                    "projection": {
+                      "column": "local_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "peer_identifier",
+                    "label": "Peer Identifier",
+                    "projection": {
+                      "column": "peer_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "peer_type",
+                    "label": "Peer Type",
+                    "projection": {
+                      "column": "peer_type",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "bgp_version",
+                    "label": "BGP Version",
+                    "projection": {
+                      "column": "bgp_version",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "established_uptime",
+                    "label": "Established Uptime",
+                    "projection": {
+                      "column": "established_uptime",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "last_received_update_age",
+                    "label": "Last Update Age",
+                    "projection": {
+                      "column": "last_received_update_age",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "description",
+                    "label": "Description",
+                    "projection": {
+                      "column": "description",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No BGP peers",
+                "id": "bgp_peers",
+                "label": "BGP Peers",
+                "order": 5,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_ip",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_bgp_peers"
+                }
+              }
+            ]
+          },
+          "ports": {
+            "show_bullets": true,
+            "sources": [
+              {
+                "actor_column": "actor",
+                "default_type": "topology",
+                "mode_column": "link_mode",
+                "name_column": "name",
+                "role_column": "topology_role",
+                "source": "actor_table",
+                "status_column": "oper_status",
+                "table": "actor_ports",
+                "type_column": "topology_role"
+              }
+            ]
+          },
+          "role": "actor",
+          "size": {
+            "mode": "link_count",
+            "scale": "emphasized"
+          }
+        },
+        "search": {
+          "columns": [
+            "display_name",
+            "sys_name",
+            "management_ip",
+            "vendor",
+            "model"
+          ],
+          "label_keys": [
+            "ospf_router_id"
+          ]
+        }
+      },
+      "endpoint": {
+        "aggregation_scopes": [
+          "endpoint",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "mac_addresses",
+          "ip_addresses"
+        ],
+        "presentation": {
+          "border": {
+            "enabled": true
+          },
+          "color_slot": "derived",
+          "icon": "remote-endpoint",
+          "label": "Inferred endpoint",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "weaker"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ip_address",
+                    "label": "IP",
+                    "max_values": 2
+                  },
+                  {
+                    "key": "mac_address",
+                    "label": "MAC",
+                    "max_values": 2
+                  },
+                  {
+                    "key": "hostname",
+                    "label": "Hostname",
+                    "max_values": 2
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_port",
+                    "label": "Local Port",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_port_column": "src_port_name",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port",
+                    "label": "Remote Port",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_port_column": "dst_port_name",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "direction",
+                    "label": "Direction",
+                    "projection": {
+                      "column": "direction",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  }
+                ],
+                "id": "links",
+                "label": "Links",
+                "order": 1,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "mode": "incident_link",
+                  "src_actor_column": "src_actor"
+                },
+                "source": {
+                  "kind": "links"
+                }
+              }
+            ]
+          },
+          "role": "endpoint",
+          "size": {
+            "mode": "fixed",
+            "scale": "compact"
+          }
+        },
+        "search": {
+          "columns": [
+            "display_name"
+          ]
+        }
+      },
+      "firewall": {
+        "aggregation_scopes": [
+          "device",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "chassis_ids",
+          "mac_addresses",
+          "ip_addresses",
+          "sys_name"
+        ],
+        "presentation": {
+          "border": {
+            "enabled": true
+          },
+          "color_slot": "warning",
+          "icon": "firewall",
+          "label": "Firewall",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name",
+              "sys_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "stronger"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "management_ip",
+                    "label": "Management IP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "vendor",
+                    "label": "Vendor",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "model",
+                    "label": "Model",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ospf_router_id",
+                    "label": "OSPF Router ID",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ports_total",
+                    "label": "Ports",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "lldp_neighbor_count",
+                    "label": "LLDP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "cdp_neighbor_count",
+                    "label": "CDP",
+                    "max_values": 1
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "oper_status",
+                    "label": "Status",
+                    "projection": {
+                      "column": "oper_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "port_type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "port_type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "link_mode",
+                    "label": "Mode",
+                    "projection": {
+                      "column": "link_mode",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "topology_role",
+                    "label": "Role",
+                    "projection": {
+                      "column": "topology_role",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "array_count",
+                    "id": "vlan_ids",
+                    "label": "VLANs",
+                    "projection": {
+                      "column": "vlan_ids",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "fdb_mac_count",
+                    "label": "FDB",
+                    "projection": {
+                      "column": "fdb_mac_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "link_count",
+                    "label": "Links",
+                    "projection": {
+                      "column": "link_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "neighbor_count",
+                    "label": "Neighbors",
+                    "projection": {
+                      "column": "neighbor_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "neighbor_actor",
+                    "label": "Neighbor",
+                    "projection": {
+                      "actor_column": "neighbor_actor",
+                      "kind": "actor_ref_label"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_port_name",
+                    "label": "Neighbor Port",
+                    "projection": {
+                      "column": "neighbor_port_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_name",
+                    "label": "ifName",
+                    "projection": {
+                      "column": "if_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_descr",
+                    "label": "ifDescr",
+                    "projection": {
+                      "column": "if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_alias",
+                    "label": "Alias",
+                    "projection": {
+                      "column": "if_alias",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "mac",
+                    "label": "MAC",
+                    "projection": {
+                      "column": "mac",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "speed",
+                    "label": "Speed",
+                    "projection": {
+                      "column": "speed",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "stp_state",
+                    "label": "STP",
+                    "projection": {
+                      "column": "stp_state",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "neighbors",
+                    "label": "Neighbor Data",
+                    "projection": {
+                      "column": "neighbors",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "vlans",
+                    "label": "VLAN Data",
+                    "projection": {
+                      "column": "vlans",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "extra",
+                    "label": "Extra",
+                    "projection": {
+                      "column": "extra",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  }
+                ],
+                "id": "ports",
+                "label": "Ports",
+                "order": 1,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ports"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_name",
+                    "label": "Remote Port",
+                    "projection": {
+                      "column": "remote_port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "remote_if_index",
+                    "label": "Remote Port ID",
+                    "projection": {
+                      "column": "remote_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_id",
+                    "label": "Remote Source Port ID",
+                    "projection": {
+                      "column": "remote_port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "confidence",
+                    "label": "Confidence",
+                    "projection": {
+                      "column": "confidence",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "discovered_at",
+                    "label": "Discovered",
+                    "projection": {
+                      "column": "discovered_at",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "last_seen",
+                    "label": "Last Seen",
+                    "projection": {
+                      "column": "last_seen",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No port neighbors",
+                "id": "port_neighbors",
+                "label": "Port Neighbors",
+                "order": 2,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_port_links"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "local_endpoint",
+                    "label": "Local Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "src_ip",
+                      "local_port_column": "src_port_name",
+                      "remote_ip_column": "dst_ip",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "remote_endpoint",
+                    "label": "Remote Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "dst_ip",
+                      "local_port_column": "dst_port_name",
+                      "remote_ip_column": "src_ip",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 adjacencies",
+                "id": "l3_adjacencies",
+                "label": "L3 Adjacencies",
+                "order": 3,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_router_id",
+                    "label": "Neighbor Router ID",
+                    "projection": {
+                      "column": "neighbor_router_id",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_router_id",
+                    "label": "Local Router ID",
+                    "projection": {
+                      "column": "local_router_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "addressless_index",
+                    "label": "Addressless Index",
+                    "projection": {
+                      "column": "addressless_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No OSPF neighbors",
+                "id": "ospf_neighbors",
+                "label": "OSPF Neighbors",
+                "order": 4,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_router_id",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ospf_neighbors"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_as",
+                    "label": "Remote AS",
+                    "projection": {
+                      "column": "remote_as",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "routing_instance",
+                    "label": "Routing Instance",
+                    "projection": {
+                      "column": "routing_instance",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_as",
+                    "label": "Local AS",
+                    "projection": {
+                      "column": "local_as",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_identifier",
+                    "label": "Local Identifier",
+                    "projection": {
+                      "column": "local_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "peer_identifier",
+                    "label": "Peer Identifier",
+                    "projection": {
+                      "column": "peer_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "peer_type",
+                    "label": "Peer Type",
+                    "projection": {
+                      "column": "peer_type",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "bgp_version",
+                    "label": "BGP Version",
+                    "projection": {
+                      "column": "bgp_version",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "established_uptime",
+                    "label": "Established Uptime",
+                    "projection": {
+                      "column": "established_uptime",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "last_received_update_age",
+                    "label": "Last Update Age",
+                    "projection": {
+                      "column": "last_received_update_age",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "description",
+                    "label": "Description",
+                    "projection": {
+                      "column": "description",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No BGP peers",
+                "id": "bgp_peers",
+                "label": "BGP Peers",
+                "order": 5,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_ip",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_bgp_peers"
+                }
+              }
+            ]
+          },
+          "ports": {
+            "show_bullets": true,
+            "sources": [
+              {
+                "actor_column": "actor",
+                "default_type": "topology",
+                "mode_column": "link_mode",
+                "name_column": "name",
+                "role_column": "topology_role",
+                "source": "actor_table",
+                "status_column": "oper_status",
+                "table": "actor_ports",
+                "type_column": "topology_role"
+              }
+            ]
+          },
+          "role": "actor",
+          "size": {
+            "mode": "link_count",
+            "scale": "emphasized"
+          }
+        },
+        "search": {
+          "columns": [
+            "display_name",
+            "sys_name",
+            "management_ip",
+            "vendor",
+            "model"
+          ],
+          "label_keys": [
+            "ospf_router_id"
+          ]
+        }
+      },
+      "load_balancer": {
+        "aggregation_scopes": [
+          "device",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "chassis_ids",
+          "mac_addresses",
+          "ip_addresses",
+          "sys_name"
+        ],
+        "presentation": {
+          "border": {
+            "enabled": true
+          },
+          "color_slot": "info",
+          "icon": "load_balancer",
+          "label": "Load Balancer",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name",
+              "sys_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "stronger"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "management_ip",
+                    "label": "Management IP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "vendor",
+                    "label": "Vendor",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "model",
+                    "label": "Model",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ospf_router_id",
+                    "label": "OSPF Router ID",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ports_total",
+                    "label": "Ports",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "lldp_neighbor_count",
+                    "label": "LLDP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "cdp_neighbor_count",
+                    "label": "CDP",
+                    "max_values": 1
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "oper_status",
+                    "label": "Status",
+                    "projection": {
+                      "column": "oper_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "port_type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "port_type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "link_mode",
+                    "label": "Mode",
+                    "projection": {
+                      "column": "link_mode",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "topology_role",
+                    "label": "Role",
+                    "projection": {
+                      "column": "topology_role",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "array_count",
+                    "id": "vlan_ids",
+                    "label": "VLANs",
+                    "projection": {
+                      "column": "vlan_ids",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "fdb_mac_count",
+                    "label": "FDB",
+                    "projection": {
+                      "column": "fdb_mac_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "link_count",
+                    "label": "Links",
+                    "projection": {
+                      "column": "link_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "neighbor_count",
+                    "label": "Neighbors",
+                    "projection": {
+                      "column": "neighbor_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "neighbor_actor",
+                    "label": "Neighbor",
+                    "projection": {
+                      "actor_column": "neighbor_actor",
+                      "kind": "actor_ref_label"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_port_name",
+                    "label": "Neighbor Port",
+                    "projection": {
+                      "column": "neighbor_port_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_name",
+                    "label": "ifName",
+                    "projection": {
+                      "column": "if_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_descr",
+                    "label": "ifDescr",
+                    "projection": {
+                      "column": "if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_alias",
+                    "label": "Alias",
+                    "projection": {
+                      "column": "if_alias",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "mac",
+                    "label": "MAC",
+                    "projection": {
+                      "column": "mac",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "speed",
+                    "label": "Speed",
+                    "projection": {
+                      "column": "speed",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "stp_state",
+                    "label": "STP",
+                    "projection": {
+                      "column": "stp_state",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "neighbors",
+                    "label": "Neighbor Data",
+                    "projection": {
+                      "column": "neighbors",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "vlans",
+                    "label": "VLAN Data",
+                    "projection": {
+                      "column": "vlans",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "extra",
+                    "label": "Extra",
+                    "projection": {
+                      "column": "extra",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  }
+                ],
+                "id": "ports",
+                "label": "Ports",
+                "order": 1,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ports"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_name",
+                    "label": "Remote Port",
+                    "projection": {
+                      "column": "remote_port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "remote_if_index",
+                    "label": "Remote Port ID",
+                    "projection": {
+                      "column": "remote_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_id",
+                    "label": "Remote Source Port ID",
+                    "projection": {
+                      "column": "remote_port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "confidence",
+                    "label": "Confidence",
+                    "projection": {
+                      "column": "confidence",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "discovered_at",
+                    "label": "Discovered",
+                    "projection": {
+                      "column": "discovered_at",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "last_seen",
+                    "label": "Last Seen",
+                    "projection": {
+                      "column": "last_seen",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No port neighbors",
+                "id": "port_neighbors",
+                "label": "Port Neighbors",
+                "order": 2,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_port_links"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "local_endpoint",
+                    "label": "Local Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "src_ip",
+                      "local_port_column": "src_port_name",
+                      "remote_ip_column": "dst_ip",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "remote_endpoint",
+                    "label": "Remote Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "dst_ip",
+                      "local_port_column": "dst_port_name",
+                      "remote_ip_column": "src_ip",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 adjacencies",
+                "id": "l3_adjacencies",
+                "label": "L3 Adjacencies",
+                "order": 3,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_router_id",
+                    "label": "Neighbor Router ID",
+                    "projection": {
+                      "column": "neighbor_router_id",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_router_id",
+                    "label": "Local Router ID",
+                    "projection": {
+                      "column": "local_router_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "addressless_index",
+                    "label": "Addressless Index",
+                    "projection": {
+                      "column": "addressless_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No OSPF neighbors",
+                "id": "ospf_neighbors",
+                "label": "OSPF Neighbors",
+                "order": 4,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_router_id",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ospf_neighbors"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_as",
+                    "label": "Remote AS",
+                    "projection": {
+                      "column": "remote_as",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "routing_instance",
+                    "label": "Routing Instance",
+                    "projection": {
+                      "column": "routing_instance",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_as",
+                    "label": "Local AS",
+                    "projection": {
+                      "column": "local_as",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_identifier",
+                    "label": "Local Identifier",
+                    "projection": {
+                      "column": "local_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "peer_identifier",
+                    "label": "Peer Identifier",
+                    "projection": {
+                      "column": "peer_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "peer_type",
+                    "label": "Peer Type",
+                    "projection": {
+                      "column": "peer_type",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "bgp_version",
+                    "label": "BGP Version",
+                    "projection": {
+                      "column": "bgp_version",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "established_uptime",
+                    "label": "Established Uptime",
+                    "projection": {
+                      "column": "established_uptime",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "last_received_update_age",
+                    "label": "Last Update Age",
+                    "projection": {
+                      "column": "last_received_update_age",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "description",
+                    "label": "Description",
+                    "projection": {
+                      "column": "description",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No BGP peers",
+                "id": "bgp_peers",
+                "label": "BGP Peers",
+                "order": 5,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_ip",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_bgp_peers"
+                }
+              }
+            ]
+          },
+          "ports": {
+            "show_bullets": true,
+            "sources": [
+              {
+                "actor_column": "actor",
+                "default_type": "topology",
+                "mode_column": "link_mode",
+                "name_column": "name",
+                "role_column": "topology_role",
+                "source": "actor_table",
+                "status_column": "oper_status",
+                "table": "actor_ports",
+                "type_column": "topology_role"
+              }
+            ]
+          },
+          "role": "actor",
+          "size": {
+            "mode": "link_count",
+            "scale": "emphasized"
+          }
+        },
+        "search": {
+          "columns": [
+            "display_name",
+            "sys_name",
+            "management_ip",
+            "vendor",
+            "model"
+          ],
+          "label_keys": [
+            "ospf_router_id"
+          ]
+        }
+      },
+      "phone": {
+        "aggregation_scopes": [
+          "device",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "chassis_ids",
+          "mac_addresses",
+          "ip_addresses",
+          "sys_name"
+        ],
+        "presentation": {
+          "border": {
+            "enabled": true
+          },
+          "color_slot": "neutral",
+          "icon": "phone",
+          "label": "Phone",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name",
+              "sys_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "stronger"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "management_ip",
+                    "label": "Management IP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "vendor",
+                    "label": "Vendor",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "model",
+                    "label": "Model",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ospf_router_id",
+                    "label": "OSPF Router ID",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ports_total",
+                    "label": "Ports",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "lldp_neighbor_count",
+                    "label": "LLDP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "cdp_neighbor_count",
+                    "label": "CDP",
+                    "max_values": 1
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "oper_status",
+                    "label": "Status",
+                    "projection": {
+                      "column": "oper_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "port_type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "port_type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "link_mode",
+                    "label": "Mode",
+                    "projection": {
+                      "column": "link_mode",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "topology_role",
+                    "label": "Role",
+                    "projection": {
+                      "column": "topology_role",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "array_count",
+                    "id": "vlan_ids",
+                    "label": "VLANs",
+                    "projection": {
+                      "column": "vlan_ids",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "fdb_mac_count",
+                    "label": "FDB",
+                    "projection": {
+                      "column": "fdb_mac_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "link_count",
+                    "label": "Links",
+                    "projection": {
+                      "column": "link_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "neighbor_count",
+                    "label": "Neighbors",
+                    "projection": {
+                      "column": "neighbor_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "neighbor_actor",
+                    "label": "Neighbor",
+                    "projection": {
+                      "actor_column": "neighbor_actor",
+                      "kind": "actor_ref_label"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_port_name",
+                    "label": "Neighbor Port",
+                    "projection": {
+                      "column": "neighbor_port_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_name",
+                    "label": "ifName",
+                    "projection": {
+                      "column": "if_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_descr",
+                    "label": "ifDescr",
+                    "projection": {
+                      "column": "if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_alias",
+                    "label": "Alias",
+                    "projection": {
+                      "column": "if_alias",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "mac",
+                    "label": "MAC",
+                    "projection": {
+                      "column": "mac",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "speed",
+                    "label": "Speed",
+                    "projection": {
+                      "column": "speed",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "stp_state",
+                    "label": "STP",
+                    "projection": {
+                      "column": "stp_state",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "neighbors",
+                    "label": "Neighbor Data",
+                    "projection": {
+                      "column": "neighbors",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "vlans",
+                    "label": "VLAN Data",
+                    "projection": {
+                      "column": "vlans",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "extra",
+                    "label": "Extra",
+                    "projection": {
+                      "column": "extra",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  }
+                ],
+                "id": "ports",
+                "label": "Ports",
+                "order": 1,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ports"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_name",
+                    "label": "Remote Port",
+                    "projection": {
+                      "column": "remote_port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "remote_if_index",
+                    "label": "Remote Port ID",
+                    "projection": {
+                      "column": "remote_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_id",
+                    "label": "Remote Source Port ID",
+                    "projection": {
+                      "column": "remote_port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "confidence",
+                    "label": "Confidence",
+                    "projection": {
+                      "column": "confidence",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "discovered_at",
+                    "label": "Discovered",
+                    "projection": {
+                      "column": "discovered_at",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "last_seen",
+                    "label": "Last Seen",
+                    "projection": {
+                      "column": "last_seen",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No port neighbors",
+                "id": "port_neighbors",
+                "label": "Port Neighbors",
+                "order": 2,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_port_links"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "local_endpoint",
+                    "label": "Local Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "src_ip",
+                      "local_port_column": "src_port_name",
+                      "remote_ip_column": "dst_ip",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "remote_endpoint",
+                    "label": "Remote Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "dst_ip",
+                      "local_port_column": "dst_port_name",
+                      "remote_ip_column": "src_ip",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 adjacencies",
+                "id": "l3_adjacencies",
+                "label": "L3 Adjacencies",
+                "order": 3,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_router_id",
+                    "label": "Neighbor Router ID",
+                    "projection": {
+                      "column": "neighbor_router_id",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_router_id",
+                    "label": "Local Router ID",
+                    "projection": {
+                      "column": "local_router_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "addressless_index",
+                    "label": "Addressless Index",
+                    "projection": {
+                      "column": "addressless_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No OSPF neighbors",
+                "id": "ospf_neighbors",
+                "label": "OSPF Neighbors",
+                "order": 4,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_router_id",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ospf_neighbors"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_as",
+                    "label": "Remote AS",
+                    "projection": {
+                      "column": "remote_as",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "routing_instance",
+                    "label": "Routing Instance",
+                    "projection": {
+                      "column": "routing_instance",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_as",
+                    "label": "Local AS",
+                    "projection": {
+                      "column": "local_as",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_identifier",
+                    "label": "Local Identifier",
+                    "projection": {
+                      "column": "local_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "peer_identifier",
+                    "label": "Peer Identifier",
+                    "projection": {
+                      "column": "peer_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "peer_type",
+                    "label": "Peer Type",
+                    "projection": {
+                      "column": "peer_type",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "bgp_version",
+                    "label": "BGP Version",
+                    "projection": {
+                      "column": "bgp_version",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "established_uptime",
+                    "label": "Established Uptime",
+                    "projection": {
+                      "column": "established_uptime",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "last_received_update_age",
+                    "label": "Last Update Age",
+                    "projection": {
+                      "column": "last_received_update_age",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "description",
+                    "label": "Description",
+                    "projection": {
+                      "column": "description",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No BGP peers",
+                "id": "bgp_peers",
+                "label": "BGP Peers",
+                "order": 5,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_ip",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_bgp_peers"
+                }
+              }
+            ]
+          },
+          "ports": {
+            "show_bullets": true,
+            "sources": [
+              {
+                "actor_column": "actor",
+                "default_type": "topology",
+                "mode_column": "link_mode",
+                "name_column": "name",
+                "role_column": "topology_role",
+                "source": "actor_table",
+                "status_column": "oper_status",
+                "table": "actor_ports",
+                "type_column": "topology_role"
+              }
+            ]
+          },
+          "role": "actor",
+          "size": {
+            "mode": "link_count",
+            "scale": "emphasized"
+          }
+        },
+        "search": {
+          "columns": [
+            "display_name",
+            "sys_name",
+            "management_ip",
+            "vendor",
+            "model"
+          ],
+          "label_keys": [
+            "ospf_router_id"
+          ]
+        }
+      },
+      "printer": {
+        "aggregation_scopes": [
+          "device",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "chassis_ids",
+          "mac_addresses",
+          "ip_addresses",
+          "sys_name"
+        ],
+        "presentation": {
+          "border": {
+            "enabled": true
+          },
+          "color_slot": "neutral",
+          "icon": "printer",
+          "label": "Printer",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name",
+              "sys_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "stronger"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "management_ip",
+                    "label": "Management IP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "vendor",
+                    "label": "Vendor",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "model",
+                    "label": "Model",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ospf_router_id",
+                    "label": "OSPF Router ID",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ports_total",
+                    "label": "Ports",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "lldp_neighbor_count",
+                    "label": "LLDP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "cdp_neighbor_count",
+                    "label": "CDP",
+                    "max_values": 1
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "oper_status",
+                    "label": "Status",
+                    "projection": {
+                      "column": "oper_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "port_type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "port_type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "link_mode",
+                    "label": "Mode",
+                    "projection": {
+                      "column": "link_mode",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "topology_role",
+                    "label": "Role",
+                    "projection": {
+                      "column": "topology_role",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "array_count",
+                    "id": "vlan_ids",
+                    "label": "VLANs",
+                    "projection": {
+                      "column": "vlan_ids",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "fdb_mac_count",
+                    "label": "FDB",
+                    "projection": {
+                      "column": "fdb_mac_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "link_count",
+                    "label": "Links",
+                    "projection": {
+                      "column": "link_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "neighbor_count",
+                    "label": "Neighbors",
+                    "projection": {
+                      "column": "neighbor_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "neighbor_actor",
+                    "label": "Neighbor",
+                    "projection": {
+                      "actor_column": "neighbor_actor",
+                      "kind": "actor_ref_label"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_port_name",
+                    "label": "Neighbor Port",
+                    "projection": {
+                      "column": "neighbor_port_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_name",
+                    "label": "ifName",
+                    "projection": {
+                      "column": "if_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_descr",
+                    "label": "ifDescr",
+                    "projection": {
+                      "column": "if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_alias",
+                    "label": "Alias",
+                    "projection": {
+                      "column": "if_alias",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "mac",
+                    "label": "MAC",
+                    "projection": {
+                      "column": "mac",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "speed",
+                    "label": "Speed",
+                    "projection": {
+                      "column": "speed",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "stp_state",
+                    "label": "STP",
+                    "projection": {
+                      "column": "stp_state",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "neighbors",
+                    "label": "Neighbor Data",
+                    "projection": {
+                      "column": "neighbors",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "vlans",
+                    "label": "VLAN Data",
+                    "projection": {
+                      "column": "vlans",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "extra",
+                    "label": "Extra",
+                    "projection": {
+                      "column": "extra",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  }
+                ],
+                "id": "ports",
+                "label": "Ports",
+                "order": 1,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ports"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_name",
+                    "label": "Remote Port",
+                    "projection": {
+                      "column": "remote_port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "remote_if_index",
+                    "label": "Remote Port ID",
+                    "projection": {
+                      "column": "remote_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_id",
+                    "label": "Remote Source Port ID",
+                    "projection": {
+                      "column": "remote_port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "confidence",
+                    "label": "Confidence",
+                    "projection": {
+                      "column": "confidence",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "discovered_at",
+                    "label": "Discovered",
+                    "projection": {
+                      "column": "discovered_at",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "last_seen",
+                    "label": "Last Seen",
+                    "projection": {
+                      "column": "last_seen",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No port neighbors",
+                "id": "port_neighbors",
+                "label": "Port Neighbors",
+                "order": 2,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_port_links"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "local_endpoint",
+                    "label": "Local Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "src_ip",
+                      "local_port_column": "src_port_name",
+                      "remote_ip_column": "dst_ip",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "remote_endpoint",
+                    "label": "Remote Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "dst_ip",
+                      "local_port_column": "dst_port_name",
+                      "remote_ip_column": "src_ip",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 adjacencies",
+                "id": "l3_adjacencies",
+                "label": "L3 Adjacencies",
+                "order": 3,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_router_id",
+                    "label": "Neighbor Router ID",
+                    "projection": {
+                      "column": "neighbor_router_id",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_router_id",
+                    "label": "Local Router ID",
+                    "projection": {
+                      "column": "local_router_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "addressless_index",
+                    "label": "Addressless Index",
+                    "projection": {
+                      "column": "addressless_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No OSPF neighbors",
+                "id": "ospf_neighbors",
+                "label": "OSPF Neighbors",
+                "order": 4,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_router_id",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ospf_neighbors"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_as",
+                    "label": "Remote AS",
+                    "projection": {
+                      "column": "remote_as",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "routing_instance",
+                    "label": "Routing Instance",
+                    "projection": {
+                      "column": "routing_instance",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_as",
+                    "label": "Local AS",
+                    "projection": {
+                      "column": "local_as",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_identifier",
+                    "label": "Local Identifier",
+                    "projection": {
+                      "column": "local_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "peer_identifier",
+                    "label": "Peer Identifier",
+                    "projection": {
+                      "column": "peer_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "peer_type",
+                    "label": "Peer Type",
+                    "projection": {
+                      "column": "peer_type",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "bgp_version",
+                    "label": "BGP Version",
+                    "projection": {
+                      "column": "bgp_version",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "established_uptime",
+                    "label": "Established Uptime",
+                    "projection": {
+                      "column": "established_uptime",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "last_received_update_age",
+                    "label": "Last Update Age",
+                    "projection": {
+                      "column": "last_received_update_age",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "description",
+                    "label": "Description",
+                    "projection": {
+                      "column": "description",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No BGP peers",
+                "id": "bgp_peers",
+                "label": "BGP Peers",
+                "order": 5,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_ip",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_bgp_peers"
+                }
+              }
+            ]
+          },
+          "ports": {
+            "show_bullets": true,
+            "sources": [
+              {
+                "actor_column": "actor",
+                "default_type": "topology",
+                "mode_column": "link_mode",
+                "name_column": "name",
+                "role_column": "topology_role",
+                "source": "actor_table",
+                "status_column": "oper_status",
+                "table": "actor_ports",
+                "type_column": "topology_role"
+              }
+            ]
+          },
+          "role": "actor",
+          "size": {
+            "mode": "link_count",
+            "scale": "emphasized"
+          }
+        },
+        "search": {
+          "columns": [
+            "display_name",
+            "sys_name",
+            "management_ip",
+            "vendor",
+            "model"
+          ],
+          "label_keys": [
+            "ospf_router_id"
+          ]
+        }
+      },
+      "router": {
+        "aggregation_scopes": [
+          "device",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "chassis_ids",
+          "mac_addresses",
+          "ip_addresses",
+          "sys_name"
+        ],
+        "presentation": {
+          "border": {
+            "enabled": true
+          },
+          "color_slot": "primary",
+          "icon": "router",
+          "label": "Router",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name",
+              "sys_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "stronger"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "management_ip",
+                    "label": "Management IP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "vendor",
+                    "label": "Vendor",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "model",
+                    "label": "Model",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ospf_router_id",
+                    "label": "OSPF Router ID",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ports_total",
+                    "label": "Ports",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "lldp_neighbor_count",
+                    "label": "LLDP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "cdp_neighbor_count",
+                    "label": "CDP",
+                    "max_values": 1
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "oper_status",
+                    "label": "Status",
+                    "projection": {
+                      "column": "oper_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "port_type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "port_type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "link_mode",
+                    "label": "Mode",
+                    "projection": {
+                      "column": "link_mode",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "topology_role",
+                    "label": "Role",
+                    "projection": {
+                      "column": "topology_role",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "array_count",
+                    "id": "vlan_ids",
+                    "label": "VLANs",
+                    "projection": {
+                      "column": "vlan_ids",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "fdb_mac_count",
+                    "label": "FDB",
+                    "projection": {
+                      "column": "fdb_mac_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "link_count",
+                    "label": "Links",
+                    "projection": {
+                      "column": "link_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "neighbor_count",
+                    "label": "Neighbors",
+                    "projection": {
+                      "column": "neighbor_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "neighbor_actor",
+                    "label": "Neighbor",
+                    "projection": {
+                      "actor_column": "neighbor_actor",
+                      "kind": "actor_ref_label"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_port_name",
+                    "label": "Neighbor Port",
+                    "projection": {
+                      "column": "neighbor_port_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_name",
+                    "label": "ifName",
+                    "projection": {
+                      "column": "if_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_descr",
+                    "label": "ifDescr",
+                    "projection": {
+                      "column": "if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_alias",
+                    "label": "Alias",
+                    "projection": {
+                      "column": "if_alias",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "mac",
+                    "label": "MAC",
+                    "projection": {
+                      "column": "mac",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "speed",
+                    "label": "Speed",
+                    "projection": {
+                      "column": "speed",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "stp_state",
+                    "label": "STP",
+                    "projection": {
+                      "column": "stp_state",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "neighbors",
+                    "label": "Neighbor Data",
+                    "projection": {
+                      "column": "neighbors",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "vlans",
+                    "label": "VLAN Data",
+                    "projection": {
+                      "column": "vlans",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "extra",
+                    "label": "Extra",
+                    "projection": {
+                      "column": "extra",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  }
+                ],
+                "id": "ports",
+                "label": "Ports",
+                "order": 1,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ports"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_name",
+                    "label": "Remote Port",
+                    "projection": {
+                      "column": "remote_port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "remote_if_index",
+                    "label": "Remote Port ID",
+                    "projection": {
+                      "column": "remote_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_id",
+                    "label": "Remote Source Port ID",
+                    "projection": {
+                      "column": "remote_port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "confidence",
+                    "label": "Confidence",
+                    "projection": {
+                      "column": "confidence",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "discovered_at",
+                    "label": "Discovered",
+                    "projection": {
+                      "column": "discovered_at",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "last_seen",
+                    "label": "Last Seen",
+                    "projection": {
+                      "column": "last_seen",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No port neighbors",
+                "id": "port_neighbors",
+                "label": "Port Neighbors",
+                "order": 2,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_port_links"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "local_endpoint",
+                    "label": "Local Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "src_ip",
+                      "local_port_column": "src_port_name",
+                      "remote_ip_column": "dst_ip",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "remote_endpoint",
+                    "label": "Remote Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "dst_ip",
+                      "local_port_column": "dst_port_name",
+                      "remote_ip_column": "src_ip",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 adjacencies",
+                "id": "l3_adjacencies",
+                "label": "L3 Adjacencies",
+                "order": 3,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_router_id",
+                    "label": "Neighbor Router ID",
+                    "projection": {
+                      "column": "neighbor_router_id",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_router_id",
+                    "label": "Local Router ID",
+                    "projection": {
+                      "column": "local_router_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "addressless_index",
+                    "label": "Addressless Index",
+                    "projection": {
+                      "column": "addressless_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No OSPF neighbors",
+                "id": "ospf_neighbors",
+                "label": "OSPF Neighbors",
+                "order": 4,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_router_id",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ospf_neighbors"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_as",
+                    "label": "Remote AS",
+                    "projection": {
+                      "column": "remote_as",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "routing_instance",
+                    "label": "Routing Instance",
+                    "projection": {
+                      "column": "routing_instance",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_as",
+                    "label": "Local AS",
+                    "projection": {
+                      "column": "local_as",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_identifier",
+                    "label": "Local Identifier",
+                    "projection": {
+                      "column": "local_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "peer_identifier",
+                    "label": "Peer Identifier",
+                    "projection": {
+                      "column": "peer_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "peer_type",
+                    "label": "Peer Type",
+                    "projection": {
+                      "column": "peer_type",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "bgp_version",
+                    "label": "BGP Version",
+                    "projection": {
+                      "column": "bgp_version",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "established_uptime",
+                    "label": "Established Uptime",
+                    "projection": {
+                      "column": "established_uptime",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "last_received_update_age",
+                    "label": "Last Update Age",
+                    "projection": {
+                      "column": "last_received_update_age",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "description",
+                    "label": "Description",
+                    "projection": {
+                      "column": "description",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No BGP peers",
+                "id": "bgp_peers",
+                "label": "BGP Peers",
+                "order": 5,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_ip",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_bgp_peers"
+                }
+              }
+            ]
+          },
+          "ports": {
+            "show_bullets": true,
+            "sources": [
+              {
+                "actor_column": "actor",
+                "default_type": "topology",
+                "mode_column": "link_mode",
+                "name_column": "name",
+                "role_column": "topology_role",
+                "source": "actor_table",
+                "status_column": "oper_status",
+                "table": "actor_ports",
+                "type_column": "topology_role"
+              }
+            ]
+          },
+          "role": "actor",
+          "size": {
+            "mode": "link_count",
+            "scale": "emphasized"
+          }
+        },
+        "search": {
+          "columns": [
+            "display_name",
+            "sys_name",
+            "management_ip",
+            "vendor",
+            "model"
+          ],
+          "label_keys": [
+            "ospf_router_id"
+          ]
+        }
+      },
+      "segment": {
+        "aggregation_scopes": [
+          "segment",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "id"
+        ],
+        "parent_identity": [
+          "parent_devices"
+        ],
+        "presentation": {
+          "color_slot": "dim",
+          "icon": "segment",
+          "label": "Network segment",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "weakest"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ip_address",
+                    "label": "IP",
+                    "max_values": 2
+                  },
+                  {
+                    "key": "mac_address",
+                    "label": "MAC",
+                    "max_values": 2
+                  },
+                  {
+                    "key": "hostname",
+                    "label": "Hostname",
+                    "max_values": 2
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_port",
+                    "label": "Local Port",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_port_column": "src_port_name",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port",
+                    "label": "Remote Port",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_port_column": "dst_port_name",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "direction",
+                    "label": "Direction",
+                    "projection": {
+                      "column": "direction",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  }
+                ],
+                "id": "links",
+                "label": "Links",
+                "order": 1,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "mode": "incident_link",
+                  "src_actor_column": "src_actor"
+                },
+                "source": {
+                  "kind": "links"
+                }
+              }
+            ]
+          },
+          "role": "group",
+          "size": {
+            "mode": "fixed",
+            "scale": "compact"
+          }
+        },
+        "search": {
+          "enabled": false
+        }
+      },
+      "server": {
+        "aggregation_scopes": [
+          "device",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "chassis_ids",
+          "mac_addresses",
+          "ip_addresses",
+          "sys_name"
+        ],
+        "presentation": {
+          "border": {
+            "enabled": true
+          },
+          "color_slot": "secondary",
+          "icon": "server",
+          "label": "Server",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name",
+              "sys_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "stronger"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "management_ip",
+                    "label": "Management IP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "vendor",
+                    "label": "Vendor",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "model",
+                    "label": "Model",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ospf_router_id",
+                    "label": "OSPF Router ID",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ports_total",
+                    "label": "Ports",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "lldp_neighbor_count",
+                    "label": "LLDP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "cdp_neighbor_count",
+                    "label": "CDP",
+                    "max_values": 1
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "oper_status",
+                    "label": "Status",
+                    "projection": {
+                      "column": "oper_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "port_type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "port_type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "link_mode",
+                    "label": "Mode",
+                    "projection": {
+                      "column": "link_mode",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "topology_role",
+                    "label": "Role",
+                    "projection": {
+                      "column": "topology_role",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "array_count",
+                    "id": "vlan_ids",
+                    "label": "VLANs",
+                    "projection": {
+                      "column": "vlan_ids",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "fdb_mac_count",
+                    "label": "FDB",
+                    "projection": {
+                      "column": "fdb_mac_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "link_count",
+                    "label": "Links",
+                    "projection": {
+                      "column": "link_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "neighbor_count",
+                    "label": "Neighbors",
+                    "projection": {
+                      "column": "neighbor_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "neighbor_actor",
+                    "label": "Neighbor",
+                    "projection": {
+                      "actor_column": "neighbor_actor",
+                      "kind": "actor_ref_label"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_port_name",
+                    "label": "Neighbor Port",
+                    "projection": {
+                      "column": "neighbor_port_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_name",
+                    "label": "ifName",
+                    "projection": {
+                      "column": "if_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_descr",
+                    "label": "ifDescr",
+                    "projection": {
+                      "column": "if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_alias",
+                    "label": "Alias",
+                    "projection": {
+                      "column": "if_alias",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "mac",
+                    "label": "MAC",
+                    "projection": {
+                      "column": "mac",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "speed",
+                    "label": "Speed",
+                    "projection": {
+                      "column": "speed",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "stp_state",
+                    "label": "STP",
+                    "projection": {
+                      "column": "stp_state",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "neighbors",
+                    "label": "Neighbor Data",
+                    "projection": {
+                      "column": "neighbors",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "vlans",
+                    "label": "VLAN Data",
+                    "projection": {
+                      "column": "vlans",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "extra",
+                    "label": "Extra",
+                    "projection": {
+                      "column": "extra",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  }
+                ],
+                "id": "ports",
+                "label": "Ports",
+                "order": 1,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ports"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_name",
+                    "label": "Remote Port",
+                    "projection": {
+                      "column": "remote_port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "remote_if_index",
+                    "label": "Remote Port ID",
+                    "projection": {
+                      "column": "remote_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_id",
+                    "label": "Remote Source Port ID",
+                    "projection": {
+                      "column": "remote_port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "confidence",
+                    "label": "Confidence",
+                    "projection": {
+                      "column": "confidence",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "discovered_at",
+                    "label": "Discovered",
+                    "projection": {
+                      "column": "discovered_at",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "last_seen",
+                    "label": "Last Seen",
+                    "projection": {
+                      "column": "last_seen",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No port neighbors",
+                "id": "port_neighbors",
+                "label": "Port Neighbors",
+                "order": 2,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_port_links"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "local_endpoint",
+                    "label": "Local Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "src_ip",
+                      "local_port_column": "src_port_name",
+                      "remote_ip_column": "dst_ip",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "remote_endpoint",
+                    "label": "Remote Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "dst_ip",
+                      "local_port_column": "dst_port_name",
+                      "remote_ip_column": "src_ip",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 adjacencies",
+                "id": "l3_adjacencies",
+                "label": "L3 Adjacencies",
+                "order": 3,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_router_id",
+                    "label": "Neighbor Router ID",
+                    "projection": {
+                      "column": "neighbor_router_id",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_router_id",
+                    "label": "Local Router ID",
+                    "projection": {
+                      "column": "local_router_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "addressless_index",
+                    "label": "Addressless Index",
+                    "projection": {
+                      "column": "addressless_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No OSPF neighbors",
+                "id": "ospf_neighbors",
+                "label": "OSPF Neighbors",
+                "order": 4,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_router_id",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ospf_neighbors"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_as",
+                    "label": "Remote AS",
+                    "projection": {
+                      "column": "remote_as",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "routing_instance",
+                    "label": "Routing Instance",
+                    "projection": {
+                      "column": "routing_instance",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_as",
+                    "label": "Local AS",
+                    "projection": {
+                      "column": "local_as",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_identifier",
+                    "label": "Local Identifier",
+                    "projection": {
+                      "column": "local_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "peer_identifier",
+                    "label": "Peer Identifier",
+                    "projection": {
+                      "column": "peer_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "peer_type",
+                    "label": "Peer Type",
+                    "projection": {
+                      "column": "peer_type",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "bgp_version",
+                    "label": "BGP Version",
+                    "projection": {
+                      "column": "bgp_version",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "established_uptime",
+                    "label": "Established Uptime",
+                    "projection": {
+                      "column": "established_uptime",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "last_received_update_age",
+                    "label": "Last Update Age",
+                    "projection": {
+                      "column": "last_received_update_age",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "description",
+                    "label": "Description",
+                    "projection": {
+                      "column": "description",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No BGP peers",
+                "id": "bgp_peers",
+                "label": "BGP Peers",
+                "order": 5,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_ip",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_bgp_peers"
+                }
+              }
+            ]
+          },
+          "ports": {
+            "show_bullets": true,
+            "sources": [
+              {
+                "actor_column": "actor",
+                "default_type": "topology",
+                "mode_column": "link_mode",
+                "name_column": "name",
+                "role_column": "topology_role",
+                "source": "actor_table",
+                "status_column": "oper_status",
+                "table": "actor_ports",
+                "type_column": "topology_role"
+              }
+            ]
+          },
+          "role": "actor",
+          "size": {
+            "mode": "link_count",
+            "scale": "emphasized"
+          }
+        },
+        "search": {
+          "columns": [
+            "display_name",
+            "sys_name",
+            "management_ip",
+            "vendor",
+            "model"
+          ],
+          "label_keys": [
+            "ospf_router_id"
+          ]
+        }
+      },
+      "storage": {
+        "aggregation_scopes": [
+          "device",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "chassis_ids",
+          "mac_addresses",
+          "ip_addresses",
+          "sys_name"
+        ],
+        "presentation": {
+          "border": {
+            "enabled": true
+          },
+          "color_slot": "secondary",
+          "icon": "storage",
+          "label": "Storage",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name",
+              "sys_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "stronger"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "management_ip",
+                    "label": "Management IP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "vendor",
+                    "label": "Vendor",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "model",
+                    "label": "Model",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ospf_router_id",
+                    "label": "OSPF Router ID",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ports_total",
+                    "label": "Ports",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "lldp_neighbor_count",
+                    "label": "LLDP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "cdp_neighbor_count",
+                    "label": "CDP",
+                    "max_values": 1
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "oper_status",
+                    "label": "Status",
+                    "projection": {
+                      "column": "oper_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "port_type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "port_type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "link_mode",
+                    "label": "Mode",
+                    "projection": {
+                      "column": "link_mode",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "topology_role",
+                    "label": "Role",
+                    "projection": {
+                      "column": "topology_role",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "array_count",
+                    "id": "vlan_ids",
+                    "label": "VLANs",
+                    "projection": {
+                      "column": "vlan_ids",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "fdb_mac_count",
+                    "label": "FDB",
+                    "projection": {
+                      "column": "fdb_mac_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "link_count",
+                    "label": "Links",
+                    "projection": {
+                      "column": "link_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "neighbor_count",
+                    "label": "Neighbors",
+                    "projection": {
+                      "column": "neighbor_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "neighbor_actor",
+                    "label": "Neighbor",
+                    "projection": {
+                      "actor_column": "neighbor_actor",
+                      "kind": "actor_ref_label"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_port_name",
+                    "label": "Neighbor Port",
+                    "projection": {
+                      "column": "neighbor_port_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_name",
+                    "label": "ifName",
+                    "projection": {
+                      "column": "if_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_descr",
+                    "label": "ifDescr",
+                    "projection": {
+                      "column": "if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_alias",
+                    "label": "Alias",
+                    "projection": {
+                      "column": "if_alias",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "mac",
+                    "label": "MAC",
+                    "projection": {
+                      "column": "mac",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "speed",
+                    "label": "Speed",
+                    "projection": {
+                      "column": "speed",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "stp_state",
+                    "label": "STP",
+                    "projection": {
+                      "column": "stp_state",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "neighbors",
+                    "label": "Neighbor Data",
+                    "projection": {
+                      "column": "neighbors",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "vlans",
+                    "label": "VLAN Data",
+                    "projection": {
+                      "column": "vlans",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "extra",
+                    "label": "Extra",
+                    "projection": {
+                      "column": "extra",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  }
+                ],
+                "id": "ports",
+                "label": "Ports",
+                "order": 1,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ports"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_name",
+                    "label": "Remote Port",
+                    "projection": {
+                      "column": "remote_port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "remote_if_index",
+                    "label": "Remote Port ID",
+                    "projection": {
+                      "column": "remote_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_id",
+                    "label": "Remote Source Port ID",
+                    "projection": {
+                      "column": "remote_port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "confidence",
+                    "label": "Confidence",
+                    "projection": {
+                      "column": "confidence",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "discovered_at",
+                    "label": "Discovered",
+                    "projection": {
+                      "column": "discovered_at",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "last_seen",
+                    "label": "Last Seen",
+                    "projection": {
+                      "column": "last_seen",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No port neighbors",
+                "id": "port_neighbors",
+                "label": "Port Neighbors",
+                "order": 2,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_port_links"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "local_endpoint",
+                    "label": "Local Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "src_ip",
+                      "local_port_column": "src_port_name",
+                      "remote_ip_column": "dst_ip",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "remote_endpoint",
+                    "label": "Remote Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "dst_ip",
+                      "local_port_column": "dst_port_name",
+                      "remote_ip_column": "src_ip",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 adjacencies",
+                "id": "l3_adjacencies",
+                "label": "L3 Adjacencies",
+                "order": 3,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_router_id",
+                    "label": "Neighbor Router ID",
+                    "projection": {
+                      "column": "neighbor_router_id",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_router_id",
+                    "label": "Local Router ID",
+                    "projection": {
+                      "column": "local_router_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "addressless_index",
+                    "label": "Addressless Index",
+                    "projection": {
+                      "column": "addressless_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No OSPF neighbors",
+                "id": "ospf_neighbors",
+                "label": "OSPF Neighbors",
+                "order": 4,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_router_id",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ospf_neighbors"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_as",
+                    "label": "Remote AS",
+                    "projection": {
+                      "column": "remote_as",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "routing_instance",
+                    "label": "Routing Instance",
+                    "projection": {
+                      "column": "routing_instance",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_as",
+                    "label": "Local AS",
+                    "projection": {
+                      "column": "local_as",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_identifier",
+                    "label": "Local Identifier",
+                    "projection": {
+                      "column": "local_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "peer_identifier",
+                    "label": "Peer Identifier",
+                    "projection": {
+                      "column": "peer_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "peer_type",
+                    "label": "Peer Type",
+                    "projection": {
+                      "column": "peer_type",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "bgp_version",
+                    "label": "BGP Version",
+                    "projection": {
+                      "column": "bgp_version",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "established_uptime",
+                    "label": "Established Uptime",
+                    "projection": {
+                      "column": "established_uptime",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "last_received_update_age",
+                    "label": "Last Update Age",
+                    "projection": {
+                      "column": "last_received_update_age",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "description",
+                    "label": "Description",
+                    "projection": {
+                      "column": "description",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No BGP peers",
+                "id": "bgp_peers",
+                "label": "BGP Peers",
+                "order": 5,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_ip",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_bgp_peers"
+                }
+              }
+            ]
+          },
+          "ports": {
+            "show_bullets": true,
+            "sources": [
+              {
+                "actor_column": "actor",
+                "default_type": "topology",
+                "mode_column": "link_mode",
+                "name_column": "name",
+                "role_column": "topology_role",
+                "source": "actor_table",
+                "status_column": "oper_status",
+                "table": "actor_ports",
+                "type_column": "topology_role"
+              }
+            ]
+          },
+          "role": "actor",
+          "size": {
+            "mode": "link_count",
+            "scale": "emphasized"
+          }
+        },
+        "search": {
+          "columns": [
+            "display_name",
+            "sys_name",
+            "management_ip",
+            "vendor",
+            "model"
+          ],
+          "label_keys": [
+            "ospf_router_id"
+          ]
+        }
+      },
+      "switch": {
+        "aggregation_scopes": [
+          "device",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "chassis_ids",
+          "mac_addresses",
+          "ip_addresses",
+          "sys_name"
+        ],
+        "presentation": {
+          "border": {
+            "enabled": true
+          },
+          "color_slot": "primary",
+          "icon": "switch",
+          "label": "Switch",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name",
+              "sys_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "stronger"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "management_ip",
+                    "label": "Management IP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "vendor",
+                    "label": "Vendor",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "model",
+                    "label": "Model",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ospf_router_id",
+                    "label": "OSPF Router ID",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ports_total",
+                    "label": "Ports",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "lldp_neighbor_count",
+                    "label": "LLDP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "cdp_neighbor_count",
+                    "label": "CDP",
+                    "max_values": 1
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "oper_status",
+                    "label": "Status",
+                    "projection": {
+                      "column": "oper_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "port_type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "port_type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "link_mode",
+                    "label": "Mode",
+                    "projection": {
+                      "column": "link_mode",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "topology_role",
+                    "label": "Role",
+                    "projection": {
+                      "column": "topology_role",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "array_count",
+                    "id": "vlan_ids",
+                    "label": "VLANs",
+                    "projection": {
+                      "column": "vlan_ids",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "fdb_mac_count",
+                    "label": "FDB",
+                    "projection": {
+                      "column": "fdb_mac_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "link_count",
+                    "label": "Links",
+                    "projection": {
+                      "column": "link_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "neighbor_count",
+                    "label": "Neighbors",
+                    "projection": {
+                      "column": "neighbor_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "neighbor_actor",
+                    "label": "Neighbor",
+                    "projection": {
+                      "actor_column": "neighbor_actor",
+                      "kind": "actor_ref_label"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_port_name",
+                    "label": "Neighbor Port",
+                    "projection": {
+                      "column": "neighbor_port_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_name",
+                    "label": "ifName",
+                    "projection": {
+                      "column": "if_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_descr",
+                    "label": "ifDescr",
+                    "projection": {
+                      "column": "if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_alias",
+                    "label": "Alias",
+                    "projection": {
+                      "column": "if_alias",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "mac",
+                    "label": "MAC",
+                    "projection": {
+                      "column": "mac",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "speed",
+                    "label": "Speed",
+                    "projection": {
+                      "column": "speed",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "stp_state",
+                    "label": "STP",
+                    "projection": {
+                      "column": "stp_state",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "neighbors",
+                    "label": "Neighbor Data",
+                    "projection": {
+                      "column": "neighbors",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "vlans",
+                    "label": "VLAN Data",
+                    "projection": {
+                      "column": "vlans",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "extra",
+                    "label": "Extra",
+                    "projection": {
+                      "column": "extra",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  }
+                ],
+                "id": "ports",
+                "label": "Ports",
+                "order": 1,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ports"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_name",
+                    "label": "Remote Port",
+                    "projection": {
+                      "column": "remote_port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "remote_if_index",
+                    "label": "Remote Port ID",
+                    "projection": {
+                      "column": "remote_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_id",
+                    "label": "Remote Source Port ID",
+                    "projection": {
+                      "column": "remote_port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "confidence",
+                    "label": "Confidence",
+                    "projection": {
+                      "column": "confidence",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "discovered_at",
+                    "label": "Discovered",
+                    "projection": {
+                      "column": "discovered_at",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "last_seen",
+                    "label": "Last Seen",
+                    "projection": {
+                      "column": "last_seen",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No port neighbors",
+                "id": "port_neighbors",
+                "label": "Port Neighbors",
+                "order": 2,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_port_links"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "local_endpoint",
+                    "label": "Local Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "src_ip",
+                      "local_port_column": "src_port_name",
+                      "remote_ip_column": "dst_ip",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "remote_endpoint",
+                    "label": "Remote Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "dst_ip",
+                      "local_port_column": "dst_port_name",
+                      "remote_ip_column": "src_ip",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 adjacencies",
+                "id": "l3_adjacencies",
+                "label": "L3 Adjacencies",
+                "order": 3,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_router_id",
+                    "label": "Neighbor Router ID",
+                    "projection": {
+                      "column": "neighbor_router_id",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_router_id",
+                    "label": "Local Router ID",
+                    "projection": {
+                      "column": "local_router_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "addressless_index",
+                    "label": "Addressless Index",
+                    "projection": {
+                      "column": "addressless_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No OSPF neighbors",
+                "id": "ospf_neighbors",
+                "label": "OSPF Neighbors",
+                "order": 4,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_router_id",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ospf_neighbors"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_as",
+                    "label": "Remote AS",
+                    "projection": {
+                      "column": "remote_as",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "routing_instance",
+                    "label": "Routing Instance",
+                    "projection": {
+                      "column": "routing_instance",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_as",
+                    "label": "Local AS",
+                    "projection": {
+                      "column": "local_as",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_identifier",
+                    "label": "Local Identifier",
+                    "projection": {
+                      "column": "local_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "peer_identifier",
+                    "label": "Peer Identifier",
+                    "projection": {
+                      "column": "peer_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "peer_type",
+                    "label": "Peer Type",
+                    "projection": {
+                      "column": "peer_type",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "bgp_version",
+                    "label": "BGP Version",
+                    "projection": {
+                      "column": "bgp_version",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "established_uptime",
+                    "label": "Established Uptime",
+                    "projection": {
+                      "column": "established_uptime",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "last_received_update_age",
+                    "label": "Last Update Age",
+                    "projection": {
+                      "column": "last_received_update_age",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "description",
+                    "label": "Description",
+                    "projection": {
+                      "column": "description",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No BGP peers",
+                "id": "bgp_peers",
+                "label": "BGP Peers",
+                "order": 5,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_ip",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_bgp_peers"
+                }
+              }
+            ]
+          },
+          "ports": {
+            "show_bullets": true,
+            "sources": [
+              {
+                "actor_column": "actor",
+                "default_type": "topology",
+                "mode_column": "link_mode",
+                "name_column": "name",
+                "role_column": "topology_role",
+                "source": "actor_table",
+                "status_column": "oper_status",
+                "table": "actor_ports",
+                "type_column": "topology_role"
+              }
+            ]
+          },
+          "role": "actor",
+          "size": {
+            "mode": "link_count",
+            "scale": "emphasized"
+          }
+        },
+        "search": {
+          "columns": [
+            "display_name",
+            "sys_name",
+            "management_ip",
+            "vendor",
+            "model"
+          ],
+          "label_keys": [
+            "ospf_router_id"
+          ]
+        }
+      },
+      "ups": {
+        "aggregation_scopes": [
+          "device",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "chassis_ids",
+          "mac_addresses",
+          "ip_addresses",
+          "sys_name"
+        ],
+        "presentation": {
+          "border": {
+            "enabled": true
+          },
+          "color_slot": "structural",
+          "icon": "ups",
+          "label": "UPS",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name",
+              "sys_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "stronger"
+          },
+          "modal": {
+            "labels": {
+              "identification": {
+                "fields": [
+                  {
+                    "key": "display_name",
+                    "label": "Name",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "management_ip",
+                    "label": "Management IP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "vendor",
+                    "label": "Vendor",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "model",
+                    "label": "Model",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ospf_router_id",
+                    "label": "OSPF Router ID",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "ports_total",
+                    "label": "Ports",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "lldp_neighbor_count",
+                    "label": "LLDP",
+                    "max_values": 1
+                  },
+                  {
+                    "key": "cdp_neighbor_count",
+                    "label": "CDP",
+                    "max_values": 1
+                  }
+                ]
+              },
+              "table": "actor_labels"
+            },
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "oper_status",
+                    "label": "Status",
+                    "projection": {
+                      "column": "oper_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "port_type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "port_type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "link_mode",
+                    "label": "Mode",
+                    "projection": {
+                      "column": "link_mode",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "topology_role",
+                    "label": "Role",
+                    "projection": {
+                      "column": "topology_role",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "array_count",
+                    "id": "vlan_ids",
+                    "label": "VLANs",
+                    "projection": {
+                      "column": "vlan_ids",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "fdb_mac_count",
+                    "label": "FDB",
+                    "projection": {
+                      "column": "fdb_mac_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "link_count",
+                    "label": "Links",
+                    "projection": {
+                      "column": "link_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "neighbor_count",
+                    "label": "Neighbors",
+                    "projection": {
+                      "column": "neighbor_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "neighbor_actor",
+                    "label": "Neighbor",
+                    "projection": {
+                      "actor_column": "neighbor_actor",
+                      "kind": "actor_ref_label"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_port_name",
+                    "label": "Neighbor Port",
+                    "projection": {
+                      "column": "neighbor_port_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_name",
+                    "label": "ifName",
+                    "projection": {
+                      "column": "if_name",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_descr",
+                    "label": "ifDescr",
+                    "projection": {
+                      "column": "if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "if_alias",
+                    "label": "Alias",
+                    "projection": {
+                      "column": "if_alias",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "mac",
+                    "label": "MAC",
+                    "projection": {
+                      "column": "mac",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "speed",
+                    "label": "Speed",
+                    "projection": {
+                      "column": "speed",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "stp_state",
+                    "label": "STP",
+                    "projection": {
+                      "column": "stp_state",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "neighbors",
+                    "label": "Neighbor Data",
+                    "projection": {
+                      "column": "neighbors",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "vlans",
+                    "label": "VLAN Data",
+                    "projection": {
+                      "column": "vlans",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  },
+                  {
+                    "cell": "debug_json",
+                    "id": "extra",
+                    "label": "Extra",
+                    "projection": {
+                      "column": "extra",
+                      "kind": "direct"
+                    },
+                    "visibility": "debug"
+                  }
+                ],
+                "id": "ports",
+                "label": "Ports",
+                "order": 1,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ports"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "number",
+                    "id": "if_index",
+                    "label": "Port ID",
+                    "projection": {
+                      "column": "if_index",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_name",
+                    "label": "Port",
+                    "projection": {
+                      "column": "port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_name",
+                    "label": "Remote Port",
+                    "projection": {
+                      "column": "remote_port_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "type",
+                    "label": "Type",
+                    "projection": {
+                      "column": "type",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "evidence_count",
+                    "label": "Evidence",
+                    "projection": {
+                      "column": "evidence_count",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "protocol",
+                    "label": "Protocol",
+                    "projection": {
+                      "column": "protocol",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "number",
+                    "id": "remote_if_index",
+                    "label": "Remote Port ID",
+                    "projection": {
+                      "column": "remote_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "port_id",
+                    "label": "Source Port ID",
+                    "projection": {
+                      "column": "port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_port_id",
+                    "label": "Remote Source Port ID",
+                    "projection": {
+                      "column": "remote_port_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "confidence",
+                    "label": "Confidence",
+                    "projection": {
+                      "column": "confidence",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "discovered_at",
+                    "label": "Discovered",
+                    "projection": {
+                      "column": "discovered_at",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "timestamp",
+                    "id": "last_seen",
+                    "label": "Last Seen",
+                    "projection": {
+                      "column": "last_seen",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No port neighbors",
+                "id": "port_neighbors",
+                "label": "Port Neighbors",
+                "order": 2,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "if_index",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_port_links"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "remote",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "local_endpoint",
+                    "label": "Local Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "src_ip",
+                      "local_port_column": "src_port_name",
+                      "remote_ip_column": "dst_ip",
+                      "remote_port_column": "dst_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "endpoint",
+                    "id": "remote_endpoint",
+                    "label": "Remote Endpoint",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "selected_side_endpoint",
+                      "local_ip_column": "dst_ip",
+                      "local_port_column": "dst_port_name",
+                      "remote_ip_column": "src_ip",
+                      "remote_port_column": "src_port_name",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "inference",
+                    "label": "Inference",
+                    "projection": {
+                      "column": "inference",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "attachment_mode",
+                    "label": "Attachment",
+                    "projection": {
+                      "column": "attachment_mode",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 adjacencies",
+                "id": "l3_adjacencies",
+                "label": "L3 Adjacencies",
+                "order": 3,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_router_id",
+                    "label": "Neighbor Router ID",
+                    "projection": {
+                      "column": "neighbor_router_id",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_router_id",
+                    "label": "Local Router ID",
+                    "projection": {
+                      "column": "local_router_id",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "addressless_index",
+                    "label": "Addressless Index",
+                    "projection": {
+                      "column": "addressless_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No OSPF neighbors",
+                "id": "ospf_neighbors",
+                "label": "OSPF Neighbors",
+                "order": 4,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_router_id",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_ospf_neighbors"
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "cell": "text",
+                    "id": "neighbor_ip",
+                    "label": "Neighbor IP",
+                    "projection": {
+                      "column": "neighbor_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "remote_as",
+                    "label": "Remote AS",
+                    "projection": {
+                      "column": "remote_as",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "state",
+                    "label": "State",
+                    "projection": {
+                      "column": "state",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "actor_link",
+                    "id": "remote_actor",
+                    "label": "Remote Actor",
+                    "projection": {
+                      "actor_column": "remote_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "routing_instance",
+                    "label": "Routing Instance",
+                    "projection": {
+                      "column": "routing_instance",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "admin_status",
+                    "label": "Admin",
+                    "projection": {
+                      "column": "admin_status",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "local_ip",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_as",
+                    "label": "Local AS",
+                    "projection": {
+                      "column": "local_as",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "local_identifier",
+                    "label": "Local Identifier",
+                    "projection": {
+                      "column": "local_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "peer_identifier",
+                    "label": "Peer Identifier",
+                    "projection": {
+                      "column": "peer_identifier",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "peer_type",
+                    "label": "Peer Type",
+                    "projection": {
+                      "column": "peer_type",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "bgp_version",
+                    "label": "BGP Version",
+                    "projection": {
+                      "column": "bgp_version",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "established_uptime",
+                    "label": "Established Uptime",
+                    "projection": {
+                      "column": "established_uptime",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "duration",
+                    "id": "last_received_update_age",
+                    "label": "Last Update Age",
+                    "projection": {
+                      "column": "last_received_update_age",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "description",
+                    "label": "Description",
+                    "projection": {
+                      "column": "description",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No BGP peers",
+                "id": "bgp_peers",
+                "label": "BGP Peers",
+                "order": 5,
+                "owner_filter": {
+                  "actor_column": "actor",
+                  "mode": "actor_column"
+                },
+                "sort": {
+                  "column": "neighbor_ip",
+                  "direction": "asc"
+                },
+                "source": {
+                  "kind": "actor_table",
+                  "table": "actor_bgp_peers"
+                }
+              }
+            ]
+          },
+          "ports": {
+            "show_bullets": true,
+            "sources": [
+              {
+                "actor_column": "actor",
+                "default_type": "topology",
+                "mode_column": "link_mode",
+                "name_column": "name",
+                "role_column": "topology_role",
+                "source": "actor_table",
+                "status_column": "oper_status",
+                "table": "actor_ports",
+                "type_column": "topology_role"
+              }
+            ]
+          },
+          "role": "actor",
+          "size": {
+            "mode": "link_count",
+            "scale": "emphasized"
+          }
+        },
+        "search": {
+          "columns": [
+            "display_name",
+            "sys_name",
+            "management_ip",
+            "vendor",
+            "model"
+          ],
+          "label_keys": [
+            "ospf_router_id"
+          ]
+        }
+      }
+    },
+    "aggregation_scopes": {
+      "device": {
+        "columns": [
+          "id"
+        ],
+        "evidence_policy": "preserve"
+      },
+      "endpoint": {
+        "columns": [
+          "id"
+        ],
+        "evidence_policy": "preserve"
+      },
+      "network": {
+        "columns": [
+          "type"
+        ],
+        "evidence_policy": "preserve"
+      },
+      "segment": {
+        "columns": [
+          "id"
+        ],
+        "evidence_policy": "preserve"
+      }
+    },
+    "evidence_types": {
+      "arp": {
+        "columns": [
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "src_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "dst_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "direction",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "dst_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "dst_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "metrics",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "link_type": "arp",
+        "match_columns": [
+          "src_actor",
+          "dst_actor",
+          "protocol",
+          "src_endpoint",
+          "dst_endpoint"
+        ],
+        "role": "observation_evidence"
+      },
+      "bgp_adjacency": {
+        "columns": [
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "src_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "dst_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "direction",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "dst_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "routing_instance",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "local_identifier",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "peer_identifier",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "local_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "neighbor_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "local_as",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "remote_as",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "source",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "dst_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "metrics",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "link_type": "bgp_adjacency",
+        "match_columns": [
+          "src_actor",
+          "dst_actor",
+          "routing_instance"
+        ],
+        "role": "observation_evidence"
+      },
+      "bridge": {
+        "columns": [
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "src_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "dst_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "direction",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "dst_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "dst_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "metrics",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "link_type": "bridge",
+        "match_columns": [
+          "src_actor",
+          "dst_actor",
+          "protocol",
+          "src_endpoint",
+          "dst_endpoint"
+        ],
+        "role": "observation_evidence"
+      },
+      "cdp": {
+        "columns": [
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "src_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "dst_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "direction",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "dst_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "dst_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "metrics",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "link_type": "cdp",
+        "match_columns": [
+          "src_actor",
+          "dst_actor",
+          "protocol",
+          "src_endpoint",
+          "dst_endpoint"
+        ],
+        "role": "observation_evidence"
+      },
+      "fdb": {
+        "columns": [
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "src_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "dst_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "direction",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "dst_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "dst_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "metrics",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "link_type": "fdb",
+        "match_columns": [
+          "src_actor",
+          "dst_actor",
+          "protocol",
+          "src_endpoint",
+          "dst_endpoint"
+        ],
+        "role": "observation_evidence"
+      },
+      "l2_observation": {
+        "columns": [
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "src_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "dst_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "direction",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "dst_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "dst_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "metrics",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "link_type": "l2_observation",
+        "match_columns": [
+          "src_actor",
+          "dst_actor",
+          "protocol",
+          "src_endpoint",
+          "dst_endpoint"
+        ],
+        "role": "observation_evidence"
+      },
+      "l3_subnet": {
+        "columns": [
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "src_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "dst_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "direction",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "dst_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "subnet",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "network",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "netmask",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "prefix",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "source",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "dst_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "metrics",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "link_type": "l3_subnet",
+        "match_columns": [
+          "src_actor",
+          "dst_actor",
+          "subnet",
+          "src_ip",
+          "dst_ip"
+        ],
+        "role": "observation_evidence"
+      },
+      "lldp": {
+        "columns": [
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "src_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "dst_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "direction",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "dst_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "dst_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "metrics",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "link_type": "lldp",
+        "match_columns": [
+          "src_actor",
+          "dst_actor",
+          "protocol",
+          "src_endpoint",
+          "dst_endpoint"
+        ],
+        "role": "observation_evidence"
+      },
+      "ospf_adjacency": {
+        "columns": [
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "src_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "dst_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "direction",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "dst_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_router_id",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_router_id",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "subnet",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "network",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "netmask",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "prefix",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "source",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "dst_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "metrics",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "link_type": "ospf_adjacency",
+        "match_columns": [
+          "src_actor",
+          "dst_actor",
+          "src_router_id",
+          "dst_router_id",
+          "src_ip",
+          "dst_ip"
+        ],
+        "role": "observation_evidence"
+      },
+      "probable": {
+        "columns": [
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "src_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "dst_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "direction",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "dst_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "dst_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "metrics",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "link_type": "probable",
+        "match_columns": [
+          "src_actor",
+          "dst_actor",
+          "protocol",
+          "src_endpoint",
+          "dst_endpoint"
+        ],
+        "role": "observation_evidence"
+      },
+      "snmp": {
+        "columns": [
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "src_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "dst_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "direction",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "dst_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "dst_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "metrics",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "link_type": "snmp",
+        "match_columns": [
+          "src_actor",
+          "dst_actor",
+          "protocol",
+          "src_endpoint",
+          "dst_endpoint"
+        ],
+        "role": "observation_evidence"
+      },
+      "stp": {
+        "columns": [
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "src_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "dst_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "direction",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "dst_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "dst_endpoint",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "metrics",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "link_type": "stp",
+        "match_columns": [
+          "src_actor",
+          "dst_actor",
+          "protocol",
+          "src_endpoint",
+          "dst_endpoint"
+        ],
+        "role": "observation_evidence"
+      }
+    },
+    "link_types": {
+      "arp": {
+        "aggregation": {
+          "direction": "canonicalize_unordered",
+          "evidence": "append",
+          "metrics": {
+            "evidence_count": "sum"
+          }
+        },
+        "direction_role": "observation",
+        "evidence_types": [
+          "arp"
+        ],
+        "orientation": "observed_bidirectional",
+        "presentation": {
+          "arrow": "none",
+          "color_slot": "muted",
+          "curve": "straight",
+          "label": "ARP",
+          "line_style": "solid",
+          "width": "normal"
+        },
+        "semantic_role": "normal"
+      },
+      "bgp_adjacency": {
+        "aggregation": {
+          "direction": "canonicalize_unordered",
+          "evidence": "append",
+          "metrics": {
+            "evidence_count": "sum"
+          }
+        },
+        "direction_role": "observation",
+        "evidence_types": [
+          "bgp_adjacency"
+        ],
+        "orientation": "observed_bidirectional",
+        "presentation": {
+          "arrow": "none",
+          "color_slot": "accent",
+          "curve": "straight",
+          "label": "BGP adjacency",
+          "line_style": "dashed",
+          "width": "normal"
+        },
+        "semantic_role": "control"
+      },
+      "bridge": {
+        "aggregation": {
+          "direction": "canonicalize_unordered",
+          "evidence": "append",
+          "metrics": {
+            "evidence_count": "sum"
+          }
+        },
+        "direction_role": "observation",
+        "evidence_types": [
+          "bridge"
+        ],
+        "orientation": "observed_bidirectional",
+        "presentation": {
+          "arrow": "none",
+          "color_slot": "neutral",
+          "curve": "straight",
+          "label": "Bridge",
+          "line_style": "solid",
+          "width": "normal"
+        },
+        "semantic_role": "normal"
+      },
+      "cdp": {
+        "aggregation": {
+          "direction": "canonicalize_unordered",
+          "evidence": "append",
+          "metrics": {
+            "evidence_count": "sum"
+          }
+        },
+        "direction_role": "observation",
+        "evidence_types": [
+          "cdp"
+        ],
+        "orientation": "observed_bidirectional",
+        "presentation": {
+          "arrow": "none",
+          "color_slot": "accent",
+          "curve": "straight",
+          "label": "CDP",
+          "line_style": "solid",
+          "width": "thick"
+        },
+        "semantic_role": "discovery"
+      },
+      "fdb": {
+        "aggregation": {
+          "direction": "canonicalize_unordered",
+          "evidence": "append",
+          "metrics": {
+            "evidence_count": "sum"
+          }
+        },
+        "direction_role": "observation",
+        "evidence_types": [
+          "fdb"
+        ],
+        "orientation": "observed_bidirectional",
+        "presentation": {
+          "arrow": "none",
+          "color_slot": "neutral",
+          "curve": "straight",
+          "label": "FDB",
+          "line_style": "solid",
+          "width": "normal"
+        },
+        "semantic_role": "normal"
+      },
+      "l2_observation": {
+        "aggregation": {
+          "direction": "canonicalize_unordered",
+          "evidence": "append",
+          "metrics": {
+            "evidence_count": "sum"
+          }
+        },
+        "direction_role": "observation",
+        "evidence_types": [
+          "l2_observation"
+        ],
+        "orientation": "observed_bidirectional",
+        "presentation": {
+          "arrow": "none",
+          "color_slot": "neutral",
+          "curve": "straight",
+          "label": "L2 observation",
+          "line_style": "solid",
+          "width": "normal"
+        },
+        "semantic_role": "normal"
+      },
+      "l3_subnet": {
+        "aggregation": {
+          "direction": "canonicalize_unordered",
+          "evidence": "append",
+          "metrics": {
+            "evidence_count": "sum"
+          }
+        },
+        "direction_role": "observation",
+        "evidence_types": [
+          "l3_subnet"
+        ],
+        "orientation": "observed_bidirectional",
+        "presentation": {
+          "arrow": "none",
+          "color_slot": "info",
+          "curve": "straight",
+          "label": "L3 subnet",
+          "line_style": "dashed",
+          "width": "normal"
+        },
+        "semantic_role": "normal"
+      },
+      "lldp": {
+        "aggregation": {
+          "direction": "canonicalize_unordered",
+          "evidence": "append",
+          "metrics": {
+            "evidence_count": "sum"
+          }
+        },
+        "direction_role": "observation",
+        "evidence_types": [
+          "lldp"
+        ],
+        "orientation": "observed_bidirectional",
+        "presentation": {
+          "arrow": "none",
+          "color_slot": "accent",
+          "curve": "straight",
+          "label": "LLDP",
+          "line_style": "solid",
+          "width": "thick"
+        },
+        "semantic_role": "discovery"
+      },
+      "ospf_adjacency": {
+        "aggregation": {
+          "direction": "canonicalize_unordered",
+          "evidence": "append",
+          "metrics": {
+            "evidence_count": "sum"
+          }
+        },
+        "direction_role": "observation",
+        "evidence_types": [
+          "ospf_adjacency"
+        ],
+        "orientation": "observed_bidirectional",
+        "presentation": {
+          "arrow": "none",
+          "color_slot": "purple",
+          "curve": "straight",
+          "label": "OSPF adjacency",
+          "line_style": "dashed",
+          "width": "normal"
+        },
+        "semantic_role": "control"
+      },
+      "probable": {
+        "aggregation": {
+          "direction": "canonicalize_unordered",
+          "evidence": "append",
+          "metrics": {
+            "evidence_count": "sum"
+          }
+        },
+        "direction_role": "observation",
+        "evidence_types": [
+          "probable"
+        ],
+        "orientation": "observed_bidirectional",
+        "presentation": {
+          "arrow": "none",
+          "color_slot": "dim",
+          "curve": "straight",
+          "label": "Probable",
+          "line_style": "solid",
+          "width": "normal"
+        },
+        "semantic_role": "normal"
+      },
+      "snmp": {
+        "aggregation": {
+          "direction": "canonicalize_unordered",
+          "evidence": "append",
+          "metrics": {
+            "evidence_count": "sum"
+          }
+        },
+        "direction_role": "observation",
+        "evidence_types": [
+          "snmp"
+        ],
+        "orientation": "observed_bidirectional",
+        "presentation": {
+          "arrow": "none",
+          "color_slot": "primary",
+          "curve": "straight",
+          "label": "SNMP",
+          "line_style": "solid",
+          "width": "normal"
+        },
+        "semantic_role": "normal"
+      },
+      "stp": {
+        "aggregation": {
+          "direction": "canonicalize_unordered",
+          "evidence": "append",
+          "metrics": {
+            "evidence_count": "sum"
+          }
+        },
+        "direction_role": "observation",
+        "evidence_types": [
+          "stp"
+        ],
+        "orientation": "observed_bidirectional",
+        "presentation": {
+          "arrow": "none",
+          "color_slot": "muted",
+          "curve": "straight",
+          "label": "STP",
+          "line_style": "solid",
+          "width": "normal"
+        },
+        "semantic_role": "normal"
+      }
+    },
+    "port_types": {
+      "access": {
+        "presentation": {
+          "color_slot": "derived",
+          "label": "access",
+          "opacity": "normal"
+        }
+      },
+      "host_candidate": {
+        "presentation": {
+          "color_slot": "info",
+          "label": "host-candidate",
+          "opacity": "normal"
+        }
+      },
+      "host_facing": {
+        "presentation": {
+          "color_slot": "secondary",
+          "label": "host-facing",
+          "opacity": "normal"
+        }
+      },
+      "idle": {
+        "presentation": {
+          "color_slot": "muted",
+          "label": "idle",
+          "opacity": "muted"
+        }
+      },
+      "lldp": {
+        "presentation": {
+          "color_slot": "accent",
+          "label": "lldp/cdp",
+          "opacity": "normal"
+        }
+      },
+      "switch_facing": {
+        "presentation": {
+          "color_slot": "primary",
+          "label": "switch-facing",
+          "opacity": "normal"
+        }
+      },
+      "topology": {
+        "presentation": {
+          "color_slot": "neutral",
+          "label": "unclassified",
+          "opacity": "normal"
+        }
+      },
+      "trunk": {
+        "presentation": {
+          "color_slot": "warning",
+          "label": "trunk",
+          "opacity": "normal"
+        }
+      },
+      "unknown": {
+        "presentation": {
+          "color_slot": "dim",
+          "label": "unknown",
+          "opacity": "muted"
+        }
+      }
+    },
+    "table_types": {
+      "actor_bgp_peers": {
+        "aggregation": "append",
+        "columns": [
+          {
+            "id": "actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "remote_actor",
+            "nullable": true,
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "routing_instance",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "neighbor_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "remote_as",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "admin_status",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "local_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "local_as",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "local_identifier",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "peer_identifier",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "peer_type",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "bgp_version",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "description",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "established_uptime",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "last_received_update_age",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "source",
+            "nullable": true,
+            "type": "string_ref"
+          }
+        ],
+        "owner": "actor",
+        "presentation": {
+          "columns": [
+            {
+              "cell": "text",
+              "id": "neighbor_ip",
+              "label": "Neighbor IP",
+              "projection": {
+                "column": "neighbor_ip",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "text",
+              "id": "remote_as",
+              "label": "Remote AS",
+              "projection": {
+                "column": "remote_as",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "badge",
+              "id": "state",
+              "label": "State",
+              "projection": {
+                "column": "state",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "actor_link",
+              "id": "remote_actor",
+              "label": "Remote Actor",
+              "projection": {
+                "actor_column": "remote_actor",
+                "kind": "actor_ref_label"
+              }
+            },
+            {
+              "cell": "text",
+              "id": "routing_instance",
+              "label": "Routing Instance",
+              "projection": {
+                "column": "routing_instance",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "badge",
+              "id": "admin_status",
+              "label": "Admin",
+              "projection": {
+                "column": "admin_status",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "local_ip",
+              "label": "Local IP",
+              "projection": {
+                "column": "local_ip",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "local_as",
+              "label": "Local AS",
+              "projection": {
+                "column": "local_as",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "local_identifier",
+              "label": "Local Identifier",
+              "projection": {
+                "column": "local_identifier",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "peer_identifier",
+              "label": "Peer Identifier",
+              "projection": {
+                "column": "peer_identifier",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "badge",
+              "id": "peer_type",
+              "label": "Peer Type",
+              "projection": {
+                "column": "peer_type",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "bgp_version",
+              "label": "BGP Version",
+              "projection": {
+                "column": "bgp_version",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "duration",
+              "id": "established_uptime",
+              "label": "Established Uptime",
+              "projection": {
+                "column": "established_uptime",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "duration",
+              "id": "last_received_update_age",
+              "label": "Last Update Age",
+              "projection": {
+                "column": "last_received_update_age",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "description",
+              "label": "Description",
+              "projection": {
+                "column": "description",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "badge",
+              "id": "source",
+              "label": "Source",
+              "projection": {
+                "column": "source",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            }
+          ],
+          "label": "BGP Peers",
+          "order": 5
+        },
+        "role": "actor_detail"
+      },
+      "actor_inventory": {
+        "aggregation": "append",
+        "columns": [
+          {
+            "id": "actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "enabled",
+            "nullable": true,
+            "type": "bool"
+          },
+          {
+            "id": "sensor_labels",
+            "nullable": true,
+            "type": "array"
+          },
+          {
+            "dictionary": "strings",
+            "id": "slot",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "temperature_c",
+            "nullable": true,
+            "type": "float"
+          }
+        ],
+        "owner": "actor",
+        "role": "actor_detail"
+      },
+      "actor_labels": {
+        "aggregation": "set",
+        "columns": [
+          {
+            "id": "actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "key",
+            "role": "attribute",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "value",
+            "role": "attribute",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "source",
+            "nullable": true,
+            "role": "attribute",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "kind",
+            "nullable": true,
+            "role": "attribute",
+            "type": "string_ref"
+          },
+          {
+            "id": "value_index",
+            "nullable": true,
+            "role": "attribute",
+            "type": "uint"
+          }
+        ],
+        "owner": "actor",
+        "presentation": {
+          "columns": [
+            {
+              "cell": "text",
+              "id": "key",
+              "label": "Label",
+              "projection": {
+                "column": "key",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "text",
+              "id": "value",
+              "label": "Value",
+              "projection": {
+                "column": "value",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "badge",
+              "id": "source",
+              "label": "Source",
+              "projection": {
+                "column": "source",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "badge",
+              "id": "kind",
+              "label": "Kind",
+              "projection": {
+                "column": "kind",
+                "kind": "direct"
+              }
+            }
+          ],
+          "label": "Labels"
+        },
+        "role": "actor_inventory"
+      },
+      "actor_metadata": {
+        "aggregation": "append",
+        "columns": [
+          {
+            "id": "actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "attributes",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "labels",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "owner": "actor",
+        "presentation": {
+          "columns": [
+            {
+              "cell": "debug_json",
+              "id": "attributes",
+              "label": "Attributes",
+              "projection": {
+                "column": "attributes",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "debug_json",
+              "id": "labels",
+              "label": "Labels",
+              "projection": {
+                "column": "labels",
+                "kind": "direct"
+              }
+            }
+          ],
+          "default_visibility": "debug",
+          "label": "Debug metadata"
+        },
+        "role": "actor_detail"
+      },
+      "actor_ospf_neighbors": {
+        "aggregation": "append",
+        "columns": [
+          {
+            "id": "actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "remote_actor",
+            "nullable": true,
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "local_router_id",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "neighbor_router_id",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "neighbor_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "local_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "subnet",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "addressless_index",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "source",
+            "nullable": true,
+            "type": "string_ref"
+          }
+        ],
+        "owner": "actor",
+        "presentation": {
+          "columns": [
+            {
+              "cell": "text",
+              "id": "neighbor_router_id",
+              "label": "Neighbor Router ID",
+              "projection": {
+                "column": "neighbor_router_id",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "text",
+              "id": "neighbor_ip",
+              "label": "Neighbor IP",
+              "projection": {
+                "column": "neighbor_ip",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "badge",
+              "id": "state",
+              "label": "State",
+              "projection": {
+                "column": "state",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "actor_link",
+              "id": "remote_actor",
+              "label": "Remote Actor",
+              "projection": {
+                "actor_column": "remote_actor",
+                "kind": "actor_ref_label"
+              }
+            },
+            {
+              "cell": "text",
+              "id": "local_router_id",
+              "label": "Local Router ID",
+              "projection": {
+                "column": "local_router_id",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "local_ip",
+              "label": "Local IP",
+              "projection": {
+                "column": "local_ip",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "subnet",
+              "label": "Subnet",
+              "projection": {
+                "column": "subnet",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "addressless_index",
+              "label": "Addressless Index",
+              "projection": {
+                "column": "addressless_index",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "badge",
+              "id": "source",
+              "label": "Source",
+              "projection": {
+                "column": "source",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            }
+          ],
+          "label": "OSPF Neighbors",
+          "order": 4
+        },
+        "role": "actor_detail"
+      },
+      "actor_port_links": {
+        "aggregation": "append",
+        "columns": [
+          {
+            "id": "actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "remote_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "port_id",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "remote_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "remote_port_id",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "remote_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "type",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "aggregation": "sum",
+            "id": "evidence_count",
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "discovered_at",
+            "nullable": true,
+            "role": "timestamp",
+            "type": "timestamp"
+          },
+          {
+            "id": "last_seen",
+            "nullable": true,
+            "role": "timestamp",
+            "type": "timestamp"
+          }
+        ],
+        "owner": "actor",
+        "presentation": {
+          "columns": [
+            {
+              "cell": "number",
+              "id": "if_index",
+              "label": "Port ID",
+              "projection": {
+                "column": "if_index",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "text",
+              "id": "port_name",
+              "label": "Port",
+              "projection": {
+                "column": "port_name",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "actor_link",
+              "id": "remote_actor",
+              "label": "Remote Actor",
+              "projection": {
+                "actor_column": "remote_actor",
+                "kind": "actor_ref_label"
+              }
+            },
+            {
+              "cell": "text",
+              "id": "remote_port_name",
+              "label": "Remote Port",
+              "projection": {
+                "column": "remote_port_name",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "badge",
+              "id": "type",
+              "label": "Type",
+              "projection": {
+                "column": "type",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "badge",
+              "id": "state",
+              "label": "State",
+              "projection": {
+                "column": "state",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "number",
+              "id": "evidence_count",
+              "label": "Evidence",
+              "projection": {
+                "column": "evidence_count",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "badge",
+              "id": "protocol",
+              "label": "Protocol",
+              "projection": {
+                "column": "protocol",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "number",
+              "id": "remote_if_index",
+              "label": "Remote Port ID",
+              "projection": {
+                "column": "remote_if_index",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "port_id",
+              "label": "Source Port ID",
+              "projection": {
+                "column": "port_id",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "remote_port_id",
+              "label": "Remote Source Port ID",
+              "projection": {
+                "column": "remote_port_id",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "badge",
+              "id": "confidence",
+              "label": "Confidence",
+              "projection": {
+                "column": "confidence",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "badge",
+              "id": "inference",
+              "label": "Inference",
+              "projection": {
+                "column": "inference",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "badge",
+              "id": "attachment_mode",
+              "label": "Attachment",
+              "projection": {
+                "column": "attachment_mode",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "timestamp",
+              "id": "discovered_at",
+              "label": "Discovered",
+              "projection": {
+                "column": "discovered_at",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "timestamp",
+              "id": "last_seen",
+              "label": "Last Seen",
+              "projection": {
+                "column": "last_seen",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            }
+          ],
+          "label": "Port Neighbors",
+          "order": 2
+        },
+        "role": "actor_detail"
+      },
+      "actor_ports": {
+        "aggregation": "append",
+        "columns": [
+          {
+            "id": "actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "port_id",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "if_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "if_descr",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "if_alias",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "mac",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "speed",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "topology_role",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "oper_status",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "admin_status",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "port_type",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "link_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "stp_state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "vlan_ids",
+            "nullable": true,
+            "type": "array"
+          },
+          {
+            "id": "fdb_mac_count",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "link_count",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "neighbor_count",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "neighbor_actor",
+            "nullable": true,
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "neighbor_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "neighbors",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "vlans",
+            "nullable": true,
+            "type": "json"
+          },
+          {
+            "id": "extra",
+            "nullable": true,
+            "type": "json"
+          }
+        ],
+        "owner": "actor",
+        "presentation": {
+          "columns": [
+            {
+              "cell": "number",
+              "id": "if_index",
+              "label": "Port ID",
+              "projection": {
+                "column": "if_index",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "text",
+              "id": "name",
+              "label": "Port",
+              "projection": {
+                "column": "name",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "badge",
+              "id": "oper_status",
+              "label": "Status",
+              "projection": {
+                "column": "oper_status",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "badge",
+              "id": "admin_status",
+              "label": "Admin",
+              "projection": {
+                "column": "admin_status",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "badge",
+              "id": "port_type",
+              "label": "Type",
+              "projection": {
+                "column": "port_type",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "badge",
+              "id": "link_mode",
+              "label": "Mode",
+              "projection": {
+                "column": "link_mode",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "badge",
+              "id": "topology_role",
+              "label": "Role",
+              "projection": {
+                "column": "topology_role",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "array_count",
+              "id": "vlan_ids",
+              "label": "VLANs",
+              "projection": {
+                "column": "vlan_ids",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "number",
+              "id": "fdb_mac_count",
+              "label": "FDB",
+              "projection": {
+                "column": "fdb_mac_count",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "number",
+              "id": "link_count",
+              "label": "Links",
+              "projection": {
+                "column": "link_count",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "number",
+              "id": "neighbor_count",
+              "label": "Neighbors",
+              "projection": {
+                "column": "neighbor_count",
+                "kind": "direct"
+              }
+            },
+            {
+              "cell": "actor_link",
+              "id": "neighbor_actor",
+              "label": "Neighbor",
+              "projection": {
+                "actor_column": "neighbor_actor",
+                "kind": "actor_ref_label"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "neighbor_port_name",
+              "label": "Neighbor Port",
+              "projection": {
+                "column": "neighbor_port_name",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "if_name",
+              "label": "ifName",
+              "projection": {
+                "column": "if_name",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "if_descr",
+              "label": "ifDescr",
+              "projection": {
+                "column": "if_descr",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "if_alias",
+              "label": "Alias",
+              "projection": {
+                "column": "if_alias",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "port_id",
+              "label": "Source Port ID",
+              "projection": {
+                "column": "port_id",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "text",
+              "id": "mac",
+              "label": "MAC",
+              "projection": {
+                "column": "mac",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "number",
+              "id": "speed",
+              "label": "Speed",
+              "projection": {
+                "column": "speed",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "badge",
+              "id": "stp_state",
+              "label": "STP",
+              "projection": {
+                "column": "stp_state",
+                "kind": "direct"
+              },
+              "visibility": "expanded"
+            },
+            {
+              "cell": "debug_json",
+              "id": "neighbors",
+              "label": "Neighbor Data",
+              "projection": {
+                "column": "neighbors",
+                "kind": "direct"
+              },
+              "visibility": "debug"
+            },
+            {
+              "cell": "debug_json",
+              "id": "vlans",
+              "label": "VLAN Data",
+              "projection": {
+                "column": "vlans",
+                "kind": "direct"
+              },
+              "visibility": "debug"
+            },
+            {
+              "cell": "debug_json",
+              "id": "extra",
+              "label": "Extra",
+              "projection": {
+                "column": "extra",
+                "kind": "direct"
+              },
+              "visibility": "debug"
+            }
+          ],
+          "label": "Ports",
+          "order": 1
+        },
+        "role": "actor_detail"
+      }
+    }
+  },
+  "view": {
+    "id": "summary",
+    "mode": "detailed",
+    "scope": "network"
+  }
+}


### PR DESCRIPTION
##### Summary

Part of #22619

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a topology v1 golden oracle test for `snmp_topology` that locks down the v1 conversion pipeline. It normalizes and canonicalizes actors, links, evidence, and tables, then compares to a checked-in golden JSON payload.

- **Migration**
  - To refresh the golden payload: go test -count=1 ./plugin/go.d/collector/snmp_topology -run TestSNMPTopologyToV1_NormalizedGolden -update-snmp-topology-v1-golden

<sup>Written for commit bb56db557fa3fda1b33d6147bae6826901650c67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

