### PR TITLE
fix(go.d/snmp): tolerate invalid optional typed row values

### DIFF
--- a/.agents/sow/specs/snmp-profile-projection.md
+++ b/.agents/sow/specs/snmp-profile-projection.md
@@ -147,6 +147,12 @@ Supported licensing signal fields are:
 Timer signals may declare exactly one of the shorthand timer value,
 `timestamp`, or `remaining`. Sentinel policies are closed names and are
 evaluated by the typed licensing producer before runtime consumers see the row.
+Known no-value timer placeholders are treated as absent rather than as expired.
+For `snmp_dateandtime`, a one-byte zero placeholder (`"0"` or `0x00`) is a
+known no-value placeholder and is warning-logged through limited logging.
+Malformed timer values are also treated as absent and warning-logged through
+limited logging, so valid state/usage from the same row remains visible.
+Identity, state, and usage values remain strict row errors.
 
 ## BGP Rows
 
@@ -207,6 +213,11 @@ fields are `peers`, `ibgp_peers`, `ebgp_peers`, and per-state fields under
 Peer rows must declare stable `neighbor` and `remote_as` identity fields.
 Peer-family rows must additionally declare canonical `address_family` and
 `subsequent_address_family` identity fields.
+
+BGP descriptor fields are enrichment-only. Descriptor decode failures omit that
+descriptor and keep the row, while identity, state, and signal decode failures
+remain strict row errors. Descriptor omissions are debug-logged so profile
+authoring defects are diagnosable without noisy default logs.
 
 The BGP state mapping is a closed RFC 4271 state contract. Rows that declare
 state must map all six states by default:

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/cisco_bgp_prefix_external_fixture_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/cisco_bgp_prefix_external_fixture_test.go
@@ -66,6 +66,45 @@ func TestCollector_Collect_CiscoBgpPeer2Prefixes_FromLibreNMSFixtures(t *testing
 	}
 }
 
