### PR TITLE
fix(go.d/snmp-topology): preserve capability actor type

### DIFF
--- a/src/go/pkg/l2topology/internal/model/types.go
+++ b/src/go/pkg/l2topology/internal/model/types.go
@@ -89,6 +89,7 @@ type L2Observation struct {
 	SysObjectID       string
 	ChassisID         string
 	BaseBridgeAddress string
+	Labels            map[string]string
 	Interfaces        []ObservedInterface
 	BridgePorts       []BridgePortObservation
 	STPPorts          []STPPortObservation

--- a/src/go/pkg/l2topology/internal/pipeline/pipeline_test.go
+++ b/src/go/pkg/l2topology/internal/pipeline/pipeline_test.go
@@ -179,6 +179,31 @@ func TestBuildL2ResultFromObservations_DeviceProtocolsObservedLabel(t *testing.T
 	require.Equal(t, "arp,bridge,fdb,stp", result.Devices[0].Labels["protocols_observed"])
 }
 
+func TestBuildL2ResultFromObservations_PreservesObservationDeviceLabels(t *testing.T) {
+	observations := []model.L2Observation{
+		{
+			DeviceID: "router-a",
+			Hostname: "router-a.example.test",
+			Labels: map[string]string{
+				"type":   "router",
+				"vendor": "synthetic",
+			},
+			BridgePorts: []model.BridgePortObservation{
+				{BasePort: "3", IfIndex: 3},
+			},
+		},
+	}
+
+	result, err := BuildL2ResultFromObservations(observations, model.DiscoverOptions{EnableBridge: true})
+	require.NoError(t, err)
+
+	device := findDeviceByID(result.Devices, "router-a")
+	require.NotNil(t, device)
+	require.Equal(t, "router", device.Labels["type"])
+	require.Equal(t, "synthetic", device.Labels["vendor"])
+	require.Equal(t, "bridge", device.Labels["protocols_observed"])
+}
+
 func TestBuildL2ResultFromObservations_MergesDuplicateDeviceObservations(t *testing.T) {
 	observations := []model.L2Observation{
 		{

--- a/src/go/pkg/l2topology/internal/pipeline/registration.go
+++ b/src/go/pkg/l2topology/internal/pipeline/registration.go
@@ -31,6 +31,7 @@ func (s *l2BuildState) registerObservation(obs model.L2Observation) error {
 		Hostname:  strings.TrimSpace(obs.Hostname),
 		SysObject: strings.TrimSpace(obs.SysObjectID),
 		ChassisID: strings.TrimSpace(obs.ChassisID),
+		Labels:    mergeObservedDeviceLabels(nil, obs.Labels),
 	}
 	if primaryMAC := primaryL2MACIdentity(obs.ChassisID, obs.BaseBridgeAddress); primaryMAC != "" {
 		device.ChassisID = primaryMAC

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
@@ -579,6 +579,46 @@ func TestTopologyCache_LLDPManagementAddressesAndCaps(t *testing.T) {
 	}))
 }
 
+func TestTopologyCache_LLDPCapabilitiesDriveLocalActorType(t *testing.T) {
+	tests := map[string]struct {
+		sysName      string
+		capabilities string
+		wantType     string
+	}{
+		"bridge":        {sysName: "switch-a", capabilities: "20", wantType: "switch"},
+		"bridge-router": {sysName: "l3-switch-a", capabilities: "28", wantType: "router"},
+		"none":          {sysName: "device-a", capabilities: "", wantType: "device"},
+		"router":        {sysName: "router-a", capabilities: "08", wantType: "router"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := newTestTopologyCache(ddsnmp.DeviceConnectionInfo{
+				Hostname: tc.sysName + ".example.test",
+				SysName:  tc.sysName,
+			})
+			if tc.capabilities != "" {
+				cache.updateTopologyProfileTags([]*ddsnmp.ProfileMetrics{{
+					DeviceMetadata: map[string]ddsnmp.MetaTag{
+						tagLldpLocChassisID:        {Value: "00:11:22:33:44:55"},
+						tagLldpLocChassisIDSubtype: {Value: "4"},
+						tagLldpLocSysCapEnabled:    {Value: tc.capabilities},
+						tagLldpLocSysCapSupported:  {Value: tc.capabilities},
+					},
+				}})
+			}
+			cache.finalizeTopologyCache()
+
+			data, ok := snapshotTopologyCacheForTest(cache)
+			require.True(t, ok)
+
+			actor := findManagedDeviceActorBySysName(data, tc.sysName)
+			require.NotNil(t, actor)
+			require.Equal(t, tc.wantType, actor.ActorType)
+		})
+	}
+}
+
 func TestTopologyCache_CDPManagementAddresses(t *testing.T) {
 	cache := newTopologyCache()
 	cache.updateTime = time.Now()
@@ -1587,9 +1627,13 @@ func linkHasRawAddressHint(link topologymodel.Link, raw string) bool {
 }
 
 func findDeviceActorBySysName(snapshot topologymodel.Data, sysName string) *topologymodel.Actor {
+	return findManagedDeviceActorBySysName(snapshot, sysName)
+}
+
+func findManagedDeviceActorBySysName(snapshot topologymodel.Data, sysName string) *topologymodel.Actor {
 	for i := range snapshot.Actors {
 		actor := &snapshot.Actors[i]
-		if actor.ActorType != "device" {
+		if !topologyengine.IsDeviceActorType(actor.ActorType) {
 			continue
 		}
 		if actor.Match.SysName == sysName {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local.go
@@ -30,6 +30,7 @@ func (c *topologyCache) buildEngineObservation(local topologymodel.Device) topol
 		SysObjectID:       strings.TrimSpace(local.SysObjectID),
 		ChassisID:         strings.TrimSpace(local.ChassisID),
 		BaseBridgeAddress: baseBridgeAddress,
+		Labels:            cloneTopologyLabels(local.Labels),
 	}
 	if observation.BaseBridgeAddress == "" {
 		observation.BaseBridgeAddress = stpBridgeAddressToMAC(observation.ChassisID)


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves capability-derived actor type (switch/router/device) in `go.d/snmp-topology` and carries device labels from observations through the L2 pipeline. Prevents managed device actors from being downgraded to a generic `device`.

- **Bug Fixes**
  - Map LLDP capabilities to the local actor type and keep it during cache finalization.
  - Accept any device actor kind by using `IsDeviceActorType` instead of filtering only `device`.
  - Add `Labels` to `L2Observation` and merge them into device results to preserve values like `type` and `vendor`.
  - Add tests for actor type selection and label preservation.

<sup>Written for commit 1f2ae5fb523501de7014f37cefc57fa7c2722a96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

