### PR TITLE
feat(go.d/snmp_topology): add l3 subnet segments

### DIFF
--- a/.agents/sow/specs/topology-function-schema.md
+++ b/.agents/sow/specs/topology-function-schema.md
@@ -108,6 +108,13 @@ Actor/link modal composition is declared separately under actor/link type
 presentation and table type presentation. Modal recipes are selectors and
 projections over existing facts; they are not duplicate row stores.
 
+Helper actors that represent grouping constructs may use distinct actor types
+instead of overloading a generic `segment` type. Each such type must declare
+its own identity, merge identity, presentation, modal sections, legend entry,
+and aggregation behavior. Consumers must use the declared type metadata and
+must not infer semantics only from a type id containing words such as
+`segment`, `subnet`, or `network`.
+
 Cloud aggregation may only canonicalize endpoint order when link type policy
 explicitly allows unordered aggregation. Direction-significant links must
 preserve direction.

--- a/.agents/sow/specs/topology-modes-correlation-aggregation.md
+++ b/.agents/sow/specs/topology-modes-correlation-aggregation.md
@@ -515,6 +515,22 @@ state collected from IP-MIB `ipAddrTable`, limited to IPv4 point-to-point
 same point-to-point subnet; it does not prove that the devices are physically
 connected.
 
+`l3_subnet_segment` represents a broader IPv4 shared subnet observed from
+managed SNMP device interface state. SNMP currently emits these segment actors
+for `/24` through `/29` subnets. The segment actor is a logical grouping point,
+not a physical switch, bridge domain, VLAN, or endpoint. Each member device is
+connected to the segment by an `l3_subnet_membership` link. Membership evidence
+contains the member actor, subnet, member IP, interface index/name/description,
+network, netmask, prefix, and source. Only resolved managed SNMP network-device
+actors participate; unmanaged endpoints and unresolved rows are suppression
+state, not graph actors.
+
+`l3_subnet_segment` actor ids must be scoped by a stable producer scope, such
+as the parent Agent registry id, plus the subnet identity. If the producer
+cannot obtain a stable scope id, it must omit L3 subnet segments rather than
+fall back to a process-local or random id. This prevents identical private
+subnets from different Agents from colliding after Cloud aggregation.
+
 `ospf_adjacency` represents OSPF control-plane adjacency between two resolved
 managed SNMP device actors. It is a logical L3 routing-protocol relationship,
 not physical, L2, discovery, or port-neighbor evidence. The producer emits graph
@@ -592,6 +608,14 @@ evidence type. Replacement may rewire endpoint actors to stronger managed
 device actors, but it MUST NOT reinterpret `l3_subnet` as discovery protocol
 evidence or port-neighbor evidence.
 
+For `l3_subnet_segment`, aggregation MUST preserve the explicit
+`l3_subnet_segment` actor type and `l3_subnet_membership` link/evidence type.
+Replacement may rewire member actors to stronger managed device actors, but it
+MUST NOT reinterpret subnet membership as L2 segment membership, discovery
+protocol evidence, or port-neighbor evidence. Aggregation may merge identical
+scoped subnet segment actors from the same producer scope, but must not merge
+identical private subnet strings across different producer scopes.
+
 For `ospf_adjacency`, aggregation MUST preserve the explicit `ospf_adjacency`
 link and evidence type, including its `semantic_role: control`. Replacement may
 rewire endpoint actors to stronger managed device actors, but it MUST NOT
@@ -626,6 +650,10 @@ Device modals should remain port-centric:
   relationship rows so local port identity never contradicts the port table.
 - L3 adjacency information: derived from typed `l3_subnet` relationship
   evidence, not from `actor_port_links`.
+- L3 subnet membership information: derived from typed
+  `l3_subnet_membership` evidence. A focused device may show the shared subnet
+  segment and the focused membership without automatically fanning out to every
+  other managed device in that broader subnet.
 - routing protocol neighbor information: derived from typed actor-owned detail
   rows such as `actor_ospf_neighbors` and `actor_bgp_peers`, not from
   `actor_port_links`. The modal may show unresolved or non-established protocol

--- a/.agents/sow/specs/topology-modes-correlation-aggregation.md
+++ b/.agents/sow/specs/topology-modes-correlation-aggregation.md
@@ -531,6 +531,12 @@ cannot obtain a stable scope id, it must omit L3 subnet segments rather than
 fall back to a process-local or random id. This prevents identical private
 subnets from different Agents from colliding after Cloud aggregation.
 
+Current SNMP L3 subnet segments are single-routing-context. `L3Interface` does
+not currently carry a VRF or routing-context field, so identical subnet/prefix
+values inside one producer scope are treated as one logical segment. Producers
+MUST NOT present these segments as VRF-aware until collection adds routing
+context to L3 interface observations and segment identity includes it.
+
 `ospf_adjacency` represents OSPF control-plane adjacency between two resolved
 managed SNMP device actors. It is a logical L3 routing-protocol relationship,
 not physical, L2, discovery, or port-neighbor evidence. The producer emits graph
@@ -615,6 +621,8 @@ MUST NOT reinterpret subnet membership as L2 segment membership, discovery
 protocol evidence, or port-neighbor evidence. Aggregation may merge identical
 scoped subnet segment actors from the same producer scope, but must not merge
 identical private subnet strings across different producer scopes.
+Within one producer scope, the current identity is subnet/prefix only because
+SNMP topology does not yet collect VRF/routing-context for L3 interfaces.
 
 For `ospf_adjacency`, aggregation MUST preserve the explicit `ospf_adjacency`
 link and evidence type, including its `semantic_role: control`. Replacement may

--- a/src/go/pkg/pluginconfig/pluginconfig.go
+++ b/src/go/pkg/pluginconfig/pluginconfig.go
@@ -83,7 +83,8 @@ func MustInit(input InitInput) {
 	})
 }
 
-func EnvLogLevel() string { return env.logLevel }
+func EnvLogLevel() string      { return env.logLevel }
+func RegistryUniqueID() string { return readRegistryUniqueID(registryUniqueIDVarLibDir()) }
 
 func UserConfigDirs() multipath.MultiPath { return dirs.userConfigDirsClone() }
 func StockConfigDir() string              { return dirs.stockConfigDir }
@@ -304,6 +305,28 @@ func handleDirOnWin(base, p string, execDir string) string {
 		return p
 	}
 	return filepath.Join(base, strings.TrimPrefix(p, "/"))
