### PR TITLE
chore(go.d/l2topology): extract model types

### DIFF
--- a/src/go/pkg/l2topology/internal/model/options.go
+++ b/src/go/pkg/l2topology/internal/model/options.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package model
+
+import "time"
+
+// GraphOptions controls conversion from Result to the internal graph projection.
+type GraphOptions struct {
+	SchemaVersion             string
+	Source                    string
+	Layer                     string
+	View                      string
+	AgentID                   string
+	LocalDeviceID             string
+	CollectedAt               time.Time
+	ResolveDNSName            func(ip string) string
+	CollapseActorsByIP        bool
+	EliminateNonIPInferred    bool
+	ProbabilisticConnectivity bool
+	InferenceStrategy         string
+}

--- a/src/go/pkg/l2topology/internal/model/projection.go
+++ b/src/go/pkg/l2topology/internal/model/projection.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package model
+
+import "github.com/netdata/netdata/go/plugins/pkg/topology/graph"
+
+// Projection is the L2 graph output consumed by topology producers.
+type Projection struct {
+	Graph        graph.Graph
+	Stats        ProjectionStats
+	ActorDetails map[string]ProjectionActorDetail
+}
+
+// OptionalValue keeps value presence explicit when a zero value is a real value.
+type OptionalValue[T any] struct {
+	Value T
+	Has   bool
+}
+
+// ProjectionActorDetail carries typed L2-owned actor facts keyed by graph actor id.
+type ProjectionActorDetail struct {
+	DisplayName   string
+	DisplaySource string
+
+	Device   ProjectionDeviceActorDetail
+	Endpoint ProjectionEndpointActorDetail
+	Segment  ProjectionSegmentActorDetail
+
+	CollapsedByIP  bool
+	CollapsedCount int
+}
+
+type ProjectionDeviceActorDetail struct {
+	DeviceID                 string
+	Discovered               bool
+	Inferred                 bool
+	ManagementIP             string
+	ManagementAddresses      []string
+	Protocols                []string
+	ProtocolsCollected       []string
+	Capabilities             []string
+	CapabilitiesSupported    []string
+	CapabilitiesEnabled      []string
+	Vendor                   string
+	VendorSource             string
+	VendorConfidence         string
+	VendorDerived            string
+	VendorDerivedSource      string
+	VendorDerivedConfidence  string
+	VendorDerivedMatchPrefix string
+	VendorMatchPrefix        string
+	PortsTotal               OptionalValue[int]
+	IfIndexes                []string
+	IfNames                  []string
+	PortsUp                  OptionalValue[int]
+	PortsDown                OptionalValue[int]
+	PortsAdminDown           OptionalValue[int]
+	TotalBandwidthBps        OptionalValue[int64]
+	FDBTotalMACs             OptionalValue[int]
+	VLANCount                OptionalValue[int]
+	LLDPNeighborCount        OptionalValue[int]
+	CDPNeighborCount         OptionalValue[int]
+	AdminStatusCounts        map[string]int
+	OperStatusCounts         map[string]int
+	LinkModeCounts           map[string]int
+	TopologyRoleCounts       map[string]int
+	Ports                    []ProjectionPortDetail
+}
+
+type ProjectionEndpointActorDetail struct {
+	Discovered               bool
+	LearnedSources           []string
+	LearnedDeviceIDs         []string
+	LearnedIfIndexes         []string
+	LearnedIfNames           []string
+	Vendor                   string
+	VendorSource             string
+	VendorConfidence         string
+	VendorMatchPrefix        string
+	VendorDerived            string
+	VendorDerivedSource      string
+	VendorDerivedConfidence  string
+	VendorDerivedMatchPrefix string
+	AttachmentSource         string
+	AttachedDeviceID         string
+	AttachedDevice           string
+	AttachedPort             string
+	AttachedIfName           string
+	AttachedIfIndex          int
+	AttachedBridgePort       string
+	AttachedVLAN             string
+	AttachedVLANID           string
+	AttachedBy               string
+}
+
+type ProjectionSegmentActorDetail struct {
+	SegmentID      string
+	SegmentType    string
+	ParentDevices  []string
+	IfNames        []string
+	IfIndexes      []string
+	BridgePorts    []string
+	VLANIDs        []string
+	LearnedSources []string
+	PortsTotal     OptionalValue[int]
+	EndpointsTotal OptionalValue[int]
+	DesignatedPort string
+	SegmentKind    string
+}
+
+type ProjectionPortDetail struct {
+	IfIndex                OptionalValue[int]
+	PortID                 string
+	Name                   string
+	IfName                 string
+	IfDescr                string
+	IfAlias                string
+	MAC                    string
+	Speed                  OptionalValue[int64]
+	TopologyRole           string
+	OperStatus             string
+	AdminStatus            string
+	PortType               string
+	LinkMode               string
+	STPState               string
+	VLANIDs                []string
+	FDBMACCount            OptionalValue[int]
+	LinkCount              OptionalValue[int]
+	NeighborCount          OptionalValue[int]
+	Neighbors              []ProjectionPortNeighbor
+	VLANs                  []ProjectionPortVLAN
+	Duplex                 string
+	LinkModeConfidence     string
+	TopologyRoleConfidence string
+	LinkModeSources        []string
+	TopologyRoleSources    []string
+	LastChange             string
+	ChartIDSuffix          string
+	AvailableMetrics       []string
+}
+
+type ProjectionPortNeighbor struct {
+	Protocol           string
+	RemoteDevice       string
+	RemotePort         string
+	RemoteIP           string
+	RemoteChassisID    string
+	RemoteCapabilities []string
+}
+
+type ProjectionPortVLAN struct {
+	VLANID   string
+	VLANName string
+	Tagged   bool
+}

