### PR TITLE
build: enable netflow plugin in static and docker builds

### DIFF
--- a/docs/npm/network-flows/installation.md
+++ b/docs/npm/network-flows/installation.md
@@ -14,13 +14,13 @@ The netflow plugin is **packaged separately from the main Netdata Agent**. You i
 
 The package name is **`netdata-plugin-netflow`** on both Debian and RPM distributions. It is not installed by the standard `netdata` package or by the netdata-updater on its own — you have to install it explicitly on native-package systems.
 
-The static install (the kickstart `--static-only` path) bundles the plugin automatically. If you used the kickstart installer with the static option, no extra step is needed.
+The static install (the kickstart `--static-only` path) bundles the plugin automatically on x86_64, ARMv7, and ARM64. It is **not** included in the ARMv6 static build (Raspberry Pi 1 / Zero). If you used the kickstart installer with the static option on a supported architecture, no extra step is needed.
 
 ## Prerequisites
 
 - A working Netdata Agent on the host that will receive flow data.
 - That host must be reachable on UDP from your routers and switches (default port `2055`).
-- A Netdata installation that includes `netdata-plugin-netflow`. Native Linux packages install it as a separate package; static installs bundle it automatically; source builds need a Rust toolchain.
+- A Netdata installation that includes `netdata-plugin-netflow`. Native Linux packages install it as a separate package; static installs bundle it automatically (except the ARMv6 build — Raspberry Pi 1 / Zero); source builds need a Rust toolchain.
 
 ## Install on Debian / Ubuntu / Mint
 
@@ -55,7 +55,7 @@ wget -O /tmp/netdata-kickstart.sh https://get.netdata.cloud/kickstart.sh && \
   sh /tmp/netdata-kickstart.sh --static-only
 ```
 
-…the netflow plugin is already installed under `/opt/netdata/usr/libexec/netdata/plugins.d/netflow-plugin`. No extra step.
+…the netflow plugin is already installed under `/opt/netdata/usr/libexec/netdata/plugins.d/netflow-plugin`. No extra step. (The ARMv6 static build — Raspberry Pi 1 / Zero — does not include the plugin; build from source there, see [Source build](#source-build) below.)
 
 To verify:
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -39,6 +39,7 @@ RUN chmod +x netdata-installer.sh && \
    --disable-ebpf \
    --enable-plugin-otel \
    --enable-plugin-otel-signal-viewer \
+   --enable-plugin-netflow \
    --internal-systemd-journal \
    ${EXTRA_INSTALL_OPTS} \
    --install-no-prefix / \

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -29,11 +29,11 @@ export RUSTFLAGS="-C target-feature=+crt-static"
 case "${BUILDARCH}" in
     armv6l)
         export NETDATA_CMAKE_OPTIONS="-DSTATIC_BUILD=On -DENABLE_LIBBACKTRACE=On"
-        export INSTALLER_ARGS="--disable-plugin-systemd-journal --disable-plugin-otel --disable-plugin-otel-signal-viewer"
+        export INSTALLER_ARGS="--disable-plugin-systemd-journal --disable-plugin-otel --disable-plugin-otel-signal-viewer --disable-plugin-netflow"
         ;;
     *)
         export NETDATA_CMAKE_OPTIONS="-DSTATIC_BUILD=On -DENABLE_LIBBACKTRACE=On"
-        export INSTALLER_ARGS="--enable-plugin-systemd-journal --internal-systemd-journal --enable-plugin-otel --enable-plugin-otel-signal-viewer"
+        export INSTALLER_ARGS="--enable-plugin-systemd-journal --internal-systemd-journal --enable-plugin-otel --enable-plugin-otel-signal-viewer --enable-plugin-netflow"
         ;;
 esac
 


### PR DESCRIPTION
The NetFlow/IPFIX/sFlow plugin shipped only in native deb/rpm packages. It was absent from static (makeself) and docker builds because neither passed --enable-plugin-netflow and the cmake default is off.

- makeself: enable on x86_64/armv7l/aarch64; keep it disabled on armv6l (Raspberry Pi 1 / Zero), consistent with the other heavy Rust plugins (otel, otel-signal-viewer, internal systemd-journal) already disabled there.
- docker: enable for all platforms, matching the otel plugins.
- docs: qualify the "static installs bundle it automatically" claims in the network-flows install guide with the ARMv6 exception.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the NetFlow/IPFIX/sFlow plugin in static and Docker builds to match native packages. This adds flow collection to static installers and all Docker images, with ARMv6 still excluded.

- **New Features**
  - Static (makeself): enabled on x86_64, ARMv7, and ARM64; kept disabled on ARMv6 (Raspberry Pi 1/Zero) like other heavy Rust plugins.
  - Docker: added `--enable-plugin-netflow` across all platforms.
  - Docs: clarified that static installs bundle `netdata-plugin-netflow` except on ARMv6.

<sup>Written for commit bde1f5a86ec83e48addf2e020de536724df0c066. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