+}
+
+func registryUniqueIDVarLibDir() string {
+	if dir := strings.TrimSpace(VarLibDir()); dir != "" {
+		return dir
+	}
+	if dir := strings.TrimSpace(buildinfo.VarLibDir); dir != "" {
+		return dir
+	}
+	return buildinfo.DefaultVarLibDir
+}
+
+func readRegistryUniqueID(varLibDir string) string {
+	varLibDir = strings.TrimSpace(varLibDir)
+	if varLibDir == "" {
+		return ""
+	}
+	bs, err := os.ReadFile(filepath.Join(varLibDir, "registry", "netdata.public.unique.id"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(bs))
 }
 
 func isDirExists(dir string) bool {

--- a/src/go/pkg/pluginconfig/pluginconfig_test.go
+++ b/src/go/pkg/pluginconfig/pluginconfig_test.go
@@ -18,6 +18,15 @@ func mkdir(t *testing.T, p string) {
 
 const testPluginName = "test.plugin"
 
+func TestReadRegistryUniqueID(t *testing.T) {
+	tmp := t.TempDir()
+	mkdir(t, filepath.Join(tmp, "registry"))
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "registry", "netdata.public.unique.id"), []byte("  test-machine-guid\n"), 0o644))
+
+	assert.Equal(t, "test-machine-guid", readRegistryUniqueID(tmp))
+	assert.Empty(t, readRegistryUniqueID(filepath.Join(tmp, "missing")))
+}
+
 func TestDirectoriesBuild(t *testing.T) {
 	tmp := t.TempDir()
 	execDir := filepath.Join(tmp, "root", "opt", "netdata", "bin")

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -207,6 +207,12 @@ include only managed SNMP network devices that can be resolved to topology
 actors. Depth/focus filtering may show a focused device and the subnet segment
 without fanning out to every other device on that subnet.
 
+Current L3 subnet segments are single-routing-context. `L3Interface` has no
+VRF/routing-context field, so segment identity is producer scope plus
+subnet/prefix. Identical subnet/prefix values in multiple VRFs inside the same
+producer scope are therefore one logical segment until collection adds routing
+context and segment identity includes it.
+
 ## Internal Packages
 
 The root package owns collector lifecycle, cache ingestion, registry snapshots,

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -162,6 +162,12 @@ Each cache snapshot is converted into:
   peers;
 - local device detail used to enrich the selected local actor.
 
+The aggregate also carries the producer scope id read from the parent Agent
+registry id. L3 subnet segment actor ids use that scope so identical private
+subnets observed by different Agents do not collide after Cloud aggregation.
+If the registry id is unavailable, L3 subnet segment actors are omitted; direct
+L3 subnet links, OSPF, and BGP enrichment still run.
+
 Only fresh caches contribute snapshots. Stale caches are ignored until refreshed
 or pruned.
 
@@ -187,6 +193,19 @@ aggregate observations
 For the low-confidence map type, the builder creates a strict map and a
 probable map, marks probable-only link deltas, then applies the same L3/OSPF/BGP
 enrichment and depth/focus filtering to the probable map.
+
+L3 subnet enrichment has two grains:
+
+- `/30` and `/31` shared subnets emit direct managed-device
+  `l3_subnet` links.
+- `/24` through `/29` shared subnets emit an `l3_subnet_segment` actor plus
+  `l3_subnet_membership` links from each resolved managed SNMP device to that
+  segment.
+
+L3 subnet segments are logical shared-subnet evidence, not physical links. They
+include only managed SNMP network devices that can be resolved to topology
+actors. Depth/focus filtering may show a focused device and the subnet segment
+without fanning out to every other device on that subnet.
 
 ## Internal Packages
 

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_test.go
@@ -378,7 +378,7 @@ func TestSNMPTopologyToV1_BuildsTypedActorDetailTables(t *testing.T) {
 	require.NotNil(t, deviceType.Presentation.Modal.Labels)
 	require.NotNil(t, deviceType.Presentation.Modal.Labels.Identification)
 	assert.Equal(t, "management_ip", deviceType.Presentation.Modal.Labels.Identification.Fields[1].Key)
-	require.Len(t, deviceType.Presentation.Modal.Sections, 5)
+	require.Len(t, deviceType.Presentation.Modal.Sections, 6)
 	assert.Equal(t, "ports", deviceType.Presentation.Modal.Sections[0].ID)
 	assert.Equal(t, "if_index", deviceType.Presentation.Modal.Sections[0].Columns[0].ID)
 	assert.Equal(t, "Port ID", deviceType.Presentation.Modal.Sections[0].Columns[0].Label)
@@ -391,12 +391,15 @@ func TestSNMPTopologyToV1_BuildsTypedActorDetailTables(t *testing.T) {
 	assert.Equal(t, "l3_adjacencies", deviceType.Presentation.Modal.Sections[2].ID)
 	assert.Equal(t, "evidence", deviceType.Presentation.Modal.Sections[2].Source.Kind)
 	assert.Equal(t, topologymodel.L3SubnetLinkType, deviceType.Presentation.Modal.Sections[2].Source.Evidence)
-	assert.Equal(t, "ospf_neighbors", deviceType.Presentation.Modal.Sections[3].ID)
-	assert.Equal(t, "actor_table", deviceType.Presentation.Modal.Sections[3].Source.Kind)
-	assert.Equal(t, "actor_ospf_neighbors", deviceType.Presentation.Modal.Sections[3].Source.Table)
-	assert.Equal(t, "bgp_peers", deviceType.Presentation.Modal.Sections[4].ID)
+	assert.Equal(t, "l3_subnet_memberships", deviceType.Presentation.Modal.Sections[3].ID)
+	assert.Equal(t, "evidence", deviceType.Presentation.Modal.Sections[3].Source.Kind)
+	assert.Equal(t, topologymodel.L3SubnetMembershipLinkType, deviceType.Presentation.Modal.Sections[3].Source.Evidence)
+	assert.Equal(t, "ospf_neighbors", deviceType.Presentation.Modal.Sections[4].ID)
 	assert.Equal(t, "actor_table", deviceType.Presentation.Modal.Sections[4].Source.Kind)
-	assert.Equal(t, "actor_bgp_peers", deviceType.Presentation.Modal.Sections[4].Source.Table)
+	assert.Equal(t, "actor_ospf_neighbors", deviceType.Presentation.Modal.Sections[4].Source.Table)
+	assert.Equal(t, "bgp_peers", deviceType.Presentation.Modal.Sections[5].ID)
+	assert.Equal(t, "actor_table", deviceType.Presentation.Modal.Sections[5].Source.Kind)
+	assert.Equal(t, "actor_bgp_peers", deviceType.Presentation.Modal.Sections[5].Source.Table)
 
 	endpointType := payload.Types.ActorTypes["endpoint"]
 	require.NotNil(t, endpointType.Presentation)
@@ -758,6 +761,129 @@ func TestSNMPTopologyToV1_PreservesL3SubnetPresentationAndEvidence(t *testing.T)
 	assert.Equal(t, "subnet", l3Section.Sort.Column)
 	assert.Equal(t, "selected_side_endpoint", l3Section.Columns[1].Projection.Kind)
 	assert.Equal(t, "endpoint", l3Section.Columns[1].Cell)
+
+	if payload.Tables != nil {
+		assert.NotContains(t, payload.Tables.Actor, "actor_port_links")
+	}
+}
+
+func TestSNMPTopologyToV1_PreservesL3SubnetMembershipPresentationAndEvidence(t *testing.T) {
+	data := topologymodel.Data{
+		AgentID: "agent-test",
+		View:    "summary",
+		Actors: []topologymodel.Actor{
+			{
+				ActorID:   "router-a",
+				ActorType: "router",
+				Match: topologymodel.Match{
+					IPAddresses: []string{"192.0.2.10"},
+					SysName:     "router-a",
+				},
+			},
+			{
+				ActorID:     "subnet-a",
+				ActorType:   topologymodel.L3SubnetSegmentActorType,
+				SegmentKind: topologymodel.SegmentKindL3Subnet,
+				Detail: topologymodel.ActorDetail{
+					L2: topologyengine.ProjectionActorDetail{
+						DisplayName: "192.0.2.0/24",
+					},
+				},
+			},
+		},
+		Links: []topologymodel.Link{
+			{
+				Protocol:   topologymodel.L3SubnetMembershipLinkType,
+				LinkType:   topologymodel.L3SubnetMembershipLinkType,
+				Direction:  "observed",
+				SrcActorID: "router-a",
+				DstActorID: "subnet-a",
+				Src: topologymodel.LinkEndpoint{
+					IfIndex: 10,
+					IfName:  "xe-0/0/0",
+				},
+				Inference: &graph.LinkInference{
+					Inference:      "shared_subnet_membership",
+					AttachmentMode: "logical_l3_subnet_membership",
+				},
+				Detail: topologymodel.LinkDetail{
+					L3SubnetMembership: &topologymodel.L3SubnetMembershipLinkDetail{
+						Source:  "ip_mib",
+						Subnet:  "192.0.2.0/24",
+						Network: "192.0.2.0",
+						Netmask: "255.255.255.0",
+						Prefix:  24,
+						Interfaces: []topologymodel.L3SubnetMembershipInterface{
+							{MemberIP: "192.0.2.10", IfIndex: 10, IfName: "xe-0/0/0", IfDescr: "primary"},
+							{MemberIP: "192.0.2.11", IfIndex: 11, IfName: "xe-0/0/1", IfDescr: "secondary"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	payload, err := topologyv1renderer.Render(data)
+	require.NoError(t, err)
+	require.NoError(t, validateTopologyV1Data(payload))
+
+	assert.Contains(t, payload.Producer.Capabilities, "l3_subnet_membership")
+	assert.Contains(t, topologyV1LegendActorTypes(payload), topologymodel.L3SubnetSegmentActorType)
+	assert.Contains(t, topologyV1LegendLinkTypes(payload), topologymodel.L3SubnetMembershipLinkType)
+
+	require.Contains(t, payload.Types.ActorTypes, topologymodel.L3SubnetSegmentActorType)
+	segmentType := payload.Types.ActorTypes[topologymodel.L3SubnetSegmentActorType]
+	assert.Equal(t, []string{"id"}, segmentType.Identity)
+	assert.Equal(t, []string{"id"}, segmentType.MergeIdentity)
+	assert.Empty(t, segmentType.ParentIdentity)
+	require.NotNil(t, segmentType.Presentation)
+	assert.Equal(t, "L3 subnet", segmentType.Presentation.Label)
+	require.NotNil(t, segmentType.Presentation.Modal)
+	segmentMembers := requireTopologyV1ModalSection(t, segmentType.Presentation.Modal.Sections, "l3_subnet_members")
+	assert.Equal(t, topologymodel.L3SubnetMembershipLinkType, segmentMembers.Source.Evidence)
+	assert.Equal(t, "member", segmentMembers.Columns[0].ID)
+
+	require.Contains(t, payload.Types.LinkTypes, topologymodel.L3SubnetMembershipLinkType)
+	linkType := payload.Types.LinkTypes[topologymodel.L3SubnetMembershipLinkType]
+	assert.Equal(t, "observed_bidirectional", linkType.Orientation)
+	assert.Equal(t, "observation", linkType.DirectionRole)
+	assert.Equal(t, "normal", linkType.SemanticRole)
+	require.NotNil(t, linkType.Presentation)
+	assert.Equal(t, "L3 subnet membership", linkType.Presentation.Label)
+	assert.Equal(t, "dashed", linkType.Presentation.LineStyle)
+
+	require.Contains(t, payload.Types.EvidenceTypes, topologymodel.L3SubnetMembershipLinkType)
+	evidenceType := payload.Types.EvidenceTypes[topologymodel.L3SubnetMembershipLinkType]
+	assert.Equal(t, topologymodel.L3SubnetMembershipLinkType, evidenceType.LinkType)
+	assert.Equal(t, []string{"member_actor", "segment_actor", "member_ip", "subnet"}, evidenceType.MatchColumns)
+
+	require.Contains(t, payload.Evidence, topologymodel.L3SubnetMembershipLinkType)
+	evidenceTable := payload.Evidence[topologymodel.L3SubnetMembershipLinkType].Table
+	require.Equal(t, 2, evidenceTable.Rows)
+	assert.Equal(t, "actor_ref", topologyV1ColumnType(evidenceTable, "member_actor"))
+	assert.Equal(t, "actor_ref", topologyV1ColumnType(evidenceTable, "segment_actor"))
+	assert.Equal(t, "string_ref", topologyV1ColumnType(evidenceTable, "member_ip"))
+	assert.Equal(t, "uint", topologyV1ColumnType(evidenceTable, "member_if_index"))
+	assert.Equal(t, []any{0, 0}, topologyV1ColumnValues(t, evidenceTable, "link"))
+	assert.Equal(t, []any{0, 0}, topologyV1ColumnValues(t, evidenceTable, "member_actor"))
+	assert.Equal(t, []any{1, 1}, topologyV1ColumnValues(t, evidenceTable, "segment_actor"))
+	assert.Equal(t, []string{"192.0.2.10", "192.0.2.11"}, topologyV1StringColumnValues(t, payload, evidenceTable, "member_ip"))
+	assert.Equal(t, []any{uint64(10), uint64(11)}, topologyV1ColumnValues(t, evidenceTable, "member_if_index"))
+	assert.Equal(t, []string{"xe-0/0/0", "xe-0/0/1"}, topologyV1StringColumnValues(t, payload, evidenceTable, "member_if_name"))
+	assert.Equal(t, []string{"192.0.2.0/24", "192.0.2.0/24"}, topologyV1StringColumnValues(t, payload, evidenceTable, "subnet"))
+	assert.Equal(t, []any{uint64(24), uint64(24)}, topologyV1ColumnValues(t, evidenceTable, "prefix"))
+
+	assert.Equal(t, []string{topologymodel.L3SubnetMembershipLinkType}, topologyV1StringColumnValues(t, payload, payload.Links, "type"))
+	assert.Equal(t, []any{2}, topologyV1ColumnValues(t, payload.Links, "evidence_count"))
+
+	routerType := payload.Types.ActorTypes["router"]
+	require.NotNil(t, routerType.Presentation)
+	require.NotNil(t, routerType.Presentation.Modal)
+	membershipSection := requireTopologyV1ModalSection(t, routerType.Presentation.Modal.Sections, "l3_subnet_memberships")
+	assert.Equal(t, "evidence", membershipSection.Source.Kind)
+	assert.Equal(t, topologymodel.L3SubnetMembershipLinkType, membershipSection.Source.Evidence)
+	require.NotNil(t, membershipSection.OwnerFilter)
+	assert.Equal(t, "incident_evidence", membershipSection.OwnerFilter.Mode)
 
 	if payload.Tables != nil {
 		assert.NotContains(t, payload.Tables.Actor, "actor_port_links")
@@ -1520,6 +1646,17 @@ func topologyV1LegendLinkTypes(data topologyv1.Data) []string {
 	}
 	out := make([]string, 0, len(data.Presentation.Legend.Links))
 	for _, entry := range data.Presentation.Legend.Links {
+		out = append(out, entry.Type)
+	}
+	return out
+}
+
+func topologyV1LegendActorTypes(data topologyv1.Data) []string {
+	if data.Presentation == nil || data.Presentation.Legend == nil {
+		return nil
+	}
+	out := make([]string, 0, len(data.Presentation.Legend.Actors))
+	for _, entry := range data.Presentation.Legend.Actors {
 		out = append(out, entry.Type)
 	}
 	return out

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyenrich/l3_links.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyenrich/l3_links.go
@@ -3,15 +3,20 @@
 package topologyenrich
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"sort"
 	"strconv"
 	"strings"
 
+	topologyengine "github.com/netdata/netdata/go/plugins/pkg/l2topology"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
 
 	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
+
+const topologyL3SubnetSource = "ip_mib"
 
 func ApplyL3Subnet(data *topologymodel.Data, aggregate topologymodel.ObservationAggregate) topologymodel.L3EnrichmentStats {
 	var stats topologymodel.L3EnrichmentStats
@@ -19,15 +24,15 @@ func ApplyL3Subnet(data *topologymodel.Data, aggregate topologymodel.Observation
 		return finishTopologyL3SubnetEnrichment(data, stats)
 	}
 
-	adjacencies, subnetStats := buildTopologyL3SubnetAdjacencies(aggregate.L3Interfaces)
+	candidates, subnetStats := buildTopologyL3SubnetCandidates(aggregate.L3Interfaces)
 	stats.SubnetStats = subnetStats
-	if len(adjacencies) == 0 {
+	if len(candidates.Adjacencies) == 0 && len(candidates.Segments) == 0 {
 		return finishTopologyL3SubnetEnrichment(data, stats)
 	}
 
 	resolver := newTopologyL3ActorResolver(data, aggregate.Snapshots)
-	seen := existingTopologyL3LinkKeys(data.Links)
-	for _, adjacency := range adjacencies {
+	directSeen := existingTopologyL3LinkKeys(data.Links)
+	for _, adjacency := range candidates.Adjacencies {
 		srcRef, ok := resolver.resolve(adjacency.A)
 		if !ok {
 			stats.SuppressedUnresolvedActor++
@@ -44,15 +49,20 @@ func ApplyL3Subnet(data *topologymodel.Data, aggregate topologymodel.Observation
 		}
 		link := topologyL3SubnetLink(adjacency, srcRef, dstRef)
 		key := topologyL3SubnetLinkKey(link)
-		if _, exists := seen[key]; exists {
+		if _, exists := directSeen[key]; exists {
 			stats.SuppressedDuplicateLink++
 			continue
 		}
-		seen[key] = struct{}{}
+		directSeen[key] = struct{}{}
 		data.Links = append(data.Links, link)
 		stats.EmittedLinks++
 	}
 
+	applyTopologyL3SubnetSegments(data, candidates.Segments, resolver, strings.TrimSpace(aggregate.ProducerScopeID), &stats)
+
+	sort.Slice(data.Actors, func(i, j int) bool {
+		return strings.TrimSpace(data.Actors[i].ActorID) < strings.TrimSpace(data.Actors[j].ActorID)
+	})
 	sort.Slice(data.Links, func(i, j int) bool {
 		return topologymodel.LinkSortKey(data.Links[i]) < topologymodel.LinkSortKey(data.Links[j])
 	})
@@ -91,7 +101,7 @@ func topologyL3SubnetLink(adjacency topologyL3SubnetAdjacency, srcRef, dstRef to
 		},
 		Detail: topologymodel.LinkDetail{
 			L3Subnet: &topologymodel.L3SubnetLinkDetail{
-				Source:  "ip_mib",
+				Source:  topologyL3SubnetSource,
 				SrcIP:   topologyutil.NormalizeIPAddress(adjacency.A.IP),
 				DstIP:   topologyutil.NormalizeIPAddress(adjacency.B.IP),
 				Subnet:  adjacency.Subnet,
@@ -103,11 +113,212 @@ func topologyL3SubnetLink(adjacency topologyL3SubnetAdjacency, srcRef, dstRef to
 	}
 }
 
+type topologyL3SubnetMember struct {
+	ref        topologyL3ActorRef
+	interfaces []topologymodel.L3SubnetMembershipInterface
+}
+
+func applyTopologyL3SubnetSegments(
+	data *topologymodel.Data,
+	segments []topologyL3SubnetSegment,
+	resolver topologyL3ActorResolver,
+	producerScopeID string,
+	stats *topologymodel.L3EnrichmentStats,
+) {
+	if data == nil || len(segments) == 0 {
+		return
+	}
+	if producerScopeID == "" {
+		stats.SuppressedNoProducerScope += len(segments)
+		return
+	}
+
+	actorSeen := existingTopologyActorIDs(data.Actors)
+	membershipSeen := existingTopologyL3MembershipLinkKeys(data.Links)
+	for _, segment := range segments {
+		members := topologyL3SubnetSegmentMembers(segment, resolver, stats)
+		if len(members) < 2 {
+			stats.SuppressedMembershipUnmatched++
+			continue
+		}
+
+		segmentActor := topologyL3SubnetSegmentActor(producerScopeID, segment, members)
+		segmentActorID := strings.TrimSpace(segmentActor.ActorID)
+		segmentActorEmitted := false
+		for _, member := range members {
+			link := topologyL3SubnetMembershipLink(segment, segmentActorID, member)
+			key := topologyL3SubnetMembershipLinkKey(link)
+			if _, exists := membershipSeen[key]; exists {
+				stats.SuppressedDuplicateMembershipLink++
+				continue
+			}
+			membershipSeen[key] = struct{}{}
+			if _, exists := actorSeen[segmentActorID]; !exists && !segmentActorEmitted {
+				data.Actors = append(data.Actors, segmentActor)
+				actorSeen[segmentActorID] = struct{}{}
+				segmentActorEmitted = true
+				stats.EmittedSegments++
+			}
+			data.Links = append(data.Links, link)
+			stats.EmittedMembershipLinks++
+		}
+	}
+}
+
+func topologyL3SubnetSegmentMembers(
+	segment topologyL3SubnetSegment,
+	resolver topologyL3ActorResolver,
+	stats *topologymodel.L3EnrichmentStats,
+) []topologyL3SubnetMember {
+	byActor := make(map[string]*topologyL3SubnetMember, len(segment.Rows))
+	for _, row := range segment.Rows {
+		ref, ok := resolver.resolve(row)
+		if !ok {
+			stats.SuppressedMembershipUnresolvedActor++
+			continue
+		}
+		actorID := strings.TrimSpace(ref.actorID)
+		if actorID == "" {
+			stats.SuppressedMembershipUnresolvedActor++
+			continue
+		}
+		member := byActor[actorID]
+		if member == nil {
+			member = &topologyL3SubnetMember{ref: ref}
+			byActor[actorID] = member
+		}
+		member.interfaces = append(member.interfaces, topologyL3SubnetMembershipInterface(row))
+	}
+
+	actorIDs := make([]string, 0, len(byActor))
+	for actorID := range byActor {
+		actorIDs = append(actorIDs, actorID)
+	}
+	sort.Strings(actorIDs)
+
+	out := make([]topologyL3SubnetMember, 0, len(actorIDs))
+	for _, actorID := range actorIDs {
+		member := byActor[actorID]
+		sort.Slice(member.interfaces, func(i, j int) bool {
+			return topologyL3SubnetMembershipInterfaceSortKey(member.interfaces[i]) < topologyL3SubnetMembershipInterfaceSortKey(member.interfaces[j])
+		})
+		out = append(out, *member)
+	}
+	return out
+}
+
+func topologyL3SubnetMembershipInterface(row topologymodel.L3Interface) topologymodel.L3SubnetMembershipInterface {
+	return topologymodel.L3SubnetMembershipInterface{
+		MemberIP: topologyutil.NormalizeIPAddress(row.IP),
+		IfIndex:  topologyutil.ParseIndex(row.IfIndex),
+		IfName:   strings.TrimSpace(row.IfName),
+		IfDescr:  strings.TrimSpace(row.IfDescr),
+	}
+}
+
+func topologyL3SubnetMembershipInterfaceSortKey(row topologymodel.L3SubnetMembershipInterface) string {
+	return strings.Join([]string{
+		strings.TrimSpace(row.MemberIP),
+		strconv.Itoa(row.IfIndex),
+		strings.TrimSpace(row.IfName),
+		strings.TrimSpace(row.IfDescr),
+	}, "\x00")
+}
+
+func topologyL3SubnetSegmentActor(producerScopeID string, segment topologyL3SubnetSegment, members []topologyL3SubnetMember) topologymodel.Actor {
+	actorID := topologyL3SubnetSegmentActorID(producerScopeID, segment)
+	portCount := 0
+	for _, member := range members {
+		portCount += len(member.interfaces)
+	}
+	return topologymodel.Actor{
+		ActorID:     actorID,
+		ActorType:   topologymodel.L3SubnetSegmentActorType,
+		SegmentKind: topologymodel.SegmentKindL3Subnet,
+		Layer:       "3",
+		Source:      topologyL3SubnetSource,
+		Detail: topologymodel.ActorDetail{
+			L2: topologyengine.ProjectionActorDetail{
+				DisplayName: segment.Subnet,
+				Segment: topologyengine.ProjectionSegmentActorDetail{
+					SegmentID:      actorID,
+					SegmentType:    topologymodel.SegmentKindL3Subnet,
+					SegmentKind:    topologymodel.SegmentKindL3Subnet,
+					PortsTotal:     topologyengine.OptionalValue[int]{Value: portCount, Has: true},
+					EndpointsTotal: topologyengine.OptionalValue[int]{Value: len(members), Has: true},
+				},
+			},
+		},
+	}
+}
+
+func topologyL3SubnetSegmentActorID(producerScopeID string, segment topologyL3SubnetSegment) string {
+	sum := sha1.Sum([]byte(topologyutil.JoinKeyParts(
+		strings.TrimSpace(producerScopeID),
+		strings.TrimSpace(segment.Network),
+		strconv.Itoa(segment.Prefix),
+	)))
+	return "l3_subnet_segment:" + hex.EncodeToString(sum[:8])
+}
+
+func topologyL3SubnetMembershipLink(segment topologyL3SubnetSegment, segmentActorID string, member topologyL3SubnetMember) topologymodel.Link {
+	src := topologymodel.LinkEndpoint{Match: member.ref.match}
+	if len(member.interfaces) > 0 {
+		src.IfIndex = member.interfaces[0].IfIndex
+		src.IfName = member.interfaces[0].IfName
+		src.IfDescr = member.interfaces[0].IfDescr
+	}
+	return topologymodel.Link{
+		Layer:      "3",
+		Protocol:   topologymodel.L3SubnetMembershipLinkType,
+		LinkType:   topologymodel.L3SubnetMembershipLinkType,
+		Direction:  "observed",
+		SrcActorID: member.ref.actorID,
+		DstActorID: segmentActorID,
+		Src:        src,
+		Dst:        topologymodel.LinkEndpoint{},
+		Inference: &graph.LinkInference{
+			Inference:      "shared_subnet_membership",
+			AttachmentMode: "logical_l3_subnet_membership",
+		},
+		Detail: topologymodel.LinkDetail{
+			L3SubnetMembership: &topologymodel.L3SubnetMembershipLinkDetail{
+				Source:     topologyL3SubnetSource,
+				Subnet:     segment.Subnet,
+				Network:    segment.Network,
+				Netmask:    segment.Netmask,
+				Prefix:     segment.Prefix,
+				Interfaces: append([]topologymodel.L3SubnetMembershipInterface(nil), member.interfaces...),
+			},
+		},
+	}
+}
+
 func existingTopologyL3LinkKeys(links []topologymodel.Link) map[string]struct{} {
 	seen := make(map[string]struct{})
 	for _, link := range links {
 		if strings.EqualFold(strings.TrimSpace(topologyutil.FirstNonEmptyString(link.LinkType, link.Protocol)), topologymodel.L3SubnetLinkType) {
 			seen[topologyL3SubnetLinkKey(link)] = struct{}{}
+		}
+	}
+	return seen
+}
+
+func existingTopologyL3MembershipLinkKeys(links []topologymodel.Link) map[string]struct{} {
+	seen := make(map[string]struct{})
+	for _, link := range links {
+		if strings.EqualFold(strings.TrimSpace(topologyutil.FirstNonEmptyString(link.LinkType, link.Protocol)), topologymodel.L3SubnetMembershipLinkType) {
+			seen[topologyL3SubnetMembershipLinkKey(link)] = struct{}{}
+		}
+	}
+	return seen
+}
+
+func existingTopologyActorIDs(actors []topologymodel.Actor) map[string]struct{} {
+	seen := make(map[string]struct{}, len(actors))
+	for _, actor := range actors {
+		if actorID := strings.TrimSpace(actor.ActorID); actorID != "" {
+			seen[actorID] = struct{}{}
 		}
 	}
 	return seen
@@ -127,6 +338,15 @@ func topologyL3SubnetLinkKey(link topologymodel.Link) string {
 	)
 }
 
+func topologyL3SubnetMembershipLinkKey(link topologymodel.Link) string {
+	return topologyutil.JoinKeyParts(
+		strings.TrimSpace(link.SrcActorID),
+		strings.TrimSpace(link.DstActorID),
+		topologyL3SubnetMembershipSubnet(link),
+		strconv.Itoa(topologyL3SubnetMembershipPrefix(link)),
+	)
+}
+
 func topologyL3Subnet(link topologymodel.Link) string {
 	if link.Detail.L3Subnet == nil {
 		return ""
@@ -139,6 +359,20 @@ func topologyL3SubnetPrefix(link topologymodel.Link) int {
 		return 0
 	}
 	return link.Detail.L3Subnet.Prefix
+}
+
+func topologyL3SubnetMembershipSubnet(link topologymodel.Link) string {
+	if link.Detail.L3SubnetMembership == nil {
+		return ""
+	}
+	return strings.TrimSpace(link.Detail.L3SubnetMembership.Subnet)
+}
+
+func topologyL3SubnetMembershipPrefix(link topologymodel.Link) int {
+	if link.Detail.L3SubnetMembership == nil {
+		return 0
+	}
+	return link.Detail.L3SubnetMembership.Prefix
 }
 
 func recordTopologyL3EnrichmentStats(data *topologymodel.Data, stats topologymodel.L3EnrichmentStats) {

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyenrich/l3_links_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyenrich/l3_links_test.go
@@ -114,6 +114,77 @@ func TestApplyTopologyL3SubnetEnrichmentSuppressions(t *testing.T) {
 	}
 }
 
+func TestApplyTopologyL3SubnetEnrichmentEmitsSegmentMemberships(t *testing.T) {
+	data := topologymodel.Data{
+		Actors: []topologymodel.Actor{
+			topologyL3ManagedActorForTest("router-a", nil, "203.0.113.1"),
+			topologyL3ManagedActorForTest("router-b", nil, "203.0.113.2"),
+			topologyL3ManagedActorForTest("router-c", nil, "203.0.113.3"),
+		},
+	}
+	aggregate := topologymodel.ObservationAggregate{
+		ProducerScopeID: "producer-a",
+		L3Interfaces: []topologymodel.L3Interface{
+			{DeviceID: "router-c", IP: "203.0.113.3", Netmask: "255.255.255.0", IfIndex: "3", IfName: "xe-0/0/3", IfDescr: "transit-c"},
+			{DeviceID: "router-a", IP: "203.0.113.1", Netmask: "255.255.255.0", IfIndex: "1", IfName: "xe-0/0/1", IfDescr: "transit-a"},
+			{DeviceID: "router-b", IP: "203.0.113.2", Netmask: "255.255.255.0", IfIndex: "2", IfName: "xe-0/0/2", IfDescr: "transit-b"},
+			{DeviceID: "unmanaged", IP: "203.0.113.4", Netmask: "255.255.255.0", IfIndex: "4", IfName: "xe-0/0/4", IfDescr: "unmanaged"},
+		},
+	}
+
+	stats := ApplyL3Subnet(&data, aggregate)
+
+	require.Equal(t, 1, stats.EmittedSegments)
+	require.Equal(t, 3, stats.EmittedMembershipLinks)
+	require.Equal(t, 0, stats.EmittedLinks)
+	require.Equal(t, 1, stats.SubnetStats.CandidateSegments)
+	require.Equal(t, 4, stats.SubnetStats.CandidateMemberships)
+	require.Equal(t, 1, stats.SuppressedMembershipUnresolvedActor)
+	require.Equal(t, 1, topologyStatsToV1ForTest(t, data.Stats)["l3_subnet_segment_emitted_segments"])
+	require.Equal(t, 3, topologyStatsToV1ForTest(t, data.Stats)["l3_subnet_membership_visible_links"])
+	require.Equal(t, 1, topologyStatsToV1ForTest(t, data.Stats)["l3_subnet_membership_suppressed_unresolved_actor"])
+
+	segments := topologyActorsByTypeForTest(data.Actors, topologymodel.L3SubnetSegmentActorType)
+	require.Len(t, segments, 1)
+	require.Equal(t, topologymodel.SegmentKindL3Subnet, segments[0].SegmentKind)
+	require.Equal(t, "203.0.113.0/24", topologymodel.ActorDetailDisplayName(segments[0]))
+	require.Equal(t, topologyengine.OptionalValue[int]{Value: 3, Has: true}, segments[0].Detail.L2.Segment.PortsTotal)
+	require.Equal(t, topologyengine.OptionalValue[int]{Value: 3, Has: true}, segments[0].Detail.L2.Segment.EndpointsTotal)
+
+	memberships := topologyLinksByTypeForTest(data.Links, topologymodel.L3SubnetMembershipLinkType)
+	require.Len(t, memberships, 3)
+	require.Equal(t, "router-a", memberships[0].SrcActorID)
+	require.Equal(t, segments[0].ActorID, memberships[0].DstActorID)
+	require.NotNil(t, memberships[0].Detail.L3SubnetMembership)
+	require.Equal(t, "203.0.113.0/24", memberships[0].Detail.L3SubnetMembership.Subnet)
+	require.Equal(t, []topologymodel.L3SubnetMembershipInterface{
+		{MemberIP: "203.0.113.1", IfIndex: 1, IfName: "xe-0/0/1", IfDescr: "transit-a"},
+	}, memberships[0].Detail.L3SubnetMembership.Interfaces)
+}
+
+func TestApplyTopologyL3SubnetEnrichmentOmitsSegmentsWithoutProducerScope(t *testing.T) {
+	data := topologymodel.Data{
+		Actors: []topologymodel.Actor{
+			topologyL3ManagedActorForTest("router-a", nil, "203.0.113.1"),
+			topologyL3ManagedActorForTest("router-b", nil, "203.0.113.2"),
+		},
+	}
+	aggregate := topologymodel.ObservationAggregate{
+		L3Interfaces: []topologymodel.L3Interface{
+			l3InterfaceForTest("router-a", "203.0.113.1", "255.255.255.0", "1"),
+			l3InterfaceForTest("router-b", "203.0.113.2", "255.255.255.0", "2"),
+		},
+	}
+
+	stats := ApplyL3Subnet(&data, aggregate)
+
+	require.Equal(t, 1, stats.SuppressedNoProducerScope)
+	require.Empty(t, topologyActorsByTypeForTest(data.Actors, topologymodel.L3SubnetSegmentActorType))
+	require.Empty(t, topologyLinksByTypeForTest(data.Links, topologymodel.L3SubnetMembershipLinkType))
+	require.Equal(t, 1, topologyStatsToV1ForTest(t, data.Stats)["l3_subnet_segment_suppressed_no_producer_scope"])
+	require.Equal(t, 0, topologyStatsToV1ForTest(t, data.Stats)["l3_subnet_membership_visible_links"])
+}
+
 func topologyL3SubnetLinkForTest(srcActorID, dstActorID, subnet string, prefix any) topologymodel.Link {
 	return topologymodel.Link{
 		Protocol:   topologymodel.L3SubnetLinkType,
@@ -127,6 +198,26 @@ func topologyL3SubnetLinkForTest(srcActorID, dstActorID, subnet string, prefix a
 			},
 		},
 	}
+}
+
+func topologyActorsByTypeForTest(actors []topologymodel.Actor, actorType string) []topologymodel.Actor {
+	var out []topologymodel.Actor
+	for _, actor := range actors {
+		if strings.EqualFold(strings.TrimSpace(actor.ActorType), actorType) {
+			out = append(out, actor)
+		}
+	}
+	return out
+}
+
+func topologyLinksByTypeForTest(links []topologymodel.Link, linkType string) []topologymodel.Link {
+	var out []topologymodel.Link
+	for _, link := range links {
+		if strings.EqualFold(strings.TrimSpace(topologyutil.FirstNonEmptyString(link.LinkType, link.Protocol)), linkType) {
+			out = append(out, link)
+		}
+	}
+	return out
 }
 
 func TestTopologyL3SubnetLinkKeySeparatesDelimitedFields(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyenrich/l3_links_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyenrich/l3_links_test.go
@@ -162,6 +162,76 @@ func TestApplyTopologyL3SubnetEnrichmentEmitsSegmentMemberships(t *testing.T) {
 	}, memberships[0].Detail.L3SubnetMembership.Interfaces)
 }
 
+func TestApplyTopologyL3SubnetEnrichmentDropsDuplicateSegmentMemberIP(t *testing.T) {
+	data := topologymodel.Data{
+		Actors: []topologymodel.Actor{
+			topologyL3ManagedActorForTest("router-a", nil, "203.0.113.1"),
+			topologyL3ManagedActorForTest("router-b", nil, "203.0.113.2"),
+			topologyL3ManagedActorForTest("router-c", nil, "203.0.113.2"),
+			topologyL3ManagedActorForTest("router-d", nil, "203.0.113.4"),
+		},
+	}
+	aggregate := topologymodel.ObservationAggregate{
+		ProducerScopeID: "producer-a",
+		L3Interfaces: []topologymodel.L3Interface{
+			{DeviceID: "router-c", IP: "203.0.113.2", Netmask: "255.255.255.0", IfIndex: "3", IfName: "xe-0/0/3"},
+			{DeviceID: "router-a", IP: "203.0.113.1", Netmask: "255.255.255.0", IfIndex: "1", IfName: "xe-0/0/1"},
+			{DeviceID: "router-d", IP: "203.0.113.4", Netmask: "255.255.255.0", IfIndex: "4", IfName: "xe-0/0/4"},
+			{DeviceID: "router-b", IP: "203.0.113.2", Netmask: "255.255.255.0", IfIndex: "2", IfName: "xe-0/0/2"},
+		},
+	}
+
+	stats := ApplyL3Subnet(&data, aggregate)
+
+	require.Equal(t, 1, stats.EmittedSegments)
+	require.Equal(t, 3, stats.EmittedMembershipLinks)
+	require.Equal(t, 1, stats.SubnetStats.SuppressedSegmentDuplicateIP)
+	require.Equal(t, 1, topologyStatsToV1ForTest(t, data.Stats)["l3_subnet_membership_suppressed_duplicate_ip"])
+	require.Equal(t, 3, topologyStatsToV1ForTest(t, data.Stats)["l3_subnet_membership_visible_links"])
+	require.Len(t, topologyActorsByTypeForTest(data.Actors, topologymodel.L3SubnetSegmentActorType), 1)
+
+	memberships := topologyLinksByTypeForTest(data.Links, topologymodel.L3SubnetMembershipLinkType)
+	require.Len(t, memberships, 3)
+	require.Equal(t, []string{"router-a", "router-b", "router-d"}, topologyLinkSrcActorIDsForTest(memberships))
+}
+
+func TestApplyTopologyL3SubnetEnrichmentAggregatesMultipleMemberInterfaces(t *testing.T) {
+	data := topologymodel.Data{
+		Actors: []topologymodel.Actor{
+			topologyL3ManagedActorForTest("router-a", nil, "203.0.113.1", "203.0.113.5"),
+			topologyL3ManagedActorForTest("router-b", nil, "203.0.113.2"),
+		},
+	}
+	aggregate := topologymodel.ObservationAggregate{
+		ProducerScopeID: "producer-a",
+		L3Interfaces: []topologymodel.L3Interface{
+			{DeviceID: "router-a", IP: "203.0.113.5", Netmask: "255.255.255.0", IfIndex: "5", IfName: "xe-0/0/5", IfDescr: "transit-a-secondary"},
+			{DeviceID: "router-b", IP: "203.0.113.2", Netmask: "255.255.255.0", IfIndex: "2", IfName: "xe-0/0/2", IfDescr: "transit-b"},
+			{DeviceID: "router-a", IP: "203.0.113.1", Netmask: "255.255.255.0", IfIndex: "1", IfName: "xe-0/0/1", IfDescr: "transit-a-primary"},
+		},
+	}
+
+	stats := ApplyL3Subnet(&data, aggregate)
+
+	require.Equal(t, 1, stats.EmittedSegments)
+	require.Equal(t, 2, stats.EmittedMembershipLinks)
+	require.Equal(t, 3, stats.SubnetStats.CandidateMemberships)
+
+	segments := topologyActorsByTypeForTest(data.Actors, topologymodel.L3SubnetSegmentActorType)
+	require.Len(t, segments, 1)
+	require.Equal(t, topologyengine.OptionalValue[int]{Value: 3, Has: true}, segments[0].Detail.L2.Segment.PortsTotal)
+	require.Equal(t, topologyengine.OptionalValue[int]{Value: 2, Has: true}, segments[0].Detail.L2.Segment.EndpointsTotal)
+
+	memberships := topologyLinksByTypeForTest(data.Links, topologymodel.L3SubnetMembershipLinkType)
+	require.Len(t, memberships, 2)
+	routerALink := requireTopologyLinkBySrcActorIDForTest(t, memberships, "router-a")
+	require.NotNil(t, routerALink.Detail.L3SubnetMembership)
+	require.Equal(t, []topologymodel.L3SubnetMembershipInterface{
+		{MemberIP: "203.0.113.1", IfIndex: 1, IfName: "xe-0/0/1", IfDescr: "transit-a-primary"},
+		{MemberIP: "203.0.113.5", IfIndex: 5, IfName: "xe-0/0/5", IfDescr: "transit-a-secondary"},
+	}, routerALink.Detail.L3SubnetMembership.Interfaces)
+}
+
 func TestApplyTopologyL3SubnetEnrichmentOmitsSegmentsWithoutProducerScope(t *testing.T) {
 	data := topologymodel.Data{
 		Actors: []topologymodel.Actor{
@@ -218,6 +288,25 @@ func topologyLinksByTypeForTest(links []topologymodel.Link, linkType string) []t
 		}
 	}
 	return out
+}
+
+func topologyLinkSrcActorIDsForTest(links []topologymodel.Link) []string {
+	out := make([]string, 0, len(links))
+	for _, link := range links {
+		out = append(out, link.SrcActorID)
+	}
+	return out
+}
+
+func requireTopologyLinkBySrcActorIDForTest(t *testing.T, links []topologymodel.Link, actorID string) topologymodel.Link {
+	t.Helper()
+	for _, link := range links {
+		if link.SrcActorID == actorID {
+			return link
+		}
+	}
+	require.Failf(t, "missing link", "src actor id %q", actorID)
+	return topologymodel.Link{}
 }
 
 func TestTopologyL3SubnetLinkKeySeparatesDelimitedFields(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyenrich/l3_subnets.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyenrich/l3_subnets.go
@@ -21,6 +21,19 @@ type topologyL3SubnetAdjacency struct {
 	B       topologymodel.L3Interface
 }
 
+type topologyL3SubnetCandidates struct {
+	Adjacencies []topologyL3SubnetAdjacency
+	Segments    []topologyL3SubnetSegment
+}
+
+type topologyL3SubnetSegment struct {
+	Subnet  string
+	Network string
+	Netmask string
+	Prefix  int
+	Rows    []topologymodel.L3Interface
+}
+
 type topologyL3SubnetGroup struct {
 	network netip.Addr
 	netmask netip.Addr
@@ -28,10 +41,10 @@ type topologyL3SubnetGroup struct {
 	rows    []topologymodel.L3Interface
 }
 
-func buildTopologyL3SubnetAdjacencies(rows []topologymodel.L3Interface) ([]topologyL3SubnetAdjacency, topologymodel.L3SubnetBuildStats) {
+func buildTopologyL3SubnetCandidates(rows []topologymodel.L3Interface) (topologyL3SubnetCandidates, topologymodel.L3SubnetBuildStats) {
 	var stats topologymodel.L3SubnetBuildStats
 	if len(rows) == 0 {
-		return nil, stats
+		return topologyL3SubnetCandidates{}, stats
 	}
 
 	groups := make(map[string]*topologyL3SubnetGroup)
@@ -60,39 +73,77 @@ func buildTopologyL3SubnetAdjacencies(rows []topologymodel.L3Interface) ([]topol
 	}
 	sort.Strings(keys)
 
-	adjacencies := make([]topologyL3SubnetAdjacency, 0, len(keys))
+	var candidates topologyL3SubnetCandidates
+	candidates.Adjacencies = make([]topologyL3SubnetAdjacency, 0, len(keys))
+	candidates.Segments = make([]topologyL3SubnetSegment, 0, len(keys))
 	for _, key := range keys {
 		group := groups[key]
 		stats.CandidateSubnets++
 		sortTopologyL3Interfaces(group.rows)
-		if topologyL3SubnetHasDuplicateIP(group.rows) {
-			stats.SuppressedDuplicateIP++
-			continue
+
+		switch {
+		case topologyL3SubnetDirectPrefixSupported(group.prefix):
+			adjacency, ok := buildTopologyL3SubnetAdjacency(group, &stats)
+			if !ok {
+				continue
+			}
+			candidates.Adjacencies = append(candidates.Adjacencies, adjacency)
+			stats.CandidateLinks++
+		case topologyL3SubnetSegmentPrefixSupported(group.prefix):
+			segment, ok := buildTopologyL3SubnetSegment(group, &stats)
+			if !ok {
+				continue
+			}
+			candidates.Segments = append(candidates.Segments, segment)
+			stats.CandidateSegments++
+			stats.CandidateMemberships += len(segment.Rows)
 		}
-		if len(group.rows) < 2 {
-			stats.SuppressedUnmatched++
-			continue
-		}
-		if len(group.rows) > 2 {
-			stats.SuppressedMultiAccess++
-			continue
-		}
-		if strings.TrimSpace(group.rows[0].DeviceID) == strings.TrimSpace(group.rows[1].DeviceID) {
-			stats.SuppressedSelfLink++
-			continue
-		}
-		adjacencies = append(adjacencies, topologyL3SubnetAdjacency{
-			Subnet:  group.network.String() + "/" + strconv.Itoa(group.prefix),
-			Network: group.network.String(),
-			Netmask: group.netmask.String(),
-			Prefix:  group.prefix,
-			A:       group.rows[0],
-			B:       group.rows[1],
-		})
-		stats.CandidateLinks++
 	}
 
-	return adjacencies, stats
+	return candidates, stats
+}
+
+func buildTopologyL3SubnetAdjacency(group *topologyL3SubnetGroup, stats *topologymodel.L3SubnetBuildStats) (topologyL3SubnetAdjacency, bool) {
+	if topologyL3SubnetHasDuplicateIP(group.rows) {
+		stats.SuppressedDuplicateIP++
+		return topologyL3SubnetAdjacency{}, false
+	}
+	if len(group.rows) < 2 {
+		stats.SuppressedUnmatched++
+		return topologyL3SubnetAdjacency{}, false
+	}
+	if len(group.rows) > 2 {
+		stats.SuppressedMultiAccess++
+		return topologyL3SubnetAdjacency{}, false
+	}
+	if strings.TrimSpace(group.rows[0].DeviceID) == strings.TrimSpace(group.rows[1].DeviceID) {
+		stats.SuppressedSelfLink++
+		return topologyL3SubnetAdjacency{}, false
+	}
+	return topologyL3SubnetAdjacency{
+		Subnet:  group.network.String() + "/" + strconv.Itoa(group.prefix),
+		Network: group.network.String(),
+		Netmask: group.netmask.String(),
+		Prefix:  group.prefix,
+		A:       group.rows[0],
+		B:       group.rows[1],
+	}, true
+}
+
+func buildTopologyL3SubnetSegment(group *topologyL3SubnetGroup, stats *topologymodel.L3SubnetBuildStats) (topologyL3SubnetSegment, bool) {
+	rows, duplicates := topologyL3SubnetUniqueIPRows(group.rows)
+	stats.SuppressedSegmentDuplicateIP += duplicates
+	if len(rows) < 2 {
+		stats.SuppressedSegmentUnmatched++
+		return topologyL3SubnetSegment{}, false
+	}
+	return topologyL3SubnetSegment{
+		Subnet:  group.network.String() + "/" + strconv.Itoa(group.prefix),
+		Network: group.network.String(),
+		Netmask: group.netmask.String(),
+		Prefix:  group.prefix,
+		Rows:    rows,
+	}, true
 }
 
 func topologyL3SubnetGroupForInterface(row topologymodel.L3Interface) (*topologyL3SubnetGroup, bool) {
@@ -112,7 +163,15 @@ func topologyL3SubnetGroupForInterface(row topologymodel.L3Interface) (*topology
 }
 
 func topologyL3SubnetPrefixSupported(prefix int) bool {
+	return topologyL3SubnetDirectPrefixSupported(prefix) || topologyL3SubnetSegmentPrefixSupported(prefix)
+}
+
+func topologyL3SubnetDirectPrefixSupported(prefix int) bool {
 	return prefix == 30 || prefix == 31
+}
+
+func topologyL3SubnetSegmentPrefixSupported(prefix int) bool {
+	return prefix >= 24 && prefix <= 29
 }
 
 func topologyL3SubnetKey(network netip.Addr, prefix int) string {
@@ -147,4 +206,26 @@ func topologyL3SubnetHasDuplicateIP(rows []topologymodel.L3Interface) bool {
 		seen[ip] = deviceID
 	}
 	return false
+}
+
+func topologyL3SubnetUniqueIPRows(rows []topologymodel.L3Interface) ([]topologymodel.L3Interface, int) {
+	seen := make(map[string]string, len(rows))
+	out := make([]topologymodel.L3Interface, 0, len(rows))
+	duplicates := 0
+	for _, row := range rows {
+		ip := topologyutil.NormalizeIPAddress(row.IP)
+		if ip == "" {
+			continue
+		}
+		deviceID := strings.TrimSpace(row.DeviceID)
+		if owner, ok := seen[ip]; ok {
+			if owner != deviceID {
+				duplicates++
+			}
+			continue
+		}
+		seen[ip] = deviceID
+		out = append(out, row)
+	}
+	return out, duplicates
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyenrich/l3_subnets_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyenrich/l3_subnets_test.go
@@ -10,26 +10,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildTopologyL3SubnetAdjacencies(t *testing.T) {
+func TestBuildTopologyL3SubnetCandidates(t *testing.T) {
 	tests := map[string]struct {
-		rows      []topologymodel.L3Interface
-		wantLinks []topologyL3SubnetAdjacency
-		wantStats topologymodel.L3SubnetBuildStats
+		rows           []topologymodel.L3Interface
+		wantCandidates topologyL3SubnetCandidates
+		wantStats      topologymodel.L3SubnetBuildStats
 	}{
 		"ipv4-point-to-point": {
 			rows: []topologymodel.L3Interface{
 				l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
 				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
 			},
-			wantLinks: []topologyL3SubnetAdjacency{
-				{
+			wantCandidates: topologyL3SubnetCandidates{
+				Adjacencies: []topologyL3SubnetAdjacency{{
 					Subnet:  "198.51.100.0/30",
 					Network: "198.51.100.0",
 					Netmask: "255.255.255.252",
 					Prefix:  30,
 					A:       l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.252", "2"),
 					B:       l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
-				},
+				}},
 			},
 			wantStats: topologymodel.L3SubnetBuildStats{
 				CandidateSubnets: 1,
@@ -41,25 +41,52 @@ func TestBuildTopologyL3SubnetAdjacencies(t *testing.T) {
 				l3InterfaceForTest("device-a", "198.51.100.0", "255.255.255.254", "2"),
 				l3InterfaceForTest("device-b", "198.51.100.1", "255.255.255.254", "3"),
 			},
-			wantLinks: []topologyL3SubnetAdjacency{
-				{
+			wantCandidates: topologyL3SubnetCandidates{
+				Adjacencies: []topologyL3SubnetAdjacency{{
 					Subnet:  "198.51.100.0/31",
 					Network: "198.51.100.0",
 					Netmask: "255.255.255.254",
 					Prefix:  31,
 					A:       l3InterfaceForTest("device-a", "198.51.100.0", "255.255.255.254", "2"),
 					B:       l3InterfaceForTest("device-b", "198.51.100.1", "255.255.255.254", "3"),
-				},
+				}},
 			},
 			wantStats: topologymodel.L3SubnetBuildStats{
 				CandidateSubnets: 1,
 				CandidateLinks:   1,
 			},
 		},
+		"ipv4-subnet-segment": {
+			rows: []topologymodel.L3Interface{
+				l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.0", "3"),
+				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.0", "2"),
+				l3InterfaceForTest("device-c", "198.51.100.3", "255.255.255.0", "4"),
+			},
+			wantCandidates: topologyL3SubnetCandidates{
+				Segments: []topologyL3SubnetSegment{
+					{
+						Subnet:  "198.51.100.0/24",
+						Network: "198.51.100.0",
+						Netmask: "255.255.255.0",
+						Prefix:  24,
+						Rows: []topologymodel.L3Interface{
+							l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.0", "2"),
+							l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.0", "3"),
+							l3InterfaceForTest("device-c", "198.51.100.3", "255.255.255.0", "4"),
+						},
+					},
+				},
+			},
+			wantStats: topologymodel.L3SubnetBuildStats{
+				CandidateSubnets:     1,
+				CandidateSegments:    1,
+				CandidateMemberships: 3,
+			},
+		},
 		"unsupported-prefix": {
 			rows: []topologymodel.L3Interface{
-				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.0", "2"),
-				l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.0", "3"),
+				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.254.0", "2"),
+				l3InterfaceForTest("device-b", "198.51.100.2", "255.255.254.0", "3"),
 			},
 			wantStats: topologymodel.L3SubnetBuildStats{
 				SuppressedUnsupportedPrefix: 2,
@@ -120,19 +147,24 @@ func TestBuildTopologyL3SubnetAdjacencies(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			links, stats := buildTopologyL3SubnetAdjacencies(tc.rows)
+			candidates, stats := buildTopologyL3SubnetCandidates(tc.rows)
 
-			if len(tc.wantLinks) == 0 {
-				require.Empty(t, links)
+			if len(tc.wantCandidates.Adjacencies) == 0 {
+				require.Empty(t, candidates.Adjacencies)
 			} else {
-				require.Equal(t, tc.wantLinks, links)
+				require.Equal(t, tc.wantCandidates.Adjacencies, candidates.Adjacencies)
+			}
+			if len(tc.wantCandidates.Segments) == 0 {
+				require.Empty(t, candidates.Segments)
+			} else {
+				require.Equal(t, tc.wantCandidates.Segments, candidates.Segments)
 			}
 			require.Equal(t, tc.wantStats, stats)
 		})
 	}
 }
 
-func TestBuildTopologyL3SubnetAdjacenciesDeterministic(t *testing.T) {
+func TestBuildTopologyL3SubnetCandidatesDeterministic(t *testing.T) {
 	rows := []topologymodel.L3Interface{
 		l3InterfaceForTest("device-d", "198.51.100.6", "255.255.255.252", "6"),
 		l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.252", "3"),
@@ -142,14 +174,14 @@ func TestBuildTopologyL3SubnetAdjacenciesDeterministic(t *testing.T) {
 	reversed := slices.Clone(rows)
 	slices.Reverse(reversed)
 
-	links, stats := buildTopologyL3SubnetAdjacencies(rows)
-	reversedLinks, reversedStats := buildTopologyL3SubnetAdjacencies(reversed)
+	candidates, stats := buildTopologyL3SubnetCandidates(rows)
+	reversedCandidates, reversedStats := buildTopologyL3SubnetCandidates(reversed)
 
-	require.Equal(t, links, reversedLinks)
+	require.Equal(t, candidates, reversedCandidates)
 	require.Equal(t, stats, reversedStats)
-	require.Len(t, links, 2)
-	require.Equal(t, "198.51.100.0/30", links[0].Subnet)
-	require.Equal(t, "198.51.100.4/30", links[1].Subnet)
+	require.Len(t, candidates.Adjacencies, 2)
+	require.Equal(t, "198.51.100.0/30", candidates.Adjacencies[0].Subnet)
+	require.Equal(t, "198.51.100.4/30", candidates.Adjacencies[1].Subnet)
 }
 
 func l3InterfaceForTest(deviceID, ip, netmask, ifIndex string) topologymodel.L3Interface {

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyenrich/l3_subnets_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyenrich/l3_subnets_test.go
@@ -83,6 +83,31 @@ func TestBuildTopologyL3SubnetCandidates(t *testing.T) {
 				CandidateMemberships: 3,
 			},
 		},
+		"ipv4-subnet-segment-twenty-nine-boundary": {
+			rows: []topologymodel.L3Interface{
+				l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.248", "3"),
+				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.248", "2"),
+			},
+			wantCandidates: topologyL3SubnetCandidates{
+				Segments: []topologyL3SubnetSegment{
+					{
+						Subnet:  "198.51.100.0/29",
+						Network: "198.51.100.0",
+						Netmask: "255.255.255.248",
+						Prefix:  29,
+						Rows: []topologymodel.L3Interface{
+							l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.248", "2"),
+							l3InterfaceForTest("device-b", "198.51.100.2", "255.255.255.248", "3"),
+						},
+					},
+				},
+			},
+			wantStats: topologymodel.L3SubnetBuildStats{
+				CandidateSubnets:     1,
+				CandidateSegments:    1,
+				CandidateMemberships: 2,
+			},
+		},
 		"unsupported-prefix": {
 			rows: []topologymodel.L3Interface{
 				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.254.0", "2"),
@@ -119,6 +144,15 @@ func TestBuildTopologyL3SubnetCandidates(t *testing.T) {
 			wantStats: topologymodel.L3SubnetBuildStats{
 				CandidateSubnets:    1,
 				SuppressedUnmatched: 1,
+			},
+		},
+		"single-member-subnet-segment": {
+			rows: []topologymodel.L3Interface{
+				l3InterfaceForTest("device-a", "198.51.100.1", "255.255.255.0", "2"),
+			},
+			wantStats: topologymodel.L3SubnetBuildStats{
+				CandidateSubnets:           1,
+				SuppressedSegmentUnmatched: 1,
 			},
 		},
 		"multi-access-rows": {

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologymodel/observations.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologymodel/observations.go
@@ -23,14 +23,15 @@ type ObservationSnapshot struct {
 }
 
 type ObservationAggregate struct {
-	Snapshots      []ObservationSnapshot
-	L2Observations []topologyengine.L2Observation
-	L3Interfaces   []L3Interface
-	OSPFNeighbors  []OSPFNeighbor
-	BGPPeers       []BGPPeer
-	LocalDeviceID  string
-	AgentID        string
-	CollectedAt    time.Time
+	Snapshots       []ObservationSnapshot
+	L2Observations  []topologyengine.L2Observation
+	L3Interfaces    []L3Interface
+	OSPFNeighbors   []OSPFNeighbor
+	BGPPeers        []BGPPeer
+	LocalDeviceID   string
+	AgentID         string
+	ProducerScopeID string
+	CollectedAt     time.Time
 }
 
 type L3Interface struct {

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologymodel/predicates.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologymodel/predicates.go
@@ -51,6 +51,18 @@ func IsManagedSNMPDeviceActor(actor Actor) bool {
 	return !ActorIsInferred(actor)
 }
 
+func ActorSegmentKind(actor Actor) string {
+	return strings.ToLower(strings.TrimSpace(actor.SegmentKind))
+}
+
+func ActorIsSegment(actor Actor) bool {
+	return ActorSegmentKind(actor) != ""
+}
+
+func ActorIsL3SubnetSegment(actor Actor) bool {
+	return ActorSegmentKind(actor) == SegmentKindL3Subnet
+}
+
 func MatchLocalActor(match Match, local Device) bool {
 	localChassisID := strings.TrimSpace(local.ChassisID)
 	if localChassisID != "" {

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologymodel/stats.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologymodel/stats.go
@@ -48,31 +48,42 @@ type FocusDepth struct {
 }
 
 type RecomputedStats struct {
-	ActorsTotal               int
-	LinksTotal                int
-	LinksProbable             int
-	L3SubnetVisibleLinks      int
-	OSPFAdjacencyVisibleLinks int
-	BGPAdjacencyVisibleLinks  int
+	ActorsTotal                    int
+	LinksTotal                     int
+	LinksProbable                  int
+	L3SubnetVisibleLinks           int
+	L3SubnetMembershipVisibleLinks int
+	OSPFAdjacencyVisibleLinks      int
+	BGPAdjacencyVisibleLinks       int
 }
 
 type L3EnrichmentStats struct {
-	SubnetStats               L3SubnetBuildStats
-	EmittedLinks              int
-	SuppressedUnresolvedActor int
-	SuppressedSelfActor       int
-	SuppressedDuplicateLink   int
+	SubnetStats                         L3SubnetBuildStats
+	EmittedLinks                        int
+	EmittedSegments                     int
+	EmittedMembershipLinks              int
+	SuppressedUnresolvedActor           int
+	SuppressedSelfActor                 int
+	SuppressedDuplicateLink             int
+	SuppressedNoProducerScope           int
+	SuppressedMembershipUnresolvedActor int
+	SuppressedMembershipUnmatched       int
+	SuppressedDuplicateMembershipLink   int
 }
 
 type L3SubnetBuildStats struct {
-	CandidateSubnets            int
-	CandidateLinks              int
-	SuppressedInvalid           int
-	SuppressedUnsupportedPrefix int
-	SuppressedDuplicateIP       int
-	SuppressedSelfLink          int
-	SuppressedUnmatched         int
-	SuppressedMultiAccess       int
+	CandidateSubnets             int
+	CandidateLinks               int
+	CandidateSegments            int
+	CandidateMemberships         int
+	SuppressedInvalid            int
+	SuppressedUnsupportedPrefix  int
+	SuppressedDuplicateIP        int
+	SuppressedSegmentDuplicateIP int
+	SuppressedSelfLink           int
+	SuppressedUnmatched          int
+	SuppressedMultiAccess        int
+	SuppressedSegmentUnmatched   int
 }
 
 type OSPFEnrichmentStats struct {
@@ -124,13 +135,18 @@ func RecomputeL3VisibleLinkStats(data *Data) {
 	if data == nil || !data.Stats.HasL3 {
 		return
 	}
-	count := 0
+	directCount := 0
+	membershipCount := 0
 	for _, link := range data.Links {
-		if strings.EqualFold(strings.TrimSpace(topologyutil.FirstNonEmptyString(link.LinkType, link.Protocol)), L3SubnetLinkType) {
-			count++
+		switch strings.ToLower(strings.TrimSpace(topologyutil.FirstNonEmptyString(link.LinkType, link.Protocol))) {
+		case L3SubnetLinkType:
+			directCount++
+		case L3SubnetMembershipLinkType:
+			membershipCount++
 		}
 	}
-	data.Stats.Recomputed.L3SubnetVisibleLinks = count
+	data.Stats.Recomputed.L3SubnetVisibleLinks = directCount
+	data.Stats.Recomputed.L3SubnetMembershipVisibleLinks = membershipCount
 }
 
 func RecomputeOSPFVisibleLinkStats(data *Data) {

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologymodel/types.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologymodel/types.go
@@ -12,9 +12,16 @@ import (
 const SchemaVersion = "2.0"
 
 const (
-	L3SubnetLinkType      = "l3_subnet"
-	OSPFAdjacencyLinkType = "ospf_adjacency"
-	BGPAdjacencyLinkType  = "bgp_adjacency"
+	L3SubnetSegmentActorType   = "l3_subnet_segment"
+	L3SubnetLinkType           = "l3_subnet"
+	L3SubnetMembershipLinkType = "l3_subnet_membership"
+	OSPFAdjacencyLinkType      = "ospf_adjacency"
+	BGPAdjacencyLinkType       = "bgp_adjacency"
+)
+
+const (
+	SegmentKindBroadcastDomain = "broadcast_domain"
+	SegmentKindL3Subnet        = "l3_subnet"
 )
 
 type Match = graph.Match
@@ -39,9 +46,10 @@ type Link struct {
 }
 
 type LinkDetail struct {
-	L3Subnet *L3SubnetLinkDetail
-	OSPF     *OSPFAdjacencyLinkDetail
-	BGP      *BGPAdjacencyLinkDetail
+	L3Subnet           *L3SubnetLinkDetail
+	L3SubnetMembership *L3SubnetMembershipLinkDetail
+	OSPF               *OSPFAdjacencyLinkDetail
+	BGP                *BGPAdjacencyLinkDetail
 }
 
 type L3SubnetLinkDetail struct {
@@ -52,6 +60,22 @@ type L3SubnetLinkDetail struct {
 	Network string
 	Netmask string
 	Prefix  int
+}
+
+type L3SubnetMembershipLinkDetail struct {
+	Source     string
+	Subnet     string
+	Network    string
+	Netmask    string
+	Prefix     int
+	Interfaces []L3SubnetMembershipInterface
+}
+
+type L3SubnetMembershipInterface struct {
+	MemberIP string
+	IfIndex  int
+	IfName   string
+	IfDescr  string
 }
 
 type OSPFAdjacencyLinkDetail struct {
@@ -81,6 +105,7 @@ type BGPAdjacencyLinkDetail struct {
 type Actor struct {
 	ActorID     string
 	ActorType   string
+	SegmentKind string
 	Layer       string
 	Source      string
 	Match       Match

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/cleanup.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/cleanup.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
 )
 
 func eliminateNonIPInferredActors(data *topologymodel.Data) int {
@@ -50,9 +51,18 @@ func pruneSparseSegments(data *topologymodel.Data, threshold int) int {
 	removedTotal := 0
 	for {
 		segmentSet := make(map[string]struct{})
+		l3SegmentSet := make(map[string]struct{})
 		for _, actor := range data.Actors {
-			if strings.EqualFold(strings.TrimSpace(actor.ActorType), "segment") {
-				segmentSet[actor.ActorID] = struct{}{}
+			if !topologymodel.ActorIsSegment(actor) {
+				continue
+			}
+			actorID := strings.TrimSpace(actor.ActorID)
+			if actorID == "" {
+				continue
+			}
+			segmentSet[actorID] = struct{}{}
+			if topologymodel.ActorIsL3SubnetSegment(actor) {
+				l3SegmentSet[actorID] = struct{}{}
 			}
 		}
 		if len(segmentSet) == 0 {
@@ -72,8 +82,12 @@ func pruneSparseSegments(data *topologymodel.Data, threshold int) int {
 			}
 		}
 
+		protectedSegments := l3SubnetSegmentsWithMembershipLinks(data.Links, l3SegmentSet)
 		removeSegments := make(map[string]struct{})
 		for segmentID, neighbors := range neighborSet {
+			if _, protected := protectedSegments[segmentID]; protected {
+				continue
+			}
 			if len(neighbors) <= threshold {
 				removeSegments[segmentID] = struct{}{}
 			}
@@ -104,6 +118,25 @@ func pruneSparseSegments(data *topologymodel.Data, threshold int) int {
 		}
 		data.Links = filteredLinks
 	}
+}
+
+func l3SubnetSegmentsWithMembershipLinks(links []topologymodel.Link, l3SegmentSet map[string]struct{}) map[string]struct{} {
+	protected := make(map[string]struct{})
+	if len(l3SegmentSet) == 0 {
+		return protected
+	}
+	for _, link := range links {
+		if !strings.EqualFold(strings.TrimSpace(topologyutil.FirstNonEmptyString(link.LinkType, link.Protocol)), topologymodel.L3SubnetMembershipLinkType) {
+			continue
+		}
+		if _, ok := l3SegmentSet[strings.TrimSpace(link.SrcActorID)]; ok {
+			protected[strings.TrimSpace(link.SrcActorID)] = struct{}{}
+		}
+		if _, ok := l3SegmentSet[strings.TrimSpace(link.DstActorID)]; ok {
+			protected[strings.TrimSpace(link.DstActorID)] = struct{}{}
+		}
+	}
+	return protected
 }
 
 func filterDanglingLinks(data *topologymodel.Data) {

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/cleanup.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/cleanup.go
@@ -18,7 +18,7 @@ func eliminateNonIPInferredActors(data *topologymodel.Data) int {
 	keptActors := make([]topologymodel.Actor, 0, len(data.Actors))
 	for _, actor := range data.Actors {
 		if topologymodel.ActorIsInferred(actor) && len(topologymodel.NormalizedMatchIPs(actor.Match)) == 0 {
-			removedIDs[actor.ActorID] = struct{}{}
+			removedIDs[strings.TrimSpace(actor.ActorID)] = struct{}{}
 			continue
 		}
 		keptActors = append(keptActors, actor)
@@ -31,10 +31,10 @@ func eliminateNonIPInferredActors(data *topologymodel.Data) int {
 	data.Actors = keptActors
 	links := make([]topologymodel.Link, 0, len(data.Links))
 	for _, link := range data.Links {
-		if _, removed := removedIDs[link.SrcActorID]; removed {
+		if _, removed := removedIDs[strings.TrimSpace(link.SrcActorID)]; removed {
 			continue
 		}
-		if _, removed := removedIDs[link.DstActorID]; removed {
+		if _, removed := removedIDs[strings.TrimSpace(link.DstActorID)]; removed {
 			continue
 		}
 		links = append(links, link)
@@ -74,11 +74,13 @@ func pruneSparseSegments(data *topologymodel.Data, threshold int) int {
 			neighborSet[segmentID] = make(map[string]struct{})
 		}
 		for _, link := range data.Links {
-			if _, ok := segmentSet[link.SrcActorID]; ok {
-				neighborSet[link.SrcActorID][link.DstActorID] = struct{}{}
+			srcActorID := strings.TrimSpace(link.SrcActorID)
+			dstActorID := strings.TrimSpace(link.DstActorID)
+			if _, ok := segmentSet[srcActorID]; ok {
+				neighborSet[srcActorID][dstActorID] = struct{}{}
 			}
-			if _, ok := segmentSet[link.DstActorID]; ok {
-				neighborSet[link.DstActorID][link.SrcActorID] = struct{}{}
+			if _, ok := segmentSet[dstActorID]; ok {
+				neighborSet[dstActorID][srcActorID] = struct{}{}
 			}
 		}
 
@@ -99,7 +101,7 @@ func pruneSparseSegments(data *topologymodel.Data, threshold int) int {
 
 		filteredActors := make([]topologymodel.Actor, 0, len(data.Actors)-len(removeSegments))
 		for _, actor := range data.Actors {
-			if _, drop := removeSegments[actor.ActorID]; drop {
+			if _, drop := removeSegments[strings.TrimSpace(actor.ActorID)]; drop {
 				continue
 			}
 			filteredActors = append(filteredActors, actor)
@@ -108,10 +110,10 @@ func pruneSparseSegments(data *topologymodel.Data, threshold int) int {
 
 		filteredLinks := make([]topologymodel.Link, 0, len(data.Links))
 		for _, link := range data.Links {
-			if _, drop := removeSegments[link.SrcActorID]; drop {
+			if _, drop := removeSegments[strings.TrimSpace(link.SrcActorID)]; drop {
 				continue
 			}
-			if _, drop := removeSegments[link.DstActorID]; drop {
+			if _, drop := removeSegments[strings.TrimSpace(link.DstActorID)]; drop {
 				continue
 			}
 			filteredLinks = append(filteredLinks, link)

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/cleanup_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/cleanup_test.go
@@ -48,6 +48,26 @@ func TestPruneSparseSegmentsRemovesMultiRoundFixpoint(t *testing.T) {
 	require.Empty(t, data.Links)
 }
 
+func TestPruneSparseSegmentsTrimsLinkEndpointIDsBeforeNeighborLookup(t *testing.T) {
+	data := &topologymodel.Data{
+		Actors: []topologymodel.Actor{
+			{ActorID: "device-a", ActorType: "device"},
+			{ActorID: "device-b", ActorType: "device"},
+			{ActorID: "segment-a", ActorType: "segment", SegmentKind: topologymodel.SegmentKindBroadcastDomain},
+		},
+		Links: []topologymodel.Link{
+			{SrcActorID: "device-a", DstActorID: " segment-a "},
+			{SrcActorID: "\tsegment-a\n", DstActorID: "device-b"},
+		},
+	}
+
+	removed := pruneSparseSegments(data, 1)
+
+	require.Zero(t, removed)
+	require.Len(t, data.Actors, 3)
+	require.Len(t, data.Links, 2)
+}
+
 func TestPruneSparseSegmentsKeepsVisibleL3SubnetSegment(t *testing.T) {
 	data := &topologymodel.Data{
 		Actors: []topologymodel.Actor{

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/cleanup_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/cleanup_test.go
@@ -32,8 +32,8 @@ func TestPruneSparseSegmentsRemovesMultiRoundFixpoint(t *testing.T) {
 	data := &topologymodel.Data{
 		Actors: []topologymodel.Actor{
 			{ActorID: "device-a", ActorType: "device"},
-			{ActorID: "segment-a", ActorType: "segment"},
-			{ActorID: "segment-b", ActorType: "segment"},
+			{ActorID: "segment-a", ActorType: "segment", SegmentKind: topologymodel.SegmentKindBroadcastDomain},
+			{ActorID: "segment-b", ActorType: "segment", SegmentKind: topologymodel.SegmentKindBroadcastDomain},
 		},
 		Links: []topologymodel.Link{
 			{SrcActorID: "device-a", DstActorID: "segment-a"},
@@ -46,4 +46,22 @@ func TestPruneSparseSegmentsRemovesMultiRoundFixpoint(t *testing.T) {
 	require.Equal(t, 2, removed)
 	require.Equal(t, []topologymodel.Actor{{ActorID: "device-a", ActorType: "device"}}, data.Actors)
 	require.Empty(t, data.Links)
+}
+
+func TestPruneSparseSegmentsKeepsVisibleL3SubnetSegment(t *testing.T) {
+	data := &topologymodel.Data{
+		Actors: []topologymodel.Actor{
+			{ActorID: "router-a", ActorType: "router"},
+			{ActorID: "subnet-a", ActorType: topologymodel.L3SubnetSegmentActorType, SegmentKind: topologymodel.SegmentKindL3Subnet},
+		},
+		Links: []topologymodel.Link{
+			{SrcActorID: "router-a", DstActorID: "subnet-a", Protocol: topologymodel.L3SubnetMembershipLinkType, LinkType: topologymodel.L3SubnetMembershipLinkType},
+		},
+	}
+
+	removed := pruneSparseSegments(data, 1)
+
+	require.Zero(t, removed)
+	require.Len(t, data.Actors, 2)
+	require.Len(t, data.Links, 1)
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/collapse.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/collapse.go
@@ -45,7 +45,7 @@ func collapseActorsByIP(data *topologymodel.Data) int {
 
 	ipOwner := make(map[string]int)
 	for idx, actor := range data.Actors {
-		if strings.EqualFold(strings.TrimSpace(actor.ActorType), "segment") {
+		if topologymodel.ActorIsSegment(actor) {
 			continue
 		}
 		ips := topologymodel.NormalizedMatchIPs(actor.Match)
@@ -96,6 +96,7 @@ func collapseActorsByIP(data *topologymodel.Data) int {
 			replaceActorID[data.Actors[idx].ActorID] = repActor.ActorID
 			repActor.Match = mergeTopologyMatch(repActor.Match, data.Actors[idx].Match)
 			repActor.Labels = mergeTopologyStringMap(repActor.Labels, data.Actors[idx].Labels)
+			repActor.SegmentKind = topologyutil.FirstNonEmptyString(repActor.SegmentKind, data.Actors[idx].SegmentKind)
 			repActor.Detail = mergeTopologyActorDetail(repActor.Detail, data.Actors[idx].Detail)
 			keep[idx] = false
 		}

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/focus_graph.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/focus_graph.go
@@ -12,6 +12,7 @@ import (
 type topologyFocusGraph struct {
 	actorByID        map[string]topologymodel.Actor
 	segmentSet       map[string]struct{}
+	segmentKind      map[string]string
 	nonSegmentSet    map[string]struct{}
 	nonSegmentAdj    map[string]map[string]struct{}
 	nodeSegments     map[string]map[string]struct{}
@@ -22,6 +23,7 @@ func buildTopologyFocusGraph(data *topologymodel.Data) topologyFocusGraph {
 	graph := topologyFocusGraph{
 		actorByID:        make(map[string]topologymodel.Actor, len(data.Actors)),
 		segmentSet:       make(map[string]struct{}),
+		segmentKind:      make(map[string]string),
 		nonSegmentSet:    make(map[string]struct{}),
 		nonSegmentAdj:    make(map[string]map[string]struct{}),
 		nodeSegments:     make(map[string]map[string]struct{}),
@@ -34,8 +36,9 @@ func buildTopologyFocusGraph(data *topologymodel.Data) topologyFocusGraph {
 			continue
 		}
 		graph.actorByID[id] = actor
-		if strings.EqualFold(strings.TrimSpace(actor.ActorType), "segment") {
+		if topologymodel.ActorIsSegment(actor) {
 			graph.segmentSet[id] = struct{}{}
+			graph.segmentKind[id] = topologymodel.ActorSegmentKind(actor)
 		} else {
 			graph.nonSegmentSet[id] = struct{}{}
 		}
@@ -101,6 +104,9 @@ func traverseTopologyFocusDepth(graph topologyFocusGraph, roots map[string]struc
 		}
 
 		for segmentID := range graph.nodeSegments[current] {
+			if graph.segmentKind[segmentID] == topologymodel.SegmentKindL3Subnet {
+				continue
+			}
 			if expandedAt, ok := segmentExpandedDepth[segmentID]; ok && expandedAt <= currentDepth {
 				continue
 			}

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/focus_graph_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/focus_graph_test.go
@@ -37,10 +37,11 @@ func TestTopologyFocusGraphBuildAndDepthTraversal(t *testing.T) {
 				},
 			},
 			{
-				ActorID:   "segment-1",
-				ActorType: "segment",
-				Layer:     "2",
-				Source:    "snmp",
+				ActorID:     "segment-1",
+				ActorType:   "segment",
+				SegmentKind: topologymodel.SegmentKindBroadcastDomain,
+				Layer:       "2",
+				Source:      "snmp",
 			},
 			{
 				ActorID:   "device-c",
@@ -126,6 +127,32 @@ func TestTopologyFocusGraphBuildAndDepthTraversal(t *testing.T) {
 		"device-c":  {},
 		"segment-1": {},
 	}, includedActorsDepth2)
+}
+
+func TestTopologyFocusGraphDoesNotFanOutThroughL3SubnetSegment(t *testing.T) {
+	data := &topologymodel.Data{
+		Actors: []topologymodel.Actor{
+			{ActorID: "router-a", ActorType: "router"},
+			{ActorID: "router-b", ActorType: "router"},
+			{ActorID: "router-c", ActorType: "router"},
+			{ActorID: "subnet-a", ActorType: topologymodel.L3SubnetSegmentActorType, SegmentKind: topologymodel.SegmentKindL3Subnet},
+		},
+		Links: []topologymodel.Link{
+			{SrcActorID: "router-a", DstActorID: "subnet-a", Protocol: topologymodel.L3SubnetMembershipLinkType, LinkType: topologymodel.L3SubnetMembershipLinkType},
+			{SrcActorID: "router-b", DstActorID: "subnet-a", Protocol: topologymodel.L3SubnetMembershipLinkType, LinkType: topologymodel.L3SubnetMembershipLinkType},
+			{SrcActorID: "router-c", DstActorID: "subnet-a", Protocol: topologymodel.L3SubnetMembershipLinkType, LinkType: topologymodel.L3SubnetMembershipLinkType},
+		},
+	}
+
+	graph := buildTopologyFocusGraph(data)
+	distance := traverseTopologyFocusDepth(graph, map[string]struct{}{"router-a": {}}, topologyoptions.DepthAllInternal)
+	_, includedActors := collectTopologyFocusDepthSets(graph, distance, topologyoptions.DepthAllInternal)
+
+	require.Equal(t, map[string]int{"router-a": 0}, distance)
+	require.Contains(t, includedActors, "router-a")
+	require.Contains(t, includedActors, "subnet-a")
+	require.NotContains(t, includedActors, "router-b")
+	require.NotContains(t, includedActors, "router-c")
 }
 
 func TestTopologyActorHasIPMatchesMatchAndManagementAddresses(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/stats_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyshape/stats_test.go
@@ -14,7 +14,7 @@ func TestApplyPoliciesRecordsShapeStats(t *testing.T) {
 	data := topologymodel.Data{
 		Actors: []topologymodel.Actor{
 			{ActorID: "device-a", ActorType: "device", Match: topologymodel.Match{IPAddresses: []string{"10.0.0.1"}}},
-			{ActorID: "segment-a", ActorType: "segment"},
+			{ActorID: "segment-a", ActorType: "segment", SegmentKind: topologymodel.SegmentKindBroadcastDomain},
 			{ActorID: "endpoint-a", ActorType: "endpoint"},
 		},
 		Links: []topologymodel.Link{

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/actors.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/actors.go
@@ -213,6 +213,8 @@ func snmpTopologyV1ActorType(actorType string) string {
 		return snmpTopologyV1ActorEndpoint
 	case snmpTopologyV1ActorSegment:
 		return snmpTopologyV1ActorSegment
+	case snmpTopologyV1ActorL3SubnetSegment:
+		return snmpTopologyV1ActorL3SubnetSegment
 	default:
 		return "custom"
 	}
@@ -224,7 +226,7 @@ func snmpTopologyV1DisplayName(actor topologymodel.Actor) string {
 
 func snmpTopologyV1ActorLayer(actor topologymodel.Actor) string {
 	switch snmpTopologyV1ActorType(actor.ActorType) {
-	case snmpTopologyV1ActorEndpoint, snmpTopologyV1ActorSegment:
+	case snmpTopologyV1ActorEndpoint, snmpTopologyV1ActorSegment, snmpTopologyV1ActorL3SubnetSegment:
 		return "network"
 	default:
 		if topologyengine.IsDeviceActorType(actor.ActorType) {

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/golden_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/golden_test.go
@@ -311,16 +311,36 @@ func snmpTopologyV1GoldenInput() topologymodel.Data {
 				},
 			},
 			{
-				ActorID:   "segment-198-51-100-0-30",
-				ActorType: "segment",
-				Layer:     "3",
-				Source:    "ip_mib",
+				ActorID:     "segment-198-51-100-0-30",
+				ActorType:   "segment",
+				SegmentKind: topologymodel.SegmentKindBroadcastDomain,
+				Layer:       "3",
+				Source:      "ip_mib",
 				Match: topologymodel.Match{
 					IPAddresses: []string{"198.51.100.0"},
 				},
 				Detail: topologymodel.ActorDetail{
 					L2: topologyengine.ProjectionActorDetail{
 						DisplayName: "198.51.100.0/30",
+					},
+				},
+			},
+			{
+				ActorID:     "l3-subnet-segment-203-0-113-0-24",
+				ActorType:   topologymodel.L3SubnetSegmentActorType,
+				SegmentKind: topologymodel.SegmentKindL3Subnet,
+				Layer:       "3",
+				Source:      "ip_mib",
+				Detail: topologymodel.ActorDetail{
+					L2: topologyengine.ProjectionActorDetail{
+						DisplayName: "203.0.113.0/24",
+						Segment: topologyengine.ProjectionSegmentActorDetail{
+							SegmentID:      "l3-subnet-segment-203-0-113-0-24",
+							SegmentType:    topologymodel.SegmentKindL3Subnet,
+							SegmentKind:    topologymodel.SegmentKindL3Subnet,
+							PortsTotal:     topologyengine.OptionalValue[int]{Value: 2, Has: true},
+							EndpointsTotal: topologyengine.OptionalValue[int]{Value: 2, Has: true},
+						},
 					},
 				},
 			},
@@ -460,6 +480,64 @@ func snmpTopologyV1GoldenInput() topologymodel.Data {
 					},
 				},
 			},
+			{
+				Layer:      "3",
+				Protocol:   topologymodel.L3SubnetMembershipLinkType,
+				LinkType:   topologymodel.L3SubnetMembershipLinkType,
+				Direction:  "observed",
+				SrcActorID: "router-a",
+				DstActorID: "l3-subnet-segment-203-0-113-0-24",
+				Src: topologymodel.LinkEndpoint{
+					IfIndex: 302,
+					IfName:  "xe-0/0/2",
+				},
+				Dst: topologymodel.LinkEndpoint{},
+				Inference: &graph.LinkInference{
+					AttachmentMode: "logical_l3_subnet_membership",
+					Inference:      "shared_subnet_membership",
+				},
+				Detail: topologymodel.LinkDetail{
+					L3SubnetMembership: &topologymodel.L3SubnetMembershipLinkDetail{
+						Source:  "ip_mib",
+						Subnet:  "203.0.113.0/24",
+						Network: "203.0.113.0",
+						Netmask: "255.255.255.0",
+						Prefix:  24,
+						Interfaces: []topologymodel.L3SubnetMembershipInterface{
+							{MemberIP: "203.0.113.1", IfIndex: 302, IfName: "xe-0/0/2", IfDescr: "Transit VLAN"},
+						},
+					},
+				},
+			},
+			{
+				Layer:      "3",
+				Protocol:   topologymodel.L3SubnetMembershipLinkType,
+				LinkType:   topologymodel.L3SubnetMembershipLinkType,
+				Direction:  "observed",
+				SrcActorID: "router-b",
+				DstActorID: "l3-subnet-segment-203-0-113-0-24",
+				Src: topologymodel.LinkEndpoint{
+					IfIndex: 402,
+					IfName:  "xe-0/0/2",
+				},
+				Dst: topologymodel.LinkEndpoint{},
+				Inference: &graph.LinkInference{
+					AttachmentMode: "logical_l3_subnet_membership",
+					Inference:      "shared_subnet_membership",
+				},
+				Detail: topologymodel.LinkDetail{
+					L3SubnetMembership: &topologymodel.L3SubnetMembershipLinkDetail{
+						Source:  "ip_mib",
+						Subnet:  "203.0.113.0/24",
+						Network: "203.0.113.0",
+						Netmask: "255.255.255.0",
+						Prefix:  24,
+						Interfaces: []topologymodel.L3SubnetMembershipInterface{
+							{MemberIP: "203.0.113.2", IfIndex: 402, IfName: "xe-0/0/2", IfDescr: "Transit VLAN"},
+						},
+					},
+				},
+			},
 		},
 		Stats: topologymodel.Stats{
 			Shape: topologymodel.ShapeStats{
@@ -474,7 +552,14 @@ func snmpTopologyV1GoldenInput() topologymodel.Data {
 			},
 			HasFocus: true,
 			L3: topologymodel.L3EnrichmentStats{
-				EmittedLinks: 1,
+				SubnetStats: topologymodel.L3SubnetBuildStats{
+					CandidateLinks:       1,
+					CandidateSegments:    1,
+					CandidateMemberships: 2,
+				},
+				EmittedLinks:           1,
+				EmittedSegments:        1,
+				EmittedMembershipLinks: 2,
 			},
 			HasL3: true,
 			OSPF: topologymodel.OSPFEnrichmentStats{
@@ -486,12 +571,13 @@ func snmpTopologyV1GoldenInput() topologymodel.Data {
 			},
 			HasBGP: true,
 			Recomputed: topologymodel.RecomputedStats{
-				ActorsTotal:               5,
-				LinksTotal:                5,
-				LinksProbable:             1,
-				L3SubnetVisibleLinks:      1,
-				OSPFAdjacencyVisibleLinks: 1,
-				BGPAdjacencyVisibleLinks:  1,
+				ActorsTotal:                    6,
+				LinksTotal:                     7,
+				LinksProbable:                  1,
+				L3SubnetVisibleLinks:           1,
+				L3SubnetMembershipVisibleLinks: 2,
+				OSPFAdjacencyVisibleLinks:      1,
+				BGPAdjacencyVisibleLinks:       1,
 			},
 			HasComputed: true,
 		},

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/links.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/links.go
@@ -49,12 +49,11 @@ func buildSNMPTopologyV1Links(
 		states[i] = nullableStringRef(stringsDict, link.State)
 		srcPortNames[i] = nullableStringRef(stringsDict, topologyV1EndpointPortName(link.Src))
 		dstPortNames[i] = nullableStringRef(stringsDict, topologyV1EndpointPortName(link.Dst))
-		evidenceCounts[i] = 1
 		discoveredAt[i] = nullableTime(link.DiscoveredAt)
 		lastSeen[i] = nullableTime(link.LastSeen)
 		subnet := topologyEvidenceSubnet(link)
-		if linkType == snmpTopologyV1LinkL3Subnet && subnet == "" {
-			return topologyapi.Table{}, nil, fmt.Errorf("l3_subnet link %d is missing subnet", i)
+		if (linkType == snmpTopologyV1LinkL3Subnet || linkType == snmpTopologyV1LinkL3SubnetMembership) && subnet == "" {
+			return topologyapi.Table{}, nil, fmt.Errorf("%s link %d is missing subnet", linkType, i)
 		}
 
 		evidenceRows := evidenceRowsByType[linkType]
@@ -62,6 +61,15 @@ func buildSNMPTopologyV1Links(
 			evidenceRows = &snmpTopologyV1EvidenceRows{}
 			evidenceRowsByType[linkType] = evidenceRows
 		}
+		if linkType == snmpTopologyV1LinkL3SubnetMembership {
+			count, err := appendSNMPTopologyV1L3SubnetMembershipEvidenceRows(evidenceRows, i, src, dst, link, protocol, stringsDict)
+			if err != nil {
+				return topologyapi.Table{}, nil, err
+			}
+			evidenceCounts[i] = count
+			continue
+		}
+		evidenceCounts[i] = 1
 		evidenceRows.linkRefs = append(evidenceRows.linkRefs, i)
 		evidenceRows.srcActors = append(evidenceRows.srcActors, src)
 		evidenceRows.dstActors = append(evidenceRows.dstActors, dst)
@@ -144,6 +152,58 @@ func buildSNMPTopologyV1Links(
 	return linkTable, evidenceSections, nil
 }
 
+func appendSNMPTopologyV1L3SubnetMembershipEvidenceRows(
+	rows *snmpTopologyV1EvidenceRows,
+	linkIndex int,
+	srcActor, dstActor int,
+	link topologymodel.Link,
+	protocol string,
+	stringsDict *topologyapi.StringDictionary,
+) (any, error) {
+	detail := link.Detail.L3SubnetMembership
+	if detail == nil {
+		return nil, fmt.Errorf("l3_subnet_membership link %d is missing detail", linkIndex)
+	}
+	if len(detail.Interfaces) == 0 {
+		return nil, fmt.Errorf("l3_subnet_membership link %d is missing member interfaces", linkIndex)
+	}
+	for _, iface := range detail.Interfaces {
+		rows.linkRefs = append(rows.linkRefs, linkIndex)
+		rows.srcActors = append(rows.srcActors, srcActor)
+		rows.dstActors = append(rows.dstActors, dstActor)
+		rows.protocols = append(rows.protocols, stringsDict.Ref(protocol))
+		rows.directions = append(rows.directions, stringsDict.Ref(topologyutil.FirstNonEmptyString(link.Direction, "observed")))
+		rows.states = append(rows.states, nullableStringRef(stringsDict, link.State))
+		rows.srcPortNames = append(rows.srcPortNames, nullableStringRef(stringsDict, topologyV1L3SubnetMembershipPortName(iface)))
+		rows.dstPortNames = append(rows.dstPortNames, nil)
+		rows.srcIfIndexes = append(rows.srcIfIndexes, nullableUintFromInt(iface.IfIndex))
+		rows.dstIfIndexes = append(rows.dstIfIndexes, nil)
+		rows.srcPortIDs = append(rows.srcPortIDs, nil)
+		rows.dstPortIDs = append(rows.dstPortIDs, nil)
+		rows.srcManagementIPs = append(rows.srcManagementIPs, nullableStringRef(stringsDict, topologyV1EndpointString(link.Src, "management_ip")))
+		rows.dstManagementIPs = append(rows.dstManagementIPs, nil)
+		rows.confidences = append(rows.confidences, nullableStringRef(stringsDict, topologymodel.LinkConfidenceValue(link)))
+		rows.inferences = append(rows.inferences, nullableStringRef(stringsDict, topologymodel.LinkInferenceValue(link)))
+		rows.attachmentModes = append(rows.attachmentModes, nullableStringRef(stringsDict, topologymodel.LinkAttachmentModeValue(link)))
+		rows.memberActors = append(rows.memberActors, srcActor)
+		rows.segmentActors = append(rows.segmentActors, dstActor)
+		rows.memberIPs = append(rows.memberIPs, nullableStringRef(stringsDict, iface.MemberIP))
+		rows.memberIfIndexes = append(rows.memberIfIndexes, nullableUintFromInt(iface.IfIndex))
+		rows.memberIfNames = append(rows.memberIfNames, nullableStringRef(stringsDict, iface.IfName))
+		rows.memberIfDescrs = append(rows.memberIfDescrs, nullableStringRef(stringsDict, iface.IfDescr))
+		rows.subnets = append(rows.subnets, nullableStringRef(stringsDict, detail.Subnet))
+		rows.networks = append(rows.networks, nullableStringRef(stringsDict, detail.Network))
+		rows.netmasks = append(rows.netmasks, nullableStringRef(stringsDict, detail.Netmask))
+		rows.prefixes = append(rows.prefixes, nullableUintFromInt(detail.Prefix))
+		rows.sources = append(rows.sources, nullableStringRef(stringsDict, detail.Source))
+	}
+	return len(detail.Interfaces), nil
+}
+
+func topologyV1L3SubnetMembershipPortName(iface topologymodel.L3SubnetMembershipInterface) string {
+	return topologyutil.FirstNonEmptyString(iface.IfName, iface.IfDescr)
+}
+
 type snmpTopologyV1EvidenceRows struct {
 	linkRefs         []any
 	srcActors        []any
@@ -162,6 +222,12 @@ type snmpTopologyV1EvidenceRows struct {
 	confidences      []any
 	inferences       []any
 	attachmentModes  []any
+	memberActors     []any
+	segmentActors    []any
+	memberIPs        []any
+	memberIfIndexes  []any
+	memberIfNames    []any
+	memberIfDescrs   []any
 	srcRouterIDs     []any
 	dstRouterIDs     []any
 	srcIPs           []any
@@ -236,6 +302,21 @@ func (rows *snmpTopologyV1EvidenceRows) columnEncodingsForType(linkType string) 
 			topologyapi.Values(rows.sources...),
 		)
 	}
+	if linkType == snmpTopologyV1LinkL3SubnetMembership {
+		encodings = append(encodings,
+			topologyapi.Values(rows.memberActors...),
+			topologyapi.Values(rows.segmentActors...),
+			topologyapi.Values(rows.memberIPs...),
+			topologyapi.Values(rows.memberIfIndexes...),
+			topologyapi.Values(rows.memberIfNames...),
+			topologyapi.Values(rows.memberIfDescrs...),
+			topologyapi.Values(rows.subnets...),
+			topologyapi.Values(rows.networks...),
+			topologyapi.Values(rows.netmasks...),
+			topologyapi.Values(rows.prefixes...),
+			topologyapi.Values(rows.sources...),
+		)
+	}
 	return encodings
 }
 
@@ -264,6 +345,22 @@ func snmpTopologyV1EvidenceColumnsForType(linkType string) []topologyapi.Column 
 			topologyapi.NewColumn("neighbor_ip", "string_ref", topologyapi.WithDictionary("strings"), topologyapi.WithNullable()),
 			topologyapi.NewColumn("local_as", "string_ref", topologyapi.WithDictionary("strings"), topologyapi.WithNullable()),
 			topologyapi.NewColumn("remote_as", "string_ref", topologyapi.WithDictionary("strings"), topologyapi.WithNullable()),
+			topologyapi.NewColumn("source", "string_ref", topologyapi.WithDictionary("strings"), topologyapi.WithNullable()),
+		}
+		return snmpTopologyV1EvidenceColumnsWithExtras(columns, extras)
+	}
+	if linkType == snmpTopologyV1LinkL3SubnetMembership {
+		extras := []topologyapi.Column{
+			topologyapi.NewColumn("member_actor", "actor_ref", topologyapi.WithRole("reference")),
+			topologyapi.NewColumn("segment_actor", "actor_ref", topologyapi.WithRole("reference")),
+			topologyapi.NewColumn("member_ip", "string_ref", topologyapi.WithDictionary("strings"), topologyapi.WithNullable()),
+			topologyapi.NewColumn("member_if_index", "uint", topologyapi.WithNullable()),
+			topologyapi.NewColumn("member_if_name", "string_ref", topologyapi.WithDictionary("strings"), topologyapi.WithNullable()),
+			topologyapi.NewColumn("member_if_descr", "string_ref", topologyapi.WithDictionary("strings"), topologyapi.WithNullable()),
+			topologyapi.NewColumn("subnet", "string_ref", topologyapi.WithDictionary("strings"), topologyapi.WithRole("group_key")),
+			topologyapi.NewColumn("network", "string_ref", topologyapi.WithDictionary("strings"), topologyapi.WithNullable()),
+			topologyapi.NewColumn("netmask", "string_ref", topologyapi.WithDictionary("strings"), topologyapi.WithNullable()),
+			topologyapi.NewColumn("prefix", "uint", topologyapi.WithNullable()),
 			topologyapi.NewColumn("source", "string_ref", topologyapi.WithDictionary("strings"), topologyapi.WithNullable()),
 		}
 		return snmpTopologyV1EvidenceColumnsWithExtras(columns, extras)
@@ -318,6 +415,9 @@ func topologyEvidenceSource(link topologymodel.Link) string {
 	if link.Detail.L3Subnet != nil {
 		return strings.TrimSpace(link.Detail.L3Subnet.Source)
 	}
+	if link.Detail.L3SubnetMembership != nil {
+		return strings.TrimSpace(link.Detail.L3SubnetMembership.Source)
+	}
 	if link.Detail.OSPF != nil {
 		return strings.TrimSpace(link.Detail.OSPF.Source)
 	}
@@ -351,6 +451,9 @@ func topologyEvidenceSubnet(link topologymodel.Link) string {
 	if link.Detail.L3Subnet != nil {
 		return strings.TrimSpace(link.Detail.L3Subnet.Subnet)
 	}
+	if link.Detail.L3SubnetMembership != nil {
+		return strings.TrimSpace(link.Detail.L3SubnetMembership.Subnet)
+	}
 	if link.Detail.OSPF != nil {
 		return strings.TrimSpace(link.Detail.OSPF.Subnet)
 	}
@@ -360,6 +463,9 @@ func topologyEvidenceSubnet(link topologymodel.Link) string {
 func topologyEvidenceNetwork(link topologymodel.Link) string {
 	if link.Detail.L3Subnet != nil {
 		return strings.TrimSpace(link.Detail.L3Subnet.Network)
+	}
+	if link.Detail.L3SubnetMembership != nil {
+		return strings.TrimSpace(link.Detail.L3SubnetMembership.Network)
 	}
 	if link.Detail.OSPF != nil {
 		return strings.TrimSpace(link.Detail.OSPF.Network)
@@ -371,6 +477,9 @@ func topologyEvidenceNetmask(link topologymodel.Link) string {
 	if link.Detail.L3Subnet != nil {
 		return strings.TrimSpace(link.Detail.L3Subnet.Netmask)
 	}
+	if link.Detail.L3SubnetMembership != nil {
+		return strings.TrimSpace(link.Detail.L3SubnetMembership.Netmask)
+	}
 	if link.Detail.OSPF != nil {
 		return strings.TrimSpace(link.Detail.OSPF.Netmask)
 	}
@@ -381,6 +490,8 @@ func nullableEvidencePrefix(link topologymodel.Link) any {
 	prefix := 0
 	if link.Detail.L3Subnet != nil {
 		prefix = link.Detail.L3Subnet.Prefix
+	} else if link.Detail.L3SubnetMembership != nil {
+		prefix = link.Detail.L3SubnetMembership.Prefix
 	} else if link.Detail.OSPF != nil {
 		prefix = link.Detail.OSPF.Prefix
 	}
@@ -412,6 +523,8 @@ func snmpTopologyV1LinkType(link topologymodel.Link) string {
 		return snmpTopologyV1LinkSNMP
 	case snmpTopologyV1LinkL3Subnet:
 		return snmpTopologyV1LinkL3Subnet
+	case snmpTopologyV1LinkL3SubnetMembership:
+		return snmpTopologyV1LinkL3SubnetMembership
 	case snmpTopologyV1LinkOSPF:
 		return snmpTopologyV1LinkOSPF
 	case snmpTopologyV1LinkBGP:
@@ -423,7 +536,7 @@ func snmpTopologyV1LinkType(link topologymodel.Link) string {
 
 func snmpTopologyV1LinkIsLogicalL3(link topologymodel.Link) bool {
 	switch snmpTopologyV1LinkType(link) {
-	case snmpTopologyV1LinkL3Subnet, snmpTopologyV1LinkOSPF, snmpTopologyV1LinkBGP:
+	case snmpTopologyV1LinkL3Subnet, snmpTopologyV1LinkL3SubnetMembership, snmpTopologyV1LinkOSPF, snmpTopologyV1LinkBGP:
 		return true
 	default:
 		return false

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/presentation.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/presentation.go
@@ -113,6 +113,28 @@ func snmpTopologyV1ActorTypes() map[string]topologyapi.ActorType {
 			Modal: snmpTopologyV1EndpointModal(),
 		},
 	}
+	types[snmpTopologyV1ActorL3SubnetSegment] = topologyapi.ActorType{
+		Layer:             "network",
+		Identity:          []string{"id"},
+		MergeIdentity:     []string{"id"},
+		AggregationScopes: []string{"segment", "network"},
+		Search:            &topologyapi.ActorSearchPolicy{Enabled: new(false)},
+		Presentation: &topologyapi.ActorPresentation{
+			Label:     "L3 subnet",
+			Role:      "group",
+			Icon:      "segment",
+			ColorSlot: "info",
+			Size:      &topologyapi.ActorSizePresentation{Mode: "fixed", Scale: "compact"},
+			Layout:    &topologyapi.ActorLayoutPresentation{Repulsion: "weakest"},
+			LabelPolicy: &topologyapi.LabelPolicy{
+				Columns:   []string{"display_name"},
+				Fallback:  "type_label",
+				MaxLength: 80,
+				Array:     "reject",
+			},
+			Modal: snmpTopologyV1L3SubnetSegmentModal(),
+		},
+	}
 	types["custom"] = topologyapi.ActorType{
 		Layer:             "custom",
 		Identity:          []string{"id"},
@@ -158,8 +180,9 @@ func snmpTopologyV1DeviceModal() *topologyapi.ModalPresentation {
 			},
 			snmpTopologyV1PortLinksSection(2),
 			snmpTopologyV1L3SubnetSection(3),
-			snmpTopologyV1OSPFNeighborsSection(4),
-			snmpTopologyV1BGPPeersSection(5),
+			snmpTopologyV1L3SubnetMembershipSection(4),
+			snmpTopologyV1OSPFNeighborsSection(5),
+			snmpTopologyV1BGPPeersSection(6),
 		},
 	}
 }
@@ -169,6 +192,15 @@ func snmpTopologyV1EndpointModal() *topologyapi.ModalPresentation {
 		Labels:       snmpTopologyV1EndpointModalLabels(),
 		MiniTopology: &topologyapi.ModalMiniTopologyPresentation{Depth: 1},
 		Sections:     []topologyapi.ModalSection{snmpTopologyV1LinksSection(1)},
+	}
+}
+
+func snmpTopologyV1L3SubnetSegmentModal() *topologyapi.ModalPresentation {
+	return &topologyapi.ModalPresentation{
+		MiniTopology: &topologyapi.ModalMiniTopologyPresentation{Depth: 1},
+		Sections: []topologyapi.ModalSection{
+			snmpTopologyV1L3SubnetSegmentMembersSection(1),
+		},
 	}
 }
 
@@ -295,6 +327,79 @@ func snmpTopologyV1L3SubnetSection(order int) topologyapi.ModalSection {
 		},
 		Sort:       &topologyapi.ModalSort{Column: "subnet", Direction: "asc"},
 		EmptyLabel: "No L3 adjacencies",
+	}
+}
+
+func snmpTopologyV1L3SubnetMembershipSection(order int) topologyapi.ModalSection {
+	return topologyapi.ModalSection{
+		ID:    "l3_subnet_memberships",
+		Label: "L3 Subnet Memberships",
+		Order: order,
+		Source: topologyapi.ModalSource{
+			Kind:     "evidence",
+			Evidence: snmpTopologyV1LinkL3SubnetMembership,
+		},
+		OwnerFilter: &topologyapi.ModalOwnerFilter{
+			Mode:           "incident_evidence",
+			LinkColumn:     "link",
+			SrcActorColumn: "src_actor",
+			DstActorColumn: "dst_actor",
+		},
+		Columns: []topologyapi.ModalColumn{
+			{
+				ID:    "subnet_actor",
+				Label: "Subnet",
+				Projection: topologyapi.ModalProjection{
+					Kind:           "opposite_actor",
+					SrcActorColumn: "src_actor",
+					DstActorColumn: "dst_actor",
+				},
+				Cell: "actor_link",
+			},
+			modalDirectColumn("member_ip", "Local IP", "member_ip", "text"),
+			modalDirectColumn("member_if_name", "Interface", "member_if_name", "text"),
+			modalDirectColumn("subnet", "Subnet", "subnet", "text"),
+			modalDirectColumn("prefix", "Prefix", "prefix", "number"),
+			modalDirectColumnWithVisibility("member_if_index", "IfIndex", "member_if_index", "number", "expanded"),
+			modalDirectColumnWithVisibility("member_if_descr", "IfDescr", "member_if_descr", "text", "expanded"),
+			modalDirectColumnWithVisibility("network", "Network", "network", "text", "expanded"),
+			modalDirectColumnWithVisibility("netmask", "Netmask", "netmask", "text", "expanded"),
+			modalDirectColumnWithVisibility("source", "Source", "source", "badge", "expanded"),
+		},
+		Sort:       &topologyapi.ModalSort{Column: "subnet", Direction: "asc"},
+		EmptyLabel: "No L3 subnet memberships",
+	}
+}
+
+func snmpTopologyV1L3SubnetSegmentMembersSection(order int) topologyapi.ModalSection {
+	return topologyapi.ModalSection{
+		ID:    "l3_subnet_members",
+		Label: "Members",
+		Order: order,
+		Source: topologyapi.ModalSource{
+			Kind:     "evidence",
+			Evidence: snmpTopologyV1LinkL3SubnetMembership,
+		},
+		OwnerFilter: &topologyapi.ModalOwnerFilter{
+			Mode:           "incident_evidence",
+			LinkColumn:     "link",
+			SrcActorColumn: "src_actor",
+			DstActorColumn: "dst_actor",
+		},
+		Columns: []topologyapi.ModalColumn{
+			modalActorRefColumn("member", "Member", "member_actor"),
+			modalDirectColumn("member_ip", "Member IP", "member_ip", "text"),
+			modalDirectColumn("member_if_name", "Interface", "member_if_name", "text"),
+			modalDirectColumn("subnet", "Subnet", "subnet", "text"),
+			modalDirectColumn("prefix", "Prefix", "prefix", "number"),
+			modalDirectColumnWithVisibility("member_if_index", "IfIndex", "member_if_index", "number", "expanded"),
+			modalDirectColumnWithVisibility("member_if_descr", "IfDescr", "member_if_descr", "text", "expanded"),
+			modalDirectColumnWithVisibility("network", "Network", "network", "text", "expanded"),
+			modalDirectColumnWithVisibility("netmask", "Netmask", "netmask", "text", "expanded"),
+			modalDirectColumnWithVisibility("source", "Source", "source", "badge", "expanded"),
+		},
+		Sort:       &topologyapi.ModalSort{Column: "member_ip", Direction: "asc"},
+		EmptyLabel: "No subnet members",
 	}
 }
 
@@ -433,6 +538,7 @@ func snmpTopologyV1LinkTypeSpecs() []snmpTopologyV1LinkTypeSpec {
 		{id: snmpTopologyV1LinkSTP, label: "STP", colorSlot: "muted", lineStyle: "solid", width: "normal", semanticRole: "normal"},
 		{id: snmpTopologyV1LinkARP, label: "ARP", colorSlot: "muted", lineStyle: "solid", width: "normal", semanticRole: "normal"},
 		{id: snmpTopologyV1LinkL3Subnet, label: "L3 subnet", colorSlot: "info", lineStyle: "dashed", width: "normal", semanticRole: "normal"},
+		{id: snmpTopologyV1LinkL3SubnetMembership, label: "L3 subnet membership", colorSlot: "info", lineStyle: "dashed", width: "normal", semanticRole: "normal"},
 		{id: snmpTopologyV1LinkOSPF, label: "OSPF adjacency", colorSlot: "purple", lineStyle: "dashed", width: "normal", semanticRole: "control"},
 		{id: snmpTopologyV1LinkBGP, label: "BGP adjacency", colorSlot: "accent", lineStyle: "dashed", width: "normal", semanticRole: "control"},
 		{id: snmpTopologyV1LinkSNMP, label: "SNMP", colorSlot: "primary", lineStyle: "solid", width: "normal", semanticRole: "normal"},
@@ -494,6 +600,14 @@ func snmpTopologyV1EvidenceMatchColumnsForType(linkType string) []string {
 			"dst_ip",
 		}
 	}
+	if linkType == snmpTopologyV1LinkL3SubnetMembership {
+		return []string{
+			"member_actor",
+			"segment_actor",
+			"member_ip",
+			"subnet",
+		}
+	}
 	if linkType == snmpTopologyV1LinkOSPF {
 		return []string{
 			"src_actor",
@@ -547,6 +661,7 @@ func snmpTopologyV1Presentation() *topologyapi.Presentation {
 				{Type: "custom", Label: "Other"},
 				{Type: "endpoint", Label: "Inferred endpoint"},
 				{Type: "segment", Label: "Network segment"},
+				{Type: snmpTopologyV1ActorL3SubnetSegment, Label: "L3 subnet"},
 			},
 			Links: []topologyapi.LegendEntry{
 				{Type: snmpTopologyV1LinkLLDP, Label: "LLDP"},
@@ -554,6 +669,7 @@ func snmpTopologyV1Presentation() *topologyapi.Presentation {
 				{Type: snmpTopologyV1LinkSNMP, Label: "SNMP"},
 				{Type: snmpTopologyV1LinkBridge, Label: "Bridge"},
 				{Type: snmpTopologyV1LinkL3Subnet, Label: "L3 subnet"},
+				{Type: snmpTopologyV1LinkL3SubnetMembership, Label: "L3 subnet membership"},
 				{Type: snmpTopologyV1LinkOSPF, Label: "OSPF adjacency"},
 				{Type: snmpTopologyV1LinkBGP, Label: "BGP adjacency"},
 				{Type: snmpTopologyV1LinkProbable, Label: "Probable"},

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/render.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/render.go
@@ -14,22 +14,24 @@ const (
 	snmpTopologyV1ProducerSource = "snmp-l2"
 	snmpTopologyV1Instance       = "local"
 
-	snmpTopologyV1ActorDevice   = "device"
-	snmpTopologyV1ActorEndpoint = "endpoint"
-	snmpTopologyV1ActorSegment  = "segment"
+	snmpTopologyV1ActorDevice          = "device"
+	snmpTopologyV1ActorEndpoint        = "endpoint"
+	snmpTopologyV1ActorSegment         = "segment"
+	snmpTopologyV1ActorL3SubnetSegment = topologymodel.L3SubnetSegmentActorType
 
-	snmpTopologyV1LinkObservation = "l2_observation"
-	snmpTopologyV1LinkLLDP        = "lldp"
-	snmpTopologyV1LinkCDP         = "cdp"
-	snmpTopologyV1LinkBridge      = "bridge"
-	snmpTopologyV1LinkFDB         = "fdb"
-	snmpTopologyV1LinkSTP         = "stp"
-	snmpTopologyV1LinkARP         = "arp"
-	snmpTopologyV1LinkSNMP        = "snmp"
-	snmpTopologyV1LinkProbable    = "probable"
-	snmpTopologyV1LinkL3Subnet    = topologymodel.L3SubnetLinkType
-	snmpTopologyV1LinkOSPF        = topologymodel.OSPFAdjacencyLinkType
-	snmpTopologyV1LinkBGP         = topologymodel.BGPAdjacencyLinkType
+	snmpTopologyV1LinkObservation        = "l2_observation"
+	snmpTopologyV1LinkLLDP               = "lldp"
+	snmpTopologyV1LinkCDP                = "cdp"
+	snmpTopologyV1LinkBridge             = "bridge"
+	snmpTopologyV1LinkFDB                = "fdb"
+	snmpTopologyV1LinkSTP                = "stp"
+	snmpTopologyV1LinkARP                = "arp"
+	snmpTopologyV1LinkSNMP               = "snmp"
+	snmpTopologyV1LinkProbable           = "probable"
+	snmpTopologyV1LinkL3Subnet           = topologymodel.L3SubnetLinkType
+	snmpTopologyV1LinkL3SubnetMembership = topologymodel.L3SubnetMembershipLinkType
+	snmpTopologyV1LinkOSPF               = topologymodel.OSPFAdjacencyLinkType
+	snmpTopologyV1LinkBGP                = topologymodel.BGPAdjacencyLinkType
 )
 
 func Render(data topologymodel.Data) (topologyapi.Data, error) {
@@ -118,6 +120,7 @@ func Render(data topologymodel.Data) (topologyapi.Data, error) {
 				"fdb",
 				"stp",
 				"l3_subnet",
+				"l3_subnet_membership",
 				"ospf",
 				"bgp",
 			},

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/stats.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/stats.go
@@ -123,9 +123,18 @@ func addTopologyL3Stats(out map[string]any, stats topologymodel.Stats) {
 	out["l3_subnet_candidate_subnets"] = l3.SubnetStats.CandidateSubnets
 	out["l3_subnet_candidate_links"] = l3.SubnetStats.CandidateLinks
 	out["l3_subnet_emitted_links"] = l3.EmittedLinks
+	out["l3_subnet_segment_candidate_segments"] = l3.SubnetStats.CandidateSegments
+	out["l3_subnet_segment_emitted_segments"] = l3.EmittedSegments
+	out["l3_subnet_membership_candidate_links"] = l3.SubnetStats.CandidateMemberships
+	out["l3_subnet_membership_emitted_links"] = l3.EmittedMembershipLinks
 	out["l3_subnet_suppressed_invalid"] = l3.SubnetStats.SuppressedInvalid
 	out["l3_subnet_suppressed_unsupported_prefix"] = l3.SubnetStats.SuppressedUnsupportedPrefix
 	out["l3_subnet_suppressed_duplicate_ip"] = l3.SubnetStats.SuppressedDuplicateIP
+	out["l3_subnet_segment_suppressed_no_producer_scope"] = l3.SuppressedNoProducerScope
+	out["l3_subnet_membership_suppressed_duplicate_ip"] = l3.SubnetStats.SuppressedSegmentDuplicateIP
+	out["l3_subnet_membership_suppressed_unmatched"] = l3.SuppressedMembershipUnmatched + l3.SubnetStats.SuppressedSegmentUnmatched
+	out["l3_subnet_membership_suppressed_unresolved_actor"] = l3.SuppressedMembershipUnresolvedActor
+	out["l3_subnet_membership_suppressed_duplicate_link"] = l3.SuppressedDuplicateMembershipLink
 	out["l3_subnet_suppressed_self_link"] = l3.SubnetStats.SuppressedSelfLink
 	out["l3_subnet_suppressed_unmatched"] = l3.SubnetStats.SuppressedUnmatched
 	out["l3_subnet_suppressed_multi_access"] = l3.SubnetStats.SuppressedMultiAccess
@@ -133,8 +142,10 @@ func addTopologyL3Stats(out map[string]any, stats topologymodel.Stats) {
 	out["l3_subnet_suppressed_self_actor"] = l3.SuppressedSelfActor
 	out["l3_subnet_suppressed_duplicate_link"] = l3.SuppressedDuplicateLink
 	out["l3_subnet_visible_links"] = l3.EmittedLinks
+	out["l3_subnet_membership_visible_links"] = l3.EmittedMembershipLinks
 	if stats.HasComputed {
 		out["l3_subnet_visible_links"] = stats.Recomputed.L3SubnetVisibleLinks
+		out["l3_subnet_membership_visible_links"] = stats.Recomputed.L3SubnetMembershipVisibleLinks
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/values.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyv1/values.go
@@ -58,6 +58,13 @@ func nullableOptionalUint64Value(value topologyengine.OptionalValue[int64]) any 
 	return uint64(value.Value)
 }
 
+func nullableUintFromInt(value int) any {
+	if value <= 0 {
+		return nil
+	}
+	return uint64(value)
+}
+
 func uintValue(value any) (uint64, bool) {
 	switch typed := value.(type) {
 	case int:

--- a/src/go/plugin/go.d/collector/snmp_topology/testdata/topology_v1_normalized_golden.json
+++ b/src/go/plugin/go.d/collector/snmp_topology/testdata/topology_v1_normalized_golden.json
@@ -150,6 +150,23 @@
       },
       {
         "chassis_ids": [],
+        "display_name": "203.0.113.0/24",
+        "dns_names": [],
+        "endpoints_total": 2,
+        "hostnames": [],
+        "id": "l3-subnet-segment-203-0-113-0-24",
+        "ip_addresses": [],
+        "layer": "network",
+        "mac_addresses": [],
+        "parent_devices": [],
+        "ports_total": 2,
+        "source": "ip_mib",
+        "sys_name": "",
+        "sys_object_id": "",
+        "type": "l3_subnet_segment"
+      },
+      {
+        "chassis_ids": [],
         "display_name": "Server A",
         "dns_names": [],
         "hostnames": [
@@ -281,6 +298,87 @@
         ]
       },
       "type": "l3_subnet"
+    },
+    "l3_subnet_membership": {
+      "table": {
+        "columns": [
+          "link:link_ref:role=reference",
+          "src_actor:actor_ref:role=reference",
+          "dst_actor:actor_ref:role=reference",
+          "protocol:string_ref:dict=strings:role=group_key",
+          "direction:string_ref:dict=strings:role=group_key",
+          "state:string_ref:dict=strings:nullable",
+          "src_port_name:string_ref:dict=strings:nullable",
+          "dst_port_name:string_ref:dict=strings:nullable",
+          "src_if_index:uint:nullable",
+          "dst_if_index:uint:nullable",
+          "src_port_id:string_ref:dict=strings:nullable",
+          "dst_port_id:string_ref:dict=strings:nullable",
+          "src_management_ip:string_ref:dict=strings:nullable",
+          "dst_management_ip:string_ref:dict=strings:nullable",
+          "confidence:string_ref:dict=strings:nullable",
+          "inference:string_ref:dict=strings:nullable",
+          "attachment_mode:string_ref:dict=strings:nullable",
+          "member_actor:actor_ref:role=reference",
+          "segment_actor:actor_ref:role=reference",
+          "member_ip:string_ref:dict=strings:nullable",
+          "member_if_index:uint:nullable",
+          "member_if_name:string_ref:dict=strings:nullable",
+          "member_if_descr:string_ref:dict=strings:nullable",
+          "subnet:string_ref:dict=strings:role=group_key",
+          "network:string_ref:dict=strings:nullable",
+          "netmask:string_ref:dict=strings:nullable",
+          "prefix:uint:nullable",
+          "source:string_ref:dict=strings:nullable"
+        ],
+        "rows": [
+          {
+            "attachment_mode": "logical_l3_subnet_membership",
+            "direction": "observed",
+            "dst_actor": "l3-subnet-segment-203-0-113-0-24",
+            "inference": "shared_subnet_membership",
+            "link": "router-a -\u003e l3-subnet-segment-203-0-113-0-24 | l3_subnet_membership | l3_subnet_membership | \u003cnil\u003e | xe-0/0/2 | \u003cnil\u003e",
+            "member_actor": "router-a",
+            "member_if_descr": "Transit VLAN",
+            "member_if_index": 302,
+            "member_if_name": "xe-0/0/2",
+            "member_ip": "203.0.113.1",
+            "netmask": "255.255.255.0",
+            "network": "203.0.113.0",
+            "prefix": 24,
+            "protocol": "l3_subnet_membership",
+            "segment_actor": "l3-subnet-segment-203-0-113-0-24",
+            "source": "ip_mib",
+            "src_actor": "router-a",
+            "src_if_index": 302,
+            "src_port_name": "xe-0/0/2",
+            "subnet": "203.0.113.0/24"
+          },
+          {
+            "attachment_mode": "logical_l3_subnet_membership",
+            "direction": "observed",
+            "dst_actor": "l3-subnet-segment-203-0-113-0-24",
+            "inference": "shared_subnet_membership",
+            "link": "router-b -\u003e l3-subnet-segment-203-0-113-0-24 | l3_subnet_membership | l3_subnet_membership | \u003cnil\u003e | xe-0/0/2 | \u003cnil\u003e",
+            "member_actor": "router-b",
+            "member_if_descr": "Transit VLAN",
+            "member_if_index": 402,
+            "member_if_name": "xe-0/0/2",
+            "member_ip": "203.0.113.2",
+            "netmask": "255.255.255.0",
+            "network": "203.0.113.0",
+            "prefix": 24,
+            "protocol": "l3_subnet_membership",
+            "segment_actor": "l3-subnet-segment-203-0-113-0-24",
+            "source": "ip_mib",
+            "src_actor": "router-b",
+            "src_if_index": 402,
+            "src_port_name": "xe-0/0/2",
+            "subnet": "203.0.113.0/24"
+          }
+        ]
+      },
+      "type": "l3_subnet_membership"
     },
     "lldp": {
       "table": {
@@ -452,6 +550,24 @@
       },
       {
         "direction": "observed",
+        "dst_actor": "l3-subnet-segment-203-0-113-0-24",
+        "evidence_count": 1,
+        "protocol": "l3_subnet_membership",
+        "src_actor": "router-a",
+        "src_port_name": "xe-0/0/2",
+        "type": "l3_subnet_membership"
+      },
+      {
+        "direction": "observed",
+        "dst_actor": "l3-subnet-segment-203-0-113-0-24",
+        "evidence_count": 1,
+        "protocol": "l3_subnet_membership",
+        "src_actor": "router-b",
+        "src_port_name": "xe-0/0/2",
+        "type": "l3_subnet_membership"
+      },
+      {
+        "direction": "observed",
         "dst_actor": "router-b",
         "dst_port_name": "xe-0/0/1",
         "evidence_count": 1,
@@ -552,6 +668,10 @@
         {
           "label": "Network segment",
           "type": "segment"
+        },
+        {
+          "label": "L3 subnet",
+          "type": "l3_subnet_segment"
         }
       ],
       "links": [
@@ -574,6 +694,10 @@
         {
           "label": "L3 subnet",
           "type": "l3_subnet"
+        },
+        {
+          "label": "L3 subnet membership",
+          "type": "l3_subnet_membership"
         },
         {
           "label": "OSPF adjacency",
@@ -663,6 +787,7 @@
       "fdb",
       "stp",
       "l3_subnet",
+      "l3_subnet_membership",
       "ospf",
       "bgp"
     ],
@@ -676,7 +801,7 @@
     "actors_focus_depth_filtered": 0,
     "actors_map_type_suppressed": 2,
     "actors_non_ip_inferred_suppressed": 0,
-    "actors_total": 5,
+    "actors_total": 6,
     "bgp_adjacency_emitted_links": 1,
     "bgp_adjacency_suppressed_duplicate_link": 0,
     "bgp_adjacency_suppressed_non_established_state": 0,
@@ -687,9 +812,19 @@
     "bgp_peer_detail_rows": 0,
     "bgp_peer_rows": 0,
     "depth": "all",
-    "l3_subnet_candidate_links": 0,
+    "l3_subnet_candidate_links": 1,
     "l3_subnet_candidate_subnets": 0,
     "l3_subnet_emitted_links": 1,
+    "l3_subnet_membership_candidate_links": 2,
+    "l3_subnet_membership_emitted_links": 2,
+    "l3_subnet_membership_suppressed_duplicate_ip": 0,
+    "l3_subnet_membership_suppressed_duplicate_link": 0,
+    "l3_subnet_membership_suppressed_unmatched": 0,
+    "l3_subnet_membership_suppressed_unresolved_actor": 0,
+    "l3_subnet_membership_visible_links": 2,
+    "l3_subnet_segment_candidate_segments": 1,
+    "l3_subnet_segment_emitted_segments": 1,
+    "l3_subnet_segment_suppressed_no_producer_scope": 0,
     "l3_subnet_suppressed_duplicate_ip": 0,
     "l3_subnet_suppressed_duplicate_link": 0,
     "l3_subnet_suppressed_invalid": 0,
@@ -702,7 +837,7 @@
     "l3_subnet_visible_links": 1,
     "links_focus_depth_filtered": 0,
     "links_probable": 1,
-    "links_total": 5,
+    "links_total": 7,
     "managed_snmp_device_focus": "all_devices",
     "map_type": "high_confidence_inferred",
     "ospf_adjacency_emitted_links": 1,
@@ -794,6 +929,55 @@
             "value_index:uint:nullable:role=attribute"
           ],
           "rows": [
+            {
+              "actor": "l3-subnet-segment-203-0-113-0-24",
+              "key": "actor_type",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "l3_subnet_segment"
+            },
+            {
+              "actor": "l3-subnet-segment-203-0-113-0-24",
+              "key": "display_name",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "203.0.113.0/24"
+            },
+            {
+              "actor": "l3-subnet-segment-203-0-113-0-24",
+              "key": "display_name",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "203.0.113.0/24"
+            },
+            {
+              "actor": "l3-subnet-segment-203-0-113-0-24",
+              "key": "endpoints_total",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "2"
+            },
+            {
+              "actor": "l3-subnet-segment-203-0-113-0-24",
+              "key": "layer",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "network"
+            },
+            {
+              "actor": "l3-subnet-segment-203-0-113-0-24",
+              "key": "ports_total",
+              "kind": "attribute",
+              "source": "snmp-l2",
+              "value": "2"
+            },
+            {
+              "actor": "l3-subnet-segment-203-0-113-0-24",
+              "key": "source",
+              "kind": "identity",
+              "source": "snmp-l2",
+              "value": "ip_mib"
+            },
             {
               "actor": "router-a",
               "key": "actor_type",
@@ -2393,6 +2577,124 @@
               {
                 "columns": [
                   {
+                    "cell": "actor_link",
+                    "id": "subnet_actor",
+                    "label": "Subnet",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "member_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_name",
+                    "label": "Interface",
+                    "projection": {
+                      "column": "member_if_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "member_if_index",
+                    "label": "IfIndex",
+                    "projection": {
+                      "column": "member_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_descr",
+                    "label": "IfDescr",
+                    "projection": {
+                      "column": "member_if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 subnet memberships",
+                "id": "l3_subnet_memberships",
+                "label": "L3 Subnet Memberships",
+                "order": 4,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet_membership",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
                     "cell": "text",
                     "id": "neighbor_router_id",
                     "label": "Neighbor Router ID",
@@ -2482,7 +2784,7 @@
                 "empty_label": "No OSPF neighbors",
                 "id": "ospf_neighbors",
                 "label": "OSPF Neighbors",
-                "order": 4,
+                "order": 5,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -2658,7 +2960,7 @@
                 "empty_label": "No BGP peers",
                 "id": "bgp_peers",
                 "label": "BGP Peers",
-                "order": 5,
+                "order": 6,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -3387,6 +3689,124 @@
               {
                 "columns": [
                   {
+                    "cell": "actor_link",
+                    "id": "subnet_actor",
+                    "label": "Subnet",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "member_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_name",
+                    "label": "Interface",
+                    "projection": {
+                      "column": "member_if_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "member_if_index",
+                    "label": "IfIndex",
+                    "projection": {
+                      "column": "member_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_descr",
+                    "label": "IfDescr",
+                    "projection": {
+                      "column": "member_if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 subnet memberships",
+                "id": "l3_subnet_memberships",
+                "label": "L3 Subnet Memberships",
+                "order": 4,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet_membership",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
                     "cell": "text",
                     "id": "neighbor_router_id",
                     "label": "Neighbor Router ID",
@@ -3476,7 +3896,7 @@
                 "empty_label": "No OSPF neighbors",
                 "id": "ospf_neighbors",
                 "label": "OSPF Neighbors",
-                "order": 4,
+                "order": 5,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -3652,7 +4072,7 @@
                 "empty_label": "No BGP peers",
                 "id": "bgp_peers",
                 "label": "BGP Peers",
-                "order": 5,
+                "order": 6,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -4531,6 +4951,124 @@
               {
                 "columns": [
                   {
+                    "cell": "actor_link",
+                    "id": "subnet_actor",
+                    "label": "Subnet",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "member_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_name",
+                    "label": "Interface",
+                    "projection": {
+                      "column": "member_if_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "member_if_index",
+                    "label": "IfIndex",
+                    "projection": {
+                      "column": "member_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_descr",
+                    "label": "IfDescr",
+                    "projection": {
+                      "column": "member_if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 subnet memberships",
+                "id": "l3_subnet_memberships",
+                "label": "L3 Subnet Memberships",
+                "order": 4,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet_membership",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
                     "cell": "text",
                     "id": "neighbor_router_id",
                     "label": "Neighbor Router ID",
@@ -4620,7 +5158,7 @@
                 "empty_label": "No OSPF neighbors",
                 "id": "ospf_neighbors",
                 "label": "OSPF Neighbors",
-                "order": 4,
+                "order": 5,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -4796,7 +5334,7 @@
                 "empty_label": "No BGP peers",
                 "id": "bgp_peers",
                 "label": "BGP Peers",
-                "order": 5,
+                "order": 6,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -5687,6 +6225,124 @@
               {
                 "columns": [
                   {
+                    "cell": "actor_link",
+                    "id": "subnet_actor",
+                    "label": "Subnet",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "member_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_name",
+                    "label": "Interface",
+                    "projection": {
+                      "column": "member_if_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "member_if_index",
+                    "label": "IfIndex",
+                    "projection": {
+                      "column": "member_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_descr",
+                    "label": "IfDescr",
+                    "projection": {
+                      "column": "member_if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 subnet memberships",
+                "id": "l3_subnet_memberships",
+                "label": "L3 Subnet Memberships",
+                "order": 4,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet_membership",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
                     "cell": "text",
                     "id": "neighbor_router_id",
                     "label": "Neighbor Router ID",
@@ -5776,7 +6432,7 @@
                 "empty_label": "No OSPF neighbors",
                 "id": "ospf_neighbors",
                 "label": "OSPF Neighbors",
-                "order": 4,
+                "order": 5,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -5952,7 +6608,7 @@
                 "empty_label": "No BGP peers",
                 "id": "bgp_peers",
                 "label": "BGP Peers",
-                "order": 5,
+                "order": 6,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -6001,6 +6657,167 @@
           "label_keys": [
             "ospf_router_id"
           ]
+        }
+      },
+      "l3_subnet_segment": {
+        "aggregation_scopes": [
+          "segment",
+          "network"
+        ],
+        "identity": [
+          "id"
+        ],
+        "layer": "network",
+        "merge_identity": [
+          "id"
+        ],
+        "presentation": {
+          "color_slot": "info",
+          "icon": "segment",
+          "label": "L3 subnet",
+          "label_policy": {
+            "array": "reject",
+            "columns": [
+              "display_name"
+            ],
+            "fallback": "type_label",
+            "max_length": 80
+          },
+          "layout": {
+            "repulsion": "weakest"
+          },
+          "modal": {
+            "mini_topology": {
+              "depth": 1
+            },
+            "sections": [
+              {
+                "columns": [
+                  {
+                    "cell": "actor_link",
+                    "id": "member",
+                    "label": "Member",
+                    "projection": {
+                      "actor_column": "member_actor",
+                      "kind": "actor_ref_label"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_ip",
+                    "label": "Member IP",
+                    "projection": {
+                      "column": "member_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_name",
+                    "label": "Interface",
+                    "projection": {
+                      "column": "member_if_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "member_if_index",
+                    "label": "IfIndex",
+                    "projection": {
+                      "column": "member_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_descr",
+                    "label": "IfDescr",
+                    "projection": {
+                      "column": "member_if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No subnet members",
+                "id": "l3_subnet_members",
+                "label": "Members",
+                "order": 1,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "member_ip",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet_membership",
+                  "kind": "evidence"
+                }
+              }
+            ]
+          },
+          "role": "group",
+          "size": {
+            "mode": "fixed",
+            "scale": "compact"
+          }
+        },
+        "search": {
+          "enabled": false
         }
       },
       "load_balancer": {
@@ -6681,6 +7498,124 @@
               {
                 "columns": [
                   {
+                    "cell": "actor_link",
+                    "id": "subnet_actor",
+                    "label": "Subnet",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "member_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_name",
+                    "label": "Interface",
+                    "projection": {
+                      "column": "member_if_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "member_if_index",
+                    "label": "IfIndex",
+                    "projection": {
+                      "column": "member_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_descr",
+                    "label": "IfDescr",
+                    "projection": {
+                      "column": "member_if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 subnet memberships",
+                "id": "l3_subnet_memberships",
+                "label": "L3 Subnet Memberships",
+                "order": 4,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet_membership",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
                     "cell": "text",
                     "id": "neighbor_router_id",
                     "label": "Neighbor Router ID",
@@ -6770,7 +7705,7 @@
                 "empty_label": "No OSPF neighbors",
                 "id": "ospf_neighbors",
                 "label": "OSPF Neighbors",
-                "order": 4,
+                "order": 5,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -6946,7 +7881,7 @@
                 "empty_label": "No BGP peers",
                 "id": "bgp_peers",
                 "label": "BGP Peers",
-                "order": 5,
+                "order": 6,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -7675,6 +8610,124 @@
               {
                 "columns": [
                   {
+                    "cell": "actor_link",
+                    "id": "subnet_actor",
+                    "label": "Subnet",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "member_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_name",
+                    "label": "Interface",
+                    "projection": {
+                      "column": "member_if_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "member_if_index",
+                    "label": "IfIndex",
+                    "projection": {
+                      "column": "member_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_descr",
+                    "label": "IfDescr",
+                    "projection": {
+                      "column": "member_if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 subnet memberships",
+                "id": "l3_subnet_memberships",
+                "label": "L3 Subnet Memberships",
+                "order": 4,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet_membership",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
                     "cell": "text",
                     "id": "neighbor_router_id",
                     "label": "Neighbor Router ID",
@@ -7764,7 +8817,7 @@
                 "empty_label": "No OSPF neighbors",
                 "id": "ospf_neighbors",
                 "label": "OSPF Neighbors",
-                "order": 4,
+                "order": 5,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -7940,7 +8993,7 @@
                 "empty_label": "No BGP peers",
                 "id": "bgp_peers",
                 "label": "BGP Peers",
-                "order": 5,
+                "order": 6,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -8669,6 +9722,124 @@
               {
                 "columns": [
                   {
+                    "cell": "actor_link",
+                    "id": "subnet_actor",
+                    "label": "Subnet",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "member_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_name",
+                    "label": "Interface",
+                    "projection": {
+                      "column": "member_if_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "member_if_index",
+                    "label": "IfIndex",
+                    "projection": {
+                      "column": "member_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_descr",
+                    "label": "IfDescr",
+                    "projection": {
+                      "column": "member_if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 subnet memberships",
+                "id": "l3_subnet_memberships",
+                "label": "L3 Subnet Memberships",
+                "order": 4,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet_membership",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
                     "cell": "text",
                     "id": "neighbor_router_id",
                     "label": "Neighbor Router ID",
@@ -8758,7 +9929,7 @@
                 "empty_label": "No OSPF neighbors",
                 "id": "ospf_neighbors",
                 "label": "OSPF Neighbors",
-                "order": 4,
+                "order": 5,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -8934,7 +10105,7 @@
                 "empty_label": "No BGP peers",
                 "id": "bgp_peers",
                 "label": "BGP Peers",
-                "order": 5,
+                "order": 6,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -9663,6 +10834,124 @@
               {
                 "columns": [
                   {
+                    "cell": "actor_link",
+                    "id": "subnet_actor",
+                    "label": "Subnet",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "member_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_name",
+                    "label": "Interface",
+                    "projection": {
+                      "column": "member_if_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "member_if_index",
+                    "label": "IfIndex",
+                    "projection": {
+                      "column": "member_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_descr",
+                    "label": "IfDescr",
+                    "projection": {
+                      "column": "member_if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 subnet memberships",
+                "id": "l3_subnet_memberships",
+                "label": "L3 Subnet Memberships",
+                "order": 4,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet_membership",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
                     "cell": "text",
                     "id": "neighbor_router_id",
                     "label": "Neighbor Router ID",
@@ -9752,7 +11041,7 @@
                 "empty_label": "No OSPF neighbors",
                 "id": "ospf_neighbors",
                 "label": "OSPF Neighbors",
-                "order": 4,
+                "order": 5,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -9928,7 +11217,7 @@
                 "empty_label": "No BGP peers",
                 "id": "bgp_peers",
                 "label": "BGP Peers",
-                "order": 5,
+                "order": 6,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -10816,6 +12105,124 @@
               {
                 "columns": [
                   {
+                    "cell": "actor_link",
+                    "id": "subnet_actor",
+                    "label": "Subnet",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "member_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_name",
+                    "label": "Interface",
+                    "projection": {
+                      "column": "member_if_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "member_if_index",
+                    "label": "IfIndex",
+                    "projection": {
+                      "column": "member_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_descr",
+                    "label": "IfDescr",
+                    "projection": {
+                      "column": "member_if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 subnet memberships",
+                "id": "l3_subnet_memberships",
+                "label": "L3 Subnet Memberships",
+                "order": 4,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet_membership",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
                     "cell": "text",
                     "id": "neighbor_router_id",
                     "label": "Neighbor Router ID",
@@ -10905,7 +12312,7 @@
                 "empty_label": "No OSPF neighbors",
                 "id": "ospf_neighbors",
                 "label": "OSPF Neighbors",
-                "order": 4,
+                "order": 5,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -11081,7 +12488,7 @@
                 "empty_label": "No BGP peers",
                 "id": "bgp_peers",
                 "label": "BGP Peers",
-                "order": 5,
+                "order": 6,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -11810,6 +13217,124 @@
               {
                 "columns": [
                   {
+                    "cell": "actor_link",
+                    "id": "subnet_actor",
+                    "label": "Subnet",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "member_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_name",
+                    "label": "Interface",
+                    "projection": {
+                      "column": "member_if_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "member_if_index",
+                    "label": "IfIndex",
+                    "projection": {
+                      "column": "member_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_descr",
+                    "label": "IfDescr",
+                    "projection": {
+                      "column": "member_if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 subnet memberships",
+                "id": "l3_subnet_memberships",
+                "label": "L3 Subnet Memberships",
+                "order": 4,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet_membership",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
                     "cell": "text",
                     "id": "neighbor_router_id",
                     "label": "Neighbor Router ID",
@@ -11899,7 +13424,7 @@
                 "empty_label": "No OSPF neighbors",
                 "id": "ospf_neighbors",
                 "label": "OSPF Neighbors",
-                "order": 4,
+                "order": 5,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -12075,7 +13600,7 @@
                 "empty_label": "No BGP peers",
                 "id": "bgp_peers",
                 "label": "BGP Peers",
-                "order": 5,
+                "order": 6,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -12804,6 +14329,124 @@
               {
                 "columns": [
                   {
+                    "cell": "actor_link",
+                    "id": "subnet_actor",
+                    "label": "Subnet",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "member_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_name",
+                    "label": "Interface",
+                    "projection": {
+                      "column": "member_if_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "member_if_index",
+                    "label": "IfIndex",
+                    "projection": {
+                      "column": "member_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_descr",
+                    "label": "IfDescr",
+                    "projection": {
+                      "column": "member_if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 subnet memberships",
+                "id": "l3_subnet_memberships",
+                "label": "L3 Subnet Memberships",
+                "order": 4,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet_membership",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
                     "cell": "text",
                     "id": "neighbor_router_id",
                     "label": "Neighbor Router ID",
@@ -12893,7 +14536,7 @@
                 "empty_label": "No OSPF neighbors",
                 "id": "ospf_neighbors",
                 "label": "OSPF Neighbors",
-                "order": 4,
+                "order": 5,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -13069,7 +14712,7 @@
                 "empty_label": "No BGP peers",
                 "id": "bgp_peers",
                 "label": "BGP Peers",
-                "order": 5,
+                "order": 6,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -13798,6 +15441,124 @@
               {
                 "columns": [
                   {
+                    "cell": "actor_link",
+                    "id": "subnet_actor",
+                    "label": "Subnet",
+                    "projection": {
+                      "dst_actor_column": "dst_actor",
+                      "kind": "opposite_actor",
+                      "src_actor_column": "src_actor"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_ip",
+                    "label": "Local IP",
+                    "projection": {
+                      "column": "member_ip",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_name",
+                    "label": "Interface",
+                    "projection": {
+                      "column": "member_if_name",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "text",
+                    "id": "subnet",
+                    "label": "Subnet",
+                    "projection": {
+                      "column": "subnet",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "prefix",
+                    "label": "Prefix",
+                    "projection": {
+                      "column": "prefix",
+                      "kind": "direct"
+                    }
+                  },
+                  {
+                    "cell": "number",
+                    "id": "member_if_index",
+                    "label": "IfIndex",
+                    "projection": {
+                      "column": "member_if_index",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "member_if_descr",
+                    "label": "IfDescr",
+                    "projection": {
+                      "column": "member_if_descr",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "network",
+                    "label": "Network",
+                    "projection": {
+                      "column": "network",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "text",
+                    "id": "netmask",
+                    "label": "Netmask",
+                    "projection": {
+                      "column": "netmask",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  },
+                  {
+                    "cell": "badge",
+                    "id": "source",
+                    "label": "Source",
+                    "projection": {
+                      "column": "source",
+                      "kind": "direct"
+                    },
+                    "visibility": "expanded"
+                  }
+                ],
+                "empty_label": "No L3 subnet memberships",
+                "id": "l3_subnet_memberships",
+                "label": "L3 Subnet Memberships",
+                "order": 4,
+                "owner_filter": {
+                  "dst_actor_column": "dst_actor",
+                  "link_column": "link",
+                  "mode": "incident_evidence",
+                  "src_actor_column": "src_actor"
+                },
+                "sort": {
+                  "column": "subnet",
+                  "direction": "asc"
+                },
+                "source": {
+                  "evidence": "l3_subnet_membership",
+                  "kind": "evidence"
+                }
+              },
+              {
+                "columns": [
+                  {
                     "cell": "text",
                     "id": "neighbor_router_id",
                     "label": "Neighbor Router ID",
@@ -13887,7 +15648,7 @@
                 "empty_label": "No OSPF neighbors",
                 "id": "ospf_neighbors",
                 "label": "OSPF Neighbors",
-                "order": 4,
+                "order": 5,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -14063,7 +15824,7 @@
                 "empty_label": "No BGP peers",
                 "id": "bgp_peers",
                 "label": "BGP Peers",
-                "order": 5,
+                "order": 6,
                 "owner_filter": {
                   "actor_column": "actor",
                   "mode": "actor_column"
@@ -15019,6 +16780,177 @@
         ],
         "role": "observation_evidence"
       },
+      "l3_subnet_membership": {
+        "columns": [
+          {
+            "id": "link",
+            "role": "reference",
+            "type": "link_ref"
+          },
+          {
+            "id": "src_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "dst_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "protocol",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "direction",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "state",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "src_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "id": "dst_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_port_id",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_port_id",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "src_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "dst_management_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "confidence",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "inference",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "attachment_mode",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "member_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "id": "segment_actor",
+            "role": "reference",
+            "type": "actor_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "member_ip",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "member_if_index",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "member_if_name",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "member_if_descr",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "subnet",
+            "role": "group_key",
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "network",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "dictionary": "strings",
+            "id": "netmask",
+            "nullable": true,
+            "type": "string_ref"
+          },
+          {
+            "id": "prefix",
+            "nullable": true,
+            "type": "uint"
+          },
+          {
+            "dictionary": "strings",
+            "id": "source",
+            "nullable": true,
+            "type": "string_ref"
+          }
+        ],
+        "link_type": "l3_subnet_membership",
+        "match_columns": [
+          "member_actor",
+          "segment_actor",
+          "member_ip",
+          "subnet"
+        ],
+        "role": "observation_evidence"
+      },
       "lldp": {
         "columns": [
           {
@@ -15797,6 +17729,29 @@
           "color_slot": "info",
           "curve": "straight",
           "label": "L3 subnet",
+          "line_style": "dashed",
+          "width": "normal"
+        },
+        "semantic_role": "normal"
+      },
+      "l3_subnet_membership": {
+        "aggregation": {
+          "direction": "canonicalize_unordered",
+          "evidence": "append",
+          "metrics": {
+            "evidence_count": "sum"
+          }
+        },
+        "direction_role": "observation",
+        "evidence_types": [
+          "l3_subnet_membership"
+        ],
+        "orientation": "observed_bidirectional",
+        "presentation": {
+          "arrow": "none",
+          "color_slot": "info",
+          "curve": "straight",
+          "label": "L3 subnet membership",
           "line_style": "dashed",
           "width": "normal"
         },

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_projection_convert.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_projection_convert.go
@@ -3,6 +3,8 @@
 package snmptopology
 
 import (
+	"strings"
+
 	topologyengine "github.com/netdata/netdata/go/plugins/pkg/l2topology"
 	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
@@ -12,6 +14,7 @@ func topologyActorFromGraph(actor graph.Actor, detail topologyengine.ProjectionA
 	return topologymodel.Actor{
 		ActorID:     actor.ActorID,
 		ActorType:   actor.ActorType,
+		SegmentKind: strings.TrimSpace(detail.Segment.SegmentKind),
 		Layer:       actor.Layer,
 		Source:      actor.Source,
 		Match:       actor.Match,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
@@ -3,20 +3,24 @@
 package snmptopology
 
 import (
+	"strings"
 	"sync"
 
+	"github.com/netdata/netdata/go/plugins/pkg/pluginconfig"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyoptions"
 )
 
 type topologyRegistry struct {
-	mu     sync.RWMutex
-	caches map[*topologyCache]struct{}
+	mu              sync.RWMutex
+	caches          map[*topologyCache]struct{}
+	producerScopeID string
 }
 
 func newTopologyRegistry() *topologyRegistry {
 	return &topologyRegistry{
-		caches: make(map[*topologyCache]struct{}),
+		caches:          make(map[*topologyCache]struct{}),
+		producerScopeID: strings.TrimSpace(pluginconfig.RegistryUniqueID()),
 	}
 }
 
@@ -48,8 +52,32 @@ func (r *topologyRegistry) snapshotWithOptions(options topologyoptions.QueryOpti
 	if !ok {
 		return topologymodel.Data{}, false
 	}
+	aggregate.ProducerScopeID = r.producerScope()
 
 	return buildSNMPTopologySnapshot(aggregate, options)
+}
+
+func (r *topologyRegistry) producerScope() string {
+	r.mu.RLock()
+	scope := strings.TrimSpace(r.producerScopeID)
+	r.mu.RUnlock()
+	if scope != "" {
+		return scope
+	}
+
+	scope = strings.TrimSpace(pluginconfig.RegistryUniqueID())
+	if scope == "" {
+		return ""
+	}
+
+	r.mu.Lock()
+	if strings.TrimSpace(r.producerScopeID) == "" {
+		r.producerScopeID = scope
+	} else {
+		scope = strings.TrimSpace(r.producerScopeID)
+	}
+	r.mu.Unlock()
+	return scope
 }
 
 func (r *topologyRegistry) managedDeviceFocusTargets() []topologyoptions.ManagedFocusTarget {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -194,6 +194,116 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetForManagedRoutersWithoutLLDP(t 
 	require.Equal(t, 1, topologyStatsToV1ForTest(t, data.Stats)["links_total"])
 }
 
+func TestTopologyRegistry_DefaultMapEmitsL3SubnetSegmentForManagedRouters(t *testing.T) {
+	registry := newTopologyRegistry()
+	registry.producerScopeID = "producer-a"
+
+	cacheA := newTopologyCache()
+	cacheA.updateTime = time.Now()
+	cacheA.lastUpdate = cacheA.updateTime
+	cacheA.agentID = "agent-test"
+	cacheA.localDevice = topologymodel.Device{
+		ChassisID:     "00:11:22:33:44:55",
+		ChassisIDType: "macAddress",
+		SysName:       "router-a",
+		ManagementIP:  "10.0.0.1",
+	}
+	cacheA.updateIfIndexByIP(map[string]string{
+		tagTopoIfIndex: "2",
+		tagTopoIPAddr:  "203.0.113.1",
+		tagTopoIPMask:  "255.255.255.0",
+	})
+	cacheA.updateIfNameByIndex(map[string]string{
+		tagTopoIfIndex: "2",
+		tagTopoIfName:  "wan0",
+	})
+
+	cacheB := newTopologyCache()
+	cacheB.updateTime = time.Now().Add(time.Second)
+	cacheB.lastUpdate = cacheB.updateTime
+	cacheB.agentID = "agent-test"
+	cacheB.localDevice = topologymodel.Device{
+		ChassisID:     "aa:bb:cc:dd:ee:ff",
+		ChassisIDType: "macAddress",
+		SysName:       "router-b",
+		ManagementIP:  "10.0.0.2",
+	}
+	cacheB.updateIfIndexByIP(map[string]string{
+		tagTopoIfIndex: "7",
+		tagTopoIPAddr:  "203.0.113.2",
+		tagTopoIPMask:  "255.255.255.0",
+	})
+	cacheB.updateIfNameByIndex(map[string]string{
+		tagTopoIfIndex: "7",
+		tagTopoIfName:  "wan7",
+	})
+
+	cacheC := newTopologyCache()
+	cacheC.updateTime = time.Now().Add(2 * time.Second)
+	cacheC.lastUpdate = cacheC.updateTime
+	cacheC.agentID = "agent-test"
+	cacheC.localDevice = topologymodel.Device{
+		ChassisID:     "cc:dd:ee:ff:00:11",
+		ChassisIDType: "macAddress",
+		SysName:       "router-c",
+		ManagementIP:  "10.0.0.3",
+	}
+	cacheC.updateIfIndexByIP(map[string]string{
+		tagTopoIfIndex: "9",
+		tagTopoIPAddr:  "203.0.113.3",
+		tagTopoIPMask:  "255.255.255.0",
+	})
+	cacheC.updateIfNameByIndex(map[string]string{
+		tagTopoIfIndex: "9",
+		tagTopoIfName:  "wan9",
+	})
+
+	registry.register(cacheA)
+	registry.register(cacheB)
+	registry.register(cacheC)
+
+	data, ok := snapshotTopologyRegistryForTest(registry)
+
+	require.True(t, ok)
+	require.Len(t, data.Actors, 4)
+	require.Equal(t, 3, testCountTopologyLinksByType(data.Links, topologymodel.L3SubnetMembershipLinkType))
+	require.Equal(t, 0, testCountTopologyLinksByType(data.Links, topologymodel.L3SubnetLinkType))
+
+	var segment *topologymodel.Actor
+	for i := range data.Actors {
+		if data.Actors[i].ActorType == topologymodel.L3SubnetSegmentActorType {
+			segment = &data.Actors[i]
+			break
+		}
+	}
+	require.NotNil(t, segment)
+	require.Equal(t, topologymodel.SegmentKindL3Subnet, segment.SegmentKind)
+	require.Equal(t, "203.0.113.0/24", topologymodel.ActorDetailDisplayName(*segment))
+
+	memberIDs := make([]string, 0, 3)
+	for _, link := range data.Links {
+		if link.LinkType != topologymodel.L3SubnetMembershipLinkType {
+			continue
+		}
+		require.Equal(t, segment.ActorID, link.DstActorID)
+		require.NotNil(t, link.Detail.L3SubnetMembership)
+		require.Equal(t, "203.0.113.0/24", link.Detail.L3SubnetMembership.Subnet)
+		require.Len(t, link.Detail.L3SubnetMembership.Interfaces, 1)
+		memberIDs = append(memberIDs, link.SrcActorID)
+	}
+	routerA := findDeviceActorBySysName(data, "router-a")
+	require.NotNil(t, routerA)
+	routerB := findDeviceActorBySysName(data, "router-b")
+	require.NotNil(t, routerB)
+	routerC := findDeviceActorBySysName(data, "router-c")
+	require.NotNil(t, routerC)
+	require.ElementsMatch(t, []string{routerA.ActorID, routerB.ActorID, routerC.ActorID}, memberIDs)
+	require.Equal(t, 1, topologyStatsToV1ForTest(t, data.Stats)["l3_subnet_segment_emitted_segments"])
+	require.Equal(t, 3, topologyStatsToV1ForTest(t, data.Stats)["l3_subnet_membership_emitted_links"])
+	require.Equal(t, 3, topologyStatsToV1ForTest(t, data.Stats)["l3_subnet_membership_visible_links"])
+	require.Equal(t, 3, topologyStatsToV1ForTest(t, data.Stats)["links_total"])
+}
+
 func TestTopologyRegistry_OSPFSnapshotEnrichesSubnetAfterNeighborIngest(t *testing.T) {
 	registry := newTopologyRegistry()
 
@@ -795,8 +905,9 @@ func TestApplySNMPTopologyShapePolicies_EliminatesNonIPInferredActorsAndSparseSe
 	data := topologymodel.Data{
 		Actors: []topologymodel.Actor{
 			{
-				ActorID:   "segment:s1",
-				ActorType: "segment",
+				ActorID:     "segment:s1",
+				ActorType:   "segment",
+				SegmentKind: topologymodel.SegmentKindBroadcastDomain,
 				Match: topologymodel.Match{
 					Hostnames: []string{"segment:s1"},
 				},
@@ -983,10 +1094,11 @@ func TestApplyTopologyDepthFocusFilter_ManagedFocusDepthZero(t *testing.T) {
 				Match:     topologymodel.Match{IPAddresses: []string{"10.0.0.3"}},
 			},
 			{
-				ActorID:   "segment:s1",
-				ActorType: "segment",
-				Source:    "snmp",
-				Match:     topologymodel.Match{Hostnames: []string{"segment:s1"}},
+				ActorID:     "segment:s1",
+				ActorType:   "segment",
+				SegmentKind: topologymodel.SegmentKindBroadcastDomain,
+				Source:      "snmp",
+				Match:       topologymodel.Match{Hostnames: []string{"segment:s1"}},
 			},
 		},
 		Links: []topologymodel.Link{
@@ -1045,10 +1157,11 @@ func TestApplyTopologyDepthFocusFilter_ManagedFocusDepthOneIncludesDirectNeighbo
 				Match:     topologymodel.Match{IPAddresses: []string{"10.0.0.3"}},
 			},
 			{
-				ActorID:   "segment:s1",
-				ActorType: "segment",
-				Source:    "snmp",
-				Match:     topologymodel.Match{Hostnames: []string{"segment:s1"}},
+				ActorID:     "segment:s1",
+				ActorType:   "segment",
+				SegmentKind: topologymodel.SegmentKindBroadcastDomain,
+				Source:      "snmp",
+				Match:       topologymodel.Match{Hostnames: []string{"segment:s1"}},
 			},
 		},
 		Links: []topologymodel.Link{
@@ -1107,10 +1220,11 @@ func TestApplyTopologyDepthFocusFilter_MultiFocusDepthZeroIncludesAllShortestPat
 				Match:     topologymodel.Match{IPAddresses: []string{"10.0.0.3"}},
 			},
 			{
-				ActorID:   "segment:s1",
-				ActorType: "segment",
-				Source:    "snmp",
-				Match:     topologymodel.Match{Hostnames: []string{"segment:s1"}},
+				ActorID:     "segment:s1",
+				ActorType:   "segment",
+				SegmentKind: topologymodel.SegmentKindBroadcastDomain,
+				Source:      "snmp",
+				Match:       topologymodel.Match{Hostnames: []string{"segment:s1"}},
 			},
 		},
 		Links: []topologymodel.Link{

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_v1_stats_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_v1_stats_test.go
@@ -107,9 +107,18 @@ func TestSNMPTopologyToV1_RealPipelineStatsCensus(t *testing.T) {
 		"l3_subnet_candidate_subnets",
 		"l3_subnet_candidate_links",
 		"l3_subnet_emitted_links",
+		"l3_subnet_segment_candidate_segments",
+		"l3_subnet_segment_emitted_segments",
+		"l3_subnet_membership_candidate_links",
+		"l3_subnet_membership_emitted_links",
 		"l3_subnet_suppressed_invalid",
 		"l3_subnet_suppressed_unsupported_prefix",
 		"l3_subnet_suppressed_duplicate_ip",
+		"l3_subnet_segment_suppressed_no_producer_scope",
+		"l3_subnet_membership_suppressed_duplicate_ip",
+		"l3_subnet_membership_suppressed_unmatched",
+		"l3_subnet_membership_suppressed_unresolved_actor",
+		"l3_subnet_membership_suppressed_duplicate_link",
 		"l3_subnet_suppressed_self_link",
 		"l3_subnet_suppressed_unmatched",
 		"l3_subnet_suppressed_multi_access",
@@ -117,6 +126,7 @@ func TestSNMPTopologyToV1_RealPipelineStatsCensus(t *testing.T) {
 		"l3_subnet_suppressed_self_actor",
 		"l3_subnet_suppressed_duplicate_link",
 		"l3_subnet_visible_links",
+		"l3_subnet_membership_visible_links",
 		"ospf_neighbor_rows",
 		"ospf_neighbor_detail_rows",
 		"ospf_adjacency_emitted_links",
@@ -143,6 +153,9 @@ func TestSNMPTopologyToV1_RealPipelineStatsCensus(t *testing.T) {
 	require.Equal(t, topologyoptions.DepthAll, payload.Stats["depth"])
 	require.Equal(t, 1, payload.Stats["l3_subnet_emitted_links"])
 	require.Equal(t, 1, payload.Stats["l3_subnet_visible_links"])
+	require.Equal(t, 0, payload.Stats["l3_subnet_segment_emitted_segments"])
+	require.Equal(t, 0, payload.Stats["l3_subnet_membership_emitted_links"])
+	require.Equal(t, 0, payload.Stats["l3_subnet_membership_visible_links"])
 	require.Equal(t, 1, payload.Stats["ospf_adjacency_emitted_links"])
 	require.Equal(t, 1, payload.Stats["ospf_adjacency_visible_links"])
 	require.Equal(t, 1, payload.Stats["bgp_adjacency_emitted_links"])
@@ -188,6 +201,11 @@ func TestSNMPTopologyToV1_RealPipelineStatsCensusNoProtocolDataEmitsZeroProtocol
 	require.Equal(t, 0, payload.Stats["l3_subnet_candidate_links"])
 	require.Equal(t, 0, payload.Stats["l3_subnet_emitted_links"])
 	require.Equal(t, 0, payload.Stats["l3_subnet_visible_links"])
+	require.Equal(t, 0, payload.Stats["l3_subnet_segment_candidate_segments"])
+	require.Equal(t, 0, payload.Stats["l3_subnet_segment_emitted_segments"])
+	require.Equal(t, 0, payload.Stats["l3_subnet_membership_candidate_links"])
+	require.Equal(t, 0, payload.Stats["l3_subnet_membership_emitted_links"])
+	require.Equal(t, 0, payload.Stats["l3_subnet_membership_visible_links"])
 	require.Equal(t, 0, payload.Stats["ospf_neighbor_rows"])
 	require.Equal(t, 0, payload.Stats["ospf_adjacency_emitted_links"])
 	require.Equal(t, 0, payload.Stats["ospf_adjacency_visible_links"])
@@ -199,7 +217,12 @@ func TestSNMPTopologyToV1_RealPipelineStatsCensusNoProtocolDataEmitsZeroProtocol
 func TestTopologyStatsToV1_OmitsFocusKeysWhenFocusFilterReturnsEarly(t *testing.T) {
 	data := &topologymodel.Data{
 		Actors: []topologymodel.Actor{
-			{ActorID: "segment-a", ActorType: "segment", Match: topologymodel.Match{IPAddresses: []string{"10.0.0.1"}}},
+			{
+				ActorID:     "segment-a",
+				ActorType:   "segment",
+				SegmentKind: topologymodel.SegmentKindBroadcastDomain,
+				Match:       topologymodel.Match{IPAddresses: []string{"10.0.0.1"}},
+			},
 		},
 	}
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds L3 subnet segment grouping to `go.d/snmp_topology` so shared IPv4 subnets (/24–/29) appear as logical segment actors with membership evidence, improving visualization and aggregation safety. Direct /30–/31 links remain unchanged.

- **New Features**
  - Emit `l3_subnet_segment` actors for `/24`–`/29` with `l3_subnet_membership` links; keep `/30`–`/31` as direct `l3_subnet`.
  - Scope segment IDs by the producer (Agent registry unique ID) to avoid private subnet collisions; skip segments if scope is missing.
  - v1 updates: new actor type and legend, device modal section “L3 Subnet Memberships,” segment modal for members; focus depth does not fan out; cleanup keeps visible L3 subnet segments.
  - Stats/capabilities: new counters for segments and membership links; producer advertises `l3_subnet_membership`. Docs/specs and tests updated.

- **Bug Fixes**
  - Normalize cleanup by trimming actor and link endpoint IDs before neighbor lookup to prevent accidental segment pruning.

<sup>Written for commit fa22809211a8192eef9b569e608d544884f4ade6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

