### PR TITLE
test(go.d/snmp_topology): add semantic scenario assertions

### DIFF
--- a/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_builder_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_builder_test.go
@@ -4,6 +4,7 @@ package snmptopology
 
 import (
 	"fmt"
+	"hash/fnv"
 	"net"
 	"strconv"
 	"strings"
@@ -480,13 +481,20 @@ func topologyScenarioPortMAC(chassisMAC string, ifIndex int) string {
 	if mac == "" {
 		return ""
 	}
-	parts := strings.Split(mac, ":")
-	if len(parts) != 6 {
-		return mac
-	}
-	parts[1] = "aa"
-	parts[5] = fmt.Sprintf("%02x", ifIndex&0xff)
-	return strings.Join(parts, ":")
+	// Keep synthetic interface MACs unique across devices; duplicate port MACs
+	// collapse projected actors before semantic link assertions can see them.
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(mac))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(strconv.Itoa(ifIndex)))
+	sum := h.Sum64()
+	return fmt.Sprintf("02:%02x:%02x:%02x:%02x:%02x",
+		byte(sum>>32),
+		byte(sum>>24),
+		byte(sum>>16),
+		byte(sum>>8),
+		byte(sum),
+	)
 }
 
 func topologyScenarioIPv4CIDR(cidr string) (string, string) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_golden_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_golden_test.go
@@ -861,12 +861,6 @@ func assertScenarioNoActorPortLinkType(t testing.TB, data topologyv1test.Normali
 	}
 }
 
-func assertScenarioNoVisibleLinks(t testing.TB, data topologyv1test.NormalizedData) {
-	t.Helper()
-
-	require.Empty(t, data.Links.Rows)
-}
-
 func assertScenarioStatEquals(t testing.TB, data topologyv1test.NormalizedData, stat string, want any) {
 	t.Helper()
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_golden_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_golden_test.go
@@ -56,6 +56,27 @@ func topologyScenarioCases() map[string]topologyScenarioCase {
 			scenario: newFocusDepthL2Scenario(),
 			assert:   assertFocusDepthL2Scenario,
 		},
+		"cdp_direct": {
+			scenario: newCDPDirectScenario(),
+			assert:   assertCDPDirectScenario,
+		},
+		"stp_inferred": {
+			scenario: newSTPInferredScenario(),
+			assert:   assertSTPInferredScenario,
+		},
+		"l3_p2p_31": {
+			scenario: newL3P2P31Scenario(),
+			assert:   assertL3P2P31Scenario,
+		},
+	}
+}
+
+func topologyScenarioGoldenCases() map[string]topologyScenarioCase {
+	all := topologyScenarioCases()
+	return map[string]topologyScenarioCase{
+		"mixed_l2_l3_control":         all["mixed_l2_l3_control"],
+		"probable_fdb_low_confidence": all["probable_fdb_low_confidence"],
+		"focus_depth_l2":              all["focus_depth_l2"],
 	}
 }
 
@@ -82,11 +103,10 @@ func TestSNMPTopologyScenarioGoldens(t *testing.T) {
 		t.Skipf("SNMP topology scenario golden directory is missing; set %s or checkout netdata/testdata into src/go/testdata", topologyScenarioGoldenDirEnv)
 	}
 