--- a/src/go/pkg/l2topology/internal/model/stats.go
+++ b/src/go/pkg/l2topology/internal/model/stats.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package model
+
+type ResultStats struct {
+	DevicesTotal                       int
+	LinksTotal                         int
+	LinksLLDP                          int
+	LinksCDP                           int
+	LinksSTP                           int
+	AttachmentsTotal                   int
+	AttachmentsFDB                     int
+	EnrichmentsTotal                   int
+	EnrichmentsARPND                   int
+	BridgeDomainsTotal                 int
+	EndpointsTotal                     int
+	IdentityAliasEndpointsMapped       int
+	IdentityAliasEndpointsAmbiguousMAC int
+	IdentityAliasIPsMerged             int
+	IdentityAliasIPsConflictSkipped    int
+}
+
+type ProjectionStats struct {
+	ResultStats
+
+	DevicesDiscovered          int
+	LinksBidirectional         int
+	LinksUnidirectional        int
+	LinksFDB                   int
+	LinksFDBEndpointCandidates int
+	LinksFDBEndpointEmitted    int
+	LinksFDBEndpointSuppressed int
+	EndpointsAmbiguousSegments int
+	LinksARP                   int
+	LinksProbable              int
+	SegmentsSuppressed         int
+	ActorsTotal                int
+	ActorsUnlinkedSuppressed   int
+	InferenceStrategy          string
+}

