### PR TITLE
NPM docs: capability overviews + Integrations submenu

### DIFF
--- a/docs/npm/README.md
+++ b/docs/npm/README.md
@@ -10,43 +10,32 @@ endmeta-->
 
 # Network Performance Monitoring
 
-You run a network — devices spread across sites, the traffic moving between them, and the events and logs they emit. Netdata gives you **one way to see all of it**, without building a monitoring system to do it.
+Network Performance Monitoring (NPM) in Netdata covers your network devices and the traffic between them — metrics, topology, flows, events, and logs — collected by the Netdata Agent and visualized per second in Netdata dashboards and Netdata Cloud.
 
-This section is for the network and SRE teams who keep the fabric running: you want to find the saturated link, the unhealthy device, the flapping peer, the expiring license — across your whole network, in one place.
+## What you can monitor
 
-## One Agent per site, and it does the rest
+- **Device metrics (SNMP)** — poll routers, switches, firewalls, access points, UPSs, and PDUs. Netdata matches each device to a vendor profile by its `sysObjectID` and collects interfaces (traffic, errors, discards, operational state), system and host resources, and vendor-specific hardware, environmental, and protocol metrics. Every metric is a chart you can alert on, with interactive per-interface and per-device tables.
 
-Put a Netdata Agent at each site and point it at your network. It becomes the **hub** for that part of the network:
+- **Topology** — see how your network connects. Netdata builds Layer 2 maps (LLDP, CDP, MAC/FDB, STP) and Layer 3 maps (BGP, OSPF, ARP), plus live host connections, the Netdata streaming hierarchy, and virtual infrastructure (VMware vSphere, Cato).
 
-- it **discovers your devices** and monitors them — interfaces, health, errors;
-- it **maps how they connect** — the Layer 2 and Layer 3 topology;
-- it **catches the events and logs** they send — traps and syslog.
+- **BGP monitoring** — peer state, advertised and received prefixes, and session health on your routers, with an interactive peer table and alerts on session changes.
 
-These come up **together, automatically, already correlated**: a trap arrives knowing which device sent it and where it sits in the topology. There are no correlation rules to write. Add **network flows** and you also see who is talking to whom, how much, and where.
+- **Licensing** — license state, entitlements, and expiry on devices that report them (Cisco Smart Licensing, Fortinet, Check Point, and others), so a feature never silently stops.
 
-## Scale by adding Agents — the view stays the same
+- **Network flows** — collect NetFlow, sFlow, and IPFIX. See who is talking to whom, how much, and over which ports and protocols, enriched with geolocation, ASN, and IPAM data, in Sankey, time-series, and map views.
 
-Grow the way your network is shaped: a **bigger Agent** for more devices, or **more Agents**, each owning a site, a building, or a subnet. Keep a slice's SNMP, traps, and topology on the same Agent and the correlation stays automatic; flows can run wherever you like.
+- **SNMP traps** — receive and decode the events your devices report (thousands of trap definitions across hundreds of vendors) into structured, searchable journal entries with severity and category, queryable in Netdata Logs and forwardable to your SIEM.
 
-However you split it, **Netdata Cloud gives you one unified view** — dashboards and a single topology of the whole network. There's no central server to size or babysit: you add a site by adding an Agent.
+- **Syslog from network devices** — ingest device syslog through the OpenTelemetry Collector into Netdata Logs.
 
-## What's in this section
+## Supported devices
 
-- **[Device Metrics](/docs/npm/device-metrics/README.md)** — discover and monitor your devices over SNMP: interfaces, health, errors, and more.
-- **[Topologies](/docs/npm/topology/README.md)** — see how your network is connected: device topology, live connections, and virtual infrastructure.
-- **[BGP Monitoring](/docs/npm/bgp/README.md)** — peer state, prefixes, and session health on your routers.
-- **[Licensing Monitoring](/docs/npm/licensing/README.md)** — track license state and expiry before a feature silently stops.
-- **[Network Flows](/docs/npm/network-flows/README.md)** — who is talking to whom, how much, over what, and to where (NetFlow / IPFIX / sFlow).
-- **[SNMP Traps](/docs/npm/snmp-traps/README.md)** — the asynchronous events your devices report.
-- **[Syslog from Network Devices](/docs/npm/syslog/README.md)** — device logs, ingested through the OpenTelemetry Collector.
+Netdata ships profiles for hundreds of device and trap vendors. Each capability lists exactly what it covers under its **Integrations** submenu: if your device is there, Netdata collects it out of the box; if it isn't, you can add a custom profile. Start from [Device Metrics](/docs/npm/device-metrics/README.md) to check coverage and add devices.
 
 ## Where to start
 