+func TestCollector_Collect_CiscoBgpPeer2PrefixRows_OmitsInvalidOptionalLocalAddress(t *testing.T) {
+	ctrl, mockHandler := setupMockHandler(t)
+	defer ctrl.Finish()
+
+	prefixIndex := "1.4.198.19.220.34.1.128"
+	peerIndex := "1.4.198.19.220.34"
+
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.4.1.9.9.187.1.2.8", []gosnmp.SnmpPDU{
+		createCounter32PDU("1.3.6.1.4.1.9.9.187.1.2.8.1.1."+prefixIndex, 12),
+	})
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.4.1.9.9.187.1.2.5.1", []gosnmp.SnmpPDU{
+		createPDU("1.3.6.1.4.1.9.9.187.1.2.5.1.6."+peerIndex, gosnmp.OctetString, []byte("00 00 7F C3 ")),
+		createGauge32PDU("1.3.6.1.4.1.9.9.187.1.2.5.1.11."+peerIndex, 65001),
+	})
+
+	profile := matchedProfileByFile(t, "1.3.6.1.4.1.9.1.923", "cisco-asr.yaml")
+	filterProfileForTypedBGPByID(t, profile, "cisco-bgp-peer-family")
+
+	collector := New(Config{
+		SnmpClient:  mockHandler,
+		Profiles:    []*ddsnmp.Profile{profile},
+		Log:         logger.New(),
+		SysObjectID: "1.3.6.1.4.1.9.1.923",
+	})
+
+	results, err := collector.Collect()
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Len(t, results[0].BGPRows, 1)
+
+	row := results[0].BGPRows[0]
+	assert.Equal(t, "198.19.220.34", row.Identity.Neighbor)
+	assert.Equal(t, "65001", row.Identity.RemoteAS)
+	assert.Equal(t, "ipv4", string(row.Identity.AddressFamily))
+	assert.Equal(t, "vpn", string(row.Identity.SubsequentAddressFamily))
+	assert.Empty(t, row.Descriptors.LocalAddress)
+	assert.EqualValues(t, 12, row.Routes.Current.Accepted.Value)
+}
+
 func collectCiscoPeer2PrefixRowsFromFixture(t *testing.T, sysObjectID, profileFile, fixturePath string) []ddsnmp.BGPRow {
 	t.Helper()
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_bgp.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_bgp.go
@@ -816,6 +816,8 @@ func (c *Collector) bgpTextValue(cfg ddprofiledefinition.BGPValueConfig, ctx bgp
 func (c *Collector) bgpOptionalTextValue(cfg ddprofiledefinition.BGPValueConfig, ctx bgpValueContext) string {
 	value, err := c.bgpTextValue(cfg, ctx)
 	if err != nil {
+		sym := bgpValueSymbol(cfg)
+		c.log.Debugf("BGP optional descriptor %q on table %q row %q is unavailable: %v", sym.Name, ctx.tableName, ctx.rowIndex, err)
 		// Descriptors enrich the row, but identity and signals already decide
 		// whether the row is usable. Some devices publish malformed descriptor
 		// placeholders, so keep the row and omit the descriptor.

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_bgp.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_bgp.go
@@ -401,27 +401,13 @@ func (c *Collector) populateBGPRow(row *ddsnmp.BGPRow, cfg ddprofiledefinition.B
 	if row.Identity.SubsequentAddressFamily, err = c.bgpSubsequentAddressFamilyValue(cfg.Identity.SubsequentAddressFamily.BGPValueConfig, ctx); err != nil {
 		return fmt.Errorf("identity.subsequent_address_family: %w", err)
 	}
-	if row.Descriptors.LocalAddress, err = c.bgpTextValue(cfg.Descriptors.LocalAddress, ctx); err != nil {
-		return fmt.Errorf("descriptors.local_address: %w", err)
-	}
-	if row.Descriptors.LocalAS, err = c.bgpTextValue(cfg.Descriptors.LocalAS, ctx); err != nil {
-		return fmt.Errorf("descriptors.local_as: %w", err)
-	}
-	if row.Descriptors.LocalIdentifier, err = c.bgpTextValue(cfg.Descriptors.LocalIdentifier, ctx); err != nil {
-		return fmt.Errorf("descriptors.local_identifier: %w", err)
-	}
-	if row.Descriptors.PeerIdentifier, err = c.bgpTextValue(cfg.Descriptors.PeerIdentifier, ctx); err != nil {
-		return fmt.Errorf("descriptors.peer_identifier: %w", err)
-	}
-	if row.Descriptors.PeerType, err = c.bgpTextValue(cfg.Descriptors.PeerType, ctx); err != nil {
-		return fmt.Errorf("descriptors.peer_type: %w", err)
-	}
-	if row.Descriptors.BGPVersion, err = c.bgpTextValue(cfg.Descriptors.BGPVersion, ctx); err != nil {
-		return fmt.Errorf("descriptors.bgp_version: %w", err)
-	}
-	if row.Descriptors.Description, err = c.bgpTextValue(cfg.Descriptors.Description, ctx); err != nil {
-		return fmt.Errorf("descriptors.description: %w", err)
-	}
+	row.Descriptors.LocalAddress = c.bgpOptionalTextValue(cfg.Descriptors.LocalAddress, ctx)
+	row.Descriptors.LocalAS = c.bgpOptionalTextValue(cfg.Descriptors.LocalAS, ctx)
+	row.Descriptors.LocalIdentifier = c.bgpOptionalTextValue(cfg.Descriptors.LocalIdentifier, ctx)
+	row.Descriptors.PeerIdentifier = c.bgpOptionalTextValue(cfg.Descriptors.PeerIdentifier, ctx)
+	row.Descriptors.PeerType = c.bgpOptionalTextValue(cfg.Descriptors.PeerType, ctx)
+	row.Descriptors.BGPVersion = c.bgpOptionalTextValue(cfg.Descriptors.BGPVersion, ctx)
+	row.Descriptors.Description = c.bgpOptionalTextValue(cfg.Descriptors.Description, ctx)
 
 	if err := c.populateBGPStateValue(&row.State, cfg.State, ctx); err != nil {
 		return fmt.Errorf("state: %w", err)
@@ -825,6 +811,17 @@ func (c *Collector) bgpTextValue(cfg ddprofiledefinition.BGPValueConfig, ctx bgp
 		value = mapped
 	}
 	return value, nil
+}
+
+func (c *Collector) bgpOptionalTextValue(cfg ddprofiledefinition.BGPValueConfig, ctx bgpValueContext) string {
+	value, err := c.bgpTextValue(cfg, ctx)
+	if err != nil {
+		// Descriptors enrich the row, but identity and signals already decide
+		// whether the row is usable. Some devices publish malformed descriptor
+		// placeholders, so keep the row and omit the descriptor.
+		return ""
+	}
+	return value
 }
 
 func (c *Collector) bgpAddressFamilyValue(cfg ddprofiledefinition.BGPValueConfig, ctx bgpValueContext) (ddprofiledefinition.BGPAddressFamily, error) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_cisco_traditional_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_cisco_traditional_test.go
@@ -91,6 +91,40 @@ func TestCollector_Collect_CiscoTraditionalLicensingProfile(t *testing.T) {
 				assert.False(t, grace.Expiry.Has)
 			},
 		},
+		"invalid expiry DateAndTime is absent": {
+			rows: []ciscoTraditionalRow{
+				{
+					entPhysical:   1,
+					storeUsed:     1,
+					index:         2,
+					name:          "WLC-BASE",
+					version:       "1.0",
+					licenseType:   4,
+					remaining:     0,
+					capacity:      100,
+					available:     100,
+					impact:        "Permanent base license",
+					status:        1,
+					endDatePDU:    []byte("0"),
+					hasEndDatePDU: true,
+				},
+			},
+			assertRows: func(t *testing.T, rows []ddsnmp.LicenseRow) {
+				require.Len(t, rows, 1)
+				row := rows[0]
+				assert.Equal(t, "1.1.2", row.ID)
+				assert.Equal(t, "WLC-BASE", row.Name)
+				assert.Equal(t, "permanent", row.Type)
+				assert.True(t, row.IsPerpetual)
+				assert.False(t, row.Expiry.Has)
+				require.True(t, row.Usage.HasCapacity)
+				assert.EqualValues(t, 100, row.Usage.Capacity)
+				require.True(t, row.Usage.HasAvailable)
+				assert.EqualValues(t, 100, row.Usage.Available)
+				require.True(t, row.State.Has)
+				assert.EqualValues(t, 0, row.State.Severity)
+			},
+		},
 	}
 
 	for name, tc := range tests {
@@ -136,6 +170,7 @@ type ciscoTraditionalRow struct {
 	impact        string
 	status        int
 	endDate       time.Time
+	endDatePDU    []byte
 	hasEndDatePDU bool
 }
 
@@ -156,7 +191,12 @@ func expectCiscoTraditionalLicensingWalk(mockHandler *snmpmock.MockHandler, rows
 			createIntegerPDU("1.3.6.1.4.1.9.9.543.1.2.3.1.14."+idx, row.status),
 		)
 		if row.hasEndDatePDU {
-			pdus = append(pdus, createDateAndTimePDU("1.3.6.1.4.1.9.9.543.1.2.3.1.16."+idx, row.endDate))
+			oid := "1.3.6.1.4.1.9.9.543.1.2.3.1.16." + idx
+			if row.endDatePDU != nil {
+				pdus = append(pdus, createPDU(oid, gosnmp.OctetString, row.endDatePDU))
+			} else {
+				pdus = append(pdus, createDateAndTimePDU(oid, row.endDate))
+			}
 		}
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_cisco_traditional_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_cisco_traditional_test.go
@@ -157,7 +157,7 @@ func TestCollector_Collect_CiscoTraditionalLicensingProfile(t *testing.T) {
 	}
 }
 
-func TestCollector_Collect_CiscoTraditionalLicensingProfile_RejectsMalformedNonPlaceholderExpiry(t *testing.T) {
+func TestCollector_Collect_CiscoTraditionalLicensingProfile_OmitsMalformedNonPlaceholderExpiry(t *testing.T) {
 	ctrl, mockHandler := setupMockHandler(t)
 	defer ctrl.Finish()
 
@@ -188,9 +188,19 @@ func TestCollector_Collect_CiscoTraditionalLicensingProfile_RejectsMalformedNonP
 	})
 
 	rows, err := collector.collectLicenseRows(profile, &ddsnmp.CollectionStats{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "expiry.timestamp: invalid SNMP DateAndTime length 3")
-	assert.Empty(t, rows)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	row := rows[0]
+	assert.Equal(t, "1.1.2", row.ID)
+	assert.Equal(t, "WLC-BASE", row.Name)
+	assert.False(t, row.Expiry.Has)
+	require.True(t, row.Usage.HasCapacity)
+	assert.EqualValues(t, 100, row.Usage.Capacity)
+	require.True(t, row.Usage.HasAvailable)
+	assert.EqualValues(t, 100, row.Usage.Available)
+	require.True(t, row.State.Has)
+	assert.EqualValues(t, 0, row.State.Severity)
 }
 
 type ciscoTraditionalRow struct {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_cisco_traditional_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_cisco_traditional_test.go
@@ -157,6 +157,42 @@ func TestCollector_Collect_CiscoTraditionalLicensingProfile(t *testing.T) {
 	}
 }
 
+func TestCollector_Collect_CiscoTraditionalLicensingProfile_RejectsMalformedNonPlaceholderExpiry(t *testing.T) {
+	ctrl, mockHandler := setupMockHandler(t)
+	defer ctrl.Finish()
+
+	expectCiscoTraditionalLicensingWalk(mockHandler, ciscoTraditionalRow{
+		entPhysical:   1,
+		storeUsed:     1,
+		index:         2,
+		name:          "WLC-BASE",
+		version:       "1.0",
+		licenseType:   4,
+		capacity:      100,
+		available:     100,
+		impact:        "Permanent base license",
+		status:        1,
+		endDatePDU:    []byte("bad"),
+		hasEndDatePDU: true,
+	})
+	profile := mustLoadTypedLicensingProfile(t, "cisco", func(row ddprofiledefinition.LicensingConfig) bool {
+		return strings.TrimPrefix(row.Table.OID, ".") == "1.3.6.1.4.1.9.9.543.1.2.3.1"
+	})
+	require.Len(t, profile.Definition.Licensing, 1)
+
+	collector := New(Config{
+		SnmpClient:  mockHandler,
+		Profiles:    []*ddsnmp.Profile{profile},
+		Log:         logger.New(),
+		SysObjectID: "",
+	})
+
+	rows, err := collector.collectLicenseRows(profile, &ddsnmp.CollectionStats{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expiry.timestamp: invalid SNMP DateAndTime length 3")
+	assert.Empty(t, rows)
+}
+
 type ciscoTraditionalRow struct {
 	entPhysical   int
 	storeUsed     int

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing.go
@@ -20,6 +20,7 @@ import (
 const (
 	licenseRowsPartialErrorLogKey = "snmp-licensing-rows-partial-error:"
 	licenseRowsFailedLogKey       = "snmp-licensing-rows-failed:"
+	licenseTimerNoValueLogKey     = "snmp-licensing-timer-no-value:"
 	licenseRowsErrorLogEvery      = time.Hour
 )
 
@@ -381,16 +382,16 @@ func (c *Collector) populateLicenseRow(row *ddsnmp.LicenseRow, cfg ddprofiledefi
 	if err := c.populateLicenseState(row, cfg.State, ctx); err != nil {
 		return fmt.Errorf("state: %w", err)
 	}
-	if err := c.populateLicenseTimer(&row.Expiry, cfg.Signals.Expiry, ctx); err != nil {
+	if err := c.populateLicenseTimer(&row.Expiry, cfg.Signals.Expiry, ctx, "expiry"); err != nil {
 		return err
 	}
-	if err := c.populateLicenseTimer(&row.Authorization, cfg.Signals.Authorization, ctx); err != nil {
+	if err := c.populateLicenseTimer(&row.Authorization, cfg.Signals.Authorization, ctx, "authorization"); err != nil {
 		return err
 	}
-	if err := c.populateLicenseTimer(&row.Certificate, cfg.Signals.Certificate, ctx); err != nil {
+	if err := c.populateLicenseTimer(&row.Certificate, cfg.Signals.Certificate, ctx, "certificate"); err != nil {
 		return err
 	}
-	if err := c.populateLicenseTimer(&row.Grace, cfg.Signals.Grace, ctx); err != nil {
+	if err := c.populateLicenseTimer(&row.Grace, cfg.Signals.Grace, ctx, "grace"); err != nil {
 		return err
 	}
 	if err := c.populateLicenseUsage(&row.Usage, cfg.Signals.Usage, ctx); err != nil {
@@ -450,32 +451,35 @@ func licenseStateRawValueByPolicy(raw string, policy ddprofiledefinition.License
 	return raw
 }
 
-func (c *Collector) populateLicenseTimer(timer *ddsnmp.LicenseTimer, cfg ddprofiledefinition.LicenseTimerSignalsConfig, ctx licenseValueContext) error {
+func (c *Collector) populateLicenseTimer(timer *ddsnmp.LicenseTimer, cfg ddprofiledefinition.LicenseTimerSignalsConfig, ctx licenseValueContext, name string) error {
 	if cfg.LicenseValueConfig.IsSet() {
-		if err := c.populateLicenseTimerTimestamp(timer, cfg.LicenseValueConfig, ctx); err != nil {
+		if err := c.populateLicenseTimerTimestamp(timer, cfg.LicenseValueConfig, ctx, name); err != nil {
 			return err
 		}
 	}
 	if cfg.Timestamp.IsSet() {
-		if err := c.populateLicenseTimerTimestamp(timer, cfg.Timestamp, ctx); err != nil {
+		if err := c.populateLicenseTimerTimestamp(timer, cfg.Timestamp, ctx, name+".timestamp"); err != nil {
 			return err
 		}
 	}
 	if cfg.Remaining.IsSet() {
-		if err := c.populateLicenseTimerRemaining(timer, cfg.Remaining, ctx); err != nil {
+		if err := c.populateLicenseTimerRemaining(timer, cfg.Remaining, ctx, name+".remaining"); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (c *Collector) populateLicenseTimerTimestamp(timer *ddsnmp.LicenseTimer, cfg ddprofiledefinition.LicenseValueConfig, ctx licenseValueContext) error {
+func (c *Collector) populateLicenseTimerTimestamp(timer *ddsnmp.LicenseTimer, cfg ddprofiledefinition.LicenseValueConfig, ctx licenseValueContext, name string) error {
+	if sourceOID, ok := licenseTimerZeroDateAndTimePlaceholder(cfg, ctx); ok {
+		c.log.Limit(licenseTimerNoValueLogKey+sourceOID, 1, licenseRowsErrorLogEvery).
+			Warningf("license timer %q returned zero DateAndTime placeholder; treating timer as absent", sourceOID)
+		return nil
+	}
+
 	value, sourceOID, ok, err := c.licenseNumericValue(cfg, ctx)
 	if err != nil {
-		// Timer values are optional. Devices can publish malformed placeholders
-		// for non-expiring or not-applicable licenses; keep the row and omit the
-		// timer rather than dropping state/usage data.
-		return nil
+		return fmt.Errorf("%s: %w", name, err)
 	}
 	if !ok || licenseValueRejectedBySentinel(value, cfg.Sentinel) {
 		return nil
@@ -487,10 +491,10 @@ func (c *Collector) populateLicenseTimerTimestamp(timer *ddsnmp.LicenseTimer, cf
 	return nil
 }
 
-func (c *Collector) populateLicenseTimerRemaining(timer *ddsnmp.LicenseTimer, cfg ddprofiledefinition.LicenseValueConfig, ctx licenseValueContext) error {
+func (c *Collector) populateLicenseTimerRemaining(timer *ddsnmp.LicenseTimer, cfg ddprofiledefinition.LicenseValueConfig, ctx licenseValueContext, name string) error {
 	value, sourceOID, ok, err := c.licenseNumericValue(cfg, ctx)
 	if err != nil {
-		return nil
+		return fmt.Errorf("%s: %w", name, err)
 	}
 	if !ok || licenseValueRejectedBySentinel(value, cfg.Sentinel) {
 		return nil
@@ -500,6 +504,29 @@ func (c *Collector) populateLicenseTimerRemaining(timer *ddsnmp.LicenseTimer, cf
 	timer.RemainingSeconds = value
 	timer.SourceOID = sourceOID
 	return nil
+}
+
+func licenseTimerZeroDateAndTimePlaceholder(cfg ddprofiledefinition.LicenseValueConfig, ctx licenseValueContext) (string, bool) {
+	sym := licenseValueSymbol(cfg)
+	if sym.Format != "snmp_dateandtime" || sym.OID == "" {
+		return "", false
+	}
+	pdu, ok := ctx.lookupPDU(sym.OID)
+	if !ok || !isZeroDateAndTimePlaceholderPDU(pdu) {
+		return "", false
+	}
+	return trimOID(sym.OID), true
+}
+
+func isZeroDateAndTimePlaceholderPDU(pdu gosnmp.SnmpPDU) bool {
+	switch v := pdu.Value.(type) {
+	case []byte:
+		return string(v) == "0" || (len(v) == 1 && v[0] == 0)
+	case string:
+		return v == "0"
+	default:
+		return false
+	}
 }
 
 func (c *Collector) populateLicenseUsage(usage *ddsnmp.LicenseUsage, cfg ddprofiledefinition.LicenseUsageSignalsConfig, ctx licenseValueContext) error {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing.go
@@ -20,6 +20,7 @@ import (
 const (
 	licenseRowsPartialErrorLogKey = "snmp-licensing-rows-partial-error:"
 	licenseRowsFailedLogKey       = "snmp-licensing-rows-failed:"
+	licenseTimerMalformedLogKey   = "snmp-licensing-timer-malformed:"
 	licenseTimerNoValueLogKey     = "snmp-licensing-timer-no-value:"
 	licenseRowsErrorLogEvery      = time.Hour
 )
@@ -479,7 +480,10 @@ func (c *Collector) populateLicenseTimerTimestamp(timer *ddsnmp.LicenseTimer, cf
 
 	value, sourceOID, ok, err := c.licenseNumericValue(cfg, ctx)
 	if err != nil {
-		return fmt.Errorf("%s: %w", name, err)
+		source := licenseTimerSource(cfg, name)
+		c.log.Limit(licenseTimerMalformedLogKey+source, 1, licenseRowsErrorLogEvery).
+			Warningf("license timer %q is malformed: %v; treating timer as absent", source, err)
+		return nil
 	}
 	if !ok || licenseValueRejectedBySentinel(value, cfg.Sentinel) {
 		return nil
@@ -494,7 +498,10 @@ func (c *Collector) populateLicenseTimerTimestamp(timer *ddsnmp.LicenseTimer, cf
 func (c *Collector) populateLicenseTimerRemaining(timer *ddsnmp.LicenseTimer, cfg ddprofiledefinition.LicenseValueConfig, ctx licenseValueContext, name string) error {
 	value, sourceOID, ok, err := c.licenseNumericValue(cfg, ctx)
 	if err != nil {
-		return fmt.Errorf("%s: %w", name, err)
+		source := licenseTimerSource(cfg, name)
+		c.log.Limit(licenseTimerMalformedLogKey+source, 1, licenseRowsErrorLogEvery).
+			Warningf("license timer %q is malformed: %v; treating timer as absent", source, err)
+		return nil
 	}
 	if !ok || licenseValueRejectedBySentinel(value, cfg.Sentinel) {
 		return nil
@@ -516,6 +523,13 @@ func licenseTimerZeroDateAndTimePlaceholder(cfg ddprofiledefinition.LicenseValue
 		return "", false
 	}
 	return trimOID(sym.OID), true
+}
+
+func licenseTimerSource(cfg ddprofiledefinition.LicenseValueConfig, fallback string) string {
+	if oid := trimOID(licenseValueSymbol(cfg).OID); oid != "" {
+		return oid
+	}
+	return fallback
 }
 
 func isZeroDateAndTimePlaceholderPDU(pdu gosnmp.SnmpPDU) bool {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing.go
@@ -381,16 +381,16 @@ func (c *Collector) populateLicenseRow(row *ddsnmp.LicenseRow, cfg ddprofiledefi
 	if err := c.populateLicenseState(row, cfg.State, ctx); err != nil {
 		return fmt.Errorf("state: %w", err)
 	}
-	if err := c.populateLicenseTimer(&row.Expiry, cfg.Signals.Expiry, ctx, "expiry"); err != nil {
+	if err := c.populateLicenseTimer(&row.Expiry, cfg.Signals.Expiry, ctx); err != nil {
 		return err
 	}
-	if err := c.populateLicenseTimer(&row.Authorization, cfg.Signals.Authorization, ctx, "authorization"); err != nil {
+	if err := c.populateLicenseTimer(&row.Authorization, cfg.Signals.Authorization, ctx); err != nil {
 		return err
 	}
-	if err := c.populateLicenseTimer(&row.Certificate, cfg.Signals.Certificate, ctx, "certificate"); err != nil {
+	if err := c.populateLicenseTimer(&row.Certificate, cfg.Signals.Certificate, ctx); err != nil {
 		return err
 	}
-	if err := c.populateLicenseTimer(&row.Grace, cfg.Signals.Grace, ctx, "grace"); err != nil {
+	if err := c.populateLicenseTimer(&row.Grace, cfg.Signals.Grace, ctx); err != nil {
 		return err
 	}
 	if err := c.populateLicenseUsage(&row.Usage, cfg.Signals.Usage, ctx); err != nil {
@@ -450,29 +450,32 @@ func licenseStateRawValueByPolicy(raw string, policy ddprofiledefinition.License
 	return raw
 }
 
-func (c *Collector) populateLicenseTimer(timer *ddsnmp.LicenseTimer, cfg ddprofiledefinition.LicenseTimerSignalsConfig, ctx licenseValueContext, name string) error {
+func (c *Collector) populateLicenseTimer(timer *ddsnmp.LicenseTimer, cfg ddprofiledefinition.LicenseTimerSignalsConfig, ctx licenseValueContext) error {
 	if cfg.LicenseValueConfig.IsSet() {
-		if err := c.populateLicenseTimerTimestamp(timer, cfg.LicenseValueConfig, ctx, name); err != nil {
+		if err := c.populateLicenseTimerTimestamp(timer, cfg.LicenseValueConfig, ctx); err != nil {
 			return err
 		}
 	}
 	if cfg.Timestamp.IsSet() {
-		if err := c.populateLicenseTimerTimestamp(timer, cfg.Timestamp, ctx, name+".timestamp"); err != nil {
+		if err := c.populateLicenseTimerTimestamp(timer, cfg.Timestamp, ctx); err != nil {
 			return err
 		}
 	}
 	if cfg.Remaining.IsSet() {
-		if err := c.populateLicenseTimerRemaining(timer, cfg.Remaining, ctx, name+".remaining"); err != nil {
+		if err := c.populateLicenseTimerRemaining(timer, cfg.Remaining, ctx); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (c *Collector) populateLicenseTimerTimestamp(timer *ddsnmp.LicenseTimer, cfg ddprofiledefinition.LicenseValueConfig, ctx licenseValueContext, name string) error {
+func (c *Collector) populateLicenseTimerTimestamp(timer *ddsnmp.LicenseTimer, cfg ddprofiledefinition.LicenseValueConfig, ctx licenseValueContext) error {
 	value, sourceOID, ok, err := c.licenseNumericValue(cfg, ctx)
 	if err != nil {
-		return fmt.Errorf("%s: %w", name, err)
+		// Timer values are optional. Devices can publish malformed placeholders
+		// for non-expiring or not-applicable licenses; keep the row and omit the
+		// timer rather than dropping state/usage data.
+		return nil
 	}
 	if !ok || licenseValueRejectedBySentinel(value, cfg.Sentinel) {
 		return nil
@@ -484,10 +487,10 @@ func (c *Collector) populateLicenseTimerTimestamp(timer *ddsnmp.LicenseTimer, cf
 	return nil
 }
 
-func (c *Collector) populateLicenseTimerRemaining(timer *ddsnmp.LicenseTimer, cfg ddprofiledefinition.LicenseValueConfig, ctx licenseValueContext, name string) error {
+func (c *Collector) populateLicenseTimerRemaining(timer *ddsnmp.LicenseTimer, cfg ddprofiledefinition.LicenseValueConfig, ctx licenseValueContext) error {
 	value, sourceOID, ok, err := c.licenseNumericValue(cfg, ctx)
 	if err != nil {
-		return fmt.Errorf("%s: %w", name, err)
+		return nil
 	}
 	if !ok || licenseValueRejectedBySentinel(value, cfg.Sentinel) {
 		return nil


### PR DESCRIPTION
##### Summary

Fixes

```
Jun 24 11:54:23 nd-demo-snmp netdata[1645712]: level=warn msg="failed to collect BGP rows for profile \"/opt/netdata/usr/lib/netdata/conf.d/go.d/snmp.profiles/default/cisco-asr.yaml\": BGP table \"cisco-bgp-peer-family\" row \"1.4.198.19.220.34.1.128\": descriptors.local_address: cannot convert []uint8 to IP address\nBGP table \"cisco-bgp-peer-family\" row \"1.4.198.19.220.37.1.128\": descriptors.local_address: cannot convert []uint8 to IP address\nBGP table \"cisco-bgp-peer-family\" row \"1.4.198.19.220.34.1.66\": descriptors.local_address: cannot convert []uint8 to IP address\nBGP table \"cisco-bgp-peer-family\" row \"1.4.198.19.220.37.1.66\": descriptors.local_address: cannot convert []uint8 to IP address" plugin=go.d collector=snmp job=NYC-Cisco-ASR100-Core-Router-ip-20_20_20_2 config_source=discovered/sd:snmpdiscoverer ddsnmp=collector

Jun 24 11:54:28 nd-demo-snmp netdata[1645712]: level=warn msg="failed to collect licensing rows for profile \"/opt/netdata/usr/lib/netdata/conf.d/go.d/snmp.profiles/default/cisco.yaml\": licensing table \"cisco_traditional_licenses\" row \"1.1.3\": expiry.timestamp: invalid SNMP DateAndTime length 1\nlicensing table \"cisco_traditional_licenses\" row \"1.1.2\": expiry.timestamp: invalid SNMP DateAndTime length 1" plugin=go.d collector=snmp job=NYC-Cisco-WLC-5520-ip-20_20_21_2 config_source=discovered/sd:snmpdiscoverer ddsnmp=collector
```

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves `go.d/snmp` robustness around typed rows. Keeps BGP rows when optional descriptors are malformed, and preserves licensing rows by treating zero or malformed timer DateAndTime values as absent.

- **Bug Fixes**
  - BGP: descriptor fields are optional; decode failures are omitted without dropping the row and are debug-logged.
  - Licensing: timer signals treat zero DateAndTime placeholders and malformed values as no value; rows are kept, identity/state/usage stay strict; warnings are rate-limited.
  - Tests: added cases for malformed BGP LocalAddress, zero placeholder expiry PDUs, and malformed non-placeholder expiry PDUs being omitted.

<sup>Written for commit 704ba42f61efc5c32547c97a1575b79efe738368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



