### PR TITLE
fix(streaming): reject oversized ZSTD frames instead of fatal()

### DIFF
--- a/src/streaming/stream-compression/compression.c
+++ b/src/streaming/stream-compression/compression.c
@@ -681,8 +681,16 @@ cleanup:
     return errors;
 }
 
+#ifdef ENABLE_ZSTD
+int unittest_stream_decompress_bomb_zstd(void);
+#endif
+
 int unittest_stream_compressions(void) {
     int ret = 0;
+
+#ifdef ENABLE_ZSTD
+    ret += unittest_stream_decompress_bomb_zstd();
+#endif
 
     ret += unittest_stream_compression(COMPRESSION_ALGORITHM_ZSTD, "ZSTD");
     ret += unittest_stream_compression(COMPRESSION_ALGORITHM_LZ4, "LZ4");

--- a/src/streaming/stream-compression/zstd.c
+++ b/src/streaming/stream-compression/zstd.c
@@ -215,6 +215,11 @@ int unittest_stream_decompress_bomb_zstd(void) {
         size_t cbound = ZSTD_compressBound(msg_len);
         char *cmsg = mallocz(cbound);
         size_t cmsg_len = ZSTD_compress(cmsg, cbound, msg, msg_len, 1);
+        if (ZSTD_isError(cmsg_len)) {
+            fprintf(stderr, "  FAILED: ZSTD_compress() error: %s\n", ZSTD_getErrorName(cmsg_len));
+            freez(cmsg); freez(plain); freez(comp);
+            return errors + 1;
+        }
 
         struct decompressor_state dctx = { .initialized = false, .algorithm = COMPRESSION_ALGORITHM_ZSTD };
         stream_decompressor_init(&dctx);

--- a/src/streaming/stream-compression/zstd.c
+++ b/src/streaming/stream-compression/zstd.c
@@ -142,10 +142,18 @@ size_t stream_decompress_zstd(struct decompressor_state *state, const char *comp
         return 0;
     }
 
-    if(inBuffer.pos < inBuffer.size)
-        fatal("STREAM_DECOMPRESS: ZSTD ZSTD_decompressStream() decompressed %zu bytes, "
-              "but %zu bytes of compressed data remain",
-              inBuffer.pos, inBuffer.size);
+    if(inBuffer.pos < inBuffer.size) {
+        // The peer sent a frame that decompresses to more than our output buffer.
+        // A conforming sender never does this (it compresses in <= COMPRESSION_MAX_CHUNK
+        // plaintext chunks), but a malicious/compromised peer is not bound by that.
+        // Return an error (like the gzip path and the ZSTD_isError branch above) so the
+        // caller fails the stream connection, instead of fatal()-ing the whole Agent.
+        netdata_log_error("STREAM_DECOMPRESS: ZSTD_decompressStream() consumed only %zu of %zu compressed bytes "
+                          "after filling the %zu-byte output buffer (frame decompresses to more than the buffer); "
+                          "failing the connection",
+                          inBuffer.pos, inBuffer.size, outBuffer.size);
+        return 0;
+    }
 
     size_t decompressed_size = outBuffer.pos;
 
@@ -158,6 +166,71 @@ size_t stream_decompress_zstd(struct decompressor_state *state, const char *comp
     state->total_compressions++;
 
     return decompressed_size;
+}
+
+// Regression test for the decompression-bomb guard: a malicious peer can send one small
+// ZSTD frame that decompresses to far more than the receiver's fixed output buffer.
+// stream_decompress_zstd() must reject it (return 0), NOT fatal()/abort the agent.
+// (Pre-fix this aborted the process, so a regression makes this test crash, not soft-fail.)
+//
+// Each sub-case uses a fresh decompressor_state, mirroring production: on a decompress
+// failure the receiver tears down the connection, so a destroyed state is never reused.
+int unittest_stream_decompress_bomb_zstd(void) {
+    fprintf(stderr, "\nTesting ZSTD decompression-bomb guard\n");
+    int errors = 0;
+
+    // 2MB of zeros: decompresses to far more than the ~128KB output buffer, but the
+    // compressed frame is only a few dozen bytes (a conforming sender never produces this).
+    size_t plain_len = 2 * 1024 * 1024;
+    char *plain = callocz(1, plain_len);
+    size_t bound = ZSTD_compressBound(plain_len);
+    char *comp = mallocz(bound);
+    size_t comp_len = ZSTD_compress(comp, bound, plain, plain_len, 1);
+    if (ZSTD_isError(comp_len)) {
+        fprintf(stderr, "  FAILED: ZSTD_compress() error: %s\n", ZSTD_getErrorName(comp_len));
+        freez(plain); freez(comp);
+        return 1;
+    }
+
+    // (1) the bomb must be rejected gracefully (return 0), not fatal()
+    {
+        struct decompressor_state dctx = { .initialized = false, .algorithm = COMPRESSION_ALGORITHM_ZSTD };
+        stream_decompressor_init(&dctx);
+        size_t out = stream_decompress(&dctx, comp, comp_len);
+        if (out != 0) {
+            fprintf(stderr, "  FAILED: oversized frame (%zuB compressed) accepted, decompressed %zuB "
+                            "(expected rejection)\n", comp_len, out);
+            errors++;
+        }
+        else
+            fprintf(stderr, "  OK: oversized frame (%zuB compressed) rejected gracefully, no fatal()\n", comp_len);
+        stream_decompressor_destroy(&dctx);
+    }
+
+    // (2) a normal frame still decompresses correctly (fresh decompressor, as a new
+    //     connection would get) - the guard must not break legitimate traffic.
+    {
+        const char *msg = "the quick brown fox jumps over the lazy dog";
+        size_t msg_len = strlen(msg);
+        size_t cbound = ZSTD_compressBound(msg_len);
+        char *cmsg = mallocz(cbound);
+        size_t cmsg_len = ZSTD_compress(cmsg, cbound, msg, msg_len, 1);
+
+        struct decompressor_state dctx = { .initialized = false, .algorithm = COMPRESSION_ALGORITHM_ZSTD };
+        stream_decompressor_init(&dctx);
+        size_t dlen = stream_decompress(&dctx, cmsg, cmsg_len);
+        if (dlen != msg_len || memcmp(&dctx.output.data[dctx.output.read_pos], msg, msg_len) != 0) {
+            fprintf(stderr, "  FAILED: normal frame did not round-trip (got %zuB, expected %zuB)\n", dlen, msg_len);
+            errors++;
+        }
+        else
+            fprintf(stderr, "  OK: normal frame round-trips\n");
+        stream_decompressor_destroy(&dctx);
+        freez(cmsg);
+    }
+
+    freez(plain); freez(comp);
+    return errors;
 }
 
 #endif // ENABLE_ZSTD

--- a/src/streaming/stream-compression/zstd.c
+++ b/src/streaming/stream-compression/zstd.c
@@ -144,7 +144,7 @@ size_t stream_decompress_zstd(struct decompressor_state *state, const char *comp
 
     if(inBuffer.pos < inBuffer.size) {
         // The peer sent a frame that decompresses to more than our output buffer.
-        // A conforming sender never does this (it compresses in <= COMPRESSION_MAX_CHUNK
+        // A conforming sender never does this (it compresses in <= COMPRESSION_MAX_MSG_SIZE
         // plaintext chunks), but a malicious/compromised peer is not bound by that.
         // Return an error (like the gzip path and the ZSTD_isError branch above) so the
         // caller fails the stream connection, instead of fatal()-ing the whole Agent.


### PR DESCRIPTION
##### Summary
- Add regression test for ZSTD decompression-bomb guard to verify grace…ful failure handling
- Handle oversized ZSTD frames gracefully by logging an error and failing the connection instead of crashing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject oversized ZSTD frames by logging and cleanly failing the stream instead of fatal()-ing the agent. Adds a regression test and improves ZSTD error handling.

- **Bug Fixes**
  - In `stream_decompress_zstd`, if compressed bytes remain after filling the output buffer, log with `netdata_log_error` and return 0 to drop the connection.
  - Handle ZSTD compression/decompression errors by logging and returning failure instead of crashing.
  - Add `unittest_stream_decompress_bomb_zstd()` and wire it into `unittest_stream_compressions()` (behind `ENABLE_ZSTD`) to verify rejection and a normal-frame round trip; fix comment to reference `COMPRESSION_MAX_MSG_SIZE`.

<sup>Written for commit 25154f8d3374ba2cdce6b0c747fd58c932471ac6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

