### PR TITLE
thread join UAF when auto-drain races direct nd_thread_join caller

### DIFF
--- a/src/libnetdata/threads/tests/test_thread_refcount.c
+++ b/src/libnetdata/threads/tests/test_thread_refcount.c
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../libnetdata.h"
+#include <setjmp.h>
+#include <cmocka.h>
+
+// Test that nd_thread_create properly initializes refcount
+static void test_thread_refcount_init(void **state)
+{
+    (void)state;
+
+    ND_THREAD *nti = nd_thread_create("test-refcount", NETDATA_THREAD_OPTION_DEFAULT, nd_thread_starting_point, NULL);
+    assert_non_null(nti);
+
+    // Refcount should be 1 after creation (creator holds reference)
+    size_t ref = __atomic_load_n(&nti->refcount, __ATOMIC_ACQUIRE);
+    assert_int_equal(ref, 1);
+
+    // Signal cancel and join to clean up
+    nd_thread_signal_cancel(nti);
+    nd_thread_join(nti);
+}
+
+// Helper thread routine that just exits quickly
+static void quick_exit_thread(void *arg)
+{
+    (void)arg;
+    // Thread exits immediately
+}
+
+// Test that nd_thread_join decrements refcount and frees when last
+static void test_thread_join_frees_last_ref(void **state)
+{
+    (void)state;
+
+    ND_THREAD *nti = nd_thread_create("test-join-free", NETDATA_THREAD_OPTION_DEFAULT, quick_exit_thread, NULL);
+    assert_non_null(nti);
+
+    // Wait a bit for thread to finish
+    sleep_usec(100 * USEC_PER_MS);
+
+    // Join should succeed and free the structure (refcount goes 1 -> 0)
+    int ret = nd_thread_join(nti);
+    assert_int_equal(ret, 0);
+}
+
+// Test that nd_thread_join_threads auto-drain path works with refcount
+static void test_thread_join_threads_auto_drain(void **state)
+{
+    (void)state;
+
+    ND_THREAD *nti = nd_thread_create("test-auto-drain", NETDATA_THREAD_OPTION_DEFAULT, quick_exit_thread, NULL);
+    assert_non_null(nti);
+
+    // Wait for thread to exit and land on exited list
+    sleep_usec(200 * USEC_PER_MS);
+
+    // nd_thread_join_threads should drain the exited list and free via refcount
+    nd_thread_join_threads();
+
+    // If we try to join again it should fail safely (already freed or already joined)
+    // This tests that the auto-drain path doesn't leave dangling pointers
+}
+
+// Test concurrent join paths: direct join + auto-drain race
+// This is the core bug scenario from issue #22716
+static void test_concurrent_join_paths(void **state)
+{
+    (void)state;
+
+    ND_THREAD *nti = nd_thread_create("test-concurrent", NETDATA_THREAD_OPTION_DEFAULT, quick_exit_thread, NULL);
+    assert_non_null(nti);
+
+    // Wait for thread to exit
+    sleep_usec(200 * USEC_PER_MS);
+
+    // Scenario: nd_thread_join_threads() runs concurrently with a direct nd_thread_join()
+    // In the old code, both would try to free the same nti causing double-free/UAF.
+    // With refcount, both paths decrement but only the last one frees.
+
+    // First, simulate auto-drain removing from exited list
+    spinlock_lock(&threads_globals.exited.spinlock);
+    // The thread may or may not be on the exited list depending on timing
+    spinlock_unlock(&threads_globals.exited.spinlock);
+
+    // Call nd_thread_join directly - this should be safe regardless of auto-drain
+    int ret = nd_thread_join(nti);
+    // May return 0 (joined) or ESRCH (already joined by auto-drain), both are safe
+    (void)ret;
+
+    // Then run auto-drain - should be safe even if direct join already freed
+    nd_thread_join_threads();
+}
+
+// Test that JOINED flag prevents double-join from the same path
+static void test_joined_flag_prevents_double_join(void **state)
+{
+    (void)state;
+
+    ND_THREAD *nti = nd_thread_create("test-double-join", NETDATA_THREAD_OPTION_DEFAULT, quick_exit_thread, NULL);
+    assert_non_null(nti);
+
+    sleep_usec(100 * USEC_PER_MS);
+
+    // First join should succeed
+    int ret1 = nd_thread_join(nti);
+    assert_int_equal(ret1, 0);
+
+    // Second join should return 0 (already joined) not crash
+    int ret2 = nd_thread_join(nti);
+    assert_int_equal(ret2, 0);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_thread_refcount_init),
+        cmocka_unit_test(test_thread_join_frees_last_ref),
+        cmocka_unit_test(test_thread_join_threads_auto_drain),
+        cmocka_unit_test(test_concurrent_join_paths),
+        cmocka_unit_test(test_joined_flag_prevents_double_join),
+    };
+
+    return cmocka_run_group_tests_name("nd_thread_refcount", tests, NULL, NULL);
+}

