### PR TITLE
chore(go.d/l2topology): move L2 pipeline internal

### DIFF
--- a/src/go/pkg/l2topology/internal/addrnorm/addrnorm.go
+++ b/src/go/pkg/l2topology/internal/addrnorm/addrnorm.go
@@ -5,6 +5,7 @@ package addrnorm
 import (
 	"encoding/hex"
 	"fmt"
+	"net/netip"
 	"strconv"
 	"strings"
 )
@@ -74,6 +75,14 @@ func NormalizeMAC(value string) string {
 		return formatMAC(bs)
 	}
 	return ""
+}
+
+func ParseAddr(value string) netip.Addr {
+	addr, err := netip.ParseAddr(strings.TrimSpace(value))
+	if err != nil {
+		return netip.Addr{}
+	}
+	return addr.Unmap()
 }
 
 func decodeGroupedHexParts(parts []string) []byte {

--- a/src/go/pkg/l2topology/internal/addrnorm/addrnorm_test.go
+++ b/src/go/pkg/l2topology/internal/addrnorm/addrnorm_test.go
@@ -30,3 +30,42 @@ func TestDecodeHexBytes(t *testing.T) {
 	require.Equal(t, []byte{0, 17, 34, 51, 68, 85}, DecodeHexBytes("0:11:22:33:44:55"))
 	require.Nil(t, DecodeHexBytes("not-hex"))
 }
+
+func TestParseAddr(t *testing.T) {
+	tests := map[string]struct {
+		input string
+		want  string
+	}{
+		"ipv4": {
+			input: "10.0.0.1",
+			want:  "10.0.0.1",
+		},
+		"trimmed": {
+			input: " 10.0.0.1 ",
+			want:  "10.0.0.1",
+		},
+		"ipv6": {
+			input: "2001:db8::1",
+			want:  "2001:db8::1",
+		},
+		"ipv6 mapped ipv4": {
+			input: "::ffff:10.0.0.1",
+			want:  "10.0.0.1",
+		},
+		"invalid": {
+			input: "not-an-ip",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			addr := ParseAddr(tc.input)
+			if tc.want == "" {
+				require.False(t, addr.IsValid())
+				return
+			}
+			require.True(t, addr.IsValid())
+			require.Equal(t, tc.want, addr.String())
+		})
+	}
+}

--- a/src/go/pkg/l2topology/internal/keyutil/keyutil.go
+++ b/src/go/pkg/l2topology/internal/keyutil/keyutil.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package keyutil
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Sep separates delimiter-based identifiers that some topology paths still split later.
+// Opaque keys built from observation data should use OpaqueCompositeKey instead.
+const Sep = "\x00"
+
+func OpaqueCompositeKey(parts ...string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, part := range parts {
+		b.WriteString(strconv.Itoa(len(part)))
+		b.WriteByte(':')
+		b.WriteString(part)
+	}
+	return b.String()
+}
+
+func DeviceIfIndexKey(deviceID string, ifIndex int) string {
+	return OpaqueCompositeKey(deviceID, strconv.Itoa(ifIndex))
+}

--- a/src/go/pkg/l2topology/internal/keyutil/keyutil.go
+++ b/src/go/pkg/l2topology/internal/keyutil/keyutil.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+// Package keyutil contains shared internal topology key helpers for the L2
+// pipeline and graph projection code.
 package keyutil
 
 import (

--- a/src/go/pkg/l2topology/internal/keyutil/keyutil_test.go
+++ b/src/go/pkg/l2topology/internal/keyutil/keyutil_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package keyutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpaqueCompositeKey(t *testing.T) {
+	tests := map[string]struct {
+		parts []string
+		want  string
+	}{
+		"empty": {
+			want: "",
+		},
+		"encodes lengths": {
+			parts: []string{"a:b", "c"},
+			want:  "3:a:b1:c",
+		},
+		"preserves empty parts": {
+			parts: []string{"a", "", "b"},
+			want:  "1:a0:1:b",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, OpaqueCompositeKey(tc.parts...))
+		})
+	}
+}
+
+func TestDeviceIfIndexKey(t *testing.T) {
+	require.Equal(t, OpaqueCompositeKey("switch-a", "7"), DeviceIfIndexKey("switch-a", 7))
+}