-- **Monitor your devices** — [Device Metrics](/docs/npm/device-metrics/README.md).
-- **See how they connect** — [Topologies](/docs/npm/topology/README.md).
-- **Catch their events** — [SNMP Traps](/docs/npm/snmp-traps/README.md).
-- **Analyze their traffic** — [Network Flows](/docs/npm/network-flows/README.md).
-- **Read their logs** — [Syslog from Network Devices](/docs/npm/syslog/README.md).
-- **Watch routing and licensing** — [BGP Monitoring](/docs/npm/bgp/README.md) and [Licensing Monitoring](/docs/npm/licensing/README.md).
-
-Each one runs on the same hub. Start with whichever question is in front of you.
+- **Monitor your devices** → [Device Metrics](/docs/npm/device-metrics/README.md)
+- **See how they connect** → [Topologies](/docs/npm/topology/README.md)
+- **Watch routing and licensing** → [BGP Monitoring](/docs/npm/bgp/README.md) and [Licensing Monitoring](/docs/npm/licensing/README.md)
+- **Analyze their traffic** → [Network Flows](/docs/npm/network-flows/README.md)
+- **Catch their events and logs** → [SNMP Traps](/docs/npm/snmp-traps/README.md) and [Syslog from Network Devices](/docs/npm/syslog/README.md)

--- a/docs/npm/bgp/README.md
+++ b/docs/npm/bgp/README.md
@@ -10,9 +10,7 @@ endmeta-->
 
 # BGP Monitoring
 
-Netdata monitors the BGP sessions on your routers — peer state, the prefixes they exchange, and the health of each session — so you can see when a peer goes down, flaps, or quietly stops sending updates.
-
-This section is for the teams running BGP at their edge or between sites who want clear operational visibility into their peers: is the session up, is it stable, is it still carrying routes.
+Netdata monitors the BGP sessions on your routers — peer state, the prefixes they exchange, and the health of each session — so you see when a peer goes down, flaps, or quietly stops sending updates.
 
 ## What Netdata watches
 
@@ -22,23 +20,22 @@ For every BGP peer on a monitored router:
 - **Uptime and stability** — how long the session has held, and how often it has flapped.
 - **Prefixes** — per address family, the routes exchanged (received, accepted, active, advertised, rejected, suppressed, withdrawn), where the device reports them.
 - **Update recency** — how long since the peer last sent an update.
-- **Why it last went down** — the last error, plus the down reason and graceful-restart state where the vendor MIB reports them.
+- **Last-down detail** — the last error, down reason, and graceful-restart state, where the vendor MIB reports them.
 
-The session and traffic metrics appear as live charts per peer; the full per-peer detail — including the last error, down reason, and graceful-restart state — is in the **`snmp:bgp-peers`** function, a sortable table of every peer.
+Session and traffic metrics appear as live charts per peer; the full per-peer detail is in the **`snmp:bgp-peers`** function, a sortable table of every peer.
 
-## The check that catches silent trouble
+## Up-but-stale detection
 
-A BGP session can show **Established** while it has quietly stopped receiving routes — the session looks fine, but the routing behind it is stale. Netdata tracks the **time since each peer's last update**, so you can spot a peer that's up-but-stale: state Established, last-update age climbing. Watch the two together and you catch the failure that peer-state alone hides.
+A BGP session can show **Established** while it has quietly stopped receiving routes — the session looks fine, but the routing behind it is stale. Netdata tracks the time since each peer's last update, so an up-but-stale peer (state Established, last-update age climbing) is visible.
 
 ## Which devices
 
-BGP monitoring works on any router that exposes its peers over SNMP through the standard BGP4-MIB, with vendor BGP MIB profiles for Alcatel-Lucent, Arista, Cisco, Dell, Huawei, Juniper, and Nokia adding per-vendor detail. It comes up automatically with the device's profile.
+Any router that exposes its peers over the standard BGP4-MIB, with vendor BGP profiles for Alcatel-Lucent, Arista, Cisco, Dell, Huawei, Juniper, and Nokia adding per-vendor detail. It comes up automatically with the device's profile.
 
 ## Alerts
 
