### PR TITLE
Fix response help message

### DIFF
--- a/src/crates/netdata-log-viewer/otel-signal-viewer-plugin/src/catalog.rs
+++ b/src/crates/netdata-log-viewer/otel-signal-viewer-plugin/src/catalog.rs
@@ -670,7 +670,7 @@ impl FunctionHandler for CatalogFunction {
             has_history: true,
             status: 200,
             response_type: String::from("table"),
-            help: String::from("View, search and analyze systemd journal entries."),
+            help: String::from("View, search and analyze OpenTelemetry logs."),
             pagination: netdata::Pagination::default(),
         };
 


### PR DESCRIPTION
##### Summary

SSIA.

##### Test Plan

- CI jobs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the response help message in the OTel signal viewer to say “View, search and analyze OpenTelemetry logs” instead of referencing systemd journal entries. This corrects misleading copy in the UI.

<sup>Written for commit 82f6b1e0091f0247b9666efd798e220df12900d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

