### PR TITLE
chore(go.d/topology): remove unused graph dto surface

### DIFF
--- a/src/go/pkg/topology/graph/graph_types.go
+++ b/src/go/pkg/topology/graph/graph_types.go
@@ -29,7 +29,6 @@ type Actor struct {
 	Match       Match                       `json:"match"`
 	ParentMatch *Match                      `json:"parent_match,omitempty"`
 	Attributes  map[string]any              `json:"attributes,omitempty"`
-	Derived     map[string]any              `json:"derived,omitempty"`
 	Labels      map[string]string           `json:"labels,omitempty"`
 	Tables      map[string][]map[string]any `json:"tables,omitempty"`
 }
@@ -54,34 +53,6 @@ type Link struct {
 	Metrics      map[string]any `json:"metrics,omitempty"`
 }
 
-type FlowExporter struct {
-	IP           string `json:"ip,omitempty"`
-	Name         string `json:"name,omitempty"`
-	SamplingRate int    `json:"sampling_rate,omitempty"`
-	FlowVersion  string `json:"flow_version,omitempty"`
-}
-
-type Flow struct {
-	Timestamp   time.Time      `json:"timestamp"`
-	DurationSec int            `json:"duration_sec,omitempty"`
-	Exporter    *FlowExporter  `json:"exporter,omitempty"`
-	Src         LinkEndpoint   `json:"src"`
-	Dst         LinkEndpoint   `json:"dst"`
-	Key         map[string]any `json:"key,omitempty"`
-	Metrics     map[string]any `json:"metrics,omitempty"`
-}
-
-type LiveTopN struct {
-	Enabled bool   `json:"enabled,omitempty"`
-	Limit   int    `json:"limit,omitempty"`
-	SortBy  string `json:"sort_by,omitempty"`
-}
-
-type IPPolicy struct {
-	PublicAllowlist []string  `json:"public_allowlist,omitempty"`
-	LiveTopN        *LiveTopN `json:"live_top_n,omitempty"`
-}
-
 type Graph struct {
 	SchemaVersion string         `json:"schema_version"`
 	Source        string         `json:"source,omitempty"`
@@ -89,10 +60,7 @@ type Graph struct {
 	AgentID       string         `json:"agent_id"`
 	CollectedAt   time.Time      `json:"collected_at"`
 	View          string         `json:"view,omitempty"`
-	IPPolicy      *IPPolicy      `json:"ip_policy,omitempty"`
 	Actors        []Actor        `json:"actors,omitempty"`
 	Links         []Link         `json:"links,omitempty"`
-	Flows         []Flow         `json:"flows,omitempty"`
 	Stats         map[string]any `json:"stats,omitempty"`
-	Metrics       map[string]any `json:"metrics,omitempty"`
 }

--- a/src/go/pkg/topology/graph/graph_types_test.go
+++ b/src/go/pkg/topology/graph/graph_types_test.go
@@ -19,10 +19,6 @@ func TestGraphJSONShape(t *testing.T) {
 		AgentID:       "agent-id",
 		CollectedAt:   tm,
 		View:          "summary",
-		IPPolicy: &IPPolicy{
-			PublicAllowlist: []string{"10.0.0.0/8"},
-			LiveTopN:        &LiveTopN{Enabled: true, Limit: 10, SortBy: "bytes"},
-		},
 		Actors: []Actor{{
 			ActorID:   "actor-a",
 			ActorType: "router",
@@ -46,7 +42,6 @@ func TestGraphJSONShape(t *testing.T) {
 			},
 			ParentMatch: &Match{SysName: "parent"},
 			Attributes:  map[string]any{"role": "core"},
-			Derived:     map[string]any{"score": float64(1)},
 			Labels:      map[string]string{"site": "lab"},
 			Tables:      map[string][]map[string]any{"ports": {{"if_name": "eth0"}}},
 		}},
@@ -64,17 +59,7 @@ func TestGraphJSONShape(t *testing.T) {
 			LastSeen:     &tm,
 			Metrics:      map[string]any{"cost": float64(10)},
 		}},
-		Flows: []Flow{{
-			Timestamp:   tm,
-			DurationSec: 60,
-			Exporter:    &FlowExporter{IP: "10.0.0.1", Name: "router-a", SamplingRate: 1000, FlowVersion: "v9"},
-			Src:         LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.0.10"}}},
-			Dst:         LinkEndpoint{Match: Match{IPAddresses: []string{"10.0.0.20"}}},
-			Key:         map[string]any{"protocol": "tcp"},
-			Metrics:     map[string]any{"bytes": float64(42)},
-		}},
-		Stats:   map[string]any{"links": float64(1)},
-		Metrics: map[string]any{"refresh": float64(1)},
+		Stats: map[string]any{"links": float64(1)},
 	}
 
 	bs, err := json.Marshal(payload)
@@ -87,10 +72,6 @@ func TestGraphJSONShape(t *testing.T) {
 		"agent_id":"agent-id",
 		"collected_at":"2026-06-20T08:09:10Z",
 		"view":"summary",
-		"ip_policy":{
-			"public_allowlist":["10.0.0.0/8"],
-			"live_top_n":{"enabled":true,"limit":10,"sort_by":"bytes"}
-		},
 		"actors":[{
 			"actor_id":"actor-a",
 			"actor_type":"router",
@@ -114,7 +95,6 @@ func TestGraphJSONShape(t *testing.T) {
 			},
 			"parent_match":{"sys_name":"parent"},
 			"attributes":{"role":"core"},
-			"derived":{"score":1},
 			"labels":{"site":"lab"},
 			"tables":{"ports":[{"if_name":"eth0"}]}
 		}],
@@ -132,16 +112,6 @@ func TestGraphJSONShape(t *testing.T) {
 			"last_seen":"2026-06-20T08:09:10Z",
 			"metrics":{"cost":10}
 		}],
-		"flows":[{
-			"timestamp":"2026-06-20T08:09:10Z",
-			"duration_sec":60,
-			"exporter":{"ip":"10.0.0.1","name":"router-a","sampling_rate":1000,"flow_version":"v9"},
-			"src":{"match":{"ip_addresses":["10.0.0.10"]}},
-			"dst":{"match":{"ip_addresses":["10.0.0.20"]}},
-			"key":{"protocol":"tcp"},
-			"metrics":{"bytes":42}
-		}],
-		"stats":{"links":1},
-		"metrics":{"refresh":1}
+		"stats":{"links":1}
 	}`, string(bs))
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_types.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_types.go
@@ -11,8 +11,6 @@ type topologyActor = graph.Actor
 type topologyMatch = graph.Match
 type topologyLink = graph.Link
 type topologyLinkEndpoint = graph.LinkEndpoint
-type topologyFlow = graph.Flow
-type topologyIPPolicy = graph.IPPolicy
 
 type topologyManagementAddress struct {
 	Address     string `json:"address"`


### PR DESCRIPTION
##### Summary

Part of #22619

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused fields and types from the topology graph DTO to shrink the JSON surface and simplify the code. Cleaned up tests and `snmp_topology` aliases accordingly.

- **Refactors**
  - Removed Actor.Derived; Graph.IPPolicy, Flows, Metrics; Flow/FlowExporter, LiveTopN.
  - Updated JSON shape test to match the reduced schema.
  - Dropped unused `Flow` and `IPPolicy` type aliases in `go.d/collector/snmp_topology`.

<sup>Written for commit 036d07c13b0db5c1ecb351fcfc17078d3c499bcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

