### PR TITLE
Fix coverity issues

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup_ebpfgo_cachestat.c
+++ b/src/collectors/cgroups.plugin/cgroup_ebpfgo_cachestat.c
@@ -36,8 +36,7 @@ static procfile *cgroup_ebpfgo_open_nonempty_procs_file(char *path_buf, size_t p
                 if (read) {
                     size_t lines = procfile_lines(read);
                     if (lines > 0) {
-                        if (path_buf && path_buf_size)
-                            snprintfz(best_path, sizeof(best_path) - 1, "%s", path_buf);
+                        snprintfz(best_path, sizeof(best_path) - 1, "%s", path_buf);
                         best = read;
                     } else {
                         procfile_close(read);
@@ -49,8 +48,7 @@ static procfile *cgroup_ebpfgo_open_nonempty_procs_file(char *path_buf, size_t p
         }
 
         if (best) {
-            if (path_buf && path_buf_size)
-                snprintfz(path_buf, path_buf_size - 1, "%s", best_path);
+            snprintfz(path_buf, path_buf_size - 1, "%s", best_path);
             return best;
         }
 

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -4,6 +4,8 @@
 
 #include <array>
 
+#include <dlib/error.h>
+
 #include "ad_charts.h"
 #include "sqlite3.h"
 #include "streaming/stream-control.h"
@@ -1008,10 +1010,13 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
         try {
             ml_kmeans_train(&dim->kmeans, worker->training_samples, Cfg.max_kmeans_iters, training_response.query_after_t, training_response.query_before_t);
         }
-        catch (const std::exception &e) {
-            // dlib (kmeans/matrix) can throw dlib::fatal_error on numerical
-            // edge cases. Letting it escape ml_train_main terminates the
-            // process. Skip this dimension's model for this round instead.
+        catch (const dlib::error &e) {
+            // dlib (kmeans/matrix) can throw dlib::fatal_error (and other
+            // dlib::error subtypes) on numerical edge cases. Letting it escape
+            // ml_train_main terminates the process. Skip this dimension's model
+            // for this round instead. A non-dlib std::exception such as
+            // std::bad_alloc is a genuine fatal condition, not a transient
+            // training failure, so it is intentionally left to propagate.
             // Clear training_in_progress here (the normal path clears it via
             // ml_dimension_update_models()); otherwise the precheck would keep
             // returning TRAINING_IN_PROGRESS and the dimension would be stuck.

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1012,7 +1012,15 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
             // dlib (kmeans/matrix) can throw dlib::fatal_error on numerical
             // edge cases. Letting it escape ml_train_main terminates the
             // process. Skip this dimension's model for this round instead.
+            // Clear training_in_progress here (the normal path clears it via
+            // ml_dimension_update_models()); otherwise the precheck would keep
+            // returning TRAINING_IN_PROGRESS and the dimension would be stuck.
+            // Do NOT finalize constant state -- this is a transient failure and
+            // the dimension should retrain normally next round.
             netdata_log_error("ML: KMeans training raised an exception (%s); skipping model creation for this dimension this round", e.what());
+            spinlock_lock(&dim->slock);
+            dim->training_in_progress = false;
+            spinlock_unlock(&dim->slock);
             return ML_WORKER_RESULT_NOT_ENOUGH_COLLECTED_VALUES;
         }
     }

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1005,7 +1005,16 @@ ml_dimension_train_model(ml_worker_t *worker, ml_dimension_t *dim)
         }
 
         ml_kmeans_init(&dim->kmeans);
-        ml_kmeans_train(&dim->kmeans, worker->training_samples, Cfg.max_kmeans_iters, training_response.query_after_t, training_response.query_before_t);
+        try {
+            ml_kmeans_train(&dim->kmeans, worker->training_samples, Cfg.max_kmeans_iters, training_response.query_after_t, training_response.query_before_t);
+        }
+        catch (const std::exception &e) {
+            // dlib (kmeans/matrix) can throw dlib::fatal_error on numerical
+            // edge cases. Letting it escape ml_train_main terminates the
+            // process. Skip this dimension's model for this round instead.
+            netdata_log_error("ML: KMeans training raised an exception (%s); skipping model creation for this dimension this round", e.what());
+            return ML_WORKER_RESULT_NOT_ENOUGH_COLLECTED_VALUES;
+        }
     }
 
     // update models

--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -511,8 +511,11 @@ static void stream_receiver_remove_internal(struct stream_thread *sth, struct re
 
     receiver_set_exit_reason(rpt, reason, false);
 
+    // rpt->host may be NULL here (e.g. removal on an early handshake failure,
+    // before the host is attached) -- this path null-checks it below at the
+    // iface/replication reads, so guard the log field too.
     ND_LOG_STACK lgs[] = {
-        ND_LOG_FIELD_STR(NDF_NIDL_NODE, rpt->host->hostname),
+        ND_LOG_FIELD_STR(NDF_NIDL_NODE, rpt->host ? rpt->host->hostname : NULL),
         ND_LOG_FIELD_TXT(NDF_SRC_IP, rpt->remote_ip),
         ND_LOG_FIELD_TXT(NDF_SRC_PORT, rpt->remote_port),
         ND_LOG_FIELD_CB(NDF_SRC_TRANSPORT, stream_receiver_log_transport, rpt),


### PR DESCRIPTION
##### Summary
- stream-receiver: guard rpt->host in disconnect log field; it can be NULL on early handshake-failure removal (consistent with the host checks below) [CID 503806]
- cgroup_ebpfgo_cachestat: drop redundant path_buf null-checks; the sole caller passes a stack array, so the checks (not the derefs) were the defect [CID 503817]
- ml: catch dlib exceptions from ml_kmeans_train so a numerical fatal_error skips the model for one round (clearing training_in_progress) instead of terminating the training thread or leaving the dimension stuck [CID 503827]



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three Coverity findings to improve stability: guards a potential null dereference in stream receiver logs, treats ML KMeans numerical errors as transient to avoid aborts and stuck state, and removes redundant checks in cgroup cache stat.

- **Bug Fixes**
  - stream-receiver: Guard `rpt->host` in disconnect logs to avoid null deref on early handshake failures.
  - cgroup_ebpfgo_cachestat: Remove redundant `path_buf` null checks; caller always passes a stack buffer.
  - ML: Catch `dlib::error` from `ml_kmeans_train`, log it, clear `training_in_progress`, and skip the model for this round; let non-dlib exceptions propagate.

<sup>Written for commit dc8034e11a53826b2bb18180c2abd86151263b45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