-Netdata ships stock alerts for BGP health — a peer or address family dropping out of Established, plus ML-based anomaly alerts on session-transition rate, update churn, and accepted-prefix drift — raised automatically without you writing one.
+Stock alerts for BGP health — a peer or address family dropping out of Established, plus ML-based anomaly alerts on session-transition rate, update churn, and accepted-prefix drift.
 
 ## Where to start
 
 - BGP comes up automatically when you [monitor a router](/docs/npm/device-metrics/README.md) that runs it — open its charts or the `snmp:bgp-peers` function.
-- Any router exposing the BGP4-MIB is covered; the per-vendor entries add platform-specific detail.

--- a/docs/npm/device-metrics/README.md
+++ b/docs/npm/device-metrics/README.md
@@ -10,60 +10,31 @@ endmeta-->
 
 # Device Metrics
 
-Netdata monitors your network devices over SNMP — routers, switches, firewalls, access points, load balancers, UPS and PDU units. Point it at your network and it **discovers your devices, recognizes each model automatically, and starts monitoring them** — interface traffic, errors, device health, BGP, licenses — with no OID lists to build and no per-device dashboards to design.
+Netdata monitors your network devices over SNMP — routers, switches, firewalls, access points, load balancers, UPS and PDU units. It recognizes each device's model automatically and collects interface, health, and vendor-specific metrics, with no OID lists to build and no per-device dashboards to design.
 
-SNMP devices answer from a small management processor, so Netdata polls them at a cadence the device can sustain: a safe **10 seconds by default**, tunable per device — tighter where the data is worth it and the device can take it, gentler on heavy or fragile gear.
+## What you can monitor
 
-This section is for the network and SRE teams who run the fabric: you want to know which links are saturated, which devices are unhealthy, and you want it for every device in every site without hand-building a monitoring system.
+- **Interfaces** — traffic, errors, discards, and operational status, per interface.
+- **Device health** — control-plane CPU and memory, and environmental sensors (temperature, fans, power supplies) where the device's profile exposes them.
+- **Vendor-specific metrics** — hardware, protocol, and feature metrics from the matched vendor profile, plus BGP peers and license state where the device reports them.
+- **Reachability** — optional ICMP latency and loss alongside every device.
 
-## What you get, with almost no configuration
+Each device becomes its own node, with live charts, labels, and alerts.
 