--- a/src/go/pkg/l2topology/internal/model/types.go
+++ b/src/go/pkg/l2topology/internal/model/types.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package model
+
+import (
+	"net/netip"
+	"time"
+)
+
+// DiscoverOptions controls which normalized L2 observation families contribute
+// to the result.
+type DiscoverOptions struct {
+	EnableLLDP   bool
+	EnableCDP    bool
+	EnableBridge bool
+	EnableARP    bool
+	EnableSTP    bool
+	CollectedAt  time.Time
+}
+
+// Result is the deterministic L2 topology result derived from normalized
+// observations.
+type Result struct {
+	CollectedAt  time.Time
+	Devices      []Device
+	Interfaces   []Interface
+	Adjacencies  []Adjacency
+	Attachments  []Attachment
+	Enrichments  []Enrichment
+	Stats        ResultStats
+	SourceLabels map[string]string
+}
+
+// Device is a discovered network device.
+type Device struct {
+	ID        string
+	Hostname  string
+	Addresses []netip.Addr
+	SysObject string
+	ChassisID string
+	Labels    map[string]string
+}
+
+// Interface is a discovered interface on a device.
+type Interface struct {
+	DeviceID string
+	IfIndex  int
+	IfName   string
+	IfDescr  string
+	MAC      string
+	Labels   map[string]string
+}
+
+// Adjacency represents a direct device-to-device neighbor relation.
+type Adjacency struct {
+	Protocol   string
+	SourceID   string
+	SourcePort string
+	TargetID   string
+	TargetPort string
+	Labels     map[string]string
+}
+
+// Attachment ties an endpoint to a device interface.
+type Attachment struct {
+	DeviceID   string
+	IfIndex    int
+	EndpointID string
+	Method     string
+	Labels     map[string]string
+}
+
+// Enrichment carries non-structural observations that can assist correlation.
+type Enrichment struct {
+	EndpointID string
+	IPs        []netip.Addr
+	MAC        string
+	Labels     map[string]string
+}
+
+// L2Observation contains one device's normalized layer-2 observations.
+type L2Observation struct {
+	DeviceID string
+	// Inferred marks observations synthesized from neighbor advertisements
+	// (for example LLDP/CDP remotes), not directly observed local devices.
+	Inferred          bool
+	Hostname          string
+	ManagementIP      string
+	SysObjectID       string
+	ChassisID         string
+	BaseBridgeAddress string
+	Interfaces        []ObservedInterface
+	BridgePorts       []BridgePortObservation
+	STPPorts          []STPPortObservation
+	FDBEntries        []FDBObservation
+	ARPNDEntries      []ARPNDObservation
+	LLDPRemotes       []LLDPRemoteObservation
+	CDPRemotes        []CDPRemoteObservation
+}
+
+// ObservedInterface describes one local interface seen on a device.
+type ObservedInterface struct {
+	IfIndex       int
+	IfName        string
+	IfDescr       string
+	IfAlias       string
+	MAC           string
+	SpeedBps      int64
+	LastChange    int64
+	Duplex        string
+	InterfaceType string
+	AdminStatus   string
+	OperStatus    string
+}
+
+// LLDPRemoteObservation captures one remote LLDP neighbor advertised by a device.
+type LLDPRemoteObservation struct {
+	LocalPortNum       string
+	RemoteIndex        string
+	LocalPortID        string
+	LocalPortIDSubtype string
+	LocalPortDesc      string
+	ChassisID          string
+	SysName            string
+	PortID             string
+	PortIDSubtype      string
+	PortDesc           string
+	ManagementIP       string
+}
+
+// CDPRemoteObservation captures one remote CDP neighbor advertised by a device.
+type CDPRemoteObservation struct {
+	LocalIfIndex int
+	LocalIfName  string
+	DeviceIndex  string
+	DeviceID     string
+	SysName      string
+	DevicePort   string
+	Address      string
+}
+
+// BridgePortObservation maps one bridge base port to an interface index.
+type BridgePortObservation struct {
+	BasePort string
+	IfIndex  int
+}
+
+// FDBObservation captures one forwarding database entry from a bridge table.
+type FDBObservation struct {
+	MAC        string
+	BridgePort string
+	IfIndex    int
+	Status     string
+	VLANID     string
+	VLANName   string
+}
+
+// STPPortObservation captures one spanning-tree port row.
+type STPPortObservation struct {
+	Port             string
+	IfIndex          int
+	IfName           string
+	VLANID           string
+	VLANName         string
+	State            string
+	Enable           string
+	PathCost         string
+	DesignatedRoot   string
+	DesignatedBridge string
+	DesignatedPort   string
+}
+
+// ARPNDObservation captures one ARP or ND neighbor-table observation.
+type ARPNDObservation struct {
+	Protocol string
+	IfIndex  int
+	IfName   string
+	IP       string
+	MAC      string
+	State    string
+	AddrType string
+}

--- a/src/go/pkg/l2topology/l2_pipeline_stats.go
+++ b/src/go/pkg/l2topology/l2_pipeline_stats.go
@@ -2,39 +2,8 @@
 
 package l2topology
 
-type ResultStats struct {
-	DevicesTotal                       int
-	LinksTotal                         int
-	LinksLLDP                          int
-	LinksCDP                           int
-	LinksSTP                           int
-	AttachmentsTotal                   int
-	AttachmentsFDB                     int
-	EnrichmentsTotal                   int
-	EnrichmentsARPND                   int
-	BridgeDomainsTotal                 int
-	EndpointsTotal                     int
-	IdentityAliasEndpointsMapped       int
-	IdentityAliasEndpointsAmbiguousMAC int
-	IdentityAliasIPsMerged             int
-	IdentityAliasIPsConflictSkipped    int
-}
+import "github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/model"
 
-type ProjectionStats struct {
-	ResultStats
+type ResultStats = model.ResultStats
 
-	DevicesDiscovered          int
-	LinksBidirectional         int
-	LinksUnidirectional        int
-	LinksFDB                   int
-	LinksFDBEndpointCandidates int
-	LinksFDBEndpointEmitted    int
-	LinksFDBEndpointSuppressed int
-	EndpointsAmbiguousSegments int
-	LinksARP                   int
-	LinksProbable              int
-	SegmentsSuppressed         int
-	ActorsTotal                int
-	ActorsUnlinkedSuppressed   int
-	InferenceStrategy          string
-}
+type ProjectionStats = model.ProjectionStats

