### PR TITLE
chore(go.d): clarify l2topology public surface

### DIFF
--- a/src/go/pkg/l2topology/doc.go
+++ b/src/go/pkg/l2topology/doc.go
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// Package l2topology provides a reusable topology discovery interface that can be
-// shared by multiple collectors and services.
+// Package l2topology converts normalized layer-2 observations into a generic
+// topology graph projection.
+//
+// The package is collection-method neutral: callers provide already-normalized
+// LLDP, CDP, bridge/FDB, STP, and ARP/ND observations. The current production
+// caller is the SNMP topology collector.
 package l2topology

--- a/src/go/pkg/l2topology/l2_pipeline.go
+++ b/src/go/pkg/l2topology/l2_pipeline.go
@@ -11,8 +11,8 @@ const (
 )
 
 // BuildL2ResultFromObservations converts normalized L2 observations into a
-// deterministic engine result. Callers that need a stable timestamp should set
-// DiscoverOptions.CollectedAt explicitly.
+// deterministic L2 topology result. Callers that need a stable timestamp should
+// set DiscoverOptions.CollectedAt explicitly.
 func BuildL2ResultFromObservations(observations []L2Observation, opts DiscoverOptions) (Result, error) {
 	if len(observations) == 0 {
 		return Result{}, errors.New("at least one observation is required")

--- a/src/go/pkg/l2topology/parity/README.md
+++ b/src/go/pkg/l2topology/parity/README.md
@@ -1,7 +1,7 @@
 # Topology Parity Runbook
 
 ## Scope
-- Validate topology engine parity against imported Enlinkd fixtures and assertion inventories.
+- Validate l2topology behavior against imported Enlinkd fixtures and assertion inventories.
 - Evidence files live in `src/go/pkg/l2topology/parity/evidence`.
 
 ## Prerequisites
@@ -54,7 +54,7 @@ Outputs:
 
 ## Run Go Test Gates
 ```bash
-go test ./pkg/l2topology/... ./plugin/go.d/collector/snmp ./tools/topology-parity-evidence -count=1
+go test ./pkg/l2topology/... ./plugin/go.d/collector/snmp_topology ./tools/topology-parity-evidence -count=1
 ```
 
 Expected:

--- a/src/go/pkg/l2topology/parity/doc.go
+++ b/src/go/pkg/l2topology/parity/doc.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// Package parity contains fixture and golden helpers used by topology engine
-// parity tests.
+// Package parity contains fixture and golden helpers used by l2topology parity
+// tests.
 package parity

--- a/src/go/pkg/l2topology/parity/l2_builder.go
+++ b/src/go/pkg/l2topology/parity/l2_builder.go
@@ -14,7 +14,7 @@ import (
 )
 
 // BuildOptions configures protocol extraction when converting walk fixtures
-// into an engine result.
+// into an L2 topology result.
 type BuildOptions struct {
 	EnableLLDP   bool
 	EnableCDP    bool

--- a/src/go/pkg/l2topology/topology_adapter.go
+++ b/src/go/pkg/l2topology/topology_adapter.go
@@ -226,7 +226,8 @@ func topologyInferenceStrategyConfigFor(strategy string) topologyInferenceStrate
 	}
 }
 
-// ToGraph converts an engine result to the internal graph projection.
+// ToGraph converts an L2 topology result to the graph projection consumed by
+// topology producers.
 func ToGraph(result Result, opts GraphOptions) Projection {
 	builder := newGraphBuilder(result, opts)
 	builder.prepareIndexes()

--- a/src/go/pkg/l2topology/topology_projection.go
+++ b/src/go/pkg/l2topology/topology_projection.go
@@ -4,7 +4,7 @@ package l2topology
 
 import "github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 
-// Projection is the L2 engine output consumed by topology producers.
+// Projection is the L2 graph output consumed by topology producers.
 type Projection struct {
 	Graph        graph.Graph
 	Stats        ProjectionStats

--- a/src/go/pkg/l2topology/types.go
+++ b/src/go/pkg/l2topology/types.go
@@ -7,56 +7,19 @@ import (
 	"time"
 )
 
-// Credential describes one SNMP authentication profile.
-type Credential struct {
-	Version      string
-	Community    string
-	Username     string
-	AuthProtocol string
-	AuthPassword string
-	PrivProtocol string
-	PrivPassword string
-	ContextName  string
-	Port         uint16
-	Timeout      time.Duration
-	Retries      int
-}
-
-// DiscoverOptions controls the discovery behavior.
+// DiscoverOptions controls which normalized L2 observation families contribute
+// to the result.
 type DiscoverOptions struct {
 	EnableLLDP   bool
 	EnableCDP    bool
 	EnableBridge bool
 	EnableARP    bool
 	EnableSTP    bool
-	MaxDepth     int
-	Concurrency  int
 	CollectedAt  time.Time
 }
 
-// CIDRRequest starts discovery from CIDR ranges.
-type CIDRRequest struct {
-	CIDRs       []netip.Prefix
-	Credentials []Credential
-	Options     DiscoverOptions
-}
-
-// DeviceRequest starts discovery from known device addresses.
-type DeviceRequest struct {
-	Devices     []DeviceTarget
-	Credentials []Credential
-	Options     DiscoverOptions
-}
-
-// DeviceTarget identifies one seed device.
-type DeviceTarget struct {
-	Address  netip.Addr
-	Port     uint16
-	Hostname string
-	Labels   map[string]string
-}
-
-// Result is the discovery output from the engine.
+// Result is the deterministic L2 topology result derived from normalized
+// observations.
 type Result struct {
 	CollectedAt  time.Time
 	Devices      []Device
@@ -115,11 +78,11 @@ type Enrichment struct {
 	Labels     map[string]string
 }
 
-// L2Observation contains one device's normalized layer-2 SNMP observations.
+// L2Observation contains one device's normalized layer-2 observations.
 type L2Observation struct {
 	DeviceID string
 	// Inferred marks observations synthesized from neighbor advertisements
-	// (for example LLDP/CDP remotes), not directly polled SNMP targets.
+	// (for example LLDP/CDP remotes), not directly observed local devices.
 	Inferred          bool
 	Hostname          string
 	ManagementIP      string

--- a/src/go/tools/topology-parity-evidence/main.go
+++ b/src/go/tools/topology-parity-evidence/main.go
@@ -1026,7 +1026,7 @@ func runPhase2(opts options) error {
 	}
 
 	reversePairQuality, err := runSelectionGroup("reverse_pair_quality", []testSelection{{
-		packagePath: "./plugin/go.d/collector/snmp",
+		packagePath: "./plugin/go.d/collector/snmp_topology",
 		tests: []string{
 			"TestTopologyCache_LldpSnapshot",
 			"TestTopologyCache_CdpSnapshot",
@@ -1043,7 +1043,7 @@ func runPhase2(opts options) error {
 	}
 
 	identityMergeQuality, err := runSelectionGroup("identity_merge_quality", []testSelection{{
-		packagePath: "./plugin/go.d/collector/snmp",
+		packagePath: "./plugin/go.d/collector/snmp_topology",
 		tests: []string{
 			"TestTopologyCache_SnapshotMergesRemoteIdentityAcrossProtocols",
 		},
@@ -1553,8 +1553,8 @@ func runRequiredGoTests() []goTestSummary {
 			args:         []string{"test", "./tools/topology-parity-evidence"},
 		},
 		{
-			packageLabel: "./plugin/go.d/collector/snmp -run ^TestTopology",
-			args:         []string{"test", "./plugin/go.d/collector/snmp", "-run", "^TestTopology"},
+			packageLabel: "./plugin/go.d/collector/snmp_topology -run ^TestTopology",
+			args:         []string{"test", "./plugin/go.d/collector/snmp_topology", "-run", "^TestTopology"},
 		},
 	}
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the `l2topology` public API and docs to state it consumes normalized L2 observations and outputs a generic topology graph. Removes SNMP-specific types from the exported surface and aligns parity tooling with the `snmp_topology` package.

- **Refactors**
  - Clarified package/type comments around “L2 topology result” and “graph projection”.
  - `DiscoverOptions`: removed `MaxDepth` and `Concurrency`; keeps family toggles and `CollectedAt`.
  - Removed exported SNMP-centric types: `Credential`, `CIDRRequest`, `DeviceRequest`, `DeviceTarget`.
  - Parity docs and tests now reference `./plugin/go.d/collector/snmp_topology`.

<sup>Written for commit 5c46913365766a9d13c4826fdacef3d478bf4979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

