### PR TITLE
Fix debugfs audit capability service limit

### DIFF
--- a/packaging/makeself/jobs/81-netdata-runtime-check.sh
+++ b/packaging/makeself/jobs/81-netdata-runtime-check.sh
@@ -146,6 +146,11 @@ check_static_installer_systemd_capability_bounding_set() {
   [ -f "${installer}" ] || return 0
   [ -f "${unit}" ] || return 0
 
+  if [ ! -r "${installer}" ]; then
+    echo >&2 "!!! ${installer} is not a readable regular file"
+    return 1
+  fi
+
   if [ ! -r "${unit}" ]; then
     echo >&2 "!!! ${unit} is not a readable regular file"
     return 1

--- a/packaging/makeself/jobs/81-netdata-runtime-check.sh
+++ b/packaging/makeself/jobs/81-netdata-runtime-check.sh
@@ -11,6 +11,66 @@ dump_log() {
   cat ./netdata.log
 }
 
+static_installer_declared_file_caps() {
+  local installer="${1}"
+
+  sed -n 's/.*run setcap "\([^"$]*\)" "usr\/libexec\/netdata\/plugins.d\/.*".*/\1/p' "${installer}" |
+    awk '
+      {
+        for (i = 1; i <= NF; i++) {
+          split($i, caps, /,/)
+          for (cap in caps) {
+            sub(/[=+].*/, "", caps[cap])
+            if (caps[cap] ~ /^cap_/)
+              print toupper(caps[cap])
+          }
+        }
+      }
+    ' |
+    sort -u
+}
+
+static_systemd_unit_capability_bounding_set() {
+  local unit="${1}"
+
+  awk '
+    /^[[:space:]]*CapabilityBoundingSet=/ {
+      line = $0
+      sub(/^[[:space:]]*CapabilityBoundingSet=/, "", line)
+      split(line, caps, /[[:space:]]+/)
+      for (i in caps) {
+        if (caps[i] != "" && caps[i] !~ /^~/)
+          print toupper(caps[i])
+      }
+    }
+  ' "${unit}" | sort -u
+}
+
+check_static_installer_systemd_capability_bounding_set() {
+  local installer="${NETDATA_MAKESELF_PATH}/install-or-update.sh"
+  local unit="${NETDATA_INSTALL_PATH}/usr/lib/netdata/system/systemd/netdata.service"
+  local bounding_caps=
+  local cap=
+  local success=0
+
+  [ -f "${installer}" ] || return 0
+  [ -f "${unit}" ] || return 0
+
+  bounding_caps="$(static_systemd_unit_capability_bounding_set "${unit}")"
+  [ -n "${bounding_caps}" ] || return 0
+
+  while IFS= read -r cap; do
+    [ -n "${cap}" ] || continue
+
+    if ! printf '%s\n' "${bounding_caps}" | grep -qx "${cap}"; then
+      echo >&2 "!!! static installer grants ${cap}, but ${unit} CapabilityBoundingSet does not allow it"
+      success=1
+    fi
+  done < <(static_installer_declared_file_caps "${installer}")
+
+  return "${success}"
+}
+
 trap dump_log EXIT
 
 export NETDATA_LIBEXEC_PREFIX="${NETDATA_INSTALL_PATH}/usr/libexec/netdata"
@@ -21,6 +81,8 @@ case "${BUILDARCH}" in
     armv6l) NETDATA_SKIP_LIBEXEC_PARTS="${NETDATA_SKIP_LIBEXEC_PARTS}|ebpf|otel|systemd-journal" ;;
     *) NETDATA_SKIP_LIBEXEC_PARTS="${NETDATA_SKIP_LIBEXEC_PARTS}|ebpf" ;;
 esac
+
+check_static_installer_systemd_capability_bounding_set || exit 1
 
 "${NETDATA_INSTALL_PATH}/bin/netdata" -D > ./netdata.log 2>&1 &
 

--- a/packaging/makeself/jobs/81-netdata-runtime-check.sh
+++ b/packaging/makeself/jobs/81-netdata-runtime-check.sh
@@ -30,42 +30,147 @@ static_installer_declared_file_caps() {
     sort -u
 }
 