--- a/src/go/pkg/l2topology/topology_adapter.go
+++ b/src/go/pkg/l2topology/topology_adapter.go
@@ -5,26 +5,13 @@ package l2topology
 import (
 	"net/netip"
 	"strings"
-	"time"
 
+	"github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/model"
 	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 )
 
 // GraphOptions controls conversion from Result to the internal graph projection.
-type GraphOptions struct {
-	SchemaVersion             string
-	Source                    string
-	Layer                     string
-	View                      string
-	AgentID                   string
-	LocalDeviceID             string
-	CollectedAt               time.Time
-	ResolveDNSName            func(ip string) string
-	CollapseActorsByIP        bool
-	EliminateNonIPInferred    bool
-	ProbabilisticConnectivity bool
-	InferenceStrategy         string
-}
+type GraphOptions = model.GraphOptions
 
 const (
 	topologyInferenceStrategyFDBMinimumKnowledge = "fdb_minimum_knowledge"

--- a/src/go/pkg/l2topology/topology_projection.go
+++ b/src/go/pkg/l2topology/topology_projection.go
@@ -2,154 +2,25 @@
 
 package l2topology
 
-import "github.com/netdata/netdata/go/plugins/pkg/topology/graph"
+import "github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/model"
 
 // Projection is the L2 graph output consumed by topology producers.
-type Projection struct {
-	Graph        graph.Graph
-	Stats        ProjectionStats
-	ActorDetails map[string]ProjectionActorDetail
-}
+type Projection = model.Projection
 
 // OptionalValue keeps value presence explicit when a zero value is a real value.
-type OptionalValue[T any] struct {
-	Value T
-	Has   bool
-}
+type OptionalValue[T any] = model.OptionalValue[T]
 
 // ProjectionActorDetail carries typed L2-owned actor facts keyed by graph actor id.
-type ProjectionActorDetail struct {
-	DisplayName   string
-	DisplaySource string
+type ProjectionActorDetail = model.ProjectionActorDetail
 
-	Device   ProjectionDeviceActorDetail
-	Endpoint ProjectionEndpointActorDetail
-	Segment  ProjectionSegmentActorDetail
+type ProjectionDeviceActorDetail = model.ProjectionDeviceActorDetail
 
-	CollapsedByIP  bool
-	CollapsedCount int
-}
+type ProjectionEndpointActorDetail = model.ProjectionEndpointActorDetail
 
-type ProjectionDeviceActorDetail struct {
-	DeviceID                 string
-	Discovered               bool
-	Inferred                 bool
-	ManagementIP             string
-	ManagementAddresses      []string
-	Protocols                []string
-	ProtocolsCollected       []string
-	Capabilities             []string
-	CapabilitiesSupported    []string
-	CapabilitiesEnabled      []string
-	Vendor                   string
-	VendorSource             string
-	VendorConfidence         string
-	VendorDerived            string
-	VendorDerivedSource      string
-	VendorDerivedConfidence  string
-	VendorDerivedMatchPrefix string
-	VendorMatchPrefix        string
-	PortsTotal               OptionalValue[int]
-	IfIndexes                []string
-	IfNames                  []string
-	PortsUp                  OptionalValue[int]
-	PortsDown                OptionalValue[int]
-	PortsAdminDown           OptionalValue[int]
-	TotalBandwidthBps        OptionalValue[int64]
-	FDBTotalMACs             OptionalValue[int]
-	VLANCount                OptionalValue[int]
-	LLDPNeighborCount        OptionalValue[int]
-	CDPNeighborCount         OptionalValue[int]
-	AdminStatusCounts        map[string]int
-	OperStatusCounts         map[string]int
-	LinkModeCounts           map[string]int
-	TopologyRoleCounts       map[string]int
-	Ports                    []ProjectionPortDetail
-}
+type ProjectionSegmentActorDetail = model.ProjectionSegmentActorDetail
 
-type ProjectionEndpointActorDetail struct {
-	Discovered               bool
-	LearnedSources           []string
-	LearnedDeviceIDs         []string
-	LearnedIfIndexes         []string
-	LearnedIfNames           []string
-	Vendor                   string
-	VendorSource             string
-	VendorConfidence         string
-	VendorMatchPrefix        string
-	VendorDerived            string
-	VendorDerivedSource      string
-	VendorDerivedConfidence  string
-	VendorDerivedMatchPrefix string
-	AttachmentSource         string
-	AttachedDeviceID         string
-	AttachedDevice           string
-	AttachedPort             string
-	AttachedIfName           string
-	AttachedIfIndex          int
-	AttachedBridgePort       string
-	AttachedVLAN             string
-	AttachedVLANID           string
-	AttachedBy               string
-}
+type ProjectionPortDetail = model.ProjectionPortDetail
 
-type ProjectionSegmentActorDetail struct {
-	SegmentID      string
-	SegmentType    string
-	ParentDevices  []string
-	IfNames        []string
-	IfIndexes      []string
-	BridgePorts    []string
-	VLANIDs        []string
-	LearnedSources []string
-	PortsTotal     OptionalValue[int]
-	EndpointsTotal OptionalValue[int]
-	DesignatedPort string
-	SegmentKind    string
-}
+type ProjectionPortNeighbor = model.ProjectionPortNeighbor
 
-type ProjectionPortDetail struct {
-	IfIndex                OptionalValue[int]
-	PortID                 string
-	Name                   string
-	IfName                 string
-	IfDescr                string
-	IfAlias                string
-	MAC                    string
-	Speed                  OptionalValue[int64]
-	TopologyRole           string
-	OperStatus             string
-	AdminStatus            string
-	PortType               string
-	LinkMode               string
-	STPState               string
-	VLANIDs                []string
-	FDBMACCount            OptionalValue[int]
-	LinkCount              OptionalValue[int]
-	NeighborCount          OptionalValue[int]
-	Neighbors              []ProjectionPortNeighbor
-	VLANs                  []ProjectionPortVLAN
-	Duplex                 string
-	LinkModeConfidence     string
-	TopologyRoleConfidence string
-	LinkModeSources        []string
-	TopologyRoleSources    []string
-	LastChange             string
-	ChartIDSuffix          string
-	AvailableMetrics       []string
-}
-
-type ProjectionPortNeighbor struct {
-	Protocol           string
-	RemoteDevice       string
-	RemotePort         string
-	RemoteIP           string
-	RemoteChassisID    string
-	RemoteCapabilities []string
-}
-
-type ProjectionPortVLAN struct {
-	VLANID   string
-	VLANName string
-	Tagged   bool
-}
+type ProjectionPortVLAN = model.ProjectionPortVLAN

--- a/src/go/pkg/l2topology/types.go
+++ b/src/go/pkg/l2topology/types.go
@@ -2,181 +2,51 @@
 
 package l2topology
 
-import (
-	"net/netip"
-	"time"
-)
+import "github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/model"
 
 // DiscoverOptions controls which normalized L2 observation families contribute
 // to the result.
-type DiscoverOptions struct {
-	EnableLLDP   bool
-	EnableCDP    bool
-	EnableBridge bool
-	EnableARP    bool
-	EnableSTP    bool
-	CollectedAt  time.Time
-}
+type DiscoverOptions = model.DiscoverOptions
 
 // Result is the deterministic L2 topology result derived from normalized
 // observations.
-type Result struct {
-	CollectedAt  time.Time
-	Devices      []Device
-	Interfaces   []Interface
-	Adjacencies  []Adjacency
-	Attachments  []Attachment
-	Enrichments  []Enrichment
-	Stats        ResultStats
-	SourceLabels map[string]string
-}
+type Result = model.Result
 
 // Device is a discovered network device.
-type Device struct {
-	ID        string
-	Hostname  string
-	Addresses []netip.Addr
-	SysObject string
-	ChassisID string
-	Labels    map[string]string
-}
+type Device = model.Device
 
 // Interface is a discovered interface on a device.
-type Interface struct {
-	DeviceID string
-	IfIndex  int
-	IfName   string
-	IfDescr  string
-	MAC      string
-	Labels   map[string]string
-}
+type Interface = model.Interface
 
 // Adjacency represents a direct device-to-device neighbor relation.
-type Adjacency struct {
-	Protocol   string
-	SourceID   string
-	SourcePort string
-	TargetID   string
-	TargetPort string
-	Labels     map[string]string
-}
+type Adjacency = model.Adjacency
 
 // Attachment ties an endpoint to a device interface.
-type Attachment struct {
-	DeviceID   string
-	IfIndex    int
-	EndpointID string
-	Method     string
-	Labels     map[string]string
-}
+type Attachment = model.Attachment
 
 // Enrichment carries non-structural observations that can assist correlation.
-type Enrichment struct {
-	EndpointID string
-	IPs        []netip.Addr
-	MAC        string
-	Labels     map[string]string
-}
+type Enrichment = model.Enrichment
 
 // L2Observation contains one device's normalized layer-2 observations.
-type L2Observation struct {
-	DeviceID string
-	// Inferred marks observations synthesized from neighbor advertisements
-	// (for example LLDP/CDP remotes), not directly observed local devices.
-	Inferred          bool
-	Hostname          string
-	ManagementIP      string
-	SysObjectID       string
-	ChassisID         string
-	BaseBridgeAddress string
-	Interfaces        []ObservedInterface
-	BridgePorts       []BridgePortObservation
-	STPPorts          []STPPortObservation
-	FDBEntries        []FDBObservation
-	ARPNDEntries      []ARPNDObservation
-	LLDPRemotes       []LLDPRemoteObservation
-	CDPRemotes        []CDPRemoteObservation
-}
+type L2Observation = model.L2Observation
 
 // ObservedInterface describes one local interface seen on a device.
-type ObservedInterface struct {
-	IfIndex       int
-	IfName        string
-	IfDescr       string
-	IfAlias       string
-	MAC           string
-	SpeedBps      int64
-	LastChange    int64
-	Duplex        string
-	InterfaceType string
-	AdminStatus   string
-	OperStatus    string
-}
+type ObservedInterface = model.ObservedInterface
 
 // LLDPRemoteObservation captures one remote LLDP neighbor advertised by a device.
-type LLDPRemoteObservation struct {
-	LocalPortNum       string
-	RemoteIndex        string
-	LocalPortID        string
-	LocalPortIDSubtype string
-	LocalPortDesc      string
-	ChassisID          string
-	SysName            string
-	PortID             string
-	PortIDSubtype      string
-	PortDesc           string
-	ManagementIP       string
-}
+type LLDPRemoteObservation = model.LLDPRemoteObservation
 
 // CDPRemoteObservation captures one remote CDP neighbor advertised by a device.
-type CDPRemoteObservation struct {
-	LocalIfIndex int
-	LocalIfName  string
-	DeviceIndex  string
-	DeviceID     string
-	SysName      string
-	DevicePort   string
-	Address      string
-}
+type CDPRemoteObservation = model.CDPRemoteObservation
 
 // BridgePortObservation maps one bridge base port to an interface index.
-type BridgePortObservation struct {
-	BasePort string
-	IfIndex  int
-}
+type BridgePortObservation = model.BridgePortObservation
 
 // FDBObservation captures one forwarding database entry from a bridge table.
-type FDBObservation struct {
-	MAC        string
-	BridgePort string
-	IfIndex    int
-	Status     string
-	VLANID     string
-	VLANName   string
-}
+type FDBObservation = model.FDBObservation
 
 // STPPortObservation captures one spanning-tree port row.
-type STPPortObservation struct {
-	Port             string
-	IfIndex          int
-	IfName           string
-	VLANID           string
-	VLANName         string
-	State            string
-	Enable           string
-	PathCost         string
-	DesignatedRoot   string
-	DesignatedBridge string
-	DesignatedPort   string
-}
+type STPPortObservation = model.STPPortObservation
 
 // ARPNDObservation captures one ARP or ND neighbor-table observation.
-type ARPNDObservation struct {
-	Protocol string
-	IfIndex  int
-	IfName   string
-	IP       string
-	MAC      string
-	State    string
-	AddrType string
-}
+type ARPNDObservation = model.ARPNDObservation


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted L2 topology model types into `internal/model` and replaced previous in-package structs with type aliases. This consolidates ownership of types and removes duplication with no behavior change.

- **Refactors**
  - Added `src/go/pkg/l2topology/internal/model` with `GraphOptions`, `Projection` and details, `ProjectionStats`/`ResultStats`, `DiscoverOptions`, `Result`, `Device`, `Interface`, `Adjacency`, `Attachment`, `Enrichment`, `L2Observation` and related structs.
  - Updated `l2topology` to alias these types (e.g., `type Result = model.Result`) and import `internal/model`.
  - Removed duplicate definitions from `l2_pipeline_stats.go`, `topology_adapter.go`, `topology_projection.go`, and `types.go`.
  - Public API remains unchanged via aliases; no functional changes.

<sup>Written for commit 5ce906f0846873b8e73ad2cfc44d808381de4a6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

