### PR TITLE
fix(go.d/snmp_topology): restore reverse DNS warming

### DIFF
--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -301,8 +301,16 @@ snmp:topology:snmp request
 
 The Function returns `503` while no usable topology snapshot exists yet.
 
-Reverse DNS is intentionally disabled in the Function adapter. Rendering must
-not block on network I/O while serving a Function call.
+Reverse DNS is cache-backed and non-blocking on the Function path:
+
+- Function rendering uses a registry-owned cache-only resolver.
+- The same display-name code records IPs it tried to resolve.
+- `Run(ctx)` warms those candidates asynchronously after refresh snapshots and
+  after Function requests enqueue newly observed candidates.
+- DNS failures, timeouts, and cache misses fall through to the existing
+  sysName, hostname, IP, and MAC display-name order.
+
+Function requests must not perform live DNS I/O while serving a response.
 
 ## Trap Enrichment
 

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -128,8 +128,11 @@ func (c *Collector) Run(ctx context.Context) error {
 	}
 	c.publishTrapTopologyEnrichment()
 	defer c.unpublishTrapTopologyEnrichment()
+	c.topologyRegistry.setReverseDNSWarmContext(ctx)
+	defer c.topologyRegistry.setReverseDNSWarmContext(nil)
 
 	c.refreshTopologyRecovering(ctx)
+	c.topologyRegistry.enqueueReverseDNSWarmFromDefaultSnapshot()
 
 	ticker := time.NewTicker(c.deviceCheckEvery())
 	defer ticker.Stop()
@@ -140,6 +143,7 @@ func (c *Collector) Run(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			c.refreshTopologyRecovering(ctx)
+			c.topologyRegistry.enqueueReverseDNSWarmFromDefaultSnapshot()
 		}
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/func_deps.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_deps.go
@@ -20,10 +20,16 @@ func (a funcDepsAdapter) Snapshot(options topologyoptions.QueryOptions) (topolog
 		return topologyv1.Data{}, false, nil
 	}
 
-	options.ResolveDNSName = resolveTopologyReverseDNSNameNoop // never block on network I/O
+	dnsCandidates := a.registry.reverseDNSCandidateCollector()
+	if dnsCandidates != nil {
+		options.ResolveDNSName = dnsCandidates.lookupCached
+	}
 	data, ok := a.registry.snapshotWithOptions(options)
 	if !ok {
 		return topologyv1.Data{}, false, nil
+	}
+	if dnsCandidates != nil {
+		a.registry.enqueueReverseDNSWarm(dnsCandidates.collectedCandidates())
 	}
 
 	payload, err := topologyv1renderer.Render(data)