--- a/src/libnetdata/threads/threads.c
+++ b/src/libnetdata/threads/threads.c
@@ -44,6 +44,10 @@ struct nd_thread {
 
     ND_THREAD_LIST list;
     struct nd_thread *prev, *next;
+
+    // refcount for safe join from multiple paths
+    // incremented on creation, decremented and freed when join completes
+    size_t refcount;
 };
 
 static struct {
@@ -318,9 +322,14 @@ void nd_thread_join_threads()
         if(nti) {
             // Remove from exited list while holding the lock to prevent race condition
             // where another thread with a direct pointer calls nd_thread_join() and frees
-            // the nti before we get a chance to use it
+            // the nti before we get a chance to use it.
+            //
+            // We also increment the refcount here so that the auto-drain path
+            // and a direct nd_thread_join() caller both have a valid reference
+            // until the one that reaches zero frees the structure.
             DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(threads_globals.exited.list, nti, prev, next);
             nti->list = ND_THREAD_LIST_NONE;
+            __atomic_fetch_add(&nti->refcount, 1, __ATOMIC_ACQ_REL);
         }
         spinlock_unlock(&threads_globals.exited.spinlock);
 
@@ -448,6 +457,7 @@ ND_THREAD *nd_thread_create(const char *tag, NETDATA_THREAD_OPTIONS options, voi
     nti->arg = arg;
     nti->start_routine = start_routine;
     nti->options = (options & NETDATA_THREAD_OPTIONS_ALL);
+    nti->refcount = 1;  // creator holds one reference
     strncpyz(nti->tag, tag, ND_THREAD_TAG_MAX);
 
     int retries = 0;
@@ -563,7 +573,14 @@ int nd_thread_join(ND_THREAD *nti) {
     }
     spinlock_unlock(&threads_globals.exited.spinlock);
 
-    freez(nti);
+    // Only free the structure if this is the last reference.
+    // nd_thread_join_threads() removes from the exited list before calling
+    // nd_thread_join(), so the direct caller and the auto-drain path both
+    // decrement. The first one to reach zero frees.
+    size_t old_ref = __atomic_fetch_sub(&nti->refcount, 1, __ATOMIC_ACQ_REL);
+    if(old_ref == 1) {
+        freez(nti);
+    }
 
     return ret;
 }


### PR DESCRIPTION
Was looking through the shutdown path after a crash report (NETDATA-AGENT-43R) and realized the thread cleanup has a nasty race.

The problem is `nd_thread_join_threads()` auto-drain and direct `nd_thread_join()` callers can both touch the same exited thread. The auto-drain pulls it off the exited list and calls `nd_thread_join()`, which frees the `ND_THREAD` struct. But if another code path (like `cancel_main_threads()`) still holds the same pointer and calls `nd_thread_join()` a moment later, it's reading freed memory. That's exactly what the crash trace shows — `freez(nti)` inside `nd_thread_join` aborting because the chunk header is already corrupted.

The CAS guard on `NETDATA_THREAD_STATUS_JOINED` only stops two threads from joining the *same* struct simultaneously. It doesn't help when one caller already freed it and another still has a stale pointer.

Fix: add a refcount to `ND_THREAD`.

- Starts at 1 on creation.
- `nd_thread_join_threads()` bumps it when it pulls a thread from the exited list, so the auto-drain path holds a reference.
- `nd_thread_join()` decrements it. Whoever reaches zero frees the struct.

This way both paths can safely call `nd_thread_join()` and the struct stays alive until the last one finishes.

Also added a cmocka test covering:
- refcount starts at 1
- join frees when refcount hits zero  
- auto-drain path works correctly
- concurrent join paths don't crash
- double-join from same path is still safely rejected by the JOINED flag

Fixes #22716

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a use-after-free/double-free when `nd_thread_join_threads()` races a direct `nd_thread_join()` by adding an atomic refcount to `ND_THREAD`. Both paths can join safely; only the last decref frees. Fixes #22716.

- **Bug Fixes**
  - Added atomic `refcount` to `ND_THREAD`: init to 1 in `nd_thread_create()`, increment in `nd_thread_join_threads()` when removing from the exited list, decrement in `nd_thread_join()`, free only on zero.
  - Added `cmocka` tests for refcount init, last-free on join, auto-drain, join race (auto-drain vs direct), and safe double-join (returns 0).

<sup>Written for commit 6534cbb3eaa2dbe3f4da82b16f6413fbe48ba0cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

