### PR TITLE
feat(go.d): publish SNMP topology function after data is ready

### DIFF
--- a/.agents/sow/specs/README.md
+++ b/.agents/sow/specs/README.md
@@ -15,6 +15,7 @@ research cannot be mistaken for product specification.
 
 | Spec | Scope | Main consumers |
 |---|---|---|
+| [go-function-publication-lifecycle.md](go-function-publication-lifecycle.md) | Go Function publication lifecycle for module/static methods, `Available`, monotonic late publication, and job-method boundaries. | go.d Function producers, `funcctl`, `jobmgr`, collector authors with runtime-gated Functions. |
 | [go-v2-host-scope.md](go-v2-host-scope.md) | Go framework V2 host-scope and vnode metric routing contract. | Go V2 collector work, `metrix`, `jobruntime`, `chartengine`, go.d collector docs and skills. |
 | [journal-log-writer-directory-contract.md](journal-log-writer-directory-contract.md) | `Log::new` requires an absolute journal directory (rejected early otherwise); consumers must resolve relative config against a stable base. | journal-log-writer consumers: otel-plugin logs, netflow-plugin tiers. |
 | [netflow-tier-commit-workers.md](netflow-tier-commit-workers.md) | NetFlow rollup-tier commit worker contract: ownership, doorbell protocol, shutdown order, stretch semantics, lock discipline, telemetry. | netflow-plugin ingest/tiering work, tier benchmark and soak/crash tests, network-flows operator docs. |

--- a/.agents/sow/specs/go-function-publication-lifecycle.md
+++ b/.agents/sow/specs/go-function-publication-lifecycle.md
@@ -1,0 +1,60 @@
+# Go Function Publication Lifecycle
+
+## Scope
+
+This spec applies to go.d Functions registered through:
+
+- `collectorapi.Creator.Methods` for module/static methods.
+- `collectorapi.Creator.JobMethods` for per-job methods.
+- `funcapi.MethodConfig.Available` for first-publication gating.
+
+It does not define Netdata Cloud discovery behavior beyond the Agent-side
+publication stream emitted by go.d.
+
+## Module And Static Methods
+
+- Module/static methods MUST be declared through `collectorapi.Creator.Methods`.
+- funcctl owns module/static Function publication. Collectors MUST NOT publish
+  their module/static Functions by calling `funcctl`, `dyncfg.Responder`,
+  `netdataapi`, or plugins.d `FUNCTION` commands directly.
+- `Available == nil` means the method is available for publication.
+- `Available != nil` gates first publication only.
+- funcctl MAY recheck unpublished module/static methods while jobs are running.
+  jobmgr currently performs this recheck from the running-job tick loop.
+- Publication is monotonic:
+  - once funcctl publishes a module/static Function, later `Available == false`
+    results MUST NOT withdraw it;
+  - the Function remains published until go.d cleanup or restart;
+  - withdrawal-on-empty requires a separate explicit lifecycle design.
+- Rechecks MUST reuse the normal funcctl publication path so public names,
+  aliases, tags, `RequireCloud`, `AgentWide`, handler wiring, and collision
+  behavior stay consistent.
+
+## `Available` Predicate Contract
+
+- `Available` MUST be cheap and non-blocking.
+- `Available` MUST NOT perform network I/O, expensive rendering, or long-running
+  collection work.
+- Collectors that need runtime readiness SHOULD update collector-owned state
+  from their normal collection or refresh path. `Available` SHOULD only read
+  that state.
+- `Available` SHOULD match the Function's user-visible not-ready boundary. For
+  example, a topology Function should become available when it can return
+  renderable topology data instead of its normal not-ready response.
+
+## Job Methods
+
+- Per-job methods remain tied to job lifecycle.
+- `collectorapi.Creator.JobMethods` methods are registered for a job on job
+  start and unregistered on job stop.
+- This spec does not add late-publication or monotonic behavior to job methods.
+
+## Validation Guidance
+
+- Tests for a module/static method with `Available` SHOULD cover:
+  - not published at module registration or job start while unavailable;
+  - published after a running-job recheck when availability turns true;
+  - not duplicated after publication;
+  - not withdrawn when availability later turns false.
+- Race tests SHOULD cover concurrent running-job rechecks and job lifecycle
+  hooks for modules with availability-gated methods.