--- a/src/go/pkg/l2topology/internal/model/labels.go
+++ b/src/go/pkg/l2topology/internal/model/labels.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package model
+
+const (
+	AdjacencyLabelPairID   = "pair_id"
+	AdjacencyLabelPairPass = "pair_pass"
+)
+
+const (
+	LLDPMatchPassDefault      = "default"
+	LLDPMatchPassPortDesc     = "port_description"
+	LLDPMatchPassSysName      = "sysname"
+	LLDPMatchPassChassisPort  = "chassis_port_id_subtype"
+	LLDPMatchPassChassisDescr = "chassis_port_descr"
+	LLDPMatchPassChassis      = "chassis"
+	CDPMatchPassDefault       = "default"
+)

--- a/src/go/pkg/l2topology/internal/pipeline/address_normalization.go
+++ b/src/go/pkg/l2topology/internal/pipeline/address_normalization.go
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"net/netip"
-	"strings"
 
 	"github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/addrnorm"
 )
@@ -39,11 +38,7 @@ func canonicalIP(v string) string {
 }
 
 func parseAddr(v string) netip.Addr {
-	addr, err := netip.ParseAddr(strings.TrimSpace(v))
-	if err != nil {
-		return netip.Addr{}
-	}
-	return addr.Unmap()
+	return addrnorm.ParseAddr(v)
 }
 
 func decodeHexIP(v string) string {

--- a/src/go/pkg/l2topology/internal/pipeline/adjacencies.go
+++ b/src/go/pkg/l2topology/internal/pipeline/adjacencies.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import "strings"
 

--- a/src/go/pkg/l2topology/internal/pipeline/builder.go
+++ b/src/go/pkg/l2topology/internal/pipeline/builder.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"strings"

--- a/src/go/pkg/l2topology/internal/pipeline/collections.go
+++ b/src/go/pkg/l2topology/internal/pipeline/collections.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"net/netip"

--- a/src/go/pkg/l2topology/internal/pipeline/endpoints.go
+++ b/src/go/pkg/l2topology/internal/pipeline/endpoints.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"strconv"

--- a/src/go/pkg/l2topology/internal/pipeline/enrichment.go
+++ b/src/go/pkg/l2topology/internal/pipeline/enrichment.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"maps"

--- a/src/go/pkg/l2topology/internal/pipeline/fdb.go
+++ b/src/go/pkg/l2topology/internal/pipeline/fdb.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"sort"

--- a/src/go/pkg/l2topology/internal/pipeline/fdb_test.go
+++ b/src/go/pkg/l2topology/internal/pipeline/fdb_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"testing"

--- a/src/go/pkg/l2topology/internal/pipeline/keys.go
+++ b/src/go/pkg/l2topology/internal/pipeline/keys.go
@@ -1,29 +1,19 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/keyutil"
 )
 