--- a/src/go/plugin/go.d/collector/snmp_topology/func_deps_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_deps_test.go
@@ -73,7 +73,6 @@ func TestFuncDepsAdapterSnapshotEnqueuesReverseDNSWarmCandidates(t *testing.T) {
 		timeout:     time.Second,
 		positiveTTL: time.Hour,
 		negativeTTL: time.Minute,
-		maxEntries:  10,
 		concurrency: 1,
 		lookup: func(_ context.Context, ip string) ([]string, error) {
 			warmed <- ip

--- a/src/go/plugin/go.d/collector/snmp_topology/func_deps_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_deps_test.go
@@ -3,7 +3,10 @@
 package snmptopology
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	topologyv1 "github.com/netdata/netdata/go/plugins/pkg/topology/v1"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyoptions"
@@ -35,4 +38,64 @@ func TestFuncDepsAdapterSnapshotUnavailable(t *testing.T) {
 
 func TestFuncDepsAdapterManagedDeviceFocusTargetsNilRegistry(t *testing.T) {
 	require.Nil(t, funcDepsAdapter{}.ManagedDeviceFocusTargets())
+}
+
+func TestFuncDepsAdapterSnapshotUsesCachedReverseDNSWithoutLiveLookup(t *testing.T) {
+	clock := newReverseDNSTestClock()
+	var liveCalls atomic.Int64
+	registry := newTopologyRegistry()
+	registry.reverseDNS = newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
+		now: clock.Now,
+		lookup: func(context.Context, string) ([]string, error) {
+			liveCalls.Add(1)
+			return []string{"unexpected.example.test"}, nil
+		},
+	})
+	registry.reverseDNS.store("10.0.0.10", "switch-a.example.test", clock.Now().Add(time.Hour))
+
+	cache := newTopologyCache()
+	seedPublishedEndpointSnapshot(cache)
+	registry.register(cache)
+
+	data, ok, err := (funcDepsAdapter{registry: registry}).Snapshot(topologyoptions.QueryOptions{})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Contains(t, topologyV1StringColumnValues(t, data, data.Actors, "display_name"), "switch-a.example.test")
+	require.Zero(t, liveCalls.Load())
+}
+
+func TestFuncDepsAdapterSnapshotEnqueuesReverseDNSWarmCandidates(t *testing.T) {
+	clock := newReverseDNSTestClock()
+	warmed := make(chan string, 4)
+	registry := newTopologyRegistry()
+	registry.reverseDNS = newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
+		now:         clock.Now,
+		timeout:     time.Second,
+		positiveTTL: time.Hour,
+		negativeTTL: time.Minute,
+		maxEntries:  10,
+		concurrency: 1,
+		lookup: func(_ context.Context, ip string) ([]string, error) {
+			warmed <- ip
+			return []string{ip + ".example.test"}, nil
+		},
+	})
+	registry.setReverseDNSWarmContext(context.Background())
+
+	cache := newTopologyCache()
+	seedPublishedEndpointSnapshot(cache)
+	registry.register(cache)
+
+	_, ok, err := (funcDepsAdapter{registry: registry}).Snapshot(topologyoptions.QueryOptions{})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.Eventually(t, func() bool {
+		select {
+		case ip := <-warmed:
+			return ip == "10.0.0.10" || ip == "10.0.0.20"
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyoptions/options.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyoptions/options.go
@@ -42,6 +42,17 @@ type ManagedFocusTarget struct {
 	Name  string
 }
 
+func DefaultQueryOptions() QueryOptions {
+	return QueryOptions{
+		CollapseActorsByIP:     true,
+		EliminateNonIPInferred: true,
+		MapType:                MapTypeLLDPCDPManaged,
+		InferenceStrategy:      InferenceStrategyFDBMinimumKnowledge,
+		ManagedDeviceFocus:     ManagedFocusAllDevices,
+		Depth:                  DepthAllInternal,
+	}
+}
+
 func NormalizeQueryOptions(options QueryOptions) QueryOptions {
 	options.MapType = NormalizeMapType(options.MapType)
 	if options.MapType == "" {

--- a/src/go/plugin/go.d/collector/snmp_topology/snmptopologyfunc/options.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/snmptopologyfunc/options.go
@@ -10,14 +10,7 @@ import (
 )
 
 func resolveQueryOptions(params funcapi.ResolvedParams) topologyoptions.QueryOptions {
-	options := topologyoptions.QueryOptions{
-		CollapseActorsByIP:     true,
-		EliminateNonIPInferred: true,
-		MapType:                topologyoptions.MapTypeLLDPCDPManaged,
-		InferenceStrategy:      topologyoptions.InferenceStrategyFDBMinimumKnowledge,
-		ManagedDeviceFocus:     topologyoptions.ManagedFocusAllDevices,
-		Depth:                  topologyoptions.DepthAllInternal,
-	}
+	options := topologyoptions.DefaultQueryOptions()
 
 	if identity := normalizeNodesIdentity(params.GetOne(ParamNodesIdentity)); identity == NodesIdentityMAC {
 		options.CollapseActorsByIP = false

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_dns.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_dns.go
@@ -14,12 +14,11 @@ import (
 )
 
 const (
-	topologyReverseDNSLookupTimeout   = 500 * time.Millisecond
-	topologyReverseDNSPositiveTTL     = 24 * time.Hour
-	topologyReverseDNSNegativeTTL     = 6 * time.Hour
-	topologyReverseDNSMaxCandidates   = 1024
-	topologyReverseDNSMaxCacheEntries = 4096
-	topologyReverseDNSMaxConcurrency  = 4
+	topologyReverseDNSLookupTimeout  = 500 * time.Millisecond
+	topologyReverseDNSPositiveTTL    = 24 * time.Hour
+	topologyReverseDNSNegativeTTL    = 24 * time.Hour
+	topologyReverseDNSMaxCandidates  = 1024
+	topologyReverseDNSMaxConcurrency = 4
 )
 
 type topologyReverseDNSLookupFunc func(context.Context, string) ([]string, error)
@@ -31,14 +30,12 @@ type topologyReverseDNSConfig struct {
 	positiveTTL   time.Duration
 	negativeTTL   time.Duration
 	maxCandidates int
-	maxEntries    int
 	concurrency   int
 }
 
 type topologyReverseDNSCacheEntry struct {
-	name       string
-	expiresAt  time.Time
-	lastAccess time.Time
+	name      string
+	expiresAt time.Time
 }
 
 type topologyReverseDNSResolver struct {
@@ -87,9 +84,6 @@ func normalizeTopologyReverseDNSConfig(config topologyReverseDNSConfig) topology
 	if config.maxCandidates <= 0 {
 		config.maxCandidates = topologyReverseDNSMaxCandidates
 	}
-	if config.maxEntries <= 0 {
-		config.maxEntries = topologyReverseDNSMaxCacheEntries
-	}
 	if config.concurrency <= 0 {
 		config.concurrency = topologyReverseDNSMaxConcurrency
 	}
@@ -121,8 +115,6 @@ func (r *topologyReverseDNSResolver) lookupCachedNormalized(ip string) string {
 		delete(r.cache, ip)
 		return ""
 	}
-	entry.lastAccess = now
-	r.cache[ip] = entry
 	return entry.name
 }
 
@@ -264,8 +256,6 @@ func (r *topologyReverseDNSResolver) hasFreshEntry(ip string, now time.Time) boo
 		delete(r.cache, ip)
 		return false
 	}
-	entry.lastAccess = now
-	r.cache[ip] = entry
 	return true
 }
 
@@ -302,32 +292,17 @@ func (r *topologyReverseDNSResolver) store(ip, name string, expiresAt time.Time)
 	defer r.mu.Unlock()
 
 	r.cache[ip] = topologyReverseDNSCacheEntry{
-		name:       name,
-		expiresAt:  expiresAt,
-		lastAccess: now,
+		name:      name,
+		expiresAt: expiresAt,
 	}
-	r.evictLocked(now)
+	r.deleteExpiredLocked(now)
 }
 
-func (r *topologyReverseDNSResolver) evictLocked(now time.Time) {
+func (r *topologyReverseDNSResolver) deleteExpiredLocked(now time.Time) {
 	for ip, entry := range r.cache {
 		if !now.Before(entry.expiresAt) {
 			delete(r.cache, ip)
 		}
-	}
-	for len(r.cache) > r.config.maxEntries {
-		oldestIP := ""
-		var oldest time.Time
-		for ip, entry := range r.cache {
-			if oldestIP == "" || entry.lastAccess.Before(oldest) || (entry.lastAccess.Equal(oldest) && ip < oldestIP) {
-				oldestIP = ip
-				oldest = entry.lastAccess
-			}
-		}
-		if oldestIP == "" {
-			return
-		}
-		delete(r.cache, oldestIP)
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_dns.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_dns.go
@@ -201,15 +201,12 @@ func (r *topologyReverseDNSResolver) warmStarted(ctx context.Context, candidates
 		return
 	}
 
-	workers := r.config.concurrency
-	if workers > len(ips) {
-		workers = len(ips)
-	}
+	workers := min(r.config.concurrency, len(ips))
 
 	jobs := make(chan string)
 	var wg sync.WaitGroup
 	wg.Add(workers)
-	for i := 0; i < workers; i++ {
+	for range workers {
 		go func() {
 			defer wg.Done()
 			for ip := range jobs {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_dns.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_dns.go
@@ -2,8 +2,376 @@
 
 package snmptopology
 
-// resolveTopologyReverseDNSNameNoop is the non-blocking DNS resolver hook used
-// during function responses. SNMP topology has no reverse-DNS warmer today.
-func resolveTopologyReverseDNSNameNoop(_ string) string {
-	return ""
+import (
+	"context"
+	"net"
+	"net/netip"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	topologyReverseDNSLookupTimeout   = 500 * time.Millisecond
+	topologyReverseDNSPositiveTTL     = 24 * time.Hour
+	topologyReverseDNSNegativeTTL     = 6 * time.Hour
+	topologyReverseDNSMaxCandidates   = 1024
+	topologyReverseDNSMaxCacheEntries = 4096
+	topologyReverseDNSMaxConcurrency  = 4
+)
+
+type topologyReverseDNSLookupFunc func(context.Context, string) ([]string, error)
+
+type topologyReverseDNSConfig struct {
+	lookup        topologyReverseDNSLookupFunc
+	now           func() time.Time
+	timeout       time.Duration
+	positiveTTL   time.Duration
+	negativeTTL   time.Duration
+	maxCandidates int
+	maxEntries    int
+	concurrency   int
+}
+
+type topologyReverseDNSCacheEntry struct {
+	name       string
+	expiresAt  time.Time
+	lastAccess time.Time
+}
+
+type topologyReverseDNSResolver struct {
+	mu      sync.Mutex
+	cache   map[string]topologyReverseDNSCacheEntry
+	config  topologyReverseDNSConfig
+	warming atomic.Bool
+}
+
+type topologyReverseDNSCandidateCollector struct {
+	resolver   *topologyReverseDNSResolver
+	mu         sync.Mutex
+	candidates map[string]struct{}
+}
+
+func newTopologyReverseDNSResolver() *topologyReverseDNSResolver {
+	return newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{})
+}
+
+func newTopologyReverseDNSResolverWithConfig(config topologyReverseDNSConfig) *topologyReverseDNSResolver {
+	config = normalizeTopologyReverseDNSConfig(config)
+	return &topologyReverseDNSResolver{
+		cache:  make(map[string]topologyReverseDNSCacheEntry),
+		config: config,
+	}
+}
+
+func normalizeTopologyReverseDNSConfig(config topologyReverseDNSConfig) topologyReverseDNSConfig {
+	if config.lookup == nil {
+		config.lookup = func(ctx context.Context, ip string) ([]string, error) {
+			return net.DefaultResolver.LookupAddr(ctx, ip)
+		}
+	}
+	if config.now == nil {
+		config.now = time.Now
+	}
+	if config.timeout <= 0 {
+		config.timeout = topologyReverseDNSLookupTimeout
+	}
+	if config.positiveTTL <= 0 {
+		config.positiveTTL = topologyReverseDNSPositiveTTL
+	}
+	if config.negativeTTL <= 0 {
+		config.negativeTTL = topologyReverseDNSNegativeTTL
+	}
+	if config.maxCandidates <= 0 {
+		config.maxCandidates = topologyReverseDNSMaxCandidates
+	}
+	if config.maxEntries <= 0 {
+		config.maxEntries = topologyReverseDNSMaxCacheEntries
+	}
+	if config.concurrency <= 0 {
+		config.concurrency = topologyReverseDNSMaxConcurrency
+	}
+	return config
+}
+
+func (r *topologyReverseDNSResolver) lookupCached(ip string) string {
+	if r == nil {
+		return ""
+	}
+	ip, ok := normalizeTopologyReverseDNSCandidateIP(ip)
+	if !ok {
+		return ""
+	}
+	return r.lookupCachedNormalized(ip)
+}
+
+func (r *topologyReverseDNSResolver) lookupCachedNormalized(ip string) string {
+	now := r.config.now()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.cache[ip]
+	if !ok {
+		return ""
+	}
+	if !now.Before(entry.expiresAt) {
+		delete(r.cache, ip)
+		return ""
+	}
+	entry.lastAccess = now
+	r.cache[ip] = entry
+	return entry.name
+}
+
+func (r *topologyReverseDNSResolver) newCandidateCollector() *topologyReverseDNSCandidateCollector {
+	if r == nil {
+		return nil
+	}
+	return &topologyReverseDNSCandidateCollector{
+		resolver:   r,
+		candidates: make(map[string]struct{}),
+	}
+}
+
+func (c *topologyReverseDNSCandidateCollector) lookupCached(ip string) string {
+	if c == nil {
+		return ""
+	}
+	ip, ok := normalizeTopologyReverseDNSCandidateIP(ip)
+	if !ok {
+		return ""
+	}
+
+	c.mu.Lock()
+	c.candidates[ip] = struct{}{}
+	c.mu.Unlock()
+
+	if c.resolver == nil {
+		return ""
+	}
+	return c.resolver.lookupCachedNormalized(ip)
+}
+
+func (c *topologyReverseDNSCandidateCollector) collectedCandidates() []string {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	out := make([]string, 0, len(c.candidates))
+	for ip := range c.candidates {
+		out = append(out, ip)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (r *topologyReverseDNSResolver) warm(ctx context.Context, candidates []string) {
+	if r == nil || ctx == nil || len(candidates) == 0 || ctx.Err() != nil {
+		return
+	}
+	if !r.warming.CompareAndSwap(false, true) {
+		return
+	}
+	defer r.warming.Store(false)
+	r.warmStarted(ctx, candidates)
+}
+
+func (r *topologyReverseDNSResolver) warmAsync(ctx context.Context, candidates []string) bool {
+	if r == nil || ctx == nil || len(candidates) == 0 || ctx.Err() != nil {
+		return false
+	}
+	if !r.warming.CompareAndSwap(false, true) {
+		return false
+	}
+	go func() {
+		defer r.warming.Store(false)
+		r.warmStarted(ctx, candidates)
+	}()
+	return true
+}
+
+func (r *topologyReverseDNSResolver) warmStarted(ctx context.Context, candidates []string) {
+	ips := r.warmCandidates(candidates)
+	if len(ips) == 0 {
+		return
+	}
+
+	workers := r.config.concurrency
+	if workers > len(ips) {
+		workers = len(ips)
+	}
+
+	jobs := make(chan string)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for ip := range jobs {
+				r.resolveAndStore(ctx, ip)
+			}
+		}()
+	}
+
+sendJobs:
+	for _, ip := range ips {
+		select {
+		case <-ctx.Done():
+			break sendJobs
+		case jobs <- ip:
+		}
+	}
+	close(jobs)
+	wg.Wait()
+}
+
+func (r *topologyReverseDNSResolver) warmCandidates(candidates []string) []string {
+	now := r.config.now()
+	seen := make(map[string]struct{}, len(candidates))
+	out := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if len(out) >= r.config.maxCandidates {
+			break
+		}
+		ip, ok := normalizeTopologyReverseDNSCandidateIP(candidate)
+		if !ok {
+			continue
+		}
+		if _, ok := seen[ip]; ok {
+			continue
+		}
+		seen[ip] = struct{}{}
+		if r.hasFreshEntry(ip, now) {
+			continue
+		}
+		out = append(out, ip)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (r *topologyReverseDNSResolver) hasFreshEntry(ip string, now time.Time) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.cache[ip]
+	if !ok {
+		return false
+	}
+	if !now.Before(entry.expiresAt) {
+		delete(r.cache, ip)
+		return false
+	}
+	entry.lastAccess = now
+	r.cache[ip] = entry
+	return true
+}
+
+func (r *topologyReverseDNSResolver) resolveAndStore(ctx context.Context, ip string) {
+	if ctx.Err() != nil {
+		return
+	}
+
+	lookupCtx, cancel := context.WithTimeout(ctx, r.config.timeout)
+	names, err := r.config.lookup(lookupCtx, ip)
+	cancel()
+	if ctx.Err() != nil {
+		return
+	}
+
+	name := ""
+	ttl := r.config.negativeTTL
+	if err == nil {
+		name = normalizeTopologyReverseDNSName(names)
+		if name != "" {
+			ttl = r.config.positiveTTL
+		}
+	}
+	if ttl <= 0 {
+		return
+	}
+	r.store(ip, name, r.config.now().Add(ttl))
+}
+
+func (r *topologyReverseDNSResolver) store(ip, name string, expiresAt time.Time) {
+	now := r.config.now()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.cache[ip] = topologyReverseDNSCacheEntry{
+		name:       name,
+		expiresAt:  expiresAt,
+		lastAccess: now,
+	}
+	r.evictLocked(now)
+}
+
+func (r *topologyReverseDNSResolver) evictLocked(now time.Time) {
+	for ip, entry := range r.cache {
+		if !now.Before(entry.expiresAt) {
+			delete(r.cache, ip)
+		}
+	}
+	for len(r.cache) > r.config.maxEntries {
+		oldestIP := ""
+		var oldest time.Time
+		for ip, entry := range r.cache {
+			if oldestIP == "" || entry.lastAccess.Before(oldest) || (entry.lastAccess.Equal(oldest) && ip < oldestIP) {
+				oldestIP = ip
+				oldest = entry.lastAccess
+			}
+		}
+		if oldestIP == "" {
+			return
+		}
+		delete(r.cache, oldestIP)
+	}
+}
+
+func normalizeTopologyReverseDNSName(names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+	seen := make(map[string]struct{}, len(names))
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		name = strings.TrimSuffix(name, ".")
+		name = strings.ToLower(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	if len(out) == 0 {
+		return ""
+	}
+	sort.Strings(out)
+	return out[0]
+}
+
+func normalizeTopologyReverseDNSCandidateIP(ip string) (string, bool) {
+	addr, err := netip.ParseAddr(strings.TrimSpace(ip))
+	if err != nil || !addr.IsValid() {
+		return "", false
+	}
+	addr = addr.Unmap()
+	if addr.IsUnspecified() || addr.IsLoopback() || addr.IsMulticast() ||
+		addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() {
+		return "", false
+	}
+	if addr.Is4() && addr == netip.MustParseAddr("255.255.255.255") {
+		return "", false
+	}
+	return addr.String(), true
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_dns_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_dns_test.go
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type reverseDNSTestClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newReverseDNSTestClock() *reverseDNSTestClock {
+	return &reverseDNSTestClock{now: time.Date(2026, time.June, 22, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *reverseDNSTestClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *reverseDNSTestClock) Add(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	c.mu.Unlock()
+}
+
+func TestTopologyReverseDNSDefaultConfig(t *testing.T) {
+	config := normalizeTopologyReverseDNSConfig(topologyReverseDNSConfig{})
+
+	require.Equal(t, 500*time.Millisecond, config.timeout)
+	require.Equal(t, 24*time.Hour, config.positiveTTL)
+	require.Equal(t, 6*time.Hour, config.negativeTTL)
+	require.Equal(t, 1024, config.maxCandidates)
+	require.Equal(t, 4096, config.maxEntries)
+	require.Equal(t, 4, config.concurrency)
+	require.NotNil(t, config.lookup)
+	require.NotNil(t, config.now)
+}
+
+func TestNormalizeTopologyReverseDNSCandidateIP(t *testing.T) {
+	tests := map[string]struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		"ipv4":                 {in: " 192.0.2.10 ", want: "192.0.2.10", wantOK: true},
+		"ipv6":                 {in: "2001:db8::10", want: "2001:db8::10", wantOK: true},
+		"ipv6-mapped ipv4":     {in: "::ffff:192.0.2.10", want: "192.0.2.10", wantOK: true},
+		"private ipv4 kept":    {in: "10.0.0.10", want: "10.0.0.10", wantOK: true},
+		"invalid":              {in: "not-an-ip"},
+		"unspecified ipv4":     {in: "0.0.0.0"},
+		"unspecified ipv6":     {in: "::"},
+		"loopback":             {in: "127.0.0.1"},
+		"link local":           {in: "169.254.1.1"},
+		"multicast":            {in: "224.0.0.1"},
+		"ipv4 broadcast":       {in: "255.255.255.255"},
+		"link local multicast": {in: "ff02::1"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, ok := normalizeTopologyReverseDNSCandidateIP(tc.in)
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestTopologyReverseDNSResolverWarmCachesNormalizedPositiveResult(t *testing.T) {
+	clock := newReverseDNSTestClock()
+	var calls []string
+	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
+		now:         clock.Now,
+		positiveTTL: time.Hour,
+		negativeTTL: time.Minute,
+		maxEntries:  10,
+		concurrency: 1,
+		lookup: func(_ context.Context, ip string) ([]string, error) {
+			calls = append(calls, ip)
+			return []string{"Switch-A.Example.Test.", "switch-a.example.test."}, nil
+		},
+	})
+
+	resolver.warm(context.Background(), []string{"::ffff:192.0.2.10", "127.0.0.1", "192.0.2.10"})
+
+	require.Equal(t, []string{"192.0.2.10"}, calls)
+	require.Equal(t, "switch-a.example.test", resolver.lookupCached("192.0.2.10"))
+	require.Equal(t, "switch-a.example.test", resolver.lookupCached("::ffff:192.0.2.10"))
+}
+
+func TestNormalizeTopologyReverseDNSName(t *testing.T) {
+	tests := map[string]struct {
+		in   []string
+		want string
+	}{
+		"empty":               {},
+		"blank names":         {in: []string{"", " ", "."}},
+		"trim lower suffix":   {in: []string{" Switch-A.Example.Test. "}, want: "switch-a.example.test"},
+		"dedupe":              {in: []string{"switch-a.example.test.", "SWITCH-A.EXAMPLE.TEST"}, want: "switch-a.example.test"},
+		"deterministic first": {in: []string{"switch-b.example.test.", "switch-a.example.test."}, want: "switch-a.example.test"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, normalizeTopologyReverseDNSName(tc.in))
+		})
+	}
+}
+
+func TestTopologyReverseDNSResolverNegativeCacheSuppressesRetriesUntilTTL(t *testing.T) {
+	clock := newReverseDNSTestClock()
+	var calls atomic.Int64
+	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
+		now:         clock.Now,
+		positiveTTL: time.Hour,
+		negativeTTL: time.Minute,
+		maxEntries:  10,
+		concurrency: 1,
+		lookup: func(context.Context, string) ([]string, error) {
+			calls.Add(1)
+			return nil, errors.New("not found")
+		},
+	})
+
+	resolver.warm(context.Background(), []string{"192.0.2.10"})
+	resolver.warm(context.Background(), []string{"192.0.2.10"})
+	require.Equal(t, int64(1), calls.Load())
+	require.Empty(t, resolver.lookupCached("192.0.2.10"))
+
+	clock.Add(time.Minute + time.Second)
+	resolver.warm(context.Background(), []string{"192.0.2.10"})
+	require.Equal(t, int64(2), calls.Load())
+}
+
+func TestTopologyReverseDNSResolverPositiveCacheSuppressesRetriesUntilTTL(t *testing.T) {
+	clock := newReverseDNSTestClock()
+	var calls atomic.Int64
+	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
+		now:         clock.Now,
+		positiveTTL: time.Minute,
+		negativeTTL: time.Hour,
+		maxEntries:  10,
+		concurrency: 1,
+		lookup: func(context.Context, string) ([]string, error) {
+			call := calls.Add(1)
+			if call == 1 {
+				return []string{"switch-a.example.test"}, nil
+			}
+			return []string{"switch-b.example.test"}, nil
+		},
+	})
+
+	resolver.warm(context.Background(), []string{"192.0.2.10"})
+	resolver.warm(context.Background(), []string{"192.0.2.10"})
+	require.Equal(t, int64(1), calls.Load())
+	require.Equal(t, "switch-a.example.test", resolver.lookupCached("192.0.2.10"))
+
+	clock.Add(time.Minute + time.Second)
+	resolver.warm(context.Background(), []string{"192.0.2.10"})
+	require.Equal(t, int64(2), calls.Load())
+	require.Equal(t, "switch-b.example.test", resolver.lookupCached("192.0.2.10"))
+}
+
+func TestTopologyReverseDNSResolverEvictsLeastRecentlyUsedWhenCacheIsCapped(t *testing.T) {
+	clock := newReverseDNSTestClock()
+	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
+		now:        clock.Now,
+		maxEntries: 2,
+	})
+
+	resolver.store("192.0.2.10", "a.example.test", clock.Now().Add(time.Hour))
+	clock.Add(time.Second)
+	resolver.store("192.0.2.11", "b.example.test", clock.Now().Add(time.Hour))
+	clock.Add(time.Second)
+	require.Equal(t, "a.example.test", resolver.lookupCached("192.0.2.10"))
+	clock.Add(time.Second)
+	resolver.store("192.0.2.12", "c.example.test", clock.Now().Add(time.Hour))
+
+	require.Equal(t, "a.example.test", resolver.lookupCached("192.0.2.10"))
+	require.Empty(t, resolver.lookupCached("192.0.2.11"))
+	require.Equal(t, "c.example.test", resolver.lookupCached("192.0.2.12"))
+}
+
+func TestTopologyReverseDNSResolverEvictsLexicographicallyWhenLastAccessTies(t *testing.T) {
+	clock := newReverseDNSTestClock()
+	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
+		now:        clock.Now,
+		maxEntries: 2,
+	})
+
+	expiresAt := clock.Now().Add(time.Hour)
+	resolver.store("192.0.2.10", "a.example.test", expiresAt)
+	resolver.store("192.0.2.11", "b.example.test", expiresAt)
+	resolver.store("192.0.2.12", "c.example.test", expiresAt)
+
+	require.Empty(t, resolver.lookupCached("192.0.2.10"))
+	require.Equal(t, "b.example.test", resolver.lookupCached("192.0.2.11"))
+	require.Equal(t, "c.example.test", resolver.lookupCached("192.0.2.12"))
+}
+
+func TestTopologyReverseDNSCandidateCollectorRecordsCandidatesAndUsesOnlyCache(t *testing.T) {
+	clock := newReverseDNSTestClock()
+	var liveCalls atomic.Int64
+	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
+		now: clock.Now,
+		lookup: func(context.Context, string) ([]string, error) {
+			liveCalls.Add(1)
+			return []string{"unexpected.example.test"}, nil
+		},
+	})
+	resolver.store("192.0.2.10", "switch-a.example.test", clock.Now().Add(time.Hour))
+	collector := resolver.newCandidateCollector()
+
+	require.Equal(t, "switch-a.example.test", collector.lookupCached("192.0.2.10"))
+	require.Empty(t, collector.lookupCached("192.0.2.11"))
+	require.Empty(t, collector.lookupCached("127.0.0.1"))
+
+	require.Equal(t, []string{"192.0.2.10", "192.0.2.11"}, collector.collectedCandidates())
+	require.Zero(t, liveCalls.Load())
+}
+
+func TestTopologyReverseDNSResolverWarmStopsOnContextCancel(t *testing.T) {
+	clock := newReverseDNSTestClock()
+	started := make(chan struct{}, 3)
+	var calls atomic.Int64
+	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
+		now:         clock.Now,
+		timeout:     time.Minute,
+		maxEntries:  10,
+		concurrency: 2,
+		lookup: func(ctx context.Context, _ string) ([]string, error) {
+			calls.Add(1)
+			started <- struct{}{}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		resolver.warm(ctx, []string{"192.0.2.10", "192.0.2.11", "192.0.2.12"})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		require.FailNow(t, "warm lookup did not start")
+	}
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		require.Fail(t, "warm did not stop after context cancellation")
+	}
+	require.LessOrEqual(t, calls.Load(), int64(2))
+}
+
+func TestTopologyReverseDNSResolverWarmHonorsConcurrencyLimit(t *testing.T) {
+	clock := newReverseDNSTestClock()
+	var calls atomic.Int64
+	var inFlight atomic.Int64
+	var maxInFlight atomic.Int64
+	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
+		now:         clock.Now,
+		timeout:     time.Second,
+		maxEntries:  20,
+		concurrency: 3,
+		lookup: func(context.Context, string) ([]string, error) {
+			calls.Add(1)
+			current := inFlight.Add(1)
+			for {
+				max := maxInFlight.Load()
+				if current <= max || maxInFlight.CompareAndSwap(max, current) {
+					break
+				}
+			}
+			time.Sleep(10 * time.Millisecond)
+			inFlight.Add(-1)
+			return []string{"host.example.test"}, nil
+		},
+	})
+
+	resolver.warm(context.Background(), []string{
+		"192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4", "192.0.2.5",
+		"192.0.2.6", "192.0.2.7", "192.0.2.8", "192.0.2.9", "192.0.2.10",
+	})
+
+	require.Equal(t, int64(10), calls.Load())
+	require.LessOrEqual(t, maxInFlight.Load(), int64(3))
+}
+
+func TestTopologyReverseDNSResolverWarmHonorsCandidateLimit(t *testing.T) {
+	clock := newReverseDNSTestClock()
+	var calls atomic.Int64
+	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
+		now:           clock.Now,
+		timeout:       time.Second,
+		maxEntries:    10,
+		maxCandidates: 3,
+		concurrency:   1,
+		lookup: func(context.Context, string) ([]string, error) {
+			calls.Add(1)
+			return []string{"host.example.test"}, nil
+		},
+	})
+
+	resolver.warm(context.Background(), []string{
+		"192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4", "192.0.2.5",
+	})
+
+	require.Equal(t, int64(3), calls.Load())
+}
+
+func TestTopologyReverseDNSResolverWarmAsyncDoesNotOverlap(t *testing.T) {
+	clock := newReverseDNSTestClock()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int64
+	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
+		now:         clock.Now,
+		timeout:     time.Second,
+		maxEntries:  10,
+		concurrency: 1,
+		lookup: func(ctx context.Context, ip string) ([]string, error) {
+			calls.Add(1)
+			close(started)
+			select {
+			case <-release:
+				return []string{ip + ".example.test"}, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	})
+
+	require.True(t, resolver.warmAsync(context.Background(), []string{"192.0.2.10"}))
+	<-started
+	require.False(t, resolver.warmAsync(context.Background(), []string{"192.0.2.11"}))
+	close(release)
+
+	require.Eventually(t, func() bool { return !resolver.warming.Load() }, time.Second, 10*time.Millisecond)
+	require.Equal(t, int64(1), calls.Load())
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_dns_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_dns_test.go
@@ -39,9 +39,8 @@ func TestTopologyReverseDNSDefaultConfig(t *testing.T) {
 
 	require.Equal(t, 500*time.Millisecond, config.timeout)
 	require.Equal(t, 24*time.Hour, config.positiveTTL)
-	require.Equal(t, 6*time.Hour, config.negativeTTL)
+	require.Equal(t, 24*time.Hour, config.negativeTTL)
 	require.Equal(t, 1024, config.maxCandidates)
-	require.Equal(t, 4096, config.maxEntries)
 	require.Equal(t, 4, config.concurrency)
 	require.NotNil(t, config.lookup)
 	require.NotNil(t, config.now)
@@ -83,7 +82,6 @@ func TestTopologyReverseDNSResolverWarmCachesNormalizedPositiveResult(t *testing
 		now:         clock.Now,
 		positiveTTL: time.Hour,
 		negativeTTL: time.Minute,
-		maxEntries:  10,
 		concurrency: 1,
 		lookup: func(_ context.Context, ip string) ([]string, error) {
 			calls = append(calls, ip)
@@ -124,7 +122,6 @@ func TestTopologyReverseDNSResolverNegativeCacheSuppressesRetriesUntilTTL(t *tes
 		now:         clock.Now,
 		positiveTTL: time.Hour,
 		negativeTTL: time.Minute,
-		maxEntries:  10,
 		concurrency: 1,
 		lookup: func(context.Context, string) ([]string, error) {
 			calls.Add(1)
@@ -149,7 +146,6 @@ func TestTopologyReverseDNSResolverPositiveCacheSuppressesRetriesUntilTTL(t *tes
 		now:         clock.Now,
 		positiveTTL: time.Minute,
 		negativeTTL: time.Hour,
-		maxEntries:  10,
 		concurrency: 1,
 		lookup: func(context.Context, string) ([]string, error) {
 			call := calls.Add(1)
@@ -169,43 +165,6 @@ func TestTopologyReverseDNSResolverPositiveCacheSuppressesRetriesUntilTTL(t *tes
 	resolver.warm(context.Background(), []string{"192.0.2.10"})
 	require.Equal(t, int64(2), calls.Load())
 	require.Equal(t, "switch-b.example.test", resolver.lookupCached("192.0.2.10"))
-}
-
-func TestTopologyReverseDNSResolverEvictsLeastRecentlyUsedWhenCacheIsCapped(t *testing.T) {
-	clock := newReverseDNSTestClock()
-	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
-		now:        clock.Now,
-		maxEntries: 2,
-	})
-
-	resolver.store("192.0.2.10", "a.example.test", clock.Now().Add(time.Hour))
-	clock.Add(time.Second)
-	resolver.store("192.0.2.11", "b.example.test", clock.Now().Add(time.Hour))
-	clock.Add(time.Second)
-	require.Equal(t, "a.example.test", resolver.lookupCached("192.0.2.10"))
-	clock.Add(time.Second)
-	resolver.store("192.0.2.12", "c.example.test", clock.Now().Add(time.Hour))
-
-	require.Equal(t, "a.example.test", resolver.lookupCached("192.0.2.10"))
-	require.Empty(t, resolver.lookupCached("192.0.2.11"))
-	require.Equal(t, "c.example.test", resolver.lookupCached("192.0.2.12"))
-}
-
-func TestTopologyReverseDNSResolverEvictsLexicographicallyWhenLastAccessTies(t *testing.T) {
-	clock := newReverseDNSTestClock()
-	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
-		now:        clock.Now,
-		maxEntries: 2,
-	})
-
-	expiresAt := clock.Now().Add(time.Hour)
-	resolver.store("192.0.2.10", "a.example.test", expiresAt)
-	resolver.store("192.0.2.11", "b.example.test", expiresAt)
-	resolver.store("192.0.2.12", "c.example.test", expiresAt)
-
-	require.Empty(t, resolver.lookupCached("192.0.2.10"))
-	require.Equal(t, "b.example.test", resolver.lookupCached("192.0.2.11"))
-	require.Equal(t, "c.example.test", resolver.lookupCached("192.0.2.12"))
 }
 
 func TestTopologyReverseDNSCandidateCollectorRecordsCandidatesAndUsesOnlyCache(t *testing.T) {
@@ -236,7 +195,6 @@ func TestTopologyReverseDNSResolverWarmStopsOnContextCancel(t *testing.T) {
 	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
 		now:         clock.Now,
 		timeout:     time.Minute,
-		maxEntries:  10,
 		concurrency: 2,
 		lookup: func(ctx context.Context, _ string) ([]string, error) {
 			calls.Add(1)
@@ -276,7 +234,6 @@ func TestTopologyReverseDNSResolverWarmHonorsConcurrencyLimit(t *testing.T) {
 	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
 		now:         clock.Now,
 		timeout:     time.Second,
-		maxEntries:  20,
 		concurrency: 3,
 		lookup: func(context.Context, string) ([]string, error) {
 			calls.Add(1)
@@ -308,7 +265,6 @@ func TestTopologyReverseDNSResolverWarmHonorsCandidateLimit(t *testing.T) {
 	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
 		now:           clock.Now,
 		timeout:       time.Second,
-		maxEntries:    10,
 		maxCandidates: 3,
 		concurrency:   1,
 		lookup: func(context.Context, string) ([]string, error) {
@@ -332,7 +288,6 @@ func TestTopologyReverseDNSResolverWarmAsyncDoesNotOverlap(t *testing.T) {
 	resolver := newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
 		now:         clock.Now,
 		timeout:     time.Second,
-		maxEntries:  10,
 		concurrency: 1,
 		lookup: func(ctx context.Context, ip string) ([]string, error) {
 			calls.Add(1)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
@@ -3,8 +3,10 @@
 package snmptopology
 
 import (
+	"context"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/netdata/netdata/go/plugins/pkg/pluginconfig"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
@@ -12,15 +14,19 @@ import (
 )
 
 type topologyRegistry struct {
-	mu              sync.RWMutex
-	caches          map[*topologyCache]struct{}
-	producerScopeID string
+	mu                    sync.RWMutex
+	caches                map[*topologyCache]struct{}
+	producerScopeID       string
+	reverseDNS            *topologyReverseDNSResolver
+	reverseDNSWarmCtx     context.Context
+	reverseDNSSnapshotRun atomic.Bool
 }
 
 func newTopologyRegistry() *topologyRegistry {
 	return &topologyRegistry{
 		caches:          make(map[*topologyCache]struct{}),
 		producerScopeID: strings.TrimSpace(pluginconfig.RegistryUniqueID()),
+		reverseDNS:      newTopologyReverseDNSResolver(),
 	}
 }
 
@@ -85,4 +91,69 @@ func (r *topologyRegistry) managedDeviceFocusTargets() []topologyoptions.Managed
 		return nil
 	}
 	return buildTopologyManagedFocusTargets(r.observationSnapshots())
+}
+
+func (r *topologyRegistry) setReverseDNSWarmContext(ctx context.Context) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.reverseDNSWarmCtx = ctx
+	r.mu.Unlock()
+}
+
+func (r *topologyRegistry) reverseDNSContext() context.Context {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	ctx := r.reverseDNSWarmCtx
+	r.mu.RUnlock()
+	return ctx
+}
+
+func (r *topologyRegistry) reverseDNSCandidateCollector() *topologyReverseDNSCandidateCollector {
+	if r == nil || r.reverseDNS == nil {
+		return nil
+	}
+	return r.reverseDNS.newCandidateCollector()
+}
+
+func (r *topologyRegistry) enqueueReverseDNSWarm(candidates []string) bool {
+	if r == nil || r.reverseDNS == nil || len(candidates) == 0 {
+		return false
+	}
+	ctx := r.reverseDNSContext()
+	if ctx == nil || ctx.Err() != nil {
+		return false
+	}
+	return r.reverseDNS.warmAsync(ctx, candidates)
+}
+
+func (r *topologyRegistry) enqueueReverseDNSWarmFromDefaultSnapshot() bool {
+	if r == nil || r.reverseDNS == nil {
+		return false
+	}
+	ctx := r.reverseDNSContext()
+	if ctx == nil || ctx.Err() != nil {
+		return false
+	}
+	if !r.reverseDNSSnapshotRun.CompareAndSwap(false, true) {
+		return false
+	}
+
+	go func() {
+		defer r.reverseDNSSnapshotRun.Store(false)
+		collector := r.reverseDNSCandidateCollector()
+		if collector == nil {
+			return
+		}
+		options := topologyoptions.DefaultQueryOptions()
+		options.ResolveDNSName = collector.lookupCached
+		if _, ok := r.snapshotWithOptions(options); !ok {
+			return
+		}
+		r.reverseDNS.warm(ctx, collector.collectedCandidates())
+	}()
+	return true
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -3,6 +3,7 @@
 package snmptopology
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -84,6 +85,39 @@ func TestTopologyRegistry_SnapshotAggregatesAcrossCaches(t *testing.T) {
 	require.GreaterOrEqual(t, topologyStatsToV1ForTest(t, data.Stats)["devices_total"].(int), 2)
 	require.GreaterOrEqual(t, topologyStatsToV1ForTest(t, data.Stats)["links_total"].(int), 1)
 	require.GreaterOrEqual(t, topologyStatsToV1ForTest(t, data.Stats)["links_lldp"].(int), 1)
+}
+
+func TestTopologyRegistry_EnqueueReverseDNSWarmFromDefaultSnapshotUsesDisplayCandidates(t *testing.T) {
+	clock := newReverseDNSTestClock()
+	warmed := make(chan string, 4)
+	registry := newTopologyRegistry()
+	registry.reverseDNS = newTopologyReverseDNSResolverWithConfig(topologyReverseDNSConfig{
+		now:         clock.Now,
+		timeout:     time.Second,
+		positiveTTL: time.Hour,
+		negativeTTL: time.Minute,
+		maxEntries:  10,
+		concurrency: 1,
+		lookup: func(_ context.Context, ip string) ([]string, error) {
+			warmed <- ip
+			return []string{ip + ".example.test"}, nil
+		},
+	})
+	registry.setReverseDNSWarmContext(context.Background())
+
+	cache := newTopologyCache()
+	seedPublishedEndpointSnapshot(cache)
+	registry.register(cache)
+
+	require.True(t, registry.enqueueReverseDNSWarmFromDefaultSnapshot())
+	require.Eventually(t, func() bool {
+		select {
+		case ip := <-warmed:
+			return ip == "10.0.0.10" || ip == "10.0.0.20"
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestTopologyRegistry_SnapshotSingleCacheKeepsLLDPUnidirectional(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -96,7 +96,6 @@ func TestTopologyRegistry_EnqueueReverseDNSWarmFromDefaultSnapshotUsesDisplayCan
 		timeout:     time.Second,
 		positiveTTL: time.Hour,
 		negativeTTL: time.Minute,
-		maxEntries:  10,
 		concurrency: 1,
 		lookup: func(_ context.Context, ip string) ([]string, error) {
 			warmed <- ip

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
@@ -42,9 +42,6 @@ func testCountTopologyLinksByType(links []topologymodel.Link, linkType string) i
 }
 
 func snapshotTopologyRegistryForTestWithOptions(registry *topologyRegistry, options topologyoptions.QueryOptions) (topologymodel.Data, bool) {
-	if options.ResolveDNSName == nil {
-		options.ResolveDNSName = resolveTopologyReverseDNSNameNoop
-	}
 	return registry.snapshotWithOptions(options)
 }
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores reverse DNS warming for `snmp_topology`. Function responses now use a cache-only resolver (no live DNS), and the cache is warmed asynchronously from snapshots and request candidates to improve display names.

- **New Features**
  - Added a cache-backed reverse DNS resolver with positive/negative TTLs, IP normalization, candidate limits, and bounded concurrency.
  - Function path records candidate IPs and uses a cache-only lookup; the registry warms candidates after snapshot refresh and on requests, honoring context and never blocking responses.
  - Display-name resolution falls back to sysName → hostname → IP → MAC on cache miss or error.

- **Refactors**
  - Introduced `topologyoptions.DefaultQueryOptions()` and updated the Function to use it.
  - Updated architecture docs and added tests for the resolver, registry enqueue, and Function behavior.

<sup>Written for commit 22bc0cabc108cd6eb71da90b9b8fc2c8b7939a25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