-	for name, tc := range topologyScenarioCases() {
+	for name, tc := range topologyScenarioGoldenCases() {
 		t.Run(name, func(t *testing.T) {
 			payload := tc.scenario.render(t)
 			normalized := topologyv1test.NormalizeData(t, payload)
-			tc.assert(t, normalized)
 
 			actual := topologyv1test.CanonicalJSON(t, normalized)
 			if *updateSNMPTopologyScenarioGoldens {
@@ -215,6 +235,39 @@ func newFocusDepthL2Scenario() *topologyScenario {
 	return s
 }
 
+func newCDPDirectScenario() *topologyScenario {
+	s := newTopologyScenario("cdp_direct").WithOptions(func(options *topologyoptions.QueryOptions) {
+		options.CollapseActorsByIP = false
+	})
+	switchA := s.Switch("cdp-switch-a", "192.0.2.41", "02:00:00:00:05:01")
+	switchB := s.Switch("cdp-switch-b", "192.0.2.42", "02:00:00:00:05:02")
+	s.CDP(switchA.Port("a-b", 1), switchB.Port("b-a", 1))
+	return s
+}
+
+func newSTPInferredScenario() *topologyScenario {
+	s := newTopologyScenario("stp_inferred").WithOptions(func(options *topologyoptions.QueryOptions) {
+		options.CollapseActorsByIP = false
+		options.MapType = topologyoptions.MapTypeHighConfidenceInferred
+		options.InferenceStrategy = topologyoptions.InferenceStrategySTPParentTree
+	})
+	switchA := s.Switch("stp-switch-a", "192.0.2.51", "02:00:00:00:06:01")
+	switchB := s.Switch("stp-switch-b", "192.0.2.52", "02:00:00:00:06:02")
+	s.STP(switchA.Port("a-b", 1), switchB.Port("b-a", 1))
+	return s
+}
+
+func newL3P2P31Scenario() *topologyScenario {
+	s := newTopologyScenario("l3_p2p_31").WithOptions(func(options *topologyoptions.QueryOptions) {
+		options.CollapseActorsByIP = false
+	})
+	routerA := s.Router("p2p-router-a", "192.0.2.61", "02:00:00:00:07:01", "192.0.2.161", "65061")
+	routerB := s.Router("p2p-router-b", "192.0.2.62", "02:00:00:00:07:02", "192.0.2.162", "65062")
+	routerA.Port("wan0", 1).IPv4("198.51.100.10/31")
+	routerB.Port("wan0", 1).IPv4("198.51.100.11/31")
+	return s
+}
+
 func assertMixedL2L3ControlScenario(t testing.TB, data topologyv1test.NormalizedData) {
 	t.Helper()
 
@@ -227,6 +280,7 @@ func assertMixedL2L3ControlScenario(t testing.TB, data topologyv1test.Normalized
 	})
 	assertScenarioLinks(t, data, []topologyScenarioLinkExpectation{
 		{Type: "lldp", Src: "router-a", Dst: "switch-a", Direction: "bidirectional", Protocol: "lldp", SrcPort: "lan0", DstPort: "uplink-a"},
+		{Type: "cdp", Src: "switch-a", Dst: "switch-b", Direction: "bidirectional", Protocol: "cdp", SrcPort: "uplink-a", DstPort: "uplink-b"},
 		{Type: topologymodel.L3SubnetMembershipLinkType, Src: "router-a", Dst: "10.10.10.0/24", Direction: "observed", Protocol: topologymodel.L3SubnetMembershipLinkType, SrcPort: "lan0"},
 		{Type: topologymodel.L3SubnetMembershipLinkType, Src: "switch-a", Dst: "10.10.10.0/24", Direction: "observed", Protocol: topologymodel.L3SubnetMembershipLinkType, SrcPort: "uplink-a"},
 		{Type: topologymodel.L3SubnetMembershipLinkType, Src: "switch-b", Dst: "10.10.10.0/24", Direction: "observed", Protocol: topologymodel.L3SubnetMembershipLinkType, SrcPort: "uplink-b"},
@@ -236,12 +290,14 @@ func assertMixedL2L3ControlScenario(t testing.TB, data topologyv1test.Normalized
 	})
 	assertScenarioTableRowsContain(t, data, "actor_ports", []map[string]any{
 		{"actor": "router-a", "if_index": 2, "name": "lan0", "neighbor_actor": "switch-a", "neighbor_port_name": "uplink-a", "neighbor_count": 1, "link_count": 1, "topology_role": "switch_facing"},
-		{"actor": "switch-a", "if_index": 1, "name": "uplink-a", "neighbor_actor": "router-a", "neighbor_port_name": "lan0", "neighbor_count": 2, "link_count": 4, "stp_state": "forwarding"},
+		{"actor": "switch-a", "if_index": 1, "name": "uplink-a", "neighbor_count": 2, "link_count": 4, "stp_state": "forwarding", "topology_role": "switch_facing"},
 		{"actor": "switch-a", "if_index": 2, "name": "host-a", "fdb_mac_count": 1, "topology_role": "host_facing"},
 	})
 	assertScenarioTableRowsExactly(t, data, "actor_port_links", []map[string]any{
 		{"actor": "router-a", "remote_actor": "switch-a", "type": "lldp", "protocol": "lldp", "if_index": 2, "port_name": "lan0", "remote_if_index": 1, "remote_port_name": "uplink-a"},
 		{"actor": "switch-a", "remote_actor": "router-a", "type": "lldp", "protocol": "lldp", "if_index": 1, "port_name": "uplink-a", "remote_if_index": 2, "remote_port_name": "lan0"},
+		{"actor": "switch-a", "remote_actor": "switch-b", "type": "cdp", "protocol": "cdp", "if_index": 1, "port_name": "uplink-a", "remote_if_index": 1, "remote_port_name": "uplink-b"},
+		{"actor": "switch-b", "remote_actor": "switch-a", "type": "cdp", "protocol": "cdp", "if_index": 1, "port_name": "uplink-b", "remote_if_index": 1, "remote_port_name": "uplink-a"},
 	})
 	assertScenarioTableRowsExactly(t, data, "actor_ospf_neighbors", []map[string]any{
 		{"actor": "router-a", "remote_actor": "router-b", "local_ip": "198.51.100.1", "neighbor_ip": "198.51.100.2", "local_router_id": "192.0.2.101", "neighbor_router_id": "192.0.2.102", "state": "full", "subnet": "198.51.100.0/30"},
@@ -253,6 +309,9 @@ func assertMixedL2L3ControlScenario(t testing.TB, data topologyv1test.Normalized
 	})
 	assertScenarioEvidenceRowsExactly(t, data, "lldp", []map[string]any{
 		{"src_actor": "router-a", "dst_actor": "switch-a", "src_if_index": 2, "dst_if_index": 1, "src_port_name": "lan0", "dst_port_name": "uplink-a", "protocol": "lldp"},
+	})
+	assertScenarioEvidenceRowsExactly(t, data, "cdp", []map[string]any{
+		{"src_actor": "switch-a", "dst_actor": "switch-b", "src_if_index": 1, "dst_if_index": 1, "src_port_name": "uplink-a", "dst_port_name": "uplink-b", "protocol": "cdp"},
 	})
 	assertScenarioEvidenceRowsExactly(t, data, topologymodel.L3SubnetLinkType, []map[string]any{
 		{"src_actor": "router-a", "dst_actor": "router-b", "src_ip": "198.51.100.1", "dst_ip": "198.51.100.2", "src_if_index": 1, "dst_if_index": 1, "src_port_name": "wan0", "dst_port_name": "wan0", "subnet": "198.51.100.0/30", "prefix": 30},
@@ -305,17 +364,81 @@ func assertFocusDepthL2Scenario(t testing.TB, data topologyv1test.NormalizedData
 
 	assertScenarioActors(t, data, []topologyScenarioActorExpectation{
 		{Name: "focus-switch-a", Type: "switch", ManagementIP: "192.0.2.31"},
+		{Name: "focus-switch-b", Type: "switch", ManagementIP: "192.0.2.32"},
 	})
-	assertScenarioNoVisibleLinks(t, data)
+	assertScenarioLinks(t, data, []topologyScenarioLinkExpectation{
+		{Type: "lldp", Src: "focus-switch-a", Dst: "focus-switch-b", Direction: "bidirectional", Protocol: "lldp", SrcPort: "a-b", DstPort: "b-a"},
+	})
 	assertScenarioTableRowsContain(t, data, "actor_ports", []map[string]any{
 		{"actor": "focus-switch-a", "if_index": 1, "name": "a-b", "neighbor_count": 1, "link_count": 1, "topology_role": "switch_facing"},
 	})
-	assertScenarioTableRowsExactly(t, data, "actor_port_links", nil)
-	assertScenarioStatEquals(t, data, "actors_focus_depth_filtered", 2)
-	assertScenarioStatEquals(t, data, "links_total", 0)
+	assertScenarioTableRowsExactly(t, data, "actor_port_links", []map[string]any{
+		{"actor": "focus-switch-a", "remote_actor": "focus-switch-b", "type": "lldp", "protocol": "lldp", "if_index": 1, "port_name": "a-b", "remote_if_index": 1, "remote_port_name": "b-a"},
+		{"actor": "focus-switch-b", "remote_actor": "focus-switch-a", "type": "lldp", "protocol": "lldp", "if_index": 1, "port_name": "b-a", "remote_if_index": 1, "remote_port_name": "a-b"},
+	})
+	assertScenarioEvidenceRowsExactly(t, data, "lldp", []map[string]any{
+		{"src_actor": "focus-switch-a", "dst_actor": "focus-switch-b", "src_if_index": 1, "dst_if_index": 1, "src_port_name": "a-b", "dst_port_name": "b-a", "protocol": "lldp"},
+	})
+	assertScenarioStatEquals(t, data, "actors_focus_depth_filtered", 1)
+	assertScenarioStatEquals(t, data, "links_total", 1)
 	assertScenarioStatEquals(t, data, "links_lldp", 2)
-	assertScenarioNoActor(t, data, "focus-switch-b")
 	assertScenarioNoActor(t, data, "focus-switch-c")
+}
+
+func assertCDPDirectScenario(t testing.TB, data topologyv1test.NormalizedData) {
+	t.Helper()
+
+	assertScenarioActors(t, data, []topologyScenarioActorExpectation{
+		{Name: "cdp-switch-a", Type: "switch", ManagementIP: "192.0.2.41"},
+		{Name: "cdp-switch-b", Type: "switch", ManagementIP: "192.0.2.42"},
+	})
+	assertScenarioLinks(t, data, []topologyScenarioLinkExpectation{
+		{Type: "cdp", Src: "cdp-switch-a", Dst: "cdp-switch-b", Direction: "bidirectional", Protocol: "cdp", SrcPort: "a-b", DstPort: "b-a"},
+	})
+	assertScenarioTableRowsExactly(t, data, "actor_port_links", []map[string]any{
+		{"actor": "cdp-switch-a", "remote_actor": "cdp-switch-b", "type": "cdp", "protocol": "cdp", "if_index": 1, "port_name": "a-b", "remote_if_index": 1, "remote_port_name": "b-a"},
+		{"actor": "cdp-switch-b", "remote_actor": "cdp-switch-a", "type": "cdp", "protocol": "cdp", "if_index": 1, "port_name": "b-a", "remote_if_index": 1, "remote_port_name": "a-b"},
+	})
+	assertScenarioEvidenceRowsExactly(t, data, "cdp", []map[string]any{
+		{"src_actor": "cdp-switch-a", "dst_actor": "cdp-switch-b", "src_if_index": 1, "dst_if_index": 1, "src_port_name": "a-b", "dst_port_name": "b-a", "protocol": "cdp"},
+	})
+	assertScenarioStatEquals(t, data, "links_cdp", 1)
+}
+
+func assertSTPInferredScenario(t testing.TB, data topologyv1test.NormalizedData) {
+	t.Helper()
+
+	assertScenarioActors(t, data, []topologyScenarioActorExpectation{
+		{Name: "stp-switch-a", Type: "switch", ManagementIP: "192.0.2.51"},
+		{Name: "stp-switch-b", Type: "switch", ManagementIP: "192.0.2.52"},
+	})
+	assertScenarioLinks(t, data, []topologyScenarioLinkExpectation{
+		{Type: "stp", Src: "stp-switch-a", Dst: "stp-switch-b", Direction: "unidirectional", Protocol: "stp", SrcPort: "a-b", DstPort: "b-a"},
+		{Type: "stp", Src: "stp-switch-b", Dst: "stp-switch-a", Direction: "unidirectional", Protocol: "stp", SrcPort: "b-a", DstPort: "a-b"},
+	})
+	assertScenarioEvidenceRowsExactly(t, data, "stp", []map[string]any{
+		{"src_actor": "stp-switch-a", "dst_actor": "stp-switch-b", "src_if_index": 1, "dst_if_index": 1, "src_port_name": "a-b", "dst_port_name": "b-a", "protocol": "stp"},
+		{"src_actor": "stp-switch-b", "dst_actor": "stp-switch-a", "src_if_index": 1, "dst_if_index": 1, "src_port_name": "b-a", "dst_port_name": "a-b", "protocol": "stp"},
+	})
+	assertScenarioStatEquals(t, data, "links_stp", 2)
+}
+
+func assertL3P2P31Scenario(t testing.TB, data topologyv1test.NormalizedData) {
+	t.Helper()
+
+	assertScenarioActors(t, data, []topologyScenarioActorExpectation{
+		{Name: "p2p-router-a", Type: "router", ManagementIP: "192.0.2.61"},
+		{Name: "p2p-router-b", Type: "router", ManagementIP: "192.0.2.62"},
+	})
+	assertScenarioLinks(t, data, []topologyScenarioLinkExpectation{
+		{Type: topologymodel.L3SubnetLinkType, Src: "p2p-router-a", Dst: "p2p-router-b", Direction: "observed", Protocol: topologymodel.L3SubnetLinkType, SrcPort: "wan0", DstPort: "wan0"},
+	})
+	assertScenarioEvidenceRowsExactly(t, data, topologymodel.L3SubnetLinkType, []map[string]any{
+		{"src_actor": "p2p-router-a", "dst_actor": "p2p-router-b", "src_ip": "198.51.100.10", "dst_ip": "198.51.100.11", "src_if_index": 1, "dst_if_index": 1, "src_port_name": "wan0", "dst_port_name": "wan0", "subnet": "198.51.100.10/31", "prefix": 31},
+	})
+	assertScenarioNoActor(t, data, "198.51.100.10/31")
+	assertScenarioStatEquals(t, data, "l3_subnet_visible_links", 1)
+	assertScenarioStatEquals(t, data, "l3_subnet_segment_emitted_segments", 0)
 }
 
 func assertScenarioActors(t testing.TB, data topologyv1test.NormalizedData, want []topologyScenarioActorExpectation) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_golden_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_golden_test.go
@@ -56,17 +56,45 @@ func topologyScenarioCases() map[string]topologyScenarioCase {
 			scenario: newFocusDepthL2Scenario(),
 			assert:   assertFocusDepthL2Scenario,
 		},
+		"lldp_direct": {
+			scenario: newLLDPDirectScenario(),
+			assert:   assertLLDPDirectScenario,
+		},
 		"cdp_direct": {
 			scenario: newCDPDirectScenario(),
 			assert:   assertCDPDirectScenario,
+		},
+		"lldp_cdp_same_link": {
+			scenario: newLLDPCDPSameLinkScenario(),
+			assert:   assertLLDPCDPSameLinkScenario,
 		},
 		"stp_inferred": {
 			scenario: newSTPInferredScenario(),
 			assert:   assertSTPInferredScenario,
 		},
+		"fdb_pairwise": {
+			scenario: newFDBPairwiseScenario(),
+			assert:   assertFDBPairwiseScenario,
+		},
+		"l3_p2p_30": {
+			scenario: newL3P2P30Scenario(),
+			assert:   assertL3P2P30Scenario,
+		},
 		"l3_p2p_31": {
 			scenario: newL3P2P31Scenario(),
 			assert:   assertL3P2P31Scenario,
+		},
+		"l3_segment_24": {
+			scenario: newL3Segment24Scenario(),
+			assert:   assertL3Segment24Scenario,
+		},
+		"ospf_direct": {
+			scenario: newOSPFDirectScenario(),
+			assert:   assertOSPFDirectScenario,
+		},
+		"bgp_direct": {
+			scenario: newBGPDirectScenario(),
+			assert:   assertBGPDirectScenario,
 		},
 	}
 }
@@ -235,6 +263,16 @@ func newFocusDepthL2Scenario() *topologyScenario {
 	return s
 }
 
+func newLLDPDirectScenario() *topologyScenario {
+	s := newTopologyScenario("lldp_direct").WithOptions(func(options *topologyoptions.QueryOptions) {
+		options.CollapseActorsByIP = false
+	})
+	switchA := s.Switch("lldp-switch-a", "192.0.2.71", "02:00:00:00:08:01")
+	switchB := s.Switch("lldp-switch-b", "192.0.2.72", "02:00:00:00:08:02")
+	s.LLDP(switchA.Port("a-b", 1), switchB.Port("b-a", 1))
+	return s
+}
+
 func newCDPDirectScenario() *topologyScenario {
 	s := newTopologyScenario("cdp_direct").WithOptions(func(options *topologyoptions.QueryOptions) {
 		options.CollapseActorsByIP = false
@@ -242,6 +280,19 @@ func newCDPDirectScenario() *topologyScenario {
 	switchA := s.Switch("cdp-switch-a", "192.0.2.41", "02:00:00:00:05:01")
 	switchB := s.Switch("cdp-switch-b", "192.0.2.42", "02:00:00:00:05:02")
 	s.CDP(switchA.Port("a-b", 1), switchB.Port("b-a", 1))
+	return s
+}
+
+func newLLDPCDPSameLinkScenario() *topologyScenario {
+	s := newTopologyScenario("lldp_cdp_same_link").WithOptions(func(options *topologyoptions.QueryOptions) {
+		options.CollapseActorsByIP = false
+	})
+	switchA := s.Switch("dual-switch-a", "192.0.2.81", "02:00:00:00:09:01")
+	switchB := s.Switch("dual-switch-b", "192.0.2.82", "02:00:00:00:09:02")
+	aPort := switchA.Port("a-b", 1)
+	bPort := switchB.Port("b-a", 1)
+	s.LLDP(aPort, bPort)
+	s.CDP(aPort, bPort)
 	return s
 }
 
@@ -257,6 +308,31 @@ func newSTPInferredScenario() *topologyScenario {
 	return s
 }
 
+func newFDBPairwiseScenario() *topologyScenario {
+	s := newTopologyScenario("fdb_pairwise").WithOptions(func(options *topologyoptions.QueryOptions) {
+		options.MapType = topologyoptions.MapTypeAllDevicesLowConfidence
+		options.InferenceStrategy = topologyoptions.InferenceStrategyFDBPairwise
+	})
+	switchA := s.Switch("fdb-switch-a", "192.0.2.91", "02:00:00:00:0a:01")
+	switchB := s.Switch("fdb-switch-b", "192.0.2.92", "02:00:00:00:0a:02")
+	aPort := switchA.Port("uplink-a", 1)
+	bPort := switchB.Port("uplink-b", 1)
+	s.FDBARP(aPort, switchB.chassisMAC, switchB.mgmtIP)
+	s.FDBARP(bPort, switchA.chassisMAC, switchA.mgmtIP)
+	return s
+}
+
+func newL3P2P30Scenario() *topologyScenario {
+	s := newTopologyScenario("l3_p2p_30").WithOptions(func(options *topologyoptions.QueryOptions) {
+		options.CollapseActorsByIP = false
+	})
+	routerA := s.Router("p2p30-router-a", "192.0.2.111", "02:00:00:00:0b:01", "192.0.2.211", "65111")
+	routerB := s.Router("p2p30-router-b", "192.0.2.112", "02:00:00:00:0b:02", "192.0.2.212", "65112")
+	routerA.Port("wan0", 1).IPv4("198.51.100.21/30")
+	routerB.Port("wan0", 1).IPv4("198.51.100.22/30")
+	return s
+}
+
 func newL3P2P31Scenario() *topologyScenario {
 	s := newTopologyScenario("l3_p2p_31").WithOptions(func(options *topologyoptions.QueryOptions) {
 		options.CollapseActorsByIP = false
@@ -265,6 +341,39 @@ func newL3P2P31Scenario() *topologyScenario {
 	routerB := s.Router("p2p-router-b", "192.0.2.62", "02:00:00:00:07:02", "192.0.2.162", "65062")
 	routerA.Port("wan0", 1).IPv4("198.51.100.10/31")
 	routerB.Port("wan0", 1).IPv4("198.51.100.11/31")
+	return s
+}
+
+func newL3Segment24Scenario() *topologyScenario {
+	s := newTopologyScenario("l3_segment_24").WithOptions(func(options *topologyoptions.QueryOptions) {
+		options.CollapseActorsByIP = false
+	})
+	routerA := s.Router("segment-router-a", "192.0.2.121", "02:00:00:00:0c:01", "192.0.2.221", "65121")
+	switchA := s.Switch("segment-switch-a", "192.0.2.122", "02:00:00:00:0c:02")
+	switchB := s.Switch("segment-switch-b", "192.0.2.123", "02:00:00:00:0c:03")
+	routerA.Port("lan0", 1).IPv4("203.0.113.1/24")
+	switchA.Port("uplink-a", 1).IPv4("203.0.113.2/24")
+	switchB.Port("uplink-b", 1).IPv4("203.0.113.3/24")
+	return s
+}
+
+func newOSPFDirectScenario() *topologyScenario {
+	s := newTopologyScenario("ospf_direct").WithOptions(func(options *topologyoptions.QueryOptions) {
+		options.CollapseActorsByIP = false
+	})
+	routerA := s.Router("ospf-router-a", "192.0.2.131", "02:00:00:00:0d:01", "192.0.2.231", "65131")
+	routerB := s.Router("ospf-router-b", "192.0.2.132", "02:00:00:00:0d:02", "192.0.2.232", "65132")
+	s.OSPF(routerA.Port("loopback0", 1), routerB.Port("loopback0", 1))
+	return s
+}
+
+func newBGPDirectScenario() *topologyScenario {
+	s := newTopologyScenario("bgp_direct").WithOptions(func(options *topologyoptions.QueryOptions) {
+		options.CollapseActorsByIP = false
+	})
+	routerA := s.Router("bgp-router-a", "192.0.2.141", "02:00:00:00:0e:01", "192.0.2.241", "65141")
+	routerB := s.Router("bgp-router-b", "192.0.2.142", "02:00:00:00:0e:02", "192.0.2.242", "65142")
+	s.BGP(routerA, routerB, "default")
 	return s
 }
 
@@ -385,6 +494,26 @@ func assertFocusDepthL2Scenario(t testing.TB, data topologyv1test.NormalizedData
 	assertScenarioNoActor(t, data, "focus-switch-c")
 }
 
+func assertLLDPDirectScenario(t testing.TB, data topologyv1test.NormalizedData) {
+	t.Helper()
+
+	assertScenarioActors(t, data, []topologyScenarioActorExpectation{
+		{Name: "lldp-switch-a", Type: "switch", ManagementIP: "192.0.2.71"},
+		{Name: "lldp-switch-b", Type: "switch", ManagementIP: "192.0.2.72"},
+	})
+	assertScenarioLinks(t, data, []topologyScenarioLinkExpectation{
+		{Type: "lldp", Src: "lldp-switch-a", Dst: "lldp-switch-b", Direction: "bidirectional", Protocol: "lldp", SrcPort: "a-b", DstPort: "b-a"},
+	})
+	assertScenarioTableRowsExactly(t, data, "actor_port_links", []map[string]any{
+		{"actor": "lldp-switch-a", "remote_actor": "lldp-switch-b", "type": "lldp", "protocol": "lldp", "if_index": 1, "port_name": "a-b", "remote_if_index": 1, "remote_port_name": "b-a"},
+		{"actor": "lldp-switch-b", "remote_actor": "lldp-switch-a", "type": "lldp", "protocol": "lldp", "if_index": 1, "port_name": "b-a", "remote_if_index": 1, "remote_port_name": "a-b"},
+	})
+	assertScenarioEvidenceRowsExactly(t, data, "lldp", []map[string]any{
+		{"src_actor": "lldp-switch-a", "dst_actor": "lldp-switch-b", "src_if_index": 1, "dst_if_index": 1, "src_port_name": "a-b", "dst_port_name": "b-a", "protocol": "lldp"},
+	})
+	assertScenarioStatEquals(t, data, "links_lldp", 1)
+}
+
 func assertCDPDirectScenario(t testing.TB, data topologyv1test.NormalizedData) {
 	t.Helper()
 
@@ -405,6 +534,33 @@ func assertCDPDirectScenario(t testing.TB, data topologyv1test.NormalizedData) {
 	assertScenarioStatEquals(t, data, "links_cdp", 1)
 }
 
+func assertLLDPCDPSameLinkScenario(t testing.TB, data topologyv1test.NormalizedData) {
+	t.Helper()
+
+	assertScenarioActors(t, data, []topologyScenarioActorExpectation{
+		{Name: "dual-switch-a", Type: "switch", ManagementIP: "192.0.2.81"},
+		{Name: "dual-switch-b", Type: "switch", ManagementIP: "192.0.2.82"},
+	})
+	assertScenarioLinks(t, data, []topologyScenarioLinkExpectation{
+		{Type: "cdp", Src: "dual-switch-a", Dst: "dual-switch-b", Direction: "bidirectional", Protocol: "cdp", SrcPort: "a-b", DstPort: "b-a"},
+		{Type: "lldp", Src: "dual-switch-a", Dst: "dual-switch-b", Direction: "bidirectional", Protocol: "lldp", SrcPort: "a-b", DstPort: "b-a"},
+	})
+	assertScenarioTableRowsExactly(t, data, "actor_port_links", []map[string]any{
+		{"actor": "dual-switch-a", "remote_actor": "dual-switch-b", "type": "cdp", "protocol": "cdp", "if_index": 1, "port_name": "a-b", "remote_if_index": 1, "remote_port_name": "b-a"},
+		{"actor": "dual-switch-a", "remote_actor": "dual-switch-b", "type": "lldp", "protocol": "lldp", "if_index": 1, "port_name": "a-b", "remote_if_index": 1, "remote_port_name": "b-a"},
+		{"actor": "dual-switch-b", "remote_actor": "dual-switch-a", "type": "cdp", "protocol": "cdp", "if_index": 1, "port_name": "b-a", "remote_if_index": 1, "remote_port_name": "a-b"},
+		{"actor": "dual-switch-b", "remote_actor": "dual-switch-a", "type": "lldp", "protocol": "lldp", "if_index": 1, "port_name": "b-a", "remote_if_index": 1, "remote_port_name": "a-b"},
+	})
+	assertScenarioEvidenceRowsExactly(t, data, "cdp", []map[string]any{
+		{"src_actor": "dual-switch-a", "dst_actor": "dual-switch-b", "src_if_index": 1, "dst_if_index": 1, "src_port_name": "a-b", "dst_port_name": "b-a", "protocol": "cdp"},
+	})
+	assertScenarioEvidenceRowsExactly(t, data, "lldp", []map[string]any{
+		{"src_actor": "dual-switch-a", "dst_actor": "dual-switch-b", "src_if_index": 1, "dst_if_index": 1, "src_port_name": "a-b", "dst_port_name": "b-a", "protocol": "lldp"},
+	})
+	assertScenarioStatEquals(t, data, "links_cdp", 1)
+	assertScenarioStatEquals(t, data, "links_lldp", 1)
+}
+
 func assertSTPInferredScenario(t testing.TB, data topologyv1test.NormalizedData) {
 	t.Helper()
 
@@ -423,6 +579,44 @@ func assertSTPInferredScenario(t testing.TB, data topologyv1test.NormalizedData)
 	assertScenarioStatEquals(t, data, "links_stp", 2)
 }
 
+func assertFDBPairwiseScenario(t testing.TB, data topologyv1test.NormalizedData) {
+	t.Helper()
+
+	assertScenarioActors(t, data, []topologyScenarioActorExpectation{
+		{Name: "fdb-switch-a", Type: "switch", ManagementIP: "192.0.2.91"},
+		{Name: "fdb-switch-b", Type: "switch", ManagementIP: "192.0.2.92"},
+		{Name: "fdb-switch-a.uplink-a.segment", Type: "segment"},
+	})
+	assertScenarioLinks(t, data, []topologyScenarioLinkExpectation{
+		{Type: "bridge", Src: "fdb-switch-a", Dst: "fdb-switch-a.uplink-a.segment", Direction: "bidirectional", Protocol: "bridge", SrcPort: "uplink-a"},
+		{Type: "bridge", Src: "fdb-switch-b", Dst: "fdb-switch-a.uplink-a.segment", Direction: "bidirectional", Protocol: "bridge", SrcPort: "uplink-b"},
+	})
+	assertScenarioEvidenceRowsExactly(t, data, "bridge", []map[string]any{
+		{"src_actor": "fdb-switch-a", "dst_actor": "fdb-switch-a.uplink-a.segment", "src_if_index": 1, "src_port_name": "uplink-a", "protocol": "bridge"},
+		{"src_actor": "fdb-switch-b", "dst_actor": "fdb-switch-a.uplink-a.segment", "src_if_index": 1, "src_port_name": "uplink-b", "protocol": "bridge"},
+	})
+	assertScenarioStatEquals(t, data, "attachments_fdb", 2)
+	assertScenarioStatEquals(t, data, "enrichments_arp_nd", 2)
+}
+
+func assertL3P2P30Scenario(t testing.TB, data topologyv1test.NormalizedData) {
+	t.Helper()
+
+	assertScenarioActors(t, data, []topologyScenarioActorExpectation{
+		{Name: "p2p30-router-a", Type: "router", ManagementIP: "192.0.2.111"},
+		{Name: "p2p30-router-b", Type: "router", ManagementIP: "192.0.2.112"},
+	})
+	assertScenarioLinks(t, data, []topologyScenarioLinkExpectation{
+		{Type: topologymodel.L3SubnetLinkType, Src: "p2p30-router-a", Dst: "p2p30-router-b", Direction: "observed", Protocol: topologymodel.L3SubnetLinkType, SrcPort: "wan0", DstPort: "wan0"},
+	})
+	assertScenarioEvidenceRowsExactly(t, data, topologymodel.L3SubnetLinkType, []map[string]any{
+		{"src_actor": "p2p30-router-a", "dst_actor": "p2p30-router-b", "src_ip": "198.51.100.21", "dst_ip": "198.51.100.22", "src_if_index": 1, "dst_if_index": 1, "src_port_name": "wan0", "dst_port_name": "wan0", "subnet": "198.51.100.20/30", "prefix": 30},
+	})
+	assertScenarioNoActor(t, data, "198.51.100.20/30")
+	assertScenarioStatEquals(t, data, "l3_subnet_visible_links", 1)
+	assertScenarioStatEquals(t, data, "l3_subnet_segment_emitted_segments", 0)
+}
+
 func assertL3P2P31Scenario(t testing.TB, data topologyv1test.NormalizedData) {
 	t.Helper()
 
@@ -439,6 +633,72 @@ func assertL3P2P31Scenario(t testing.TB, data topologyv1test.NormalizedData) {
 	assertScenarioNoActor(t, data, "198.51.100.10/31")
 	assertScenarioStatEquals(t, data, "l3_subnet_visible_links", 1)
 	assertScenarioStatEquals(t, data, "l3_subnet_segment_emitted_segments", 0)
+}
+
+func assertL3Segment24Scenario(t testing.TB, data topologyv1test.NormalizedData) {
+	t.Helper()
+
+	assertScenarioActors(t, data, []topologyScenarioActorExpectation{
+		{Name: "segment-router-a", Type: "router", ManagementIP: "192.0.2.121"},
+		{Name: "segment-switch-a", Type: "switch", ManagementIP: "192.0.2.122"},
+		{Name: "segment-switch-b", Type: "switch", ManagementIP: "192.0.2.123"},
+		{Name: "203.0.113.0/24", Type: topologymodel.L3SubnetSegmentActorType},
+	})
+	assertScenarioLinks(t, data, []topologyScenarioLinkExpectation{
+		{Type: topologymodel.L3SubnetMembershipLinkType, Src: "segment-router-a", Dst: "203.0.113.0/24", Direction: "observed", Protocol: topologymodel.L3SubnetMembershipLinkType, SrcPort: "lan0"},
+		{Type: topologymodel.L3SubnetMembershipLinkType, Src: "segment-switch-a", Dst: "203.0.113.0/24", Direction: "observed", Protocol: topologymodel.L3SubnetMembershipLinkType, SrcPort: "uplink-a"},
+		{Type: topologymodel.L3SubnetMembershipLinkType, Src: "segment-switch-b", Dst: "203.0.113.0/24", Direction: "observed", Protocol: topologymodel.L3SubnetMembershipLinkType, SrcPort: "uplink-b"},
+	})
+	assertScenarioEvidenceRowsExactly(t, data, topologymodel.L3SubnetMembershipLinkType, []map[string]any{
+		{"member_actor": "segment-router-a", "segment_actor": "203.0.113.0/24", "member_ip": "203.0.113.1", "member_if_index": 1, "member_if_name": "lan0", "subnet": "203.0.113.0/24", "prefix": 24},
+		{"member_actor": "segment-switch-a", "segment_actor": "203.0.113.0/24", "member_ip": "203.0.113.2", "member_if_index": 1, "member_if_name": "uplink-a", "subnet": "203.0.113.0/24", "prefix": 24},
+		{"member_actor": "segment-switch-b", "segment_actor": "203.0.113.0/24", "member_ip": "203.0.113.3", "member_if_index": 1, "member_if_name": "uplink-b", "subnet": "203.0.113.0/24", "prefix": 24},
+	})
+	assertScenarioStatEquals(t, data, "l3_subnet_visible_links", 0)
+	assertScenarioStatEquals(t, data, "l3_subnet_membership_visible_links", 3)
+	assertScenarioStatEquals(t, data, "l3_subnet_segment_emitted_segments", 1)
+}
+
+func assertOSPFDirectScenario(t testing.TB, data topologyv1test.NormalizedData) {
+	t.Helper()
+
+	assertScenarioActors(t, data, []topologyScenarioActorExpectation{
+		{Name: "ospf-router-a", Type: "router", ManagementIP: "192.0.2.131"},
+		{Name: "ospf-router-b", Type: "router", ManagementIP: "192.0.2.132"},
+	})
+	assertScenarioLinks(t, data, []topologyScenarioLinkExpectation{
+		{Type: topologymodel.OSPFAdjacencyLinkType, Src: "ospf-router-a", Dst: "ospf-router-b", Direction: "observed", Protocol: topologymodel.OSPFAdjacencyLinkType, State: "full"},
+	})
+	assertScenarioTableRowsExactly(t, data, "actor_ospf_neighbors", []map[string]any{
+		{"actor": "ospf-router-a", "remote_actor": "ospf-router-b", "local_router_id": "192.0.2.231", "neighbor_router_id": "192.0.2.232", "state": "full"},
+		{"actor": "ospf-router-b", "remote_actor": "ospf-router-a", "local_router_id": "192.0.2.232", "neighbor_router_id": "192.0.2.231", "state": "full"},
+	})
+	assertScenarioEvidenceRowsExactly(t, data, topologymodel.OSPFAdjacencyLinkType, []map[string]any{
+		{"src_actor": "ospf-router-a", "dst_actor": "ospf-router-b", "src_router_id": "192.0.2.231", "dst_router_id": "192.0.2.232", "state": "full"},
+	})
+	assertScenarioStatEquals(t, data, "ospf_adjacency_emitted_links", 1)
+	assertScenarioStatEquals(t, data, "ospf_adjacency_visible_links", 1)
+}
+
+func assertBGPDirectScenario(t testing.TB, data topologyv1test.NormalizedData) {
+	t.Helper()
+
+	assertScenarioActors(t, data, []topologyScenarioActorExpectation{
+		{Name: "bgp-router-a", Type: "router", ManagementIP: "192.0.2.141"},
+		{Name: "bgp-router-b", Type: "router", ManagementIP: "192.0.2.142"},
+	})
+	assertScenarioLinks(t, data, []topologyScenarioLinkExpectation{
+		{Type: topologymodel.BGPAdjacencyLinkType, Src: "bgp-router-a", Dst: "bgp-router-b", Direction: "observed", Protocol: topologymodel.BGPAdjacencyLinkType, State: "established"},
+	})
+	assertScenarioTableRowsExactly(t, data, "actor_bgp_peers", []map[string]any{
+		{"actor": "bgp-router-a", "remote_actor": "bgp-router-b", "local_ip": "192.0.2.141", "neighbor_ip": "192.0.2.142", "local_as": "65141", "remote_as": "65142", "local_identifier": "192.0.2.241", "peer_identifier": "192.0.2.242", "state": "established", "routing_instance": "default"},
+		{"actor": "bgp-router-b", "remote_actor": "bgp-router-a", "local_ip": "192.0.2.142", "neighbor_ip": "192.0.2.141", "local_as": "65142", "remote_as": "65141", "local_identifier": "192.0.2.242", "peer_identifier": "192.0.2.241", "state": "established", "routing_instance": "default"},
+	})
+	assertScenarioEvidenceRowsExactly(t, data, topologymodel.BGPAdjacencyLinkType, []map[string]any{
+		{"src_actor": "bgp-router-a", "dst_actor": "bgp-router-b", "local_ip": "192.0.2.141", "neighbor_ip": "192.0.2.142", "local_as": "65141", "remote_as": "65142", "local_identifier": "192.0.2.241", "peer_identifier": "192.0.2.242", "state": "established", "routing_instance": "default"},
+	})
+	assertScenarioStatEquals(t, data, "bgp_adjacency_emitted_links", 1)
+	assertScenarioStatEquals(t, data, "bgp_adjacency_visible_links", 1)
 }
 
 func assertScenarioActors(t testing.TB, data topologyv1test.NormalizedData, want []topologyScenarioActorExpectation) {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds semantic scenario assertions and broad L2/L3 coverage to `snmp_topology` tests, improving validation of link inference and evidence. Also generates unique synthetic port MACs to prevent actor collapse during testing.

- **New Features**
  - Added scenarios and assertions: LLDP, CDP, LLDP+CDP on same link, STP inferred, FDB pairwise, L3 /30 and /31 P2P, L3 /24 segment membership, OSPF, BGP.
  - Updated existing scenarios: mixed L2/L3 control now asserts CDP; focus-depth L2 asserts LLDP link and evidence.
  - Golden tests limited to a stable subset and decoupled from semantic assertions.

- **Refactors**
  - Synthetic interface MACs are now FNV-derived from chassis MAC + ifIndex to keep projected actors unique across devices.
  - Removed stale "no visible links" helper; tests use explicit link and evidence checks.

<sup>Written for commit b7bb47dd080a9849ada43c60cec318e7f06df95c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