-static_systemd_unit_capability_bounding_set() {
+static_systemd_unit_allows_capability() {
   local unit="${1}"
+  local cap="${2}"
 
-  awk '
-    /^[[:space:]]*CapabilityBoundingSet=/ {
-      line = $0
-      sub(/^[[:space:]]*CapabilityBoundingSet=/, "", line)
-      split(line, caps, /[[:space:]]+/)
-      for (i in caps) {
-        if (caps[i] != "" && caps[i] !~ /^~/)
-          print toupper(caps[i])
+  awk -v wanted="${cap}" '
+    BEGIN {
+      wanted = toupper(wanted)
+    }
+
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+
+    function contains_wanted(value,    count, caps, i) {
+      count = split(value, caps, /[[:space:]]+/)
+      for (i = 1; i <= count; i++) {
+        if (toupper(caps[i]) == wanted) {
+          return 1
+        }
+      }
+
+      return 0
+    }
+
+    function apply_capability_bounding_set(line,    inverted, value) {
+      if (line !~ /^[[:space:]]*CapabilityBoundingSet[[:space:]]*=/) {
+        return
+      }
+
+      sub(/^[^=]*=/, "", line)
+      value = trim(line)
+
+      if (value == "") {
+        allowed = 0
+        found = 1
+        return
+      }
+
+      if (value == "~") {
+        allowed = 1
+        found = 1
+        return
+      }
+
+      inverted = 0
+      if (substr(value, 1, 1) == "~") {
+        inverted = 1
+        value = trim(substr(value, 2))
+      }
+
+      if (inverted) {
+        if (!found) {
+          allowed = 1
+        }
+
+        found = 1
+        if (contains_wanted(value)) {
+          allowed = 0
+        }
+      } else {
+        if (!found) {
+          allowed = 0
+        }
+
+        found = 1
+        if (contains_wanted(value)) {
+          allowed = 1
+        }
       }
     }
-  ' "${unit}" | sort -u
+
+    {
+      line = $0
+      sub(/\r$/, "", line)
+
+      if (continued == "" && line ~ /^[[:space:]]*[#;]/) {
+        next
+      }
+
+      if (line ~ /\\[[:space:]]*$/) {
+        sub(/\\[[:space:]]*$/, " ", line)
+        continued = continued line
+        next
+      }
+
+      line = continued line
+      continued = ""
+      apply_capability_bounding_set(line)
+    }
+
+    END {
+      if (continued != "") {
+        apply_capability_bounding_set(continued)
+      }
+
+      if (!found) {
+        exit 2
+      }
+
+      exit allowed ? 0 : 1
+    }
+  ' "${unit}"
 }
 
 check_static_installer_systemd_capability_bounding_set() {
   local installer="${NETDATA_MAKESELF_PATH}/install-or-update.sh"
   local unit="${NETDATA_INSTALL_PATH}/usr/lib/netdata/system/systemd/netdata.service"
-  local bounding_caps=
   local cap=
+  local rc=
   local success=0
 
   [ -f "${installer}" ] || return 0
   [ -f "${unit}" ] || return 0
 
-  bounding_caps="$(static_systemd_unit_capability_bounding_set "${unit}")"
-  [ -n "${bounding_caps}" ] || return 0
+  if [ ! -r "${unit}" ]; then
+    echo >&2 "!!! ${unit} is not a readable regular file"
+    return 1
+  fi
 
   while IFS= read -r cap; do
     [ -n "${cap}" ] || continue
 
-    if ! printf '%s\n' "${bounding_caps}" | grep -qx "${cap}"; then
-      echo >&2 "!!! static installer grants ${cap}, but ${unit} CapabilityBoundingSet does not allow it"
-      success=1
-    fi
+    static_systemd_unit_allows_capability "${unit}" "${cap}"
+    rc="${?}"
+    case "${rc}" in
+      0)
+        ;;
+      1)
+        echo >&2 "!!! static installer grants ${cap}, but ${unit} CapabilityBoundingSet does not allow it"
+        success=1
+        ;;
+      2)
+        return 0
+        ;;
+      *)
+        echo >&2 "!!! could not parse ${unit} CapabilityBoundingSet"
+        success=1
+        ;;
+    esac
   done < <(static_installer_declared_file_caps "${installer}")
 
   return "${success}"

--- a/packaging/runtime-check.sh
+++ b/packaging/runtime-check.sh
@@ -31,6 +31,94 @@ wait_for() {
   printf "OK\n"
 }
 
+skip_libexec_part() {
+    [ -n "${NETDATA_SKIP_LIBEXEC_PARTS}" ] && printf "%s\n" "${1}" | grep -qE "${NETDATA_SKIP_LIBEXEC_PARTS}"
+}
+
+find_netdata_systemd_unit() {
+    for unit in \
+        ${NETDATA_SYSTEMD_UNIT:-} \
+        /etc/systemd/system/netdata.service \
+        /usr/lib/systemd/system/netdata.service \
+        /lib/systemd/system/netdata.service \
+        /usr/local/lib/systemd/system/netdata.service; do
+        if [ -f "${unit}" ]; then
+            printf "%s\n" "${unit}"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+systemd_unit_capability_bounding_set() {
+    awk '
+        /^[[:space:]]*CapabilityBoundingSet[[:space:]]*=/ {
+            line = $0
+            sub(/^[^=]*=/, "", line)
+            count = split(line, caps, /[[:space:]]+/)
+            for (i = 1; i <= count; i++) {
+                if (caps[i] != "") {
+                    print caps[i]
+                }
+            }
+            found = 1
+        }
+        END {
+            if (!found) {
+                exit 1
+            }
+        }
+    ' "${1}"
+}
+
+check_systemd_capability_bounding_set() {
+    command -v getcap >/dev/null 2>&1 || return 0
+
+    systemd_unit="$(find_netdata_systemd_unit)" || return 0
+    bounding_caps="$(systemd_unit_capability_bounding_set "${systemd_unit}")" || return 0
+
+    cap_success=1
+    for part in ${NETDATA_LIBEXEC_PARTS}; do
+        if skip_libexec_part "${part}"; then
+            continue
+        fi
+
+        plugin="${NETDATA_LIBEXEC_PREFIX}/${part}"
+        if [ ! -f "${plugin}" ]; then
+            continue
+        fi
+
+        file_caps="$(getcap "${plugin}" 2>/dev/null || true)"
+        if [ -z "${file_caps}" ]; then
+            continue
+        fi
+
+        file_caps="${file_caps#* }"
+        for cap_spec in ${file_caps}; do
+            cap_names="${cap_spec%%[=+]*}"
+
+            old_ifs="${IFS}"
+            IFS=","
+            for cap_name in ${cap_names}; do
+                IFS="${old_ifs}"
+                cap_name="$(printf "%s" "${cap_name}" | tr "[:lower:]" "[:upper:]")"
+
+                if ! printf "%s\n" "${bounding_caps}" | grep -qx "${cap_name}"; then
+                    cap_success=0
+                    printf "!!! %s has file capability %s, but %s CapabilityBoundingSet does not allow it\n" \
+                        "${plugin}" "${cap_name}" "${systemd_unit}"
+                fi
+
+                IFS=","
+            done
+            IFS="${old_ifs}"
+        done
+    done
+
+    [ "${cap_success}" -eq 1 ]
+}
+
 wait_for localhost 19999 netdata
 
 case $? in
@@ -96,6 +184,10 @@ if [ -d "${NETDATA_LIBEXEC_PREFIX}" ]; then
         fi
     elif [ -f "${ebpf_plugin}" ] && [ ! -e "${ebpf_go_plugin}" ]; then
         :
+    fi
+
+    if ! check_systemd_capability_bounding_set; then
+        success=0
     fi
 
     if [ "${success}" -eq 0 ]; then

--- a/packaging/runtime-check.sh
+++ b/packaging/runtime-check.sh
@@ -36,38 +36,136 @@ skip_libexec_part() {
 }
 
 find_netdata_systemd_unit() {
+    if [ -n "${NETDATA_SYSTEMD_UNIT}" ]; then
+        if [ -f "${NETDATA_SYSTEMD_UNIT}" ] && [ -r "${NETDATA_SYSTEMD_UNIT}" ]; then
+            printf "%s\n" "${NETDATA_SYSTEMD_UNIT}"
+            return 0
+        fi
+
+        printf "!!! %s is not a readable regular file\n" "${NETDATA_SYSTEMD_UNIT}" >&2
+        return 2
+    fi
+
     for unit in \
-        ${NETDATA_SYSTEMD_UNIT:-} \
         /etc/systemd/system/netdata.service \
         /usr/lib/systemd/system/netdata.service \
         /lib/systemd/system/netdata.service \
         /usr/local/lib/systemd/system/netdata.service; do
-        if [ -f "${unit}" ]; then
+        if [ ! -e "${unit}" ] && [ ! -L "${unit}" ]; then
+            continue
+        fi
+
+        if [ -f "${unit}" ] && [ -r "${unit}" ]; then
             printf "%s\n" "${unit}"
             return 0
         fi
+
+        printf "!!! %s is not a readable regular file\n" "${unit}" >&2
+        return 2
     done
 
     return 1
 }
 
-systemd_unit_capability_bounding_set() {
-    awk '
-        /^[[:space:]]*CapabilityBoundingSet[[:space:]]*=/ {
-            line = $0
-            sub(/^[^=]*=/, "", line)
-            count = split(line, caps, /[[:space:]]+/)
+systemd_unit_allows_capability() {
+    awk -v wanted="${2}" '
+        BEGIN {
+            wanted = toupper(wanted)
+        }
+
+        function trim(value) {
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            return value
+        }
+
+        function contains_wanted(value,    count, caps, i) {
+            count = split(value, caps, /[[:space:]]+/)
             for (i = 1; i <= count; i++) {
-                if (caps[i] != "") {
-                    print caps[i]
+                if (toupper(caps[i]) == wanted) {
+                    return 1
                 }
             }
-            found = 1
+
+            return 0
         }
-        END {
-            if (!found) {
-                exit 1
+
+        function apply_capability_bounding_set(line,    inverted, value) {
+            if (line !~ /^[[:space:]]*CapabilityBoundingSet[[:space:]]*=/) {
+                return
             }
+
+            sub(/^[^=]*=/, "", line)
+            value = trim(line)
+
+            if (value == "") {
+                allowed = 0
+                found = 1
+                return
+            }
+
+            if (value == "~") {
+                allowed = 1
+                found = 1
+                return
+            }
+
+            inverted = 0
+            if (substr(value, 1, 1) == "~") {
+                inverted = 1
+                value = trim(substr(value, 2))
+            }
+
+            if (inverted) {
+                if (!found) {
+                    allowed = 1
+                }
+
+                found = 1
+                if (contains_wanted(value)) {
+                    allowed = 0
+                }
+            } else {
+                if (!found) {
+                    allowed = 0
+                }
+
+                found = 1
+                if (contains_wanted(value)) {
+                    allowed = 1
+                }
+            }
+        }
+
+        {
+            line = $0
+            sub(/\r$/, "", line)
+
+            if (continued == "" && line ~ /^[[:space:]]*[#;]/) {
+                next
+            }
+
+            if (line ~ /\\[[:space:]]*$/) {
+                sub(/\\[[:space:]]*$/, " ", line)
+                continued = continued line
+                next
+            }
+
+            line = continued line
+            continued = ""
+            apply_capability_bounding_set(line)
+        }
+
+        END {
+            if (continued != "") {
+                apply_capability_bounding_set(continued)
+            }
+
+            if (!found) {
+                exit 2
+            }
+
+            exit allowed ? 0 : 1
         }
     ' "${1}"
 }
@@ -75,8 +173,17 @@ systemd_unit_capability_bounding_set() {
 check_systemd_capability_bounding_set() {
     command -v getcap >/dev/null 2>&1 || return 0
 
-    systemd_unit="$(find_netdata_systemd_unit)" || return 0
-    bounding_caps="$(systemd_unit_capability_bounding_set "${systemd_unit}")" || return 0
+    systemd_unit="$(find_netdata_systemd_unit)"
+    case "${?}" in
+        0)
+            ;;
+        1)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 
     cap_success=1
     for part in ${NETDATA_LIBEXEC_PARTS}; do
@@ -104,11 +211,23 @@ check_systemd_capability_bounding_set() {
                 IFS="${old_ifs}"
                 cap_name="$(printf "%s" "${cap_name}" | tr "[:lower:]" "[:upper:]")"
 
-                if ! printf "%s\n" "${bounding_caps}" | grep -qx "${cap_name}"; then
-                    cap_success=0
-                    printf "!!! %s has file capability %s, but %s CapabilityBoundingSet does not allow it\n" \
-                        "${plugin}" "${cap_name}" "${systemd_unit}"
-                fi
+                systemd_unit_allows_capability "${systemd_unit}" "${cap_name}"
+                case "${?}" in
+                    0)
+                        ;;
+                    1)
+                        cap_success=0
+                        printf "!!! %s has file capability %s, but %s CapabilityBoundingSet does not allow it\n" \
+                            "${plugin}" "${cap_name}" "${systemd_unit}"
+                        ;;
+                    2)
+                        return 0
+                        ;;
+                    *)
+                        cap_success=0
+                        printf "!!! could not parse %s CapabilityBoundingSet\n" "${systemd_unit}"
+                        ;;
+                esac
 
                 IFS=","
             done

--- a/src/collectors/README.md
+++ b/src/collectors/README.md
@@ -26,7 +26,7 @@ This section outlines the required privileges and how they are configured in dif
 | Plugin/Binary          | Privileges (Linux)                              | Privileges (Non-Linux or Containerized Environment) |   
 |------------------------|-------------------------------------------------|-----------------------------------------------------|
 | apps.plugin            | CAP_DAC_READ_SEARCH, CAP_SYS_PTRACE             | setuid root                                         |
-| debugfs.plugin         | CAP_DAC_READ_SEARCH                             | setuid root                                         |
+| debugfs.plugin         | CAP_DAC_READ_SEARCH, CAP_AUDIT_CONTROL          | setuid root                                         |
 | systemd-journal.plugin | CAP_DAC_READ_SEARCH                             | setuid root                                         |
 | perf.plugin            | CAP_PERFMON                                     | setuid root                                         |
 | slabinfo.plugin        | CAP_DAC_READ_SEARCH                             | setuid root                                         |

--- a/system/systemd/netdata.service.in
+++ b/system/systemd/netdata.service.in
@@ -40,6 +40,8 @@ Nice=0
 CapabilityBoundingSet=CAP_DAC_OVERRIDE
 # is required for apps plugin
 CapabilityBoundingSet=CAP_DAC_READ_SEARCH
+# is required for debugfs plugin audit subsystem monitoring
+CapabilityBoundingSet=CAP_AUDIT_CONTROL
 # is required for freeipmi plugin
 CapabilityBoundingSet=CAP_FOWNER CAP_SYS_RAWIO
 # is required for apps, perf and slabinfo plugins


### PR DESCRIPTION
## Summary
- Allow `CAP_AUDIT_CONTROL` in the systemd `CapabilityBoundingSet` so `debugfs.plugin` can execute with its packaged audit capability.
- Document the `debugfs.plugin` audit capability requirement.
- Add runtime/package validation for installed plugin file capabilities versus the installed systemd unit.
- Add static archive validation for static installer-declared plugin capabilities versus the packaged systemd unit.


## Root Cause
`debugfs.plugin` is granted `cap_dac_read_search,cap_audit_control` by package/install paths, but the modern systemd unit constrained `CapabilityBoundingSet` without `CAP_AUDIT_CONTROL`. Linux capability semantics mask file capabilities outside the process bounding set during `execve()`, so the plugin can fail before its own code runs.


## Container And Static Install Check
- Static installs use the generated modern systemd unit, so they inherit the runtime fix; the new static archive guard catches future drift before publishing an archive.
- Docker packaging installs privileged plugins as setuid and launches Netdata directly, so there is no container-local systemd `CapabilityBoundingSet` to update.
- Docker/Kubernetes examples are left unchanged because adding `AUDIT_CONTROL` changes the documented container privilege profile and should be a separate product/security decision.


## Validation
- `sh -n packaging/runtime-check.sh`
- `shellcheck packaging/runtime-check.sh`
- `bash -n packaging/makeself/jobs/81-netdata-runtime-check.sh`
- `shellcheck -x packaging/makeself/jobs/81-netdata-runtime-check.sh`
- `systemd-analyze verify` on the generated service unit after substituting `@sbindir_POST@`
- fake installed-tree runtime positive/negative test for `CAP_AUDIT_CONTROL`
- fake static archive positive/negative test for `CAP_AUDIT_CONTROL`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `CAP_AUDIT_CONTROL` in the Netdata systemd service so `debugfs.plugin` can run with its audit capability. Validation now detects capability mismatches at install time and in static archives, and checks installer/unit readability.

- **Bug Fixes**
  - Added `CAP_AUDIT_CONTROL` to `CapabilityBoundingSet` in `netdata.service` for `debugfs.plugin`.

- **New Features**
  - Validation: hardened `CapabilityBoundingSet` parsing (supports `~`, empty, multiline), `NETDATA_SYSTEMD_UNIT` override and common path search, skipping via `NETDATA_SKIP_LIBEXEC_PARTS`, safe no-op if unit or `getcap` is missing; static archive guard compares installer-declared caps to the packaged unit and verifies the installer/unit are readable; docs updated for `debugfs.plugin`.

<sup>Written for commit fa76e031352aeb57aa59095194e4b2dc32cf3943. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