--- a/src/go/pkg/funcapi/response.go
+++ b/src/go/pkg/funcapi/response.go
@@ -18,8 +18,8 @@ type MethodConfig struct {
 	Tags         string   // Function tags for registration; empty defaults to "top"
 	ResponseType string   // Response schema type; empty defaults to "table" when dispatched
 	// Available gates publication of module/static methods. Nil means available.
-	// Unavailable module methods may be rechecked while jobs are running.
-	// Once a Function is published, later false results do not remove it.
+	// funcctl may recheck unavailable module methods while jobs are running.
+	// Once a Function is published, later false results do not withdraw it.
 	Available func() bool
 	// RawRequest routes the complete Function request to a RawMethodHandler.
 	// Use this for Function APIs that need raw payloads, args, or full response envelopes.

--- a/src/go/pkg/funcapi/response.go
+++ b/src/go/pkg/funcapi/response.go
@@ -17,7 +17,8 @@ type MethodConfig struct {
 	RequireCloud bool     // Indicates whether the method requires cloud connection
 	Tags         string   // Function tags for registration; empty defaults to "top"
 	ResponseType string   // Response schema type; empty defaults to "table" when dispatched
-	// Available gates first publication of module/static methods. Nil means available.
+	// Available gates publication of module/static methods. Nil means available.
+	// Unavailable module methods may be rechecked while jobs are running.
 	// Once a Function is published, later false results do not remove it.
 	Available func() bool
 	// RawRequest routes the complete Function request to a RawMethodHandler.

--- a/src/go/plugin/agent/jobmgr/funcctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"maps"
 	"sort"
+	"sync"
 
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
@@ -32,6 +33,7 @@ type Controller struct {
 	ctx        context.Context
 
 	registry          *moduleFuncRegistry
+	staticMethodsMu   sync.Mutex
 	staticMethodsSeen map[string]struct{}
 }
 
@@ -144,6 +146,25 @@ func (c *Controller) OnJobStart(job collectorapi.RuntimeJob) {
 	}
 }
 
+// ReconcileModuleMethodsForJob rechecks module/static method availability for a running job.
+//
+// This supports late publication for module methods whose availability depends on
+// runtime state that can appear after job start. Publication remains monotonic:
+// already-published methods are never removed here.
+func (c *Controller) ReconcileModuleMethodsForJob(job collectorapi.RuntimeJob) {
+	if job == nil || !job.IsRunning() {
+		return
+	}
+	if _, ok := c.registry.getJob(job.ModuleName(), job.Name()); !ok {
+		return
+	}
+	methods := c.registry.getMethods(job.ModuleName())
+	if len(methods) == 0 {
+		return
+	}
+	c.registerAvailableModuleMethods(job.ModuleName(), methods, false)
+}
+
 func (c *Controller) OnJobStop(job collectorapi.RuntimeJob) {
 	if job == nil {
 		return
@@ -154,6 +175,9 @@ func (c *Controller) OnJobStop(job collectorapi.RuntimeJob) {
 }
 
 func (c *Controller) Cleanup() {
+	c.staticMethodsMu.Lock()
+	defer c.staticMethodsMu.Unlock()
+
 	for funcName := range c.staticMethodsSeen {
 		c.fnReg.Unregister(funcName)
 		if c.api != nil {
@@ -163,17 +187,23 @@ func (c *Controller) Cleanup() {
 }
 
 func (c *Controller) registerModuleMethodsOnJobStart(moduleName string) {
-	creator, ok := c.registry.getCreator(moduleName)
-	if !ok || creator.Methods == nil {
+	methods := c.registry.getMethods(moduleName)
+	if len(methods) == 0 {
 		return
 	}
 
-	c.registerAvailableModuleMethods(moduleName, creator.Methods(), false)
+	c.registerAvailableModuleMethods(moduleName, methods, false)
 }
 
 func (c *Controller) registerAvailableModuleMethods(moduleName string, methods []funcapi.MethodConfig, agentWideOnly bool) {
+	c.staticMethodsMu.Lock()
+	defer c.staticMethodsMu.Unlock()
+
 	for _, method := range methods {
 		if agentWideOnly && !method.AgentWide {
+			continue
+		}
+		if method.ID != "" && c.allStaticMethodNamesSeenLocked(moduleName, method) {
 			continue
 		}
 		if !methodAvailable(method) {
@@ -223,6 +253,19 @@ func (c *Controller) registerAvailableModuleMethods(moduleName string, methods [
 			c.staticMethodsSeen[funcName] = struct{}{}
 		}
 	}
+}
+
+func (c *Controller) allStaticMethodNamesSeenLocked(moduleName string, method funcapi.MethodConfig) bool {
+	names := funcapi.MethodFunctionNames(moduleName, method)
+	if len(names) == 0 {
+		return false
+	}
+	for _, name := range names {
+		if _, seen := c.staticMethodsSeen[name]; !seen {
+			return false
+		}
+	}
+	return true
 }
 
 func methodTags(method funcapi.MethodConfig) string {

--- a/src/go/plugin/agent/jobmgr/funcctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller.go
@@ -32,10 +32,9 @@ type Controller struct {
 	fnReg      functions.Registry
 	ctx        context.Context
 
-	registry           *moduleFuncRegistry
-	staticMethodsMu    sync.Mutex
-	staticMethodsSeen  map[string]struct{}
-	staticWarningsSeen map[string]struct{}
+	registry          *moduleFuncRegistry
+	staticMethodsMu   sync.Mutex
+	staticMethodsSeen map[string]struct{}
 }
 
 func New(opts Options) *Controller {
@@ -49,13 +48,12 @@ func New(opts Options) *Controller {
 	}
 
 	return &Controller{
-		Logger:             log,
-		api:                opts.API,
-		jsonWriter:         opts.JSONWriter,
-		fnReg:              reg,
-		registry:           newModuleFuncRegistry(),
-		staticMethodsSeen:  make(map[string]struct{}),
-		staticWarningsSeen: make(map[string]struct{}),
+		Logger:            log,
+		api:               opts.API,
+		jsonWriter:        opts.JSONWriter,
+		fnReg:             reg,
+		registry:          newModuleFuncRegistry(),
+		staticMethodsSeen: make(map[string]struct{}),
 	}
 }
 
@@ -212,8 +210,8 @@ func (c *Controller) registerAvailableModuleMethods(moduleName string, methods [
 			continue
 		}
 		if method.ID == "" {
-			c.warnStaticMethodOnceLocked(fmt.Sprintf("%s:%d:empty-id", moduleName, i),
-				"skipping function registration for module '%s': empty method ID", moduleName)
+			c.Once(fmt.Sprintf("funcctl:static-method:%s:%d:empty-id", moduleName, i)).
+				Warningf("skipping function registration for module '%s': empty method ID", moduleName)
 			continue
 		}
 
@@ -256,14 +254,6 @@ func (c *Controller) registerAvailableModuleMethods(moduleName string, methods [
 			c.staticMethodsSeen[funcName] = struct{}{}
 		}
 	}
-}
-
-func (c *Controller) warnStaticMethodOnceLocked(key string, format string, args ...any) {
-	if _, seen := c.staticWarningsSeen[key]; seen {
-		return
-	}
-	c.Warningf(format, args...)
-	c.staticWarningsSeen[key] = struct{}{}
 }
 
 func (c *Controller) allStaticMethodNamesSeenLocked(moduleName string, method funcapi.MethodConfig) bool {

--- a/src/go/plugin/agent/jobmgr/funcctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller.go
@@ -32,9 +32,10 @@ type Controller struct {
 	fnReg      functions.Registry
 	ctx        context.Context
 
-	registry          *moduleFuncRegistry
-	staticMethodsMu   sync.Mutex
-	staticMethodsSeen map[string]struct{}
+	registry           *moduleFuncRegistry
+	staticMethodsMu    sync.Mutex
+	staticMethodsSeen  map[string]struct{}
+	staticWarningsSeen map[string]struct{}
 }
 
 func New(opts Options) *Controller {
@@ -48,12 +49,13 @@ func New(opts Options) *Controller {
 	}
 
 	return &Controller{
-		Logger:            log,
-		api:               opts.API,
-		jsonWriter:        opts.JSONWriter,
-		fnReg:             reg,
-		registry:          newModuleFuncRegistry(),
-		staticMethodsSeen: make(map[string]struct{}),
+		Logger:             log,
+		api:                opts.API,
+		jsonWriter:         opts.JSONWriter,
+		fnReg:              reg,
+		registry:           newModuleFuncRegistry(),
+		staticMethodsSeen:  make(map[string]struct{}),
+		staticWarningsSeen: make(map[string]struct{}),
 	}
 }
 
@@ -199,7 +201,7 @@ func (c *Controller) registerAvailableModuleMethods(moduleName string, methods [
 	c.staticMethodsMu.Lock()
 	defer c.staticMethodsMu.Unlock()
 
-	for _, method := range methods {
+	for i, method := range methods {
 		if agentWideOnly && !method.AgentWide {
 			continue
 		}
@@ -210,7 +212,8 @@ func (c *Controller) registerAvailableModuleMethods(moduleName string, methods [
 			continue
 		}
 		if method.ID == "" {
-			c.Warningf("skipping function registration for module '%s': empty method ID", moduleName)
+			c.warnStaticMethodOnceLocked(fmt.Sprintf("%s:%d:empty-id", moduleName, i),
+				"skipping function registration for module '%s': empty method ID", moduleName)
 			continue
 		}
 
@@ -253,6 +256,14 @@ func (c *Controller) registerAvailableModuleMethods(moduleName string, methods [
 			c.staticMethodsSeen[funcName] = struct{}{}
 		}
 	}
+}
+
+func (c *Controller) warnStaticMethodOnceLocked(key string, format string, args ...any) {
+	if _, seen := c.staticWarningsSeen[key]; seen {
+		return
+	}
+	c.Warningf(format, args...)
+	c.staticWarningsSeen[key] = struct{}{}
 }
 
 func (c *Controller) allStaticMethodNamesSeenLocked(moduleName string, method funcapi.MethodConfig) bool {

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
 	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/pkg/safewriter"
@@ -422,6 +424,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 		"reconcile registers late available static method":              {},
 		"reconcile ignores stopped job":                                 {},
 		"reconcile does not duplicate published static method":          {},
+		"reconcile logs empty static method ID once":                    {},
 		"public method name collision skips colliding module":           {},
 		"rejected module does not poison planned public names":          {},
 		"topology methods register direct alias":                        {},
@@ -576,6 +579,29 @@ func TestControllerLifecycleHooks(t *testing.T) {
 
 				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
 				assert.Equal(t, 1, availableCalls)
+
+			case "reconcile logs empty static method ID once":
+				var logBuf bytes.Buffer
+				controller = New(Options{
+					FnReg:  reg,
+					Logger: logger.NewWithWriter(&logBuf),
+				})
+				controller.RegisterModules(collectorapi.Registry{
+					"mod": collectorapi.Creator{
+						Methods: func() []funcapi.MethodConfig {
+							return []funcapi.MethodConfig{{Name: "invalid"}}
+						},
+					},
+				})
+
+				job1 := newTestRuntimeJob("mod", "job1", true)
+				job2 := newTestRuntimeJob("mod", "job2", true)
+				controller.OnJobStart(job1)
+				controller.ReconcileModuleMethodsForJob(job1)
+				controller.OnJobStart(job2)
+				controller.ReconcileModuleMethodsForJob(job2)
+
+				assert.Equal(t, 1, strings.Count(logBuf.String(), "empty method ID"))
 
 			case "public method name collision skips colliding module":
 				controller.RegisterModules(collectorapi.Registry{

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -416,6 +416,9 @@ func TestControllerLifecycleHooks(t *testing.T) {
 		"first job start registers static methods once":                 {},
 		"availability-gated static method registers when available":     {},
 		"availability-gated agent-wide method registers when available": {},
+		"reconcile registers late available static method":              {},
+		"reconcile ignores stopped job":                                 {},
+		"reconcile does not duplicate published static method":          {},
 		"public method name collision skips colliding module":           {},
 		"rejected module does not poison planned public names":          {},
 		"topology methods register direct alias":                        {},
@@ -507,6 +510,69 @@ func TestControllerLifecycleHooks(t *testing.T) {
 				controller.OnJobStart(newTestRuntimeJob("mod", "job2", true))
 
 				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
+
+			case "reconcile registers late available static method":
+				available := false
+				controller.RegisterModules(collectorapi.Registry{
+					"mod": collectorapi.Creator{
+						Methods: func() []funcapi.MethodConfig {
+							return []funcapi.MethodConfig{{
+								ID:        "logs",
+								Available: func() bool { return available },
+							}}
+						},
+					},
+				})
+
+				job := newTestRuntimeJob("mod", "job1", true)
+				controller.OnJobStart(job)
+				assert.Empty(t, reg.registeredNames())
+
+				available = true
+				controller.ReconcileModuleMethodsForJob(job)
+
+				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
+
+			case "reconcile ignores stopped job":
+				available := true
+				controller.RegisterModules(collectorapi.Registry{
+					"mod": collectorapi.Creator{
+						Methods: func() []funcapi.MethodConfig {
+							return []funcapi.MethodConfig{{
+								ID:        "logs",
+								Available: func() bool { return available },
+							}}
+						},
+					},
+				})
+
+				controller.ReconcileModuleMethodsForJob(newTestRuntimeJob("mod", "job1", false))
+
+				assert.Empty(t, reg.registeredNames())
+
+			case "reconcile does not duplicate published static method":
+				availableCalls := 0
+				controller.RegisterModules(collectorapi.Registry{
+					"mod": collectorapi.Creator{
+						Methods: func() []funcapi.MethodConfig {
+							return []funcapi.MethodConfig{{
+								ID: "logs",
+								Available: func() bool {
+									availableCalls++
+									return true
+								},
+							}}
+						},
+					},
+				})
+
+				job := newTestRuntimeJob("mod", "job1", true)
+				controller.OnJobStart(job)
+				controller.ReconcileModuleMethodsForJob(job)
+				controller.ReconcileModuleMethodsForJob(job)
+
+				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
+				assert.Equal(t, 1, availableCalls)
 
 			case "public method name collision skips colliding module":
 				controller.RegisterModules(collectorapi.Registry{

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -6,6 +6,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -733,6 +736,96 @@ func TestControllerLifecycleHooks(t *testing.T) {
 	}
 }
 
+func TestControllerReconcileModuleMethodsConcurrentLifecycle(t *testing.T) {
+	reg := newTestFunctionRegistry()
+	controller := New(Options{FnReg: reg})
+
+	var enabled atomic.Bool
+	var availableCalls atomic.Int32
+	var firstAvailable sync.Once
+	firstAvailableCalled := make(chan struct{})
+	releaseAvailable := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseAvailable) })
+
+	aliases := make([]string, 0, 32)
+	for i := range 32 {
+		aliases = append(aliases, fmt.Sprintf("mod:late:alias:%02d", i))
+	}
+
+	controller.RegisterModules(collectorapi.Registry{
+		"mod": collectorapi.Creator{
+			Methods: func() []funcapi.MethodConfig {
+				return []funcapi.MethodConfig{{
+					ID:      "late",
+					Aliases: aliases,
+					Available: func() bool {
+						if !enabled.Load() {
+							return false
+						}
+						if availableCalls.Add(1) == 1 {
+							firstAvailable.Do(func() { close(firstAvailableCalled) })
+						}
+						<-releaseAvailable
+						return true
+					},
+				}}
+			},
+		},
+	})
+
+	const seedJobs = 8
+	jobs := make([]collectorapi.RuntimeJob, 0, seedJobs)
+	for i := range seedJobs {
+		job := newTestRuntimeJob("mod", fmt.Sprintf("seed-%02d", i), true)
+		controller.OnJobStart(job)
+		jobs = append(jobs, job)
+	}
+	require.Empty(t, reg.registeredNames())
+
+	enabled.Store(true)
+
+	const workers = 8
+	const iterations = 40
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			<-start
+			for n := range iterations {
+				controller.ReconcileModuleMethodsForJob(jobs[(worker+n)%len(jobs)])
+			}
+		}(i)
+	}
+	for i := range workers {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			<-start
+			for n := range iterations {
+				job := newTestRuntimeJob("mod", fmt.Sprintf("runtime-%02d-%02d", worker, n), true)
+				controller.OnJobStart(job)
+				controller.OnJobStop(job)
+			}
+		}(i)
+	}
+
+	close(start)
+	select {
+	case <-firstAvailableCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("available predicate was not reached")
+	}
+	time.Sleep(20 * time.Millisecond)
+	releaseOnce.Do(func() { close(releaseAvailable) })
+	wg.Wait()
+
+	expected := append([]string{"mod:late"}, aliases...)
+	assert.ElementsMatch(t, expected, reg.registeredNames())
+}
+
 func TestControllerRegisterJobMethods(t *testing.T) {
 	tests := map[string]struct{}{
 		"fail fast on collision with static method":          {},
@@ -1412,6 +1505,7 @@ func (h *tableTestHandler) Handle(context.Context, string, funcapi.ResolvedParam
 func (h *tableTestHandler) Cleanup(context.Context) {}
 
 type testFunctionRegistry struct {
+	mu              sync.Mutex
 	handlers        map[string]func(functions.Function)
 	contextHandlers map[string]functions.Handler
 	registered      []string
@@ -1427,10 +1521,14 @@ func newTestFunctionRegistry() *testFunctionRegistry {
 }
 
 func (r *testFunctionRegistry) Register(name string, fn func(functions.Function)) {
+	r.mu.Lock()
 	r.handlers[name] = fn
 	r.registered = append(r.registered, name)
-	if r.onRegister != nil {
-		r.onRegister(name, fn)
+	onRegister := r.onRegister
+	r.mu.Unlock()
+
+	if onRegister != nil {
+		onRegister(name, fn)
 	}
 }
 
@@ -1438,15 +1536,22 @@ func (r *testFunctionRegistry) RegisterWithContext(name string, fn functions.Han
 	legacy := func(f functions.Function) {
 		fn(context.Background(), f)
 	}
+	r.mu.Lock()
 	r.handlers[name] = legacy
 	r.contextHandlers[name] = fn
 	r.registered = append(r.registered, name)
-	if r.onRegister != nil {
-		r.onRegister(name, legacy)
+	onRegister := r.onRegister
+	r.mu.Unlock()
+
+	if onRegister != nil {
+		onRegister(name, legacy)
 	}
 }
 
 func (r *testFunctionRegistry) Unregister(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	r.unregistered = append(r.unregistered, name)
 	delete(r.handlers, name)
 	delete(r.contextHandlers, name)
@@ -1458,20 +1563,31 @@ func (r *testFunctionRegistry) UnregisterPrefix(string, string)                 
 func (r *testFunctionRegistry) RegisterPrefixWithContext(string, string, functions.Handler) {}
 
 func (r *testFunctionRegistry) call(name string, ctx context.Context, fn functions.Function) {
-	if handler := r.contextHandlers[name]; handler != nil {
+	r.mu.Lock()
+	handler := r.contextHandlers[name]
+	legacy := r.handlers[name]
+	r.mu.Unlock()
+
+	if handler != nil {
 		handler(ctx, fn)
 		return
 	}
-	r.handlers[name](fn)
+	legacy(fn)
 }
 
 func (r *testFunctionRegistry) registeredNames() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	out := make([]string, len(r.registered))
 	copy(out, r.registered)
 	return out
 }
 
 func (r *testFunctionRegistry) unregisteredNames() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	out := make([]string, len(r.unregistered))
 	copy(out, r.unregistered)
 	return out

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -416,6 +416,7 @@ func (m *Manager) runNotifyRunningJobs() {
 		case clock := <-tk.C:
 			for _, job := range m.runningJobs.snapshot() {
 				job.Tick(clock)
+				m.funcCtl.ReconcileModuleMethodsForJob(job)
 			}
 		}
 	}

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -5,6 +5,7 @@ package jobmgr
 import (
 	"bytes"
 	"context"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -114,6 +115,60 @@ func TestRunNotifyRunningJobs_TickOutsideLock(t *testing.T) {
 	close(job.tickRelease)
 	cancel()
 
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runNotifyRunningJobs did not stop")
+	}
+}
+
+func TestRunNotifyRunningJobs_ReconcilesLateAvailableModuleMethods(t *testing.T) {
+	reg := &recordingFunctionRegistry{}
+	available := false
+	mgr := New(Config{
+		PluginName: testPluginName,
+		FnReg:      reg,
+		Modules: collectorapi.Registry{
+			"mod": collectorapi.Creator{
+				Methods: func() []funcapi.MethodConfig {
+					return []funcapi.MethodConfig{{
+						ID:        "late",
+						Available: func() bool { return available },
+					}}
+				},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mgr.ctx = ctx
+	mgr.funcCtl.Init(ctx)
+	mgr.funcCtl.RegisterModules(mgr.modules)
+
+	job := &tickProbeJob{
+		fullName:   "mod_job1",
+		moduleName: "mod",
+		name:       "job1",
+	}
+	mgr.funcCtl.OnJobStart(job)
+
+	mgr.runningJobs.lock()
+	mgr.runningJobs.add(job.FullName(), job)
+	mgr.runningJobs.unlock()
+
+	available = true
+	done := make(chan struct{})
+	go func() {
+		mgr.runNotifyRunningJobs()
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		return slices.Contains(reg.registeredNames(), "mod:late")
+	}, 2*time.Second, 10*time.Millisecond)
+
+	cancel()
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
@@ -474,6 +529,28 @@ func (j *lockProbeJob) IsRunning() bool                   { return true }
 func (j *lockProbeJob) Panicked() bool                    { return false }
 func (j *lockProbeJob) Vnode() vnodes.VirtualNode         { return vnodes.VirtualNode{} }
 func (j *lockProbeJob) UpdateVnode(_ *vnodes.VirtualNode) {}
+
+type tickProbeJob struct {
+	fullName   string
+	moduleName string
+	name       string
+}
+
+func (j *tickProbeJob) FullName() string                  { return j.fullName }
+func (j *tickProbeJob) ModuleName() string                { return j.moduleName }
+func (j *tickProbeJob) Name() string                      { return j.name }
+func (j *tickProbeJob) Collector() any                    { return nil }
+func (j *tickProbeJob) Start()                            {}
+func (j *tickProbeJob) Stop()                             {}
+func (j *tickProbeJob) Tick(int)                          {}
+func (j *tickProbeJob) AutoDetection() error              { return nil }
+func (j *tickProbeJob) AutoDetectionEvery() int           { return 0 }
+func (j *tickProbeJob) RetryAutoDetection() bool          { return false }
+func (j *tickProbeJob) Cleanup()                          {}
+func (j *tickProbeJob) IsRunning() bool                   { return true }
+func (j *tickProbeJob) Panicked() bool                    { return false }
+func (j *tickProbeJob) Vnode() vnodes.VirtualNode         { return vnodes.VirtualNode{} }
+func (j *tickProbeJob) UpdateVnode(_ *vnodes.VirtualNode) {}
 
 type recordingFunctionRegistry struct {
 	mu         sync.Mutex

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -134,6 +134,7 @@ func (c *Collector) Run(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return nil
 	}
+	c.functionAvailability.Reset()
 	c.publishTrapTopologyEnrichment()
 	defer c.unpublishTrapTopologyEnrichment()
 	c.topologyRegistry.setReverseDNSWarmContext(ctx)

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -267,7 +267,7 @@ func (c *Collector) updateFunctionAvailability() {
 	if c.functionAvailability == nil || c.functionAvailability.Available() {
 		return
 	}
-	if c.topologyRegistry.hasRenderableSnapshot() {
+	if c.topologyRegistry.hasRenderableObservations() {
 		c.functionAvailability.MarkAvailable()
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gosnmp/gosnmp"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
@@ -36,21 +37,26 @@ func newCreator(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmentH
 	if trapEnrichment == nil {
 		panic("snmp_topology Register requires a non-nil trap enrichment handle")
 	}
+	availability := newTopologyFunctionAvailability()
 	return collectorapi.Creator{
 		JobConfigSchema: configSchema,
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 60,
 		},
-		CreateV2:       func() collectorapi.CollectorV2 { return New(deviceStore, trapEnrichment) },
+		CreateV2:       func() collectorapi.CollectorV2 { return newCollector(deviceStore, trapEnrichment, availability) },
 		Config:         func() any { return &Config{} },
 		InstancePolicy: collectorapi.InstancePolicySingle,
-		Methods:        topologyMethods,
+		Methods:        func() []funcapi.MethodConfig { return topologyMethods(availability) },
 		MethodHandler:  topologyFunctionHandler,
 	}
 }
 
 // New returns an SNMP topology collector using the provided SNMP-family state.
 func New(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmentHandle) *Collector {
+	return newCollector(deviceStore, trapEnrichment, newTopologyFunctionAvailability())
+}
+
+func newCollector(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmentHandle, availability *topologyFunctionAvailability) *Collector {
 	if deviceStore == nil {
 		panic("snmp_topology New requires a non-nil device store")
 	}
@@ -59,12 +65,13 @@ func New(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmentHandle) 
 	}
 	metricStore := metrix.NewCollectorStore()
 	return &Collector{
-		deviceCaches:        make(map[string]*topologyCache),
-		deviceLastCollected: make(map[string]time.Time),
-		topologyRegistry:    newTopologyRegistry(),
-		deviceSource:        deviceStore,
-		trapEnrichment:      trapEnrichment,
-		newSnmpClient:       gosnmp.NewHandler,
+		deviceCaches:         make(map[string]*topologyCache),
+		deviceLastCollected:  make(map[string]time.Time),
+		topologyRegistry:     newTopologyRegistry(),
+		functionAvailability: availability,
+		deviceSource:         deviceStore,
+		trapEnrichment:       trapEnrichment,
+		newSnmpClient:        gosnmp.NewHandler,
 		newDdSnmpColl: func(cfg ddsnmpcollector.Config) ddCollector {
 			return ddsnmpcollector.New(cfg)
 		},
@@ -78,11 +85,12 @@ type (
 		collectorapi.Base `yaml:",inline"`
 		Config            `yaml:",inline"`
 
-		deviceCaches        map[string]*topologyCache // one cache per SNMP device
-		deviceLastCollected map[string]time.Time      // last collection time per device
-		topologyRegistry    *topologyRegistry
-		deviceSource        deviceSource
-		trapEnrichment      *TrapEnrichmentHandle
+		deviceCaches         map[string]*topologyCache // one cache per SNMP device
+		deviceLastCollected  map[string]time.Time      // last collection time per device
+		topologyRegistry     *topologyRegistry
+		functionAvailability *topologyFunctionAvailability
+		deviceSource         deviceSource
+		trapEnrichment       *TrapEnrichmentHandle
 
 		refreshMu sync.Mutex
 		statsMu   sync.RWMutex
@@ -251,6 +259,16 @@ func (c *Collector) refreshTopologyRecovering(ctx context.Context) {
 	}()
 
 	c.recordRefreshStats(c.refreshTopology(ctx))
+	c.updateFunctionAvailability()
+}
+
+func (c *Collector) updateFunctionAvailability() {
+	if c.functionAvailability == nil || c.functionAvailability.Available() {
+		return
+	}
+	if c.topologyRegistry.hasRenderableSnapshot() {
+		c.functionAvailability.MarkAvailable()
+	}
 }
 
 // refreshDeviceTopology collects topology data for a single device into its own cache.

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
@@ -3,7 +3,9 @@
 package snmptopology
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
@@ -81,6 +83,43 @@ func TestSNMPTopologyFunctionAvailabilityBecomesReadyAfterRenderableSnapshot(t *
 
 	require.True(t, methods[0].Available())
 	require.True(t, creator.Methods()[0].Available())
+}
+
+func TestSNMPTopologyFunctionAvailabilityResetsWhenReplacementCollectorRuns(t *testing.T) {
+	creator := newCreator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle())
+	methods := creator.Methods()
+	require.Len(t, methods, 1)
+	require.NotNil(t, methods[0].Available)
+
+	coll, ok := creator.CreateV2().(*Collector)
+	require.True(t, ok)
+	cache := newTopologyCache()
+	seedPublishedEndpointSnapshot(cache)
+	coll.topologyRegistry.register(cache)
+	coll.updateFunctionAvailability()
+	require.True(t, methods[0].Available())
+
+	replacement, ok := creator.CreateV2().(*Collector)
+	require.True(t, ok)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- replacement.Run(ctx)
+	}()
+
+	require.Eventually(t, func() bool {
+		return !methods[0].Available()
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("replacement collector did not stop")
+	}
 }
 
 func TestSNMPTopologyNewRequiresSharedDependencies(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
@@ -27,6 +27,8 @@ func TestSNMPTopologyCreatorOwnsTopologyFunction(t *testing.T) {
 	require.Equal(t, snmptopologyfunc.MethodID, methods[0].ID)
 	require.Equal(t, snmptopologyfunc.FunctionName, methods[0].FunctionName)
 	require.True(t, methods[0].AgentWide)
+	require.NotNil(t, methods[0].Available)
+	require.False(t, methods[0].Available())
 
 	coll := newTestSNMPTopologyCollector()
 	handler := creator.MethodHandler(&topologyRuntimeJobForTest{collector: coll})
@@ -60,6 +62,25 @@ func TestSNMPTopologyCreatorRequiresSharedDependencies(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestSNMPTopologyFunctionAvailabilityBecomesReadyAfterRenderableSnapshot(t *testing.T) {
+	creator := newCreator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle())
+	methods := creator.Methods()
+	require.Len(t, methods, 1)
+	require.NotNil(t, methods[0].Available)
+	require.False(t, methods[0].Available())
+
+	coll, ok := creator.CreateV2().(*Collector)
+	require.True(t, ok)
+	cache := newTopologyCache()
+	seedPublishedEndpointSnapshot(cache)
+	coll.topologyRegistry.register(cache)
+
+	coll.updateFunctionAvailability()
+
+	require.True(t, methods[0].Available())
+	require.True(t, creator.Methods()[0].Available())
 }
 
 func TestSNMPTopologyNewRequiresSharedDependencies(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
@@ -66,7 +66,7 @@ func TestSNMPTopologyCreatorRequiresSharedDependencies(t *testing.T) {
 	}
 }
 
-func TestSNMPTopologyFunctionAvailabilityBecomesReadyAfterRenderableSnapshot(t *testing.T) {
+func TestSNMPTopologyFunctionAvailabilityBecomesReadyAfterRenderableObservation(t *testing.T) {
 	creator := newCreator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle())
 	methods := creator.Methods()
 	require.Len(t, methods, 1)

--- a/src/go/plugin/go.d/collector/snmp_topology/func_availability.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_availability.go
@@ -16,6 +16,12 @@ func (a *topologyFunctionAvailability) Available() bool {
 	return a != nil && a.ready.Load()
 }
 
+func (a *topologyFunctionAvailability) Reset() {
+	if a != nil {
+		a.ready.Store(false)
+	}
+}
+
 func (a *topologyFunctionAvailability) MarkAvailable() {
 	if a != nil {
 		a.ready.Store(true)

--- a/src/go/plugin/go.d/collector/snmp_topology/func_availability.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_availability.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import "sync/atomic"
+
+type topologyFunctionAvailability struct {
+	ready atomic.Bool
+}
+
+func newTopologyFunctionAvailability() *topologyFunctionAvailability {
+	return &topologyFunctionAvailability{}
+}
+
+func (a *topologyFunctionAvailability) Available() bool {
+	return a != nil && a.ready.Load()
+}
+
+func (a *topologyFunctionAvailability) MarkAvailable() {
+	if a != nil {
+		a.ready.Store(true)
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/func_deps.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_deps.go
@@ -46,8 +46,14 @@ func (a funcDepsAdapter) ManagedDeviceFocusTargets() []topologyoptions.ManagedFo
 	return a.registry.managedDeviceFocusTargets()
 }
 
-func topologyMethods() []funcapi.MethodConfig {
-	return snmptopologyfunc.Methods()
+func topologyMethods(availability *topologyFunctionAvailability) []funcapi.MethodConfig {
+	methods := snmptopologyfunc.Methods()
+	for i := range methods {
+		if methods[i].ID == snmptopologyfunc.MethodID {
+			methods[i].Available = availability.Available
+		}
+	}
+	return methods
 }
 
 func topologyFunctionHandler(job collectorapi.RuntimeJob) funcapi.MethodHandler {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
@@ -74,6 +74,27 @@ func (c *topologyCache) hasFreshSnapshotAt(now time.Time) bool {
 	return true
 }
 
+func (c *topologyCache) hasRenderableObservationAt(now time.Time) bool {
+	if c == nil {
+		return false
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if !c.hasFreshSnapshotAt(now) {
+		return false
+	}
+
+	local := normalizeTopologyDevice(c.localDevice)
+	localManagementIP := topologyutil.NormalizeIPAddress(local.ManagementIP)
+	if localManagementIP == "" {
+		localManagementIP = pickManagementIP(local.ManagementAddresses)
+	}
+	baseBridgeAddress := c.resolveLocalBaseBridgeAddress(localManagementIP)
+	return strings.TrimSpace(ensureTopologyObservationDeviceID(local, baseBridgeAddress)) != ""
+}
+
 func (c *Collector) finalizeTopologyCache(cache *topologyCache) {
 	if cache == nil {
 		return

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/pluginconfig"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
@@ -63,9 +64,17 @@ func (r *topologyRegistry) snapshotWithOptions(options topologyoptions.QueryOpti
 	return buildSNMPTopologySnapshot(aggregate, options)
 }
 
-func (r *topologyRegistry) hasRenderableSnapshot() bool {
-	_, ok := r.snapshotWithOptions(topologyoptions.DefaultQueryOptions())
-	return ok
+func (r *topologyRegistry) hasRenderableObservations() bool {
+	if r == nil {
+		return false
+	}
+	now := time.Now()
+	for _, cache := range r.activeCaches() {
+		if cache.hasRenderableObservationAt(now) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *topologyRegistry) producerScope() string {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
@@ -63,6 +63,11 @@ func (r *topologyRegistry) snapshotWithOptions(options topologyoptions.QueryOpti
 	return buildSNMPTopologySnapshot(aggregate, options)
 }
 
+func (r *topologyRegistry) hasRenderableSnapshot() bool {
+	_, ok := r.snapshotWithOptions(topologyoptions.DefaultQueryOptions())
+	return ok
+}
+
 func (r *topologyRegistry) producerScope() string {
 	r.mu.RLock()
 	scope := strings.TrimSpace(r.producerScopeID)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -119,6 +119,67 @@ func TestTopologyRegistry_EnqueueReverseDNSWarmFromDefaultSnapshotUsesDisplayCan
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestTopologyRegistry_HasRenderableObservations(t *testing.T) {
+	var nilRegistry *topologyRegistry
+	require.False(t, nilRegistry.hasRenderableObservations())
+
+	tests := map[string]struct {
+		setup func(*topologyRegistry)
+		want  bool
+	}{
+		"empty-registry": {
+			want: false,
+		},
+		"cache-not-yet-published": {
+			setup: func(registry *topologyRegistry) {
+				registry.register(newTopologyCache())
+			},
+			want: false,
+		},
+		"cache-stale": {
+			setup: func(registry *topologyRegistry) {
+				cache := newTopologyCache()
+				seedPublishedEndpointSnapshot(cache)
+				cache.lastUpdate = time.Now().Add(-2 * time.Hour)
+				cache.staleAfter = time.Hour
+				registry.register(cache)
+			},
+			want: false,
+		},
+		"fresh-local-observation": {
+			setup: func(registry *topologyRegistry) {
+				cache := newTopologyCache()
+				now := time.Now()
+				cache.updateTime = now
+				cache.lastUpdate = now
+				cache.staleAfter = time.Hour
+				cache.localDevice = topologymodel.Device{ManagementIP: "10.0.0.1"}
+				registry.register(cache)
+			},
+			want: true,
+		},
+		"fresh-published-endpoint-snapshot": {
+			setup: func(registry *topologyRegistry) {
+				cache := newTopologyCache()
+				seedPublishedEndpointSnapshot(cache)
+				registry.register(cache)
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			registry := newTopologyRegistry()
+			if tc.setup != nil {
+				tc.setup(registry)
+			}
+
+			require.Equal(t, tc.want, registry.hasRenderableObservations())
+		})
+	}
+}
+
 func TestTopologyRegistry_SnapshotSingleCacheKeepsLLDPUnidirectional(t *testing.T) {
 	registry := newTopologyRegistry()
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish the `snmp_topology` function only after data is ready, using a cheap readiness check that doesn’t build snapshots; also support late, monotonic publication of module/static methods at runtime. Adds a lifecycle spec and hardens concurrency, duplication checks, and one-time warnings.

- **New Features**
  - Gate `snmp_topology` publication until a renderable observation exists; tracked via `topologyFunctionAvailability` and checked via the registry without building snapshots.
  - Recheck and publish module/static methods during runtime via `Controller.ReconcileModuleMethodsForJob`, invoked from the manager’s `runNotifyRunningJobs` loop; publication is monotonic.
  - Document the lifecycle in `go-function-publication-lifecycle.md` and clarify `funcapi.MethodConfig.Available` semantics.

- **Bug Fixes**
  - Reset topology function availability on new collector runs; mark available only after a renderable observation.
  - Protect static method publication with a mutex, avoid duplicates across all public names, ignore stopped jobs, and log empty method ID only once (via logger limiter).
  - Add tests for concurrent reconcile, manager tick integration, and SNMP topology availability lifecycle.

<sup>Written for commit 621364b9f5f7d7f66d203b429a0c00b0bf266e8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