-// keySep separates delimiter-based identifiers that some topology paths still split later.
-// Opaque keys built from observation data should use opaqueCompositeKey() instead.
-const keySep = "\x00"
+const keySep = keyutil.Sep
 
 func opaqueCompositeKey(parts ...string) string {
-	if len(parts) == 0 {
-		return ""
-	}
-
-	var b strings.Builder
-	for _, part := range parts {
-		b.WriteString(strconv.Itoa(len(part)))
-		b.WriteByte(':')
-		b.WriteString(part)
-	}
-	return b.String()
+	return keyutil.OpaqueCompositeKey(parts...)
 }
 
 func topologyMatchCompositeKey(parts ...string) string {
@@ -65,7 +55,7 @@ func ifaceKey(iface Interface) string {
 }
 
 func deviceIfIndexKey(deviceID string, ifIndex int) string {
-	return opaqueCompositeKey(deviceID, strconv.Itoa(ifIndex))
+	return keyutil.DeviceIfIndexKey(deviceID, ifIndex)
 }
 
 func deriveBridgeDomainFromIfIndex(deviceID string, ifIndex int) string {

--- a/src/go/pkg/l2topology/internal/pipeline/keys_test.go
+++ b/src/go/pkg/l2topology/internal/pipeline/keys_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"testing"

--- a/src/go/pkg/l2topology/internal/pipeline/labels.go
+++ b/src/go/pkg/l2topology/internal/pipeline/labels.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package pipeline
+
+import "github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/model"
+
+const (
+	adjacencyLabelPairID   = model.AdjacencyLabelPairID
+	adjacencyLabelPairPass = model.AdjacencyLabelPairPass
+)
+
+const (
+	lldpMatchPassDefault      = model.LLDPMatchPassDefault
+	lldpMatchPassPortDesc     = model.LLDPMatchPassPortDesc
+	lldpMatchPassSysName      = model.LLDPMatchPassSysName
+	lldpMatchPassChassisPort  = model.LLDPMatchPassChassisPort
+	lldpMatchPassChassisDescr = model.LLDPMatchPassChassisDescr
+	lldpMatchPassChassis      = model.LLDPMatchPassChassis
+	cdpMatchPassDefault       = model.CDPMatchPassDefault
+)

--- a/src/go/pkg/l2topology/internal/pipeline/lldp_normalization.go
+++ b/src/go/pkg/l2topology/internal/pipeline/lldp_normalization.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"encoding/hex"

--- a/src/go/pkg/l2topology/internal/pipeline/match_cdp.go
+++ b/src/go/pkg/l2topology/internal/pipeline/match_cdp.go
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"strconv"
 	"strings"
 )
-
-const cdpMatchPassDefault = "default"
 
 type cdpMatchLink struct {
 	index int

--- a/src/go/pkg/l2topology/internal/pipeline/match_lldp.go
+++ b/src/go/pkg/l2topology/internal/pipeline/match_lldp.go
@@ -1,17 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import "strings"
-
-const (
-	lldpMatchPassDefault      = "default"
-	lldpMatchPassPortDesc     = "port_description"
-	lldpMatchPassSysName      = "sysname"
-	lldpMatchPassChassisPort  = "chassis_port_id_subtype"
-	lldpMatchPassChassisDescr = "chassis_port_descr"
-	lldpMatchPassChassis      = "chassis"
-)
 
 type lldpMatchLink struct {
 	index int

--- a/src/go/pkg/l2topology/internal/pipeline/model_aliases.go
+++ b/src/go/pkg/l2topology/internal/pipeline/model_aliases.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package pipeline
+
+import "github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/model"
+
+type DiscoverOptions = model.DiscoverOptions
+type Result = model.Result
+type Device = model.Device
+type Interface = model.Interface
+type Adjacency = model.Adjacency
+type Attachment = model.Attachment
+type Enrichment = model.Enrichment
+type L2Observation = model.L2Observation
+type ObservedInterface = model.ObservedInterface
+type LLDPRemoteObservation = model.LLDPRemoteObservation
+type CDPRemoteObservation = model.CDPRemoteObservation
+type BridgePortObservation = model.BridgePortObservation
+type FDBObservation = model.FDBObservation
+type STPPortObservation = model.STPPortObservation
+type ARPNDObservation = model.ARPNDObservation
+type ResultStats = model.ResultStats

--- a/src/go/pkg/l2topology/internal/pipeline/normalization.go
+++ b/src/go/pkg/l2topology/internal/pipeline/normalization.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import "strings"
 

--- a/src/go/pkg/l2topology/internal/pipeline/normalization_test.go
+++ b/src/go/pkg/l2topology/internal/pipeline/normalization_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"testing"

--- a/src/go/pkg/l2topology/internal/pipeline/pairing.go
+++ b/src/go/pkg/l2topology/internal/pipeline/pairing.go
@@ -1,13 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import "strings"
-
-const (
-	adjacencyLabelPairID   = "pair_id"
-	adjacencyLabelPairPass = "pair_pass"
-)
 
 type matchedPairMetadata struct {
 	id   string

--- a/src/go/pkg/l2topology/internal/pipeline/pipeline.go
+++ b/src/go/pkg/l2topology/internal/pipeline/pipeline.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package pipeline
+
+import "errors"
+
+const (
+	fdbStatusLearned = "learned"
+	fdbStatusSelf    = "self"
+	fdbStatusIgnored = "ignored"
+)
+
+// BuildL2ResultFromObservations converts normalized L2 observations into a
+// deterministic L2 topology result. Callers that need a stable timestamp should
+// set DiscoverOptions.CollectedAt explicitly.
+func BuildL2ResultFromObservations(observations []L2Observation, opts DiscoverOptions) (Result, error) {
+	if len(observations) == 0 {
+		return Result{}, errors.New("at least one observation is required")
+	}
+	if !opts.EnableLLDP && !opts.EnableCDP && !opts.EnableBridge && !opts.EnableARP && !opts.EnableSTP {
+		opts.EnableLLDP = true
+		opts.EnableCDP = true
+	}
+
+	state := newL2BuildState(len(observations))
+	if err := state.registerObservations(observations); err != nil {
+		return Result{}, err
+	}
+	if opts.EnableLLDP {
+		state.applyLLDP(observations)
+	}
+	if opts.EnableCDP {
+		state.applyCDP(observations)
+	}
+	if opts.EnableSTP {
+		state.applySTP(observations)
+	}
+	if opts.EnableBridge {
+		state.applyBridge(observations)
+	}
+	if opts.EnableARP {
+		state.applyARP(observations)
+	}
+
+	identityAliasStats := reconcileDeviceIdentityAliases(state.devices, state.interfaces, state.enrichments)
+	state.markManagedDevices()
+
+	return state.buildResult(identityAliasStats, opts.CollectedAt), nil
+}

--- a/src/go/pkg/l2topology/internal/pipeline/pipeline_test.go
+++ b/src/go/pkg/l2topology/internal/pipeline/pipeline_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"testing"

--- a/src/go/pkg/l2topology/internal/pipeline/registration.go
+++ b/src/go/pkg/l2topology/internal/pipeline/registration.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"fmt"

--- a/src/go/pkg/l2topology/internal/pipeline/remote_resolution.go
+++ b/src/go/pkg/l2topology/internal/pipeline/remote_resolution.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"net/netip"

--- a/src/go/pkg/l2topology/internal/pipeline/remote_resolution_test.go
+++ b/src/go/pkg/l2topology/internal/pipeline/remote_resolution_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"testing"

--- a/src/go/pkg/l2topology/internal/pipeline/sorting.go
+++ b/src/go/pkg/l2topology/internal/pipeline/sorting.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package l2topology
+package pipeline
 
 import (
 	"sort"

--- a/src/go/pkg/l2topology/internal/pipeline/test_helpers_test.go
+++ b/src/go/pkg/l2topology/internal/pipeline/test_helpers_test.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package pipeline
+
+import "net/netip"
+
+func addressStrings(addresses []netip.Addr) []string {
+	if len(addresses) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(addresses))
+	for _, addr := range addresses {
+		if !addr.IsValid() {
+			continue
+		}
+		out = append(out, addr.Unmap().String())
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/src/go/pkg/l2topology/l2_pipeline.go
+++ b/src/go/pkg/l2topology/l2_pipeline.go
@@ -2,48 +2,11 @@
 
 package l2topology
 
-import "errors"
-
-const (
-	fdbStatusLearned = "learned"
-	fdbStatusSelf    = "self"
-	fdbStatusIgnored = "ignored"
-)
+import "github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/pipeline"
 
 // BuildL2ResultFromObservations converts normalized L2 observations into a
 // deterministic L2 topology result. Callers that need a stable timestamp should
 // set DiscoverOptions.CollectedAt explicitly.
 func BuildL2ResultFromObservations(observations []L2Observation, opts DiscoverOptions) (Result, error) {
-	if len(observations) == 0 {
-		return Result{}, errors.New("at least one observation is required")
-	}
-	if !opts.EnableLLDP && !opts.EnableCDP && !opts.EnableBridge && !opts.EnableARP && !opts.EnableSTP {
-		opts.EnableLLDP = true
-		opts.EnableCDP = true
-	}
-
-	state := newL2BuildState(len(observations))
-	if err := state.registerObservations(observations); err != nil {
-		return Result{}, err
-	}
-	if opts.EnableLLDP {
-		state.applyLLDP(observations)
-	}
-	if opts.EnableCDP {
-		state.applyCDP(observations)
-	}
-	if opts.EnableSTP {
-		state.applySTP(observations)
-	}
-	if opts.EnableBridge {
-		state.applyBridge(observations)
-	}
-	if opts.EnableARP {
-		state.applyARP(observations)
-	}
-
-	identityAliasStats := reconcileDeviceIdentityAliases(state.devices, state.interfaces, state.enrichments)
-	state.markManagedDevices()
-
-	return state.buildResult(identityAliasStats, opts.CollectedAt), nil
+	return pipeline.BuildL2ResultFromObservations(observations, opts)
 }

--- a/src/go/pkg/l2topology/topology_adapter_address_normalization.go
+++ b/src/go/pkg/l2topology/topology_adapter_address_normalization.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package l2topology
+
+import (
+	"net/netip"
+
+	"github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/addrnorm"
+)
+
+func normalizeMAC(value string) string {
+	return addrnorm.NormalizeMAC(value)
+}
+
+func parseAddr(value string) netip.Addr {
+	return addrnorm.ParseAddr(value)
+}

--- a/src/go/pkg/l2topology/topology_adapter_keys.go
+++ b/src/go/pkg/l2topology/topology_adapter_keys.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package l2topology
+
+import (
+	"github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/keyutil"
+	"github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/model"
+)
+
+const keySep = keyutil.Sep
+
+const (
+	adjacencyLabelPairID   = model.AdjacencyLabelPairID
+	adjacencyLabelPairPass = model.AdjacencyLabelPairPass
+)
+
+const (
+	lldpMatchPassDefault      = model.LLDPMatchPassDefault
+	lldpMatchPassPortDesc     = model.LLDPMatchPassPortDesc
+	lldpMatchPassSysName      = model.LLDPMatchPassSysName
+	lldpMatchPassChassisPort  = model.LLDPMatchPassChassisPort
+	lldpMatchPassChassisDescr = model.LLDPMatchPassChassisDescr
+	lldpMatchPassChassis      = model.LLDPMatchPassChassis
+	cdpMatchPassDefault       = model.CDPMatchPassDefault
+)
+
+func deviceIfIndexKey(deviceID string, ifIndex int) string {
+	return keyutil.DeviceIfIndexKey(deviceID, ifIndex)
+}

--- a/src/go/pkg/l2topology/topology_adapter_keys.go
+++ b/src/go/pkg/l2topology/topology_adapter_keys.go
@@ -14,16 +14,6 @@ const (
 	adjacencyLabelPairPass = model.AdjacencyLabelPairPass
 )
 
-const (
-	lldpMatchPassDefault      = model.LLDPMatchPassDefault
-	lldpMatchPassPortDesc     = model.LLDPMatchPassPortDesc
-	lldpMatchPassSysName      = model.LLDPMatchPassSysName
-	lldpMatchPassChassisPort  = model.LLDPMatchPassChassisPort
-	lldpMatchPassChassisDescr = model.LLDPMatchPassChassisDescr
-	lldpMatchPassChassis      = model.LLDPMatchPassChassis
-	cdpMatchPassDefault       = model.CDPMatchPassDefault
-)
-
 func deviceIfIndexKey(deviceID string, ifIndex int) string {
 	return keyutil.DeviceIfIndexKey(deviceID, ifIndex)
 }

--- a/src/go/pkg/l2topology/topology_adapter_keys_test.go
+++ b/src/go/pkg/l2topology/topology_adapter_keys_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package l2topology
+
+import "github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/model"
+
+const (
+	lldpMatchPassDefault  = model.LLDPMatchPassDefault
+	lldpMatchPassPortDesc = model.LLDPMatchPassPortDesc
+	cdpMatchPassDefault   = model.CDPMatchPassDefault
+)


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the L2 topology build pipeline into `internal/pipeline` to encapsulate internals while keeping the public `l2topology` API unchanged. Adds small utilities for address parsing and key construction, with tests.

- **Refactors**
  - `l2topology.BuildL2ResultFromObservations` now delegates to `internal/pipeline.BuildL2ResultFromObservations`.
  - Introduced `internal/keyutil` (`OpaqueCompositeKey`, `DeviceIfIndexKey`, `Sep`); top-level adapter exposes `keySep` and `deviceIfIndexKey`.
  - Added `addrnorm.ParseAddr` and used it in the pipeline; top-level adapter keeps `parseAddr`/`normalizeMAC`.
  - Moved labels and match-pass constants to `internal/model`; re-exported via `internal/pipeline`. Top-level retains adjacency pair labels; LLDP/CDP match-pass aliases are defined only in tests.
  - Added unit tests for new utilities and moved pipeline tests alongside the internal code.

<sup>Written for commit 9d3a2abd15473610e4bfa1c805f6df00ab3feaee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

