### PR TITLE
ci: fix invalid step-output references in failure notifications

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,6 +307,7 @@ jobs:
           sudo apt-get upgrade -y
           sudo apt-get install -y qemu-user-static
       - name: Build
+        id: build
         if: needs.file-check.outputs.run == 'true'
         run: |
           [ "${{ matrix.qemu }}" == "true" ] || export SKIP_EMULATION=1

--- a/.github/workflows/kickstart-upload.yml
+++ b/.github/workflows/kickstart-upload.yml
@@ -48,7 +48,7 @@ jobs:
               ${{ github.repository }}: Failed to upload updated kickstart script to repo server.
               Checkout: ${{ steps.checkout.outcome }}
               Import SSH Key: ${{ steps.ssh-setup.outcome }}
-              Upload to packages.netdata.cloud: ${{ steps.upload-packages.outcome }}
+              Upload to packages.netdata.cloud: ${{ steps.upload-primary.outcome }}
               Upload to packages2.netdata.cloud: ${{ steps.upload-packages2.outcome }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: >-


### PR DESCRIPTION
The Slack failure-notification messages referenced step outputs that did not exist, so those lines rendered empty and actionlint flagged them:

- build.yml: the static-build 'Build' step had no id, but the notification read steps.build.outcome. Added id: build to match the other Build steps.
- kickstart-upload.yml: the notification read steps.upload-packages.outcome, but the step's id is upload-primary. Fixed the reference.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Slack failure notifications in GitHub Actions by correcting step-output references so outcomes render and `actionlint` passes. Added `id: build` to the static-build "Build" step in `.github/workflows/build.yml`, and updated `.github/workflows/kickstart-upload.yml` to reference `steps.upload-primary.outcome` instead of `steps.upload-packages.outcome`.

<sup>Written for commit 7c91892ad17affd58d04198cc3beba84c6e33312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