-- **Discovery.** Give Netdata your network ranges and SNMP credentials and it finds the devices on them — or point it at a single device directly. Either way it reads the device, recognizes the model, and starts collecting.
-- **Full coverage per device, automatically.** Interface traffic, errors, discards, and operational status; device health (CPU and memory, plus environment sensors — temperature, fans, power supplies — where the device's profile exposes them); and — where the device exposes them — BGP peers and license state. Each device becomes **its own node** with live charts and alerts.
-- **Topology and traps, together, automatically.** On the same Agent, each device's **topology** (how it connects to its neighbors) and its **SNMP traps** come up alongside its metrics — and every trap arrives **already labeled with the device that sent it and its place in the topology**. There are no correlation rules to write.
+## Model recognition
 
-That last point is Netdata's zero-configuration promise applied to the network: discovery creates the jobs, topology follows the devices, and traps enrich themselves.
+Netdata matches each device to a profile by its `sysObjectID`, from a large built-in profile library. It collects standard interface and system metrics for any device that answers SNMP, and vendor-specific metrics where a profile matches; you can add custom profiles for anything special. It polls over SNMP v1, v2c, and v3.
 
-## One Agent per site is the hub
+## Functions and alerts
 
-Run the Agent on the device LAN. That Agent is the site's hub — it polls the local devices, maps their topology, and receives their traps, all in one place, close to the devices. Scale the way that fits your network:
-
-- **Up** — a larger Agent covering more devices.
-- **Out** — more Agents, each owning a part of the network.
-
-Keep a segment's SNMP, traps, and topology on the same Agent and the enrichment stays automatic. As you grow, you add Agents — and [Netdata Cloud](https://app.netdata.cloud) gives you **one unified view**, dashboards and a single topology, across every hub. See [Sizing and Scaling](/docs/npm/device-metrics/sizing-and-scaling.md).
-
-## What you can answer
-
-- Which interfaces are saturated, erroring, or discarding — on which device, right now and over time?
-- Is this device healthy — control-plane CPU, memory, temperature, fans, power supplies?
-- Which interfaces flapped, or went down?
-- What model and vendor is each device? (Netdata recognizes it for you.)
-- What is the state of a router's BGP peers, and are they still receiving updates?
-- Which firewalls have licenses about to expire?
-
-## What to reach for instead
-
-The same hub runs these too — use them for the questions SNMP polling isn't built for:
-
-- **Who is talking to whom on the wire** — [Network Flows](/docs/npm/network-flows/README.md).
-- **An event the moment a device reports it**, between polls — [SNMP Traps](/docs/npm/snmp-traps/README.md).
-- **Sub-second microbursts** — flow data or device-side counters; polling samples on an interval.
-
-## What ships with the collector
-
-- **SNMP v1, v2c, and v3 polling**, with optional ICMP latency and loss alongside every device.
-- **Automatic model recognition** from a large built-in profile library — interfaces, system health, environment sensors, and vendor-specific metrics — with custom profiles for anything special, and standard interface and system metrics for any device that reports a `sysObjectID`, even before a vendor-specific profile matches.
-- **A node per device**, with live charts, labels, and alerts.
-- **Live tables** you can open on any device: `snmp:interfaces` (traffic, status, errors, discards), `snmp:bgp-peers` (per-peer state and recency), and `snmp:licenses`.
-- **Stock alerts** for license expiry and BGP session health.
+- **Live tables** — `snmp:interfaces` (traffic, status, errors, discards), `snmp:bgp-peers` (per-peer state and recency), and `snmp:licenses`.
+- **Stock alerts** — license expiry and BGP session health.
 
 ## Where to start
 
-- **Your first device** — [Quick Start](/docs/npm/device-metrics/quick-start.md). To onboard a whole subnet at once, enable [discovery](/docs/npm/device-metrics/configuration.md).
-- **Add credentials, SNMPv3, many devices** — [Configuration](/docs/npm/device-metrics/configuration.md).
+- **Your first device** — [Quick Start](/docs/npm/device-metrics/quick-start.md).
+- **Credentials, SNMPv3, many devices, discovery** — [Configuration](/docs/npm/device-metrics/configuration.md).
 - **Understand or extend model recognition** — [SNMP Profile Format](/src/go/plugin/go.d/collector/snmp/profile-format.md).
 - **Many devices or many sites** — [Sizing and Scaling](/docs/npm/device-metrics/sizing-and-scaling.md).
 - **Trust the data** — [Validation](/docs/npm/device-metrics/validation.md); avoid the common mistakes in [Anti-patterns](/docs/npm/device-metrics/anti-patterns.md).
 - **Something's off** — [Troubleshooting](/docs/npm/device-metrics/troubleshooting.md).
-- **Topology, BGP, licensing, traps, flows, syslog** — the same hub does all of it; see the other sections of Network Performance Monitoring.

--- a/docs/npm/licensing/README.md
+++ b/docs/npm/licensing/README.md
@@ -12,12 +12,6 @@ endmeta-->
 
 Netdata tracks the license state of your network devices — what's entitled, how much is used, and when it expires — so a license doesn't quietly lapse and disable a feature you depend on.
 
-This section is for the teams running licensed network gear — firewalls especially — who need to know about an expiry **before** it turns off threat prevention, VPN, or routing at the worst possible time.
-
-## Why it matters
-
-A licensed feature can stop at midnight when its license expires — the device stays up, traffic keeps flowing, but the feature silently goes dark, and users notice hours later. Licensing monitoring exists to catch that while there's still time to renew.
-
 ## What Netdata tracks
 
 For devices that expose licensing over SNMP:
@@ -30,11 +24,11 @@ These appear as live charts and in the **`snmp:licenses`** function — a per-de
 
 ## Which vendors
 
-Licensing telemetry comes up automatically with the device's profile, for the vendors that ship dedicated licensing telemetry over SNMP — Check Point, Fortinet, Cisco (including Smart Licensing), Sophos, Blue Coat ProxySG, and MikroTik. The list grows as more vendors expose licensing telemetry over SNMP.
+Licensing telemetry comes up automatically with the device's profile, for the vendors that ship dedicated licensing telemetry over SNMP — Check Point, Fortinet, Cisco (including Smart Licensing), Sophos, Blue Coat ProxySG, and MikroTik.
 
 ## Alerts
 
-Netdata ships stock alerts on licensing health — an approaching expiry (so you renew with lead time), a license moving into a degraded or broken state, and a licensed pool filling up — so the problem surfaces before a feature stops.
+Stock alerts on licensing health — an approaching expiry, a license moving into a degraded or broken state, and a licensed pool filling up.
 
 ## Where to start
 

--- a/docs/npm/syslog/README.md
+++ b/docs/npm/syslog/README.md
@@ -10,30 +10,18 @@ endmeta-->
 
 # Syslog from Network Devices
 
-Netdata ingests the syslog your network devices emit — configuration changes, authentication events, link state, hardware alarms — and stores it as structured logs you can search, filter, and keep alongside the rest of each device's signals.
+Netdata ingests the syslog your network devices emit — configuration changes, authentication events, link state, hardware alarms — and stores it as structured logs you can search and filter alongside each device's metrics, topology, and traps.
 
-This section is for the teams who want their routers', switches', and firewalls' logs in the same place as their metrics, topology, and traps — searchable, retained, and ready when an incident needs them.
+## How it reaches Netdata
 
-## How it works
-
-Network devices send syslog. Netdata receives it through the **OpenTelemetry Collector** — the open, vendor-neutral telemetry layer Netdata builds on:
-
-1. You run an OpenTelemetry Collector with a **syslog receiver**, typically on the same host as the devices' hub.
-2. It parses each message (RFC 3164 or 5424), normalizes the fields, and forwards them to the Netdata Agent over OTLP.
-3. The Agent stores them as structured journal logs, explorable in the **Logs** tab.
-
-Because the pipeline is the OpenTelemetry Collector, you also get its full processing power — filter noisy sources, transform and enrich messages, even derive metrics from log patterns — before the logs ever reach Netdata.
+Netdata does not listen for syslog directly. Your devices send syslog to an **OpenTelemetry Collector** with a syslog receiver, which parses each message (RFC 3164 or 5424), normalizes the fields, and forwards them to the Netdata Agent over OTLP; the Agent stores them as structured journal logs in the **Logs** tab. Because the pipeline is the OpenTelemetry Collector, you can filter, transform, and enrich messages — or derive metrics from them — before they reach Netdata.
 
 ## What you get
 
 - **Searchable device logs** — by device, severity, facility, and message content.
-- **Together with everything else** — run the collector against the same hub that polls the devices, and their logs sit beside their metrics, topology, and traps.
+- **Alongside everything else** — run the collector against the same Agent that polls the devices, and their logs sit beside their metrics, topology, and traps.
 - **Retained on your terms** — stored in journal files with the rotation and retention you set.
-
-## Set it up
-
-Netdata publishes ready-to-use OpenTelemetry Collector configurations for syslog — a simple one to get started, and a more robust one with a durable sending queue. Point your devices at the collector, point the collector at your Agent, and the logs flow.
 
 ## Where to start
 
-- The entry in this section walks through the collector configuration and what to expect in the Logs tab.
+- Netdata publishes ready-to-use OpenTelemetry Collector configurations for syslog. The entry in this section walks through the collector configuration and what to expect in the Logs tab.

--- a/docs/npm/topology/README.md
+++ b/docs/npm/topology/README.md
@@ -10,46 +10,38 @@ endmeta-->
 
 # Network Topologies
 
-Netdata shows you **how your network is actually connected** — which device links to which, and where each part of your infrastructure sits — and it builds that picture automatically from the devices you're already monitoring.
+Netdata shows you how your network is connected — which device links to which, and where each part of your infrastructure sits — built automatically from the devices you already monitor.
 
-This section is for the teams who need the real shape of the network: to trace a path, find what's downstream of a failing link, or see how a site is wired — without drawing it by hand or keeping a diagram up to date.
+## Built from your devices
 
-## Built automatically from your devices
-
-When Netdata monitors your SNMP devices, it also reads what they already know about their neighbors and assembles the topology from it — with no extra setup:
+When Netdata monitors your SNMP devices, it reads what they already know about their neighbors and assembles the topology, with no extra setup:
 
 - **LLDP and CDP** — the neighbor each device advertises (device, port, platform).
 - **Forwarding (FDB) and ARP tables** — which MAC and IP addresses are seen on which switch ports.
 - **Spanning Tree (STP)** — which Layer 2 links are forwarding and which are blocked.
-- **BGP and OSPF** — the Layer 3 routing relationships between your routers.
+- **BGP and OSPF** — the Layer 3 routing relationships between routers.
 
-The result is a live Layer 2 and Layer 3 map of your network, kept current as devices come and go. Because it's built from the same devices you're polling, it stays in step with your metrics and traps — when a trap or an alert points at a device, you can already see where that device sits.
+The result is a live Layer 2 and Layer 3 map, kept current as devices come and go. Each link carries the evidence behind it — how it was discovered and how confident Netdata is in it — so a confirmed link is distinguishable from an inferred one.
 
 ## What you can do with it
 
-- **See the real wiring** — device-to-device links across your network, instead of a stale diagram.
+- **See the real wiring** — device-to-device links across your network.
 - **Trace a path** — follow how two points connect, hop by hop.
 - **Find what's affected** — what sits downstream of a link or device that's in trouble.
 - **Locate an endpoint** — which switch port an address is on, cross-referenced from forwarding and neighbor data.
 
-Each link carries the evidence behind it — how it was discovered and how confident Netdata is in it — so you can tell a freshly-confirmed link from one that's inferred.
+## Beyond the device fabric
 
-## More than the device fabric
+The same topology view brings in other infrastructure, each in the same form so it sits alongside your device topology:
 
-The same topology view brings in other parts of your infrastructure, each in the same form so they sit alongside your device topology rather than in a separate tool:
+- **Live network connections** — what your hosts and services are talking to right now (`topology:network-connections`).
+- **Netdata streaming** — how your Agents connect to each other (`topology:streaming`).
+- **VMware vSphere** — datacenters, clusters, resource pools, hosts, VMs, datastores, and networks (`topology:vsphere`).
+- **Cato Networks** — Cato SASE sites, devices, POPs, and BGP peers (`topology:cato_networks`).
 
-- **Live network connections** — what your hosts and services are actually talking to, right now.
-- **Netdata streaming** — how your Netdata Agents connect to each other.
-- **vSphere** — your VMware datacenters, clusters, resource pools, hosts, VMs, datastores, datastore clusters, and networks.
-- **Cato Networks** — your Cato SASE sites, devices, POPs, and BGP peers.
-
-The device fabric, live connections, and Agent streaming come up automatically; **vSphere** and **Cato Networks** come from their own collectors, which you configure separately. Each is its own view — `topology:snmp` for the device fabric, `topology:network-connections` for live connections, `topology:streaming` for the Agent mesh, plus `topology:vsphere` and `topology:cato_networks` — and Netdata Cloud overlays them into one picture.
-
-## One topology across every site
-
-Each hub builds the topology for its own part of the network, and **Netdata Cloud aggregates them into one** — a single topology of your entire network, however many Agents and sites you run. Scaling out adds detail to the same picture; it never fragments it.
+The device fabric (`topology:snmp`), live connections, and streaming come up automatically; vSphere and Cato come from their own collectors, configured separately.
 
 ## Where to start
 
-- Topology comes up on its own once you're [monitoring devices](/docs/npm/device-metrics/README.md) — open the topology view in Netdata to see it.
+- Topology comes up on its own once you're [monitoring devices](/docs/npm/device-metrics/README.md) — open the topology view in Netdata.
 - The entries in this section list each discovery method and source, and what each one contributes to the map.

--- a/integrations/gen_docs_integrations.py
+++ b/integrations/gen_docs_integrations.py
@@ -200,6 +200,13 @@ def build_readme_from_integration(integration, categories, mode: str = ""):
             learn_rel_path = generate_category_from_name(
                 integration["meta"]["monitored_instance"]["categories"][0].split("."), categories
             ).replace("Data Collection", "Collecting Metrics/Collectors")
+            # NPM collectors (SNMP, PAN-OS, Cato, SNMP traps) re-tagged into the
+            # Network Performance Monitoring chapters nest under the chapter's
+            # "Integrations" sub-node, alongside the per-vendor catalog tiles, so
+            # they don't sit among the hand-authored chapter pages. Non-NPM
+            # collectors (Collecting Metrics/...) are unaffected.
+            if learn_rel_path.startswith("Network Performance Monitoring/"):
+                learn_rel_path += "/Integrations"
             keywords = integration["meta"]["keywords"] if "keywords" in integration["meta"] else None
 
             md = f"""<!--startmeta
@@ -266,9 +273,13 @@ endmeta-->
         elif mode == "device":
             meta_yaml = integration["edit_link"].replace("blob", "edit")
             sidebar_label = integration["meta"]["monitored_instance"]["name"]
+            # NPM catalog tiles (per-vendor / per-profile) nest under an
+            # "Integrations" sub-node of their chapter so the hundreds of vendor
+            # pages do not flood the chapter sidebars. Sidebar placement only —
+            # the category (website integrations browser) is unchanged.
             learn_rel_path = generate_category_from_name(
                 integration["meta"]["monitored_instance"]["categories"][0].split("."), categories
-            )
+            ) + "/Integrations"
             keywords = integration["meta"]["keywords"] if "keywords" in integration["meta"] else None
 
             md = f"""<!--startmeta


### PR DESCRIPTION
## Summary

Two post-merge quality fixes for the **Network Performance Monitoring** docs (follow-up to #22840):

### 1. Overviews rewritten as capability pages

The NPM overview and the five authored chapter overviews — **Device Metrics, BGP Monitoring, Licensing, Topologies, Syslog** — were narrative/implementation/scaling prose ("You run a network…", "Put a Netdata Agent at each site", "Scale by adding Agents", "This section is for the teams who…"). They are rewritten as **capability/feature overviews**: what Netdata monitors → how → what you get, with the grounded content (metrics, Functions like `snmp:bgp-peers`, vendor coverage, alerts) and the navigation kept. Net change is a reduction in prose.

*Network Flows and SNMP Traps overviews pre-existed (#22439, #22702) and are left unchanged.*

### 2. Integration tiles nested under an "Integrations" submenu

The per-vendor / per-profile integration tiles (176 device + 806 trap + BGP/licensing/topology) were rendered at the **same sidebar level as the chapter content**, so each chapter menu exploded to hundreds of entries. They now nest under a single collapsed **Integrations** node per chapter.

- One change in `gen_docs_integrations.py` (device + collector modes): append `/Integrations` to the tile `learn_rel_path`. **Sidebar placement only** — the `categories` field that drives the website integrations browser and URLs is unchanged; no taxonomy, `map.yaml`, or learn-repo changes.
- Non-NPM collectors are unaffected (the append is gated on the NPM chapter path).

Result: each chapter menu = its hand-authored content pages + one collapsed **Integrations** node.

## Generated artifacts

The per-tile `.md` files are regenerated by the existing **Regenerate integrations docs** workflow from this change; they are not committed here.

## Validation

Isolated local Learn ingest + Docusaurus build: **ingest 0 broken links, build exit 0**. Verified the chapter menus are clean (content + Integrations node) and non-NPM collectors keep their `Collecting Metrics/...` placement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote NPM docs into clear capability pages and nested per-vendor tiles under a per-chapter Integrations submenu to simplify navigation and reduce noise.

- **Refactors**
  - Rewrote overviews as capability pages: Device Metrics, BGP, Licensing, Topology, Syslog (Flows and Traps unchanged).
  - Nested NPM integrations under an “Integrations” submenu; updated `integrations/gen_docs_integrations.py` to append `/Integrations` to NPM tiles’ `learn_rel_path` in device and collector modes. Non-NPM collectors and categories (website integrations browser/URLs) unchanged.
  - Clarified content:
    - Device Metrics: model recognition, live tables (`snmp:interfaces`, `snmp:bgp-peers`, `snmp:licenses`), stock alerts.
    - BGP: up‑but‑stale detection, stock alerts wording.
    - Syslog: via OpenTelemetry Collector; Netdata does not listen directly.
    - Topology: evidence/confidence on links; separate views for live connections, streaming, vSphere, and Cato.

<sup>Written for commit 7a7d573d8623b51a21442c452ff6174387a9e56b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

